### PR TITLE
Serialize info column

### DIFF
--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -188,7 +188,7 @@ def make_dataset(
         "total_ms": [s["timing"]["total_ms"] for s in results.state],
     }
     if save_info:
-        results_dict["info"] = results.info
+        results_dict["info"] = [json.dumps(info) for info in results.info]
     if save_answer:
         results_dict["answer"] = results.answer
     for k in results.metrics:


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

The `info` column may include fields that are not pyarrow serializable which makes the push to HF hub fail. One example is the eval results from `tau2-bench`. This PR JSON-serializes each element in the `info` column in `make_dataset` so that the HF Hub push works. 

This may have ramification for our platform if they use the info column?

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->