### PR TITLE
fix 671: don't generate assistant response when `env_response` signals stop

### DIFF
--- a/verifiers/envs/multiturn_env.py
+++ b/verifiers/envs/multiturn_env.py
@@ -119,6 +119,7 @@ class MultiTurnEnv(vf.Environment):
                 prompt_messages = await self.get_prompt_messages(state)
                 if await self.is_completed(state):
                     await self.add_model_response(state, prompt_messages, None)
+                    await self._render_completion(state)
                     return state
                 response = await self.get_model_response(state, prompt_messages)
                 await self.add_model_response(state, prompt_messages, response)

--- a/verifiers/envs/multiturn_env.py
+++ b/verifiers/envs/multiturn_env.py
@@ -83,7 +83,7 @@ class MultiTurnEnv(vf.Environment):
                 tokens is not None and bool(tokens.get("is_truncated"))
             )
         else:
-            completion_messages = []
+            completion_messages = "" if self.message_type == "completion" else []
             tokens = None
             is_truncated = False
         trajectory_step = TrajectoryStep(

--- a/verifiers/envs/tool_env.py
+++ b/verifiers/envs/tool_env.py
@@ -51,7 +51,10 @@ class ToolEnv(vf.MultiTurnEnv):
     async def no_tools_called(self, state: vf.State) -> bool:
         if len(state["trajectory"]) == 0:
             return False
-        last_message = state["trajectory"][-1]["completion"][-1]
+        last_completion = state["trajectory"][-1]["completion"]
+        if not last_completion:
+            return False
+        last_message = last_completion[-1]
         is_assistant_message = last_message["role"] == "assistant"
         no_tool_calls = (
             "tool_calls" not in last_message or last_message["tool_calls"] is None

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -63,7 +63,7 @@ class TrajectoryStepTokens(TypedDict):
 class TrajectoryStep(TypedDict):
     prompt: Messages
     completion: Messages
-    response: ModelResponse
+    response: ModelResponse | None
     tokens: TrajectoryStepTokens | None
     reward: float | None
     advantage: float | None


### PR DESCRIPTION
## Description
fixes #671 

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [x] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Addresses early-exit edge case in multi-turn rollouts when `env_response` triggers a stop before the model is called.
> 
> - `MultiTurnEnv.rollout`: after `get_prompt_messages`, re-checks `is_completed`; if true, appends a trajectory step with empty completion (`""` for `completion` mode, `[]` for `chat`) and `response=None`, then renders completion
> - `MultiTurnEnv.add_model_response`: accepts `response: ModelResponse | None` and handles tokens/truncation for `None`
> - `ToolEnv.no_tools_called`: guards against empty last completion before inspecting the last message
> - `types.TrajectoryStep.response`: allows `ModelResponse | None`
> - Tests: new cases for stop triggered by `env_response` in both chat and completion modes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1cd4096fe696c911571404f7b40865ab4010f86a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->