### PR TITLE
fix bug in overlong exception during get_model_response

### DIFF
--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -308,7 +308,7 @@ class Environment(ABC):
                     "exceeds the model's context length",
                 ]
                 if any(phrase in error_text for phrase in context_length_phrases):
-                    self.logger.warning("Caught overlong prompt.")
+                    self.logger.debug("Caught overlong prompt.")
                     return get_overlong_prompt_dummy_response(
                         message_type or self.message_type
                     )


### PR DESCRIPTION
## Description
My prime-rl runs kept crashing due to this error not being properly caught.

One line fix, we are calling `.lower()` on the exception but the canned phrase was capitalized.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes
Validated this now matches the exception:
```bash
# process one
uv run --with vllm vllm serve Qwen/Qwen2.5-0.5B-Instruct --max-model-len 512

# process two
vf-eval wordle -n 1 -m Qwen/Qwen2.5-0.5B-Instruct \
    --api-base-url http://localhost:8000/v1 \
    --sampling-args '{"max_tokens": 2000}' \
    -s
```