### PR TITLE
RLMEnv: Make sub-LLM calls work for training

### DIFF
--- a/tests/test_rlm_env.py
+++ b/tests/test_rlm_env.py
@@ -60,6 +60,8 @@ def rlm_env(mock_sandbox_client, mock_dataset):
     with (
         patch("verifiers.envs.sandbox_env.AsyncSandboxClient") as mock_client_cls,
         patch("verifiers.envs.sandbox_env.CreateSandboxRequest"),
+        # Avoid registering SIGTERM handlers that call exit(143) during tests.
+        patch("verifiers.envs.environment.signal.signal"),
     ):
         mock_client_cls.return_value = mock_sandbox_client
         env = RLMEnv(
@@ -88,6 +90,8 @@ def rlm_env_with_sub_tools(mock_sandbox_client, mock_dataset):
     with (
         patch("verifiers.envs.sandbox_env.AsyncSandboxClient") as mock_client_cls,
         patch("verifiers.envs.sandbox_env.CreateSandboxRequest"),
+        # Avoid registering SIGTERM handlers that call exit(143) during tests.
+        patch("verifiers.envs.environment.signal.signal"),
     ):
         mock_client_cls.return_value = mock_sandbox_client
         env = RLMEnv(
@@ -107,6 +111,8 @@ def rlm_env_local(mock_sandbox_client, mock_dataset):
     with (
         patch("verifiers.envs.sandbox_env.AsyncSandboxClient") as mock_client_cls,
         patch("verifiers.envs.sandbox_env.CreateSandboxRequest"),
+        # Avoid registering SIGTERM handlers that call exit(143) during tests.
+        patch("verifiers.envs.environment.signal.signal"),
     ):
         mock_client_cls.return_value = mock_sandbox_client
         env = RLMEnv(

--- a/tests/test_rlm_env.py
+++ b/tests/test_rlm_env.py
@@ -722,6 +722,9 @@ async def test_local_worker_exports_stagger_env_vars(rlm_env_local, tmp_path):
     env = kwargs["env"]
     assert env["RLM_SUB_LLM_STAGGER_MS"] == "18"
     assert env["RLM_SUB_LLM_STAGGER_JITTER_MS"] == "9"
+    session.worker_process = None
+    executor._sessions.pop(session.rollout_id, None)
+    session.temp_dir.cleanup()
 
 
 @pytest.mark.asyncio
@@ -745,6 +748,9 @@ async def test_local_worker_starts_new_session(rlm_env_local, tmp_path):
 
     _, kwargs = mock_popen.call_args
     assert kwargs["start_new_session"] is True
+    session.worker_process = None
+    executor._sessions.pop(session.rollout_id, None)
+    session.temp_dir.cleanup()
 
 
 def test_local_worker_stop_kills_process_group(rlm_env_local):
@@ -761,6 +767,9 @@ def test_local_worker_stop_kills_process_group(rlm_env_local):
 
     mock_killpg.assert_called_once_with(4242, signal.SIGTERM)
     process.wait.assert_called_once()
+    session.worker_process = None
+    executor._sessions.pop(session.rollout_id, None)
+    session.temp_dir.cleanup()
 
 
 # =============================================================================

--- a/tests/test_rlm_env.py
+++ b/tests/test_rlm_env.py
@@ -38,6 +38,7 @@ def mock_sandbox_client():
     client.execute_command = AsyncMock(return_value=MagicMock(stdout="", stderr=""))
     client.upload_file = AsyncMock()
     client.upload_bytes = AsyncMock()
+    client.teardown = MagicMock()
     return client
 
 
@@ -708,7 +709,7 @@ async def test_local_worker_exports_stagger_env_vars(rlm_env_local, tmp_path):
         patch.object(executor, "_wait_for_ready", new=AsyncMock()),
         patch("verifiers.envs.experimental.rlm_env.subprocess.Popen") as mock_popen,
     ):
-        mock_popen.return_value = MagicMock()
+        mock_popen.return_value = MagicMock(wait=MagicMock(), pid=1234)
         await executor._start_worker(state, session)
 
     _, kwargs = mock_popen.call_args

--- a/tests/test_rlm_env.py
+++ b/tests/test_rlm_env.py
@@ -2,6 +2,7 @@
 
 import json
 import math
+import signal
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -716,6 +717,45 @@ async def test_local_worker_exports_stagger_env_vars(rlm_env_local, tmp_path):
     assert env["RLM_SUB_LLM_STAGGER_JITTER_MS"] == "9"
 
 
+@pytest.mark.asyncio
+async def test_local_worker_starts_new_session(rlm_env_local, tmp_path):
+    executor = rlm_env_local._executor
+    state = {
+        "rollout_id": "rlm_test_start_session",
+        "interception_url": "http://test",
+        "model": "test-model",
+    }
+    session = executor._get_or_create_session(state)
+    session.venv_path = str(tmp_path / "venv")
+
+    with (
+        patch.object(executor, "_venv_python", return_value="python"),
+        patch.object(executor, "_wait_for_ready", new=AsyncMock()),
+        patch("verifiers.envs.experimental.rlm_env.subprocess.Popen") as mock_popen,
+    ):
+        mock_popen.return_value = MagicMock()
+        await executor._start_worker(state, session)
+
+    _, kwargs = mock_popen.call_args
+    assert kwargs["start_new_session"] is True
+
+
+def test_local_worker_stop_kills_process_group(rlm_env_local):
+    executor = rlm_env_local._executor
+    state = {"rollout_id": "rlm_test_stop_session"}
+    session = executor._get_or_create_session(state)
+    process = MagicMock()
+    process.pid = 4242
+    process.wait = MagicMock()
+    session.worker_process = process
+
+    with patch("verifiers.envs.experimental.rlm_env.os.killpg") as mock_killpg:
+        executor._stop_worker(session)
+
+    mock_killpg.assert_called_once_with(4242, signal.SIGTERM)
+    process.wait.assert_called_once()
+
+
 # =============================================================================
 # 3. Data Serialization
 # =============================================================================
@@ -1394,8 +1434,9 @@ class TestRunSubLLMWithTools:
         mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
 
         messages = [{"role": "user", "content": "Test"}]
+        state = {}
         result = await rlm_env_with_sub_tools._run_sub_llm(
-            mock_client, "gpt-4", messages
+            state, mock_client, "gpt-4", messages
         )
 
         assert result["final_content"] == "Final answer"
@@ -1453,7 +1494,8 @@ class TestRunSubLLMWithTools:
         )
 
         messages = [{"role": "user", "content": "Add 2 and 3"}]
-        await rlm_env_with_sub_tools._run_sub_llm(mock_client, "gpt-4", messages)
+        state = {}
+        await rlm_env_with_sub_tools._run_sub_llm(state, mock_client, "gpt-4", messages)
 
         assert mock_client.chat.completions.create.call_count == 2
 
@@ -1509,7 +1551,8 @@ class TestRunSubLLMWithTools:
         mock_client.chat.completions.create = AsyncMock(side_effect=responses)
 
         messages = [{"role": "user", "content": "Test"}]
-        await rlm_env_with_sub_tools._run_sub_llm(mock_client, "gpt-4", messages)
+        state = {}
+        await rlm_env_with_sub_tools._run_sub_llm(state, mock_client, "gpt-4", messages)
 
         # Should be max_turns + 1 (final call without tools)
         assert (
@@ -1519,76 +1562,67 @@ class TestRunSubLLMWithTools:
 
 
 # =============================================================================
-# 7. Sub-LLM Logprobs Handling
+# 7. Sub-LLM Request Paths
 # =============================================================================
 
 
-class TestSubLLMLogprobs:
-    """Tests for lazy logprobs detection in sub-LLM calls."""
+class TestSubLLMRequestPaths:
+    """Tests for sub-LLM request routing."""
 
     @pytest.mark.asyncio
-    async def test_lazy_logprobs_fallback_on_param_error(self, rlm_env):
-        """Retries without logprobs and marks support False on param error."""
+    async def test_interleaved_uses_tokens_endpoint(self, rlm_env):
+        """Uses /chat/completions/tokens when interleaved_rollouts is True."""
         mock_client = MagicMock()
         mock_response = MagicMock()
-        mock_client.chat.completions.create = AsyncMock(
-            side_effect=[
-                Exception("Invalid request: logprobs not supported for this model"),
-                mock_response,
-            ]
-        )
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client.chat.completions.create = AsyncMock()
 
-        rlm_env._sub_llm_supports_logprobs = None
+        rlm_env.interleaved_rollouts = True
         messages = [{"role": "user", "content": "hi"}]
-        result = await rlm_env._call_sub_llm_api(mock_client, "gpt-4", messages)
+        state = {"sampling_args": {"max_tokens": 7, "extra_body": {"foo": "bar"}}}
 
-        assert result is mock_response
-        assert rlm_env._sub_llm_supports_logprobs is False
-        calls = mock_client.chat.completions.create.call_args_list
-        assert calls[0].kwargs["logprobs"] is True
-        assert calls[1].kwargs["logprobs"] is None
+        with patch(
+            "verifiers.envs.experimental.rlm_env.tokenize_vllm",
+            new=AsyncMock(return_value=[1, 2, 3]),
+        ) as mock_tokenize:
+            await rlm_env._call_sub_llm_api(state, mock_client, "gpt-4", messages)
+
+        mock_tokenize.assert_awaited_once_with(
+            client=mock_client,
+            messages=messages,
+            tools=None,
+            model="gpt-4",
+        )
+        mock_client.post.assert_awaited_once()
+        args, kwargs = mock_client.post.call_args
+        assert args[0] == "/chat/completions/tokens"
+        body = kwargs["body"]
+        assert body["tokens"] == [1, 2, 3]
+        assert body["max_completion_tokens"] == 7
+        assert body["return_token_ids"] is True
+        assert body["foo"] == "bar"
+        assert "max_tokens" not in body
+        mock_client.chat.completions.create.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_lazy_logprobs_success_sets_true(self, rlm_env):
-        """Sets support True when the first logprobs call succeeds."""
+    async def test_non_interleaved_uses_chat_completions(self, rlm_env):
+        """Uses chat.completions.create when interleaved_rollouts is False."""
         mock_client = MagicMock()
         mock_response = MagicMock()
         mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+        mock_client.post = AsyncMock()
 
-        rlm_env._sub_llm_supports_logprobs = None
+        rlm_env.interleaved_rollouts = False
         messages = [{"role": "user", "content": "hi"}]
-        result = await rlm_env._call_sub_llm_api(mock_client, "gpt-4", messages)
+        state = {"sampling_args": {"max_tokens": 7}}
+        with patch(
+            "verifiers.envs.experimental.rlm_env.tokenize_vllm", new=AsyncMock()
+        ) as mock_tokenize:
+            await rlm_env._call_sub_llm_api(state, mock_client, "gpt-4", messages)
 
-        assert result is mock_response
-        assert rlm_env._sub_llm_supports_logprobs is True
-        call_kwargs = mock_client.chat.completions.create.call_args.kwargs
-        assert call_kwargs["logprobs"] is True
-
-    @pytest.mark.asyncio
-    async def test_lazy_logprobs_fallback_if_flag_flips(self, rlm_env):
-        """Retries without logprobs even if another call flips the flag."""
-        mock_client = MagicMock()
-        mock_response = MagicMock()
-        call_count = 0
-
-        async def side_effect(*args, **kwargs):
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
-                rlm_env._sub_llm_supports_logprobs = False
-                raise Exception("logprobs not supported")
-            return mock_response
-
-        mock_client.chat.completions.create = AsyncMock(side_effect=side_effect)
-
-        rlm_env._sub_llm_supports_logprobs = None
-        messages = [{"role": "user", "content": "hi"}]
-        result = await rlm_env._call_sub_llm_api(mock_client, "gpt-4", messages)
-
-        assert result is mock_response
-        calls = mock_client.chat.completions.create.call_args_list
-        assert calls[0].kwargs["logprobs"] is True
-        assert calls[1].kwargs["logprobs"] is None
+        mock_client.chat.completions.create.assert_awaited_once()
+        mock_client.post.assert_not_called()
+        mock_tokenize.assert_not_called()
 
 
 # =============================================================================
@@ -1643,6 +1677,7 @@ class TestHandleSubLLMRequest:
             "client": mock_client,
             "model": "test-model",
             "sub_model": "gpt-4",
+            "state": {},
         }
 
         mock_request = MagicMock()
@@ -1681,6 +1716,7 @@ class TestHandleSubLLMRequest:
             "client": mock_client,
             "model": "test-model",
             "sub_model": "gpt-4",
+            "state": {},
         }
 
         mock_request = MagicMock()
