### PR TITLE
Allow CLI to override endpoint registry

### DIFF
--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -84,7 +84,7 @@ Then use the alias directly:
 prime eval run my-env -m qwen3-235b-i
 ```
 
-If the model name isn't found in the registry, the `--api-base-url` and `--api-key-var` flags are used instead.
+If the model name is in the registry, those values are used by default, but you can override them with `--api-base-url` and/or `--api-key-var`. If the model name isn't found, the CLI flags are used (falling back to defaults when omitted).
 
 ### Sampling Parameters
 
@@ -150,4 +150,3 @@ rollouts_per_example = 5
 ```
 
 These defaults are used when flags aren't explicitly provided. Priority order: CLI flags → environment defaults → global defaults.
-


### PR DESCRIPTION
## Description

Prior to this PR, the CLI arguments `--api-key-var` (`-k`) and `--api-base-url` (`-b`) were ignored if the model was found in the model registry.

This PR lets the CLI overwrite these arguments, and also adds a default fallback to prime inference when the model isn't in the registry and the api key var and api base url aren't provided through the CLI.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Behavior change**
> - `eval.py`: When `--model` matches the endpoints registry, CLI `--api-key-var`/`--api-base-url` can override registry `key`/`url`; when not in registry, fall back to `PRIME_API_KEY` and `https://api.pinference.ai/api/v1` if flags are unset.
> 
> **CLI/interface adjustments**
> - `--api-key-var` and `--api-base-url` defaults set to `None` with updated help text; new constants `DEFAULT_API_KEY_VAR` and `DEFAULT_API_BASE_URL` introduced; improved debug logging for source of config.
> 
> **Docs**
> - `docs/evaluation.md`: Clarifies that registry values are used by default but can be overridden by CLI, and documents fallback behavior and precedence.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f37aee3cb4d98c81ec49d1b545f7cd9d2d2a114. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->