### PR TITLE
raise on empty response error (openrouter) to trigger retries

### DIFF
--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -648,3 +648,299 @@ class TestMaybeRetry:
             )
 
         assert env.call_counts[0] == 1  # No retries for non-InfraError
+
+
+class TestEmptyModelResponseErrors:
+    """Test cases for empty and invalid model response error handling."""
+
+    @pytest.mark.asyncio
+    async def test_none_response_raises_empty_model_response_error(
+        self, mock_openai_client, sample_dataset
+    ):
+        """Test that None response raises EmptyModelResponseError."""
+        env = SimpleEnvironment(
+            dataset=sample_dataset,
+            parser=Parser(),
+            rubric=Rubric(),
+        )
+
+        # Mock the client to return None
+        mock_openai_client.chat.completions.create = AsyncMock(return_value=None)
+
+        prompt: Messages = [{"role": "user", "content": "Hello"}]
+        state = await env.init_state(
+            input=RolloutInput(example_id=0, task="test", prompt=prompt),
+            client=mock_openai_client,
+            model="test-model",
+        )
+
+        with pytest.raises(vf.EmptyModelResponseError):
+            await env.get_model_response(state, prompt)
+
+    @pytest.mark.asyncio
+    async def test_none_choices_raises_empty_model_response_error(
+        self, mock_openai_client, sample_dataset
+    ):
+        """Test that response with None choices raises EmptyModelResponseError."""
+        env = SimpleEnvironment(
+            dataset=sample_dataset,
+            parser=Parser(),
+            rubric=Rubric(),
+        )
+
+        # Mock the client to return a response with None choices
+        mock_response = Mock()
+        mock_response.choices = None
+        mock_openai_client.chat.completions.create = AsyncMock(
+            return_value=mock_response
+        )
+
+        prompt: Messages = [{"role": "user", "content": "Hello"}]
+        state = await env.init_state(
+            input=RolloutInput(example_id=0, task="test", prompt=prompt),
+            client=mock_openai_client,
+            model="test-model",
+        )
+
+        with pytest.raises(vf.EmptyModelResponseError):
+            await env.get_model_response(state, prompt)
+
+    @pytest.mark.asyncio
+    async def test_wrong_number_of_choices_raises_invalid_model_response_error(
+        self, mock_openai_client, sample_dataset
+    ):
+        """Test that response with != 1 choices raises InvalidModelResponseError."""
+        env = SimpleEnvironment(
+            dataset=sample_dataset,
+            parser=Parser(),
+            rubric=Rubric(),
+        )
+
+        # Mock the client to return a response with 2 choices
+        mock_choice1 = Mock(spec=Choice)
+        mock_choice1.message = Mock()
+        mock_choice1.message.content = "Response 1"
+        mock_choice1.message.tool_calls = None
+
+        mock_choice2 = Mock(spec=Choice)
+        mock_choice2.message = Mock()
+        mock_choice2.message.content = "Response 2"
+        mock_choice2.message.tool_calls = None
+
+        mock_response = Mock()
+        mock_response.choices = [mock_choice1, mock_choice2]
+        mock_openai_client.chat.completions.create = AsyncMock(
+            return_value=mock_response
+        )
+
+        prompt: Messages = [{"role": "user", "content": "Hello"}]
+        state = await env.init_state(
+            input=RolloutInput(example_id=0, task="test", prompt=prompt),
+            client=mock_openai_client,
+            model="test-model",
+        )
+
+        with pytest.raises(vf.InvalidModelResponseError):
+            await env.get_model_response(state, prompt)
+
+    @pytest.mark.asyncio
+    async def test_empty_choices_raises_invalid_model_response_error(
+        self, mock_openai_client, sample_dataset
+    ):
+        """Test that response with empty choices list raises InvalidModelResponseError."""
+        env = SimpleEnvironment(
+            dataset=sample_dataset,
+            parser=Parser(),
+            rubric=Rubric(),
+        )
+
+        # Mock the client to return a response with empty choices
+        mock_response = Mock()
+        mock_response.choices = []
+        mock_openai_client.chat.completions.create = AsyncMock(
+            return_value=mock_response
+        )
+
+        prompt: Messages = [{"role": "user", "content": "Hello"}]
+        state = await env.init_state(
+            input=RolloutInput(example_id=0, task="test", prompt=prompt),
+            client=mock_openai_client,
+            model="test-model",
+        )
+
+        with pytest.raises(vf.InvalidModelResponseError):
+            await env.get_model_response(state, prompt)
+
+    @pytest.mark.asyncio
+    async def test_chat_empty_content_no_tool_calls_raises_empty_model_response_error(
+        self, mock_openai_client, sample_dataset
+    ):
+        """Test that chat response with no content and no tool_calls raises EmptyModelResponseError."""
+        env = SimpleEnvironment(
+            dataset=sample_dataset,
+            parser=Parser(),
+            rubric=Rubric(),
+        )
+
+        # Mock the client to return a response with empty content and no tool calls
+        mock_choice = Mock(spec=Choice)
+        mock_choice.message = Mock()
+        mock_choice.message.content = None
+        mock_choice.message.tool_calls = None
+
+        mock_response = Mock()
+        mock_response.choices = [mock_choice]
+        mock_openai_client.chat.completions.create = AsyncMock(
+            return_value=mock_response
+        )
+
+        prompt: Messages = [{"role": "user", "content": "Hello"}]
+        state = await env.init_state(
+            input=RolloutInput(example_id=0, task="test", prompt=prompt),
+            client=mock_openai_client,
+            model="test-model",
+        )
+
+        with pytest.raises(vf.EmptyModelResponseError):
+            await env.get_model_response(state, prompt)
+
+    @pytest.mark.asyncio
+    async def test_chat_empty_string_content_no_tool_calls_raises_empty_model_response_error(
+        self, mock_openai_client, sample_dataset
+    ):
+        """Test that chat response with empty string content and no tool_calls raises EmptyModelResponseError."""
+        env = SimpleEnvironment(
+            dataset=sample_dataset,
+            parser=Parser(),
+            rubric=Rubric(),
+        )
+
+        # Mock the client to return a response with empty string content
+        mock_choice = Mock(spec=Choice)
+        mock_choice.message = Mock()
+        mock_choice.message.content = ""
+        mock_choice.message.tool_calls = None
+
+        mock_response = Mock()
+        mock_response.choices = [mock_choice]
+        mock_openai_client.chat.completions.create = AsyncMock(
+            return_value=mock_response
+        )
+
+        prompt: Messages = [{"role": "user", "content": "Hello"}]
+        state = await env.init_state(
+            input=RolloutInput(example_id=0, task="test", prompt=prompt),
+            client=mock_openai_client,
+            model="test-model",
+        )
+
+        with pytest.raises(vf.EmptyModelResponseError):
+            await env.get_model_response(state, prompt)
+
+    @pytest.mark.asyncio
+    async def test_chat_with_tool_calls_but_no_content_succeeds(
+        self, mock_openai_client, sample_dataset
+    ):
+        """Test that chat response with tool_calls but no content does NOT raise error."""
+        env = SimpleEnvironment(
+            dataset=sample_dataset,
+            parser=Parser(),
+            rubric=Rubric(),
+        )
+
+        # Mock the client to return a response with tool calls but no content
+        mock_tool_call = Mock()
+        mock_tool_call.id = "call_123"
+        mock_tool_call.type = "function"
+        mock_tool_call.function = Mock()
+        mock_tool_call.function.name = "test_function"
+        mock_tool_call.function.arguments = "{}"
+
+        mock_choice = Mock(spec=Choice)
+        mock_choice.message = Mock()
+        mock_choice.message.content = None
+        mock_choice.message.tool_calls = [mock_tool_call]
+
+        mock_response = Mock()
+        mock_response.choices = [mock_choice]
+        mock_openai_client.chat.completions.create = AsyncMock(
+            return_value=mock_response
+        )
+
+        prompt: Messages = [{"role": "user", "content": "Hello"}]
+        state = await env.init_state(
+            input=RolloutInput(example_id=0, task="test", prompt=prompt),
+            client=mock_openai_client,
+            model="test-model",
+        )
+
+        # Should not raise
+        response = await env.get_model_response(state, prompt)
+        assert response is not None
+        assert response.choices[0].message.tool_calls is not None
+
+    @pytest.mark.asyncio
+    async def test_completion_empty_text_raises_empty_model_response_error(
+        self, mock_openai_client
+    ):
+        """Test that completion response with empty text raises EmptyModelResponseError."""
+        from openai.types.completion_choice import CompletionChoice
+
+        env = SimpleEnvironment(
+            eval_dataset=Dataset.from_dict({"prompt": ["test"], "answer": ["test"]}),
+            message_type="completion",
+            parser=Parser(),
+            rubric=Rubric(),
+        )
+
+        # Mock the client to return a response with empty text
+        mock_choice = Mock(spec=CompletionChoice)
+        mock_choice.text = ""
+        mock_choice.finish_reason = "stop"
+
+        mock_response = Mock()
+        mock_response.choices = [mock_choice]
+        mock_openai_client.completions.create = AsyncMock(return_value=mock_response)
+
+        prompt = "Complete this:"
+        state = await env.init_state(
+            input=RolloutInput(example_id=0, task="test", prompt=prompt),
+            client=mock_openai_client,
+            model="test-model",
+        )
+
+        with pytest.raises(vf.EmptyModelResponseError):
+            await env.get_model_response(state, prompt)
+
+    @pytest.mark.asyncio
+    async def test_completion_none_text_raises_empty_model_response_error(
+        self, mock_openai_client
+    ):
+        """Test that completion response with None text raises EmptyModelResponseError."""
+        from openai.types.completion_choice import CompletionChoice
+
+        env = SimpleEnvironment(
+            eval_dataset=Dataset.from_dict({"prompt": ["test"], "answer": ["test"]}),
+            message_type="completion",
+            parser=Parser(),
+            rubric=Rubric(),
+        )
+
+        # Mock the client to return a response with None text
+        mock_choice = Mock(spec=CompletionChoice)
+        mock_choice.text = None
+        mock_choice.finish_reason = "stop"
+
+        mock_response = Mock()
+        mock_response.choices = [mock_choice]
+        mock_openai_client.completions.create = AsyncMock(return_value=mock_response)
+
+        prompt = "Complete this:"
+        state = await env.init_state(
+            input=RolloutInput(example_id=0, task="test", prompt=prompt),
+            client=mock_openai_client,
+            model="test-model",
+        )
+
+        with pytest.raises(vf.EmptyModelResponseError):
+            await env.get_model_response(state, prompt)

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -611,15 +611,11 @@ class Environment(ABC):
 
         # Some providers (e.g. OpenRouter) may return None for response or response.choices
         if response is None:
-            raise vf.EmptyModelResponseError from ValueError(
-                "Model returned no response"
-            )
+            raise vf.EmptyModelResponseError("Model returned no response")
         if response.choices is None:
-            raise vf.EmptyModelResponseError from ValueError(
-                "Model returned no response choices"
-            )
+            raise vf.EmptyModelResponseError("Model returned no response choices")
         if not len(response.choices) == 1:
-            raise vf.InvalidModelResponseError from ValueError(
+            raise vf.InvalidModelResponseError(
                 f"Model returned {len(response.choices)} choices, expected 1"
             )
         if isinstance(response.choices[0], Choice):
@@ -627,14 +623,12 @@ class Environment(ABC):
                 response.choices[0].message.content
                 or response.choices[0].message.tool_calls
             ):
-                raise vf.EmptyModelResponseError from ValueError(
+                raise vf.EmptyModelResponseError(
                     "Model returned no content and did not call any tools"
                 )
         elif isinstance(response.choices[0], CompletionChoice):
             if not response.choices[0].text:
-                raise vf.EmptyModelResponseError from ValueError(
-                    "Model returned no content"
-                )
+                raise vf.EmptyModelResponseError("Model returned no content")
 
         return response
 

--- a/verifiers/errors.py
+++ b/verifiers/errors.py
@@ -8,8 +8,14 @@ class ModelError(Error):
     pass
 
 
-class EmptyModelResponseError(ModelError):
+class InvalidModelResponseError(ModelError):
     """Used to catch empty or invalid model responses (e.g. response.choices is None)."""
+
+    pass
+
+
+class EmptyModelResponseError(InvalidModelResponseError):
+    """Used to catch empty model responses (e.g. response.choices is None)."""
 
     pass
 

--- a/verifiers/utils/async_utils.py
+++ b/verifiers/utils/async_utils.py
@@ -1,8 +1,8 @@
 import asyncio
 import inspect
 import logging
-from time import perf_counter
 from collections.abc import Coroutine
+from time import perf_counter
 from typing import Any, AsyncContextManager, Callable, Optional, TypeVar
 
 import tenacity as tc
@@ -143,7 +143,7 @@ def maybe_retry(
     wrapper.__qualname__ = getattr(func, "__qualname__", "unknown")
 
     return tc.AsyncRetrying(
-        retry=tc.retry_if_exception_type(vf.InfraError),
+        retry=tc.retry_if_exception_type((vf.InfraError, vf.InvalidModelResponseError)),
         stop=tc.stop_after_attempt(max_retries + 1),
         wait=tc.wait_exponential_jitter(initial=initial, max=max_wait),
         before_sleep=log_retry,


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

catches a couple more common open router errors cases:
- model does not produce text or tool calls for chat completions
- model does not produce text for completions
by catching those and propagating as vf.Errors they will be retried with `--max-retries`

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [x] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens model response handling and integrates retries for invalid outputs.
> 
> - Enforces validation in `Environment.get_model_response`: `None` response/choices -> `EmptyModelResponseError`; choices count != 1 -> `InvalidModelResponseError`; chat choice with no `content` and no `tool_calls` -> `EmptyModelResponseError`; completion choice with empty/None `text` -> `EmptyModelResponseError`
> - Introduces `InvalidModelResponseError` (parent of `EmptyModelResponseError`) in `verifiers/errors.py`
> - Extends `maybe_retry` to retry on `InvalidModelResponseError` in addition to `InfraError`
> - Adds targeted tests in `tests/test_environment.py` covering empty/invalid response scenarios for chat and completion
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f610d36e18039fad7a4c93d94c318d123ae6e4f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->