### PR TITLE
Update tests and docs for pydantic typing

### DIFF
--- a/docs/source/api_reference.md
+++ b/docs/source/api_reference.md
@@ -19,6 +19,27 @@ class GenerateInputs(BaseModel):
     task: Optional[List[str]] = None
     completion: Optional[List[Messages]] = None
 
+class GenerateOutputs(BaseModel):
+    """Pydantic model for generation outputs."""
+    prompt: List[Messages]
+    completion: List[Messages]
+    answer: List[str]
+    state: List[State]
+    info: List[Info]
+    task: List[str]
+    reward: List[float]
+    metrics: Dict[str, List[float]] = {}
+
+class RolloutScore(BaseModel):
+    """Pydantic model for individual rollout scores."""
+    reward: float
+    metrics: Dict[str, float] = {}
+
+class RolloutScores(BaseModel):
+    """Pydantic model for multiple rollout scores."""
+    reward: List[float]
+    metrics: Dict[str, List[float]] = {}
+
 class ProcessedOutputs(BaseModel):
     """Pydantic model for processed outputs."""
     prompt_ids: List[List[int]]
@@ -119,7 +140,7 @@ def env_response(
     """
     Returns:
         - Response messages (List[ChatMessage] or str for completion mode)
-        - Updated state dictionary
+        - Updated state
     """
     # Return a list of ChatMessage dicts (typical case)
     response = [{"role": "user", "content": "Environment feedback"}]
@@ -192,12 +213,12 @@ async def rollout(...) -> Tuple[Messages, State]:
     """Returns (completion, final_state)"""
 
 # Evaluation results
-def evaluate(...) -> Dict[str, Any]:
-    """Returns dict with 'prompts', 'completions', 'rewards', 'states', etc."""
+def evaluate(...) -> GenerateOutputs:
+    """Returns GenerateOutputs with prompts, completions, rewards, states, etc."""
 
 # Generation results  
-def generate(...) -> Dict[str, List[Any]]:
-    """Returns dict with 'results' containing rollout data"""
+def generate(...) -> GenerateOutputs:
+    """Returns GenerateOutputs containing rollout data"""
 ```
 
 ### Parser Types

--- a/tests/test_env_group.py
+++ b/tests/test_env_group.py
@@ -7,6 +7,7 @@ from verifiers import EnvGroup
 from verifiers.envs.env_group import EnvGroupRubric
 from verifiers import SingleTurnEnv
 from verifiers import Rubric
+from verifiers.types import RolloutScores
 
 
 class TestEnvGroupRubric:
@@ -320,7 +321,9 @@ class TestEnvGroup:
         env_group = EnvGroup(envs=[env1, env2], env_names=["math", "code"])
 
         # Mock the scoring
-        env_group.rubric.score_rollouts = AsyncMock(return_value={"reward": [0.8, 0.9]})
+        env_group.rubric.score_rollouts = AsyncMock(
+            return_value=RolloutScores(reward=[0.8, 0.9], metrics={})
+        )
 
         inputs = {
             "prompt": [
@@ -335,10 +338,10 @@ class TestEnvGroup:
             inputs, client=mock_openai_client, model="test-model"
         )
 
-        assert "completion" in results
-        assert "state" in results
-        assert "reward" in results
-        assert len(results["completion"]) == 2
+        assert hasattr(results, "completion")
+        assert hasattr(results, "state")
+        assert hasattr(results, "reward")
+        assert len(results.completion) == 2
 
     def test_env_group_with_mixed_datasets(self, mock_openai_client):
         """Test EnvGroup with environments having different dataset configurations."""

--- a/tests/test_env_group.py
+++ b/tests/test_env_group.py
@@ -84,11 +84,11 @@ class TestEnvGroupRubric:
             task="math",
         )
 
-        assert "func1" in result
-        assert "func2" in result
-        assert result["func1"] == 0.8  # From env1
-        assert result["func2"] == 0.0  # Not in env1, so 0.0
-        assert result["reward"] == 0.8
+        assert "func1" in result.metrics
+        assert "func2" in result.metrics
+        assert result.metrics["func1"] == 0.8  # From env1
+        assert result.metrics["func2"] == 0.0  # Not in env1, so 0.0
+        assert result.reward == 0.8
 
     @pytest.mark.asyncio
     async def test_env_group_rubric_unknown_task(self, mock_openai_client):
@@ -107,7 +107,7 @@ class TestEnvGroupRubric:
             prompt="Test", completion="Test", task="unknown_task"
         )
 
-        assert result["reward"] == 0.0
+        assert result.reward == 0.0
 
 
 class TestEnvGroup:

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -6,6 +6,7 @@ import pytest
 from datasets import Dataset
 
 from verifiers import Environment, Parser, Rubric
+from verifiers.types import RolloutScores, GenerateOutputs
 
 
 # Create a concrete implementation for testing the abstract base class
@@ -478,16 +479,18 @@ class TestEnvironmentBase:
         )
 
         # Mock the rubric scoring
-        env.rubric.score_rollouts = AsyncMock(return_value={"reward": [1.0]})
+        env.rubric.score_rollouts = AsyncMock(
+            return_value=RolloutScores(reward=[1.0], metrics={})
+        )
 
         inputs = {"prompt": [[{"role": "user", "content": "Hello"}]], "answer": ["Hi"]}
 
         results = await env.a_generate(inputs, score_rollouts=True)
 
-        assert "completion" in results
-        assert "state" in results
-        assert "reward" in results
-        assert results["reward"] == [1.0]
+        assert hasattr(results, "completion")
+        assert hasattr(results, "state")
+        assert hasattr(results, "reward")
+        assert results.reward == [1.0]
 
     def test_generate_sync_wrapper(self, mock_openai_client, sample_dataset):
         """Test synchronous generate wrapper."""
@@ -500,15 +503,17 @@ class TestEnvironmentBase:
         )
 
         # Mock the rubric scoring
-        env.rubric.score_rollouts = AsyncMock(return_value={"reward": [1.0]})
+        env.rubric.score_rollouts = AsyncMock(
+            return_value=RolloutScores(reward=[1.0], metrics={})
+        )
 
         inputs = {"prompt": [[{"role": "user", "content": "Hello"}]], "answer": ["Hi"]}
 
         results = env.generate(inputs, client=env.client)
 
-        assert "completion" in results
-        assert "state" in results
-        assert "reward" in results
+        assert hasattr(results, "completion")
+        assert hasattr(results, "state")
+        assert hasattr(results, "reward")
 
     def test_make_dataset(self, mock_openai_client, sample_dataset):
         """Test creating a dataset from evaluation results."""
@@ -520,14 +525,16 @@ class TestEnvironmentBase:
             rubric=Rubric(),
         )
 
-        results = {
-            "prompt": [[{"role": "user", "content": "Hello"}]],
-            "completion": [[{"role": "assistant", "content": "Hi"}]],
-            "answer": ["Hi"],
-            "reward": [1.0],
-            "task": ["default"],
-            "state": [{"custom_field": "value"}],
-        }
+        results = GenerateOutputs(
+            prompt=[[{"role": "user", "content": "Hello"}]],
+            completion=[[{"role": "assistant", "content": "Hi"}]],
+            answer=["Hi"],
+            reward=[1.0],
+            task=["default"],
+            state=[{"custom_field": "value"}],
+            info=[{}],
+            metrics={}
+        )
 
         dataset = env.make_dataset(results, state_columns=["custom_field"])
 

--- a/tests/test_rubric.py
+++ b/tests/test_rubric.py
@@ -3,6 +3,7 @@
 import pytest
 
 from verifiers import Parser, Rubric
+from verifiers.types import RolloutScore, RolloutScores
 
 
 class TestRubric:
@@ -228,12 +229,12 @@ class TestRubric:
             info={},
         )
 
-        assert "func1" in result
-        assert "func2" in result
-        assert "reward" in result
-        assert result["func1"] == 1.0  # completion == answer
-        assert result["func2"] == 0.4  # len("test") * 0.1
-        assert result["reward"] == 1.0 * 1.0 + 0.4 * 0.5  # Weighted sum
+        assert "func1" in result.metrics
+        assert "func2" in result.metrics
+        assert hasattr(result, "reward")
+        assert result.metrics["func1"] == 1.0  # completion == answer
+        assert result.metrics["func2"] == 0.4  # len("test") * 0.1
+        assert result.reward == 1.0 * 1.0 + 0.4 * 0.5  # Weighted sum
 
     @pytest.mark.asyncio
     async def test_score_rollout_with_list_completion(self):
@@ -258,8 +259,8 @@ class TestRubric:
             info={},
         )
 
-        assert result["list_func"] == 2.0  # Length of completion list
-        assert result["reward"] == 2.0
+        assert result.metrics["list_func"] == 2.0  # Length of completion list
+        assert result.reward == 2.0
 
     @pytest.mark.asyncio
     async def test_score_rollouts_multiple(self):
@@ -289,16 +290,16 @@ class TestRubric:
             infos=infos,
         )
 
-        assert "accuracy_func" in results
-        assert "length_func" in results
-        assert "reward" in results
-        assert len(results["accuracy_func"]) == 3
-        assert results["accuracy_func"] == [
+        assert "accuracy_func" in results.metrics
+        assert "length_func" in results.metrics
+        assert hasattr(results, "reward")
+        assert len(results.metrics["accuracy_func"]) == 3
+        assert results.metrics["accuracy_func"] == [
             1.0,
             1.0,
             0.0,
         ]  # First two match, third doesn't
-        assert results["length_func"] == [7.0, 7.0, 5.0]  # Lengths of completions
+        assert results.metrics["length_func"] == [7.0, 7.0, 5.0]  # Lengths of completions
 
     @pytest.mark.asyncio
     async def test_score_rollouts_with_apply_weights(self):
@@ -330,7 +331,7 @@ class TestRubric:
             apply_weights=True,
         )
 
-        assert results_weighted["reward"][0] == 1.0 * 2.0 + 0.5 * 3.0  # 2.0 + 1.5 = 3.5
+        assert results_weighted.reward[0] == 1.0 * 2.0 + 0.5 * 3.0  # 2.0 + 1.5 = 3.5
 
         # Test with apply_weights=False (should not be used, but test anyway)
         results_unweighted = await rubric.score_rollouts(
@@ -363,10 +364,10 @@ class TestRubric:
         )
 
         # Should return empty lists for each function
-        assert "test_func" in results
-        assert "reward" in results
-        assert results["test_func"] == []
-        assert results["reward"] == []
+        assert "test_func" in results.metrics
+        assert hasattr(results, "reward")
+        assert results.metrics["test_func"] == []
+        assert results.reward == []
 
     @pytest.mark.asyncio
     async def test_score_rollouts_with_default_infos(self):
@@ -386,8 +387,8 @@ class TestRubric:
             infos=[{}],  # Explicitly provide infos to match other lists
         )
 
-        assert "simple_func" in results
-        assert results["simple_func"] == [1.0]
+        assert "simple_func" in results.metrics
+        assert results.metrics["simple_func"] == [1.0]
 
     def test_rubric_with_custom_parser(self):
         """Test Rubric with custom parser."""
@@ -418,5 +419,5 @@ class TestRubric:
             infos=[{}],
         )
 
-        assert results["scalar_func"] == [0.5]
-        assert results["reward"] == [0.5]
+        assert results.metrics["scalar_func"] == [0.5]
+        assert results.reward == [0.5]

--- a/tests/test_rubric.py
+++ b/tests/test_rubric.py
@@ -346,7 +346,7 @@ class TestRubric:
 
         # When apply_weights=False, only individual scores are returned, no weighted sum
         assert (
-            results_unweighted["reward"][0] == 1.0 * 2.0 + 0.5 * 3.0
+            results_unweighted.reward[0] == 1.0 * 2.0 + 0.5 * 3.0
         )  # Still weighted
 
     @pytest.mark.asyncio

--- a/tests/test_rubric_group.py
+++ b/tests/test_rubric_group.py
@@ -2,6 +2,7 @@
 
 import pytest
 from verifiers import Rubric, RubricGroup
+from verifiers.types import RolloutScores
 
 
 class TestRubricGroup:
@@ -161,13 +162,13 @@ class TestRubricGroup:
         )
 
         # Should have scores from both rubrics
-        assert "func1" in scores
-        assert "func2" in scores
-        assert "reward" in scores
-        assert len(scores["func1"]) == 1
-        assert len(scores["func2"]) == 1
-        assert scores["func1"][0] == 1.0
-        assert scores["func2"][0] == 0.5
+        assert "func1" in scores.metrics
+        assert "func2" in scores.metrics
+        assert hasattr(scores, "reward")
+        assert len(scores.metrics["func1"]) == 1
+        assert len(scores.metrics["func2"]) == 1
+        assert scores.metrics["func1"][0] == 1.0
+        assert scores.metrics["func2"][0] == 0.5
 
     @pytest.mark.asyncio
     async def test_rubric_group_score_rollouts_duplicate_names(self):
@@ -204,9 +205,9 @@ class TestRubricGroup:
         )
 
         # Should have summed scores for duplicate function names
-        assert "func1" in scores
-        assert len(scores["func1"]) == 1
-        assert scores["func1"][0] == 2.0  # 1.0 + 1.0 (same function called twice)
+        assert "func1" in scores.metrics
+        assert len(scores.metrics["func1"]) == 1
+        assert scores.metrics["func1"][0] == 2.0  # 1.0 + 1.0 (same function called twice)
 
     @pytest.mark.asyncio
     async def test_rubric_group_score_rollouts_with_kwargs(self):
@@ -240,10 +241,10 @@ class TestRubricGroup:
         )
 
         # Should pass custom kwargs to reward functions
-        assert "func1" in scores
-        assert len(scores["func1"]) == 1
+        assert "func1" in scores.metrics
+        assert len(scores.metrics["func1"]) == 1
         assert (
-            scores["func1"][0] == 2.0
+            scores.metrics["func1"][0] == 2.0
         )  # 1.0 + 1.0 (both should get custom_param="test")
 
     @pytest.mark.asyncio
@@ -276,10 +277,10 @@ class TestRubricGroup:
         )
 
         # Should work with single rubric
-        assert "func1" in scores
-        assert "reward" in scores
-        assert len(scores["func1"]) == 1
-        assert scores["func1"][0] == 1.0
+        assert "func1" in scores.metrics
+        assert hasattr(scores, "reward")
+        assert len(scores.metrics["func1"]) == 1
+        assert scores.metrics["func1"][0] == 1.0
 
     @pytest.mark.asyncio
     async def test_rubric_group_score_rollouts_empty_data(self):
@@ -311,10 +312,10 @@ class TestRubricGroup:
         )
 
         # Should return empty scores but with correct structure
-        assert "func1" in scores
-        assert "reward" in scores
-        assert len(scores["func1"]) == 0
-        assert len(scores["reward"]) == 0
+        assert "func1" in scores.metrics
+        assert hasattr(scores, "reward")
+        assert len(scores.metrics["func1"]) == 0
+        assert len(scores.reward) == 0
 
     def test_rubric_group_mixed_rubric_types(self):
         """Test RubricGroup with different types of rubrics."""
@@ -366,11 +367,11 @@ class TestRubricGroup:
         )
 
         # Should work with max_concurrent parameter
-        assert "func1" in scores
-        assert "reward" in scores
-        assert len(scores["func1"]) == 2
-        assert scores["func1"][0] == 1.0
-        assert scores["func1"][1] == 1.0
+        assert "func1" in scores.metrics
+        assert hasattr(scores, "reward")
+        assert len(scores.metrics["func1"]) == 2
+        assert scores.metrics["func1"][0] == 1.0
+        assert scores.metrics["func1"][1] == 1.0
 
     def test_rubric_group_inheritance(self):
         """Test that RubricGroup properly inherits from Rubric."""

--- a/tests/test_singleturn_env.py
+++ b/tests/test_singleturn_env.py
@@ -280,16 +280,16 @@ class TestSingleTurnEnv:
 
         # Mock the rubric.score_rollouts method
         mock_singleturn_env.rubric.score_rollouts = AsyncMock(
-            return_value={"reward": [1.0]}
+            return_value=RolloutScores(reward=[1.0], metrics={})
         )
 
         results = mock_singleturn_env.generate(
             inputs, client=mock_singleturn_env.client
         )
 
-        assert "completion" in results
-        assert "state" in results
-        assert "reward" in results
+        assert hasattr(results, "completion")
+        assert hasattr(results, "state")
+        assert hasattr(results, "reward")
 
     @pytest.mark.asyncio
     async def test_different_message_types_in_same_env(

--- a/tests/test_singleturn_env.py
+++ b/tests/test_singleturn_env.py
@@ -6,6 +6,7 @@ import pytest
 from datasets import Dataset
 
 from verifiers import Parser, Rubric, SingleTurnEnv
+from verifiers.types import RolloutScores
 
 
 class TestSingleTurnEnv:
@@ -228,17 +229,17 @@ class TestSingleTurnEnv:
 
         # Mock the rubric.score_rollouts method
         mock_singleturn_env.rubric.score_rollouts = AsyncMock(
-            return_value={"reward": [1.0, 1.0]}
+            return_value=RolloutScores(reward=[1.0, 1.0], metrics={})
         )
 
         results = await mock_singleturn_env.a_generate(inputs)
 
-        assert "completion" in results
-        assert "state" in results
-        assert "reward" in results
-        assert len(results["completion"]) == 2
-        assert len(results["state"]) == 2
-        assert results["reward"] == [1.0, 1.0]
+        assert hasattr(results, "completion")
+        assert hasattr(results, "state")
+        assert hasattr(results, "reward")
+        assert len(results.completion) == 2
+        assert len(results.state) == 2
+        assert results.reward == [1.0, 1.0]
 
     @pytest.mark.asyncio
     async def test_a_generate_with_dataset(
@@ -247,15 +248,15 @@ class TestSingleTurnEnv:
         """Test async generation with Dataset input."""
         # Mock the rubric.score_rollouts method
         mock_singleturn_env.rubric.score_rollouts = AsyncMock(
-            return_value={"reward": [1.0, 1.0]}
+            return_value=RolloutScores(reward=[1.0, 1.0], metrics={})
         )
 
         results = await mock_singleturn_env.a_generate(sample_chat_dataset)
 
-        assert "completion" in results
-        assert "state" in results
-        assert "reward" in results
-        assert len(results["completion"]) == 2
+        assert hasattr(results, "completion")
+        assert hasattr(results, "state")
+        assert hasattr(results, "reward")
+        assert len(results.completion) == 2
 
     @pytest.mark.asyncio
     async def test_a_generate_no_scoring(self, mock_singleturn_env):
@@ -264,9 +265,10 @@ class TestSingleTurnEnv:
 
         results = await mock_singleturn_env.a_generate(inputs, score_rollouts=False)
 
-        assert "completion" in results
-        assert "state" in results
-        assert "reward" not in results  # Should not score when score_rollouts=False
+        assert hasattr(results, "completion")
+        assert hasattr(results, "state")
+        assert hasattr(results, "reward")  # reward attribute exists but should be empty
+        assert results.reward == []  # Should be empty when score_rollouts=False
 
     def test_generate_sync_wrapper(self, mock_singleturn_env):
         """Test the synchronous generate wrapper."""

--- a/verifiers/envs/env_group.py
+++ b/verifiers/envs/env_group.py
@@ -66,16 +66,18 @@ class EnvGroupRubric(Rubric):
         env_results = await env.rubric.score_rollout(
             prompt, completion, answer, state, task, info, **kwargs
         )
-        print(env_results.keys())
-        print(env_results["reward"])
-
-        # Update results with scores
-        for reward_name, score in env_results.items():
+        
+        # Update results with the reward score
+        results["reward"] = env_results.reward
+        
+        # Update results with individual metric scores
+        for reward_name, score in env_results.metrics.items():
             if reward_name in results:
                 results[reward_name] = score
+        
         # dummy scores for all reward functions not in the environment
         for reward_name in self.all_reward_names:
-            if reward_name not in env_results:
+            if reward_name not in env_results.metrics:
                 results[reward_name] = 0.0
         return results
 

--- a/verifiers/envs/env_group.py
+++ b/verifiers/envs/env_group.py
@@ -11,6 +11,7 @@ from verifiers import (
 )
 from verifiers.envs.environment import Environment
 from verifiers.rubrics.rubric import Rubric
+from verifiers.types import RolloutScore
 
 
 class EnvGroupRubric(Rubric):
@@ -45,41 +46,37 @@ class EnvGroupRubric(Rubric):
         task: str = "default",
         info: dict = {},
         **kwargs,
-    ) -> Dict[str, float]:
+    ) -> RolloutScore:
         """
         Route scoring to the appropriate environment's rubric based on task.
 
-        Returns a dict with all reward function names, using 0.0 for functions
+        Returns a RolloutScore with all reward function names, using 0.0 for functions
         not applicable to this sample's environment.
         """
-        # Initialize results with all reward names set to 0.0
-        results = {name: 0.0 for name in self.all_reward_names}
-        results["reward"] = 0.0
+        # Initialize metrics with all reward names set to 0.0
+        metrics = {name: 0.0 for name in self.all_reward_names}
+        reward = 0.0
 
         # Get the appropriate environment
         env = self.env_map.get(task)
         if env is None:
             self.logger.warning(f"No environment found for task '{task}'")
-            return results
+            return RolloutScore(reward=reward, metrics=metrics)
 
         # Score with the environment's rubric
         env_results = await env.rubric.score_rollout(
             prompt, completion, answer, state, task, info, **kwargs
         )
         
-        # Update results with the reward score
-        results["reward"] = env_results.reward
-        
-        # Update results with individual metric scores
+        # Update metrics with individual metric scores from the environment
         for reward_name, score in env_results.metrics.items():
-            if reward_name in results:
-                results[reward_name] = score
+            if reward_name in metrics:
+                metrics[reward_name] = score
         
-        # dummy scores for all reward functions not in the environment
-        for reward_name in self.all_reward_names:
-            if reward_name not in env_results.metrics:
-                results[reward_name] = 0.0
-        return results
+        # The overall reward is from the environment's rubric
+        reward = env_results.reward
+        
+        return RolloutScore(reward=reward, metrics=metrics)
 
 
 class EnvGroup(Environment):


### PR DESCRIPTION
## Description
This PR updates existing test cases and documentation to align with recent changes that transitioned core data structures from dictionary-based access to Pydantic models (e.g., `RolloutScore`, `GenerateOutputs`).

The primary motivation is to resolve test failures caused by the previous dictionary-style access and ensure consistency with the new Pydantic typing system.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
- [x] All existing tests pass
- [ ] New tests have been added to cover the changes
- [x] Tests have been run locally with `python -m pytest tests/`

### Test Coverage
- Current coverage: ___%
- Coverage after changes: ___%

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
- Test files updated: `tests/test_env_group.py`, `tests/test_environment.py`, `tests/test_singleturn_env.py`, `tests/test_rubric.py`, `tests/test_rubric_group.py`.
- `verifiers/envs/env_group.py`: `EnvGroupRubric.score_rollout` now correctly returns a `RolloutScore` Pydantic model.
- `docs/source/api_reference.md`: Updated to document new Pydantic models (`GenerateOutputs`, `RolloutScore`, `RolloutScores`) and reflect correct return types for `evaluate()` and `generate()`.

---
<a href="https://cursor.com/background-agent?bcId=bc-b31adaf5-1ef6-4478-ba61-0badd1755075">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b31adaf5-1ef6-4478-ba61-0badd1755075">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>