### PR TITLE
Add prompt rewriting

### DIFF
--- a/tests/test_multiturn_env.py
+++ b/tests/test_multiturn_env.py
@@ -183,13 +183,12 @@ class TestMultiTurnEnv:
 
     @pytest.mark.asyncio
     async def test_state_initialization_allows_prompt_rewrite(self, mock_multiturn_env):
-        """Test that state is properly initialized with all required fields."""
+        """Test that `set_state` allows for prompt rewriting"""
         mock_multiturn_env.client.add_chat_response(
             messages=[{"role": "user", "content": "Test state"}], response="Quick DONE"
         )
 
         prompt = [{"role": "user", "content": "Test state"}]
-
         mutated_prompt = [{"role": "user", "content": "Mutated test state"}]
 
         def mutate_prompt(state):
@@ -209,6 +208,7 @@ class TestMultiTurnEnv:
 
         # Check prompt was mutated
         assert state["prompt"] == mutated_prompt
+
         # Check rest of state fields are initialized
         # state["completion"] is initialized to [] but not updated during rollout
         assert state["completion"] == []

--- a/verifiers/envs/multiturn_env.py
+++ b/verifiers/envs/multiturn_env.py
@@ -82,11 +82,16 @@ class MultiTurnEnv(Environment):
         }
         start_time = time.time()
         state = await maybe_await(self.setup_state, state, **kwargs)
+
         if self.message_type == "chat":
             assert isinstance(prompt, list)
+            if isinstance(state["prompt"], list):
+                prompt = state["prompt"]
             completion = []
         else:
             assert isinstance(prompt, str)
+            if isinstance(state["prompt"], str):
+                prompt = state["prompt"]
             completion = ""
             state["responses_start_idx"] = []
         rollout = list(prompt) if not isinstance(prompt, str) else prompt


### PR DESCRIPTION
## Description
Allow for prompt rewriting in `setup_state`. If the returned state contains the `prompt` field, then overwrite the prompt string with the returned value.

This enables environments that, for example, contain grounding information in the initial prompt. 

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

This could be considered a breaking change in the sense that if somebody was already mutating the prompt field in `setup_state`, then the system behavior would change. I don't know why somebody would be doing that as it would have no effect, but it's possible.

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [x] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](/AGENTS.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

This resolves a problem for a use-case that I have. Since verifiers doesn't currently support generators for datasets, my other options are:
- Regenerate my dataset for each run
- Decorate `rollout` in my subclass to modify `prompt` before `super.rollout` is called. However, I need to store metadata in `state` that corresponds to the modification to `prompt`. So I would then also need to mutate `info` to pipe that data through into the `state` object, which seems kind of lame.
- Completely override `rollout` with a custom implementation

But this seemed like the best approach and I thought that others would find this change useful.