### PR TITLE
RLM env stop condition fix

### DIFF
--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -2658,9 +2658,9 @@ class RLMEnv(SandboxEnv):
             # Subsequent turns: use parent implementation
             return await super().get_prompt_messages(state)
 
-    async def env_response(self, messages: Messages, state: State) -> Messages:                                                                                                                 
-      """Override to set final_env_response when answer is ready to avoid extra model call"""                                                                                                                          
-      tool_messages = await super().env_response(messages, state)                                                                                                                             
+    async def env_response(self, messages: Messages, state: State, **kwargs) -> Messages:
+      """Override to set final_env_response when answer is ready to avoid extra model call"""
+      tool_messages = await super().env_response(messages, state, **kwargs)
       if "final_answer" in state:                                                                                                                       
           state["final_env_response"] = tool_messages                                                                                                                                         
       return tool_messages


### PR DESCRIPTION
## Description
Previously, there would be an extra model call even after the model set answer="Ready"

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Optimizes the RLM environment to stop immediately once the answer is ready, avoiding an extra LLM call.
> 
> - Adds `env_response` override to set `state["final_env_response"]` when `final_answer` exists, ensuring the final tool messages are captured and halting further calls
> - No other behavioral changes; existing stop conditions and rendering logic remain intact
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a47b84bed0e758641ee492e5d1b80035ddac4a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->