### PR TITLE
Add immediate sub-LLM trajectory steps and incremental metrics

### DIFF
--- a/tests/test_rlm_env.py
+++ b/tests/test_rlm_env.py
@@ -1297,71 +1297,85 @@ class TestSubLLMMetricsWithTools:
 
 
 class TestSubLLMCleanup:
-    """Tests for sub-LLM cleanup."""
+    """Tests for sub-LLM trajectory insertion behavior."""
 
     @pytest.mark.asyncio
-    async def test_prepends_trajectory_steps_during_cleanup(self, rlm_env):
-        """Prepends sub-LLM trajectory steps to main trajectory during cleanup."""
+    async def test_adds_steps_immediately(self, rlm_env):
+        """Adds sub-LLM steps immediately via add_trajectory_step."""
         from verifiers.types import TrajectoryStep
 
         rollout_id = "rlm_test123"
-        # Create mock sub-LLM trajectory steps
-        sub_step1 = TrajectoryStep(
-            prompt=[{"role": "user", "content": "sub prompt 1"}],
-            completion=[{"role": "assistant", "content": "sub response 1"}],
-            response=None,
-            tokens=None,
-            reward=None,
-            advantage=None,
-            is_truncated=False,
-            trajectory_id="sub_batch1_req1",
-            extras={"is_sub_llm_call": True, "timestamp": 1.0},
-        )
-        sub_step2 = TrajectoryStep(
-            prompt=[{"role": "user", "content": "sub prompt 2"}],
-            completion=[{"role": "assistant", "content": "sub response 2"}],
-            response=None,
-            tokens=None,
-            reward=None,
-            advantage=None,
-            is_truncated=False,
-            trajectory_id="sub_batch1_req2",
-            extras={"is_sub_llm_call": True, "timestamp": 2.0},
-        )
+        state = {"trajectory": [], "trajectory_id": "root"}
         rlm_env.active_rollouts[rollout_id] = {
             "client": MagicMock(),
-            "sub_llm_trajectory_steps": [sub_step2, sub_step1],  # Out of order
+            "model": "test-model",
+            "sub_model": "test-model",
+            "state": state,
         }
 
