### PR TITLE
Fix tests for refactored evaluation pipeline

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -210,6 +210,7 @@ def sample_chat_dataset():
                 [{"role": "user", "content": "What is the capital of France?"}],
             ],
             "answer": ["4", "Paris"],
+            "id": [0, 1],
         }
     )
 

--- a/tests/test_env_group.py
+++ b/tests/test_env_group.py
@@ -346,6 +346,7 @@ class TestEnvGroup:
             ],
             "answer": ["math_answer", "code_answer"],
             "task": ["math", "code"],
+            "id": [0, 1],
         }
 
         results = await env_group.a_generate(

--- a/tests/test_environment_extra.py
+++ b/tests/test_environment_extra.py
@@ -12,6 +12,7 @@ Covers:
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 from typing import List
 
 import pytest
@@ -20,7 +21,15 @@ from datasets import Dataset
 from verifiers.envs.environment import Environment
 from verifiers.parsers.parser import Parser
 from verifiers.rubrics.rubric import Rubric
-from verifiers.types import GenerateOutputs, Info, Messages, SamplingArgs
+from verifiers.types import (
+    GenerateMetadata,
+    GenerateOutputs,
+    Info,
+    Messages,
+    SamplingArgs,
+    State,
+)
+from verifiers.utils.eval_utils import make_dataset as build_dataset
 from verifiers.utils.message_utils import sanitize_tool_calls
 
 
@@ -31,9 +40,12 @@ class DummyEnvironment(Environment):
         client,
         model,
         prompt: Messages,
+        completion: Messages | None = None,
         answer: str = "",
+        state: State | None = None,
         task: str = "default",
         info: Info | None = {},
+        id: int = 0,
         sampling_args: SamplingArgs | None = None,
         **kwargs,
     ):
@@ -41,20 +53,53 @@ class DummyEnvironment(Environment):
             prompt=prompt, client=client, model=model, sampling_args=sampling_args
         )
         assert response is not None
+        info = info or {}
+        if completion is None:
+            completion = await self.init_completion()
+        if state is None:
+            state = await self.init_state(
+                prompt=prompt,
+                completion=completion,
+                answer=answer,
+                task=task,
+                info=info,
+                id=id,
+            )
         if self.message_type == "chat":
