### PR TITLE
return last result if retries exhausted

### DIFF
--- a/verifiers/utils/async_utils.py
+++ b/verifiers/utils/async_utils.py
@@ -104,6 +104,7 @@ def maybe_retry(
     initial: float = 1.0,
     max_wait: float = 60.0,
     error_types: tuple[type[Exception], ...] = (
+        vf.ModelError,
         vf.InfraError,
         vf.InvalidModelResponseError,
     ),
@@ -111,6 +112,7 @@ def maybe_retry(
     """
     Return retry-wrapped function if max_retries > 0, else return func unchanged.
     Re-raises specified errors from state["error"] to trigger tenacity retry.
+    Returns result with error in state if retries are exhausted (does not crash).
 
     Usage:
         state = await maybe_retry(self.run_rollout, max_retries=3)(input, client, ...)
@@ -147,8 +149,30 @@ def maybe_retry(
             f"Caught {error_chain} in {caller}. Retrying in {print_time(next_action)} (retry {retry_state.attempt_number}/{max_retries})"
         )
 
+    last_result = None
+
+    def return_last_result(retry_state: tc.RetryCallState):
+        """Return the last result when retries are exhausted (instead of raising)."""
+        caller = retry_state.fn.__name__ if retry_state.fn else "unknown function"
+        error_chain = (
+            repr(
+                ErrorChain(
+                    retry_state.outcome.exception() or Exception("Unknown exception")
+                )
+            )
+            if retry_state.outcome
+            else None
+        )
+        logger.error(
+            f"Retries exhausted for {caller} after {max_retries} attempts. "
+            f"Last error: {error_chain}. Continuing with error in state."
+        )
+        return last_result
+
     async def wrapper(*args, **kwargs):
+        nonlocal last_result
         result = await func(*args, **kwargs)
+        last_result = result  # store result
         reraise_error_from_state(result, error_types)
         return result
 
@@ -160,5 +184,6 @@ def maybe_retry(
         stop=tc.stop_after_attempt(max_retries + 1),
         wait=tc.wait_exponential_jitter(initial=initial, max=max_wait),
         before_sleep=log_retry,
+        retry_error_callback=return_last_result,
         reraise=True,
     ).wraps(wrapper)

--- a/verifiers/utils/async_utils.py
+++ b/verifiers/utils/async_utils.py
@@ -104,7 +104,6 @@ def maybe_retry(
     initial: float = 1.0,
     max_wait: float = 60.0,
     error_types: tuple[type[Exception], ...] = (
-        vf.ModelError,
         vf.InfraError,
         vf.InvalidModelResponseError,
     ),


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

previously, when retries are exhausted, we raise and crash an eval run. now we return the final state (with the last error in the state), mirroring the behavior when not setting retries

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements non-crashing retry exhaustion behavior and aligns tests.
> 
> - Update `verifiers/utils/async_utils.py` `maybe_retry` to store `last_result` and use `tenacity`'s `retry_error_callback` to return it when retries are exhausted; add error-level log and keep raising only for configured error types during retries
> - Wrap `SimpleEnvironment.rollout` in `try/except vf.Error` to record errors in `state` instead of raising
> - Revise retry tests in `tests/test_environment.py`:
>   - Retry succeeds after transient retryable errors
>   - Non-retryable errors are not retried and are captured in `state`
>   - After max retries, error persists in `state` rather than raising
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34040eeb24a2aba0a056e175fad541c7d526b96d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->