### PR TITLE
Fix decorator import

### DIFF
--- a/verifiers/envs/python_env.py
+++ b/verifiers/envs/python_env.py
@@ -12,7 +12,6 @@ else:
 
 import verifiers as vf
 from verifiers.envs.sandbox_env import SandboxEnv, SandboxState
-from verifiers.utils.decorators import cleanup
 
 
 class PythonWorkerState(TypedDict):
@@ -238,7 +237,7 @@ PY
         )
         return self._format_response(python_state, sandbox_response)
 
-    @cleanup
+    @vf.cleanup
     async def cleanup_python_state(self, state: vf.State):
         state.pop("python_state", None)
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

[#655](https://github.com/PrimeIntellect-ai/verifiers/pull/655) moved the decorator file which broke `PythonEnv`

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update PythonEnv to reference the cleanup decorator via vf.cleanup and drop the obsolete decorators import.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10789f2433e0ea1d824bcba98513d6850ce332b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->