### PR TITLE
Set log level package-wide in eval script

### DIFF
--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -53,6 +53,9 @@ def setup_logging(
 
     # Get the root logger for the verifiers package
     logger = logging.getLogger("verifiers")
+    # Remove any existing handlers to avoid duplicates
+    logger.handlers.clear()
+    # Add a new handler with desired log level
     logger.setLevel(level.upper())
     logger.addHandler(handler)
 

--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -7,12 +7,13 @@ import time
 import uuid
 from datetime import datetime
 from pathlib import Path
-from typing import cast, Dict
+from typing import Dict, cast
 
 import numpy as np
 from datasets import Dataset
 
 import verifiers as vf
+from verifiers import setup_logging
 from verifiers.types import Endpoints
 from verifiers.utils.client_utils import setup_client
 from verifiers.utils.message_utils import messages_to_printable, sanitize_tool_calls
@@ -41,7 +42,7 @@ def eval_environment(
     hf_hub_dataset_name: str,
     extra_headers: Dict[str, str],
 ):
-    logger.setLevel("DEBUG" if verbose else "INFO")
+    setup_logging("DEBUG" if verbose else "INFO")
     try:
         endpoints_path_obj = Path(endpoints_path)
         if endpoints_path_obj.is_dir():


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Previously, the `-v` (verbose) mode would only affect the logs from `eval.py` itself but not from the verifiers package. This is fixed by setting up the root `verifiers` logger with the desired log verbosity.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x]  All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->