### PR TITLE
Retry on Sandbox creation- and deletion-failures

### DIFF
--- a/environments/math/math.py
+++ b/environments/math/math.py
@@ -2,7 +2,7 @@ import verifiers as vf
 
 
 def load_environment(**kwargs) -> vf.Environment:
-    '''
+    """
     Loads a custom environment.
-    '''
+    """
     raise NotImplementedError("Implement your custom environment here.")

--- a/tests/test_sandbox_env.py
+++ b/tests/test_sandbox_env.py
@@ -22,7 +22,7 @@ def sandbox_env():
     mock_async_client.return_value = mock_async_client_instance
 
     try:
-        env = SandboxEnv(dataset=mock_dataset)
+        env = SandboxEnv(dataset=mock_dataset, max_retries=1, base_delay=0.1)
         env.logger = MagicMock()
         env.active_sandboxes = {"sandbox1", "sandbox2", "sandbox3"}
         yield env

--- a/verifiers/envs/sandbox_env.py
+++ b/verifiers/envs/sandbox_env.py
@@ -3,6 +3,7 @@ import time
 from typing import Any
 
 import verifiers as vf
+from verifiers.utils.retry_utils import with_retry
 
 try:
     from prime_sandboxes import (
@@ -33,6 +34,10 @@ class SandboxEnv(vf.StatefulToolEnv):
         environment_vars: dict[str, str] | None = None,
         team_id: str | None = None,
         advanced_configs: AdvancedConfigs | None = None,
+        max_retries: int = 5,
+        base_delay: float = 0.5,
+        backoff_factor: float = 2.0,
+        max_backoff_seconds: float = 30.0,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -52,6 +57,10 @@ class SandboxEnv(vf.StatefulToolEnv):
             advanced_configs=advanced_configs,
         )
         self.active_sandboxes = set()
+        self.max_retries = max_retries
+        self.base_delay = base_delay
+        self.backoff_factor = backoff_factor
+        self.max_backoff_seconds = max_backoff_seconds
         self.add_tool(self.bash, args_to_skip=["sandbox_id"])
 
     async def bash(self, command: str, sandbox_id: str) -> str:
@@ -100,16 +109,36 @@ class SandboxEnv(vf.StatefulToolEnv):
         sandbox_id = state.get("sandbox_id")
         if sandbox_id is None:
             return
-        try:
+
+        async def _delete_sandbox(sandbox_id: str):
             await self.sandbox_client.delete(sandbox_id)
             self.active_sandboxes.discard(sandbox_id)
             self.logger.debug(f"Deleted sandbox {sandbox_id}")
+
+        try:
+            await with_retry(
+                _delete_sandbox,
+                sandbox_id,
+                logger=self.logger,
+                max_retries=self.max_retries,
+                base_delay=self.base_delay,
+                backoff_factor=self.backoff_factor,
+                max_backoff_seconds=self.max_backoff_seconds,
+            )
         except Exception as e:
             self.logger.warning(f"Failed to delete sandbox {sandbox_id}: {e}")
 
     async def setup_state(self, state: vf.State, **kwargs) -> vf.State:
         """Create per-rollout sandbox"""
-        sandbox = await self.sandbox_client.create(self.sandbox_request)
+        sandbox = await with_retry(
+            self.sandbox_client.create,
+            self.sandbox_request,
+            logger=self.logger,
+            max_retries=self.max_retries,
+            base_delay=self.base_delay,
+            backoff_factor=self.backoff_factor,
+            max_backoff_seconds=self.max_backoff_seconds,
+        )
         self.active_sandboxes.add(sandbox.id)
         self.logger.debug(f"Created sandbox {sandbox.id}")
         state["sandbox_id"] = sandbox.id
@@ -133,12 +162,17 @@ class SandboxEnv(vf.StatefulToolEnv):
     async def bulk_delete_sandboxes(self, global_ids: list[str]) -> None:
         """Delete multiple sandboxes by their global IDs"""
         sandbox_client = SandboxClient(APIClient())
-        try:
-            sandbox_client.bulk_delete(global_ids)
-            self.logger.debug(f"Bulk deleted sandboxes: {global_ids}")
-            self.active_sandboxes.difference_update(global_ids)
-        except Exception as e:
-            self.logger.error(f"Failed to bulk delete sandboxes {global_ids}: {e}")
+        await with_retry(
+            sandbox_client.bulk_delete,
+            global_ids,
+            logger=self.logger,
+            max_retries=self.max_retries,
+            base_delay=self.base_delay,
+            backoff_factor=self.backoff_factor,
+            max_backoff_seconds=self.max_backoff_seconds,
+        )
+        self.logger.debug(f"Bulk deleted sandboxes: {global_ids}")
+        self.active_sandboxes.difference_update(global_ids)
 
     @vf.teardown  # type: ignore
     async def teardown_sandboxes(self):
@@ -147,23 +181,27 @@ class SandboxEnv(vf.StatefulToolEnv):
             return
         self.logger.info(f"Deleting {len(self.active_sandboxes)} remaining sandboxes")
         sandbox_client = SandboxClient(APIClient())
+
         # TODO: Use the SandboxClient.bulk_delete method once it is more stable and faster
-        while self.active_sandboxes:
-            successfully_deleted = set()
-            for sandbox_id in self.active_sandboxes:
-                try:
-                    self.logger.debug(f"Deleting sandbox {sandbox_id}")
-                    sandbox_client.delete(sandbox_id)
-                    successfully_deleted.add(sandbox_id)
-                    self.logger.debug(f"Successfully deleted sandbox {sandbox_id}")
-                except Exception as e:
-                    self.logger.error(f"Failed to delete sandbox {sandbox_id}: {e}")
+        async def _delete_sandbox(sandbox_id: str):
+            sandbox_client.delete(sandbox_id)
+            self.active_sandboxes.discard(sandbox_id)
+            self.logger.debug(f"Deleted sandbox {sandbox_id}")
 
-            self.active_sandboxes -= successfully_deleted
+        async def _delete_sandbox_with_retry(sandbox_id: str):
+            await with_retry(
+                _delete_sandbox,
+                sandbox_id,
+                logger=self.logger,
+                max_retries=self.max_retries,
+                base_delay=self.base_delay,
+                backoff_factor=self.backoff_factor,
+                max_backoff_seconds=self.max_backoff_seconds,
+            )
 
-            # If no sandboxes were deleted in this pass, break to avoid infinite loop
-            if not successfully_deleted:
-                self.logger.error(
-                    f"Unable to delete remaining sandboxes: {self.active_sandboxes}"
-                )
-                break
+        await asyncio.gather(
+            *[
+                _delete_sandbox_with_retry(sandbox_id)
+                for sandbox_id in self.active_sandboxes
+            ]
+        )

--- a/verifiers/utils/retry_utils.py
+++ b/verifiers/utils/retry_utils.py
@@ -1,0 +1,29 @@
+import asyncio
+from typing import Any, Callable, TypeVar
+from logging import Logger
+from verifiers.utils.async_utils import maybe_await
+
+T = TypeVar("T")
+
+
+async def with_retry(
+    func: Callable[..., T],
+    *args: Any,
+    logger: Logger,
+    max_retries: int = 5,
+    base_delay: float = 0.5,
+    backoff_factor: float = 2.0,
+    max_backoff_seconds: float = 30.0,
+    **kwargs: Any,
+) -> T:
+    delay = base_delay
+    for attempt in range(max_retries):
+        try:
+            result = await maybe_await(func, *args, **kwargs)
+            return result
+        except Exception as e:
+            if attempt == max_retries - 1:
+                raise
+            logger.error(f"Error calling {func.__qualname__}: {e}")
+            await asyncio.sleep(min(delay, max_backoff_seconds))
+            delay *= backoff_factor

--- a/verifiers/utils/retry_utils.py
+++ b/verifiers/utils/retry_utils.py
@@ -24,6 +24,7 @@ async def with_retry(
         except Exception as e:
             if attempt == max_retries - 1:
                 raise
-            logger.error(f"Error calling {func.__qualname__}: {e}")
+            name = func.__name__ if hasattr(func, "__name__") else str(func)
+            logger.error(f"Error calling {name}: {e}")
             await asyncio.sleep(min(delay, max_backoff_seconds))
             delay *= backoff_factor


### PR DESCRIPTION
## Description

Create `with_retry` in *retry_utils.py* and use it to retry on Sandbox creation- and deletion-errors in `vf.SandboxEnv`.

Previously, math-python RL training always crashed before a single step was completed. This change enabled a long, crash-free training run.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->