### PR TITLE
Make logger names dynamic

### DIFF
--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -83,7 +83,7 @@ class Environment(ABC):
         interleaved_rollouts: bool = False,
         **kwargs,
     ):
-        self.logger = logging.getLogger(f"verifiers.envs.{self.__class__.__name__}")
+        self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
         self.message_type: Literal["chat", "completion"] = message_type
         self.oai_tools: list[ChatCompletionToolParam] | None = oai_tools
         self.system_prompt = system_prompt

--- a/verifiers/parsers/parser.py
+++ b/verifiers/parsers/parser.py
@@ -14,7 +14,7 @@ class Parser:
     """
 
     def __init__(self, extract_fn: Callable[[str], str] = lambda x: x):
-        self.logger = logging.getLogger(f"verifiers.parsers.{self.__class__.__name__}")
+        self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
         self.extract_fn = extract_fn
 
     def parse(self, text: str) -> Any:

--- a/verifiers/parsers/think_parser.py
+++ b/verifiers/parsers/think_parser.py
@@ -1,4 +1,3 @@
-import logging
 from typing import Callable
 
 from verifiers.parsers.parser import Parser
@@ -7,7 +6,6 @@ from verifiers.types import ChatMessage
 
 class ThinkParser(Parser):
     def __init__(self, extract_fn: Callable[[str], str] = lambda x: x):
-        self.logger = logging.getLogger(f"verifiers.parsers.{self.__class__.__name__}")
         super().__init__(extract_fn=extract_fn)
         self.extract_fn = extract_fn
         self.logger.warning(

--- a/verifiers/rubrics/rubric.py
+++ b/verifiers/rubrics/rubric.py
@@ -35,7 +35,7 @@ class Rubric:
         weights: list[float] | None = None,
         parser: vf.Parser | None = None,
     ):
-        self.logger = logging.getLogger(f"verifiers.rubrics.{self.__class__.__name__}")
+        self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
 
         self.funcs = funcs or []
         self.weights = weights or []


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

As advertised, logger names are now robust to file moves.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make logger names dynamic via __name__ and remove redundant logger initialization in ThinkParser.
> 
> - **Logging**:
>   - Update logger initialization to `f"{__name__}.{ClassName}"` in `verifiers/envs/environment.py`, `verifiers/parsers/parser.py`, and `verifiers/rubrics/rubric.py`.
>   - Remove redundant `logging` import and explicit logger setup in `verifiers/parsers/think_parser.py`; rely on base `Parser`'s logger.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f255cbaca778953216ec3e7e33705f99c3a85c50. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->