### PR TITLE
optional DatasetBuilder pattern

### DIFF
--- a/environments/AGENTS.md
+++ b/environments/AGENTS.md
@@ -11,6 +11,7 @@ This guide walks through building environments in Verifiers, from simple single-
 - [Datasets](#datasets)
   - [Building the Prompt](#building-the-prompt)
   - [Evaluation Datasets](#evaluation-datasets)
+  - [Lazy Loading with DatasetBuilder](#lazy-loading-with-datasetbuilder)
 - [Rubrics](#rubrics)
   - [Reward Functions](#reward-functions)
   - [Multiple Reward Functions](#multiple-reward-functions)
@@ -133,6 +134,37 @@ return vf.SingleTurnEnv(
 ```
 
 When running `prime eval run`, the evaluation dataset is used by default. If no `eval_dataset` is provided, evaluation falls back to the training dataset.
+
+### Lazy Loading with DatasetBuilder
+
+For large datasets or when running multiple environment replicas, you can defer dataset loading using a `DatasetBuilder`—a callable that returns a `Dataset` when invoked:
+
+```python
+def get_dataset_builder(split: str = "train", seed: int = 42) -> vf.DatasetBuilder:
+    """Returns a builder that lazily loads the dataset."""
+    def build() -> Dataset:
+        ds = load_dataset("my-dataset", split=split)
+        ds = ds.shuffle(seed=seed)
+        return ds
+    return build
+
+def load_environment():
+    dataset_builder = get_dataset_builder(split="train")
+    eval_builder = get_dataset_builder(split="test")
+    
+    return vf.SingleTurnEnv(
+        dataset=dataset_builder,      # built on first access
+        eval_dataset=eval_builder,    # built on first access
+        rubric=rubric,
+    )
+```
+
+The builder pattern is useful when:
+- Dataset loading is expensive (e.g., downloading from Hugging Face)
+- Multiple environment replicas don't all need to own the dataset
+- You want to parameterize dataset creation without loading it immediately
+
+When a raw `Dataset` is passed directly (the default pattern), it is loaded eagerly during environment initialization for backwards compatibility.
 
 ## Rubrics
 
@@ -732,4 +764,4 @@ Newer and more experimental environment classes include:
 - **`GymEnv`** — universal runner for Gym-compatible environments (OpenAI Gym / Gymnasium API)
 - **`CliAgentEnv`** — runs custom agent code inside sandboxes, intercepting API requests
 - **`HarborEnv`** — loads Harbor-format agent benchmark tasks
-- **`RLMEnv`** — implements Recursive Language Models for unbounded context processing
+- **`RLMEnv`** — implements Recursive Language Models for unbounded context processing. Supports `execution_backend="sandbox"` (default) or `"local"` for host execution. User code runs in a Python REPL with a best-effort guardrail that blocks common filesystem modules and `open` by default; customize via `disallowed_modules`/`disallowed_builtins`.

--- a/environments/alphabet_sort/pyproject.toml
+++ b/environments/alphabet_sort/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "alphabet-sort"
-version = "0.1.10"
+version = "0.1.11"
 tags = ["sorting", "names", "multi-turn", "xml", "synthetic", "tools"]
 license = "Apache-2.0"
 description = "This task requires the model to maintain and update an alphabetically sorted list of names across multiple conversation turns."

--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -12,6 +12,7 @@ from .decorators import (  # noqa # isort: skip
     stop,
     teardown,
 )
+from .types import DatasetBuilder  # noqa # isort: skip
 from .parsers.parser import Parser  # noqa # isort: skip
 from .rubrics.rubric import Rubric  # noqa # isort: skip
 from .envs.environment import Environment  # noqa # isort: skip
@@ -44,6 +45,7 @@ from .utils.logging_utils import (
 setup_logging(os.getenv("VF_LOG_LEVEL", "INFO"))
 
 __all__ = [
+    "DatasetBuilder",
     "Parser",
     "ThinkParser",
     "MaybeThinkParser",

--- a/verifiers/envs/env_group.py
+++ b/verifiers/envs/env_group.py
@@ -171,7 +171,7 @@ class EnvGroup(vf.Environment):
             add_task = make_add_task_fn(name)
 
             # Build dataset if using DatasetBuilder, returns None if not available
-            env_dataset = env._build_dataset()
+            env_dataset = env.build_dataset()
             if env_dataset is not None:
                 # override task column to use env_name for routing
                 if "task" in env_dataset.column_names:
@@ -179,7 +179,7 @@ class EnvGroup(vf.Environment):
                 env_dataset = env_dataset.map(add_task, **map_kwargs)
                 datasets.append(env_dataset)
             # Build eval_dataset if using DatasetBuilder, returns None if not available
-            env_eval_dataset = env._build_eval_dataset()
+            env_eval_dataset = env.build_eval_dataset()
             if env_eval_dataset is not None:
                 # override task column to use env_name for routing
                 if "task" in env_eval_dataset.column_names:

--- a/verifiers/envs/env_group.py
+++ b/verifiers/envs/env_group.py
@@ -170,16 +170,16 @@ class EnvGroup(vf.Environment):
         for env, name in zip(self.envs, self.env_names):
             add_task = make_add_task_fn(name)
 
-            # Access dataset directly to avoid get_dataset() raising when None
-            env_dataset = env.dataset
+            # Build dataset if using DatasetBuilder, returns None if not available
+            env_dataset = env._build_dataset()
             if env_dataset is not None:
                 # override task column to use env_name for routing
                 if "task" in env_dataset.column_names:
                     env_dataset = env_dataset.remove_columns(["task"])
                 env_dataset = env_dataset.map(add_task, **map_kwargs)
                 datasets.append(env_dataset)
-            # Access eval_dataset directly to avoid get_eval_dataset() raising when None
-            env_eval_dataset = env.eval_dataset
+            # Build eval_dataset if using DatasetBuilder, returns None if not available
+            env_eval_dataset = env._build_eval_dataset()
             if env_eval_dataset is not None:
                 # override task column to use env_name for routing
                 if "task" in env_eval_dataset.column_names:

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -101,7 +101,7 @@ class Environment(ABC):
         self.env_id = env_id or ""
         self.env_args = env_args or {}
         self.max_seq_len = max_seq_len
-        self._map_kwargs = map_kwargs
+        self.map_kwargs = map_kwargs
 
         self.set_interleaved_rollouts(interleaved_rollouts)
         self.set_score_rollouts(score_rollouts)
@@ -332,10 +332,10 @@ class Environment(ABC):
                 dataset,
                 self.system_prompt,
                 self.few_shot,
-                map_kwargs=self._map_kwargs,
+                map_kwargs=self.map_kwargs,
             )
         else:
-            return self._format_completion_dataset(dataset, map_kwargs=self._map_kwargs)
+            return self._format_completion_dataset(dataset, map_kwargs=self.map_kwargs)
 
     def build_dataset(self) -> Dataset | None:
         """Build and cache the training dataset from source if needed."""

--- a/verifiers/rl/trainer/orchestrator.py
+++ b/verifiers/rl/trainer/orchestrator.py
@@ -102,6 +102,7 @@ class Orchestrator:
         self.worker_loop = None
 
         max_length = self.max_prompt_len
+        env._build_dataset()
         assert env.dataset is not None
 
         def filter_by_prompt_length(example, processing_class):

--- a/verifiers/rl/trainer/orchestrator.py
+++ b/verifiers/rl/trainer/orchestrator.py
@@ -102,8 +102,6 @@ class Orchestrator:
         self.worker_loop = None
 
         max_length = self.max_prompt_len
-        env._build_dataset()
-        assert env.dataset is not None
 
         def filter_by_prompt_length(example, processing_class):
             prompt = example["prompt"]
@@ -116,7 +114,7 @@ class Orchestrator:
             prompt_ids = processing_class.encode(prompt_text)
             return len(prompt_ids) <= max_length
 
-        env.dataset = env.dataset.filter(
+        env.dataset = env.get_dataset().filter(
             filter_by_prompt_length,
             fn_kwargs={"processing_class": processing_class},
         )

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -7,6 +7,8 @@ from typing import (
     Literal,
 )
 
+from datasets import Dataset
+
 from verifiers.errors import Error
 
 if sys.version_info < (3, 12):
@@ -48,6 +50,7 @@ SamplingArgs = dict[str, Any]
 IndividualRewardFunc = Callable[..., float | Awaitable[float]]
 GroupRewardFunc = Callable[..., list[float] | Awaitable[list[float]]]
 RewardFunc = IndividualRewardFunc | GroupRewardFunc
+DatasetBuilder = Callable[[], Dataset]
 
 
 class TrajectoryStepTokens(TypedDict):

--- a/verifiers/utils/data_utils.py
+++ b/verifiers/utils/data_utils.py
@@ -316,17 +316,19 @@ def load_example_dataset(
     elif name == "openrs_easy":
         if split is None:
             split = "train"
-        dataset = load_dataset("knoveleng/open-rs")[split]
+        dataset = cast(Dataset, load_dataset("knoveleng/open-rs")[split])
         dataset = dataset.filter(lambda x: x["level"] == "Easy")
     elif name == "openrs_hard":
         if split is None:
             split = "train"
-        dataset = load_dataset("knoveleng/open-rs")[split]
+        dataset = cast(Dataset, load_dataset("knoveleng/open-rs")[split])
         dataset = dataset.filter(lambda x: x["level"] == "Hard")
     elif name == "prime_code":
         if split is None:
             split = "train"
-        dataset = load_dataset("PrimeIntellect/verifiable-coding-problems")[split]
+        dataset = cast(
+            Dataset, load_dataset("PrimeIntellect/verifiable-coding-problems")[split]
+        )
         dataset = dataset.filter(
             lambda x: x["prompt"].startswith(
                 "Solve the following coding problem using the programming language python:"


### PR DESCRIPTION
## Description
Allows passing a Callable[[], Dataset] in place of Dataset for `dataset` / `eval_dataset`, lazy-loads when `get_dataset` / `get_eval_dataset` is first called.


## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds optional lazy dataset loading to environments, enabling deferred construction of `Dataset`s via a `DatasetBuilder` callable.
> 
> - Core: `Environment` now accepts `Dataset | DatasetBuilder` for `dataset`/`eval_dataset`, with new `build_dataset()`/`build_eval_dataset()` and formatting via `_format_dataset_source`; `get_*_dataset` triggers builds; preserves eager build for raw `Dataset`s. Stores `map_kwargs` and validates `message_type` earlier.
> - Group/Trainer: `EnvGroup` concatenation now builds sub-env datasets via `env.build_dataset()`/`build_eval_dataset()`; RL `orchestrator` filters with `env.get_dataset()` instead of accessing `env.dataset` directly.
> - Types/Exports: Add `vf.DatasetBuilder` type alias and export from `verifiers.__init__`.
> - Docs: Add "Lazy Loading with DatasetBuilder" section to `docs/environments.md` and `environments/AGENTS.md`; expand `RLMEnv` details.
> - Example env: Refactor `environments/alphabet_sort` to use `get_dataset_builder`, extract helpers, and return builder-backed `SortingEnv`; bump version to `0.1.11`.
> - Misc: Minor typing/casts in `data_utils.py`; small eval input simplification.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 714d8b04ca654c6836bb86484ef84c1f686e2618. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->