### PR TITLE
[DRAFT] Env Client/Server refactor proposal

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -162,21 +162,11 @@ class RolloutTiming(TypedDict, total=False):
 
 ```python
 class GenerateOutputs(TypedDict):
-    prompt: list[Messages]
-    completion: list[Messages]
-    answer: list[str]
-    state: list[State]
-    task: list[str]
-    info: list[Info]
-    example_id: list[int]
-    reward: list[float]
-    metrics: dict[str, list[float]]
-    stop_conditions: list[str | None]
-    is_truncated: list[bool]
+    rollouts: list[RolloutResult]
     metadata: GenerateMetadata
 ```
 
-Output from `Environment.generate()`.
+Output from `Environment.generate()`. Contains the list of rollout results and metadata about the generation run.
 
 ### GenerateMetadata
 
@@ -193,8 +183,6 @@ class GenerateMetadata(TypedDict):
     time_ms: float
     avg_reward: float
     avg_metrics: dict[str, float]
-    state_columns: list[str]
-    path_to_save: Path
 ```
 
 ### RolloutScore / RolloutScores
@@ -544,7 +532,6 @@ class EvalConfig(BaseModel):
     extra_env_kwargs: dict = {}
     print_results: bool = False
     verbose: bool = False
-    state_columns: list[str] | None = None
     save_results: bool = False
     save_every: int = -1
     save_to_hf_hub: bool = False

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -158,6 +158,34 @@ class RolloutTiming(TypedDict, total=False):
     total_ms: float
 ```
 
