### PR TITLE
Simplify RLTrainer stat tracking

### DIFF
--- a/verifiers/rl/trainer/trainer.py
+++ b/verifiers/rl/trainer/trainer.py
@@ -454,10 +454,11 @@ class RLTrainer(Trainer):
             )
         else:
             raise ValueError(f"Unknown loss type: {self.loss_type}")
-        ratio_summary = summarize_values(ratio_values[completion_mask.bool()])
-        entropy_summary = summarize_values(
-            entropies.detach()[completion_mask.bool()]
-        )
+        with torch.no_grad():
+            ratio_summary = summarize_values(ratio_values[completion_mask.bool()])
+            entropy_summary = summarize_values(
+                entropies[completion_mask.bool()]
+            )
 
         if return_outputs:
             return loss, {

--- a/verifiers/rl/trainer/trainer.py
+++ b/verifiers/rl/trainer/trainer.py
@@ -394,17 +394,17 @@ class RLTrainer(Trainer):
         num_items_in_batch: torch.Tensor | None = None,
     ) -> torch.Tensor | tuple[torch.Tensor, dict[str, dict[str, torch.Tensor]]]:
         input_ids, attention_mask = inputs["input_ids"], inputs["attention_mask"]
-        completion_mask = attention_mask[:, 1:]
+        completion_mask = attention_mask[:, 1:]  # prompt is at least 1 token
         logits_to_keep = completion_mask.size(1)
         sampling_logprobs = inputs["sampling_logprobs"]
         logits_to_keep = min(logits_to_keep, sampling_logprobs.size(1))
         completion_mask = completion_mask[:, -logits_to_keep:]
         sampling_logprobs = sampling_logprobs[:, -logits_to_keep:]
-        token_logprobs, entropies = self.get_logprobs(
+        model_logprobs, entropies = self.get_logprobs(
             model, input_ids, attention_mask, logits_to_keep
         )
         advantages = inputs["advantages"]
-        log_ratio = token_logprobs - sampling_logprobs
+        log_ratio = model_logprobs - sampling_logprobs
         if self.importance_sampling_level == "token":
             log_importance_weights = log_ratio
         elif self.importance_sampling_level == "sequence":

--- a/verifiers/rl/trainer/trainer.py
+++ b/verifiers/rl/trainer/trainer.py
@@ -403,13 +403,7 @@ class RLTrainer(Trainer):
         model_logprobs, entropies = self.get_logprobs(
             model, input_ids, attention_mask, logits_to_keep
         )
-        reference_logprobs = inputs.get("model_logprobs")
-        if reference_logprobs is not None:
-            reference_logprobs = reference_logprobs.to(model_logprobs.device)
-            reference_logprobs = reference_logprobs[:, -logits_to_keep:]
-            reference_logprobs = reference_logprobs.detach()
-        else:
-            reference_logprobs = model_logprobs.detach()
+        reference_logprobs = model_logprobs.detach()
         advantages = inputs["advantages"]
         log_ratio = model_logprobs - reference_logprobs
         if self.importance_sampling_level == "token":

--- a/verifiers/rl/trainer/utils.py
+++ b/verifiers/rl/trainer/utils.py
@@ -19,6 +19,14 @@ from transformers import (
 )
 
 
+def entropy_from_logits(logits: torch.Tensor) -> torch.Tensor:
+    """Compute the per-token entropy from logits."""
+
+    log_probs = torch.nn.functional.log_softmax(logits, dim=-1)
+    probs = log_probs.exp()
+    return -(probs * log_probs).sum(dim=-1)
+
+
 def get_model(
     model_name: str,
     use_liger: bool = True,

--- a/verifiers/rl/trainer/utils.py
+++ b/verifiers/rl/trainer/utils.py
@@ -8,7 +8,6 @@ from typing import Any, Optional, cast
 
 import numpy as np
 import torch
-import torch.nn.functional as F
 from liger_kernel.transformers import AutoLigerKernelForCausalLM
 from peft import PeftConfig, PeftModel, get_peft_model
 from transformers import (
@@ -17,15 +16,6 @@ from transformers import (
     PreTrainedModel,
     TrainingArguments,
 )
-
-
-def entropy_from_logits(logits: torch.Tensor) -> torch.Tensor:
-    """Compute the per-token entropy from logits."""
-
-    log_probs = torch.nn.functional.log_softmax(logits, dim=-1)
-    probs = log_probs.exp()
-    return -(probs * log_probs).sum(dim=-1)
-
 
 def get_model(
     model_name: str,
@@ -50,50 +40,6 @@ def get_model_and_tokenizer(
     model = get_model(model_name, use_liger, model_kwargs)
     tokenizer = AutoTokenizer.from_pretrained(model_name)
     return model, tokenizer
-
-
-def selective_log_softmax(logits, index) -> torch.Tensor:
-    """
-    A memory-efficient implementation of the common `log_softmax -> gather` operation.
-
-    This function is equivalent to the following naive implementation:
-    ```python
-    logps = torch.gather(logits.log_softmax(-1), dim=-1, index=index.unsqueeze(-1)).squeeze(-1)
-    ```
-
-    Args:
-        logits (`torch.Tensor`):
-            Logits tensor of shape `(..., num_classes)`.
-        index (`torch.Tensor`):
-            Index tensor of shape `(...)`, specifying the positions to gather from the log-softmax output.
-
-    Returns:
-        `torch.Tensor`:
-            Gathered log probabilities with the same shape as `index`.
-    """
-    if logits.dtype in [torch.float32, torch.float64]:
-        selected_logits = torch.gather(
-            logits, dim=-1, index=index.unsqueeze(-1)
-        ).squeeze(-1)
-        # loop to reduce peak mem consumption
-        logsumexp_values = torch.stack([torch.logsumexp(lg, dim=-1) for lg in logits])
-        per_token_logps = (
-            selected_logits - logsumexp_values
-        )  # log_softmax(x_i) = x_i - logsumexp(x)
-    else:
-        # logsumexp approach is unstable with bfloat16, fall back to slightly less efficient approach
-        per_token_logps = []
-        for row_logits, row_labels in zip(
-            logits, index
-        ):  # loop to reduce peak mem consumption
-            row_logps = F.log_softmax(row_logits, dim=-1)
-            row_per_token_logps = row_logps.gather(
-                dim=-1, index=row_labels.unsqueeze(-1)
-            ).squeeze(-1)
-            per_token_logps.append(row_per_token_logps)
-        per_token_logps = torch.stack(per_token_logps)
-    return per_token_logps
-
 
 def pad(
     tensors: list[torch.Tensor],


### PR DESCRIPTION
## Summary
- replace dataclass-based logprob and tracker helpers with lightweight tensor dict utilities
- keep entropy and importance sampling aggregation while mirroring HF accumulation semantics

## Testing
- python -m compileall verifiers/rl/trainer/trainer.py verifiers/rl/trainer/utils.py

------
https://chatgpt.com/codex/tasks/task_e_68e9fc25192083268d81dfd105d5c9fd