### PR TITLE
Fix PythonEnv deadlock

### DIFF
--- a/environments/math_python/math_python.py
+++ b/environments/math_python/math_python.py
@@ -15,6 +15,7 @@ def load_environment(
     sandbox_gpu_count: int = 0,
     sandbox_timeout_minutes: int = 60,
     sandbox_timeout_per_command_seconds: int = 60,
+    sandbox_client_max_workers: int = 10,
     **kwargs,
 ):
     dataset = load_example_dataset(dataset_name, dataset_split, n=num_train_examples)
@@ -46,6 +47,7 @@ def load_environment(
         gpu_count=sandbox_gpu_count,
         timeout_minutes=sandbox_timeout_minutes,
         timeout_per_command_seconds=sandbox_timeout_per_command_seconds,
+        sandbox_client_max_workers=sandbox_client_max_workers,
         **kwargs,
     )
     assert vf_env.tools is not None

--- a/environments/math_python/math_python.py
+++ b/environments/math_python/math_python.py
@@ -18,9 +18,15 @@ def load_environment(
     **kwargs,
 ):
     dataset = load_example_dataset(dataset_name, dataset_split, n=num_train_examples)
-    system_prompt = (
-        "Use python for all calculations. Give your answer inside \\boxed{}."
+    pip_install_prompt = (
+        f"In addition to the Python standard library, you have access to: {pip_install_packages}."
+        if pip_install_packages.strip()
+        else "You may only use the Python standard library."
     )
+    system_prompt = (
+        "Use Python for all calculations. Give your answer inside \\boxed{}."
+    )
+    system_prompt += "\n\n" + pip_install_prompt
 
     parser = vf.Parser(extract_fn=extract_boxed_answer)
     math_rubric = vf.MathRubric(parser=parser)

--- a/verifiers/envs/python_env.py
+++ b/verifiers/envs/python_env.py
@@ -226,6 +226,7 @@ PY
         if not python_state["ready"]:
             await self._wait_for_worker_ready(sandbox_state, sandbox_id)
             python_state["ready"] = True
+        self.logger.debug(f"Executing code\n{code}")
         sandbox_response = await self._send_worker_request(
             sandbox_id, sandbox_state, {"code": code}
         )

--- a/verifiers/envs/python_env.py
+++ b/verifiers/envs/python_env.py
@@ -278,7 +278,10 @@ PY
             raw_response = await self.bash(command, sandbox_id, sandbox_state)
             if not raw_response:
                 raise RuntimeError("Python worker returned no output")
-            response = json.loads(raw_response)
+            try:
+                response = json.loads(raw_response)
+            except json.JSONDecodeError:
+                response = {"status": "error", "result": raw_response}
         except Exception as e:
             raise PythonWorkerRequestError from e
 

--- a/verifiers/envs/sandbox_env.py
+++ b/verifiers/envs/sandbox_env.py
@@ -155,7 +155,7 @@ class SandboxEnv(vf.StatefulToolEnv):
                 max=max_backoff_seconds,
                 jitter=jitter,
             ),
-            before_sleep=tc.before_sleep_log(self.logger, logging.ERROR),
+            before_sleep=tc.before_sleep_log(self.logger, logging.WARNING),
             reraise=True,
         ).wraps
         self.add_tool(


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Fixes for `PythonEnv`:
1. Correctly handle command timeout errors in `python` tool: Before, the timeout would be caught in `bash` but because the error string would not be JSON-parseable, it would error with JSONDecodeError in `python`. Now, it correctly handles this edge case, and shows the model that the previous command has timed out
2. Handle the case where the Python worker is dead (e.g. the worker proc is not running anymore) explicitly. Before, it would be handled as a command timeout error because the read from the FIFO queue times out, which would propagate to the model as a regular command timeout. Now, instead, the rollout aborts with a sandbox error
3. Add instructions on which extra packages are available

## Examples

### Fix 1: Command timeouts

Patch the `python` tool by adding to L230-231 to simulate a model response that generates a timeout

```py
        if random.random() < 0.5:
            code = """while True: pass"""
```

Now, the timeout correctly catches and shows an informative error to the model

```bash
uv run vf-eval math-python -n1 -r1 -v -a '{"sandbox_timeout_per_command_seconds": 5}'
```

<img width="1420" height="295" alt="Screenshot 2025-12-21 at 1 33 11 PM" src="https://github.com/user-attachments/assets/8620f99b-17ed-4914-9daa-ec060defca97" />

### Fix 2: Python worker dead

Patch the worker script tool by adding to L115 to simulate the worker dying after the first tool call

```py
            sys.exit(1)
```

Now, the crash is detected and raised as custom `PythonWorkerDead` error

```bash
uv run vf-eval math-python -n1 -r1 -v
```

<img width="1421" height="572" alt="Screenshot 2025-12-21 at 2 12 58 PM" src="https://github.com/user-attachments/assets/23406a75-121c-41ea-89f1-d746ec140f11" />

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Detects dead Python worker and robustly parses timeouts/non-JSON outputs, adds pip package availability to the system prompt, and exposes sandbox client max workers.
> 
> - **PythonEnv (`verifiers/envs/python_env.py`)**:
>   - Add `PythonWorkerDeadError` and PID tracking (`_WORKER_PID_FILE`), writing PID on start and checking liveness before requests.
>   - Replace ready wait with `_CHECK_WORKER_READY_SCRIPT`; improve readiness logging.
>   - Handle non-JSON worker outputs by wrapping as `{ "status": "error" }` instead of raising `JSONDecodeError`.
>   - Add debug log of executed code.
> - **SandboxEnv (`verifiers/envs/sandbox_env.py`)**:
>   - Reduce retry `before_sleep` log level from `ERROR` to `WARNING`.
> - **Math Python Environment (`environments/math_python/math_python.py`)**:
>   - Include pip package availability in the system prompt.
>   - Expose `sandbox_client_max_workers` and pass through to `PythonEnv`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 560549388f62c6e2f4c5c1a33c4d023fbfbb84a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->