### PR TITLE
Allow verifiers logs to propagate

### DIFF
--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -59,9 +59,6 @@ def setup_logging(
     logger.setLevel(level.upper())
     logger.addHandler(handler)
 
-    # Prevent the logger from propagating messages to the root logger
-    logger.propagate = False
-
 
 setup_logging()
 

--- a/verifiers/utils/logging_utils.py
+++ b/verifiers/utils/logging_utils.py
@@ -36,9 +36,6 @@ def setup_logging(
     logger.setLevel(level.upper())
     logger.addHandler(handler)
 
-    # Prevent the logger from propagating messages to the root logger
-    logger.propagate = False
-
 
 def print_prompt_completions_sample(
     prompts: list[Messages],


### PR DESCRIPTION
## Summary
- allow verifiers package loggers to propagate so trainer-level handlers can see environment rollouts

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e357411b648326a16a55147f1c5611