### PR TITLE
Fix **kwargs in `load_environment` breaking

### DIFF
--- a/verifiers/utils/env_utils.py
+++ b/verifiers/utils/env_utils.py
@@ -51,9 +51,6 @@ def load_environment(env_id: str, **env_args) -> Environment:
         if provided_params:
             provided_values = []
             for param_name in provided_params:
-                assert param_name in all_params, (
-                    f"Parameter {param_name} not supported by environment {env_id}"
-                )
                 provided_values.append(f"{param_name}={env_args[param_name]}")
             logger.info(f"Using provided args: {', '.join(provided_values)}")
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

This PR removes an assert in the `load_environment` function which prevents **kwargs from being passed.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->