### PR TITLE
Improve vf-eval display

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,9 +51,6 @@ dependencies = [
     "msgpack>=1.1.2",
 ]
 
-[tool.uv.sources]
-prime-tunnel = { git = "https://github.com/PrimeIntellect-ai/prime.git", branch = "feature/tunnel", subdirectory = "packages/prime-tunnel" }
-
 [dependency-groups]
 dev = [
     "ruff",

--- a/verifiers/envs/integrations/browser_env/modes/cua_mode.py
+++ b/verifiers/envs/integrations/browser_env/modes/cua_mode.py
@@ -289,8 +289,11 @@ class CUAMode:
         if loop is not None:
             import concurrent.futures
 
+            def _run_health_check() -> None:
+                asyncio.run(self._check_server_health())
+
             with concurrent.futures.ThreadPoolExecutor() as executor:
-                future = executor.submit(asyncio.run, self._check_server_health())
+                future = executor.submit(_run_health_check)
                 future.result()
         else:
             asyncio.run(self._check_server_health())

--- a/verifiers/utils/eval_display.py
+++ b/verifiers/utils/eval_display.py
@@ -92,7 +92,7 @@ def _make_histogram(values: list[float], bins: int = 10, height: int = 8) -> Tex
     out = Text()
     # Counts (top row)
     for i, count in enumerate(counts):
-        out.append(str(count).rjust(col_width), style="dim")
+        out.append(str(count).center(col_width), style="dim")
         if i < bins - 1:
             out.append(spacer)
     out.append("\n")
@@ -115,7 +115,7 @@ def _make_histogram(values: list[float], bins: int = 10, height: int = 8) -> Tex
     # Bin labels (start values)
     for i in range(bins):
         bin_start = min_val + i * bin_width
-        label = f"{bin_start:.2f}".rjust(label_width)
+        label = f"{bin_start:.2f}".center(col_width)
         out.append(label, style="dim")
         if i < bins - 1:
             out.append(spacer)

--- a/verifiers/utils/eval_display.py
+++ b/verifiers/utils/eval_display.py
@@ -415,7 +415,44 @@ class EvalDisplay(BaseDisplay):
         """Print a comprehensive summary after the display closes."""
         self.console.print()
 
-        # Summary table with main metrics
+        # Per-environment detailed sections
+        for idx, config in enumerate(self.configs):
+            env_state = self.state.envs[idx]
+            results = env_state.results
+
+            if results is None:
+                continue
+
+            self.console.print()
+            self.console.print(
+                Panel(
+                    self._make_env_detail(config, env_state, results),
+                    title=f"[bold blue]{config.env_id}[/bold blue]",
+                    border_style="dim",
+                )
+            )
+
+        # Print save paths if any
+        saved_envs = [
+            (idx, env_state)
+            for idx, env_state in self.state.envs.items()
+            if env_state.save_path is not None
+        ]
+        if saved_envs:
+            self.console.print()
+            self.console.print("[bold]Results saved to:[/bold]")
+            for idx, env_state in saved_envs:
+                self.console.print(f"  [cyan]•[/cyan] {env_state.save_path}")
+
+        # Print errors if any
+        for idx, config in enumerate(self.configs):
+            env_state = self.state.envs[idx]
+            if env_state.error:
+                self.console.print()
+                self.console.print(f"[red]error in {config.env_id}:[/red]")
+                self.console.print(f"  {env_state.error}")
+
+        # Summary table with main metrics (printed last)
         table = Table(title="Evaluation Summary")
         table.add_column("env_id", style="cyan")
         table.add_column("status", justify="center")
@@ -466,45 +503,8 @@ class EvalDisplay(BaseDisplay):
                 time_str,
             )
 
+        self.console.print()
         self.console.print(table)
