### PR TITLE
log level ctx

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -652,3 +652,28 @@ vf.setup_logging(level: str = "INFO")
 ```
 
 Configure verifiers logging. Set `VF_LOG_LEVEL` env var to change default.
+
+```python
+vf.log_level(level: str | int)
+```
+
+Context manager to temporarily set the verifiers logger to a new log level. Useful for temporarily adjusting verbosity during specific operations.
+
+```python
+with vf.log_level("DEBUG"):
+    # verifiers logs at DEBUG level here
+    ...
+# reverts to previous level
+```
+
+```python
+vf.quiet_verifiers()
+```
+
+Context manager to temporarily silence verifiers logging by setting WARNING level. Shorthand for `vf.log_level("WARNING")`.
+
+```python
+with vf.quiet_verifiers():
+    # verifiers logging is quieted here
+    outputs = env.generate(...)
+# logging restored

--- a/tests/test_log_level.py
+++ b/tests/test_log_level.py
@@ -1,0 +1,66 @@
+import logging
+
+import verifiers as vf
+
+
+class TestLogLevel:
+    """Tests for the vf.log_level context manager."""
+
+    def test_log_level_changes_level_within_context(self):
+        """Verify that the log level is changed within the context."""
+        logger = logging.getLogger("verifiers")
+        original_level = logger.level
+
+        with vf.log_level("DEBUG"):
+            assert logger.level == logging.DEBUG
+
+        # Should be restored after exiting the context
+        assert logger.level == original_level
+
+    def test_log_level_accepts_string(self):
+        """Test that log_level accepts string level names."""
+        logger = logging.getLogger("verifiers")
+        original_level = logger.level
+
+        with vf.log_level("WARNING"):
+            assert logger.level == logging.WARNING
+
+        assert logger.level == original_level
+
+    def test_log_level_accepts_int(self):
+        """Test that log_level accepts integer level values."""
+        logger = logging.getLogger("verifiers")
+        original_level = logger.level
+
+        with vf.log_level(logging.ERROR):
+            assert logger.level == logging.ERROR
+
+        assert logger.level == original_level
+
+    def test_log_level_restores_on_exception(self):
+        """Verify the log level is restored even when an exception occurs."""
+        logger = logging.getLogger("verifiers")
+        original_level = logger.level
+
+        try:
+            with vf.log_level("CRITICAL"):
+                assert logger.level == logging.CRITICAL
+                raise ValueError("Test exception")
+        except ValueError:
+            pass
+
+        # Should still be restored after the exception
+        assert logger.level == original_level
+
+    def test_log_level_case_insensitive(self):
+        """Test that string level names are case-insensitive."""
+        logger = logging.getLogger("verifiers")
+        original_level = logger.level
+
+        with vf.log_level("debug"):
+            assert logger.level == logging.DEBUG
+
+        with vf.log_level("Debug"):
+            assert logger.level == logging.DEBUG
+
+        assert logger.level == original_level

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -3,6 +3,43 @@ import logging
 import verifiers as vf
 
 
+class TestSetupLogging:
+    """Tests for the vf.setup_logging function."""
+
+    def test_setup_logging_sets_level(self):
+        """Verify that setup_logging sets the log level."""
+        logger = logging.getLogger("verifiers")
+
+        vf.setup_logging("DEBUG")
+        assert logger.level == logging.DEBUG
+
+        vf.setup_logging("WARNING")
+        assert logger.level == logging.WARNING
+
+    def test_setup_logging_overrides_on_multiple_calls(self):
+        """Verify that calling setup_logging multiple times overrides the config."""
+        logger = logging.getLogger("verifiers")
+
+        vf.setup_logging("INFO")
+        assert logger.level == logging.INFO
+        assert len(logger.handlers) == 1
+
+        vf.setup_logging("DEBUG")
+        assert logger.level == logging.DEBUG
+        # Should still have exactly one handler, not two
+        assert len(logger.handlers) == 1
+
+    def test_setup_logging_case_insensitive(self):
+        """Test that level names are case-insensitive."""
+        logger = logging.getLogger("verifiers")
+
+        vf.setup_logging("debug")
+        assert logger.level == logging.DEBUG
+
+        vf.setup_logging("Warning")
+        assert logger.level == logging.WARNING
+
+
 class TestLogLevel:
     """Tests for the vf.log_level context manager."""
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -101,3 +101,31 @@ class TestLogLevel:
             assert logger.level == logging.DEBUG
 
         assert logger.level == original_level
