### PR TITLE
Updated MultiTurnEnv to use the state during rollout

### DIFF
--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -33,12 +33,12 @@ class SimpleEnvironment(Environment):
             completion = [
                 {"role": "assistant", "content": response.choices[0].message.content}
             ]
-            state = {"responses": [response]}
+            state = {"completion": completion, "responses": [response]}
         else:
             assert isinstance(response, Completion)
             completion = response.choices[0].text
-            state = {}
-        return completion, state
+            state = {"completion": completion}
+        return state
 
 
 class TestEnvironmentBase:

--- a/tests/test_environment_extra.py
+++ b/tests/test_environment_extra.py
@@ -46,15 +46,17 @@ class DummyEnvironment(Environment):
                 {"role": "assistant", "content": response.choices[0].message.content}
             ]
             state = {
+                "completion": completion,
                 "responses": [response],
                 "timing": {"generation_ms": 0.0, "scoring_ms": 0.0, "total_ms": 0.0},
             }
         else:
             completion = response.choices[0].text
             state = {
-                "timing": {"generation_ms": 0.0, "scoring_ms": 0.0, "total_ms": 0.0}
+                "completion": completion,
+                "timing": {"generation_ms": 0.0, "scoring_ms": 0.0, "total_ms": 0.0},
             }
-        return completion, state
+        return state
 
 
 def _make_env(

--- a/tests/test_multiturn_env.py
+++ b/tests/test_multiturn_env.py
@@ -59,13 +59,13 @@ class TestMultiTurnEnv:
             response="Final response DONE",
         )
 
-        completion, state = await mock_multiturn_env.rollout(
+        state = await mock_multiturn_env.rollout(
             client=mock_multiturn_env.client,
             model="test-model",
             prompt=prompt,
             answer="target_answer",
         )
-
+        completion = state["completion"]
         # Should have: assistant + user + assistant + user + assistant
         assert len(completion) == 5
         assert completion[0]["role"] == "assistant"
@@ -79,7 +79,7 @@ class TestMultiTurnEnv:
         assert state["answer"] == "target_answer"
         assert state["prompt"] == prompt
         # state["completion"] is initialized to [] but not updated during rollout
-        assert state["completion"] == []
+        assert state["completion"] != []
         assert "responses" in state
         assert len(state["responses"]) == 3  # Three assistant responses
 
@@ -92,12 +92,13 @@ class TestMultiTurnEnv:
         )
 
         prompt = [{"role": "user", "content": "Start conversation"}]
