### PR TITLE
add trajectory_id to TrajectoryStep

### DIFF
--- a/docs/release/TRAJECTORIES.md
+++ b/docs/release/TRAJECTORIES.md
@@ -359,6 +359,8 @@ async def add_model_response(
         tokens=tokens,
         reward=None,
         advantage=None,
+        is_truncated=False,
+        trajectory_id=state["current_trajectory_id"],
         extras={},
     )
     state["trajectory"].append(trajectory_step)

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -56,6 +56,8 @@ class SimpleEnvironment(Environment):
             tokens=tokens,
             reward=None,
             advantage=None,
+            is_truncated=False,
+            trajectory_id=state["current_trajectory_id"],
             extras={},
         )
         state["trajectory"].append(trajectory_step)

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -57,7 +57,7 @@ class SimpleEnvironment(Environment):
             reward=None,
             advantage=None,
             is_truncated=False,
-            trajectory_id=state["current_trajectory_id"],
+            trajectory_id=state["trajectory_id"],
             extras={},
         )
         state["trajectory"].append(trajectory_step)

--- a/tests/test_environment_extra.py
+++ b/tests/test_environment_extra.py
@@ -67,6 +67,8 @@ class DummyEnvironment(Environment):
             tokens=tokens,
             reward=None,
             advantage=None,
+            is_truncated=False,
+            trajectory_id=state["current_trajectory_id"],
             extras={},
         )
         state["trajectory"].append(trajectory_step)

--- a/tests/test_environment_extra.py
+++ b/tests/test_environment_extra.py
@@ -68,7 +68,7 @@ class DummyEnvironment(Environment):
             reward=None,
             advantage=None,
             is_truncated=False,
-            trajectory_id=state["current_trajectory_id"],
+            trajectory_id=state["trajectory_id"],
             extras={},
         )
         state["trajectory"].append(trajectory_step)

--- a/tests/test_rlm_env.py
+++ b/tests/test_rlm_env.py
@@ -1189,6 +1189,8 @@ class TestSubLLMCleanup:
             tokens=None,
             reward=None,
             advantage=None,
+            is_truncated=False,
+            trajectory_id="sub_batch1_req1",
             extras={"is_sub_llm_call": True, "timestamp": 1.0},
         )
         sub_step2 = TrajectoryStep(
@@ -1198,6 +1200,8 @@ class TestSubLLMCleanup:
             tokens=None,
             reward=None,
             advantage=None,
+            is_truncated=False,
+            trajectory_id="sub_batch1_req2",
             extras={"is_sub_llm_call": True, "timestamp": 2.0},
         )
         rlm_env.active_rollouts[rollout_id] = {
@@ -1213,6 +1217,8 @@ class TestSubLLMCleanup:
             tokens=None,
             reward=None,
             advantage=None,
+            is_truncated=False,
+            trajectory_id="main_trajectory",
             extras={},
         )
         state = {"rollout_id": rollout_id, "trajectory": [main_step]}
@@ -1251,6 +1257,8 @@ class TestSubLLMCleanup:
                 tokens=None,
                 reward=None,
                 advantage=None,
+                is_truncated=False,
+                trajectory_id="sub_batch1_req1",
                 extras={"is_sub_llm_call": True, "timestamp": 1.0},
             )
             env.active_rollouts[rollout_id] = {
@@ -1265,6 +1273,8 @@ class TestSubLLMCleanup:
                 tokens=None,
                 reward=None,
                 advantage=None,
+                is_truncated=False,
+                trajectory_id="main_trajectory",
                 extras={},
             )
             state = {"rollout_id": rollout_id, "trajectory": [main_step]}

--- a/tests/test_singleturn_env.py
+++ b/tests/test_singleturn_env.py
@@ -77,6 +77,8 @@ class TestSingleTurnEnv:
                     tokens=None,
                     reward=None,
                     advantage=None,
+                    is_truncated=False,
+                    trajectory_id="test_trajectory",
                     extras={},
                 )
             ],
@@ -487,6 +489,8 @@ class TestSingleTurnEnv:
                 tokens=None,
                 reward=None,
                 advantage=None,
+                is_truncated=False,
+                trajectory_id="test_trajectory",
                 extras={},
             )
         ]
@@ -514,6 +518,8 @@ class TestSingleTurnEnv:
                 tokens=None,
                 reward=None,
                 advantage=None,
+                is_truncated=False,
+                trajectory_id="test_trajectory",
                 extras={},
             ),
             TrajectoryStep(
@@ -523,6 +529,8 @@ class TestSingleTurnEnv:
                 tokens=None,
                 reward=None,
                 advantage=None,
+                is_truncated=False,
+                trajectory_id="test_trajectory",
                 extras={},
             ),
         ]

