### PR TITLE
More robust rule-based math verification

### DIFF
--- a/tests/test_think_parser.py
+++ b/tests/test_think_parser.py
@@ -30,7 +30,7 @@ class TestThinkParser:
         """Test parsing text without think tags."""
         text = "Just a simple answer without thinking tags."
         result = think_parser.parse(text)
-        assert result == text
+        assert result == ""
 
     def test_parse_with_multiple_think_blocks(self, think_parser):
         """Test parsing with multiple think blocks (should use content after last one)."""

--- a/verifiers/parsers/think_parser.py
+++ b/verifiers/parsers/think_parser.py
@@ -12,6 +12,8 @@ class ThinkParser(Parser):
     def parse(self, text: str) -> str:
         if "</think>" in text:
             text = text.split("</think>")[-1].strip()
+        else:  # do not allow any further extraction/ parsing if no </think> is found
+            text = ""
         return self.extract_fn(text.strip())
 
     def get_format_reward_func(self) -> Callable:

--- a/verifiers/rubrics/math_rubric.py
+++ b/verifiers/rubrics/math_rubric.py
@@ -28,7 +28,7 @@ class MathRubric(Rubric):
                 return 0.0
             if verify(
                 parse(f"\\boxed{{{answer}}}", parsing_timeout=5),
-                response,
+                parse(f"\\boxed{{{response}}}", parsing_timeout=5),
                 timeout_seconds=5,
             ):
                 return 1.0


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

This PR makes two improvements to the `MathRubric` class:
1. Makes `ThinkParser` stricter by returning `""` if the no `</think>` tag is found, essentially preventing any downstream extraction/ parsing function from giving rewards if the model has not yet finished thinking
2. Use `math_verify.parse` with a re-boxed in the default reward function of `MathRubric`

These two changes have made the verification on `vf-math500` much more robust. To test I ran bechmarks on `mikasenghaas/vf-math500-alt` which implements four additional variants:
1. Use current/ updated `ThinkParser`
2. Use `math_verify.verify` no reboxing, use `math_verify.verify` reboxing.

These are the scores over all 500 samples (`rollouts_per_example=1`):
- `vf_math_verify_parse_response`: 0.364
- `vf_math_verify_parse_response_new`: 0.264
- `vf_math_verify_parse_boxed_response`: 0.452
- `vf_math_verify_parse_boxed_response_new`: 0.352
- `correct_answer_reward_func`: 0.268

Some findings:
- `math_verify` w/ the old parser is over-optimistic, it rewards even if thinking is not done (Example [1](https://huggingface.co/datasets/mikasenghaas/math500-check/viewer/default/train?views%5B%5D=train&conversation-viewer=11), [2](https://huggingface.co/datasets/mikasenghaas/math500-check/viewer/default/train?views%5B%5D=train&conversation-viewer=25))
- `vf_math_verify_parse_response_new` and `vf_math_verify_parse_boxed_response_new` are under-optimistic, they do not give rewards because of small formatting issues (Example [1](https://huggingface.co/datasets/mikasenghaas/math500-check/viewer/default/train?views%5B%5D=train&conversation-viewer=1), [2](https://huggingface.co/datasets/mikasenghaas/math500-check/viewer/default/train?row=0&conversation-viewer=15&views%5B%5D=train))

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass
- [ ] New tests have been added to cover the changes
- [ ] Tests have been run locally with `python -m pytest tests/`

### Test Coverage
<!-- If applicable, mention the test coverage for new code -->
- Current coverage: ___%
- Coverage after changes: ___%

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->