### PR TITLE
`add_tool` upgrade for StatefulToolEnv + `disallow_non_tool_responses` for tool envs

### DIFF
--- a/verifiers/utils/tool_utils.py
+++ b/verifiers/utils/tool_utils.py
@@ -1,4 +1,5 @@
-from typing import Any
+import inspect
+from typing import Any, Callable
 
 from agents.function_schema import function_schema
 from openai.types.chat import ChatCompletionFunctionToolParam
@@ -19,3 +20,57 @@ def convert_func_to_oai_tool(func: Any) -> ChatCompletionFunctionToolParam:
             "strict": True,
         },
     }
+
+
+def build_schema_only_tool(tool: Callable, args_to_skip: list[str]) -> Callable:
+    """
+    Convert a function to an OpenAI/Pydantic-compatible stub tool, excluding specified parameters.
+
+    Args:
+        func: The function to convert
+        exclude_params: List of parameter names to exclude from the schema
+    """
+    if not args_to_skip:
+        return tool
+
+    original_signature = inspect.signature(tool)
+
+    missing_args = [
+        name for name in args_to_skip if name not in original_signature.parameters
+    ]
+    assert not missing_args, (
+        f"{getattr(tool, '__name__')} does not define {missing_args}."
+    )
+
+    filtered_parameters = [
+        parameter
+        for name, parameter in original_signature.parameters.items()
+        if name not in args_to_skip
+    ]
+    schema_signature = original_signature.replace(parameters=filtered_parameters)
+
+    tool_annotations = dict(getattr(tool, "__annotations__", {}))
+    for arg in args_to_skip:
+        tool_annotations.pop(arg)
+
+    if inspect.iscoroutinefunction(tool):
+
+        async def schema_stub(*args: Any, **kwargs: Any) -> Any:
+            raise RuntimeError(
+                "Schema-only stub created for tool registration; this callable should not be invoked."
+            )
+    else:
+
+        def schema_stub(*args: Any, **kwargs: Any) -> Any:
+            raise RuntimeError(
+                "Schema-only stub created for tool registration; this callable should not be invoked."
+            )
+
+    schema_stub.__name__ = getattr(tool, "__name__", tool.__class__.__name__)
+    schema_stub.__qualname__ = getattr(tool, "__qualname__", schema_stub.__name__)
+    schema_stub.__module__ = getattr(tool, "__module__", schema_stub.__module__)
+    schema_stub.__doc__ = getattr(tool, "__doc__", schema_stub.__doc__)
+    schema_stub.__annotations__ = tool_annotations
+    schema_stub.__signature__ = schema_signature  # type: ignore[attr-defined]
+
+    return schema_stub


### PR DESCRIPTION
## Description
(I'm sorry I'm putting two changes into one PR, but I just noticed one while working on another...)
1) `build_schema_only_tool` added to allow for tools in StatefulToolEnv that have non-Pydanticable args (+ tests). Previously, if one had to skip non-pydantic tool args they'd got an error, because we first convert then filter args.
2)  `ToolEnv` now has `disallow_non_tool_responses` argument (True by default to keep the behaviour the same), and assert on the type of response message is thus optional. Meaning, the model can respond with text and not only tool calls (which is a common case I met during work on PaperBench and DABStep envs).

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [X] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [X] All existing tests pass when running `uv run pytest` locally.
- [X] New tests have been added to cover the changes

## Checklist
- [X] My code follows the style guidelines of this project as outlined in [AGENTS.md](/AGENTS.md)
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published
