### PR TITLE
re-add cleanup_messages

### DIFF
--- a/tests/test_message_utils_audio.py
+++ b/tests/test_message_utils_audio.py
@@ -2,9 +2,9 @@
 import copy
 
 from verifiers.utils.message_utils import (
+    cleanup_message,
     message_to_printable,
     messages_to_printable,
-    cleanup_message,
 )
 
 DUMMY_B64 = "ZHVtbXk="
@@ -85,3 +85,88 @@ def test_cleanup_message_is_idempotent():
     once = cleanup_message(copy.deepcopy(msg))
     twice = cleanup_message(copy.deepcopy(once))
     assert twice == once
+
+
+def test_cleanup_message_strips_none_fields_from_multimodal():
+    """
+    HuggingFace Dataset.map() unifies schemas across content items,
+    adding None values for missing keys. This test ensures cleanup_message
+    strips those None fields to produce valid OpenAI API payloads.
+    """
+    msg = {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "describe this image", "image_url": None},
+            {
+                "type": "image_url",
+                "image_url": {"url": "data:image/png;base64,abc123"},
+                "text": None,
+            },
+        ],
+    }
+    cleaned = cleanup_message(copy.deepcopy(msg))
+    assert cleaned["role"] == "user"
+    assert len(cleaned["content"]) == 2
+    assert cleaned["content"][0] == {"type": "text", "text": "describe this image"}
+    assert cleaned["content"][1] == {
+        "type": "image_url",
+        "image_url": {"url": "data:image/png;base64,abc123"},
+    }
+
+
+def test_dataset_map_introduces_none_fields_and_cleanup_fixes():
+    """
+    Demonstrates that HuggingFace Dataset.map() introduces None values
+    when content items have different schemas, and cleanup_messages fixes this.
+    """
+    from datasets import Dataset
+
+    from verifiers.utils.message_utils import cleanup_messages
+
+    def format_prompt(example):
+        return {
+            "prompt": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": example["question"]},
+                        {
+                            "type": "image_url",
+                            "image_url": {
+                                "url": f"data:image/png;base64,{example['image']}"
+                            },
+                        },
+                    ],
+                }
+            ]
+        }
+
+    ds = Dataset.from_dict({"question": ["What is this?"], "image": ["abc123"]})
+    ds = ds.map(format_prompt)
+
+    prompt = ds[0]["prompt"]
+    content = prompt[0]["content"]
+
+    # Dataset.map() unifies schemas, adding None for missing keys
+    assert "image_url" in content[0], (
+        "Dataset.map should add image_url key to text item"
+    )
+    assert content[0]["image_url"] is None, "text item should have image_url=None"
+    assert "text" in content[1], "Dataset.map should add text key to image_url item"
+    assert content[1]["text"] is None, "image_url item should have text=None"
+
+    # cleanup_messages should fix this
+    cleaned_prompt = cleanup_messages(prompt)
+    cleaned_content = cleaned_prompt[0]["content"]
+
+    assert "image_url" not in cleaned_content[0], (
+        "cleanup should remove image_url from text item"
+    )
+    assert "text" not in cleaned_content[1], (
+        "cleanup should remove text from image_url item"
+    )
+    assert cleaned_content[0] == {"type": "text", "text": "What is this?"}
+    assert cleaned_content[1] == {
+        "type": "image_url",
+        "image_url": {"url": "data:image/png;base64,abc123"},
+    }

--- a/tests/test_message_utils_audio.py
+++ b/tests/test_message_utils_audio.py
@@ -1,8 +1,5 @@
 # tests/test_message_utils_audio.py
-import copy
-
 from verifiers.utils.message_utils import (
-    cleanup_message,
     message_to_printable,
     messages_to_printable,
 )
@@ -48,80 +45,12 @@ def test_messages_to_printable_order_and_joining():
     assert "[audio]" in printable and "describe" in printable
 
 
