### PR TITLE
Fix environment.py generate function deepcopying state

### DIFF
--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -538,17 +538,7 @@ class Environment(ABC):
                 info["oai_tools"] = self.oai_tools
         if not results_dict.get("example_id"):
             results_dict["example_id"] = list(range(n))
-        results_dict["state"] = [
-            await self.init_state(
-                prompt=results_dict["prompt"][i],
-                completion=results_dict["completion"][i],
-                answer=results_dict["answer"][i],
-                task=results_dict["task"][i],
-                info=results_dict["info"][i],
-                example_id=results_dict["example_id"][i],
-            )
-            for i in range(n)
-        ]
+        results_dict["state"] = [{} for _ in range(n)]
 
         # prepare GenerateOutputs and run rollouts
         num_rollouts = len(results_dict)
@@ -585,7 +575,17 @@ class Environment(ABC):
             metrics={name: [0.0] * n for name in self.rubric.get_reward_func_names()},
             metadata=metadata,
         )
-
+        results.state = [
+            await self.init_state(
+                prompt=results.prompt[i],
+                completion=results.completion[i],
+                answer=results.answer[i],
+                task=results.task[i],
+                info=results.info[i],
+                example_id=results.example_id[i],
+            )
+            for i in range(n)
+        ]
         # resolve concurrency knobs
         gen_limit = max_concurrent_generation
         score_limit = max_concurrent_scoring


### PR DESCRIPTION
## Description
GenerateOuputs is doing a deepcopy so all the references inside state are no longer referencing the same object. I updated this to initialize state correctly after GenerateOuputs. 

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [x] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->