### PR TITLE
fix: use async client in sandbox teardown with concurrency control

### DIFF
--- a/verifiers/envs/sandbox_env.py
+++ b/verifiers/envs/sandbox_env.py
@@ -5,7 +5,6 @@ from typing import Any
 
 import tenacity as tc
 import verifiers as vf
-from verifiers.utils.async_utils import make_awaitable
 
 try:
     from prime_sandboxes import (
@@ -124,13 +123,13 @@ class SandboxEnv(vf.StatefulToolEnv):
             self.logger.debug(f"Deleted sandbox {sandbox_id}")
 
         try:
-            await self.with_retry(make_awaitable(_delete_sandbox))(sandbox_id)
+            await self.with_retry(_delete_sandbox)(sandbox_id)
         except Exception as e:
             self.logger.warning(f"Failed to delete sandbox {sandbox_id}: {e}")
 
     async def setup_state(self, state: vf.State, **kwargs) -> vf.State:
         """Create per-rollout sandbox"""
-        sandbox = await self.with_retry(make_awaitable(self.sandbox_client.create))(
+        sandbox = await self.with_retry(self.sandbox_client.create)(
             self.sandbox_request
         )
         self.active_sandboxes.add(sandbox.id)
@@ -156,7 +155,7 @@ class SandboxEnv(vf.StatefulToolEnv):
     async def bulk_delete_sandboxes(self, global_ids: list[str]) -> None:
         """Delete multiple sandboxes by their global IDs"""
         try:
-            await self.with_retry(make_awaitable(self.sandbox_client.bulk_delete))(
+            await self.with_retry(self.sandbox_client.bulk_delete)(
                 global_ids
             )
             self.logger.debug(f"Bulk deleted sandboxes: {global_ids}")
@@ -176,7 +175,7 @@ class SandboxEnv(vf.StatefulToolEnv):
         async def _delete_sandbox_with_retry(sandbox_id: str):
             async with semaphore:
                 try:
-                    await self.with_retry(make_awaitable(self.sandbox_client.delete))(
+                    await self.with_retry(self.sandbox_client.delete)(
                         sandbox_id
                     )
                     self.active_sandboxes.discard(sandbox_id)

--- a/verifiers/envs/sandbox_env.py
+++ b/verifiers/envs/sandbox_env.py
@@ -10,10 +10,8 @@ from verifiers.utils.async_utils import make_awaitable
 try:
     from prime_sandboxes import (
         AdvancedConfigs,
-        APIClient,
         AsyncSandboxClient,
         CreateSandboxRequest,
-        SandboxClient,
     )
 except ImportError:
     raise ImportError(
@@ -157,9 +155,8 @@ class SandboxEnv(vf.StatefulToolEnv):
 
     async def bulk_delete_sandboxes(self, global_ids: list[str]) -> None:
         """Delete multiple sandboxes by their global IDs"""
-        sandbox_client = SandboxClient(APIClient())
         try:
-            await self.with_retry(make_awaitable(sandbox_client.bulk_delete))(
+            await self.with_retry(make_awaitable(self.sandbox_client.bulk_delete))(
                 global_ids
             )
             self.logger.debug(f"Bulk deleted sandboxes: {global_ids}")
@@ -168,27 +165,30 @@ class SandboxEnv(vf.StatefulToolEnv):
             self.logger.error(f"Failed to bulk delete sandboxes {global_ids}: {e}")
 
     @vf.teardown  # type: ignore
-    async def teardown_sandboxes(self):
-        """Delete all active sandboxes"""
+    async def teardown_sandboxes(self, max_concurrent: int = 50):
+        """Delete all active sandboxes with controlled concurrency"""
         if len(self.active_sandboxes) == 0:
             return
         self.logger.info(f"Deleting {len(self.active_sandboxes)} remaining sandboxes")
-        sandbox_client = SandboxClient(APIClient())
 
-        # TODO: Use the SandboxClient.bulk_delete method once it is more stable and faster
-        async def _delete_sandbox(sandbox_id: str):
-            sandbox_client.delete(sandbox_id)
-            self.active_sandboxes.discard(sandbox_id)
-            self.logger.debug(f"Deleted sandbox {sandbox_id}")
+        semaphore = asyncio.Semaphore(max_concurrent)
 
         async def _delete_sandbox_with_retry(sandbox_id: str):
-            await self.with_retry(make_awaitable(_delete_sandbox))(sandbox_id)
+            async with semaphore:
+                try:
+                    await self.with_retry(make_awaitable(self.sandbox_client.delete))(
+                        sandbox_id
+                    )
+                    self.active_sandboxes.discard(sandbox_id)
+                    self.logger.debug(f"Deleted sandbox {sandbox_id}")
+                except Exception as e:
+                    self.logger.warning(f"Failed to delete sandbox {sandbox_id}: {e}")
 
         try:
             await asyncio.gather(
                 *[
                     _delete_sandbox_with_retry(sandbox_id)
-                    for sandbox_id in self.active_sandboxes
+                    for sandbox_id in list(self.active_sandboxes)  # copy to avoid mutation during iteration
                 ]
             )
         except Exception:

--- a/verifiers/utils/async_utils.py
+++ b/verifiers/utils/async_utils.py
@@ -1,6 +1,5 @@
 import asyncio
 import inspect
-from functools import wraps
 from typing import AsyncContextManager, Callable, Optional
 
 
@@ -9,14 +8,6 @@ async def maybe_await(func: Callable, *args, **kwargs):
     if inspect.isawaitable(result):
         return await result
     return result
-
-
-def make_awaitable(func: Callable):
-    @wraps(func)
-    async def wrapper(*args, **kwargs):
-        return await maybe_await(func, *args, **kwargs)
-
-    return wrapper
 
 
 class NullAsyncContext:


### PR DESCRIPTION
## Summary
- Replace sync `SandboxClient` with async `self.sandbox_client` in `teardown_sandboxes()` and `bulk_delete_sandboxes()`
- Add semaphore (max_concurrent=50) to prevent unbounded concurrent deletes blocking the event loop

```
❯ uv run vf-eval math-python -n 30 -r 1 -c 30 -b https://openrouter.ai/api/v1
warning: The `extra-build-dependencies` option is experimental and may change without warning. Pass `--preview-features extra-build-dependencies` to disable this warning.
2025-12-01 12:35:20 - verifiers.utils.env_utils - INFO - Loading environment: math-python
2025-12-01 12:35:20 - verifiers.utils.env_utils - INFO - Using default args: num_train_examples=-1, dataset_name='math', max_turns=100, dataset_split='train'
2025-12-01 12:35:23 - verifiers.rubrics.RubricGroup - INFO - Initialized RubricGroup with 2 rubrics
2025-12-01 12:35:23 - verifiers.utils.env_utils - INFO - Successfully loaded environment 'math-python'
2025-12-01 12:35:23 - verifiers.utils.eval_utils - INFO - Starting evaluation with model: gpt-4.1-mini
2025-12-01 12:35:23 - verifiers.utils.eval_utils - INFO - Configuration: num_examples=30, rollouts_per_example=1, max_concurrent=30
2025-12-01 12:35:23 - verifiers.envs.PythonEnv - INFO - eval_dataset is not set, falling back to train dataset
Processing 30 groups (30 total rollouts): 100%|██████████████████████| 30/30 [03:23<00:00,  6.79s/it]
2025-12-01 12:38:47 - verifiers.utils.eval_utils - INFO - Evaluation completed in 203.56 seconds
--- Evaluation ---
Environment: math-python
Model: gpt-4.1-mini
Provider: https://api.openai.com/v1/
Examples: 30
Rollouts per example: 1
--- Example ---
```