### PR TITLE
Small refactors to make using `eval_utils` easier

### DIFF
--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -136,11 +136,6 @@ async def run_evaluation(config: EvalConfig) -> GenerateOutputs:
         print_results(results)
     if config.save_results:
         save_results(results, config.save_to_hf_hub, config.hf_hub_dataset_name)
-        logger.info(f"Results saved to {results.metadata.path_to_save}")
-        if config.save_to_hf_hub:
-            logger.info(
-                f"Dataset saved to Hugging Face Hub: {config.hf_hub_dataset_name}"
-            )
     return results
 
 
@@ -165,13 +160,7 @@ def get_hf_hub_dataset_name(results: GenerateOutputs) -> str:
     return dataset_name
 
 
-def make_dataset(
-    results: GenerateOutputs,
-    push_to_hf_hub: bool = False,
-    hf_hub_dataset_name: str | None = None,
-    hf_hub_config_name: str | None = None,
-    **kwargs,
-) -> Dataset:
+def make_dataset(results: GenerateOutputs, **kwargs) -> Dataset:
     clean_prompts = [messages_to_printable(p) for p in results.prompt]
     clean_prompts = [sanitize_tool_calls(p) for p in clean_prompts]
     clean_completions = [messages_to_printable(c) for c in results.completion]
@@ -196,16 +185,7 @@ def make_dataset(
         v = results.metrics[k]
         results_dict[k] = v
 
-    dataset = Dataset.from_dict(results_dict)
-    if push_to_hf_hub:
-        dataset_name = hf_hub_dataset_name or get_hf_hub_dataset_name(results)
-        logger.info(f"Saving dataset to Hugging Face Hub: {dataset_name}")
-        if hf_hub_config_name is not None:
-            dataset.push_to_hub(dataset_name, hf_hub_config_name)
-        else:
-            dataset.push_to_hub(dataset_name)
-        logger.info(f"Dataset saved to Hugging Face Hub: {dataset_name}")
-    return dataset
+    return Dataset.from_dict(results_dict)
 
 
 @contextmanager
@@ -224,13 +204,36 @@ def save_results(
     results: GenerateOutputs,
     push_to_hf_hub: bool = False,
     hf_hub_dataset_name: str | None = None,
+    hf_hub_config_name: str | None = None,
 ):
     path_to_save = results.metadata.path_to_save
     path_to_save.parent.mkdir(parents=True, exist_ok=True)
-    dataset = make_dataset(results, push_to_hf_hub, hf_hub_dataset_name)
-    if save_results:
-        with quiet_datasets():
-            dataset.to_json(path_to_save / "results.jsonl")
-        metadata_dict = sanitize_metadata(results.metadata)
-        with open(path_to_save / "metadata.json", "w") as f:
-            json.dump(metadata_dict, f)
+    dataset = make_dataset(results)
+    metadata_dict = sanitize_metadata(results.metadata)
+    save_to_disk(dataset, metadata_dict, path_to_save)
+    logger.info(f"Results saved to {path_to_save}")
+    if push_to_hf_hub:
+        dataset_name = hf_hub_dataset_name or get_hf_hub_dataset_name(results)
+        push_to_hub(
+            dataset,
+            dataset_name,
+            hf_hub_config_name,
+        )
+        logger.info(f"Dataset saved to Hugging Face Hub: {dataset_name}")
+
+
+def save_to_disk(dataset: Dataset, metadata_dict: dict, path_to_save: Path):
+    path_to_save.parent.mkdir(parents=True, exist_ok=True)
+    with quiet_datasets():
+        dataset.to_json(path_to_save / "results.jsonl")
+    with open(path_to_save / "metadata.json", "w") as f:
+        json.dump(metadata_dict, f)
+
+
+def push_to_hub(
+    dataset: Dataset, dataset_name: str, config_name: str | None = None
+) -> None:
+    if config_name is not None:
+        dataset.push_to_hub(dataset_name, config_name)
+    else:
+        dataset.push_to_hub(dataset_name)

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -169,6 +169,7 @@ def make_dataset(
     results: GenerateOutputs,
     push_to_hf_hub: bool = False,
     hf_hub_dataset_name: str | None = None,
+    hf_hub_config_name: str | None = None,
     **kwargs,
 ) -> Dataset:
     clean_prompts = [messages_to_printable(p) for p in results.prompt]
@@ -199,7 +200,10 @@ def make_dataset(
     if push_to_hf_hub:
         dataset_name = hf_hub_dataset_name or get_hf_hub_dataset_name(results)
         logger.info(f"Saving dataset to Hugging Face Hub: {dataset_name}")
-        dataset.push_to_hub(dataset_name)
+        if hf_hub_config_name is not None:
+            dataset.push_to_hub(dataset_name, hf_hub_config_name)
+        else:
+            dataset.push_to_hub(dataset_name)
         logger.info(f"Dataset saved to Hugging Face Hub: {dataset_name}")
     return dataset
 

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -200,11 +200,18 @@ def quiet_datasets():
         enable_progress_bar()
 
 
+def save_to_disk(dataset: Dataset, metadata_dict: dict, path_to_save: Path):
+    path_to_save.parent.mkdir(parents=True, exist_ok=True)
+    with quiet_datasets():
+        dataset.to_json(path_to_save / "results.jsonl")
+    with open(path_to_save / "metadata.json", "w") as f:
+        json.dump(metadata_dict, f)
+
+
 def save_results(
     results: GenerateOutputs,
     push_to_hf_hub: bool = False,
     hf_hub_dataset_name: str | None = None,
-    hf_hub_config_name: str | None = None,
 ):
     path_to_save = results.metadata.path_to_save
     path_to_save.parent.mkdir(parents=True, exist_ok=True)
@@ -214,26 +221,5 @@ def save_results(
     logger.info(f"Results saved to {path_to_save}")
     if push_to_hf_hub:
         dataset_name = hf_hub_dataset_name or get_hf_hub_dataset_name(results)
-        push_to_hub(
-            dataset,
-            dataset_name,
-            hf_hub_config_name,
-        )
-        logger.info(f"Dataset saved to Hugging Face Hub: {dataset_name}")
-
-
-def save_to_disk(dataset: Dataset, metadata_dict: dict, path_to_save: Path):
-    path_to_save.parent.mkdir(parents=True, exist_ok=True)
-    with quiet_datasets():
-        dataset.to_json(path_to_save / "results.jsonl")
-    with open(path_to_save / "metadata.json", "w") as f:
-        json.dump(metadata_dict, f)
-
-
-def push_to_hub(
-    dataset: Dataset, dataset_name: str, config_name: str | None = None
-) -> None:
-    if config_name is not None:
-        dataset.push_to_hub(dataset_name, config_name)
-    else:
         dataset.push_to_hub(dataset_name)
+        logger.info(f"Dataset saved to Hugging Face Hub: {dataset_name}")


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Slightly restructures the exposed eval utils to make working with them in isolation easier:
- We move the push to hub functionality from `make_dataset` to `save_results` which is only used by `vf-eval`. `prime-rl` only uses `make_dataset` and has its own "push to hub"
- We extract `save_to_disk` from `save_results` such that `prime-rl` can use the same local saving behavior
- There seems to have been a weird `if save_results` in the `save_results` function which is a boolean check of a function which is always true. I removed that one.

Should be fully backwards compatible, i.e. no existing `vf-eval` behavior is changed.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->