--- a/tests/test_trajectory_processing.py
+++ b/tests/test_trajectory_processing.py
@@ -110,9 +110,13 @@ def test_process_trajectory_steps_for_training():
                 completion_ids=[3, 4],
                 completion_mask=[1, 1],
                 completion_logprobs=[-0.1, -0.2],
+                overlong_prompt=False,
+                is_truncated=False,
             ),
             reward=1.0,
             advantage=None,
+            is_truncated=False,
+            trajectory_id="test_trajectory",
             extras={},
         )
     ]
@@ -135,9 +139,13 @@ def test_process_trajectory_steps_for_training():
                 completion_ids=[6, 7, 8],
                 completion_mask=[1, 1, 1],
                 completion_logprobs=[-0.3, -0.4, -0.5],
+                overlong_prompt=False,
+                is_truncated=False,
             ),
             reward=0.5,
             advantage=None,
+            is_truncated=False,
+            trajectory_id="test_trajectory",
             extras={},
         )
     ]
@@ -192,6 +200,8 @@ def test_process_trajectory_steps_skip_missing_tokens():
             tokens=None,
             reward=1.0,
             advantage=None,
+            is_truncated=False,
+            trajectory_id="test_trajectory",
             extras={},
         ),
         TrajectoryStep(
@@ -204,9 +214,13 @@ def test_process_trajectory_steps_skip_missing_tokens():
                 completion_ids=[2, 3],
                 completion_mask=[1, 1],
                 completion_logprobs=[-0.1, -0.2],
+                overlong_prompt=False,
+                is_truncated=False,
             ),
             reward=0.5,
             advantage=None,
+            is_truncated=False,
+            trajectory_id="test_trajectory",
             extras={},
         ),
     ]

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -598,7 +598,7 @@ class Environment(ABC):
         else:
             state["oai_tools"] = []
         state["trajectory"] = []
-        state["current_trajectory_id"] = uuid.uuid4().hex
+        state["trajectory_id"] = uuid.uuid4().hex
         state["reward"] = None
         state["metrics"] = None
         state["error"] = None

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -6,6 +6,7 @@ import json
 import logging
 import signal
 import time
+import uuid
 from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
@@ -597,6 +598,7 @@ class Environment(ABC):
         else:
             state["oai_tools"] = []
         state["trajectory"] = []
+        state["current_trajectory_id"] = uuid.uuid4().hex
         state["reward"] = None
         state["metrics"] = None
         state["error"] = None

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -939,6 +939,7 @@ class RLMEnv(SandboxEnv):
                         reward=None,
                         advantage=None,
                         is_truncated=is_truncated,
+                        trajectory_id=f"{batch_id}_{request_id}",
                         extras={
                             "is_sub_llm_call": True,
                             "parent_turn": parent_turn,

--- a/verifiers/envs/multiturn_env.py
+++ b/verifiers/envs/multiturn_env.py
@@ -85,7 +85,7 @@ class MultiTurnEnv(vf.Environment):
             reward=None,
             advantage=None,
             is_truncated=is_truncated,
-            trajectory_id=state["current_trajectory_id"],
+            trajectory_id=state["trajectory_id"],
             extras={},
         )
         trajectory_step["completion"] = completion_messages

--- a/verifiers/envs/multiturn_env.py
+++ b/verifiers/envs/multiturn_env.py
@@ -85,6 +85,7 @@ class MultiTurnEnv(vf.Environment):
             reward=None,
             advantage=None,
             is_truncated=is_truncated,
+            trajectory_id=state["current_trajectory_id"],
             extras={},
         )
         trajectory_step["completion"] = completion_messages

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -68,6 +68,7 @@ class TrajectoryStep(TypedDict):
     reward: float | None
     advantage: float | None
     is_truncated: bool
+    trajectory_id: str
     extras: dict[str, Any]
 
 


### PR DESCRIPTION
## Description

Adds `trajectory_id` to `TrajectoryStep`, which is useful for training multi-agent systems. In those, there are several mostly independent, multi-turn rollouts. We want to interleave the trajectory steps for each of those rollouts for efficiency, but must keep the rollouts of the different agents separate. This PR adds a `trajectory_id` to enable the correct grouping and interleaving of rollouts for training.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds per-step `trajectory_id` to enable grouping/interleaving of trajectories and wires it through state and environments.
> 
> - Extend `TrajectoryStep` with `trajectory_id: str`
> - Initialize `state["trajectory_id"] = uuid4().hex` in `Environment.init_state`
> - Attach `trajectory_id` to steps in `MultiTurnEnv.add_model_response` and RLM sub-LLM steps (`batch_id_request_id`); preserve `is_truncated`
> - Update tests to include `trajectory_id` in all `TrajectoryStep` constructions and adjust token fields; update docs to reflect new fields
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b27db6cef30a8e7fcd3b36fd3045b8c317e1c07. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->