### PR TITLE
Log timings in vf-eval

### DIFF
--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -15,7 +15,7 @@ import verifiers as vf
 from verifiers.types import Endpoints, EvalConfig, GenerateMetadata, GenerateOutputs
 from verifiers.utils.client_utils import setup_client
 from verifiers.utils.error_utils import ErrorChain
-from verifiers.utils.logging_utils import print_prompt_completions_sample
+from verifiers.utils.logging_utils import print_prompt_completions_sample, print_time
 from verifiers.utils.message_utils import messages_to_printable, sanitize_tool_calls
 from verifiers.utils.path_utils import get_eval_results_path
 
@@ -117,6 +117,25 @@ def print_results(results: GenerateOutputs, num_samples: int = 1):
         counter = Counter(error_chains)
         for error_chain, count in counter.items():
             print(f" - {repr(error_chain)}: {count / counter.total():.3f}")
+
+    generation_ms_arr = np.array(
+        [s["timing"]["generation_ms"] for s in results["state"]]
+    )
+    scoring_ms_arr = np.array([s["timing"]["scoring_ms"] for s in results["state"]])
+    total_ms_arr = np.array([s["timing"]["total_ms"] for s in results["state"]])
+    generation_min = generation_ms_arr / 1000
+    scoring_min = scoring_ms_arr / 1000
+    total_min = total_ms_arr / 1000
+    print("Timing:")
+    print(
+        f"generation: min - {print_time(float(np.min(generation_min)))}, mean - {print_time(float(np.mean(generation_min)))}, max - {print_time(float(np.max(generation_min)))}"
+    )
+    print(
+        f"scoring: min - {print_time(float(np.min(scoring_min)))}, mean - {print_time(float(np.mean(scoring_min)))}, max - {print_time(float(np.max(scoring_min)))}"
+    )
+    print(
+        f"total: min - {print_time(float(np.min(total_min)))}, mean - {print_time(float(np.mean(total_min)))}, max - {print_time(float(np.max(total_min)))}"
+    )
 
 
 async def run_evaluation(config: EvalConfig) -> GenerateOutputs:

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -123,18 +123,18 @@ def print_results(results: GenerateOutputs, num_samples: int = 1):
     )
     scoring_ms_arr = np.array([s["timing"]["scoring_ms"] for s in results["state"]])
     total_ms_arr = np.array([s["timing"]["total_ms"] for s in results["state"]])
-    generation_min = generation_ms_arr / 1000
-    scoring_min = scoring_ms_arr / 1000
-    total_min = total_ms_arr / 1000
+    generation_arr = generation_ms_arr / 1000
+    scoring_arr = scoring_ms_arr / 1000
+    total_arr = total_ms_arr / 1000
     print("Timing:")
     print(
-        f"generation: min - {print_time(float(np.min(generation_min)))}, mean - {print_time(float(np.mean(generation_min)))}, max - {print_time(float(np.max(generation_min)))}"
+        f"generation: min - {print_time(float(np.min(generation_arr)))}, mean - {print_time(float(np.mean(generation_arr)))}, max - {print_time(float(np.max(generation_arr)))}"
     )
     print(
-        f"scoring: min - {print_time(float(np.min(scoring_min)))}, mean - {print_time(float(np.mean(scoring_min)))}, max - {print_time(float(np.max(scoring_min)))}"
+        f"scoring: min - {print_time(float(np.min(scoring_arr)))}, mean - {print_time(float(np.mean(scoring_arr)))}, max - {print_time(float(np.max(scoring_arr)))}"
     )
     print(
-        f"total: min - {print_time(float(np.min(total_min)))}, mean - {print_time(float(np.mean(total_min)))}, max - {print_time(float(np.max(total_min)))}"
+        f"total: min - {print_time(float(np.min(total_arr)))}, mean - {print_time(float(np.mean(total_arr)))}, max - {print_time(float(np.max(total_arr)))}"
     )
 
 

