### PR TITLE
Higher timeouts and limits for eval client

### DIFF
--- a/tests/test_eval_cli.py
+++ b/tests/test_eval_cli.py
@@ -44,7 +44,7 @@ def test_cli_sampling_args_precedence_over_flags(monkeypatch):
             self.api_key = api_key
             self.base_url = base_url
 
-    monkeypatch.setattr(vf_eval, "OpenAI", DummyOpenAI)
+    monkeypatch.setattr(vf_eval, "setup_client", lambda *args, **kwargs: DummyOpenAI())
 
     # Run evaluation with JSON sampling args overriding flags
     vf_eval.eval_environment(
@@ -93,7 +93,7 @@ def test_cli_sampling_args_fill_from_flags_when_missing(monkeypatch):
             self.api_key = api_key
             self.base_url = base_url
 
-    monkeypatch.setattr(vf_eval, "OpenAI", DummyOpenAI)
+    monkeypatch.setattr(vf_eval, "setup_client", lambda *args, **kwargs: DummyOpenAI())
 
     # Run evaluation with JSON lacking max_tokens/temperature
     vf_eval.eval_environment(

--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -10,9 +10,9 @@ from pathlib import Path
 
 import numpy as np
 from datasets import Dataset
-from openai import OpenAI
 
 import verifiers as vf
+from verifiers.utils.client_utils import setup_client
 from verifiers.utils.message_utils import messages_to_printable, sanitize_tool_calls
 
 # Setup logger for eval script
@@ -75,8 +75,15 @@ def eval_environment(
             f"Model '{model}' not found in endpoint registry, using command-line arguments"
         )
 
-    api_key_value = os.getenv(api_key_var, "EMPTY")
-    client = OpenAI(api_key=api_key_value, base_url=api_base_url)
+    # Setup eval client with high limits, effectively preventing any API timeout errors
+    client = setup_client(
+        api_base_url,
+        os.getenv(api_key_var, "EMPTY"),
+        timeout=36000.0,  # 10h
+        max_connections=28000,  # Number of available ports
+        max_keepalive_connections=28000,  # Number of available ports
+        max_retries=10,  # 10 retries (w/ exponential backoffs)
+    )
     logger.info(f"Initialized OpenAI client with base_url: {api_base_url}")
 
     logger.info(f"Loading environment: {env}")

--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -3,7 +3,6 @@ import importlib
 import importlib.util
 import json
 import logging
-import os
 import uuid
 from datetime import datetime
 from pathlib import Path
@@ -78,7 +77,7 @@ def eval_environment(
     # Setup eval client with high limits, effectively preventing any API timeout errors
     client = setup_client(
         api_base_url,
-        os.getenv(api_key_var, "EMPTY"),
+        api_key_var,
         timeout=36000.0,  # 10h
         max_connections=28000,  # Number of available ports
         max_keepalive_connections=28000,  # Number of available ports

--- a/verifiers/utils/client_utils.py
+++ b/verifiers/utils/client_utils.py
@@ -1,0 +1,35 @@
+import os
+
+import httpx
+from httpx import AsyncClient
+from openai import AsyncOpenAI
+
+
+def setup_client(
+    base_url: str,
+    api_key_var: str,
+    timeout: float = 600.0,  # OAI default, larger value recommened for evals
+    max_connections: int = 1000,  # OAI default, larger value recommened for evals
+    max_keepalive_connections: int = 100,  # OAI default, larger value recommened for evals
+    max_retries: int = 2,  # OAI default, larger value recommened for evals
+) -> AsyncOpenAI:
+    """
+    A helper function to setup an
+    """
+    # Setup timeouts and limits
+    timeout = httpx.Timeout(timeout, connect=5.0)
+    limits = httpx.Limits(
+        max_connections=max_connections,
+        max_keepalive_connections=max_keepalive_connections,
+    )
+
+    # Setup client
+    http_client = AsyncClient(limits=limits, timeout=timeout)
+    client = AsyncOpenAI(
+        base_url=base_url,
+        api_key=os.getenv(api_key_var, "EMPTY"),
+        max_retries=max_retries,
+        http_client=http_client,
+    )
+
+    return client

--- a/verifiers/utils/client_utils.py
+++ b/verifiers/utils/client_utils.py
@@ -6,7 +6,7 @@ from openai import AsyncOpenAI
 
 
 def setup_client(
-    base_url: str,
+    api_base_url: str,
     api_key_var: str,
     timeout: float = 600.0,  # OAI default, larger value recommened for evals
     max_connections: int = 1000,  # OAI default, larger value recommened for evals
@@ -26,7 +26,7 @@ def setup_client(
     # Setup client
     http_client = AsyncClient(limits=limits, timeout=timeout)
     client = AsyncOpenAI(
-        base_url=base_url,
+        base_url=api_base_url,
         api_key=os.getenv(api_key_var, "EMPTY"),
         max_retries=max_retries,
         http_client=http_client,


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Previously, the eval client would use OAI default timeouts and limits which is fine for running evals on a small number of examples. However, for running full benchmark suites, we need higher limits. This PR adds a utility function `setup_client` with configurable options for timeouts, connection limits and retries. This helper is used to initialize the client with extremely high timeouts and limits that is used to run evals with, effectively preventing ever running into API timeout errors.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass
- [ ] New tests have been added to cover the changes
- [ ] Tests have been run locally with `python -m pytest tests/`

### Test Coverage
<!-- If applicable, mention the test coverage for new code -->
- Current coverage: ___%
- Coverage after changes: ___%

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->