### PR TITLE
bugfix: pip_install_packages="" now doesn't break sandbox

### DIFF
--- a/verifiers/envs/python_env.py
+++ b/verifiers/envs/python_env.py
@@ -122,7 +122,7 @@ class PythonEnv(SandboxEnv):
 
         rm -f "$command_fifo" "$response_fifo" "$ready_flag"
 
-        pip install -q {pip_install_packages}
+        {pip_install_command}
 
         python - <<'PY'
 import base64
@@ -157,6 +157,11 @@ PY
         max_startup_wait_seconds: int = 30,
         **kwargs: Any,
     ) -> None:
+        pip_install_command = (
+            f"pip install -q {pip_install_packages}"
+            if pip_install_packages.strip()
+            else ""
+        )
         start_command = self._START_COMMAND_TEMPLATE.format(
             command_fifo=self._COMMAND_FIFO,
             response_fifo=self._RESPONSE_FIFO,
@@ -169,7 +174,7 @@ PY
                     ready_flag=self._READY_FLAG,
                 ).encode("utf-8")
             ).decode("utf-8"),
-            pip_install_packages=pip_install_packages,
+            pip_install_command=pip_install_command,
         )
         self.max_startup_wait_seconds = max_startup_wait_seconds
         super().__init__(


### PR DESCRIPTION
## Description

In `vf.PythonEnv`, the `pip_install_packages` argument causes Sandboxes to fail. Due to the error catching, this is only visible in the tool-outputs. The model still continues working (and succeeds in many environments like math-python).

The error is caused by the `_START_COMMAND_TEMPLATE` having `pip install -q {pip_install_packages}` in it, which errors when `pip_install_packages = ""`. This is now replaced with `{pip_install_command}`, which in turn is guaranteed to be empty if there are no packages to install.

Previously, running `uv run vf-eval math-python -n 1 -r 1 -m gpt-5-mini -a '{"pip_install_packages": ""}'` resulted in outputs like this, which resulted in full reward and a functional rollout, just no usable sandboxes:

<img width="1451" height="589" alt="image" src="https://github.com/user-attachments/assets/7967b42c-2222-463b-b5fc-5f4b746295e3" />

Now, the sandboxes work (though the models still assume the presence of numpy, scipy, and sympy for math-python; but that's not an issue with the sandboxes):

<img width="1038" height="674" alt="image" src="https://github.com/user-attachments/assets/17c1d35d-b014-4242-98ae-cf0d65fa1d6f" />

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->