### PR TITLE
Document environment setup logic

### DIFF
--- a/environments/vf_doublecheck/README.md
+++ b/environments/vf_doublecheck/README.md
@@ -1,21 +1,19 @@
 # vf-doublecheck
 
-> Replace the placeholders below, then remove this callout. Keep the Evaluation Reports section at the bottom intact so reports can auto-render.
-
 ### Overview
 - **Environment ID**: `vf-doublecheck`
-- **Short description**: <one-sentence description>
-- **Tags**: <comma-separated tags>
+- **Short description**: Two-turn math QA that asks the model to answer, then prompts “Are you sure?”; scored with a math rubric.
+- **Tags**: math, multi-turn, xml, think-answer, verification
 
 ### Datasets
-- **Primary dataset(s)**: <name(s) and brief description>
-- **Source links**: <links>
-- **Split sizes**: <train/eval counts>
+- **Primary dataset(s)**: `math` (example dataset loaded via `load_example_dataset`)
+- **Source links**: Uses the example loader in `verifiers.utils.data_utils`
+- **Split sizes**: Configurable via args; defaults to `train` split and all examples
 
 ### Task
-- **Type**: <single-turn | multi-turn | tool use>
-- **Parser**: <e.g., ThinkParser, XMLParser, custom>
-- **Rubric overview**: <briefly list reward functions and key metrics>
+- **Type**: multi-turn
+- **Parser**: XMLParser with fields `think`, `answer` (from `MathRubric`)
+- **Rubric overview**: `MathRubric` combining exact/equivalence math grading and a small format component
 
 ### Quickstart
 Run an evaluation with default settings:
@@ -27,7 +25,10 @@ uv run vf-eval vf-doublecheck
 Configure model and sampling:
 
 ```bash
-uv run vf-eval vf-doublecheck   -m gpt-4.1-mini   -n 20 -r 3 -t 1024 -T 0.7   -a '{"key": "value"}'  # env-specific args as JSON
+uv run vf-eval vf-doublecheck \
+  -m gpt-4.1-mini \
+  -n 20 -r 3 -t 1024 -T 0.7 \
+  -a '{"dataset_name": "math", "dataset_split": "train", "num_train_examples": -1}'
 ```
 
 Notes:
@@ -35,20 +36,17 @@ Notes:
 - Reports are written under `./environments/vf_doublecheck/reports/` and auto-embedded below.
 
 ### Environment Arguments
-Document any supported environment arguments and their meaning. Example:
-
 | Arg | Type | Default | Description |
 | --- | ---- | ------- | ----------- |
-| `foo` | str | `"bar"` | What this controls |
-| `max_examples` | int | `-1` | Limit on dataset size (use -1 for all) |
+| `dataset_name` | str | `"math"` | Example dataset name for math problems |
+| `dataset_split` | str | `"train"` | Dataset split to load |
+| `num_train_examples` | int | `-1` | Limit on dataset size (`-1` for all) |
 
 ### Metrics
-Summarize key metrics your rubric emits and how they’re interpreted.
-
 | Metric | Meaning |
 | ------ | ------- |
-| `reward` | Main scalar reward (weighted sum of criteria) |
-| `accuracy` | Exact match on target answer |
+| `reward` | Math answer correctness (symbolic/numeric equivalence) |
+| `format_reward` | Adherence to `<think>`/`<answer>` XML format |
 
 ## Evaluation Reports
 

--- a/environments/vf_gpqa/README.md
+++ b/environments/vf_gpqa/README.md
@@ -1,21 +1,19 @@
 # vf-gpqa
 
-> Replace the placeholders below, then remove this callout. Keep the Evaluation Reports section at the bottom intact so reports can auto-render.
-
 ### Overview
 - **Environment ID**: `vf-gpqa`
-- **Short description**: <one-sentence description>
-- **Tags**: <comma-separated tags>
+- **Short description**: Multiple-choice GPQA evaluation with optional Chain-of-Thought and Diamond/Main split selection.
+- **Tags**: multiple-choice, single-turn, gpqa, think-optional
 
 ### Datasets
-- **Primary dataset(s)**: <name(s) and brief description>
-- **Source links**: <links>
-- **Split sizes**: <train/eval counts>
+- **Primary dataset(s)**: `gpqa_diamond` (hard subset) or `gpqa_main` (full set), via `load_example_dataset`
+- **Source links**: Uses the example loader in `verifiers.utils.data_utils`
+- **Split sizes**: Uses `train` split for evaluation by default
 
 ### Task
-- **Type**: <single-turn | multi-turn | tool use>
-- **Parser**: <e.g., ThinkParser, XMLParser, custom>
-- **Rubric overview**: <briefly list reward functions and key metrics>
+- **Type**: single-turn
+- **Parser**: `ThinkParser` when `use_think=True` (default), else a basic `Parser`
+- **Rubric overview**: Exact letter match to the correct choice; optional format component from parser
 
 ### Quickstart
 Run an evaluation with default settings:
@@ -27,7 +25,10 @@ uv run vf-eval vf-gpqa
 Configure model and sampling:
 
 ```bash
-uv run vf-eval vf-gpqa   -m gpt-4.1-mini   -n 20 -r 3 -t 1024 -T 0.7   -a '{"key": "value"}'  # env-specific args as JSON
+uv run vf-eval vf-gpqa \
+  -m gpt-4.1-mini \
+  -n 20 -r 3 -t 1024 -T 0.7 \
+  -a '{"use_diamond": true, "use_think": true}'
 ```
 
 Notes:
@@ -35,20 +36,15 @@ Notes:
 - Reports are written under `./environments/vf_gpqa/reports/` and auto-embedded below.
 
 ### Environment Arguments
-Document any supported environment arguments and their meaning. Example:
-
 | Arg | Type | Default | Description |
 | --- | ---- | ------- | ----------- |
-| `foo` | str | `"bar"` | What this controls |
-| `max_examples` | int | `-1` | Limit on dataset size (use -1 for all) |
+| `use_diamond` | bool | `true` | Use the GPQA Diamond subset instead of Main |
+| `use_think` | bool | `true` | Use `<think>` CoT and `ThinkParser`; otherwise, no-think mode |
 
 ### Metrics
-Summarize key metrics your rubric emits and how they’re interpreted.
-
 | Metric | Meaning |
 | ------ | ------- |
-| `reward` | Main scalar reward (weighted sum of criteria) |
-| `accuracy` | Exact match on target answer |
+| `reward` | 1.0 if predicted letter matches target, else 0.0 |
 
 ## Evaluation Reports
 

--- a/environments/vf_gsm8k/README.md
+++ b/environments/vf_gsm8k/README.md
@@ -1,21 +1,19 @@
 # vf-gsm8k
 
-> Replace the placeholders below, then remove this callout. Keep the Evaluation Reports section at the bottom intact so reports can auto-render.
-
 ### Overview
 - **Environment ID**: `vf-gsm8k`
-- **Short description**: <one-sentence description>
-- **Tags**: <comma-separated tags>
+- **Short description**: Single-turn GSM8K math word problems with boxed numeric answers and CoT.
+- **Tags**: math, gsm8k, single-turn, think, boxed-answer
 
 ### Datasets
-- **Primary dataset(s)**: <name(s) and brief description>
-- **Source links**: <links>
-- **Split sizes**: <train/eval counts>
+- **Primary dataset(s)**: `gsm8k` train (train) and test (eval) via `load_example_dataset`
+- **Source links**: Uses the example loader in `verifiers.utils.data_utils`
+- **Split sizes**: Configurable via args; defaults to full train/test
 
 ### Task