+### RolloutResult
+
+```python
+class RolloutResultTrajectoryStep(TypedDict, total=False):
+    prompt: Messages
+    completion: Messages
+    tokens: TrajectoryStepTokens
+    advantage: float
+    extras: dict[str, Any]
+
+class RolloutResultBase(TypedDict):
+    prompt: Messages
+    completion: Messages
+    example_id: int
+    task: str
+    metrics: dict[str, float]
+
+class RolloutResult(RolloutResultBase, total=False):
+    answer: str
+    info: Info
+    reward: float
+    is_truncated: bool
+    stop_condition: str | None
+    trajectory: list[RolloutResultTrajectoryStep]
+    timing: RolloutTiming
+    error: str | None
+```
+
 ### GenerateOutputs
 
 ```python

--- a/tests/test_env_group.py
+++ b/tests/test_env_group.py
@@ -422,10 +422,9 @@ class TestEnvGroup:
             inputs, client=mock_openai_client, model="test-model"
         )
 
-        assert "completion" in results
-        assert "state" in results
-        assert "reward" in results
-        assert len(results["completion"]) == 2
+        assert "rollouts" in results
+        assert "metadata" in results
+        assert len(results["rollouts"]) == 2
 
     def test_env_group_with_mixed_datasets(self, mock_openai_client):
         """Test EnvGroup with environments having different dataset configurations."""

--- a/tests/test_eval_cli.py
+++ b/tests/test_eval_cli.py
@@ -43,6 +43,7 @@ def _run_cli(monkeypatch, overrides):
         "verbose": False,
         "print_results": False,
         "no_interleave_scoring": False,
+        "state_columns": [],
         "save_results": False,
         "save_every": -1,
         "save_to_hf_hub": False,

--- a/tests/test_eval_cli.py
+++ b/tests/test_eval_cli.py
@@ -1,5 +1,4 @@
 import argparse
-from pathlib import Path
 from types import SimpleNamespace
 
 import verifiers.scripts.eval as vf_eval
@@ -19,8 +18,6 @@ def _make_metadata(config) -> GenerateMetadata:
         time_ms=0.0,
         avg_reward=0.0,
         avg_metrics={},
-        state_columns=config.state_columns or [],
-        path_to_save=Path("test.jsonl"),
     )
 
 
@@ -46,12 +43,12 @@ def _run_cli(monkeypatch, overrides):
         "verbose": False,
         "print_results": False,
         "no_interleave_scoring": False,
-        "state_columns": [],
         "save_results": False,
         "save_every": -1,
         "save_to_hf_hub": False,
         "hf_hub_dataset_name": "",
         "extra_env_kwargs": {},
+        "num_workers": 1,
     }
     base_args.update(overrides)
     args_namespace = SimpleNamespace(**base_args)
@@ -70,23 +67,20 @@ def _run_cli(monkeypatch, overrides):
         captured["sampling_args"] = dict(config.sampling_args)
         metadata = _make_metadata(config)
         return GenerateOutputs(
-            prompt=[[{"role": "user", "content": "p"}]],
-            completion=[[{"role": "assistant", "content": "c"}]],
-            answer=[""],
-            state=[
+            rollouts=[
                 {
+                    "prompt": [{"role": "user", "content": "p"}],
+                    "completion": [{"role": "assistant", "content": "c"}],
+                    "example_id": 0,
+                    "task": "default",
+                    "reward": 1.0,
                     "timing": {
                         "generation_ms": 0.0,
                         "scoring_ms": 0.0,
                         "total_ms": 0.0,
-                    }
+                    },
                 }
             ],
-            task=["default"],
-            info=[{}],
-            example_id=[0],
-            reward=[1.0],
-            metrics={},
             metadata=metadata,
         )
 

--- a/tests/test_gym_env.py
+++ b/tests/test_gym_env.py
@@ -148,7 +148,7 @@ def test_basic_rollout_and_reward_sum(toy_env_class, client):
     )
 
     res = env.evaluate_sync(client=client, model="mock")
-    st = res["state"][0]
+    st = res["results"][0]
     steps = st.get("trajectory", [])
 
     assert len(steps) > 0
@@ -174,7 +174,7 @@ def test_action_parse_error_ends_episode(toy_env_class, client):
     )
 
     res = env.evaluate_sync(client=client, model="mock")
-    st = res["state"][0]
+    st = res["results"][0]
     steps = st.get("trajectory", [])
 
     assert st.get("gym_done") is True
@@ -201,7 +201,7 @@ def test_max_episode_steps_limits_turns(client):
         num_eval_episodes=1,
     )
     res = env.evaluate_sync(client=client, model="mock")
-    st = res["state"][0]
+    st = res["results"][0]
     steps = st.get("trajectory", [])
 
     assert len(steps) == 3
@@ -229,7 +229,7 @@ def test_system_prompt_and_few_shot(toy_env_class, client):
         num_eval_episodes=1,
     )
     res = env.evaluate_sync(client=client, model="mock")
-    st = res["state"][0]
+    st = res["results"][0]
     first_prompt = st["prompt"]
 
     roles = [m["role"] for m in first_prompt]
@@ -257,7 +257,7 @@ def test_four_tuple_step_normalization(client):
         num_eval_episodes=1,
     )
     res = env.evaluate_sync(client=client, model="mock")
-    st = res["state"][0]
+    st = res["results"][0]
     steps = st.get("trajectory", [])
 
     assert steps[0]["extras"]["gym_info"] == {"info": "done"}
@@ -275,7 +275,7 @@ def test_env_kwargs_passed_to_env(toy_env_class, client):
         num_eval_episodes=1,
     )
     res = env.evaluate_sync(client=client, model="mock")
-    st = res["state"][0]
+    st = res["results"][0]
 
     first_obs_msg = st["prompt"][-1]["content"]
     assert first_obs_msg == "x=5"
@@ -303,7 +303,7 @@ def test_custom_obs_to_text(client):
         num_eval_episodes=1,
     )
     res = env.evaluate_sync(client=client, model="mock")
-    st = res["state"][0]
+    st = res["results"][0]
     assert st["prompt"][-1]["content"] == "obs_is_0"
 
 
@@ -324,7 +324,7 @@ def test_completion_mode(toy_env_class, client):
     )
 
     res = env.evaluate_sync(client=client, model="mock")
-    st = res["state"][0]
+    st = res["results"][0]
 
     assert isinstance(st["prompt"], str)
     assert st["prompt"] == "x=0"

--- a/tests/test_singleturn_env.py
+++ b/tests/test_singleturn_env.py
@@ -302,12 +302,11 @@ class TestSingleTurnEnv:
             model="test-model",
         )
 
-        assert "completion" in results
-        assert "state" in results
-        assert "reward" in results
-        assert len(results["completion"]) == 2
-        assert len(results["state"]) == 2
-        assert results["reward"] == [1.0, 1.0]
+        assert "rollouts" in results
+        assert "metadata" in results
+        assert len(results["rollouts"]) == 2
+        assert results["rollouts"][0].get("reward") == 1.0
+        assert results["rollouts"][1].get("reward") == 1.0
 
     @pytest.mark.asyncio
     async def test_a_generate_with_dataset(
@@ -329,10 +328,9 @@ class TestSingleTurnEnv:
             model="test-model",
         )
 
-        assert "completion" in results
-        assert "state" in results
-        assert "reward" in results
-        assert len(results["completion"]) == 2
+        assert "rollouts" in results
+        assert "metadata" in results
+        assert len(results["rollouts"]) == 2
 
     @pytest.mark.asyncio
     async def test_a_generate_no_scoring(self, mock_singleturn_env):
@@ -354,11 +352,10 @@ class TestSingleTurnEnv:
             model="test-model",
         )
 
-        assert "completion" in results
-        assert "state" in results
-        assert "reward" in results  # reward attribute exists
+        assert "rollouts" in results
+        assert "metadata" in results
         # Scoring always happens now, so rewards will be set
-        assert len(results["reward"]) >= 0
+        assert len(results["rollouts"]) >= 0
 
     def test_generate_sync_wrapper(self, mock_singleturn_env):
         """Test the synchronous generate wrapper."""
@@ -388,9 +385,9 @@ class TestSingleTurnEnv:
             model="test-model",
         )
 
-        assert "completion" in results
-        assert "state" in results
-        assert "reward" in results
+        assert "rollouts" in results
+        assert "metadata" in results
+        assert len(results["rollouts"]) == 1
 
     @pytest.mark.asyncio
     async def test_different_message_types_in_same_env(

--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -34,6 +34,8 @@ from .utils.data_utils import (
     load_example_dataset,
 )
 from .utils.env_utils import load_environment
+from .workers.client import EnvClient
+from .workers.server import EnvServer
 from .utils.logging_utils import (
     log_level,
     print_prompt_completions_sample,
@@ -68,6 +70,8 @@ __all__ = [
     "StatefulToolEnv",
     "ToolEnv",
     "EnvGroup",
+    "EnvClient",
+    "EnvServer",
     "extract_boxed_answer",
     "extract_hash_answer",
     "load_example_dataset",

--- a/verifiers/rubrics/math_rubric.py
+++ b/verifiers/rubrics/math_rubric.py
@@ -3,7 +3,7 @@ import logging
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Callable
 
-from math_verify import parse, verify  # type: ignore[unresolved-import]
+from math_verify import parse, verify
 
 from verifiers.parsers.maybe_think_parser import MaybeThinkParser
 from verifiers.parsers.parser import Parser

--- a/verifiers/rubrics/rubric.py
+++ b/verifiers/rubrics/rubric.py
@@ -93,10 +93,14 @@ class Rubric:
 
     # individual-level reward helpers
     def _get_individual_reward_func_names(self) -> list[str]:
-        return [func.__name__ for func in self.funcs if not self._is_group_func(func)]  # type: ignore[possibly-missing-attribute]
+        return [
+            func.__name__  # type: ignore[possibly-missing-attribute]
+            for func in self.funcs
+            if not self._is_group_func(func)
+        ]
 
     def _get_individual_reward_funcs(self) -> list[RewardFunc]:
-        return [func for func in self.funcs if not self._is_group_func(func)]  # type: ignore[possibly-missing-attribute]
+        return [func for func in self.funcs if not self._is_group_func(func)]
 
     def _get_individual_reward_weights(self) -> list[float]:
         return [

--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -228,10 +228,10 @@ def main():
     )
     parser.add_argument(
         "--state-columns",
-        type=str,
-        nargs="*",
+        "-C",
+        type=lambda t: [s.strip() for s in t.split(",")],
         default=[],
-        help="Extra state columns to include in saved results",
+        help="Comma-separated list of state columns to save (e.g., 'turn,timing')",
     )
     parser.add_argument(
         "--extra-env-kwargs",

--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -191,13 +191,6 @@ def main():
         help="Disable interleaving of scoring",
     )
     parser.add_argument(
-        "--state-columns",
-        "-C",
-        type=lambda t: [s.strip() for s in t.split(",")],
-        default=[],
-        help="Comma-separated list of state columns to save (e.g., 'turn,timing')",
-    )
-    parser.add_argument(
         "--save-results",
         "-s",
         default=False,
@@ -234,11 +227,25 @@ def main():
         help="Name of dataset to save to Hugging Face Hub",
     )
     parser.add_argument(
+        "--state-columns",
+        type=str,
+        nargs="*",
+        default=[],
+        help="Extra state columns to include in saved results",
+    )
+    parser.add_argument(
         "--extra-env-kwargs",
         "-x",
         type=json.loads,
         default={},
         help='Extra environment as JSON object (e.g., \'{"key": "value", "num": 42}\'). Passed to environment constructor.',
+    )
+    parser.add_argument(
+        "--num-workers",
+        "-w",
+        type=int,
+        default=1,
+        help="Number of worker subprocesses for environment execution (default=1)",
     )
     args = parser.parse_args()
 
@@ -343,6 +350,7 @@ def main():
         max_concurrent=args.max_concurrent,
         max_concurrent_generation=args.max_concurrent_generation,
         max_concurrent_scoring=args.max_concurrent_scoring,
+        num_workers=args.num_workers,
         # logging
         print_results=True,
         verbose=args.verbose,

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -102,9 +102,10 @@ class RolloutResultTrajectoryStep(TypedDict, total=False):
     completion: Messages
     tokens: TrajectoryStepTokens
     advantage: float
+    extras: dict[str, Any]
 
 
-class _RolloutResultRequired(TypedDict):
+class RolloutResultBase(TypedDict):
     """Required fields for RolloutResult."""
 
     prompt: Messages
@@ -114,7 +115,7 @@ class _RolloutResultRequired(TypedDict):
     metrics: dict[str, float]
 
 
-class RolloutResult(_RolloutResultRequired, total=False):
+class RolloutResult(RolloutResultBase, total=False):
     """Serializable result from a rollout, used in GenerateOutputs.
 
     This is the public contract for what evaluation/generation returns.
@@ -181,7 +182,7 @@ class State(dict):
 JsonPrimitive = Literal["string", "number", "integer", "boolean", "array", "object"]
 
 
-class GenerateMetadata(TypedDict):
+class GenerateMetadataRequired(TypedDict):
     """Metadata about a generation run."""
 
     env_id: str
@@ -195,6 +196,11 @@ class GenerateMetadata(TypedDict):
     time_ms: float
     avg_reward: float
     avg_metrics: dict[str, float]
+
+
+class GenerateMetadata(GenerateMetadataRequired, total=False):
+    """Metadata about a generation run (optional keys are only present when saving)."""
+
     state_columns: list[str]
     path_to_save: Path
 

--- a/verifiers/utils/message_utils.py
+++ b/verifiers/utils/message_utils.py
@@ -1,5 +1,5 @@
 import json
-from typing import cast
+from typing import Any, cast
 
 from openai.types.chat import (
     ChatCompletionAssistantMessageParam,
@@ -14,14 +14,14 @@ def strip_nones_from_content(messages: list[ChatMessage]) -> list[ChatMessage]:
     for msg in messages:
         content = msg.get("content")
         if isinstance(content, list):
-            new_msg = dict(msg)
-            new_msg["content"] = [  # type: ignore[typeddict-item]
+            new_msg: dict[str, Any] = {k: v for k, v in msg.items()}
+            new_msg["content"] = [
                 {k: v for k, v in c.items() if v is not None}
                 if isinstance(c, dict)
                 else c
                 for c in content
             ]
-            result.append(new_msg)  # type: ignore[arg-type]
+            result.append(cast(ChatMessage, new_msg))
         else:
             result.append(msg)
     return result

--- a/verifiers/utils/type_utils.py
+++ b/verifiers/utils/type_utils.py
@@ -131,7 +131,8 @@ def state_to_result(
     if state.get("timing"):
         result["timing"] = state["timing"]
     if state.get("error"):
-        result["error"] = type(state["error"]).__name__
+        err = state["error"]
+        result["error"] = f"{type(err).__name__}: {err}"
 
     # Extra state columns - must be serializable
     if state_columns:

--- a/verifiers/utils/type_utils.py
+++ b/verifiers/utils/type_utils.py
@@ -1,0 +1,145 @@
+"""Type conversion utilities."""
+
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from verifiers.types import (
+    GenerateMetadata,
+    GenerateOutputs,
+    RolloutResult,
+    RolloutResultTrajectoryStep,
+    SamplingArgs,
+    State,
+)
+
+
+def build_generate_outputs(
+    rollouts: list[RolloutResult],
+    env_id: str,
+    env_args: dict,
+    model: str,
+    base_url: str,
+    sampling_args: SamplingArgs,
+    start_time: float,
+    path_to_save: Path,
+    state_columns: list[str],
+) -> GenerateOutputs:
+    """Build GenerateOutputs from a list of RolloutResults."""
+    rewards = [r.get("reward", 0.0) for r in rollouts]
+    example_ids = [r["example_id"] for r in rollouts]
+
+    # Aggregate metrics
+    metrics: dict[str, list[float]] = {}
+    for r in rollouts:
+        for name, value in r["metrics"].items():
+            if name not in metrics:
+                metrics[name] = []
+            metrics[name].append(value)
+
+    num_unique = len(set(example_ids)) if example_ids else 0
+    rollouts_per = len(rollouts) // num_unique if num_unique > 0 else 1
+
+    return GenerateOutputs(
+        rollouts=rollouts,
+        metadata=GenerateMetadata(
+            env_id=env_id,
+            env_args=env_args,
+            model=model,
+            base_url=base_url,
+            num_examples=num_unique,
+            rollouts_per_example=rollouts_per,
+            sampling_args=sampling_args,
+            date=datetime.now().isoformat(),
+            time_ms=(time.time() - start_time) * 1000.0,
+            avg_reward=sum(rewards) / len(rewards) if rewards else 0.0,
+            avg_metrics={k: sum(v) / len(v) if v else 0.0 for k, v in metrics.items()},
+            state_columns=state_columns,
+            path_to_save=path_to_save,
+        ),
+    )
+
+
+def _serialize_value(value: Any) -> Any:
+    """Attempt to serialize a value for IPC. Raises if not serializable."""
+    if value is None:
+        return None
+    if isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, (list, tuple)):
+        return [_serialize_value(v) for v in value]
+    if isinstance(value, dict):
+        return {k: _serialize_value(v) for k, v in value.items()}
+    if hasattr(value, "model_dump"):
+        return value.model_dump()
+    raise TypeError(f"Cannot serialize value of type {type(value).__name__}")
+
+
+def state_to_result(
+    state: State,
+    state_columns: list[str] | None = None,
+) -> RolloutResult:
+    """Convert internal State to serializable RolloutResult.
+
+    This is the single conversion point from runtime state to output format.
+    Call this at the boundary where internal processing ends and output begins.
+
+    Args:
+        state: The internal State object to convert.
+        state_columns: Optional list of extra state fields to include.
+            Values must be serializable (primitives, dicts, lists, or have model_dump).
+            Raises TypeError if a non-serializable value is encountered.
+    """
+    trajectory: list[RolloutResultTrajectoryStep] = []
+    for step in state.get("trajectory", []):
+        traj_step: RolloutResultTrajectoryStep = {}
+        if step.get("prompt") is not None:
+            traj_step["prompt"] = step["prompt"]
+        if step.get("completion") is not None:
+            traj_step["completion"] = step["completion"]
+        if step.get("tokens") is not None:
+            traj_step["tokens"] = step["tokens"]
+        if step.get("advantage") is not None:
+            traj_step["advantage"] = step["advantage"]
+        trajectory.append(traj_step)
+
+    # Required fields
+    result: RolloutResult = {
+        "prompt": state["prompt"],
+        "completion": state.get("completion") or [],
+        "example_id": state.get("example_id", 0),
+        "task": state.get("task", "default"),
+        "metrics": state.get("metrics") or {},
+    }
+
+    # Optional fields
+    if state.get("answer") is not None:
+        result["answer"] = state["answer"]
+    if state.get("info") is not None:
+        result["info"] = state["info"]
+    if state.get("reward") is not None:
+        result["reward"] = state["reward"]
+    if state.get("is_truncated") is not None:
+        result["is_truncated"] = state["is_truncated"]
+    if state.get("stop_condition") is not None:
+        result["stop_condition"] = state["stop_condition"]
+    if trajectory:
+        result["trajectory"] = trajectory
+    if state.get("timing"):
+        result["timing"] = state["timing"]
+    if state.get("error"):
+        result["error"] = type(state["error"]).__name__
+
+    # Extra state columns - must be serializable
+    if state_columns:
+        for col in state_columns:
+            if col in state:
+                try:
+                    result[col] = _serialize_value(state[col])  # type: ignore[literal-required]
+                except TypeError as e:
+                    raise TypeError(
+                        f"Cannot serialize state column '{col}': {e}"
+                    ) from e
+
+    return result

--- a/verifiers/utils/type_utils.py
+++ b/verifiers/utils/type_utils.py
@@ -102,6 +102,8 @@ def state_to_result(
             traj_step["tokens"] = step["tokens"]
         if step.get("advantage") is not None:
             traj_step["advantage"] = step["advantage"]
+        if step.get("extras") is not None:
+            traj_step["extras"] = _serialize_value(step["extras"])
         trajectory.append(traj_step)
 
     # Required fields

--- a/verifiers/workers/__init__.py
+++ b/verifiers/workers/__init__.py
@@ -1,0 +1,26 @@
+"""
+Workers module for multiprocessing environment execution.
+
+Provides EnvClient and EnvServer for running environments in subprocesses,
+isolating event loop lag from the main process.
+"""
+
+from verifiers.workers.client import EnvClient
+from verifiers.workers.server import EnvServer
+from verifiers.workers.types import (
+    MetadataRequest,
+    MetadataResponse,
+    RolloutRequest,
+    RolloutResponse,
+    Shutdown,
+)
+
+__all__ = [
+    "EnvClient",
+    "EnvServer",
+    "MetadataRequest",
+    "MetadataResponse",
+    "RolloutRequest",
+    "RolloutResponse",
+    "Shutdown",
+]

--- a/verifiers/workers/client.py
+++ b/verifiers/workers/client.py
@@ -1,0 +1,256 @@
+"""
+Environment client that proxies requests to worker subprocesses.
+
+Manages multiple EnvServer instances and provides an async interface
+for rollout generation. One worker materializes the dataset, main process
+dispatches group inputs to workers.
+"""
+
+import asyncio
+import logging
+from typing import Any
+
+from datasets import Dataset
+
+from verifiers.types import RolloutInput, RolloutResult, SamplingArgs
+from verifiers.workers.server import EnvServer
+from verifiers.workers.types import (
+    MetadataRequest,
+    MetadataResponse,
+    RolloutRequest,
+    RolloutResponse,
+)
+
+
+class EnvClient:
+    """Client that manages worker subprocesses for environment execution.
+
+    One worker loads the environment and returns the dataset. The client
+    owns the dataset and the orchestrator dispatches group inputs to workers.
+    """
+
+    def __init__(
+        self,
+        env_id: str,
+        env_args: dict[str, Any],
+        client_base_url: str,
+        client_api_key: str,
+        num_workers: int = 1,
+        max_concurrent: int = -1,
+        sampling_args: SamplingArgs | None = None,
+        seq_len: int | None = None,
+        interleaved_rollouts: bool = False,
+        independent_scoring: bool = False,
+        state_columns: list[str] | None = None,
+    ):
+        self.env_id = env_id
+        self.env_args = env_args
+        self.client_base_url = client_base_url
+        self.client_api_key = client_api_key
+        self.num_workers = num_workers
+        self.max_concurrent = max_concurrent
+        self.sampling_args = sampling_args or {}
+        self.seq_len = seq_len
+        self.interleaved_rollouts = interleaved_rollouts
+        self.independent_scoring = independent_scoring
+        self.state_columns = state_columns or []
+
+        self.logger = logging.getLogger("verifiers.workers.client")
+
+        self._workers: list[EnvServer] = []
+        self._pending_futures: dict[int, asyncio.Future] = {}
+        self._response_collector_task: asyncio.Task | None = None
+
+        # Populated after start() by querying first worker
+        self._dataset: Dataset | None = None
+        self._env_sampling_args: SamplingArgs = {}
+        self._max_seq_len: int | None = None
+
+    def start(self, num_examples: int = -1):
+        """Start all worker processes and fetch dataset from first worker.
+
+        Args:
+            num_examples: Number of examples to use. -1 for all.
+        """
+        self.logger.info(f"Starting {self.num_workers} worker(s) for {self.env_id}")
+
+        # Start first worker to get dataset
+        first_worker = self._create_worker(0)
+        first_worker.start()
+        self._workers.append(first_worker)
+
+        # Request dataset and metadata from first worker
+        first_worker.send_request(MetadataRequest(num_examples=num_examples))
+        response = first_worker.recv_response(timeout=120)
+        if response is None or not isinstance(response, MetadataResponse):
+            raise RuntimeError("Failed to get metadata from worker")
+
+        # Store dataset and metadata
+        self._dataset = Dataset.from_list(response.dataset)
+        self._env_sampling_args = response.sampling_args
+        self._max_seq_len = response.max_seq_len
+
+        self.logger.info(
+            f"Got dataset with {len(self._dataset)} examples, "
+            f"max_seq_len={self._max_seq_len}"
+        )
+
+        # Update sampling args from worker if we didn't specify them
+        if not self.sampling_args and self._env_sampling_args:
+            self.sampling_args = self._env_sampling_args
+
+        # Start remaining workers
+        for i in range(1, self.num_workers):
+            worker = self._create_worker(i)
+            worker.start()
+            self._workers.append(worker)
+
+    def _create_worker(self, index: int) -> EnvServer:
+        """Create a worker server instance."""
+        per_worker = (
+            self.max_concurrent // max(1, self.num_workers)
+            if self.max_concurrent > 0
+            else -1
+        )
+        return EnvServer(
+            env_id=self.env_id,
+            env_args=self.env_args,
+            client_base_url=self.client_base_url,
+            client_api_key=self.client_api_key,
+            max_concurrent=per_worker,
+            seq_len=self.seq_len,
+            interleaved_rollouts=self.interleaved_rollouts,
+            worker_name=f"{self.env_id}_{index}",
+        )
+
+    def stop(self):
+        """Stop all worker processes."""
+        self.logger.info(f"Stopping {len(self._workers)} worker(s)")
+        if self._response_collector_task:
+            self._response_collector_task.cancel()
+        for worker in self._workers:
+            worker.stop()
+        self._workers.clear()
+
+    @property
+    def dataset(self) -> Dataset:
+        """Get the evaluation dataset."""
+        if self._dataset is None:
+            raise RuntimeError("Client not started - call start() first")
+        return self._dataset
+
+    @property
+    def num_examples(self) -> int:
+        """Get number of examples in dataset."""
+        return len(self.dataset)
+
+    @property
+    def max_seq_len(self) -> int | None:
+        """Get max sequence length from environment."""
+        return self._max_seq_len
+
+    @property
+    def env_sampling_args(self) -> SamplingArgs:
+        """Get environment's default sampling args."""
+        return self._env_sampling_args
+
+    async def submit_group(
+        self,
+        group_inputs: list[RolloutInput],
+        example_id: int,
+        model_name: str,
+    ) -> asyncio.Future:
+        """Submit a group of inputs for rollout and return a future for the response.
+
+        The orchestrator is responsible for constructing group_inputs with
+        the desired duplication (e.g. [input] * rollouts_per_example).
+        """
+        request = RolloutRequest(
+            group_inputs=group_inputs,
+            example_id=example_id,
+            model_name=model_name,
+            sampling_args=self.sampling_args,
+            independent_scoring=self.independent_scoring,
+            state_columns=self.state_columns,
+        )
+
+        worker = self._select_worker()
+        worker.send_request(request)
+
+        loop = asyncio.get_event_loop()
+        future = loop.create_future()
+        self._pending_futures[example_id] = future
+
+        return future
+
+    def _select_worker(self) -> EnvServer:
+        """Select a worker for the next request (round-robin by pending count)."""
+        if not self._workers:
+            raise RuntimeError("No workers available")
+        return min(self._workers, key=lambda w: len(self._pending_futures))
+
+    async def collect_responses(self):
+        """Background task to collect responses and resolve futures."""
+        while True:
+            for worker in self._workers:
+                while True:
+                    response = worker.recv_response_nowait()
+                    if response is None:
+                        break
+                    if isinstance(response, RolloutResponse):
+                        self._handle_response(response)
+            await asyncio.sleep(0.01)
+
+    def _handle_response(self, response: RolloutResponse):
+        """Handle a response from a worker."""
+        if response.example_id in self._pending_futures:
+            future = self._pending_futures.pop(response.example_id)
+            if not future.done():
+                future.set_result(response.results)
+
+    async def run_groups(
+        self,
+        groups: list[tuple[list[RolloutInput], int]],
+        model_name: str,
+    ) -> list[list[RolloutResult]]:
+        """Run multiple groups and return all results.
+
+        Args:
+            groups: List of (group_inputs, example_id) tuples.
+                The orchestrator constructs group_inputs with desired duplication.
+            model_name: Model to use for generation.
+
+        Returns:
+            List of result lists, one per group.
+        """
+        self._response_collector_task = asyncio.create_task(self.collect_responses())
+
+        try:
+            futures = []
+            for group_inputs, example_id in groups:
+                future = await self.submit_group(
+                    group_inputs=group_inputs,
+                    example_id=example_id,
+                    model_name=model_name,
+                )
+                futures.append(future)
+
+            results = await asyncio.gather(*futures)
+            return list(results)
+        finally:
+            if self._response_collector_task:
+                self._response_collector_task.cancel()
+                try:
+                    await self._response_collector_task
+                except asyncio.CancelledError:
+                    pass
+                self._response_collector_task = None
+
+    @property
+    def pending_count(self) -> int:
+        """Number of pending requests."""
+        return len(self._pending_futures)
+
+    def update_sampling_args(self, sampling_args: SamplingArgs):
+        """Update sampling args for future requests."""
+        self.sampling_args = sampling_args

--- a/verifiers/workers/client.py
+++ b/verifiers/workers/client.py
@@ -26,7 +26,7 @@ class EnvClient:
     """Client that manages worker subprocesses for environment execution.
 
     One worker loads the environment and returns the dataset. The client
-    owns the dataset and the orchestrator dispatches group inputs to workers.
+    owns the dataset and the caller dispatches group inputs to workers.
     """
 
     def __init__(
@@ -165,8 +165,8 @@ class EnvClient:
     ) -> asyncio.Future:
         """Submit a group of inputs for rollout and return a future for the response.
 
-        The orchestrator is responsible for constructing group_inputs with
-        the desired duplication (e.g. [input] * rollouts_per_example).
+        The caller is responsible for constructing `group_inputs` (including any
+        duplication needed to get multiple samples per example).
         """
         request = RolloutRequest(
             group_inputs=group_inputs,
@@ -232,7 +232,7 @@ class EnvClient:
 
         Args:
             groups: List of (group_inputs, example_id) tuples.
-                The orchestrator constructs group_inputs with desired duplication.
+                The caller constructs group_inputs with the desired duplication.
             model_name: Model to use for generation.
 
         Returns:

--- a/verifiers/workers/server.py
+++ b/verifiers/workers/server.py
@@ -40,6 +40,7 @@ def _error_rollouts_for_request(
     results = []
     err = f"{type(error).__name__}: {error}"
     for inp in request.group_inputs:
+        assert "task" in inp, "RolloutInput is missing required field 'task'"
         prompt = inp["prompt"]
         completion: Messages = "" if isinstance(prompt, str) else []
         results.append(
@@ -63,7 +64,7 @@ async def _process_request_safe(
     logger: logging.Logger,
 ) -> RolloutResponse:
     try:
-        return await process_request(request, env, client_cycle, semaphore, logger)
+        return await process_request(request, env, client_cycle, semaphore)
     except asyncio.CancelledError:
         raise
     except Exception as e:
@@ -77,7 +78,6 @@ async def process_request(
     env: vf.Environment,
     client_cycle: Iterator[AsyncOpenAI],
     semaphore: AsyncContextManager,
-    logger: logging.Logger,
 ) -> RolloutResponse:
     """Process a single rollout request.
 

--- a/verifiers/workers/server.py
+++ b/verifiers/workers/server.py
@@ -1,0 +1,278 @@
+"""
+Environment server that runs in a subprocess.
+
+Loads and owns an Environment instance, processing rollout requests
+from the main process via IPC.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import multiprocessing
+import queue
+from itertools import cycle
+from multiprocessing import Process
+from multiprocessing.queues import Queue
+from typing import Any, AsyncContextManager, Iterator, cast
+
+from openai import AsyncOpenAI
+
+import verifiers as vf
+from verifiers.types import RolloutInput
+from verifiers.utils.async_utils import maybe_semaphore
+from verifiers.utils.type_utils import state_to_result
+from verifiers.workers.types import (
+    MetadataRequest,
+    MetadataResponse,
+    RolloutRequest,
+    RolloutResponse,
+    Shutdown,
+)
+
+WorkerRequest = RolloutRequest | MetadataRequest | Shutdown
+WorkerResponse = RolloutResponse | MetadataResponse
+
+
+async def process_request(
+    request: RolloutRequest,
+    env: vf.Environment,
+    client_cycle: Iterator[AsyncOpenAI],
+    semaphore: AsyncContextManager,
+    logger: logging.Logger,
+) -> RolloutResponse:
+    """Process a single rollout request.
+
+    The orchestrator is responsible for constructing group_inputs with
+    the desired duplication. This worker just runs the group.
+    """
+    client = next(client_cycle)
+    group_inputs = [cast(RolloutInput, inp) for inp in request.group_inputs]
+
+    if request.independent_scoring:
+        # Independent scoring: run each input separately with scoring
+        states = []
+        for rollout_input in group_inputs:
+            state = await env.run_rollout(
+                input=rollout_input,
+                client=client,
+                model=request.model_name,
+                gen_sampling_args=request.sampling_args,
+                gen_sem=semaphore,
+                score_sem=semaphore,
+                score=True,
+            )
+            states.append(state)
+    else:
+        # Group scoring: run all inputs together
+        states = await env.run_group(
+            group_inputs=group_inputs,
+            client=client,
+            model=request.model_name,
+            gen_sampling_args=request.sampling_args,
+            gen_sem=semaphore,
+            score_sem=semaphore,
+        )
+
+    results = [
+        state_to_result(state, state_columns=request.state_columns) for state in states
+    ]
+    return RolloutResponse(example_id=request.example_id, results=results)
+
+
+def handle_metadata_request(
+    request: MetadataRequest,
+    env: vf.Environment,
+) -> MetadataResponse:
+    """Handle a metadata request - returns dataset and env config."""
+    dataset = env.get_eval_dataset(n=request.num_examples)
+    return MetadataResponse(
+        dataset=dataset.to_list(),
+        sampling_args=env.sampling_args,
+        max_seq_len=env.max_seq_len,
+    )
+
+
+async def worker_loop(
+    request_queue: Queue[WorkerRequest],
+    response_queue: Queue[WorkerResponse],
+    env: vf.Environment,
+    clients: list[AsyncOpenAI],
+    max_concurrent: int,
+    logger: logging.Logger,
+) -> None:
+    """Main async loop for processing requests."""
+    client_cycle = cycle(clients)
+    semaphore = await maybe_semaphore(max_concurrent)
+
+    pending_tasks: dict[asyncio.Task, int] = {}
+
+    def check_for_requests() -> bool:
+        """Non-blocking check for new requests. Returns False on shutdown signal."""
+        while True:
+            try:
+                request = request_queue.get_nowait()
+            except queue.Empty:
+                break
+
+            if isinstance(request, Shutdown):
+                return False
+
+            if isinstance(request, MetadataRequest):
+                response = handle_metadata_request(request, env)
+                response_queue.put(response)
+                continue
+
+            task = asyncio.create_task(
+                process_request(request, env, client_cycle, semaphore, logger)
+            )
+            pending_tasks[task] = request.example_id
+        return True
+
+    try:
+        while True:
+            if not check_for_requests():
+                break
+
+            if not pending_tasks:
+                await asyncio.sleep(0.01)
+                continue
+
+            done, _ = await asyncio.wait(
+                pending_tasks.keys(), timeout=0.1, return_when=asyncio.FIRST_COMPLETED
+            )
+
+            for task in done:
+                pending_tasks.pop(task)
+                try:
+                    response = task.result()
+                    response_queue.put(response)
+                except Exception as e:
+                    logger.error(f"Task failed: {e}")
+    finally:
+        for task in pending_tasks:
+            task.cancel()
+
+
+def worker_main(
+    request_queue: Queue[WorkerRequest],
+    response_queue: Queue[WorkerResponse],
+    env_id: str,
+    env_args: dict[str, Any],
+    client_base_url: str,
+    client_api_key: str,
+    max_concurrent: int,
+    seq_len: int | None,
+    interleaved_rollouts: bool,
+    worker_name: str,
+) -> None:
+    """Main entry point for worker process."""
+    logger = logging.getLogger(f"verifiers.workers.{worker_name}")
+    logger.info(f"Worker {worker_name} starting, loading environment {env_id}")
+
+    env = vf.load_environment(env_id, **env_args)
+    if seq_len is not None:
+        env.set_max_seq_len(seq_len)
+    if interleaved_rollouts:
+        env.set_interleaved_rollouts(True)
+
+    client = AsyncOpenAI(base_url=client_base_url, api_key=client_api_key)
+    clients = [client]
+
+    logger.info(f"Worker {worker_name} ready")
+
+    asyncio.run(
+        worker_loop(
+            request_queue,
+            response_queue,
+            env,
+            clients,
+            max_concurrent,
+            logger,
+        )
+    )
+
+
+class EnvServer:
+    """Manages a worker subprocess for an environment."""
+
+    def __init__(
+        self,
+        env_id: str,
+        env_args: dict[str, Any],
+        client_base_url: str,
+        client_api_key: str,
+        max_concurrent: int,
+        seq_len: int | None = None,
+        interleaved_rollouts: bool = False,
+        worker_name: str | None = None,
+    ):
+        self.env_id = env_id
+        self.env_args = env_args
+        self.client_base_url = client_base_url
+        self.client_api_key = client_api_key
+        self.max_concurrent = max_concurrent
+        self.seq_len = seq_len
+        self.interleaved_rollouts = interleaved_rollouts
+        self.worker_name = worker_name or f"{env_id}_0"
+
+        self.request_queue: Queue[WorkerRequest] = multiprocessing.Queue()
+        self.response_queue: Queue[WorkerResponse] = multiprocessing.Queue()
+        self.process: Process | None = None
+
+        self.logger = logging.getLogger(f"verifiers.workers.{self.worker_name}")
+
+    def start(self):
+        """Start the worker process."""
+        self.logger.info(f"Starting worker process {self.worker_name}")
+        self.process = Process(
+            target=worker_main,
+            args=(
+                self.request_queue,
+                self.response_queue,
+                self.env_id,
+                self.env_args,
+                self.client_base_url,
+                self.client_api_key,
+                self.max_concurrent,
+                self.seq_len,
+                self.interleaved_rollouts,
+                self.worker_name,
+            ),
+            daemon=True,
+        )
+        self.process.start()
+
+    def stop(self):
+        """Stop the worker process."""
+        if self.process and self.process.is_alive():
+            self.request_queue.put(Shutdown())
+            self.process.join(timeout=5)
+            if self.process.is_alive():
+                self.logger.warning(
+                    f"Worker {self.worker_name} did not stop gracefully, terminating"
+                )
+                self.process.terminate()
+
+    def send_request(self, request: WorkerRequest):
+        """Send a request to the worker."""
+        self.request_queue.put(request)
+
+    def recv_response(self, timeout: float | None = None) -> WorkerResponse | None:
+        """Receive a response from the worker."""
+        try:
+            return self.response_queue.get(timeout=timeout)
+        except queue.Empty:
+            return None
+
+    def recv_response_nowait(self) -> WorkerResponse | None:
+        """Non-blocking receive of response."""
+        try:
+            return self.response_queue.get_nowait()
+        except queue.Empty:
+            return None
+
+    @property
+    def is_alive(self) -> bool:
+        """Check if the worker process is alive."""
+        return self.process is not None and self.process.is_alive()

--- a/verifiers/workers/server.py
+++ b/verifiers/workers/server.py
@@ -81,8 +81,8 @@ async def process_request(
 ) -> RolloutResponse:
     """Process a single rollout request.
 
-    The orchestrator is responsible for constructing group_inputs with
-    the desired duplication. This worker just runs the group.
+    The caller constructs `group_inputs`. This worker runs the rollout(s) and
+    returns serialized results.
     """
     client = next(client_cycle)
     group_inputs = request.group_inputs

--- a/verifiers/workers/types.py
+++ b/verifiers/workers/types.py
@@ -20,8 +20,8 @@ class Shutdown:
 class RolloutRequest:
     """Request to run a group of rollouts.
 
-    The orchestrator (vf-eval or prime-rl) is responsible for constructing
-    group_inputs with the desired duplication.
+    The caller is responsible for constructing `group_inputs` (including any
+    duplication needed to get multiple samples per example).
     """
 
     group_inputs: list[RolloutInput]

--- a/verifiers/workers/types.py
+++ b/verifiers/workers/types.py
@@ -1,0 +1,56 @@
+"""
+Request/Response types for EnvWorker IPC.
+
+These dataclasses are designed to be serializable for cross-process communication.
+"""
+
+from dataclasses import dataclass, field
+
+from verifiers.types import RolloutInput, RolloutResult, SamplingArgs
+
+
+@dataclass
+class Shutdown:
+    """Sentinel to signal worker shutdown."""
+
+    pass
+
+
+@dataclass
+class RolloutRequest:
+    """Request to run a group of rollouts.
+
+    The orchestrator (vf-eval or prime-rl) is responsible for constructing
+    group_inputs with the desired duplication.
+    """
+
+    group_inputs: list[RolloutInput]
+    example_id: int
+    model_name: str
+    sampling_args: SamplingArgs = field(default_factory=dict)
+    independent_scoring: bool = False
+    state_columns: list[str] = field(default_factory=list)
+
+
+@dataclass
+class RolloutResponse:
+    """Response containing rollout results."""
+
+    example_id: int
+    results: list[RolloutResult]
+
+
+@dataclass
+class MetadataRequest:
+    """Request for environment metadata and dataset."""
+
+    num_examples: int = -1
+
+
+@dataclass
+class MetadataResponse:
+    """Response with environment metadata and dataset."""
+
+    dataset: list[dict]
+    sampling_args: SamplingArgs
+    max_seq_len: int | None


### PR DESCRIPTION
## Description
Enables multi-processing for env workers

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a new results schema and multiprocessing evaluation pipeline.
> 
> - Define `RolloutResult` and change `GenerateOutputs` to `rollouts + metadata`; update docs, printing, dataset conversion, and save utilities to consume rollout-centric outputs
> - Refactor `Environment.generate/evaluate` to build outputs via `type_utils` (`state_to_result`, `build_generate_outputs`) and sort/persist consistently; remove legacy parallel-list fields
> - Add multiprocessing env workers (`verifiers.workers.{client,server,types}`), export `EnvClient/EnvServer`, and migrate `run_evaluation` to use workers; add `--num-workers` and wire through `EvalConfig`
> - Update RL trainer to read trajectories/timing from `rollouts`; adjust CLI, tests, and minor utilities (message/data utils, rubric, math_rubric import) accordingly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10ed83099a0d995e79d2eb49e18c7ce15879a19d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->