### PR TITLE
Limit release workflow to tag pushes

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -1,0 +1,102 @@
+name: Tag and Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing tag to release (e.g. v1.2.3)'
+        required: true
+        type: string
+
+jobs:
+  tag-and-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout tagged release (dispatch)
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: refs/tags/${{ inputs.tag }}
+
+      - name: Checkout tagged release (push)
+        if: github.event_name != 'workflow_dispatch'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve release version
+        id: release
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PUSHED_REF: ${{ github.ref_name }}
+          INPUT_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || '' }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            TAG="$INPUT_TAG"
+          else
+            TAG="$PUSHED_REF"
+          fi
+
+          if [ -z "$TAG" ]; then
+            echo "Unable to determine release tag" >&2
+            exit 1
+          fi
+
+          case "$TAG" in
+            v*)
+              ;;
+            *)
+              echo "Release tags must be prefixed with 'v' (received '$TAG')" >&2
+              exit 1
+              ;;
+          esac
+
+          VERSION="${TAG#v}"
+          FILE_VERSION=$(python - <<'PY'
+from pathlib import Path
+import re
+import sys
+
+match = re.search(r'__version__\s*=\s*"([^"]+)"', Path("verifiers/__init__.py").read_text())
+if not match:
+    sys.exit("Could not find __version__ in verifiers/__init__.py")
+print(match.group(1))
+PY
+)
+
+          if [ "$FILE_VERSION" != "$VERSION" ]; then
+            echo "Version mismatch: tag requests '$VERSION' but verifiers/__init__.py defines '$FILE_VERSION'" >&2
+            exit 1
+          fi
+
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Build sdist and wheel
+        run: uv build
+
+      - name: Publish to PyPI
+        env:
+          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        run: uv publish --token "$PYPI_TOKEN" --yes
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.release.outputs.tag }}
+          files: dist/*
+          generate_release_notes: true

--- a/notes/RELEASE_v0.1.4.md
+++ b/notes/RELEASE_v0.1.4.md
@@ -1,3 +1,65 @@
-# Verifiers v0.1.3 Release Notes
+# Verifiers v0.1.4 Release Notes
 
-*Date:* 9/21/25
+*Date:* 9/23/25
+
+Verifiers v0.1.4 focuses on getting evaluation results back to you faster while strengthening orchestration safety nets and
+modernizing our contributor tooling.
+
+## Highlights
+
+- **Interleaved rollout orchestration** streams generation and scoring concurrently with independent concurrency limits,
+  dramatically reducing end-to-end evaluation latency for large jobs and documenting the upgrade for custom integrators.
+- **Stronger guardrails** land repository-wide type checking with `ty`, import regression tests, async tool call fixes, and more
+  resilient error messaging throughout the evaluation stack.
+- **Sharper maintainer ergonomics** arrive via richer logging, saner CLI defaults, and refreshed contributor documentation plus
+  automation that keeps workflows discoverable.
+
+## Pull request catalog
+
+### Orchestration and scoring
+- [#324](https://github.com/willccbb/verifiers/pull/324) overhauled rollout orchestration to interleave generation and scoring
+  with independent concurrency controls, upgraded timing telemetry, and refreshed the public docs that explain the new flow.
+- [#357](https://github.com/willccbb/verifiers/pull/357) taught `RubricGroup.score_rollout` to accept parser-provided state so
+  interleaved scoring remains stable across rubric compositions.
+
+### Evaluation experience
+- [#319](https://github.com/willccbb/verifiers/pull/319) normalized `vf-eval`'s `-n` handling so requests larger than the dataset
+  fall back gracefully without negative sampling assertions.
+- [#326](https://github.com/willccbb/verifiers/pull/326) fixed async tool invocation inside `StatefulToolEnv` by properly
+  awaiting tool calls, restoring parity with the stateless tool runner.
+- [#309](https://github.com/willccbb/verifiers/pull/309) instrumented environment loading with detailed logging around import
+  failures, default argument usage, and instantiation success.
+- [#335](https://github.com/willccbb/verifiers/pull/335) tightened the error surfaced when a candidate environment omits the
+  required `load_environment` hook so CLI diagnostics stay actionable.
+- [#291](https://github.com/willccbb/verifiers/pull/291) wrapped judge model calls with targeted exception handling, turning
+  OpenAI API failures into actionable error messages instead of silent crashes.
+
+### Training and typing
+- [#320](https://github.com/willccbb/verifiers/pull/320) fixed GRPO trainer `num_iteration` handling to respect configured
+  iteration counts during policy updates.
+- [#347](https://github.com/willccbb/verifiers/pull/347) added the `ty` type checker to pre-commit, locking in static analysis
+  alongside `ruff` for every patch.
+- [#353](https://github.com/willccbb/verifiers/pull/353) introduced import regression tests that traverse `verifiers.__all__`,
+  preventing accidental export gaps.
+- [#355](https://github.com/willccbb/verifiers/pull/355) completed the typing cleanup by pruning unused math utilities,
+  tightening trainer types, and reorganizing dependency declarations to keep `ty` green in CI.
+
+### Documentation and contributor experience
+- [#346](https://github.com/willccbb/verifiers/pull/346) published a consolidated `AGENTS.md`, refreshed parser tests, and
+  aligned contributor expectations across the repo.
+- [#344](https://github.com/willccbb/verifiers/pull/344) expanded environment hub documentation with concrete publishing and
+  consumption workflows.
+- [#323](https://github.com/willccbb/verifiers/pull/323) unified the style workflow and introduced an automated
+  `publish-environments` action for teams distributing shared tasks.
+
+## Contributors
+
+Huge thanks to everyone who shipped improvements in this cycle:
+- @cdreetz
+- @fsndzomga
+- @srthkdev
+- @ZhichenRen
+- @bdsaglam
+- @willccbb
+
+**Full Changelog**: https://github.com/willccbb/verifiers/compare/v0.1.3...v0.1.4

--- a/notes/release_workflow.md
+++ b/notes/release_workflow.md
@@ -1,0 +1,40 @@
+# Release workflow
+
+The `Tag and Release` GitHub Actions workflow (`.github/workflows/tag-and-release.yml`) publishes a new `verifiers`
+version whenever a maintainer pushes a `v*` tag. Follow the checklist below to guarantee the workflow only runs once per
+version and finishes cleanly.
+
+## Before triggering a release
+
+- Land a release prep PR on `main` with:
+  - `verifiers/__init__.py` set to the final version (for example `0.1.4`).
+  - Updated release notes in `notes/RELEASE_vX.Y.Z.md`.
+  - Any ancillary artifacts or documentation updates that belong with the release.
+- Verify CI is green on the commit you intend to tag.
+- Confirm the organization secret `PYPI_TOKEN` is configured with publish permissions for the project.
+
+## Triggering the workflow
+
+1. From `main`, create an annotated tag that matches the version string (for example `git tag -a v0.1.4 -m "Release v0.1.4"`).
+2. Push the tag to GitHub with `git push origin v0.1.4`. The push is the only automatic trigger for the workflow, so each
+   version runs exactly once.
+3. Watch the **Actions → Tag and Release** run to confirm `uv build`, `uv publish`, and the GitHub Release creation succeed.
+
+> Optional: To republish an older tag without pushing again, start **Actions → Tag and Release** manually and provide the
+> existing tag (for example `v0.1.4`). The job checks out that tag and performs the same build and publish steps.
+
+## After the release
+
+- Verify the new version appears on PyPI and that the GitHub Release contains the built `dist/` artifacts.
+- Draft follow-up communication (blog post, changelog announcement) if needed.
+- Open a short PR that bumps `verifiers/__init__.py` to the next development version (for example `0.1.5.dev0`).
+
+## Troubleshooting
+
+- **Workflow failed before publishing to PyPI**: fix the underlying issue and re-run the failed job from the Actions UI. The
+  rerun builds from the same tag.
+- **PyPI publish failed**: address the error locally, then re-run the workflow manually with the same tag once the issue is
+  resolved. PyPI will reject duplicate uploads, so delete the partially uploaded files (if any) from the failed run before
+  retrying.
+- **Version mismatch error**: ensure the tag you pushed (e.g. `v0.1.4`) matches the version string committed to
+  `verifiers/__init__.py` before retrying.


### PR DESCRIPTION
## Summary
- trigger the Tag and Release workflow only from pushed v* tags or manual runs against an existing tag, and verify the tag matches the packaged version before building and publishing
- simplify the release workflow guide with the new tagging prerequisites, trigger steps, post-release follow-up, and targeted troubleshooting advice

## Testing
- `uv run ruff check --fix .`
- `uv run pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_68d09d101fbc8326969d8c269d07e26b