### PR TITLE
option to bypass scoring

### DIFF
--- a/verifiers/envs/env_group.py
+++ b/verifiers/envs/env_group.py
@@ -291,3 +291,9 @@ class EnvGroup(vf.Environment):
         self.interleaved_rollouts = interleaved_rollouts
         for env in self.envs:
             env.set_interleaved_rollouts(interleaved_rollouts)
+
+    def set_score_rollouts(self, score_rollouts: bool) -> None:
+        """Set the score rollouts flag for this environment group and all sub-environments."""
+        self.score_rollouts = score_rollouts
+        for env in self.envs:
+            env.set_score_rollouts(score_rollouts)

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -81,6 +81,7 @@ class Environment(ABC):
         map_kwargs: dict = {},
         max_seq_len: int | None = None,
         interleaved_rollouts: bool = False,
+        score_rollouts: bool = True,
         **kwargs,
     ):
         self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
@@ -100,6 +101,7 @@ class Environment(ABC):
         self.max_seq_len = max_seq_len
 
         self.set_interleaved_rollouts(interleaved_rollouts)
+        self.set_score_rollouts(score_rollouts)
 
         if self.message_type == "chat":
             if dataset is not None:
@@ -711,7 +713,8 @@ class Environment(ABC):
             for input in group_inputs
         ]
         group_states = await asyncio.gather(*rollout_tasks)
-        await self.rubric.score_group(group_states, score_sem=score_sem)
+        if self.score_rollouts:
+            await self.rubric.score_group(group_states, score_sem=score_sem)
         return list(group_states)
 
     def _prepare_rollout_results(
@@ -1061,6 +1064,10 @@ class Environment(ABC):
             self.logger.warning(
                 f"{self.__class__.__name__} is configured to use interleaved rollouts. All model responses after the first turn will be pre-tokenized before being sent to the model. Currently, this is a hand-crafted feature for PRIME-RL's vLLM server extension."
             )
+
+    def set_score_rollouts(self, score_rollouts: bool) -> None:
+        """Set the score rollouts flag for this environment."""
+        self.score_rollouts = score_rollouts
 
     make_dataset = make_dataset
 

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -715,6 +715,8 @@ class Environment(ABC):
         group_states = await asyncio.gather(*rollout_tasks)
         if self.score_rollouts:
             await self.rubric.score_group(group_states, score_sem=score_sem)
+        else:
+            await self.rubric.dummy_score_group(group_states)
         return list(group_states)
 
     def _prepare_rollout_results(

--- a/verifiers/rubrics/rubric.py
+++ b/verifiers/rubrics/rubric.py
@@ -244,6 +244,14 @@ class Rubric:
         state["reward"] = rewards["reward"]
         state["metrics"] = rewards["metrics"]
 
+    async def dummy_score_group(self, states: list[State]):
+        """
+        Score a group of rollouts together with dummy rewards.
+        """
+        for state in states:
+            state["reward"] = 0.0
+            state["metrics"] = {}
+
     async def score_group(self, states: list[State], score_sem: AsyncContextManager):
         """
         Score a group of rollouts together.


### PR DESCRIPTION
## Description

Adds score_rollouts bool as Environment class attr, with setter functions, to allow skipping scoring. 

Environments can optionally reference this attr to skip scoring-only resource initialization in setup_state.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a score_rollouts flag to Environment/EnvGroup to optionally skip scoring by calling Rubric.dummy_score_group instead of score_group.
> 
> - **Environment**:
>   - Add `score_rollouts` attr (default `True`) with `set_score_rollouts`; initialize via constructor.
>   - In `run_group`, conditionally call `rubric.score_group(...)` or `rubric.dummy_score_group(...)` based on `score_rollouts`.
> - **EnvGroup**:
>   - Add `set_score_rollouts` to propagate the flag to all sub-environments.
> - **Rubric**:
>   - Implement `dummy_score_group` to set zero reward and empty metrics for rollouts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e7754f15ee3f8cdcfdc2de5812bb70f1cd444f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->