### PR TITLE
Fix MCP environment imports and transport handling

### DIFF
--- a/verifiers/envs/mcp/mcp_utils/mcp_tool_wrapper.py
+++ b/verifiers/envs/mcp/mcp_utils/mcp_tool_wrapper.py
@@ -2,13 +2,11 @@ from typing import Any
 
 from mcp.types import Tool
 
-from .mcp_server_connection import MCPServerConnection
+from ..transports.base import MCPTransport
 
 
 class MCPToolWrapper:
-    def __init__(
-        self, server_name: str, tool: Tool, server_connection: MCPServerConnection
-    ):
+    def __init__(self, server_name: str, tool: Tool, server_connection: MCPTransport):
         self.server_name = server_name
         self.tool = tool
         self.server_connection = server_connection

--- a/verifiers/envs/mcp/mcp_utils/models.py
+++ b/verifiers/envs/mcp/mcp_utils/models.py
@@ -1,11 +1,10 @@
 from dataclasses import dataclass
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 
 @dataclass
 class MCPServerConfig:
     name: str
     command: str
-    args: List[str] | None = None
-    env: Dict[str, str] | None = None
-    d
+    args: Optional[List[str]] = None
+    env: Optional[Dict[str, str]] = None

--- a/verifiers/envs/mcp/transports/sandbox.py
+++ b/verifiers/envs/mcp/transports/sandbox.py
@@ -1,11 +1,9 @@
-import asyncio
 from typing import Dict, Optional
-from mcp import ClientSession
-from mcp.types import Tool, TextContent
-from mcp.client.stdio import sse_client
+
+from mcp.types import Tool
 
 from .streaming_http import StreamingHTTPTransport
-from ..models import MCPServerConfig
+from ..mcp_utils.models import MCPServerConfig
 
 class SandboxTransport(StreamingHTTPTransport):
     def __init__(

--- a/verifiers/envs/mcp/transports/stdio.py
+++ b/verifiers/envs/mcp/transports/stdio.py
@@ -1,16 +1,17 @@
 import asyncio
 from typing import Dict, Optional
-from mcp import ClientSession
-from mcp.types import Tool, TextContent
-from mcp.client.stdio import stdio_client
 
-from .baseimport MCPTransport
-from ..models import MCPServerConfig
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+from mcp.types import TextContent, Tool
+
+from .base import MCPTransport
+from ..mcp_utils.models import MCPServerConfig
 
 class StdioTransport(MCPTransport):
     def __init__(self, config: MCPServerConfig):
         self.config = config
-        self.session = Optional[ClientSession] = None
+        self.session: Optional[ClientSession] = None
         self.tools: Dict[str, Tool] = {}
         self._stdio_context = None
         self._session_context = None
@@ -20,7 +21,7 @@ class StdioTransport(MCPTransport):
         server_params = StdioServerParameters(
             command=self.config.command,
             args=self.config.args or [],
-            env=self.config.env
+            env=self.config.env,
         )
         self._stdio_context = stdio_client(server_params)
         read, write = await self._stdio_context.__aenter__()
@@ -49,7 +50,7 @@ class StdioTransport(MCPTransport):
                     text_parts.append(str(content_item))
             return "\n".join(text_parts)
 
-        return "No result return from tool"
+        return "No result returned from tool"
 
 
     async def disconnect(self) -> None:
@@ -63,5 +64,5 @@ class StdioTransport(MCPTransport):
 
         self.tools = {}
 
-    def is_connected(self) -> bool:
+    async def is_connected(self) -> bool:
         return self.session is not None

--- a/verifiers/envs/mcp/transports/streaming_http.py
+++ b/verifiers/envs/mcp/transports/streaming_http.py
@@ -1,11 +1,11 @@
-import asyncio
 from typing import Dict, Optional
+
 from mcp import ClientSession
-from mcp.types import Tool, TextContent
-from mcp.client.stdio import sse_client
+from mcp.client.sse import sse_client
+from mcp.types import TextContent, Tool
 
 from .base import MCPTransport
-from ..models import MCPServerConfig
+from ..mcp_utils.models import MCPServerConfig
 
 class StreamingHTTPTransport(MCPTransport):
     def __init__(
@@ -19,7 +19,7 @@ class StreamingHTTPTransport(MCPTransport):
         self.url = url
         self.timeout = timeout
         self.max_retries = max_retries
-        self.session = Optional[ClientSession] = None
+        self.session: Optional[ClientSession] = None
         self.tools: Dict[str, Tool] = {}
         self._sse_context = None
         self._session_context = None
@@ -47,13 +47,13 @@ class StreamingHTTPTransport(MCPTransport):
         if result.content:
             text_parts = []
             for content_item in result.content:
-                if isinstance(content_item, "text"):
+                if isinstance(content_item, TextContent):
                     text_parts.append(content_item.text)
                 else:
                     text_parts.append(str(content_item))
             return "\n".join(text_parts)
 
-        return "No result return from tool"
+        return "No result returned from tool"
 
 
     async def disconnect(self) -> None:
@@ -67,5 +67,5 @@ class StreamingHTTPTransport(MCPTransport):
 
         self.tools = {}
 
-    def is_connected(self) -> bool:
+    async def is_connected(self) -> bool:
         return self.session is not None


### PR DESCRIPTION
## Summary
- fix MCP environment imports and configuration validation
- correct HTTP/sandbox transport implementations and error messaging
- adjust tool wrapper typing for MCP transports

## Testing
- python -m py_compile verifiers/envs/mcp/mcp_env.py verifiers/envs/mcp/mcp_utils/*.py verifiers/envs/mcp/transports/*.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691c2ad5593c832c90f9041fe394c348)