### PR TITLE
Add `get_sandbox_request` hook for per-rollout customization

### DIFF
--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -1378,10 +1378,9 @@ done
 
         # Create new sandbox via parent's parent (SandboxEnv.setup_state)
         # We need to call the grandparent to avoid re-running RLM setup
+        request = self.get_sandbox_request(state)
         try:
-            sandbox = await self.with_retry(self.sandbox_client.create)(
-                self.sandbox_request
-            )
+            sandbox = await self.with_retry(self.sandbox_client.create)(request)
         except Exception as e:
             raise SandboxCreationError(e)
         self.active_sandboxes.add(sandbox.id)


### PR DESCRIPTION
Adds a `get_sandbox_request(state)` method that subclasses can override to customize the sandbox request per-rollout.

Use case: Environments with dynamic docker images per example (e.g., SWE-bench has different images per task).

Change:
- `get_sandbox_request()` returns `self.sandbox_request.model_copy()`
- `setup_state()` uses `self.get_sandbox_request(state)` instead of `self.sandbox_request`

Backwards compatible - existing subclasses work unchanged.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables per-rollout customization of sandbox creation without altering existing subclasses.
> 
> - Add `get_sandbox_request(state)` in `sandbox_env.py` returning `self.sandbox_request.model_copy()` (overrideable)
> - Update `SandboxEnv.setup_state()` and `RLMEnv._recreate_sandbox()` to call `get_sandbox_request(state)` when creating sandboxes
> - Keeps existing behavior by default via a copied base request
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a9523de47aacd6500dae4e561c7847456a6c6455. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->