### PR TITLE
Fix auto-format dataset for message_type=completions

### DIFF
--- a/verifiers/envs/env_group.py
+++ b/verifiers/envs/env_group.py
@@ -232,6 +232,27 @@ class EnvGroup(vf.Environment):
         )
         return dataset
 
+    def format_completion_dataset(
+        self, dataset: Dataset, map_kwargs: dict = {}
+    ) -> Dataset:
+        """
+        Ensure unique example_ids and mapped tasks across concatenated datasets.
+        """
+        # ensure unique example_ids across concatenated datasets
+        if "example_id" in dataset.column_names:
+            dataset = dataset.remove_columns(["example_id"])
+
+        def add_example_id(example, i):
+            example["example_id"] = i
+            return example
+
+        dataset = dataset.map(add_example_id, with_indices=True, **map_kwargs)
+        assert "example_id" in dataset.column_names
+        assert "task" in dataset.column_names, (
+            "Task column should be set during concatenation in __init__"
+        )
+        return dataset
+
     async def init_state(
         self,
         input: RolloutInput,

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -93,13 +93,13 @@ class Environment(ABC):
         self.max_seq_len = max_seq_len
         if self.message_type == "chat":
             if dataset is not None:
-                self.dataset = self.format_chat_dataset(
+                self.dataset = self.format_dataset(
                     dataset, self.system_prompt, self.few_shot, map_kwargs=map_kwargs
                 )
             else:
                 self.dataset = None
             if eval_dataset is not None:
-                self.eval_dataset = self.format_chat_dataset(
+                self.eval_dataset = self.format_dataset(
                     eval_dataset,
                     self.system_prompt,
                     self.few_shot,
@@ -115,11 +115,13 @@ class Environment(ABC):
                     'to contain a "prompt" column.'
                 )
             if dataset is not None:
-                self.dataset = self.format_dataset(dataset, map_kwargs=map_kwargs)
+                self.dataset = self.format_completion_dataset(
+                    dataset, map_kwargs=map_kwargs
+                )
             else:
                 self.dataset = None
             if eval_dataset is not None:
-                self.eval_dataset = self.format_dataset(
+                self.eval_dataset = self.format_completion_dataset(
                     eval_dataset, map_kwargs=map_kwargs
                 )
             else:
@@ -258,16 +260,6 @@ class Environment(ABC):
     def format_dataset(
         self,
         dataset: Dataset,
-        map_kwargs: dict = {},
-    ) -> Dataset:
-        """Format dataset by creating example_id and prompt columns, and setting task column."""
-        dataset = self._ensure_example_id(dataset)
-        dataset = self._ensure_task(dataset, map_kwargs)
-        return dataset
-
-    def format_chat_dataset(
-        self,
-        dataset: Dataset,
         system_prompt: str | None = None,
         few_shot: list[ChatMessage] | None = None,
         question_key: str = "question",
@@ -277,10 +269,21 @@ class Environment(ABC):
         """
         Format dataset by creating example_id and prompt columns, and setting task column.
         """
-        dataset = self.format_dataset(dataset, map_kwargs)
+        dataset = self._ensure_example_id(dataset)
         dataset = self._ensure_prompt(
             dataset, system_prompt, few_shot, question_key, answer_key, map_kwargs
         )
+        dataset = self._ensure_task(dataset, map_kwargs)
+        return dataset
+
+    def format_completion_dataset(
+        self, dataset: Dataset, map_kwargs: dict = {}
+    ) -> Dataset:
+        """
+        Format dataset by creating example_id and prompt columns, and setting task column.
+        """
+        dataset = self._ensure_example_id(dataset)
+        dataset = self._ensure_task(dataset, map_kwargs)
         return dataset
 
     def get_dataset(self, n: int = -1, seed: int | None = None) -> Dataset:

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -93,13 +93,13 @@ class Environment(ABC):
         self.max_seq_len = max_seq_len
         if self.message_type == "chat":
             if dataset is not None:
-                self.dataset = self.format_dataset(
+                self.dataset = self.format_chat_dataset(
                     dataset, self.system_prompt, self.few_shot, map_kwargs=map_kwargs
                 )
             else:
                 self.dataset = None
             if eval_dataset is not None:
-                self.eval_dataset = self.format_dataset(
+                self.eval_dataset = self.format_chat_dataset(
                     eval_dataset,
                     self.system_prompt,
                     self.few_shot,
@@ -114,8 +114,16 @@ class Environment(ABC):
                     'Please use message_type="chat" instead, or pre-format your dataset '
                     'to contain a "prompt" column.'
                 )
-            self.dataset = dataset
-            self.eval_dataset = eval_dataset
+            if dataset is not None:
+                self.dataset = self.format_dataset(dataset, map_kwargs=map_kwargs)
+            else:
+                self.dataset = None
+            if eval_dataset is not None:
+                self.eval_dataset = self.format_dataset(
+                    eval_dataset, map_kwargs=map_kwargs
+                )
+            else:
+                self.eval_dataset = None
 
         self.sampling_args = {"n": 1, "extra_body": {}}
         if sampling_args is not None:
@@ -250,6 +258,16 @@ class Environment(ABC):
     def format_dataset(
         self,
         dataset: Dataset,
+        map_kwargs: dict = {},
+    ) -> Dataset:
+        """Format dataset by creating example_id and prompt columns, and setting task column."""
+        dataset = self._ensure_example_id(dataset)
+        dataset = self._ensure_task(dataset, map_kwargs)
+        return dataset
+
+    def format_chat_dataset(
+        self,
+        dataset: Dataset,
         system_prompt: str | None = None,
         few_shot: list[ChatMessage] | None = None,
         question_key: str = "question",
@@ -259,11 +277,10 @@ class Environment(ABC):
         """
         Format dataset by creating example_id and prompt columns, and setting task column.
         """
-        dataset = self._ensure_example_id(dataset)
+        dataset = self.format_dataset(dataset, map_kwargs)
         dataset = self._ensure_prompt(
             dataset, system_prompt, few_shot, question_key, answer_key, map_kwargs
         )
-        dataset = self._ensure_task(dataset, map_kwargs)
         return dataset
 
     def get_dataset(self, n: int = -1, seed: int | None = None) -> Dataset:


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Previously, envs that use `message_type=completions` would fail because the required field `example_id` is not set up correctly. 

```bash
uv pip install -e environments/continuation_quality/

uv run vf-eval continuation_quality -n1 -r1 -v
```

<img width="1128" height="380" alt="Screenshot 2025-12-12 at 12 38 44 PM" src="https://github.com/user-attachments/assets/5914d97a-dd12-4347-bf38-e8afb035ffef" />

This PR formats completions datasets by setting up the example id and task are correctly set.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->