### PR TITLE
add metrics: repl_call_count, repl_total_time_seconds, repl_mean_time…

### DIFF
--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -1587,6 +1587,18 @@ PY
             self._extract_tokens(s.get("response"))[1] for s in main_steps
         )
 
+        # REPL call timing metrics (already tracked in tool_call_timings)
+        tool_timings = state.get("tool_call_timings", [])
+        state["repl_total_time_seconds"] = (
+            sum(t["execution_seconds"] for t in tool_timings) if tool_timings else 0.0
+        )
+        state["repl_call_count"] = len(tool_timings)
+        state["repl_mean_time_seconds"] = (
+            (state["repl_total_time_seconds"] / len(tool_timings))
+            if tool_timings
+            else 0.0
+        )
+
         # Release tunnel
         if (tunnel_url := state.get("tunnel_url")) and self._tunnel_pool:
             await self._tunnel_pool.release_tunnel(tunnel_url)


### PR DESCRIPTION
## Description

Adds the following metrics to the RLM's state:

- repl_call_count
- repl_total_time_seconds
- repl_mean_time_seconds

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds aggregate REPL timing metrics to the RLM state.
> 
> - In `rlm_env.py` `cleanup_rlm_state`, compute and persist `repl_total_time_seconds`, `repl_call_count`, and `repl_mean_time_seconds` from `tool_call_timings`
> - No changes to REPL execution flow; metrics are derived during cleanup alongside existing token and sub-LLM stats
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b796c3b22c15ca760067e4c9bfb4961d48be55f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->