### PR TITLE
fix python errors from incorrect bash-output parsing

### DIFF
--- a/verifiers/envs/python_env.py
+++ b/verifiers/envs/python_env.py
@@ -231,6 +231,15 @@ PY
         raw_response = await self.bash(command, sandbox_id=sandbox_id)
         if not raw_response:
             raise RuntimeError("Python worker returned no output")
+
+        # Quick sanity check for known error formats from bash()
+        if (
+            raw_response.startswith("Error: ")
+            or raw_response.startswith("stderr:")
+            or raw_response == "(no output)"
+        ):
+            raise RuntimeError(f"Python worker failed: {raw_response}")
+
         return json.loads(raw_response)
 
     def _format_response(

--- a/verifiers/envs/sandbox_env.py
+++ b/verifiers/envs/sandbox_env.py
@@ -155,9 +155,7 @@ class SandboxEnv(vf.StatefulToolEnv):
     async def bulk_delete_sandboxes(self, global_ids: list[str]) -> None:
         """Delete multiple sandboxes by their global IDs"""
         try:
-            await self.with_retry(self.sandbox_client.bulk_delete)(
-                global_ids
-            )
+            await self.with_retry(self.sandbox_client.bulk_delete)(global_ids)
             self.logger.debug(f"Bulk deleted sandboxes: {global_ids}")
             self.active_sandboxes.difference_update(global_ids)
         except Exception as e:
@@ -175,9 +173,7 @@ class SandboxEnv(vf.StatefulToolEnv):
         async def _delete_sandbox_with_retry(sandbox_id: str):
             async with semaphore:
                 try:
-                    await self.with_retry(self.sandbox_client.delete)(
-                        sandbox_id
-                    )
+                    await self.with_retry(self.sandbox_client.delete)(sandbox_id)
                     self.active_sandboxes.discard(sandbox_id)
                     self.logger.debug(f"Deleted sandbox {sandbox_id}")
                 except Exception as e:
@@ -187,7 +183,9 @@ class SandboxEnv(vf.StatefulToolEnv):
             await asyncio.gather(
                 *[
                     _delete_sandbox_with_retry(sandbox_id)
-                    for sandbox_id in list(self.active_sandboxes)  # copy to avoid mutation during iteration
+                    for sandbox_id in list(
+                        self.active_sandboxes
+                    )  # copy to avoid mutation during iteration
                 ]
             )
         except Exception:


### PR DESCRIPTION
## Description

In `vf.PythonEnv._send_worker_request`, the `vf.SandboxEnv.bash` tool sometimes returns a json-formatted output, and at other times one of a few strings that are associated with specific errors, but aren't json-parsable. Previously, json-format was assumed, which sometimes caused errors in tool execution (with JSON-error messages, instead of the original error messages). This commit quick-fixes that by dealing with error-outputs from `vf.SandboxEnv.bash(...)` separately.

This change was tested in RL training of math-python. Previously, the described issue caused training to fail to improve reward; this fix made it possible for reward to go up again.

Note: also includes some changes from `uv run ruff format` in *sandbox_env.py* to enable the commit to work.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->