### PR TITLE
RLM: Simplify code

### DIFF
--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -54,7 +54,6 @@ from aiohttp import web
 from openai.types.chat import ChatCompletion, ChatCompletionFunctionToolParam
 from prime_tunnel import Tunnel
 import verifiers as vf
-from verifiers.rubrics.rubric import Rubric
 from verifiers.types import (
     ChatMessage,
     ChatMessages,

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -3003,17 +3003,6 @@ class RLMEnv(vf.StatefulToolEnv):
         return "\n".join(lines)
 
     @staticmethod
-    def _extract_tokens(response: Any) -> tuple[int, int]:
-        """Extract prompt and completion tokens from response usage."""
-        usage = getattr(response, "usage", None)
-        if not usage:
-            return 0, 0
-        return (
-            getattr(usage, "prompt_tokens", 0) or 0,
-            getattr(usage, "completion_tokens", 0) or 0,
-        )
-
-    @staticmethod
     def _normalize_sampling_args(sampling_args: dict[str, Any]) -> dict[str, Any]:
         """Normalize sampling args to match main model behavior."""
         if "max_tokens" in sampling_args:
@@ -3181,7 +3170,7 @@ class RLMEnv(vf.StatefulToolEnv):
             if response is None:
                 return self._make_timeout_result([], 0, 0, 0, 0)
 
-            prompt_tokens, completion_tokens = self._extract_tokens(response)
+            prompt_tokens, completion_tokens = _extract_tokens_from_response(response)
             return SubLLMResult(
                 final_content=response.choices[0].message.content or "",
                 turns=[
@@ -3223,7 +3212,7 @@ class RLMEnv(vf.StatefulToolEnv):
                     num_turns,
                 )
 
-            prompt_tokens, completion_tokens = self._extract_tokens(response)
+            prompt_tokens, completion_tokens = _extract_tokens_from_response(response)
             total_prompt_tokens += prompt_tokens
             total_completion_tokens += completion_tokens
 
@@ -3293,7 +3282,7 @@ class RLMEnv(vf.StatefulToolEnv):
                 prompt_messages=prompt_snapshot, response=response, tool_call_count=0
             )
         )
-        prompt_tokens, completion_tokens = self._extract_tokens(response)
+        prompt_tokens, completion_tokens = _extract_tokens_from_response(response)
 
         return SubLLMResult(
             final_content=response.choices[0].message.content or "",

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -2728,8 +2728,7 @@ class RLMEnv(vf.StatefulToolEnv):
             )
         if execution_backend not in {"local", "sandbox"}:
             raise ValueError(
-                "execution_backend must be 'local' or 'sandbox', got "
-                f"'{execution_backend}'."
+                f"Unsupported execution_backend '{execution_backend}'. Expected 'local' or 'sandbox'."
             )
         self.repl_language = repl_language
         self.execution_backend = execution_backend
@@ -2873,8 +2872,7 @@ class RLMEnv(vf.StatefulToolEnv):
 
         if code_timeout < 10:
             logger.warning(
-                "code_execution_timeout=%s is low; sub-LLM calls may be unreliable",
-                code_timeout,
+                f"code_execution_timeout={code_timeout}s is low; sub-LLM calls may be unreliable"
             )
 
         return api_timeout, worker_timeout
@@ -3524,13 +3522,15 @@ class RLMEnv(vf.StatefulToolEnv):
             if meta.get("error"):
                 summary_lines.append(f"  [{index}]: error ({elapsed:.2f}s)")
                 continue
-            tokens = meta.get("prompt_tokens", 0) + meta.get("completion_tokens", 0)
+            prompt_tokens = meta.get("prompt_tokens", 0)
+            completion_tokens = meta.get("completion_tokens", 0)
             tool_calls = meta.get("tool_call_count", 0)
             max_turns = meta.get("max_turns_reached", False)
             status = "⚠ max turns" if max_turns else "✓"
             summary_lines.append(
-                f"  [{index}]: {tokens} tokens, {tool_calls} tool calls, "
-                f"{elapsed:.2f}s {status}"
+                f"  [{index}]: {prompt_tokens} prompt tokens, "
+                f"{completion_tokens} completion tokens, "
+                f"{tool_calls} tool calls, {elapsed:.2f}s {status}"
             )
 
         return contents, summary_lines

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -2723,25 +2723,6 @@ class RLMEnv(vf.StatefulToolEnv):
         rubric: Rubric | None = None,
         **kwargs,
     ):
-        if tools is None and "tools" in kwargs:
-            tools = kwargs.pop("tools")
-        elif tools is not None and "tools" in kwargs:
-            raise ValueError("Tools were provided twice: use tools=... only once.")
-
-        if root_tools is None and "root_tools" in kwargs:
-            root_tools = kwargs.pop("root_tools")
-        elif root_tools is not None and "root_tools" in kwargs:
-            raise ValueError(
-                "root_tools were provided twice: use root_tools=... only once."
-            )
-
-        if sub_tools is None and "sub_tools" in kwargs:
-            sub_tools = kwargs.pop("sub_tools")
-        elif sub_tools is not None and "sub_tools" in kwargs:
-            raise ValueError(
-                "sub_tools were provided twice: use sub_tools=... only once."
-            )
-
         if repl_language not in {"bash", "python"}:
             raise ValueError(
                 f"Unsupported repl_language '{repl_language}'. Expected 'bash' or 'python'."


### PR DESCRIPTION
## Description

Simplifies RLM code without touching functionality.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Major internal cleanup with no intended behavior changes, focusing on maintainability and consistency.
> 
> - **Worker script generation**: Replace large inline templates with `_build_python_worker_script_template(sandboxed=...)`; extract reusable blocks (guardrails, FIFOs, FS context, jail); generate both local `_RLM_WORKER_SCRIPT_TEMPLATE` and sandbox `_RLM_SANDBOX_PY_WORKER_SCRIPT_TEMPLATE` from one source.
> - **Env var setup**: New `_build_worker_env_vars()` used by local and sandbox executors; toggles inclusion of code-exec restrictions.
> - **Metrics**: `RLMMonitorRubric` now auto-registers simple state metrics via a factory (`_SIMPLE_METRICS`, `_make_state_metric`); dynamic per-root-tool metrics retained.
> - **REPL flow**: Factor shared logic into `_call_repl()` and `_maybe_add_context_warning()`; `call_python_repl` appends execution time, `call_bash_repl` does not; warning text parameterized.
> - **Tool docs/types**: Introduce `_append_tool_docs()` to avoid duplication; annotate OAI tool lists with `ChatCompletionFunctionToolParam`; simplify root tool schema handling.
> - **Sub-LLM accounting**: Use `_extract_tokens_from_response` helper; `llm_batch` summary now shows prompt vs completion tokens separately; minor log/message tweaks.
> 
> Risk is primarily around template generation and executor env var changes affecting worker startup and token/metric reporting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c619cc8a835540e1b8d686cfd98bb9a518a7bac9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->