### PR TITLE
env server/client

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -648,10 +648,16 @@ vf.print_prompt_completions_sample(outputs: GenerateOutputs, n: int = 3)
 Pretty-print sample rollouts.
 
 ```python
-vf.setup_logging(level: str = "INFO")
+vf.setup_logging(
+    level: str = "INFO",
+    log_format: str | None = None,
+    date_format: str | None = None,
+    log_file: str | None = None,
+    log_file_level: str | None = None,
+)
 ```
 
-Configure verifiers logging. Set `VF_LOG_LEVEL` env var to change default.
+Configure verifiers logging. Set `VF_LOG_LEVEL` env var to change default. Optionally specify `log_file` to write logs to a file in addition to stderr. Use `log_file_level` to set a different log level for the file handler.
 
 ```python
 vf.log_level(level: str | int)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "jinja2>=3.1.6",
     "math-verify>=0.8.0",
     "mcp>=1.14.1",
+    "msgpack>=1.1.2",
     "nest-asyncio>=1.6.0", # for jupyter notebooks
     "openai>=1.108.1",
     "openai-agents>=0.0.7",

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -1,6 +1,7 @@
 import asyncio
 import atexit
 import functools
+import hashlib
 import inspect
 import json
 import logging
@@ -14,7 +15,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
-    AsyncContextManager,
     Awaitable,
     Callable,
     List,
@@ -25,7 +25,7 @@ from typing import (
 )
 
 from datasets import Dataset
-from openai import AsyncOpenAI, BadRequestError, OpenAI
+from openai import AsyncOpenAI, BadRequestError
 from openai.types.chat import ChatCompletion
 
 import verifiers as vf
@@ -34,6 +34,7 @@ from verifiers.rubrics.rubric import Rubric
 from verifiers.types import (
     ChatCompletionToolParam,
     ChatMessage,
+    ClientConfig,
     DatasetBuilder,
     GenerateMetadata,
     GenerateOutputs,
@@ -46,6 +47,7 @@ from verifiers.types import (
     State,
 )
 from verifiers.utils.async_utils import maybe_semaphore
+from verifiers.utils.client_utils import setup_client
 from verifiers.utils.error_utils import ErrorChain
 from verifiers.utils.eval_utils import make_dataset, save_rollout_results
 from verifiers.utils.message_utils import (
@@ -162,6 +164,8 @@ class Environment(ABC):
         self._stop_conditions: list[StopCondition] = []
         self._cleanup_handlers: list[RolloutCleanup] = []
         self._teardown_handlers: list[EnvironmentTeardown] = []
+
+        self._clients: dict[str, AsyncOpenAI] = {}
 
         self.__post_init__()
 
@@ -338,6 +342,16 @@ class Environment(ABC):
             )
         else:
             return self._format_completion_dataset(dataset, map_kwargs=self._map_kwargs)
+
+    def _get_client(self, client_config: ClientConfig) -> AsyncOpenAI:
+        config_hash = hashlib.sha256(
+            client_config.model_dump_json().encode()
+        ).hexdigest()
+        client = self._clients.get(config_hash)
+        if client is None:
+            client = setup_client(client_config)
+            self._clients[config_hash] = client
+        return client
 
     def _build_dataset(self) -> Dataset | None:
         """Build and cache the training dataset from source if needed."""
@@ -627,7 +641,7 @@ class Environment(ABC):
     async def init_state(
         self,
         input: RolloutInput,
-        client: AsyncOpenAI,
+        client_config: ClientConfig,
         model: str,
         sampling_args: SamplingArgs | None = None,
     ) -> State:
@@ -644,7 +658,7 @@ class Environment(ABC):
         if "task" not in state_input:
             state_input["task"] = self.env_id or "default"
         state = State(input=RolloutInput(**state_input))  # type: ignore[missing-typed-dict-key]
-        state["client"] = client
+        state["client"] = self._get_client(client_config)
         state["model"] = model
         state["sampling_args"] = sampling_args
         state["is_completed"] = False
@@ -674,7 +688,7 @@ class Environment(ABC):
     async def rollout(
         self,
         input: RolloutInput,
-        client: AsyncOpenAI,
+        client_config: ClientConfig,
         model: str,
         sampling_args: SamplingArgs | None = None,
     ) -> State:
@@ -731,25 +745,21 @@ class Environment(ABC):
     async def run_rollout(
         self,
         input: RolloutInput,
-        client: AsyncOpenAI,
+        client_config: ClientConfig,
         model: str,
-        gen_sampling_args: SamplingArgs,
-        gen_sem: AsyncContextManager,
-        score_sem: AsyncContextManager | None = None,
-        score: bool = False,
+        sampling_args: SamplingArgs,
+        score: bool = True,
     ) -> State:
         """Generate and, optionally, score a rollout."""
-        async with gen_sem:
-            state = await self.rollout(
-                input,
-                client,
-                model,
-                gen_sampling_args,
-            )
+        state = await self.rollout(
+            input,
+            client_config,
+            model,
+            sampling_args,
+        )
         if score:
-            assert score_sem is not None
             if self.score_rollouts:
-                await self.rubric.score_rollout(state, score_sem=score_sem)
+                await self.rubric.score_rollout(state)
             else:
                 await self.rubric.dummy_score_rollout(state)
         return state
@@ -758,29 +768,21 @@ class Environment(ABC):
     async def run_group(
         self,
         group_inputs: list[RolloutInput],
-        client: AsyncOpenAI,
+        client_config: ClientConfig,
         model: str,
-        gen_sampling_args: SamplingArgs,
-        gen_sem: AsyncContextManager,
-        score_sem: AsyncContextManager,
+        sampling_args: SamplingArgs,
         score: bool = True,
         **kwargs,
     ) -> list[State]:
         """Generate and, optionally, score one group."""
         rollout_tasks = [
-            self.run_rollout(
-                input,
-                client,
-                model,
-                gen_sampling_args,
-                gen_sem,
-            )
+            self.run_rollout(input, client_config, model, sampling_args, score=False)
             for input in group_inputs
         ]
         group_states = await asyncio.gather(*rollout_tasks)
         if score:
             if self.score_rollouts:
-                await self.rubric.score_group(group_states, score_sem=score_sem)
+                await self.rubric.score_group(group_states)
             else:
                 await self.rubric.dummy_score_group(group_states)
         return list(group_states)
@@ -789,7 +791,7 @@ class Environment(ABC):
         self,
         all_states: list[State],
         model: str,
-        client: AsyncOpenAI,
+        client_config: ClientConfig,
         state_columns: list[str] | None,
         results_path: Path | None,
         gen_sampling_args: SamplingArgs,
@@ -828,7 +830,7 @@ class Environment(ABC):
             env_id=self.env_id,
             env_args=self.env_args,
             model=model,
-            base_url=str(client.base_url) if hasattr(client, "base_url") else "",
+            base_url=client_config.api_base_url,
             num_examples=num_unique_examples,
             rollouts_per_example=rollouts_per_example,
             sampling_args=gen_sampling_args,
@@ -861,12 +863,10 @@ class Environment(ABC):
     async def generate(
         self,
         inputs: Dataset | List[RolloutInput],
-        client: AsyncOpenAI,
+        client_config: ClientConfig,
         model: str,
         sampling_args: SamplingArgs | None = None,
         max_concurrent: int = -1,
-        max_concurrent_generation: int | None = None,
-        max_concurrent_scoring: int | None = None,
         results_path: Path | None = None,
         state_columns: list[str] | None = None,
         save_results: bool = False,
@@ -882,17 +882,8 @@ class Environment(ABC):
         elif isinstance(inputs, list):
             inputs_list = inputs
 
-        # resolve concurrency knobs
-        gen_limit = max_concurrent_generation
-        score_limit = max_concurrent_scoring
-        if gen_limit is None:
-            gen_limit = max_concurrent
-        if score_limit is None:
-            score_limit = max_concurrent
-
         # set up semaphores
-        gen_sem = await maybe_semaphore(gen_limit)
-        score_sem = await maybe_semaphore(score_limit)
+        sem = maybe_semaphore(max_concurrent)
 
         # set up sampling args
         gen_sampling_args = deepcopy(self.sampling_args)
@@ -904,22 +895,26 @@ class Environment(ABC):
         # create tasks based on mode
         tasks: dict[asyncio.Task, int] = {}
         if independent_scoring:
+
+            async def run_rollout_with_sem(*args, **kwargs) -> State:
+                async with sem:
+                    return await self.run_rollout(*args, **kwargs)
+
             for i, input_item in enumerate(inputs_list):
                 task = asyncio.create_task(
-                    self.run_rollout(
-                        input_item,
-                        client,
-                        model,
-                        gen_sampling_args,
-                        gen_sem,
-                        score_sem,
-                        score=True,
+                    run_rollout_with_sem(
+                        input_item, client_config, model, gen_sampling_args, sem
                     )
                 )
                 tasks[task] = i
             pbar_total = len(inputs_list)
             pbar_desc = f"Processing {len(inputs_list)} rollouts"
         else:
+
+            async def run_group_with_sem(*args, **kwargs) -> list[State]:
+                async with sem:
+                    return await self.run_group(*args, **kwargs)
+
             input_groups: dict[int, list[RolloutInput]] = {}
             for input_item in inputs_list:
                 example_id = input_item["example_id"]
@@ -930,13 +925,8 @@ class Environment(ABC):
 
             for i, group in enumerate(group_list):
                 task = asyncio.create_task(
-                    self.run_group(
-                        group,
-                        client,
-                        model,
-                        gen_sampling_args,
-                        gen_sem,
-                        score_sem,
+                    run_group_with_sem(
+                        group, client_config, model, gen_sampling_args, sem
                     )
                 )
                 tasks[task] = i
@@ -983,7 +973,7 @@ class Environment(ABC):
                     temp_results = self._prepare_rollout_results(
                         all_states,
                         model,
-                        client,
+                        client_config,
                         state_columns,
                         results_path,
                         gen_sampling_args,
@@ -1003,7 +993,7 @@ class Environment(ABC):
         results = self._prepare_rollout_results(
             all_states,
             model,
-            client,
+            client_config,
             state_columns,
             results_path,
             gen_sampling_args,
@@ -1019,14 +1009,12 @@ class Environment(ABC):
     def generate_sync(
         self,
         inputs: Dataset | List[RolloutInput],
-        client: AsyncOpenAI | OpenAI,
+        client_config: ClientConfig,
         **kwargs,
     ) -> GenerateOutputs:
-        if isinstance(client, OpenAI):
-            client = AsyncOpenAI(api_key=client.api_key, base_url=client.base_url)
         coro = self.generate(
             inputs,
-            client=client,
+            client_config=client_config,
             **kwargs,
         )
         # check if we're in existing event loop (e.g. Jupyter)
@@ -1065,14 +1053,12 @@ class Environment(ABC):
 
     async def evaluate(
         self,
-        client: AsyncOpenAI,
+        client_config: ClientConfig,
         model: str,
         sampling_args: SamplingArgs | None = None,
         num_examples: int = -1,
         rollouts_per_example: int = 1,
         max_concurrent: int = -1,
-        max_concurrent_generation: int | None = None,
-        max_concurrent_scoring: int | None = None,
         results_path: Path | None = None,
         state_columns: list[str] | None = None,
         save_results: bool = False,
@@ -1086,12 +1072,10 @@ class Environment(ABC):
         inputs = self._get_eval_inputs(num_examples, rollouts_per_example)
         return await self.generate(
             inputs,
-            client=client,
+            client_config=client_config,
             model=model,
             sampling_args=sampling_args,
             max_concurrent=max_concurrent,
-            max_concurrent_generation=max_concurrent_generation,
-            max_concurrent_scoring=max_concurrent_scoring,
             results_path=results_path,
             state_columns=state_columns,
             save_results=save_results,
@@ -1102,7 +1086,7 @@ class Environment(ABC):
 
     def evaluate_sync(
         self,
-        client: OpenAI | AsyncOpenAI,
+        client_config: ClientConfig,
         model: str,
         sampling_args: SamplingArgs | None = None,
         num_examples: int = -1,
@@ -1122,7 +1106,7 @@ class Environment(ABC):
         inputs = self._get_eval_inputs(num_examples, rollouts_per_example)
         return self.generate_sync(
             inputs,
-            client=client,
+            client_config=client_config,
             model=model,
             sampling_args=sampling_args,
             max_concurrent=max_concurrent,

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -443,7 +443,7 @@ class Environment(ABC):
             MessageType,
         ]:
             """Resolve optional arguments, fallback to state or class defaults."""
-            client = client or state["client"]
+            client = client or self._get_client(state["client_config"])
             model = model or state["model"]
             assert client is not None and model is not None
             oai_tools = oai_tools or state["oai_tools"]
@@ -657,8 +657,9 @@ class Environment(ABC):
             state_input["info"] = json.loads(state_input["info"])
         if "task" not in state_input:
             state_input["task"] = self.env_id or "default"
-        state = State(input=RolloutInput(**state_input))  # type: ignore[missing-typed-dict-key]
-        state["client"] = self._get_client(client_config)
+        input = RolloutInput(**state_input)
+        state = State(**input)  # type: ignore[missing-typed-dict-key]
+        state["client_config"] = client_config
         state["model"] = model
         state["sampling_args"] = sampling_args
         state["is_completed"] = False

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -657,8 +657,7 @@ class Environment(ABC):
             state_input["info"] = json.loads(state_input["info"])
         if "task" not in state_input:
             state_input["task"] = self.env_id or "default"
-        input = RolloutInput(**state_input)
-        state = State(**input)  # type: ignore[missing-typed-dict-key]
+        state = State(input=RolloutInput(**state_input))  # type: ignore[missing-typed-dict-key]
         state["client_config"] = client_config
         state["model"] = model
         state["sampling_args"] = sampling_args

--- a/verifiers/envs/multiturn_env.py
+++ b/verifiers/envs/multiturn_env.py
@@ -2,10 +2,9 @@ import logging
 from abc import abstractmethod
 from typing import final
 
-from openai import AsyncOpenAI
-
 import verifiers as vf
 from verifiers.types import (
+    ClientConfig,
     Messages,
     ModelResponse,
     RolloutInput,
@@ -129,11 +128,11 @@ class MultiTurnEnv(vf.Environment):
     async def rollout(
         self,
         input: RolloutInput,
-        client: AsyncOpenAI,
+        client_config: ClientConfig,
         model: str,
         sampling_args: SamplingArgs | None = None,
     ) -> State:
-        state = await self.init_state(input, client, model, sampling_args)
+        state = await self.init_state(input, client_config, model, sampling_args)
         try:
             state = await self.setup_state(state)
         except vf.Error as e:

--- a/verifiers/rubrics/rubric_group.py
+++ b/verifiers/rubrics/rubric_group.py
@@ -1,4 +1,4 @@
-from typing import Any, AsyncContextManager
+from typing import Any
 
 from verifiers.rubrics.rubric import Rubric
 from verifiers.types import (
@@ -52,7 +52,7 @@ class RubricGroup(Rubric):
         self.logger.warning("Adding class object to the first rubric in the group.")
         self.rubrics[0].add_class_object(name, obj)
 
-    async def score_rollout(self, state: State, score_sem: AsyncContextManager):
+    async def score_rollout(self, state: State):
         """
         Evaluate all reward functions in-place for a single rollout.
         """
@@ -63,7 +63,7 @@ class RubricGroup(Rubric):
             state.get("metrics", {}).copy() if state.get("metrics") else {}
         )
         for rubric in self.rubrics:
-            await rubric.score_rollout(state, score_sem=score_sem)
+            await rubric.score_rollout(state)
             rubric_reward = state.get("reward", 0.0)
             rubric_metrics = (
                 state.get("metrics", {}).copy() if state.get("metrics") else {}
@@ -77,7 +77,7 @@ class RubricGroup(Rubric):
         state["reward"] = total_reward
         state["metrics"] = aggregated_metrics
 
-    async def score_group(self, states: list[State], score_sem: AsyncContextManager):
+    async def score_group(self, states: list[State]):
         """
         Evaluate all reward functions in-place for a group of rollouts.
         """
@@ -89,7 +89,7 @@ class RubricGroup(Rubric):
             for state in states
         ]
         for rubric in self.rubrics:
-            await rubric.score_group(states, score_sem=score_sem)
+            await rubric.score_group(states)
             for i, state in enumerate(states):
                 rubric_reward = state.get("reward", 0.0)
                 rubric_metrics = (

--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -250,6 +250,13 @@ def main():
         default={},
         help='Extra environment as JSON object (e.g., \'{"key": "value", "num": 42}\'). Passed to environment constructor.',
     )
+    parser.add_argument(
+        "--use-env-worker",
+        "-W",
+        default=False,
+        action="store_true",
+        help="Use env workers (will spawn a multi-processed env server as a sidecar)",
+    )
     args = parser.parse_args()
 
     setup_logging("DEBUG" if args.verbose else os.getenv("VF_LOG_LEVEL", "INFO"))
@@ -393,6 +400,7 @@ def main():
             num_examples=num_examples,
             rollouts_per_example=rollouts_per_example,
             max_concurrent=env_args.max_concurrent,
+            use_env_worker=env_args.use_env_worker,
             # logging
             verbose=env_args.verbose,
             # saving

--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -393,8 +393,6 @@ def main():
             num_examples=num_examples,
             rollouts_per_example=rollouts_per_example,
             max_concurrent=env_args.max_concurrent,
-            max_concurrent_generation=env_args.max_concurrent_generation,
-            max_concurrent_scoring=env_args.max_concurrent_scoring,
             # logging
             verbose=env_args.verbose,
             # saving

--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -251,11 +251,11 @@ def main():
         help='Extra environment as JSON object (e.g., \'{"key": "value", "num": 42}\'). Passed to environment constructor.',
     )
     parser.add_argument(
-        "--use-env-worker",
+        "--use-env-server",
         "-W",
         default=False,
         action="store_true",
-        help="Use env workers (will spawn a multi-processed env server as a sidecar)",
+        help="Use env servers (will spawn a multi-process env server as a sidecar)",
     )
     args = parser.parse_args()
 
@@ -400,7 +400,7 @@ def main():
             num_examples=num_examples,
             rollouts_per_example=rollouts_per_example,
             max_concurrent=env_args.max_concurrent,
-            use_env_worker=env_args.use_env_worker,
+            use_env_server=env_args.use_env_server,
             # logging
             verbose=env_args.verbose,
             # saving

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -236,6 +236,7 @@ class EvalConfig(BaseModel):
     max_concurrent: int
     independent_scoring: bool = False
     extra_env_kwargs: dict = {}
+    use_env_worker: bool = False
     # logging
     verbose: bool = False
     # saving

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -95,11 +95,9 @@ class RolloutTiming(TypedDict, total=False):
 
 
 class State(dict):
-    prompt: Messages
-    example_id: int
-    task: str
-    answer: str | None
-    info: Info | None
+    INPUT_FIELDS = ["prompt", "answer", "task", "info", "example_id"]
+    # rollout inputs
+    input: RolloutInput
     client_config: "ClientConfig"
     model: str
     sampling_args: SamplingArgs | None
@@ -116,6 +114,29 @@ class State(dict):
     metrics: dict[str, float] | None
     timing: RolloutTiming | None
     error: Error | None
+
+    def __getitem__(self, key: str) -> Any:
+        # forward to input if exists
+        if key in self.INPUT_FIELDS and "input" in self:
+            input_obj = super().__getitem__("input")
+            if key in input_obj:
+                return input_obj[key]
+        return super().__getitem__(key)
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        # forward to input if exists
+        if key in self.INPUT_FIELDS and "input" in self:
+            input_obj = super().__getitem__("input")
+            if key in input_obj:
+                input_obj[key] = value
+                return
+        super().__setitem__(key, value)
+
+    def get(self, key: str, default: Any = None) -> Any:
+        try:
+            return self[key]
+        except KeyError:
+            return default
 
 
 # oai tools

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -16,7 +16,6 @@ if sys.version_info < (3, 12):
 else:
     from typing import TypedDict
 
-from openai import AsyncOpenAI
 from openai.types.chat.chat_completion import ChatCompletion
 from openai.types.chat.chat_completion_message_param import ChatCompletionMessageParam
 
@@ -96,17 +95,20 @@ class RolloutTiming(TypedDict, total=False):
 
 
 class State(dict):
-    INPUT_FIELDS = ["prompt", "answer", "task", "info", "example_id"]
-    # rollout inputs
-    input: RolloutInput
-    client: AsyncOpenAI
+    prompt: Messages
+    example_id: int
+    task: str
+    answer: str | None
+    info: Info | None
+    client_config: "ClientConfig"
     model: str
     sampling_args: SamplingArgs | None
     # created during rollout
     is_completed: bool
     is_truncated: bool
     stop_condition: str | None
-    oai_tools: list[ChatCompletionToolParam]
+    oai_tools: list[ChatCompletionToolParam] | None
+    trajectory_id: str
     trajectory: list[TrajectoryStep]
     completion: Messages | None
     reward: float | None
@@ -114,29 +116,6 @@ class State(dict):
     metrics: dict[str, float] | None
     timing: RolloutTiming | None
     error: Error | None
-
-    def __getitem__(self, key: str) -> Any:
-        # forward to input if exists
-        if key in self.INPUT_FIELDS and "input" in self:
-            input_obj = super().__getitem__("input")
-            if key in input_obj:
-                return input_obj[key]
-        return super().__getitem__(key)
-
-    def __setitem__(self, key: str, value: Any) -> None:
-        # forward to input if exists
-        if key in self.INPUT_FIELDS and "input" in self:
-            input_obj = super().__getitem__("input")
-            if key in input_obj:
-                input_obj[key] = value
-                return
-        super().__setitem__(key, value)
-
-    def get(self, key: str, default: Any = None) -> Any:
-        try:
-            return self[key]
-        except KeyError:
-            return default
 
 
 # oai tools

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -236,7 +236,7 @@ class EvalConfig(BaseModel):
     max_concurrent: int
     independent_scoring: bool = False
     extra_env_kwargs: dict = {}
-    use_env_worker: bool = False
+    use_env_server: bool = False
     # logging
     verbose: bool = False
     # saving

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -234,8 +234,6 @@ class EvalConfig(BaseModel):
     num_examples: int
     rollouts_per_example: int
     max_concurrent: int
-    max_concurrent_generation: int | None = None
-    max_concurrent_scoring: int | None = None
     independent_scoring: bool = False
     extra_env_kwargs: dict = {}
     # logging

--- a/verifiers/utils/async_utils.py
+++ b/verifiers/utils/async_utils.py
@@ -20,7 +20,7 @@ class NullAsyncContext:
         return False
 
 
-async def maybe_semaphore(
+def maybe_semaphore(
     limit: Optional[int] = None,
 ) -> AsyncContextManager:
     """

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -26,7 +26,6 @@ from verifiers.types import (
     MultiEvalConfig,
 )
 from verifiers.utils.async_utils import EventLoopLagMonitor
-from verifiers.utils.client_utils import setup_client
 from verifiers.utils.error_utils import ErrorChain
 from verifiers.utils.logging_utils import print_prompt_completions_sample, print_time
 from verifiers.utils.message_utils import messages_to_printable, sanitize_tool_calls
@@ -246,7 +245,6 @@ def print_results(
 
 async def run_evaluation(config: EvalConfig) -> GenerateOutputs:
     # set up AsyncOpenAI client with high limits to prevent timeouts
-    client = setup_client(config.client_config)
     logger.debug(
         f"Initialized AsyncOpenAI client with base_url: {config.client_config.api_base_url}"
     )
@@ -266,14 +264,12 @@ async def run_evaluation(config: EvalConfig) -> GenerateOutputs:
         f"Configuration: num_examples={config.num_examples}, rollouts_per_example={config.rollouts_per_example}, max_concurrent={config.max_concurrent}"
     )
     results = await vf_env.evaluate(
-        client=client,
+        client_config=config.client_config,
         model=config.model,
         sampling_args=config.sampling_args,
         num_examples=config.num_examples,
         rollouts_per_example=config.rollouts_per_example,
         max_concurrent=config.max_concurrent,
-        max_concurrent_generation=config.max_concurrent_generation,
-        max_concurrent_scoring=config.max_concurrent_scoring,
         results_path=results_path,
         state_columns=config.state_columns,
         save_results=config.save_results,

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -255,23 +255,11 @@ async def run_evaluation(config: EvalConfig) -> GenerateOutputs:
         from verifiers.workers.client.zmq_env_client import ZMQEnvClient
         from verifiers.workers.server.zmq_env_server import ZMQEnvServer
 
-        # NOTE: ZMQEnvServer must be created INSIDE the subprocess, not before fork.
-        # ZMQ contexts/sockets are not safe to share across fork boundaries.
-        def run_server(env_id: str, env_args: dict):
-            server = ZMQEnvServer(env_id=env_id, env_args=env_args)
-            asyncio.run(server.run())
-
         env_worker = Process(
             target=ZMQEnvServer.run_server,
             args=(config.env_id, config.env_args),
         )
         env_worker.start()
-
-        # Give the server a moment to start up and bind the socket
-        import time
-
-        time.sleep(0.5)
-
         env = ZMQEnvClient()
     else:
         env_worker = None

--- a/verifiers/utils/logging_utils.py
+++ b/verifiers/utils/logging_utils.py
@@ -20,30 +20,47 @@ def setup_logging(
     level: str = "INFO",
     log_format: str | None = None,
     date_format: str | None = None,
+    log_file: str | None = None,
+    log_file_level: str | None = None,
 ) -> None:
     """
     Setup basic logging configuration for the verifiers package.
 
     Args:
-        level: The logging level to use. Defaults to "INFO".
+        level: The logging level to use for console output. Defaults to "INFO".
         log_format: Custom log format string. If None, uses default format.
         date_format: Custom date format string. If None, uses default format.
+        log_file: Optional path to a log file. If specified, logs will be written to this file.
+        log_file_level: The logging level for the file handler. If None, uses the same level as console.
     """
     if log_format is None:
         log_format = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
     if date_format is None:
         date_format = "%Y-%m-%d %H:%M:%S"
 
-    handler = logging.StreamHandler(sys.stderr)
-    handler.setFormatter(logging.Formatter(fmt=log_format, datefmt=date_format))
+    formatter = logging.Formatter(fmt=log_format, datefmt=date_format)
 
     logger = logging.getLogger(LOGGER_NAME)
-    # Remove any existing handlers to avoid duplicates
+
+    # remove any existing handlers to avoid duplicates
     logger.handlers.clear()
     logger.setLevel(level.upper())
-    logger.addHandler(handler)
 
-    # Prevent the logger from propagating messages to the root logger
+    # add console handler (stderr)
+    console_handler = logging.StreamHandler(sys.stderr)
+    console_handler.setFormatter(formatter)
+    console_handler.setLevel(level.upper())
+    logger.addHandler(console_handler)
+
+    # add file handler if log_file is specified
+    if log_file is not None:
+        file_handler = logging.FileHandler(log_file, mode="a", encoding="utf-8")
+        file_handler.setFormatter(formatter)
+        file_level = log_file_level.upper() if log_file_level else level.upper()
+        file_handler.setLevel(file_level)
+        logger.addHandler(file_handler)
+
+    # prevent the logger from propagating messages to the root logger
     logger.propagate = False
 
 

--- a/verifiers/workers/__init__.py
+++ b/verifiers/workers/__init__.py
@@ -1,7 +1,31 @@
 from verifiers.workers.client import ZMQEnvClient
 from verifiers.workers.server import ZMQEnvServer
+from verifiers.workers.types import (
+    BaseRequest,
+    BaseResponse,
+    EvaluateRequest,
+    EvaluateResponse,
+    HealthRequest,
+    HealthResponse,
+    RunGroupRequest,
+    RunGroupResponse,
+    RunRolloutRequest,
+    RunRolloutResponse,
+)
 
 __all__ = [
+    # Client/Server
     "ZMQEnvClient",
     "ZMQEnvServer",
+    # Request/Response types
+    "BaseRequest",
+    "BaseResponse",
+    "HealthRequest",
+    "HealthResponse",
+    "RunRolloutRequest",
+    "RunRolloutResponse",
+    "RunGroupRequest",
+    "RunGroupResponse",
+    "EvaluateRequest",
+    "EvaluateResponse",
 ]

--- a/verifiers/workers/__init__.py
+++ b/verifiers/workers/__init__.py
@@ -1,0 +1,7 @@
+from verifiers.workers.client import ZMQEnvClient
+from verifiers.workers.server import ZMQEnvServer
+
+__all__ = [
+    "ZMQEnvClient",
+    "ZMQEnvServer",
+]

--- a/verifiers/workers/__init__.py
+++ b/verifiers/workers/__init__.py
@@ -14,10 +14,7 @@ from verifiers.workers.types import (
 )
 
 __all__ = [
-    # Client/Server
-    "ZMQEnvClient",
-    "ZMQEnvServer",
-    # Request/Response types
+    # types
     "BaseRequest",
     "BaseResponse",
     "HealthRequest",
@@ -28,4 +25,7 @@ __all__ = [
     "RunGroupResponse",
     "EvaluateRequest",
     "EvaluateResponse",
+    # clients/servers
+    "ZMQEnvClient",
+    "ZMQEnvServer",
 ]

--- a/verifiers/workers/client/__init__.py
+++ b/verifiers/workers/client/__init__.py
@@ -1,0 +1,3 @@
+from verifiers.workers.client.zmq_env_client import ZMQEnvClient
+
+__all__ = ["ZMQEnvClient"]

--- a/verifiers/workers/client/env_client.py
+++ b/verifiers/workers/client/env_client.py
@@ -1,6 +1,44 @@
 from abc import ABC, abstractmethod
+from pathlib import Path
 
-from verifiers.types import ClientConfig, RolloutInput, SamplingArgs, State
+from pydantic import BaseModel
+
+from verifiers.types import (
+    ClientConfig,
+    GenerateOutputs,
+    RolloutInput,
+    RolloutTiming,
+    SamplingArgs,
+    State,
+    TrajectoryStep,
+)
+
+
+class HealthResponse(BaseModel):
+    is_healthy: bool
+
+
+class RolloutRequest(BaseModel):
+    input: RolloutInput
+    client_config: ClientConfig
+    model: str
+    sampling_args: SamplingArgs
+
+
+class RolloutResponse(BaseModel):
+    is_completed: bool
+    is_truncated: bool
+    stop_condition: str | None
+    trajectory: list[TrajectoryStep]
+    reward: float | None
+    advantage: float | None
+    metrics: dict[str, float] | None
+    timing: RolloutTiming | None
+    error: str | None
+
+
+GroupRequest = list[RolloutRequest]
+GroupResponse = list[RolloutResponse]
 
 
 class EnvClient(ABC):
@@ -17,4 +55,40 @@ class EnvClient(ABC):
         client_config: ClientConfig,
         model: str,
         sampling_args: SamplingArgs,
-    ) -> State: ...
+        score: bool = True,
+    ) -> State:
+        """Mirrors Environment.run_rollout"""
+        ...
+
+    @abstractmethod
+    async def run_group(
+        self,
+        group_inputs: list[RolloutInput],
+        client_config: ClientConfig,
+        model: str,
+        sampling_args: SamplingArgs,
+        score: bool = True,
+    ) -> list[State]:
+        """Mirrors Environment.run_group"""
+        ...
+
+    @abstractmethod
+    async def evaluate(
+        self,
+        client_config: ClientConfig,
+        model: str,
+        sampling_args: SamplingArgs,
+        num_examples: int,
+        rollouts_per_example: int,
+        max_concurrent: int,
+        results_path: Path | None,
+        state_columns: list[str] | None,
+        save_results: bool,
+        save_every: int,
+        independent_scoring: bool = False,
+        # on_start: StartCallback | None = None,
+        # on_progress: ProgressCallback | None = None,
+        # on_log: LogCallback | None = None,
+    ) -> GenerateOutputs:
+        """Mirrors Environment.evaluate"""
+        ...

--- a/verifiers/workers/client/env_client.py
+++ b/verifiers/workers/client/env_client.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from pathlib import Path
+from typing import TypeVar
 
 from pydantic import BaseModel
 
@@ -12,6 +13,7 @@ from verifiers.types import (
     State,
     TrajectoryStep,
 )
+from verifiers.workers.types import BaseResponse
 
 
 class HealthResponse(BaseModel):
@@ -39,6 +41,8 @@ class RolloutResponse(BaseModel):
 
 GroupRequest = list[RolloutRequest]
 GroupResponse = list[RolloutResponse]
+
+BaseResponseT = TypeVar("BaseResponseT", bound=BaseResponse)
 
 
 class EnvClient(ABC):

--- a/verifiers/workers/client/env_client.py
+++ b/verifiers/workers/client/env_client.py
@@ -1,0 +1,20 @@
+from abc import ABC, abstractmethod
+
+from verifiers.types import ClientConfig, RolloutInput, SamplingArgs, State
+
+
+class EnvClient(ABC):
+    def __init__(self, address: str):
+        self.address = address
+
+    @abstractmethod
+    async def health(self) -> bool: ...
+
+    @abstractmethod
+    async def run_rollout(
+        self,
+        input: RolloutInput,
+        client_config: ClientConfig,
+        model: str,
+        sampling_args: SamplingArgs,
+    ) -> State: ...

--- a/verifiers/workers/client/env_client.py
+++ b/verifiers/workers/client/env_client.py
@@ -1,48 +1,13 @@
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import TypeVar
-
-from pydantic import BaseModel
 
 from verifiers.types import (
     ClientConfig,
     GenerateOutputs,
     RolloutInput,
-    RolloutTiming,
     SamplingArgs,
     State,
-    TrajectoryStep,
 )
-from verifiers.workers.types import BaseResponse
-
-
-class HealthResponse(BaseModel):
-    is_healthy: bool
-
-
-class RolloutRequest(BaseModel):
-    input: RolloutInput
-    client_config: ClientConfig
-    model: str
-    sampling_args: SamplingArgs
-
-
-class RolloutResponse(BaseModel):
-    is_completed: bool
-    is_truncated: bool
-    stop_condition: str | None
-    trajectory: list[TrajectoryStep]
-    reward: float | None
-    advantage: float | None
-    metrics: dict[str, float] | None
-    timing: RolloutTiming | None
-    error: str | None
-
-
-GroupRequest = list[RolloutRequest]
-GroupResponse = list[RolloutResponse]
-
-BaseResponseT = TypeVar("BaseResponseT", bound=BaseResponse)
 
 
 class EnvClient(ABC):
@@ -90,9 +55,6 @@ class EnvClient(ABC):
         save_results: bool,
         save_every: int,
         independent_scoring: bool = False,
-        # on_start: StartCallback | None = None,
-        # on_progress: ProgressCallback | None = None,
-        # on_log: LogCallback | None = None,
     ) -> GenerateOutputs:
         """Mirrors Environment.evaluate"""
         ...

--- a/verifiers/workers/client/zmq_env_client.py
+++ b/verifiers/workers/client/zmq_env_client.py
@@ -1,0 +1,196 @@
+import asyncio
+import logging
+import uuid
+
+import msgpack
+import zmq
+import zmq.asyncio
+
+import verifiers as vf
+from verifiers.workers.client.env_client import EnvClient
+from verifiers.workers.utils import msgpack_encoder
+
+
+class ZMQEnvClient(EnvClient):
+    def __init__(self, address: str = "tcp://127.0.0.1:5555", timeout: float = 60.0):
+        super().__init__(address=address)
+        self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
+        self.address = address
+        self.timeout = timeout
+
+        # DEALER socket for async request/response
+        self.ctx = zmq.asyncio.Context()
+        self.socket = self.ctx.socket(zmq.DEALER)
+        self.socket.setsockopt(zmq.SNDHWM, 10000)
+        self.socket.setsockopt(zmq.RCVHWM, 10000)
+        self.socket.setsockopt(zmq.LINGER, 0)
+
+        # TCP keepalive for faster dead server detection
+        self.socket.setsockopt(zmq.TCP_KEEPALIVE, 1)
+        self.socket.setsockopt(
+            zmq.TCP_KEEPALIVE_IDLE, 10
+        )  # Start probes after 10s idle
+        self.socket.setsockopt(zmq.TCP_KEEPALIVE_INTVL, 2)  # Probe every 2s
+        self.socket.setsockopt(
+            zmq.TCP_KEEPALIVE_CNT, 3
+        )  # Give up after 3 failed probes
+
+        # Connect to all endpoints
+        self.logger.debug(f"Connecting ZMQ client to {address}")
+        self.socket.connect(address)
+
+        self.pending: dict[bytes, asyncio.Future] = {}
+        self._receiver_task: asyncio.Task | None = None
+
+    async def health(self) -> bool:
+        response = await self._send_request("health")
+        return response.get("status") == "ok"
+
+    async def run_rollout(
+        self,
+        input: vf.RolloutInput,
+        client_config: vf.ClientConfig,
+        model: str,
+        sampling_args: vf.SamplingArgs,
+    ) -> vf.State:
+        response = await self._send_request(
+            "run_rollout",
+            input=input,
+            client_config=client_config,
+            model=model,
+            sampling_args=sampling_args,
+        )
+        return vf.State(**response)
+
+    def _fail_all_pending(self, reason: str):
+        """Fail all pending futures with the given reason."""
+        for request_id, future in list(self.pending.items()):
+            if not future.done():
+                future.set_exception(RuntimeError(reason))
+        self.pending.clear()
+
+    async def _receive_loop(self):
+        """Continuously receive responses from environment servers."""
+        while True:
+            try:
+                # Receive multipart: [request_id, payload]
+                msg = await self.socket.recv_multipart()
+
+                if len(msg) < 2:
+                    self.logger.error(
+                        f"Invalid message format: expected 2 frames, got {len(msg)}"
+                    )
+                    continue
+
+                request_id, response_data = msg[0], msg[1]
+
+                if request_id in self.pending:
+                    future = self.pending.pop(request_id)
+                    if not future.done():
+                        try:
+                            response = msgpack.unpackb(response_data, raw=False)
+                            future.set_result(response)
+                        except Exception as unpack_error:
+                            # Unpacking failed - fail the specific future
+                            self.logger.error(
+                                f"Failed to unpack response for request {request_id.hex()}: {unpack_error}"
+                            )
+                            future.set_exception(
+                                RuntimeError(
+                                    f"Failed to deserialize response: {unpack_error}"
+                                )
+                            )
+                else:
+                    self.logger.warning(
+                        f"Received response for unknown request_id: {request_id.hex()}"
+                    )
+
+            except asyncio.CancelledError:
+                break
+            except zmq.ZMQError as e:
+                # Socket-level error - fail all pending futures and exit
+                self.logger.error(f"ZMQ socket error in receive loop: {e}")
+                self._fail_all_pending(f"ZMQ socket error: {e}")
+                break
+            except Exception as e:
+                self.logger.error(
+                    f"Unexpected error in ZMQ receive loop: {e}", exc_info=True
+                )
+                # Don't break - log and continue for non-socket errors
+
+    async def start(self):
+        self._receiver_task = asyncio.create_task(self._receive_loop())
+        self.logger.debug("ZMQ client started")
+
+    async def _send_request(self, action: str, **kwargs) -> dict:
+        """
+        Send request to environment.
+
+        Args:
+            action: Action type (generate, get_dataset, etc.)
+            **kwargs: Action-specific parameters
+
+        Returns:
+            Response dict
+        """
+        # Auto-start receiver if not already running
+        if self._receiver_task is None:
+            await self.start()
+
+        request_id = uuid.uuid4().bytes
+
+        # Let msgpack traverse dicts/lists in C - only call msgpack_encoder for unknown types
+        payload_bytes = msgpack.packb(
+            {"action": action, **kwargs},
+            default=msgpack_encoder,
+            use_bin_type=True,
+        )
+
+        future = asyncio.Future()
+        self.pending[request_id] = future
+
+        await self.socket.send_multipart([request_id, payload_bytes])
+
+        try:
+            response = await asyncio.wait_for(future, timeout=self.timeout)
+        except asyncio.TimeoutError:
+            self.pending.pop(request_id, None)
+            raise TimeoutError(f"Environment timeout for action: {action}")
+
+        if response.get("status") == "error":
+            raise RuntimeError(f"Environment error: {response.get('error')}")
+
+        return response
+
+
+async def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(description="ZMQ Environment Client")
+    parser.add_argument(
+        "--address", type=str, default="tcp://127.0.0.1:5555", help="ZMQ bind address"
+    )
+
+    args = parser.parse_args()
+
+    # initialize client
+    client = ZMQEnvClient(address=args.address)
+
+    response = await client.health()
+    print(response)
+
+    state = await client.run_rollout(
+        input=vf.RolloutInput(
+            example_id=0,
+            task="default",
+            prompt=[{"role": "user", "content": "What is 1+1?"}],
+        ),
+        client_config=vf.ClientConfig(),
+        model="openai/gpt-4.1-mini",
+        sampling_args=vf.SamplingArgs(temperature=0.5),
+    )
+    print(state)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/verifiers/workers/server/__init__.py
+++ b/verifiers/workers/server/__init__.py
@@ -1,0 +1,3 @@
+from verifiers.workers.server.zmq_env_server import ZMQEnvServer
+
+__all__ = ["ZMQEnvServer"]

--- a/verifiers/workers/server/env_server.py
+++ b/verifiers/workers/server/env_server.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import signal
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import Any
 
 import verifiers as vf
@@ -26,7 +27,20 @@ class EnvServer(ABC):
         env_id: str,
         env_args: dict[str, Any] = {},
         extra_env_kwargs: dict[str, Any] = {},
+        log_level: str | None = None,
+        log_file: str | None = None,
+        log_file_level: str | None = None,
     ):
+        # setup logging
+        log_file = log_file or f"logs/{env_id}.log"
+        Path(log_file).parent.mkdir(parents=True, exist_ok=True)
+        if log_level is None:
+            vf.setup_logging(log_file=log_file, log_file_level=log_file_level)
+        else:
+            vf.setup_logging(
+                level=log_level, log_file=log_file, log_file_level=log_file_level
+            )
+
         self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
         self.logger.info(
             f"Initializing {self.__class__.__name__} to serve {env_id} ({env_args=}, {extra_env_kwargs=}"

--- a/verifiers/workers/server/env_server.py
+++ b/verifiers/workers/server/env_server.py
@@ -48,3 +48,8 @@ class EnvServer(ABC):
     @abstractmethod
     async def run(self, stop_event: asyncio.Event | None = None):
         pass
+
+    @classmethod
+    def run_server(cls, *args, **kwargs):
+        server = cls(*args, **kwargs)
+        return asyncio.run(server.run())

--- a/verifiers/workers/server/env_server.py
+++ b/verifiers/workers/server/env_server.py
@@ -1,0 +1,50 @@
+import asyncio
+import logging
+import multiprocessing
+from abc import ABC, abstractmethod
+from typing import Any
+
+import verifiers as vf
+from verifiers.utils.async_utils import maybe_semaphore
+
+
+class EnvServer(ABC):
+    """Server that exposes an environment as a service."""
+
+    def __init__(
+        self,
+        # environment
+        env_id: str,
+        env_args: dict[str, Any] = {},
+        extra_env_kwargs: dict[str, Any] = {},
+        # server
+        max_concurrent: int = -1,
+        num_workers: int = 1,
+    ):
+        self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
+        self.logger.info(
+            f"Initializing {self.__class__.__name__} with env_id={env_id}, env_args={env_args}, extra_env_kwargs={extra_env_kwargs}, max_concurrent={max_concurrent}, num_workers={num_workers}"
+        )
+
+        self.env_id = env_id
+        self.env_args = env_args
+        self.extra_env_kwargs = extra_env_kwargs
+
+        self.max_concurrent = max_concurrent
+        self.num_workers = num_workers
+
+        self.workers = multiprocessing.Pool(num_workers)
+        self.semaphore = maybe_semaphore(max_concurrent)
+
+        # load environment
+        self.env = vf.load_environment(env_id, **self.env_args)
+        if self.extra_env_kwargs:
+            self.env.set_kwargs(**self.extra_env_kwargs)
+
+        self.logger.info(
+            f"Initialized {self.num_workers} worker process(es) to serve {self.env_id}"
+        )
+
+    @abstractmethod
+    async def run(self, stop_event: asyncio.Event | None = None):
+        pass

--- a/verifiers/workers/server/env_server.py
+++ b/verifiers/workers/server/env_server.py
@@ -43,7 +43,7 @@ class EnvServer(ABC):
 
         self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
         self.logger.info(
-            f"Initializing {self.__class__.__name__} to serve {env_id} ({env_args=}, {extra_env_kwargs=}"
+            f"Initializing {self.__class__.__name__} to serve {env_id} ({env_args=}, {extra_env_kwargs=})"
         )
 
         self.env_id = env_id

--- a/verifiers/workers/server/zmq_env_server.py
+++ b/verifiers/workers/server/zmq_env_server.py
@@ -1,0 +1,197 @@
+import asyncio
+import hashlib
+import json
+from typing import cast
+
+import msgpack
+import zmq
+import zmq.asyncio
+from openai import AsyncOpenAI
+
+from verifiers.types import ClientConfig, RolloutInput, SamplingArgs
+from verifiers.utils.client_utils import setup_client
+from verifiers.workers.server.env_server import EnvServer
+from verifiers.workers.utils import msgpack_encoder
+
+
+class ZMQEnvServer(EnvServer):
+    """Server that exposes an environment via ZMQ."""
+
+    def __init__(self, *args, address: str = "tcp://127.0.0.1:5000", **kwargs):
+        super().__init__(*args, **kwargs)
+        self.address = address
+
+        self.ctx = zmq.asyncio.Context()
+        self.socket = self.ctx.socket(zmq.ROUTER)
+        self.socket.setsockopt(zmq.SNDHWM, 10000)
+        self.socket.setsockopt(zmq.RCVHWM, 10000)
+        self.socket.setsockopt(zmq.LINGER, 0)
+        self.socket.bind(address)
+
+        self.clients: dict[str, AsyncOpenAI] = {}
+
+    async def run(self, stop_event: asyncio.Event | None = None):
+        self.logger.info(f"Environment server listening on {self.address}")
+
+        # Create a task to wait for stop signal
+        stop_task = asyncio.create_task(stop_event.wait()) if stop_event else None
+
+        try:
+            while True:
+                # exit gracefully on stop signal
+                if stop_event and stop_event.is_set():
+                    self.logger.info("Stop event received, shutting down gracefully")
+                    break
+
+                try:
+                    # receive with timeout to periodically check stop_event
+                    frames = await asyncio.wait_for(
+                        self.socket.recv_multipart(),
+                        timeout=1.0 if stop_event else None,
+                    )
+
+                    if len(frames) != 3:
+                        self.logger.warning(
+                            f"Invalid message: expected 3 frames, got {len(frames)}"
+                        )
+                        continue
+
+                    client_id, request_id, payload_bytes = frames
+
+                    # Process in background with concurrency limit
+                    asyncio.create_task(
+                        self._process_request(client_id, request_id, payload_bytes)
+                    )
+
+                except asyncio.TimeoutError:
+                    continue
+                except asyncio.CancelledError:
+                    break
+                except Exception as e:
+                    self.logger.error(f"Error in server loop: {e}", exc_info=True)
+        finally:
+            if stop_task and not stop_task.done():
+                stop_task.cancel()
+
+    async def close(self):
+        # TODO: close clients
+
+        # close zmq socket
+        self.socket.close()
+        self.ctx.term()
+        self.logger.info("Environment server shut down")
+
+    async def _process_request(
+        self,
+        client_id: bytes,
+        request_id: bytes,
+        payload_bytes: bytes,
+    ):
+        async with self.semaphore:
+            try:
+                # deserialize request
+                request = msgpack.unpackb(payload_bytes, raw=False)
+                action = request.get("action")
+
+                # route to handler
+                if action == "health":
+                    response = await self._handle_health(request)
+                elif action == "run_rollout":
+                    response = await self._handle_run_rollout(request)
+                else:
+                    response = {"status": "error", "error": f"Unknown action: {action}"}
+
+                # serialize response
+                response_bytes = cast(
+                    bytes,
+                    msgpack.packb(response, default=msgpack_encoder, use_bin_type=True),
+                )
+
+                # send response: [client_id, request_id, response]
+                await self.socket.send_multipart(
+                    [client_id, request_id, response_bytes]
+                )
+
+                self.logger.info(
+                    f"Sent {action} response ({len(response_bytes)} bytes)"
+                )
+
+            except Exception as e:
+                self.logger.error(f"Error processing request: {e}", exc_info=True)
+
+                # send error response
+                error_response = {"status": "error", "error": str(e)}
+                error_bytes = msgpack.packb(
+                    error_response, default=msgpack_encoder, use_bin_type=True
+                )
+                await self.socket.send_multipart([client_id, request_id, error_bytes])
+
+    async def _handle_health(self, request: dict) -> dict:
+        return {"status": "ok"}
+
+    async def _handle_run_rollout(self, request: dict) -> dict:
+        client = self._get_client(
+            ClientConfig.model_construct(**request.get("client_config", {}))
+        )
+        state = await self.env.run_rollout(
+            input=RolloutInput(**request.get("input", {})),
+            client=client,
+            model=request.get("model", ""),
+            gen_sampling_args=SamplingArgs(**request.get("sampling_args", {})),
+            gen_sem=self.semaphore,
+        )
+        # Remove non-serializable fields before sending over the wire
+        state.pop("client", None)
+        return state
+
+    def _get_client(self, client_config: ClientConfig) -> AsyncOpenAI:
+        config_hash = hashlib.sha256(
+            json.dumps(client_config.model_dump()).encode()
+        ).hexdigest()
+        client = self.clients.get(config_hash)
+        if client is None:
+            client = setup_client(client_config)
+            self.clients[config_hash] = client
+        return client
+
+
+async def main():
+    import argparse
+    import signal
+
+    parser = argparse.ArgumentParser(description="ZMQ Environment Server")
+    parser.add_argument("env_id", type=str, help="Environment ID to load")
+    parser.add_argument(
+        "--env-args", type=json.loads, default={}, help="Environment args as JSON"
+    )
+    parser.add_argument(
+        "--address", default="tcp://127.0.0.1:5555", help="ZMQ bind address"
+    )
+
+    args = parser.parse_args()
+
+    # initialize server
+    server = ZMQEnvServer(
+        env_id=args.env_id,
+        env_args=args.env_args,
+        address=args.address,
+    )
+
+    # setup graceful shutdown for SIGTERM (K8s, Docker, Slurm) and SIGINT (Ctrl+C)
+    stop_event = asyncio.Event()
+
+    def signal_handler(sig):
+        stop_event.set()
+
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        loop.add_signal_handler(sig, lambda s=sig: signal_handler(s))
+
+    try:
+        await server.run(stop_event=stop_event)
+    finally:
+        await server.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/verifiers/workers/types.py
+++ b/verifiers/workers/types.py
@@ -92,12 +92,12 @@ class EvaluateResponse(BaseResponse):
 
     @field_validator("results", mode="before")
     @classmethod
-    def convert_results_state(cls, v: dict | None) -> GenerateOutputs | None:
+    def convert_results_state(cls, v: dict | None) -> dict | None:
         if v is None:
             return None
         if isinstance(v, dict) and "state" in v:
             v["state"] = [State(**s) for s in v["state"]]
-        return GenerateOutputs(**v)
+        return v
 
 
 BaseRequestT = TypeVar("BaseRequestT", bound=BaseRequest)

--- a/verifiers/workers/types.py
+++ b/verifiers/workers/types.py
@@ -1,0 +1,111 @@
+from typing import Any, Literal, TypeVar
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
+from verifiers.types import (
+    ClientConfig,
+    GenerateOutputs,
+    RolloutInput,
+    SamplingArgs,
+    State,
+)
+
+
+def _dict_to_state(v: Any) -> State:
+    """Convert a dict to a State object if needed."""
+    if isinstance(v, State):
+        return v
+    if isinstance(v, dict):
+        return State(v)
+    raise ValueError(f"Expected State or dict, got {type(v)}")
+
+
+class BaseRequest(BaseModel):
+    request_type: str
+
+
+class BaseResponse(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    success: bool = True
+    error: str | None = None  # TODO: type errors later
+
+
+class HealthRequest(BaseRequest):
+    request_type: Literal["health"] = "health"  # type: ignore[override]
+
+
+class HealthResponse(BaseResponse): ...
+
+
+class RunRolloutRequest(BaseRequest):
+    request_type: Literal["run_rollout"] = "run_rollout"  # type: ignore[override]
+
+    input: RolloutInput
+    client_config: ClientConfig
+    model: str
+    sampling_args: SamplingArgs
+    score: bool = True
+
+
+class RunRolloutResponse(BaseResponse):
+    state: State | None = None
+
+    @field_validator("state", mode="before")
+    @classmethod
+    def convert_state(cls, v: Any) -> State | None:
+        if v is None:
+            return None
+        return _dict_to_state(v)
+
+
+class RunGroupRequest(BaseRequest):
+    request_type: Literal["run_group"] = "run_group"  # type: ignore[override]
+
+    group_inputs: list[RolloutInput]
+    client_config: ClientConfig
+    model: str
+    sampling_args: SamplingArgs
+    score: bool = True
+
+
+class RunGroupResponse(BaseResponse):
+    states: list[State]
+
+    @field_validator("states", mode="before")
+    @classmethod
+    def convert_states(cls, v: Any) -> list[State]:
+        if not isinstance(v, list):
+            raise ValueError(f"Expected list, got {type(v)}")
+        return [_dict_to_state(s) for s in v]
+
+
+class EvaluateRequest(BaseRequest):
+    request_type: Literal["evaluate"] = "evaluate"  # type: ignore[override]
+
+    client_config: ClientConfig
+    model: str
+    sampling_args: SamplingArgs
+    num_examples: int = -1
+    rollouts_per_example: int = 1
+    max_concurrent: int = -1
+    results_path: str | None = None
+    state_columns: list[str] | None = None
+    save_results: bool = False
+    save_every: int = -1
+    independent_scoring: bool = False
+
+
+class EvaluateResponse(BaseResponse):
+    results: GenerateOutputs
+
+    @field_validator("results", mode="before")
+    @classmethod
+    def convert_results_state(cls, v: Any) -> GenerateOutputs:
+        if isinstance(v, dict) and "state" in v:
+            v["state"] = [_dict_to_state(s) for s in v["state"]]
+        return v
+
+
+BaseRequestT = TypeVar("BaseRequestT", bound=BaseRequest)
+BaseResponseT = TypeVar("BaseResponseT", bound=BaseResponse)

--- a/verifiers/workers/utils.py
+++ b/verifiers/workers/utils.py
@@ -1,0 +1,32 @@
+from datetime import date, datetime
+from enum import Enum
+from pathlib import Path
+from uuid import UUID
+
+import numpy as np
+
+
+def msgpack_encoder(obj):
+    """
+    Custom encoder for non-standard types.
+
+    IMPORTANT: msgpack traverses lists/dicts in optimized C code. This function
+    is ONLY called for types msgpack doesn't recognize. This avoids the massive
+    performance penalty of recursing through millions of tokens in Python.
+
+    Handles: Path, UUID, Enum, datetime, Pydantic models, numpy scalars.
+    Does NOT handle: lists, dicts, basic types (msgpack does this natively in C).
+    """
+    if isinstance(obj, (Path, UUID)):
+        return str(obj)
+    elif isinstance(obj, Enum):
+        return obj.value
+    elif isinstance(obj, (datetime, date)):
+        return obj.isoformat()
+    elif isinstance(obj, (np.integer, np.floating)):
+        return obj.item()
+    elif hasattr(obj, "model_dump"):
+        return obj.model_dump()
+    else:
+        # raise on unknown types to make issues visible
+        raise TypeError(f"Object of type {type(obj)} is not msgpack serializable")

--- a/verifiers/workers/utils.py
+++ b/verifiers/workers/utils.py
@@ -1,3 +1,4 @@
+import socket
 from datetime import date, datetime
 from enum import Enum
 from pathlib import Path
@@ -30,3 +31,10 @@ def msgpack_encoder(obj):
     else:
         # raise on unknown types to make issues visible
         raise TypeError(f"Object of type {type(obj)} is not msgpack serializable")
+
+
+def get_free_port() -> int:
+    """Get a free port on the system."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("localhost", 0))
+        return s.getsockname()[1]


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

> WIP. Based on #734 and #739.

This PR introduces the `EnvClient` and `EnvServer` which are a drop-in replacement for executing environments in a separate process (pool). This is especially useful for multi-env training (e.g. in `prime-rl`) and evals (e.g. via `vf-eval` or in online evals during training). A couple of notes on design decisions:
- The `EnvClient` mirrors the in-process `Environment` for the most common public facing methods, such as `run_rollout`, `run_group`, `generate` and `evaluate`
- The client/server pattern is protocol-agnostic, i.e. the client may communicate with the server via any protocol (gRPC/ZMQ/HTTP/...). _For now, only ZMQ is implemented_.

## Example

The env server pattern is integrated into `vf-eval` to sidecar an env server

```bash
uv run vf-eval gsm8k -n5 -r3 --use-env-server
```

## Design

### EnvServer

A `EnvServer` is initialized like a regular environment with an `env_id` and `env_args`

```python
env_server = ZMQEnvServer(
    env_id=args.env_id,
    env_args=args.env_args,
    address=address
)

