### PR TITLE
Propagate RLM stop errors from root and sub tools

### DIFF
--- a/tests/test_rlm_env.py
+++ b/tests/test_rlm_env.py
@@ -930,7 +930,7 @@ class TestCallSubTool:
     @pytest.mark.asyncio
     async def test_executes_tool_successfully(self, rlm_env_with_sub_tools):
         result = await rlm_env_with_sub_tools._call_sub_tool(
-            "sample_tool", {"x": 2, "y": 3}, "call_123"
+            "sample_tool", {"x": 2, "y": 3}, "call_123", state={}
         )
 
         assert result["role"] == "tool"
@@ -940,7 +940,7 @@ class TestCallSubTool:
     @pytest.mark.asyncio
     async def test_handles_tool_error(self, rlm_env_with_sub_tools):
         result = await rlm_env_with_sub_tools._call_sub_tool(
-            "sample_tool", {"x": "not_an_int", "y": 3}, "call_456"
+            "sample_tool", {"x": "not_an_int", "y": 3}, "call_456", state={}
         )
 
         assert result["role"] == "tool"

--- a/tests/test_rlm_env.py
+++ b/tests/test_rlm_env.py
@@ -930,7 +930,7 @@ class TestCallSubTool:
     @pytest.mark.asyncio
     async def test_executes_tool_successfully(self, rlm_env_with_sub_tools):
         result = await rlm_env_with_sub_tools._call_sub_tool(
-            "sample_tool", {"x": 2, "y": 3}, "call_123", state={}
+            "sample_tool", {"x": 2, "y": 3}, "call_123"
         )
 
         assert result["role"] == "tool"
@@ -940,7 +940,7 @@ class TestCallSubTool:
     @pytest.mark.asyncio
     async def test_handles_tool_error(self, rlm_env_with_sub_tools):
         result = await rlm_env_with_sub_tools._call_sub_tool(
-            "sample_tool", {"x": "not_an_int", "y": 3}, "call_456", state={}
+            "sample_tool", {"x": "not_an_int", "y": 3}, "call_456"
         )
 
         assert result["role"] == "tool"

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -3009,7 +3009,6 @@ class RLMEnv(vf.StatefulToolEnv):
             }
         except Exception as e:
             if self._should_stop_for_error(e):
-                state["_rlm_stop_error"] = e
                 raise
             return {
                 "role": "tool",

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -2765,10 +2765,6 @@ class RLMEnv(vf.StatefulToolEnv):
 
         return api_timeout, worker_timeout
 
-    def _record_stop_error(self, state: State, exc: Exception) -> None:
-        state["error"] = str(exc)
-        state["_rlm_stop_error"] = exc
-
     def _build_fixed_root_tools(self) -> list[Callable]:
         """Return the fixed root REPL tools (non-overridable)."""
 
@@ -3013,7 +3009,7 @@ class RLMEnv(vf.StatefulToolEnv):
             }
         except Exception as e:
             if self._should_stop_for_error(e):
-                self._record_stop_error(state, e)
+                state["_rlm_stop_error"] = e
                 raise
             return {
                 "role": "tool",
@@ -3560,7 +3556,7 @@ class RLMEnv(vf.StatefulToolEnv):
                 print_lines = None
         except Exception as e:
             if self._should_stop_for_error(e):
-                self._record_stop_error(state_ref, e)
+                state_ref["_rlm_stop_error"] = e
             return web.json_response({"error": str(e)}, status=500)
         finally:
             self._root_tool_context_var.reset(token)
@@ -3615,7 +3611,7 @@ class RLMEnv(vf.StatefulToolEnv):
             return web.json_response(response_dict)
         except Exception as e:
             if self._should_stop_for_error(e):
-                self._record_stop_error(state_ref, e)
+                state_ref["_rlm_stop_error"] = e
             return web.json_response({"error": str(e)}, status=500)
 
     async def _teardown_interception_server(self):

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -2996,7 +2996,7 @@ class RLMEnv(vf.StatefulToolEnv):
         return "\n".join(lines)
 
     async def _call_sub_tool(
-        self, tool_name: str, tool_args: dict, tool_call_id: str, *, state: State
+        self, tool_name: str, tool_args: dict, tool_call_id: str
     ) -> dict:
         """Execute a sub-agent tool call. Returns tool message dict."""
         try:
@@ -3172,7 +3172,7 @@ class RLMEnv(vf.StatefulToolEnv):
                 except json.JSONDecodeError:
                     tool_args = {}
                 tool_result = await self._call_sub_tool(
-                    tool_name, tool_args, tool_call.id, state=state
+                    tool_name, tool_args, tool_call.id
                 )
                 current_messages.append(cast(ChatMessage, tool_result))
 


### PR DESCRIPTION
## Description

Make sure all tools (`root_tools` and `sub_tools` and thus also `tools`) propagate `stop_errors` to `call_bash/python_repl`, so that `StatefulToolEnv`'s handling of `stop_error` still works.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures RLM stop errors raised by tools are surfaced to the REPL so `StatefulToolEnv` stop conditions trigger correctly.
> 
> - In sub-tool execution and `llm_batch` batching, re-raise exceptions that satisfy `_should_stop_for_error`, instead of swallowing them as error messages
> - In interception handlers for root tools and sub-LLM requests, set `state_ref["_rlm_stop_error"]` when a stop error is detected
> - In REPL execution (`_call_repl`), pop and re-raise `_rlm_stop_error` after code execution to propagate the stop upstream
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c92ad5e41f39205ac095442b22ef7d8361c7e2d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->