-def test_cleanup_message_strips_extraneous_fields_from_audio():
-    msg = {
-        "role": "user",
-        "content": [
-            {"type": "text", "text": "t"},
-            {
-                "type": "input_audio",
-                "input_audio": {"data": DUMMY_B64, "format": "wav"},
-                "text": "ignore",
-                "image_url": {"url": "ignore"},
-                "random": "ignore",
-            },
-        ],
-    }
-    cleaned = cleanup_message(copy.deepcopy(msg))
-    assert cleaned["role"] == "user"
-    assert len(cleaned["content"]) == 2
-    assert cleaned["content"][1] == {
-        "type": "input_audio",
-        "input_audio": {"data": DUMMY_B64, "format": "wav"},
-    }
-
-
-def test_cleanup_message_is_idempotent():
-    msg = {
-        "role": "user",
-        "content": [
-            {"type": "text", "text": "t"},
-            {
-                "type": "input_audio",
-                "input_audio": {"data": DUMMY_B64, "format": "wav"},
-            },
-        ],
-    }
-    once = cleanup_message(copy.deepcopy(msg))
-    twice = cleanup_message(copy.deepcopy(once))
-    assert twice == once
-
-
-def test_cleanup_message_strips_none_fields_from_multimodal():
-    """
-    HuggingFace Dataset.map() unifies schemas across content items,
-    adding None values for missing keys. This test ensures cleanup_message
-    strips those None fields to produce valid OpenAI API payloads.
-    """
-    msg = {
-        "role": "user",
-        "content": [
-            {"type": "text", "text": "describe this image", "image_url": None},
-            {
-                "type": "image_url",
-                "image_url": {"url": "data:image/png;base64,abc123"},
-                "text": None,
-            },
-        ],
-    }
-    cleaned = cleanup_message(copy.deepcopy(msg))
-    assert cleaned["role"] == "user"
-    assert len(cleaned["content"]) == 2
-    assert cleaned["content"][0] == {"type": "text", "text": "describe this image"}
-    assert cleaned["content"][1] == {
-        "type": "image_url",
-        "image_url": {"url": "data:image/png;base64,abc123"},
-    }
-
-
-def test_dataset_map_introduces_none_fields_and_cleanup_fixes():
+def test_dataset_map_introduces_none_fields_and_stripping_fixes():
     """
     Demonstrates that HuggingFace Dataset.map() introduces None values
-    when content items have different schemas, and cleanup_messages fixes this.
+    when content items have different schemas, and stripping Nones fixes this.
     """
     from datasets import Dataset
