### PR TITLE
Refactor eval configs: add EvalRunConfig and separate run-level vs env-level settings

### DIFF
--- a/configs/evals/multi-env-single-model.toml
+++ b/configs/evals/multi-env-single-model.toml
@@ -1,0 +1,19 @@
+[env]
+num_examples = 10
+rollouts_per_example = 2
+
+[model]
+model = "openai/gpt-4.1-mini"
+max_concurrent = 32
+
+[save]
+save_results = true
+
+[[eval]]
+[eval.env]
+env_id = "gsm8k"
+
+[[eval]]
+[eval.env]
+env_id = "alphabet-sort"
+num_examples = 5

--- a/configs/evals/single-env-multi-model.toml
+++ b/configs/evals/single-env-multi-model.toml
@@ -1,0 +1,26 @@
+[env]
+num_examples = 5
+rollouts_per_example = 1
+
+[save]
+save_results = true
+
+[[eval]]
+[eval.env]
+env_id = "math-python"
+
+[eval.model]
+model = "openai/gpt-4.1-mini"
+
+[eval.save]
+hf_hub_dataset_name = "math-python-gpt-4.1-mini"
+
+[[eval]]
+[eval.env]
+env_id = "math-python"
+
+[eval.model]
+model = "qwen3-235b-i"
+
+[eval.save]
+hf_hub_dataset_name = "math-python-qwen3-235b-i"

--- a/configs/evals/single-env-multi-model.toml
+++ b/configs/evals/single-env-multi-model.toml
@@ -1,26 +1,16 @@
 [env]
+env_id = "math-python"
 num_examples = 5
 rollouts_per_example = 1
 
-[save]
-save_results = true
+[[eval]]
+[eval.model]
+model = "openai/gpt-5-nano"
 
 [[eval]]
-[eval.env]
-env_id = "math-python"
-
 [eval.model]
-model = "openai/gpt-4.1-mini"
-
-[eval.save]
-hf_hub_dataset_name = "math-python-gpt-4.1-mini"
+model = "openai/gpt-5-mini"
 
 [[eval]]
-[eval.env]
-env_id = "math-python"
-
 [eval.model]
-model = "qwen3-235b-i"
-
-[eval.save]
-hf_hub_dataset_name = "math-python-qwen3-235b-i"
+model = "openai/gpt-5"

--- a/configs/local/vf-eval/debug.toml
+++ b/configs/local/vf-eval/debug.toml
@@ -1,5 +1,7 @@
 [[env]]
 id = "gsm8k"
+num_examples = 1
+rollouts_per_example = 1
 
 [[env]]
 id = "alphabet-sort"

--- a/configs/local/vf-eval/debug.toml
+++ b/configs/local/vf-eval/debug.toml
@@ -1,0 +1,5 @@
+[[env]]
+id = "gsm8k"
+
+[[env]]
+id = "alphabet-sort"

--- a/configs/local/vf-eval/debug.toml
+++ b/configs/local/vf-eval/debug.toml
@@ -1,7 +1,7 @@
 [[env]]
-id = "gsm8k"
+env_id = "gsm8k"
 num_examples = 1
 rollouts_per_example = 1
 
 [[env]]
-id = "alphabet-sort"
+env_id = "alphabet-sort"

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -214,7 +214,7 @@ env_id = "math-python"
 # Uses CLI args or defaults for num_examples and rollouts_per_example
 ```
 
-Each `[[env]]` section must contain an `env_id` field. All other fields are optional and correspond to the same options available via CLI flags:
+Each `[[env]]` section must contain an `env_id` field. All other fields are optional and correspond to per-environment options:
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -222,7 +222,6 @@ Each `[[env]]` section must contain an `env_id` field. All other fields are opti
 | `env_args` | table | Arguments passed to `load_environment()` |
 | `num_examples` | integer | Number of dataset examples to evaluate |
 | `rollouts_per_example` | integer | Rollouts per example |
-| `extra_env_kwargs` | table | Arguments passed to environment constructor |
 
 Example with `env_args`:
 
@@ -238,7 +237,7 @@ split = "test"
 
 ### Configuration Precedence
 
-Settings are resolved with the following priority order (highest to lowest):
+Settings are resolved with the following priority order (highest to lowest) for per-environment fields:
 
 1. **TOML per-environment settings** — Values specified in `[[env]]` sections
 2. **CLI arguments** — Flags passed on the command line
@@ -261,3 +260,5 @@ env_id = "alphabet-sort"
 # gsm8k uses 100 examples (from TOML), alphabet-sort uses 10 (from CLI)
 prime eval run configs/eval/mixed.toml -n 10
 ```
+
+Run-level settings (model, sampling args, concurrency, saving, etc.) are configured via CLI flags and apply to all environments in the run. These are not set in the TOML file, so CLI flags always win for those settings.

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -239,10 +239,10 @@ Eval TOML files define an evaluation run with defaults plus one or more `[[eval]
 | `[model]` or `[eval.model]` | `api_key_var` | string | API key env var name override |
 | `[model]` or `[eval.model]` | `api_base_url` | string | API base URL override |
 | `[model]` or `[eval.model]` | `extra_headers` | table | Extra HTTP headers |
-| `[save]` | `save_results` | boolean | Save results to disk |
-| `[save]` | `save_every` | integer | Save every N rollouts |
-| `[save]` | `save_to_hf_hub` | boolean | Save dataset to Hugging Face Hub |
-| `[save]` | `hf_hub_dataset_name` | string | Hugging Face dataset name override |
+| `[save]` or `[eval.save]` | `save_results` | boolean | Save results to disk |
+| `[save]` or `[eval.save]` | `save_every` | integer | Save every N rollouts |
+| `[save]` or `[eval.save]` | `save_to_hf_hub` | boolean | Save dataset to Hugging Face Hub |
+| `[save]` or `[eval.save]` | `hf_hub_dataset_name` | string | Hugging Face dataset name override |
 
 Example with defaults and per-eval overrides:
 
@@ -275,6 +275,9 @@ env_id = "gsm8k"
 
 [eval.model]
 model = "qwen3-235b-i"
+
+[eval.save]
+hf_hub_dataset_name = "gsm8k-qwen3-235b-i"
 ```
 
 ### Configuration Precedence
@@ -315,4 +318,8 @@ Model settings resolve with the following priority (highest to lowest):
 2. **TOML model defaults** — Values in `[model]`
 3. **CLI arguments** — Flags passed on the command line
 
-Save settings resolve with CLI flags taking precedence over `[save]` defaults.
+Save settings resolve with the following priority (highest to lowest):
+
+1. **Per-eval TOML save settings** — Values in `[eval.save]`
+2. **TOML save defaults** — Values in `[save]`
+3. **CLI arguments** — Flags passed on the command line

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -557,6 +557,7 @@ class EvalModelConfig(BaseModel):
 class EvalConfig(BaseModel):
     env: EvalEnvConfig
     model: EvalModelConfig
+    save: EvalSaveConfig
 ```
 
 ### EvalRunConfig
@@ -565,6 +566,12 @@ class EvalConfig(BaseModel):
 class EvalRunConfig(BaseModel):
     evals: list[EvalConfig]
     env_dir_path: str
+```
+
+### EvalSaveConfig
+
+```python
+class EvalSaveConfig(BaseModel):
     save_results: bool = False
     save_every: int = -1
     save_to_hf_hub: bool = False

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -531,18 +531,25 @@ This allows seamless use after running `prime login`.
 ```python
 class EvalConfig(BaseModel):
     env_id: str
-    env_args: dict
+    env_args: dict = {}
+    num_examples: int
+    rollouts_per_example: int
+```
+
+### EvalRunConfig
+
+```python
+class EvalRunConfig(BaseModel):
+    env: list[EvalConfig]
     env_dir_path: str
     model: str
     client_config: ClientConfig
     sampling_args: SamplingArgs
-    num_examples: int
-    rollouts_per_example: int
     max_concurrent: int
     max_concurrent_generation: int | None = None
     max_concurrent_scoring: int | None = None
+    independent_scoring: bool = False
     extra_env_kwargs: dict = {}
-    print_results: bool = False
     verbose: bool = False
     state_columns: list[str] | None = None
     save_results: bool = False

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -526,32 +526,45 @@ When `api_key_var` is `"PRIME_API_KEY"` (the default), credentials are loaded wi
 
 This allows seamless use after running `prime login`.
 
-### EvalConfig
+### EvalEnvConfig
 
 ```python
-class EvalConfig(BaseModel):
+class EvalEnvConfig(BaseModel):
     env_id: str
     env_args: dict = {}
     num_examples: int
     rollouts_per_example: int
+    interleave_scoring: bool = True
+    state_columns: list[str] | None = None
+    extra_env_kwargs: dict = {}
 ```
 
