### PR TITLE
Add RLM monitor rubric

### DIFF
--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -158,6 +158,67 @@ def update_rlm_metrics_from_step(state: State, step: TrajectoryStep) -> None:
         state["main_rlm_completion_tokens"] += completion_tokens
 
 
+class RLMMonitorRubric(vf.Rubric):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.add_metric(self.sub_llm_call_count)
+        self.add_metric(self.sub_llm_total_turns)
+        self.add_metric(self.sub_llm_prompt_tokens)
+        self.add_metric(self.sub_llm_completion_tokens)
+        self.add_metric(self.sub_llm_total_tool_calls)
+        self.add_metric(self.sub_llm_batch_count)
+        self.add_metric(self.sub_llm_max_batch_size)
+        self.add_metric(self.sub_llm_mean_batch_size)
+        self.add_metric(self.main_rlm_turns)
+        self.add_metric(self.main_rlm_prompt_tokens)
+        self.add_metric(self.main_rlm_completion_tokens)
+        self.add_metric(self.repl_total_time_seconds)
+        self.add_metric(self.repl_call_count)
+        self.add_metric(self.repl_mean_time_seconds)
+
+    async def sub_llm_call_count(self, state: State) -> int:
+        return state["sub_llm_call_count"]
+
+    async def sub_llm_total_turns(self, state: State) -> int:
+        return state["sub_llm_total_turns"]
+
+    async def sub_llm_prompt_tokens(self, state: State) -> int:
+        return state["sub_llm_prompt_tokens"]
+
+    async def sub_llm_completion_tokens(self, state: State) -> int:
+        return state["sub_llm_completion_tokens"]
+
+    async def sub_llm_total_tool_calls(self, state: State) -> int:
+        return state["sub_llm_total_tool_calls"]
+
+    async def sub_llm_batch_count(self, state: State) -> int:
+        return state["sub_llm_batch_count"]
+
+    async def sub_llm_max_batch_size(self, state: State) -> int:
+        return state["sub_llm_max_batch_size"]
+
+    async def sub_llm_mean_batch_size(self, state: State) -> float:
+        return state["sub_llm_mean_batch_size"]
+
+    async def main_rlm_turns(self, state: State) -> int:
+        return state["main_rlm_turns"]
+
+    async def main_rlm_prompt_tokens(self, state: State) -> int:
+        return state["main_rlm_prompt_tokens"]
+
+    async def main_rlm_completion_tokens(self, state: State) -> int:
+        return state["main_rlm_completion_tokens"]
+
+    async def repl_total_time_seconds(self, state: State) -> float:
+        return state["repl_total_time_seconds"]
+
+    async def repl_call_count(self, state: State) -> int:
+        return state["repl_call_count"]
+
+    async def repl_mean_time_seconds(self, state: State) -> float:
+        return state["repl_mean_time_seconds"]
+
+
 class SubLLMTurn(TypedDict):
     """A single turn in a sub-LLM call (used by RLMEnv)."""
 
@@ -646,6 +707,7 @@ class RLMEnv(SandboxEnv):
             rubric=rubric,
             **kwargs,
         )
+        self.add_rubric(RLMMonitorRubric())
 
         # Remove bash tool from parent - we use our own REPL tool
         if hasattr(self, "tool_map") and "bash" in self.tool_map:


### PR DESCRIPTION
## Description

Adds `RLMMonitorMetric` so that the individual environments don't have to implement it

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a shared rubric to standardize RLM monitoring across environments.
> 
> - New `RLMMonitorRubric` in `verifiers/envs/experimental/rlm_env.py` exposes metrics for `sub_llm_*` (calls, turns, tokens, tool calls, batch stats), `main_rlm_*` (turns, tokens), and REPL timing (`repl_*`)
> - `RLMEnv.__init__` now registers the rubric via `add_rubric(RLMMonitorRubric())` for automatic metric collection
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 20d426beb1ab7cb89aebcc755c2e349a00cf38fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->