### PR TITLE
lazy import datasets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
 dependencies = [
     "datasets>=3.0.0",
     "jinja2>=3.1.6",
+    "numpy",
     "math-verify>=0.8.0",
     "mcp>=1.14.1",
     "nest-asyncio>=1.6.0", # for jupyter notebooks

--- a/verifiers/envs/env_group.py
+++ b/verifiers/envs/env_group.py
@@ -1,14 +1,15 @@
+from __future__ import annotations
+
 import time
 from typing import TYPE_CHECKING, AsyncContextManager, Mapping, final
 
-from datasets import Dataset, concatenate_datasets
 from openai import AsyncOpenAI
 
 import verifiers as vf
 from verifiers.types import RolloutInput, SamplingArgs
 
 if TYPE_CHECKING:
-    pass
+    from datasets import Dataset
 
 
 class EnvGroupRubric(vf.Rubric):
@@ -142,6 +143,8 @@ class EnvGroup(vf.Environment):
                       If not provided, uses "env_0", "env_1", etc.
             **kwargs: Additional arguments passed to parent Environment
         """
+        from datasets import concatenate_datasets
+
         if not envs:
             raise ValueError("EnvGroup requires at least one environment")
 

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import atexit
 import functools
@@ -24,8 +26,10 @@ from typing import (
     final,
 )
 
-from datasets import Dataset
 from openai import AsyncOpenAI, BadRequestError, OpenAI
+
+if TYPE_CHECKING:
+    from datasets import Dataset
 from openai.types.chat import ChatCompletion
 from openai.types.chat.chat_completion import Choice
 from openai.types.completion_choice import CompletionChoice
@@ -907,6 +911,8 @@ class Environment(ABC):
         """
         Generate rollouts for a set of inputs.
         """
+        from datasets import Dataset
+
         if isinstance(inputs, Dataset):
             inputs_list = inputs.to_list()
         elif isinstance(inputs, list):

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -11,7 +11,7 @@ from typing import (
     TypeAlias,
 )
 
-from .errors import Error
+from verifiers.errors import Error
 
 if TYPE_CHECKING:
     from datasets import Dataset

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -1,15 +1,20 @@
+from __future__ import annotations
+
 import sys
 from pathlib import Path
 from typing import (
+    TYPE_CHECKING,
     Any,
     Awaitable,
     Callable,
     Literal,
+    TypeAlias,
 )
 
-from datasets import Dataset
+from .errors import Error
 
-from verifiers.errors import Error
+if TYPE_CHECKING:
+    from datasets import Dataset
 
 if sys.version_info < (3, 12):
     from typing_extensions import TypedDict
@@ -50,7 +55,7 @@ SamplingArgs = dict[str, Any]
 IndividualRewardFunc = Callable[..., float | Awaitable[float]]
 GroupRewardFunc = Callable[..., list[float] | Awaitable[list[float]]]
 RewardFunc = IndividualRewardFunc | GroupRewardFunc
-DatasetBuilder = Callable[[], Dataset]
+DatasetBuilder: TypeAlias = "Callable[[], Dataset]"
 
 
 class TrajectoryStepTokens(TypedDict):

--- a/verifiers/utils/data_utils.py
+++ b/verifiers/utils/data_utils.py
@@ -1,11 +1,14 @@
 # NOTE: Helper functions for example datasets. Not intended for core functionality.
 
-import random
-from typing import Any, Callable, cast
+from __future__ import annotations
 
-from datasets import Dataset, concatenate_datasets, load_dataset
+import random
+from typing import TYPE_CHECKING, Any, Callable, cast
 
 from verifiers.types import ChatMessage
+
+if TYPE_CHECKING:
+    from datasets import Dataset
 
 ### PROMPTS ###
 
@@ -259,6 +262,8 @@ def get_preprocess_fn(name: str) -> Callable[[dict], dict]:
 def load_example_dataset(
     name: str = "gsm8k", split: str | None = None, n: int | None = None, seed: int = 0
 ) -> Dataset:
+    from datasets import Dataset, concatenate_datasets, load_dataset
+
     if name == "aime2024":
         if split is None:
             split = "train"

--- a/verifiers/utils/display_utils.py
+++ b/verifiers/utils/display_utils.py
@@ -16,7 +16,6 @@ import sys
 from collections import deque
 from typing import Any
 
-from datasets import disable_progress_bar, enable_progress_bar
 from rich.console import Console
 from rich.live import Live
 from rich.panel import Panel
@@ -126,6 +125,8 @@ class BaseDisplay:
     def start(self) -> None:
         """Start the live display."""
         # Suppress datasets progress bars (e.g. from .map())
+        from datasets import disable_progress_bar
+
         disable_progress_bar()
 
         # Suppress console output from existing handlers but capture logs for display
@@ -171,6 +172,8 @@ class BaseDisplay:
             self._live = None
 
         # Restore datasets progress bar
+        from datasets import enable_progress_bar
+
         enable_progress_bar()
 
         # Remove our log handler and restore original handler levels

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import importlib.util
 import json
@@ -6,7 +8,7 @@ import time
 from collections import Counter, defaultdict
 from contextlib import contextmanager
 from pathlib import Path
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 try:
     import tomllib  # type: ignore[import-not-found]
@@ -14,10 +16,11 @@ except ImportError:
     import tomli as tomllib  # type: ignore[import-not-found]
 
 import numpy as np
-from datasets import Dataset, disable_progress_bar, enable_progress_bar
-from datasets.utils import logging as ds_logging
 
 import verifiers as vf
+
+if TYPE_CHECKING:
+    from datasets import Dataset
 from verifiers.types import (
     Endpoints,
     EvalConfig,
@@ -536,6 +539,8 @@ def get_hf_hub_dataset_name(results: GenerateOutputs) -> str:
 
 
 def make_dataset(results: GenerateOutputs, **kwargs) -> Dataset:
+    from datasets import Dataset
+
     clean_prompts = [messages_to_printable(p) for p in results["prompt"]]
     clean_prompts = [sanitize_tool_calls(p) for p in clean_prompts]
     clean_completions = [messages_to_printable(c) for c in results["completion"]]
@@ -578,6 +583,9 @@ def make_dataset(results: GenerateOutputs, **kwargs) -> Dataset:
 
 @contextmanager
 def quiet_datasets():
+    from datasets import disable_progress_bar, enable_progress_bar
+    from datasets.utils import logging as ds_logging
+
     prev_level = ds_logging.get_verbosity()
     ds_logging.set_verbosity(ds_logging.WARNING)
     disable_progress_bar()


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Shifts `datasets` imports to be lazy to reduce import-time overhead and optionalize the dependency in most code paths. Also tightens typing and forward references.
> 
> - Convert top-level `datasets` imports to TYPE_CHECKING stubs or local imports within functions/methods (e.g., `EnvGroup.__init__`, `Environment.generate`, `data_utils.load_example_dataset`, `eval_utils.make_dataset`/`quiet_datasets`, `display_utils.BaseDisplay.start/stop`)
> - Add `from __future__ import annotations` broadly and change `DatasetBuilder` to a `TypeAlias` string; minor typing cleanups
> - Update `pyproject.toml` to include `numpy` in `dependencies`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4186897a948b7cace69c90ddfbd2f6e84f1b2952. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->