### PR TITLE
Do not print traceback for caught errors

### DIFF
--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -6,7 +6,6 @@ import json
 import logging
 import signal
 import time
-import traceback
 from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
@@ -642,7 +641,6 @@ class Environment(ABC):
             if state.get("stop_condition") == "has_error":
                 err = state["error"]
                 self.logger.error(f"Aborted rollout due to {err!r}")
-                traceback.print_exception(type(err), err, err.__traceback__)
             return True
         return False
 

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -43,6 +43,7 @@ from verifiers.types import (
     State,
 )
 from verifiers.utils.async_utils import maybe_semaphore
+from verifiers.utils.error_utils import ErrorChain
 from verifiers.utils.eval_utils import make_dataset, save_rollout_results
 from verifiers.utils.message_utils import (
     concat_messages,
@@ -640,7 +641,8 @@ class Environment(ABC):
             state["stop_condition"] = condition.__name__
             if state.get("stop_condition") == "has_error":
                 err = state["error"]
-                self.logger.error(f"Aborted rollout due to {err!r}")
+                err_chain = ErrorChain(err)
+                self.logger.error(f"Aborted rollout due to {err_chain}")
             return True
         return False
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Do not print traceback, because it looks like a crash has happened. Prints error chain with details instead to make clear that the run is still ongoing, while giving some details on the root error.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves error reporting during rollouts without emitting crash-like tracebacks.
> 
> - In `Environment._render_stop`, replace `traceback.print_exception` with `ErrorChain(err)` and log the chain when `stop_condition` is `has_error`
> - Add `ErrorChain` import from `verifiers.utils.error_utils` and remove `traceback` import
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb3bae36c93b2f574e13a39da2908609d4ec4b2f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->