### PR TITLE
Allow resuming vf-eval

### DIFF
--- a/tests/test_eval_cli.py
+++ b/tests/test_eval_cli.py
@@ -48,6 +48,7 @@ def _run_cli(monkeypatch, overrides):
         "state_columns": [],
         "save_results": False,
         "save_every": -1,
+        "resume_from_path": None,
         "save_to_hf_hub": False,
         "hf_hub_dataset_name": "",
     }

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -557,6 +557,7 @@ class Environment(ABC):
         tasks = [state.get("task", "default") for state in all_states]
         infos = [state.get("info", {}) for state in all_states]
         example_ids = [state.get("example_id", 0) for state in all_states]
+        rollout_ids = [state.get("rollout_id", 0) for state in all_states]
         rewards = [state.get("reward", 0.0) for state in all_states]
 
         metrics: dict[str, list[float]] = {}
@@ -599,6 +600,7 @@ class Environment(ABC):
             task=tasks,
             info=infos,
             example_id=example_ids,
+            rollout_id=rollout_ids,
             reward=rewards,
             metrics=metrics,
             metadata=metadata,

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -4,6 +4,7 @@ import inspect
 import json
 import logging
 import signal
+import sys
 import time
 from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor
@@ -809,8 +810,11 @@ class Environment(ABC):
             finished_rollouts, _ = load_from_disk(resume_from_path)
             finished_example_ids = list(finished_rollouts["example_id"])
             inputs = [i for i in inputs if i["example_id"] not in finished_example_ids]
