### PR TITLE
Do not cleanup python state + init wait time to zero

### DIFF
--- a/verifiers/envs/python_env.py
+++ b/verifiers/envs/python_env.py
@@ -210,7 +210,7 @@ PY
         state["python_state"] = {
             "ready": False,
             "execution_count": 0,
-            "ready_wait_time": -1.0,
+            "ready_wait_time": 0.0,
         }
         return state
 
@@ -248,10 +248,6 @@ PY
             sandbox_id, sandbox_state, {"code": code}
         )
         return self._format_response(python_state, sandbox_response)
-
-    @vf.cleanup
-    async def cleanup_python_state(self, state: vf.State):
-        state.pop("python_state", None)
 
     async def _wait_for_worker_ready(
         self,

--- a/verifiers/envs/sandbox_env.py
+++ b/verifiers/envs/sandbox_env.py
@@ -282,7 +282,7 @@ class SandboxEnv(vf.StatefulToolEnv):
         state["sandbox_id"] = sandbox.id
         state["sandbox_state"] = {
             "ready": False,
-            "ready_wait_time": -1.0,
+            "ready_wait_time": 0.0,
             "command_execution_times": [],
         }
         return await super().setup_state(state, **kwargs)


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Two minor fixes to monitors in `PythonEnv` and `SandboxEnv`:
- Initialize the `ready_wait_time` in `setup_state` to 0 instead of -1, such that rollouts which do not use tools correct have zero wait time
- Do not cleanup the `python_state` from `state` so that it can be accessed by the rubric. Before, the `python_ready_wait_time` was always zero because the dict would be popped from the state before the rubric could add it.

## TODOs

- [ ] Handle tokenize client copying if base OAI client is threaded 

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **Initialize wait-time metrics to zero**: Set `ready_wait_time` to `0.0` in `PythonEnv.setup_state` and `SandboxEnv.setup_state`.
> - **Retain Python worker state**: Remove `cleanup_python_state` so `python_state` remains available in `state` for monitoring/rubrics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79741adc84728c61998970a36e710203fda8f31f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->