### PR TITLE
Fix documentation link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Verifiers: Environments for LLM Reinforcement Learning
 </h3>
 
 <p align="center">
-  <a href="https://docs.primeintellect.ai/verifiers">Documentation</a> •
+  <a href="https://verifiers.readthedocs.io/en/latest/">Documentation</a> •
   <a href="https://app.primeintellect.ai/dashboard/environments?ex_sort=most_stars">Environments Hub</a> •
   <a href="https://github.com/PrimeIntellect-ai/prime-rl">PRIME-RL</a>
 </p>


### PR DESCRIPTION
## Description
Update `README.md` to the new documentation (old one gets 404)

old one: https://docs.primeintellect.ai/verifiers/source

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update the README documentation link to https://verifiers.readthedocs.io/en/latest/.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e04229771f75fc9e977f0ecef5bc88ed868ed064. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->