### PR TITLE
Improvements to math rubric

### DIFF
--- a/environments/gsm8k/gsm8k.py
+++ b/environments/gsm8k/gsm8k.py
@@ -1,7 +1,6 @@
 import verifiers as vf
 from verifiers.utils.data_utils import (
     BOXED_SYSTEM_PROMPT,
-    extract_boxed_answer,
     load_example_dataset,
 )
 
@@ -18,23 +17,12 @@ def load_environment(
     if num_eval_examples != -1:
         eval_dataset = eval_dataset.select(range(num_eval_examples))
 
-    parser = vf.Parser(extract_fn=extract_boxed_answer)
-
-    def correct_answer_reward_func(parser, completion, answer, **kwargs):
-        response = parser.parse_answer(completion) or ""
-        return 1.0 if response == answer else 0.0
-
-    rubric = vf.Rubric(
-        parser=parser,
-        funcs=[correct_answer_reward_func, parser.get_format_reward_func()],
-        weights=[1.0, 0.0],
-    )
-
+    rubric = vf.MathRubric()
     vf_env = vf.SingleTurnEnv(
         dataset=dataset,
         eval_dataset=eval_dataset,
         system_prompt=system_prompt,
-        parser=parser,
+        parser=rubric.parser,
         rubric=rubric,
     )
     return vf_env

--- a/environments/gsm8k/pyproject.toml
+++ b/environments/gsm8k/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "gsm8k"
-version = "0.1.2"
+version = "0.1.3"
 description = "GSM8K environment"
 tags = ["gsm8k", "single-turn", "math", "train", "eval"]
 requires-python = ">=3.10"
 dependencies = [
-    "verifiers>=0.1.5.post0",
+    "verifiers>=0.1.8",
 ]
 
 [build-system]

--- a/tests/test_math_rubric.py
+++ b/tests/test_math_rubric.py
@@ -107,7 +107,7 @@ class TestMathRubric:
         # very large input triggers timeout, takes ~2s to parse and verify
         completion = "1" * int(1e6)
 
-        rubric = vf.MathRubric(timeout_seconds=timeout_seconds)
+        rubric = vf.MathRubric(max_workers=1, timeout_seconds=timeout_seconds)
 
         state = vf.State(
             input=vf.RolloutInput(

--- a/verifiers/rubrics/math_rubric.py
+++ b/verifiers/rubrics/math_rubric.py
@@ -1,4 +1,7 @@
 import asyncio
+import logging
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, Callable
 
 from math_verify import parse, verify  # type: ignore[unresolved-import]
 
@@ -15,12 +18,28 @@ class MathRubric(Rubric):
         funcs: list[RewardFunc] | None = None,
         weights: list[float] | None = None,
         parser: Parser | None = None,
+        max_workers: int = 10,
         timeout_seconds: float = 5,
     ):
         parser = parser or MaybeThinkParser(extract_fn=extract_boxed_answer)
         super().__init__(funcs=funcs, weights=weights, parser=parser)
         self.add_reward_func(self.correct_answer)
         self.timeout_seconds = timeout_seconds
+
+        # Thread pool executor for running sync math verify functions
+        self.executor = ThreadPoolExecutor(
+            max_workers=max_workers,
+            thread_name_prefix="math-rubric",
+        )
+
+        # suppress math_verify timeout warnings (we handle timeouts ourselves via asyncio.wait_for)
+        logging.getLogger("math_verify.parser").setLevel(logging.ERROR)
+        logging.getLogger("math_verify.grader").setLevel(logging.ERROR)
+
+    async def run_in_executor(self, func: Callable, *args) -> Any:
+        """Run a sync function in the math verify thread pool."""
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(self.executor, func, *args)
 
     async def correct_answer(
         self, parser: Parser, completion: Messages, answer: str, **kwargs
@@ -30,40 +49,26 @@ class MathRubric(Rubric):
         async def _correct_answer() -> float:
             try:
                 response = (
-                    await asyncio.to_thread(parser.parse_answer, completion)
-                ) or ""
+                    await self.run_in_executor(lambda: parser.parse_answer(completion))
+                    or ""
+                )
                 if response == "":
                     return 0.0
 
-                def parse_answer():
-                    return parse(
-                        f"\\boxed{{{answer}}}",
-                        parsing_timeout=None,  # type: ignore
-                    )
-
-                parsed_answer = await asyncio.to_thread(parse_answer)
-
-                def parse_response():
-                    return parse(
-                        f"\\boxed{{{response}}}",
-                        parsing_timeout=None,  # type: ignore
-                    )
-
-                parsed_response = await asyncio.to_thread(parse_response)
-
-                def verify_result():
-                    return verify(
-                        parsed_answer,
-                        parsed_response,
-                        timeout_seconds=None,
-                    )
-
-                result = await asyncio.to_thread(verify_result)
-                if result:
-                    return 1.0
-                else:
-                    return 0.0
-            except BaseException:
+                parsed_answer = await self.run_in_executor(
+                    lambda: parse(f"\\boxed{{{answer}}}", parsing_timeout=None)  # type: ignore
+                )
+                parsed_response = await self.run_in_executor(
+                    lambda: parse(f"\\boxed{{{response}}}", parsing_timeout=None)  # type: ignore
+                )
+                result = await self.run_in_executor(
+                    lambda: verify(parsed_answer, parsed_response, timeout_seconds=None)
+                )
+                return 1.0 if result else 0.0
+            except BaseException as e:
+                self.logger.warning(
+                    f"Math verification failed with {type(e).__name__}: {e!r}"
+                )
                 return 0.0
 
         try:
@@ -71,4 +76,7 @@ class MathRubric(Rubric):
                 _correct_answer(), timeout=self.timeout_seconds
             )
         except asyncio.TimeoutError:
+            self.logger.warning(
+                f"Math verification timed out after {self.timeout_seconds:.1f}s"
+            )
             return 0.0

--- a/verifiers/rubrics/math_rubric.py
+++ b/verifiers/rubrics/math_rubric.py
@@ -53,11 +53,6 @@ class MathRubric(Rubric):
                 if response == "":
                     self.logger.warning("Parsed response is empty")
                     return 0.0
-                if len(response) > 500:
-                    self.logger.warning(
-                        f"Parsed response is too long ({len(response)} chars)"
-                    )
-                    return 0.0
 
                 parsed_answer = await self.run_in_executor(
                     lambda: parse(f"\\boxed{{{answer}}}", parsing_timeout=None)  # type: ignore

--- a/verifiers/rubrics/math_rubric.py
+++ b/verifiers/rubrics/math_rubric.py
@@ -84,4 +84,5 @@ class MathRubric(Rubric):
 
     def __del__(self):
         """Shutdown the thread pool executor when the object is garbage collected."""
-        self.executor.shutdown(wait=False)
+        if hasattr(self, "executor"):
+            self.executor.shutdown(wait=False)

--- a/verifiers/rubrics/math_rubric.py
+++ b/verifiers/rubrics/math_rubric.py
@@ -81,3 +81,7 @@ class MathRubric(Rubric):
                 f"Math verification timed out after {self.timeout_seconds:.1f}s"
             )
             return 0.0
+
+    def __del__(self):
+        """Shutdown the thread pool executor when the object is garbage collected."""
+        self.executor.shutdown(wait=False)

--- a/verifiers/rubrics/math_rubric.py
+++ b/verifiers/rubrics/math_rubric.py
@@ -35,7 +35,7 @@ class MathRubric(Rubric):
         logging.getLogger("math_verify.grader").setLevel(logging.ERROR)
 
     async def run_in_executor(self, func: Callable, *args) -> Any:
-        """Run a sync function in the math verify thread pool."""
+        """Run a sync function in the thread pool."""
         loop = asyncio.get_running_loop()
         return await loop.run_in_executor(self.executor, func, *args)
 

--- a/verifiers/rubrics/math_rubric.py
+++ b/verifiers/rubrics/math_rubric.py
@@ -64,6 +64,8 @@ class MathRubric(Rubric):
                     lambda: verify(parsed_answer, parsed_response, timeout_seconds=None)
                 )
                 return 1.0 if result else 0.0
