### PR TITLE
Lazy import everything in verifiers

### DIFF
--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -64,3 +64,16 @@ class TestImports:
                 else:
                     # This is an unexpected AttributeError, re-raise it
                     raise
+
+    def test_dir_includes_public_api(self):
+        """Test that dir(verifiers) exposes the public API."""
+        directory = dir(verifiers)
+        for name in verifiers.__all__:
+            assert name in directory, f"{name} missing from dir(verifiers)"
+
+    def test_star_import_matches_all(self):
+        """Test that star import exposes __all__ names."""
+        namespace: dict[str, object] = {}
+        exec("from verifiers import *", namespace)
+        for name in verifiers.__all__:
+            assert name in namespace, f"{name} missing from star import"

--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -84,6 +84,15 @@ __all__ = [
     "cleanup",
     "stop",
     "teardown",
+    "Error",
+    "ModelError",
+    "EmptyModelResponseError",
+    "OverlongPromptError",
+    "ToolError",
+    "ToolParseError",
+    "ToolCallError",
+    "InfraError",
+    "SandboxError",
 ]
 
 _LAZY_IMPORTS = {


### PR DESCRIPTION
## Description

I noticed that vf-tui startup was getting really slow. The reason is that it imports verifiers, which is slow but also completely unnecessary. Other programs might be similar. This PR makes all vf imports lazy.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [x] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes the `verifiers` top-level API fully lazy and aligns introspection/star-imports with the public surface.
> 
> - Replaces eager imports in `__init__.py` with a comprehensive `_LAZY_IMPORTS` map covering parsers, rubrics, envs, RL utilities, decorators, and errors
> - Implements `__getattr__` to resolve lazy targets and fall back to `verifiers.errors`/`verifiers.types`; raises clear optional-deps `AttributeError`
> - Expands `__all__`, adds `__dir__` to expose the public API, and keeps `setup_logging` initialization
> - Adds tests (`tests/test_imports.py`) verifying: items in `__all__` are importable (or properly gated by optional deps), lazy entries are included in `__all__`, `dir(verifiers)` includes public names, and `from verifiers import *` matches `__all__`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 75a909489c6d1ed455fcb85c4ef730c78a432cc5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->