### PR TITLE
Misc fixes for (Stateful)ToolEnv + SandboxEnv + PythonEnv

### DIFF
--- a/environments/math_python/math_python.py
+++ b/environments/math_python/math_python.py
@@ -7,14 +7,14 @@ def load_environment(
     dataset_split: str = "train",
     num_train_examples: int = -1,
     max_turns: int = 100,
-    max_startup_wait_seconds: int = 30,
+    max_startup_wait_seconds: int = 60,
     pip_install_packages: str = "numpy sympy scipy",
     sandbox_cpu_cores: int = 1,
     sandbox_memory_gb: int = 2,
     sandbox_disk_size_gb: int = 5,
     sandbox_gpu_count: int = 0,
     sandbox_timeout_minutes: int = 60,
-    sandbox_timeout_per_command_seconds: int = 30,
+    sandbox_timeout_per_command_seconds: int = 60,
     **kwargs,
 ):
     dataset = load_example_dataset(dataset_name, dataset_split, n=num_train_examples)

--- a/tests/test_stateful_tool_env.py
+++ b/tests/test_stateful_tool_env.py
@@ -1,6 +1,7 @@
 """Tests for the StatefulToolEnv class."""
 
 import json
+from json import JSONDecodeError
 
 import pytest
 from openai.types.chat import ChatCompletionUserMessageParam
@@ -92,7 +93,7 @@ class TestStatefulToolEnv:
 
         class ParseErrorStatefulToolEnv(vf.StatefulToolEnv):
             def __init__(self, **kwargs):
-                super().__init__(tools=[], stop_errors=[vf.ToolParseError], **kwargs)
+                super().__init__(tools=[], stop_errors=[JSONDecodeError], **kwargs)
 
             def update_tool_args(self, tool_name, tool_args, messages, state, **kwargs):
                 return tool_args
@@ -158,9 +159,7 @@ class TestStatefulToolEnv:
 
         class ErrorStatefulToolEnv(vf.StatefulToolEnv):
             def __init__(self, **kwargs):
-                super().__init__(
-                    tools=[faulty_tool], stop_errors=[vf.ToolCallError], **kwargs
-                )
+                super().__init__(tools=[faulty_tool], stop_errors=[Exception], **kwargs)
 
             def update_tool_args(self, tool_name, tool_args, messages, state, **kwargs):
                 return tool_args

--- a/tests/test_tool_env.py
+++ b/tests/test_tool_env.py
@@ -1,6 +1,7 @@
 """Tests for the ToolEnv class."""
 
 import json