+
+
+class TestQuietVerifiers:
+    """Tests for the vf.quiet_verifiers context manager."""
+
+    def test_quiet_verifiers_sets_warning_level(self):
+        """Verify that quiet_verifiers sets the log level to WARNING."""
+        logger = logging.getLogger("verifiers")
+        original_level = logger.level
+
+        with vf.quiet_verifiers():
+            assert logger.level == logging.WARNING
+
+        assert logger.level == original_level
+
+    def test_quiet_verifiers_restores_on_exception(self):
+        """Verify the log level is restored even when an exception occurs."""
+        logger = logging.getLogger("verifiers")
+        original_level = logger.level
+
+        try:
+            with vf.quiet_verifiers():
+                assert logger.level == logging.WARNING
+                raise ValueError("Test exception")
+        except ValueError:
+            pass
+
+        assert logger.level == original_level

--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -1,10 +1,8 @@
 __version__ = "0.1.9.post3"
 
 import importlib
-import logging
 import os
-import sys
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 # early imports to avoid circular dependencies
 from .errors import *  # noqa # isort: skip
@@ -35,44 +33,13 @@ from .utils.data_utils import (
     load_example_dataset,
 )
 from .utils.env_utils import load_environment
-from .utils.logging_utils import log_level, print_prompt_completions_sample
-
+from .utils.logging_utils import (
+    log_level,
+    print_prompt_completions_sample,
+    setup_logging,
+)
 
 # Setup default logging configuration
