### PR TITLE
Fix tool test env

### DIFF
--- a/environments/tool_test/tool_test.py
+++ b/environments/tool_test/tool_test.py
@@ -65,7 +65,9 @@ tool_name_list = [tool.__name__ for tool in tool_list]
 def tool_call_reward_func(completion, info):
     # check if completion tool calls exactly matches info tool calls
     tool_calls = completion[-1].get("tool_calls", [])
-    called_tool_names = sorted([call.function.name for call in tool_calls])
+    called_tool_names = sorted(
+        [call.get("function", {}).get("name", "") for call in tool_calls]
+    )
     expected_tool_names = sorted(info["tool_names"])
     if called_tool_names == expected_tool_names:
         return 1.0
@@ -101,8 +103,7 @@ def load_environment(
     dataset = Dataset.from_list(train_rows)
     eval_dataset = Dataset.from_list(eval_rows)
     parser = vf.Parser()
-    rubric = vf.ToolRubric(tools=tool_list)
-    rubric.add_reward_func(tool_call_reward_func)
+    rubric = vf.Rubric(funcs=[tool_call_reward_func])
     vf_env = vf.ToolEnv(
         dataset=dataset,
         eval_dataset=eval_dataset,


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

#653 broke `tool-test` env because it imported `ToolRubric`. This PR fixes the rubric pattern + the access to the called tools (seems like its a dict now, not a Pydantic object) to get the expected behavior of the reward function.

```bash
uv run vf-eval tool_test -n1 -r1 -v 
```

<img width="1065" height="648" alt="Screenshot 2026-01-06 at 2 39 26 PM" src="https://github.com/user-attachments/assets/6ec4d3b9-6e1d-489a-a134-05824aabaedf" />

Now, all env tests pass again

<img width="1417" height="679" alt="Screenshot 2026-01-06 at 2 47 45 PM" src="https://github.com/user-attachments/assets/2c2ba724-785a-4363-8c51-6b6a4ef80400" />

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns `tool_test` with updated verifier APIs and message schema.
> 
> - Replace `ToolRubric`/`add_reward_func` with `vf.Rubric(funcs=[tool_call_reward_func])`
> - Update `tool_call_reward_func` to read tool names via `call.get("function", {}).get("name", "")` from `tool_calls`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c8c4d3701c2d69b0077eae5dea12d39c862b61d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->