### PR TITLE
fix: pydantic validation failure

### DIFF
--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -22,7 +22,7 @@ from openai.types.shared_params import (  # noqa: F401
     FunctionDefinition,
     FunctionParameters,
 )
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, SkipValidation
 
 # typing aliases
 ChatMessage = ChatCompletionMessageParam

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -1,4 +1,5 @@
 from typing import (
+    Annotated,
     Any,
     Awaitable,
     Callable,
@@ -25,7 +26,7 @@ from openai.types.shared_params import (  # noqa: F401
 from pydantic import BaseModel, Field, SkipValidation
 
 # typing aliases
-ChatMessage = ChatCompletionMessageParam
+ChatMessage = Annotated[ChatCompletionMessageParam, SkipValidation]
 MessageType = Literal["chat", "completion"]
 ModelResponse = Completion | ChatCompletion | None
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Restores the previous behavior of `Messages` (updated in https://github.com/PrimeIntellect-ai/verifiers/pull/355) by reintroducing `SkipValidation` on the `ChatMessage` alias. Currently `cleanup_message` in `message_utils.py` returns a dict, not a `ChatMessage`, so Pydantic Validation fails when calling `GenerateOutputs()` during the `a_generate` method in the `Environment` class. 

Happy to edit the code so that `cleanup_messages` returns a `ChatMessage`, if preferred!

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](/AGENTS.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->