### PR TITLE
Allowing running + scoring per-rollout

### DIFF
--- a/tests/test_eval_cli.py
+++ b/tests/test_eval_cli.py
@@ -39,6 +39,7 @@ def _run_cli(monkeypatch, overrides):
         "max_concurrent": 1,
         "max_concurrent_generation": None,
         "max_concurrent_scoring": None,
+        "independent_scoring": False,
         "max_tokens": 42,
         "temperature": 0.9,
         "sampling_args": None,

--- a/verifiers/rubrics/rubric.py
+++ b/verifiers/rubrics/rubric.py
@@ -212,6 +212,11 @@ class Rubric:
         async with score_sem:
             return await _call()
 
+    async def dummy_score_rollout(self, state: State):
+        """Score a single rollout with dummy rewards."""
+        state["reward"] = 0.0
+        state["metrics"] = {}
+
     async def score_rollout(self, state: State, score_sem: AsyncContextManager):
         """
         Evaluate all reward functions for a single rollout.
@@ -252,12 +257,9 @@ class Rubric:
         state["metrics"] = rewards["metrics"]
 
     async def dummy_score_group(self, states: list[State]):
-        """
-        Score a group of rollouts together with dummy rewards.
-        """
+        """Score a group of rollouts together with dummy rewards."""
         for state in states:
-            state["reward"] = 0.0
-            state["metrics"] = {}
+            await self.dummy_score_rollout(state)
 
     async def score_group(self, states: list[State], score_sem: AsyncContextManager):
         """

--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -205,6 +205,13 @@ def main():
         help="Save dataset every n rollouts",
     )
     parser.add_argument(
+        "--independent-scoring",
+        "-R",
+        default=False,
+        action="store_true",
+        help="Score each rollout individually instead of scoring by group",
+    )
+    parser.add_argument(
         "--save-to-hf-hub",
         "-H",
         default=False,
@@ -320,6 +327,7 @@ def main():
         state_columns=args.state_columns,
         save_results=args.save_results,
         save_every=args.save_every,
+        independent_scoring=args.independent_scoring,
         save_to_hf_hub=args.save_to_hf_hub,
         hf_hub_dataset_name=args.hf_hub_dataset_name,
     )

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -233,6 +233,7 @@ class EvalConfig(BaseModel):
     max_concurrent: int
     max_concurrent_generation: int | None = None
     max_concurrent_scoring: int | None = None
+    independent_scoring: bool = False
     extra_env_kwargs: dict = {}
     # logging
     print_results: bool = False

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -194,6 +194,7 @@ async def run_evaluation(config: EvalConfig) -> GenerateOutputs:
         state_columns=config.state_columns,
         save_results=config.save_results,
         save_every=config.save_every,
+        independent_scoring=config.independent_scoring,
     )
     end_time = time.time()
     logger.info(f"Evaluation completed in {end_time - start_time:.2f} seconds")


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

This PR implements a "per-rollout" generation + scoring mode that can be used in `Environment.generate` and `vf-eval`. 

When enabled, 
- runs and scores each rollout independently (no grouping)
- tracks progress per-rollout (not per-group)
- saves intermediate results every N rollouts (not N groups)
- leaves advantage as None (group-relative advantage doesn't apply)

The main motivation for this mode is to enable more frequent intermediate saving of results because rollouts are not blocked by stragglers within the group. Since it can only be used for envs which do not have group rubrics, this is a optional opt-in flag, but not enabled by default.

Points of discussion (@willccbb)

1. `run_rollout`/ `run_group` signatures: I changed the signature of `Environment.run_rollout` (breaking) and `Environment.run_group` (non-breaking) to be aligned, i.e. they share the same args, except that `run_group` operates on list of inputs/ outputs. Both allow to optionally score the rollout/ group via `score`. This is disabled by default for `run_rollout` and enabled by default for `run_group` to match the previous defaults. The main motivation for this change was to have aligned interfaces. We could of course do it without any signatures changes by having another method `run_and_score_rollout` which would call `run_rollout` and then the scoring logic of the rubric but it felt ugly and unnecessarily unaligned with the `run_group` method. Open to hear your thoughts here tho.
2. Naming: Right now I named the eval config arg `--independent-scoring` or `-R` (for rollout mode), but I am not convinced this is the best name. Open to ideas here too

## Example

The default is unchanged

```bash
uv run vf-eval gsm8k -n 5 -r 3
```

```bash
uv run vf-eval gsm8k -n 5 -r 3 --independent-scoring
```

<img width="1425" height="604" alt="Screenshot 2026-01-06 at 4 04 12 PM" src="https://github.com/user-attachments/assets/8ce5f23e-2a7e-4a75-82c6-6273e9854767" />


## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces an optional per‑rollout generation+scoring mode and threads it through env, rubric, CLI, and types.
> 
> - Adds `independent_scoring` flag across `vf-eval`, `EvalConfig`, and `Environment.generate/evaluate` to score each `rollout` independently (no grouping)
> - Refactors `Environment.run_rollout`/`run_group` to aligned signatures; `run_rollout` now supports optional scoring via `score`, `gen_sampling_args`, `gen_sem`, and `score_sem`
> - Updates task orchestration: when `independent_scoring=True`, schedules per‑rollout tasks, updates tqdm to per‑rollout progress, and saves intermediates every N rollouts; otherwise retains group mode
> - Adds `Rubric.dummy_score_rollout` and reuses it in `dummy_score_group`
> - Wires CLI `--independent-scoring` (`-R`) and propagates through evaluation utilities; updates tests to include the new arg
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09a9b8cecd785302a7ceb8f8255a230327a0e04c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->