### PR TITLE
Move RLM prompt assembly into setup_state

### DIFF
--- a/tests/test_rlm_env.py
+++ b/tests/test_rlm_env.py
@@ -502,9 +502,26 @@ class TestGetPromptMessages:
     @pytest.mark.asyncio
     async def test_adds_system_prompt_on_first_turn(self, rlm_env):
         """Adds system prompt on first turn (empty trajectory)."""
+        metadata_summary = rlm_env._generate_metadata_documentation({})
+        base_system_prompt = (
+            rlm_env.custom_system_prompt or rlm_module._RLM_SYSTEM_PROMPT
+        )
+        if "{metadata_summary}" in base_system_prompt:
+            base_system_prompt = base_system_prompt.replace(
+                "{metadata_summary}", metadata_summary
+            )
+        else:
+            base_system_prompt = f"{metadata_summary}\n\n{base_system_prompt}"
+        packages_docs = rlm_env._generate_packages_documentation()
+        sub_tools_docs = rlm_env._generate_sub_tools_documentation()
+        system_prompt = base_system_prompt + packages_docs + sub_tools_docs
         state = {
             "trajectory": [],
             "prompt": [{"role": "user", "content": "What is 2+2?"}],
+            "rlm_context": {"input_data_metadata": {}},
+            "rlm_system_prompt": system_prompt,
+            "rlm_packages_docs": packages_docs,
+            "rlm_sub_tools_docs": sub_tools_docs,
         }
 
         messages = await rlm_env.get_prompt_messages(state)
@@ -515,9 +532,26 @@ class TestGetPromptMessages:
     @pytest.mark.asyncio
     async def test_appends_sub_tools_docs(self, rlm_env_with_sub_tools):
         """Appends sub-tools documentation to system prompt."""
+        metadata_summary = rlm_env_with_sub_tools._generate_metadata_documentation({})
+        base_system_prompt = (
+            rlm_env_with_sub_tools.custom_system_prompt or rlm_module._RLM_SYSTEM_PROMPT
+        )
+        if "{metadata_summary}" in base_system_prompt:
+            base_system_prompt = base_system_prompt.replace(
+                "{metadata_summary}", metadata_summary
+            )
+        else:
+            base_system_prompt = f"{metadata_summary}\n\n{base_system_prompt}"
+        packages_docs = rlm_env_with_sub_tools._generate_packages_documentation()
+        sub_tools_docs = rlm_env_with_sub_tools._generate_sub_tools_documentation()
+        system_prompt = base_system_prompt + packages_docs + sub_tools_docs
         state = {
             "trajectory": [],
             "prompt": [{"role": "user", "content": "Test"}],
+            "rlm_context": {"input_data_metadata": {}},
+            "rlm_system_prompt": system_prompt,
+            "rlm_packages_docs": packages_docs,
+            "rlm_sub_tools_docs": sub_tools_docs,
         }
 
         messages = await rlm_env_with_sub_tools.get_prompt_messages(state)
@@ -528,9 +562,26 @@ class TestGetPromptMessages:
     @pytest.mark.asyncio
     async def test_string_prompt_converted_to_messages(self, rlm_env):
         """String prompt is converted to message format."""
+        metadata_summary = rlm_env._generate_metadata_documentation({})
+        base_system_prompt = (
+            rlm_env.custom_system_prompt or rlm_module._RLM_SYSTEM_PROMPT
+        )
+        if "{metadata_summary}" in base_system_prompt:
+            base_system_prompt = base_system_prompt.replace(
+                "{metadata_summary}", metadata_summary
+            )
+        else:
+            base_system_prompt = f"{metadata_summary}\n\n{base_system_prompt}"
+        packages_docs = rlm_env._generate_packages_documentation()
+        sub_tools_docs = rlm_env._generate_sub_tools_documentation()
+        system_prompt = base_system_prompt + packages_docs + sub_tools_docs
         state = {
             "trajectory": [],
             "prompt": "What is 2+2?",
+            "rlm_context": {"input_data_metadata": {}},
+            "rlm_system_prompt": system_prompt,
+            "rlm_packages_docs": packages_docs,
+            "rlm_sub_tools_docs": sub_tools_docs,
         }
 
         messages = await rlm_env.get_prompt_messages(state)


### PR DESCRIPTION
## Description

In `RLMEnv`, move prompt construction and everything required for it from `__init__` to `setup_state`.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [x] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Shifts RLM prompt construction to rollout setup for clearer flow and reuse.
> 
> - Build `rlm_system_prompt` in `setup_state` using metadata summary plus `packages` and `sub_tools` docs; store as `rlm_system_prompt`, `rlm_packages_docs`, `rlm_sub_tools_docs`
> - `get_prompt_messages` now requires these precomputed fields and injects/augments the system message; raises error if setup was skipped
> - Tests updated to construct and pass the precomputed prompt/doc fields, aligning with the new flow
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9780c15a09391c12d2bdd9908eefe6be50845810. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->