### PR TITLE
Fix cleanup_message keyerror

### DIFF
--- a/tests/test_message_utils_image.py
+++ b/tests/test_message_utils_image.py
@@ -1,0 +1,35 @@
+# tests/test_message_utils_image.py
+import copy
+
+from verifiers.utils.message_utils import cleanup_message
+
+
+def test_cleanup_message_image_url():
+    msg = {
+        "role": "user",
+        "content": [
+            {
+                "text": "t",
+                "type": "image_url",
+                "image_url": {"url": "https://example.com/image.jpg"},
+            },
+        ],
+    }
+    cleaned = cleanup_message(copy.deepcopy(msg))
+    assert cleaned["role"] == "user"
+    assert len(cleaned["content"]) == 1
+    assert cleaned["content"][0]["type"] == "image_url"
+    assert "text" not in cleaned["content"][0]
+
+
+def test_cleanup_message_no_pop():
+    msg = {
+        "role": "user",
+        "content": [
+            {
+                "type": "image_url",
+                "image_url": {"url": "https://example.com/image.jpg"},
+            },
+        ],
+    }
+    cleanup_message(copy.deepcopy(msg))

--- a/verifiers/utils/message_utils.py
+++ b/verifiers/utils/message_utils.py
@@ -71,9 +71,7 @@ def cleanup_message(message: ChatMessage) -> ChatMessage:
                 new_c.pop("image_url")
                 new_message["content"].append(new_c)
             elif (
-                "image_url" in c_dict
-                and "type" in c_dict
-                and c_dict["type"] == "image_url"
+                "text" in c_dict and "type" in c_dict and c_dict["type"] == "image_url"
             ):
                 new_c.pop("text")
                 new_message["content"].append(new_c)


### PR DESCRIPTION
## Description
The cleanup_message function checks a field incorrectly. It should be checking for "text" when the type is image_url. Right now, this always throws a KeyError. I fixed this to check for "text" correctly instead of "image_url".

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [x] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->