### PR TITLE
Add retry support for infrastructure errors in vf-eval

### DIFF
--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -117,8 +117,11 @@ Multiple rollouts per example enable metrics like pass@k and help measure varian
 | `--max-concurrent-generation` | — | same as `-c` | Concurrent generation requests |
 | `--max-concurrent-scoring` | — | same as `-c` | Concurrent scoring requests |
 | `--no-interleave-scoring` | `-N` | false | Disable interleaved scoring |
+| `--max-retries` | — | 0 | Retries per rollout on transient `InfraError` |
 
 By default, scoring runs interleaved with generation. Use `--no-interleave-scoring` to score all rollouts after generation completes.
+
+The `--max-retries` flag enables automatic retry with exponential backoff when rollouts fail due to transient infrastructure errors (e.g., sandbox timeouts, API failures).
 
 ### Output and Saving
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -541,7 +541,9 @@ class EvalConfig(BaseModel):
     max_concurrent: int
     max_concurrent_generation: int | None = None
     max_concurrent_scoring: int | None = None
+    independent_scoring: bool = False
     extra_env_kwargs: dict = {}
+    max_retries: int = 0
     print_results: bool = False
     verbose: bool = False
     state_columns: list[str] | None = None

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -550,3 +550,73 @@ class TestRenderStopErrorHandling:
             assert "RuntimeError" in call_args
             assert "caused by" not in call_args
             assert "something went wrong" in call_args
+
+
+class RetryCounterEnv(SimpleEnvironment):
+    """Environment that fails first N times with InfraError."""
+
+    def __init__(self, fail_count: int, **kwargs):
+        super().__init__(**kwargs)
+        self.fail_count = fail_count
+        self.call_counts: dict[int, int] = {}
+
+    async def setup_state(self, state, **kwargs):
+        example_id = state["example_id"]
+        self.call_counts.setdefault(example_id, 0)
+        self.call_counts[example_id] += 1
+
+        if self.call_counts[example_id] <= self.fail_count:
+            raise vf.InfraError(
+                f"Simulated failure {self.call_counts[example_id]}/{self.fail_count}"
+            )
+
+        return state
+
+
+class TestMaybeRetry:
+    """Test cases for maybe_retry functionality in Environment.generate()."""
+
+    @pytest.mark.asyncio
+    async def test_retry_succeeds_after_transient_infra_error(self, mock_openai_client):
+        """InfraError on first 2 attempts, succeeds on 3rd with max_retries=3."""
+        dataset = Dataset.from_dict({"question": ["test"], "answer": ["test"]})
+        env = RetryCounterEnv(
+            fail_count=2, dataset=dataset, parser=Parser(), rubric=Rubric()
+        )
+
+        inputs = [
+            RolloutInput(
+                prompt=[{"role": "user", "content": "test"}],
+                answer="test",
+                example_id=0,
+            )
+        ]
+        results = await env.generate(
+            inputs, client=mock_openai_client, model="test-model", max_retries=3
+        )
+
+        assert results["state"][0].get("error") is None
+        assert env.call_counts[0] == 3
+
+    @pytest.mark.asyncio
+    async def test_retry_fails_after_max_retries_exhausted(self, mock_openai_client):
+        """InfraError persists after all retries exhausted."""
+        dataset = Dataset.from_dict({"question": ["test"], "answer": ["test"]})
+        env = RetryCounterEnv(
+            fail_count=10, dataset=dataset, parser=Parser(), rubric=Rubric()
+        )
+
+        inputs = [
+            RolloutInput(
+                prompt=[{"role": "user", "content": "test"}],
+                answer="test",
+                example_id=0,
+            )
+        ]
+
+        with pytest.raises(vf.InfraError):
+            await env.generate(
+                inputs, client=mock_openai_client, model="test-model", max_retries=2
+            )
+
+        assert env.call_counts[0] == 3  # 1 initial + 2 retries

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -553,11 +553,12 @@ class TestRenderStopErrorHandling:
 
 
 class RetryCounterEnv(SimpleEnvironment):
-    """Environment that fails first N times with InfraError."""
+    """Environment that fails first N times with configurable error type."""
 
