### PR TITLE
fix typos and mentions to `dev` group

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ git clone https://github.com/PrimeIntellect-ai/verifiers.git
 cd verifiers
 
 # CPU-only development:
-uv sync --extra dev
+uv sync
 
 # GPU-based trainer development:
 uv sync --all-extras && uv pip install flash-attn --no-build-isolation

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ uv add 'verifiers[train]' && uv pip install flash-attn --no-build-isolation
 
 To use the latest `main` branch, do:
 ```bash
-uv add verifiers @ git+https://github.com/PrimeIntellect-ai/verifiers.git
+uv add verifiers@git+https://github.com/PrimeIntellect-ai/verifiers.git
 ```
 
 To use with `prime-rl`, see [here](https://github.com/PrimeIntellect-ai/prime-rl).
@@ -68,7 +68,7 @@ git clone https://github.com/PrimeIntellect-ai/verifiers.git
 cd verifiers
 
 # for CPU-only dev:
-uv sync --extra dev
+uv sync
 
 # or, for trainer dev:
 uv sync --all-extras && uv pip install flash-attn --no-build-isolation

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -51,7 +51,7 @@ uv add 'verifiers[all]' && uv pip install flash-attn --no-build-isolation
 
 To use the latest `main` branch:
 ```bash
-uv add verifiers @ git+https://github.com/PrimeIntellect-ai/verifiers.git
+uv add verifiers@git+https://github.com/PrimeIntellect-ai/verifiers.git
 ```
 
 ### Development Setup

--- a/tests/README.md
+++ b/tests/README.md
@@ -11,7 +11,7 @@ This directory contains the test suite for the verifiers package.
 Install test dependencies:
 
 ```bash
-uv sync --extra dev
+uv sync
 ```
 
 ## Running Tests


### PR DESCRIPTION
## Description
Fixing small typos and incorrect instructions in README and docs

- the command to install from main was not working due to spaces
- since `dev` group is part of `dependency-groups`, it is [automatically synced by uv](https://docs.astral.sh/uv/concepts/projects/sync/?utm_source=chatgpt.com#syncing-development-dependencies). `uv sync --extra dev` fails.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->