### PR TITLE
[Small][Bugfix] Fix Environment make_dataset method (from main README)

### DIFF
--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -1074,7 +1074,7 @@ class Environment(ABC):
         """Set the score rollouts flag for this environment."""
         self.score_rollouts = score_rollouts
 
-    make_dataset = make_dataset
+    make_dataset = staticmethod(make_dataset)
 
 
 _EnvT = TypeVar("_EnvT", bound=Environment)


### PR DESCRIPTION
## Description
Following the evaluation example in the README was throwing errors in the make_dataset step.

This PR fixes that. 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
- [ ] All existing tests pass when running `uv run pytest` locally.
   All tests passed except for a few environment loads (due to lack of API keys). 
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes dataset creation errors in evaluation by adjusting method binding.
> 
> - Convert `Environment.make_dataset` to a `staticmethod`, preventing unintended `self` binding and aligning with README usage
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 252e1f8ff482f05b7aa049aef238d088fc92df5f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->