### PR TITLE
always cast tool call output to str

### DIFF
--- a/verifiers/envs/tool_env.py
+++ b/verifiers/envs/tool_env.py
@@ -133,10 +133,9 @@ class ToolEnv(vf.MultiTurnEnv):
         """Call a tool based on JSON command."""
         tool_func = self.tool_map[tool_name]
         result = await maybe_await(tool_func, **tool_args)
-        content = result if isinstance(result, list) else str(result)
         return cast(
             vf.Message,
-            {"role": "tool", "content": content, "tool_call_id": tool_call_id},
+            {"role": "tool", "content": str(result), "tool_call_id": tool_call_id},
         )
 
     async def env_response(


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

fixes a regression from #732. casts tool call output to `str` as this is the expected type for tool messages in oai spec. this is the reason `wiki-search` is currently failing in ci.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to tool message serialization; low risk aside from minor behavior changes for tools that previously relied on list-valued `content`.
> 
> **Overview**
> Fixes `ToolEnv.call_tool` to **always stringify tool outputs** when constructing `{"role": "tool"}` messages, removing the previous special-casing that forwarded `list` results as-is. This aligns tool message `content` with the OpenAI spec and prevents failures when tools return non-string types.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 101eaa7441e4dd16f18bfa1864499d8070f07fd9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->