@@ -1818,8 +1854,9 @@ class TestSubLLMMetricsWithTools:
         )
 
         messages = [{"role": "user", "content": "Add 2 and 3"}]
+        state = {}
         result = await rlm_env_with_sub_tools._run_sub_llm(
-            mock_client, "gpt-4", messages
+            state, mock_client, "gpt-4", messages
         )
 
         # Should accumulate tokens from both calls

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -536,6 +536,7 @@ class Environment(ABC):
                 **sampling_args,
                 **extra_body,
             )
+
             return await client.post(
                 "/chat/completions/tokens",
                 body=body,

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -484,15 +484,6 @@ class Environment(ABC):
                     }
 
                 if oai_tools:
-                    state["last_model_request"] = {
-                        "endpoint": "/chat/completions",
-                        "body": {
-                            "model": model,
-                            "messages": prompt,
-                            "tools": oai_tools,
-                            **sampling_args,
-                        },
-                    }
                     response = await client.chat.completions.create(
                         model=model,
                         messages=prompt,
@@ -500,14 +491,6 @@ class Environment(ABC):
                         **sampling_args,
                     )
                 else:
-                    state["last_model_request"] = {
-                        "endpoint": "/chat/completions",
-                        "body": {
-                            "model": model,
-                            "messages": prompt,
-                            **sampling_args,
-                        },
-                    }
                     response = await client.chat.completions.create(
                         model=model,
                         messages=prompt,
@@ -520,14 +503,6 @@ class Environment(ABC):
                         "oai_tools are not supported for completion tasks."
                     )
                 assert isinstance(prompt, str)
