### PR TITLE
debug init log in rubric group

### DIFF
--- a/verifiers/rubrics/rubric_group.py
+++ b/verifiers/rubrics/rubric_group.py
@@ -17,7 +17,7 @@ class RubricGroup(Rubric):
             raise ValueError("RubricGroup must have at least one rubric")
         super().__init__(**kwargs)
         self.rubrics = rubrics
-        self.logger.info(f"Initialized RubricGroup with {len(rubrics)} rubrics")
+        self.logger.debug(f"Initialized RubricGroup with {len(rubrics)} rubrics")
 
     def _get_reward_func_names(self) -> list[str]:
         names = []


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

demotes the init log in rubric group to a debug log because it is a bit spammy, espcially in conjunction with env groups + monitor rubrics

<img width="954" height="322" alt="Screenshot 2026-01-14 at 5 11 01 PM" src="https://github.com/user-attachments/assets/0aafb841-c8fd-4a73-983d-1d14c91582d9" />


## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reduces logging verbosity for rubric aggregation initialization.
> 
> - Changes `logger.info` to `logger.debug` in `RubricGroup.__init__` to minimize log noise during construction
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0122e3d5a67062093cbcb3d182ed48c394aa8bf4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->