### PR TITLE
Allow setting env args in pyproject for num_examples + rollouts_per_example

### DIFF
--- a/environments/gsm8k/pyproject.toml
+++ b/environments/gsm8k/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gsm8k"
-version = "0.1.1"
+version = "0.1.2"
 description = "GSM8K environment"
 tags = ["gsm8k", "single-turn", "math", "train", "eval"]
 requires-python = ">=3.10"
@@ -13,4 +13,8 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build]
-include = ["gsm8k.py"]
+include = ["gsm8k.py", "pyproject.toml"]
+
+[tool.verifiers.eval]
+num_examples = 20
+rollouts_per_example = 5

--- a/environments/wiki_search/pyproject.toml
+++ b/environments/wiki_search/pyproject.toml
@@ -16,4 +16,8 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build]
-include = ["wiki_search.py"]
+include = ["wiki_search.py", "pyproject.toml"]
+
+[tool.verifiers.eval]
+num_examples = 10
+rollouts_per_example = 2

--- a/environments/wordle/pyproject.toml
+++ b/environments/wordle/pyproject.toml
@@ -15,3 +15,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build]
 include = ["wordle.py"]
+
+[tool.verifiers.eval]
+num_examples = 20
+rollouts_per_example = 1

--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -1,14 +1,68 @@
 import argparse
 import asyncio
+import importlib.resources
 import json
 import logging
-from typing import Dict
+from typing import Any, Dict
+
+try:
+    import tomllib  # type: ignore[unresolved-import]
+except ImportError:
+    import tomli as tomllib  # type: ignore[unresolved-import]
 
 from verifiers import setup_logging
 from verifiers.types import ClientConfig, EvalConfig
 from verifiers.utils.eval_utils import load_endpoints, run_evaluation
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_NUM_EXAMPLES = 5
+DEFAULT_ROLLOUTS_PER_EXAMPLE = 3
+
+
+def get_env_eval_defaults(env_id: str) -> Dict[str, Any]:
+    """Get eval config defaults from environment package's pyproject.toml.
+
+    Returns dict with 'num_examples' and 'rollouts_per_example' keys if found,
+    otherwise returns empty dict. All errors are silently handled.
+    """
+    defaults: Dict[str, Any] = {}
+    module_name = env_id.replace("-", "_").split("/")[-1]
+
+    try:
+        # read pyproject.toml from installed package
+        package_ref = importlib.resources.files(module_name)
+        pyproject_file = package_ref / "pyproject.toml"
+
+        if not pyproject_file.is_file():
+            logger.debug(f"pyproject.toml not found in installed package {module_name}")
+            return defaults
+
+        with pyproject_file.open("rb") as f:
+            pyproject_data = tomllib.load(f)
+
+        # Extract [tool.verifiers.eval] section
+        eval_config = (
+            pyproject_data.get("tool", {}).get("verifiers", {}).get("eval", {})
+        )
+
+        if "num_examples" in eval_config:
+            defaults["num_examples"] = eval_config["num_examples"]
+        if "rollouts_per_example" in eval_config:
+            defaults["rollouts_per_example"] = eval_config["rollouts_per_example"]
+
+        if defaults:
+            logger.debug(
+                f"Loaded eval defaults from {module_name} pyproject.toml: {defaults}"
+            )
+    except ModuleNotFoundError:
+        logger.debug(f"Package {module_name} not installed")
+    except Exception as e:
+        logger.debug(
+            f"Could not load eval defaults from {module_name} pyproject.toml: {e}"
+        )
+
+    return defaults
 
 
 def main():
@@ -68,14 +122,14 @@ def main():
         "--num-examples",
         "-n",
         type=int,
-        default=5,
+        default=None,
         help="Number of examples to evaluate",
     )
     parser.add_argument(
         "--rollouts-per-example",
         "-r",
         type=int,
-        default=3,
+        default=None,
         help="Number of rollouts per example",
     )
     parser.add_argument(
@@ -167,6 +221,32 @@ def main():
 
     setup_logging("DEBUG" if args.verbose else "INFO")
 
+    # apply defaults: CLI args take precedence, then env defaults, then global defaults
+    env_defaults = get_env_eval_defaults(args.env_id)
+    num_examples = (
+        args.num_examples
+        if args.num_examples is not None
+        else env_defaults.get("num_examples", DEFAULT_NUM_EXAMPLES)
+    )
+    rollouts_per_example = (
+        args.rollouts_per_example
+        if args.rollouts_per_example is not None
+        else env_defaults.get("rollouts_per_example", DEFAULT_ROLLOUTS_PER_EXAMPLE)
+    )
+
+    if args.num_examples is None:
+        source = (
+            "pyproject.toml" if "num_examples" in env_defaults else "global default"
+        )
+        logger.debug(f"Using num_examples={num_examples} from {source}")
+    if args.rollouts_per_example is None:
+        source = (
+            "pyproject.toml"
+            if "rollouts_per_example" in env_defaults
+            else "global default"
+        )
+        logger.debug(f"Using rollouts_per_example={rollouts_per_example} from {source}")
+
     # load endpoints and get model config
     endpoints = load_endpoints(args.endpoints_path)
     if args.model in endpoints:
@@ -219,8 +299,8 @@ def main():
         model=args.model,
         client_config=client_config,
         sampling_args=merged_sampling_args,
-        num_examples=args.num_examples,
-        rollouts_per_example=args.rollouts_per_example,
+        num_examples=num_examples,
+        rollouts_per_example=rollouts_per_example,
         max_concurrent=args.max_concurrent,
         max_concurrent_generation=args.max_concurrent_generation,
         max_concurrent_scoring=args.max_concurrent_scoring,

--- a/verifiers/scripts/init.py
+++ b/verifiers/scripts/init.py
@@ -74,6 +74,13 @@ dependencies = [
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.build]
+include = ["{{env_file}}.py", "pyproject.toml"] 
+
+[tool.verifiers.eval]
+num_examples = 5
+rollouts_per_example = 3
 """
 
 INIT_TEMPLATE = """\


### PR DESCRIPTION
## Description
Allows users to set default configurations 

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->