### PR TITLE
Multi-turn chat template tokenization fix

### DIFF
--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -905,14 +905,20 @@ class Environment(ABC):
                 while j < len(zipped) and zipped[j][0]["role"] != "assistant":
                     consecutive_messages.append(zipped[j][0])
                     j += 1
+                
+                # Tokenize conversation ending at last completed assistant response
                 token_prefix: list[int] = processing_class.apply_chat_template(
-                    conversation=messages_consumed  # type: ignore
+                    conversation=messages_consumed,
+                    add_generation_prompt=False,
                 )
-                token_prefix_with_turn: list[int] = (
-                    processing_class.apply_chat_template(
-                        conversation=messages_consumed + consecutive_messages,  # type: ignore
-                    )
+
+                # Tokenize with new user/tool messages and assistant prompt for next generation
+                # Must include add_generation_prompt=True to match what vLLM sees
+                token_prefix_with_turn: list[int] = processing_class.apply_chat_template(
+                    conversation=messages_consumed + consecutive_messages,
+                    add_generation_prompt=True,
                 )
+                
                 assert token_prefix_with_turn[: len(token_prefix)] == token_prefix, (
                     f"Token prefix mismatch. Token prefix: {token_prefix}, token prefix with turn: {token_prefix_with_turn}"
                 )

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -283,9 +283,9 @@ class Environment(ABC):
             if isinstance(e, BadRequestError):
                 error_text = e.response.text.lower()
                 context_length_phrases = [
-                    "This model\'s maximum context length is",
-                    "is longer than the model\'s context length",
-                    "exceeds the model\'s context length"
+                    "This model's maximum context length is",
+                    "is longer than the model's context length",
+                    "exceeds the model's context length",
                 ]
                 if any(phrase in error_text for phrase in context_length_phrases):
                     self.logger.debug("Caught overlong prompt.")
@@ -905,7 +905,7 @@ class Environment(ABC):
                 while j < len(zipped) and zipped[j][0]["role"] != "assistant":
                     consecutive_messages.append(zipped[j][0])
                     j += 1
-                
+
                 # Tokenize conversation ending at last completed assistant response
                 token_prefix: list[int] = processing_class.apply_chat_template(
                     conversation=messages_consumed,
@@ -914,11 +914,13 @@ class Environment(ABC):
 
                 # Tokenize with new user/tool messages and assistant prompt for next generation
                 # Must include add_generation_prompt=True to match what vLLM sees
-                token_prefix_with_turn: list[int] = processing_class.apply_chat_template(
-                    conversation=messages_consumed + consecutive_messages,
-                    add_generation_prompt=True,
+                token_prefix_with_turn: list[int] = (
+                    processing_class.apply_chat_template(
+                        conversation=messages_consumed + consecutive_messages,
+                        add_generation_prompt=True,
+                    )
                 )
-                
+
                 assert token_prefix_with_turn[: len(token_prefix)] == token_prefix, (
                     f"Token prefix mismatch. Token prefix: {token_prefix}, token prefix with turn: {token_prefix_with_turn}"
                 )


### PR DESCRIPTION
# THE BUG

**TURN 1 - Initial prompt (already correct):**
```
USER: What is the capital of France?
ASSISTANT:
```
Stops here ▲ (`add_generation_prompt=True`)

vLLM generates: "Paris"

Tokens stored:
```
USER: What is the capital of France?
ASSISTANT: Paris
```

---

**TURN 2 BEFORE FIX:**

token_prefix (line 236):
```
USER: What is the capital of France?
ASSISTANT: Paris
```
Stops here ▲ (`add_generation_prompt` not specified - defaults to False, which is correct here)

token_prefix_with_turn (line 240):
```
USER: What is the capital of France?
ASSISTANT: Paris
USER: What is the capital of Spain?
```
Stops here ▲ (`add_generation_prompt` not specified - defaults to False, which is WRONG here)

vLLM generates: "Madrid"

Tokens stored (cumulative):
```
USER: What is the capital of France?
ASSISTANT: Paris
USER: What is the capital of Spain?
Madrid
```
✗ "Madrid" appears without ASSISTANT: prefix

---

# THE FIX

**TURN 2 AFTER FIX:**

token_prefix (line 236):
```
USER: What is the capital of France?
ASSISTANT: Paris
```
Stops here ▲ (`add_generation_prompt=False` - _explicitly_ correct)

token_prefix_with_turn (line 240):
```
USER: What is the capital of France?
ASSISTANT: Paris
USER: What is the capital of Spain?
ASSISTANT:
```
Stops here ▲ (`add_generation_prompt=True` - NOW CORRECT)

vLLM generates: "Madrid"

Tokens stored (cumulative):
```
USER: What is the capital of France?
ASSISTANT: Paris
USER: What is the capital of Spain?
ASSISTANT: Madrid
```
✓ "Madrid" has ASSISTANT: prefix

---

# THE OUTCOME

<img width="259" height="194" alt="image" src="https://github.com/user-attachments/assets/7b750b79-2149-4e2d-b40a-69154cf01ba7" />