### PR TITLE
Handle all BadRequestError exceptions with a dummy response

### DIFF
--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -29,7 +29,7 @@ from verifiers.types import (
 )
 from verifiers.utils.message_utils import (
     cleanup_messages,
-    get_overlong_prompt_dummy_response,
+    get_error_dummy_response,
     sanitize_tool_calls,
 )
 
@@ -280,12 +280,12 @@ class Environment(ABC):
         except Exception as e:
             # In case of making a request with an overlong prompt, e.g from a too-long
             # environment response, we return a dummy response to with finish_reason "length"
-            if isinstance(e, BadRequestError) and e.response.text.startswith(
-                '{"error":{"message":"This model\'s maximum context length is'
-            ):
-                self.logger.debug("Caught overlong prompt.")
-                return get_overlong_prompt_dummy_response(
-                    message_type or self.message_type
+            if isinstance(e, BadRequestError):
+                self.logger.error(f"Error getting model response: {e}")
+                return get_error_dummy_response(
+                    message_type or self.message_type,
+                    error_message=str(e),
+                    model=model,
                 )
             self.logger.error(f"Error getting model response: {e} \n\nExiting...")
             raise e

--- a/verifiers/utils/message_utils.py
+++ b/verifiers/utils/message_utils.py
@@ -121,35 +121,45 @@ def sanitize_tool_calls(messages: Messages):
     return sanitized_messages
 
 
-def get_overlong_prompt_dummy_response(message_type: MessageType) -> ModelResponse:
+def get_error_dummy_response(
+    message_type: MessageType, error_message: str, model: str = ""
+) -> ModelResponse:
+    """
+    Return a dummy response for general errors (non-context-length issues)
+    """
+    content = "Error occurred during model request."
+    if error_message:
+        # Truncate error message to avoid overly long content
+        content = f"Error occurred during model request: {error_message}"
+
     if message_type == "chat":
         return ChatCompletion(
-            id="overlong-prompt",
+            id="bad_request",
             created=0,
-            model="",
+            model=model,
             object="chat.completion",
             choices=[
                 Choice(
                     index=0,
                     message=ChatCompletionMessage(
                         role="assistant",
-                        content="Prompt too long.",
+                        content=content,
                     ),
-                    finish_reason="length",
+                    finish_reason="stop",
                 )
             ],
         )
     elif message_type == "completion":
         return Completion(
-            id="overlong-prompt",
+            id="bad_request",
             created=0,
-            model="",
+            model=model,
             object="text_completion",
             choices=[
                 CompletionChoice(
                     index=0,
-                    text="Prompt too long.",
-                    finish_reason="length",
+                    text=content,
+                    finish_reason="stop",
                 )
             ],
         )


### PR DESCRIPTION
## Description
We were having issues with the error handling in #402. We were using sglang and the error message is slightly different from vllm so this didn't catch our exception. 

I saw in the AGENTS.md that it should fail fast and fail loud but failing the whole evaluate call instead of the individual rollout seems excessive. Would it make sense to not throw an exception here and just cancel the rollout?

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->