-def setup_logging(
-    level: str = "INFO",
-    log_format: Optional[str] = None,
-    date_format: Optional[str] = None,
-) -> None:
-    """
-    Setup basic logging configuration for the verifiers package.
-
-    Args:
-        level: The logging level to use. Defaults to "INFO".
-        log_format: Custom log format string. If None, uses default format.
-        date_format: Custom date format string. If None, uses default format.
-    """
-    if log_format is None:
-        log_format = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-    if date_format is None:
-        date_format = "%Y-%m-%d %H:%M:%S"
-
-    # Create a StreamHandler that writes to stderr
-    handler = logging.StreamHandler(sys.stderr)
-    handler.setFormatter(logging.Formatter(fmt=log_format, datefmt=date_format))
-
-    # Get the root logger for the verifiers package
-    logger = logging.getLogger("verifiers")
-    # Remove any existing handlers to avoid duplicates
-    logger.handlers.clear()
-    # Add a new handler with desired log level
-    logger.setLevel(level.upper())
-    logger.addHandler(handler)
-
-    # Prevent the logger from propagating messages to the root logger
-    logger.propagate = False
-
-
 setup_logging(os.getenv("VF_LOG_LEVEL", "INFO"))
 
 __all__ = [

--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -73,6 +73,37 @@ def setup_logging(
     logger.propagate = False
 
 
+class log_level:
+    """
+    Context manager to temporarily set the verifiers logger to a new log level.
+    Useful for temporarily silencing verifiers logging.
+
+    with log_level("DEBUG"):
+        # verifiers logs at DEBUG level here
+        ...
+    # reverts to previous level
+    """
+
+    def __init__(self, log_level: str | int):
+        self.log_level = (
+            log_level
+            if isinstance(log_level, int)
+            else getattr(logging, log_level.upper())
+        )
+        self.logger = logging.getLogger("verifiers")
+        self.previous_level: int | None = None
+
+    def __enter__(self):
+        self.previous_level = self.logger.level
+        self.logger.setLevel(self.log_level)
+        return self
+
+    def __exit__(self, _exc_type, _exc_val, _exc_tb):
+        if self.previous_level is not None:
+            self.logger.setLevel(self.previous_level)
+        return False
+
+
 setup_logging(os.getenv("VF_LOG_LEVEL", "INFO"))
 
 __all__ = [
@@ -102,6 +133,7 @@ __all__ = [
     "extract_hash_answer",
     "load_example_dataset",
     "setup_logging",
+    "log_level",
     "load_environment",
     "print_prompt_completions_sample",
     "get_model",

--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -35,7 +35,7 @@ from .utils.data_utils import (
     load_example_dataset,
 )
 from .utils.env_utils import load_environment
-from .utils.logging_utils import print_prompt_completions_sample
+from .utils.logging_utils import log_level, print_prompt_completions_sample
 
 
 # Setup default logging configuration
@@ -71,37 +71,6 @@ def setup_logging(
 
     # Prevent the logger from propagating messages to the root logger
     logger.propagate = False
-
-
-class log_level:
-    """
-    Context manager to temporarily set the verifiers logger to a new log level.
-    Useful for temporarily silencing verifiers logging.
-
-    with log_level("DEBUG"):
-        # verifiers logs at DEBUG level here
-        ...
-    # reverts to previous level
-    """
-
-    def __init__(self, log_level: str | int):
-        self.log_level = (
-            log_level
-            if isinstance(log_level, int)
-            else getattr(logging, log_level.upper())
-        )
-        self.logger = logging.getLogger("verifiers")
-        self.previous_level: int | None = None
-
-    def __enter__(self):
-        self.previous_level = self.logger.level
-        self.logger.setLevel(self.log_level)
-        return self
-
-    def __exit__(self, _exc_type, _exc_val, _exc_tb):
-        if self.previous_level is not None:
-            self.logger.setLevel(self.previous_level)
-        return False
 
 
 setup_logging(os.getenv("VF_LOG_LEVEL", "INFO"))

--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -36,6 +36,7 @@ from .utils.env_utils import load_environment
 from .utils.logging_utils import (
     log_level,
     print_prompt_completions_sample,
+    quiet_verifiers,
     setup_logging,
 )
 
@@ -70,6 +71,7 @@ __all__ = [
     "load_example_dataset",
     "setup_logging",
     "log_level",
+    "quiet_verifiers",
     "load_environment",
     "print_prompt_completions_sample",
     "get_model",

--- a/verifiers/utils/logging_utils.py
+++ b/verifiers/utils/logging_utils.py
@@ -12,6 +12,8 @@ from verifiers.errors import Error
 from verifiers.types import Messages
 from verifiers.utils.error_utils import ErrorChain
 
+LOGGER_NAME = "verifiers"
+
 
 def setup_logging(
     level: str = "INFO",
@@ -34,7 +36,9 @@ def setup_logging(
     handler = logging.StreamHandler(sys.stderr)
     handler.setFormatter(logging.Formatter(fmt=log_format, datefmt=date_format))
 
-    logger = logging.getLogger("verifiers")
+    logger = logging.getLogger(LOGGER_NAME)
+    # Remove any existing handlers to avoid duplicates
+    logger.handlers.clear()
     logger.setLevel(level.upper())
     logger.addHandler(handler)
 
@@ -59,7 +63,7 @@ class log_level:
             if isinstance(log_level, int)
             else getattr(logging, log_level.upper())
         )
-        self.logger = logging.getLogger("verifiers")
+        self.logger = logging.getLogger(LOGGER_NAME)
         self.previous_level: int | None = None
 
     def __enter__(self):

--- a/verifiers/utils/logging_utils.py
+++ b/verifiers/utils/logging_utils.py
@@ -42,6 +42,37 @@ def setup_logging(
     logger.propagate = False
 
 
+class log_level:
+    """
+    Context manager to temporarily set the verifiers logger to a new log level.
+    Useful for temporarily silencing verifiers logging.
+
+    with log_level("DEBUG"):
+        # verifiers logs at DEBUG level here
+        ...
+    # reverts to previous level
+    """
+
+    def __init__(self, log_level: str | int):
+        self.log_level = (
+            log_level
+            if isinstance(log_level, int)
+            else getattr(logging, log_level.upper())
+        )
+        self.logger = logging.getLogger("verifiers")
+        self.previous_level: int | None = None
+
+    def __enter__(self):
+        self.previous_level = self.logger.level
+        self.logger.setLevel(self.log_level)
+        return self
+
+    def __exit__(self, _exc_type, _exc_val, _exc_tb):
+        if self.previous_level is not None:
+            self.logger.setLevel(self.previous_level)
+        return False
+
+
 def print_prompt_completions_sample(
     prompts: list[Messages],
     completions: list[Messages],


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

This PR introduces a small QoL logging improvement `vf.log_level` which is a context manager to temporarily change the log level

```python
>>> import verifiers as vf
>>> import logging
>>> logging.getLogger("verifiers").info("Hi")
2026-01-14 12:21:25 - verifiers - INFO - Hi
>>> with vf.log_level("ERROR"):
...     logging.getLogger("verifiers").info("Hi")
>>>
```

Note that the second info log does not show. Additionally:
- removes the redundant `setup_logging` function in the package init because it already exists in `logging_utils` (just need the clear handlers call, so that it can be called multiple times without stacking handlers)
- adds some basic unit tests for the intended behavior

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [x] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces temporary logging controls and consolidates logging setup.
> 
> - Adds `vf.log_level(level: str | int)` and `vf.quiet_verifiers()` context managers in `utils/logging_utils.py` to adjust/silence `verifiers` logger within a `with` block
> - Moves and standardizes `setup_logging` in `utils/logging_utils.py` (clears existing handlers to avoid duplicates) and removes redundant init implementation
> - Exposes `setup_logging`, `log_level`, and `quiet_verifiers` via `verifiers/__init__.py` and initializes with `VF_LOG_LEVEL`
> - Updates `docs/reference.md` with new logging utilities and examples
> - Adds `tests/test_logging.py` covering level setting, handler non-duplication, context behavior, and exception safety
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b36d7b637fadbc14afc367f1603be8d897042a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->