### PR TITLE
fix double save results in vf-eval

### DIFF
--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -881,6 +881,8 @@ class Environment(ABC):
         state_columns: list[str] | None = None,
         save_results: bool = False,
         save_every: int = -1,
+        push_to_hf_hub: bool = False,
+        hf_hub_dataset_name: str | None = None,
         use_tqdm: bool = True,
         independent_scoring: bool = False,
         max_retries: int = 0,
@@ -1033,7 +1035,7 @@ class Environment(ABC):
 
         # save if requested
         if save_results:
-            save_rollout_results(results)
+            save_rollout_results(results, push_to_hf_hub, hf_hub_dataset_name)
             if on_log is not None:
                 on_log(f"Saved final results to {results['metadata']['path_to_save']}")
 
@@ -1100,6 +1102,8 @@ class Environment(ABC):
         state_columns: list[str] | None = None,
         save_results: bool = False,
         save_every: int = -1,
+        push_to_hf_hub: bool = False,
+        hf_hub_dataset_name: str | None = None,
         use_tqdm: bool = True,
         independent_scoring: bool = False,
         max_retries: int = 0,
@@ -1124,6 +1128,8 @@ class Environment(ABC):
             state_columns=state_columns,
             save_results=save_results,
             save_every=save_every,
+            push_to_hf_hub=push_to_hf_hub,
+            hf_hub_dataset_name=hf_hub_dataset_name,
             use_tqdm=use_tqdm,
             independent_scoring=independent_scoring,
             max_retries=max_retries,
@@ -1147,6 +1153,8 @@ class Environment(ABC):
         state_columns: list[str] | None = None,
         save_results: bool = False,
         save_every: int = -1,
+        push_to_hf_hub: bool = False,
+        hf_hub_dataset_name: str | None = None,
         independent_scoring: bool = False,
         max_retries: int = 0,
     ) -> GenerateOutputs:
@@ -1166,6 +1174,8 @@ class Environment(ABC):
             state_columns=state_columns,
             save_results=save_results,
             save_every=save_every,
+            push_to_hf_hub=push_to_hf_hub,
+            hf_hub_dataset_name=hf_hub_dataset_name,
             independent_scoring=independent_scoring,
             max_retries=max_retries,
         )

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -326,6 +326,8 @@ async def run_evaluation(
         state_columns=config.state_columns,
         save_results=config.save_results,
         save_every=config.save_every,
+        push_to_hf_hub=config.save_to_hf_hub,
+        hf_hub_dataset_name=config.hf_hub_dataset_name,
         use_tqdm=use_tqdm,
         independent_scoring=config.independent_scoring,
         max_retries=config.max_retries,

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -334,8 +334,6 @@ async def run_evaluation(
         on_log=on_log,
     )
 
-    if config.save_results:
-        save_rollout_results(results, config.save_to_hf_hub, config.hf_hub_dataset_name)
     return results
 
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

previously we would redundantly save the results in `generate` and `run_evaluation` (just once also pushing to HF hub). this makes it so that generate is entirely responsible for the saving and pushing to hub to avid unnecessary redundant disk writes.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes redundant saving of evaluation results.
> 
> - Removes the post-evaluation `save_rollout_results` call in `run_evaluation` so results are saved only by `vf_env.evaluate` when `save_results` is enabled
> - No changes to evaluation flow, callbacks, or output formatting
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc3af89146b8b5d6a401635afca6939fbf0f7237. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->