### PR TITLE
dont request prompt logprobs as we dont use them and they disable prefix cache and burst vllm memory usage

### DIFF
--- a/docs/release/TRAJECTORIES.md
+++ b/docs/release/TRAJECTORIES.md
@@ -447,7 +447,6 @@ sampling_args = {
     "extra_body": {
         "return_tokens_as_token_ids": True,  # Return tokens as token IDs
         "return_token_ids": True,             # Include token_ids in response
-        "prompt_logprobs": 1,                 # Optional: include prompt logprobs
     },
 }
 ```

--- a/verifiers/rl/trainer/config.py
+++ b/verifiers/rl/trainer/config.py
@@ -321,7 +321,6 @@ class RLConfig(TrainingArguments):
                 "include_stop_str_in_output": False,
                 "return_tokens_as_token_ids": True,
                 "return_token_ids": True,
-                "prompt_logprobs": True,
             },
         }
         self.gradient_accumulation_steps = 1

--- a/verifiers/utils/token_utils.py
+++ b/verifiers/utils/token_utils.py
@@ -73,7 +73,7 @@ def prepare_sampling_args_for_token_prompts(
 ) -> SamplingArgs:
     """Ensures necessary fields are set for token prompts to work."""
     sampling_args["logprobs"] = True
-    extra_body = dict(return_token_ids=True, prompt_logprobs=True)
+    extra_body = dict(return_token_ids=True)
     if "extra_body" in sampling_args:
         sampling_args["extra_body"].update(extra_body)
     else:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes unused prompt logprobs requests to improve vLLM behavior and aligns documentation.
> 
> - In `RLConfig.sampling_args.extra_body` and `token_utils.prepare_sampling_args_for_token_prompts()`, remove `prompt_logprobs` while keeping `return_token_ids`/`return_tokens_as_token_ids` and `logprobs` enabled
> - Update `docs/release/TRAJECTORIES.md` to no longer recommend `prompt_logprobs` in `sampling_args`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1ee6c95f1cb5d05286ca785bc4d14101ee89e5b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->