### PR TITLE
Fix typo in README.md: 'with along' → 'along with'

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ See the full [docs](https://verifiers.readthedocs.io/en/latest/) for more inform
 
 ## Contribution Guidelines
 
-Verifiers warmlyy welcomes community contributions! Please open an issue or PR if you encounter bugs or other pain points during your development, or start a discussion for more open-ended questions.
+Verifiers warmly welcomes community contributions! Please open an issue or PR if you encounter bugs or other pain points during your development, or start a discussion for more open-ended questions.
 
 Please note that the core `verifiers/` library is intended to be a relatively lightweight set of reusable components rather than an exhaustive catalog of RL environments. Consider sharing any environments you create to the [Environments Hub](https://app.primeintellect.ai/dashboard/environments) 🙂
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Verifiers is also the native library used by Prime Intellect's [Environments Hub
 
 ## Setup
 
-We recommend using `verifiers` with along [uv](https://docs.astral.sh/uv/getting-started/installation/) for dependency management in your own project:
+We recommend using `verifiers` along with [uv](https://docs.astral.sh/uv/getting-started/installation/) for dependency management in your own project:
 ```bash
 # install uv (first time only)
 curl -LsSf https://astral.sh/uv/install.sh | sh
@@ -284,7 +284,7 @@ See the full [docs](https://verifiers.readthedocs.io/en/latest/) for more inform
 
 ## Contribution Guidelines
 
-Verifiers warmly welcomes community contributions! Please open an issue or PR if you encounter bugs or other pain points during your development, or start a discussion for more open-ended questions.
+Verifiers warmlyy welcomes community contributions! Please open an issue or PR if you encounter bugs or other pain points during your development, or start a discussion for more open-ended questions.
 
 Please note that the core `verifiers/` library is intended to be a relatively lightweight set of reusable components rather than an exhaustive catalog of RL environments. Consider sharing any environments you create to the [Environments Hub](https://app.primeintellect.ai/dashboard/environments) 🙂
 


### PR DESCRIPTION
## Description
Fix typo in README.md: changed "with along uv" → "along with uv" for clarity.

## Type of Change
- [x] Documentation update

## Testing
- [x] All existing tests pass when running `uv run pytest` locally. (No code changes, so irrelevant)
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](/AGENTS.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
Small documentation-only change; no code or functionality affected.