### PR TITLE
Fix wiki-search

### DIFF
--- a/environments/wiki_search/wiki_search.py
+++ b/environments/wiki_search/wiki_search.py
@@ -222,7 +222,6 @@ def load_environment(
     ]
     parser = vf.Parser()
     dataset = load_dataset("willcb/wiki-trivia-questions-v4", split="train")
-    tool_rubric = vf.ToolRubric(tools=tools)
 
     JUDGE_PROMPT = """Given a ground truth answer \
     and a response, determine if the response is both correct and coherent.
@@ -265,12 +264,11 @@ def load_environment(
 
     system_prompt = "Use the provided Wikipedia search tools to help answer questions."
     judge_rubric.add_reward_func(judge_reward_func, weight=1.0)
-    rubric = vf.RubricGroup(rubrics=[tool_rubric, judge_rubric])
     vf_env = vf.ToolEnv(
         dataset=dataset,
         system_prompt=system_prompt,
         parser=parser,
-        rubric=rubric,
+        rubric=judge_rubric,
         tools=tools,
         max_turns=max_turns,
     )

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -15,8 +15,6 @@ SKIPPED_ENVS = [
     #                 ~~~~~~~~~~^^^^^^^^^^^^^^
     # KeyError: 'example_id'
     "continuation_quality",
-    # Slow expensive first-time setup
-    "wiki_search",
 ]
 
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Also uses `ToolRubric` which got deprecated. Also brings it back into CI so this would've been caught earlier (it takes 40s locally for me the run tests so I think this is better than catching regressions late)

<img width="1427" height="261" alt="Screenshot 2026-01-06 at 10 05 58 PM" src="https://github.com/user-attachments/assets/9816bd04-76ea-47fb-8904-8a9ce77b58d5" />

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **fix: update `wiki_search` to use judge-only rubric and re-enable tests**
> 
> - Removes deprecated `ToolRubric`/`RubricGroup` usage; `vf.ToolEnv` now receives `rubric=judge_rubric` only in `environments/wiki_search/wiki_search.py`
> - Keeps tool definitions and dataset loading unchanged; no API surface changes to tools
> - Re-enables CI coverage by unskipping `wiki_search` in `tests/test_envs.py` (it will now run in the slow env tests)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ae79eef8768e1fa62f9ca3622655d65a29d5745. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->