### PR TITLE
Assert datasets>=3.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "datasets",
+    "datasets>=3.0.0",
     "jinja2>=3.1.6",
     "openai>=1.108.1",
     "openai-agents>=0.0.7",


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Before `import datasets` would fail from a fresh `uv sync` venv with the following error

<img width="1287" height="595" alt="Screenshot_2025-12-03_at_1 49 49_PM" src="https://github.com/user-attachments/assets/46a7a671-cb62-4315-a44c-e11ff07d45c0" />

For some reason it defaulted to `datasets 2.4.1` which is two major version behind.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->