### PR TITLE
feat: Always save final checkpoint in RLTrainer

### DIFF
--- a/verifiers/rl/trainer/trainer.py
+++ b/verifiers/rl/trainer/trainer.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import time
 from collections import defaultdict, deque
 from contextlib import nullcontext
@@ -387,13 +388,41 @@ class RLTrainer(Trainer):
         return DataLoader(StepsDataset(self.max_steps))
 
     def _inner_training_loop(self, *args, **kwargs):
-        """Override to ensure async orchestrator is stopped when training ends"""
+        """Override to ensure final checkpoint saved and orchestrator stopped."""
         try:
             return super()._inner_training_loop(*args, **kwargs)
         finally:
+            # Save final checkpoint BEFORE cleanup
+            if self.state.global_step > 0:
+                try:
+                    self._save_final_checkpoint()
+                except Exception as e:
+                    self.logger.warning(f"Failed to save final checkpoint: {e}")
+
             # cleanup
             if self.orchestrator:
                 self.orchestrator.stop()
+
+    def _save_final_checkpoint(self):
+        """Save final checkpoint to broadcasts/step_N/ directory.
+
+        This ensures adapters are always available even for short runs where
+        save_steps > max_steps would otherwise skip checkpointing.
+        """
+        if not self.accelerator.is_main_process:
+            return
+
+        final_step = self.state.global_step
+        broadcasts_dir = os.path.join(self.args.output_dir, "broadcasts", f"step_{final_step}")
+
+        if os.path.exists(broadcasts_dir):
+            self.logger.info(f"Final checkpoint already exists at {broadcasts_dir}")
+            return
+
+        self.logger.info(f"Saving final checkpoint to {broadcasts_dir}")
+        os.makedirs(broadcasts_dir, exist_ok=True)
+        self.save_model(broadcasts_dir)
+        self.logger.info(f"Final checkpoint saved at step {final_step}")
 
     def log(self, logs: dict[str, float], start_time: float | None = None) -> None:
         mode = "train" if self.model is not None and self.model.training else "eval"


### PR DESCRIPTION
## Summary
Ensure a checkpoint is always saved at the end of training, regardless of `save_steps` interval.

## Problem
Short training runs (`max_steps < save_steps`) produce no checkpoints because HuggingFace Trainer only saves at `save_steps` intervals. The cleanup job then finds no `step_*` folder and deletes the adapter record.

## Solution
Add `_save_final_checkpoint()` method that:
1. Runs in `_inner_training_loop` finally block (before orchestrator cleanup)
2. Saves to `broadcasts/step_{final_step}/` directory
3. Skips if checkpoint already exists at that step
4. Only runs on main process

## Changes
- Add `import os` for path operations
- Add `_save_final_checkpoint()` method
- Call in `_inner_training_loop` finally block

## Related
- Platform PR: https://github.com/PrimeIntellect-ai/platform/pull/72
- CLI PR: https://github.com/PrimeIntellect-ai/prime/pull/280