### PR TITLE
Dynamically adjust token budget during multi-turn rollout

### DIFF
--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -215,13 +215,10 @@ class Environment(ABC):
         if message_type is None:
             message_type = self.message_type
         # Normalize sampling args:
-        # - If max_tokens is provided for chat, rename to max_completion_tokens
         # - Drop any None-valued entries to avoid sending them to the client
         if "max_tokens" in sampling_args:
             if sampling_args["max_tokens"] is None:
                 sampling_args.pop("max_tokens")
-            elif message_type == "chat":
-                sampling_args["max_completion_tokens"] = sampling_args.pop("max_tokens")
         if (
             "max_completion_tokens" in sampling_args
             and sampling_args["max_completion_tokens"] is None

--- a/verifiers/envs/multiturn_env.py
+++ b/verifiers/envs/multiturn_env.py
@@ -21,12 +21,12 @@ class MultiTurnEnv(Environment):
     def __init__(
         self,
         max_turns: int = -1,
-        processing_class: PreTrainedTokenizerBase | None = None,
+        tokenizer: PreTrainedTokenizerBase | None = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
         self.max_turns = max_turns
-        self.processing_class = processing_class
+        self.tokenizer = tokenizer
 
     async def setup_state(self, state: State, **kwargs) -> State:
         return state
@@ -92,9 +92,9 @@ class MultiTurnEnv(Environment):
                 break
 
             if max_tokens is not None:
-                assert self.processing_class is not None and sampling_args is not None
+                assert self.tokenizer is not None and sampling_args is not None
                 len_rollout = len(
-                    self.processing_class.apply_chat_template(
+                    self.tokenizer.apply_chat_template(
                         rollout, tokenize=True, tools=info.get("oai_tools", None)
                     )
                 )

--- a/verifiers/envs/multiturn_env.py
+++ b/verifiers/envs/multiturn_env.py
@@ -15,6 +15,7 @@ from verifiers.types import (
     State,
 )
 from verifiers.utils.async_utils import maybe_await
+from verifiers.utils.message_utils import deserialize_tool_calls
 
 
 class MultiTurnEnv(Environment):
@@ -95,7 +96,9 @@ class MultiTurnEnv(Environment):
                 assert self.tokenizer is not None and sampling_args is not None
                 len_rollout = len(
                     self.tokenizer.apply_chat_template(
-                        rollout, tokenize=True, tools=info.get("oai_tools", None)
+                        deserialize_tool_calls(rollout),
+                        tokenize=True,
+                        tools=info.get("oai_tools", None),
                     )
                 )
                 if len_rollout > max_tokens:

--- a/verifiers/envs/multiturn_env.py
+++ b/verifiers/envs/multiturn_env.py
@@ -1,5 +1,6 @@
 import time
 from abc import abstractmethod
+from copy import deepcopy
 
 from openai import AsyncOpenAI
 from transformers import PreTrainedTokenizerBase
@@ -61,6 +62,7 @@ class MultiTurnEnv(Environment):
         """
         info = info or {}
         is_completed = False
+        sampling_args = deepcopy(sampling_args)
         max_tokens = sampling_args.get("max_tokens") if sampling_args else None
         state = {
             "id": 0,  # TODO: add id

--- a/verifiers/envs/multiturn_env.py
+++ b/verifiers/envs/multiturn_env.py
@@ -104,7 +104,7 @@ class MultiTurnEnv(Environment):
                         tools=info.get("oai_tools", None),
                     )
                 )
-                if rollout_len > max_tokens:
+                if rollout_len >= max_tokens:
                     is_completed = True
                     break
                 sampling_args["max_tokens"] = max_tokens - rollout_len

--- a/verifiers/envs/multiturn_env.py
+++ b/verifiers/envs/multiturn_env.py
@@ -93,18 +93,19 @@ class MultiTurnEnv(Environment):
                 break
 
             if max_tokens is not None:
-                assert self.tokenizer is not None and sampling_args is not None
-                len_rollout = len(
+                assert sampling_args is not None and self.tokenizer is not None
+                rollout_len = len(
                     self.tokenizer.apply_chat_template(
                         deserialize_tool_calls(rollout),
                         tokenize=True,
+                        add_generation_prompt=True,
                         tools=info.get("oai_tools", None),
                     )
                 )
-                if len_rollout > max_tokens:
+                if rollout_len > max_tokens:
                     is_completed = True
                     break
-                sampling_args["max_tokens"] = max_tokens - len_rollout
+                sampling_args["max_tokens"] = max_tokens - rollout_len
 
             response = await self.get_model_response(
                 client=client,

--- a/verifiers/utils/env_utils.py
+++ b/verifiers/utils/env_utils.py
@@ -51,9 +51,6 @@ def load_environment(env_id: str, **env_args) -> Environment:
         if provided_params:
             provided_values = []
             for param_name in provided_params:
-                assert param_name in all_params, (
-                    f"Parameter {param_name} not supported by environment {env_id}"
-                )
                 provided_values.append(f"{param_name}={env_args[param_name]}")
             logger.info(f"Using provided args: {', '.join(provided_values)}")
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

> Based on #376 and used for RL training experiments in `math-python` environment. Does not need to be merged as is, although I do think the feature is needed in general. 

As far as I could tell the only way to constrain the rollout length in multi-turn is with `max_tokens` which limits the number of tokens *per turn*. However, in most RL training scenarios I want to limit the number of tokens *per rollout*. Doing this on the inference server via `max_model_len` does not work because the training crashes if the multi-turn prompt exceeds the max context. This PR just makes it work for my specific usecase and might not be the right general API but we definitely need a way to constrain the number of tokens per rollout, and ideally also per turn.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->