### PR TITLE
fix: handle empty completions in parse_answer

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -45,6 +45,17 @@ class TestParser:
         result = basic_parser.parse_answer(completion)
         assert result == "The answer is 4"
 
+    def test_parse_answer_with_empty_completion(self, basic_parser):
+        """Test parse_answer with empty completion list."""
+        result = basic_parser.parse_answer([])
+        assert result is None
+
+    def test_parse_answer_with_no_assistant_messages(self, basic_parser):
+        """Test parse_answer with completion containing no assistant messages."""
+        completion = [{"role": "user", "content": "Hello"}]
+        result = basic_parser.parse_answer(completion)
+        assert result is None
+
     def test_get_format_reward_func(self, basic_parser):
         """Test that format reward function returns 1.0 by default."""
         reward_func = basic_parser.get_format_reward_func()

--- a/verifiers/parsers/parser.py
+++ b/verifiers/parsers/parser.py
@@ -42,7 +42,10 @@ class Parser:
         if isinstance(completion, str):
             return self.parse(completion)
         else:
-            ans = str(self.get_assistant_messages(completion)[-1].get("content", ""))
+            assistant_messages = self.get_assistant_messages(completion)
+            if not assistant_messages:
+                return None
+            ans = str(assistant_messages[-1].get("content", ""))
             return self.parse(ans)
 
     def get_format_reward_func(self) -> Callable:


### PR DESCRIPTION
Fixes crash when API times out and returns empty completion.

- Return `None` instead of crashing with `IndexError` when no assistant messages
- Added test cases for empty completions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents crashes when completions lack assistant messages.
> 
> - Update `parse_answer` to safely handle empty lists or completions without assistant messages by returning `None`
> - Add tests: `test_parse_answer_with_empty_completion` and `test_parse_answer_with_no_assistant_messages` to validate behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a43bc49d970ebd1bd89776b3f158919c2fba1316. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->