-        # Main trajectory step
-        main_step = TrajectoryStep(
-            prompt=[{"role": "user", "content": "main prompt"}],
-            completion=[{"role": "assistant", "content": "main response"}],
-            response=None,
-            tokens=None,
-            reward=None,
-            advantage=None,
-            is_truncated=False,
-            trajectory_id="main_trajectory",
-            extras={},
+        mock_turn_1 = {
+            "prompt_messages": [],
+            "response": MagicMock(),
+            "tool_call_count": 0,
+        }
+        mock_turn_2 = {
+            "prompt_messages": [],
+            "response": MagicMock(),
+            "tool_call_count": 0,
+        }
+        rlm_env._run_sub_llm = AsyncMock(
+            return_value={
+                "final_content": "done",
+                "total_prompt_tokens": 0,
+                "total_completion_tokens": 0,
+                "tool_call_count": 0,
+                "num_turns": 2,
+                "max_turns_reached": False,
+                "turns": [mock_turn_1, mock_turn_2],
+            }
         )
-        state = {"rollout_id": rollout_id, "trajectory": [main_step]}
-        await rlm_env.cleanup_rlm_state(state)
 
-        # Trajectory should have sub-LLM steps (sorted by timestamp) prepended
-        assert len(state["trajectory"]) == 3
-        assert state["trajectory"][0]["extras"].get("is_sub_llm_call") is True
-        assert (
-            state["trajectory"][0]["extras"]["timestamp"] == 1.0
-        )  # First by timestamp
-        assert state["trajectory"][1]["extras"]["timestamp"] == 2.0
-        assert state["trajectory"][2]["extras"].get("is_sub_llm_call") is not True
+        with (
+            patch.object(
+                rlm_module, "parse_response_tokens", new=AsyncMock(return_value=None)
+            ),
+            patch.object(
+                rlm_module,
+                "parse_response_messages",
+                new=AsyncMock(return_value=[{"role": "assistant", "content": "ok"}]),
+            ),
+            patch.object(
+                rlm_module, "parse_is_truncated", new=AsyncMock(return_value=False)
+            ),
+        ):
+            mock_request = MagicMock()
+            mock_request.match_info = {"rollout_id": rollout_id}
+            mock_request.json = AsyncMock(
+                return_value={
+                    "messages": [{"role": "user", "content": "test"}],
+                    "_batch_id": "batch1",
+                    "_request_id": "req1",
+                }
+            )
+
+            recorded: list[TrajectoryStep] = []
+
+            async def _add_step(state, step):
+                recorded.append(step)
+                state["trajectory"].append(step)
+
+            rlm_env.add_trajectory_step = AsyncMock(side_effect=_add_step)
+
+            await rlm_env._handle_sub_llm_request(mock_request)
+
+        assert len(state["trajectory"]) == 2
+        assert recorded == state["trajectory"]
+        assert state["trajectory"][0]["extras"]["sub_turn_index"] == 0
+        assert state["trajectory"][1]["extras"]["sub_turn_index"] == 1
 
     @pytest.mark.asyncio
-    async def test_no_prepend_when_disabled(self, mock_sandbox_client, mock_dataset):
-        """Does not prepend sub-LLM steps when include_sub_llm_in_trajectory=False."""
-        from verifiers.types import TrajectoryStep
-
+    async def test_no_add_when_disabled(self, mock_sandbox_client, mock_dataset):
+        """Does not add sub-LLM steps when include_sub_llm_in_trajectory=False."""
         with (
             patch("verifiers.envs.sandbox_env.AsyncSandboxClient") as mock_client_cls,
             patch("verifiers.envs.sandbox_env.CreateSandboxRequest"),
@@ -1374,39 +1388,62 @@ class TestSubLLMCleanup:
             env.sandbox_client = mock_sandbox_client
 
             rollout_id = "rlm_test123"
-            sub_step = TrajectoryStep(
-                prompt=[{"role": "user", "content": "sub prompt"}],
-                completion=[{"role": "assistant", "content": "sub response"}],
-                response=None,
-                tokens=None,
-                reward=None,
-                advantage=None,
-                is_truncated=False,
-                trajectory_id="sub_batch1_req1",
-                extras={"is_sub_llm_call": True, "timestamp": 1.0},
-            )
+            state = {"trajectory": [], "trajectory_id": "root"}
             env.active_rollouts[rollout_id] = {
                 "client": MagicMock(),
-                "sub_llm_trajectory_steps": [sub_step],
+                "model": "test-model",
+                "sub_model": "test-model",
+                "state": state,
             }
 
-            main_step = TrajectoryStep(
-                prompt=[{"role": "user", "content": "main prompt"}],
-                completion=[{"role": "assistant", "content": "main response"}],
-                response=None,
-                tokens=None,
-                reward=None,
-                advantage=None,
-                is_truncated=False,
-                trajectory_id="main_trajectory",
-                extras={},
+            env._run_sub_llm = AsyncMock(
+                return_value={
+                    "final_content": "done",
+                    "total_prompt_tokens": 0,
+                    "total_completion_tokens": 0,
+                    "tool_call_count": 0,
+                    "num_turns": 1,
+                    "max_turns_reached": False,
+                    "turns": [
+                        {
+                            "prompt_messages": [],
+                            "response": MagicMock(),
+                            "tool_call_count": 0,
+                        }
+                    ],
+                }
             )
-            state = {"rollout_id": rollout_id, "trajectory": [main_step]}
-            await env.cleanup_rlm_state(state)
 
-            # Should only have main step
-            assert len(state["trajectory"]) == 1
-            assert state["trajectory"][0]["extras"].get("is_sub_llm_call") is not True
+            with (
+                patch.object(
+                    rlm_module,
+                    "parse_response_tokens",
+                    new=AsyncMock(return_value=None),
+                ),
+                patch.object(
+                    rlm_module,
+                    "parse_response_messages",
+                    new=AsyncMock(
+                        return_value=[{"role": "assistant", "content": "ok"}]
+                    ),
+                ),
+                patch.object(
+                    rlm_module, "parse_is_truncated", new=AsyncMock(return_value=False)
+                ),
+            ):
+                mock_request = MagicMock()
+                mock_request.match_info = {"rollout_id": rollout_id}
+                mock_request.json = AsyncMock(
+                    return_value={
+                        "messages": [{"role": "user", "content": "test"}],
+                        "_batch_id": "batch1",
+                        "_request_id": "req1",
+                    }
+                )
+
+                await env._handle_sub_llm_request(mock_request)
+
+            assert state["trajectory"] == []
 
             # Cleanup
             env.active_sandboxes.clear()

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -1677,9 +1677,17 @@ PY
 
         # Inject context limit warning if approaching limit
         if self.max_seq_len and not state.get("context_warning_sent"):
-            # Get prompt token count from latest trajectory response
+            # Get prompt token count from latest main-model trajectory response
             trajectory = state.get("trajectory", [])
-            response = trajectory[-1].get("response") if trajectory else None
+            last_main = next(
+                (
+                    step
+                    for step in reversed(trajectory)
+                    if not step.get("extras", {}).get("is_sub_llm_call")
+                ),
+                None,
+            )
+            response = last_main.get("response") if last_main else None
             usage = getattr(response, "usage", None) if response else None
             prompt_tokens = getattr(usage, "prompt_tokens", 0) or 0 if usage else 0
             warning_threshold = int(self.max_seq_len * self.context_warning_threshold)

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -129,8 +129,9 @@ def update_rlm_metrics_from_step(state: State, step: TrajectoryStep) -> None:
         call_ids: dict[str, bool] = state.get("_rlm_sub_llm_call_ids", {})
         batch_counts: dict[str, int] = state.get("_rlm_sub_llm_batch_counts", {})
 
-        if batch_id and request_id:
-            key = f"{batch_id}:{request_id}"
+        if batch_id:
+            request_id_norm = request_id if request_id not in (None, "") else "_missing"
+            key = f"{batch_id}:{request_id_norm}"
             if key not in call_ids:
                 call_ids[key] = True
                 state["sub_llm_call_count"] += 1
@@ -138,8 +139,6 @@ def update_rlm_metrics_from_step(state: State, step: TrajectoryStep) -> None:
         else:
             # Fallback: treat each turn as its own call if identifiers are missing.
             state["sub_llm_call_count"] += 1
-            if batch_id:
-                batch_counts[batch_id] = batch_counts.get(batch_id, 0) + 1
 
         state["_rlm_sub_llm_call_ids"] = call_ids
         state["_rlm_sub_llm_batch_counts"] = batch_counts


### PR DESCRIPTION
## Description

Instead of adding the sub-LLM `TrajectoryStep`s and the metric during cleanup, this PR changes that to happen incrementally as the sub-LLM responses come in; and the metrics are also updated incrementally as the main model's steps come in.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [x] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements immediate insertion of sub-LLM turns and incremental metric tracking throughout RLM execution.
> 
> - Adds `update_rlm_metrics_from_step`, `_extract_tokens_from_response`, and `_ensure_rlm_metric_state` to track sub-LLM/main turns, tokens, tool calls, batches, and REPL timing incrementally; overrides `add_trajectory_step` to update metrics on each step
> - `_handle_sub_llm_request` now constructs per-turn `TrajectoryStep`s with extras and either immediately calls `add_trajectory_step` (when enabled) or updates metrics only; `active_rollouts` stores `state` for this
> - Tracks REPL execution timings via `_update_rlm_repl_metrics`; initializes metric fields in `setup_state`
> - Context warning in `call_python_repl` now uses the last main-model step (ignores sub-LLM steps)
> - Simplifies `cleanup_rlm_state` to just remove rollout and release tunnels (metrics/steps no longer computed here)
> - Tests updated/added for immediate sub-LLM trajectory insertion, disabled behavior, token/tool-turn accumulation, and main-step-only context warning
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d6beb5c53a1e1ab7c37fd89f70557b45f3573370. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->