-
-        # Per-environment detailed sections
-        for idx, config in enumerate(self.configs):
-            env_state = self.state.envs[idx]
-            results = env_state.results
-
-            if results is None:
-                continue
-
-            self.console.print()
-            self.console.print(
-                Panel(
-                    self._make_env_detail(config, env_state, results),
-                    title=f"[bold blue]{config.env_id}[/bold blue]",
-                    border_style="dim",
-                )
-            )
-
-        # Print save paths if any
-        saved_envs = [
-            (idx, env_state)
-            for idx, env_state in self.state.envs.items()
-            if env_state.save_path is not None
-        ]
-        if saved_envs:
-            self.console.print()
-            self.console.print("[bold]Results saved to:[/bold]")
-            for idx, env_state in saved_envs:
-                self.console.print(f"  [cyan]•[/cyan] {env_state.save_path}")
-
-        # Print errors if any
-        for idx, config in enumerate(self.configs):
-            env_state = self.state.envs[idx]
-            if env_state.error:
-                self.console.print()
-                self.console.print(f"[red]error in {config.env_id}:[/red]")
-                self.console.print(f"  {env_state.error}")
-
         self.console.print()
 
     def _make_env_detail(

--- a/verifiers/utils/eval_display.py
+++ b/verifiers/utils/eval_display.py
@@ -58,8 +58,8 @@ class EnvEvalState:
         return end - self.start_time
 
 
-def _make_histogram(values: list[float], bins: int = 10, width: int = 20) -> Text:
-    """Create a simple text histogram of values."""
+def _make_histogram(values: list[float], bins: int = 10, height: int = 8) -> Text:
+    """Create a simple vertical text histogram of values."""
     if not values:
         return Text("no data", style="dim")
 
@@ -74,16 +74,51 @@ def _make_histogram(values: list[float], bins: int = 10, width: int = 20) -> Tex
         counts[bin_idx] += 1
 
     max_count = max(counts)
+    scaled = [
+        int(round((c / max_count) * height)) if max_count > 0 else 0 for c in counts
+    ]
+
+    label_width = max(
+        4,
+        len(f"{min_val:.2f}"),
+        len(f"{max_val:.2f}"),  # keep labels aligned
+    )
+    count_width = max(len(str(c)) for c in counts)
+    col_width = max(label_width, count_width)
+    spacer = " "
+    bar_on = "█" * col_width
+    bar_off = "░" * col_width
+
     out = Text()
-
+    # Counts (top row)
     for i, count in enumerate(counts):
-        bin_start = min_val + i * bin_width
-        bar_len = int((count / max_count) * width) if max_count > 0 else 0
-        bar = "█" * bar_len + "░" * (width - bar_len)
+        out.append(str(count).rjust(col_width), style="dim")
+        if i < bins - 1:
+            out.append(spacer)
+    out.append("\n")
 
-        out.append(f"{bin_start:5.2f} ", style="dim")
-        out.append(bar, style="cyan")
-        out.append(f" {count}\n", style="dim")
+    # Bars (top to bottom)
+    for row in range(height, 0, -1):
+        for i, h in enumerate(scaled):
+            if h >= row:
+                out.append(bar_on, style="cyan")
+            else:
+                out.append(bar_off, style="dim")
+            if i < bins - 1:
+                out.append(spacer)
+        out.append("\n")
+
+    # Baseline
+    out.append("─" * (bins * col_width + (bins - 1)), style="dim")
+    out.append("\n")
+
+    # Bin labels (start values)
+    for i in range(bins):
+        bin_start = min_val + i * bin_width
+        label = f"{bin_start:.2f}".rjust(label_width)
+        out.append(label, style="dim")
+        if i < bins - 1:
+            out.append(spacer)
 
     return out
 
@@ -552,7 +587,7 @@ class EvalDisplay(BaseDisplay):
             # All rollouts histogram
             all_rollouts_content = Group(
                 Text("all rollouts:", style="bold"),
-                _make_histogram(rewards, bins=8, width=25),
+                _make_histogram(rewards, bins=8, height=8),
             )
 
             # Per-example averages if multiple rollouts
@@ -566,7 +601,7 @@ class EvalDisplay(BaseDisplay):
 
                 per_example_content = Group(
                     Text("per-example avg:", style="bold"),
-                    _make_histogram(example_avgs, bins=8, width=25),
+                    _make_histogram(example_avgs, bins=8, height=8),
                 )
 
                 # Side by side


### PR DESCRIPTION
## Description

Three updates to the way `vf-eval` displays progress and results:

- The time on the progress bar updates live every second
- The *Evaluation Summary* is moved to the very end of the results section
- The *reward distribution* histogram now uses vertical instead of horizontal bars
- Two small other changes

### Progress timer

The time shown on the very right of the progress bar now updates every second. The time taken for a rollout is an important metric, and we aim to update metrics as soon as they come in. For long-running rollouts, an increasing timer is very useful.

There is a remaining issue where the time-difference between the timer updates isn't always exactly 1 second apart, but it's pretty good and a big improvement over no timer updates.

Below is an example. Note that the progress bar shows "3s" despite no rollout having finished yet:

<img width="921" height="231" alt="image" src="https://github.com/user-attachments/assets/8cdf2de0-2d3c-46f1-ac21-4084e885cbd7" />

### Move Evaluation Summary to the end

The *Evaluation Summary* contains important high-level statistics like `examples`, `rollouts`, `errors`, `reward`, and `time`, but it was previously displayed before the example prompt and completion. for long rollouts, this meant that users had to scroll up very far to see the *Evaluation Summary*, and might miss it entirely.

Moving it to the bottom of the results section doesn't take much space, but makes this important information immediately visible. This is what it looks like now:

<img width="921" height="511" alt="image" src="https://github.com/user-attachments/assets/d8bcffea-1afa-49ca-9812-e0a4d894c5ed" />

### Vertical-bar histogram

This is what the histogram in *reward distribution* looked like before:

<img width="896" height="179" alt="image" src="https://github.com/user-attachments/assets/b56a334c-6fa6-429b-a609-7da83961b748" />

And this is what it looks like after this PR:

<img width="895" height="212" alt="image" src="https://github.com/user-attachments/assets/5cad226c-e4ba-4a0a-ae51-25eec8379c6a" />


While it takes up a bit more space now, it's also more immediately recognizable as a histogram.

### Other changes

- Remove the uv.sources for the `prime-tunnel` package. The branch of prime that was fixed doesn't exist anymore, causing the build to break, but the `prime-tunnel` package is now released so we simply don't need a pinned source anymore
- Fixed a ty error in browser_env to make the checks pass

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily display/UX changes plus a small async/thread invocation fix; minimal impact on core evaluation logic, but could affect TUI refresh behavior and shutdown if cancellation handling is wrong.
> 
> **Overview**
> Improves `vf-eval` UX by adding a periodic (1s) refresh loop so progress-bar timers update live during long-running rollouts, and by reordering the final output to show per-environment details/errors/save paths first and the **Evaluation Summary** table last.
> 
> Updates the reward distribution display to a vertical-bar histogram, fixes an asyncio/thread interaction in `CUAMode.verify_server_connection`, and removes the pinned `prime-tunnel` git source from `pyproject.toml` now that the package is released.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0604b2e40857118b3b35c41502b5c2bbc81be823. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->