### PR TITLE
Fix empty slice

### DIFF
--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -140,7 +140,7 @@ def print_results(
     print(
         f"total: min - {print_time(float(np.min(total_arr)))}, mean - {print_time(float(np.mean(total_arr)))}, max - {print_time(float(np.max(total_arr)))}"
     )
-    if event_loop_lags is not None:
+    if event_loop_lags:
         print("Performance:")
         event_loop_lags_arr = np.array(event_loop_lags)
         med_lag, p90_lag, max_lag = (


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

If `vf-eval` crashes before any event loop lag is measured, the printing of results fails because numpy cannot compute statistics over an empty list. This PR fixes this by guarding the printing, i.e. only print if >= 1 measurement has been made.

**Before**

<img width="1120" height="623" alt="Screenshot 2026-01-07 at 4 01 26 PM" src="https://github.com/user-attachments/assets/78bd8f5f-a123-4cfd-866b-c933b64cb4a2" />

**After**

<img width="1424" height="459" alt="Screenshot 2026-01-07 at 4 02 06 PM" src="https://github.com/user-attachments/assets/9119502b-d69f-4002-8f31-0db50d965495" />

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents a crash when printing evaluation results if no event loop lag measurements were collected.
> 
> - In `verifiers/utils/eval_utils.py`, `print_results` now prints the "Performance" section only when `event_loop_lags` is non-empty (`if event_loop_lags:`), avoiding numpy empty-slice statistics on an empty list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e245e019ab59d2a8d3b139e347c57d50253f4edb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->