### PR TITLE
Basic multi client support

### DIFF
--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -37,6 +37,8 @@ from verifiers.types import (
     DatasetBuilder,
     GenerateMetadata,
     GenerateOutputs,
+    LLMClient,
+    LLMClientMap,
     LogCallback,
     Messages,
     MessageType,
@@ -47,8 +49,6 @@ from verifiers.types import (
     SamplingArgs,
     StartCallback,
     State,
-    ClientConfig,
-    LLMClient,
 )
 from verifiers.utils.async_utils import maybe_retry, maybe_semaphore
 from verifiers.utils.error_utils import ErrorChain
@@ -624,7 +624,7 @@ class Environment(ABC):
     async def init_state(
         self,
         input: RolloutInput,
-        client: ClientConfig | LLMClient,
+        client: LLMClientMap | LLMClient,
         model: str,
         sampling_args: SamplingArgs | None = None,
     ) -> State:
@@ -677,7 +677,7 @@ class Environment(ABC):
     async def rollout(
         self,
         input: RolloutInput,
-        client: AsyncOpenAI,
+        client: LLMClientMap | LLMClient,
         model: str,
         sampling_args: SamplingArgs | None = None,
     ) -> State:

--- a/verifiers/envs/multiturn_env.py
+++ b/verifiers/envs/multiturn_env.py
@@ -6,14 +6,14 @@ from openai import AsyncOpenAI
 
 import verifiers as vf
 from verifiers.types import (
+    LLMClient,
+    LLMClientMap,
     Messages,
     ModelResponse,
     RolloutInput,
     SamplingArgs,
     State,
     TrajectoryStep,
-    ClientConfig,
-    LLMClient,
 )
 from verifiers.utils.message_utils import concat_messages
 from verifiers.utils.response_utils import (
@@ -144,7 +144,7 @@ class MultiTurnEnv(vf.Environment):
     async def rollout(
         self,
         input: RolloutInput,
-        client: ClientConfig | LLMClient,
+        client: LLMClientMap | LLMClient,
         model: str,
         sampling_args: SamplingArgs | None = None,
     ) -> State:

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -51,6 +51,8 @@ IndividualRewardFunc = Callable[..., float | Awaitable[float]]
 GroupRewardFunc = Callable[..., list[float] | Awaitable[list[float]]]
 RewardFunc = IndividualRewardFunc | GroupRewardFunc
 DatasetBuilder = Callable[[], Dataset]
+LLMClient = AsyncOpenAI # add anthropic support later
+ClientConfig = dict[str, LLMClient]
 
 
 class TrajectoryStepTokens(TypedDict):
@@ -99,7 +101,8 @@ class State(dict):
     INPUT_FIELDS = ["prompt", "answer", "task", "info", "example_id"]
     # rollout inputs
     input: RolloutInput
-    client: AsyncOpenAI
+    client: ClientConfig
+    current_client: str
     model: str
     sampling_args: SamplingArgs | None
     # created during rollout

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -51,8 +51,8 @@ IndividualRewardFunc = Callable[..., float | Awaitable[float]]
 GroupRewardFunc = Callable[..., list[float] | Awaitable[list[float]]]
 RewardFunc = IndividualRewardFunc | GroupRewardFunc
 DatasetBuilder = Callable[[], Dataset]
-LLMClient = AsyncOpenAI # add anthropic support later
-ClientConfig = dict[str, LLMClient]
+LLMClient = AsyncOpenAI  # add anthropic support later
+LLMClientMap = dict[str, LLMClient]
 
 
 class TrajectoryStepTokens(TypedDict):
@@ -101,7 +101,7 @@ class State(dict):
     INPUT_FIELDS = ["prompt", "answer", "task", "info", "example_id"]
     # rollout inputs
     input: RolloutInput
-    client: ClientConfig
+    client: LLMClientMap
     current_client: str
     model: str
     sampling_args: SamplingArgs | None


### PR DESCRIPTION
## Description
State['client'] now becomes a dictionary mapping from str -> client object
we then need to add a new field to State to track what the current client is
in init_state, we handle whether the user passed in a dictionary for the llm client mapping or a single client
add a get_next_client function to multi_turn_env to implement client switching logic
decided that get_prompt_messages should own this model switching logic, but not sure if that is best option
for more robust solution, would need prompt message rewrite logic according to what client we are on