### PR TITLE
no need for multiple calls

### DIFF
--- a/environments/simpleqa/simpleqa.py
+++ b/environments/simpleqa/simpleqa.py
@@ -123,14 +123,16 @@ Just return the letters "A", "B", or "C", with no text around it.
     def incorrect_answer_reward_func(
         prompt, completion, answer, state, **kwargs
     ) -> float:
-        match = re.search(r"(A|B|C)", state["judge_response"])
+        resp = list(state["judge_response"].values())[-1]
+        match = re.search(r"(A|B|C)", resp)
         result = match.group(0) if match else "C"
         return 1.0 if result == "B" else 0.0
 
     def not_attempted_answer_reward_func(
         prompt, completion, answer, state, **kwargs
     ) -> float:
-        match = re.search(r"(A|B|C)", state["judge_response"])
+        resp = list(state["judge_response"].values())[-1]
+        match = re.search(r"(A|B|C)", resp)
         result = match.group(0) if match else "C"
         return 1.0 if result == "C" else 0.0
 

--- a/environments/simpleqa/simpleqa.py
+++ b/environments/simpleqa/simpleqa.py
@@ -123,16 +123,14 @@ Just return the letters "A", "B", or "C", with no text around it.
     def incorrect_answer_reward_func(
         prompt, completion, answer, state, **kwargs
     ) -> float:
-        judge_response = rubric.judge(prompt, completion, answer, state, **kwargs)
-        match = re.search(r"(A|B|C)", judge_response)
+        match = re.search(r"(A|B|C)", state["judge_response"])
         result = match.group(0) if match else "C"
         return 1.0 if result == "B" else 0.0
 
     def not_attempted_answer_reward_func(
         prompt, completion, answer, state, **kwargs
     ) -> float:
-        judge_response = rubric.judge(prompt, completion, answer, state, **kwargs)
-        match = re.search(r"(A|B|C)", judge_response)
+        match = re.search(r"(A|B|C)", state["judge_response"])
         result = match.group(0) if match else "C"
         return 1.0 if result == "C" else 0.0
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

The simpleqa does not need to call .judge from JudgeRubric, instead the first reward function can make the call and then the next reward functions can use the state to return their own reward.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->