### PR TITLE
Increase Sandbox Default Thread Worker Count

### DIFF
--- a/environments/math_python/math_python.py
+++ b/environments/math_python/math_python.py
@@ -15,7 +15,7 @@ def load_environment(
     sandbox_gpu_count: int = 0,
     sandbox_timeout_minutes: int = 60,
     sandbox_timeout_per_command_seconds: int = 60,
-    sandbox_client_max_workers: int = 10,
+    sandbox_client_max_workers: int = 50,
     **kwargs,
 ):
     dataset = load_example_dataset(dataset_name, dataset_split, n=num_train_examples)

--- a/verifiers/envs/experimental/cli_agent_env.py
+++ b/verifiers/envs/experimental/cli_agent_env.py
@@ -133,7 +133,10 @@ class CliAgentEnv(vf.MultiTurnEnv):
         env_vars = await self.build_env_vars(state)
         docker_image = await self.get_docker_image(state)
 
-        sandbox_client = AsyncSandboxClient()
+        sandbox_client = AsyncSandboxClient(
+            max_connections=100,
+            max_keepalive_connections=50,
+        )
         sandbox_request = CreateSandboxRequest(
             name=rollout_id,
             docker_image=docker_image,
@@ -243,7 +246,10 @@ class CliAgentEnv(vf.MultiTurnEnv):
         self, state: State, sandbox_id: str, background_job: BackgroundJob
     ) -> None:
         """Poll until background job completes, capturing output."""
-        sandbox_client = AsyncSandboxClient()
+        sandbox_client = AsyncSandboxClient(
+            max_connections=100,
+            max_keepalive_connections=50,
+        )
         while True:
             status: BackgroundJobStatus = await sandbox_client.get_background_job(
                 sandbox_id, background_job
@@ -793,7 +799,10 @@ class CliAgentEnv(vf.MultiTurnEnv):
         sandbox_id = state.get("sandbox_id")
         if sandbox_id:
             try:
-                sandbox_client = AsyncSandboxClient()
+                sandbox_client = AsyncSandboxClient(
+                    max_connections=100,
+                    max_keepalive_connections=50,
+                )
                 await sandbox_client.delete(sandbox_id)
                 self.active_sandboxes.discard(sandbox_id)
                 logger.debug(f"Deleted sandbox {sandbox_id}")

--- a/verifiers/envs/experimental/harbor_env.py
+++ b/verifiers/envs/experimental/harbor_env.py
@@ -213,7 +213,10 @@ class HarborEnv(vf.CliAgentEnv):
             logger.error(f"Task directory not found: {task_dir}")
             return 0.0
 
-        sandbox_client = AsyncSandboxClient()
+        sandbox_client = AsyncSandboxClient(
+            max_connections=100,
+            max_keepalive_connections=50,
+        )
         try:
             # Upload test assets now that agent has completed
             await self.upload_test_assets(sandbox_client, sandbox_id, task_dir)

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -2460,7 +2460,7 @@ class RLMEnv(vf.StatefulToolEnv):
         sandbox_team_id: str | None = None,
         sandbox_advanced_configs: Any | None = None,
         sandbox_labels: list[str] | None = None,
-        sandbox_client_max_workers: int = 10,
+        sandbox_client_max_workers: int = 50,
         sandbox_client_max_connections: int = 100,
         sandbox_client_max_keepalive_connections: int = 50,
         **kwargs,

--- a/verifiers/envs/sandbox_env.py
+++ b/verifiers/envs/sandbox_env.py
@@ -139,7 +139,7 @@ class SandboxEnv(vf.StatefulToolEnv):
         max_backoff_seconds: float = 30.0,
         jitter: float = 1e-3,
         stop_errors: list[type[Exception]] | None = None,
-        sandbox_client_max_workers: int = 10,
+        sandbox_client_max_workers: int = 50,
         sandbox_client_max_connections: int = 100,
         sandbox_client_max_keepalive_connections: int = 50,
         **kwargs,

--- a/verifiers/utils/sandbox_exec_utils.py
+++ b/verifiers/utils/sandbox_exec_utils.py
@@ -19,7 +19,7 @@ class SandboxExecutorMixin:
     def _init_sandbox_executor(
         self,
         *,
-        sandbox_client_max_workers: int = 10,
+        sandbox_client_max_workers: int = 50,
         sandbox_client_max_connections: int = 100,
         sandbox_client_max_keepalive_connections: int = 50,
         max_retries: int = 5,


### PR DESCRIPTION
## Description

When running an env with very high concurrency, the sanbox_client's asyncio threadpool executor gets clogged up. The default value of 10 is quite low and hardware can comfortably support 50.

This took down the "sandbox is ready" time for a swe benchmark from 250s down to about 75s.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [X] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [I couldnt find the style guidelines] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- Message of single commit: -->

refactor: Increase max workers for sandbox client setup

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Concurrency tuning only; behavior changes are limited to resource usage (more threads/connections) and could surface rate-limit or saturation issues in constrained runtimes.
> 
> **Overview**
> Increases the default `sandbox_client_max_workers` from 10 to 50 across sandbox-backed environments (including `SandboxEnv`, `RLMEnv`, and the `math_python` environment) to prevent the sandbox client threadpool from becoming a bottleneck at high concurrency.
> 
> Also configures `AsyncSandboxClient` instances in experimental envs (`CliAgentEnv`, `HarborEnv`) with explicit higher HTTP connection/keepalive limits (`max_connections=100`, `max_keepalive_connections=50`) to better support parallel sandbox operations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e60b52f335d0993c277381c914fe9afc9951ff3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->