### PR TITLE
Streamline RL metrics logging and refresh trainer docs

### DIFF
--- a/docs/source/rl_loss_normalization.md
+++ b/docs/source/rl_loss_normalization.md
@@ -1,0 +1,134 @@
+# Reinforcement Learning Loss Normalization
+
+This note documents how the RL trainer keeps gradient magnitudes invariant to
+how rollouts are partitioned across processes or microbatches.  The end goal is
+that a distributed update matches the update we would compute if every rollout
+were processed in a single microbatch on a single device.
+
+## Notation
+
+We work with the following notation for one optimizer step:
+
+- $\mathcal{P}$ – set of processes participating in data parallel training.
+- $\mathcal{B}_p$ – microbatches assigned to process $p \in \mathcal{P}$.
+- $\mathcal{S}_{b}$ – sequences contained in microbatch $b$.
+- $\mathcal{T}_{s}$ – completion tokens for sequence $s$ (prompt tokens are
+  masked out before loss aggregation).
+- $A_s$ – group-normalized advantage for sequence $s$.
+- $r_{s,t}$ – truncated importance sampling (TIS) weight applied to token $t$ in
+  sequence $s$.
+- $g_{s,t}(\theta)$ – policy gradient contribution for token $t$ in sequence
+  $s$ under parameters $\theta$ before any normalization is applied.
+
+Two aggregate counts appear throughout the loss definitions:
+
+- $N_{\text{seq}} = \sum_{p \in \mathcal{P}} \sum_{b \in \mathcal{B}_p}
+  |\mathcal{S}_b|$ – the total number of sequences in the global batch.
+- $N_{\text{tok}} = \sum_{p \in \mathcal{P}} \sum_{b \in \mathcal{B}_p}
+  \sum_{s \in \mathcal{S}_b} |\mathcal{T}_s|$ – the total number of
+  completion tokens that remain after masking and truncation.
+
+For DR-GRPO we additionally cap every sequence at a fixed horizon
+$H = \texttt{max\_seq\_len}$, so the global denominator is
+$N_{\text{seq}} \cdot H$.
+
+## Shared objective and truncated importance sampling
+
+Every loss variant in the trainer implements the same clipped-TIS REINFORCE
+objective.  For each token we form a truncated importance weight
+
+$$
+\tau_{s,t} = \min\left(\exp(\log \pi_\theta - \log \pi_{\text{ref}}),
+                       1 + \varepsilon\right),
+$$
+
+optionally averaged over the sequence when `importance_sampling_level="sequence"`.
+The trainer then applies the environment-supplied sampling correction
+
+$$
+\rho_{s,t} = \min\left(\exp(\log \pi_{\text{ref}} - \log \pi_{\text{sampler}}),
+                       c_{\text{vllm}}\right),
+$$
+
+and the per-token gradient contribution becomes
+
+$$
+ g_{s,t}(\theta) = - \min(\tau_{s,t}, 1 + \varepsilon)
+                    \, \rho_{s,t} \, A_s \, \nabla_\theta \log \pi_\theta.
+$$
+
+The only remaining choice is how to normalize the sum of these contributions.
+
+## Loss-specific normalization
+
+### GRPO (sequence-level normalization)
+
+GRPO keeps the per-sequence mean of masked token contributions and then averages
+across sequences:
+
+$$
+\mathcal{L}_{\text{GRPO}}
+  = \frac{1}{N_{\text{seq}}}
+    \sum_{p,b} \sum_{s \in \mathcal{S}_b}
+      \frac{1}{|\mathcal{T}_s|}
+      \sum_{t \in \mathcal{T}_s} g_{s,t}(\theta).
+$$
+
+Dividing by $N_{\text{seq}}$ ensures that adding more processes or slicing the
+batch into additional microbatches does not change the effective learning rate.
+
+### DR-GRPO (fixed-horizon normalization)
+
+DR-GRPO follows GRPO’s token averaging but always divides by
+$N_{\text{seq}} \cdot H$ with $H$ equal to the configured
+`max_seq_len`.  This mirrors the delayed-reward objective in Prime RL where the
+loss is normalized by the number of sequences times the fixed horizon, ensuring
+that partial rollouts and padded tokens contribute consistently.
+
+> **Note**
+> The earlier BNPO option normalized by the live token count, which introduced
+> cross-process variance once asynchronous generation created uneven
+> microbatching.  Prime RL defaults to GRPO-style sequence averaging or the
+> fixed-horizon DR-GRPO objective, so the trainer now exposes the same two
+> choices.
+
+## Implementation in the trainer
+
+The training loop mirrors the mathematics above:
+
+1. The async generator packages the batch with precomputed per-process item
+   totals and the global denominator so that every rank receives the same
+   metadata alongside the token tensors.【F:verifiers/rl/trainer/generator.py†L24-L54】【F:verifiers/rl/trainer/generator.py†L332-L383】
+2. `training_step` materializes each microbatch once, padding and truncating on
+   the fly before dispatching the tensors to `compute_loss`.  Every call passes
+   the shared `global_item_count`, so gradient scaling happens before
+   `Accelerate` reduces the partitions.【F:verifiers/rl/trainer/trainer.py†L223-L279】
+3. `compute_loss` receives the shared denominator through
+   `num_items_in_batch` and applies the appropriate normalization rule
+   for the selected loss type, reproducing the behaviour of the reference
+   implementation even when different ranks see different numbers of
+   microbatches.【F:verifiers/rl/trainer/trainer.py†L415-L505】
+
+Because the denominator is derived from the global counts, increasing the number
+of GPUs, changing the microbatch size, or rearranging rollouts (e.g. future
+packing of non-sequential trajectories) leaves the effective update unchanged as
+long as the global batch size and optimization hyperparameters are fixed.
+
+### Interaction with the Hugging Face Trainer and ZeRO-3
+
+`training_step` performs the normalization before invoking
+`self.accelerator.backward(loss)`, letting `Accelerate` and DeepSpeed’s ZeRO-3
+collectives combine the gradients without altering the per-token weights.  When
+ZeRO-3 is active, the trainer temporarily gathers partitioned parameters before
+syncing with vLLM, matching Hugging Face’s expectation that every rank returns a
+loss already reduced over its local work.【F:verifiers/rl/trainer/trainer.py†L270-L314】【F:verifiers/rl/trainer/trainer.py†L370-L405】
+
+## Relationship to Prime RL
+
+Prime RL’s trainer accumulates a `loss_scale` per process equal to the number of
+unmasked tokens when operating in token ratio mode, or to the number of
+sequences in the local batch when using sequence ratio mode, and divides the
+summed loss by that value.  Our trainer follows the same semantics by computing
+those totals as part of batch preparation and shipping the aggregated
+`global_item_count` with the rollout data so that every rank applies the same
+normalizer even when asynchronous generation yields uneven microbatch counts.

