### PR TITLE
Pass map_kwargs to base env

### DIFF
--- a/verifiers/envs/env_group.py
+++ b/verifiers/envs/env_group.py
@@ -1,6 +1,6 @@
+from collections import defaultdict
 from typing import TYPE_CHECKING, Mapping
 
-from collections import defaultdict
 from datasets import concatenate_datasets
 from openai import AsyncOpenAI
 
@@ -153,6 +153,7 @@ class EnvGroup(Environment):
             eval_dataset=eval_dataset,
             rubric=rubric,
             oai_tools=None,
+            map_kwargs=map_kwargs,
             **kwargs,
         )
         self.logger.info(
@@ -288,9 +289,7 @@ class EnvGroup(Environment):
                     env_processed_outputs.completion_logprobs[i]
                 )
                 all_rewards[original_idx] = env_processed_outputs.rewards[i]
-                all_is_truncated[original_idx] = (
-                    env_processed_outputs.is_truncated[i]
-                )
+                all_is_truncated[original_idx] = env_processed_outputs.is_truncated[i]
         return ProcessedOutputs(
             prompt_ids=all_prompt_ids,
             prompt_mask=all_prompt_masks,


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

`map_kwargs` should be passed to the base env from the env group. Otherwise, `format_dataset` called from the base env might not use them -- as I had to experience in prod lol.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->