### PR TITLE
Fix cleanup_message keyerror

### DIFF
--- a/tests/test_message_utils_audio.py
+++ b/tests/test_message_utils_audio.py
@@ -85,3 +85,20 @@ def test_cleanup_message_is_idempotent():
     once = cleanup_message(copy.deepcopy(msg))
     twice = cleanup_message(copy.deepcopy(once))
     assert twice == once
+
+
+def test_cleanup_message_image_url_without_text_field():
+    msg = {
+        "role": "user",
+        "content": [
+            {
+                "type": "image_url",
+                "image_url": {"url": "https://example.com/image.jpg"},
+            },
+        ],
+    }
+    cleaned = cleanup_message(copy.deepcopy(msg))
+    assert cleaned["role"] == "user"
+    assert len(cleaned["content"]) == 1
+    assert cleaned["content"][0]["type"] == "image_url"
+    assert "text" not in cleaned["content"][0]

--- a/verifiers/envs/multiturn_env.py
+++ b/verifiers/envs/multiturn_env.py
@@ -119,8 +119,14 @@ class MultiTurnEnv(Environment):
                     "role": "assistant",
                     "content": response_text,
                 }
-                if response.choices and response.choices[0].message and response.choices[0].message.tool_calls:
-                    response_message["tool_calls"] = response.choices[0].message.tool_calls #type:ignore
+                if (
+                    response.choices
+                    and response.choices[0].message
+                    and response.choices[0].message.tool_calls
+                ):
+                    response_message["tool_calls"] = response.choices[
+                        0
+                    ].message.tool_calls  # type:ignore
                 rollout.append(response_message)
                 completion.append(response_message)
             else:

--- a/verifiers/utils/message_utils.py
+++ b/verifiers/utils/message_utils.py
@@ -75,7 +75,7 @@ def cleanup_message(message: ChatMessage) -> ChatMessage:
                 and "type" in c_dict
                 and c_dict["type"] == "image_url"
             ):
-                new_c.pop("text")
+                new_c.pop("text", None)
                 new_message["content"].append(new_c)
             elif str(c_dict.get("type", "")).startswith("input_audio"):
                 # Ensure input_audio content blocks only have the required fields


### PR DESCRIPTION
## Description
In the cleanup_message function within message_utils, there's a bug where attempting to pop("text") from the dictionary without providing a default value can raise a KeyError if the "text" key is missing. To fix this, "text" is popped with a default value of None to ensure safe handling when the key is absent.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [x] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->