### PR TITLE
warn: ignore system prompt/few-shot when `prompt` is present

### DIFF
--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -255,6 +255,16 @@ class Environment(ABC):
                     },
                     **map_kwargs,
                 )
+
+        else:
+            if system_prompt is not None:
+                self.logger.warning(
+                    "Dataset already has a 'prompt' column, so the provided system_prompt will be ignored."
+                )
+            if few_shot is not None:
+                self.logger.warning(
+                    "Dataset already has a 'prompt' column, so the provided few_shot examples will be ignored."
+                )
         return dataset
 
     def _ensure_task(self, dataset: Dataset, map_kwargs: dict = {}) -> Dataset:


### PR DESCRIPTION
## Description
warn when provided system prompt or few-shot example will be ignored because `prompt` column being already present.
especially helpful when loading existing upstream datasets which do `prompt` column differently.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds guardrails for pre-formatted datasets.
> 
> - In `Environment._ensure_prompt`, when a `prompt` column already exists, the provided `system_prompt` and `few_shot` are ignored and a warning is logged to inform the user
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a414ef6d8c32787948bc1aec042bbac7791b6fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->