### PR TITLE
[fix] Pass cli headers directly to AsyncOpenAI client

### DIFF
--- a/verifiers/utils/client_utils.py
+++ b/verifiers/utils/client_utils.py
@@ -31,6 +31,7 @@ def setup_client(
         api_key=os.getenv(config.api_key_var, "EMPTY"),
         max_retries=config.max_retries,
         http_client=http_client,
+        default_headers=config.extra_headers,
     )
 
     return client


### PR DESCRIPTION
## Description
AsyncOpenAI(AsyncAPIClient) expects default_headers to be passed directly during initialization. Default headers are supplied through CLI, and are particularly useful in cases where the Auth headers are necessary, like https://generativelanguage.googleapis.com/v1beta/openai/

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->