### PR TITLE
QoL improvements for `SandboxEnv`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ envs = [
     "brave-search",
     "nltk",
     "textarena",
-    #"prime"
+    "prime"
 ]
 all = [
     "torch>=2.7.0",

--- a/verifiers/envs/sandbox_env.py
+++ b/verifiers/envs/sandbox_env.py
@@ -149,10 +149,27 @@ class SandboxEnv(vf.StatefulToolEnv):
         """Delete all active sandboxes"""
         if len(self.active_sandboxes) == 0:
             return
-        self.logger.info(f"Cleaning up {len(self.active_sandboxes)} sandboxes")
+        self.logger.info(
+            f"Cleaning up {len(self.active_sandboxes)} remaining sandboxes"
+        )
         sandbox_client = SandboxClient(APIClient())
-        try:
-            sandbox_client.bulk_wait_for_creation(list(self.active_sandboxes))
-            sandbox_client.bulk_delete(list(self.active_sandboxes))
-        except Exception as e:
-            self.logger.error(f"Failed to cleanup sandboxes: {e}")
+        # TODO: Use the SandboxClient.bulk_delete method once it is more stable
+        while self.active_sandboxes:
+            successfully_deleted = set()
+            for sandbox_id in self.active_sandboxes:
+                try:
+                    sandbox_client.wait_for_creation(sandbox_id)
+                    sandbox_client.delete(sandbox_id)
+                    successfully_deleted.add(sandbox_id)
+                    self.logger.debug(f"Successfully deleted sandbox {sandbox_id}")
+                except Exception as e:
+                    self.logger.error(f"Failed to delete sandbox {sandbox_id}: {e}")
+
+            self.active_sandboxes -= successfully_deleted
+
+            # If no sandboxes were deleted in this pass, break to avoid infinite loop
+            if not successfully_deleted:
+                self.logger.error(
+                    f"Unable to delete remaining sandboxes: {self.active_sandboxes}"
+                )
+                break

--- a/verifiers/envs/sandbox_env.py
+++ b/verifiers/envs/sandbox_env.py
@@ -151,7 +151,7 @@ class SandboxEnv(vf.StatefulToolEnv):
             f"Cleaning up {len(self.active_sandboxes)} remaining sandboxes"
         )
         sandbox_client = SandboxClient(APIClient())
-        # TODO: Use the SandboxClient.bulk_delete method once it is more stable
+        # TODO: Use the SandboxClient.bulk_delete method once it is more stable and faster
         while self.active_sandboxes:
             successfully_deleted = set()
             for sandbox_id in self.active_sandboxes:

--- a/verifiers/envs/sandbox_env.py
+++ b/verifiers/envs/sandbox_env.py
@@ -1,4 +1,5 @@
 import time
+from asyncio import Semaphore
 from typing import Any
 
 import verifiers as vf
@@ -29,6 +30,7 @@ class SandboxEnv(vf.StatefulToolEnv):
         environment_vars: dict[str, str] | None = None,
         team_id: str | None = None,
         advanced_configs: AdvancedConfigs | None = None,
+        max_concurrent_sandboxes: int = 32,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -46,6 +48,8 @@ class SandboxEnv(vf.StatefulToolEnv):
             team_id=team_id,
             advanced_configs=advanced_configs,
         )
+        self.logger.info(f"Using {max_concurrent_sandboxes} max concurrent sandboxes")
+        self.sandbox_semaphore = Semaphore(max_concurrent_sandboxes)
 
         self.add_tool(self.bash, args_to_skip=["sandbox_id"])
 
@@ -80,12 +84,14 @@ class SandboxEnv(vf.StatefulToolEnv):
             return
         try:
             await self.sandbox_client.delete(sandbox_id)
+            self.sandbox_semaphore.release()
             self.logger.debug(f"Deleted sandbox {sandbox_id}")
         except Exception as e:
             self.logger.warning(f"Failed to delete sandbox {sandbox_id}: {e}")
 
     async def setup_state(self, state: vf.State, **kwargs) -> vf.State:
         """Create per-rollout sandbox"""
+        await self.sandbox_semaphore.acquire()
         sandbox = await self.sandbox_client.create(self.sandbox_request)
         self.logger.debug(f"Created sandbox {sandbox.id}")
         state["sandbox_id"] = sandbox.id

--- a/verifiers/envs/sandbox_env.py
+++ b/verifiers/envs/sandbox_env.py
@@ -93,9 +93,7 @@ class SandboxEnv(vf.StatefulToolEnv):
             else:
                 combined = f"stderr:\n{stderr}"
         output = combined or "(no output)"
-        self.logger.debug(
-            f"Executed command in {time.time() - s:.1f}s. Got output: {output}"
-        )
+        self.logger.debug(f"Executed command in {e - s:.1f}s. Got output: {output}")
         return output
 
     async def _destroy_sandbox(self, sandbox_id: str | None) -> None:

--- a/verifiers/envs/sandbox_env.py
+++ b/verifiers/envs/sandbox_env.py
@@ -149,7 +149,7 @@ class SandboxEnv(vf.StatefulToolEnv):
             successfully_deleted = set()
             for sandbox_id in self.active_sandboxes:
                 try:
-                    sandbox_client.wait_for_creation(sandbox_id)
+                    self.logger.debug(f"Deleting sandbox {sandbox_id}")
                     sandbox_client.delete(sandbox_id)
                     successfully_deleted.add(sandbox_id)
                     self.logger.debug(f"Successfully deleted sandbox {sandbox_id}")

--- a/verifiers/envs/sandbox_env.py
+++ b/verifiers/envs/sandbox_env.py
@@ -3,16 +3,15 @@ import signal
 import time
 from typing import Any
 
-from prime_cli.api.client import APIClient
-from prime_cli.api.sandbox import SandboxClient
-
 import verifiers as vf
 
 try:
+    from prime_cli.api.client import APIClient
     from prime_cli.api.sandbox import (  # type: ignore[import-untyped]
         AdvancedConfigs,
         AsyncSandboxClient,
         CreateSandboxRequest,
+        SandboxClient,
     )
 except ImportError:
     raise ImportError(


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Addresses issues #400 and #399:
- Adds `asncio.Semaphore` to hard control the maximum number of sandboxes in use concurrently. Acquires before creating the sandbox, releases after deleting the sandbox. This was because I observed that just setting the `max_concurrent` during `a_generate` would not keep the actual number of sandboxes active on the platform below this value
- Registers handlers on SIGINT, SIGTERM (using `signal`) and general exception (using `atexit`) to clean up all remaining sandboxes. This should cover most unexpected program exits and automatically cleanup any dangling sandboxes.
- Also makes all sandbox create arguments configurable by the environment (e.g. memory/ disk usage)

Note: There is known issue around the cleanup handler not cleaning up all the sandboxes as there might be some creation requests in-flight that don't get added to the `active_sandboxes` set which is used for cleanup. Made a [separate issue](https://github.com/PrimeIntellect-ai/verifiers/issues/411) for this that we can tackle in another PR. 

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->