### PR TITLE
raise ModelError when response.choices is None

### DIFF
--- a/tests/test_environment_audio_modality.py
+++ b/tests/test_environment_audio_modality.py
@@ -3,7 +3,7 @@ import pytest
 from datasets import Dataset
 
 import verifiers as vf
-from tests.mock_openai_client import MockOpenAIClient
+from tests.mock_openai_client import MockCompletionResponse, MockOpenAIClient
 from verifiers.envs.singleturn_env import SingleTurnEnv
 from verifiers.types import RolloutInput
 
@@ -19,7 +19,7 @@ class MockClientWithKwargsCapture(MockOpenAIClient):
 
         async def _wrap_create(**kwargs):
             self._captured_kwargs = kwargs
-            return {"ok": True}
+            return MockCompletionResponse("test response")
 
         self.chat.completions.create = _wrap_create
 

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -522,7 +522,7 @@ class Environment(ABC):
 
         if self.interleaved_rollouts and len(state["trajectory"]) > 0:
             prompt_ids = await get_prompt_ids(state, prompt, client)
-            return await get_model_response_with_tokens(
+            response = await get_model_response_with_tokens(
                 client=client,
                 model=model,
                 prompt=prompt,
@@ -532,7 +532,7 @@ class Environment(ABC):
                 message_type=message_type,
             )
         else:
-            return await get_model_response_with_messages(
+            response = await get_model_response_with_messages(
                 client=client,
                 model=model,
                 prompt=prompt,
@@ -540,6 +540,13 @@ class Environment(ABC):
                 sampling_args=sampling_args,
                 message_type=message_type,
             )
+
+        # Some providers (e.g. OpenRouter) return None for response.choices
+        if response is None or not response.choices:
+            raise vf.EmptyModelResponseError(
+                ValueError("Model returned no response choices")
+            )
+        return response
 
     async def init_state(
         self,

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -541,8 +541,10 @@ class Environment(ABC):
                 message_type=message_type,
             )
 
-        # Some providers (e.g. OpenRouter) return None for response.choices
-        if response is None or not response.choices:
+        # Some providers (e.g. OpenRouter) may return None for response or response.choices
+        if response is None:
+            raise vf.EmptyModelResponseError(ValueError("Model returned no response"))
+        if response.choices is None:
             raise vf.EmptyModelResponseError(
                 ValueError("Model returned no response choices")
             )

--- a/verifiers/envs/multiturn_env.py
+++ b/verifiers/envs/multiturn_env.py
@@ -68,11 +68,6 @@ class MultiTurnEnv(vf.Environment):
         prompt_messages: Messages,
         response: ModelResponse,
     ):
-        if response is not None and response.id == "overlong-prompt":
-            state["prompt_too_long"] = True
-        # Some providers (e.g. OpenRouter) return None for response or response.choices
-        if response is None or not response.choices:
-            raise vf.ModelError(ValueError("Model returned no response choices"))
         completion_messages = await parse_response_messages(response, self.message_type)
         tokens = await parse_response_tokens(
             response, self.message_type, self.max_seq_len

--- a/verifiers/envs/multiturn_env.py
+++ b/verifiers/envs/multiturn_env.py
@@ -70,10 +70,17 @@ class MultiTurnEnv(vf.Environment):
     ):
         if response is not None and response.id == "overlong-prompt":
             state["prompt_too_long"] = True
-        completion_messages = await parse_response_messages(response, self.message_type)
-        tokens = await parse_response_tokens(
-            response, self.message_type, self.max_seq_len
-        )
+        try:
+            completion_messages = await parse_response_messages(
+                response, self.message_type
+            )
+            tokens = await parse_response_tokens(
+                response, self.message_type, self.max_seq_len
+            )
+        except Exception as e:
+            # Example: response.choices is None, which happens with OpenRouter models
+            # This triggers a TypeError in parse_response_tokens
+            raise vf.ModelError(e)
         trajectory_step = TrajectoryStep(
             prompt=prompt_messages,
             completion=completion_messages,

--- a/verifiers/envs/multiturn_env.py
+++ b/verifiers/envs/multiturn_env.py
@@ -70,17 +70,13 @@ class MultiTurnEnv(vf.Environment):
     ):
         if response is not None and response.id == "overlong-prompt":
             state["prompt_too_long"] = True
-        try:
-            completion_messages = await parse_response_messages(
-                response, self.message_type
-            )
-            tokens = await parse_response_tokens(
-                response, self.message_type, self.max_seq_len
-            )
-        except Exception as e:
-            # Example: response.choices is None, which happens with OpenRouter models
-            # This triggers a TypeError in parse_response_tokens
-            raise vf.ModelError(e)
+        # Some providers (e.g. OpenRouter) return None for response or response.choices
+        if response is None or not response.choices:
+            raise vf.ModelError(ValueError("Model returned no response choices"))
+        completion_messages = await parse_response_messages(response, self.message_type)
+        tokens = await parse_response_tokens(
+            response, self.message_type, self.max_seq_len
+        )
         trajectory_step = TrajectoryStep(
             prompt=prompt_messages,
             completion=completion_messages,

--- a/verifiers/envs/multiturn_env.py
+++ b/verifiers/envs/multiturn_env.py
@@ -68,6 +68,8 @@ class MultiTurnEnv(vf.Environment):
         prompt_messages: Messages,
         response: ModelResponse,
     ):
+        if response is not None and response.id == "overlong-prompt":
+            state["prompt_too_long"] = True
         completion_messages = await parse_response_messages(response, self.message_type)
         tokens = await parse_response_tokens(
             response, self.message_type, self.max_seq_len

--- a/verifiers/errors.py
+++ b/verifiers/errors.py
@@ -14,6 +14,12 @@ class ModelError(Error):
     pass
 
 
+class EmptyModelResponseError(ModelError):
+    """Used to catch empty or invalid model responses (e.g. response.choices is None)."""
+
+    pass
+
+
 class OverlongPromptError(Error):
     """Used to catch overlong prompt errors (e.g. prompt + requested number of tokens exceeds model context length)"""
 


### PR DESCRIPTION
## Description

There is a bug in `MultiTurnEnv`  where if `response.choices` is `None`, a `TypeError` is raised in `parse_response_messages` (which is in *response_utils.py*  and called in the `MultiTurnEnv` in `add_model_response`).

This edgecase can happen with OpenRouter models, but shouldn't crash the rollout. It now raises a `vf.ModelError`.

The PR is designed to explicitly *only* raise a `vf.ModelError` in this specific situation, not if for example `len(response.choices) > 1` (which would lead to an AssertionError).

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Validate model responses and raise a new EmptyModelResponseError when response or choices are None; adjust env flow and update tests' mock to return a completion response.
> 
> - **Environment**:
>   - Validate `response` from `get_model_response` and raise `vf.EmptyModelResponseError` if `response` or `response.choices` is `None`.
>   - Refactor to assign `response` before returning in both token and messages paths.
> - **Errors**:
>   - Add `vf.EmptyModelResponseError` in `verifiers/errors.py`.
> - **Tests**:
>   - Update audio modality tests to import `MockCompletionResponse` and have mock client return it.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cce64474f12abf530623a3319e66059ddbc6445a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->