### PR TITLE
integrations/art_framework: add ART↔verifiers adapter 

### DIFF
--- a/environments/math/math.py
+++ b/environments/math/math.py
@@ -2,7 +2,7 @@ import verifiers as vf
 
 
 def load_environment(**kwargs) -> vf.Environment:
-    '''
+    """
     Loads a custom environment.
-    '''
+    """
     raise NotImplementedError("Implement your custom environment here.")

--- a/integrations/art_framework/README.md
+++ b/integrations/art_framework/README.md
@@ -1,0 +1,99 @@
+# art_framework
+
+### Overview
+- **Environment ID**: `art_framework`
+- **Source Implementation**: [Occupying-Mars/prime-environments](https://github.com/Occupying-Mars/prime-environments/tree/ART-verifier/environments/art_framework)
+- **Author**: [@OccupyingM](https://x.com/OccupyingM)
+- **Short description**: Universal adapter enabling bidirectional portability between ART (Autonomous Reasoning Tool) and verifiers ecosystems
+- **Tags**: `art`, `framework`, `portability`, `tool-use`, `adapter`, `multi-turn`
+
+### Purpose
+
+This environment provides a portability layer between [OpenPipe's ART framework](https://github.com/OpenPipe/ART) and the verifiers evaluation system. It enables:
+
+1. ART → verifiers: Load any ART task configuration and run it as a verifiers environment
+2. verifiers → ART: Export any verifiers ToolEnv to run with ART agents
+3. Shared tool definitions: Use the same tool schemas across both frameworks
+4. Unified evaluation: Compare agent performance using consistent rubrics
+
+### Key Features
+
+- Automatic tool conversion between ART and verifiers tool schemas
+- JSON schema validation and strict JSON output (no markdown fences)
+- Flexible evaluation: exact match or LLM judge scoring
+- Example configs and simple end-to-end test
+- Bidirectional export utilities
+
+### Quickstart
+
+Setup:
+```bash
+uv run vf-install art_framework
+
+# Set API key if using LLM judge
+export OPENAI_API_KEY=sk-your-key
+```
+
+Test:
+```bash
+cd environments/art_framework
+uv run python test_env.py
+```
+
+Evaluate:
+```bash
+uv run vf-eval -s art_framework -m gpt-4.1-mini -n 5 -r 3
+```
+
+### Environment Arguments
+
+| Arg | Type | Default | Description |
+| --- | ---- | ------- | ----------- |
+| `task_config_path` | str | `None` | Path to ART task config JSON file |
+| `task_config_dict` | dict | `None` | ART config as dictionary (alternative to file path) |
+| `dataset` | Dataset | `None` | Custom training dataset (uses examples if None) |
+| `eval_dataset` | Dataset | `None` | Custom evaluation dataset |
+| `max_turns` | int | `10` | Maximum interaction turns per episode |
+| `use_llm_judge` | bool | `False` | Whether to use LLM judge for evaluation |
+| `judge_model` | str | `"gpt-4.1-mini"` | Model for LLM judge |
+| `judge_client` | OpenAI | `None` | Custom OpenAI client (creates default if None) |
+| `judge_api_key_var` | str | `"OPENAI_API_KEY"` | Environment variable for judge API key |
+
+### ART Task Config Format
+
+```json
+{
+  "name": "task_name",
+  "tools": [
+    {
+      "name": "tool_name",
+      "description": "What it does",
+      "parameters": {"type": "object", "properties": {"x": {"type": "number"}}, "required": ["x"]},
+      "implementation": "lambda x: x"
+    }
+  ],
+  "completion_tool_name": "submit_answer",
+  "system_prompt": "System prompt"
+}
+```
+
+### Portability
+
+ART → verifiers:
+```bash
+uv run vf-eval -s art_framework -a '{"task_config_path": "art_task.json"}'
+```
+
+verifiers → ART:
+```python
+from art_framework.utils.verifiers_adapter import export_verifiers_env
+export_verifiers_env(my_env, "exported.json")
+```
+
+### Dependencies
+
+- verifiers>=0.1.3
+- datasets>=2.19
+- pydantic>=2.0.0
+- openai>=1.0.0 (optional, for LLM judge)
+

--- a/integrations/art_framework/art_framework.py
+++ b/integrations/art_framework/art_framework.py
@@ -1,0 +1,119 @@
+import json
+from typing import Any, Callable
+
+import verifiers as vf
+from datasets import Dataset
+
+from utils.art_adapter import (
+    art_config_to_tools,
+    build_dataset_from_art_config,
+    get_completion_tool_name,
+)
+from utils.verifiers_adapter import export_verifiers_env
+
+
+class ARTParser(vf.Parser):
+    def __init__(self, completion_tool_name: str):
+        super().__init__()
+        self.completion_tool_name = completion_tool_name
+
+    def parse_answer(self, completion: vf.Messages) -> str | None:
+        if not isinstance(completion, list):
+            return super().parse_answer(completion)
+        # find the last assistant tool-call with completion tool name
+        for msg in reversed(completion):
+            if msg.get("role") == "assistant" and msg.get("tool_calls"):
+                tool_calls = msg["tool_calls"] or []
+                for tc in tool_calls:
+                    try:
+                        # handle both typed and dict tool-calls
+                        if hasattr(tc, "function"):
+                            name = tc.function.name
+                            args_s = tc.function.arguments
+                        else:
+                            name = tc["function"]["name"]
+                            args_s = tc["function"]["arguments"]
+                        if name == self.completion_tool_name:
+                            args = json.loads(args_s)
+                            # answer field is any single value or "answer"
+                            if isinstance(args, dict):
+                                if "answer" in args:
+                                    return str(args["answer"])
+                                # fallback: stringified dict
+                                return json.dumps(args)
+                            return str(args)
+                    except Exception:
+                        continue
+        return None
+
+
+def load_environment(
+    task_config_path: str | None = None,
+    task_config_dict: dict | None = None,
+    dataset: Dataset | None = None,
+    eval_dataset: Dataset | None = None,
+    max_turns: int = 10,
+    use_llm_judge: bool = False,
+    judge_model: str = "gpt-4.1-mini",
+    judge_client: Any | None = None,
+    judge_api_key_var: str = "OPENAI_API_KEY",
+    **kwargs,
+) -> vf.Environment:
+    """Load ART framework adapter environment.
+
+    If no datasets are provided, builds tiny train/eval datasets from the task config examples.
+    """
+
+    if task_config_path is None and task_config_dict is None:
+        raise ValueError("Provide task_config_path or task_config_dict")
+    if task_config_dict is None:
+        with open(task_config_path, "r") as f:  # type: ignore[arg-type]
+            task_config_dict = json.load(f)
+
+    assert isinstance(task_config_dict, dict)
+    completion_tool_name = get_completion_tool_name(task_config_dict)
+    tools: list[Callable] = art_config_to_tools(task_config_dict)
+
+    # default datasets from config examples if not supplied
+    if dataset is None or eval_dataset is None:
+        ds_train, ds_eval = build_dataset_from_art_config(task_config_dict)
+        dataset = dataset or ds_train
+        eval_dataset = eval_dataset or ds_eval
+
+    parser = ARTParser(completion_tool_name=completion_tool_name)
+    if use_llm_judge:
+        rubric = vf.JudgeRubric(parser=parser, judge_model=judge_model, judge_client=judge_client)
+    else:
+        class ExactMatchRubric(vf.Rubric):
+            async def correct_answer(self, parser: vf.Parser, completion: vf.Messages, answer: str, **_: Any) -> float:
+                pred = parser.parse_answer(completion) or ""
+                return 1.0 if str(pred) == str(answer) and pred != "" else 0.0
+
+        rubric = ExactMatchRubric(parser=parser)
+        rubric.add_reward_func(rubric.correct_answer, weight=1.0)  # type: ignore
+
+    env = vf.ToolEnv(
+        dataset=dataset,
+        eval_dataset=eval_dataset,
+        parser=parser,
+        rubric=rubric,
+        tools=tools,
+        max_turns=max_turns,
+        env_id="art_framework",
+        env_args={
+            "task_config": task_config_dict,
+            "use_llm_judge": use_llm_judge,
+            "judge_model": judge_model,
+        },
+        **kwargs,
+    )
+    return env
+
+
+__all__ = [
+    "load_environment",
+    "ARTParser",
+    "export_verifiers_env",
+]
+
+

--- a/integrations/art_framework/art_framework.py
+++ b/integrations/art_framework/art_framework.py
@@ -82,10 +82,15 @@ def load_environment(
 
     parser = ARTParser(completion_tool_name=completion_tool_name)
     if use_llm_judge:
-        rubric = vf.JudgeRubric(parser=parser, judge_model=judge_model, judge_client=judge_client)
+        rubric = vf.JudgeRubric(
+            parser=parser, judge_model=judge_model, judge_client=judge_client
+        )
     else:
+
         class ExactMatchRubric(vf.Rubric):
-            async def correct_answer(self, parser: vf.Parser, completion: vf.Messages, answer: str, **_: Any) -> float:
+            async def correct_answer(
+                self, parser: vf.Parser, completion: vf.Messages, answer: str, **_: Any
+            ) -> float:
                 pred = parser.parse_answer(completion) or ""
                 return 1.0 if str(pred) == str(answer) and pred != "" else 0.0
 
@@ -115,5 +120,3 @@ __all__ = [
     "ARTParser",
     "export_verifiers_env",
 ]
-
-

--- a/integrations/art_framework/examples/calculator.json
+++ b/integrations/art_framework/examples/calculator.json
@@ -1,0 +1,36 @@
+{
+  "name": "calculator",
+  "system_prompt": "Use tools and return via submit_answer.",
+  "completion_tool_name": "submit_answer",
+  "tools": [
+    {
+      "name": "add",
+      "description": "Add two integers",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "a": {"type": "integer"},
+          "b": {"type": "integer"}
+        },
+        "required": ["a", "b"]
+      },
+      "implementation": "lambda a, b: a + b"
+    },
+    {
+      "name": "submit_answer",
+      "description": "Return final answer",
+      "parameters": {
+        "type": "object",
+        "properties": {"answer": {"type": "string"}},
+        "required": ["answer"]
+      },
+      "implementation": "lambda answer: answer"
+    }
+  ],
+  "examples": [
+    {"question": "Add 2 and 3", "answer": "5"},
+    {"question": "Add 7 and 3", "answer": "10"},
+    {"question": "Add 1 and 9", "answer": "10"},
+    {"question": "Add 4 and 4", "answer": "8"}
+  ]
+}

--- a/integrations/art_framework/pyproject.toml
+++ b/integrations/art_framework/pyproject.toml
@@ -1,0 +1,21 @@
+[project]
+name = "art-framework"
+description = "ART <-> verifiers adapter environment"
+tags = ["train", "eval"]
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+    "verifiers>=0.1.3",
+    "datasets>=2.19",
+    "pydantic>=2.0.0",
+    "openai>=1.0.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build]
+include = ["art_framework.py", "utils/*.py", "README.md", "test_env.py"]
+
+

--- a/integrations/art_framework/test_env.py
+++ b/integrations/art_framework/test_env.py
@@ -55,16 +55,27 @@ def test_art_tool_conversion_and_parser(tmp_path):
 
     # construct a fake completion that calls submit_answer
     completion = [
-        {"role": "assistant", "content": "", "tool_calls": [
-            {"id": "1", "type": "function", "function": {"name": "submit_answer", "arguments": json.dumps({"answer": "10"})}}
-        ]}
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "1",
+                    "type": "function",
+                    "function": {
+                        "name": "submit_answer",
+                        "arguments": json.dumps({"answer": "10"}),
+                    },
+                }
+            ],
+        }
     ]
     parsed = env.parser.parse_answer(completion)
     assert parsed == "10"
 
     # reward should be 1.0 for matching answer
     prompt = [{"role": "user", "content": "What is 7+3?"}]
-    rs = env.rubric.score_rollout_sync(prompt=prompt, completion=completion, answer="10", state={})  # type: ignore[attr-defined]
+    rs = env.rubric.score_rollout_sync(
+        prompt=prompt, completion=completion, answer="10", state={}
+    )  # type: ignore[attr-defined]
     assert rs.reward == 1.0
-
-

--- a/integrations/art_framework/test_env.py
+++ b/integrations/art_framework/test_env.py
@@ -1,0 +1,70 @@
+import json
+from pathlib import Path
+
+import verifiers as vf
+
+from .art_framework import load_environment
+
+
+def _write_tmp_config(tmp_path: Path) -> str:
+    cfg = {
+        "name": "calc",
+        "system_prompt": "Use tools and return via submit_answer.",
+        "completion_tool_name": "submit_answer",
+        "tools": [
+            {
+                "name": "add",
+                "description": "Add two integers",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"a": {"type": "integer"}, "b": {"type": "integer"}},
+                    "required": ["a", "b"],
+                },
+                "implementation": "lambda a, b: a + b",
+            },
+            {
+                "name": "submit_answer",
+                "description": "Return final answer",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"answer": {"type": "string"}},
+                    "required": ["answer"],
+                },
+                "implementation": "lambda answer: answer",
+            },
+        ],
+        "examples": [
+            {"question": "Add 2 and 3", "answer": "5"},
+            {"question": "Add 7 and 3", "answer": "10"},
+            {"question": "Add 1 and 9", "answer": "10"},
+            {"question": "Add 4 and 4", "answer": "8"},
+        ],
+    }
+    p = tmp_path / "art_task.json"
+    p.write_text(json.dumps(cfg))
+    return str(p)
+
+
+def test_art_tool_conversion_and_parser(tmp_path):
+    cfg_path = _write_tmp_config(tmp_path)
+    env = load_environment(task_config_path=cfg_path, max_turns=2)
+    assert isinstance(env, vf.ToolEnv)
+    # smoke test: ensure tools exist and parser extracts from completion tool
+    tool_names = [t.__name__ for t in env.tools]  # type: ignore
+    assert "add" in tool_names and "submit_answer" in tool_names
+
+    # construct a fake completion that calls submit_answer
+    completion = [
+        {"role": "assistant", "content": "", "tool_calls": [
+            {"id": "1", "type": "function", "function": {"name": "submit_answer", "arguments": json.dumps({"answer": "10"})}}
+        ]}
+    ]
+    parsed = env.parser.parse_answer(completion)
+    assert parsed == "10"
+
+    # reward should be 1.0 for matching answer
+    prompt = [{"role": "user", "content": "What is 7+3?"}]
+    rs = env.rubric.score_rollout_sync(prompt=prompt, completion=completion, answer="10", state={})  # type: ignore[attr-defined]
+    assert rs.reward == 1.0
+
+

--- a/integrations/art_framework/utils/art_adapter.py
+++ b/integrations/art_framework/utils/art_adapter.py
@@ -1,0 +1,110 @@
+import json
+from typing import Any, Callable, Tuple
+
+from datasets import Dataset
+
+
+def _compile_lambda(src: str) -> Callable:
+    # Very small, controlled lambda support for examples; fail fast otherwise
+    src = src.strip()
+    if not (src.startswith("lambda ") and (":" in src)):
+        raise ValueError("Only simple lambda implementations are supported in examples")
+    return eval(src, {"__builtins__": {}})
+
+
+def art_tool_to_callable(tool_spec: dict) -> Callable:
+    name = tool_spec.get("name")
+    description = tool_spec.get("description", "")
+    parameters = tool_spec.get("parameters", {"type": "object", "properties": {}})
+    implementation = tool_spec.get("implementation")
+
+    if implementation is None:
+        raise ValueError(f"Tool {name} missing implementation")
+
+    impl = implementation
+    if isinstance(implementation, str):
+        impl = _compile_lambda(implementation)
+
+    # Build a strongly-typed function with explicit parameters (no **kwargs)
+    props: dict = parameters.get("properties", {}) if isinstance(parameters, dict) else {}
+    required: list[str] = parameters.get("required", []) if isinstance(parameters, dict) else []
+
+    def _map_type(t: str) -> str:
+        return {
+            "string": "str",
+            "integer": "int",
+            "number": "float",
+            "boolean": "bool",
+            "array": "list",
+            "object": "dict",
+        }.get(t, "Any")
+
+    # Order params: required first, then optional (default=None)
+    ordered_keys = [k for k in required if k in props] + [k for k in props.keys() if k not in required]
+    annot_params: list[str] = []
+    call_kwargs: list[str] = []
+    for key in ordered_keys:
+        spec = props.get(key, {}) or {}
+        tname = _map_type(str(spec.get("type", "Any")))
+        if key in required:
+            annot_params.append(f"{key}: {tname}")
+        else:
+            annot_params.append(f"{key}: {tname} | None = None")
+        call_kwargs.append(f"{key}={key}")
+
+    params_sig = ", ".join(annot_params)
+    call_sig = ", ".join(call_kwargs)
+    fn_src = f"def {name}({params_sig}):\n    return __impl({call_sig})\n"
+    ns: dict[str, Any] = {"__impl": impl, "Any": Any}
+    exec(fn_src, ns)
+    typed_fn = ns[name]
+    typed_fn.__name__ = name
+    typed_fn.__doc__ = description
+    setattr(typed_fn, "__art_schema__", {
+        "name": name,
+        "description": description,
+        "parameters": parameters,
+    })
+    return typed_fn
+
+
+def art_config_to_tools(config: dict) -> list[Callable]:
+    tools = config.get("tools", [])
+    return [art_tool_to_callable(t) for t in tools]
+
+
+def get_completion_tool_name(config: dict) -> str:
+    name = config.get("completion_tool_name")
+    if not isinstance(name, str) or not name:
+        raise ValueError("completion_tool_name must be a non-empty string")
+    return name
+
+
+def build_dataset_from_art_config(config: dict) -> Tuple[Dataset, Dataset]:
+    # Minimal examples: if provided under config["examples"], split 2/2 else create trivial
+    examples = config.get("examples") or []
+    if not examples:
+        # trivial calculator example
+        examples = [
+            {"question": "Add 2 and 3", "answer": "5"},
+            {"question": "Add 10 and 1", "answer": "11"},
+            {"question": "Add 4 and 4", "answer": "8"},
+            {"question": "Add 7 and 3", "answer": "10"},
+        ]
+    # ensure fields
+    rows = []
+    sys_prompt = config.get("system_prompt") or "Use tools to solve the task."
+    for ex in examples:
+        question = ex.get("question") or ex.get("prompt") or ""
+        answer = str(ex.get("answer", ""))
+        rows.append({
+            "prompt": [{"role": "system", "content": sys_prompt}, {"role": "user", "content": question}],
+            "answer": answer,
+        })
+    # split 2 train / 2 eval by default
+    split = max(1, min(2, len(rows)//2))
+    train_rows = rows[:split]
+    eval_rows = rows[split:split*2] or rows[:split]
+    return Dataset.from_list(train_rows), Dataset.from_list(eval_rows)
+
+

--- a/integrations/art_framework/utils/art_adapter.py
+++ b/integrations/art_framework/utils/art_adapter.py
@@ -1,4 +1,3 @@
-import json
 from typing import Any, Callable, Tuple
 
 from datasets import Dataset
@@ -26,8 +25,12 @@ def art_tool_to_callable(tool_spec: dict) -> Callable:
         impl = _compile_lambda(implementation)
 
     # Build a strongly-typed function with explicit parameters (no **kwargs)
-    props: dict = parameters.get("properties", {}) if isinstance(parameters, dict) else {}
-    required: list[str] = parameters.get("required", []) if isinstance(parameters, dict) else []
+    props: dict = (
+        parameters.get("properties", {}) if isinstance(parameters, dict) else {}
+    )
+    required: list[str] = (
+        parameters.get("required", []) if isinstance(parameters, dict) else []
+    )
 
     def _map_type(t: str) -> str:
         return {
@@ -40,7 +43,9 @@ def art_tool_to_callable(tool_spec: dict) -> Callable:
         }.get(t, "Any")
 
     # Order params: required first, then optional (default=None)
-    ordered_keys = [k for k in required if k in props] + [k for k in props.keys() if k not in required]
+    ordered_keys = [k for k in required if k in props] + [
+        k for k in props.keys() if k not in required
+    ]
     annot_params: list[str] = []
     call_kwargs: list[str] = []
     for key in ordered_keys:
@@ -60,11 +65,15 @@ def art_tool_to_callable(tool_spec: dict) -> Callable:
     typed_fn = ns[name]
     typed_fn.__name__ = name
     typed_fn.__doc__ = description
-    setattr(typed_fn, "__art_schema__", {
-        "name": name,
-        "description": description,
-        "parameters": parameters,
-    })
+    setattr(
+        typed_fn,
+        "__art_schema__",
+        {
+            "name": name,
+            "description": description,
+            "parameters": parameters,
+        },
+    )
     return typed_fn
 
 
@@ -97,14 +106,17 @@ def build_dataset_from_art_config(config: dict) -> Tuple[Dataset, Dataset]:
     for ex in examples:
         question = ex.get("question") or ex.get("prompt") or ""
         answer = str(ex.get("answer", ""))
-        rows.append({
-            "prompt": [{"role": "system", "content": sys_prompt}, {"role": "user", "content": question}],
-            "answer": answer,
-        })
+        rows.append(
+            {
+                "prompt": [
+                    {"role": "system", "content": sys_prompt},
+                    {"role": "user", "content": question},
+                ],
+                "answer": answer,
+            }
+        )
     # split 2 train / 2 eval by default
-    split = max(1, min(2, len(rows)//2))
+    split = max(1, min(2, len(rows) // 2))
     train_rows = rows[:split]
-    eval_rows = rows[split:split*2] or rows[:split]
+    eval_rows = rows[split : split * 2] or rows[:split]
     return Dataset.from_list(train_rows), Dataset.from_list(eval_rows)
-
-

--- a/integrations/art_framework/utils/verifiers_adapter.py
+++ b/integrations/art_framework/utils/verifiers_adapter.py
@@ -1,0 +1,39 @@
+import json
+from typing import Any
+
+
+def export_verifiers_env(env: Any, path: str) -> None:
+    """Export a verifiers ToolEnv as an ART-compatible JSON config.
+
+    Notes:
+    - Only exports tool names/descriptions/parameters when available.
+    - Implementations are not serialized; ART side should plug in real code.
+    """
+    # tools
+    tools = []
+    for tool in getattr(env, "tools", []) or []:
+        schema = getattr(tool, "__art_schema__", None)
+        if schema is None:
+            # best-effort: name + empty schema
+            schema = {
+                "name": getattr(tool, "__name__", "tool"),
+                "description": getattr(tool, "__doc__", "") or "",
+                "parameters": {"type": "object", "properties": {}},
+            }
+        tools.append({
+            "name": schema.get("name"),
+            "description": schema.get("description", ""),
+            "parameters": schema.get("parameters", {"type": "object", "properties": {}}),
+            "implementation": None,
+        })
+
+    config = {
+        "name": getattr(env, "env_id", "verifiers_env"),
+        "tools": tools,
+        "completion_tool_name": "submit_answer",
+        "system_prompt": getattr(env, "system_prompt", None) or "Use tools to solve the task.",
+    }
+    with open(path, "w") as f:
+        json.dump(config, f, indent=2)
+
+

--- a/integrations/art_framework/utils/verifiers_adapter.py
+++ b/integrations/art_framework/utils/verifiers_adapter.py
@@ -20,20 +20,23 @@ def export_verifiers_env(env: Any, path: str) -> None:
                 "description": getattr(tool, "__doc__", "") or "",
                 "parameters": {"type": "object", "properties": {}},
             }
-        tools.append({
-            "name": schema.get("name"),
-            "description": schema.get("description", ""),
-            "parameters": schema.get("parameters", {"type": "object", "properties": {}}),
-            "implementation": None,
-        })
+        tools.append(
+            {
+                "name": schema.get("name"),
+                "description": schema.get("description", ""),
+                "parameters": schema.get(
+                    "parameters", {"type": "object", "properties": {}}
+                ),
+                "implementation": None,
+            }
+        )
 
     config = {
         "name": getattr(env, "env_id", "verifiers_env"),
         "tools": tools,
         "completion_tool_name": "submit_answer",
-        "system_prompt": getattr(env, "system_prompt", None) or "Use tools to solve the task.",
+        "system_prompt": getattr(env, "system_prompt", None)
+        or "Use tools to solve the task.",
     }
     with open(path, "w") as f:
         json.dump(config, f, indent=2)
-
-

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -674,7 +674,7 @@ class TestEnvironmentBase:
             rubric=Rubric(),
         )
 
-        env.rubric.score_rollouts = AsyncMock( # type: ignore[attr-defined]
+        env.rubric.score_rollouts = AsyncMock(  # type: ignore[attr-defined]
             return_value=RolloutScores(reward=[1.0], metrics={})
         )
 


### PR DESCRIPTION
## Description
Adds ART ↔ verifiers integration under `integrations/art_framework`:
- `art_framework.py`: loads ART task configs, converts tools to `ToolEnv`, exact-match rubric by default, optional `JudgeRubric`.
- `utils/art_adapter.py`: ART→verifiers tool conversion with strict JSON schemas (no additionalProperties).
- `utils/verifiers_adapter.py`: verifiers→ART export (schema-only).
- `examples/calculator.json`: small, real, runnable example.
- `test_env.py`: unit test for conversion, parser, and reward.

Key behaviors:
- Enforces strict JSON tool schemas compatible with agents’ validator.
- `ARTParser` extracts the final answer from the configured completion tool.
- Works as an integration (installed via `vf-install`, not a core env).

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [x] Test improvement

## Testing
- [x] All existing tests pass when running `uv run pytest` locally.
- [x] New tests have been added to cover the changes

What I ran:
- Unit test (no network):
  - `uv run pytest integrations/art_framework/test_env.py -q`
- Local install + eval (exact-match rubric):
  - `uv run vf-install art_framework -p integrations`
  - `UV_NO_PROJECT=1 uv run vf-eval -s art_framework -a '{"task_config_path":"integrations/art_framework/examples/calculator.json"}' -m gpt-5-nano -n 2 -r 1`
- Optional judge (requires `OPENAI_API_KEY`):
  - `export OPENAI_API_KEY=sk-...`
  - `UV_NO_PROJECT=1 uv run vf-eval -s art_framework -a '{"task_config_path":"integrations/art_framework/examples/calculator.json","use_llm_judge":true,"judge_model":"gpt-5-nano"}' -m gpt-5-nano -n 2 -r 1`

i tested it myself since it's just integration didn't really need to see rollouts but it works 
<img width="825" height="760" alt="Screenshot 2025-10-28 at 5 27 57 PM" src="https://github.com/user-attachments/assets/9be5a0ad-6f46-47e9-a475-8cbac3898226" />

## Checklist
- [x] My code follows the style guidelines of this project as outlined in `AGENTS.md`
  - ruff clean; explicit types where useful; fail-fast error handling
- [x] I have performed a self-review of my own code
- [x] I have commented code where non-obvious (conversion, strict schema rationale)
- [x] I have made corresponding changes to the documentation
  - `integrations/art_framework/README.md` with Overview, Quickstart, Env Args, ART config format, Portability
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
  - None; integration is self-contained and optional

## Additional Notes
- Alignment: Follows integrations layout and roadmap; mirrors patterns from MCP and wiki_search (ToolEnv + optional JudgeRubric).
- Strict schema: Tools are generated with explicit parameters (no `**kwargs`) to satisfy agents’ strict JSON schema validation (no `additionalProperties`).
- Portability: Includes export helper and runnable example config.
- Known limitations: Example `implementation` supports simple lambdas for demos; real deployments should provide proper functions/modules.