### PR TITLE
fix: pull request template agents.md link doesn't work

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,7 +15,7 @@
 - [ ] New tests have been added to cover the changes
 
 ## Checklist
-- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](/AGENTS.md)
+- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
 - [ ] I have performed a self-review of my own code
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

The relative link to AGENTS.md doesn't work in the PR Template, goes to github.com/AGENTS.md. I Replaced it with a direct link instead.

OLD: [AGENTS.md](/AGENTS.md)
NEW: [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

NA

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published


NA

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

I noticed this when doing my other PR