### PR TITLE
fix Wordle command and mentions to `dev` extra

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,6 @@ Environment APIs live in `verifiers/envs/`. Actual environment implementations g
 ```bash
 # Add verifiers
 uv add verifiers            # core
-uv add 'verifiers[dev]'     # + dev tools  
 uv add 'verifiers[all]'     # + training
 
 # Scaffold new environment

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ uv init && uv venv --python 3.12
 
 For local (CPU) development and evaluation with API models, do:
 ```bash
-uv add verifiers # uv add 'verifiers[dev]' for Jupyter + testing support
+uv add verifiers
 ```
 
 For training on GPUs with `vf.GRPOTrainer`, do:
@@ -252,10 +252,10 @@ The included trainer (`vf.GRPOTrainer`) supports running GRPO-style RL training 
 
 ```bash
 # install environment
-vf-install vf-wordle (-p /path/to/environments | --from-repo)
+vf-install wordle (-p /path/to/environments | --from-repo)
 
 # quick eval
-vf-eval vf-wordle -m (model_name in configs/endpoints.py) -n NUM_EXAMPLES -r ROLLOUTS_PER_EXAMPLE
+vf-eval wordle -m (model_name in configs/endpoints.py) -n NUM_EXAMPLES -r ROLLOUTS_PER_EXAMPLE
 
 # inference (shell 0)
 CUDA_VISIBLE_DEVICES=0,1,2,3,4,5 vf-vllm --model willcb/Qwen3-1.7B-Wordle \


### PR DESCRIPTION
## Description
- use `vf-eval wordle` instead of `vf-eval vf-wordle` (that does not work)
- remove remaining mentions to the `dev` extra (`dev` is no longer an extra but a dependency group and cannot be installed with `uv add 'verifiers[dev]'`)

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->