--- a/verifiers/utils/logging_utils.py
+++ b/verifiers/utils/logging_utils.py
@@ -147,18 +147,18 @@ def print_time(time_s: float) -> str:
     - <1s -> Xms
     - Else: Xs
     """
-    if time_s > 86400:  # >1d
+    if time_s >= 86400:  # >1d
         d = time_s // 86400
         h = (time_s % 86400) // 3600
-        return f"{d:.0f}d {h:.0f}h"
-    elif time_s > 3600:  # >1h
+        return f"{d:.0f}d" + (f" {h:.0f}h" if h > 0 else "")
+    elif time_s >= 3600:  # >1h
         h = time_s // 3600
         m = (time_s % 3600) // 60
-        return f"{h:.0f}h {m:.0f}m"
-    elif time_s > 60:  # >1m
+        return f"{h:.0f}h" + (f" {m:.0f}m" if m > 0 else "")
+    elif time_s >= 60:  # >1m
         m = time_s // 60
         s = time_s % 60
-        return f"{m:.0f}m {s:.0f}s"
+        return f"{m:.0f}m" + (f" {s:.0f}s" if s > 0 else "")
     elif time_s < 1:  # <1s
         ms = time_s * 1e3
         return f"{ms:.0f}ms"

--- a/verifiers/utils/logging_utils.py
+++ b/verifiers/utils/logging_utils.py
@@ -136,3 +136,31 @@ def print_prompt_completions_sample(
 
     panel = Panel(table, expand=False, title=f"Step {step}", border_style="bold white")
     console.print(panel)
+
+
+def print_time(time_s: float) -> str:
+    """
+    Format a time in seconds to a human-readable format:
+    - >1d -> Xd Yh
+    - >1h -> Xh Ym
+    - >1m -> Xm Ys
+    - <1s -> Xms
+    - Else: Xs
+    """
+    if time_s > 86.400:  # >1d
+        d = time_s // 86.400
+        h = (time_s % 86.400) // 3600
+        return f"{d}d {h}h"
+    elif time_s > 3600:  # >1h
+        h = time_s // 3600
+        m = (time_s % 3600) // 60
+        return f"{h}h {m}m"
+    elif time_s > 60:  # >1m
+        m = time_s // 60
+        s = time_s % 60
+        return f"{m}m {s}s"
+    elif time_s < 1:  # <1s
+        ms = time_s * 1e3
+        return f"{ms:.0f}ms"
+    else:
+        return f"{time_s:.0f}s"

--- a/verifiers/utils/logging_utils.py
+++ b/verifiers/utils/logging_utils.py
@@ -147,9 +147,9 @@ def print_time(time_s: float) -> str:
     - <1s -> Xms
     - Else: Xs
     """
-    if time_s > 86.400:  # >1d
-        d = time_s // 86.400
-        h = (time_s % 86.400) // 3600
+    if time_s > 86400:  # >1d
+        d = time_s // 86400
+        h = (time_s % 86400) // 3600
         return f"{d}d {h}h"
     elif time_s > 3600:  # >1h
         h = time_s // 3600

--- a/verifiers/utils/logging_utils.py
+++ b/verifiers/utils/logging_utils.py
@@ -150,15 +150,15 @@ def print_time(time_s: float) -> str:
     if time_s > 86400:  # >1d
         d = time_s // 86400
         h = (time_s % 86400) // 3600
-        return f"{d}d {h}h"
+        return f"{d:.0f}d {h:.0f}h"
     elif time_s > 3600:  # >1h
         h = time_s // 3600
         m = (time_s % 3600) // 60
-        return f"{h}h {m}m"
+        return f"{h:.0f}h {m:.0f}m"
     elif time_s > 60:  # >1m
         m = time_s // 60
         s = time_s % 60
-        return f"{m}m {s}s"
+        return f"{m:.0f}m {s:.0f}s"
     elif time_s < 1:  # <1s
         ms = time_s * 1e3
         return f"{ms:.0f}ms"

--- a/verifiers/utils/logging_utils.py
+++ b/verifiers/utils/logging_utils.py
@@ -157,7 +157,7 @@ def print_time(time_s: float) -> str:
         return f"{h:.0f}h" + (f" {m:.0f}m" if m > 0 else "")
     elif time_s >= 60:  # >1m
         m = time_s // 60
-        s = time_s % 60
+        s = (time_s % 60) // 1
         return f"{m:.0f}m" + (f" {s:.0f}s" if s > 0 else "")
     elif time_s < 1:  # <1s
         ms = time_s * 1e3


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

This PR adds logging for rollout times in`vf-eval`. Logs min/mean/max recorded timings in human-readable format

```bash
uv run vf-eval math-python -n1 -r1 -v
```

<img width="340" height="264" alt="Screenshot 2026-01-05 at 6 17 32 PM" src="https://github.com/user-attachments/assets/bec1a8d2-52cd-4248-b1e6-df97f3600417" />


## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds concise rollout timing stats to evaluation output.
> 
> - In `eval_utils.print_results`, aggregates `generation_ms`, `scoring_ms`, and `total_ms`, converts to seconds, and prints min/mean/max via `print_time`
> - Introduces `print_time` in `logging_utils` to format seconds into human-readable strings and updates import usage
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4987f9cce9f76064632db847d732664a013e26f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->