### PR TITLE
verifiers: fix tool call rendering from saved outputs

### DIFF
--- a/verifiers/utils/eval_display.py
+++ b/verifiers/utils/eval_display.py
@@ -6,11 +6,10 @@ Provides a visual progress display that works in two modes:
 - TUI mode (screen=True): Alternate screen buffer with echo handling
 """
 
-import json
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Literal
+from typing import Literal
 
 from rich.columns import Columns
 from rich.console import Group
@@ -21,7 +20,7 @@ from rich.text import Text
 
 from verifiers.types import EvalConfig, GenerateOutputs
 from verifiers.utils.display_utils import BaseDisplay, make_aligned_row
-from verifiers.utils.message_utils import normalize_tool_call
+from verifiers.utils.message_utils import format_messages
 
 
 @dataclass
@@ -57,35 +56,6 @@ class EnvEvalState:
             return 0.0
         end = self.end_time or time.time()
         return end - self.start_time
-
-
-def _format_messages(messages: Any) -> Text:
-    """Format messages for display (similar to print_prompt_completions_sample)."""
-
-    if isinstance(messages, str):
-        return Text(messages)
-
-    out = Text()
-    for idx, msg in enumerate(messages):
-        if idx:
-            out.append("\n\n")
-
-        assert isinstance(msg, dict)
-        role = msg.get("role", "")
-        content = msg.get("content", "")
-        style = "bright_cyan" if role == "assistant" else "bright_magenta"
-
-        out.append(f"{role}: ", style="bold")
-        out.append(str(content) if content else "", style=style)
-
-        for tc in msg.get("tool_calls") or []:
-            payload = normalize_tool_call(tc)
-            out.append(
-                "\n\n[tool call]\n" + json.dumps(payload, indent=2, ensure_ascii=False),
-                style=style,
-            )
-
-    return out
 
 
 def _make_histogram(values: list[float], bins: int = 10, width: int = 20) -> Text:
@@ -558,14 +528,14 @@ class EvalDisplay(BaseDisplay):
             # Prompt panel
             items.append(
                 Panel(
-                    _format_messages(prompt),
+                    format_messages(prompt),
                     title="[dim]example 0 — prompt[/dim]",
                     border_style="dim",
                 )
             )
 
             # Completion panel (with error if any)
-            completion_text = _format_messages(completion)
+            completion_text = format_messages(completion)
             if error_0 is not None:
                 completion_text.append("\n\nerror: ", style="bold red")
                 completion_text.append(error_0, style="bold red")

--- a/verifiers/utils/eval_display.py
+++ b/verifiers/utils/eval_display.py
@@ -71,6 +71,11 @@ def _format_messages(messages: Any) -> Text:
         return default
 
     def _normalize_tool_call(tc: Any) -> dict[str, str]:
+        if isinstance(tc, str):
+            try:
+                tc = json.loads(tc)
+            except Exception:
+                return {"name": "", "args": tc}
         src = _attr_or_key(tc, "function") or tc
         name = _attr_or_key(src, "name", "") or ""
         args = _attr_or_key(src, "arguments", {}) or {}

--- a/verifiers/utils/logging_utils.py
+++ b/verifiers/utils/logging_utils.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import sys
 from contextlib import contextmanager
@@ -11,7 +10,7 @@ from rich.text import Text
 from verifiers.errors import Error
 from verifiers.types import Messages
 from verifiers.utils.error_utils import ErrorChain
-from verifiers.utils.message_utils import normalize_tool_call
+from verifiers.utils.message_utils import format_messages
 
 LOGGER_NAME = "verifiers"
 
@@ -81,33 +80,6 @@ def print_prompt_completions_sample(
     step: int,
     num_samples: int = 1,
 ) -> None:
-    def _format_messages(messages) -> Text:
-        if isinstance(messages, str):
-            return Text(messages)
-
-        out = Text()
-        for idx, msg in enumerate(messages):
-            if idx:
-                out.append("\n\n")
-
-            assert isinstance(msg, dict)
-            role = msg.get("role", "")
-            content = msg.get("content", "")
-            style = "bright_cyan" if role == "assistant" else "bright_magenta"
-
-            out.append(f"{role}: ", style="bold")
-            out.append(content, style=style)
-
-            for tc in msg.get("tool_calls") or []:  # treat None as empty list
-                payload = normalize_tool_call(tc)
-                out.append(
-                    "\n\n[tool call]\n"
-                    + json.dumps(payload, indent=2, ensure_ascii=False),
-                    style=style,
-                )
-
-        return out
-
     def _format_error(error: str | BaseException) -> Text:
         out = Text()
         if isinstance(error, str):
@@ -134,8 +106,8 @@ def print_prompt_completions_sample(
         error = errors[i]
         reward = reward_values[i]
 
-        formatted_prompt = _format_messages(prompt)
-        formatted_completion = _format_messages(completion)
+        formatted_prompt = format_messages(prompt)
+        formatted_completion = format_messages(completion)
         if error is not None:
             formatted_completion += Text("\n\n") + _format_error(error)
 

--- a/verifiers/utils/logging_utils.py
+++ b/verifiers/utils/logging_utils.py
@@ -92,6 +92,11 @@ def print_prompt_completions_sample(
 
     def _normalize_tool_call(tc):
         """Return {"name": ..., "args": ...} from a dict or Pydantic-like object."""
+        if isinstance(tc, str):
+            try:
+                tc = json.loads(tc)
+            except Exception:
+                return {"name": "", "args": tc}
         src = (
             _attr_or_key(tc, "function") or tc
         )  # prefer nested function object if present

--- a/verifiers/utils/logging_utils.py
+++ b/verifiers/utils/logging_utils.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import sys
-from collections.abc import Mapping
 from contextlib import contextmanager
 
 from rich.console import Console
@@ -12,6 +11,7 @@ from rich.text import Text
 from verifiers.errors import Error
 from verifiers.types import Messages
 from verifiers.utils.error_utils import ErrorChain
+from verifiers.utils.message_utils import normalize_tool_call
 
 LOGGER_NAME = "verifiers"
 
@@ -81,35 +81,6 @@ def print_prompt_completions_sample(
     step: int,
     num_samples: int = 1,
 ) -> None:
-    def _attr_or_key(obj, key: str, default=None):
-        """Return obj.key if present, else obj[key] if Mapping, else default."""
-        val = getattr(obj, key, None)
-        if val is not None:
-            return val
-        if isinstance(obj, Mapping):
-            return obj.get(key, default)
-        return default
-
-    def _normalize_tool_call(tc):
-        """Return {"name": ..., "args": ...} from a dict or Pydantic-like object."""
-        if isinstance(tc, str):
-            try:
-                tc = json.loads(tc)
-            except Exception:
-                return {"name": "", "args": tc}
-        src = (
-            _attr_or_key(tc, "function") or tc
-        )  # prefer nested function object if present
-        name = _attr_or_key(src, "name", "") or ""
-        args = _attr_or_key(src, "arguments", {}) or {}
-
-        if not isinstance(args, str):
-            try:
-                args = json.dumps(args)
-            except Exception:
-                args = str(args)
-        return {"name": name, "args": args}
-
     def _format_messages(messages) -> Text:
         if isinstance(messages, str):
             return Text(messages)
@@ -128,7 +99,7 @@ def print_prompt_completions_sample(
             out.append(content, style=style)
 
             for tc in msg.get("tool_calls") or []:  # treat None as empty list
-                payload = _normalize_tool_call(tc)
+                payload = normalize_tool_call(tc)
                 out.append(
                     "\n\n[tool call]\n"
                     + json.dumps(payload, indent=2, ensure_ascii=False),

--- a/verifiers/utils/message_utils.py
+++ b/verifiers/utils/message_utils.py
@@ -86,7 +86,7 @@ def messages_to_printable(messages: Messages) -> Messages:
     return [message_to_printable(m) for m in messages or []]
 
 
-def attr_or_key(obj: Any, key: str, default: Any = None) -> Any:
+def _attr_or_key(obj: Any, key: str, default: Any = None) -> Any:
     val = getattr(obj, key, None)
     if val is not None:
         return val
@@ -98,9 +98,9 @@ def attr_or_key(obj: Any, key: str, default: Any = None) -> Any:
 def normalize_tool_call(tc: Any) -> dict[str, str]:
     if isinstance(tc, str):
         tc = json.loads(tc)
-    src = attr_or_key(tc, "function") or tc
-    name = attr_or_key(src, "name", "") or ""
-    args = attr_or_key(src, "arguments", {}) or {}
+    src = _attr_or_key(tc, "function") or tc
+    name = _attr_or_key(src, "name", "") or ""
+    args = _attr_or_key(src, "arguments", {}) or {}
     if not isinstance(args, str):
         try:
             args = json.dumps(args)

--- a/verifiers/utils/message_utils.py
+++ b/verifiers/utils/message_utils.py
@@ -5,6 +5,7 @@ from typing import Any, cast
 from openai.types.chat import (
     ChatCompletionAssistantMessageParam,
 )
+from rich.text import Text
 
 from verifiers.types import ChatMessage, Messages
 
@@ -86,27 +87,53 @@ def messages_to_printable(messages: Messages) -> Messages:
     return [message_to_printable(m) for m in messages or []]
 
 
-def _attr_or_key(obj: Any, key: str, default: Any = None) -> Any:
-    val = getattr(obj, key, None)
-    if val is not None:
-        return val
-    if isinstance(obj, Mapping):
-        return obj.get(key, default)
-    return default
+def format_messages(messages: Any) -> Text:
+    def _attr_or_key(obj: Any, key: str, default: Any = None) -> Any:
+        val = getattr(obj, key, None)
+        if val is not None:
+            return val
+        if isinstance(obj, Mapping):
+            return obj.get(key, default)
+        return default
 
 
-def normalize_tool_call(tc: Any) -> dict[str, str]:
-    if isinstance(tc, str):
-        tc = json.loads(tc)
-    src = _attr_or_key(tc, "function") or tc
-    name = _attr_or_key(src, "name", "") or ""
-    args = _attr_or_key(src, "arguments", {}) or {}
-    if not isinstance(args, str):
-        try:
-            args = json.dumps(args)
-        except Exception:
-            args = str(args)
-    return {"name": name, "args": args}
+    def _normalize_tool_call(tc: Any) -> dict[str, str]:
+        if isinstance(tc, str):
+            tc = json.loads(tc)
+        src = _attr_or_key(tc, "function") or tc
+        name = _attr_or_key(src, "name", "") or ""
+        args = _attr_or_key(src, "arguments", {}) or {}
+        if not isinstance(args, str):
+            try:
+                args = json.dumps(args)
+            except Exception:
+                args = str(args)
+        return {"name": name, "args": args}
+
+    if isinstance(messages, str):
+        return Text(messages)
+
+    out = Text()
+    for idx, msg in enumerate(messages):
+        if idx:
+            out.append("\n\n")
+
+        assert isinstance(msg, dict)
+        role = msg.get("role", "")
+        content = msg.get("content", "")
+        style = "bright_cyan" if role == "assistant" else "bright_magenta"
+
+        out.append(f"{role}: ", style="bold")
+        out.append(str(content) if content else "", style=style)
+
+        for tc in msg.get("tool_calls") or []:
+            payload = _normalize_tool_call(tc)
+            out.append(
+                "\n\n[tool call]\n" + json.dumps(payload, indent=2, ensure_ascii=False),
+                style=style,
+            )
+
+    return out
 
 
 def sanitize_tool_calls(messages: Messages):


### PR DESCRIPTION
## Description

Since tools are json-serialized, they are no longer correctly displayed in the tui:

<img width="854" height="483" alt="image" src="https://github.com/user-attachments/assets/648d3c88-84dd-4cf4-8cbc-4ab104337ea7" />

This PR fixes that problem:

<img width="867" height="483" alt="image" src="https://github.com/user-attachments/assets/ec8923f7-22e8-452b-8acd-64a960570e6b" />

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor/bugfix limited to Rich formatting utilities and call sites; main risk is minor display regressions or unexpected tool-call string shapes causing JSON decode errors.
> 
> **Overview**
> Fixes Rich/TUI rendering of prompts/completions when `tool_calls` are stored as JSON strings by introducing a shared `format_messages()` helper that deserializes and pretty-prints tool calls.
> 
> Removes duplicated message-formatting code in `eval_display.py` and `logging_utils.py` and switches both to the new shared formatter to keep prompt/completion display consistent.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c684082427d5bb1c4e9767447d244672e1da33b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->