### PR TITLE
Fix math verify timeout

### DIFF
--- a/tests/test_math_rubric.py
+++ b/tests/test_math_rubric.py
@@ -1,0 +1,141 @@
+"""Tests for the MathRubric class."""
+
+import time
+
+import pytest
+
+import verifiers as vf
+from verifiers.utils.async_utils import NullAsyncContext
+
+
+class TestMathRubric:
+    """Test cases for the MathRubric class."""
+
+    def test_math_rubric_initialization_empty(self):
+        """Test MathRubric initialization with no parameters."""
+        rubric = vf.MathRubric()
+
+        assert rubric.funcs == [rubric.correct_answer]
+        assert rubric.weights == [1.0]
+        assert isinstance(rubric.parser, vf.MaybeThinkParser)
+
+    def test_math_rubric_initialization_with_kwargs(self):
+        """Test MathRubric initialization - kwargs not supported."""
+        # MathRubric doesn't accept arbitrary kwargs
+        with pytest.raises(TypeError):
+            vf.MathRubric(custom_param="test_value", another_param=42)  # type: ignore
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "test_case",
+        [
+            {"completion": "1", "answer": "1"},
+            {"completion": "x + 1", "answer": "1 + x"},
+            {"completion": "\\frac{1}{2}", "answer": "0.5"},
+        ],
+        ids=lambda x: f"{x['completion']} == {x['answer']}",
+    )
+    async def test_score_valid_answers(self, test_case):
+        """Test scoring a single rollout."""
+
+        rubric = vf.MathRubric()
+
+        state = vf.State(
+            input=vf.RolloutInput(
+                prompt="test prompt",
+                answer=test_case["answer"],
+                task="test_task",
+                example_id=0,
+            )
+        )
+        state["completion"] = test_case["completion"]
+        state["trajectory"] = []
+        state["timing"] = {
+            "generation_ms": 0.0,
+            "scoring_ms": 0.0,
+            "total_ms": 0.0,
+            "start_time": 0.0,
+        }
+        score_sem = NullAsyncContext()
+
+        await rubric.score_rollout(state, score_sem)
+
+        assert state["metrics"]["correct_answer"] == 1.0
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "test_case",
+        [
+            {"completion": "1", "answer": "2"},
+            {"completion": "\\frac{1}{3}", "answer": "0.5"},
+        ],
+        ids=lambda x: f"{x['completion']} != {x['answer']}",
+    )
+    async def test_score_invalid_answers(self, test_case):
+        """Test scoring a single rollout."""
+
+        rubric = vf.MathRubric()
+
+        state = vf.State(
+            input=vf.RolloutInput(
+                prompt="test prompt",
+                answer=test_case["answer"],
+                task="test_task",
+                example_id=0,
+            )
+        )
+        state["completion"] = test_case["completion"]
+        state["trajectory"] = []
+        state["timing"] = {
+            "generation_ms": 0.0,
+            "scoring_ms": 0.0,
+            "total_ms": 0.0,
+            "start_time": 0.0,
+        }
+        score_sem = NullAsyncContext()
+
+        await rubric.score_rollout(state, score_sem)
+
+        assert state["metrics"]["correct_answer"] == 0.0
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("timeout_seconds", [0.1, 1, 10])
+    async def test_timeout(self, timeout_seconds):
+        """Test scoring a single rollout."""
+
+        answer = "1"
+        # very large input triggers timeout, takes ~2s to parse and verify
+        completion = "1" * int(1e6)
+
+        rubric = vf.MathRubric(timeout_seconds=timeout_seconds)
+
+        state = vf.State(
+            input=vf.RolloutInput(
+                prompt="test prompt",
+                answer=answer,
+                task="test_task",
+                example_id=0,
+            )
+        )
+        state["completion"] = completion
+        state["trajectory"] = []
+        state["timing"] = {
+            "generation_ms": 0.0,
+            "scoring_ms": 0.0,
+            "total_ms": 0.0,
+            "start_time": 0.0,
+        }
+        score_sem = NullAsyncContext()
+
+        start_time = time.time()
+        await rubric.score_rollout(state, score_sem)
+        end_time = time.time()
+        elapsed_time = end_time - start_time
+        assert state["metrics"]["correct_answer"] == 0.0
+
+        # Entire function should timeout within timeout + small overhead
+        print(f"Time taken: {elapsed_time:.2f}s")
+        overhead_seconds = 0.5
+        assert elapsed_time < timeout_seconds + overhead_seconds, (
+            f"Time taken: {elapsed_time:.2f}s (expected < {timeout_seconds + overhead_seconds}s)"
+        )

