### PR TITLE
Serialize OAI responses before saving

### DIFF
--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -189,7 +189,12 @@ def make_dataset(results: GenerateOutputs, **kwargs) -> Dataset:
     state_columns = results.metadata.state_columns
     if state_columns:
         for col in state_columns:
-            results_dict[col] = [s.get(col) for s in results.state]
+            if col == "responses":
+                results_dict[col] = [
+                    [r.model_dump() for r in s.get(col, [])] for s in results.state
+                ]
+            else:
+                results_dict[col] = [s.get(col) for s in results.state]
 
     return Dataset.from_dict(results_dict)
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Previously doing `vf-eval ... -C responses` would fail because the OAI Pydantic models can not be put into HF dataset columns. This PR serializes each chat completion response in `responses` state field (which I think is always present in the state) before saving, giving us access to all metadata in the response, including the reasoning content and tool calls etc.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->