### PR TITLE
fix tests, allow non-vf error types

### DIFF
--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,12 +1,13 @@
 """Tests for the base Environment class."""
 
 from pathlib import Path
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from datasets import Dataset
 from openai.types.chat.chat_completion import Choice
 
+import verifiers as vf
 from verifiers import Environment, Parser, Rubric, ThinkParser
 from verifiers.types import (
     GenerateMetadata,
@@ -465,3 +466,85 @@ class TestEnvironmentBase:
         # Scoring always happens now, so rewards will be set by score_group
         # If score_group doesn't set rewards, they'll be None/0
         assert results["metadata"]["avg_reward"] >= 0.0
+
+
+class TestRenderStopErrorHandling:
+    """Test cases for _render_stop error handling paths."""
+
+    @pytest.mark.asyncio
+    async def test_render_stop_with_vf_error(self, mock_openai_client, sample_dataset):
+        """Test that _render_stop logs correctly for vf.Error with cause."""
+        env = SimpleEnvironment(
+            dataset=sample_dataset,
+            parser=Parser(),
+            rubric=Rubric(),
+        )
+
+        cause = ValueError("underlying cause")
+        error = vf.ToolCallError(cause=cause)
+
+        state = await env.init_state(
+            input=RolloutInput(
+                prompt=[{"role": "user", "content": "test"}],
+                answer="test",
+                example_id=0,
+            ),
+            client=mock_openai_client,
+            model="test-model",
+        )
+        state["error"] = error
+
+        async def has_error(state):
+            return state.get("error") is not None
+
+        has_error.__name__ = "has_error"
+
+        with patch.object(env.logger, "error") as mock_logger_error:
+            result = await env._render_stop(state, has_error)
+
+            assert result is True
+            assert state["stop_condition"] == "has_error"
+            mock_logger_error.assert_called_once()
+            call_args = mock_logger_error.call_args[0][0]
+            assert "ToolCallError" in call_args
+            assert "caused by" in call_args
+
+    @pytest.mark.asyncio
+    async def test_render_stop_with_regular_exception(
+        self, mock_openai_client, sample_dataset
+    ):
+        """Test that _render_stop logs correctly for regular exceptions without cause."""
+        env = SimpleEnvironment(
+            dataset=sample_dataset,
+            parser=Parser(),
+            rubric=Rubric(),
+        )
+
+        error = RuntimeError("something went wrong")
+
+        state = await env.init_state(
+            input=RolloutInput(
+                prompt=[{"role": "user", "content": "test"}],
+                answer="test",
+                example_id=0,
+            ),
+            client=mock_openai_client,
+            model="test-model",
+        )
+        state["error"] = error
+
+        async def has_error(state):
+            return state.get("error") is not None
+
+        has_error.__name__ = "has_error"
+
+        with patch.object(env.logger, "error") as mock_logger_error:
+            result = await env._render_stop(state, has_error)
+
+            assert result is True
+            assert state["stop_condition"] == "has_error"
+            mock_logger_error.assert_called_once()
+            call_args = mock_logger_error.call_args[0][0]
+            assert "RuntimeError" in call_args
+            assert "caused by" not in call_args
+            assert "something went wrong" in call_args

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -636,11 +636,16 @@ class Environment(ABC):
             )
             state["stop_condition"] = condition.__name__
             if state.get("stop_condition") == "has_error":
-                self.logger.error(
-                    f"Got {state['error'].__class__.__name__}, caused by {state['error'].cause!r}"
-                )
-                cause = state["error"].cause
-                traceback.print_exception(type(cause), cause, cause.__traceback__)
+                err = state["error"]
+                cause = getattr(err, "cause", None)
+                if cause is not None:
+                    self.logger.error(
+                        f"Got {err.__class__.__name__}, caused by {cause!r}"
+                    )
+                    traceback.print_exception(type(cause), cause, cause.__traceback__)
+                else:
+                    self.logger.error(f"Got {err.__class__.__name__}: {err}")
+                    traceback.print_exception(type(err), err, err.__traceback__)
             return True
         return False
 


### PR DESCRIPTION
## Description

Fallback for stop_errors that are not vf.Error types

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make _render_stop robust to errors without a `cause`, adjusting logging/tracebacks, and add tests validating both vf.Error and regular Exception paths.
> 
> - **Environment**:
>   - Update `_render_stop` to gracefully handle errors without `cause`; log class and message, and print appropriate traceback. Retains detailed logging when `cause` exists.
> - **Tests**:
>   - Add `TestRenderStopErrorHandling` with cases for `vf.ToolCallError` (with `cause`) and a regular `RuntimeError` (no `cause`) to verify logging behavior.
>   - Minor test import update to include `patch`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 584365a0ca3eee549271b49170aa014e38c7be7e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->