+            if len(inputs) == 0:
+                self.logger.info("No inputs left to evaluate. Exiting.")
+                sys.exit(0)
             self.logger.info(
-                f"Found {len(set(finished_example_ids))} finished groups ({len(finished_example_ids)} total rollouts), skipping them"
+                f"Found {len(set(finished_example_ids))} finished group(s) ({len(finished_example_ids)} total rollouts), skipping them"
             )
         return await self.generate(
             inputs,

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -557,7 +557,6 @@ class Environment(ABC):
         tasks = [state.get("task", "default") for state in all_states]
         infos = [state.get("info", {}) for state in all_states]
         example_ids = [state.get("example_id", 0) for state in all_states]
-        rollout_ids = [state.get("rollout_id", 0) for state in all_states]
         rewards = [state.get("reward", 0.0) for state in all_states]
 
         metrics: dict[str, list[float]] = {}
@@ -600,7 +599,6 @@ class Environment(ABC):
             task=tasks,
             info=infos,
             example_id=example_ids,
-            rollout_id=rollout_ids,
             reward=rewards,
             metrics=metrics,
             metadata=metadata,
@@ -780,8 +778,6 @@ class Environment(ABC):
         assert inputs is not None, "No dataset found"
         if rollouts_per_example > 1:
             inputs = inputs.repeat(rollouts_per_example)
-        rollout_ids = list(range(len(inputs)))
-        inputs = inputs.add_column("rollout_id", rollout_ids)  # type: ignore (weird datasets thing)
         return inputs.to_list()
 
     async def evaluate(
@@ -811,10 +807,10 @@ class Environment(ABC):
                     f"Resume path does not exist: {resume_from_path}"
                 )
             finished_rollouts, _ = load_from_disk(resume_from_path)
-            finished_rollout_ids = list(finished_rollouts["rollout_id"])
-            inputs = [i for i in inputs if i["rollout_id"] not in finished_rollout_ids]
+            finished_example_ids = list(finished_rollouts["example_id"])
+            inputs = [i for i in inputs if i["example_id"] not in finished_example_ids]
             self.logger.info(
-                f"Found {len(finished_rollout_ids)} finished rollouts, skipping them"
+                f"Found {len(finished_example_ids)} finished groups, skipping them"
             )
         return await self.generate(
             inputs,

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -810,7 +810,7 @@ class Environment(ABC):
             finished_example_ids = list(finished_rollouts["example_id"])
             inputs = [i for i in inputs if i["example_id"] not in finished_example_ids]
             self.logger.info(
-                f"Found {len(finished_example_ids)} finished groups, skipping them"
+                f"Found {len(set(finished_example_ids))} finished groups ({len(finished_example_ids)} total rollouts), skipping them"
             )
         return await self.generate(
             inputs,

--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -204,6 +204,13 @@ def main():
         help="Save dataset every n rollouts",
     )
     parser.add_argument(
+        "--resume-from-path",
+        "-R",
+        type=str,
+        default=None,
+        help="Path to resume evaluation from (to be used in conjunction with -f)",
+    )
+    parser.add_argument(
         "--save-to-hf-hub",
         "-H",
         default=False,
@@ -311,6 +318,7 @@ def main():
         state_columns=args.state_columns,
         save_results=args.save_results,
         save_every=args.save_every,
+        resume_from_path=args.resume_from_path,
         save_to_hf_hub=args.save_to_hf_hub,
         hf_hub_dataset_name=args.hf_hub_dataset_name,
     )

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -71,11 +71,12 @@ class TrajectoryStep(TypedDict):
 class BaseRolloutInput(TypedDict):
     prompt: Messages
     example_id: int
+    rollout_id: int
     task: str
 
 
 class RolloutInput(BaseRolloutInput, total=False):
-    # required: prompt, example_id, task
+    # required: prompt, example_id, rollout_id, task
     # optional: answer, info
     answer: str
     info: Info
@@ -89,7 +90,7 @@ class RolloutTiming(TypedDict, total=False):
 
 
 class State(dict):
-    INPUT_FIELDS = ["prompt", "answer", "task", "info", "example_id"]
+    INPUT_FIELDS = ["prompt", "answer", "task", "info", "example_id", "rollout_id"]
     # required
     input: RolloutInput
     # created during rollout
@@ -159,6 +160,7 @@ class GenerateOutputs(TypedDict):
     task: list[str]
     info: list[Info]
     example_id: list[int]
+    rollout_id: list[int]
     reward: list[float]
     metrics: dict[str, list[float]]
     metadata: GenerateMetadata
@@ -229,5 +231,6 @@ class EvalConfig(BaseModel):
     state_columns: list[str] | None = None
     save_results: bool = False
     save_every: int = -1
+    resume_from_path: str | None = None
     save_to_hf_hub: bool = False
     hf_hub_dataset_name: str | None = None

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -71,12 +71,11 @@ class TrajectoryStep(TypedDict):
 class BaseRolloutInput(TypedDict):
     prompt: Messages
     example_id: int
-    rollout_id: int
     task: str
 
 
 class RolloutInput(BaseRolloutInput, total=False):
-    # required: prompt, example_id, rollout_id, task
+    # required: prompt, example_id, task
     # optional: answer, info
     answer: str
     info: Info
@@ -90,7 +89,7 @@ class RolloutTiming(TypedDict, total=False):
 
 
 class State(dict):
-    INPUT_FIELDS = ["prompt", "answer", "task", "info", "example_id", "rollout_id"]
+    INPUT_FIELDS = ["prompt", "answer", "task", "info", "example_id"]
     # required
     input: RolloutInput
     # created during rollout
@@ -160,7 +159,6 @@ class GenerateOutputs(TypedDict):
     task: list[str]
     info: list[Info]
     example_id: list[int]
-    rollout_id: list[int]
     reward: list[float]
     metrics: dict[str, list[float]]
     metadata: GenerateMetadata

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -182,7 +182,6 @@ def make_dataset(results: GenerateOutputs, **kwargs) -> Dataset:
     save_answer = any(answer != "" for answer in results["answer"])
     results_dict = {
         "example_id": results["example_id"],
-        "rollout_id": results["rollout_id"],
         "prompt": clean_prompts,
         "completion": clean_completions,
         "task": results["task"],

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -177,6 +177,7 @@ def make_dataset(results: GenerateOutputs, **kwargs) -> Dataset:
     save_answer = any(answer != "" for answer in results["answer"])
     results_dict = {
         "example_id": results["example_id"],
+        "rollout_id": results["rollout_id"],
         "prompt": clean_prompts,
         "completion": clean_completions,
         "task": results["task"],

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -244,7 +244,17 @@ def save_to_disk(dataset: Dataset, metadata_dict: dict, path_to_save: Path):
                 for metric_name in existing_metadata_dict["avg_metrics"]
             },
         }
-        dataset = concatenate_datasets([existing_dataset, dataset])
+        seen = set()
+
+        def is_new(example: dict) -> bool:
+            """De-duplicate based on completion."""
+            k = json.dumps(list(example["completion"]))
+            if k in seen:
+                return False
+            seen.add(k)
+            return True
+
+        dataset = concatenate_datasets([existing_dataset, dataset]).filter(is_new)
     except FileNotFoundError:
         pass
 

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -279,10 +279,3 @@ def save_rollout_results(
         dataset_name = hf_hub_dataset_name or get_hf_hub_dataset_name(results)
         dataset.push_to_hub(dataset_name)
         logger.info(f"Dataset saved to Hugging Face Hub: {dataset_name}")
-
-
-if __name__ == "__main__":
-    path_to_load = Path("outputs/evals/math500--gpt-5-nano/89e29bdf")
-    dataset, metadata_dict = load_from_disk(path_to_load)
-    print(dataset)
-    print(metadata_dict)

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -254,7 +254,8 @@ def save_to_disk(dataset: Dataset, metadata_dict: dict, path_to_save: Path):
             seen.add(k)
             return True
 
-        dataset = concatenate_datasets([existing_dataset, dataset]).filter(is_new)
+        with quiet_datasets():
+            dataset = concatenate_datasets([existing_dataset, dataset]).filter(is_new)
     except FileNotFoundError:
         pass
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

This PR adds support for resuming an evaluation run via `vf-eval` using the `-R` (`--resume-from-path`) flag which is supposed to be used in conjunction with `-s` and `-f` to allow to resume an evaluation run. It will:
- Load all completed `example_ids` from `results.jsonl` in the specified resume path
- Skip the already finished rollouts from the eval inputs 
- Append new rollout results to `results.jsonl` and update the metadata (e.g. timings are summed, avg. reward and metrics are averaged)

Notes:
- This is a not a "full" checkpointing since we do not recover mid-trajectory failures but its the simplest solution  to quickly resume a . Useful in long-running evals or synthetic data gen.
- Intermediate saving is only supported on the group level. If one needs rollout-level intermediate saving, it makes sense to duplicate prompts before running vf-eval and run with `rollouts_per_example=1`

## Examples

Default behavior is unchanged

```bash
uv run vf-eval math500 -m gpt-5-nano -s
```

To use the resume feature and save each finished group, specify `-s` and `-f 1`. To illustrate, I sys.exit after every intermediate saving. For the initial command I run:

```bash
uv run vf-eval math500 -m gpt-5-nano -n 3 -r 1 -s -f 1
```

Then, each subsequent resume from the output dir

```bash
uv run vf-eval math500 -m gpt-5-nano -n 3 -r 1 -s -f 1 -R outputs/evals/math500--gpt-5-nano/67681b1d
```

<img width="2054" height="721" alt="Screenshot 2025-11-13 at 2 22 45 PM" src="https://github.com/user-attachments/assets/d7d6b894-ec39-4fec-8632-05761a366af3" />

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->