### PR TITLE
Handle all truncation cases

### DIFF
--- a/notes/TRAJECTORIES.md
+++ b/notes/TRAJECTORIES.md
@@ -350,9 +350,6 @@ async def add_model_response(
     response: ModelResponse,
 ):
     """Add a model response as a trajectory step."""
-    if response is not None and response.id == "overlong-prompt":
-        state["prompt_too_long"] = True
-        return
     completion_messages = await parse_response_messages(response, self.message_type)
     tokens = await parse_response_tokens(response, self.message_type)
     trajectory_step = TrajectoryStep(

--- a/tests/test_eval_utils.py
+++ b/tests/test_eval_utils.py
@@ -64,6 +64,8 @@ def test_print_results_rollout_indexing(capsys):
         example_id=example_ids,
         reward=rewards,
         metrics={"test_metric": metric_values},
+        is_truncated=[False] * 6,
+        stop_conditions=[None] * 6,
         metadata=_make_metadata(num_examples, rollouts_per_example),
     )
 
@@ -102,6 +104,8 @@ def test_print_results_single_rollout(capsys):
         example_id=example_ids,
         reward=rewards,
         metrics={},
+        is_truncated=[False] * 3,
+        stop_conditions=[None] * 3,
         metadata=_make_metadata(num_examples, rollouts_per_example),
     )
 
@@ -134,6 +138,8 @@ def test_print_results_three_rollouts(capsys):
         example_id=example_ids,
         reward=rewards,
         metrics={},
+        is_truncated=[False] * 6,
+        stop_conditions=[None] * 6,
         metadata=_make_metadata(num_examples, rollouts_per_example),
     )
 

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -565,6 +565,7 @@ class Environment(ABC):
         state["model"] = model
         state["sampling_args"] = sampling_args
         state["is_completed"] = False
+        state["is_truncated"] = False
         state["oai_tools"] = None
         if "info" in state and hasattr(state["info"], "oai_tools"):
             state["oai_tools"] = state["info"]["oai_tools"]
@@ -621,6 +622,9 @@ class Environment(ABC):
     async def _render_stop(self, state: State, condition) -> bool:
         if await condition(state):
             state["is_completed"] = True
+            state["is_truncated"] = state.get("is_truncated", False) or any(
+                step.get("is_truncated", False) for step in state.get("trajectory", [])
+            )
             state["stop_condition"] = condition.__name__
             if state.get("stop_condition") == "has_error":
                 self.logger.error(
@@ -725,10 +729,7 @@ class Environment(ABC):
         example_ids = [state.get("example_id", 0) for state in all_states]
         rewards = [state.get("reward", 0.0) for state in all_states]
         stop_conditions = [state.get("stop_condition", None) for state in all_states]
-        is_truncated = [
-            any(step.get("is_truncated", False) for step in state.get("trajectory", []))
-            for state in all_states
-        ]
+        is_truncated = [state.get("is_truncated", False) for state in all_states]
 
         metrics: dict[str, list[float]] = {}
         for state in all_states:

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -724,6 +724,11 @@ class Environment(ABC):
         infos = [state.get("info", {}) for state in all_states]
         example_ids = [state.get("example_id", 0) for state in all_states]
         rewards = [state.get("reward", 0.0) for state in all_states]
+        stop_conditions = [state.get("stop_condition", None) for state in all_states]
+        is_truncated = [
+            any(step.get("is_truncated", False) for step in state.get("trajectory", []))
+            for state in all_states
+        ]
 
         metrics: dict[str, list[float]] = {}
         for state in all_states:
@@ -767,6 +772,8 @@ class Environment(ABC):
             example_id=example_ids,
             reward=rewards,
             metrics=metrics,
+            stop_conditions=stop_conditions,
+            is_truncated=is_truncated,
             metadata=metadata,
         )
 

--- a/verifiers/envs/multiturn_env.py
+++ b/verifiers/envs/multiturn_env.py
@@ -69,8 +69,6 @@ class MultiTurnEnv(vf.Environment):
         prompt_messages: Messages,
         response: ModelResponse,
     ):
