### PR TITLE
Sebastian/vf tui search 2026 01

### DIFF
--- a/verifiers/scripts/tui.py
+++ b/verifiers/scripts/tui.py
@@ -802,9 +802,17 @@ class ViewRunScreen(Screen):
         if max_scroll is None:
             max_scroll = getattr(scroll, "scroll_y_max", None)
         if max_scroll is None:
-            scroll.scroll_y = max(0, target)
+            target = max(0, target)
         else:
-            scroll.scroll_y = max(0, min(target, max_scroll))
+            target = max(0, min(target, max_scroll))
+
+        if hasattr(scroll, "scroll_to"):
+            try:
+                scroll.scroll_to(y=target, animate=False)
+            except TypeError:
+                scroll.scroll_to(y=target)
+        else:
+            scroll.scroll_y = target
 
 
 # ----------------------------

--- a/verifiers/scripts/tui.py
+++ b/verifiers/scripts/tui.py
@@ -335,9 +335,6 @@ class SelectModelScreen(Screen):
         option_list.focus()
 
     def action_back(self) -> None:
-        if self._highlight_timer is not None:
-            self._highlight_timer.stop()
-            self._highlight_timer = None
         self.app.pop_screen()
 
     @on(OptionList.OptionSelected, "#model-list")


### PR DESCRIPTION
## Description

Added two new features:

- the run choice shows a bit extra info about the specific run
- there is a search function to search inside a rollout (triggered by `s`)

https://github.com/user-attachments/assets/5f308273-fd6d-4925-9961-11ec0d85ed16

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds in-run search and richer run selection details to the Textual TUI.
> 
> - New case-insensitive regex search (press `s`) in `ViewRunScreen`; displays results in a modal, highlights matches in `prompt`/`completion`, auto-scrolls to the selected line, and clears highlight after a short delay
> - Added run details side panel in `SelectRunScreen` showing metadata like avg reward, metrics, runtime, `env_args`, and `sampling_args`; updates as runs are highlighted
> - Introduces helpers for match styling and wrapped-line offset calculation to enable precise scrolling; updates key bindings and layout/CSS for search and details panels
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f45f1c6e143dd08452b7c348d3a3423b897903f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->