### PR TITLE
Error handling and propagation

### DIFF
--- a/environments/math_python/math_python.py
+++ b/environments/math_python/math_python.py
@@ -7,6 +7,14 @@ def load_environment(
     dataset_split: str = "train",
     num_train_examples: int = -1,
     max_turns: int = 100,
+    max_startup_wait_seconds: int = 30,
+    pip_install_packages: str = "numpy sympy scipy",
+    sandbox_cpu_cores: int = 1,
+    sandbox_memory_gb: int = 2,
+    sandbox_disk_size_gb: int = 5,
+    sandbox_gpu_count: int = 0,
+    sandbox_timeout_minutes: int = 60,
+    sandbox_timeout_per_command_seconds: int = 30,
     **kwargs,
 ):
     dataset = load_example_dataset(dataset_name, dataset_split, n=num_train_examples)
@@ -22,6 +30,16 @@ def load_environment(
         parser=parser,
         rubric=math_rubric,
         max_turns=max_turns,
+        # python env args
+        max_startup_wait_seconds=max_startup_wait_seconds,
+        pip_install_packages=pip_install_packages,
+        # sandbox env args
+        cpu_cores=sandbox_cpu_cores,
+        memory_gb=sandbox_memory_gb,
+        disk_size_gb=sandbox_disk_size_gb,
+        gpu_count=sandbox_gpu_count,
+        timeout_minutes=sandbox_timeout_minutes,
+        timeout_per_command_seconds=sandbox_timeout_per_command_seconds,
         **kwargs,
     )
     assert vf_env.tools is not None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ from verifiers import (
     State,
     StatefulToolEnv,
     ThinkParser,
+    ToolCallError,
     ToolEnv,
     XMLParser,
     stop,
@@ -353,7 +354,7 @@ def square_tool(x: int) -> int:
 
 
 def faulty_tool() -> None:
-    raise ValueError("failure")
+    raise ToolCallError(cause=ValueError("failure"))
 
 
 class BasicToolEnv(ToolEnv):

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -39,12 +39,7 @@ class SimpleEnvironment(Environment):
         state = await self.setup_state(state)
 
         prompt_messages = state["prompt"]
-        response = await self.get_model_response(
-            client=client,
-            model=model,
-            prompt=prompt_messages,
-            sampling_args=sampling_args or {},
-        )
+        response = await self.get_model_response(state, prompt_messages)
 
         from verifiers.utils.response_utils import parse_response_messages
 
@@ -201,11 +196,14 @@ class TestEnvironmentBase:
         )
 
         prompt: Messages = [{"role": "user", "content": "Hello"}]
-        response = await env.get_model_response(
-            prompt=prompt,
+        state = await env.init_state(
+            input=RolloutInput(example_id=0, task="test", prompt=prompt),
             client=mock_openai_client,
             model="test-model",
-            message_type="chat",
+        )
+        response = await env.get_model_response(
+            state,
+            prompt,
         )
 
         # Check response structure
@@ -233,11 +231,14 @@ class TestEnvironmentBase:
         )
 
         prompt = "Complete this:"
-        response = await env.get_model_response(
-            prompt=prompt,
+        state = await env.init_state(
+            input=RolloutInput(example_id=0, task="test", prompt=prompt),
             client=mock_openai_client,
             model="test-model",
-            message_type="completion",
+        )
+        response = await env.get_model_response(
+            state,
+            prompt,
         )
 
         # Check response structure

--- a/tests/test_environment_extra.py
+++ b/tests/test_environment_extra.py
@@ -17,6 +17,7 @@ from pathlib import Path
 import pytest
 from datasets import Dataset
 
+import verifiers as vf
 from verifiers.envs.environment import Environment
 from verifiers.parsers.parser import Parser
 from verifiers.rubrics.rubric import Rubric
@@ -42,16 +43,13 @@ class DummyEnvironment(Environment):
         model: str,
         sampling_args: SamplingArgs | None = None,
     ):
-        state = await self.init_state(input, client=client, model=model)
+        state = await self.init_state(
+            input, client=client, model=model, sampling_args=sampling_args
+        )
         state = await self.setup_state(state)
 
         prompt_messages = state["prompt"]
-        response = await self.get_model_response(
-            prompt=prompt_messages,
-            client=client,
-            model=model,
-            sampling_args=sampling_args,
-        )
+        response = await self.get_model_response(state=state, prompt=prompt_messages)
         assert response is not None
 
         from verifiers.types import TrajectoryStep
