### PR TITLE
Remove `cause` error field

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -354,7 +354,8 @@ def square_tool(x: int) -> int:
 
 
 def faulty_tool() -> None:
-    raise ToolCallError(cause=ValueError("failure"))
+    cause = ValueError("failure")
+    raise ToolCallError from cause
 
 
 class BasicToolEnv(ToolEnv):

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -481,7 +481,8 @@ class TestRenderStopErrorHandling:
         )
 
         cause = ValueError("underlying cause")
-        error = vf.ToolCallError(cause=cause)
+        error = vf.ToolCallError()
+        error.__cause__ = cause
 
         state = await env.init_state(
             input=RolloutInput(
@@ -507,7 +508,6 @@ class TestRenderStopErrorHandling:
             mock_logger_error.assert_called_once()
             call_args = mock_logger_error.call_args[0][0]
             assert "ToolCallError" in call_args
-            assert "caused by" in call_args
 
     @pytest.mark.asyncio
     async def test_render_stop_with_regular_exception(

--- a/tests/test_tool_env.py
+++ b/tests/test_tool_env.py
@@ -169,9 +169,7 @@ class TestToolEnv:
 
         class ErrorToolEnv(vf.ToolEnv):
             def __init__(self, **kwargs):
-                super().__init__(
-                    tools=[faulty_tool], stop_errors=[vf.ToolCallError], **kwargs
-                )
+                super().__init__(tools=[faulty_tool], stop_errors=[Exception], **kwargs)
 
         env = ErrorToolEnv(
             client=mock_openai_client,

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -639,7 +639,7 @@ class Environment(ABC):
             state["stop_condition"] = condition.__name__
             if state.get("stop_condition") == "has_error":
                 err = state["error"]
-                self.logger.error(f"Got {err.__class__.__name__}: {err!r}")
+                self.logger.error(f"Aborted rollout due to {err!r}")
                 traceback.print_exception(type(err), err, err.__traceback__)
             return True
         return False

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -412,9 +412,9 @@ class Environment(ABC):
                             phrase in error_text for phrase in context_length_phrases
                         ):
                             self.logger.debug("Caught overlong prompt.")
-                            raise vf.OverlongPromptError(e)
+                            raise vf.OverlongPromptError from e
                     # in all other case we raise a generic model error
-                    raise vf.ModelError(e)
+                    raise vf.ModelError from e
 
             return wrapper
 
@@ -543,10 +543,12 @@ class Environment(ABC):
 
         # Some providers (e.g. OpenRouter) may return None for response or response.choices
         if response is None:
-            raise vf.EmptyModelResponseError(ValueError("Model returned no response"))
+            raise vf.EmptyModelResponseError from ValueError(
+                "Model returned no response"
+            )
         if response.choices is None:
-            raise vf.EmptyModelResponseError(
-                ValueError("Model returned no response choices")
+            raise vf.EmptyModelResponseError from ValueError(
+                "Model returned no response choices"
             )
         return response
 
@@ -637,7 +639,7 @@ class Environment(ABC):
             state["stop_condition"] = condition.__name__
             if state.get("stop_condition") == "has_error":
                 err = state["error"]
-                cause = getattr(err, "cause", None)
+                cause = getattr(err, "__cause__", None)
                 if cause is not None:
                     self.logger.error(
                         f"Got {err.__class__.__name__}, caused by {cause!r}"

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -639,15 +639,8 @@ class Environment(ABC):
             state["stop_condition"] = condition.__name__
             if state.get("stop_condition") == "has_error":
                 err = state["error"]
-                cause = getattr(err, "__cause__", None)
-                if cause is not None:
-                    self.logger.error(
-                        f"Got {err.__class__.__name__}, caused by {cause!r}"
-                    )
-                    traceback.print_exception(type(cause), cause, cause.__traceback__)
-                else:
-                    self.logger.error(f"Got {err.__class__.__name__}: {err}")
-                    traceback.print_exception(type(err), err, err.__traceback__)
+                self.logger.error(f"Got {err.__class__.__name__}: {err!r}")
+                traceback.print_exception(type(err), err, err.__traceback__)
             return True
         return False
 

--- a/verifiers/envs/python_env.py
+++ b/verifiers/envs/python_env.py
@@ -252,7 +252,7 @@ PY
                 f"Waited {time.time() - s:.1f}s for Python worker to be ready"
             )
         except Exception as e:
-            raise PythonWorkerNotReadyError(e)
+            raise PythonWorkerNotReadyError from e
 
     async def _send_worker_request(
         self, sandbox_id: str, sandbox_state, payload: dict[str, Any]
@@ -280,7 +280,7 @@ PY
                 raise RuntimeError("Python worker returned no output")
             response = json.loads(raw_response)
         except Exception as e:
-            raise PythonWorkerRequestError(e)
+            raise PythonWorkerRequestError from e
 
         return response
 

--- a/verifiers/envs/sandbox_env.py
+++ b/verifiers/envs/sandbox_env.py
@@ -202,7 +202,7 @@ class SandboxEnv(vf.StatefulToolEnv):
             self.logger.warning(f"{timeout_msg} in sandbox {sandbox_id}")
             return f"Error: {timeout_msg}"
         except Exception as e:
-            raise vf.SandboxError(cause=e)
+            raise vf.SandboxError from e
         e = time.time()
         stdout = results.stdout.strip()
         stderr = (results.stderr or "").strip()

--- a/verifiers/envs/stateful_tool_env.py
+++ b/verifiers/envs/stateful_tool_env.py
@@ -123,7 +123,7 @@ class StatefulToolEnv(vf.ToolEnv):
                 tool_args: dict = parsed_args
             except Exception as e:
                 if self._should_stop_for_error(e):
-                    raise vf.ToolParseError(e)
+                    raise vf.ToolParseError from e
                 tool_messages.append(
                     cast(
                         vf.Message,
@@ -146,7 +146,7 @@ class StatefulToolEnv(vf.ToolEnv):
                 tool_messages.append(tool_message)
             except Exception as e:
                 if self._should_stop_for_error(e):
-                    raise vf.ToolCallError(e)
+                    raise vf.ToolCallError from e
                 tool_messages.append(
                     cast(
                         vf.Message,

--- a/verifiers/envs/tool_env.py
+++ b/verifiers/envs/tool_env.py
@@ -85,7 +85,7 @@ class ToolEnv(vf.MultiTurnEnv):
                 )
             except Exception as e:
                 if self._should_stop_for_error(e):
-                    raise vf.ToolParseError(e)
+                    raise vf.ToolParseError from e
                 tool_messages.append(
                     cast(
                         vf.Message,
@@ -105,7 +105,7 @@ class ToolEnv(vf.MultiTurnEnv):
                 tool_messages.append(tool_message)
             except Exception as e:
                 if self._should_stop_for_error(e):
-                    raise vf.ToolCallError(e)
+                    raise vf.ToolCallError from e
                 tool_messages.append(
                     cast(
                         vf.Message,

--- a/verifiers/errors.py
+++ b/verifiers/errors.py
@@ -1,12 +1,6 @@
 class Error(Exception):
     """Base class for all errors."""
 
-    def __init__(self, cause: Exception):
-        self.cause = cause
-
-    def __repr__(self) -> str:
-        return f"{self.__class__.__name__}({self.cause!r})"
-
 
 class ModelError(Error):
     """Used to catch errors while interacting with the model."""

--- a/verifiers/utils/logging_utils.py
+++ b/verifiers/utils/logging_utils.py
@@ -100,7 +100,7 @@ def print_prompt_completions_sample(
 
         return out
 
-    def _format_error(error: Error) -> Text:
+    def _format_error(error: BaseException) -> Text:
         out = Text()
         out.append("error: ", style="bold red")
         while True:

--- a/verifiers/utils/logging_utils.py
+++ b/verifiers/utils/logging_utils.py
@@ -103,7 +103,13 @@ def print_prompt_completions_sample(
     def _format_error(error: Error) -> Text:
         out = Text()
         out.append("error: ", style="bold red")
-        out.append(repr(error), style="red")
+        while True:
+            out.append(Text(repr(error), style="red"))
+            if error.__cause__ is None:
+                break
+            out.append(Text(", caused by ", style="red"))
+            error = error.__cause__
+
         return out
 
     console = Console()

--- a/verifiers/utils/token_utils.py
+++ b/verifiers/utils/token_utils.py
@@ -65,7 +65,7 @@ async def tokenize_vllm(
             )
         return tokenize_response.tokens
     except Exception as e:
-        raise vf.ModelError(e)
+        raise vf.ModelError from e
 
 
 def prepare_sampling_args_for_token_prompts(


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

The `BaseException` has a native way to trace error chains via the `__cause__` field. Hence, this PR removes the explicit `cause` field from the `vf.Error` base class so that it behaves _exactly_ like a regular exception which avoids unnecessary branching logic as had to be introduced #646. Two additional cosmetic changes:
- in `render_stop` we only print the top-level error (not the whole chain with `caused by ...`) because we print the detailed traceback below
- in the rollout viewer of `vf-eval` we now show the error chain with `caused by...`

## Example

```bash
# too low startup timeout to simulate infrastructure failure
uv run vf-eval math-python -n1 -r1 -v -a '{"max_startup_wait_seconds": 1}'
```

<img width="1420" height="407" alt="Screenshot 2025-12-20 at 12 07 56 PM" src="https://github.com/user-attachments/assets/afa42414-6fbc-4fd1-8094-13990449d930" />

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove `Error.cause`, switch to Python exception chaining (`raise ... from e`), simplify error logging, and update tests accordingly.
> 
> - **Errors & Logging**:
>   - Remove custom `cause` from `verifiers/errors.py::Error` and rely on native `__cause__`.
>   - Update logging in `verifiers/utils/logging_utils.py::_format_error` to render chained causes; `Environment._render_stop` now logs a concise top-level error.
> - **Environments & Tools**:
>   - Replace `raise X(e)` with `raise X from e` across:
>     - `verifiers/envs/environment.py` (model errors, overlong prompt, empty response)
>     - `verifiers/envs/sandbox_env.py` (sandbox errors)
>     - `verifiers/envs/python_env.py` (worker readiness/request errors)
>     - `verifiers/envs/tool_env.py` and `verifiers/envs/stateful_tool_env.py` (tool parse/call errors)
>     - `verifiers/utils/token_utils.py` (tokenize errors)
> - **Tests**:
>   - Adjust fixtures and expectations to use chained exceptions (e.g., `faulty_tool` raises `ToolCallError` via `from`, `stop_errors` broadened to `Exception` where needed).
>   - Update `_render_stop` tests to reflect simplified error log output and removed "caused by" string.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17b88a7325c615bdba665fc506a95f9d5d858721. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->