### PR TITLE
Show intermediate reward in vf-eval

### DIFF
--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -867,8 +867,10 @@ class Environment(ABC):
             pbar = tqdm(
                 total=len(group_list),
                 desc=f"Processing {len(group_list)} groups ({len(inputs_list)} total rollouts)",
+                postfix=dict(reward="?"),
             )
 
+        reward_sum, reward_count = 0, 0
         groups_completed = 0
         all_states: list[State] = []
         try:
@@ -877,8 +879,17 @@ class Environment(ABC):
                 all_states.extend(group_states)
                 groups_completed += 1
 
+                # track reward for rolling average
+                for s in group_states:
+                    r = s.get("reward")
+                    if r is not None:
+                        reward_sum += r
+                        reward_count += 1
+
                 if pbar is not None:
                     pbar.update(1)
+                    if reward_count > 0:
+                        pbar.set_postfix(reward=f"{reward_sum / reward_count:.3f}")
 
                 # save intermediate results
                 if (


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Show intermediate reward in `vf-eval` via tqdm postfix as groups finish

```bash
 uv run vf-eval gsm8k
```

<img width="1425" height="158" alt="Screenshot 2026-01-06 at 3 19 40 PM" src="https://github.com/user-attachments/assets/29d9b528-1a2e-4179-9cb8-d770823a19f9" />

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a rolling average reward display to the tqdm progress bar during generation/evaluation.
> 
> - Initializes tqdm with `postfix` and tracks `reward_sum`/`reward_count` from completed group states
> - Updates progress with `pbar.set_postfix(reward=...)` to show the current average reward as groups finish
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ba1544891e2f30884f2dcf0a9810efa9dad64ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->