### PR TITLE
mirror cli args in toml config

### DIFF
--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -120,7 +120,41 @@ def load_toml_config(path: Path) -> list[dict]:
     # extract global defaults (everything except 'eval' key)
     global_defaults = {k: v for k, v in raw_config.items() if k != "eval"}
 
-    valid_fields = set(EvalConfig.model_fields.keys())
+    # valid fields mirror cli args, not evalconfig
+    # TODO: properly tie EvalConfig to CLI
+    valid_fields = {
+        # environment
+        "env_id",
+        "env_args",
+        "env_dir_path",
+        "endpoints_path",
+        "extra_env_kwargs",
+        # model/client
+        "model",
+        "api_key_var",
+        "api_base_url",
+        "header",
+        # sampling
+        "sampling_args",
+        "max_tokens",
+        "temperature",
+        # evaluation
+        "num_examples",
+        "rollouts_per_example",
+        "max_concurrent",
+        "max_concurrent_generation",
+        "max_concurrent_scoring",
+        "independent_scoring",
+        "max_retries",
+        # logging
+        "verbose",
+        # saving
+        "state_columns",
+        "save_results",
+        "save_every",
+        "save_to_hf_hub",
+        "hf_hub_dataset_name",
+    }
 
     # validate global fields
     if global_defaults:


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

previously, we used `EvalConfig` to determine the valid fields in CLI but this is (a) confusing UX and (b) leads to some fields being ignored (e.g. all of `client_config`) because the resolution logic to build the eval expects the CLI syntax. for example:
- if you try api_key_var = "MY_KEY" → rejected by validation as "invalid field"0 
- if you try client_config.api_key_var → validation might pass but build_eval_config won't find it

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Bug fix: align TOML validation with CLI args**
> 
> - Replace `valid_fields` derived from `EvalConfig` with an explicit set mirroring CLI flags (env, model/client, sampling, evaluation, logging, saving) in `load_toml_config`
> - Global and per-`[[eval]]` validation now checks against these CLI-aligned fields, reducing false rejections and ignored fields during config resolution
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 200e08f2774cfff65b3fef54fa7f0f07e2a0f3e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->