### PR TITLE
RLM: Fix trajectory collision

### DIFF
--- a/environments/rlm_secrets/README.md
+++ b/environments/rlm_secrets/README.md
@@ -72,13 +72,15 @@ Both reward functions have equal weight (0.5 each):
 | Parameter | Default | Description |
 |-----------|---------|-------------|
 | `num_train_examples` | 100 | Training puzzles |
-| `num_eval_examples` | 20 | Evaluation puzzles |
 | `num_files` | 4 | Files per puzzle |
 | `max_turns` | 50 | Max REPL iterations |
 | `sub_tool_max_turns` | 3 | Max tool turns for sub-LLMs |
 | `max_sub_llm_parallelism` | 5 | Concurrent sub-LLM calls |
 | `code_execution_timeout` | 120 | Bash execution timeout (seconds) |
 | `**kwargs` | - | Passed on `RLMEnv.__init__` |
+
+Note: The eval dataset is not built separately. For evaluation, re-instantiate the
+environment with a different `seed` to generate a new synthetic split.
 
 ## Why This Environment?
 

--- a/environments/rlm_secrets/rlm_secrets.py
+++ b/environments/rlm_secrets/rlm_secrets.py
@@ -318,6 +318,7 @@ def build_dataset(
         Dataset with prompt, answer, and info columns
     """
     rows = []
+    task_name = "rlm-secrets"
 
     for i in range(num_examples):
         puzzle = generate_puzzle(num_files=num_files)
@@ -359,9 +360,11 @@ def build_dataset(
 
         rows.append(
             {
+                "example_id": i,
                 "prompt": prompt,
                 "answer": str(puzzle["correct_position"]),
                 "info": {"puzzle": puzzle},
+                "task": task_name,
             }
         )
 

--- a/environments/rlm_secrets/rlm_secrets.py
+++ b/environments/rlm_secrets/rlm_secrets.py
@@ -446,7 +446,6 @@ async def correct_filesystem_state(state: State) -> float:
 
 def load_environment(
     num_train_examples: int = 100,
-    num_eval_examples: int = 20,
     num_files: int = 4,
     max_turns: int = 50,
     seed: int | None = None,
@@ -461,7 +460,6 @@ def load_environment(
 
     Args:
         num_train_examples: Number of training puzzle instances
-        num_eval_examples: Number of evaluation puzzle instances
         num_files: Number of files per puzzle (default: 4)
         max_turns: Maximum REPL iterations (default: 50)
         seed: Random seed for dataset generation
@@ -480,11 +478,6 @@ def load_environment(
         num_files=num_files,
     )
 
-    eval_dataset = build_dataset(
-        num_examples=num_eval_examples,
-        num_files=num_files,
-    )
-
     rubric = vf.Rubric(
         funcs=[correct_answer, correct_filesystem_state],
         weights=[0.5, 0.5],
@@ -492,7 +485,6 @@ def load_environment(
 
     return RLMSecretsEnv(
         dataset=train_dataset,
-        eval_dataset=eval_dataset,
         num_files=num_files,
         repl_language=repl_language,
         rubric=rubric,

--- a/tests/test_rlm_env.py
+++ b/tests/test_rlm_env.py
@@ -1067,6 +1067,103 @@ class TestSubLLMRequestPaths:
         assert "max_tokens" not in body
         mock_client.chat.completions.create.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_sub_llm_normalizes_messages(self, rlm_env):
+        mock_client = MagicMock()
+        mock_message = MagicMock()
+        mock_message.tool_calls = None
+        mock_message.content = "ok"
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock(message=mock_message)]
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+        rlm_env.interleaved_rollouts = False
+        messages = [
+            {"role": "user", "content": {"type": "text", "text": "hello"}},
+            {"role": "user", "content": {"role": "user", "content": "inner"}},
+        ]
+        state = {}
+
+        await rlm_env._call_sub_llm_api(state, mock_client, "gpt-4", messages)
+
+        args, kwargs = mock_client.chat.completions.create.call_args
+        assert args == ()
+        sent_messages = kwargs["messages"]
+        assert sent_messages[0]["content"] == [{"type": "text", "text": "hello"}]
+        assert sent_messages[1]["content"] == "inner"
+
+    @pytest.mark.asyncio
+    async def test_interleaved_sub_llm_uses_incremental_prompt_ids(
+        self, rlm_env_with_sub_tools
+    ):
+        mock_client = MagicMock()
+        mock_client.chat.completions.create = AsyncMock()
+
+        mock_tool_call = MagicMock()
+        mock_tool_call.id = "call_1"
+        mock_tool_call.function.name = "sample_tool"
+        mock_tool_call.function.arguments = '{"x": 2, "y": 3}'
+
+        mock_message1 = MagicMock()
+        mock_message1.tool_calls = [mock_tool_call]
+        mock_message1.content = None
+
+        mock_message2 = MagicMock()
+        mock_message2.tool_calls = None
+        mock_message2.content = "done"
+
+        response1 = MagicMock()
+        response1.choices = [MagicMock(message=mock_message1)]
+        response2 = MagicMock()
+        response2.choices = [MagicMock(message=mock_message2)]
+
+        mock_client.post = AsyncMock(side_effect=[response1, response2])
+
+        rlm_env_with_sub_tools.interleaved_rollouts = True
+        messages = [{"role": "user", "content": "Add 2 and 3"}]
+        state = {"sampling_args": {"max_tokens": 7}}
+
+        token_payload = {
+            "prompt_ids": [1],
+            "prompt_mask": [0],
+            "completion_ids": [2],
+            "completion_mask": [1],
+            "completion_logprobs": [0.0],
+            "overlong_prompt": False,
+            "is_truncated": False,
+        }
+
+        with (
+            patch(
+                "verifiers.envs.experimental.rlm_env.tokenize_vllm",
+                new=AsyncMock(return_value=[1, 2, 3]),
+            ) as mock_tokenize,
+            patch(
+                "verifiers.envs.experimental.rlm_env.get_prompt_ids",
+                new=AsyncMock(return_value=[4, 5, 6]),
+            ) as mock_get_prompt_ids,
+            patch(
+                "verifiers.envs.experimental.rlm_env.parse_response_tokens",
+                new=AsyncMock(return_value=token_payload),
+            ),
+            patch(
+                "verifiers.envs.experimental.rlm_env.parse_response_messages",
+                new=AsyncMock(return_value=[{"role": "assistant", "content": "ok"}]),
+            ),
+            patch(
+                "verifiers.envs.experimental.rlm_env.parse_is_truncated",
+                new=AsyncMock(return_value=False),
+            ),
+        ):
+            await rlm_env_with_sub_tools._run_sub_llm(
+                state, mock_client, "gpt-4", messages
+            )
+
+        assert mock_client.post.await_count == 2
+        mock_tokenize.assert_awaited_once()
+        mock_get_prompt_ids.assert_awaited_once()
+        mock_client.chat.completions.create.assert_not_called()
+
 
 # =============================================================================
 # 8. Root Tool Serialization (pickle)

--- a/tests/test_rlm_env.py
+++ b/tests/test_rlm_env.py
@@ -1036,6 +1036,7 @@ class TestSubLLMRequestPaths:
     async def test_interleaved_uses_tokens_endpoint(self, rlm_env):
         mock_client = MagicMock()
         mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
         mock_client.post = AsyncMock(return_value=mock_response)
         mock_client.chat.completions.create = AsyncMock()
 

--- a/tests/test_rlm_env.py
+++ b/tests/test_rlm_env.py
@@ -1055,34 +1055,34 @@ class TestSubLLMRequestPaths:
         assert "max_tokens" not in kwargs
         mock_client.post.assert_not_called()
 
+
+# =============================================================================
+# 8. llm_batch Prompt Validation
+# =============================================================================
+
+
+class TestLLMBatchPromptValidation:
     @pytest.mark.asyncio
-    async def test_sub_llm_normalizes_messages(self, rlm_env):
-        mock_client = MagicMock()
-        mock_message = MagicMock()
-        mock_message.tool_calls = None
-        mock_message.content = "ok"
-        mock_response = MagicMock()
-        mock_response.choices = [MagicMock(message=mock_message)]
-        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+    async def test_llm_batch_rejects_non_string_prompts(self, rlm_env):
+        context = {
+            "client": MagicMock(),
+            "sub_model": "gpt-4",
+            "state": {"trajectory": []},
+        }
 
-        rlm_env.interleaved_rollouts = False
-        messages = [
-            {"role": "user", "content": {"type": "text", "text": "hello"}},
-            {"role": "user", "content": {"role": "user", "content": "inner"}},
-        ]
-        state = {}
+        contents, _ = await rlm_env._root_llm_batch(
+            context, [{"role": "user", "content": "hi"}]
+        )
+        assert "must be a string" in contents[0]
 
-        await rlm_env._call_sub_llm_api(state, mock_client, "gpt-4", messages)
-
-        args, kwargs = mock_client.chat.completions.create.call_args
-        assert args == ()
-        sent_messages = kwargs["messages"]
-        assert sent_messages[0]["content"] == [{"type": "text", "text": "hello"}]
-        assert sent_messages[1]["content"] == "inner"
+        contents, _ = await rlm_env._root_llm_batch(
+            context, [[{"role": "user", "content": "hi"}]]
+        )
+        assert "must be a string" in contents[0]
 
 
 # =============================================================================
-# 8. Root Tool Serialization (pickle)
+# 9. Root Tool Serialization (pickle)
 # =============================================================================
 
 
@@ -1129,7 +1129,7 @@ class TestRootToolSerialization:
 
 
 # =============================================================================
-# 9. Context Limit Configuration
+# 10. Context Limit Configuration
 # =============================================================================
 
 
@@ -1144,7 +1144,7 @@ class TestContextLimitConfiguration:
 
 
 # =============================================================================
-# 10. Sub-LLM Metrics with Tools
+# 11. Sub-LLM Metrics with Tools
 # =============================================================================
 
 
@@ -1214,7 +1214,7 @@ class TestSubLLMMetricsWithTools:
 
 
 # =============================================================================
-# 11. Sub-LLM Trajectory Steps
+# 12. Sub-LLM Trajectory Steps
 # =============================================================================
 
 
@@ -1301,7 +1301,7 @@ class TestSubLLMTrajectorySteps:
 
 
 # =============================================================================
-# 12. Tunnel Utils (kept for coverage)
+# 13. Tunnel Utils (kept for coverage)
 # =============================================================================
 
 

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -456,6 +456,40 @@ class Environment(ABC):
                 sampling_args.pop("max_completion_tokens")
             return {k: v for k, v in sampling_args.items() if v is not None}
 
+        client, model, oai_tools, sampling_args, message_type = resolve_optional_args(
+            client, model, oai_tools, sampling_args, message_type
+        )
+        sampling_args = normalize_sampling_args(sampling_args)
+        if self.interleaved_rollouts:
+            sampling_args = prepare_sampling_args_for_token_prompts(sampling_args)
+
+        prompt_ids: list[int] | None = None
+        if self.interleaved_rollouts and len(state["trajectory"]) > 0:
+            prompt_ids = await get_prompt_ids(state, prompt, client)
+
+        return await self._call_model_api(
+            client=client,
+            model=model,
+            prompt=prompt,
+            oai_tools=oai_tools,
+            sampling_args=sampling_args,
+            message_type=message_type,
+            prompt_ids=prompt_ids,
+        )
+
+    async def _call_model_api(
+        self,
+        *,
+        client: AsyncOpenAI,
+        model: str,
+        prompt: Messages,
+        oai_tools: list[ChatCompletionToolParam] | None,
+        sampling_args: SamplingArgs,
+        message_type: MessageType,
+        prompt_ids: list[int] | None = None,
+    ) -> ModelResponse:
+        """Shared low-level model call used by main and sub-LLM paths."""
+
         def handle_overlong_prompt(func):
             """Decorator to handle overlong prompt errors from the model API."""
 
@@ -487,7 +521,7 @@ class Environment(ABC):
             return wrapper
 
         @handle_overlong_prompt
-        async def get_model_response_with_messages(
+        async def call_with_messages(
             client: AsyncOpenAI,
             model: str,
             prompt: Messages,
@@ -547,7 +581,7 @@ class Environment(ABC):
                 return response
 
         @handle_overlong_prompt
-        async def get_model_response_with_tokens(
+        async def call_with_tokens(
             client: AsyncOpenAI,
             model: str,
             prompt: Messages,
@@ -581,16 +615,8 @@ class Environment(ABC):
                 cast_to=ChatCompletion,
             )
 
-        client, model, oai_tools, sampling_args, message_type = resolve_optional_args(
-            client, model, oai_tools, sampling_args, message_type
-        )
-        sampling_args = normalize_sampling_args(sampling_args)
-        if self.interleaved_rollouts:
-            sampling_args = prepare_sampling_args_for_token_prompts(sampling_args)
-
-        if self.interleaved_rollouts and len(state["trajectory"]) > 0:
-            prompt_ids = await get_prompt_ids(state, prompt, client)
-            response = await get_model_response_with_tokens(
+        if prompt_ids is not None:
+            response = await call_with_tokens(
                 client=client,
                 model=model,
                 prompt=prompt,
@@ -600,7 +626,7 @@ class Environment(ABC):
                 message_type=message_type,
             )
         else:
-            response = await get_model_response_with_messages(
+            response = await call_with_messages(
                 client=client,
                 model=model,
                 prompt=prompt,

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -51,14 +51,18 @@ else:
     from typing import TypedDict
 
 from aiohttp import web
+from openai import AsyncOpenAI
 from openai.types.chat import ChatCompletionFunctionToolParam
 from prime_tunnel import Tunnel
 import verifiers as vf
 from verifiers.types import (
+    ChatCompletionToolParam,
     ChatMessage,
     ChatMessages,
     Messages,
+    MessageType,
     ModelResponse,
+    SamplingArgs,
     State,
     TrajectoryStep,
 )
@@ -4200,6 +4204,120 @@ class RLMEnv(vf.StatefulToolEnv):
     # =========================================================================
     # MultiTurnEnv Interface
     # =========================================================================
+
+    async def get_model_response(
+        self,
+        state: State,
+        prompt: Messages,
+        client: AsyncOpenAI | None = None,
+        model: str | None = None,
+        oai_tools: list[ChatCompletionToolParam] | None = None,
+        sampling_args: SamplingArgs | None = None,
+        message_type: MessageType | None = None,
+    ) -> ModelResponse:
+        """
+        Override to keep interleaved prompt_id computation scoped to main-LLM steps.
+
+        RLMEnv injects sub-LLM turns into state["trajectory"] for training. If we
+        feed that mixed trajectory into get_prompt_ids, the "previous turn"
+        becomes a sub-LLM step and the main prompt looks unrelated. That produces
+        an empty env_response and breaks /tokenize. We avoid that by filtering
+        trajectory steps to the main trajectory_id only.
+        """
+
+        def resolve_optional_args(
+            client: AsyncOpenAI | None,
+            model: str | None,
+            oai_tools: list[ChatCompletionToolParam] | None,
+            sampling_args: SamplingArgs | None,
+            message_type: MessageType | None,
+        ) -> tuple[
+            AsyncOpenAI,
+            str,
+            list[ChatCompletionToolParam] | None,
+            SamplingArgs,
+            MessageType,
+        ]:
+            client = client or state["client"]
+            model = model or state["model"]
+            assert client is not None and model is not None
+            oai_tools = oai_tools or state["oai_tools"]
+            sampling_args = cast(
+                SamplingArgs, sampling_args or state["sampling_args"] or {}
+            )
+            message_type = message_type or self.message_type
+            return client, model, oai_tools, sampling_args, message_type
+
+        def normalize_sampling_args(sampling_args: SamplingArgs) -> SamplingArgs:
+            if "max_tokens" in sampling_args:
+                if sampling_args["max_tokens"] is None:
+                    sampling_args.pop("max_tokens")
+                elif message_type == "chat":
+                    sampling_args["max_completion_tokens"] = sampling_args.pop(
+                        "max_tokens"
+                    )
+            if (
+                "max_completion_tokens" in sampling_args
+                and sampling_args["max_completion_tokens"] is None
+            ):
+                sampling_args.pop("max_completion_tokens")
+            return {k: v for k, v in sampling_args.items() if v is not None}
+
+        client, model, oai_tools, sampling_args, message_type = resolve_optional_args(
+            client, model, oai_tools, sampling_args, message_type
+        )
+        sampling_args = normalize_sampling_args(sampling_args)
+        if self.interleaved_rollouts:
+            sampling_args = prepare_sampling_args_for_token_prompts(sampling_args)
+
+        prompt_ids: list[int] | None = None
+        if (
+            self.interleaved_rollouts
+            and message_type == "chat"
+            and len(state["trajectory"]) > 0
+        ):
+            main_trajectory_id = state.get("trajectory_id")
+            main_steps = [
+                step
+                for step in state["trajectory"]
+                if step.get("trajectory_id") == main_trajectory_id
+            ]
+            if main_steps:
+                # Do not mutate the original state; build a minimal view for
+                # prompt_id computation that excludes sub-LLM turns.
+                prompt_state = State()
+                prompt_state["trajectory"] = main_steps
+                prompt_state["client"] = client
+                prompt_state["model"] = model
+                prompt_state["oai_tools"] = oai_tools or []
+                # Reuse cached suffix ids if available to avoid extra tokenization.
+                if "_cached_suffix_ids" in state:
+                    prompt_state["_cached_suffix_ids"] = state["_cached_suffix_ids"]
+                # Keep sub-LLM debug context for empty-env-response logging.
+                if "_last_sub_llm_root_call" in state:
+                    prompt_state["_last_sub_llm_root_call"] = state[
+                        "_last_sub_llm_root_call"
+                    ]
+                prompt_ids = await get_prompt_ids(prompt_state, prompt, client)
+            else:
+                # If no main steps are present (should be rare), fall back to
+                # full-tokenize so we still use the tokens endpoint.
+                prompt_ids = await tokenize_vllm(
+                    client=client,
+                    messages=prompt,
+                    tools=oai_tools,
+                    model=model,
+                )
+
+        return await self._call_model_api(
+            client=client,
+            model=model,
+            prompt=prompt,
+            oai_tools=oai_tools,
+            sampling_args=sampling_args,
+            message_type=message_type,
+            prompt_ids=prompt_ids,
+        )
 
     async def get_prompt_messages(self, state: State) -> Messages:
         """Build prompt messages, adding system prompt with tool docs on first turn."""

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -1140,26 +1140,11 @@ _RLM_BASH_WORKER_SCRIPT_TEMPLATE = textwrap.dedent(
                         break
         return buffer
 
-    def _drain_fd():
-        # Drain any immediately-available output (e.g., prompt text) so it
-        # doesn't leak into the next command's captured output.
-        while True:
-            ready, _, _ = select.select([master_fd], [], [], 0)
-            if master_fd not in ready:
-                break
-            try:
-                chunk = os.read(master_fd, 4096)
-            except Exception:
-                break
-            if not chunk:
-                break
-
     def _parse_bool(value: str) -> bool:
         return value.strip().lower() in {"1", "true", "yes", "y", "on"}
 
     try:
         _read_until_marker(init_marker.encode("utf-8"))
-        _drain_fd()
     except Exception:
         pass
 
@@ -1203,7 +1188,6 @@ _RLM_BASH_WORKER_SCRIPT_TEMPLATE = textwrap.dedent(
             continue
 
         raw = _read_until_marker(env_marker.encode("utf-8"))
-        _drain_fd()
         text = raw.decode("utf-8", errors="replace")
 
         output = text

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -4299,6 +4299,10 @@ class RLMEnv(vf.StatefulToolEnv):
                         "_last_sub_llm_root_call"
                     ]
                 prompt_ids = await get_prompt_ids(prompt_state, prompt, client)
+                # If suffix ids were computed on the temporary state, persist them
+                # on the main state to avoid re-tokenizing every turn.
+                if "_cached_suffix_ids" in prompt_state:
+                    state["_cached_suffix_ids"] = prompt_state["_cached_suffix_ids"]
             else:
                 # If no main steps are present (should be rare), fall back to
                 # full-tokenize so we still use the tokens endpoint.

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -51,7 +51,6 @@ else:
     from typing import TypedDict
 
 from aiohttp import web
-from openai import AsyncOpenAI
 from openai.types.chat import ChatCompletionFunctionToolParam
 from prime_tunnel import Tunnel
 import verifiers as vf

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -1140,11 +1140,26 @@ _RLM_BASH_WORKER_SCRIPT_TEMPLATE = textwrap.dedent(
                         break
         return buffer
 
+    def _drain_fd():
+        # Drain any immediately-available output (e.g., prompt text) so it
+        # doesn't leak into the next command's captured output.
+        while True:
+            ready, _, _ = select.select([master_fd], [], [], 0)
+            if master_fd not in ready:
+                break
+            try:
+                chunk = os.read(master_fd, 4096)
+            except Exception:
+                break
+            if not chunk:
+                break
+
     def _parse_bool(value: str) -> bool:
         return value.strip().lower() in {"1", "true", "yes", "y", "on"}
 
     try:
         _read_until_marker(init_marker.encode("utf-8"))
+        _drain_fd()
     except Exception:
         pass
 
@@ -1188,6 +1203,7 @@ _RLM_BASH_WORKER_SCRIPT_TEMPLATE = textwrap.dedent(
             continue
 
         raw = _read_until_marker(env_marker.encode("utf-8"))
+        _drain_fd()
         text = raw.decode("utf-8", errors="replace")
 
         output = text


### PR DESCRIPTION
## Description

- Fixes interleaved prompt‑ID computation in `RLMEnv` (root cause of `/tokenize` empty‑messages errors). Sub‑LLM calls now go through `Environment.get_model_response` using a fake state with an empty trajectory and mirrored `sampling_args`/`oai_tools`, so prompt‑id computation can’t be polluted. The old `/chat/completions/tokens` path and explicit tokenization are gone for sub‑LLMs
- `include_sub_llm_in_trajectory` default is `False`, and interleaving is explicitly disallowed when it’s `True` (guards in `set_interleaved_rollouts` and `setup_state`)
- `llm_batch` is now strings‑only (enforced + documented). Non‑string prompts return an error message
- Removed sub‑LLM message normalization and sampling‑arg normalization helpers; sampling args are now just defensively copied and normalization is handled by `get_model_response`
- RLM‑secrets dataset updates: add `example_id`/`task`, remove eval dataset creation, README updated with eval guidance

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [x] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Resolves sub-LLM rollout collisions and simplifies request paths; tightens llm_batch usage; and streamlines the rlm_secrets environment.
> 
> - Sub-LLM calls now always go through `get_model_response` (chat path) with a fake state, ignoring interleaving; removed `/chat/completions/tokens` and explicit tokenization. Sampling args are mirrored; message/sampling normalization moved to module-level helpers.
> - `include_sub_llm_in_trajectory` defaults to `False`. Interleaved rollouts are explicitly disallowed when it’s `True` (guards in `set_interleaved_rollouts` and `setup_state`). Sub-LLM steps can be added to the trajectory with `extras.is_sub_llm_call`.
> - `llm_batch` accepts a list of strings only; docs and tool help updated accordingly.
> - rlm_secrets: dataset rows include `example_id` and `task`; removed eval split creation; `load_environment` no longer builds `eval_dataset`. README adds guidance to re-seed for eval.
> - Tests updated/added for chat-only sub-LLM path and arg normalization, prompt validation, new trajectory default/guards, and sub-LLM step recording.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 631b24a20aa0245b98cc6baa609ca706b2aa0585. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->