### PR TITLE
Log eventloop lag during vf-eval

### DIFF
--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -122,14 +122,13 @@ def print_results(
             print(f" - {repr(error_chain)}: {count / counter.total():.3f}")
     print("Performance:")
     event_loop_lags_arr = np.array(event_loop_lags)
-    mean_lag, med_lag, p90_lag, max_lag = (
-        np.mean(event_loop_lags_arr),
+    med_lag, p90_lag, max_lag = (
         np.median(event_loop_lags_arr),
         np.percentile(event_loop_lags_arr, 90),
         np.max(event_loop_lags_arr),
     )
     print(
-        f"event_loop_lag: mean - {mean_lag:.3f}, med - {med_lag:.3f}, p90 - {p90_lag:.3f}, max - {max_lag:.3f}"
+        f"event_loop_lag: med - {print_time(float(med_lag))}, p90 - {print_time(float(p90_lag))}, max - {print_time(float(max_lag))}"
     )
 
     generation_ms_arr = np.array(

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -60,7 +60,9 @@ def load_endpoints(endpoints_path: str):
 
 
 def print_results(
-    results: GenerateOutputs, event_loop_lags: list[float], num_samples: int = 1
+    results: GenerateOutputs,
+    event_loop_lags: list[float] | None = None,
+    num_samples: int = 1,
 ):
     assert results["metadata"] is not None
     print("--- Evaluation ---")
@@ -120,17 +122,6 @@ def print_results(
         counter = Counter(error_chains)
         for error_chain, count in counter.items():
             print(f" - {repr(error_chain)}: {count / counter.total():.3f}")
-    print("Performance:")
-    event_loop_lags_arr = np.array(event_loop_lags)
-    med_lag, p90_lag, max_lag = (
-        np.median(event_loop_lags_arr),
-        np.percentile(event_loop_lags_arr, 90),
-        np.max(event_loop_lags_arr),
-    )
-    print(
-        f"event_loop_lag: med - {print_time(float(med_lag))}, p90 - {print_time(float(p90_lag))}, max - {print_time(float(max_lag))}"
-    )
-
     generation_ms_arr = np.array(
         [s["timing"]["generation_ms"] for s in results["state"]]
     )
@@ -149,6 +140,17 @@ def print_results(
     print(
         f"total: min - {print_time(float(np.min(total_arr)))}, mean - {print_time(float(np.mean(total_arr)))}, max - {print_time(float(np.max(total_arr)))}"
     )
+    if event_loop_lags is not None:
+        print("Performance:")
+        event_loop_lags_arr = np.array(event_loop_lags)
+        med_lag, p90_lag, max_lag = (
+            np.median(event_loop_lags_arr),
+            np.percentile(event_loop_lags_arr, 90),
+            np.max(event_loop_lags_arr),
+        )
+        print(
+            f"event_loop_lag: med - {print_time(float(med_lag))}, p90 - {print_time(float(p90_lag))}, max - {print_time(float(max_lag))}"
+        )
 
 
 async def run_evaluation(config: EvalConfig) -> GenerateOutputs:

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -121,11 +121,12 @@ def print_results(
         for error_chain, count in counter.items():
             print(f" - {repr(error_chain)}: {count / counter.total():.3f}")
     print("Performance:")
+    event_loop_lags_arr = np.array(event_loop_lags)
     mean_lag, med_lag, p90_lag, max_lag = (
-        np.mean(event_loop_lags),
-        np.median(event_loop_lags),
-        np.percentile(event_loop_lags, 90),
-        np.max(event_loop_lags),
+        np.mean(event_loop_lags_arr),
+        np.median(event_loop_lags_arr),
+        np.percentile(event_loop_lags_arr, 90),
+        np.max(event_loop_lags_arr),
     )
     print(
         f"event_loop_lag: mean - {mean_lag:.3f}, med - {med_lag:.3f}, p90 - {p90_lag:.3f}, max - {max_lag:.3f}"


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

> Based on #686. Do not merge before

Logs event loop lag during `vf-eval` as env monitoring util to detect if an env overloads the main event loop, thereby degrading performance.

```bash
# low event loop lag
uv run vf-eval gsm8k -n1 -r1 -v
```

<img width="362" height="100" alt="Screenshot 2026-01-05 at 6 42 10 PM" src="https://github.com/user-attachments/assets/13440df2-6e9c-402e-a2a8-8b0df0781bed" />

```bash
# high event loop lag (>1k parallel reqs)
uv run vf-eval gsm8k -n-1 -r1 -c-1 -v
```

<img width="373" height="137" alt="Screenshot 2026-01-05 at 6 41 24 PM" src="https://github.com/user-attachments/assets/25dd14bd-c2ad-430c-8eae-5048fe8ae798" />

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces performance monitoring in evaluation and standardized metrics across environments.
> 
> - **Eval telemetry**: New `EventLoopLagMonitor` (async_utils) integrated into `run_evaluation` and `print_results` to report event loop lag and detailed generation/scoring timings; adds `print_time()` formatter
> - **Monitor rubrics**: Auto-attached rubrics per env layer
>   - `MultiTurnEnv`: `num_turns`
>   - `ToolEnv`: `total_tool_calls` and per-tool call counts (replaces removed `ToolRubric`)
>   - `SandboxEnv`: `sandbox_ready_wait_time`, `sandbox_command_execution_time`
>   - `PythonEnv`: `python_ready_wait_time`
>   - New `Environment.add_rubric()` stacks rubrics automatically
> - **State & metrics plumbing**: Sandbox/Python states now track ready wait and command durations; methods updated to record timings
> - **API cleanups**: Remove `ToolRubric` export/file; `math_python` stops manually adding it—`ToolEnv` now tracks tool metrics by default
> - **Docs**: New/expanded `docs/evaluation.md`, enriched `docs/environments.md` (monitor rubrics), updated navigation and RTD redirect
> - **Tests**: EnvGroup tests updated to include `num_turns` metric in expectations
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d304d801dbd80ab05e85481cec836643349613d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->