### PR TITLE
fix reward with zero_truncated_completions

### DIFF
--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -828,7 +828,7 @@ Model copies with swapped templates are available here: https://huggingface.co/c
             all_completion_ids.append(completion_ids)
             all_completion_masks.append(completion_mask)
             all_completion_logprobs.append(completion_logprobs)
-            if zero_truncated_completions:
+            if zero_truncated_completions and is_truncated:
                 all_rewards.append(0)
             else:
                 all_rewards.append(reward)


### PR DESCRIPTION
## Description
this pr fix a bug where the rewards are all set to 0 when using `if zero_truncated_completions` even if the response are not truncated

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass
- [ ] New tests have been added to cover the changes
- [ ] Tests have been run locally with `python -m pytest tests/`

### Test Coverage
<!-- If applicable, mention the test coverage for new code -->
- Current coverage: ___%
- Coverage after changes: ___%

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->