### PR TITLE
Tool content validation

### DIFF
--- a/tests/test_tool_env.py
+++ b/tests/test_tool_env.py
@@ -10,21 +10,21 @@ from openai.types.chat.chat_completion_user_message_param import (
 
 import verifiers as vf
 from tests.conftest import faulty_tool, offset_tool, square_tool
-from verifiers.envs.tool_env import _is_valid_tool_content_parts
+from verifiers.utils.tool_utils import is_valid_tool_content_parts
 
 
 class TestIsValidToolContentParts:
     def test_valid_text_content_part(self):
         """Valid list with text content parts."""
         content = [{"type": "text", "text": "Hello world"}]
-        assert _is_valid_tool_content_parts(content) is True
+        assert is_valid_tool_content_parts(content) is True
 
     def test_valid_image_url_content_part(self):
         """Valid list with image_url content parts."""
         content = [
             {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc123"}}
         ]
-        assert _is_valid_tool_content_parts(content) is True
+        assert is_valid_tool_content_parts(content) is True
 
     def test_valid_mixed_content_parts(self):
         """Valid list with mixed text and image_url content parts."""
@@ -32,38 +32,38 @@ class TestIsValidToolContentParts:
             {"type": "text", "text": "Here's the screenshot"},
             {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc123"}},
         ]
-        assert _is_valid_tool_content_parts(content) is True
+        assert is_valid_tool_content_parts(content) is True
 
     def test_empty_list_is_valid(self):
         """Empty list is valid (no invalid parts)."""
-        assert _is_valid_tool_content_parts([]) is True
+        assert is_valid_tool_content_parts([]) is True
 
     def test_invalid_type_value(self):
         """Content part with invalid type value should fail."""
         content = [{"type": "invalid_type", "data": "some data"}]
-        assert _is_valid_tool_content_parts(content) is False
+        assert is_valid_tool_content_parts(content) is False
 
     def test_missing_type_key(self):
         """Content part without type key should fail."""
         content = [{"text": "Hello world"}]
-        assert _is_valid_tool_content_parts(content) is False
+        assert is_valid_tool_content_parts(content) is False
 
     def test_non_dict_item_in_list(self):
         """Non-dict item in list should fail."""
         content = ["just a string", {"type": "text", "text": "hello"}]
-        assert _is_valid_tool_content_parts(content) is False
+        assert is_valid_tool_content_parts(content) is False
 
     def test_non_list_input(self):
         """Non-list input should fail."""
-        assert _is_valid_tool_content_parts("just a string") is False
-        assert _is_valid_tool_content_parts({"type": "text", "text": "hi"}) is False
-        assert _is_valid_tool_content_parts(42) is False
-        assert _is_valid_tool_content_parts(None) is False
+        assert is_valid_tool_content_parts("just a string") is False
+        assert is_valid_tool_content_parts({"type": "text", "text": "hi"}) is False
+        assert is_valid_tool_content_parts(42) is False
+        assert is_valid_tool_content_parts(None) is False
 
     def test_list_of_primitives(self):
         """List of primitives should fail (not valid content parts)."""
-        assert _is_valid_tool_content_parts([1, 2, 3]) is False
-        assert _is_valid_tool_content_parts(["a", "b", "c"]) is False
+        assert is_valid_tool_content_parts([1, 2, 3]) is False
+        assert is_valid_tool_content_parts(["a", "b", "c"]) is False
 
 
 def _build_tool_call(name: str, arguments: dict, tool_call_id: str = "call_0"):

--- a/verifiers/envs/tool_env.py
+++ b/verifiers/envs/tool_env.py
@@ -1,29 +1,12 @@
 import json
-from typing import Any, Callable, cast
+from typing import Callable, cast
 
 from openai.types.chat import ChatCompletionAssistantMessageParam
 
 import verifiers as vf
 from verifiers.types import Messages
 from verifiers.utils.async_utils import maybe_await
-from verifiers.utils.tool_utils import convert_func_to_oai_tool
-
-VALID_TOOL_CONTENT_PART_TYPES = frozenset({"text", "image_url"})
-
-
-def _is_valid_tool_content_parts(value: Any) -> bool:
-    """Check if value is a valid list of tool content parts.
-
-    Valid content parts have a "type" field with value "text" or "image_url".
-    """
-    if not isinstance(value, list):
-        return False
-    for item in value:
-        if not isinstance(item, dict):
-            return False
-        if item.get("type") not in VALID_TOOL_CONTENT_PART_TYPES:
-            return False
-    return True
+from verifiers.utils.tool_utils import convert_func_to_oai_tool, is_valid_tool_content_parts
 
 
 class ToolMonitorRubric(vf.Rubric):
@@ -150,7 +133,7 @@ class ToolEnv(vf.MultiTurnEnv):
         """Call a tool based on JSON command."""
         tool_func = self.tool_map[tool_name]
         result = await maybe_await(tool_func, **tool_args)
-        content = result if _is_valid_tool_content_parts(result) else str(result)
+        content = result if is_valid_tool_content_parts(result) else str(result)
         return cast(
             vf.Message,
             {"role": "tool", "content": content, "tool_call_id": tool_call_id},

--- a/verifiers/utils/tool_utils.py
+++ b/verifiers/utils/tool_utils.py
@@ -3,6 +3,23 @@ from typing import Any
 from agents.function_schema import function_schema
 from openai.types.chat import ChatCompletionFunctionToolParam
 
+VALID_TOOL_CONTENT_PART_TYPES = frozenset({"text", "image_url"})
+
+
+def is_valid_tool_content_parts(value: Any) -> bool:
+    """Check if value is a valid list of tool content parts.
+
+    Valid content parts have a "type" field with value "text" or "image_url".
+    """
+    if not isinstance(value, list):
+        return False
+    for item in value:
+        if not isinstance(item, dict):
+            return False
+        if item.get("type") not in VALID_TOOL_CONTENT_PART_TYPES:
+            return False
+    return True
+
 
 def convert_func_to_oai_tool(func: Any) -> ChatCompletionFunctionToolParam:
     """Convert *func* to an OpenAI function-calling tool schema.


### PR DESCRIPTION
## Description
Tightens the content validation in `ToolEnv.call_tool` to ensure that tool return values are only preserved as lists if they conform to the `text` or `image_url` content part format. Any other list types or invalid content part structures are now cast to a string.

This change aligns tool output handling with expected message formats, allowing for structured `text` and `image_url` content while ensuring other unexpected list formats are serialized.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
- [x] All existing tests pass when running `uv run pytest` locally.
- [x] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes
While the OpenAI SDK (v2.16.0) officially supports only `str | Iterable[ChatCompletionContentPartTextParam]` for `ChatCompletionToolMessageParam` content, this implementation includes `image_url` support for tool returns to be forward-compatible with providers that may accept this format, and to align with potential practical use cases as suggested by the task.

---
<a href="https://cursor.com/background-agent?bcId=bc-853b91e0-a26b-44b1-a9ae-03efcbf54a1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-853b91e0-a26b-44b1-a9ae-03efcbf54a1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, well-tested validation change limited to how tool return values are serialized into tool messages; main risk is behavior change for tools that previously returned arbitrary lists.
> 
> **Overview**
> **Tightens tool output handling in `ToolEnv.call_tool`.** Tool return values are now preserved as a list only when they validate as structured content parts with `type: "text"` or `type: "image_url"`; all other list-shaped returns are coerced to `str`.
> 
> Adds `is_valid_tool_content_parts` (with a shared `VALID_TOOL_CONTENT_PART_TYPES`) and expands tests to cover valid/mixed content parts as well as invalid list shapes that should be stringified.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 54e997f96cb8329c91251cbe55618fae5ebd3f54. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->