-        completion, state = await mock_multiturn_env_max_turns.rollout(
+        state = await mock_multiturn_env_max_turns.rollout(
             client=mock_multiturn_env_max_turns.client,
             model="test-model",
             prompt=prompt,
             answer="target_answer",
         )
+        completion = state["completion"]
 
         # Should stop at max_turns=2: assistant + user + assistant (3 messages)
         assert len(completion) == 3
@@ -141,12 +142,13 @@ class TestMultiTurnEnv:
         mock_openai_client.set_default_responses(chat_response="Still thinking")
 
         prompt = [{"role": "user", "content": "Start"}]
-        completion, state = await env.rollout(
+        state = await env.rollout(
             client=mock_openai_client,
             model="test-model",
             prompt=prompt,
             answer="target",
         )
+        completion = state["completion"]
 
         assert state["turn"] == 2
         assert state.get("env_calls", 0) == 1
@@ -162,7 +164,7 @@ class TestMultiTurnEnv:
         )
 
         prompt = [{"role": "user", "content": "Test state"}]
-        completion, state = await mock_multiturn_env.rollout(
+        state = await mock_multiturn_env.rollout(
             client=mock_multiturn_env.client,
             model="test-model",
             prompt=prompt,
@@ -173,8 +175,7 @@ class TestMultiTurnEnv:
 
         # Check all state fields are initialized
         assert state["prompt"] == prompt
-        # state["completion"] is initialized to [] but not updated during rollout
-        assert state["completion"] == []
+        assert state["completion"] != []
         assert state["answer"] == "test_answer"
         assert state["task"] == "test_task"
         assert state["info"] == {"extra": "data"}
@@ -190,12 +191,13 @@ class TestMultiTurnEnv:
         )
 
         prompt = [{"role": "user", "content": "Quick question"}]
-        completion, state = await mock_multiturn_env.rollout(
+        state = await mock_multiturn_env.rollout(
             client=mock_multiturn_env.client,
             model="test-model",
             prompt=prompt,
             answer="target_answer",
         )
+        completion = state["completion"]
 
         # Should complete immediately
         assert len(completion) == 1
@@ -220,12 +222,13 @@ class TestMultiTurnEnv:
         )
 
         prompt = [{"role": "user", "content": "Start conversation"}]
-        completion, state = await mock_multiturn_env.rollout(
+        state = await mock_multiturn_env.rollout(
             client=mock_multiturn_env.client,
             model="test-model",
             prompt=prompt,
             answer="target_answer",
         )
+        completion = state["completion"]
 
         # Verify environment responses are included
         assert len(completion) >= 3
@@ -243,14 +246,12 @@ class TestMultiTurnEnv:
             messages=[{"role": "user", "content": "Original message"}],
             response="Response DONE",
         )
-
-        completion, state = await mock_multiturn_env.rollout(
+        await mock_multiturn_env.rollout(
             client=mock_multiturn_env.client,
             model="test-model",
             prompt=original_prompt,
             answer="test_answer",
         )
-
         # Original prompt should be unchanged
         assert original_prompt == prompt_copy
 
@@ -265,7 +266,7 @@ class TestMultiTurnEnv:
         prompt = [{"role": "user", "content": "Test sampling"}]
         sampling_args = {"temperature": 0.8, "max_tokens": 50}
 
-        completion, state = await mock_multiturn_env.rollout(
+        await mock_multiturn_env.rollout(
             client=mock_multiturn_env.client,
             model="test-model",
             prompt=prompt,
@@ -309,9 +310,10 @@ class TestMultiTurnEnv:
         )
 
         prompt = "Start:"
-        completion, state = await env.rollout(
+        state = await env.rollout(
             client=mock_openai_client, model="test-model", prompt=prompt, answer="Done"
         )
+        completion = state["completion"]
 
         assert isinstance(completion, str)
         assert "First response" in completion
@@ -346,12 +348,13 @@ class TestMultiTurnEnv:
         env.client.set_default_responses(chat_response="Continue")  # type: ignore
 
         prompt = [{"role": "user", "content": "Start"}]
-        completion, state = await env.rollout(
+        state = await env.rollout(
             client=env.client,  # type: ignore
             model="test-model",
             prompt=prompt,  # type: ignore
             answer="test",  # type: ignore
         )
+        completion = state["completion"]
 
         # Should complete when turn_count reaches 2
         assert state["turn_count"] == 2
@@ -397,12 +400,13 @@ class TestMultiTurnEnv:
         )
 
         prompt = [{"role": "user", "content": "Start"}]
-        completion, state = await env.rollout(
+        state = await env.rollout(
             client=env.client,  # type: ignore
             model="test-model",
             prompt=prompt,  # type: ignore
             answer="test",  # type: ignore
         )
+        completion = state["completion"]
 
         # Should complete immediately after first assistant response
         assert len(completion) == 1
@@ -436,7 +440,7 @@ class TestMultiTurnEnv:
         )
 
         prompt = [{"role": "user", "content": "Start"}]
-        completion, state = await mock_multiturn_env.rollout(
+        state = await mock_multiturn_env.rollout(
             client=mock_multiturn_env.client,
             model="test-model",
             prompt=prompt,

--- a/tests/test_singleturn_env.py
+++ b/tests/test_singleturn_env.py
@@ -80,12 +80,13 @@ class TestSingleTurnEnv:
         prompt = [{"role": "user", "content": "What is 2+2?"}]
         answer = "4"
 
-        completion, state = await mock_singleturn_env.rollout(
+        state = await mock_singleturn_env.rollout(
             client=mock_singleturn_env.client,
             model="test-model",
             prompt=prompt,
             answer=answer,
         )
+        completion = state["completion"]
 
         # Should return list format for chat
         assert isinstance(completion, list)
@@ -107,12 +108,13 @@ class TestSingleTurnEnv:
         prompt = "Calculate 2+2:"
         answer = "4"
 
-        completion, state = await mock_singleturn_env_completion.rollout(
+        state = await mock_singleturn_env_completion.rollout(
             client=mock_singleturn_env_completion.client,
             model="test-model",
             prompt=prompt,
             answer=answer,
         )
+        completion = state["completion"]
 
         # Should return string format for completion
         assert isinstance(completion, str)
@@ -132,13 +134,14 @@ class TestSingleTurnEnv:
         answer = "Hi"
         sampling_args = {"temperature": 0.8, "max_tokens": 100}
 
-        completion, state = await mock_singleturn_env.rollout(
+        state = await mock_singleturn_env.rollout(
             client=mock_singleturn_env.client,
             model="test-model",
             prompt=prompt,
             answer=answer,
             sampling_args=sampling_args,
         )
+        completion = state["completion"]
 
         assert isinstance(completion, list)
         assert completion[0]["content"] == "This is a test response"
@@ -156,7 +159,7 @@ class TestSingleTurnEnv:
         task = "math"
         info = {"difficulty": "easy"}
 
-        completion, state = await mock_singleturn_env.rollout(
+        state = await mock_singleturn_env.rollout(
             client=mock_singleturn_env.client,
             model="test-model",
             prompt=prompt,
@@ -164,6 +167,7 @@ class TestSingleTurnEnv:
             task=task,
             info=info,
         )
+        completion = state["completion"]
 
         assert isinstance(completion, list)
         # Check state contains all the information
@@ -198,7 +202,7 @@ class TestSingleTurnEnv:
         task = "greeting"
         info = {"context": "test"}
 
-        completion, state = await mock_singleturn_env.rollout(
+        state = await mock_singleturn_env.rollout(
             client=mock_singleturn_env.client,
             model="test-model",
             prompt=prompt,
@@ -209,8 +213,7 @@ class TestSingleTurnEnv:
 
         # Check all expected state fields
         assert state["prompt"] == prompt
-        # state["completion"] is initialized to [] but not updated during rollout
-        assert state["completion"] == []
+        assert state["completion"] != []
         assert state["answer"] == answer
         assert state["task"] == task
         assert state["info"] == info
@@ -336,21 +339,23 @@ class TestSingleTurnEnv:
         )
 
         # Test chat rollout
-        chat_completion, chat_state = await chat_env.rollout(
+        chat_state = await chat_env.rollout(
             client=mock_openai_client,
             model="test-model",
             prompt=[{"role": "user", "content": "Hello"}],
             answer="Hi",
         )
+        chat_completion = chat_state["completion"]
         assert isinstance(chat_completion, list)
 
         # Test completion rollout
-        completion_result, comp_state = await completion_env.rollout(
+        comp_state = await completion_env.rollout(
             client=mock_openai_client,
             model="test-model",
             prompt="Complete this:",
             answer="Done",
         )
+        completion_result = comp_state["completion"]
         assert isinstance(completion_result, str)
 
     @pytest.mark.asyncio

--- a/tests/test_stateful_tool_env.py
+++ b/tests/test_stateful_tool_env.py
@@ -51,12 +51,13 @@ class TestStatefulToolEnv:
             response="Done",
         )
 
-        completion, state = await mock_stateful_tool_env.rollout(
+        state = await mock_stateful_tool_env.rollout(
             client=mock_openai_client,
             model="test-model",
             prompt=[user_message],
             answer="",
         )
+        completion = state["completion"]
 
         tool_messages = [m for m in completion if m.get("role") == "tool"]
         assert tool_messages and tool_messages[0]["content"] == "8"

--- a/tests/test_tool_env.py
+++ b/tests/test_tool_env.py
@@ -46,12 +46,13 @@ class TestToolEnv:
             response="Done",
         )
 
-        completion, state = await mock_tool_env.rollout(
+        state = await mock_tool_env.rollout(
             client=mock_openai_client,
             model="test-model",
             prompt=[user_message],
             answer="",
         )
+        completion = state["completion"]
 
         tool_messages = [m for m in completion if m.get("role") == "tool"]
         assert tool_messages and tool_messages[0]["content"] == "16"
@@ -66,12 +67,13 @@ class TestToolEnv:
             response="Hi",
         )
 
-        completion, state = await mock_tool_env.rollout(
+        state = await mock_tool_env.rollout(
             client=mock_openai_client,
             model="test-model",
             prompt=[{"role": "user", "content": "Hello"}],
             answer="",
         )
+        completion = state["completion"]
 
         assert len(state["responses"]) == 1
         assert completion[-1]["role"] == "assistant"
@@ -100,12 +102,13 @@ class TestToolEnv:
             tool_calls=[tool_call],
         )
 
-        completion, _ = await env.rollout(
+        state = await env.rollout(
             client=mock_openai_client,
             model="test-model",
             prompt=[{"role": "user", "content": "Invoke"}],
             answer="",
         )
+        completion = state["completion"]
 
         tool_messages = [m for m in completion if m.get("role") == "tool"]
         assert tool_messages and "failure" in tool_messages[0]["content"]

--- a/verifiers/envs/env_group.py
+++ b/verifiers/envs/env_group.py
@@ -158,7 +158,7 @@ class EnvGroup(Environment):
         info: Info | None = None,
         sampling_args: SamplingArgs | None = None,
         **kwargs,
-    ) -> tuple[str | list[ChatMessage], State]:
+    ) -> State:
         """
         Route rollout to the appropriate sub-environment based on task.
 

--- a/verifiers/envs/multiturn_env.py
+++ b/verifiers/envs/multiturn_env.py
@@ -59,7 +59,7 @@ class MultiTurnEnv(Environment):
         info: Info | None = None,
         sampling_args: SamplingArgs | None = None,
         **kwargs,
-    ) -> tuple[Messages, State]:
+    ) -> State:
         """
         Generate a multi-turn rollout with the environment (messages, state).
         """
@@ -165,4 +165,5 @@ class MultiTurnEnv(Environment):
                     assert isinstance(completion, str)
                     rollout += env_msgs
                     completion += env_msgs
-        return completion, state
+            state["completion"] = completion
+        return state


### PR DESCRIPTION
## Description
Update the MultiTurnEnv to use the state during rollout. This should allow people to modify the prompt as needed during the rollout. 

Specifically for my use case, I need to update the prompt during setup_state.

@willccbb 
Does it make sense to move rollout, completions, and anything else I'm missing into state? 

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->