-        if response is not None and response.id == "overlong-prompt":
-            state["prompt_too_long"] = True
         completion_messages = await parse_response_messages(response, self.message_type)
         response_is_truncated = await parse_is_truncated(response, self.message_type)
         tokens = await parse_response_tokens(

--- a/verifiers/envs/multiturn_env.py
+++ b/verifiers/envs/multiturn_env.py
@@ -115,6 +115,7 @@ class MultiTurnEnv(vf.Environment):
             except vf.Error as e:
                 if isinstance(e, vf.OverlongPromptError):
                     state["prompt_too_long"] = True
+                    state["is_truncated"] = True
                 else:
                     state["error"] = e
         return state

--- a/verifiers/envs/multiturn_env.py
+++ b/verifiers/envs/multiturn_env.py
@@ -107,5 +107,8 @@ class MultiTurnEnv(vf.Environment):
                 response = await self.get_model_response(state, prompt_messages)
                 await self.add_model_response(state, prompt_messages, response)
             except vf.Error as e:
-                state["error"] = e
+                if isinstance(e, vf.OverlongPromptError):
+                    state["prompt_too_long"] = True
+                else:
+                    state["error"] = e
         return state

--- a/verifiers/envs/multiturn_env.py
+++ b/verifiers/envs/multiturn_env.py
@@ -77,7 +77,7 @@ class MultiTurnEnv(vf.Environment):
             response, self.message_type, self.max_seq_len
         )
         is_truncated = response_is_truncated or (
-            tokens and tokens.get("is_truncated") or False
+            tokens is not None and bool(tokens.get("is_truncated"))
         )
         trajectory_step = TrajectoryStep(
             prompt=prompt_messages,

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -67,6 +67,7 @@ class TrajectoryStep(TypedDict):
     tokens: TrajectoryStepTokens | None
     reward: float | None
     advantage: float | None
+    is_truncated: bool
     extras: dict[str, Any]
 
 
@@ -167,6 +168,8 @@ class GenerateOutputs(TypedDict):
     example_id: list[int]
     reward: list[float]
     metrics: dict[str, list[float]]
+    stop_conditions: list[str] | None
+    is_truncated: list[bool]
     metadata: GenerateMetadata
 
 

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -100,6 +100,7 @@ class State(dict):
     sampling_args: SamplingArgs | None
     # created during rollout
     is_completed: bool
+    is_truncated: bool
     stop_condition: str | None
     oai_tools: list[ChatCompletionToolParam]
     trajectory: list[TrajectoryStep]

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -169,7 +169,7 @@ class GenerateOutputs(TypedDict):
     example_id: list[int]
     reward: list[float]
     metrics: dict[str, list[float]]
-    stop_conditions: list[str] | None
+    stop_conditions: list[str | None]
     is_truncated: list[bool]
     metadata: GenerateMetadata
 

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -108,7 +108,7 @@ def print_results(results: GenerateOutputs, num_samples: int = 1):
     errors = [e for e in errors if e is not None]
     if errors:
         print(
-            f"errors: {', '.join([f'{k}: {v / len(errors):.3f}' for k, v in Counter(errors).items()])}"
+            f"errors: {', '.join([f'{k}: {v / len(errors):.3f}' for k, v in Counter([type(e).__name__ for e in errors]).items()])}"
         )
 
 

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -2,6 +2,7 @@ import importlib.util
 import json
 import logging
 import time
+from collections import Counter
 from contextlib import contextmanager
 from pathlib import Path
 from typing import cast
@@ -96,6 +97,19 @@ def print_results(results: GenerateOutputs, num_samples: int = 1):
             trials = [round(v[i + (j * r)], 3) for j in range(n)]
             out = f"r{i + 1}: {trials}"
             print(out)
+
+    print("Info:")
+    print(
+        f"is_truncated: avg - {np.mean(results['is_truncated']):.3f}, std - {np.std(results['is_truncated']):.3f}"
+    )
+    print(
+        f"stop_conditions: {', '.join([f'{k}={v}' for k, v in Counter(results['stop_conditions']).items()])}"
+    )
+    errors = [e for e in errors if e is not None]
+    if errors:
+        print(
+            f"errors: {', '.join([f'{k}: {v / len(errors):.3f}' for k, v in Counter(errors).items()])}"
+        )
 
 
 async def run_evaluation(config: EvalConfig) -> GenerateOutputs:

--- a/verifiers/utils/response_utils.py
+++ b/verifiers/utils/response_utils.py
@@ -85,8 +85,7 @@ async def parse_response_tokens(
             is_truncated = False
     else:
         overlong_prompt = False
-        # if max_model_len or max_tokens (per turn) is hit during completion
-        is_truncated = response.choices[0].finish_reason == "length"
+        is_truncated = False
     return TrajectoryStepTokens(
         prompt_ids=prompt_ids,
         prompt_mask=prompt_mask,
@@ -126,3 +125,18 @@ async def parse_response_messages(
             response_text = response.choices[0].text or ""
         completion_messages = str(response_text)
     return completion_messages
+
+
+async def parse_is_truncated(
+    response: ModelResponse, message_type: MessageType
+) -> bool:
+    if message_type == "chat":
+        assert isinstance(response, ChatCompletion)
+        assert len(response.choices) == 1, "Response should always have one choice"
+        return response.choices[0].finish_reason == "length"
+    elif message_type == "completion":
+        assert isinstance(response, Completion)
+        assert len(response.choices) == 1, "Response should always have one choice"
+        return response.choices[0].finish_reason == "length"
+    else:
+        return False

--- a/verifiers/utils/response_utils.py
+++ b/verifiers/utils/response_utils.py
@@ -85,7 +85,8 @@ async def parse_response_tokens(
             is_truncated = False
     else:
         overlong_prompt = False
-        is_truncated = False
+        # if max_model_len or max_tokens (per turn) is hit during completion
+        is_truncated = response.choices[0].finish_reason == "length"
     return TrajectoryStepTokens(
         prompt_ids=prompt_ids,
         prompt_mask=prompt_mask,


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Currently, we only populate the `is_truncated` field only when processing tokens by checking whether the prompt and completions tokens at the current turn exceed the environment's `max_seq_len`. This only catches 1 out of 4 truncation cases:
1. We truncate based on `max_seq_len` in environment
2. The response is truncated based on the maximum context (typically `max_model_len` on the inference server)
3. The response is truncated based on the a user-defined token limit (per turn, e.g. `max_tokens` or `max_completion_tokens`)
4. We could not obtain a response because the previous turn's tokens + token/ turn exceeds the maximum context (hence, we get a `BadRequestError` back

As mentioned, 1) is already handled, 2) and 3) are part of the OAI spec, i.e. the (chat) completion response choices contain a `finish_reason` field which is set in either of the cases.  We add a small util to check this field and set a _new attribute_ in the trajectory step called `is_truncated` if _any_ of the three conditions above is met.

Further, we do not raise anymore on `OverlongPromptError` but instead set the `prompt_too_long` flag directly to abrupt the rollout based on the known truncation condition, rather than on an exception. This is because e.g. PRIME-RL will treat all exception cases by masking the rollout, whereas the truncation case should be handled differently (and in the same way as the other truncation cases)

I also took the liberty to add some info summary into the `vf-eval` outputs for `is_truncated` (true if any turn is truncated, shows mean and std) and stop and error conditions (prob dist)

## Examples

We handle case 2) correctly, i.e. when setting max_tokens, the is truncated field abrupts the rollout

```bash
uv run inference --model.name Qwen/Qwen3-4B-Instruct-2507 --enable-auto-tool-choice --tool-call-parser hermes --max-model-len 128
```

```bash
uv run vf-eval gsm8k -n1 -r1 -b http://localhost:8000/v1 -m Qwen/Qwen3-4B-Instruct-2507 -v
```

<img width="1426" height="455" alt="Screenshot 2025-12-17 at 10 50 24 AM" src="https://github.com/user-attachments/assets/2e6fed38-2efb-4d6e-9088-3ee1773449d6" />

We handle case 3) correctly, i.e. when setting max_tokens, the is truncated field abrupts the rollout

```bash
uv run vf-eval gsm8k -n1 -r1 -b http://localhost:8000/v1 -m Qwen/Qwen3-4B-Instruct-2507 -v -t 16 
```

<img width="1426" height="445" alt="Screenshot 2025-12-17 at 10 48 24 AM" src="https://github.com/user-attachments/assets/0b66fc83-2f99-4fff-aa4c-d3f64d823a9d" />

We handle case 4) correctly, i.e we catch (but raise) the overlong prompt error and gracefully abrupt the rollout. We do not set the is_truncated flag here because the turn has not completed, and so there's no place to set it (maybe it should be set globally?)