try:
    await server.run()
finally:
    await server.close()
```

### EnvClient

A `EnvClient` communicates with a env server over the configured `address`

```python
env = ZMQEnvClient(address=address)

await env.run_rollout(...) # same as Environment.run_rollout
await env.run_group(...) # same as Environment.run_group
await env.evaluate(...) # same as Environment.evaluate
```

### Sidecar Pattern

To sidecar an env server (e.g. from `vf-eval`) simply wrap the `run_server` class method in a `Process` and connect the client to the same address

```python
env_server = Process(
    target=ZMQEnvServer.run_server,
    args=(config.env_id, config.env_args),
    kwargs=dict(address=address)
)
env_server.start()
env = ZMQEnvClient(address=address)

try:
   results = await env.evaluate(...)
finally:
  env_worker.terminate()
  env_worker.join(timeout=5)
  if env_worker.is_alive():
      env_worker.kill()
      env_worker.join()
```

## Breaking

- Pass `client_config: ClientConfig` instead of `client: AsyncOpenAI` to public-facing methods. This is because clients are not serializable, so there is no way to mirror the `Environment` API otherwise
- Can only limit concurrency for an entire rollout for now because the `AsyncContextManagers` are not serializable. We can prob define an env-level gen+score concurrency limits that is enforced across all calls but it's still breakng in the user for `run_rollout` and `run_group`

## TODOs

- [x] Typed inputs/outputs (this required lazily creating clients and removing them from the public-facing API)
- [x] Integrate with multi-env evals
- [x] Logging
- [x] Graceful server termination
- [ ] Unit tests
- [ ] Multi-process environment execution

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->