### PR TITLE
better sampling args handling for vf-eval and grpo trainer

### DIFF
--- a/tests/test_sampling_utils.py
+++ b/tests/test_sampling_utils.py
@@ -1,0 +1,57 @@
+"""Tests for sampling argument utilities and merging logic."""
+
+from verifiers.utils.sampling_utils import SamplingArgs, merge_sampling_args
+
+
+class TestSamplingArgs:
+    """Test the SamplingArgs dataclass and serialization."""
+
+    def test_to_dict_empty(self):
+        """Test that empty SamplingArgs converts to empty dict."""
+        args = SamplingArgs()
+
+        result = args.to_dict()
+
+        assert result == {}
+
+    def test_to_dict_separates_extra_body(self):
+        """Test that extra_body fields are correctly separated from standard fields."""
+        args = SamplingArgs(temperature=0.7, top_k=40, min_p=0.05)
+
+        result = args.to_dict()
+
+        assert result["temperature"] == 0.7
+        assert result["extra_body"] == {"top_k": 40, "min_p": 0.05}
+        assert "_EXTRA_BODY_FIELDS" not in result
+
+
+class TestMergeSamplingArgs:
+    """Test sampling argument merging behavior."""
+
+    def test_merge_without_overrides(self):
+        """Test that args are converted correctly when no overrides provided."""
+        args = SamplingArgs(max_tokens=128)
+
+        merged = merge_sampling_args(args)
+
+        assert merged == {"max_tokens": 128}
+
+    def test_overrides_take_precedence(self):
+        """Test that override values replace base argument values."""
+        args = SamplingArgs(temperature=0.4)
+        overrides = {"temperature": 0.9, "max_tokens": 256}
+
+        merged = merge_sampling_args(args, overrides)
+
+        assert merged["temperature"] == 0.9
+        assert merged["max_tokens"] == 256
+
+    def test_extra_body_merges_correctly(self):
+        """Test that extra_body fields from both sources are merged."""
+        args = SamplingArgs(top_k=20)
+        overrides = {"extra_body": {"top_k": 5, "min_p": 0.03}}
+
+        merged = merge_sampling_args(args, overrides)
+
+        assert merged["extra_body"]["top_k"] == 5
+        assert merged["extra_body"]["min_p"] == 0.03

--- a/verifiers/utils/sampling_utils.py
+++ b/verifiers/utils/sampling_utils.py
@@ -1,0 +1,58 @@
+from dataclasses import dataclass, fields
+from typing import Any, ClassVar
+
+
+@dataclass
+class SamplingArgs:
+    """Container for supported inference sampling arguments."""
+
+    # Standard OpenAI parameters
+    temperature: float | None = None
+    top_p: float | None = None
+    max_tokens: int | None = None
+    presence_penalty: float | None = None
+    frequency_penalty: float | None = None
+
+    # Extra vLLM parameters that belong under extra_body
+    _EXTRA_BODY_FIELDS: ClassVar[set[str]] = {"top_k", "min_p", "repetition_penalty"}
+
+    top_k: int | None = None
+    min_p: float | None = None
+    repetition_penalty: float | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert parameters to an OpenAI-compatible payload."""
+        payload: dict[str, Any] = {}
+        extra_body: dict[str, Any] = {}
+
+        for field in fields(self):
+            value = getattr(self, field.name)
+            if value is not None:
+                if field.name in self._EXTRA_BODY_FIELDS:
+                    extra_body[field.name] = value
+                else:
+                    payload[field.name] = value
+
+        if extra_body:
+            payload["extra_body"] = extra_body
+
+        return payload
+
+
+def merge_sampling_args(
+    args: SamplingArgs,
+    extra_dict: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Merge serialized args with an optional extra (overriding) dictionary."""
+    merged = args.to_dict()
+    if not extra_dict:
+        return merged
+
+    for key, value in extra_dict.items():
+        if key == "extra_body":
+            existing_extra = merged.setdefault("extra_body", {})
+            existing_extra.update(value)
+        else:
+            merged[key] = value
+
+    return merged


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

in the current `vf-eval` implementation, when using a vLLM backend, passing sampling parameters like `top_k` and `min_p` is not that straightforward. i have to pass a nested JSON to get it to work `--sampling-args '{"top_p": 0.95, "extra_body": {"top_k": 20, "min_p": 0.05}}'`

- introduce `sampling_utils` to help with serialization of vLLM-specific sampling parameters
- expand `vf-eval` CLI support with dedicated sampling flags similar to `GRPOTrainer`, while preserving JSON overrides 
- refactor `GRPOTrainer` to create sampling payloads using sampling utils

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [x] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->
The changes are made for easier support of sampling parameters such as `top_k` and `min_p` in vf-eval script when using vLLM backend. OpenAI backend does not support these arguments and will drop them. If using some other backend which supports these arguments but does not follow the vLLM format, they should still be passed using --sampling-args.