+            except asyncio.CancelledError:
+                raise
             except BaseException as e:
                 self.logger.warning(
                     f"Math verification failed with {type(e).__name__}: {e!r}"

--- a/verifiers/rubrics/math_rubric.py
+++ b/verifiers/rubrics/math_rubric.py
@@ -25,8 +25,6 @@ class MathRubric(Rubric):
         super().__init__(funcs=funcs, weights=weights, parser=parser)
         self.add_reward_func(self.correct_answer)
         self.timeout_seconds = timeout_seconds
-
-        # Thread pool executor for running sync math verify functions
         self.executor = ThreadPoolExecutor(
             max_workers=max_workers,
             thread_name_prefix="math-rubric",
@@ -53,6 +51,12 @@ class MathRubric(Rubric):
                     or ""
                 )
                 if response == "":
+                    self.logger.warning("Parsed response is empty")
+                    return 0.0
+                if len(response) > 500:
+                    self.logger.warning(
+                        f"Parsed response is too long ({len(response)} chars)"
+                    )
                     return 0.0
 
                 parsed_answer = await self.run_in_executor(


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Fixes to `MathRubric`:
- Run in thread pool with configurable number of workers for higher performance
- Warning logs on exceptions and timeouts
- Re-raise `CancelledError` so that timeouts don't show print warnings twice
- Suppress wrong `math_verify` logs (`Timeout is disabled as parsing_timeout is None or <= 0, you must provide the logic for timeout interuption yourself to prevent code getting stuck.`)

Also, use `MathRubric` in `gsm8k` for testing.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Run MathRubric parse/verify in a thread pool with proper timeout/logging, use it in gsm8k, and bump gsm8k to verifiers>=0.1.8.
> 
> - **Rubrics (`verifiers/rubrics/math_rubric.py`)**:
>   - Run `parse`/`verify` via `ThreadPoolExecutor` (configurable `max_workers`) with `run_in_executor` helper.
>   - Enforce timeouts using `asyncio.wait_for`; re-raise `CancelledError`; add warning logs on failures/timeouts; suppress `math_verify` logs.
>   - Clean up executor in `__del__`.
> - **Environment (`environments/gsm8k/gsm8k.py`)**:
>   - Replace custom parser/rubric with `vf.MathRubric`; pass `rubric.parser` to `SingleTurnEnv`.
> - **Tests (`tests/test_math_rubric.py`)**:
>   - Set `max_workers=1` in timeout test.
> - **Packaging (`environments/gsm8k/pyproject.toml`)**:
>   - Bump version to `0.1.3`; require `verifiers>=0.1.8`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b50d99ca0d3cdff4bb9ecb93b470bf8b2018ca4d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->