### PR TITLE
Retry MultiTurnEnv.rollout in case of JSONDecodeError

### DIFF
--- a/environments/math/math.py
+++ b/environments/math/math.py
@@ -2,7 +2,7 @@ import verifiers as vf
 
 
 def load_environment(**kwargs) -> vf.Environment:
-    '''
+    """
     Loads a custom environment.
-    '''
+    """
     raise NotImplementedError("Implement your custom environment here.")

--- a/verifiers/envs/multiturn_env.py
+++ b/verifiers/envs/multiturn_env.py
@@ -115,10 +115,9 @@ class MultiTurnEnv(vf.Environment):
             # then cut it off and finish with >30k newlines instead.
             # This causes a JSONDecodeError, but is rare enough that retrying solves the issue.
             except JSONDecodeError as e:
-                state = old_state
                 retry_count += 1
                 if retry_count > self.max_retries:
                     raise e
+                state = deepcopy(old_state)
                 await asyncio.sleep(1)
-                continue
         return state


### PR DESCRIPTION
## Description

Sometimes, OpenAI will start returning a valid JSON response, then cut it off and finish with >30k newlines instead. This causes a JSONDecodeError in the case of tool-use. This is best caught in the `vf.MultiTurnEnv` (not the `vf.ToolEnv`), because that allows for easy re-trying, which fixes the issue almost 100% of the time (because the issue is so rare and appears randomly).

This is not a pretty, but it works and is important to have.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->