### PR TITLE
Add Responses API support for reasoning models

### DIFF
--- a/verifiers/envs/multiturn_env.py
+++ b/verifiers/envs/multiturn_env.py
@@ -106,7 +106,9 @@ class MultiTurnEnv(Environment):
             response_text: str = ""
             if self.message_type == "chat":
                 assert isinstance(context_messages, list)
-                assert isinstance(response, ChatCompletion)
+                assert isinstance(response, ChatCompletion) or hasattr(
+                    response, "choices"
+                )
                 if response.choices and response.choices[0].message:
                     response_text = response.choices[0].message.content or ""
                 response_message: ChatMessage = {

--- a/verifiers/utils/message_utils.py
+++ b/verifiers/utils/message_utils.py
@@ -155,3 +155,41 @@ def get_overlong_prompt_dummy_response(message_type: MessageType) -> ModelRespon
         )
     else:
         raise ValueError(f"Invalid message type: {message_type}")
+
+
+def extract_system_message(messages: list) -> tuple[str | None, list]:
+    """Extract system message as instructions for Responses API."""
+    instructions = None
+    remaining = []
+
+    for msg in messages:
+        if msg.get("role") == "system":
+            if instructions is None:
+                instructions = msg.get("content")
+        else:
+            remaining.append(msg)
+
+    return instructions, remaining
+
+
+def adapt_tools_for_responses_api(chat_tools: list | None) -> list | None:
+    """Convert Chat Completions tool format to Responses API format."""
+    if not chat_tools:
+        return None
+
+    adapted = []
+    for tool in chat_tools:
+        if tool.get("type") == "function":
+            func = tool.get("function", {})
+            adapted.append(
+                {
+                    "type": "function",
+                    "name": func.get("name"),
+                    "description": func.get("description"),
+                    "parameters": func.get("parameters"),
+                }
+            )
+        else:
+            adapted.append(tool)
+
+    return adapted

--- a/verifiers/utils/responses_api_adapter.py
+++ b/verifiers/utils/responses_api_adapter.py
@@ -1,0 +1,61 @@
+from openai.types.chat import ChatCompletionMessage
+from openai.types.chat.chat_completion import Choice
+
+
+class ResponsesAPIAdapter:
+    """Adapter to normalize Responses API responses to ChatCompletion format."""
+
+    def __init__(self, responses_response):
+        self._response = responses_response
+        self._text = getattr(responses_response, "output_text", "")
+        self._tool_calls = self._extract_tool_calls()
+
+    def _extract_tool_calls(self):
+        tool_calls = []
+        output = getattr(self._response, "output", [])
+
+        for item in output:
+            item_type = getattr(item, "type", None)
+            if item_type == "function_call":
+                tool_calls.append(
+                    {
+                        "id": getattr(item, "call_id", ""),
+                        "type": "function",
+                        "function": {
+                            "name": getattr(item, "name", ""),
+                            "arguments": str(getattr(item, "arguments", {})),
+                        },
+                    }
+                )
+
+        return tool_calls if tool_calls else None
+
+    @property
+    def choices(self):
+        return [
+            Choice(
+                index=0,
+                message=ChatCompletionMessage(role="assistant", content=self._text, tool_calls=self._tool_calls),
+                finish_reason="stop",
+            )
+        ]
+
+    @property
+    def id(self):
+        return getattr(self._response, "id", "responses-api-adapter")
+
+    @property
+    def model(self):
+        return getattr(self._response, "model", "")
+
+    @property
+    def created(self):
+        return getattr(self._response, "created_at", 0)
+
+    @property
+    def object(self):
+        return "chat.completion"
+
+    @property
+    def usage(self):
+        return getattr(self._response, "usage", None)


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Add Responses API support for reasoning models

- Implement ResponsesAPIAdapter to normalize Responses API to ChatCompletion format
- Add helper functions for system to instructions extraction and tool format adaptation
- Introduce use_responses_api flag in Environment for opt-in 
- Verified on AgentClinic Multiturn env with o3-mini and gpt-4o and all tests pass

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add optional notes, screenshots, or context about the PR here -->
