### PR TITLE
Add support for re-scoring evaluations

### DIFF
--- a/docs/source/environments.md
+++ b/docs/source/environments.md
@@ -99,6 +99,16 @@ Use the CLI to quickly test:
 vf-eval my-math-env -m gpt-4.1-mini -n 5 # runs a small batch of rollouts; use -h to see options
 ```
 
+A common workflow is to run an evaluation once, save the results (`-s`), and then iterate on your rubric. You can re-score the saved rollouts using the `--rerun-scoring-from` flag, passing the unique ID of the run.
+
+```bash
+# First, run and save the results
+vf-eval my-math-env -m gpt-4.1-mini -n 5 -s
+
+# Then, after modifying your rubric, re-score the same rollouts
+vf-eval my-math-env --rerun-scoring-from -m gpt-4.1-mini <RUN_ID_FROM_PREVIOUS_STEP>
+```
+
 Or test programmatically:
 
 ```python

--- a/docs/source/overview.md
+++ b/docs/source/overview.md
@@ -228,6 +228,13 @@ vf-install my-environment-module # from ./environments/my_environment_module
 vf-eval my-environment-module -m gpt-5 -n 10 -r 5 -s 
 ```
 
+You can re-run the scoring on a previously saved evaluation (`-s` flag), which is useful for debugging a rubric without re-running expensive model inferences.
+
+```bash
+# Re-score a previous run using its unique ID.
+vf-eval my-environment-module -m gpt-5 --rerun-scoring-from <RUN_ID> -s
+```
+
 We also provide a TUI for browsing locally-cached (with `-s`) eval results:
 ```bash
 vf-tui 

--- a/tests/test_eval_cli.py
+++ b/tests/test_eval_cli.py
@@ -70,6 +70,7 @@ def test_cli_sampling_args_precedence_over_flags(monkeypatch):
         save_dataset=False,
         save_to_hf_hub=False,
         hf_hub_dataset_name="",
+        rerun_scoring_from=None,
     )
 
     sa = captured["sampling_args"]
@@ -118,6 +119,7 @@ def test_cli_sampling_args_fill_from_flags_when_missing(monkeypatch):
         save_dataset=False,
         save_to_hf_hub=False,
         hf_hub_dataset_name="",
+        rerun_scoring_from=None,
     )
 
     sa = captured["sampling_args"]


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

My attempt to implement #438. I ran into a few edge-cases I need to solve before this can be merged. 

I successfully tested the re-score workflow with the following envs: `gsm8k`, `wordle`, `simpleqa`, `continuation_quality` and `reverse_text`.

But found some edge-cases in these:

- `tool_test`: since the re-scoring logic doesn't deserialize the tool call objects from the original results, it fails to apply the rubrics;
- [acebench_agent_multistep](https://app.primeintellect.ai/dashboard/environments/ob1/acebench-agent-multistep): if i got this right, the re-scoring doesn't work here because this `MultiTurnEnv` relies on non-serializable state.

Any direction here would be very much appreciated.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes
- [x] Relevant tests have been updated.

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published **[not relevant]**

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->