-- **Type**: <single-turn | multi-turn | tool use>
-- **Parser**: <e.g., ThinkParser, XMLParser, custom>
-- **Rubric overview**: <briefly list reward functions and key metrics>
+- **Type**: single-turn
+- **Parser**: `ThinkParser` with boxed answer extraction
+- **Rubric overview**: Exact match on parsed boxed answer; optional format check
 
 ### Quickstart
 Run an evaluation with default settings:
@@ -27,7 +25,10 @@ uv run vf-eval vf-gsm8k
 Configure model and sampling:
 
 ```bash
-uv run vf-eval vf-gsm8k   -m gpt-4.1-mini   -n 20 -r 3 -t 1024 -T 0.7   -a '{"key": "value"}'  # env-specific args as JSON
+uv run vf-eval vf-gsm8k \
+  -m gpt-4.1-mini \
+  -n 20 -r 3 -t 1024 -T 0.7 \
+  -a '{"num_train_examples": -1, "num_eval_examples": -1}'
 ```
 
 Notes:
@@ -35,20 +36,16 @@ Notes:
 - Reports are written under `./environments/vf_gsm8k/reports/` and auto-embedded below.
 
 ### Environment Arguments
-Document any supported environment arguments and their meaning. Example:
-
 | Arg | Type | Default | Description |
 | --- | ---- | ------- | ----------- |
-| `foo` | str | `"bar"` | What this controls |
-| `max_examples` | int | `-1` | Limit on dataset size (use -1 for all) |
+| `num_train_examples` | int | `-1` | Limit training set size (`-1` for all) |
+| `num_eval_examples` | int | `-1` | Limit eval set size (`-1` for all) |
 
 ### Metrics
-Summarize key metrics your rubric emits and how they’re interpreted.
-
 | Metric | Meaning |
 | ------ | ------- |
-| `reward` | Main scalar reward (weighted sum of criteria) |
-| `accuracy` | Exact match on target answer |
+| `reward` | 1.0 if parsed boxed answer equals target, else 0.0 |
+| `format_reward` | Adherence to `<think>` + boxed `\boxed{...}` format |
 
 ## Evaluation Reports
 

--- a/environments/vf_math_group/README.md
+++ b/environments/vf_math_group/README.md
@@ -1,21 +1,19 @@
 # vf-math-group
 
-> Replace the placeholders below, then remove this callout. Keep the Evaluation Reports section at the bottom intact so reports can auto-render.
-
 ### Overview
 - **Environment ID**: `vf-math-group`
-- **Short description**: <one-sentence description>
-- **Tags**: <comma-separated tags>
+- **Short description**: Groups GSM8K and MATH single-turn sub-environments into one evaluation with a shared math CoT parser.
+- **Tags**: math, group, single-turn, gsm8k, math, think
 
 ### Datasets
-- **Primary dataset(s)**: <name(s) and brief description>
-- **Source links**: <links>
-- **Split sizes**: <train/eval counts>
+- **Primary dataset(s)**: `gsm8k` (subset of 1000 train examples) and `math` (subset of 1000 train examples)
+- **Source links**: Uses example loader in `verifiers.utils.data_utils`
+- **Split sizes**: 1000 per sub-environment (train-only in this group)
 
 ### Task
-- **Type**: <single-turn | multi-turn | tool use>
-- **Parser**: <e.g., ThinkParser, XMLParser, custom>
-- **Rubric overview**: <briefly list reward functions and key metrics>
+- **Type**: single-turn (EnvGroup of two SingleTurnEnv instances)
+- **Parser**: `ThinkParser` with boxed answer extraction
+- **Rubric overview**: Exact numeric/equivalent match per sub-environment plus optional format check
 
 ### Quickstart
 Run an evaluation with default settings:
@@ -27,28 +25,23 @@ uv run vf-eval vf-math-group
 Configure model and sampling:
 
 ```bash
-uv run vf-eval vf-math-group   -m gpt-4.1-mini   -n 20 -r 3 -t 1024 -T 0.7   -a '{"key": "value"}'  # env-specific args as JSON
+uv run vf-eval vf-math-group \
+  -m gpt-4.1-mini \
+  -n 20 -r 3 -t 1024 -T 0.7
 ```
 
 Notes:
-- Use `-a` / `--env-args` to pass environment-specific configuration as a JSON object.
+- This environment bundles two math datasets; reporting aggregates across both.
 - Reports are written under `./environments/vf_math_group/reports/` and auto-embedded below.
 
 ### Environment Arguments
-Document any supported environment arguments and their meaning. Example:
-
-| Arg | Type | Default | Description |
-| --- | ---- | ------- | ----------- |
-| `foo` | str | `"bar"` | What this controls |
-| `max_examples` | int | `-1` | Limit on dataset size (use -1 for all) |
+This loader does not expose custom arguments.
 
 ### Metrics
-Summarize key metrics your rubric emits and how they’re interpreted.
-
 | Metric | Meaning |
 | ------ | ------- |
-| `reward` | Main scalar reward (weighted sum of criteria) |
-| `accuracy` | Exact match on target answer |
+| `reward` | 1.0 if parsed boxed answer equals target (per sub-env), else 0.0 |
+| `format_reward` | Adherence to `<think>` + boxed `\boxed{...}` format |
 
 ## Evaluation Reports
 

--- a/environments/vf_math_python/README.md
+++ b/environments/vf_math_python/README.md
@@ -1,21 +1,19 @@
 # vf-math-python
 
-> Replace the placeholders below, then remove this callout. Keep the Evaluation Reports section at the bottom intact so reports can auto-render.
-
 ### Overview
 - **Environment ID**: `vf-math-python`
-- **Short description**: <one-sentence description>
-- **Tags**: <comma-separated tags>
+- **Short description**: Tool-using math environment requiring Python tool calls to compute answers; graded by symbolic equivalence.
+- **Tags**: math, tools, python, single-turn, boxed-answer
 
 ### Datasets
-- **Primary dataset(s)**: <name(s) and brief description>
-- **Source links**: <links>
-- **Split sizes**: <train/eval counts>
+- **Primary dataset(s)**: Example `math` dataset via `load_example_dataset`
+- **Source links**: Uses example loader in `verifiers.utils.data_utils`
+- **Split sizes**: Configurable via args; defaults to `train` split and all examples
 
 ### Task