--- a/docs/source/training.md
+++ b/docs/source/training.md
@@ -4,9 +4,9 @@ This guide covers training models with Verifiers using GRPO (Group Relative Poli
 
 ## Training options
 
-You can train with the built-in `GRPOTrainer` or with the external `prime-rl` project.
+You can train with the built-in `RLTrainer` (exported as `vf.GRPOTrainer`) or with the external `prime-rl` project.
 
-- Use `GRPOTrainer` when you want a lightweight Python training loop, LoRA/PEFT support, or small-to-mid scale runs (2–16 GPUs) using Accelerate/DeepSpeed.
+- Use `vf.GRPOTrainer` when you want a lightweight Python training loop, LoRA/PEFT support, or small-to-mid scale runs (2–16 GPUs) using Accelerate/DeepSpeed.
 - Use `prime-rl` when you want an FSDP-first, higher-throughput setup with more configuration surface area and performance-oriented defaults.
 
 ### Summary of similarities and differences
@@ -16,12 +16,12 @@ You can train with the built-in `GRPOTrainer` or with the external `prime-rl` pr
   - One-step off-policy overlap by default (generate at step n-1 while training at step n)
 
 - Differences
-  - GRPOTrainer: Accelerate/DeepSpeed-based; optional LoRA/PEFT; easy to script and extend in Python
+- RLTrainer: Accelerate/DeepSpeed-based; optional LoRA/PEFT; easy to script and extend in Python
   - PRIME-RL: FSDP-first; `rl` entrypoint; strong checkpointing; extensive CLI/TOML configuration
 
-## Train with GRPOTrainer
+## Train with RLTrainer
 
-The included `GRPOTrainer` supports GRPO-style training via Accelerate/DeepSpeed with vLLM inference. It's designed for:
+The included trainer exposes GRPO-style updates via Accelerate/DeepSpeed with vLLM inference. It overlaps generation with training, scales losses by the global sample count, and logs aggregate reward components (overall and per-function means, standard deviation). It's designed for:
 - LoRA and smaller setups (2–16 GPUs)
 - Full-parameter finetuning
 - Experimentation and prototyping

--- a/verifiers/rl/README.md
+++ b/verifiers/rl/README.md
@@ -1,9 +1,10 @@
 ### Verifiers Trainers
 
-This directory contains the built-in GRPO trainer and configuration utilities for training with Verifiers environments.
+This directory contains the built-in RL trainer and configuration utilities for training with Verifiers environments.
 
 - **Modules**: `RLTrainer`, `RLConfig`, `rl_defaults`, `lora_defaults`
-- **Exports**: available directly from `verifiers` (lazy-imported)
+- **Exports**: available directly from `verifiers` (lazy-imported as `vf.GRPOTrainer`)
+- **Features**: async vLLM rollouts, distributed loss scaling, aggregated reward metrics, LoRA/full-parameter support
 
 ### Installation
 

--- a/verifiers/rl/trainer/config.py
+++ b/verifiers/rl/trainer/config.py
@@ -117,17 +117,12 @@ class RLConfig(TrainingArguments):
     loss_type: str = field(
         default="dr_grpo",
         metadata={
-            "help": "Specifies the loss formulation to use. Supported values are `grpo`, `bnpo`, and `dr_grpo`. "
+            "help": "Specifies the loss formulation to use. Supported values are `grpo` and `dr_grpo`. "
             "`'grpo'`: Aggregates token-level losses by normalizing over sequence length. Not recommended due to "
             "length bias—this approach tends to prefer shorter completions with positive advantages and longer ones "
             "with negative advantages. "
-            "`'bnpo'`: Aggregates token-level losses by normalizing number of active token in the local batch. "
-            "Note that normalization is performed over the local batch only, so results may slightly vary depending "
-            "on the local batch size, despite a constant effective batch size. When using "
-            "`per_device_train_batch_size==1`, the loss is equivalent to the GRPO loss. "
-            "`'dr_grpo'`: Aggregates token-level losses by normalizing with a global constant. This method was "
-            "introduced in the Dr. GRPO paper to eliminate length bias. The value of the constant corresponds to "
-            "`max_completion_length`."
+            "`'dr_grpo'`: Aggregates token-level losses by normalizing with a global constant equal to "
+            "`max_completion_length`, eliminating the length bias described in the Dr. GRPO paper."
         },
     )
     mask_env_responses: bool = field(


### PR DESCRIPTION
## Summary
- simplify training-time statistics to track means only and log sampling ratio and entropy without redundant extrema
- report reward means, per-function reward components, advantage absolute mean, and streamlined token statistics from the generator
- refresh the RL trainer documentation to describe the current feature set and logging behavior

## Testing
- python -m compileall -f verifiers/rl/trainer/trainer.py verifiers/rl/trainer/generator.py

------
https://chatgpt.com/codex/tasks/task_e_68ea1c7c312483269b7419da6bd7508d