### PR TITLE
Allow setting log level via VF_LOG_LEVEL

### DIFF
--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -2,6 +2,7 @@ __version__ = "0.1.8.post1"
 
 import importlib
 import logging
+import os
 import sys
 from typing import TYPE_CHECKING, Optional
 
@@ -72,7 +73,7 @@ def setup_logging(
     logger.propagate = False
 
 
-setup_logging()
+setup_logging(os.getenv("VF_LOG_LEVEL", "INFO"))
 
 __all__ = [
     "Parser",

--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -3,6 +3,7 @@ import asyncio
 import importlib.resources
 import json
 import logging
+import os
 from typing import Any, Dict
 
 try:
@@ -219,7 +220,7 @@ def main():
     )
     args = parser.parse_args()
 
-    setup_logging("DEBUG" if args.verbose else "INFO")
+    setup_logging("DEBUG" if args.verbose else os.getenv("VF_LOG_LEVEL", "INFO"))
 
     # apply defaults: CLI args take precedence, then env defaults, then global defaults
     env_defaults = get_env_eval_defaults(args.env_id)


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

This PR allows setting the logging level via `VF_LOG_LEVEL` package-wide. This allows to dynamically configure the log level via CLI for any downstream application using verifiers. For the `vf-eval` script the `-v` flag takes precedence, i.e. it will always use debug mode if set, otherwise it looks up for the env var, and if not found falls back to info. The default remains to be info logs, so no changes in default behavior.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->