-- **Type**: <single-turn | multi-turn | tool use>
-- **Parser**: <e.g., ThinkParser, XMLParser, custom>
-- **Rubric overview**: <briefly list reward functions and key metrics>
+- **Type**: tool use (single-turn ToolEnv)
+- **Parser**: Basic `Parser` with boxed answer extraction
+- **Rubric overview**: Correctness by `math_verify.parse` + `verify`; logs auxiliary metrics (#turns, #tool calls, #errors)
 
 ### Quickstart
 Run an evaluation with default settings:
@@ -27,7 +25,10 @@ uv run vf-eval vf-math-python
 Configure model and sampling:
 
 ```bash
-uv run vf-eval vf-math-python   -m gpt-4.1-mini   -n 20 -r 3 -t 1024 -T 0.7   -a '{"key": "value"}'  # env-specific args as JSON
+uv run vf-eval vf-math-python \
+  -m gpt-4.1-mini \
+  -n 20 -r 3 -t 1024 -T 0.7 \
+  -a '{"dataset_name": "math", "dataset_split": "train", "num_train_examples": -1}'
 ```
 
 Notes:
@@ -35,20 +36,19 @@ Notes:
 - Reports are written under `./environments/vf_math_python/reports/` and auto-embedded below.
 
 ### Environment Arguments
-Document any supported environment arguments and their meaning. Example:
-
 | Arg | Type | Default | Description |
 | --- | ---- | ------- | ----------- |
-| `foo` | str | `"bar"` | What this controls |
-| `max_examples` | int | `-1` | Limit on dataset size (use -1 for all) |
+| `dataset_name` | str | `"math"` | Example dataset to load |
+| `dataset_split` | str | `"train"` | Split to load |
+| `num_train_examples` | int | `-1` | Limit dataset size (`-1` for all) |
 
 ### Metrics
-Summarize key metrics your rubric emits and how they’re interpreted.
-
 | Metric | Meaning |
 | ------ | ------- |
-| `reward` | Main scalar reward (weighted sum of criteria) |
-| `accuracy` | Exact match on target answer |
+| `correct_answer_reward_func` | 1.0 if symbolic verification passes, else 0.0 |
+| `num_turns` | Number of assistant messages in completion |
+| `num_tool_calls` | Number of tool messages in completion |
+| `num_errors` | Count of tool error messages |
 
 ## Evaluation Reports
 

--- a/environments/vf_reasoning_gym/README.md
+++ b/environments/vf_reasoning_gym/README.md
@@ -1,21 +1,19 @@
 # vf-reasoning-gym
 
-> Replace the placeholders below, then remove this callout. Keep the Evaluation Reports section at the bottom intact so reports can auto-render.
-
 ### Overview
 - **Environment ID**: `vf-reasoning-gym`
-- **Short description**: <one-sentence description>
-- **Tags**: <comma-separated tags>
+- **Short description**: Single-turn evaluation over `reasoning_gym` procedural tasks with XML formatting.
+- **Tags**: reasoning, procedural, single-turn, xml, synthetic
 
 ### Datasets
-- **Primary dataset(s)**: <name(s) and brief description>
-- **Source links**: <links>
-- **Split sizes**: <train/eval counts>
+- **Primary dataset(s)**: Generated via `reasoning_gym` (e.g., `arc_1d`, or composite configs)
+- **Source links**: `reasoning_gym` library
+- **Split sizes**: Configurable counts for train/eval via loader args
 
 ### Task
-- **Type**: <single-turn | multi-turn | tool use>
-- **Parser**: <e.g., ThinkParser, XMLParser, custom>
-- **Rubric overview**: <briefly list reward functions and key metrics>
+- **Type**: single-turn
+- **Parser**: `XMLParser(["think","answer"])`
+- **Rubric overview**: Score computed via `reasoning_gym` task-specific scorer; optional format component
 
 ### Quickstart
 Run an evaluation with default settings:
@@ -27,28 +25,29 @@ uv run vf-eval vf-reasoning-gym
 Configure model and sampling:
 
 ```bash
-uv run vf-eval vf-reasoning-gym   -m gpt-4.1-mini   -n 20 -r 3 -t 1024 -T 0.7   -a '{"key": "value"}'  # env-specific args as JSON
+uv run vf-eval vf-reasoning-gym \
+  -m gpt-4.1-mini \
+  -n 20 -r 3 -t 1024 -T 0.7 \
+  -a '{"gym": "arc_1d", "num_train_examples": 2000, "num_eval_examples": 2000}'
 ```
 
 Notes:
-- Use `-a` / `--env-args` to pass environment-specific configuration as a JSON object.
+- Use `gym` to select a single dataset name, a list of names, or a composite specification.
 - Reports are written under `./environments/vf_reasoning_gym/reports/` and auto-embedded below.
 
 ### Environment Arguments
-Document any supported environment arguments and their meaning. Example:
-
 | Arg | Type | Default | Description |
 | --- | ---- | ------- | ----------- |
-| `foo` | str | `"bar"` | What this controls |
-| `max_examples` | int | `-1` | Limit on dataset size (use -1 for all) |
+| `gym` | str | `"arc_1d"` | Single task name, list of names, or composite config |
+| `num_train_examples` | int | `2000` | Number of training examples |
+| `num_eval_examples` | int | `2000` | Number of evaluation examples |
+| `seed` | int | `0` | Random seed for dataset generation |
 
 ### Metrics
-Summarize key metrics your rubric emits and how they’re interpreted.
-
 | Metric | Meaning |
 | ------ | ------- |
-| `reward` | Main scalar reward (weighted sum of criteria) |
-| `accuracy` | Exact match on target answer |
+| `reward` | Task-specific score from `reasoning_gym` for parsed answer |
+| `format_reward` | Adherence to `<think>`/`<answer>` XML format |
 
 ## Evaluation Reports
 

--- a/environments/vf_reverse_text/README.md
+++ b/environments/vf_reverse_text/README.md
@@ -1,21 +1,19 @@
 # vf-reverse-text
 
-> Replace the placeholders below, then remove this callout. Keep the Evaluation Reports section at the bottom intact so reports can auto-render.
-
 ### Overview
 - **Environment ID**: `vf-reverse-text`
-- **Short description**: <one-sentence description>
-- **Tags**: <comma-separated tags>
+- **Short description**: Reverse a given paragraph; evaluated by LCS similarity to the exact reversal.
+- **Tags**: text, transformation, single-turn, xml
 
 ### Datasets
-- **Primary dataset(s)**: <name(s) and brief description>
-- **Source links**: <links>
-- **Split sizes**: <train/eval counts>
+- **Primary dataset(s)**: `agentlans/wikipedia-paragraphs` mapped to question/answer pairs
+- **Source links**: Hugging Face Datasets
+- **Split sizes**: Train/eval split controlled by `num_train_examples` and `num_eval_examples`
 
 ### Task
-- **Type**: <single-turn | multi-turn | tool use>
-- **Parser**: <e.g., ThinkParser, XMLParser, custom>
-- **Rubric overview**: <briefly list reward functions and key metrics>
+- **Type**: single-turn
+- **Parser**: `XMLParser(["think","answer"])`
+- **Rubric overview**: LCS similarity between parsed answer and ground-truth reversed text; optional format check
 
 ### Quickstart
 Run an evaluation with default settings:
@@ -27,7 +25,10 @@ uv run vf-eval vf-reverse-text
 Configure model and sampling:
 
 ```bash
-uv run vf-eval vf-reverse-text   -m gpt-4.1-mini   -n 20 -r 3 -t 1024 -T 0.7   -a '{"key": "value"}'  # env-specific args as JSON
+uv run vf-eval vf-reverse-text \
+  -m gpt-4.1-mini \
+  -n 20 -r 3 -t 1024 -T 0.7 \
+  -a '{"num_train_examples": 2000, "num_eval_examples": 200}'
 ```
 
 Notes:
@@ -35,20 +36,16 @@ Notes:
 - Reports are written under `./environments/vf_reverse_text/reports/` and auto-embedded below.
 
 ### Environment Arguments
-Document any supported environment arguments and their meaning. Example:
-
 | Arg | Type | Default | Description |
 | --- | ---- | ------- | ----------- |
-| `foo` | str | `"bar"` | What this controls |
-| `max_examples` | int | `-1` | Limit on dataset size (use -1 for all) |
+| `num_train_examples` | int | `2000` | Number of training examples |
+| `num_eval_examples` | int | `200` | Number of evaluation examples |
 
 ### Metrics
-Summarize key metrics your rubric emits and how they’re interpreted.
-
 | Metric | Meaning |
 | ------ | ------- |
-| `reward` | Main scalar reward (weighted sum of criteria) |
-| `accuracy` | Exact match on target answer |
+| `reward` | LCS similarity between reversed text and parsed answer |
+| `format_reward` | Adherence to `<think>`/`<answer>` XML format |
 
 ## Evaluation Reports
 

--- a/environments/vf_self_reward/README.md
+++ b/environments/vf_self_reward/README.md
@@ -1,33 +1,34 @@
 # vf-self-reward
 
-> Replace the placeholders below, then remove this callout. Keep the Evaluation Reports section at the bottom intact so reports can auto-render.
-
 ### Overview
 - **Environment ID**: `vf-self-reward`
-- **Short description**: <one-sentence description>
-- **Tags**: <comma-separated tags>
+- **Short description**: Single-turn evaluation where a judge model scores responses based on a simple scoring prompt.
+- **Tags**: judge, single-turn, self-reward, openai-compatible
 
 ### Datasets
-- **Primary dataset(s)**: <name(s) and brief description>
-- **Source links**: <links>
-- **Split sizes**: <train/eval counts>
+- **Primary dataset(s)**: Any HF dataset with `question`/`answer` columns (specified by `dataset_name`)
+- **Source links**: Hugging Face Datasets
+- **Split sizes**: Uses the dataset’s `train` file by default
 
 ### Task
-- **Type**: <single-turn | multi-turn | tool use>
-- **Parser**: <e.g., ThinkParser, XMLParser, custom>
-- **Rubric overview**: <briefly list reward functions and key metrics>
+- **Type**: single-turn
+- **Parser**: default `Parser`
+- **Rubric overview**: `JudgeRubric` uses a judge client/model/prompt to produce a 0–1 score
 
 ### Quickstart
-Run an evaluation with default settings:
+Run an evaluation with default settings (example):
 
 ```bash
-uv run vf-eval vf-self-reward
+uv run vf-eval vf-self-reward -a '{"dataset_name": "your/dataset", "model_name": "gpt-4.1-mini"}'
 ```
 
 Configure model and sampling:
 
 ```bash
-uv run vf-eval vf-self-reward   -m gpt-4.1-mini   -n 20 -r 3 -t 1024 -T 0.7   -a '{"key": "value"}'  # env-specific args as JSON
+uv run vf-eval vf-self-reward \
+  -m gpt-4.1-mini \
+  -n 20 -r 3 -t 1024 -T 0.7 \
+  -a '{"dataset_name": "your/dataset", "model_name": "gpt-4.1-mini", "base_url": "http://0.0.0.0:8000/v1", "api_key_var": "JUDGE_API_KEY"}'
 ```
 
 Notes:
@@ -35,20 +36,17 @@ Notes:
 - Reports are written under `./environments/vf_self_reward/reports/` and auto-embedded below.
 
 ### Environment Arguments
-Document any supported environment arguments and their meaning. Example:
-
 | Arg | Type | Default | Description |
 | --- | ---- | ------- | ----------- |
-| `foo` | str | `"bar"` | What this controls |
-| `max_examples` | int | `-1` | Limit on dataset size (use -1 for all) |
+| `dataset_name` | str | — | HF dataset name or path containing `question`/`answer` |
+| `model_name` | str | — | Judge model name (OpenAI-compatible) |
+| `base_url` | str | `"http://0.0.0.0:8000/v1"` | Judge API base URL |
+| `api_key_var` | str | `"JUDGE_API_KEY"` | Env var containing judge API key |
 
 ### Metrics
-Summarize key metrics your rubric emits and how they’re interpreted.
-
 | Metric | Meaning |
 | ------ | ------- |
-| `reward` | Main scalar reward (weighted sum of criteria) |
-| `accuracy` | Exact match on target answer |
+| `reward` | Judge-produced score, normalized to 0–1 |
 
 ## Evaluation Reports
 

--- a/environments/vf_sentence_repeater/README.md
+++ b/environments/vf_sentence_repeater/README.md
@@ -1,21 +1,19 @@
 # vf-sentence-repeater
 
-> Replace the placeholders below, then remove this callout. Keep the Evaluation Reports section at the bottom intact so reports can auto-render.
-
 ### Overview
 - **Environment ID**: `vf-sentence-repeater`
-- **Short description**: <one-sentence description>
-- **Tags**: <comma-separated tags>
+- **Short description**: Multi-turn QA over a paragraph to retrieve specific sentences in random order.
+- **Tags**: retrieval, multi-turn, text, similarity
 
 ### Datasets
-- **Primary dataset(s)**: <name(s) and brief description>
-- **Source links**: <links>
-- **Split sizes**: <train/eval counts>
+- **Primary dataset(s)**: `agentlans/wikipedia-paragraphs` processed into 5 Q/A turns per paragraph
+- **Source links**: Hugging Face Datasets
+- **Split sizes**: Train split filtered to paragraphs with 5 adequate-length sentences
 
 ### Task
-- **Type**: <single-turn | multi-turn | tool use>
-- **Parser**: <e.g., ThinkParser, XMLParser, custom>
-- **Rubric overview**: <briefly list reward functions and key metrics>
+- **Type**: multi-turn
+- **Parser**: default `Parser`
+- **Rubric overview**: Sequence similarity against the 5 target answers across turns
 
 ### Quickstart
 Run an evaluation with default settings:
@@ -27,28 +25,21 @@ uv run vf-eval vf-sentence-repeater
 Configure model and sampling:
 
 ```bash
-uv run vf-eval vf-sentence-repeater   -m gpt-4.1-mini   -n 20 -r 3 -t 1024 -T 0.7   -a '{"key": "value"}'  # env-specific args as JSON
+uv run vf-eval vf-sentence-repeater \
+  -m gpt-4.1-mini \
+  -n 20 -r 3 -t 1024 -T 0.7
 ```
 
 Notes:
-- Use `-a` / `--env-args` to pass environment-specific configuration as a JSON object.
 - Reports are written under `./environments/vf_sentence_repeater/reports/` and auto-embedded below.
 
 ### Environment Arguments
-Document any supported environment arguments and their meaning. Example:
-
-| Arg | Type | Default | Description |
-| --- | ---- | ------- | ----------- |
-| `foo` | str | `"bar"` | What this controls |
-| `max_examples` | int | `-1` | Limit on dataset size (use -1 for all) |
+This loader does not expose custom arguments.
 
 ### Metrics
-Summarize key metrics your rubric emits and how they’re interpreted.
-
 | Metric | Meaning |
 | ------ | ------- |
-| `reward` | Main scalar reward (weighted sum of criteria) |
-| `accuracy` | Exact match on target answer |
+| `reward` | Mean SequenceMatcher ratio across the 5 repeated sentences |
 
 ## Evaluation Reports
 

--- a/environments/vf_simpleqa/README.md
+++ b/environments/vf_simpleqa/README.md
@@ -1,21 +1,19 @@
 # vf-simpleqa
 
-> Replace the placeholders below, then remove this callout. Keep the Evaluation Reports section at the bottom intact so reports can auto-render.
-
 ### Overview
 - **Environment ID**: `vf-simpleqa`
-- **Short description**: <one-sentence description>
-- **Tags**: <comma-separated tags>
+- **Short description**: Single-turn factual QA judged by a configurable LLM rubric with CORRECT/INCORRECT/NOT_ATTEMPTED labels.
+- **Tags**: qa, judge, single-turn, openai-compatible
 
 ### Datasets
-- **Primary dataset(s)**: <name(s) and brief description>
-- **Source links**: <links>
-- **Split sizes**: <train/eval counts>
+- **Primary dataset(s)**: `basicv8vc/SimpleQA` (test split)
+- **Source links**: Hugging Face Datasets
+- **Split sizes**: Uses the `test` split for evaluation
 
 ### Task
-- **Type**: <single-turn | multi-turn | tool use>
-- **Parser**: <e.g., ThinkParser, XMLParser, custom>
-- **Rubric overview**: <briefly list reward functions and key metrics>
+- **Type**: single-turn
+- **Parser**: default `Parser` (judge-based scoring)
+- **Rubric overview**: `JudgeRubric` asks a judge model to label A/B/C, then maps to binary reward
 
 ### Quickstart
 Run an evaluation with default settings:
@@ -24,31 +22,30 @@ Run an evaluation with default settings:
 uv run vf-eval vf-simpleqa
 ```
 
-Configure model and sampling:
+Configure model and sampling (judge config shown):
 
 ```bash
-uv run vf-eval vf-simpleqa   -m gpt-4.1-mini   -n 20 -r 3 -t 1024 -T 0.7   -a '{"key": "value"}'  # env-specific args as JSON
+uv run vf-eval vf-simpleqa \
+  -m gpt-4.1-mini \
+  -n 20 -r 3 -t 1024 -T 0.7 \
+  -a '{"judge_model": "gpt-4.1-mini", "judge_base_url": "https://api.openai.com/v1", "judge_api_key_var": "OPENAI_API_KEY"}'
 ```
 
 Notes:
-- Use `-a` / `--env-args` to pass environment-specific configuration as a JSON object.
+- Use `-a` / `--env-args` to configure the judge model/provider.
 - Reports are written under `./environments/vf_simpleqa/reports/` and auto-embedded below.
 
 ### Environment Arguments
-Document any supported environment arguments and their meaning. Example:
-
 | Arg | Type | Default | Description |
 | --- | ---- | ------- | ----------- |
-| `foo` | str | `"bar"` | What this controls |
-| `max_examples` | int | `-1` | Limit on dataset size (use -1 for all) |
+| `judge_model` | str | `"gpt-4.1-mini"` | Judge model name |
+| `judge_base_url` | str | — | Judge provider base URL |
+| `judge_api_key_var` | str | — | Env var containing judge API key |
 
 ### Metrics
-Summarize key metrics your rubric emits and how they’re interpreted.
-
 | Metric | Meaning |
 | ------ | ------- |
-| `reward` | Main scalar reward (weighted sum of criteria) |
-| `accuracy` | Exact match on target answer |
+| `reward` | 1.0 if judge returns A (correct), else 0.0 |
 
 ## Evaluation Reports
 

--- a/environments/vf_smolagents_math_tools/README.md
+++ b/environments/vf_smolagents_math_tools/README.md
@@ -1,21 +1,19 @@
 # vf-smolagents-math-tools
 
-> Replace the placeholders below, then remove this callout. Keep the Evaluation Reports section at the bottom intact so reports can auto-render.
-
 ### Overview
 - **Environment ID**: `vf-smolagents-math-tools`
-- **Short description**: <one-sentence description>
-- **Tags**: <comma-separated tags>
+- **Short description**: Multi-turn math tool-use environment using SmolAgents PythonInterpreter and a custom Calculator tool.
+- **Tags**: math, tools, multi-turn, smolagents, xml
 
 ### Datasets
-- **Primary dataset(s)**: <name(s) and brief description>
-- **Source links**: <links>
-- **Split sizes**: <train/eval counts>
+- **Primary dataset(s)**: Train from example `math`; eval from concatenated `aime2024` + `aime2025` (30 each)
+- **Source links**: Uses example loader in `verifiers.utils.data_utils`
+- **Split sizes**: Train≈6000; Eval≈60 (AIME 2024/2025 subsets)
 
 ### Task
-- **Type**: <single-turn | multi-turn | tool use>
-- **Parser**: <e.g., ThinkParser, XMLParser, custom>
-- **Rubric overview**: <briefly list reward functions and key metrics>
+- **Type**: multi-turn tool use
+- **Parser**: Custom `SmolagentsParser` with fields `reasoning`, `tool`/`answer`
+- **Rubric overview**: Format adherence plus tool execution success metrics; per-tool reward hooks available
 
 ### Quickstart
 Run an evaluation with default settings:
@@ -27,28 +25,27 @@ uv run vf-eval vf-smolagents-math-tools
 Configure model and sampling:
 
 ```bash
-uv run vf-eval vf-smolagents-math-tools   -m gpt-4.1-mini   -n 20 -r 3 -t 1024 -T 0.7   -a '{"key": "value"}'  # env-specific args as JSON
+uv run vf-eval vf-smolagents-math-tools \
+  -m gpt-4.1-mini \
+  -n 20 -r 3 -t 1024 -T 0.7 \
+  -a '{"use_few_shot": false}'
 ```
 
 Notes:
-- Use `-a` / `--env-args` to pass environment-specific configuration as a JSON object.
+- Use `-a` / `--env-args` to toggle few-shot examples in the system.
 - Reports are written under `./environments/vf_smolagents_math_tools/reports/` and auto-embedded below.
 
 ### Environment Arguments
-Document any supported environment arguments and their meaning. Example:
-
 | Arg | Type | Default | Description |
 | --- | ---- | ------- | ----------- |
-| `foo` | str | `"bar"` | What this controls |
-| `max_examples` | int | `-1` | Limit on dataset size (use -1 for all) |
+| `use_few_shot` | bool | `false` | Include SmolAgents few-shot examples in prompt |
 
 ### Metrics
-Summarize key metrics your rubric emits and how they’re interpreted.
-
 | Metric | Meaning |
 | ------ | ------- |
-| `reward` | Main scalar reward (weighted sum of criteria) |
-| `accuracy` | Exact match on target answer |
+| `format_reward` | Adherence to `SmolagentsParser` message schema |
+| `calculator_reward_func` | Tool execution success rate for calculator (if present) |
+| `python_interpreter_reward_func` | Tool execution success rate for PythonInterpreter (if present) |
 
 ## Evaluation Reports
 

--- a/environments/vf_summarize_text/README.md
+++ b/environments/vf_summarize_text/README.md
@@ -1,21 +1,19 @@
 # vf-summarize-text
 
-> Replace the placeholders below, then remove this callout. Keep the Evaluation Reports section at the bottom intact so reports can auto-render.
-
 ### Overview
 - **Environment ID**: `vf-summarize-text`
-- **Short description**: <one-sentence description>
-- **Tags**: <comma-separated tags>
+- **Short description**: Summarize a paragraph into three sentences using a specified XML response format.
+- **Tags**: summarization, single-turn, xml, lcs
 
 ### Datasets
-- **Primary dataset(s)**: <name(s) and brief description>
-- **Source links**: <links>
-- **Split sizes**: <train/eval counts>
+- **Primary dataset(s)**: `agentlans/wikipedia-paragraphs` mapped to `question`=`text`, `answer`=`text`
+- **Source links**: Hugging Face Datasets
+- **Split sizes**: Uses the `train` split for evaluation
 
 ### Task
-- **Type**: <single-turn | multi-turn | tool use>
-- **Parser**: <e.g., ThinkParser, XMLParser, custom>
-- **Rubric overview**: <briefly list reward functions and key metrics>
+- **Type**: single-turn
+- **Parser**: `XMLParser(["think","answer"])`
+- **Rubric overview**: (1) Exactly 3 sentences; (2) LCS similarity to source; (3) format check
 
 ### Quickstart
 Run an evaluation with default settings:
@@ -27,28 +25,23 @@ uv run vf-eval vf-summarize-text
 Configure model and sampling:
 
 ```bash
-uv run vf-eval vf-summarize-text   -m gpt-4.1-mini   -n 20 -r 3 -t 1024 -T 0.7   -a '{"key": "value"}'  # env-specific args as JSON
+uv run vf-eval vf-summarize-text \
+  -m gpt-4.1-mini \
+  -n 20 -r 3 -t 1024 -T 0.7
 ```
 
 Notes:
-- Use `-a` / `--env-args` to pass environment-specific configuration as a JSON object.
 - Reports are written under `./environments/vf_summarize_text/reports/` and auto-embedded below.
 
 ### Environment Arguments
-Document any supported environment arguments and their meaning. Example:
-
-| Arg | Type | Default | Description |
-| --- | ---- | ------- | ----------- |
-| `foo` | str | `"bar"` | What this controls |
-| `max_examples` | int | `-1` | Limit on dataset size (use -1 for all) |
+This loader does not expose custom arguments.
 
 ### Metrics
-Summarize key metrics your rubric emits and how they’re interpreted.
-
 | Metric | Meaning |
 | ------ | ------- |
-| `reward` | Main scalar reward (weighted sum of criteria) |
-| `accuracy` | Exact match on target answer |
+| `sentence_reward_func` | 1.0 if exactly three sentences, else 0.0 |
+| `lcs_reward_func` | LCS similarity between source and parsed summary |
+| `format_reward` | Adherence to `<think>`/`<answer>` XML format |
 
 ## Evaluation Reports
 

--- a/environments/vf_tool_test/README.md
+++ b/environments/vf_tool_test/README.md
@@ -1,21 +1,19 @@
 # vf-tool-test
 
-> Replace the placeholders below, then remove this callout. Keep the Evaluation Reports section at the bottom intact so reports can auto-render.
-
 ### Overview
 - **Environment ID**: `vf-tool-test`
-- **Short description**: <one-sentence description>
-- **Tags**: <comma-separated tags>
+- **Short description**: Sanity-check tool-calling environment that asks models to invoke a random subset of dummy tools.
+- **Tags**: tools, single-turn, function-calling, sanity
 
 ### Datasets
-- **Primary dataset(s)**: <name(s) and brief description>
-- **Source links**: <links>
-- **Split sizes**: <train/eval counts>
+- **Primary dataset(s)**: Synthetic HF dataset generated in-memory with prompts specifying required tools
+- **Source links**: N/A (programmatically generated)
+- **Split sizes**: Controlled by `num_train_examples` and `num_eval_examples`
 
 ### Task
-- **Type**: <single-turn | multi-turn | tool use>
-- **Parser**: <e.g., ThinkParser, XMLParser, custom>
-- **Rubric overview**: <briefly list reward functions and key metrics>
+- **Type**: tool use (single-turn ToolEnv)
+- **Parser**: default `Parser`
+- **Rubric overview**: ToolRubric checks tool execution and adds exact match on the required tool set
 
 ### Quickstart
 Run an evaluation with default settings:
@@ -27,28 +25,26 @@ uv run vf-eval vf-tool-test
 Configure model and sampling:
 
 ```bash
-uv run vf-eval vf-tool-test   -m gpt-4.1-mini   -n 20 -r 3 -t 1024 -T 0.7   -a '{"key": "value"}'  # env-specific args as JSON
+uv run vf-eval vf-tool-test \
+  -m gpt-4.1-mini \
+  -n 20 -r 3 -t 1024 -T 0.7 \
+  -a '{"num_train_examples": 1000, "num_eval_examples": 100}'
 ```
 
 Notes:
-- Use `-a` / `--env-args` to pass environment-specific configuration as a JSON object.
 - Reports are written under `./environments/vf_tool_test/reports/` and auto-embedded below.
 
 ### Environment Arguments
-Document any supported environment arguments and their meaning. Example:
-
 | Arg | Type | Default | Description |
 | --- | ---- | ------- | ----------- |
-| `foo` | str | `"bar"` | What this controls |
-| `max_examples` | int | `-1` | Limit on dataset size (use -1 for all) |
+| `num_train_examples` | int | `1000` | Number of training examples |
+| `num_eval_examples` | int | `100` | Number of evaluation examples |
 
 ### Metrics
-Summarize key metrics your rubric emits and how they’re interpreted.
-
 | Metric | Meaning |
 | ------ | ------- |
-| `reward` | Main scalar reward (weighted sum of criteria) |
-| `accuracy` | Exact match on target answer |
+| `reward` | 1.0 if called tool set equals required set, else 0.0 |
+| ToolRubric metrics | Tool execution success and format adherence |
 
 ## Evaluation Reports
 

--- a/environments/vf_toxicity_explanation/README.md
+++ b/environments/vf_toxicity_explanation/README.md
@@ -1,21 +1,19 @@
 # vf-toxicity-explanation
 
-> Replace the placeholders below, then remove this callout. Keep the Evaluation Reports section at the bottom intact so reports can auto-render.
-
 ### Overview
 - **Environment ID**: `vf-toxicity-explanation`
-- **Short description**: <one-sentence description>
-- **Tags**: <comma-separated tags>
+- **Short description**: Judge-based evaluation for toxicity classification with explanations using Civil Comments.
+- **Tags**: toxicity, classification, explanation, judge, single-turn
 
 ### Datasets
-- **Primary dataset(s)**: <name(s) and brief description>
-- **Source links**: <links>
-- **Split sizes**: <train/eval counts>
+- **Primary dataset(s)**: `google/civil_comments` mapped to toxicity targets and metadata
+- **Source links**: Hugging Face Datasets
+- **Split sizes**: Train split; size optionally limited via `max_examples`
 
 ### Task
-- **Type**: <single-turn | multi-turn | tool use>
-- **Parser**: <e.g., ThinkParser, XMLParser, custom>
-- **Rubric overview**: <briefly list reward functions and key metrics>
+- **Type**: single-turn
+- **Parser**: default `Parser`
+- **Rubric overview**: `JudgeRubric` with a numeric (0–10) rubric normalized to 0–1; evaluates correctness and explanation quality
 
 ### Quickstart
 Run an evaluation with default settings:
@@ -27,28 +25,28 @@ uv run vf-eval vf-toxicity-explanation
 Configure model and sampling:
 
 ```bash
-uv run vf-eval vf-toxicity-explanation   -m gpt-4.1-mini   -n 20 -r 3 -t 1024 -T 0.7   -a '{"key": "value"}'  # env-specific args as JSON
+uv run vf-eval vf-toxicity-explanation \
+  -m gpt-4.1-mini \
+  -n 20 -r 3 -t 1024 -T 0.7 \
+  -a '{"judge_model": "gpt-4.1-mini", "judge_base_url": "https://api.openai.com/v1", "judge_api_key_var": "OPENAI_API_KEY", "max_examples": -1}'
 ```
 
 Notes:
-- Use `-a` / `--env-args` to pass environment-specific configuration as a JSON object.
+- Use `-a` / `--env-args` to configure the judge model/provider and dataset size.
 - Reports are written under `./environments/vf_toxicity_explanation/reports/` and auto-embedded below.
 
 ### Environment Arguments
-Document any supported environment arguments and their meaning. Example:
-
 | Arg | Type | Default | Description |
 | --- | ---- | ------- | ----------- |
-| `foo` | str | `"bar"` | What this controls |
-| `max_examples` | int | `-1` | Limit on dataset size (use -1 for all) |
+| `judge_model` | str | `"gpt-4.1-mini"` | Judge model name |
+| `judge_base_url` | str | `"https://api.openai.com/v1"` | Judge provider base URL |
+| `judge_api_key_var` | str | `"OPENAI_API_KEY"` | Env var containing judge API key |
+| `max_examples` | int | `-1` | If > 0, limit dataset to this many examples |
 
 ### Metrics
-Summarize key metrics your rubric emits and how they’re interpreted.
-
 | Metric | Meaning |
 | ------ | ------- |
-| `reward` | Main scalar reward (weighted sum of criteria) |
-| `accuracy` | Exact match on target answer |
+| `reward` | Normalized judge score (0–1) |
 
 ## Evaluation Reports
 

--- a/environments/vf_wiki_search/README.md
+++ b/environments/vf_wiki_search/README.md
@@ -1,21 +1,19 @@
 # vf-wiki-search
 
-> Replace the placeholders below, then remove this callout. Keep the Evaluation Reports section at the bottom intact so reports can auto-render.
-
 ### Overview
 - **Environment ID**: `vf-wiki-search`
-- **Short description**: <one-sentence description>
-- **Tags**: <comma-separated tags>
+- **Short description**: Multi-turn tool-use QA over a small Wikipedia corpus using ChromaDB and OpenAI embeddings, with judge-based scoring.
+- **Tags**: retrieval, tools, multi-turn, embeddings, judge
 
 ### Datasets
-- **Primary dataset(s)**: <name(s) and brief description>
-- **Source links**: <links>
-- **Split sizes**: <train/eval counts>
+- **Primary dataset(s)**: `willcb/wiki-trivia-questions` (HF) and a local wiki markdown corpus indexed in ChromaDB
+- **Source links**: Hugging Face Datasets, ChromaDB
+- **Split sizes**: Uses the `train` split for prompts; corpus is on-disk
 
 ### Task
-- **Type**: <single-turn | multi-turn | tool use>
-- **Parser**: <e.g., ThinkParser, XMLParser, custom>
-- **Rubric overview**: <briefly list reward functions and key metrics>
+- **Type**: multi-turn tool use
+- **Parser**: XML-like tool formatting inside `<tool>` blocks; final answer in `<answer>`
+- **Rubric overview**: Combines the default tool rubric with a `JudgeRubric` for answer quality
 
 ### Quickstart
 Run an evaluation with default settings:
@@ -27,28 +25,33 @@ uv run vf-eval vf-wiki-search
 Configure model and sampling:
 
 ```bash
-uv run vf-eval vf-wiki-search   -m gpt-4.1-mini   -n 20 -r 3 -t 1024 -T 0.7   -a '{"key": "value"}'  # env-specific args as JSON
+uv run vf-eval vf-wiki-search \
+  -m gpt-4.1-mini \
+  -n 20 -r 3 -t 1024 -T 0.7 \
+  -a '{"judge_model": "gpt-4.1-mini", "judge_base_url": "https://api.openai.com/v1", "judge_api_key_var": "OPENAI_API_KEY", "embed_model": "text-embedding-3-small", "embed_base_url": "https://api.openai.com/v1", "embed_api_key_var": "OPENAI_API_KEY"}'
 ```
 
 Notes:
-- Use `-a` / `--env-args` to pass environment-specific configuration as a JSON object.
+- Requires a prebuilt ChromaDB at `notebooks/.chroma_db` and markdown pages under `notebooks/data/wiki`.
 - Reports are written under `./environments/vf_wiki_search/reports/` and auto-embedded below.
 
 ### Environment Arguments
-Document any supported environment arguments and their meaning. Example:
-
 | Arg | Type | Default | Description |
 | --- | ---- | ------- | ----------- |
-| `foo` | str | `"bar"` | What this controls |
-| `max_examples` | int | `-1` | Limit on dataset size (use -1 for all) |
+| `judge_model` | str | `"gpt-4.1-mini"` | Judge model name |
+| `judge_base_url` | str | `"https://api.openai.com/v1"` | Judge provider base URL |
+| `judge_api_key_var` | str | `"OPENAI_API_KEY"` | Env var for judge API key |
+| `embed_model` | str | `"text-embedding-3-small"` | Embedding model name |
+| `embed_base_url` | str | `"https://api.openai.com/v1"` | Embedding provider base URL |
+| `embed_api_key_var` | str | `"OPENAI_API_KEY"` | Env var for embed API key |
+| `wiki_dir` | str | `notebooks/data/wiki` | Path to markdown wiki pages |
+| `chroma_db_dir` | str | `notebooks/.chroma_db` | Path to ChromaDB index |
 
 ### Metrics
-Summarize key metrics your rubric emits and how they’re interpreted.
-
 | Metric | Meaning |
 | ------ | ------- |
-| `reward` | Main scalar reward (weighted sum of criteria) |
-| `accuracy` | Exact match on target answer |
+| ToolRubric metrics | Tool execution success and format adherence |
+| JudgeRubric metrics | Judge-scored answer quality |
 
 ## Evaluation Reports
 

--- a/environments/vf_wordle/README.md
+++ b/environments/vf_wordle/README.md
@@ -1,21 +1,19 @@
 # vf-wordle
 
-> Replace the placeholders below, then remove this callout. Keep the Evaluation Reports section at the bottom intact so reports can auto-render.
-
 ### Overview
 - **Environment ID**: `vf-wordle`
-- **Short description**: <one-sentence description>
-- **Tags**: <comma-separated tags>
+- **Short description**: Multi-turn Wordle game environment with optional `<think>` reasoning; rewards correctness, partial credit, turns, and format.
+- **Tags**: games, multi-turn, wordle, xml, feedback
 
 ### Datasets
-- **Primary dataset(s)**: <name(s) and brief description>
-- **Source links**: <links>
-- **Split sizes**: <train/eval counts>
+- **Primary dataset(s)**: TextArena `Wordle-v0` (environment provides episodes)
+- **Source links**: TextArena
+- **Split sizes**: Number of episodes controlled via args
 
 ### Task
-- **Type**: <single-turn | multi-turn | tool use>
-- **Parser**: <e.g., ThinkParser, XMLParser, custom>
-- **Rubric overview**: <briefly list reward functions and key metrics>
+- **Type**: multi-turn (game interaction)
+- **Parser**: `XMLParser` with `think`/`guess` or just `guess` depending on `use_think`
+- **Rubric overview**: Exact guess match, partial credit from feedback, turns-based reward, and format check
 
 ### Quickstart
 Run an evaluation with default settings:
@@ -27,28 +25,29 @@ uv run vf-eval vf-wordle
 Configure model and sampling:
 
 ```bash
-uv run vf-eval vf-wordle   -m gpt-4.1-mini   -n 20 -r 3 -t 1024 -T 0.7   -a '{"key": "value"}'  # env-specific args as JSON
+uv run vf-eval vf-wordle \
+  -m gpt-4.1-mini \
+  -n 20 -r 3 -t 1024 -T 0.7 \
+  -a '{"num_train_examples": 2000, "num_eval_examples": 20, "use_think": true}'
 ```
 
 Notes:
-- Use `-a` / `--env-args` to pass environment-specific configuration as a JSON object.
 - Reports are written under `./environments/vf_wordle/reports/` and auto-embedded below.
 
 ### Environment Arguments
-Document any supported environment arguments and their meaning. Example:
-
 | Arg | Type | Default | Description |
 | --- | ---- | ------- | ----------- |
-| `foo` | str | `"bar"` | What this controls |
-| `max_examples` | int | `-1` | Limit on dataset size (use -1 for all) |
+| `num_train_examples` | int | `2000` | Number of training episodes |
+| `num_eval_examples` | int | `20` | Number of evaluation episodes |
+| `use_think` | bool | `true` | Use `<think>` with `guess`; if false, guess-only format |
 
 ### Metrics
-Summarize key metrics your rubric emits and how they’re interpreted.
-
 | Metric | Meaning |
 | ------ | ------- |
-| `reward` | Main scalar reward (weighted sum of criteria) |
-| `accuracy` | Exact match on target answer |
+| `check_answer_reward_func` | 1.0 if final guess equals target, else 0.0 |
+| `partial_credit_reward_func` | Partial credit from greens/yellows in feedback |
+| `count_turns_reward_func` | Higher score for solving in fewer turns |
+| `format_reward` | Adherence to expected XML format |
 
 ## Evaluation Reports
 

--- a/environments/vf_xlam_function_calling/README.md
+++ b/environments/vf_xlam_function_calling/README.md
@@ -1,21 +1,19 @@
 # vf-xlam-function-calling
 
-> Replace the placeholders below, then remove this callout. Keep the Evaluation Reports section at the bottom intact so reports can auto-render.
-
 ### Overview
 - **Environment ID**: `vf-xlam-function-calling`
-- **Short description**: <one-sentence description>
-- **Tags**: <comma-separated tags>
+- **Short description**: Function-calling reproduction from XLAM-60k: model must emit a JSON array of tool calls.
+- **Tags**: tools, function-calling, single-turn, xml+json
 
 ### Datasets
-- **Primary dataset(s)**: <name(s) and brief description>
-- **Source links**: <links>
-- **Split sizes**: <train/eval counts>
+- **Primary dataset(s)**: `Salesforce/xlam-function-calling-60k` (train split)
+- **Source links**: Hugging Face Datasets
+- **Split sizes**: Uses the `train` split for training/evaluation
 
 ### Task
-- **Type**: <single-turn | multi-turn | tool use>
-- **Parser**: <e.g., ThinkParser, XMLParser, custom>
-- **Rubric overview**: <briefly list reward functions and key metrics>
+- **Type**: single-turn
+- **Parser**: `XMLParser(["think","tool"], answer_field="tool")`
+- **Rubric overview**: Exact set equality between parsed JSON array and target tool list
 
 ### Quickstart
 Run an evaluation with default settings:
@@ -27,28 +25,21 @@ uv run vf-eval vf-xlam-function-calling
 Configure model and sampling:
 
 ```bash
-uv run vf-eval vf-xlam-function-calling   -m gpt-4.1-mini   -n 20 -r 3 -t 1024 -T 0.7   -a '{"key": "value"}'  # env-specific args as JSON
+uv run vf-eval vf-xlam-function-calling \
+  -m gpt-4.1-mini \
+  -n 20 -r 3 -t 1024 -T 0.7
 ```
 
 Notes:
-- Use `-a` / `--env-args` to pass environment-specific configuration as a JSON object.
 - Reports are written under `./environments/vf_xlam_function_calling/reports/` and auto-embedded below.
 
 ### Environment Arguments
-Document any supported environment arguments and their meaning. Example:
-
-| Arg | Type | Default | Description |
-| --- | ---- | ------- | ----------- |
-| `foo` | str | `"bar"` | What this controls |
-| `max_examples` | int | `-1` | Limit on dataset size (use -1 for all) |
+This loader does not expose custom arguments.
 
 ### Metrics
-Summarize key metrics your rubric emits and how they’re interpreted.
-
 | Metric | Meaning |
 | ------ | ------- |
-| `reward` | Main scalar reward (weighted sum of criteria) |
-| `accuracy` | Exact match on target answer |
+| `reward` | 1.0 if parsed tool JSON exactly matches target, else 0.0 |
 
 ## Evaluation Reports
 

--- a/environments/vf_xml_tool_env/README.md
+++ b/environments/vf_xml_tool_env/README.md
@@ -1,54 +1,57 @@
 # vf-xml-tool-env
 
-> Replace the placeholders below, then remove this callout. Keep the Evaluation Reports section at the bottom intact so reports can auto-render.
-
 ### Overview
 - **Environment ID**: `vf-xml-tool-env`
-- **Short description**: <one-sentence description>
-- **Tags**: <comma-separated tags>
+- **Short description**: Multi-turn XML-formatted tool-use environment with automatic tool schema inference from Python callables.
+- **Tags**: tools, multi-turn, xml, schema-inference
 
 ### Datasets
-- **Primary dataset(s)**: <name(s) and brief description>
-- **Source links**: <links>
-- **Split sizes**: <train/eval counts>
+- **Primary dataset(s)**: Loaded via `load_example_dataset(dataset_name, split)`
+- **Source links**: Uses example loader in `verifiers.utils.data_utils`
+- **Split sizes**: Based on provided split
 
 ### Task
-- **Type**: <single-turn | multi-turn | tool use>
-- **Parser**: <e.g., ThinkParser, XMLParser, custom>
-- **Rubric overview**: <briefly list reward functions and key metrics>
+- **Type**: multi-turn tool use
+- **Parser**: `XMLParser(["think", ("tool","answer")])` and env `XMLParser(["result"])`
+- **Rubric overview**: Correctness on final answer, tool execution success, and format adherence; per-tool metrics available
 
 ### Quickstart
-Run an evaluation with default settings:
+Run an evaluation with default settings (example):
 
 ```bash
-uv run vf-eval vf-xml-tool-env
+uv run vf-eval vf-xml-tool-env -a '{"dataset_name": "math", "split": "train"}'
 ```
 
 Configure model and sampling:
 
 ```bash
-uv run vf-eval vf-xml-tool-env   -m gpt-4.1-mini   -n 20 -r 3 -t 1024 -T 0.7   -a '{"key": "value"}'  # env-specific args as JSON
+uv run vf-eval vf-xml-tool-env \
+  -m gpt-4.1-mini \
+  -n 20 -r 3 -t 1024 -T 0.7 \
+  -a '{"dataset_name": "math", "split": "train"}'
 ```
 
 Notes:
-- Use `-a` / `--env-args` to pass environment-specific configuration as a JSON object.
+- Provide `tools` as Python callables; schemas are inferred from signatures/docstrings.
 - Reports are written under `./environments/vf_xml_tool_env/reports/` and auto-embedded below.
 
 ### Environment Arguments
-Document any supported environment arguments and their meaning. Example:
-
 | Arg | Type | Default | Description |
 | --- | ---- | ------- | ----------- |
-| `foo` | str | `"bar"` | What this controls |
-| `max_examples` | int | `-1` | Limit on dataset size (use -1 for all) |
+| `dataset_name` | str | — | Example dataset name |
+| `split` | str | — | Split to load |
+| `tools` | List[Callable] | `[]` | Tool functions to expose |
+| `system_prompt` | str | `""` | Prompt template (auto-formats with tool descriptions when `format_prompt=True`) |
+| `format_prompt` | bool | `true` | Whether to insert tool descriptions into the prompt |
+| `max_turns` | int | `10` | Maximum number of tool-use turns |
 
 ### Metrics
-Summarize key metrics your rubric emits and how they’re interpreted.
-
 | Metric | Meaning |
 | ------ | ------- |
-| `reward` | Main scalar reward (weighted sum of criteria) |
-| `accuracy` | Exact match on target answer |
+| `reward` | Final answer correctness |
+| `tool_execution_reward_func` | Success rate of tool calls with non-error results |
+| `format_reward` | Adherence to `<think>` and `<tool>` XML format |
+| Tool-specific metrics | Per-tool success/count/attempt rates |
 
 ## Evaluation Reports
 


### PR DESCRIPTION
## Description
Filled in placeholder sections in `README.md` files across the `environments` directory, populating details such as environment overview, datasets, task type, parser, rubric, quickstart commands, environment arguments, and metrics based on each environment's `load_environment` implementation.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Test improvement

## Testing
- [ ] All existing tests pass
- [ ] New tests have been added to cover the changes
- [x] Tests have been run locally with `python -m pytest tests/` (no functional code changes, so existing tests are sufficient)

### Test Coverage
- Current coverage: ___%
- Coverage after changes: ___%

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas (N/A for READMEs)
- [x] I have made corresponding changes to the documentation (this PR *is* the documentation change)
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
This PR is purely a documentation update. No functional code changes were made. An accidental change in `environments/vf_wiki_search/vf_wiki_search.py` was reverted to ensure no behavior modification.

---
<a href="https://cursor.com/background-agent?bcId=bc-a9cdb48d-900d-4698-9b0a-c51aca3417de">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a9cdb48d-900d-4698-9b0a-c51aca3417de">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

