### PR TITLE
Fix string match condition

### DIFF
--- a/verifiers/envs/multiturn_env.py
+++ b/verifiers/envs/multiturn_env.py
@@ -105,8 +105,8 @@ class MultiTurnEnv(Environment):
             # environment response, we set the prompt_too_long flag to True, which
             # will trigger the is_completed check to exit.
             except BadRequestError as e:
-                if len(state["responses"]) != 0 and e.message.startswith(
-                    "This model's maximum context length is"
+                if len(state["responses"]) != 0 and e.response.text.startswith(
+                    '{"error":{"message":"This model\'s maximum context length is'
                 ):
                     state["prompt_too_long"] = True
                     break


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

The fix for catching overlong multi-turn prompts from #360 did not have the correct string to catch the error we wanted to catch. Running evals against `wordle` env with a server with max 1k context (to get the error quick) with

```bash
uv run vf-eval wordle -m PrimeIntellect/Qwen3-1.7B-Wordle-SFT -b http://localhost:8000/v1 -n 5 -r 3
```

Throws an exception on current main but is caught on this branch, see screenshot of the errors getting caught but not stopping execution (btw, how does this log occur? @willccbb)

<img width="1008" height="376" alt="Screenshot 2025-09-30 at 4 49 09 PM" src="https://github.com/user-attachments/assets/b09fa821-7535-4982-86a0-6612278098f5" />

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->