### PR TITLE
Update tests for tool and sandbox env changes

### DIFF
--- a/tests/test_multiturn_env.py
+++ b/tests/test_multiturn_env.py
@@ -107,6 +107,17 @@ class TestMultiTurnEnv:
         assert len(state["responses"]) == 2  # Two assistant responses
 
     @pytest.mark.asyncio
+    async def test_max_turns_helper(self, mock_multiturn_env):
+        """max_turns_reached returns True only when limit exceeded and limit is active."""
+
+        mock_multiturn_env.max_turns = -1
+        assert not await mock_multiturn_env.max_turns_reached({"turn": 100})
+
+        mock_multiturn_env.max_turns = 2
+        assert not await mock_multiturn_env.max_turns_reached({"turn": 1})
+        assert await mock_multiturn_env.max_turns_reached({"turn": 2})
+
+    @pytest.mark.asyncio
     async def test_state_initialization(self, mock_multiturn_env):
         """Test that state is properly initialized with all required fields."""
         mock_multiturn_env.client.add_chat_response(

--- a/tests/test_sandbox_python_env.py
+++ b/tests/test_sandbox_python_env.py
@@ -1,0 +1,173 @@
+"""Tests for SandboxEnv and PythonEnv using a mocked sandbox client."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from typing import Any
+
+import pytest
+from datasets import Dataset
+from unittest.mock import AsyncMock
+
+from verifiers.parsers.parser import Parser
+from verifiers.rubrics.rubric import Rubric
+
+
+@pytest.fixture
+def mock_prime_cli(monkeypatch):
+    sandbox_module = types.ModuleType("prime_cli.api.sandbox")
+
+    class FakeCreateSandboxRequest:
+        def __init__(self, name: str, docker_image: str, start_command: str):
+            self.name = name
+            self.docker_image = docker_image
+            self.start_command = start_command
+
+    class FakeSandboxClient:
+        def __init__(self):
+            self.create = AsyncMock(return_value=types.SimpleNamespace(id="sandbox-123"))
+            self.wait_for_creation = AsyncMock()
+            self.execute_command = AsyncMock(
+                return_value=types.SimpleNamespace(stdout="ok", stderr="")
+            )
+            self.delete = AsyncMock()
+
+    sandbox_module.AsyncSandboxClient = FakeSandboxClient
+    sandbox_module.CreateSandboxRequest = FakeCreateSandboxRequest
+
+    api_module = types.ModuleType("prime_cli.api")
+    api_module.sandbox = sandbox_module
+
+    prime_module = types.ModuleType("prime_cli")
+    prime_module.api = api_module
+
+    monkeypatch.setitem(sys.modules, "prime_cli", prime_module)
+    monkeypatch.setitem(sys.modules, "prime_cli.api", api_module)
+    monkeypatch.setitem(sys.modules, "prime_cli.api.sandbox", sandbox_module)
+
+    return sandbox_module
+
+
+def _reload_env_module(module_name: str) -> Any:
+    sys.modules.pop(module_name, None)
+    module = importlib.import_module(module_name)
+    return importlib.reload(module)
+
+
+@pytest.fixture
+def sandbox_env_module(mock_prime_cli):
+    return _reload_env_module("verifiers.envs.sandbox_env")
+
+
+@pytest.fixture
+def python_env_module(mock_prime_cli):
+    _reload_env_module("verifiers.envs.sandbox_env")
+    return _reload_env_module("verifiers.envs.python_env")
+
+
+def _make_dataset() -> Dataset:
+    return Dataset.from_dict(
+        {
+            "prompt": [[{"role": "user", "content": "hi"}]],
+            "answer": [""],
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_sandbox_env_setup_and_cleanup(
+    sandbox_env_module, mock_openai_client, sample_chat_dataset
+):
+    SandboxEnv = sandbox_env_module.SandboxEnv
+
+    env = SandboxEnv(
+        client=mock_openai_client,
+        model="test-model",
+        dataset=sample_chat_dataset,
+        parser=Parser(),
+        rubric=Rubric(),
+        max_turns=1,
+    )
+
+    state: dict[str, Any] = {"turn": 0}
+    state = await env.setup_state(state)
+    assert state["sandbox_id"] == "sandbox-123"
+
+    updated_args = env.update_tool_args("bash", {"command": "ls"}, [], state)
+    assert updated_args["sandbox_id"] == "sandbox-123"
+
+    env.sandbox_client.delete.assert_not_called()
+
+    state["turn"] = 1
+    messages = [{"role": "assistant", "content": "done"}]
+    completed = await env.is_completed(messages, state)
+    assert completed is True
+    env.sandbox_client.delete.assert_awaited_once_with("sandbox-123")
+    assert "sandbox_id" not in state
+
+
+@pytest.mark.asyncio
+async def test_python_env_execution_flow(
+    python_env_module, mock_openai_client
+):
+    PythonEnv = python_env_module.PythonEnv
+
+    env = PythonEnv(
+        client=mock_openai_client,
+        model="test-model",
+        dataset=_make_dataset(),
+        parser=Parser(),
+        rubric=Rubric(),
+        max_turns=2,
+    )
+
+    state: dict[str, Any] = {"turn": 0}
+    state = await env.setup_state(state)
+    sandbox_id = state["sandbox_id"]
+    python_state = state["python_env"]
+    assert python_state == {"ready": False, "execution_count": 0}
+
+    env._wait_for_worker_ready = AsyncMock()
+    env._send_worker_request = AsyncMock(
+        return_value={
+            "status": "ok",
+            "stdout": "",
+            "stderr": "",
+            "result": "42",
+            "execution_count": 1,
+        }
+    )
+
+    result = await env.python("6 * 7", sandbox_id=sandbox_id, python_state=python_state)
+    assert "Out[1]: 42" in result
+    assert python_state["ready"] is True
+    assert python_state["execution_count"] == 1
+    env._wait_for_worker_ready.assert_awaited_once()
+    env._send_worker_request.assert_awaited_once()
+
+    env._send_worker_request.reset_mock()
+    env._send_worker_request.return_value = {
+        "status": "ok",
+        "stdout": "hello\n",
+        "stderr": "",
+        "result": None,
+    }
+
+    result_again = await env.python(
+        "print(\"hello\")", sandbox_id=sandbox_id, python_state=python_state
+    )
+    assert result_again.strip() == "hello"
+    assert env._wait_for_worker_ready.await_count == 1
+
+    args = env.update_tool_args("python", {"code": "1+1"}, [], state)
+    assert args["sandbox_id"] == sandbox_id
+    assert args["python_state"] is python_state
+
+    state["turn"] = env.max_turns
+    messages = [{"role": "assistant", "content": "done"}]
+    completed = await env.is_completed(messages, state)
+    assert completed is True
+    env.sandbox_client.delete.assert_awaited()
+    assert "python_env" not in state

--- a/tests/test_tool_env_behavior.py
+++ b/tests/test_tool_env_behavior.py
@@ -1,0 +1,120 @@
+"""Tests covering ToolEnv and StatefulToolEnv helper behaviours."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from datasets import Dataset
+from openai.types.chat.chat_completion_message_tool_call import (
+    ChatCompletionMessageToolCall,
+    Function as ChatCompletionMessageToolCallFunction,
+)
+
+from verifiers.envs.stateful_tool_env import StatefulToolEnv
+from verifiers.envs.tool_env import ToolEnv
+from verifiers.parsers.parser import Parser
+from verifiers.rubrics.rubric import Rubric
+
+
+class _BaseToolEnv(ToolEnv):
+    async def env_response(self, messages, state, **kwargs):  # type: ignore[override]
+        return [], state
+
+
+class _DummyStatefulToolEnv(StatefulToolEnv):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.update_invocations: list[tuple[str, dict[str, Any]]] = []
+
+    def update_tool_args(self, tool_name, tool_args, messages, state, **kwargs):  # type: ignore[override]
+        # Track calls and inject stateful arguments
+        captured = dict(tool_args)
+        self.update_invocations.append((tool_name, captured))
+        updated = dict(tool_args)
+        if tool_name == "_dummy_tool":
+            updated["injected"] = state["injected"]
+        return updated
+
+
+def _make_dataset() -> Dataset:
+    return Dataset.from_dict(
+        {
+            "question": [""],
+            "answer": [""],
+        }
+    )
+
+
+def _make_env(env_cls, tools=None, **kwargs):
+    return env_cls(
+        client=None,
+        model="test-model",
+        dataset=_make_dataset(),
+        parser=Parser(),
+        rubric=Rubric(),
+        tools=tools,
+        **kwargs,
+    )
+
+
+def _dummy_tool(x: int, injected: str = "") -> str:
+    return f"{x}:{injected}"
+
+
+@pytest.mark.asyncio
+async def test_tool_env_remove_tool_updates_internal_state():
+    env = _make_env(_BaseToolEnv, tools=[], max_turns=1)
+
+    env.add_tool(_dummy_tool)
+    assert _dummy_tool in env.tools
+    assert "_dummy_tool" in env.tool_map
+
+    env.remove_tool(_dummy_tool)
+    assert _dummy_tool not in env.tools
+    assert "_dummy_tool" not in env.tool_map
+    assert all(
+        tool_spec["function"]["name"] != "_dummy_tool" for tool_spec in env.oai_tools
+    )
+
+    # Ensure max_turns enforcement short-circuits completion detection
+    messages = [{"role": "assistant", "content": "done"}]
+    state = {"turn": 1}
+    env.max_turns = 1
+    assert await env.is_completed(messages, state)
+
+
+@pytest.mark.asyncio
+async def test_stateful_tool_env_update_receives_tool_name_and_cleanup():
+    env = _make_env(_DummyStatefulToolEnv, tools=[], max_turns=2)
+    env.add_tool(_dummy_tool, args_to_skip=["injected"])
+
+    tool_call = ChatCompletionMessageToolCall(
+        id="call-1",
+        function=ChatCompletionMessageToolCallFunction(
+            name="_dummy_tool", arguments=json.dumps({"x": 1})
+        ),
+        type="function",
+    )
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [tool_call],
+        }
+    ]
+    state = {"injected": "secret"}
+
+    tool_messages, _ = await env.env_response(messages, state)
+
+    assert env.update_invocations == [("_dummy_tool", {"x": 1})]
+    assert tool_messages == [
+        {"role": "tool", "content": "1:secret", "tool_call_id": "call-1"}
+    ]
+
+    env.remove_tool(_dummy_tool)
+    assert "_dummy_tool" not in env.skipped_args
+    assert all(
+        tool_spec["function"]["name"] != "_dummy_tool" for tool_spec in env.oai_tools
+    )


### PR DESCRIPTION
## Summary
- add a compatibility stub for older openai builds and update the SimpleMultiTurnEnv fixture to honor the base max-turn logic
- exercise MultiTurnEnv.max_turns_reached plus ToolEnv and StatefulToolEnv removal/update behaviour in new focused tests
- add mocked sandbox and python environment tests to validate setup, teardown, and python execution paths

## Testing
- pip install pytest-asyncio
- pytest tests/test_multiturn_env.py::TestMultiTurnEnv::test_max_turns_limiting -q
- pytest tests/test_tool_env_behavior.py -q
- pytest tests/test_sandbox_python_env.py -q

------
https://chatgpt.com/codex/tasks/task_e_68db5f73a26483269c823326983a4f81