### PR TITLE
fix(tui): use sampling_args

### DIFF
--- a/verifiers/scripts/tui.py
+++ b/verifiers/scripts/tui.py
@@ -429,11 +429,19 @@ class ViewRunScreen(Screen):
 
     def _get_metadata_text(self) -> Text:
         meta = self.run.metadata
+        sampling_args = meta.get("sampling_args", {})
         avg_reward = meta.get("avg_reward", "")
         if isinstance(avg_reward, (int, float)):
             avg_reward_str = f"{avg_reward:.3f}"
         else:
             avg_reward_str = str(avg_reward) if avg_reward else "N/A"
+
+        def format_sampling_param(value: Any) -> str:
+            return str(value) if value is not None else "N/A"
+
+        temperature_str = format_sampling_param(sampling_args.get("temperature"))
+        max_tokens_str = format_sampling_param(sampling_args.get("max_tokens"))
+
         # Create three columns of information without markup, with styled labels
         col1_items = [
             ("Environment: ", str(self.run.env_id)),
@@ -454,8 +462,8 @@ class ViewRunScreen(Screen):
 
         col3_items = [
             ("Avg reward: ", avg_reward_str),
-            ("Max tokens: ", str(meta.get("max_tokens", ""))),
-            ("Temperature: ", str(meta.get("temperature", ""))),
+            ("Max tokens: ", max_tokens_str),
+            ("Temperature: ", temperature_str),
             ("", ""),
         ]
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Fix a bug where the TUI was trying to get the sampling args (temperature and max_tokens) from the root metadata, which caused them to always appear empty in every env. 

Also replaced the fallback empty string to "N/A" for cases where these args were not used in the eval.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](/AGENTS.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->