### PR TITLE
Fix args_to_skip validation failure for dict type parameters

### DIFF
--- a/tests/test_stateful_tool_env.py
+++ b/tests/test_stateful_tool_env.py
@@ -85,6 +85,19 @@ class TestStatefulToolEnv:
         assert mock_stateful_tool_env.skipped_args["secret_tool"] == ["secret"]
         assert "secret_tool" in mock_stateful_tool_env.tool_map
 
+    def test_add_tool_skips_dict_type_args(self, mock_stateful_tool_env):
+        def tool_with_dict(command: str, state: dict | None = None) -> str:
+            return command
+
+        mock_stateful_tool_env.add_tool(tool_with_dict, args_to_skip=["state"])
+
+        schema = next(
+            t
+            for t in mock_stateful_tool_env.oai_tools
+            if t["function"]["name"] == "tool_with_dict"
+        )
+        assert "state" not in schema["function"]["parameters"]["properties"]
+
     @pytest.mark.asyncio
     async def test_tool_env_tool_invalid_json_arguments(
         self, mock_openai_client, sample_chat_dataset

--- a/tests/test_stateful_tool_env.py
+++ b/tests/test_stateful_tool_env.py
@@ -98,6 +98,64 @@ class TestStatefulToolEnv:
         )
         assert "state" not in schema["function"]["parameters"]["properties"]
 
+    def test_add_tool_does_not_mutate_original_signature(self, mock_stateful_tool_env):
+        """Verify that add_tool with args_to_skip doesn't mutate the original function."""
+        import inspect
+
+        def my_tool(command: str, hidden: int, visible: bool = True) -> str:
+            """A tool with multiple parameters."""
+            return command
+
+        original_params = list(inspect.signature(my_tool).parameters.keys())
+        original_annotations = dict(my_tool.__annotations__)
+
+        mock_stateful_tool_env.add_tool(my_tool, args_to_skip=["hidden"])
+
+        # Original function signature should be unchanged
+        assert list(inspect.signature(my_tool).parameters.keys()) == original_params
+        assert my_tool.__annotations__ == original_annotations
+        assert "hidden" in inspect.signature(my_tool).parameters
+
+        # But schema should have hidden removed
+        schema = next(
+            t
+            for t in mock_stateful_tool_env.oai_tools
+            if t["function"]["name"] == "my_tool"
+        )
+        assert "hidden" not in schema["function"]["parameters"]["properties"]
+        assert "command" in schema["function"]["parameters"]["properties"]
+
+    def test_add_tool_does_not_mutate_bound_method_signature(
+        self, mock_stateful_tool_env
+    ):
+        """Verify that add_tool with args_to_skip doesn't mutate bound method signatures."""
+        import inspect
+
+        class ToolProvider:
+            def my_tool(self, command: str, hidden: int, visible: bool = True) -> str:
+                """A tool with multiple parameters."""
+                return command
+
+        bound_method = ToolProvider().my_tool
+        original_params = list(inspect.signature(bound_method).parameters.keys())
+
+        mock_stateful_tool_env.add_tool(bound_method, args_to_skip=["hidden"])
+
+        # Original bound method signature should be unchanged
+        assert (
+            list(inspect.signature(bound_method).parameters.keys()) == original_params
+        )
+        assert "hidden" in inspect.signature(bound_method).parameters
+
+        # But schema should have hidden removed
+        schema = next(
+            t
+            for t in mock_stateful_tool_env.oai_tools
+            if t["function"]["name"] == "my_tool"
+        )
+        assert "hidden" not in schema["function"]["parameters"]["properties"]
+        assert "command" in schema["function"]["parameters"]["properties"]
+
     @pytest.mark.asyncio
     async def test_tool_env_tool_invalid_json_arguments(
         self, mock_openai_client, sample_chat_dataset

--- a/verifiers/envs/stateful_tool_env.py
+++ b/verifiers/envs/stateful_tool_env.py
@@ -36,10 +36,10 @@ def filter_signature(func, args_to_skip):
     def wrapper(*args, **kwargs):
         return func(*args, **kwargs)
 
-    wrapper.__name__ = getattr(func, "__name__", "unknown")
-    wrapper.__doc__ = getattr(func, "__doc__", None)
-    wrapper.__signature__ = filtered_sig
-    wrapper.__annotations__ = filtered_annotations
+    setattr(wrapper, "__name__", getattr(func, "__name__", "unknown"))
+    setattr(wrapper, "__doc__", getattr(func, "__doc__", None))
+    setattr(wrapper, "__signature__", filtered_sig)
+    setattr(wrapper, "__annotations__", filtered_annotations)
     return wrapper
 
 


### PR DESCRIPTION
## Description
  - Filters function signature before schema generation to avoid strict JSON schema validation errors on skipped parameters
  - Parameters with dict type (which produce additionalProperties: true) no longer cause validation failures when listed in args_to_skip

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents schema validation issues when skipping non-JSON-friendly params by filtering function signatures prior to tool schema generation.
> 
> - Adds `filter_signature` to create a non-mutating wrapper with a reduced signature and annotations
> - Updates `StatefulToolEnv.add_tool` to generate the OpenAI schema from the filtered signature
> - Ensures skipped `dict`-typed params are excluded from `parameters.properties`
> - Adds tests verifying dict-arg skipping and that original/bound method signatures and annotations remain unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0860463477858dcc35f14cd60a15e807381f81f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->