### PR TITLE
allow eval only env group

### DIFF
--- a/tests/test_env_group.py
+++ b/tests/test_env_group.py
@@ -462,6 +462,36 @@ class TestEnvGroup:
         assert eval_dataset["task"][0] == "task1"
         assert eval_dataset["task"][1] == "task2"
 
+    def test_env_group_with_only_eval_datasets(self, mock_openai_client):
+        """Test EnvGroup with environments that only have eval datasets (no train datasets)."""
+        # Environment with only eval dataset
+        env1 = SingleTurnEnv(
+            client=mock_openai_client,
+            model="test-model",
+            eval_dataset=Dataset.from_dict({"question": ["eq1"], "answer": ["ea1"]}),
+            rubric=Rubric(),
+        )
+
+        # Another environment with only eval dataset
+        env2 = SingleTurnEnv(
+            client=mock_openai_client,
+            model="test-model",
+            eval_dataset=Dataset.from_dict({"question": ["eq2"], "answer": ["ea2"]}),
+            rubric=Rubric(),
+        )
+
+        env_group = EnvGroup(envs=[env1, env2], env_names=["task1", "task2"])
+
+        # Train dataset should be None
+        assert env_group.dataset is None
+
+        # Should have concatenated eval datasets from both
+        eval_dataset = env_group.eval_dataset
+        assert eval_dataset is not None
+        assert len(eval_dataset) == 2
+        assert eval_dataset["task"][0] == "task1"
+        assert eval_dataset["task"][1] == "task2"
+
     def test_env_group_task_assignment_on_iteration(self, mock_openai_client):
         """Test that task values are correct when iterating over dataset rows.
 

--- a/verifiers/envs/env_group.py
+++ b/verifiers/envs/env_group.py
@@ -170,14 +170,16 @@ class EnvGroup(vf.Environment):
         for env, name in zip(self.envs, self.env_names):
             add_task = make_add_task_fn(name)
 
-            env_dataset = env.get_dataset()
+            # Access dataset directly to avoid get_dataset() raising when None
+            env_dataset = env.dataset
             if env_dataset is not None:
                 # override task column to use env_name for routing
                 if "task" in env_dataset.column_names:
                     env_dataset = env_dataset.remove_columns(["task"])
                 env_dataset = env_dataset.map(add_task, **map_kwargs)
                 datasets.append(env_dataset)
-            env_eval_dataset = env.get_eval_dataset()
+            # Access eval_dataset directly to avoid get_eval_dataset() raising when None
+            env_eval_dataset = env.eval_dataset
             if env_eval_dataset is not None:
                 # override task column to use env_name for routing
                 if "task" in env_eval_dataset.column_names:


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Previously, creating an `vf.EnvGroup` with eval envs (do not contain `dataset`) would fail because calls to `get_dataset` would raise. This PR fixes this and adds a test so that we don't break this behavior in the future.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [x] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes `EnvGroup` compatible with environments that have only eval datasets.
> 
> - In `EnvGroup.__init__`, access `env.dataset`/`env.eval_dataset` directly (instead of `get_dataset`/`get_eval_dataset`) to avoid exceptions when train datasets are missing; still map `task` and concatenate when present
> - Add `test_env_group_with_only_eval_datasets` to verify `dataset is None` and concatenated `eval_dataset` with correct `task` labels
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e8f6a731ae8e925a54c88b46f38f63f69529c1ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->