-                state["last_model_request"] = {
-                    "endpoint": "/completions",
-                    "body": {
-                        "model": model,
-                        "prompt": prompt,
-                        **sampling_args,
-                    },
-                }
                 response = await client.completions.create(
                     model=model, prompt=prompt, **sampling_args
                 )
@@ -561,11 +536,6 @@ class Environment(ABC):
                 **sampling_args,
                 **extra_body,
             )
-            state["last_model_request"] = {
-                "endpoint": "/chat/completions/tokens",
-                "body": body,
-            }
-
             return await client.post(
                 "/chat/completions/tokens",
                 body=body,

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -484,6 +484,15 @@ class Environment(ABC):
                     }
 
                 if oai_tools:
+                    state["last_model_request"] = {
+                        "endpoint": "/chat/completions",
+                        "body": {
+                            "model": model,
+                            "messages": prompt,
+                            "tools": oai_tools,
+                            **sampling_args,
+                        },
+                    }
                     response = await client.chat.completions.create(
                         model=model,
                         messages=prompt,
@@ -491,6 +500,14 @@ class Environment(ABC):
                         **sampling_args,
                     )
                 else:
+                    state["last_model_request"] = {
+                        "endpoint": "/chat/completions",
+                        "body": {
+                            "model": model,
+                            "messages": prompt,
+                            **sampling_args,
+                        },
+                    }
                     response = await client.chat.completions.create(
                         model=model,
                         messages=prompt,
@@ -503,6 +520,14 @@ class Environment(ABC):
                         "oai_tools are not supported for completion tasks."
                     )
                 assert isinstance(prompt, str)
