### PR TITLE
Sandbox hotfix

### DIFF
--- a/environments/math_python/pyproject.toml
+++ b/environments/math_python/pyproject.toml
@@ -5,9 +5,8 @@ tags = ["tool-use", "math", "sandbox", "train"]
 version = "0.1.3"
 requires-python = ">=3.11"
 dependencies = [
-    "verifiers>=0.1.5",
+    "verifiers>=0.1.5.post1",
     "math-verify>=0.8.0",
-    "prime>=0.3.34",
 ]
 
 [build-system]

--- a/environments/math_python/pyproject.toml
+++ b/environments/math_python/pyproject.toml
@@ -2,7 +2,7 @@
 name = "math-python"
 description = "Solve math problems using Python in a sandbox environment"
 tags = ["tool-use", "math", "sandbox", "train"]
-version = "0.1.3"
+version = "0.1.4"
 requires-python = ">=3.11"
 dependencies = [
     "verifiers>=0.1.5.post0",

--- a/environments/math_python/pyproject.toml
+++ b/environments/math_python/pyproject.toml
@@ -5,7 +5,7 @@ tags = ["tool-use", "math", "sandbox", "train"]
 version = "0.1.3"
 requires-python = ">=3.11"
 dependencies = [
-    "verifiers>=0.1.5.post1",
+    "verifiers>=0.1.5.post0",
     "math-verify>=0.8.0",
 ]
 

--- a/notes/RELEASE_v0.1.5.post0.md
+++ b/notes/RELEASE_v0.1.5.post0.md
@@ -1,0 +1,17 @@
+# Verifiers v0.1.5 Release Notes
+
+*Date:* 10/8/25
+
+***Update***: 10/9/25
+- Update SandboxEnv to use prime-sandboxes instead of prime-cli, disable Python 3.14 as `datasets` is not compatible (blocked by `arrow`).
+
+Verifiers v0.1.5 adds a new SandboxEnv environment for running code in a sandboxed environment, along with a number of bug fixes and QoL improvements.
+
+## Highlights
+
+- New SandboxEnv environment for running code in a sandboxed environment. This environment is configured for use with Prime Intellect's sandboxes, but can be adapted for other sandbox providers.
+- Improvements to `StatefulToolEnv` and `ToolEnv` for handling stateful tools and tools with arguments that should not be passed to the model, and managing active tools + schemas (`add_tool` and `remove_tool`).
+- Bug fixes and improvements (`vf-tui`, tool call serialization, documentation, examples).
+
+
+**Full Changelog**: https://github.com/willccbb/verifiers/compare/v0.1.4...v0.1.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dynamic = ["version"]  # load from verifiers/__init__.py
 description = "Verifiers: Environments for LLM Reinforcement Learning"
 readme = "README.md"
 license = "MIT"
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.14"
 keywords = ["reinforcement-learning", "llm", "rl", "grpo", "environments", "multi-turn", "agents", "agentic-rl", "tool-use", "train", "eval", "harness", "verifiers", "rlvr"]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -37,6 +37,7 @@ dependencies = [
     "rich",
     "textual",
     "pydantic>=2.11.9",
+    "prime-sandboxes>=0.1.0",
 ]
 
 [dependency-groups]
@@ -71,7 +72,6 @@ envs = [
     "brave-search",
     "nltk",
     "textarena",
-    "prime"
 ]
 all = [
     "torch>=2.7.0",

--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.5.post1"
+__version__ = "0.1.5.post0"
 
 import importlib
 import logging

--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.5"
+__version__ = "0.1.5.post1"
 
 import importlib
 import logging

--- a/verifiers/envs/sandbox_env.py
+++ b/verifiers/envs/sandbox_env.py
@@ -6,16 +6,16 @@ from typing import Any
 import verifiers as vf
 
 try:
-    from prime_cli.api.client import APIClient
-    from prime_cli.api.sandbox import (  # type: ignore[import-untyped]
+    from prime_sandboxes import (
         AdvancedConfigs,
+        APIClient,
         AsyncSandboxClient,
         CreateSandboxRequest,
         SandboxClient,
     )
 except ImportError:
     raise ImportError(
-        "prime-cli is not installed. Please install it with `uv pip install prime`."
+        "prime-sandboxes is not installed. Please install it with `uv pip install prime-sandboxes`."
     )
 
 


### PR DESCRIPTION
## Description
Hotfix / post0 release for 2 issues:
- updated prime-sandboxes dependency/import
- disabling python3.14 as arrow (required by datasets) is not yet supported

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->