### PR TITLE
wandb chat completion fix

### DIFF
--- a/verifiers/trainers/grpo_trainer.py
+++ b/verifiers/trainers/grpo_trainer.py
@@ -33,7 +33,7 @@ from verifiers import Environment
 from verifiers.trainers.grpo_config import GRPOConfig
 from verifiers.trainers.async_batch_generator import AsyncBatchGenerator, BatchRequest
 from verifiers.trainers.async_dataloader_wrapper import AsyncDataLoaderWrapper
-from verifiers.utils.logging_utils import print_prompt_completions_sample   
+from verifiers.utils.logging_utils import print_prompt_completions_sample, format_chat_response  
 
 class RepeatSampler(Sampler):
     """
@@ -1077,8 +1077,8 @@ class GRPOTrainer(Trainer):
                 
                 table_data = {
                     "step": [str(self.state.global_step)] * len(prompts),
-                    "prompt": prompts,
-                    "completion": completions,
+                    "prompt": [format_chat_response(prompt) for prompt in prompts],
+                    "completion": [format_chat_response(completion) for completion in completions],
                 }
                 for k, v in reward_dict.items():
                     table_data[k] = v
@@ -1122,8 +1122,8 @@ class GRPOTrainer(Trainer):
  
                 table = {
                     "step": [str(self.state.global_step)] * len(self._textual_logs["prompt"]),
-                    "prompt": list(self._textual_logs["prompt"]),
-                    "completion": list(self._textual_logs["completion"]),
+                    "prompt": [format_chat_response(prompt) for prompt in self._textual_logs["prompt"]],
+                    "completion": [format_chat_response(completion) for completion in self._textual_logs["completion"]],
                     **{k: list(v) for k, v in self._textual_logs["rewards"].items()},
                 }
                 if len(table["prompt"]) > 0:

--- a/verifiers/utils/logging_utils.py
+++ b/verifiers/utils/logging_utils.py
@@ -7,6 +7,18 @@ from rich.table import Table
 from rich.text import Text
 from rich.panel import Panel
 
+
+def format_chat_response(chat_response):
+    if isinstance(chat_response, list):
+        # For chat format, only show the last message content (typically the user's question and the assistant's response)
+        # Excludes system prompt from wandb logging.
+        last_message = chat_response[-1]
+        content = last_message.get("content", "")
+        return content
+    else:
+        return chat_response
+
+
 def setup_logging(
     level: str = "INFO",
     log_format: Optional[str] = None,


### PR DESCRIPTION
Sorry for the double PR, ran into some github issues.

This PR fixes wandb loggin for the chat completion format. I was getting logs which look like this (for prompt / completion):

<img width="846" alt="image" src="https://github.com/user-attachments/assets/993d46ad-d37f-46f0-9beb-c4f475fc73c8" />

<img width="536" alt="image" src="https://github.com/user-attachments/assets/8db5b818-92bd-4baa-9dd0-d937faccd364" />

I fixed this by writing a new chat format function and applying it to the prompt and completion logging. The function is basically copied from `print_prompt_completions_sample` in `logging_utils.py`. I have omitted types from the input /output in order to hopefully not interfere with anything if there is an error with the parsing.

Let me know if you see any issues with this!