### PR TITLE
Make local RLM REPL concurrency configurable

### DIFF
--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -1721,7 +1721,9 @@ class LocalRLMExecutor(BaseRLMExecutor):
         super().__init__(env)
         self._sessions: dict[str, LocalRLMReplSession] = {}
         self._retained_dirs: set[str] = set()
-        self._io_executor = ThreadPoolExecutor(max_workers=4)
+        self._io_executor = ThreadPoolExecutor(
+            max_workers=self.env.local_repl_max_workers
+        )
 
     def create_rollout_dirs(self, state: State) -> None:
         session = self._get_or_create_session(state)
@@ -2669,6 +2671,7 @@ class RLMEnv(vf.StatefulToolEnv):
         sandbox_client_max_workers: Sandbox client pool size (default: 10)
         sandbox_client_max_connections: Sandbox client max connections (default: 100)
         sandbox_client_max_keepalive_connections: Sandbox client keepalive conns (default: 50)
+        local_repl_max_workers: Max worker threads for local REPL execution.
         **kwargs: Additional arguments passed to StatefulToolEnv
     """
 
@@ -2716,6 +2719,7 @@ class RLMEnv(vf.StatefulToolEnv):
         sandbox_client_max_workers: int = 10,
         sandbox_client_max_connections: int = 100,
         sandbox_client_max_keepalive_connections: int = 50,
+        local_repl_max_workers: int | None = None,
         rubric: Rubric | None = None,
         **kwargs,
     ):
@@ -2792,6 +2796,11 @@ class RLMEnv(vf.StatefulToolEnv):
         self.sandbox_client_max_keepalive_connections = (
             sandbox_client_max_keepalive_connections
         )
+        self.local_repl_max_workers = local_repl_max_workers or max(
+            1, min(64, os.cpu_count() or 1)
+        )
+        if self.local_repl_max_workers < 1:
+            raise ValueError("local_repl_max_workers must be >= 1")
         # Server-side timeout for LLM API calls (shorter than worker HTTP timeout)
         # This ensures server responds before the worker request times out
         (

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -2796,8 +2796,10 @@ class RLMEnv(vf.StatefulToolEnv):
         self.sandbox_client_max_keepalive_connections = (
             sandbox_client_max_keepalive_connections
         )
-        self.local_repl_max_workers = local_repl_max_workers or max(
-            1, min(64, os.cpu_count() or 1)
+        self.local_repl_max_workers = (
+            local_repl_max_workers
+            if local_repl_max_workers is not None
+            else max(1, min(64, os.cpu_count() or 1))
         )
         if self.local_repl_max_workers < 1:
             raise ValueError("local_repl_max_workers must be >= 1")


### PR DESCRIPTION
## Description

Make local RLM REPL concurrency configurable, set high default.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces configurable local REPL concurrency and wires it into the local executor.
> 
> - Adds `local_repl_max_workers` param to `RLMEnv.__init__` and documents it
> - Sets default to `clamp(os.cpu_count(), 1..64)` and validates `>= 1`
> - `LocalRLMExecutor` now constructs `ThreadPoolExecutor(max_workers=self.env.local_repl_max_workers)`
> - No functional changes to sandbox path; only local backend behavior is affected
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ebbcf3d1c48ec97d1f6e7f55360f63851936a4f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->