### PR TITLE
Support env mixing with interleave_datasets

### DIFF
--- a/tests/test_env_group.py
+++ b/tests/test_env_group.py
@@ -234,6 +234,77 @@ class TestEnvGroup:
         assert tasks[1] == "math"
         assert tasks[2] == "code"
 
+    def test_env_group_dataset_interleaving_first_exhausted(self, mock_openai_client):
+        """Test that EnvGroup properly interleaves datasets with task labels."""
+        env1 = SingleTurnEnv(
+            client=mock_openai_client,
+            model="test-model",
+            dataset=Dataset.from_dict(
+                {"question": ["q1", "q2"], "answer": ["a1", "a2"]}
+            ),
+            rubric=Rubric(),
+        )
+
+        env2 = SingleTurnEnv(
+            client=mock_openai_client,
+            model="test-model",
+            dataset=Dataset.from_dict({"question": ["q3"], "answer": ["a3"]}),
+            rubric=Rubric(),
+        )
+
+        env_group = EnvGroup(
+            envs=[env1, env2],
+            env_names=["math", "code"],
+            env_mix_strategy="interleave",
+        )
+
+        # Check concatenated dataset
+        dataset = env_group.get_dataset()
+        assert len(dataset) == 2
+        assert "task" in dataset.column_names
+
+        # Check task labels
+        tasks = dataset["task"]
+        assert tasks[0] == "math"
+        assert tasks[1] == "code"
+
+    def test_env_group_dataset_interleaving_all_exhausted(self, mock_openai_client):
+        """Test that EnvGroup properly interleaves datasets with task labels."""
+        env1 = SingleTurnEnv(
+            client=mock_openai_client,
+            model="test-model",
+            dataset=Dataset.from_dict(
+                {"question": ["q1", "q2"], "answer": ["a1", "a2"]}
+            ),
+            rubric=Rubric(),
+        )
+
+        env2 = SingleTurnEnv(
+            client=mock_openai_client,
+            model="test-model",
+            dataset=Dataset.from_dict({"question": ["q3"], "answer": ["a3"]}),
+            rubric=Rubric(),
+        )
+
+        env_group = EnvGroup(
+            envs=[env1, env2],
+            env_names=["math", "code"],
+            env_mix_strategy="interleave",
+            env_mix_kwargs=dict(stopping_strategy="all_exhausted"),
+        )
+
+        # Check concatenated dataset
+        dataset = env_group.get_dataset()
+        assert len(dataset) == 4
+        assert "task" in dataset.column_names
+
+        # Check task labels
+        tasks = dataset["task"]
+        assert tasks[0] == "math"
+        assert tasks[1] == "code"
+        assert tasks[2] == "math"
+        assert tasks[1] == "code"
+
     def test_env_group_rubric_type(self, mock_openai_client):
         """Test that EnvGroup creates EnvGroupRubric."""
         env1 = SingleTurnEnv(

--- a/verifiers/envs/env_group.py
+++ b/verifiers/envs/env_group.py
@@ -99,7 +99,6 @@ class EnvGroup(Environment):
         self,
         envs: list[Environment],
         env_names: list[str] | None = None,
-        probabilities: list[float] | None = None,
         env_mix_strategy: Literal["interleave", "concatenate"] = "concatenate",
         env_mix_kwargs: dict = {},
         map_kwargs: dict = {},


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

This PR adds support for mixing the underlying datasets in an EnvGroup using `interleave_datasets` or `concatenate_datasets`. The former allows for easy customization of the env mixes (e.g. sampling probabilities to deal with uneven dataset sizes). The PR does not change any default behavior, ie. its fully backwards compatible. Added tests for new interleaving functionality.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [x] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->