### PR TITLE
docs: fix training examples link

### DIFF
--- a/docs/source/training.md
+++ b/docs/source/training.md
@@ -228,4 +228,4 @@ However, the best way to improve training is ensuring appropriate task difficult
 
 - Explore [Environments](environments.md) to create custom tasks
 - Review [Components](components.md) for advanced patterns
-- See the [examples directory](https://github.com/PrimeIntellect-ai/verifiers/tree/main/examples) on GitHub for complete training scripts
+- See the [prime-rl examples directory](https://github.com/PrimeIntellect-ai/prime-rl/tree/main/examples) on GitHub for complete training scripts


### PR DESCRIPTION
## Summary

point training docs to prime-rl examples (verifiers repo no longer has /examples)\n\n## Context

Fixes #608

---

Updates the `training.md` "Next Steps" section to reference the `prime-rl` examples (`https://github.com/PrimeIntellect-ai/prime-rl/tree/main/examples`) instead of the removed `verifiers/examples` link.
