### PR TITLE
Higher buffer in math rubric timeout test

### DIFF
--- a/tests/test_math_rubric.py
+++ b/tests/test_math_rubric.py
@@ -135,7 +135,7 @@ class TestMathRubric:
 
         # Entire function should timeout within timeout + small overhead
         print(f"Time taken: {elapsed_time:.2f}s")
-        overhead_seconds = 0.5
+        overhead_seconds = 1
         assert elapsed_time < timeout_seconds + overhead_seconds, (
             f"Time taken: {elapsed_time:.2f}s (expected < {timeout_seconds + overhead_seconds}s)"
         )


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->