-    def __init__(self, fail_count: int, **kwargs):
+    def __init__(self, fail_count: int, error_type: type = vf.InfraError, **kwargs):
         super().__init__(**kwargs)
         self.fail_count = fail_count
+        self.error_type = error_type
         self.call_counts: dict[int, int] = {}
 
     async def setup_state(self, state, **kwargs):
@@ -566,7 +567,7 @@ class RetryCounterEnv(SimpleEnvironment):
         self.call_counts[example_id] += 1
 
         if self.call_counts[example_id] <= self.fail_count:
-            raise vf.InfraError(
+            raise self.error_type(
                 f"Simulated failure {self.call_counts[example_id]}/{self.fail_count}"
             )
 
@@ -620,3 +621,30 @@ class TestMaybeRetry:
             )
 
         assert env.call_counts[0] == 3  # 1 initial + 2 retries
+
+    @pytest.mark.asyncio
+    async def test_non_infra_error_not_retried(self, mock_openai_client):
+        """ToolError is NOT retried even with max_retries > 0."""
+        dataset = Dataset.from_dict({"question": ["test"], "answer": ["test"]})
+        env = RetryCounterEnv(
+            fail_count=10,
+            error_type=vf.ToolError,
+            dataset=dataset,
+            parser=Parser(),
+            rubric=Rubric(),
+        )
+
+        inputs = [
+            RolloutInput(
+                prompt=[{"role": "user", "content": "test"}],
+                answer="test",
+                example_id=0,
+            )
+        ]
+
+        with pytest.raises(vf.ToolError):
+            await env.generate(
+                inputs, client=mock_openai_client, model="test-model", max_retries=3
+            )
+
+        assert env.call_counts[0] == 1  # No retries for non-InfraError

--- a/tests/test_eval_cli.py
+++ b/tests/test_eval_cli.py
@@ -52,6 +52,7 @@ def _run_cli(monkeypatch, overrides):
         "save_to_hf_hub": False,
         "hf_hub_dataset_name": "",
         "extra_env_kwargs": {},
+        "max_retries": 0,
     }
     base_args.update(overrides)
     args_namespace = SimpleNamespace(**base_args)

--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -240,6 +240,12 @@ def main():
         default={},
         help='Extra environment as JSON object (e.g., \'{"key": "value", "num": 42}\'). Passed to environment constructor.',
     )
+    parser.add_argument(
+        "--max-retries",
+        type=int,
+        default=0,
+        help="Max retries for transient infrastructure errors (default: 0)",
+    )
     args = parser.parse_args()
 
     setup_logging("DEBUG" if args.verbose else os.getenv("VF_LOG_LEVEL", "INFO"))
@@ -343,6 +349,7 @@ def main():
         max_concurrent=args.max_concurrent,
         max_concurrent_generation=args.max_concurrent_generation,
         max_concurrent_scoring=args.max_concurrent_scoring,
+        max_retries=args.max_retries,
         # logging
         print_results=True,
         verbose=args.verbose,

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -238,6 +238,7 @@ class EvalConfig(BaseModel):
     max_concurrent_scoring: int | None = None
     independent_scoring: bool = False
     extra_env_kwargs: dict = {}
+    max_retries: int = 0
     # logging
     print_results: bool = False
     verbose: bool = False

