### PR TITLE
fix(logging): Isolate logger configuration in vf-eval script

### DIFF
--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -313,7 +313,8 @@ def main():
 
     # Setup logging based on verbose flag
     log_level = "DEBUG" if args.verbose else "INFO"
-    logging.basicConfig(level=log_level, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    verifiers_logger = logging.getLogger("verifiers")
+    verifiers_logger.setLevel(log_level)
     logger = logging.getLogger(__name__)
     logger.info("Starting vf-eval with arguments")
     logger.debug(f"Parsed arguments: {vars(args)}")


### PR DESCRIPTION
## Description
This PR fixes an issue where the `vf-eval` script produces excessive INFO-level logs from third-party libraries (e.g., `httpx`), cluttering the console output.

The root cause was the use of `logging.basicConfig()`, which globally configured the root logger for the entire process. This is an anti-pattern that affects all imported modules and was introduced on PR #262. 

[`basicConfig` documentation](https://docs.python.org/3/library/logging.html#logging.basicConfig)

The fix replaces the global configuration with a targeted `setLevel()` on the namespaced `'verifiers'` logger. This isolates the script's logging, silences the unwanted logs, and restores a clean developer experience, while still respecting the `--verbose` flag for debugging.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass
- [ ] New tests have been added to cover the changes
- [x] Tests have been run locally with `python -m pytest tests/`

### Test Coverage
<!-- If applicable, mention the test coverage for new code -->
- Current coverage: ___%
- Coverage after changes: ___%

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published