+                state["last_model_request"] = {
+                    "endpoint": "/completions",
+                    "body": {
+                        "model": model,
+                        "prompt": prompt,
+                        **sampling_args,
+                    },
+                }
                 response = await client.completions.create(
                     model=model, prompt=prompt, **sampling_args
                 )
@@ -536,6 +561,10 @@ class Environment(ABC):
                 **sampling_args,
                 **extra_body,
             )
+            state["last_model_request"] = {
+                "endpoint": "/chat/completions/tokens",
+                "body": body,
+            }
 
             return await client.post(
                 "/chat/completions/tokens",

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -1829,6 +1829,9 @@ class RLMEnv(SandboxEnv):
         self, state: State, *, interleaved: bool
     ) -> dict[str, Any]:
         sampling_args = dict(state.get("sampling_args") or {})
+        extra_body = sampling_args.get("extra_body")
+        if isinstance(extra_body, dict):
+            sampling_args["extra_body"] = dict(extra_body)
         sampling_args = self._normalize_sampling_args(sampling_args)
         if interleaved:
             return prepare_sampling_args_for_token_prompts(sampling_args)

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -1865,7 +1865,7 @@ class RLMEnv(SandboxEnv):
         """
         normalized: ChatMessages = []
         for msg in messages:
-            msg_copy: dict[str, Any] = dict(msg)
+            msg_copy: dict[str, Any] = cast(dict[str, Any], msg).copy()
             content = msg_copy.get("content")
 
             if content is not None and isinstance(content, dict):

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -2260,6 +2260,9 @@ class RLMEnv(SandboxEnv):
                 repl_request = state_ref.get("rlm_last_repl_request")
                 if isinstance(repl_request, dict):
                     repl_code = repl_request.get("code")
+            main_request = None
+            if state_ref is not None:
+                main_request = state_ref.get("last_model_request")
             payload = None
             if isinstance(e, RLMSubLLMRequestError):
                 payload = self._sanitize_payload_for_json(e.payload)
@@ -2268,6 +2271,7 @@ class RLMEnv(SandboxEnv):
                 "request_id": request_id,
                 "repl_request": repl_request,
                 "repl_code": repl_code,
+                "main_request": main_request,
                 "sub_llm_payload": payload,
                 "messages": messages_with_system,
             }

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -26,6 +26,7 @@ import logging
 import os
 import shlex
 import shutil
+import signal
 import subprocess
 import sys
 import tempfile
@@ -1427,6 +1428,7 @@ class LocalRLMExecutor(BaseRLMExecutor):
                 stdout=log_file,
                 stderr=subprocess.STDOUT,
                 env=env_vars,
+                start_new_session=True,
             )
         session.worker_process = process
 
@@ -1456,12 +1458,23 @@ class LocalRLMExecutor(BaseRLMExecutor):
     def _stop_worker(self, session: LocalRLMReplSession) -> None:
         if not session.worker_process:
             return
+        process = session.worker_process
         try:
-            session.worker_process.terminate()
-            session.worker_process.wait(timeout=5)
+            if os.name != "nt":
+                os.killpg(process.pid, signal.SIGTERM)
+            else:
+                process.terminate()
+            process.wait(timeout=5)
         except Exception:
             try:
-                session.worker_process.kill()
+                if os.name != "nt":
+                    os.killpg(process.pid, signal.SIGKILL)
+                else:
+                    process.kill()
+            except Exception:
+                pass
+            try:
+                process.wait(timeout=5)
             except Exception:
                 pass
         session.worker_process = None

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -84,14 +84,6 @@ class RLMCodeExecutionTimeout(Exception):
     """Raised when code execution exceeds the configured timeout."""
 
 
-class RLMSubLLMRequestError(Exception):
-    """Raised when a sub-LLM API request fails, carrying the request payload."""
-
-    def __init__(self, message: str, payload: dict[str, Any]) -> None:
-        super().__init__(message)
-        self.payload = payload
-
-
 @dataclass(frozen=True)
 class RLMWorkerPaths:
     base_dir: str
@@ -1881,14 +1873,6 @@ class RLMEnv(SandboxEnv):
             normalized.append(msg_copy)
         return normalized
 
-    @staticmethod
-    def _sanitize_payload_for_json(payload: dict[str, Any]) -> dict[str, Any]:
-        try:
-            json.dumps(payload)
-            return payload
-        except TypeError:
-            return json.loads(json.dumps(payload, default=str))
-
     async def _call_sub_llm_api(
         self,
         state: State,
@@ -1951,7 +1935,7 @@ class RLMEnv(SandboxEnv):
             )
             return None
         except Exception as e:
-            raise RLMSubLLMRequestError(str(e), payload) from e
+            raise e
 
     def _make_timeout_result(
         self,
@@ -2267,35 +2251,7 @@ class RLMEnv(SandboxEnv):
 
             return web.json_response(response_dict)
         except Exception as e:
-            repl_request = None
-            repl_code = None
-            if state_ref is not None:
-                repl_request = state_ref.get("rlm_last_repl_request")
-                if isinstance(repl_request, dict):
-                    repl_code = repl_request.get("code")
-            main_request = None
-            if state_ref is not None:
-                main_request = state_ref.get("last_model_request")
-            payload = None
-            if isinstance(e, RLMSubLLMRequestError):
-                payload = self._sanitize_payload_for_json(e.payload)
-            debug_payload = {
-                "batch_id": batch_id,
-                "request_id": request_id,
-                "repl_request": repl_request,
-                "repl_code": repl_code,
-                "main_request": main_request,
-                "sub_llm_payload": payload,
-                "messages": messages_with_system,
-            }
-            logger.error(
-                "Sub-LLM call failed: %s\n%s",
-                e,
-                json.dumps(debug_payload, ensure_ascii=True, default=str),
-            )
-            return web.json_response(
-                {"error": str(e), "debug": debug_payload}, status=500
-            )
+            return web.json_response({"error": str(e)}, status=500)
 
     @vf.teardown
     async def teardown_tunnels(self):
@@ -2602,8 +2558,6 @@ class RLMEnv(SandboxEnv):
         rollout_id = state.get("rollout_id")
         if rollout_id and rollout_id in self.active_rollouts:
             self.active_rollouts[rollout_id]["current_turn"] = state.get("turn", 0)
-        state["rlm_last_repl_request"] = {"code": code}
-
         # Time the full tool call execution
         execution_start = perf_counter()
         result = await self._execute_code(sandbox_id, code, state)


### PR DESCRIPTION
## Description

Align sub‑LLM requests with interleaved rollouts; tighten local RLM worker shutdown

Context
Sub‑LLM requests were hitting the wrong endpoint when interleaved rollouts are enabled, causing vLLM 400s and token accounting issues. Also, local code execution left child processes alive on teardown.

What changed

- Sub‑LLM calls now follow the same interleaved path as the main model: tokenize + /chat/completions/tokens when interleaved_rollouts=True, otherwise standard chat completions.
- Sub‑LLM sampling args are normalized for token‑prompt mode to match main‑model behavior.
- Local RLM worker is launched in its own process group and terminated by group on teardown to avoid orphaned children.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns sub‑LLM requests with main-model interleaved flow and improves local worker robustness.
> 
> - Sub‑LLM API: when `interleaved_rollouts=True`, tokenize via `tokenize_vllm` and POST to `/chat/completions/tokens` with normalized sampling args; otherwise use `chat.completions.create`. Removes logprobs fallback logic and adds message content normalization.
> - Execution/local: launch local worker with `start_new_session=True` and terminate via `os.killpg(.., SIGTERM/SIGKILL)` to avoid orphaned children.
> - Interception/typing: pass `state` into sub‑LLM paths, use `ChatMessages` types, and record sub‑LLM turns/metrics in trajectory steps.
> - Tests: add coverage for interleaved request path, env var export, new-session start, and process-group kill; adjust fixtures to avoid SIGTERM handler registration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit abd8127d89b5e5dc9af1d87d95b11b709df44cb0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->