--- a/verifiers/rubrics/math_rubric.py
+++ b/verifiers/rubrics/math_rubric.py
@@ -13,10 +13,14 @@ class MathRubric(Rubric):
         funcs: list[RewardFunc] | None = None,
         weights: list[float] | None = None,
         parser: Parser | None = None,
+        parsing_timeout_seconds: int = 5,
+        verify_timeout_seconds: int = 5,
     ):
         parser = parser or MaybeThinkParser(extract_fn=extract_boxed_answer)
         super().__init__(funcs=funcs, weights=weights, parser=parser)
         self.add_reward_func(self.correct_answer)
+        self.parsing_timeout_seconds = parsing_timeout_seconds
+        self.verify_timeout_seconds = verify_timeout_seconds
 
     def correct_answer(
         self, parser: Parser, completion: Messages, answer: str, **kwargs
@@ -26,10 +30,16 @@ class MathRubric(Rubric):
             response = parser.parse_answer(completion) or ""
             if response == "":
                 return 0.0
+            parsed_answer = parse(
+                f"\\boxed{{{answer}}}", parsing_timeout=self.parsing_timeout_seconds
+            )
+            parsed_response = parse(
+                f"\\boxed{{{response}}}", parsing_timeout=self.parsing_timeout_seconds
+            )
             if verify(
-                parse(f"\\boxed{{{answer}}}", parsing_timeout=5),
-                parse(f"\\boxed{{{response}}}", parsing_timeout=5),
-                timeout_seconds=5,
+                parsed_answer,
+                parsed_response,
+                timeout_seconds=self.verify_timeout_seconds,
             ):
                 return 1.0
             else:

--- a/verifiers/rubrics/math_rubric.py
+++ b/verifiers/rubrics/math_rubric.py
@@ -34,22 +34,31 @@ class MathRubric(Rubric):
                 ) or ""
                 if response == "":
                     return 0.0
-                parsed_answer = await asyncio.to_thread(
-                    parse,
-                    f"\\boxed{{{answer}}}",
-                    parsing_timeout=None,  # type: ignore
-                )
-                parsed_response = await asyncio.to_thread(
-                    parse,
-                    f"\\boxed{{{response}}}",
-                    parsing_timeout=None,  # type: ignore
-                )
-                result = await asyncio.to_thread(
-                    verify,
-                    parsed_answer,
-                    parsed_response,
-                    timeout_seconds=None,
-                )
+
+                def parse_answer():
+                    return parse(
+                        f"\\boxed{{{answer}}}",
+                        parsing_timeout=None,  # type: ignore
+                    )
+
+                parsed_answer = await asyncio.to_thread(parse_answer)
+
+                def parse_response():
+                    return parse(
+                        f"\\boxed{{{response}}}",
+                        parsing_timeout=None,  # type: ignore
+                    )
+
+                parsed_response = await asyncio.to_thread(parse_response)
+
+                def verify_result():
+                    return verify(
+                        parsed_answer,
+                        parsed_response,
+                        timeout_seconds=None,
+                    )
+
+                result = await asyncio.to_thread(verify_result)
                 if result:
                     return 1.0
                 else:

--- a/verifiers/rubrics/math_rubric.py
+++ b/verifiers/rubrics/math_rubric.py
@@ -16,9 +16,9 @@ class MathRubric(Rubric):
     ):
         parser = parser or MaybeThinkParser(extract_fn=extract_boxed_answer)
         super().__init__(funcs=funcs, weights=weights, parser=parser)
-        self.add_reward_func(self.correct_answer_reward_func)
+        self.add_reward_func(self.correct_answer)
 
-    def correct_answer_reward_func(
+    def correct_answer(
         self, parser: Parser, completion: Messages, answer: str, **kwargs
     ) -> float:
         """Reward function that checks if the final answer matches the expected answer."""


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

`math-verify` uses handlers with `signal.alarm` to implement parsing and verification timeouts. These may cause race conditions in async contexts. This PR updates the `MathRubric` class to avoid this issue:
- Passes `None` as timeout to all `math_verify` function so that internal timeouts are not used
- Runs all synchronous blocking operations with `asyncio.to_thread(...)`
- Implements a global timeout using `asyncio.wait_for(...)`
Adds basic tests to ensure that timeouts are enforced correctly.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [x] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->