### PR TITLE
Implement MaybeThinkParser

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import pytest
 from datasets import Dataset
 
 from verifiers import (
+    MaybeThinkParser,
     Messages,
     MultiTurnEnv,
     Parser,
@@ -35,6 +36,12 @@ def xml_parser():
 def xml_parser_with_alternatives():
     """Return an XMLParser instance with alternative field names."""
     return XMLParser(fields=["reasoning", ("code", "answer")], answer_field="answer")
+
+
+@pytest.fixture
+def maybe_think_parser():
+    """Return a MaybeThinkParser instance."""
+    return MaybeThinkParser()
 
 
 @pytest.fixture

--- a/tests/test_maybe_think_parser.py
+++ b/tests/test_maybe_think_parser.py
@@ -1,0 +1,45 @@
+"""Tests for the ThinkParser class."""
+
+from verifiers import MaybeThinkParser
+
+
+class TestMaybeThinkParser:
+    """Test cases for the MaybeThinkParser class."""
+
+    def test_parser_initialization(self, maybe_think_parser):
+        """Test that MaybeThinkParser initializes correctly."""
+        assert isinstance(maybe_think_parser, MaybeThinkParser)
+        assert hasattr(maybe_think_parser, "logger")
+
+    def test_does_not_parse_non_reasoner_text(self, maybe_think_parser):
+        """Test that parse method returns text unchanged."""
+        text = "This is a test string without thinking tags"
+        result = maybe_think_parser.parse(text)
+        assert result == text
+
+    def test_parses_reasoner_text(self, maybe_think_parser):
+        """Test that parse method returns text after thinking tags."""
+        text = "<think>This is a test string with thinking tags</think> This is the final answer"
+        result = maybe_think_parser.parse(text)
+        assert result == "This is the final answer"
+
+    def test_does_not_parse_non_reasoner_messages(self, maybe_think_parser):
+        """Test that parse method returns text unchanged."""
+        messages = [
+            {"role": "user", "content": "What is 2+2?"},
+            {"role": "assistant", "content": "The answer is 4"},
+        ]
+        result = maybe_think_parser.parse_answer(messages)
+        assert result == messages[-1]["content"]
+
+    def test_parses_reasoner_messages(self, maybe_think_parser):
+        """Test parse_answer with completion list."""
+        messages = [
+            {"role": "user", "content": "What is 2+2?"},
+            {
+                "role": "assistant",
+                "content": "<think>This is a test string with thinking tags</think>The answer is 4",
+            },
+        ]
+        result = maybe_think_parser.parse_answer(messages)
+        assert result == "The answer is 4"

--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -12,6 +12,7 @@ from .envs.multiturn_env import MultiTurnEnv
 from .envs.singleturn_env import SingleTurnEnv
 from .envs.stateful_tool_env import StatefulToolEnv
 from .envs.tool_env import ToolEnv
+from .parsers.maybe_think_parser import MaybeThinkParser
 from .parsers.parser import Parser
 from .parsers.think_parser import ThinkParser
 from .parsers.xml_parser import XMLParser
@@ -68,6 +69,7 @@ setup_logging()
 __all__ = [
     "Parser",
     "ThinkParser",
+    "MaybeThinkParser",
     "XMLParser",
     "Rubric",
     "JudgeRubric",

--- a/verifiers/parsers/maybe_think_parser.py
+++ b/verifiers/parsers/maybe_think_parser.py
@@ -1,0 +1,12 @@
+from typing import Callable
+
+from verifiers.parsers.parser import Parser
+
+
+class MaybeThinkParser(Parser):
+    def __init__(self, extract_fn: Callable[[str], str] = lambda x: x):
+        super().__init__(extract_fn=extract_fn)
+
+    def parse(self, text: str) -> str:
+        text = text.split("</think>")[-1].strip()
+        return self.extract_fn(text)

--- a/verifiers/rubrics/math_rubric.py
+++ b/verifiers/rubrics/math_rubric.py
@@ -1,7 +1,7 @@
 from math_verify import parse, verify  # type: ignore[unresolved-import]
 
 from verifiers.parsers.parser import Parser
-from verifiers.parsers.think_parser import ThinkParser
+from verifiers.parsers.think_parser import MaybeThinkParser
 from verifiers.rubrics.rubric import Rubric
 from verifiers.types import Messages, RewardFunc
 from verifiers.utils.data_utils import extract_boxed_answer
@@ -14,7 +14,7 @@ class MathRubric(Rubric):
         weights: list[float] | None = None,
         parser: Parser | None = None,
     ):
-        parser = parser or ThinkParser(extract_fn=extract_boxed_answer)
+        parser = parser or MaybeThinkParser(extract_fn=extract_boxed_answer)
         super().__init__(funcs=funcs, weights=weights, parser=parser)
         self.add_reward_func(self.correct_answer_reward_func)
 

--- a/verifiers/rubrics/math_rubric.py
+++ b/verifiers/rubrics/math_rubric.py
@@ -1,7 +1,7 @@
 from math_verify import parse, verify  # type: ignore[unresolved-import]
 
+from verifiers.parsers.maybe_think_parser import MaybeThinkParser
 from verifiers.parsers.parser import Parser
-from verifiers.parsers.think_parser import MaybeThinkParser
 from verifiers.rubrics.rubric import Rubric
 from verifiers.types import Messages, RewardFunc
 from verifiers.utils.data_utils import extract_boxed_answer


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

This PR implements the `MaybeThinkParser` abstraction which implements a best-effort attempt of stripping away think content before potential verification. For non-reasoning models, this parser behaves exactly like the standard `Parser` in that it just returns the text as-is. For reasoners, it only keeps the content after a closing `</think>` tag.

I also make this the default parser of `MathRubric` - this way we can basically get rid of all the ugly `use_think` env args in all the envs using it.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [x] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->