### PR TITLE
fix state columns parsing in `vf-eval` cli

### DIFF
--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -184,9 +184,9 @@ def main():
     parser.add_argument(
         "--state-columns",
         "-C",
-        nargs="+",
+        type=lambda t: [s.strip() for s in t.split(",")],
         default=[],
-        help="List of state columns to save",
+        help="Comma-separated list of state columns to save (e.g., 'turn,timing')",
     )
     parser.add_argument(
         "--save-results",


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
before:
```
  "state_columns": [
    "t",
    "i",
    "m",
    "i",
    "n",
    "g"
  ],
  ```
  
  after:
  ```
    "state_columns": [
    "timing",
    "turn"
  ],
  ```


## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->