### PR TITLE
eval --debug mode to skip Rich

### DIFF
--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -136,6 +136,7 @@ The `--max-retries` flag enables automatic retry with exponential backoff when r
 |------|-------|---------|-------------|
 | `--verbose` | `-v` | false | Enable debug logging |
 | `--tui` | `-u` | false | Use alternate screen mode (TUI) for display |
+| `--debug` | `-d` | false | Disable Rich display; use normal logging and tqdm progress |
 | `--save-results` | `-s` | false | Save results to disk |
 | `--save-every` | `-f` | -1 | Save checkpoint every N rollouts |
 | `--state-columns` | `-C` | — | Extra state columns to save (comma-separated) |

--- a/tests/test_eval_cli.py
+++ b/tests/test_eval_cli.py
@@ -120,6 +120,7 @@ def _run_cli(monkeypatch, overrides, capture_all_configs: bool = False):
         "extra_env_kwargs": {},
         "max_retries": 0,
         "tui": False,
+        "debug": False,
     }
     base_args.update(overrides)
     args_namespace = SimpleNamespace(**base_args)

--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -21,6 +21,7 @@ from verifiers.types import ClientConfig, EvalConfig, EvalRunConfig
 from verifiers.utils.eval_utils import (
     load_endpoints,
     load_toml_config,
+    run_evaluations,
     run_evaluations_tui,
 )
 from verifiers.utils.install_utils import check_hub_env_installed
@@ -265,6 +266,13 @@ def main():
         help="Use TUI mode for live evaluation display",
     )
     parser.add_argument(
+        "--debug",
+        "-d",
+        default=False,
+        action="store_true",
+        help="Disable Rich display; use normal logging and tqdm progress instead",
+    )
+    parser.add_argument(
         "--max-retries",
         type=int,
         default=0,
@@ -434,8 +442,10 @@ def main():
         logger.debug(f"Evaluation config: {config.model_dump_json(indent=2)}")
 
     eval_run_config = EvalRunConfig(evals=eval_configs)
-    # Always use Rich display; --tui flag controls screen mode (alternate screen vs in-place)
-    asyncio.run(run_evaluations_tui(eval_run_config, tui_mode=args.tui))
+    if args.debug:
+        asyncio.run(run_evaluations(eval_run_config))
+    else:
+        asyncio.run(run_evaluations_tui(eval_run_config, tui_mode=args.tui))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a non-Rich execution path for evals and documents the new flag.
> 
> - Adds `--debug`/`-d` to `prime eval` to disable Rich UI and use standard logging + tqdm
> - `eval.py`: when `--debug` is set, calls `run_evaluations`; otherwise continues using `run_evaluations_tui` (with `--tui` controlling screen mode)
> - Updates docs (`docs/evaluation.md`) to include the new flag; adjusts tests to include `debug` in CLI defaults
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d9b8a6c1c7371ee1c1f87963a0c090dd966f1bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->