### PR TITLE
Fix sandbox teardown event loop errors on Ctrl+C

### DIFF
--- a/verifiers/envs/sandbox_env.py
+++ b/verifiers/envs/sandbox_env.py
@@ -177,7 +177,7 @@ class SandboxEnv(vf.StatefulToolEnv):
         self.logger.info(f"Deleting {len(self.active_sandboxes)} remaining sandboxes")
 
         # Use sync client for teardown - avoids event loop issues during shutdown
-        sync_client = SandboxClient(APIClient(api_key=self.sandbox_client.client.api_key))
+        sync_client = SandboxClient(APIClient())
         sandbox_ids = list(self.active_sandboxes)
 
         # Try bulk delete first (most efficient)

--- a/verifiers/envs/sandbox_env.py
+++ b/verifiers/envs/sandbox_env.py
@@ -13,6 +13,7 @@ try:
         CreateSandboxRequest,
         SandboxClient,
     )
+    from prime_sandboxes.core import APIClient
 except ImportError:
     raise ImportError(
         "prime-sandboxes is not installed. Please install it with `uv pip install prime-sandboxes`."
@@ -176,7 +177,7 @@ class SandboxEnv(vf.StatefulToolEnv):
         self.logger.info(f"Deleting {len(self.active_sandboxes)} remaining sandboxes")
 
         # Use sync client for teardown - avoids event loop issues during shutdown
-        sync_client = SandboxClient()
+        sync_client = SandboxClient(APIClient())
         sandbox_ids = list(self.active_sandboxes)
 
         # Try bulk delete first (most efficient)

--- a/verifiers/envs/sandbox_env.py
+++ b/verifiers/envs/sandbox_env.py
@@ -177,7 +177,7 @@ class SandboxEnv(vf.StatefulToolEnv):
         self.logger.info(f"Deleting {len(self.active_sandboxes)} remaining sandboxes")
 
         # Use sync client for teardown - avoids event loop issues during shutdown
-        sync_client = SandboxClient(APIClient())
+        sync_client = SandboxClient(APIClient(api_key=self.sandbox_client.client.api_key))
         sandbox_ids = list(self.active_sandboxes)
 
         # Try bulk delete first (most efficient)


### PR DESCRIPTION
## Summary
- Fixes Event loop is closed errors when hitting Ctrl+C during async execution
- Uses sync SandboxClient for teardown to avoid event loop issues during signal handling
- Normal runtime sandbox deletion still uses async client (no performance impact)

## Problem
When hitting Ctrl+C during async execution, the teardown code would fail with cascading errors like RuntimeError: Event loop is closed and RuntimeError: cannot schedule new futures after interpreter shutdown.

This happened because signal handlers tried to run async cleanup while the event loop was running/shutting down, and the retry logic would keep trying indefinitely.

## Solution
Use the synchronous SandboxClient for teardown operations only. Since the HTTP calls do not need asyncio, this avoids event loop issues entirely.

## Test plan
- [ ] Run a sandbox-based environment and hit Ctrl+C mid-execution
- [ ] Verify sandboxes are cleaned up without error spam