### PR TITLE
Allow passing map_kwargs

### DIFF
--- a/verifiers/envs/env_group.py
+++ b/verifiers/envs/env_group.py
@@ -92,7 +92,11 @@ class EnvGroup(Environment):
     """
 
     def __init__(
-        self, envs: list[Environment], env_names: list[str] | None = None, **kwargs
+        self,
+        envs: list[Environment],
+        env_names: list[str] | None = None,
+        map_kwargs: dict = {},
+        **kwargs,
     ):
         """
         Initialize EnvGroup with a list of environments.
@@ -126,11 +130,11 @@ class EnvGroup(Environment):
 
             env_dataset = env.get_dataset()
             if env_dataset is not None:
-                env_dataset = env_dataset.map(add_task)
+                env_dataset = env_dataset.map(add_task, **map_kwargs)
                 datasets.append(env_dataset)
             env_eval_dataset = env.get_eval_dataset()
             if env_eval_dataset is not None:
-                env_eval_dataset = env_eval_dataset.map(add_task)
+                env_eval_dataset = env_eval_dataset.map(add_task, **map_kwargs)
                 eval_datasets.append(env_eval_dataset)
         dataset = concatenate_datasets(datasets) if datasets else None
         eval_dataset = concatenate_datasets(eval_datasets) if eval_datasets else None

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -66,6 +66,7 @@ class Environment(ABC):
         max_workers: int = 512,
         env_id: str | None = None,
         env_args: dict | None = None,
+        map_kwargs: dict = {},
         **kwargs,
     ):
         self.logger = logging.getLogger(f"verifiers.envs.{self.__class__.__name__}")
@@ -83,13 +84,16 @@ class Environment(ABC):
         if self.message_type == "chat":
             if dataset is not None:
                 self.dataset = self.format_dataset(
-                    dataset, self.system_prompt, self.few_shot
+                    dataset, self.system_prompt, self.few_shot, map_kwargs=map_kwargs
                 )
             else:
                 self.dataset = None
             if eval_dataset is not None:
                 self.eval_dataset = self.format_dataset(
-                    eval_dataset, self.system_prompt, self.few_shot
+                    eval_dataset,
+                    self.system_prompt,
+                    self.few_shot,
+                    map_kwargs=map_kwargs,
                 )
             else:
                 self.eval_dataset = None
@@ -144,6 +148,7 @@ class Environment(ABC):
         few_shot: list[ChatMessage] | None = None,
         question_key: str = "question",
         answer_key: str = "answer",
+        map_kwargs: dict = {},
     ) -> Dataset:
         """
         Create `example_id` and `prompt` columns if not present.
@@ -171,14 +176,16 @@ class Environment(ABC):
                 dataset = dataset.map(
                     lambda x: {
                         "prompt": format_prompt_fn(x[question_key]),
-                    }
+                    },
+                    **map_kwargs,
                 )
             else:
                 dataset = dataset.map(
                     lambda x: {
                         "prompt": format_prompt_fn(x[question_key]),
                         "answer": x[answer_key],
-                    }
+                    },
+                    **map_kwargs,
                 )
         assert "example_id" in dataset.column_names
         assert "prompt" in dataset.column_names


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

`Environment.format_dataset` and `EnvGroup.__init__` call `.map()` on datasets without any additional kwargs. This is fine for 99% of the datasets, but for some special cases it is convenient to pass map kwargs like `num_proc` or `writer_batch_size`. 

For example, coding datasets often contain many MBs of serialized test cases in their column. Regular map fails because it tries to process too large chunks, which can be solved by passing `writer_batch_size`.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->