--- a/verifiers/utils/async_utils.py
+++ b/verifiers/utils/async_utils.py
@@ -143,6 +143,7 @@ def maybe_retry(
     wrapper.__qualname__ = getattr(func, "__qualname__", "unknown")
 
     return tc.AsyncRetrying(
+        retry=tc.retry_if_exception_type(vf.InfraError),
         stop=tc.stop_after_attempt(max_retries + 1),
         wait=tc.wait_exponential_jitter(initial=initial, max=max_wait),
         before_sleep=_log_retry,

--- a/verifiers/utils/async_utils.py
+++ b/verifiers/utils/async_utils.py
@@ -2,7 +2,8 @@ import asyncio
 import inspect
 import logging
 from time import perf_counter
-from typing import Any, AsyncContextManager, Awaitable, Callable, Optional, TypeVar
+from collections.abc import Coroutine
+from typing import Any, AsyncContextManager, Callable, Optional, TypeVar
 
 import tenacity as tc
 
@@ -119,11 +120,11 @@ def _log_retry(retry_state):
 
 
 def maybe_retry(
-    func: Callable[..., Awaitable[T]],
+    func: Callable[..., Coroutine[Any, Any, T]],
     max_retries: int = 0,
     initial: float = 1.0,
     max_wait: float = 60.0,
-) -> Callable[..., Awaitable[T]]:
+) -> Callable[..., Coroutine[Any, Any, T]]:
     """
     Return retry-wrapped function if max_retries > 0, else return func unchanged.
     Re-raises vf.InfraError from state["error"] to trigger retry.

--- a/verifiers/utils/async_utils.py
+++ b/verifiers/utils/async_utils.py
@@ -2,7 +2,7 @@ import asyncio
 import inspect
 import logging
 from time import perf_counter
-from typing import Any, AsyncContextManager, Callable, Optional, TypeVar
+from typing import Any, AsyncContextManager, Awaitable, Callable, Optional, TypeVar
 
 import tenacity as tc
 
@@ -119,11 +119,11 @@ def _log_retry(retry_state):
 
 
 def maybe_retry(
-    func: Callable[..., T],
+    func: Callable[..., Awaitable[T]],
     max_retries: int = 0,
     initial: float = 1.0,
     max_wait: float = 60.0,
-) -> Callable[..., T]:
+) -> Callable[..., Awaitable[T]]:
     """
     Return retry-wrapped function if max_retries > 0, else return func unchanged.
     Re-raises vf.InfraError from state["error"] to trigger retry.
@@ -139,8 +139,8 @@ def maybe_retry(
         _raise_error_from_state(result)
         return result
 
-    wrapper.__name__ = func.__name__
-    wrapper.__qualname__ = func.__qualname__
+    wrapper.__name__ = getattr(func, "__name__", "unknown")
+    wrapper.__qualname__ = getattr(func, "__qualname__", "unknown")
 
     return tc.AsyncRetrying(
         stop=tc.stop_after_attempt(max_retries + 1),

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -252,6 +252,7 @@ async def run_evaluation(config: EvalConfig) -> GenerateOutputs:
         save_results=config.save_results,
         save_every=config.save_every,
         independent_scoring=config.independent_scoring,
+        max_retries=config.max_retries,
     )
     end_time = time.time()
     logger.info(f"Evaluation completed in {end_time - start_time:.2f} seconds")


### PR DESCRIPTION
## Description
Adds --max-retries CLI flag to retry rollouts when vf.InfraError occurs.     
I've opted to only retry on `vf.InfraError` right now, as we don't assure yet that any `vf.Error` is retry-able.                                                                                                                                        
                                                                                                                                                                                                                     
Changes:                                                                                                                                                                                                             
- async_utils.py: Add maybe_retry() utility using tenacity with exponential backoff + jitter                                                                                                                         
- types.py: Add max_retries to EvalConfig                                                                                                                                                                            
- eval.py: Add --max-retries CLI argument (default: 0)                                                                                                                                                               
- eval_utils.py / environment.py: Thread parameter through to generate()                                                                                                                                             
                                                                                                                                                                                                                     
Behavior:                                                                                                                                                                                                            
- Only retries vf.InfraError (transient infra failures)                                                                                                                                                              
- Does NOT retry ToolError, OverlongPromptError, etc.                                                                                                                                                                
- Logs retries at WARNING level                                                                                                                                                                                      
                                                                                                                                                                                                                     
Usage:                                                                                                                                                                                                               
vf-eval my-env --max-retries 3 

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [x] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds configurable retries for transient infrastructure failures.
> 
> - Introduces `maybe_retry()` in `utils/async_utils.py` (tenacity-based exponential backoff + jitter) and applies it to `Environment.generate()` by wrapping `run_rollout`/`run_group`
> - Threads `max_retries` through `Environment.generate/evaluate/evaluate_sync`, `EvalConfig` (`verifiers/types.py`), and `run_evaluation`
> - Extends CLI with `--max-retries` in `verifiers/scripts/eval.py`; default `0`
> - Updates docs (`docs/evaluation.md`, `docs/reference.md`) to document the flag and config fields
> - Adds tests for retry behavior and CLI defaults (`tests/test_environment.py`, `tests/test_eval_cli.py`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit adc524afd1109dfd573630500a77560d5d445cb0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->