### PR TITLE
Fix eval saving failing on `-n -1`

### DIFF
--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -116,10 +116,7 @@ Please specify the model name (-m), API host base URL (-b), and API key variable
             print(out)
 
     if save_dataset or save_to_hf_hub:
-        ids = [
-            i // rollouts_per_example
-            for i in range(num_examples * rollouts_per_example)
-        ]
+        ids = [i // rollouts_per_example for i in range(n * rollouts_per_example)]
         rewards = results.reward
         tasks = results.task
         data_dict = {
@@ -141,7 +138,7 @@ Please specify the model name (-m), API host base URL (-b), and API key variable
         metadata = {
             "env": env,
             "model": model,
-            "num_examples": num_examples,
+            "num_examples": n,
             "rollouts_per_example": rollouts_per_example,
             "sampling_args": merged_sampling_args,
             "date": datetime.now().strftime("%Y-%m-%d"),
@@ -170,7 +167,9 @@ Please specify the model name (-m), API host base URL (-b), and API key variable
             print(f"Saved dataset to {results_path}")
         if save_to_hf_hub:
             if hf_hub_dataset_name == "":
-                dataset_name = f"{env}_{model.replace('/', '-')}_n{num_examples}_r{rollouts_per_example}"
+                dataset_name = (
+                    f"{env}_{model.replace('/', '-')}_n{n}_r{rollouts_per_example}"
+                )
             else:
                 dataset_name = hf_hub_dataset_name
             dataset.push_to_hub(dataset_name)


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Previously

```bash
vf-eval math500 -p environments -b https://api.openai.com/v1 -k OPENAI_API_KEY -m gpt-4.1-mini -a '{"use_think": false}' -n -1 -r 1 -s -t 128
```

Throws the following error when trying to save the outputs.

```txt
Traceback (most recent call last):
  File "/root/prime-rl/.venv/bin/vf-eval", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/root/prime-rl/.venv/lib/python3.12/site-packages/verifiers/scripts/eval.py", line 294, in main
    eval_environment(
  File "/root/prime-rl/.venv/lib/python3.12/site-packages/verifiers/scripts/eval.py", line 140, in eval_environment
    dataset = Dataset.from_dict(data_dict)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/prime-rl/.venv/lib/python3.12/site-packages/datasets/arrow_dataset.py", line 940, in from_dict
    pa_table = InMemoryTable.from_pydict(mapping=mapping)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/prime-rl/.venv/lib/python3.12/site-packages/datasets/table.py", line 758, in from_pydict
    return cls(pa.Table.from_pydict(*args, **kwargs))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "pyarrow/table.pxi", line 1982, in pyarrow.lib._Tabular.from_pydict
  File "pyarrow/table.pxi", line 6380, in pyarrow.lib._from_pydict
  File "pyarrow/table.pxi", line 4910, in pyarrow.lib.Table.from_arrays
  File "pyarrow/table.pxi", line 4256, in pyarrow.lib.Table.validate
  File "pyarrow/error.pxi", line 92, in pyarrow.lib.check_status
pyarrow.lib.ArrowInvalid: Column 1 named prompt expected length 0 but got length 500
```

When specifying `n` as the total number of samples manually, the issue does not exist.

```bash
vf-eval math500 -p environments -b https://api.openai.com/v1 -k OPENAI_API_KEY -m gpt-4.1-mini -a '{"use_think": false}' -n 500 -r 1 -s -t 128
```

This is because the input IDs and therefore the total number of rows in the dataset is miscalculate based on `num_examples` not on the auto-computed `n`. This PR fixes this, so that the first command runs without problems as well.


## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass
- [ ] New tests have been added to cover the changes
- [ ] Tests have been run locally with `python -m pytest tests/`

### Test Coverage
<!-- If applicable, mention the test coverage for new code -->
- Current coverage: ___%
- Coverage after changes: ___%

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->