### PR TITLE
Add average_reward column to make_dataset

### DIFF
--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -6,6 +6,7 @@ from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
 from typing import TYPE_CHECKING, Literal
 
+import torch
 from datasets import Dataset
 from openai import AsyncOpenAI, OpenAI
 

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -663,6 +663,7 @@ class Environment(ABC):
     def make_dataset(
         self,
         results: GenerateOutputs,
+        rollouts_per_example: int = 1,
         push_to_hf_hub: bool = False,
         hub_name: str | None = None,
         state_columns: list[str] | None = None,
@@ -673,6 +674,7 @@ class Environment(ABC):
 
         Args:
             results: The evaluation results to convert to a dataset
+            rollouts_per_example: The number of rollouts per example
             push_to_hf_hub: Whether to push the dataset to the Hugging Face Hub
             hub_name: The name of the dataset on the Hugging Face Hub
             state_columns: List of state columns to include in the dataset
@@ -687,7 +689,10 @@ class Environment(ABC):
         if push_to_hf_hub and hub_name is None:
             raise ValueError("hub_name must be provided if push_to_hf_hub is True")
 
-        cols = ["prompt", "completion", "answer", "task", "reward"]
+        cols = ["prompt", "completion", "answer", "task", "reward", "average_reward"]
+
+        rewards = torch.tensor(results.reward).reshape(-1, rollouts_per_example).float().mean(dim=1).tolist()
+        average_reward = [reward for reward in rewards for _ in range(rollouts_per_example)]
 
         results_dict = {
             "prompt": results.prompt,
@@ -695,6 +700,7 @@ class Environment(ABC):
             "answer": results.answer,
             "task": results.task,
             "reward": results.reward,
+            "average_reward": average_reward,
         }
         if results.info[0] != {}:
             results_dict["info"] = results.info


### PR DESCRIPTION
Tracking the average_reward for each prompt (over rollouts_per_example) is a useful metric both for difficulty filtering in RL and SFT data