### PR TITLE
lazy init locked chromadb instance in wiki-search

### DIFF
--- a/environments/wiki_search/README.md
+++ b/environments/wiki_search/README.md
@@ -67,3 +67,7 @@ Notes:
 | ToolRubric metrics | Tool execution success and format adherence |
 | JudgeRubric metrics | Judge-scored answer quality |
 
+### Changelog
+
+#### v0.1.22 (Jan 22, 2026)
+- Make ChromaDB initialization lazy to allow multiple env instances to run concurrently

--- a/environments/wiki_search/pyproject.toml
+++ b/environments/wiki_search/pyproject.toml
@@ -3,7 +3,7 @@ name = "wiki-search"
 description = "Agentic RAG over Wikipedia pages for trivia Q&A"
 tags = ["wikipedia", "multi-turn", "agentic-search", "rag", "train", "eval", "llm-judge"]
 requires-python = ">=3.11"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
     "verifiers>=0.1.8",
     "chromadb",

--- a/environments/wiki_search/wiki_search.py
+++ b/environments/wiki_search/wiki_search.py
@@ -34,18 +34,6 @@ def load_environment(
     corpus_split: str = "train",
     chroma_db_dir: str = CHROMA_DB_DIR,
 ) -> vf.Environment:
-    # ensure Chroma server is running in client/server mode
-    # ensure_chroma_server(chroma_db_dir)
-    openai_ef = embedding_functions.OpenAIEmbeddingFunction(
-        model_name=embed_model,
-        api_base=embed_base_url,
-        api_key=os.getenv(embed_api_key_var, "EMPTY"),
-    )
-    client = chromadb.PersistentClient(path=chroma_db_dir)
-    collection = client.get_or_create_collection(
-        name="wiki_titles",
-        embedding_function=cast(EmbeddingFunction[Embeddable], openai_ef),
-    )
     # load corpus into memory and build page_id -> row index
     corpus = load_dataset(corpus_dataset, split=corpus_split)
     page_id_to_title: dict[str, str] = {}
@@ -58,8 +46,29 @@ def load_environment(
         page_id_to_title[pid] = title
         page_id_to_content[pid] = content
 
-    # initialize chroma collection
-    def init_chroma() -> None:
+    # Lazy ChromaDB initialization - only initialize when first tool call happens
+    # This avoids SQLite file locking issues when multiple processes load the environment
+    _chroma_state: dict = {"collection": None, "initialized": False}
+
+    def _get_collection():
+        if _chroma_state["collection"] is None:
+            openai_ef = embedding_functions.OpenAIEmbeddingFunction(
+                model_name=embed_model,
+                api_base=embed_base_url,
+                api_key=os.getenv(embed_api_key_var, "EMPTY"),
+            )
+            client = chromadb.PersistentClient(path=chroma_db_dir)
+            _chroma_state["collection"] = client.get_or_create_collection(
+                name="wiki_titles",
+                embedding_function=cast(EmbeddingFunction[Embeddable], openai_ef),
+            )
+            # Initialize chroma with missing pages on first access
+            if not _chroma_state["initialized"]:
+                _init_chroma(_chroma_state["collection"])
+                _chroma_state["initialized"] = True
+        return _chroma_state["collection"]
+
+    def _init_chroma(collection) -> None:
         # upsert missing pages
         all_ids = list(page_id_to_title.keys())
         existing: set[str] = set()
@@ -85,8 +94,6 @@ def load_environment(
                     metadatas=metadatas[i : i + bs],
                 )
 
-    init_chroma()
-
     # helper function to normalize section ids
     def normalize_id(text: str) -> str:
         """Normalize free text into an id: lowercased with spaces as underscores.
@@ -108,6 +115,7 @@ def load_environment(
         example:
             "basketball" -> [{"page_id": "basketball", "title": "Basketball"}, {"page_id": "basketball_rules", "title": "Basketball Rules"}, ...]
         """
+        collection = _get_collection()  # Lazy init on first tool call
         async with _get_chroma_semaphore():
             results = await asyncio.to_thread(
                 collection.query, query_texts=[query], n_results=10

--- a/environments/wiki_search/wiki_search.py
+++ b/environments/wiki_search/wiki_search.py
@@ -47,7 +47,7 @@ def load_environment(
         page_id_to_content[pid] = content
 
     # lazy chroma initialization (once across all env instances)
-    _chroma_state: dict = {"collection": None, "initialized": False}
+    _chroma_state: dict = {"collection": None}
 
     def _get_collection():
         if _chroma_state["collection"] is None:
@@ -61,10 +61,7 @@ def load_environment(
                 name="wiki_titles",
                 embedding_function=cast(EmbeddingFunction[Embeddable], openai_ef),
             )
-            # Initialize chroma with missing pages on first access
-            if not _chroma_state["initialized"]:
-                _init_chroma(_chroma_state["collection"])
-                _chroma_state["initialized"] = True
+            _init_chroma(_chroma_state["collection"])
         return _chroma_state["collection"]
 
     def _init_chroma(collection) -> None:

--- a/environments/wiki_search/wiki_search.py
+++ b/environments/wiki_search/wiki_search.py
@@ -46,8 +46,7 @@ def load_environment(
         page_id_to_title[pid] = title
         page_id_to_content[pid] = content
 
-    # Lazy ChromaDB initialization - only initialize when first tool call happens
-    # This avoids SQLite file locking issues when multiple processes load the environment
+    # lazy chroma initialization (once across all env instances)
     _chroma_state: dict = {"collection": None, "initialized": False}
 
     def _get_collection():
@@ -115,7 +114,7 @@ def load_environment(
         example:
             "basketball" -> [{"page_id": "basketball", "title": "Basketball"}, {"page_id": "basketball_rules", "title": "Basketball Rules"}, ...]
         """
-        collection = _get_collection()  # Lazy init on first tool call
+        collection = _get_collection()  # lazy init on first earch call
         async with _get_chroma_semaphore():
             results = await asyncio.to_thread(
                 collection.query, query_texts=[query], n_results=10


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

previously, `wiki-search` could not be loaded in processes on the same machine without deadlocking because it eagerly created a local chroma instance with locks. now, the chroma instance is only initted on first tool call. this allows multiple instances to at least exist (e.g. prime-rl orchestrator loads to obtain dataset + env worker loads to execute env)

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces lazy ChromaDB setup to prevent startup lock contention and enable multiple concurrent `wiki-search` env instances.
> 
> - Replace eager Chroma client/collection creation with `_get_collection` that initializes once per process and calls `_init_chroma` on first use
> - Initialize collection on first `search_pages` call; query concurrency still guarded by `_get_chroma_semaphore`
> - Bump version to `0.1.22` and add README changelog entry documenting the change
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c34176040419f2c1e9b72675714d6a0f60fb4b29. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->