+from json import JSONDecodeError
 
 import pytest
 from openai.types.chat.chat_completion_user_message_param import (
@@ -102,7 +103,7 @@ class TestToolEnv:
         class TestToolEnv(vf.ToolEnv):
             def __init__(self, **kwargs):
                 super().__init__(
-                    tools=[square_tool], stop_errors=[vf.ToolParseError], **kwargs
+                    tools=[square_tool], stop_errors=[JSONDecodeError], **kwargs
                 )
 
         env = TestToolEnv(

--- a/verifiers/envs/python_env.py
+++ b/verifiers/envs/python_env.py
@@ -224,7 +224,7 @@ PY
     ) -> str:
         """Execute `code` inside persistent Python REPL."""
         if not python_state["ready"]:
-            await self._wait_for_worker_ready(sandbox_id)
+            await self._wait_for_worker_ready(sandbox_state, sandbox_id)
             python_state["ready"] = True
         sandbox_response = await self._send_worker_request(
             sandbox_id, sandbox_state, {"code": code}
@@ -235,10 +235,12 @@ PY
     async def cleanup_python_state(self, state: vf.State):
         state.pop("python_state", None)
 
-    async def _wait_for_worker_ready(self, sandbox_id: str) -> None:
+    async def _wait_for_worker_ready(
+        self, sandbox_state: SandboxState, sandbox_id: str
+    ) -> None:
         s = time.time()
         try:
-            await self._wait_for_sandbox_ready(sandbox_id)
+            await self._wait_for_sandbox_ready(sandbox_state, sandbox_id)
             wait_script = self._READY_WAIT_SCRIPT.format(ready_flag=self._READY_FLAG)
             self.logger.debug(f"Setting up Python worker in sandbox {sandbox_id}")
             result = await self.sandbox_client.execute_command(

--- a/verifiers/envs/python_env.py
+++ b/verifiers/envs/python_env.py
@@ -2,6 +2,7 @@ import base64
 import json
 import sys
 import textwrap
+import time
 from typing import Any
 
 if sys.version_info < (3, 12):
@@ -235,14 +236,19 @@ PY
         state.pop("python_state", None)
 
     async def _wait_for_worker_ready(self, sandbox_id: str) -> None:
+        s = time.time()
         try:
             await self._wait_for_sandbox_ready(sandbox_id)
             wait_script = self._READY_WAIT_SCRIPT.format(ready_flag=self._READY_FLAG)
+            self.logger.debug(f"Setting up Python worker in sandbox {sandbox_id}")
             result = await self.sandbox_client.execute_command(
                 sandbox_id, wait_script, timeout=self.max_startup_wait_seconds
             )
             if result.exit_code != 0:
                 raise RuntimeError(result.stderr)
+            self.logger.debug(
+                f"Waited {time.time() - s:.1f}s for Python worker to be ready"
+            )
         except Exception as e:
             raise PythonWorkerNotReadyError(e)
 

--- a/verifiers/envs/sandbox_env.py
+++ b/verifiers/envs/sandbox_env.py
@@ -61,8 +61,7 @@ class SandboxEnv(vf.StatefulToolEnv):
         stop_errors: list[type[Exception]] | None = None,
         **kwargs,
     ):
-        stop_errors = stop_errors or [vf.SandboxError]
-        super().__init__(stop_errors=stop_errors, **kwargs)
+        super().__init__(stop_errors=stop_errors or [vf.SandboxError], **kwargs)
         self.timeout_per_command_seconds = timeout_per_command_seconds
         self.sandbox_client = AsyncSandboxClient()
         self.sandbox_request = CreateSandboxRequest(

--- a/verifiers/envs/sandbox_env.py
+++ b/verifiers/envs/sandbox_env.py
@@ -58,9 +58,10 @@ class SandboxEnv(vf.StatefulToolEnv):
         backoff_factor: float = 2.0,
         max_backoff_seconds: float = 30.0,
         jitter: float = 1e-3,
-        stop_errors: list[type[Exception]] | None = [vf.SandboxError],
+        stop_errors: list[type[Exception]] | None = None,
         **kwargs,
     ):
+        stop_errors = stop_errors or [vf.SandboxError]
         super().__init__(stop_errors=stop_errors, **kwargs)
         self.timeout_per_command_seconds = timeout_per_command_seconds
         self.sandbox_client = AsyncSandboxClient()

--- a/verifiers/envs/sandbox_env.py
+++ b/verifiers/envs/sandbox_env.py
@@ -61,7 +61,10 @@ class SandboxEnv(vf.StatefulToolEnv):
         stop_errors: list[type[Exception]] | None = None,
         **kwargs,
     ):
-        super().__init__(stop_errors=stop_errors or [vf.SandboxError], **kwargs)
+        super().__init__(
+            stop_errors=stop_errors if stop_errors is not None else [vf.SandboxError],
+            **kwargs,
+        )
         self.timeout_per_command_seconds = timeout_per_command_seconds
         self.sandbox_client = AsyncSandboxClient()
         self.sandbox_request = CreateSandboxRequest(

--- a/verifiers/envs/sandbox_env.py
+++ b/verifiers/envs/sandbox_env.py
@@ -58,9 +58,10 @@ class SandboxEnv(vf.StatefulToolEnv):
         backoff_factor: float = 2.0,
         max_backoff_seconds: float = 30.0,
         jitter: float = 1e-3,
+        stop_errors: list[type[Exception]] | None = [vf.SandboxError],
         **kwargs,
     ):
-        super().__init__(**kwargs)
+        super().__init__(stop_errors=stop_errors, **kwargs)
         self.timeout_per_command_seconds = timeout_per_command_seconds
         self.sandbox_client = AsyncSandboxClient()
         self.sandbox_request = CreateSandboxRequest(
@@ -93,6 +94,7 @@ class SandboxEnv(vf.StatefulToolEnv):
     async def _wait_for_sandbox_ready(self, sandbox_id: str):
         """Wait for sandbox to be created"""
         s = time.time()
+        self.logger.debug(f"Waiting for sandbox {sandbox_id} to be ready")
         try:
             await self.sandbox_client.wait_for_creation(sandbox_id)
         except Exception as e:

--- a/verifiers/envs/stateful_tool_env.py
+++ b/verifiers/envs/stateful_tool_env.py
@@ -122,9 +122,8 @@ class StatefulToolEnv(vf.ToolEnv):
                     )
                 tool_args: dict = parsed_args
             except Exception as e:
-                err = vf.ToolParseError(cause=e)
-                if self._should_stop_for_error(err):
-                    raise err
+                if self._should_stop_for_error(e):
+                    raise vf.ToolParseError(e)
                 tool_messages.append(
                     cast(
                         vf.Message,
@@ -146,9 +145,8 @@ class StatefulToolEnv(vf.ToolEnv):
                 )
                 tool_messages.append(tool_message)
             except Exception as e:
-                err = vf.ToolCallError(cause=e)
-                if self._should_stop_for_error(err):
-                    raise err
+                if self._should_stop_for_error(e):
+                    raise vf.ToolCallError(e)
                 tool_messages.append(
                     cast(
                         vf.Message,

--- a/verifiers/envs/tool_env.py
+++ b/verifiers/envs/tool_env.py
@@ -28,7 +28,7 @@ class ToolEnv(vf.MultiTurnEnv):
         }
         super().__init__(oai_tools=self.oai_tools, max_turns=max_turns, **kwargs)
 
-    def _should_stop_for_error(self, err: vf.Error) -> bool:
+    def _should_stop_for_error(self, err: Exception) -> bool:
         """Check if error is in stop_errors."""
         return any(isinstance(err, err_type) for err_type in self.stop_errors)
 
@@ -84,9 +84,8 @@ class ToolEnv(vf.MultiTurnEnv):
                     tool_call.get("function", {}).get("arguments", "")
                 )
             except Exception as e:
-                err = vf.ToolParseError(cause=e)
-                if self._should_stop_for_error(err):
-                    raise err
+                if self._should_stop_for_error(e):
+                    raise vf.ToolParseError(e)
                 tool_messages.append(
                     cast(
                         vf.Message,
@@ -105,9 +104,8 @@ class ToolEnv(vf.MultiTurnEnv):
                 )
                 tool_messages.append(tool_message)
             except Exception as e:
-                err = vf.ToolCallError(cause=e)
-                if self._should_stop_for_error(err):
-                    raise err
+                if self._should_stop_for_error(e):
+                    raise vf.ToolCallError(e)
                 tool_messages.append(
                     cast(
                         vf.Message,


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Fixes the following things in the above mentioned envs:
- `ToolEnv`/ `StatefulToolEnv`: The `stop_errors` was previously checked against the exception wrapped in `ToolError` which means one can only catch parents of this class (e.g. `vf.ToolError` and `vf.Error`) but not arbitrary errors (like `JSONDecodeError` or even `vf.SandboxError`
- `SandboxEnv` now by default sets `vf.SandboxError` as a stop condition
- The helper in `_wait_for_sandbox_ready` now sets the state to avoid redundantly check the sandbox state in `PythonEnv` (previously it checked 1) on call to `_wait_for_worker_ready` and then on call to `bash`
- `math_python` uses default timeouts of 60s instead of 30s right now because sandbox infra doesn't allow less

Also added some more debug logs around timing I am using all the time and that help for spotting issues like the above.

## Example

**With sandbox error**

```bash
uv run vf-eval math-python -n1 -r1 -v -a '{"max_startup_wait_seconds": 5}'
```

Before, we would incorrectly leak the Python worker not setting up in time (but not failing on it)

<img width="1152" height="479" alt="Screenshot 2025-12-16 at 7 15 50 PM" src="https://github.com/user-attachments/assets/31f4ee1c-4386-4e18-8bbf-793766a7bdab" />

Now, we correctly error on the Python worker not being ready in time

<img width="1153" height="400" alt="Screenshot 2025-12-16 at 7 12 53 PM" src="https://github.com/user-attachments/assets/6f18a4e4-5de6-49af-a6e8-4e9e9d0353eb" />

**Without sandbox error**

All good of course.

<img width="1157" height="701" alt="Screenshot 2025-12-16 at 7 11 52 PM" src="https://github.com/user-attachments/assets/6f630004-7b30-4e41-86c0-bcfc7f10d136" />

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Align error-stop checks to raw exceptions, propagate sandbox readiness via state with improved logging, and bump Python/math sandbox timeouts; tests updated accordingly.
> 
> - **Core envs**
>   - **`ToolEnv` / `StatefulToolEnv`**:
>     - `stop_errors` now matches against raw `Exception` types; re-raise as `vf.ToolParseError`/`vf.ToolCallError` only when configured to stop.
>   - **`SandboxEnv`**:
>     - Accepts `stop_errors` with default `[vf.SandboxError]`.
>     - `_wait_for_sandbox_ready(sandbox_state, sandbox_id)` sets `state["ready"]` and adds timing/debug logs.
>     - `bash` now relies on the updated readiness helper.
>   - **`PythonEnv`**:
>     - Worker readiness waits on `_wait_for_sandbox_ready(sandbox_state, ...)`, adds timing/debug logs.
>     - `_wait_for_worker_ready` signature updated to take `sandbox_state`.
> - **Config**
>   - **`environments/math_python/math_python.py`**: Increase defaults to `max_startup_wait_seconds=60` and `sandbox_timeout_per_command_seconds=60`.
> - **Tests**
>   - Use `JSONDecodeError`/`Exception` in `stop_errors` where appropriate; adapt imports and expectations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d1b75ddef7345cfdbac109dde74af7a6e6bf834. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->