### PR TITLE
fix missing ToolRubric import

### DIFF
--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -27,6 +27,7 @@ from .parsers.think_parser import ThinkParser
 from .parsers.xml_parser import XMLParser
 from .rubrics.judge_rubric import JudgeRubric
 from .rubrics.rubric_group import RubricGroup
+from .rubrics.tool_rubric import ToolRubric
 from .utils.data_utils import (
     extract_boxed_answer,
     extract_hash_answer,
@@ -51,6 +52,7 @@ __all__ = [
     "Rubric",
     "JudgeRubric",
     "RubricGroup",
+    "ToolRubric",
     "MathRubric",
     "TextArenaEnv",
     "ReasoningGymEnv",
@@ -143,3 +145,4 @@ if TYPE_CHECKING:
         get_model_and_tokenizer,
     )
     from .rubrics.math_rubric import MathRubric  # noqa: F401
+    from .rubrics.tool_rubric import ToolRubric  # noqa: F401

--- a/verifiers/rubrics/tool_rubric.py
+++ b/verifiers/rubrics/tool_rubric.py
@@ -1,0 +1,63 @@
+from typing import Callable
+
+from verifiers.rubrics.rubric import Rubric
+from verifiers.types import Messages
+from verifiers.utils.tool_utils import convert_func_to_oai_tool
+
+
+class ToolRubric(Rubric):
+    """Simple rubric that counts tool calls in completion messages."""
+
+    def __init__(self, tools: list[Callable] | None = None):
+        self.tools = tools or []
+        self.oai_tools = [convert_func_to_oai_tool(tool) for tool in self.tools]
+        self.tool_names = [tool.__name__ for tool in self.tools]
+
+        # Build initial reward functions and weights
+        reward_funcs = [self.total_tool_calls]
+        reward_weights = [0.0]
+
+        for tool_name in self.tool_names:
+            reward_funcs.append(self.get_tool_call_count_func(tool_name))
+            reward_weights.append(0.0)
+
+        # Pass them to parent class
+        super().__init__(funcs=reward_funcs, weights=reward_weights)
+
+    def total_tool_calls(self, completion: Messages, **kwargs) -> float:
+        """Count the total number of tool calls across all assistant messages."""
+        total = 0
+        for msg in completion:
+            if msg.get("role") == "assistant" and "tool_calls" in msg:
+                tool_calls = msg.get("tool_calls", [])
+                if isinstance(tool_calls, list):
+                    total += len(tool_calls)
+        return float(total)
+
+    def get_tool_call_count_func(self, tool_name: str) -> Callable:
+        """Create a reward function that counts calls to a specific tool."""
+
+        def tool_call_count_func(completion: Messages, **kwargs) -> float:
+            """Count calls to {tool_name} tool."""
+            count = 0
+
+            # Find tool calls in assistant messages
+            for msg in completion:
+                if msg.get("role") == "assistant" and "tool_calls" in msg:
+                    tool_calls = msg.get("tool_calls", [])
+                    if not isinstance(tool_calls, list):
+                        continue
+
+                    for tool_call in tool_calls:
+                        if hasattr(tool_call, "function") and hasattr(
+                            tool_call.function, "name"
+                        ):
+                            if tool_call.function.name == tool_name:
+                                count += 1
+
+            return float(count)
+
+        tool_call_count_func.__name__ = f"{tool_name}_calls"
+        return tool_call_count_func
+
+


### PR DESCRIPTION
## Description
When I ran "wiki-search" example, it gave an error saying "verifiers has no attribute ToolRubric".
So, I created file verifiers/verifiers/rubrics/tool_rubric.py with ToolRubric class
Added the import .rubrics.tool_rubric import ToolRubric to __init__.py


## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ x] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a rubric to evaluate tool usage and exposes it as part of the public API.
> 
> - New `ToolRubric` counts total tool calls and per-tool calls from assistant messages; initializes reward funcs dynamically from provided `tools`
> - Exports `ToolRubric` in `verifiers/__init__.py` (runtime exports and TYPE_CHECKING) to fix `verifiers has no attribute ToolRubric`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 284335b1175317c0543be77fe55c1ac04cce2359. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->