### PR TITLE
feat: support prime CLI config for API key and team ID, and PRIME_TEAM_ID env var

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -517,8 +517,14 @@ class ClientConfig(BaseModel):
     max_connections: int = 28000
     max_keepalive_connections: int = 28000
     max_retries: int = 10
-    extra_headers: dict[str, str] | None = None
+    extra_headers: dict[str, str] = {}
 ```
+
+When `api_key_var` is `"PRIME_API_KEY"` (the default), credentials are loaded with the following precedence:
+- **API key**: `PRIME_API_KEY` env var > `~/.prime/config.json` > `"EMPTY"`
+- **Team ID**: `PRIME_TEAM_ID` env var > `~/.prime/config.json` > not set
+
+This allows seamless use after running `prime login`.
 
 ### EvalConfig
 

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -214,7 +214,7 @@ class ClientConfig(BaseModel):
     max_connections: int = 28000
     max_keepalive_connections: int = 28000
     max_retries: int = 10
-    extra_headers: dict[str, str] | None = None
+    extra_headers: dict[str, str] = {}
 
 
 class EvalConfig(BaseModel):

--- a/verifiers/utils/client_utils.py
+++ b/verifiers/utils/client_utils.py
@@ -1,10 +1,28 @@
+import json
+import logging
 import os
+from pathlib import Path
 
 import httpx
 from httpx import AsyncClient
 from openai import AsyncOpenAI
 
 from verifiers.types import ClientConfig
+
+logger = logging.getLogger(__name__)
+
+
+def load_prime_config() -> dict:
+    try:
+        config_file = Path.home() / ".prime" / "config.json"
+        if config_file.exists():
+            data = json.loads(config_file.read_text())
+            if isinstance(data, dict):
+                return data
+            logger.warning("Invalid prime config: expected dict")
+    except (RuntimeError, json.JSONDecodeError, OSError) as e:
+        logger.warning(f"Failed to load prime config: {e}")
+    return {}
 
 
 def setup_client(
@@ -20,15 +38,27 @@ def setup_client(
         max_keepalive_connections=config.max_keepalive_connections,
     )
 
+    headers = config.extra_headers
+    api_key = os.getenv(config.api_key_var)
+
+    # Fall back to prime config if using PRIME_API_KEY
+    if config.api_key_var == "PRIME_API_KEY":
+        prime_config = load_prime_config()
+        if not api_key:
+            api_key = prime_config.get("api_key", "")
+        team_id = os.getenv("PRIME_TEAM_ID") or prime_config.get("team_id")
+        if team_id:
+            headers = {**config.extra_headers, "X-Prime-Team-ID": team_id}
+
     # Setup client
     http_client = AsyncClient(
         limits=limits,
         timeout=http_timeout,
-        headers=config.extra_headers,
+        headers=headers,
     )
     client = AsyncOpenAI(
         base_url=config.api_base_url,
-        api_key=os.getenv(config.api_key_var, "EMPTY"),
+        api_key=api_key or "EMPTY",
         max_retries=config.max_retries,
         http_client=http_client,
     )


### PR DESCRIPTION
## Description
When using `PRIME_API_KEY` (the default), automatically reads credentials from `~/.prime/config.json` if environment variables are not set. This allows verifiers to work seamlessly after running `prime login`.

**Precedence order:**
- API key: `PRIME_API_KEY` env var > `~/.prime/config.json` > `"EMPTY"`
- Team ID: `PRIME_TEAM_ID` env var > `~/.prime/config.json` > `None`

When team_id is configured, automatically adds `X-Prime-Team-ID` header to requests.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Testing
- [x] All existing tests pass when running `uv run pytest` locally.

Manually tested:
- API key read from env var when set
- API key read from config file when env var not set
- Team ID header added when using PRIME_API_KEY
- No prime config fallback when using other api_key_var (e.g. OPENAI_API_KEY)

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes
Also changed `extra_headers` default in `ClientConfig` from `None` to `{}` for cleaner code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements prime CLI credential fallback and header injection for smoother defaults.
> 
> - Add `load_prime_config` and update `setup_client` to read API key/team ID from env or `~/.prime/config.json` when `api_key_var` is `"PRIME_API_KEY"`, and set `X-Prime-Team-ID` header when present
> - Change `ClientConfig.extra_headers` default from `None` to `{}`
> - Update `docs/reference.md` to document credential precedence and new defaults
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ddc84ef181ab291cee35955189335fa6c6446923. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->