### PR TITLE
filter out MathRubric timeout disabled warning

### DIFF
--- a/verifiers/rubrics/math_rubric.py
+++ b/verifiers/rubrics/math_rubric.py
@@ -12,6 +12,21 @@ from verifiers.types import Messages, RewardFunc
 from verifiers.utils.data_utils import extract_boxed_answer
 
 
+class _TimeoutWarningFilter(logging.Filter):
+    """Filter to suppress math_verify timeout disabled warnings."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        # Suppress the specific warning about timeout being disabled
+        if "Timeout is disabled" in record.getMessage():
+            return False
+        return True
+
+
+# Apply the filter once at module load time to ensure it's set before any MathRubric usage
+_grader_logger = logging.getLogger("math_verify.grader")
+_grader_logger.addFilter(_TimeoutWarningFilter())
+
+
 class MathRubric(Rubric):
     def __init__(
         self,


### PR DESCRIPTION
## Description
Fixes #621

Add a logging filter to suppress the "Timeout is disabled as timeout_seconds is None or <= 0" warning from `math_verify.grader`. This warning is expected since `MathRubric` handles timeouts via `asyncio.wait_for` instead of using `math_verify`'s internal signal-based timeout mechanism.

The existing `setLevel(logging.ERROR)` approach in `__init__` doesn't reliably suppress this warning in all cases (e.g., depending on logging configuration, handler hierarchy, or timing). Using a logging filter that specifically targets this message is more robust.

The filter is applied at module load time (before the `MathRubric` class definition) to ensure it's in place before any `MathRubric` instances are created.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
- [x] All existing tests pass when running `uv run pytest` locally.
- [x] Verified the warning is properly suppressed:
  - Without the filter: `WARNING:math_verify.grader:Timeout is disabled as timeout_seconds is None or <= 0...` appears
  - With the filter: No warning appears

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Suppresses a noisy warning from `math_verify.grader` to keep logs clean and avoid confusion.
> 
> - Add `_TimeoutWarningFilter` to drop "Timeout is disabled" messages
> - Apply the filter to `math_verify.grader` at module load time before any `MathRubric` usage
> - Retain existing logger level adjustments in `MathRubric.__init__`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e88aae81e23fefef422a502c654a7a64d0684dbe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->