### PR TITLE
Optionally init environment as multi-file package

### DIFF
--- a/verifiers/scripts/init.py
+++ b/verifiers/scripts/init.py
@@ -149,7 +149,7 @@ def init_environment(
     # create environment file if it doesn't exist
     environment_file = environment_dir / f"{env_id_underscore}.py"
     if not environment_file.exists():
-        environment_file.write_text(ENVIRONMENT_TEMPLATE.format(env_id=env_id_dash))
+        environment_file.write_text(ENVIRONMENT_TEMPLATE)
     else:
         print(
             f"{env_id_underscore}.py already exists at {environment_file}, skipping..."

--- a/verifiers/scripts/init.py
+++ b/verifiers/scripts/init.py
@@ -74,9 +74,12 @@ dependencies = [
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+"""
 
-[tool.hatch.build]
-include = ["{{env_file}}.py"]
+INIT_TEMPLATE = """\
+from .{env_id} import load_environment
+
+__all__ = ["load_environment"]
 """
 
 ENVIRONMENT_TEMPLATE = """\
@@ -132,8 +135,19 @@ def init_environment(
     else:
         print(f"pyproject.toml already exists at {pyproject_file}, skipping...")
 
+    # create environment directory if it doesn't exist
+    environment_dir = local_dir / env_id_underscore
+    environment_dir.mkdir(parents=True, exist_ok=True)
+
+    # create init file if it doesn't exist
+    init_file = environment_dir / "__init__.py"
+    if not init_file.exists():
+        init_file.write_text(INIT_TEMPLATE.format(env_id=env_id_underscore))
+    else:
+        print(f"__init__.py already exists at {init_file}, skipping...")
+
     # create environment file if it doesn't exist
-    environment_file = local_dir / f"{env_id_underscore}.py"
+    environment_file = environment_dir / f"{env_id_underscore}.py"
     if not environment_file.exists():
         environment_file.write_text(ENVIRONMENT_TEMPLATE.format(env_id=env_id_dash))
     else:

--- a/verifiers/scripts/init.py
+++ b/verifiers/scripts/init.py
@@ -95,7 +95,10 @@ def load_environment(**kwargs) -> vf.Environment:
 
 
 def init_environment(
-    env: str, path: str = "./environments", rewrite_readme: bool = False
+    env: str,
+    path: str = "./environments",
+    rewrite_readme: bool = False,
+    multi_file: bool = False,
 ) -> Path:
     """
     Initialize a new verifiers environment.
@@ -136,15 +139,16 @@ def init_environment(
         print(f"pyproject.toml already exists at {pyproject_file}, skipping...")
 
     # create environment directory if it doesn't exist
-    environment_dir = local_dir / env_id_underscore
+    environment_dir = local_dir / env_id_underscore if multi_file else local_dir
     environment_dir.mkdir(parents=True, exist_ok=True)
 
     # create init file if it doesn't exist
-    init_file = environment_dir / "__init__.py"
-    if not init_file.exists():
-        init_file.write_text(INIT_TEMPLATE.format(env_id=env_id_underscore))
-    else:
-        print(f"__init__.py already exists at {init_file}, skipping...")
+    if multi_file:
+        init_file = environment_dir / "__init__.py"
+        if not init_file.exists():
+            init_file.write_text(INIT_TEMPLATE.format(env_id=env_id_underscore))
+        else:
+            print(f"__init__.py already exists at {init_file}, skipping...")
 
     # create environment file if it doesn't exist
     environment_file = environment_dir / f"{env_id_underscore}.py"
@@ -163,7 +167,7 @@ def main():
     parser.add_argument(
         "env",
         type=str,
-        help=("The environment id to init"),
+        help="The environment id to init",
     )
     parser.add_argument(
         "--path",
@@ -178,9 +182,20 @@ def main():
         default=False,
         help="Rewrite README.md even if it already exists",
     )
+    parser.add_argument(
+        "--multi-file",
+        action="store_true",
+        default=False,
+        help="Create multi-file package structure instead of single file",
+    )
     args = parser.parse_args()
 
-    init_environment(args.env, args.path, rewrite_readme=args.rewrite_readme)
+    init_environment(
+        args.env,
+        args.path,
+        rewrite_readme=args.rewrite_readme,
+        multi_file=args.multi_file,
+    )
 
 
 if __name__ == "__main__":

--- a/verifiers/scripts/init.py
+++ b/verifiers/scripts/init.py
@@ -6,7 +6,7 @@ import verifiers as vf
 README_TEMPLATE = """\
 # {env_id_dash}
 
-> Replace the placeholders below, then remove this callout. Keep the Evaluation Reports section at the bottom intact so reports can auto-render.
+> Replace the placeholders below, then remove this callout.
 
 ### Overview
 - **Environment ID**: `{env_id_dash}`


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Previously, `vf-init` would generate a single Python file `<env-id>.py` inside the environment folder. While this worked for single-file development, it often led to broken imports once developers split their logic into multiple files (see issues in lisanbench, arc-agi-tool, browsecomp-openai, med-agent-bench, phybench within prime-environments).

These problems typically went unnoticed because everything still worked during local development and even when running vf-eval, but imports broke once the environment was packaged and pushed to the hub. This PR adds the `--multi-file` boolean flag to `vf-init` which initializes an environment template with multi-file package structure.

Two taste choices that I will leave to you @willccbb 
- Could use "global" instead of "local" imports, e.g. `from <env-id>.submodule import x` instead of `from .submodule import x`
- Avoid the extra file and put the `load_environment` function straight in `__init__.py`

## Example

**Single File** (Default is unchanged)

```bash
uv run vf-init mika
```

```txt
environments/mika/
├── README.md
├── mika.py
└── pyproject.toml

0 directories, 3 files
```

```bash
uv run vf-init mika --multi-file
```

```txt
environments/mika/
├── README.md
├── mika
│   ├── __init__.py
│   └── mika.py
└── pyproject.toml

1 directory, 4 files
```

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass
- [ ] New tests have been added to cover the changes
- [ ] Tests have been run locally with `python -m pytest tests/`

### Test Coverage
<!-- If applicable, mention the test coverage for new code -->
- Current coverage: ___%
- Coverage after changes: ___%

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->