### PR TITLE
final_env_response pattern; updated docs/tests/example

### DIFF
--- a/docs/source/environments.md
+++ b/docs/source/environments.md
@@ -331,30 +331,25 @@ def load_environment(**kwargs):
 For interactive tasks requiring multiple steps:
 
 ```python
+from typing import cast
 from verifiers.types import Messages, State
-from typing import Tuple
 
 class MyGameEnv(vf.MultiTurnEnv):
 
-    async def env_response(self, messages: Messages, state: State) -> Tuple[Messages, State]:
+    @vf.stop
+    async def game_over(self, state: State) -> bool:
+        return state.get("game_over", False)
+
+    async def env_response(self, messages: Messages, state: State) -> Messages:
         """Define how the environment responds."""
-        last_msg = messages[-1]
-        if last_msg["role"] != "assistant":
-            return [], state
+        player_action = messages[-1]["content"]
+        
+        if self.check_win(state, player_action):
+            state["game_over"] = True
+            return cast(Messages, [{"role": "user", "content": "You won!"}])
 
-        player_action = last_msg["content"]
-        if self.is_game_over(state):
-            state["done"] = True
-            return [{"role": "user", "content": "Game over!"}], state
-
-        state = self.update_state(state, player_action)
-        feedback = self.get_game_feedback(state)
-        return [{"role": "user", "content": feedback}], state
-
-    async def is_completed(self, messages: Messages, state: State) -> bool:
-        if await super().is_completed(messages, state):
-            return True
-        return state.get("solved", False) or state.get("failed", False)
+        feedback = self.get_feedback(state, player_action)
+        return cast(Messages, [{"role": "user", "content": feedback}])
 ```
 
 ### ToolEnv
@@ -362,7 +357,7 @@ class MyGameEnv(vf.MultiTurnEnv):
 For tasks requiring external tools:
 
 ```python
-def calculate(expression: str) -> float:
+async def calculate(expression: str) -> float:
     """Calculate a mathematical expression."""
     return eval(expression)  # Simplified example
 
@@ -488,6 +483,35 @@ This is particularly useful for:
 - Training on multiple task types simultaneously
 - Evaluating general capabilities across domains
 - Creating curriculum learning setups
+
+### Final Environment Responses
+
+In multi-turn environments, rollouts normally alternate between model responses and environment responses until a stop condition is met. However, stop conditions are evaluated *before* `env_response` runs, which means if `env_response` determines the rollout should end (e.g., a game is won, an answer is submitted), the model will generate one more unnecessary response.
+
+To handle this, set `state["final_env_response"]` in `env_response` when the environment produces its final message:
+
+```python
+class GameEnv(vf.MultiTurnEnv):
+    async def env_response(self, messages: Messages, state: State) -> Messages:
+        result = self.process_action(messages[-1]["content"])
+        
+        if result.game_over:
+            response = cast(Messages, [{"role": "user", "content": result.feedback}])
+            state["final_env_response"] = response
+            return response
+        
+        return cast(Messages, [{"role": "user", "content": result.feedback}])
+```
+
+When `final_env_response` is set:
+- The rollout exits immediately without generating another model response
+- The final environment message is included in `state["completion"]` for reward computation
+- The trajectory maintains its `(prompt, completion)` structure for training (the final env message is not added to the trajectory)
+
+This pattern is useful when:
+- Rewards depend on the final environment feedback (e.g., "Correct!" or score)
+- A tool call signals completion (e.g., `submit_answer`)
+- You want to preserve trailing environment responses while maintaining clean trajectory objects (i.e. `(prompt, completion)` sequences)
 
 ## Installing from Repository
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,7 +154,7 @@ filterwarnings = [
     "ignore::UserWarning:transformers.*",
     "ignore:The 'repr' attribute.*:UserWarning:pydantic.*",
     "ignore:The 'frozen' attribute.*:UserWarning:pydantic.*",
-    "ignore:.*is.*with.*str.*literal:SyntaxWarning:cellpylib",
+    "ignore:.*is.*with.*str.*literal:SyntaxWarning:cellpylib.*",
 ]
 asyncio_mode = "auto"
 norecursedirs = [".git", ".tox", "dist", "build", "*.egg", "__pycache__"]

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -65,6 +65,7 @@ def test_readme_exists(env_dir: Path):
     assert (env_dir / "README.md").exists(), "README.md does not exist"
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("env_dir", get_environments(), ids=lambda x: x.name)
 def test_env(env_dir: Path, tmp_path_factory: pytest.TempPathFactory):
     """Test environment in a fresh venv with local verifiers installed first."""

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -600,6 +600,7 @@ class Environment(ABC):
         state["reward"] = None
         state["metrics"] = None
         state["error"] = None
+        state["final_env_response"] = None
         state["timing"] = RolloutTiming(
             generation_ms=0.0,
             scoring_ms=0.0,
@@ -669,6 +670,10 @@ class Environment(ABC):
         last_prompt = state["trajectory"][-1]["prompt"]
         last_completion = state["trajectory"][-1]["completion"]
         full_conversation = concat_messages([last_prompt, last_completion])
+        if state.get("final_env_response"):
+            full_conversation = concat_messages(
+                [full_conversation, state["final_env_response"]]
+            )
         state["completion"] = full_conversation[len(state["prompt"]) :]
 
     async def is_completed(self, state: State, **kwargs) -> bool:

--- a/verifiers/envs/multiturn_env.py
+++ b/verifiers/envs/multiturn_env.py
@@ -44,6 +44,11 @@ class MultiTurnEnv(vf.Environment):
         """Check if the maximum number of turns has been reached."""
         return len(state["trajectory"]) >= self.max_turns and self.max_turns > 0
 
+    @vf.stop
+    async def has_final_env_response(self, state: State) -> bool:
+        """Check if env_response signaled termination via final_env_response."""
+        return state.get("final_env_response") is not None
+
     @abstractmethod
     async def env_response(
         self, messages: Messages, state: State, **kwargs
@@ -108,6 +113,8 @@ class MultiTurnEnv(vf.Environment):
         while not await self.is_completed(state):
             try:
                 prompt_messages = await self.get_prompt_messages(state)
+                if state.get("final_env_response") is not None:
+                    continue
                 response = await self.get_model_response(state, prompt_messages)
                 await self.add_model_response(state, prompt_messages, response)
             except vf.Error as e:


### PR DESCRIPTION
## Description

Introduces proper support for rollouts to include final_env_response in state, which can be set in env_response, resulting in early termination mid-step.

We treat these as cosmetic/metadata, accessible by Rubric classes + for logging, but not included in trajectory (as token representations are never materialized). 

Resolves #671 ; replaces #673 

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation update
- [X] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [X] All existing tests pass when running `uv run pytest` locally.
- [X] New tests have been added to cover the changes

## Checklist
- [X] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements a clean termination path for multi-turn rollouts when the environment produces a final message.
> 
> - Core changes: add `state["final_env_response"]` (initialized in `Environment.init_state`), new stop condition `has_final_env_response`, rollout loop skips extra model call when set, and `_render_completion` appends the final env message for scoring while keeping it out of the trajectory
> - Wordle: on game completion, sets `final_env_response` and returns it; minor typing/casting cleanups
> - Docs: refine `MultiTurnEnv` example, make `ToolEnv` sample tool async, and add a "Final Environment Responses" section describing the pattern and its effects
> - Tests: add coverage for early stop and completion inclusion; mark env package tests as `slow`; minor warning-filter tweak in `pyproject.toml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6fcf3990a24b00117d373e24adbafe74a3fc225d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->