-            completion = [
-                {"role": "assistant", "content": response.choices[0].message.content}
-            ]
-            state = {
-                "responses": [response],
-                "timing": {"generation_ms": 0.0, "scoring_ms": 0.0, "total_ms": 0.0},
+            assert isinstance(completion, list)
+            state.setdefault("responses", [])
+            state["responses"].append(response)
+            message = {
+                "role": "assistant",
+                "content": response.choices[0].message.content,
             }
+            completion.append(message)
+            state["completion"] = completion
         else:
-            completion = response.choices[0].text
-            state = {
-                "timing": {"generation_ms": 0.0, "scoring_ms": 0.0, "total_ms": 0.0}
-            }
+            assert isinstance(completion, str)
+            state.setdefault("responses", [])
+            state["responses"].append(response)
+            completion = completion + (response.choices[0].text or "")
+            state["completion"] = completion
         return completion, state
+
+
+def _make_metadata(num_examples: int, rollouts_per_example: int = 1) -> GenerateMetadata:
+    return GenerateMetadata(
+        env_id="dummy-env",
+        env_args={},
+        model="test-model",
+        base_url="http://localhost",
+        num_examples=num_examples,
+        rollouts_per_example=rollouts_per_example,
+        sampling_args={},
+        date="1970-01-01",
+        time_ms=0.0,
+        avg_reward=0.0,
+        avg_metrics={},
+        state_columns=[],
+        path_to_save=Path("test.jsonl"),
+    )
 
 
 def _make_env(
@@ -120,6 +165,7 @@ def test_run_rollouts_with_semaphore(mock_openai_client):
         tasks=["default"] * 3,
         infos=[{}] * 3,
         max_concurrent=2,
+        ids=list(range(len(prompts))),
     )
     results: List = asyncio.run(coro)
     assert len(results) == 3
@@ -175,13 +221,15 @@ def test_evaluate_fallback_and_repeat(mock_openai_client):
 
     ds = Dataset.from_dict({"question": ["q1", "q2"], "answer": ["a1", "a2"]})
     env = _make_env(mock_openai_client, dataset=ds)
-    res = env.evaluate(
-        client=mock_openai_client,
-        model="test-model",
-        num_examples=2,
-        rollouts_per_example=2,
-        score_rollouts=False,
-        interleave_scoring=False,
+    res = asyncio.run(
+        env.evaluate(
+            client=mock_openai_client,
+            model="test-model",
+            num_examples=2,
+            rollouts_per_example=2,
+            score_rollouts=False,
+            interleave_scoring=False,
+        )
     )
     # Expect n * r rollouts in outputs
     assert len(res.prompt) == 2 * 2
@@ -191,7 +239,11 @@ def test_evaluate_fallback_and_repeat(mock_openai_client):
 @pytest.mark.asyncio
 async def test_generate_inside_running_loop(mock_openai_client):
     env = _make_env(mock_openai_client)
-    inputs = {"prompt": [[{"role": "user", "content": "Hi"}]], "answer": [""]}
+    inputs = {
+        "prompt": [[{"role": "user", "content": "Hi"}]],
+        "answer": [""],
+        "id": [0],
+    }
     # Call the async API directly inside a running event loop to avoid nested sync wrapper issues
     out = await env.a_generate(
         inputs, client=mock_openai_client, model="test-model", interleave_scoring=False
@@ -228,13 +280,23 @@ def test_make_dataset_basic_without_tools(mock_openai_client):
         prompt=[[{"role": "user", "content": "Hi"}]],
         completion=[[{"role": "assistant", "content": "Hello"}]],
         answer=[""],
-        state=[{}],
+        state=[
+            {
+                "timing": {
+                    "generation_ms": 0.0,
+                    "scoring_ms": 0.0,
+                    "total_ms": 0.0,
+                }
+            }
+        ],
         info=[{}],
         task=["default"],
         reward=[1.0],
         metrics={"foo": [0.1]},
+        id=[0],
+        metadata=_make_metadata(num_examples=1),
     )
-    ds = env.make_dataset(results)
+    ds = build_dataset(results)
     assert len(ds) == 1 and "foo" in ds.column_names
 
 

--- a/tests/test_eval_cli.py
+++ b/tests/test_eval_cli.py
@@ -1,75 +1,109 @@
+import argparse
+from pathlib import Path
+from types import SimpleNamespace
+
 import verifiers.scripts.eval as vf_eval
+from verifiers.types import GenerateMetadata, GenerateOutputs
 
 
-def _make_fake_env(captured):
-    class FakeEnv:
-        def evaluate(
-            self,
-            client,
-            model,
-            sampling_args=None,
-            num_examples=-1,
-            rollouts_per_example=1,
-            **kwargs,
-        ):
-            captured["sampling_args"] = dict(sampling_args or {})
+def _make_metadata(config) -> GenerateMetadata:
+    return GenerateMetadata(
+        env_id=config.env_id,
+        env_args=config.env_args,
+        model=config.model,
+        base_url=config.client_config.api_base_url,
+        num_examples=config.num_examples,
+        rollouts_per_example=config.rollouts_per_example,
+        sampling_args=config.sampling_args,
+        date="1970-01-01",
+        time_ms=0.0,
+        avg_reward=0.0,
+        avg_metrics={},
+        state_columns=config.state_columns or [],
+        path_to_save=Path("test.jsonl"),
+    )
 
-            class Result:
-                prompt = ["p"]
-                completion = ["c"]
-                reward = [1.0]
-                info = [{}]
-                task = ["default"]
-                answer = [""]
-                metrics = {}
 
-            return Result()
+def _run_cli(monkeypatch, overrides):
+    base_args = {
+        "env_id": "dummy-env",
+        "env_args": {},
+        "env_dir_path": "./environments",
+        "endpoints_path": "./configs/endpoints.py",
+        "model": "gpt-4.1-mini",
+        "api_key_var": "OPENAI_API_KEY",
+        "api_base_url": "https://api.openai.com/v1",
+        "header": None,
+        "num_examples": 1,
+        "rollouts_per_example": 1,
+        "max_concurrent": 1,
+        "max_concurrent_generation": None,
+        "max_concurrent_scoring": None,
+        "max_tokens": 42,
+        "temperature": 0.9,
+        "sampling_args": None,
+        "verbose": False,
+        "print_results": False,
+        "no_interleave_scoring": False,
+        "state_columns": [],
+        "save_results": False,
+        "save_every": -1,
+        "save_to_hf_hub": False,
+        "hf_hub_dataset_name": "",
+    }
+    base_args.update(overrides)
+    args_namespace = SimpleNamespace(**base_args)
 
-    return FakeEnv()
+    captured: dict[str, dict] = {}
+
+    monkeypatch.setattr(
+        argparse.ArgumentParser,
+        "parse_args",
+        lambda self: args_namespace,
+    )
+    monkeypatch.setattr(vf_eval, "setup_logging", lambda *_, **__: None)
+    monkeypatch.setattr(vf_eval, "load_endpoints", lambda *_: {})
+
+    async def fake_run_evaluation(config):
+        captured["sampling_args"] = dict(config.sampling_args)
+        metadata = _make_metadata(config)
+        return GenerateOutputs(
+            prompt=[[{"role": "user", "content": "p"}]],
+            completion=[[{"role": "assistant", "content": "c"}]],
+            answer=[""],
+            state=[
+                {
+                    "timing": {
+                        "generation_ms": 0.0,
+                        "scoring_ms": 0.0,
+                        "total_ms": 0.0,
+                    }
+                }
+            ],
+            task=["default"],
+            info=[{}],
+            id=[0],
+            reward=[1.0],
+            metrics={},
+            metadata=metadata,
+        )
+
+    monkeypatch.setattr(vf_eval, "run_evaluation", fake_run_evaluation)
+
+    vf_eval.main()
+    return captured
 
 
 def test_cli_sampling_args_precedence_over_flags(monkeypatch):
-    captured = {}
-
-    # Patch environment loader to return our fake env
-    monkeypatch.setattr(
-        vf_eval.vf,
-        "load_environment",
-        lambda env_id, **env_args: _make_fake_env(captured),
-    )
-
-    # Patch OpenAI client used by the CLI to a simple dummy
-    class DummyOpenAI:
-        def __init__(self, api_key=None, base_url=None):
-            self.api_key = api_key
-            self.base_url = base_url
-
-    monkeypatch.setattr(vf_eval, "setup_client", lambda *args, **kwargs: DummyOpenAI())
-
-    # Run evaluation with JSON sampling args overriding flags
-    vf_eval.eval_environment(
-        env="dummy-env",
-        env_args={},
-        env_dir_path="./environments",
-        endpoints_path="./configs/endpoints.py",
-        model="gpt-4.1-mini",
-        api_key_var="OPENAI_API_KEY",
-        api_base_url="https://api.openai.com/v1",
-        extra_headers={},
-        num_examples=1,
-        rollouts_per_example=1,
-        max_concurrent=1,
-        max_tokens=42,
-        temperature=0.9,
-        sampling_args={
-            "enable_thinking": False,
-            "max_tokens": 77,
-            "temperature": 0.1,
+    captured = _run_cli(
+        monkeypatch,
+        {
+            "sampling_args": {
+                "enable_thinking": False,
+                "max_tokens": 77,
+                "temperature": 0.1,
+            },
         },
-        verbose=False,
-        save_dataset=False,
-        save_to_hf_hub=False,
-        hf_hub_dataset_name="",
     )
 
     sa = captured["sampling_args"]
@@ -79,45 +113,13 @@ def test_cli_sampling_args_precedence_over_flags(monkeypatch):
 
 
 def test_cli_sampling_args_fill_from_flags_when_missing(monkeypatch):
-    captured = {}
-
-    # Patch environment loader to return our fake env
-    monkeypatch.setattr(
-        vf_eval.vf,
-        "load_environment",
-        lambda env_id, **env_args: _make_fake_env(captured),
-    )
-
-    # Patch OpenAI client used by the CLI to a simple dummy
-    class DummyOpenAI:
-        def __init__(self, api_key=None, base_url=None):
-            self.api_key = api_key
-            self.base_url = base_url
-
-    monkeypatch.setattr(vf_eval, "setup_client", lambda *args, **kwargs: DummyOpenAI())
-
-    # Run evaluation with JSON lacking max_tokens/temperature
-    vf_eval.eval_environment(
-        env="dummy-env",
-        env_args={},
-        env_dir_path="./environments",
-        endpoints_path="./configs/endpoints.py",
-        model="gpt-4.1-mini",
-        api_key_var="OPENAI_API_KEY",
-        api_base_url="https://api.openai.com/v1",
-        extra_headers={},
-        num_examples=1,
-        rollouts_per_example=1,
-        max_concurrent=1,
-        max_tokens=55,
-        temperature=0.8,
-        sampling_args={
-            "enable_thinking": True,
+    captured = _run_cli(
+        monkeypatch,
+        {
+            "sampling_args": {"enable_thinking": True},
+            "max_tokens": 55,
+            "temperature": 0.8,
         },
-        verbose=False,
-        save_dataset=False,
-        save_to_hf_hub=False,
-        hf_hub_dataset_name="",
     )
 
     sa = captured["sampling_args"]

--- a/tests/test_multiturn_env.py
+++ b/tests/test_multiturn_env.py
@@ -78,8 +78,7 @@ class TestMultiTurnEnv:
         # Check state structure
         assert state["answer"] == "target_answer"
         assert state["prompt"] == prompt
-        # state["completion"] is initialized to [] but not updated during rollout
-        assert state["completion"] == []
+        assert state["completion"] == completion
         assert "responses" in state
         assert len(state["responses"]) == 3  # Three assistant responses
 
@@ -173,8 +172,7 @@ class TestMultiTurnEnv:
 
         # Check all state fields are initialized
         assert state["prompt"] == prompt
-        # state["completion"] is initialized to [] but not updated during rollout
-        assert state["completion"] == []
+        assert state["completion"] == completion
         assert state["answer"] == "test_answer"
         assert state["task"] == "test_task"
         assert state["info"] == {"extra": "data"}

--- a/tests/test_rubric.py
+++ b/tests/test_rubric.py
@@ -185,8 +185,8 @@ class TestRubric:
             info={},
         )
 
-        # Should receive parser, prompt, answer, state, task, info (completion used directly)
-        assert result == 6
+        # Should receive parser, prompt, answer, state, task, info, id (completion used directly)
+        assert result == 7
 
     @pytest.mark.asyncio
     async def test_call_reward_func_error_handling(self):

--- a/tests/test_singleturn_env.py
+++ b/tests/test_singleturn_env.py
@@ -209,8 +209,7 @@ class TestSingleTurnEnv:
 
         # Check all expected state fields
         assert state["prompt"] == prompt
-        # state["completion"] is initialized to [] but not updated during rollout
-        assert state["completion"] == []
+        assert state["completion"] == completion
         assert state["answer"] == answer
         assert state["task"] == task
         assert state["info"] == info
@@ -227,6 +226,7 @@ class TestSingleTurnEnv:
                 [{"role": "user", "content": "What is 3+3?"}],
             ],
             "answer": ["4", "6"],
+            "id": [0, 1],
         }
 
         # Mock the rubric.score_rollouts method
@@ -273,7 +273,11 @@ class TestSingleTurnEnv:
     @pytest.mark.asyncio
     async def test_a_generate_no_scoring(self, mock_singleturn_env):
         """Test async generation without scoring rollouts."""
-        inputs = {"prompt": [[{"role": "user", "content": "Hello"}]], "answer": ["Hi"]}
+        inputs = {
+            "prompt": [[{"role": "user", "content": "Hello"}]],
+            "answer": ["Hi"],
+            "id": [0],
+        }
 
         results = await mock_singleturn_env.a_generate(
             inputs,
@@ -293,6 +297,7 @@ class TestSingleTurnEnv:
             "prompt": [[{"role": "user", "content": "Hello"}]],
             "answer": ["Hi"],
             "info": [{}],
+            "id": [0],
         }
 
         # Mock the rubric.score_rollouts method
@@ -300,7 +305,7 @@ class TestSingleTurnEnv:
             return_value=RolloutScores(reward=[1.0], metrics={})
         )
 
-        results = mock_singleturn_env.generate(
+        results = mock_singleturn_env.generate_sync(
             inputs,
             client=mock_singleturn_env.client,
             model="test-model",

--- a/verifiers/envs/env_group.py
+++ b/verifiers/envs/env_group.py
@@ -153,9 +153,12 @@ class EnvGroup(Environment):
         client: AsyncOpenAI,
         model: str,
         prompt: str | list[ChatMessage],
+        completion: str | list[ChatMessage] | None = None,
         answer: str = "",
+        state: State | None = None,
         task: str = "default",
         info: Info | None = None,
+        id: int = 0,
         sampling_args: SamplingArgs | None = None,
         **kwargs,
     ) -> tuple[str | list[ChatMessage], State]:
@@ -169,13 +172,25 @@ class EnvGroup(Environment):
         """
         info = info or {}
         sampling_args = sampling_args or {}
+        if state is None:
+            state = {}
 
         # Route to appropriate environment
         env = self.env_map[task]
 
         # Pass through all arguments
         return await env.rollout(
-            client, model, prompt, answer, task, info, sampling_args, **kwargs
+            client,
+            model,
+            prompt,
+            completion,
+            answer,
+            state,
+            task,
+            info,
+            id,
+            sampling_args,
+            **kwargs,
         )
 
     def get_env_for_task(self, task: str) -> Environment:

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -659,6 +659,7 @@ class Environment(ABC):
                 states=results.state,
                 tasks=results.task,
                 infos=results.info,
+                ids=results.id,
                 sampling_args=gen_sampling_args,
                 max_concurrent=gen_limit if gen_limit is not None else max_concurrent,
                 **kwargs,
@@ -673,6 +674,7 @@ class Environment(ABC):
                     states=results.state,
                     tasks=results.task,
                     infos=results.info,
+                    ids=results.id,
                     max_concurrent=score_limit
                     if score_limit is not None
                     else max_concurrent,

--- a/verifiers/rubrics/rubric_group.py
+++ b/verifiers/rubrics/rubric_group.py
@@ -99,7 +99,7 @@ class RubricGroup(Rubric):
                 states,
                 tasks,
                 infos,
-                max_concurrent,
+                max_concurrent=max_concurrent,
                 **kwargs,
             )
             # aggregate reward (element-wise sum across rubrics)


### PR DESCRIPTION
## Summary
- update environment and single/multi-turn env tests to work with new rollout state and id requirements
- refresh CLI tests to exercise the new eval entrypoint and capture merged sampling arguments
- fix EnvGroup and RubricGroup helper methods to pass new rollout identifiers and ensure completions propagate in Environment.generate

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68f2ff04d45c8326b28b9b8f06a3a609