### PR TITLE
Expose vLLM group port in RL config

### DIFF
--- a/verifiers/rl/trainer/config.py
+++ b/verifiers/rl/trainer/config.py
@@ -198,6 +198,12 @@ class RLConfig(TrainingArguments):
         default=8000,
         metadata={"help": "Port of the vLLM server to connect to."},
     )
+    vllm_group_port: int = field(
+        default=51216,
+        metadata={
+            "help": "Port for vLLM weight synchronization (StatelessProcessGroup)."
+        },
+    )
     vllm_server_timeout: float = field(
         default=300.0,
         metadata={

--- a/verifiers/rl/trainer/trainer.py
+++ b/verifiers/rl/trainer/trainer.py
@@ -91,7 +91,10 @@ class RLTrainer(Trainer):
             host = args.vllm_server_host
             port = args.vllm_server_port
             self.client = VLLMClient(
-                host=host, port=port, connection_timeout=args.vllm_server_timeout
+                host=host,
+                port=port,
+                group_port=args.vllm_group_port,
+                connection_timeout=args.vllm_server_timeout,
             )
             self.client.init_communicator()
             vllm_base_url = f"http://{host}:{port}/v1"


### PR DESCRIPTION
## Summary
- add configurable vLLM group port to RLConfig
- pass group port into VLLMClient init

## Testing
- not run

Fixes #760