### PR TITLE
Expose render_completion + add_trajectory_step, private/final guardrails

### DIFF
--- a/verifiers/envs/env_group.py
+++ b/verifiers/envs/env_group.py
@@ -1,5 +1,5 @@
 import time
-from typing import TYPE_CHECKING, AsyncContextManager, Mapping
+from typing import TYPE_CHECKING, AsyncContextManager, Mapping, final
 
 from datasets import Dataset, concatenate_datasets
 from openai import AsyncOpenAI
@@ -197,7 +197,7 @@ class EnvGroup(vf.Environment):
             f"Initialized EnvGroup with {len(envs)} environments: {self.env_names}"
         )
 
-    def format_dataset(
+    def _format_dataset(
         self,
         dataset: Dataset,
         system_prompt: str | None = None,
@@ -232,7 +232,7 @@ class EnvGroup(vf.Environment):
         )
         return dataset
 
-    def format_completion_dataset(
+    def _format_completion_dataset(
         self, dataset: Dataset, map_kwargs: dict = {}
     ) -> Dataset:
         """
@@ -253,20 +253,7 @@ class EnvGroup(vf.Environment):
         )
         return dataset
 
-    async def init_state(
-        self,
-        input: RolloutInput,
-        client: AsyncOpenAI,
-        model: str,
-        sampling_args: SamplingArgs | None = None,
-    ) -> vf.State:
-        env = self.get_env_for_task(input["task"])
-        return await env.init_state(input, client, model, sampling_args)
-
-    async def setup_state(self, state: vf.State) -> vf.State:
-        env = self.get_env_for_task(state["task"])
-        return await env.setup_state(state)
-
+    @final
     async def rollout(
         self,
         input: RolloutInput,
@@ -281,19 +268,19 @@ class EnvGroup(vf.Environment):
         return self.env_map.get(task, self.envs[0])
 
     def set_max_seq_len(self, max_seq_len: int | None) -> None:
-        """Set the maximum sequence length for this environment group and all sub-environments."""
+        """Set the max_seq_len value for this environment group and all sub-environments."""
         self.max_seq_len = max_seq_len
         for env in self.envs:
             env.set_max_seq_len(max_seq_len)
 
     def set_interleaved_rollouts(self, interleaved_rollouts: bool) -> None:
-        """Set the interleaved rollouts flag for this environment group and all sub-environments."""
+        """Set the interleaved_rollouts flag for this environment group and all sub-environments."""
         self.interleaved_rollouts = interleaved_rollouts
         for env in self.envs:
             env.set_interleaved_rollouts(interleaved_rollouts)
 
     def set_score_rollouts(self, score_rollouts: bool) -> None:
-        """Set the score rollouts flag for this environment group and all sub-environments."""
+        """Set the score_rollouts flag for this environment group and all sub-environments."""
         self.score_rollouts = score_rollouts
         for env in self.envs:
             env.set_score_rollouts(score_rollouts)

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -336,7 +336,6 @@ class Environment(ABC):
             return self.eval_dataset.select(range(n))
         return self.eval_dataset
 
-    @final
     async def get_model_response(
         self,
         state: State,

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -21,6 +21,7 @@ from typing import (
     Literal,
     TypeVar,
     cast,
+    final,
 )
 
 from datasets import Dataset
@@ -47,7 +48,6 @@ from verifiers.utils.async_utils import maybe_semaphore
 from verifiers.utils.error_utils import ErrorChain
 from verifiers.utils.eval_utils import make_dataset, save_rollout_results
 from verifiers.utils.message_utils import (
-    concat_messages,
     strip_nones_from_content,
 )
 from verifiers.utils.path_utils import get_results_path
@@ -106,13 +106,13 @@ class Environment(ABC):
 
         if self.message_type == "chat":
             if dataset is not None:
-                self.dataset = self.format_dataset(
+                self.dataset = self._format_dataset(
                     dataset, self.system_prompt, self.few_shot, map_kwargs=map_kwargs
                 )
             else:
                 self.dataset = None
             if eval_dataset is not None:
-                self.eval_dataset = self.format_dataset(
+                self.eval_dataset = self._format_dataset(
                     eval_dataset,
                     self.system_prompt,
                     self.few_shot,
@@ -128,13 +128,13 @@ class Environment(ABC):
                     'to contain a "prompt" column.'
                 )
             if dataset is not None:
-                self.dataset = self.format_completion_dataset(
+                self.dataset = self._format_completion_dataset(
                     dataset, map_kwargs=map_kwargs
                 )
             else:
                 self.dataset = None
             if eval_dataset is not None:
-                self.eval_dataset = self.format_completion_dataset(
+                self.eval_dataset = self._format_completion_dataset(
                     eval_dataset, map_kwargs=map_kwargs
                 )
             else:
@@ -280,7 +280,7 @@ class Environment(ABC):
             dataset = dataset.map(add_task, **map_kwargs)
         return dataset
 
-    def format_dataset(
+    def _format_dataset(
         self,
         dataset: Dataset,
         system_prompt: str | None = None,
@@ -299,7 +299,7 @@ class Environment(ABC):
         dataset = self._ensure_task(dataset, map_kwargs)
         return dataset
 
-    def format_completion_dataset(
+    def _format_completion_dataset(
         self, dataset: Dataset, map_kwargs: dict = {}
     ) -> Dataset:
         """
@@ -309,6 +309,7 @@ class Environment(ABC):
         dataset = self._ensure_task(dataset, map_kwargs)
         return dataset
 
+    @final
     def get_dataset(self, n: int = -1, seed: int | None = None) -> Dataset:
         if self.dataset is None:
             raise ValueError("dataset is not set")
@@ -320,6 +321,7 @@ class Environment(ABC):
             return self.dataset.select(range(n))
         return self.dataset
 
+    @final
     def get_eval_dataset(self, n: int = -1, seed: int | None = None) -> Dataset:
         if self.eval_dataset is None:
             self.logger.warning(
@@ -334,6 +336,7 @@ class Environment(ABC):
             return self.eval_dataset.select(range(n))
         return self.eval_dataset
 
+    @final
     async def get_model_response(
         self,
         state: State,
@@ -565,6 +568,7 @@ class Environment(ABC):
             )
         return response
 
+    @final
     async def init_state(
         self,
         input: RolloutInput,
@@ -609,13 +613,6 @@ class Environment(ABC):
             total_ms=0.0,
             start_time=time.time(),
         )
-        return state
-
-    @abstractmethod
-    async def setup_state(self, state: State) -> State:
-        """
-        Setup the state.
-        """
         return state
 
     @abstractmethod
@@ -665,29 +662,17 @@ class Environment(ABC):
         state["timing"]["generation_ms"] = (end_time - start_time) * 1000
         state["timing"]["total_ms"] = (end_time - start_time) * 1000
 
-    async def _render_completion(self, state: State):
-        if len(state["trajectory"]) == 0:
-            state["completion"] = []
-            return
-        last_prompt = state["trajectory"][-1]["prompt"]
-        last_completion = state["trajectory"][-1]["completion"]
-        full_conversation = concat_messages([last_prompt, last_completion])
-        if state.get("final_env_response"):
-            full_conversation = concat_messages(
-                [full_conversation, state["final_env_response"]]
-            )
-        state["completion"] = full_conversation[len(state["prompt"]) :]
-
+    @final
     async def is_completed(self, state: State, **kwargs) -> bool:
         """Check all stop conditions. Sets state.is_completed=True if any condition is met."""
         for condition in self._stop_conditions:
             if await self._render_stop(state, condition):
                 await self._render_timing(state)
-                await self._render_completion(state)
                 await self._cleanup(state)
                 return True
         return False
 
+    @final
     async def run_rollout(
         self,
         sem: AsyncContextManager,
@@ -708,6 +693,7 @@ class Environment(ABC):
             )
         return state
 
+    @final
     async def run_group(
         self,
         group_inputs: list[RolloutInput],
@@ -974,7 +960,7 @@ class Environment(ABC):
             executor.shutdown(wait=False)
 
     # evaluation
-    def get_eval_inputs(
+    def _get_eval_inputs(
         self, num_examples: int = -1, rollouts_per_example: int = 1
     ) -> List[RolloutInput]:
         if self.eval_dataset is None:
@@ -1007,7 +993,7 @@ class Environment(ABC):
         """
         Evaluate model on the Environment evaluation dataset.
         """
-        inputs = self.get_eval_inputs(num_examples, rollouts_per_example)
+        inputs = self._get_eval_inputs(num_examples, rollouts_per_example)
         return await self.generate(
             inputs,
             client=client,
@@ -1041,7 +1027,7 @@ class Environment(ABC):
         """
         Evaluate model on the Environment evaluation dataset synchronously.
         """
-        inputs = self.get_eval_inputs(num_examples, rollouts_per_example)
+        inputs = self._get_eval_inputs(num_examples, rollouts_per_example)
         return self.generate_sync(
             inputs,
             client=client,
@@ -1056,6 +1042,7 @@ class Environment(ABC):
             save_every=save_every,
         )
 
+    # setters for use by trainers
     def set_kwargs(self, **kwargs) -> None:
         """
         Set environment attributes, using setter methods when available.

--- a/verifiers/envs/multiturn_env.py
+++ b/verifiers/envs/multiturn_env.py
@@ -87,7 +87,6 @@ class MultiTurnEnv(vf.Environment):
         """Override to set intermediate rewards, advantages, or extra metadata."""
         state["trajectory"].append(trajectory_step)
 
-    @final
     async def add_model_response(
         self,
         state: State,

--- a/verifiers/envs/multiturn_env.py
+++ b/verifiers/envs/multiturn_env.py
@@ -1,5 +1,6 @@
 import logging
 from abc import abstractmethod
+from typing import final
 
 from openai import AsyncOpenAI
 
@@ -27,28 +28,6 @@ class MultiTurnEnv(vf.Environment):
         super().__init__(**kwargs)
         self.max_turns = max_turns
 
-    async def setup_state(self, state: State) -> State:
-        return state
-
-    @vf.stop(priority=100)  # high priority to always check for errors first
-    async def has_error(self, state: State, **kwargs) -> bool:
-        """Abrupts rollout early if an error has occurred."""
-        return state.get("error") is not None
-
-    @vf.stop
-    async def prompt_too_long(self, state: State) -> bool:
-        return state.get("prompt_too_long", False)
-
-    @vf.stop
-    async def max_turns_reached(self, state: State) -> bool:
-        """Check if the maximum number of turns has been reached."""
-        return len(state["trajectory"]) >= self.max_turns and self.max_turns > 0
-
-    @vf.stop
-    async def has_final_env_response(self, state: State) -> bool:
-        """Check if env_response signaled termination via final_env_response."""
-        return state.get("final_env_response") is not None
-
     @abstractmethod
     async def env_response(
         self, messages: Messages, state: State, **kwargs
@@ -58,7 +37,29 @@ class MultiTurnEnv(vf.Environment):
         """
         pass
 
+    @vf.stop(priority=100)  # always check for errors first
+    async def has_error(self, state: State, **kwargs) -> bool:
+        return state.get("error") is not None
+
+    @vf.stop
+    async def prompt_too_long(self, state: State) -> bool:
+        return state.get("prompt_too_long", False)
+
+    @vf.stop
+    async def max_turns_reached(self, state: State) -> bool:
+        return len(state["trajectory"]) >= self.max_turns and self.max_turns > 0
+
+    @vf.stop
+    async def has_final_env_response(self, state: State) -> bool:
+        """Check if env_response signaled termination via final_env_response."""
+        return state.get("final_env_response") is not None
+
+    async def setup_state(self, state: State) -> State:
+        """Override to add environment-specific state fields."""
+        return state
+
     async def get_prompt_messages(self, state: State) -> Messages:
+        """Override for rollouts with non-linear message sequences."""
         if len(state["trajectory"]) == 0:
             return state["prompt"]
         else:
@@ -68,6 +69,25 @@ class MultiTurnEnv(vf.Environment):
             env_response = await self.env_response(messages, state)
             return concat_messages([messages, env_response])
 
+    async def render_completion(self, state: State):
+        """Override for rollouts with non-linear message sequences."""
+        if len(state["trajectory"]) == 0:
+            state["completion"] = []
+            return
+        last_prompt = state["trajectory"][-1]["prompt"]
+        last_completion = state["trajectory"][-1]["completion"]
+        full_conversation = concat_messages([last_prompt, last_completion])
+        if state.get("final_env_response"):
+            full_conversation = concat_messages(
+                [full_conversation, state["final_env_response"]]
+            )
+        state["completion"] = full_conversation[len(state["prompt"]) :]
+
+    async def add_trajectory_step(self, state: State, trajectory_step: TrajectoryStep):
+        """Override to set intermediate rewards, advantages, or extra metadata."""
+        state["trajectory"].append(trajectory_step)
+
+    @final
     async def add_model_response(
         self,
         state: State,
@@ -93,9 +113,9 @@ class MultiTurnEnv(vf.Environment):
             trajectory_id=state["trajectory_id"],
             extras={},
         )
-        trajectory_step["completion"] = completion_messages
-        state["trajectory"].append(trajectory_step)
+        await self.add_trajectory_step(state, trajectory_step)
 
+    @final
     async def rollout(
         self,
         input: RolloutInput,
@@ -103,9 +123,6 @@ class MultiTurnEnv(vf.Environment):
         model: str,
         sampling_args: SamplingArgs | None = None,
     ) -> State:
-        """
-        Generate a multi-turn rollout with the environment.
-        """
         state = await self.init_state(input, client, model, sampling_args)
         try:
             state = await self.setup_state(state)
@@ -124,4 +141,5 @@ class MultiTurnEnv(vf.Environment):
                     state["is_truncated"] = True
                 else:
                     state["error"] = e
+        await self.render_completion(state)
         return state

--- a/verifiers/rubrics/tool_rubric.py
+++ b/verifiers/rubrics/tool_rubric.py
@@ -33,7 +33,7 @@ class ToolRubric(Rubric):
         assert isinstance(completion, list)
         for msg in completion:
             if msg["role"] == "assistant" and "tool_calls" in msg:
-                assistant_msg = cast(ChatCompletionAssistantMessageParam, msg)
+                assistant_msg = cast(ChatCompletionAssistantMessageParam, msg)  # type: ignore[redundant-cast]
                 tool_calls = assistant_msg.get("tool_calls", [])
                 if isinstance(tool_calls, list):
                     total += len(tool_calls)
@@ -49,7 +49,7 @@ class ToolRubric(Rubric):
             assert isinstance(completion, list)
             for msg in completion:
                 if msg["role"] == "assistant" and "tool_calls" in msg:
-                    assistant_msg = cast(ChatCompletionAssistantMessageParam, msg)
+                    assistant_msg = cast(ChatCompletionAssistantMessageParam, msg)  # type: ignore[redundant-cast]
                     tool_calls = assistant_msg.get("tool_calls", [])
                     for tool_call in tool_calls:
                         if tool_call.get("function", {}).get("name") == tool_name:

--- a/verifiers/utils/data_utils.py
+++ b/verifiers/utils/data_utils.py
@@ -268,10 +268,10 @@ def load_example_dataset(
             split = "test"
         aime_i = cast(
             Dataset, load_dataset("opencompass/AIME2025", "AIME2025-I")[split]
-        )
+        )  # type: ignore[redundant-cast]
         aime_ii = cast(
             Dataset, load_dataset("opencompass/AIME2025", "AIME2025-II")[split]
-        )
+        )  # type: ignore[redundant-cast]
         dataset = concatenate_datasets([aime_i, aime_ii])
     elif name == "amc2023":
         if split is None:
@@ -316,17 +316,19 @@ def load_example_dataset(
     elif name == "openrs_easy":
         if split is None:
             split = "train"
-        dataset = load_dataset("knoveleng/open-rs")[split]
+        dataset = cast(Dataset, load_dataset("knoveleng/open-rs")[split])
         dataset = dataset.filter(lambda x: x["level"] == "Easy")
     elif name == "openrs_hard":
         if split is None:
             split = "train"
-        dataset = load_dataset("knoveleng/open-rs")[split]
+        dataset = cast(Dataset, load_dataset("knoveleng/open-rs")[split])
         dataset = dataset.filter(lambda x: x["level"] == "Hard")
     elif name == "prime_code":
         if split is None:
             split = "train"
-        dataset = load_dataset("PrimeIntellect/verifiable-coding-problems")[split]
+        dataset = cast(
+            Dataset, load_dataset("PrimeIntellect/verifiable-coding-problems")[split]
+        )
         dataset = dataset.filter(
             lambda x: x["prompt"].startswith(
                 "Solve the following coding problem using the programming language python:"

--- a/verifiers/utils/data_utils.py
+++ b/verifiers/utils/data_utils.py
@@ -266,8 +266,12 @@ def load_example_dataset(
     elif name == "aime2025":
         if split is None:
             split = "test"
-        aime_i = load_dataset("opencompass/AIME2025", "AIME2025-I")[split]
-        aime_ii = load_dataset("opencompass/AIME2025", "AIME2025-II")[split]
+        aime_i = cast(
+            Dataset, load_dataset("opencompass/AIME2025", "AIME2025-I")[split]
+        )
+        aime_ii = cast(
+            Dataset, load_dataset("opencompass/AIME2025", "AIME2025-II")[split]
+        )
         dataset = concatenate_datasets([aime_i, aime_ii])
     elif name == "amc2023":
         if split is None:


### PR DESCRIPTION
## Description

Elevates `render_completion` to an overridable MultiTurnEnv method, and adds an overridable method `add_trajectory_step` for setting step-level rewards/advantages/extras. Logic not intended for overriding is marked as final if public-facing, private if internal. Additional methods in Environment/EnvGroup are marked as private/final (or removed if no longer needed).

Minor reorganizations + docstring improvements.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [X] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **API additions and overrides**
> - `MultiTurnEnv`: new overridable `render_completion` and `add_trajectory_step`; `rollout` marked `final`; `env_response` is abstract; completion rendered at end of rollout.
> - `experimental/RLMEnv`: implements `render_completion` to ignore sub-LLM steps when computing `completion`.
> 
> **Core refactors and guardrails**
> - `Environment`: internal helpers renamed private (`_format_dataset`, `_format_completion_dataset`, `_get_eval_inputs`); several public methods marked `final` (`get_dataset`, `get_eval_dataset`, `init_state`, `is_completed`, `run_rollout`, `run_group`); removed internal completion rendering; minor doc/docstring updates.
> - `EnvGroup`: aligns to private dataset formatters (`_format_dataset`, `_format_completion_dataset`); `rollout` marked `final`; docstrings clarified.
> 
> **Misc**
> - `ToolRubric` and `data_utils`: minor typing/cast cleanups without behavior changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4546247c812e1a3a1305aacffcc18a64b20f60f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->