### PR TITLE
Lazy-load vf-tui results and metadata

### DIFF
--- a/verifiers/scripts/tui.py
+++ b/verifiers/scripts/tui.py
@@ -31,7 +31,17 @@ class RunInfo:
     model: str
     run_id: str
     path: Path
-    metadata: Dict[str, Any]
+    metadata: Optional[Dict[str, Any]] = None
+
+    def load_metadata(self) -> Dict[str, Any]:
+        if self.metadata is not None:
+            return self.metadata
+        meta_path = self.path / "metadata.json"
+        try:
+            self.metadata = json.loads(meta_path.read_text())
+        except Exception:
+            self.metadata = {}
+        return self.metadata
 
 
 def _iter_eval_roots(env_dir: Path, global_outputs_dir: Path) -> List[Path]:
@@ -82,46 +92,101 @@ def discover_results(
                 meta = run_dir / "metadata.json"
                 results = run_dir / "results.jsonl"
                 if meta.exists() and results.exists():
-                    try:
-                        metadata = json.loads(meta.read_text())
-                    except Exception:
-                        metadata = {}
                     run = RunInfo(
                         env_id=env_id,
                         model=model,
                         run_id=run_dir.name,
                         path=run_dir,
-                        metadata=metadata,
                     )
                     discovered.setdefault(env_id, {}).setdefault(model, []).append(run)
 
-    # Sort runs by time
-    for env_id, models in discovered.items():
-        for model, runs in models.items():
-            runs.sort(
-                key=lambda r: (
-                    r.metadata.get("date", ""),
-                    r.metadata.get("time", ""),
-                    r.run_id,
-                )
-            )
     return discovered
 
 
-def load_run_results(run: RunInfo) -> List[Dict[str, Any]]:
-    """Load results.jsonl into memory."""
-    data: List[Dict[str, Any]] = []
-    results_path = run.path / "results.jsonl"
-    with results_path.open("r") as f:
-        for line in f:
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                data.append(json.loads(line))
-            except json.JSONDecodeError:
-                continue
-    return data
+class LazyRunResults:
+    """Lazy loader for results.jsonl with optional metadata count."""
+
+    def __init__(self, run: RunInfo):
+        self._path = run.path / "results.jsonl"
+        self._fh = self._path.open("r", encoding="utf-8")
+        self._offsets: List[int] = []
+        self._cache: Dict[int, Dict[str, Any]] = {}
+        self._eof = False
+        self._count: Optional[int] = None
+
+        meta = run.load_metadata()
+        num_examples = meta.get("num_examples")
+        if isinstance(num_examples, int) and num_examples >= 0:
+            self._count = num_examples
+
+    def close(self) -> None:
+        if not self._fh.closed:
+            self._fh.close()
+
+    def _read_next_line(self) -> Optional[str]:
+        if self._eof:
+            return None
+        pos = self._fh.tell()
+        line = self._fh.readline()
+        if not line:
+            self._eof = True
+            return None
+        self._offsets.append(pos)
+        return line
+
+    def _ensure_index(self, index: int) -> bool:
+        if index < 0:
+            return False
+        while len(self._offsets) <= index and not self._eof:
+            line = self._read_next_line()
+            if line is None:
+                break
+        return index < len(self._offsets)
+
+    def _ensure_count(self) -> int:
+        if self._count is not None:
+            return self._count
+        while not self._eof:
+            line = self._read_next_line()
+            if line is None:
+                break
+        self._count = len(self._offsets)
+        return self._count
+
+    def get(self, index: int) -> Dict[str, Any]:
+        if index in self._cache:
+            return self._cache[index]
+        if not self._ensure_index(index):
+            return {}
+        self._fh.seek(self._offsets[index])
+        line = self._fh.readline()
+        try:
+            data = json.loads(line)
+        except json.JSONDecodeError:
+            data = {}
+        self._cache[index] = data
+        return data
+
+    def __getitem__(self, index: int) -> Dict[str, Any]:
+        return self.get(index)
+
+    def __len__(self) -> int:
+        return self._ensure_count()
+
+    def __bool__(self) -> bool:
+        if self._count is not None:
+            return self._count > 0
+        if self._offsets:
+            return True
+        if self._eof:
+            return False
+        line = self._read_next_line()
+        return line is not None
+
+
+def load_run_results(run: RunInfo) -> LazyRunResults:
+    """Open results.jsonl lazily."""
+    return LazyRunResults(run)
 
 
 # ----------------------------
@@ -394,8 +459,17 @@ class SelectRunScreen(Screen):
     def on_mount(self) -> None:
         option_list = self.query_one("#run-list", OptionList)
 
+        # Load metadata only for runs in this model, when the run list is shown.
+        self.runs.sort(
+            key=lambda r: (
+                r.load_metadata().get("date", ""),
+                r.load_metadata().get("time", ""),
+                r.run_id,
+            )
+        )
+
         for i, run in enumerate(self.runs):
-            meta = run.metadata
+            meta = run.load_metadata()
             datetime_str = f"{meta.get('date', '')} {meta.get('time', '')}".strip()
             reward = meta.get("avg_reward", "")
             if isinstance(reward, (int, float)):
@@ -449,7 +523,7 @@ class SelectRunScreen(Screen):
         details_widget.update(details)
 
     def _build_run_details(self, run: RunInfo) -> Text:
-        meta = run.metadata
+        meta = run.load_metadata()
         out = Text()
         out.append("Run ID: ", style="bold")
         out.append(str(run.run_id))
@@ -569,7 +643,7 @@ class ViewRunScreen(Screen):
         yield Footer()
 
     def _get_metadata_text(self) -> Text:
-        meta = self.run.metadata
+        meta = self.run.load_metadata()
         sampling_args = meta.get("sampling_args", {})
         avg_reward = meta.get("avg_reward", "")
         if isinstance(avg_reward, (int, float)):
@@ -641,6 +715,10 @@ class ViewRunScreen(Screen):
 
     def on_mount(self) -> None:
         self.update_display()
+
+    def on_unmount(self) -> None:
+        if hasattr(self.records, "close"):
+            self.records.close()
 
     def update_display(self) -> None:
         """Update the display with current record."""

--- a/verifiers/scripts/tui.py
+++ b/verifiers/scripts/tui.py
@@ -162,12 +162,16 @@ class LazyRunResults:
             return self._cache[index]
         if not self._ensure_index(index):
             return {}
-        self._fh.seek(self._offsets[index])
-        line = self._fh.readline()
+        pos = self._fh.tell()
         try:
-            data = json.loads(line)
-        except json.JSONDecodeError:
-            data = {}
+            self._fh.seek(self._offsets[index])
+            line = self._fh.readline()
+            try:
+                data = json.loads(line)
+            except json.JSONDecodeError:
+                data = {}
+        finally:
+            self._fh.seek(pos)
         self._cache[index] = data
         return data
 

--- a/verifiers/scripts/tui.py
+++ b/verifiers/scripts/tui.py
@@ -116,8 +116,12 @@ class LazyRunResults:
 
         meta = run.load_metadata()
         num_examples = meta.get("num_examples")
+        rollouts_per_example = meta.get("rollouts_per_example")
         if isinstance(num_examples, int) and num_examples >= 0:
-            self._count = num_examples
+            if isinstance(rollouts_per_example, int) and rollouts_per_example >= 0:
+                self._count = num_examples * rollouts_per_example
+            else:
+                self._count = num_examples
 
     def close(self) -> None:
         if not self._fh.closed:


### PR DESCRIPTION
## Description

Lazily load metadata and results in vf-tui for speed when there are large numbers of results.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Speeds up vf-tui by deferring file reads and loading only what's needed.
> 
> - Add `RunInfo.load_metadata()` and make `metadata` optional; stop reading metadata during discovery
> - Introduce `LazyRunResults` to lazily index and fetch records from `results.jsonl`, derive length from metadata when available, and provide caching; `load_run_results` now returns this loader
> - Defer sorting of runs to `SelectRunScreen` by loading metadata on mount; update views to call `load_metadata()` instead of accessing `metadata` directly
> - Ensure file handle cleanup via `ViewRunScreen.on_unmount()`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79da8edfc97b1664b50ca6ef2d2a734bd3f5a062. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->