### PR TITLE
fix reasoning gym enviroment

### DIFF
--- a/environments/reasoning_gym_env/pyproject.toml
+++ b/environments/reasoning_gym_env/pyproject.toml
@@ -2,7 +2,7 @@
 name = "reasoning-gym-env"
 description = "ReasoningGym suite of programmatically-generated reasoning tasks"
 tags = ["reasoning-gym", "logic", "puzzles", "math", "train"]
-version = "0.1.1"
+version = "0.1.2"
 requires-python = ">=3.11"
 dependencies = [
     "verifiers>=0.1.4",

--- a/environments/reasoning_gym_env/reasoning_gym_env.py
+++ b/environments/reasoning_gym_env/reasoning_gym_env.py
@@ -29,7 +29,7 @@ class ReasoningGymEnv(SingleTurnEnv):
         rubric = Rubric(parser=parser)
 
         def check_answer_reward_func(completion, answer, **kwargs) -> float:
-            entry = self.rg_dataset[answer]
+            entry = self.rg_dataset[int(answer)]
             response = str(parser.parse_answer(completion)).strip()
             reward = self.rg_dataset.score_answer(answer=response, entry=entry)
             return reward
@@ -73,7 +73,7 @@ class ReasoningGymEnv(SingleTurnEnv):
         for i, x in enumerate(rg_dataset):
             row = {
                 "question": x["question"],
-                "answer": i,
+                "answer": str(i),
                 "task": x["metadata"]["source_dataset"],
             }
             if i < self.num_train_examples:

--- a/environments/reasoning_gym_env/reasoning_gym_env.py
+++ b/environments/reasoning_gym_env/reasoning_gym_env.py
@@ -29,6 +29,7 @@ class ReasoningGymEnv(SingleTurnEnv):
         rubric = Rubric(parser=parser)
 
         def check_answer_reward_func(completion, answer, **kwargs) -> float:
+            # rg_dataset expects an int index
             entry = self.rg_dataset[int(answer)]
             response = str(parser.parse_answer(completion)).strip()
             reward = self.rg_dataset.score_answer(answer=response, entry=entry)
@@ -73,7 +74,7 @@ class ReasoningGymEnv(SingleTurnEnv):
         for i, x in enumerate(rg_dataset):
             row = {
                 "question": x["question"],
-                "answer": str(i),
+                "answer": str(i),  # in verifiers, an answer must be a string
                 "task": x["metadata"]["source_dataset"],
             }
             if i < self.num_train_examples:


### PR DESCRIPTION
## Description
Might be a fix for https://github.com/PrimeIntellect-ai/verifiers/issues/397

`ReasoningGymEnv` was failing with a Pydantic validation error because verifiers expects answer fields to be strings, but integers were used.

Changes:
- Convert the integer index to a string in `rg_to_hf`
- Convert it back to an integer when accessing the reasoning gym dataset in `check_answer_reward_func`

Now running `uv run vf-eval reasoning_gym_env -n 1 -r 1 -m gpt-5-mini` works and gives the following results:
```
--- All ---
Rewards:
reward: avg - 1.200, std - 0.000
r1: [1.2]
check_answer_reward_func: avg - 1.000, std - 0.000
r1: [1.0]
format_reward_func: avg - 1.000, std - 0.000
r1: [1.0]
```


## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->