### PR TITLE
Refactor MCP streamable HTTP helper to use native transports

### DIFF
--- a/environments/mcp_env/README.md
+++ b/environments/mcp_env/README.md
@@ -26,10 +26,44 @@ Run an evaluation with default settings:
 uv run vf-eval mcp-env
 ```
 
+The default configuration launches the Exa and Fetch MCP servers over stdio.
+These are real MCP servers maintained by the community and require no manual
+setup beyond providing an `EXA_API_KEY` when you want Exa search access.
+
+To run servers with StreamableHTTP, build configurations with the
+`build_streamable_http_server_config` helper in `mcp_env.py`. The helper
+allocates a port, formats placeholders in your launch arguments, and points the
+client at the resulting `http://host:port/path` endpoint—matching the
+deployment flow described in the official MCP SDK documentation for
+StreamableHTTP transports.【b1dc47†L1-L18】
+
+```python
+from environments.mcp_env.mcp_env import build_streamable_http_server_config
+
+streamable_local = build_streamable_http_server_config(
+    name="local-http",
+    command="uv",
+    args=[
+        "run",
+        "examples/snippets/servers/streamable_config.py",
+        "--",
+        "--port",
+        "{port}",
+    ],
+    url_path="/mcp",
+)
+```
+
+For remote StreamableHTTP providers, skip the command entirely and supply the
+endpoint and headers directly—for example, Telnyx exposes an MCP endpoint at
+`https://api.telnyx.com/v2/mcp` that can be accessed with a bearer token.【0a9bd8†L1-L6】
+
 Configure model and sampling:
 
 ```bash
-uv run vf-eval mcp-env   -m gpt-4.1-mini   -n 1 -r 1
+uv run vf-eval mcp-env \
+  -m gpt-4.1-mini \
+  -n 1 -r 1
 ```
 
 Notes:

--- a/environments/mcp_env/src/models.py
+++ b/environments/mcp_env/src/models.py
@@ -1,11 +1,17 @@
 from dataclasses import dataclass
-from typing import Dict, List
+from typing import Dict, List, Literal, Optional
+
+
+Transport = Literal["stdio", "streamablehttp"]
 
 
 @dataclass
 class MCPServerConfig:
     name: str
-    command: str
+    transport: Transport = "stdio"
+    command: Optional[str] = None
     args: List[str] | None = None
     env: Dict[str, str] | None = None
+    headers: Dict[str, str] | None = None
+    url: str | None = None
     description: str = ""


### PR DESCRIPTION
## Summary
- replace the custom stdio bridge with a generic streamable HTTP helper that configures native MCP endpoints using placeholder-aware launch arguments
- document how to spin up or connect to StreamableHTTP servers following the official MCP guidance and point to a real remote provider example
- drop bridge-only dependencies now that the environment no longer vendors an HTTP proxy

## Testing
- python -m compileall environments/mcp_env/src
- python - <<'PY'
import sys
from pathlib import Path
sys.path.append(str(Path('environments/mcp_env').resolve()))

from mcp_env import build_streamable_http_server_config

config = build_streamable_http_server_config(
    name="demo",
    command="uv",
    args=["run", "script.py", "--", "--port", "{port}", "--host", "{host}", "--url", "{url}"],
)
print(config["url"])
print(config["args"])
PY

------
https://chatgpt.com/codex/tasks/task_e_68cd8600593c83268b073194eef6feb2