-
-    from verifiers.utils.message_utils import cleanup_messages
 
     def format_prompt(example):
         return {
@@ -155,15 +84,24 @@ def test_dataset_map_introduces_none_fields_and_cleanup_fixes():
     assert "text" in content[1], "Dataset.map should add text key to image_url item"
     assert content[1]["text"] is None, "image_url item should have text=None"
 
-    # cleanup_messages should fix this
-    cleaned_prompt = cleanup_messages(prompt)
-    cleaned_content = cleaned_prompt[0]["content"]
+    # Strip None values (same logic as in get_model_response)
+    for msg in prompt:
+        msg_content = msg.get("content")
+        if isinstance(msg_content, list):
+            msg["content"] = [
+                {k: v for k, v in c.items() if v is not None}
+                if isinstance(c, dict)
+                else c
+                for c in msg_content
+            ]
+
+    cleaned_content = prompt[0]["content"]
 
     assert "image_url" not in cleaned_content[0], (
-        "cleanup should remove image_url from text item"
+        "stripping should remove image_url from text item"
     )
     assert "text" not in cleaned_content[1], (
-        "cleanup should remove text from image_url item"
+        "stripping should remove text from image_url item"
     )
     assert cleaned_content[0] == {"type": "text", "text": "What is this?"}
     assert cleaned_content[1] == {

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -41,9 +41,9 @@ from verifiers.types import (
 from verifiers.utils.async_utils import maybe_semaphore
 from verifiers.utils.eval_utils import make_dataset, save_rollout_results
 from verifiers.utils.message_utils import (
-    cleanup_messages,
     concat_messages,
     get_overlong_prompt_dummy_response,
+    strip_nones_from_content,
 )
 from verifiers.utils.path_utils import get_results_path
 
@@ -325,7 +325,7 @@ class Environment(ABC):
         try:
             if message_type == "chat":
                 assert isinstance(prompt, list)
-                prompt = cleanup_messages(prompt)  # strip None fields from messages
+                prompt = strip_nones_from_content(prompt)
                 # --- detect audio parts and force text-only modality if caller didn't set one ---
                 has_audio = False
                 try:

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -41,6 +41,7 @@ from verifiers.types import (
 from verifiers.utils.async_utils import maybe_semaphore
 from verifiers.utils.eval_utils import make_dataset, save_rollout_results
 from verifiers.utils.message_utils import (
+    cleanup_messages,
     concat_messages,
     get_overlong_prompt_dummy_response,
 )
@@ -324,6 +325,7 @@ class Environment(ABC):
         try:
             if message_type == "chat":
                 assert isinstance(prompt, list)
+                prompt = cleanup_messages(prompt)  # strip None fields from messages
                 # --- detect audio parts and force text-only modality if caller didn't set one ---
                 has_audio = False
                 try:

--- a/verifiers/utils/message_utils.py
+++ b/verifiers/utils/message_utils.py
@@ -5,13 +5,31 @@ from openai.types.chat import (
     ChatCompletion,
     ChatCompletionAssistantMessageParam,
     ChatCompletionMessage,
-    ChatCompletionToolMessageParam,
 )
 from openai.types.chat.chat_completion import Choice
 from openai.types.completion import Completion
 from openai.types.completion_choice import CompletionChoice
 
 from verifiers.types import ChatMessage, Messages, MessageType, ModelResponse
+
+
+def strip_nones_from_content(messages: list[ChatMessage]) -> list[ChatMessage]:
+    """Return messages with None values stripped from content dicts (fixes HF Dataset schema unification)."""
+    result: list[ChatMessage] = []
+    for msg in messages:
+        content = msg.get("content")
+        if isinstance(content, list):
+            new_msg = dict(msg)
+            new_msg["content"] = [  # type: ignore[typeddict-item]
+                {k: v for k, v in c.items() if v is not None}
+                if isinstance(c, dict)
+                else c
+                for c in content
+            ]
+            result.append(new_msg)  # type: ignore[arg-type]
+        else:
+            result.append(msg)
+    return result
 
 
 def concat_messages(messages_list: list[Messages | ChatMessage]) -> Messages:
@@ -70,58 +88,6 @@ def messages_to_printable(messages: Messages) -> Messages:
     if isinstance(messages, str):
         return messages
     return [message_to_printable(m) for m in messages or []]
-
-
-def cleanup_message(message: ChatMessage) -> ChatMessage:
-    new_message: dict[str, object] = {}
-    new_message["role"] = message["role"]
-    if "tool_calls" in message:
-        assistant_msg = cast(ChatCompletionAssistantMessageParam, message)
-        new_message["tool_calls"] = assistant_msg.get("tool_calls")
-
-    if "tool_call_id" in message:
-        tool_msg = cast(ChatCompletionToolMessageParam, message)
-        new_message["tool_call_id"] = tool_msg.get("tool_call_id")
-
-    new_message["content"] = []
-    content = message.get("content")
-    if content is None:
-        return cast(ChatMessage, new_message)
-    if isinstance(content, str):
-        new_message["content"] = content
-    else:
-        content_list = cast(list[object], new_message["content"])
-        for c in content:
-            new_c = dict(c)
-            c_dict = dict(c)
-            if "image_url" in c_dict and "type" in c_dict and c_dict["type"] == "text":
-                new_c.pop("image_url")
-                content_list.append(new_c)
-            elif (
-                "image_url" in c_dict
-                and "type" in c_dict
-                and c_dict["type"] == "image_url"
-            ):
-                new_c.pop("text")
-                content_list.append(new_c)
-            elif str(c_dict.get("type", "")).startswith("input_audio"):
-                clean_c = {
-                    "type": "input_audio",
-                    "input_audio": c_dict.get("input_audio", {}),
-                }
-                content_list.append(clean_c)
-            else:
-                content_list.append(new_c)
-    return cast(ChatMessage, new_message)
-
-
-def cleanup_messages(messages: Messages) -> Messages:
-    if isinstance(messages, str):
-        return messages
-    new_messages = []
-    for m in messages:
-        new_messages.append(cleanup_message(m))
-    return new_messages
 
 
 def sanitize_tool_calls(messages: Messages):


### PR DESCRIPTION
## Description

The v0.1.8 refactor removed (unintentionally) the `cleanup_messages` function, which strips extra `None`s from `vf.State` which are introduced to `prompt` by `Dataset.map`. This only materializes for multimodal tasks where message content schemas differ across content types.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [X] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->