```bash
uv run inference --model.name Qwen/Qwen3-4B-Instruct-2507 --enable-auto-tool-choice --tool-call-parser hermes --max-model-len 16
```

```bash
uv run vf-eval gsm8k -n1 -r1 -b http://localhost:8000/v1 -m Qwen/Qwen3-4B-Instruct-2507 -v
```

<img width="1154" height="441" alt="Screenshot 2025-12-17 at 10 56 58 AM" src="https://github.com/user-attachments/assets/bfda8fcc-2e4a-45e5-96d6-a11a7bbe70a7" />

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add end-to-end truncation tracking (step/state), include stop conditions in outputs, print truncation/stop/error summaries, and handle overlong prompts without raising.
> 
> - **Core runtime**:
>   - Track truncation: add `state['is_truncated']` and aggregate from trajectory in `_render_stop()`.
>   - `MultiTurnEnv.add_model_response()`: compute `is_truncated` via `finish_reason` and token truncation; store on `TrajectoryStep`.
>   - Handle `OverlongPromptError` by setting `prompt_too_long=True` and `is_truncated=True` (no raise to error path).
> - **Types/Results**:
>   - Extend `TrajectoryStep` and `State` with `is_truncated`.
>   - Extend `GenerateOutputs` with `stop_conditions` and `is_truncated` lists.
> - **Response parsing**:
>   - Add `parse_is_truncated()` to read `finish_reason`.
>   - `parse_response_tokens()` already truncates by `max_seq_len`; retain flags.
> - **Evaluation**:
>   - `print_results()`: print truncation stats, stop condition counts, and error type distribution.
> - **Tests/Docs**:
>   - Update tests to provide `is_truncated` and `stop_conditions`.
>   - Remove obsolete overlong-prompt sentinel from docs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09343e40aa972a9f9528103da31483c9f3ed57c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->