-### EvalRunConfig
+### EvalModelConfig
 
 ```python
-class EvalRunConfig(BaseModel):
-    env: list[EvalConfig]
-    env_dir_path: str
+class EvalModelConfig(BaseModel):
     model: str
     client_config: ClientConfig
     sampling_args: SamplingArgs
     max_concurrent: int
     max_concurrent_generation: int | None = None
     max_concurrent_scoring: int | None = None
-    independent_scoring: bool = False
-    extra_env_kwargs: dict = {}
-    verbose: bool = False
-    state_columns: list[str] | None = None
+```
+
+### EvalConfig
+
+```python
+class EvalConfig(BaseModel):
+    env: EvalEnvConfig
+    model: EvalModelConfig
+```
+
+### EvalRunConfig
+
+```python
+class EvalRunConfig(BaseModel):
+    evals: list[EvalConfig]
+    env_dir_path: str
     save_results: bool = False
     save_every: int = -1
     save_to_hf_hub: bool = False

--- a/tests/test_eval_cli.py
+++ b/tests/test_eval_cli.py
@@ -1,10 +1,24 @@
 import argparse
+import tempfile
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 import verifiers.scripts.eval as vf_eval
 import verifiers.utils.eval_utils
-from verifiers.types import GenerateMetadata, GenerateOutputs
+from verifiers.types import (
+    EvalConfig,
+    GenerateMetadata,
+    GenerateOutputs,
+    MultiEvalConfig,
+    State,
+)
+from verifiers.utils.eval_utils import (
+    get_results_by_task,
+    is_toml_config,
+    load_toml_config,
+)
 
 
 def _make_metadata(config) -> GenerateMetadata:
@@ -25,7 +39,65 @@ def _make_metadata(config) -> GenerateMetadata:
     )
 
 
-def _run_cli(monkeypatch, overrides):
+def _make_generate_outputs(
+    env_id: str = "test-env",
+    model: str = "gpt-4.1-mini",
+    num_examples: int = 1,
+    rollouts_per_example: int = 1,
+    rewards: list[float] | None = None,
+    tasks: list[str] | None = None,
+) -> GenerateOutputs:
+    """Helper to create GenerateOutputs for testing."""
+    n = num_examples * rollouts_per_example
+    rewards = rewards or [1.0] * n
+    tasks = tasks or ["default"] * n
+    return GenerateOutputs(
+        prompt=[[{"role": "user", "content": "p"}] for _ in range(n)],
+        completion=[[{"role": "assistant", "content": "c"}] for _ in range(n)],
+        answer=["" for _ in range(n)],
+        state=[
+            State(
+                timing={
+                    "generation_ms": 100.0,
+                    "scoring_ms": 50.0,
+                    "total_ms": 150.0,
+                }
+            )
+            for _ in range(n)
+        ],
+        task=tasks,
+        info=[{} for _ in range(n)],
+        example_id=list(range(n)),
+        reward=rewards,
+        metrics={"accuracy": rewards},
+        stop_conditions=[None for _ in range(n)],
+        is_truncated=[False for _ in range(n)],
+        metadata=GenerateMetadata(
+            env_id=env_id,
+            env_args={},
+            model=model,
+            base_url="https://api.openai.com/v1",
+            num_examples=num_examples,
+            rollouts_per_example=rollouts_per_example,
+            sampling_args={"max_tokens": 100},
+            date="1970-01-01",
+            time_ms=0.0,
+            avg_reward=sum(rewards) / len(rewards),
+            avg_metrics={},
+            state_columns=[],
+            path_to_save=Path("test.jsonl"),
+        ),
+    )
+
+
+def _run_cli(monkeypatch, overrides, capture_all_configs: bool = False):
+    """Run CLI with mocked arguments and capture config(s).
+
+    Args:
+        monkeypatch: pytest monkeypatch fixture
+        overrides: dict of args to override
+        capture_all_configs: if True, returns list of all configs (for multi-env)
+    """
     base_args = {
         "env_id_or_path": "dummy-env",
         "env_args": {},
@@ -57,7 +129,7 @@ def _run_cli(monkeypatch, overrides):
     base_args.update(overrides)
     args_namespace = SimpleNamespace(**base_args)
 
-    captured: dict[str, dict] = {}
+    captured: dict = {"sampling_args": None, "configs": []}
 
     monkeypatch.setattr(
         argparse.ArgumentParser,
@@ -69,19 +141,20 @@ def _run_cli(monkeypatch, overrides):
 
     async def fake_run_evaluation(config):
         captured["sampling_args"] = dict(config.sampling_args)
+        captured["configs"].append(config)
         metadata = _make_metadata(config)
         return GenerateOutputs(
             prompt=[[{"role": "user", "content": "p"}]],
             completion=[[{"role": "assistant", "content": "c"}]],
             answer=[""],
             state=[
-                {
-                    "timing": {
+                State(
+                    timing={
                         "generation_ms": 0.0,
                         "scoring_ms": 0.0,
                         "total_ms": 0.0,
                     }
-                }
+                )
             ],
             task=["default"],
             info=[{}],
@@ -101,7 +174,13 @@ def _run_cli(monkeypatch, overrides):
     return captured
 
 
+# =============================================================================
+# Tests for sampling args CLI handling
+# =============================================================================
+
+
 def test_cli_sampling_args_precedence_over_flags(monkeypatch):
+    """sampling_args JSON takes precedence over individual flags."""
     captured = _run_cli(
         monkeypatch,
         {
@@ -120,6 +199,7 @@ def test_cli_sampling_args_precedence_over_flags(monkeypatch):
 
 
 def test_cli_sampling_args_fill_from_flags_when_missing(monkeypatch):
+    """Flags fill in missing sampling_args values."""
     captured = _run_cli(
         monkeypatch,
         {
@@ -133,3 +213,1007 @@ def test_cli_sampling_args_fill_from_flags_when_missing(monkeypatch):
     assert sa["max_tokens"] == 55
     assert sa["temperature"] == 0.8
     assert sa["enable_thinking"] is True
+
+
+def test_cli_no_sampling_args_uses_flags(monkeypatch):
+    """When no sampling_args provided, uses flag values."""
+    captured = _run_cli(
+        monkeypatch,
+        {
+            "sampling_args": None,
+            "max_tokens": 128,
+            "temperature": 0.5,
+        },
+    )
+
+    sa = captured["sampling_args"]
+    assert sa["max_tokens"] == 128
+    assert sa["temperature"] == 0.5
+
+
+def test_cli_temperature_not_added_when_none(monkeypatch):
+    """Temperature flag with None is not added to sampling_args."""
+    captured = _run_cli(
+        monkeypatch,
+        {
+            "sampling_args": None,
+            "max_tokens": 100,
+            "temperature": None,
+        },
+    )
+
+    sa = captured["sampling_args"]
+    assert sa["max_tokens"] == 100
+    assert "temperature" not in sa
+
+
+# =============================================================================
+# Tests for is_toml_config
+# =============================================================================
+
+
+def test_is_toml_config_with_valid_toml():
+    """Valid TOML file path returns True."""
+    with tempfile.NamedTemporaryFile(suffix=".toml", delete=False) as f:
+        f.write(b"[[env]]\nenv_id = 'test'\n")
+        f.flush()
+        assert is_toml_config(f.name) is True
+
+
+def test_is_toml_config_with_nonexistent_file():
+    """Nonexistent file returns False."""
+    assert is_toml_config("/nonexistent/path/config.toml") is False
+
+
+def test_is_toml_config_with_non_toml_extension():
+    """File with non-toml extension returns False."""
+    with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as f:
+        f.write(b"test: value\n")
+        f.flush()
+        assert is_toml_config(f.name) is False
+
+
+def test_is_toml_config_with_directory():
+    """Directory path returns False."""
+    with tempfile.TemporaryDirectory() as d:
+        assert is_toml_config(d) is False
+
+
+def test_is_toml_config_with_env_id():
+    """Simple env ID string returns False."""
+    assert is_toml_config("gsm8k") is False
+    assert is_toml_config("primeintellect/math-python") is False
+
+
+# =============================================================================
+# Tests for load_toml_config
+# =============================================================================
+
+
+def test_load_toml_config_single_env():
+    """Single [[env]] section loads correctly."""
+    with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
+        f.write('[[env]]\nenv_id = "gsm8k"\n')
+        f.flush()
+        result = load_toml_config(Path(f.name))
+        assert len(result) == 1
+        assert result[0]["env_id"] == "gsm8k"
+
+
+def test_load_toml_config_multi_env():
+    """Multiple [[env]] sections load correctly."""
+    with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
+        f.write('[[env]]\nenv_id = "gsm8k"\n\n[[env]]\nenv_id = "math-python"\n')
+        f.flush()
+        result = load_toml_config(Path(f.name))
+        assert len(result) == 2
+        assert result[0]["env_id"] == "gsm8k"
+        assert result[1]["env_id"] == "math-python"
+
+
+def test_load_toml_config_with_env_args():
+    """[[env]] section with env_args field loads correctly."""
+    with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
+        f.write(
+            '[[env]]\nenv_id = "test-env"\n[env.env_args]\nsplit = "train"\nmax_examples = 100\n'
+        )
+        f.flush()
+        result = load_toml_config(Path(f.name))
+        assert len(result) == 1
+        assert result[0]["env_id"] == "test-env"
+        assert result[0]["env_args"]["split"] == "train"
+        assert result[0]["env_args"]["max_examples"] == 100
+
+
+def test_load_toml_config_missing_file():
+    """Missing file raises FileNotFoundError."""
+    with pytest.raises(FileNotFoundError):
+        load_toml_config(Path("/nonexistent/path/config.toml"))
+
+
+def test_load_toml_config_missing_env_section():
+    """TOML without [[env]] section raises ValueError."""
+    with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
+        f.write('model = "gpt-4"\nmax_tokens = 100\n')
+        f.flush()
+        with pytest.raises(ValueError, match="must contain at least one"):
+            load_toml_config(Path(f.name))
+
+
+def test_load_toml_config_empty_env_list():
+    """Empty env list raises ValueError."""
+    with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
+        f.write("env = []\n")
+        f.flush()
+        with pytest.raises(ValueError, match="must contain at least one"):
+            load_toml_config(Path(f.name))
+
+
+def test_load_toml_config_missing_env_id():
+    """[[env]] without env_id field raises ValueError."""
+    with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
+        f.write('[[env]]\nname = "test"\n')
+        f.flush()
+        with pytest.raises(ValueError, match="must contain an env_id field"):
+            load_toml_config(Path(f.name))
+
+
+def test_load_toml_config_partial_missing_env_id():
+    """Some [[env]] sections missing env_id raises ValueError."""
+    with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
+        f.write('[[env]]\nenv_id = "valid"\n\n[[env]]\nname = "no-id"\n')
+        f.flush()
+        with pytest.raises(ValueError, match="must contain an env_id field"):
+            load_toml_config(Path(f.name))
+
+
+def test_load_toml_config_invalid_field():
+    """[[env]] with invalid field raises ValueError."""
+    with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
+        f.write('[[env]]\nenv_id = "test"\ninvalid_field = "value"\n')
+        f.flush()
+        with pytest.raises(ValueError, match="Invalid field"):
+            load_toml_config(Path(f.name))
+
+
+# =============================================================================
+# Tests for get_results_by_task
+# =============================================================================
+
+
+def test_get_results_by_task_single_task():
+    """Results with single task returns one group."""
+    results = _make_generate_outputs(
+        num_examples=3,
+        rollouts_per_example=1,
+        tasks=["default", "default", "default"],
+        rewards=[0.5, 0.7, 0.9],
+    )
+    by_task = get_results_by_task(results)
+
+    assert len(by_task) == 1
+    assert "default" in by_task
+    assert len(by_task["default"]["reward"]) == 3
+    assert by_task["default"]["reward"] == [0.5, 0.7, 0.9]
+
+
+def test_get_results_by_task_multiple_tasks():
+    """Results with multiple tasks are grouped correctly."""
+    results = _make_generate_outputs(
+        num_examples=4,
+        rollouts_per_example=1,
+        tasks=["math", "code", "math", "code"],
+        rewards=[0.5, 0.6, 0.7, 0.8],
+    )
+    by_task = get_results_by_task(results)
+
+    assert len(by_task) == 2
+    assert "math" in by_task
+    assert "code" in by_task
+    assert by_task["math"]["reward"] == [0.5, 0.7]
+    assert by_task["code"]["reward"] == [0.6, 0.8]
+
+
+def test_get_results_by_task_preserves_metadata():
+    """Grouped results preserve metadata."""
+    results = _make_generate_outputs(
+        env_id="test-env",
+        num_examples=2,
+        rollouts_per_example=1,
+        tasks=["task1", "task2"],
+    )
+    by_task = get_results_by_task(results)
+
+    # Both task groups should have the same metadata
+    assert by_task["task1"]["metadata"]["env_id"] == "test-env"
+    assert by_task["task2"]["metadata"]["env_id"] == "test-env"
+
+
+def test_get_results_by_task_preserves_metrics():
+    """Grouped results preserve metrics correctly."""
+    results = _make_generate_outputs(
+        num_examples=4,
+        rollouts_per_example=1,
+        tasks=["a", "b", "a", "b"],
+        rewards=[0.1, 0.2, 0.3, 0.4],
+    )
+    by_task = get_results_by_task(results)
+
+    # Metrics should be split by task
+    assert by_task["a"]["metrics"]["accuracy"] == [0.1, 0.3]
+    assert by_task["b"]["metrics"]["accuracy"] == [0.2, 0.4]
+
+
+# =============================================================================
+# Tests for multi-env evaluation via TOML config
+# =============================================================================
+
+
+def test_cli_multi_env_via_toml_config(monkeypatch):
+    """CLI with TOML config creates multiple eval configs."""
+    with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
+        f.write('[[env]]\nenv_id = "env-one"\n\n[[env]]\nenv_id = "env-two"\n')
+        f.flush()
+        captured = _run_cli(
+            monkeypatch,
+            {
+                "env_id_or_path": f.name,
+                "num_examples": 5,
+                "rollouts_per_example": 2,
+            },
+            capture_all_configs=True,
+        )
+
+    configs = captured["configs"]
+    assert len(configs) == 2
+    assert configs[0].env_id == "env-one"
+    assert configs[1].env_id == "env-two"
+
+
+def test_cli_multi_env_shares_common_args(monkeypatch):
+    """All env configs in multi-env inherit common CLI args."""
+    with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
+        f.write('[[env]]\nenv_id = "env-a"\n\n[[env]]\nenv_id = "env-b"\n')
+        f.flush()
+        captured = _run_cli(
+            monkeypatch,
+            {
+                "env_id_or_path": f.name,
+                "num_examples": 10,
+                "rollouts_per_example": 4,
+                "max_concurrent": 16,
+                "max_tokens": 512,
+            },
+        )
+
+    configs = captured["configs"]
+    for config in configs:
+        assert config.num_examples == 10
+        assert config.rollouts_per_example == 4
+        assert config.max_concurrent == 16
+        assert config.sampling_args["max_tokens"] == 512
+
+
+def test_cli_toml_per_env_num_examples(monkeypatch):
+    """TOML per-env num_examples is used when CLI arg not provided."""
+    with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
+        f.write(
+            '[[env]]\nenv_id = "env-a"\nnum_examples = 10\n\n'
+            '[[env]]\nenv_id = "env-b"\nnum_examples = 20\n'
+        )
+        f.flush()
+        captured = _run_cli(
+            monkeypatch,
+            {
+                "env_id_or_path": f.name,
+                "num_examples": None,  # not provided via CLI
+                "rollouts_per_example": 1,
+            },
+        )
+
+    configs = captured["configs"]
+    assert len(configs) == 2
+    assert configs[0].env_id == "env-a"
+    assert configs[0].num_examples == 10
+    assert configs[1].env_id == "env-b"
+    assert configs[1].num_examples == 20
+
+
+def test_cli_toml_per_env_rollouts_per_example(monkeypatch):
+    """TOML per-env rollouts_per_example is used when CLI arg not provided."""
+    with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
+        f.write(
+            '[[env]]\nenv_id = "env-a"\nrollouts_per_example = 3\n\n'
+            '[[env]]\nenv_id = "env-b"\nrollouts_per_example = 5\n'
+        )
+        f.flush()
+        captured = _run_cli(
+            monkeypatch,
+            {
+                "env_id_or_path": f.name,
+                "num_examples": 1,
+                "rollouts_per_example": None,  # not provided via CLI
+            },
+        )
+
+    configs = captured["configs"]
+    assert len(configs) == 2
+    assert configs[0].rollouts_per_example == 3
+    assert configs[1].rollouts_per_example == 5
+
+
+def test_cli_toml_per_env_overrides_cli_args(monkeypatch):
+    """TOML per-env settings take precedence over CLI args."""
+    with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
+        f.write(
+            '[[env]]\nenv_id = "env-a"\nnum_examples = 100\nrollouts_per_example = 10\n\n'
+            '[[env]]\nenv_id = "env-b"\nnum_examples = 200\nrollouts_per_example = 20\n'
+        )
+        f.flush()
+        captured = _run_cli(
+            monkeypatch,
+            {
+                "env_id_or_path": f.name,
+                "num_examples": 5,  # CLI arg (lower priority)
+                "rollouts_per_example": 2,  # CLI arg (lower priority)
+            },
+        )
+
+    configs = captured["configs"]
+    # TOML per-env settings should override CLI args
+    assert configs[0].num_examples == 100
+    assert configs[0].rollouts_per_example == 10
+    assert configs[1].num_examples == 200
+    assert configs[1].rollouts_per_example == 20
+
+
+def test_cli_toml_mixed_per_env_and_cli_fallback(monkeypatch):
+    """TOML with some envs having settings, others fall back to CLI args."""
+    with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
+        f.write(
+            '[[env]]\nenv_id = "env-with-settings"\nnum_examples = 15\nrollouts_per_example = 4\n\n'
+            '[[env]]\nenv_id = "env-without-settings"\n'
+        )
+        f.flush()
+        captured = _run_cli(
+            monkeypatch,
+            {
+                "env_id_or_path": f.name,
+                "num_examples": 10,  # CLI fallback for envs without TOML settings
+                "rollouts_per_example": 2,  # CLI fallback
+            },
+        )
+
+    configs = captured["configs"]
+    assert len(configs) == 2
+    # First env uses TOML settings (takes precedence over CLI)
+    assert configs[0].env_id == "env-with-settings"
+    assert configs[0].num_examples == 15
+    assert configs[0].rollouts_per_example == 4
+    # Second env uses CLI args as fallback
+    assert configs[1].env_id == "env-without-settings"
+    assert configs[1].num_examples == 10
+    assert configs[1].rollouts_per_example == 2
+
+
+def test_cli_toml_without_settings_uses_defaults(monkeypatch):
+    """TOML envs without settings and no CLI args use global defaults."""
+    with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
+        f.write('[[env]]\nenv_id = "env-a"\n\n[[env]]\nenv_id = "env-b"\n')
+        f.flush()
+        captured = _run_cli(
+            monkeypatch,
+            {
+                "env_id_or_path": f.name,
+                "num_examples": None,
+                "rollouts_per_example": None,
+            },
+        )
+
+    configs = captured["configs"]
+    # Both envs use global defaults
+    for config in configs:
+        assert config.num_examples == 5  # DEFAULT_NUM_EXAMPLES
+        assert config.rollouts_per_example == 3  # DEFAULT_ROLLOUTS_PER_EXAMPLE
+
+
+# =============================================================================
+# Tests for multi-env evaluation via comma-separated IDs
+# =============================================================================
+
+
+def test_cli_comma_separated_env_ids(monkeypatch):
+    """CLI with comma-separated env IDs creates multiple eval configs."""
+    captured = _run_cli(
+        monkeypatch,
+        {
+            "env_id_or_path": "gsm8k,alphabet-sort,math-python",
+            "num_examples": 5,
+            "rollouts_per_example": 3,
+        },
+    )
+
+    configs = captured["configs"]
+    assert len(configs) == 3
+    assert configs[0].env_id == "gsm8k"
+    assert configs[1].env_id == "alphabet-sort"
+    assert configs[2].env_id == "math-python"
+
+
+def test_cli_comma_separated_env_ids_two_envs(monkeypatch):
+    """CLI with two comma-separated env IDs."""
+    captured = _run_cli(
+        monkeypatch,
+        {
+            "env_id_or_path": "env-a,env-b",
+        },
+    )
+
+    configs = captured["configs"]
+    assert len(configs) == 2
+    assert configs[0].env_id == "env-a"
+    assert configs[1].env_id == "env-b"
+
+
+def test_cli_comma_separated_shares_common_args(monkeypatch):
+    """All comma-separated env configs inherit common CLI args."""
+    captured = _run_cli(
+        monkeypatch,
+        {
+            "env_id_or_path": "env-one,env-two,env-three",
+            "num_examples": 10,
+            "rollouts_per_example": 4,
+            "max_concurrent": 16,
+            "max_tokens": 512,
+            "temperature": 0.7,
+        },
+    )
+
+    configs = captured["configs"]
+    assert len(configs) == 3
+    for config in configs:
+        assert config.num_examples == 10
+        assert config.rollouts_per_example == 4
+        assert config.max_concurrent == 16
+        assert config.sampling_args["max_tokens"] == 512
+        assert config.sampling_args["temperature"] == 0.7
+
+
+def test_cli_comma_separated_with_spaces(monkeypatch):
+    """CLI handles spaces around commas in env IDs."""
+    captured = _run_cli(
+        monkeypatch,
+        {
+            "env_id_or_path": "gsm8k , alphabet-sort , math-python",
+        },
+    )
+
+    configs = captured["configs"]
+    assert len(configs) == 3
+    assert configs[0].env_id == "gsm8k"
+    assert configs[1].env_id == "alphabet-sort"
+    assert configs[2].env_id == "math-python"
+
+
+def test_cli_comma_separated_with_org_prefix(monkeypatch):
+    """CLI handles org/env format in comma-separated list."""
+    captured = _run_cli(
+        monkeypatch,
+        {
+            "env_id_or_path": "primeintellect/gsm8k,primeintellect/math-python",
+        },
+    )
+
+    configs = captured["configs"]
+    assert len(configs) == 2
+    assert configs[0].env_id == "primeintellect/gsm8k"
+    assert configs[1].env_id == "primeintellect/math-python"
+
+
+def test_cli_comma_separated_ignores_empty_entries(monkeypatch):
+    """CLI ignores empty entries from trailing/double commas."""
+    captured = _run_cli(
+        monkeypatch,
+        {
+            "env_id_or_path": "gsm8k,,alphabet-sort,",
+        },
+    )
+
+    configs = captured["configs"]
+    assert len(configs) == 2
+    assert configs[0].env_id == "gsm8k"
+    assert configs[1].env_id == "alphabet-sort"
+
+
+def test_cli_single_env_id_no_comma(monkeypatch):
+    """Single env ID without comma creates one config."""
+    captured = _run_cli(
+        monkeypatch,
+        {
+            "env_id_or_path": "gsm8k",
+        },
+    )
+
+    configs = captured["configs"]
+    assert len(configs) == 1
+    assert configs[0].env_id == "gsm8k"
+
+
+# =============================================================================
+# Tests for header parsing
+# =============================================================================
+
+
+def test_cli_header_parsing_single(monkeypatch):
+    """Single header is parsed correctly."""
+    captured = _run_cli(
+        monkeypatch,
+        {
+            "header": ["X-Custom-Header: my-value"],
+        },
+    )
+
+    config = captured["configs"][0]
+    assert config.client_config.extra_headers == {"X-Custom-Header": "my-value"}
+
+
+def test_cli_header_parsing_multiple(monkeypatch):
+    """Multiple headers are parsed correctly."""
+    captured = _run_cli(
+        monkeypatch,
+        {
+            "header": [
+                "Authorization: Bearer token123",
+                "X-Request-ID: req-456",
+            ],
+        },
+    )
+
+    config = captured["configs"][0]
+    assert config.client_config.extra_headers == {
+        "Authorization": "Bearer token123",
+        "X-Request-ID": "req-456",
+    }
+
+
+def test_cli_header_with_multiple_colons(monkeypatch):
+    """Header with multiple colons is parsed correctly (value can contain colons)."""
+    captured = _run_cli(
+        monkeypatch,
+        {
+            "header": ["X-URL: https://example.com:8080/path"],
+        },
+    )
+
+    config = captured["configs"][0]
+    assert config.client_config.extra_headers == {
+        "X-URL": "https://example.com:8080/path"
+    }
+
+
+def test_cli_header_invalid_format_no_colon(monkeypatch):
+    """Header without colon raises ValueError."""
+    with pytest.raises(ValueError, match="must be 'Name: Value'"):
+        _run_cli(
+            monkeypatch,
+            {
+                "header": ["InvalidHeaderNoColon"],
+            },
+        )
+
+
+def test_cli_header_invalid_empty_name(monkeypatch):
+    """Header with empty name raises ValueError."""
+    with pytest.raises(ValueError, match="name cannot be empty"):
+        _run_cli(
+            monkeypatch,
+            {
+                "header": [": value-only"],
+            },
+        )
+
+
+# =============================================================================
+# Tests for state columns parsing
+# =============================================================================
+
+
+def test_cli_state_columns_parsed(monkeypatch):
+    """State columns string is parsed into list."""
+    captured = _run_cli(
+        monkeypatch,
+        {
+            "state_columns": ["turn", "timing", "responses"],
+        },
+    )
+
+    config = captured["configs"][0]
+    assert config.state_columns == ["turn", "timing", "responses"]
+
+
+def test_cli_state_columns_empty(monkeypatch):
+    """Empty state columns list is handled."""
+    captured = _run_cli(
+        monkeypatch,
+        {
+            "state_columns": [],
+        },
+    )
+
+    config = captured["configs"][0]
+    assert config.state_columns == []
+
+
+# =============================================================================
+# Tests for endpoint resolution
+# =============================================================================
+
+
+def test_cli_endpoint_from_registry(monkeypatch):
+    """Model found in endpoint registry uses registry values."""
+    base_args = {
+        "env_id_or_path": "test-env",
+        "env_args": {},
+        "env_dir_path": "./environments",
+        "endpoints_path": "./configs/endpoints.py",
+        "model": "my-alias",
+        "api_key_var": None,
+        "api_base_url": None,
+        "header": None,
+        "num_examples": 1,
+        "rollouts_per_example": 1,
+        "max_concurrent": 1,
+        "max_concurrent_generation": None,
+        "max_concurrent_scoring": None,
+        "independent_scoring": False,
+        "max_tokens": 100,
+        "temperature": None,
+        "sampling_args": None,
+        "verbose": False,
+        "print_results": False,
+        "no_interleave_scoring": False,
+        "state_columns": [],
+        "save_results": False,
+        "save_every": -1,
+        "save_to_hf_hub": False,
+        "hf_hub_dataset_name": "",
+        "extra_env_kwargs": {},
+    }
+    args_namespace = SimpleNamespace(**base_args)
+    captured: dict = {"configs": []}
+
+    monkeypatch.setattr(
+        argparse.ArgumentParser,
+        "parse_args",
+        lambda self: args_namespace,
+    )
+    monkeypatch.setattr(vf_eval, "setup_logging", lambda *_, **__: None)
+
+    # Mock endpoint registry
+    monkeypatch.setattr(
+        vf_eval,
+        "load_endpoints",
+        lambda *_: {
+            "my-alias": {
+                "key": "MY_CUSTOM_KEY",
+                "url": "https://custom.api.com/v1",
+                "model": "actual-model-name",
+            }
+        },
+    )
+
+    async def fake_run_evaluation(config):
+        captured["configs"].append(config)
+        return _make_generate_outputs(env_id=config.env_id)
+
+    monkeypatch.setattr(
+        verifiers.utils.eval_utils, "run_evaluation", fake_run_evaluation
+    )
+
+    vf_eval.main()
+
+    config = captured["configs"][0]
+    assert config.client_config.api_key_var == "MY_CUSTOM_KEY"
+    assert config.client_config.api_base_url == "https://custom.api.com/v1"
+    assert config.model == "actual-model-name"
+
+
+def test_cli_endpoint_cli_overrides_registry(monkeypatch):
+    """CLI args override endpoint registry values."""
+    base_args = {
+        "env_id_or_path": "test-env",
+        "env_args": {},
+        "env_dir_path": "./environments",
+        "endpoints_path": "./configs/endpoints.py",
+        "model": "my-alias",
+        "api_key_var": "OVERRIDE_KEY",
+        "api_base_url": "https://override.api.com/v1",
+        "header": None,
+        "num_examples": 1,
+        "rollouts_per_example": 1,
+        "max_concurrent": 1,
+        "max_concurrent_generation": None,
+        "max_concurrent_scoring": None,
+        "independent_scoring": False,
+        "max_tokens": 100,
+        "temperature": None,
+        "sampling_args": None,
+        "verbose": False,
+        "print_results": False,
+        "no_interleave_scoring": False,
+        "state_columns": [],
+        "save_results": False,
+        "save_every": -1,
+        "save_to_hf_hub": False,
+        "hf_hub_dataset_name": "",
+        "extra_env_kwargs": {},
+    }
+    args_namespace = SimpleNamespace(**base_args)
+    captured: dict = {"configs": []}
+
+    monkeypatch.setattr(
+        argparse.ArgumentParser,
+        "parse_args",
+        lambda self: args_namespace,
+    )
+    monkeypatch.setattr(vf_eval, "setup_logging", lambda *_, **__: None)
+
+    monkeypatch.setattr(
+        vf_eval,
+        "load_endpoints",
+        lambda *_: {
+            "my-alias": {
+                "key": "REGISTRY_KEY",
+                "url": "https://registry.api.com/v1",
+                "model": "actual-model-name",
+            }
+        },
+    )
+
+    async def fake_run_evaluation(config):
+        captured["configs"].append(config)
+        return _make_generate_outputs(env_id=config.env_id)
+
+    monkeypatch.setattr(
+        verifiers.utils.eval_utils, "run_evaluation", fake_run_evaluation
+    )
+
+    vf_eval.main()
+
+    config = captured["configs"][0]
+    assert config.client_config.api_key_var == "OVERRIDE_KEY"
+    assert config.client_config.api_base_url == "https://override.api.com/v1"
+
+
+def test_cli_endpoint_not_in_registry_uses_defaults(monkeypatch):
+    """Model not in registry uses CLI defaults or global defaults."""
+    base_args = {
+        "env_id_or_path": "test-env",
+        "env_args": {},
+        "env_dir_path": "./environments",
+        "endpoints_path": "./configs/endpoints.py",
+        "model": "unknown-model",
+        "api_key_var": None,
+        "api_base_url": None,
+        "header": None,
+        "num_examples": 1,
+        "rollouts_per_example": 1,
+        "max_concurrent": 1,
+        "max_concurrent_generation": None,
+        "max_concurrent_scoring": None,
+        "independent_scoring": False,
+        "max_tokens": 100,
+        "temperature": None,
+        "sampling_args": None,
+        "verbose": False,
+        "print_results": False,
+        "no_interleave_scoring": False,
+        "state_columns": [],
+        "save_results": False,
+        "save_every": -1,
+        "save_to_hf_hub": False,
+        "hf_hub_dataset_name": "",
+        "extra_env_kwargs": {},
+    }
+    args_namespace = SimpleNamespace(**base_args)
+    captured: dict = {"configs": []}
+
+    monkeypatch.setattr(
+        argparse.ArgumentParser,
+        "parse_args",
+        lambda self: args_namespace,
+    )
+    monkeypatch.setattr(vf_eval, "setup_logging", lambda *_, **__: None)
+    monkeypatch.setattr(vf_eval, "load_endpoints", lambda *_: {})
+
+    async def fake_run_evaluation(config):
+        captured["configs"].append(config)
+        return _make_generate_outputs(env_id=config.env_id)
+
+    monkeypatch.setattr(
+        verifiers.utils.eval_utils, "run_evaluation", fake_run_evaluation
+    )
+
+    vf_eval.main()
+
+    config = captured["configs"][0]
+    # Should use DEFAULT values from eval.py
+    assert config.client_config.api_key_var == "PRIME_API_KEY"
+    assert config.client_config.api_base_url == "https://api.pinference.ai/api/v1"
+    assert config.model == "unknown-model"
+
+
+# =============================================================================
+# Tests for EvalConfig and MultiEvalConfig types
+# =============================================================================
+
+
+def test_eval_config_creation():
+    """EvalConfig can be created with required fields."""
+    from verifiers.types import ClientConfig
+
+    config = EvalConfig(
+        env_id="test-env",
+        env_args={"key": "value"},
+        env_dir_path="./environments",
+        model="gpt-4",
+        client_config=ClientConfig(),
+        sampling_args={"max_tokens": 100},
+        num_examples=10,
+        rollouts_per_example=3,
+        max_concurrent=32,
+    )
+
+    assert config.env_id == "test-env"
+    assert config.num_examples == 10
+    assert config.independent_scoring is False  # default
+
+
+def test_multi_eval_config_creation():
+    """MultiEvalConfig can be created with list of EvalConfigs."""
+    from verifiers.types import ClientConfig
+
+    configs = [
+        EvalConfig(
+            env_id=f"env-{i}",
+            env_args={},
+            env_dir_path="./environments",
+            model="gpt-4",
+            client_config=ClientConfig(),
+            sampling_args={},
+            num_examples=5,
+            rollouts_per_example=1,
+            max_concurrent=8,
+        )
+        for i in range(3)
+    ]
+
+    multi_config = MultiEvalConfig(env=configs)
+    assert len(multi_config.env) == 3
+    assert multi_config.env[0].env_id == "env-0"
+    assert multi_config.env[2].env_id == "env-2"
+
+
+# =============================================================================
+# Tests for extra environment kwargs
+# =============================================================================
+
+
+def test_cli_extra_env_kwargs(monkeypatch):
+    """Extra env kwargs are passed to config."""
+    captured = _run_cli(
+        monkeypatch,
+        {
+            "extra_env_kwargs": {"custom_key": "custom_value", "num_param": 42},
+        },
+    )
+
+    config = captured["configs"][0]
+    assert config.extra_env_kwargs == {"custom_key": "custom_value", "num_param": 42}
+
+
+def test_cli_extra_env_kwargs_empty(monkeypatch):
+    """Empty extra env kwargs is handled."""
+    captured = _run_cli(
+        monkeypatch,
+        {
+            "extra_env_kwargs": {},
+        },
+    )
+
+    config = captured["configs"][0]
+    assert config.extra_env_kwargs == {}
+
+
+# =============================================================================
+# Tests for concurrent generation/scoring options
+# =============================================================================
+
+
+def test_cli_concurrent_options(monkeypatch):
+    """Concurrent generation/scoring options are captured."""
+    captured = _run_cli(
+        monkeypatch,
+        {
+            "max_concurrent": 64,
+            "max_concurrent_generation": 32,
+            "max_concurrent_scoring": 16,
+        },
+    )
+
+    config = captured["configs"][0]
+    assert config.max_concurrent == 64
+    assert config.max_concurrent_generation == 32
+    assert config.max_concurrent_scoring == 16
+
+
+def test_cli_concurrent_options_none(monkeypatch):
+    """None concurrent options use defaults."""
+    captured = _run_cli(
+        monkeypatch,
+        {
+            "max_concurrent": 8,
+            "max_concurrent_generation": None,
+            "max_concurrent_scoring": None,
+        },
+    )
+
+    config = captured["configs"][0]
+    assert config.max_concurrent == 8
+    assert config.max_concurrent_generation is None
+    assert config.max_concurrent_scoring is None
+
+
+# =============================================================================
+# Tests for independent scoring option
+# =============================================================================
+
+
+def test_cli_independent_scoring_enabled(monkeypatch):
+    """Independent scoring flag is captured."""
+    captured = _run_cli(
+        monkeypatch,
+        {
+            "independent_scoring": True,
+        },
+    )
+
+    config = captured["configs"][0]
+    assert config.independent_scoring is True
+
+
+def test_cli_independent_scoring_disabled(monkeypatch):
+    """Independent scoring disabled by default."""
+    captured = _run_cli(
+        monkeypatch,
+        {
+            "independent_scoring": False,
+        },
+    )
+
+    config = captured["configs"][0]
+    assert config.independent_scoring is False
+
+
+# =============================================================================
+# Tests for save options
+# =============================================================================
+
+
+def test_cli_save_options(monkeypatch):
+    """Save options are captured correctly."""
+    captured = _run_cli(
+        monkeypatch,
+        {
+            "save_results": True,
+            "save_every": 50,
+            "save_to_hf_hub": True,
+            "hf_hub_dataset_name": "my-org/my-dataset",
+        },
+    )
+
+    config = captured["configs"][0]
+    assert config.save_results is True
+    assert config.save_every == 50
+    assert config.save_to_hf_hub is True
+    assert config.hf_hub_dataset_name == "my-org/my-dataset"

--- a/tests/test_eval_cli.py
+++ b/tests/test_eval_cli.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import verifiers.scripts.eval as vf_eval
+import verifiers.utils.eval_utils
 from verifiers.types import GenerateMetadata, GenerateOutputs
 
 
@@ -26,7 +27,7 @@ def _make_metadata(config) -> GenerateMetadata:
 
 def _run_cli(monkeypatch, overrides):
     base_args = {
-        "env_id": "dummy-env",
+        "env_id_or_path": "dummy-env",
         "env_args": {},
         "env_dir_path": "./environments",
         "endpoints_path": "./configs/endpoints.py",
@@ -87,10 +88,14 @@ def _run_cli(monkeypatch, overrides):
             example_id=[0],
             reward=[1.0],
             metrics={},
+            stop_conditions=[None],
+            is_truncated=[False],
             metadata=metadata,
         )
 
-    monkeypatch.setattr(vf_eval, "run_evaluation", fake_run_evaluation)
+    monkeypatch.setattr(
+        verifiers.utils.eval_utils, "run_evaluation", fake_run_evaluation
+    )
 
     vf_eval.main()
     return captured

--- a/tests/test_eval_cli.py
+++ b/tests/test_eval_cli.py
@@ -8,14 +8,11 @@ import pytest
 import verifiers.scripts.eval as vf_eval
 import verifiers.utils.eval_utils
 from verifiers.types import (
-    EvalConfig,
     GenerateMetadata,
     GenerateOutputs,
-    MultiEvalConfig,
     State,
 )
 from verifiers.utils.eval_utils import (
-    get_results_by_task,
     is_toml_config,
     load_toml_config,
 )
@@ -174,9 +171,18 @@ def _run_cli(monkeypatch, overrides, capture_all_configs: bool = False):
     return captured
 
 
-# =============================================================================
-# Tests for sampling args CLI handling
-# =============================================================================
+def test_cli_single_env_id(monkeypatch):
+    """Single env ID without comma creates one config."""
+    captured = _run_cli(
+        monkeypatch,
+        {
+            "env_id_or_path": "env1",
+        },
+    )
+
+    configs = captured["configs"]
+    assert len(configs) == 1
+    assert configs[0].env_id == "env1"
 
 
 def test_cli_sampling_args_precedence_over_flags(monkeypatch):
@@ -247,9 +253,92 @@ def test_cli_temperature_not_added_when_none(monkeypatch):
     assert "temperature" not in sa
 
 
-# =============================================================================
-# Tests for is_toml_config
-# =============================================================================
+def test_cli_comma_separated_env_ids(monkeypatch):
+    """CLI with comma-separated env IDs creates multiple eval configs."""
+    captured = _run_cli(
+        monkeypatch,
+        {
+            "env_id_or_path": "env1,env2,env3",
+            "num_examples": 5,
+            "rollouts_per_example": 3,
+        },
+    )
+
+    configs = captured["configs"]
+    assert len(configs) == 3
+    assert configs[0].env_id == "env1"
+    assert configs[1].env_id == "env2"
+    assert configs[2].env_id == "env3"
+
+
+def test_cli_comma_separated_with_spaces(monkeypatch):
+    """CLI handles spaces around commas in env IDs."""
+    captured = _run_cli(
+        monkeypatch,
+        {
+            "env_id_or_path": "env1 , env2 , env3",
+        },
+    )
+
+    configs = captured["configs"]
+    assert len(configs) == 3
+    assert configs[0].env_id == "env1"
+    assert configs[1].env_id == "env2"
+    assert configs[2].env_id == "env3"
+
+
+def test_cli_comma_separated_with_org_prefix(monkeypatch):
+    """CLI handles org/env format in comma-separated list."""
+    captured = _run_cli(
+        monkeypatch,
+        {
+            "env_id_or_path": "org/env1,org/env2",
+        },
+    )
+
+    configs = captured["configs"]
+    assert len(configs) == 2
+    assert configs[0].env_id == "org/env1"
+    assert configs[1].env_id == "org/env2"
+
+
+def test_cli_comma_separated_shared_args(monkeypatch):
+    """All comma-separated envs inherit shared CLI args."""
+    captured = _run_cli(
+        monkeypatch,
+        {
+            "env_id_or_path": "env1,env2,env3",
+            "num_examples": 10,
+            "rollouts_per_example": 4,
+            "max_concurrent": 16,
+            "max_tokens": 512,
+            "temperature": 0.7,
+        },
+    )
+
+    configs = captured["configs"]
+    assert len(configs) == 3
+    for config in configs:
+        assert config.num_examples == 10
+        assert config.rollouts_per_example == 4
+        assert config.max_concurrent == 16
+        assert config.sampling_args["max_tokens"] == 512
+        assert config.sampling_args["temperature"] == 0.7
+
+
+def test_cli_comma_separated_ignores_empty_entries(monkeypatch):
+    """CLI ignores empty entries from trailing/double commas."""
+    captured = _run_cli(
+        monkeypatch,
+        {
+            "env_id_or_path": "gsm8k,,alphabet-sort,",
+        },
+    )
+
+    configs = captured["configs"]
+    assert len(configs) == 2
+    assert configs[0].env_id == "gsm8k"
+    assert configs[1].env_id == "alphabet-sort"
 
 
 def test_is_toml_config_with_valid_toml():
@@ -281,62 +370,52 @@ def test_is_toml_config_with_directory():
 
 def test_is_toml_config_with_env_id():
     """Simple env ID string returns False."""
-    assert is_toml_config("gsm8k") is False
-    assert is_toml_config("primeintellect/math-python") is False
-
-
-# =============================================================================
-# Tests for load_toml_config
-# =============================================================================
+    assert is_toml_config("env") is False
+    assert is_toml_config("env1,env2") is False
+    assert is_toml_config("org/env") is False
 
 
 def test_load_toml_config_single_env():
-    """Single [[env]] section loads correctly."""
+    """Single env loads correctly."""
     with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
-        f.write('[[env]]\nenv_id = "gsm8k"\n')
+        f.write('[[env]]\nenv_id = "env1"\n')
         f.flush()
         result = load_toml_config(Path(f.name))
         assert len(result) == 1
-        assert result[0]["env_id"] == "gsm8k"
+        assert result[0]["env_id"] == "env1"
 
 
 def test_load_toml_config_multi_env():
-    """Multiple [[env]] sections load correctly."""
+    """Multiple envs load correctly."""
     with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
-        f.write('[[env]]\nenv_id = "gsm8k"\n\n[[env]]\nenv_id = "math-python"\n')
+        f.write('[[env]]\nenv_id = "env1"\n\n[[env]]\nenv_id = "env2"\n')
         f.flush()
         result = load_toml_config(Path(f.name))
         assert len(result) == 2
-        assert result[0]["env_id"] == "gsm8k"
-        assert result[1]["env_id"] == "math-python"
+        assert result[0]["env_id"] == "env1"
+        assert result[1]["env_id"] == "env2"
 
 
 def test_load_toml_config_with_env_args():
-    """[[env]] section with env_args field loads correctly."""
+    """Multiple sections with env_args field loads correctly."""
     with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
         f.write(
-            '[[env]]\nenv_id = "test-env"\n[env.env_args]\nsplit = "train"\nmax_examples = 100\n'
+            '[[env]]\nenv_id = "env1"\n[env.env_args]\nsplit = "train"\nmax_examples = 100\n'
         )
         f.flush()
         result = load_toml_config(Path(f.name))
         assert len(result) == 1
-        assert result[0]["env_id"] == "test-env"
+        assert result[0]["env_id"] == "env1"
         assert result[0]["env_args"]["split"] == "train"
         assert result[0]["env_args"]["max_examples"] == 100
-
-
-def test_load_toml_config_missing_file():
-    """Missing file raises FileNotFoundError."""
-    with pytest.raises(FileNotFoundError):
-        load_toml_config(Path("/nonexistent/path/config.toml"))
 
 
 def test_load_toml_config_missing_env_section():
     """TOML without [[env]] section raises ValueError."""
     with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
-        f.write('model = "gpt-4"\nmax_tokens = 100\n')
+        f.write('model = "env1"\nmax_tokens = 100\n')
         f.flush()
-        with pytest.raises(ValueError, match="must contain at least one"):
+        with pytest.raises(ValueError):
             load_toml_config(Path(f.name))
 
 
@@ -345,114 +424,41 @@ def test_load_toml_config_empty_env_list():
     with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
         f.write("env = []\n")
         f.flush()
-        with pytest.raises(ValueError, match="must contain at least one"):
+        with pytest.raises(ValueError):
             load_toml_config(Path(f.name))
 
 
 def test_load_toml_config_missing_env_id():
     """[[env]] without env_id field raises ValueError."""
     with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
-        f.write('[[env]]\nname = "test"\n')
+        f.write('[[env]]\nname = "env1"\n')
         f.flush()
-        with pytest.raises(ValueError, match="must contain an env_id field"):
+        with pytest.raises(ValueError):
             load_toml_config(Path(f.name))
 
 
 def test_load_toml_config_partial_missing_env_id():
     """Some [[env]] sections missing env_id raises ValueError."""
     with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
-        f.write('[[env]]\nenv_id = "valid"\n\n[[env]]\nname = "no-id"\n')
+        f.write('[[env]]\nenv_id = "env1"\n\n[[env]]\nname = "env2"\n')
         f.flush()
-        with pytest.raises(ValueError, match="must contain an env_id field"):
+        with pytest.raises(ValueError):
             load_toml_config(Path(f.name))
 
 
 def test_load_toml_config_invalid_field():
     """[[env]] with invalid field raises ValueError."""
     with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
-        f.write('[[env]]\nenv_id = "test"\ninvalid_field = "value"\n')
+        f.write('[[env]]\nenv_id = "env1"\ninvalid_field = "value"\n')
         f.flush()
-        with pytest.raises(ValueError, match="Invalid field"):
+        with pytest.raises(ValueError):
             load_toml_config(Path(f.name))
-
-
-# =============================================================================
-# Tests for get_results_by_task
-# =============================================================================
-
-
-def test_get_results_by_task_single_task():
-    """Results with single task returns one group."""
-    results = _make_generate_outputs(
-        num_examples=3,
-        rollouts_per_example=1,
-        tasks=["default", "default", "default"],
-        rewards=[0.5, 0.7, 0.9],
-    )
-    by_task = get_results_by_task(results)
-
-    assert len(by_task) == 1
-    assert "default" in by_task
-    assert len(by_task["default"]["reward"]) == 3
-    assert by_task["default"]["reward"] == [0.5, 0.7, 0.9]
-
-
-def test_get_results_by_task_multiple_tasks():
-    """Results with multiple tasks are grouped correctly."""
-    results = _make_generate_outputs(
-        num_examples=4,
-        rollouts_per_example=1,
-        tasks=["math", "code", "math", "code"],
-        rewards=[0.5, 0.6, 0.7, 0.8],
-    )
-    by_task = get_results_by_task(results)
-
-    assert len(by_task) == 2
-    assert "math" in by_task
-    assert "code" in by_task
-    assert by_task["math"]["reward"] == [0.5, 0.7]
-    assert by_task["code"]["reward"] == [0.6, 0.8]
-
-
-def test_get_results_by_task_preserves_metadata():
-    """Grouped results preserve metadata."""
-    results = _make_generate_outputs(
-        env_id="test-env",
-        num_examples=2,
-        rollouts_per_example=1,
-        tasks=["task1", "task2"],
-    )
-    by_task = get_results_by_task(results)
-
-    # Both task groups should have the same metadata
-    assert by_task["task1"]["metadata"]["env_id"] == "test-env"
-    assert by_task["task2"]["metadata"]["env_id"] == "test-env"
-
-
-def test_get_results_by_task_preserves_metrics():
-    """Grouped results preserve metrics correctly."""
-    results = _make_generate_outputs(
-        num_examples=4,
-        rollouts_per_example=1,
-        tasks=["a", "b", "a", "b"],
-        rewards=[0.1, 0.2, 0.3, 0.4],
-    )
-    by_task = get_results_by_task(results)
-
-    # Metrics should be split by task
-    assert by_task["a"]["metrics"]["accuracy"] == [0.1, 0.3]
-    assert by_task["b"]["metrics"]["accuracy"] == [0.2, 0.4]
-
-
-# =============================================================================
-# Tests for multi-env evaluation via TOML config
-# =============================================================================
 
 
 def test_cli_multi_env_via_toml_config(monkeypatch):
     """CLI with TOML config creates multiple eval configs."""
     with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
-        f.write('[[env]]\nenv_id = "env-one"\n\n[[env]]\nenv_id = "env-two"\n')
+        f.write('[[env]]\nenv_id = "env1"\n\n[[env]]\nenv_id = "env2"\n')
         f.flush()
         captured = _run_cli(
             monkeypatch,
@@ -466,14 +472,14 @@ def test_cli_multi_env_via_toml_config(monkeypatch):
 
     configs = captured["configs"]
     assert len(configs) == 2
-    assert configs[0].env_id == "env-one"
-    assert configs[1].env_id == "env-two"
+    assert configs[0].env_id == "env1"
+    assert configs[1].env_id == "env2"
 
 
 def test_cli_multi_env_shares_common_args(monkeypatch):
     """All env configs in multi-env inherit common CLI args."""
     with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
-        f.write('[[env]]\nenv_id = "env-a"\n\n[[env]]\nenv_id = "env-b"\n')
+        f.write('[[env]]\nenv_id = "env1"\n\n[[env]]\nenv_id = "env2"\n')
         f.flush()
         captured = _run_cli(
             monkeypatch,
@@ -498,8 +504,8 @@ def test_cli_toml_per_env_num_examples(monkeypatch):
     """TOML per-env num_examples is used when CLI arg not provided."""
     with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
         f.write(
-            '[[env]]\nenv_id = "env-a"\nnum_examples = 10\n\n'
-            '[[env]]\nenv_id = "env-b"\nnum_examples = 20\n'
+            '[[env]]\nenv_id = "env1"\nnum_examples = 10\n\n'
+            '[[env]]\nenv_id = "env2"\nnum_examples = 20\n'
         )
         f.flush()
         captured = _run_cli(
@@ -513,9 +519,9 @@ def test_cli_toml_per_env_num_examples(monkeypatch):
 
     configs = captured["configs"]
     assert len(configs) == 2
-    assert configs[0].env_id == "env-a"
+    assert configs[0].env_id == "env1"
     assert configs[0].num_examples == 10
-    assert configs[1].env_id == "env-b"
+    assert configs[1].env_id == "env2"
     assert configs[1].num_examples == 20
 
 
@@ -523,8 +529,8 @@ def test_cli_toml_per_env_rollouts_per_example(monkeypatch):
     """TOML per-env rollouts_per_example is used when CLI arg not provided."""
     with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
         f.write(
-            '[[env]]\nenv_id = "env-a"\nrollouts_per_example = 3\n\n'
-            '[[env]]\nenv_id = "env-b"\nrollouts_per_example = 5\n'
+            '[[env]]\nenv_id = "env1"\nrollouts_per_example = 3\n\n'
+            '[[env]]\nenv_id = "env2"\nrollouts_per_example = 5\n'
         )
         f.flush()
         captured = _run_cli(
@@ -615,605 +621,3 @@ def test_cli_toml_without_settings_uses_defaults(monkeypatch):
     for config in configs:
         assert config.num_examples == 5  # DEFAULT_NUM_EXAMPLES
         assert config.rollouts_per_example == 3  # DEFAULT_ROLLOUTS_PER_EXAMPLE
-
-
-# =============================================================================
-# Tests for multi-env evaluation via comma-separated IDs
-# =============================================================================
-
-
-def test_cli_comma_separated_env_ids(monkeypatch):
-    """CLI with comma-separated env IDs creates multiple eval configs."""
-    captured = _run_cli(
-        monkeypatch,
-        {
-            "env_id_or_path": "gsm8k,alphabet-sort,math-python",
-            "num_examples": 5,
-            "rollouts_per_example": 3,
-        },
-    )
-
-    configs = captured["configs"]
-    assert len(configs) == 3
-    assert configs[0].env_id == "gsm8k"
-    assert configs[1].env_id == "alphabet-sort"
-    assert configs[2].env_id == "math-python"
-
-
-def test_cli_comma_separated_env_ids_two_envs(monkeypatch):
-    """CLI with two comma-separated env IDs."""
-    captured = _run_cli(
-        monkeypatch,
-        {
-            "env_id_or_path": "env-a,env-b",
-        },
-    )
-
-    configs = captured["configs"]
-    assert len(configs) == 2
-    assert configs[0].env_id == "env-a"
-    assert configs[1].env_id == "env-b"
-
-
-def test_cli_comma_separated_shares_common_args(monkeypatch):
-    """All comma-separated env configs inherit common CLI args."""
-    captured = _run_cli(
-        monkeypatch,
-        {
-            "env_id_or_path": "env-one,env-two,env-three",
-            "num_examples": 10,
-            "rollouts_per_example": 4,
-            "max_concurrent": 16,
-            "max_tokens": 512,
-            "temperature": 0.7,
-        },
-    )
-
-    configs = captured["configs"]
-    assert len(configs) == 3
-    for config in configs:
-        assert config.num_examples == 10
-        assert config.rollouts_per_example == 4
-        assert config.max_concurrent == 16
-        assert config.sampling_args["max_tokens"] == 512
-        assert config.sampling_args["temperature"] == 0.7
-
-
-def test_cli_comma_separated_with_spaces(monkeypatch):
-    """CLI handles spaces around commas in env IDs."""
-    captured = _run_cli(
-        monkeypatch,
-        {
-            "env_id_or_path": "gsm8k , alphabet-sort , math-python",
-        },
-    )
-
-    configs = captured["configs"]
-    assert len(configs) == 3
-    assert configs[0].env_id == "gsm8k"
-    assert configs[1].env_id == "alphabet-sort"
-    assert configs[2].env_id == "math-python"
-
-
-def test_cli_comma_separated_with_org_prefix(monkeypatch):
-    """CLI handles org/env format in comma-separated list."""
-    captured = _run_cli(
-        monkeypatch,
-        {
-            "env_id_or_path": "primeintellect/gsm8k,primeintellect/math-python",
-        },
-    )
-
-    configs = captured["configs"]
-    assert len(configs) == 2
-    assert configs[0].env_id == "primeintellect/gsm8k"
-    assert configs[1].env_id == "primeintellect/math-python"
-
-
-def test_cli_comma_separated_ignores_empty_entries(monkeypatch):
-    """CLI ignores empty entries from trailing/double commas."""
-    captured = _run_cli(
-        monkeypatch,
-        {
-            "env_id_or_path": "gsm8k,,alphabet-sort,",
-        },
-    )
-
-    configs = captured["configs"]
-    assert len(configs) == 2
-    assert configs[0].env_id == "gsm8k"
-    assert configs[1].env_id == "alphabet-sort"
-
-
-def test_cli_single_env_id_no_comma(monkeypatch):
-    """Single env ID without comma creates one config."""
-    captured = _run_cli(
-        monkeypatch,
-        {
-            "env_id_or_path": "gsm8k",
-        },
-    )
-
-    configs = captured["configs"]
-    assert len(configs) == 1
-    assert configs[0].env_id == "gsm8k"
-
-
-# =============================================================================
-# Tests for header parsing
-# =============================================================================
-
-
-def test_cli_header_parsing_single(monkeypatch):
-    """Single header is parsed correctly."""
-    captured = _run_cli(
-        monkeypatch,
-        {
-            "header": ["X-Custom-Header: my-value"],
-        },
-    )
-
-    config = captured["configs"][0]
-    assert config.client_config.extra_headers == {"X-Custom-Header": "my-value"}
-
-
-def test_cli_header_parsing_multiple(monkeypatch):
-    """Multiple headers are parsed correctly."""
-    captured = _run_cli(
-        monkeypatch,
-        {
-            "header": [
-                "Authorization: Bearer token123",
-                "X-Request-ID: req-456",
-            ],
-        },
-    )
-
-    config = captured["configs"][0]
-    assert config.client_config.extra_headers == {
-        "Authorization": "Bearer token123",
-        "X-Request-ID": "req-456",
-    }
-
-
-def test_cli_header_with_multiple_colons(monkeypatch):
-    """Header with multiple colons is parsed correctly (value can contain colons)."""
-    captured = _run_cli(
-        monkeypatch,
-        {
-            "header": ["X-URL: https://example.com:8080/path"],
-        },
-    )
-
-    config = captured["configs"][0]
-    assert config.client_config.extra_headers == {
-        "X-URL": "https://example.com:8080/path"
-    }
-
-
-def test_cli_header_invalid_format_no_colon(monkeypatch):
-    """Header without colon raises ValueError."""
-    with pytest.raises(ValueError, match="must be 'Name: Value'"):
-        _run_cli(
-            monkeypatch,
-            {
-                "header": ["InvalidHeaderNoColon"],
-            },
-        )
-
-
-def test_cli_header_invalid_empty_name(monkeypatch):
-    """Header with empty name raises ValueError."""
-    with pytest.raises(ValueError, match="name cannot be empty"):
-        _run_cli(
-            monkeypatch,
-            {
-                "header": [": value-only"],
-            },
-        )
-
-
-# =============================================================================
-# Tests for state columns parsing
-# =============================================================================
-
-
-def test_cli_state_columns_parsed(monkeypatch):
-    """State columns string is parsed into list."""
-    captured = _run_cli(
-        monkeypatch,
-        {
-            "state_columns": ["turn", "timing", "responses"],
-        },
-    )
-
-    config = captured["configs"][0]
-    assert config.state_columns == ["turn", "timing", "responses"]
-
-
-def test_cli_state_columns_empty(monkeypatch):
-    """Empty state columns list is handled."""
-    captured = _run_cli(
-        monkeypatch,
-        {
-            "state_columns": [],
-        },
-    )
-
-    config = captured["configs"][0]
-    assert config.state_columns == []
-
-
-# =============================================================================
-# Tests for endpoint resolution
-# =============================================================================
-
-
-def test_cli_endpoint_from_registry(monkeypatch):
-    """Model found in endpoint registry uses registry values."""
-    base_args = {
-        "env_id_or_path": "test-env",
-        "env_args": {},
-        "env_dir_path": "./environments",
-        "endpoints_path": "./configs/endpoints.py",
-        "model": "my-alias",
-        "api_key_var": None,
-        "api_base_url": None,
-        "header": None,
-        "num_examples": 1,
-        "rollouts_per_example": 1,
-        "max_concurrent": 1,
-        "max_concurrent_generation": None,
-        "max_concurrent_scoring": None,
-        "independent_scoring": False,
-        "max_tokens": 100,
-        "temperature": None,
-        "sampling_args": None,
-        "verbose": False,
-        "print_results": False,
-        "no_interleave_scoring": False,
-        "state_columns": [],
-        "save_results": False,
-        "save_every": -1,
-        "save_to_hf_hub": False,
-        "hf_hub_dataset_name": "",
-        "extra_env_kwargs": {},
-    }
-    args_namespace = SimpleNamespace(**base_args)
-    captured: dict = {"configs": []}
-
-    monkeypatch.setattr(
-        argparse.ArgumentParser,
-        "parse_args",
-        lambda self: args_namespace,
-    )
-    monkeypatch.setattr(vf_eval, "setup_logging", lambda *_, **__: None)
-
-    # Mock endpoint registry
-    monkeypatch.setattr(
-        vf_eval,
-        "load_endpoints",
-        lambda *_: {
-            "my-alias": {
-                "key": "MY_CUSTOM_KEY",
-                "url": "https://custom.api.com/v1",
-                "model": "actual-model-name",
-            }
-        },
-    )
-
-    async def fake_run_evaluation(config):
-        captured["configs"].append(config)
-        return _make_generate_outputs(env_id=config.env_id)
-
-    monkeypatch.setattr(
-        verifiers.utils.eval_utils, "run_evaluation", fake_run_evaluation
-    )
-
-    vf_eval.main()
-
-    config = captured["configs"][0]
-    assert config.client_config.api_key_var == "MY_CUSTOM_KEY"
-    assert config.client_config.api_base_url == "https://custom.api.com/v1"
-    assert config.model == "actual-model-name"
-
-
-def test_cli_endpoint_cli_overrides_registry(monkeypatch):
-    """CLI args override endpoint registry values."""
-    base_args = {
-        "env_id_or_path": "test-env",
-        "env_args": {},
-        "env_dir_path": "./environments",
-        "endpoints_path": "./configs/endpoints.py",
-        "model": "my-alias",
-        "api_key_var": "OVERRIDE_KEY",
-        "api_base_url": "https://override.api.com/v1",
-        "header": None,
-        "num_examples": 1,
-        "rollouts_per_example": 1,
-        "max_concurrent": 1,
-        "max_concurrent_generation": None,
-        "max_concurrent_scoring": None,
-        "independent_scoring": False,
-        "max_tokens": 100,
-        "temperature": None,
-        "sampling_args": None,
-        "verbose": False,
-        "print_results": False,
-        "no_interleave_scoring": False,
-        "state_columns": [],
-        "save_results": False,
-        "save_every": -1,
-        "save_to_hf_hub": False,
-        "hf_hub_dataset_name": "",
-        "extra_env_kwargs": {},
-    }
-    args_namespace = SimpleNamespace(**base_args)
-    captured: dict = {"configs": []}
-
-    monkeypatch.setattr(
-        argparse.ArgumentParser,
-        "parse_args",
-        lambda self: args_namespace,
-    )
-    monkeypatch.setattr(vf_eval, "setup_logging", lambda *_, **__: None)
-
-    monkeypatch.setattr(
-        vf_eval,
-        "load_endpoints",
-        lambda *_: {
-            "my-alias": {
-                "key": "REGISTRY_KEY",
-                "url": "https://registry.api.com/v1",
-                "model": "actual-model-name",
-            }
-        },
-    )
-
-    async def fake_run_evaluation(config):
-        captured["configs"].append(config)
-        return _make_generate_outputs(env_id=config.env_id)
-
-    monkeypatch.setattr(
-        verifiers.utils.eval_utils, "run_evaluation", fake_run_evaluation
-    )
-
-    vf_eval.main()
-
-    config = captured["configs"][0]
-    assert config.client_config.api_key_var == "OVERRIDE_KEY"
-    assert config.client_config.api_base_url == "https://override.api.com/v1"
-
-
-def test_cli_endpoint_not_in_registry_uses_defaults(monkeypatch):
-    """Model not in registry uses CLI defaults or global defaults."""
-    base_args = {
-        "env_id_or_path": "test-env",
-        "env_args": {},
-        "env_dir_path": "./environments",
-        "endpoints_path": "./configs/endpoints.py",
-        "model": "unknown-model",
-        "api_key_var": None,
-        "api_base_url": None,
-        "header": None,
-        "num_examples": 1,
-        "rollouts_per_example": 1,
-        "max_concurrent": 1,
-        "max_concurrent_generation": None,
-        "max_concurrent_scoring": None,
-        "independent_scoring": False,
-        "max_tokens": 100,
-        "temperature": None,
-        "sampling_args": None,
-        "verbose": False,
-        "print_results": False,
-        "no_interleave_scoring": False,
-        "state_columns": [],
-        "save_results": False,
-        "save_every": -1,
-        "save_to_hf_hub": False,
-        "hf_hub_dataset_name": "",
-        "extra_env_kwargs": {},
-    }
-    args_namespace = SimpleNamespace(**base_args)
-    captured: dict = {"configs": []}
-
-    monkeypatch.setattr(
-        argparse.ArgumentParser,
-        "parse_args",
-        lambda self: args_namespace,
-    )
-    monkeypatch.setattr(vf_eval, "setup_logging", lambda *_, **__: None)
-    monkeypatch.setattr(vf_eval, "load_endpoints", lambda *_: {})
-
-    async def fake_run_evaluation(config):
-        captured["configs"].append(config)
-        return _make_generate_outputs(env_id=config.env_id)
-
-    monkeypatch.setattr(
-        verifiers.utils.eval_utils, "run_evaluation", fake_run_evaluation
-    )
-
-    vf_eval.main()
-
-    config = captured["configs"][0]
-    # Should use DEFAULT values from eval.py
-    assert config.client_config.api_key_var == "PRIME_API_KEY"
-    assert config.client_config.api_base_url == "https://api.pinference.ai/api/v1"
-    assert config.model == "unknown-model"
-
-
-# =============================================================================
-# Tests for EvalConfig and MultiEvalConfig types
-# =============================================================================
-
-
-def test_eval_config_creation():
-    """EvalConfig can be created with required fields."""
-    from verifiers.types import ClientConfig
-
-    config = EvalConfig(
-        env_id="test-env",
-        env_args={"key": "value"},
-        env_dir_path="./environments",
-        model="gpt-4",
-        client_config=ClientConfig(),
-        sampling_args={"max_tokens": 100},
-        num_examples=10,
-        rollouts_per_example=3,
-        max_concurrent=32,
-    )
-
-    assert config.env_id == "test-env"
-    assert config.num_examples == 10
-    assert config.independent_scoring is False  # default
-
-
-def test_multi_eval_config_creation():
-    """MultiEvalConfig can be created with list of EvalConfigs."""
-    from verifiers.types import ClientConfig
-
-    configs = [
-        EvalConfig(
-            env_id=f"env-{i}",
-            env_args={},
-            env_dir_path="./environments",
-            model="gpt-4",
-            client_config=ClientConfig(),
-            sampling_args={},
-            num_examples=5,
-            rollouts_per_example=1,
-            max_concurrent=8,
-        )
-        for i in range(3)
-    ]
-
-    multi_config = MultiEvalConfig(env=configs)
-    assert len(multi_config.env) == 3
-    assert multi_config.env[0].env_id == "env-0"
-    assert multi_config.env[2].env_id == "env-2"
-
-
-# =============================================================================
-# Tests for extra environment kwargs
-# =============================================================================
-
-
-def test_cli_extra_env_kwargs(monkeypatch):
-    """Extra env kwargs are passed to config."""
-    captured = _run_cli(
-        monkeypatch,
-        {
-            "extra_env_kwargs": {"custom_key": "custom_value", "num_param": 42},
-        },
-    )
-
-    config = captured["configs"][0]
-    assert config.extra_env_kwargs == {"custom_key": "custom_value", "num_param": 42}
-
-
-def test_cli_extra_env_kwargs_empty(monkeypatch):
-    """Empty extra env kwargs is handled."""
-    captured = _run_cli(
-        monkeypatch,
-        {
-            "extra_env_kwargs": {},
-        },
-    )
-
-    config = captured["configs"][0]
-    assert config.extra_env_kwargs == {}
-
-
-# =============================================================================
-# Tests for concurrent generation/scoring options
-# =============================================================================
-
-
-def test_cli_concurrent_options(monkeypatch):
-    """Concurrent generation/scoring options are captured."""
-    captured = _run_cli(
-        monkeypatch,
-        {
-            "max_concurrent": 64,
-            "max_concurrent_generation": 32,
-            "max_concurrent_scoring": 16,
-        },
-    )
-
-    config = captured["configs"][0]
-    assert config.max_concurrent == 64
-    assert config.max_concurrent_generation == 32
-    assert config.max_concurrent_scoring == 16
-
-
-def test_cli_concurrent_options_none(monkeypatch):
-    """None concurrent options use defaults."""
-    captured = _run_cli(
-        monkeypatch,
-        {
-            "max_concurrent": 8,
-            "max_concurrent_generation": None,
-            "max_concurrent_scoring": None,
-        },
-    )
-
-    config = captured["configs"][0]
-    assert config.max_concurrent == 8
-    assert config.max_concurrent_generation is None
-    assert config.max_concurrent_scoring is None
-
-
-# =============================================================================
-# Tests for independent scoring option
-# =============================================================================
-
-
-def test_cli_independent_scoring_enabled(monkeypatch):
-    """Independent scoring flag is captured."""
-    captured = _run_cli(
-        monkeypatch,
-        {
-            "independent_scoring": True,
-        },
-    )
-
-    config = captured["configs"][0]
-    assert config.independent_scoring is True
-
-
-def test_cli_independent_scoring_disabled(monkeypatch):
-    """Independent scoring disabled by default."""
-    captured = _run_cli(
-        monkeypatch,
-        {
-            "independent_scoring": False,
-        },
-    )
-
-    config = captured["configs"][0]
-    assert config.independent_scoring is False
-
-
-# =============================================================================
-# Tests for save options
-# =============================================================================
-
-
-def test_cli_save_options(monkeypatch):
-    """Save options are captured correctly."""
-    captured = _run_cli(
-        monkeypatch,
-        {
-            "save_results": True,
-            "save_every": 50,
-            "save_to_hf_hub": True,
-            "hf_hub_dataset_name": "my-org/my-dataset",
-        },
-    )
-
-    config = captured["configs"][0]
-    assert config.save_results is True
-    assert config.save_every == 50
-    assert config.save_to_hf_hub is True
-    assert config.hf_hub_dataset_name == "my-org/my-dataset"

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -877,7 +877,7 @@ class Environment(ABC):
                 )
                 tasks[task] = i
             pbar_total = len(inputs_list)
-            pbar_desc = f"Processing {len(inputs_list)} rollouts"
+            pbar_desc = f"Processing {len(inputs_list)} {self.env_id} rollouts"
         else:
             input_groups: dict[int, list[RolloutInput]] = {}
             for input_item in inputs_list:
@@ -900,7 +900,7 @@ class Environment(ABC):
                 )
                 tasks[task] = i
             pbar_total = len(group_list)
-            pbar_desc = f"Processing {len(group_list)} groups ({len(inputs_list)} total rollouts)"
+            pbar_desc = f"Processing {len(group_list)} {self.env_id} groups ({len(inputs_list)} total rollouts)"
 
         # set up progress bar
         pbar = None

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -877,7 +877,7 @@ class Environment(ABC):
                 )
                 tasks[task] = i
             pbar_total = len(inputs_list)
-            pbar_desc = f"Processing {len(inputs_list)} {self.env_id} rollouts"
+            pbar_desc = f"Processing {len(inputs_list)} rollouts"
         else:
             input_groups: dict[int, list[RolloutInput]] = {}
             for input_item in inputs_list:
@@ -900,7 +900,7 @@ class Environment(ABC):
                 )
                 tasks[task] = i
             pbar_total = len(group_list)
-            pbar_desc = f"Processing {len(group_list)} {self.env_id} groups ({len(inputs_list)} total rollouts)"
+            pbar_desc = f"Processing {len(group_list)} groups ({len(inputs_list)} total rollouts)"
 
         # set up progress bar
         pbar = None

--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -302,29 +302,31 @@ def main():
         api_key_override = args.api_key_var is not None
         api_base_url_override = args.api_base_url is not None
 
+        # use local variable to avoid mutating args.model across loop iterations
+        model = args.model
         if args.model in endpoints:
             endpoint = endpoints[args.model]
             api_key_var = args.api_key_var if api_key_override else endpoint["key"]
             api_base_url = (
                 args.api_base_url if api_base_url_override else endpoint["url"]
             )
-            args.model = endpoint["model"]
+            model = endpoint["model"]
             if api_key_override or api_base_url_override:
                 logger.debug(
                     "Using endpoint registry for model '%s' with CLI overrides (key: %s, url: %s)",
-                    args.model,
+                    model,
                     "cli" if api_key_override else "registry",
                     "cli" if api_base_url_override else "registry",
                 )
             else:
                 logger.debug(
                     "Using endpoint configuration for model '%s' from registry",
-                    args.model,
+                    model,
                 )
         else:
             logger.debug(
                 "Model '%s' not found in endpoint registry, using command-line arguments",
-                args.model,
+                model,
             )
             api_key_var = args.api_key_var if api_key_override else DEFAULT_API_KEY_VAR
             api_base_url = (
@@ -365,7 +367,7 @@ def main():
             env_dir_path=args.env_dir_path,
             extra_env_kwargs=args.extra_env_kwargs,
             # evaluation
-            model=args.model,
+            model=model,
             client_config=client_config,
             sampling_args=merged_sampling_args,
             num_examples=num_examples,

--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -13,12 +13,18 @@ except ImportError:
     import tomli as tomllib  # type: ignore[unresolved-import]
 
 from verifiers import setup_logging
-from verifiers.types import ClientConfig, EvalConfig, EvalRunConfig
+from verifiers.types import (
+    ClientConfig,
+    EvalConfig,
+    EvalEnvConfig,
+    EvalModelConfig,
+    EvalRunConfig,
+)
 from verifiers.utils.eval_utils import (
     is_toml_config,
     load_endpoints,
     load_toml_config,
-    run_multi_evaluation,
+    run_evaluations,
 )
 
 logger = logging.getLogger(__name__)
@@ -55,10 +61,16 @@ def get_env_eval_defaults(env_id: str) -> Dict[str, Any]:
             pyproject_data.get("tool", {}).get("verifiers", {}).get("eval", {})
         )
 
-        if "num_examples" in eval_config:
-            defaults["num_examples"] = eval_config["num_examples"]
-        if "rollouts_per_example" in eval_config:
-            defaults["rollouts_per_example"] = eval_config["rollouts_per_example"]
+        for key in (
+            "env_args",
+            "num_examples",
+            "rollouts_per_example",
+            "interleave_scoring",
+            "state_columns",
+            "extra_env_kwargs",
+        ):
+            if key in eval_config:
+                defaults[key] = eval_config[key]
 
         if defaults:
             logger.debug(
@@ -74,6 +86,184 @@ def get_env_eval_defaults(env_id: str) -> Dict[str, Any]:
     return defaults
 
 
+def merge_nested_dicts(base: dict, override: dict) -> dict:
+    merged = dict(base)
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            merged[key] = merge_nested_dicts(merged[key], value)
+        else:
+            merged[key] = value
+    return merged
+
+
+def normalize_model_overrides(raw_model: dict | None) -> dict:
+    if not raw_model:
+        return {}
+    model_overrides = dict(raw_model)
+    client_config = dict(model_overrides.pop("client_config", {}))
+    for key in ("api_key_var", "api_base_url", "extra_headers"):
+        if key in model_overrides:
+            client_config[key] = model_overrides.pop(key)
+    if client_config:
+        model_overrides["client_config"] = client_config
+    return model_overrides
+
+
+def resolve_client_config(
+    model_name: str,
+    endpoints: dict,
+    api_key_var_override: str | None,
+    api_base_url_override: str | None,
+    extra_headers: Dict[str, str],
+) -> tuple[str, ClientConfig]:
+    api_key_override = api_key_var_override is not None
+    api_base_url_override = api_base_url_override is not None
+
+    if model_name in endpoints:
+        endpoint = endpoints[model_name]
+        api_key_var = api_key_var_override if api_key_override else endpoint["key"]
+        api_base_url = (
+            api_base_url_override if api_base_url_override else endpoint["url"]
+        )
+        resolved_model = endpoint["model"]
+        if api_key_override or api_base_url_override:
+            logger.debug(
+                "Using endpoint registry for model '%s' with overrides (key: %s, url: %s)",
+                resolved_model,
+                "override" if api_key_override else "registry",
+                "override" if api_base_url_override else "registry",
+            )
+        else:
+            logger.debug(
+                "Using endpoint configuration for model '%s' from registry",
+                resolved_model,
+            )
+    else:
+        logger.debug(
+            "Model '%s' not found in endpoint registry, using defaults",
+            model_name,
+        )
+        api_key_var = api_key_var_override or DEFAULT_API_KEY_VAR
+        api_base_url = api_base_url_override or DEFAULT_API_BASE_URL
+        resolved_model = model_name
+
+    return resolved_model, ClientConfig(
+        api_key_var=api_key_var,
+        api_base_url=api_base_url,
+        extra_headers=extra_headers,
+    )
+
+
+def build_model_config(
+    model_overrides: dict,
+    model_defaults: dict,
+    cli_defaults: dict,
+    endpoints: dict,
+    cli_api_key_var: str | None,
+    cli_api_base_url: str | None,
+    cli_headers: Dict[str, str],
+) -> EvalModelConfig:
+    normalized_defaults = normalize_model_overrides(model_defaults)
+    normalized_overrides = normalize_model_overrides(model_overrides)
+    model_name = (
+        normalized_overrides.get("model")
+        or normalized_defaults.get("model")
+        or cli_defaults["model"]
+    )
+    merged_headers = merge_nested_dicts(
+        cli_headers,
+        merge_nested_dicts(
+            normalized_defaults.get("client_config", {}).get("extra_headers", {}),
+            normalized_overrides.get("client_config", {}).get("extra_headers", {}),
+        ),
+    )
+    api_key_var_override = normalized_overrides.get("client_config", {}).get(
+        "api_key_var",
+        normalized_defaults.get("client_config", {}).get(
+            "api_key_var", cli_api_key_var
+        ),
+    )
+    api_base_url_override = normalized_overrides.get("client_config", {}).get(
+        "api_base_url",
+        normalized_defaults.get("client_config", {}).get(
+            "api_base_url", cli_api_base_url
+        ),
+    )
+    resolved_model, client_config = resolve_client_config(
+        model_name,
+        endpoints,
+        api_key_var_override,
+        api_base_url_override,
+        merged_headers,
+    )
+
+    sampling_args = merge_nested_dicts(
+        cli_defaults["sampling_args"],
+        normalized_defaults.get("sampling_args", {}),
+    )
+    sampling_args = merge_nested_dicts(
+        sampling_args,
+        normalized_overrides.get("sampling_args", {}),
+    )
+
+    return EvalModelConfig(
+        model=resolved_model,
+        client_config=client_config,
+        sampling_args=sampling_args,
+        max_concurrent=normalized_overrides.get(
+            "max_concurrent",
+            normalized_defaults.get("max_concurrent", cli_defaults["max_concurrent"]),
+        ),
+        max_concurrent_generation=normalized_overrides.get(
+            "max_concurrent_generation",
+            normalized_defaults.get(
+                "max_concurrent_generation", cli_defaults["max_concurrent_generation"]
+            ),
+        ),
+        max_concurrent_scoring=normalized_overrides.get(
+            "max_concurrent_scoring",
+            normalized_defaults.get(
+                "max_concurrent_scoring", cli_defaults["max_concurrent_scoring"]
+            ),
+        ),
+    )
+
+
+def build_env_config(
+    env_id: str,
+    env_overrides: dict,
+    env_defaults: dict,
+    cli_defaults: dict,
+    pyproject_defaults: dict,
+) -> EvalEnvConfig:
+    env_overrides = dict(env_overrides)
+    env_overrides.pop("env_id", None)
+    merged_defaults = merge_nested_dicts(
+        {
+            "num_examples": DEFAULT_NUM_EXAMPLES,
+            "rollouts_per_example": DEFAULT_ROLLOUTS_PER_EXAMPLE,
+            "interleave_scoring": True,
+            "env_args": {},
+            "state_columns": None,
+            "extra_env_kwargs": {},
+        },
+        pyproject_defaults,
+    )
+    merged_defaults = merge_nested_dicts(merged_defaults, cli_defaults)
+    merged_defaults = merge_nested_dicts(merged_defaults, env_defaults)
+    merged = merge_nested_dicts(merged_defaults, env_overrides)
+
+    return EvalEnvConfig(
+        env_id=env_id,
+        env_args=merged.get("env_args", {}),
+        num_examples=merged["num_examples"],
+        rollouts_per_example=merged["rollouts_per_example"],
+        interleave_scoring=merged.get("interleave_scoring", True),
+        state_columns=merged.get("state_columns"),
+        extra_env_kwargs=merged.get("extra_env_kwargs", {}),
+    )
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -86,7 +276,7 @@ def main():
         "--env-args",
         "-a",
         type=json.loads,
-        default={},
+        default=None,
         help='Environment module arguments as JSON object (e.g., \'{"key": "value", "num": 42}\')',
     )
     parser.add_argument(
@@ -195,7 +385,7 @@ def main():
     parser.add_argument(
         "--no-interleave-scoring",
         "-N",
-        default=False,
+        default=None,
         action="store_true",
         help="Disable interleaving of scoring",
     )
@@ -203,13 +393,13 @@ def main():
         "--state-columns",
         "-C",
         type=lambda t: [s.strip() for s in t.split(",")],
-        default=[],
+        default=None,
         help="Comma-separated list of state columns to save (e.g., 'turn,timing')",
     )
     parser.add_argument(
         "--save-results",
         "-s",
-        default=False,
+        default=None,
         action="store_true",
         help="Save results to disk",
     )
@@ -218,20 +408,20 @@ def main():
         "--save-every",
         "-f",
         type=int,
-        default=-1,
+        default=None,
         help="Save dataset every n rollouts",
     )
     parser.add_argument(
         "--independent-scoring",
         "-R",
-        default=False,
+        default=None,
         action="store_true",
         help="Score each rollout individually instead of scoring by group",
     )
     parser.add_argument(
         "--save-to-hf-hub",
         "-H",
-        default=False,
+        default=None,
         action="store_true",
         help="Save dataset to Hugging Face Hub",
     )
@@ -239,122 +429,21 @@ def main():
         "--hf-hub-dataset-name",
         "-D",
         type=str,
-        default="",
+        default=None,
         help="Name of dataset to save to Hugging Face Hub",
     )
     parser.add_argument(
         "--extra-env-kwargs",
         "-x",
         type=json.loads,
-        default={},
+        default=None,
         help='Extra environment as JSON object (e.g., \'{"key": "value", "num": 42}\'). Passed to environment constructor.',
     )
     args = parser.parse_args()
 
     setup_logging("DEBUG" if args.verbose else os.getenv("VF_LOG_LEVEL", "INFO"))
 
-    # resolve env_id_or_path: TOML config > comma-separated list > single env ID
-    if is_toml_config(args.env_id_or_path):
-        # single/multi-env eval via single TOML config
-        path = Path(args.env_id_or_path)
-        raw_multi_env_config = load_toml_config(path)
-    elif "," in args.env_id_or_path:
-        # multi-env eval via comma-separated list
-        env_ids = [
-            env_id.strip()
-            for env_id in args.env_id_or_path.split(",")
-            if env_id.strip()
-        ]
-        if not env_ids:
-            raise ValueError(
-                f"No valid env_ids found in comma-separated list {args.env_id_or_path!r}"
-            )
-        raw_multi_env_config = [{"env_id": env_id} for env_id in env_ids]
-    else:
-        # single-eval env
-        raw_multi_env_config = [{"env_id": args.env_id_or_path}]
-
-    def resolve_eval_config(raw_env_config: dict) -> EvalConfig:
-        """Resolve per-env eval config. TOML > CLI > Env Defaults > Global Defaults"""
-        assert "env_id" in raw_env_config
-        env_id = raw_env_config["env_id"]
-        env_defaults = get_env_eval_defaults(env_id)
-        num_examples = raw_env_config.get("num_examples", args.num_examples)
-        rollouts_per_example = raw_env_config.get(
-            "rollouts_per_example", args.rollouts_per_example
-        )
-
-        if num_examples is None:
-            num_examples = env_defaults.get("num_examples", DEFAULT_NUM_EXAMPLES)
-        if rollouts_per_example is None:
-            rollouts_per_example = env_defaults.get(
-                "rollouts_per_example", DEFAULT_ROLLOUTS_PER_EXAMPLE
-            )
-
-        if raw_env_config.get("num_examples") is None and args.num_examples is None:
-            source = (
-                "pyproject.toml" if "num_examples" in env_defaults else "global default"
-            )
-            logger.debug(f"Using num_examples={num_examples} from {source}")
-        if (
-            raw_env_config.get("rollouts_per_example") is None
-            and args.rollouts_per_example is None
-        ):
-            source = (
-                "pyproject.toml"
-                if "rollouts_per_example" in env_defaults
-                else "global default"
-            )
-            logger.debug(
-                f"Using rollouts_per_example={rollouts_per_example} from {source}"
-            )
-
-        env_args = raw_env_config.get("env_args", args.env_args) or {}
-
-        return EvalConfig(
-            env_id=env_id,
-            env_args=env_args,
-            num_examples=num_examples,
-            rollouts_per_example=rollouts_per_example,
-        )
-
-    eval_configs: list[EvalConfig] = []
-    for raw_env_config in raw_multi_env_config:
-        eval_config = resolve_eval_config(raw_env_config)
-        eval_configs.append(eval_config)
-        logger.debug(f"Evaluation config: {eval_config.model_dump_json(indent=2)}")
-
     endpoints = load_endpoints(args.endpoints_path)
-    api_key_override = args.api_key_var is not None
-    api_base_url_override = args.api_base_url is not None
-
-    model = args.model
-    if args.model in endpoints:
-        endpoint = endpoints[args.model]
-        api_key_var = args.api_key_var if api_key_override else endpoint["key"]
-        api_base_url = args.api_base_url if api_base_url_override else endpoint["url"]
-        model = endpoint["model"]
-        if api_key_override or api_base_url_override:
-            logger.debug(
-                "Using endpoint registry for model '%s' with CLI overrides (key: %s, url: %s)",
-                model,
-                "cli" if api_key_override else "registry",
-                "cli" if api_base_url_override else "registry",
-            )
-        else:
-            logger.debug(
-                "Using endpoint configuration for model '%s' from registry",
-                model,
-            )
-    else:
-        logger.debug(
-            "Model '%s' not found in endpoint registry, using command-line arguments",
-            model,
-        )
-        api_key_var = args.api_key_var if api_key_override else DEFAULT_API_KEY_VAR
-        api_base_url = (
-            args.api_base_url if api_base_url_override else DEFAULT_API_BASE_URL
-        )
 
     # merge sampling args with precedence to JSON payload over explicit flags
     merged_sampling_args: dict = {}
@@ -376,33 +465,120 @@ def main():
             raise ValueError("--header name cannot be empty")
         merged_headers[k] = v
 
-    client_config = ClientConfig(
-        api_key_var=api_key_var,
-        api_base_url=api_base_url,
-        extra_headers=merged_headers,
+    cli_model_defaults = {
+        "model": args.model,
+        "sampling_args": merged_sampling_args,
+        "max_concurrent": args.max_concurrent,
+        "max_concurrent_generation": args.max_concurrent_generation,
+        "max_concurrent_scoring": args.max_concurrent_scoring,
+    }
+
+    interleave_override = None
+    if args.no_interleave_scoring:
+        interleave_override = False
+    if args.independent_scoring:
+        interleave_override = False
+
+    cli_env_defaults = {
+        "env_args": args.env_args if args.env_args is not None else None,
+        "num_examples": args.num_examples,
+        "rollouts_per_example": args.rollouts_per_example,
+        "interleave_scoring": interleave_override,
+        "state_columns": args.state_columns,
+        "extra_env_kwargs": args.extra_env_kwargs,
+    }
+
+    cli_env_defaults = {k: v for k, v in cli_env_defaults.items() if v is not None}
+
+    if is_toml_config(args.env_id_or_path):
+        path = Path(args.env_id_or_path)
+        toml_config = load_toml_config(path)
+        raw_eval_list = toml_config["evals"]
+        toml_env_defaults = toml_config["env_defaults"]
+        toml_model_defaults = toml_config["model_defaults"]
+        toml_save_defaults = toml_config["save_defaults"]
+    elif "," in args.env_id_or_path:
+        env_ids = [
+            env_id.strip()
+            for env_id in args.env_id_or_path.split(",")
+            if env_id.strip()
+        ]
+        if not env_ids:
+            raise ValueError(
+                f"No valid env_ids found in comma-separated list {args.env_id_or_path!r}"
+            )
+        raw_eval_list = [{"env": {"env_id": env_id}} for env_id in env_ids]
+        toml_env_defaults = {}
+        toml_model_defaults = {}
+        toml_save_defaults = {}
+    else:
+        raw_eval_list = [{"env": {"env_id": args.env_id_or_path}}]
+        toml_env_defaults = {}
+        toml_model_defaults = {}
+        toml_save_defaults = {}
+
+    eval_configs: list[EvalConfig] = []
+    for raw_eval in raw_eval_list:
+        raw_env = raw_eval.get("env", {})
+        if "env_id" in raw_eval:
+            raw_env = {**raw_env, "env_id": raw_eval["env_id"]}
+        env_id = raw_env["env_id"]
+        raw_model = raw_eval.get("model", {})
+
+        env_config = build_env_config(
+            env_id,
+            raw_env,
+            toml_env_defaults,
+            cli_env_defaults,
+            get_env_eval_defaults(env_id),
+        )
+
+        model_config = build_model_config(
+            raw_model,
+            toml_model_defaults,
+            cli_model_defaults,
+            endpoints,
+            args.api_key_var,
+            args.api_base_url,
+            merged_headers,
+        )
+
+        eval_config = EvalConfig(env=env_config, model=model_config)
+        eval_configs.append(eval_config)
+        logger.debug(f"Evaluation config: {eval_config.model_dump_json(indent=2)}")
+
+    save_results = (
+        args.save_results
+        if args.save_results is not None
+        else toml_save_defaults.get("save_results", False)
+    )
+    save_every = (
+        args.save_every
+        if args.save_every is not None
+        else toml_save_defaults.get("save_every", -1)
+    )
+    save_to_hf_hub = (
+        args.save_to_hf_hub
+        if args.save_to_hf_hub is not None
+        else toml_save_defaults.get("save_to_hf_hub", False)
+    )
+    hf_hub_dataset_name = (
+        args.hf_hub_dataset_name
+        if args.hf_hub_dataset_name is not None
+        else toml_save_defaults.get("hf_hub_dataset_name")
     )
 
     run_config = EvalRunConfig(
-        env=eval_configs,
+        evals=eval_configs,
         env_dir_path=args.env_dir_path,
-        model=model,
-        client_config=client_config,
-        sampling_args=merged_sampling_args,
-        max_concurrent=args.max_concurrent,
-        max_concurrent_generation=args.max_concurrent_generation,
-        max_concurrent_scoring=args.max_concurrent_scoring,
-        independent_scoring=args.independent_scoring,
-        extra_env_kwargs=args.extra_env_kwargs,
-        verbose=args.verbose,
-        state_columns=args.state_columns,
-        save_results=args.save_results,
-        save_every=args.save_every,
-        save_to_hf_hub=args.save_to_hf_hub,
-        hf_hub_dataset_name=args.hf_hub_dataset_name,
+        save_results=save_results,
+        save_every=save_every,
+        save_to_hf_hub=save_to_hf_hub,
+        hf_hub_dataset_name=hf_hub_dataset_name,
     )
     logger.debug(f"Evaluation run config: {run_config.model_dump_json(indent=2)}")
 
-    asyncio.run(run_multi_evaluation(run_config))
+    asyncio.run(run_evaluations(run_config))
 
 
 if __name__ == "__main__":

--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -555,7 +555,11 @@ def main():
         raw_env = raw_eval.get("env", {})
         if "env_id" in raw_eval:
             raw_env = {**raw_env, "env_id": raw_eval["env_id"]}
-        env_id = raw_env["env_id"]
+        env_id = raw_env.get("env_id") or toml_env_defaults.get("env_id")
+        if not env_id or not isinstance(env_id, str):
+            raise ValueError(
+                "Each [[eval]] entry must have env_id either in [eval.env] or [env] defaults"
+            )
         raw_model = raw_eval.get("model", {})
         raw_save = raw_eval.get("save", {})
 

--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -261,15 +261,15 @@ def main():
     elif "," in args.env_id_or_path:
         # multi-env eval via comma-separated list
         env_ids = [env_id.strip() for env_id in args.env_id_or_path.split(",")]
-        raw_multi_env_config = [{"id": env_id} for env_id in env_ids if env_id]
+        raw_multi_env_config = [{"env_id": env_id} for env_id in env_ids if env_id]
     else:
         # single-eval env
-        raw_multi_env_config = [{"id": args.env_id_or_path}]
+        raw_multi_env_config = [{"env_id": args.env_id_or_path}]
 
     def resolve_eval_config(raw_env_config: dict) -> EvalConfig:
         """Resolve per-env eval config. TOML > CLI > Env Defaults > Global Defaults"""
-        assert "id" in raw_env_config
-        env_id = raw_env_config["id"]
+        assert "env_id" in raw_env_config
+        env_id = raw_env_config["env_id"]
         env_defaults = get_env_eval_defaults(env_id)
         num_examples = (
             args.num_examples

--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -80,7 +80,7 @@ def main():
         "env_id_or_path",
         type=str,
         default="gsm8k",
-        help="Environment module name or path to TOML config file",
+        help="Environment module name(s) (comma-separated) or path to TOML config.",
     )
     parser.add_argument(
         "--env-args",
@@ -257,6 +257,10 @@ def main():
     if is_toml_config(args.env_id_or_path):
         path = Path(args.env_id_or_path)
         raw_multi_env_config = load_toml_config(path)
+    elif "," in args.env_id_or_path:
+        # comma-separated list of env IDs: "gsm8k,alphabet-sort,math-python"
+        env_ids = [env_id.strip() for env_id in args.env_id_or_path.split(",")]
+        raw_multi_env_config = [{"id": env_id} for env_id in env_ids if env_id]
     else:
         raw_multi_env_config = [{"id": args.env_id_or_path}]
 

--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -260,8 +260,16 @@ def main():
         raw_multi_env_config = load_toml_config(path)
     elif "," in args.env_id_or_path:
         # multi-env eval via comma-separated list
-        env_ids = [env_id.strip() for env_id in args.env_id_or_path.split(",")]
-        raw_multi_env_config = [{"env_id": env_id} for env_id in env_ids if env_id]
+        env_ids = [
+            env_id.strip()
+            for env_id in args.env_id_or_path.split(",")
+            if env_id.strip()
+        ]
+        if not env_ids:
+            raise ValueError(
+                f"No valid env_ids found in comma-separated list {args.env_id_or_path!r}"
+            )
+        raw_multi_env_config = [{"env_id": env_id} for env_id in env_ids]
     else:
         # single-eval env
         raw_multi_env_config = [{"env_id": args.env_id_or_path}]

--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -118,21 +118,21 @@ def resolve_client_config(
     extra_headers: Dict[str, str],
 ) -> tuple[str, ClientConfig]:
     api_key_override = api_key_var_override is not None
-    api_base_url_override = api_base_url_override is not None
+    api_base_url_override_is_set = api_base_url_override is not None
 
     if model_name in endpoints:
         endpoint = endpoints[model_name]
         api_key_var = api_key_var_override if api_key_override else endpoint["key"]
         api_base_url = (
-            api_base_url_override if api_base_url_override else endpoint["url"]
+            api_base_url_override if api_base_url_override_is_set else endpoint["url"]
         )
         resolved_model = endpoint["model"]
-        if api_key_override or api_base_url_override:
+        if api_key_override or api_base_url_override_is_set:
             logger.debug(
                 "Using endpoint registry for model '%s' with overrides (key: %s, url: %s)",
                 resolved_model,
                 "override" if api_key_override else "registry",
-                "override" if api_base_url_override else "registry",
+                "override" if api_base_url_override_is_set else "registry",
             )
         else:
             logger.debug(

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -236,7 +236,6 @@ class EvalConfig(BaseModel):
     independent_scoring: bool = False
     extra_env_kwargs: dict = {}
     # logging
-    print_results: bool = False
     verbose: bool = False
     # saving
     state_columns: list[str] | None = None

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -244,3 +244,9 @@ class EvalConfig(BaseModel):
     save_every: int = -1
     save_to_hf_hub: bool = False
     hf_hub_dataset_name: str | None = None
+
+
+class MultiEvalConfig(BaseModel):
+    """Pydantic model for multi-environment evaluation configuration."""
+
+    env: list[EvalConfig]

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -240,11 +240,21 @@ class EvalModelConfig(BaseModel):
     max_concurrent_scoring: int | None = None
 
 
+class EvalSaveConfig(BaseModel):
+    """Pydantic model for evaluation save configuration."""
+
+    save_results: bool = False
+    save_every: int = -1
+    save_to_hf_hub: bool = False
+    hf_hub_dataset_name: str | None = None
+
+
 class EvalConfig(BaseModel):
     """Pydantic model for evaluation configuration."""
 
     env: EvalEnvConfig
     model: EvalModelConfig
+    save: EvalSaveConfig
 
 
 class EvalRunConfig(BaseModel):
@@ -252,7 +262,3 @@ class EvalRunConfig(BaseModel):
 
     evals: list[EvalConfig]
     env_dir_path: str
-    save_results: bool = False
-    save_every: int = -1
-    save_to_hf_hub: bool = False
-    hf_hub_dataset_name: str | None = None

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -222,14 +222,20 @@ class EvalConfig(BaseModel):
 
     # environment
     env_id: str
-    env_args: dict
+    env_args: dict = {}
+    num_examples: int
+    rollouts_per_example: int
+
+
+class EvalRunConfig(BaseModel):
+    """Pydantic model for evaluation run configuration."""
+
+    env: list[EvalConfig]
+    # run
     env_dir_path: str
-    # evaluation
     model: str
     client_config: ClientConfig
     sampling_args: SamplingArgs
-    num_examples: int
-    rollouts_per_example: int
     max_concurrent: int
     max_concurrent_generation: int | None = None
     max_concurrent_scoring: int | None = None
@@ -243,9 +249,3 @@ class EvalConfig(BaseModel):
     save_every: int = -1
     save_to_hf_hub: bool = False
     hf_hub_dataset_name: str | None = None
-
-
-class MultiEvalConfig(BaseModel):
-    """Pydantic model for multi-environment evaluation configuration."""
-
-    env: list[EvalConfig]

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -217,34 +217,41 @@ class ClientConfig(BaseModel):
     extra_headers: dict[str, str] = {}
 
 
-class EvalConfig(BaseModel):
-    """Pydantic model for evaluation configuration."""
+class EvalEnvConfig(BaseModel):
+    """Pydantic model for environment-specific evaluation configuration."""
 
-    # environment
     env_id: str
     env_args: dict = {}
     num_examples: int
     rollouts_per_example: int
+    interleave_scoring: bool = True
+    state_columns: list[str] | None = None
+    extra_env_kwargs: dict = {}
 
 
-class EvalRunConfig(BaseModel):
-    """Pydantic model for evaluation run configuration."""
+class EvalModelConfig(BaseModel):
+    """Pydantic model for model-specific evaluation configuration."""
 
-    env: list[EvalConfig]
-    # run
-    env_dir_path: str
     model: str
     client_config: ClientConfig
     sampling_args: SamplingArgs
     max_concurrent: int
     max_concurrent_generation: int | None = None
     max_concurrent_scoring: int | None = None
-    independent_scoring: bool = False
-    extra_env_kwargs: dict = {}
-    # logging
-    verbose: bool = False
-    # saving
-    state_columns: list[str] | None = None
+
+
+class EvalConfig(BaseModel):
+    """Pydantic model for evaluation configuration."""
+
+    env: EvalEnvConfig
+    model: EvalModelConfig
+
+
+class EvalRunConfig(BaseModel):
+    """Pydantic model for evaluation run configuration."""
+
+    evals: list[EvalConfig]
+    env_dir_path: str
     save_results: bool = False
     save_every: int = -1
     save_to_hf_hub: bool = False

--- a/verifiers/utils/async_utils.py
+++ b/verifiers/utils/async_utils.py
@@ -54,7 +54,7 @@ class EventLoopLagMonitor:
             f"{__name__}.{self.__class__.__name__}"
         )
         self.lags = []
-        self.logger.info(
+        self.logger.debug(
             f"Event loop lag monitor initialized with measure_interval={self.measure_interval} and max_measurements={self.max_measurements}"
         )
 

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -104,7 +104,7 @@ def load_toml_config(path: Path) -> list[dict]:
         invalid_fields = set(env.keys()) - valid_fields
         if invalid_fields:
             raise ValueError(
-                f"Invalid field(s) {invalid_fields} in [[env]] section for '{env.get('id', 'unknown')}'. "
+                f"Invalid field(s) {invalid_fields} for {env.get('id', 'unknown')}. "
                 f"Valid fields are: {sorted(valid_fields)}"
             )
 

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -85,19 +85,14 @@ def load_toml_config(path: Path) -> list[dict]:
         raw_config = tomllib.load(f)
 
     # validate schema
-    if "env" not in raw_config:
-        raise ValueError(
-            f"Config file must contain at least one [[env]] section: {path}"
-        )
-
     env_list: list[dict] = raw_config.get("env", [])
     if not env_list:
         raise ValueError(
             f"Config file must contain at least one [[env]] section: {path}"
         )
 
-    if not all("id" in e for e in env_list):
-        raise ValueError(f"All [[env]] sections must contain an 'id' field: {path}")
+    if not all("env_id" in e for e in env_list):
+        raise ValueError(f"All [[env]] sections must contain an env_id field: {path}")
 
     valid_fields = set(EvalConfig.model_fields.keys())
     for env in env_list:

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -158,6 +158,7 @@ def load_toml_config(path: Path) -> dict[str, dict | list]:
             raise ValueError("Each [[eval]] entry must be a table")
         raw_env = eval_entry.get("env", {})
         raw_model = eval_entry.get("model", {})
+        raw_save = eval_entry.get("save", {})
         if "env_id" in eval_entry:
             raw_env = {**raw_env, "env_id": eval_entry["env_id"]}
 
@@ -179,6 +180,13 @@ def load_toml_config(path: Path) -> dict[str, dict | list]:
             raise ValueError(
                 f"Invalid model field(s) {invalid_model_fields} for {raw_env.get('env_id', 'unknown')}. "
                 f"Valid fields are: {sorted(valid_model_fields)}"
+            )
+
+        invalid_save_fields = set(raw_save.keys()) - valid_save_fields
+        if invalid_save_fields:
+            raise ValueError(
+                f"Invalid save field(s) {invalid_save_fields} for {raw_env.get('env_id', 'unknown')}. "
+                f"Valid fields are: {sorted(valid_save_fields)}"
             )
 
     return {
@@ -368,16 +376,16 @@ async def run_evaluation(
         max_concurrent_scoring=eval_config.model.max_concurrent_scoring,
         results_path=results_path,
         state_columns=eval_config.env.state_columns,
-        save_results=run_config.save_results,
-        save_every=run_config.save_every,
+        save_results=eval_config.save.save_results,
+        save_every=eval_config.save.save_every,
         independent_scoring=not eval_config.env.interleave_scoring,
     )
 
-    if run_config.save_results:
+    if eval_config.save.save_results:
         save_rollout_results(
             results,
-            run_config.save_to_hf_hub,
-            run_config.hf_hub_dataset_name,
+            eval_config.save.save_to_hf_hub,
+            eval_config.save.hf_hub_dataset_name,
         )
     return results
 

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -99,7 +99,7 @@ def load_toml_config(path: Path) -> list[dict]:
         invalid_fields = set(env.keys()) - valid_fields
         if invalid_fields:
             raise ValueError(
-                f"Invalid field(s) {invalid_fields} for {env.get('id', 'unknown')}. "
+                f"Invalid field(s) {invalid_fields} for {env.get('env_id', 'unknown')}. "
                 f"Valid fields are: {sorted(valid_fields)}"
             )
 

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -99,6 +99,15 @@ def load_toml_config(path: Path) -> list[dict]:
     if not all("id" in e for e in env_list):
         raise ValueError(f"All [[env]] sections must contain an 'id' field: {path}")
 
+    valid_fields = set(EvalConfig.model_fields.keys())
+    for env in env_list:
+        invalid_fields = set(env.keys()) - valid_fields
+        if invalid_fields:
+            raise ValueError(
+                f"Invalid field(s) {invalid_fields} in [[env]] section for '{env.get('id', 'unknown')}'. "
+                f"Valid fields are: {sorted(valid_fields)}"
+            )
+
     return env_list
 
 
@@ -289,7 +298,7 @@ async def run_multi_evaluation(config: MultiEvalConfig) -> None:
 
     start_time = time.time()
     all_results = await asyncio.gather(
-        *[run_evaluation(env_config) for env_config in config.env]
+        *[run_evaluation(eval_config) for eval_config in config.env]
     )
     end_time = time.time()
     event_loop_lags = event_loop_lag_monitor.get_lags()

--- a/verifiers/utils/path_utils.py
+++ b/verifiers/utils/path_utils.py
@@ -14,14 +14,18 @@ def get_results_path(
     return base_path / "evals" / env_model_str / uuid_str
 
 
-def get_eval_results_path(run_config: EvalRunConfig, env_config: EvalConfig) -> Path:
-    module_name = env_config.env_id.replace("-", "_")
+def get_eval_results_path(run_config: EvalRunConfig, eval_config: EvalConfig) -> Path:
+    module_name = eval_config.env.env_id.replace("-", "_")
     local_env_dir = Path(run_config.env_dir_path) / module_name
 
     if local_env_dir.exists():
         base_path = local_env_dir / "outputs"
-        results_path = get_results_path(env_config.env_id, run_config.model, base_path)
+        results_path = get_results_path(
+            eval_config.env.env_id, eval_config.model.model, base_path
+        )
     else:
         base_path = Path("./outputs")
-        results_path = get_results_path(env_config.env_id, run_config.model, base_path)
+        results_path = get_results_path(
+            eval_config.env.env_id, eval_config.model.model, base_path
+        )
     return results_path

--- a/verifiers/utils/path_utils.py
+++ b/verifiers/utils/path_utils.py
@@ -1,7 +1,7 @@
 import uuid
 from pathlib import Path
 
-from verifiers.types import EvalConfig
+from verifiers.types import EvalConfig, EvalRunConfig
 
 
 def get_results_path(
@@ -14,14 +14,14 @@ def get_results_path(
     return base_path / "evals" / env_model_str / uuid_str
 
 
-def get_eval_results_path(config: EvalConfig) -> Path:
-    module_name = config.env_id.replace("-", "_")
-    local_env_dir = Path(config.env_dir_path) / module_name
+def get_eval_results_path(run_config: EvalRunConfig, env_config: EvalConfig) -> Path:
+    module_name = env_config.env_id.replace("-", "_")
+    local_env_dir = Path(run_config.env_dir_path) / module_name
 
     if local_env_dir.exists():
         base_path = local_env_dir / "outputs"
-        results_path = get_results_path(config.env_id, config.model, base_path)
+        results_path = get_results_path(env_config.env_id, run_config.model, base_path)
     else:
         base_path = Path("./outputs")
-        results_path = get_results_path(config.env_id, config.model, base_path)
+        results_path = get_results_path(env_config.env_id, run_config.model, base_path)
     return results_path


### PR DESCRIPTION
### Motivation
- Narrow the per-environment config to only the fields that come from TOML (`env_id`, `env_args`, `num_examples`, `rollouts_per_example`) so TOML / env pyproject settings are decoupled from run-wide options.
- Allow multiple environments per run while keeping run-level settings (model, sampling, concurrency, saving) shared and overridable from the CLI.
- Simplify configuration precedence and make CLI overrides for run-level options unambiguous.

### Description
- Introduced a new `EvalRunConfig` pydantic model and reduced `EvalConfig` to env-only fields (`env_id`, `env_args`, `num_examples`, `rollouts_per_example`) in `verifiers/types.py`.
- Updated evaluation runner signatures and behavior: `run_evaluation` now accepts `(env_config: EvalConfig, run_config: EvalRunConfig)` and `run_multi_evaluation` accepts an `EvalRunConfig`, and result-path construction now takes both run and env config via `get_eval_results_path(run_config, env_config)` in `verifiers/utils/path_utils.py` and `verifiers/utils/eval_utils.py`.
- Reworked CLI resolution in `verifiers/scripts/eval.py` so per-env TOML settings build `EvalConfig` objects, while run-level settings (model, endpoints, sampling args, concurrency, saving, headers, etc.) are collected into a single `EvalRunConfig` constructed from CLI flags and endpoint registry lookup.
- Updated documentation in `docs/evaluation.md` and `docs/reference.md` to reflect the new TOML scope (per-env fields) and the new `EvalRunConfig` type and precedence: TOML controls only per-env fields and CLI controls run-level options.
- Adjusted imports, logging messages, and save logic to use the new config split and preserved existing behavior for parallel multi-env runs.

### Testing
- No automated tests were executed as part of this change (no `pytest` or CI run was requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969aa9cb3bc8326a947f71319d928e0)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables parallel evaluation of multiple environments and clarifies config boundaries between per-env and run-level settings.
> 
> - Introduces `EvalEnvConfig`, `EvalModelConfig`, `EvalSaveConfig`, and `EvalRunConfig`; `EvalConfig` now nests `env`, `model`, and `save`
> - Refactors CLI (`verifiers/scripts/eval.py`) to accept `env_id_or_path` (single, comma-separated, or TOML), build multiple `EvalConfig`s, and apply clear precedence (per-eval TOML → TOML defaults → CLI → env defaults → global)
> - Adds TOML loader/validator (`load_toml_config`), detection (`is_toml_config`), and run executor `run_evaluations` to execute evals in parallel
> - Updates result path construction to `get_eval_results_path(run_config, eval_config)` and prints per-eval results plus aggregate event loop lag performance
> - Extends docs (`docs/evaluation.md`, `docs/reference.md`) with multi-env usage, TOML schema, and precedence; adds sample configs under `configs/evals/` and local debug config
> - Adds comprehensive CLI/TOML tests (`tests/test_eval_cli.py`); minor logging tweak in `EventLoopLagMonitor`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ee8aa7af3e809d59cafc6fccc3d2596f195272a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->