@@ -121,19 +119,22 @@ def _make_env(
 @pytest.mark.asyncio
 async def test_get_model_response_chat_with_tools(mock_openai_client):
     env = _make_env(mock_openai_client)
-    prompt = [{"role": "user", "content": "Hello"}]
+    prompt: vf.Messages = [{"role": "user", "content": "Hello"}]
     tools = [
         {
             "type": "function",
             "function": {"name": "echo", "description": "echo", "parameters": {}},
         }
     ]
-    resp = await env.get_model_response(
+    state = await env.init_state(
+        input=RolloutInput(example_id=0, task="test", prompt=prompt),
         client=mock_openai_client,
         model="test-model",
+    )
+    state["oai_tools"] = tools
+    resp = await env.get_model_response(
+        state=state,
         prompt=prompt,
-        oai_tools=tools,
-        message_type="chat",
     )
     # Ensure the client was invoked and received tools kwarg
     assert hasattr(resp, "choices")
@@ -146,13 +147,13 @@ async def test_get_model_response_chat_with_tools(mock_openai_client):
 async def test_get_model_response_completion_rejects_tools(mock_openai_client):
     env = _make_env(mock_openai_client, message_type="completion")
     with pytest.raises(ValueError, match="oai_tools are not supported for completion"):
-        await env.get_model_response(
+        state = await env.init_state(
+            input=RolloutInput(example_id=0, task="test", prompt="Complete this"),
             client=mock_openai_client,
             model="test-model",
-            prompt="Complete this",
-            oai_tools=[{"type": "function", "function": {"name": "noop"}}],
-            message_type="completion",
         )
+        state["oai_tools"] = [{"type": "function", "function": {"name": "noop"}}]
+        await env.get_model_response(state=state, prompt="Complete this")
 
 
 def test_run_rollouts_with_max_concurrent(mock_openai_client):

--- a/tests/test_environment_extra.py
+++ b/tests/test_environment_extra.py
@@ -146,7 +146,7 @@ async def test_get_model_response_chat_with_tools(mock_openai_client):
 @pytest.mark.asyncio
 async def test_get_model_response_completion_rejects_tools(mock_openai_client):
     env = _make_env(mock_openai_client, message_type="completion")
-    with pytest.raises(ValueError, match="oai_tools are not supported for completion"):
+    with pytest.raises(vf.ModelError):
         state = await env.init_state(
             input=RolloutInput(example_id=0, task="test", prompt="Complete this"),
             client=mock_openai_client,

--- a/tests/test_singleturn_env.py
+++ b/tests/test_singleturn_env.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from datasets import Dataset
 
+import verifiers as vf
 from verifiers import Parser, Rubric, SingleTurnEnv
 from verifiers.types import RolloutInput, RolloutTiming
 
@@ -222,16 +223,17 @@ class TestSingleTurnEnv:
         prompt = [{"role": "user", "content": "Hello"}]
         answer = "Hi"
 
-        with pytest.raises(Exception, match="API Error"):
-            await mock_singleturn_env.rollout(
-                input=RolloutInput(
-                    prompt=prompt,
-                    answer=answer,
-                    example_id=0,
-                ),
-                client=mock_singleturn_env.client,
-                model="test-model",
-            )
+        state = await mock_singleturn_env.rollout(
+            input=RolloutInput(
+                prompt=prompt,
+                answer=answer,
+                example_id=0,
+            ),
+            client=mock_singleturn_env.client,
+            model="test-model",
+        )
+        assert state.get("error") is not None
+        assert isinstance(state["error"], vf.ModelError)
 
     @pytest.mark.asyncio
     async def test_rollout_state_structure(self, mock_singleturn_env):

--- a/tests/test_stateful_tool_env.py
+++ b/tests/test_stateful_tool_env.py
@@ -3,7 +3,9 @@
 import json
 
 import pytest
+from openai.types.chat import ChatCompletionUserMessageParam
 
+import verifiers as vf
 from tests.conftest import secret_tool
 from verifiers.types import RolloutInput
 
@@ -32,7 +34,7 @@ class TestStatefulToolEnv:
             "content": None,
             "tool_calls": [tool_call],
         }
-        user_message = {"role": "user", "content": "Offset 5"}
+        user_message = ChatCompletionUserMessageParam(content="Offset 5", role="user")
 
         mock_openai_client.add_chat_response(
             messages=[user_message],
@@ -55,6 +57,7 @@ class TestStatefulToolEnv:
         state = await mock_stateful_tool_env.rollout(
             input=RolloutInput(
                 prompt=[user_message],
+                task="",
                 answer="",
                 example_id=0,
             ),
@@ -80,3 +83,95 @@ class TestStatefulToolEnv:
         assert "secret" not in schema["function"]["parameters"]["properties"]
         assert mock_stateful_tool_env.skipped_args["secret_tool"] == ["secret"]
         assert "secret_tool" in mock_stateful_tool_env.tool_map
+
+    @pytest.mark.asyncio
+    async def test_tool_env_tool_invalid_json_arguments(
+        self, mock_stateful_tool_env, mock_openai_client, sample_chat_dataset
+    ):
+        """Test that ToolEnv stops rollout when tool call is not JSON-parsable."""
+
+        # Create a tool call with invalid JSON arguments
+        from openai.types.chat.chat_completion_message_tool_call import (
+            ChatCompletionMessageToolCall,
+            Function,
+        )
+
+        tool_call_with_invalid_json_arguments = ChatCompletionMessageToolCall(
+            id="call_0",
+            type="function",
+            function=Function(
+                name="square_tool",
+                arguments='{"x": invalid json}',  # Invalid JSON
+            ),
+        )
+
+        # First response triggers tool call with invalid JSON
+        mock_openai_client.add_chat_response(
+            messages=[{"role": "user", "content": "Square 4"}],
+            response="Using tool",
+            tool_calls=[tool_call_with_invalid_json_arguments],
+        )
+
+        state = await mock_stateful_tool_env.rollout(
+            input=RolloutInput(
+                prompt=[{"role": "user", "content": "Square 4"}],
+                answer="",
+                task="",
+                example_id=0,
+            ),
+            client=mock_openai_client,
+            model="test-model",
+        )
+
+        # Should have error set
+        assert state.get("error") is not None
+        assert isinstance(state["error"], vf.ToolParseError)
+        assert isinstance(state["error"], vf.ToolError)
+
+        # Should have partial trajectory (one step with the tool call attempt)
+        assert len(state["trajectory"]) == 1
+
+        # Should render completion conditions (e.g. is_completed, timing, stop_condition)
+        assert state["is_completed"] is True
+        assert state["stop_condition"] == "has_error"
+        assert state["timing"] is not None
+        assert state["completion"] is not None
+
+    @pytest.mark.asyncio
+    async def test_tool_env_tool_call_error(
+        self, mock_stateful_tool_env, mock_openai_client, sample_chat_dataset
+    ):
+        """Test that ToolEnv stops rollout when tool raises an exception."""
+
+        tool_call = _build_tool_call("faulty_tool", {})
+
+        mock_openai_client.add_chat_response(
+            messages=[{"role": "user", "content": "Invoke"}],
+            response="Using tool",
+            tool_calls=[tool_call],
+        )
+
+        state = await mock_stateful_tool_env.rollout(
+            input=RolloutInput(
+                prompt=[{"role": "user", "content": "Invoke"}],
+                answer="",
+                task="",
+                example_id=0,
+            ),
+            client=mock_openai_client,
+            model="test-model",
+        )
+
+        # Should have error set
+        assert state.get("error") is not None
+        assert isinstance(state["error"], vf.ToolCallError)
+        assert isinstance(state["error"], vf.ToolError)
+
+        # Should have partial trajectory (one step with the tool call attempt)
+        assert len(state["trajectory"]) == 1
+
+        # Should render completion conditions (e.g. is_completed, timing, stop_condition)
+        assert state["is_completed"] is True
+        assert state["stop_condition"] == "has_error"
+        assert state["timing"] is not None
+        assert state["completion"] is not None

--- a/tests/test_tool_env.py
+++ b/tests/test_tool_env.py
@@ -166,7 +166,9 @@ class TestToolEnv:
 
         class ErrorToolEnv(vf.ToolEnv):
             def __init__(self, **kwargs):
-                super().__init__(tools=[faulty_tool], **kwargs)
+                super().__init__(
+                    tools=[faulty_tool], stop_errors=[vf.ToolCallError], **kwargs
+                )
 
         env = ErrorToolEnv(
             client=mock_openai_client,

--- a/tests/test_tool_env.py
+++ b/tests/test_tool_env.py
@@ -101,7 +101,9 @@ class TestToolEnv:
 
         class TestToolEnv(vf.ToolEnv):
             def __init__(self, **kwargs):
-                super().__init__(tools=[square_tool], **kwargs)
+                super().__init__(
+                    tools=[square_tool], stop_errors=[vf.ToolParseError], **kwargs
+                )
 
         env = TestToolEnv(
             client=mock_openai_client,

--- a/tests/test_tool_env.py
+++ b/tests/test_tool_env.py
@@ -3,6 +3,9 @@
 import json
 
 import pytest
+from openai.types.chat.chat_completion_user_message_param import (
+    ChatCompletionUserMessageParam,
+)
 
 from tests.conftest import faulty_tool
 from verifiers.envs.tool_env import ToolEnv
@@ -31,7 +34,7 @@ class TestToolEnv:
             "content": None,
             "tool_calls": [tool_call],
         }
-        user_message = {"role": "user", "content": "Square 4"}
+        user_message = ChatCompletionUserMessageParam(content="Square 4", role="user")
 
         mock_openai_client.add_chat_response(
             messages=[user_message],
@@ -51,6 +54,7 @@ class TestToolEnv:
             input=RolloutInput(
                 prompt=[user_message],
                 answer="",
+                task="",
                 example_id=0,
             ),
             client=mock_openai_client,
@@ -77,6 +81,7 @@ class TestToolEnv:
             input=RolloutInput(
                 prompt=[{"role": "user", "content": "Hello"}],
                 answer="",
+                task="",
                 example_id=0,
             ),
             client=mock_openai_client,
@@ -114,6 +119,7 @@ class TestToolEnv:
             input=RolloutInput(
                 prompt=[{"role": "user", "content": "Invoke"}],
                 answer="",
+                task="",
                 example_id=0,
             ),
             client=mock_openai_client,

--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -7,7 +7,7 @@ import sys
 from typing import TYPE_CHECKING, Optional
 
 # early imports to avoid circular dependencies
-from .exceptions import *  # noqa # isort: skip
+from .errors import *  # noqa # isort: skip
 from .types import *  # noqa # isort: skip
 from .utils.decorators import (  # noqa # isort: skip
     cleanup,

--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -7,6 +7,7 @@ import sys
 from typing import TYPE_CHECKING, Optional
 
 # early imports to avoid circular dependencies
+from .exceptions import *  # noqa # isort: skip
 from .types import *  # noqa # isort: skip
 from .utils.decorators import (  # noqa # isort: skip
     cleanup,

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -510,11 +510,6 @@ class Environment(ABC):
                 return True
         return False
 
-    @vf.stop(priority=100)  # high priority to always check for errors first
-    async def has_error(self, state: State, **kwargs) -> bool:
-        """Abrupts rollout early if an error has occurred."""
-        return state.get("error") is not None
-
     async def run_rollout(
         self,
         sem: AsyncContextManager,

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -291,9 +291,10 @@ class Environment(ABC):
 
     async def get_model_response(
         self,
-        client: AsyncOpenAI,
-        model: str,
+        state: State,
         prompt: Messages,
+        client: AsyncOpenAI | None = None,
+        model: str | None = None,
         oai_tools: list[ChatCompletionToolParam] | None = None,
         sampling_args: SamplingArgs | None = None,
         message_type: MessageType | None = None,
@@ -304,10 +305,16 @@ class Environment(ABC):
         Convenience function for wrapping (chat, completion) API calls.
         Returns special error messages for context length issues.
         """
-        sampling_args = sampling_args or {}
-        # resolve message type first
-        if message_type is None:
-            message_type = self.message_type
+        # resolve optional argument, fallback to state or class defaults
+        client = client or state["client"]
+        model = model or state["model"]
+        oai_tools = oai_tools or state["oai_tools"]
+        sampling_args = sampling_args or state["sampling_args"]
+        message_type = message_type or self.message_type
+        assert model is not None
+        assert client is not None
+        assert sampling_args is not None
+
         # normalize sampling args:
         # - if max_tokens is provided for chat, rename to max_completion_tokens
         # - drop any None-valued entries to avoid sending to the client

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -23,7 +23,6 @@ from typing import (
 from datasets import Dataset
 from openai import AsyncOpenAI, BadRequestError, OpenAI
 
-import verifiers as vf
 from verifiers.parsers.parser import Parser
 from verifiers.rubrics.rubric import Rubric
 from verifiers.types import (
@@ -454,10 +453,6 @@ class Environment(ABC):
         """
         pass
 
-    @vf.stop
-    async def has_error(self, state: State) -> bool:
-        return state.get("error") is not None
-
     async def _cleanup(self, state: State):
         """
         Clean up rollout resources.
@@ -500,6 +495,14 @@ class Environment(ABC):
                 await self._cleanup(state)
                 return True
         return False
+
+    async def has_error(self, state: State, **kwargs) -> bool:
+        """Checks if an error has occurred in the environment."""
+        has_error = state.get("error") is not None
+        if has_error:
+            print(state["error"])
+            self.logger.error(f"An error has occurred: {state['error']!r}. Exiting...")
+        return has_error
 
     async def run_rollout(
         self,

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -399,8 +399,7 @@ class Environment(ABC):
                     return get_overlong_prompt_dummy_response(
                         message_type or self.message_type
                     )
-            self.logger.error(f"Error getting model response: {e} \n\nExiting...")
-            raise e
+            raise vf.ModelError(e)
 
     async def init_state(
         self,
@@ -498,6 +497,9 @@ class Environment(ABC):
         state["timing"]["total_ms"] = (end_time - start_time) * 1000
 
     async def _render_completion(self, state: State):
+        if len(state["trajectory"]) == 0:
+            state["completion"] = []
+            return
         last_prompt = state["trajectory"][-1]["prompt"]
         last_completion = state["trajectory"][-1]["completion"]
         full_conversation = concat_messages([last_prompt, last_completion])

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -43,10 +43,7 @@ from verifiers.types import (
 )
 from verifiers.utils.async_utils import maybe_semaphore
 from verifiers.utils.eval_utils import make_dataset, save_rollout_results
-from verifiers.utils.message_utils import (
-    concat_messages,
-    get_overlong_prompt_dummy_response,
-)
+from verifiers.utils.message_utils import concat_messages
 from verifiers.utils.path_utils import get_results_path
 
 if TYPE_CHECKING:
@@ -396,9 +393,7 @@ class Environment(ABC):
                 ]
                 if any(phrase in error_text for phrase in context_length_phrases):
                     self.logger.debug("Caught overlong prompt.")
-                    return get_overlong_prompt_dummy_response(
-                        message_type or self.message_type
-                    )
+                    raise vf.OverlongPromptError(e)
             raise vf.ModelError(e)
 
     async def init_state(

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -5,6 +5,7 @@ import json
 import logging
 import signal
 import time
+import traceback
 from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
@@ -481,8 +482,10 @@ class Environment(ABC):
             state["stop_condition"] = condition.__name__
             if state.get("stop_condition") == "has_error":
                 self.logger.error(
-                    f"An error has occurred: {state['error']!r}. Exiting..."
+                    f"Got {state['error'].__class__.__name__}, caused by {state['error'].cause!r}"
                 )
+                cause = state["error"].cause
+                traceback.print_exception(type(cause), cause, cause.__traceback__)
             return True
         return False
 

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -430,6 +430,7 @@ class Environment(ABC):
         state["trajectory"] = []
         state["reward"] = None
         state["metrics"] = None
+        state["error"] = None
         state["timing"] = RolloutTiming(
             generation_ms=0.0,
             scoring_ms=0.0,

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -43,10 +43,8 @@ from verifiers.types import (
 )
 from verifiers.utils.async_utils import maybe_semaphore
 from verifiers.utils.eval_utils import make_dataset, save_rollout_results
-from verifiers.utils.message_utils import concat_messages
 from verifiers.utils.message_utils import (
     concat_messages,
-    get_overlong_prompt_dummy_response,
     strip_nones_from_content,
 )
 from verifiers.utils.path_utils import get_results_path

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -23,6 +23,7 @@ from typing import (
 from datasets import Dataset
 from openai import AsyncOpenAI, BadRequestError, OpenAI
 
+import verifiers as vf
 from verifiers.parsers.parser import Parser
 from verifiers.rubrics.rubric import Rubric
 from verifiers.types import (
@@ -452,6 +453,10 @@ class Environment(ABC):
         Run a rollout for a given input.
         """
         pass
+
+    @vf.stop
+    async def has_error(self, state: State) -> bool:
+        return state.get("error") is not None
 
     async def _cleanup(self, state: State):
         """

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -19,6 +19,7 @@ from typing import (
     List,
     Literal,
     TypeVar,
+    cast,
 )
 
 from datasets import Dataset
@@ -310,11 +311,12 @@ class Environment(ABC):
         client = client or state["client"]
         model = model or state["model"]
         oai_tools = oai_tools or state["oai_tools"]
-        sampling_args = sampling_args or state["sampling_args"]
+        sampling_args = cast(
+            SamplingArgs, sampling_args or state["sampling_args"] or {}
+        )
         message_type = message_type or self.message_type
         assert model is not None
         assert client is not None
-        assert sampling_args is not None
 
         # normalize sampling args:
         # - if max_tokens is provided for chat, rename to max_completion_tokens

--- a/verifiers/envs/multiturn_env.py
+++ b/verifiers/envs/multiturn_env.py
@@ -93,8 +93,10 @@ class MultiTurnEnv(vf.Environment):
         """
         state = await self.init_state(input, client, model, sampling_args)
         state = await self.setup_state(state)
-        while not await self.is_completed(state):
+        while not await self.is_completed(state) and not await self.has_error(state):
             prompt_messages = await self.get_prompt_messages(state)
+            if await self.has_error(state):
+                break
             response = await self.get_model_response(
                 client,
                 model,
@@ -103,5 +105,7 @@ class MultiTurnEnv(vf.Environment):
                 sampling_args=sampling_args,
                 message_type=self.message_type,
             )
+            if await self.has_error(state):
+                break
             await self.add_model_response(state, prompt_messages, response)
         return state

--- a/verifiers/envs/multiturn_env.py
+++ b/verifiers/envs/multiturn_env.py
@@ -95,10 +95,10 @@ class MultiTurnEnv(vf.Environment):
         state = await self.setup_state(state)
         while not await self.is_completed(state):
             prompt_messages = await self.get_prompt_messages(state)
-            if await self.has_error(state):
+            if state.get("error") is not None:
                 continue
             response = await self.get_model_response(state, prompt_messages)
-            if await self.has_error(state):
+            if state.get("error") is not None:
                 continue
             await self.add_model_response(state, prompt_messages, response)
         return state

--- a/verifiers/envs/multiturn_env.py
+++ b/verifiers/envs/multiturn_env.py
@@ -97,14 +97,7 @@ class MultiTurnEnv(vf.Environment):
             prompt_messages = await self.get_prompt_messages(state)
             if await self.has_error(state):
                 continue
-            response = await self.get_model_response(
-                client,
-                model,
-                prompt_messages,
-                oai_tools=state["oai_tools"],
-                sampling_args=sampling_args,
-                message_type=self.message_type,
-            )
+            response = await self.get_model_response(state, prompt_messages)
             if await self.has_error(state):
                 continue
             await self.add_model_response(state, prompt_messages, response)

--- a/verifiers/envs/multiturn_env.py
+++ b/verifiers/envs/multiturn_env.py
@@ -93,10 +93,10 @@ class MultiTurnEnv(vf.Environment):
         """
         state = await self.init_state(input, client, model, sampling_args)
         state = await self.setup_state(state)
-        while not await self.is_completed(state) and not await self.has_error(state):
+        while not await self.is_completed(state):
             prompt_messages = await self.get_prompt_messages(state)
             if await self.has_error(state):
-                break
+                continue
             response = await self.get_model_response(
                 client,
                 model,
@@ -106,6 +106,6 @@ class MultiTurnEnv(vf.Environment):
                 message_type=self.message_type,
             )
             if await self.has_error(state):
-                break
+                continue
             await self.add_model_response(state, prompt_messages, response)
         return state

--- a/verifiers/envs/multiturn_env.py
+++ b/verifiers/envs/multiturn_env.py
@@ -29,6 +29,11 @@ class MultiTurnEnv(vf.Environment):
     async def setup_state(self, state: State) -> State:
         return state
 
+    @vf.stop(priority=100)  # high priority to always check for errors first
+    async def has_error(self, state: State, **kwargs) -> bool:
+        """Abrupts rollout early if an error has occurred."""
+        return state.get("error") is not None
+
     @vf.stop
     async def prompt_too_long(self, state: State) -> bool:
         return state.get("prompt_too_long", False)

--- a/verifiers/envs/python_env.py
+++ b/verifiers/envs/python_env.py
@@ -6,13 +6,19 @@ from typing import Any
 from typing_extensions import TypedDict
 
 import verifiers as vf
-from verifiers.envs.sandbox_env import SandboxEnv
+from verifiers.envs.sandbox_env import SandboxEnv, SandboxState
 from verifiers.utils.decorators import cleanup
 
 
 class PythonWorkerState(TypedDict):
     ready: bool
     execution_count: int
+
+
+class PythonWorkerNotReadyError(vf.SandboxError): ...
+
+
+class PythonWorkerRequestError(vf.SandboxError): ...
 
 
 class PythonEnv(SandboxEnv):
@@ -130,17 +136,10 @@ PY
     _READY_WAIT_SCRIPT = textwrap.dedent(
         """
         bash -lc '
-        start_time=$(date +%s)
         
         while true; do
           if [ -f "{ready_flag}" ]; then
             exit 0
-          fi
-          current_time=$(date +%s)
-          elapsed=$((current_time - start_time))
-          if [ $elapsed -ge {max_wait_seconds} ]; then
-            echo "python worker failed to start within {max_wait_seconds}s" >&2
-            exit 1
           fi
           sleep 0.05
         done
@@ -178,7 +177,7 @@ PY
 
     async def setup_state(self, state: vf.State, **kwargs: Any) -> vf.State:
         state = await super().setup_state(state, **kwargs)
-        state["python_env"] = {
+        state["python_state"] = {
             "ready": False,
             "execution_count": 0,
         }
@@ -193,62 +192,71 @@ PY
         **kwargs: Any,
     ) -> dict[str, Any]:
         updated_args = dict(tool_args)
-        if tool_name != "python":
-            return updated_args
-        sandbox_id = state["sandbox_id"]
-        python_state = state["python_env"]
-        updated_args["python_state"] = python_state
-        updated_args["sandbox_id"] = sandbox_id
+        if tool_name == "python":
+            updated_args["sandbox_id"] = state["sandbox_id"]
+            updated_args["sandbox_state"] = state["sandbox_state"]
+            updated_args["python_state"] = state["python_state"]
         return updated_args
 
     async def python(
-        self, code: str, sandbox_id: str, python_state: PythonWorkerState
+        self,
+        code: str,
+        sandbox_id: str,
+        sandbox_state: SandboxState,
+        python_state: PythonWorkerState,
     ) -> str:
         """Execute `code` inside persistent Python REPL."""
         if not python_state["ready"]:
-            try:
-                await self._wait_for_worker_ready(sandbox_id)
-                python_state["ready"] = True
-            except Exception as e:
-                raise vf.SandboxError(cause=e)
-        sandbox_response = await self._send_worker_request(sandbox_id, {"code": code})
+            await self._wait_for_worker_ready(sandbox_id)
+            python_state["ready"] = True
+        sandbox_response = await self._send_worker_request(
+            sandbox_id, sandbox_state, {"code": code}
+        )
         return self._format_response(python_state, sandbox_response)
 
     @cleanup
-    async def cleanup_python_env(self, state: vf.State):
-        state.pop("python_env", None)
+    async def cleanup_python_state(self, state: vf.State):
+        state.pop("python_state", None)
 
     async def _wait_for_worker_ready(self, sandbox_id: str) -> None:
-        wait_script = self._READY_WAIT_SCRIPT.format(
-            ready_flag=self._READY_FLAG,
-            max_wait_seconds=self.timeout_per_command_seconds,
-        )
-        await self.bash(wait_script, sandbox_id=sandbox_id)
+        try:
+            await self._wait_for_sandbox_ready(sandbox_id)
+            wait_script = self._READY_WAIT_SCRIPT.format(ready_flag=self._READY_FLAG)
+            await self.sandbox_client.execute_command(
+                sandbox_id, wait_script, timeout=self.max_startup_wait_seconds
+            )
+        except Exception as e:
+            raise PythonWorkerNotReadyError(e)
 
     async def _send_worker_request(
-        self, sandbox_id: str, payload: dict[str, Any]
+        self, sandbox_id: str, sandbox_state, payload: dict[str, Any]
     ) -> dict[str, Any]:
-        payload_json = json.dumps(payload)
-        payload_b64 = base64.b64encode(payload_json.encode("utf-8")).decode("utf-8")
-        command = textwrap.dedent(
-            f"""
-            python - <<'PY'
-import base64
-import json
-import sys
+        try:
+            payload_json = json.dumps(payload)
+            payload_b64 = base64.b64encode(payload_json.encode("utf-8")).decode("utf-8")
+            command = textwrap.dedent(
+                f"""
+                python - <<'PY'
+    import base64
+    import json
+    import sys
 
-data = base64.b64decode('{payload_b64}').decode('utf-8')
-with open('{self._COMMAND_FIFO}', 'w', encoding='utf-8') as command_file:
-    command_file.write(data)
-with open('{self._RESPONSE_FIFO}', 'r', encoding='utf-8') as response_file:
-    sys.stdout.write(response_file.read())
-PY
-            """
-        )
-        raw_response = await self.bash(command, sandbox_id=sandbox_id)
-        if not raw_response:
-            raise RuntimeError("Python worker returned no output")
-        return json.loads(raw_response)
+    data = base64.b64decode('{payload_b64}').decode('utf-8')
+    with open('{self._COMMAND_FIFO}', 'w', encoding='utf-8') as command_file:
+        command_file.write(data)
+    with open('{self._RESPONSE_FIFO}', 'r', encoding='utf-8') as response_file:
+        sys.stdout.write(response_file.read())
+    PY
+                """
+            )
+            raw_response = await self.bash(command, sandbox_id, sandbox_state)
+            if not raw_response:
+                raise RuntimeError("Python worker returned no output")
+            response = json.loads(raw_response)
+        except Exception as e:
+            raise PythonWorkerRequestError(e)
+
+        return response
 
     def _format_response(
         self, python_state: PythonWorkerState, sandbox_response: dict[str, Any]

--- a/verifiers/envs/python_env.py
+++ b/verifiers/envs/python_env.py
@@ -199,6 +199,9 @@ PY
         state: vf.State,
         **kwargs: Any,
     ) -> dict[str, Any]:
+        assert isinstance(tool_args, dict), (
+            f"Expected tool_args to be a dict, got {type(tool_args)}: {tool_args}"
+        )
         updated_args = dict(tool_args)
         if tool_name == "python":
             updated_args["sandbox_id"] = state["sandbox_id"]

--- a/verifiers/envs/python_env.py
+++ b/verifiers/envs/python_env.py
@@ -178,7 +178,9 @@ PY
             start_command=start_command,
             **kwargs,
         )
-        self.add_tool(self.python, args_to_skip=["sandbox_id", "python_state"])
+        self.add_tool(
+            self.python, args_to_skip=["sandbox_id", "sandbox_state", "python_state"]
+        )
         self.remove_tool(self.bash)  # omit from agent tool list
 
     async def setup_state(self, state: vf.State, **kwargs: Any) -> vf.State:

--- a/verifiers/envs/python_env.py
+++ b/verifiers/envs/python_env.py
@@ -224,9 +224,11 @@ PY
         try:
             await self._wait_for_sandbox_ready(sandbox_id)
             wait_script = self._READY_WAIT_SCRIPT.format(ready_flag=self._READY_FLAG)
-            await self.sandbox_client.execute_command(
+            result = await self.sandbox_client.execute_command(
                 sandbox_id, wait_script, timeout=self.max_startup_wait_seconds
             )
+            if result.exit_code != 0:
+                raise RuntimeError(result.stderr)
         except Exception as e:
             raise PythonWorkerNotReadyError(e)
 

--- a/verifiers/envs/python_env.py
+++ b/verifiers/envs/python_env.py
@@ -118,7 +118,7 @@ class PythonEnv(SandboxEnv):
 
         rm -f "$command_fifo" "$response_fifo" "$ready_flag"
 
-        pip install -q numpy sympy scipy
+        pip install -q {pip_install_packages}
 
         python - <<'PY'
 import base64
@@ -149,6 +149,7 @@ PY
 
     def __init__(
         self,
+        pip_install_packages: str = "numpy sympy scipy",
         max_startup_wait_seconds: int = 30,
         **kwargs: Any,
     ) -> None:
@@ -164,6 +165,7 @@ PY
                     ready_flag=self._READY_FLAG,
                 ).encode("utf-8")
             ).decode("utf-8"),
+            pip_install_packages=pip_install_packages,
         )
         self.max_startup_wait_seconds = max_startup_wait_seconds
         super().__init__(

--- a/verifiers/envs/python_env.py
+++ b/verifiers/envs/python_env.py
@@ -1,9 +1,13 @@
 import base64
 import json
+import sys
 import textwrap
 from typing import Any
 
-from typing_extensions import TypedDict
+if sys.version_info < (3, 12):
+    from typing_extensions import TypedDict
+else:
+    from typing import TypedDict
 
 import verifiers as vf
 from verifiers.envs.sandbox_env import SandboxEnv, SandboxState

--- a/verifiers/envs/sandbox_env.py
+++ b/verifiers/envs/sandbox_env.py
@@ -1,6 +1,13 @@
 import logging
+import sys
 import time
-from typing import Any, TypedDict
+from typing import Any
+
+if sys.version_info < (3, 12):
+    from typing_extensions import TypedDict
+else:
+    from typing import TypedDict
+
 
 import tenacity as tc
 from prime_sandboxes import CommandTimeoutError

--- a/verifiers/envs/sandbox_env.py
+++ b/verifiers/envs/sandbox_env.py
@@ -83,23 +83,19 @@ class SandboxEnv(vf.StatefulToolEnv):
         ).wraps
         self.add_tool(self.bash, args_to_skip=["sandbox_id", "sandbox_state"])
 
-    async def _wait_for_sandbox_ready(self, sandbox_id: str):
-        """Wait for sandbox to be created"""
-        s = time.time()
-        try:
-            await self.sandbox_client.wait_for_creation(sandbox_id)
-        except Exception as e:
-            raise SandboxNotReadyError(e)
-        self.logger.debug(f"Waited {time.time() - s:.1f}s for sandbox to be ready")
-
     async def bash(
         self, command: str, sandbox_id: str, sandbox_state: SandboxState
     ) -> str:
         """Execute `command` inside persistent sandbox container."""
         # sandbox_id is passed via update_tool_args, not seen by model
         if not sandbox_state["ready"]:
-            await self._wait_for_sandbox_ready(sandbox_id)
+            s = time.time()
+            try:
+                await self.sandbox_client.wait_for_creation(sandbox_id)
+            except Exception as e:
+                raise SandboxNotReadyError(e)
             sandbox_state["ready"] = True
+            self.logger.debug(f"Waited {time.time() - s:.1f}s for sandbox to be ready")
 
         s = time.time()
         self.logger.debug(f"Executing command {command} in sandbox {sandbox_id}")

--- a/verifiers/envs/stateful_tool_env.py
+++ b/verifiers/envs/stateful_tool_env.py
@@ -62,6 +62,8 @@ class StatefulToolEnv(vf.ToolEnv):
                 and arg in params["required"]
             ):
                 cast(list[str], params["required"]).remove(arg)
+        if "$defs" in params and not params["$defs"]:
+            params.pop("$defs")
         if self.oai_tools is None:
             self.oai_tools = []
         self.oai_tools.append(oai_tool)

--- a/verifiers/envs/stateful_tool_env.py
+++ b/verifiers/envs/stateful_tool_env.py
@@ -112,9 +112,14 @@ class StatefulToolEnv(vf.ToolEnv):
         for tool_call in last_msg.get("tool_calls", []):
             try:
                 tool_name: str = tool_call.get("function", {}).get("name", "")
-                tool_args: dict = json.loads(
+                parsed_args = json.loads(
                     tool_call.get("function", {}).get("arguments", "")
                 )
+                if not isinstance(parsed_args, dict):
+                    raise ValueError(
+                        f"Expected tool arguments to be a dict, got {type(parsed_args).__name__}: {parsed_args}"
+                    )
+                tool_args: dict = parsed_args
             except Exception as e:
                 raise vf.ToolParseError(cause=e)
             tool_call_id: str = tool_call.get("id", "")

--- a/verifiers/envs/stateful_tool_env.py
+++ b/verifiers/envs/stateful_tool_env.py
@@ -54,7 +54,7 @@ class StatefulToolEnv(vf.ToolEnv):
                 if "$ref" in arg_properties:
                     refs = arg_properties["$ref"]
                     ref_type = refs.split("/")[-1]
-                    if "$defs" in params and ref_type in params["$defs"]:
+                    if "$defs" in params and ref_type in cast(dict, params["$defs"]):
                         params["$defs"].pop(ref_type)  # type: ignore
             if (
                 "required" in params

--- a/verifiers/envs/stateful_tool_env.py
+++ b/verifiers/envs/stateful_tool_env.py
@@ -116,8 +116,7 @@ class StatefulToolEnv(vf.ToolEnv):
                     tool_call.get("function", {}).get("arguments", "")
                 )
             except Exception as e:
-                state["error"] = vf.ToolParseError(cause=e)
-                return []
+                raise vf.ToolParseError(cause=e)
             tool_call_id: str = tool_call.get("id", "")
             tool_args = self.update_tool_args(
                 tool_name, tool_args, messages, state, **kwargs
@@ -127,7 +126,6 @@ class StatefulToolEnv(vf.ToolEnv):
                     tool_name, tool_args, tool_call_id
                 )
             except Exception as e:
-                state["error"] = vf.ToolCallError(cause=e)
-                return []
+                raise vf.ToolCallError(cause=e)
             tool_messages.append(tool_message)
         return tool_messages

--- a/verifiers/envs/stateful_tool_env.py
+++ b/verifiers/envs/stateful_tool_env.py
@@ -17,13 +17,11 @@ class StatefulToolEnv(vf.ToolEnv):
         self,
         tools: list[Callable] | None = None,
         max_turns: int = 10,
-        error_formatter: Callable[[Exception], str] = lambda e: f"{str(e)}",
         **kwargs,
     ):
         super().__init__(
             tools=tools,
             max_turns=max_turns,
-            error_formatter=error_formatter,
             **kwargs,
         )
         self.tools: list[Callable] = tools or []
@@ -36,7 +34,6 @@ class StatefulToolEnv(vf.ToolEnv):
         }
         self.skipped_args: dict[str, list[str]] = {}
         self.max_turns: int = max_turns
-        self.error_formatter: Callable[[Exception], str] = error_formatter
 
     def add_tool(self, tool: Callable, args_to_skip: list[str] = []):
         self.tools.append(tool)
@@ -98,22 +95,12 @@ class StatefulToolEnv(vf.ToolEnv):
         self, tool_name: str, tool_args: dict, tool_call_id: str, **kwargs
     ) -> vf.Message:
         """Call a tool based on JSON command."""
-        try:
-            tool_func = self.tool_map[tool_name]
-            result = await maybe_await(tool_func, **tool_args)
-            return cast(
-                vf.Message,
-                {"role": "tool", "content": str(result), "tool_call_id": tool_call_id},
-            )
-        except Exception as e:
-            return cast(
-                vf.Message,
-                {
-                    "role": "tool",
-                    "content": self.error_formatter(e),
-                    "tool_call_id": tool_call_id,
-                },
-            )
+        tool_func = self.tool_map[tool_name]
+        result = await maybe_await(tool_func, **tool_args)
+        return cast(
+            vf.Message,
+            {"role": "tool", "content": str(result), "tool_call_id": tool_call_id},
+        )
 
     async def env_response(
         self, messages: vf.Messages, state: vf.State, **kwargs
@@ -123,22 +110,24 @@ class StatefulToolEnv(vf.ToolEnv):
         tool_messages = []
         last_msg = cast(ChatCompletionAssistantMessageParam, messages[-1])
         for tool_call in last_msg.get("tool_calls", []):
-            tool_name: str = tool_call.get("function", {}).get("name", "")
             try:
+                tool_name: str = tool_call.get("function", {}).get("name", "")
                 tool_args: dict = json.loads(
                     tool_call.get("function", {}).get("arguments", "")
                 )
             except Exception as e:
-                state["error"] = vf.ToolError(
-                    message=f"Error parsing tool arguments: {e}", cause=e
-                )
+                state["error"] = vf.ToolParseError(cause=e)
                 return []
             tool_call_id: str = tool_call.get("id", "")
             tool_args = self.update_tool_args(
                 tool_name, tool_args, messages, state, **kwargs
             )
-            tool_message: vf.Message = await self.call_tool(
-                tool_name, tool_args, tool_call_id
-            )
+            try:
+                tool_message: vf.Message = await self.call_tool(
+                    tool_name, tool_args, tool_call_id
+                )
+            except Exception as e:
+                state["error"] = vf.ToolCallError(cause=e)
+                return []
             tool_messages.append(tool_message)
         return tool_messages

--- a/verifiers/envs/stateful_tool_env.py
+++ b/verifiers/envs/stateful_tool_env.py
@@ -124,9 +124,15 @@ class StatefulToolEnv(vf.ToolEnv):
         last_msg = cast(ChatCompletionAssistantMessageParam, messages[-1])
         for tool_call in last_msg.get("tool_calls", []):
             tool_name: str = tool_call.get("function", {}).get("name", "")
-            tool_args: dict = json.loads(
-                tool_call.get("function", {}).get("arguments", "")
-            )
+            try:
+                tool_args: dict = json.loads(
+                    tool_call.get("function", {}).get("arguments", "")
+                )
+            except Exception as e:
+                state["error"] = vf.ToolError(
+                    message=f"Error parsing tool arguments: {e}", cause=e
+                )
+                return []
             tool_call_id: str = tool_call.get("id", "")
             tool_args = self.update_tool_args(
                 tool_name, tool_args, messages, state, **kwargs

--- a/verifiers/envs/stateful_tool_env.py
+++ b/verifiers/envs/stateful_tool_env.py
@@ -39,6 +39,14 @@ class StatefulToolEnv(vf.ToolEnv):
         self.max_turns: int = max_turns
 
     def add_tool(self, tool: Callable, args_to_skip: list[str] = []):
+        """Add a tool, optionally hiding arguments from the agent's view.
+
+        Skipped args are removed from the schema shown to the agent but can be
+        injected at call time via update_tool_args. If a skipped arg uses a $ref
+        to a type in $defs, that definition is also removed to keep the schema clean.
+
+        Assumes all non-skipped args use standard JSON types (no remaining $ref/$defs).
+        """
         self.tools.append(tool)
         oai_tool = convert_func_to_oai_tool(tool)
         assert "function" in oai_tool

--- a/verifiers/envs/tool_env.py
+++ b/verifiers/envs/tool_env.py
@@ -87,8 +87,10 @@ class ToolEnv(vf.MultiTurnEnv):
                     tool_call.get("function", {}).get("arguments", "")
                 )
             except Exception as e:
-                self.logger.error(f"Error parsing tool arguments: {e}")
-                tool_args = {}
+                state["error"] = vf.ToolError(
+                    cause=e, message=f"Error parsing tool arguments: {e}"
+                )
+                return []
             tool_call_id: str = tool_call.get("id", "")
             tool_message: vf.Message = await self.call_tool(
                 tool_name, tool_args, tool_call_id

--- a/verifiers/envs/tool_env.py
+++ b/verifiers/envs/tool_env.py
@@ -75,15 +75,13 @@ class ToolEnv(vf.MultiTurnEnv):
                     tool_call.get("function", {}).get("arguments", "")
                 )
             except Exception as e:
-                state["error"] = vf.ToolParseError(cause=e)
-                return []
+                raise vf.ToolParseError(cause=e)
             tool_call_id: str = tool_call.get("id", "")
             try:
                 tool_message: vf.Message = await self.call_tool(
                     tool_name, tool_args, tool_call_id
                 )
             except Exception as e:
-                state["error"] = vf.ToolCallError(cause=e)
-                return []
+                raise vf.ToolCallError(cause=e)
             tool_messages.append(tool_message)
         return tool_messages

--- a/verifiers/errors.py
+++ b/verifiers/errors.py
@@ -8,6 +8,12 @@ class Error(Exception):
         return f"{self.__class__.__name__}({self.cause!r})"
 
 
+class ModelError(Error):
+    """Used to catch errors while interacting with the model."""
+
+    pass
+
+
 class ToolError(Error):
     """Parent class for all tool errors."""
 

--- a/verifiers/errors.py
+++ b/verifiers/errors.py
@@ -5,7 +5,7 @@ class Error(Exception):
         self.cause = cause
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}(cause={repr(self.cause)})"
+        return f"{self.__class__.__name__}({self.cause!r})"
 
 
 class ToolError(Error):

--- a/verifiers/errors.py
+++ b/verifiers/errors.py
@@ -14,6 +14,12 @@ class ModelError(Error):
     pass
 
 
+class OverlongPromptError(Error):
+    """Used to catch overlong prompt errors (e.g. prompt + requested number of tokens exceeds model context length)"""
+
+    pass
+
+
 class ToolError(Error):
     """Parent class for all tool errors."""
 

--- a/verifiers/errors.py
+++ b/verifiers/errors.py
@@ -26,13 +26,13 @@ class ToolCallError(ToolError):
     pass
 
 
-class InfrastructureError(Error):
+class InfraError(Error):
     """Used to catch errors while interacting with infrastructure."""
 
     pass
 
 
-class SandboxError(InfrastructureError):
+class SandboxError(InfraError):
     """Used to catch errors while interacting with sandboxes."""
 
     pass

--- a/verifiers/errors.py
+++ b/verifiers/errors.py
@@ -24,3 +24,15 @@ class ToolCallError(ToolError):
     """Used to catch errors while calling tools."""
 
     pass
+
+
+class InfrastructureError(Error):
+    """Used to catch errors while interacting with infrastructure."""
+
+    pass
+
+
+class SandboxError(InfrastructureError):
+    """Used to catch errors while interacting with sandboxes."""
+
+    pass

--- a/verifiers/errors.py
+++ b/verifiers/errors.py
@@ -1,8 +1,6 @@
 class Error(Exception):
     """Base class for all errors."""
 
-    root: Exception
-
     def __init__(self, cause: Exception):
         self.cause = cause
 

--- a/verifiers/exceptions.py
+++ b/verifiers/exceptions.py
@@ -8,3 +8,6 @@ class ToolError(Error):
     def __init__(self, message: str, cause: Exception):
         self.message = message
         self.cause = cause
+
+    def __repr__(self) -> str:
+        return f"ToolError(message={self.message}, cause={repr(self.cause)})"

--- a/verifiers/exceptions.py
+++ b/verifiers/exceptions.py
@@ -1,13 +1,28 @@
-class Error(Exception): ...
+class Error(Exception):
+    """Base class for all errors."""
 
+    root: Exception
 
-class ToolError(Error):
-    message: str
-    cause: Exception
-
-    def __init__(self, message: str, cause: Exception):
-        self.message = message
+    def __init__(self, cause: Exception):
         self.cause = cause
 
     def __repr__(self) -> str:
-        return f"ToolError(message={self.message}, cause={repr(self.cause)})"
+        return f"{self.__class__.__name__}(cause={repr(self.cause)})"
+
+
+class ToolError(Error):
+    """Parent class for all tool errors."""
+
+    pass
+
+
+class ToolParseError(ToolError):
+    """Used to catch errors while parsing tool calls."""
+
+    pass
+
+
+class ToolCallError(ToolError):
+    """Used to catch errors while calling tools."""
+
+    pass

--- a/verifiers/exceptions.py
+++ b/verifiers/exceptions.py
@@ -1,0 +1,10 @@
+class Error(Exception): ...
+
+
+class ToolError(Error):
+    message: str
+    cause: Exception
+
+    def __init__(self, message: str, cause: Exception):
+        self.message = message
+        self.cause = cause

--- a/verifiers/rl/trainer/orchestrator.py
+++ b/verifiers/rl/trainer/orchestrator.py
@@ -36,6 +36,7 @@ class Batch(BaseModel):
     generation_time: float = 0.0
     prompts: list[Any] = Field(default_factory=list)
     completions: list[Any] = Field(default_factory=list)
+    errors: list[Any] = Field(default_factory=list)
     metrics_dict: dict[str, float] = Field(default_factory=dict)
     rewards_dict: dict[str, list[float]] = Field(default_factory=dict)
 
@@ -307,6 +308,7 @@ class Orchestrator:
             metrics_dict["timing/total_ms"] = float(np.mean(total_ms))
 
         metrics_dict["wall_clock/generate_s"] = float(wall_clock_s)
+        errors = [state.get("error") for state in env_results["state"]]
 
         # build per-process microbatches
         N = len(advantages)
@@ -355,5 +357,6 @@ class Orchestrator:
             rewards_dict=rewards_dict,
             completions=env_results["completion"],
             prompts=env_results["prompt"],
+            errors=errors,
             metrics_dict=metrics_dict,
         )

--- a/verifiers/rl/trainer/trainer.py
+++ b/verifiers/rl/trainer/trainer.py
@@ -20,6 +20,7 @@ from transformers.tokenization_utils_base import PreTrainedTokenizerBase
 from transformers.trainer import Trainer
 
 import verifiers as vf
+from verifiers.errors import Error
 from verifiers.rl.inference.client import VLLMClient
 from verifiers.rl.trainer.config import RLConfig
 from verifiers.rl.trainer.orchestrator import Orchestrator
@@ -236,6 +237,7 @@ class RLTrainer(Trainer):
             self.log_rollouts(
                 prompts=batch.prompts,
                 completions=batch.completions,
+                errors=batch.errors,
                 rewards_dict=batch.rewards_dict,
             )
 
@@ -454,6 +456,7 @@ class RLTrainer(Trainer):
             # clear after logging
             self._textual_logs["prompt"].clear()
             self._textual_logs["completion"].clear()
+            self._textual_logs["error"].clear()
             for key in self._textual_logs["rewards"]:
                 self._textual_logs["rewards"][key].clear()
 
@@ -461,10 +464,12 @@ class RLTrainer(Trainer):
         self,
         prompts: List[Messages],
         completions: List[Messages],
+        errors: List[Error | None],
         rewards_dict: Dict[str, Any],
     ) -> None:
         self._textual_logs["prompt"].extend(prompts)  # type: ignore[union-attr]
         self._textual_logs["completion"].extend(completions)  # type: ignore[union-attr]
+        self._textual_logs["error"].extend(errors)  # type: ignore[union-attr]
         for reward_key in rewards_dict:
             reward_values = rewards_dict[reward_key]
             self._textual_logs["rewards"][reward_key].extend(reward_values)  # type: ignore[union-attr]

--- a/verifiers/rl/trainer/trainer.py
+++ b/verifiers/rl/trainer/trainer.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Optional
 
 import deepspeed
 import torch
+import wandb
 from accelerate.utils import (
     broadcast_object_list,
     is_peft_model,
@@ -19,7 +20,6 @@ from transformers.tokenization_utils_base import PreTrainedTokenizerBase
 from transformers.trainer import Trainer
 
 import verifiers as vf
-import wandb
 from verifiers.rl.inference.client import VLLMClient
 from verifiers.rl.trainer.config import RLConfig
 from verifiers.rl.trainer.orchestrator import Orchestrator
@@ -125,6 +125,7 @@ class RLTrainer(Trainer):
         self._textual_logs = {
             "prompt": deque(),
             "completion": deque(),
+            "error": deque(),
             "rewards": defaultdict(lambda: deque()),
         }
 
@@ -409,6 +410,7 @@ class RLTrainer(Trainer):
             print_prompt_completions_sample(
                 list(self._textual_logs["prompt"]),  # type: ignore[arg-type]
                 list(self._textual_logs["completion"]),  # type: ignore[arg-type]
+                list(self._textual_logs["error"]),  # type: ignore[arg-type]
                 list(self._textual_logs["rewards"]["reward"]),  # type: ignore[arg-type]
                 self.state.global_step,
             )

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -7,7 +7,7 @@ from typing import (
     Literal,
 )
 
-from verifiers.exceptions import Error
+from verifiers.errors import Error
 
 if sys.version_info < (3, 12):
     from typing_extensions import TypedDict

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -7,6 +7,8 @@ from typing import (
     Literal,
 )
 
+from verifiers.exceptions import Error
+
 if sys.version_info < (3, 12):
     from typing_extensions import TypedDict
 else:
@@ -105,6 +107,7 @@ class State(dict):
     advantage: float | None
     metrics: dict[str, float] | None
     timing: RolloutTiming | None
+    error: Error | None
 
     def __getitem__(self, key: str) -> Any:
         # forward to input if exists

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -68,9 +68,11 @@ def print_results(results: GenerateOutputs, num_samples: int = 1):
 
     printable_prompts = [messages_to_printable(p) for p in results["prompt"]]
     printable_completions = [messages_to_printable(c) for c in results["completion"]]
+    errors = [s.get("error") for s in results["state"]]
     print_prompt_completions_sample(
         printable_prompts,
         printable_completions,
+        errors,
         results["reward"],
         step=0,
         num_samples=num_samples,

--- a/verifiers/utils/logging_utils.py
+++ b/verifiers/utils/logging_utils.py
@@ -8,6 +8,7 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
+from verifiers.errors import Error
 from verifiers.types import Messages
 
 
@@ -43,6 +44,7 @@ def setup_logging(
 def print_prompt_completions_sample(
     prompts: list[Messages],
     completions: list[Messages],
+    errors: list[Error | None],
     rewards: list[float],
     step: int,
     num_samples: int = 1,
@@ -98,6 +100,12 @@ def print_prompt_completions_sample(
 
         return out
 
+    def _format_error(error: Error) -> Text:
+        out = Text()
+        out.append("error: ", style="bold red")
+        out.append(repr(error), style="red")
+        return out
+
     console = Console()
     table = Table(show_header=True, header_style="bold white", expand=True)
 
@@ -113,10 +121,13 @@ def print_prompt_completions_sample(
     for i in range(samples_to_show):
         prompt = list(prompts)[i]
         completion = list(completions)[i]
+        error = errors[i]
         reward = reward_values[i]
 
         formatted_prompt = _format_messages(prompt)
         formatted_completion = _format_messages(completion)
+        if error is not None:
+            formatted_completion += Text("\n\n") + _format_error(error)
 
         table.add_row(formatted_prompt, formatted_completion, Text(f"{reward:.2f}"))
         if i < samples_to_show - 1:

--- a/verifiers/utils/message_utils.py
+++ b/verifiers/utils/message_utils.py
@@ -2,16 +2,11 @@ import json
 from typing import cast
 
 from openai.types.chat import (
-    ChatCompletion,
     ChatCompletionAssistantMessageParam,
-    ChatCompletionMessage,
     ChatCompletionToolMessageParam,
 )
-from openai.types.chat.chat_completion import Choice
-from openai.types.completion import Completion
-from openai.types.completion_choice import CompletionChoice
 
-from verifiers.types import ChatMessage, Messages, MessageType, ModelResponse
+from verifiers.types import ChatMessage, Messages
 
 
 def concat_messages(messages_list: list[Messages | ChatMessage]) -> Messages:
@@ -152,39 +147,3 @@ def sanitize_tool_calls(messages: Messages):
         else:
             sanitized_messages.append(m)
     return sanitized_messages
-
-
-def get_overlong_prompt_dummy_response(message_type: MessageType) -> ModelResponse:
-    if message_type == "chat":
-        return ChatCompletion(
-            id="overlong-prompt",
-            created=0,
-            model="",
-            object="chat.completion",
-            choices=[
-                Choice(
-                    index=0,
-                    message=ChatCompletionMessage(
-                        role="assistant",
-                        content="Prompt too long.",
-                    ),
-                    finish_reason="length",
-                )
-            ],
-        )
-    elif message_type == "completion":
-        return Completion(
-            id="overlong-prompt",
-            created=0,
-            model="",
-            object="text_completion",
-            choices=[
-                CompletionChoice(
-                    index=0,
-                    text="Prompt too long.",
-                    finish_reason="length",
-                )
-            ],
-        )
-    else:
-        raise ValueError(f"Invalid message type: {message_type}")

--- a/verifiers/utils/message_utils.py
+++ b/verifiers/utils/message_utils.py
@@ -3,8 +3,6 @@ from typing import cast
 
 from openai.types.chat import (
     ChatCompletionAssistantMessageParam,
-    ChatCompletionToolMessageParam,
-    ChatCompletionMessage,
 )
 
 from verifiers.types import ChatMessage, Messages


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

This PR implements exception handling as a first class citizen in verifiers. The main unlocks are:
- Different downstream applications (RL trainer, evals, synthetic data, etc.) can explicitly handle different error classes, e.g. masking/ zero reward/ dropping trajectories with errors
- Improved robustness, especially around tool calling (e.g. not crash on non-JSON decodable outputs)

Main implementation details:
- Define hierarchical error classes. Base error is `vf.Error`, currently with 3 children: `vf.ModelError` (raised if error while getting model response from API), `vf.ToolError` (contains `vf.ToolParseError` and `vf.ToolCallError`) and `vf.InfraError` (contains `vf.SandboxError`), can be expanded in the future as we see need (in my mind, these will be upstreamed somewhat analogous to envs; as we figure out and upstream env patterns, we will also discover and upstream error patterns)
- Environments may define new types of errors, which should subclass the base verifiers error classes. For example, `vf.SandboxEnv` defines `SandboxCreationError` and `SandboxNotReadyError`, and `vf.PythonEnv` defines `PythonWorkerNotReadyError` and `PythonWorkerRequestError`
- Define a new attribute `error: vf.Error | None` on `vf.State` which is used to mark which, if any, error has occurred during the rollout
- Defines a new stop condition `has_error` on the base `Environment` which is check in main multi-turn loop and piggybacks on the completion rendering/ cleanup logic running if triggered
- We try..catch for `vf.Error` in setup and in each turn in `MultiTurnEnv.rollout`, if an error occurs we populate the `error` field in state which will lead to termination of the rollout

Misc. changes:
- Adjusted `get_model_response` function signature to more closely mimic the v0.1.8 pattern--it now only takes `prompt_messages` and `state`
- Updated `ToolEnv`, `StatefulToolEnv` to explicitly catch tool call errors
- Updated `SandboxEnv` and `PythonEnv` to showcase catching infra errors
- Borrows some changes around configurability of PythonEnv from #602 which was used for debugging and the illustration examples
- Update `SandboxEnv` to not wait for creation on every `bash` tool call but only once (borrow pattern from `python` tool in `PythonEnv` which maintains `ready` flag in state)
- Update `math-python` to have more configurability via env args
- Adjusted and expanded tests

## Examples

### Regular Case

We run a regular `math-python` rollout because it's multi-turn, uses sandboxes and tools

```bash
uv run vf-eval math-python -n1 -r1 -v
```

<img width="1274" height="486" alt="Screenshot 2025-12-09 at 3 47 19 PM" src="https://github.com/user-attachments/assets/1720a060-2264-4049-b52c-17508efe7e5b" />

### Expected error

Expected tool errors, such as the model trying to use a package that is not installed in the environment does not raise. Instead the error message is shown to the model (same behavior as before)

```bash
# removing sympy from the list of pre-installed packages
uv run vf-eval math-python -n1 -r1 -v -a '{"pip_install_packages": "numpy scipy"}'
```

<img width="1280" height="361" alt="Screenshot 2025-12-09 at 3 45 04 PM" src="https://github.com/user-attachments/assets/79ca834d-69fa-440f-bdda-90e03ca90ff9" />

### Unexpected error

One example of an unexpected error that should abrupt the rollout and mark as errored (after sufficient retries ofc) are infrastructure errors, such as the sandbox not booting up (in time). We simulate this by setting a too low startup time which won't allow the Python worker to be ready. This will now early exit the rollout and mark the rollout with an error that can be caught as an infra error

```bash
# too low startup timeout to simulate infrastructure failure
uv run vf-eval math-python -n1 -r1 -v -a '{"max_startup_wait_seconds": 5}'
```

<img width="1272" height="540" alt="Screenshot 2025-12-09 at 3 47 54 PM" src="https://github.com/user-attachments/assets/b98f076d-1b51-4fa9-94b5-4b15475095fb" />

## TODOs/ Questions

- [x] Fix tests
- [x] Nail error class anatomy (is the wrapping of root error flexible enough?)
- [x] Should tool errors be defined in`ToolEnv` and sandbox errors in `SandboxEnv` or are they fine in global error
- [ ] Figure out whether we can easily catch an infra error if it is wrapped, e.g. in a tool call error (eg. in prime-rl we would like to handle any infra error in the "error tree")
- [ ] Improved logging for errors in vf-tui and vf-eval

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [x] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->