### PR TITLE
add default sandbox_labels to rlm-secrets

### DIFF
--- a/environments/rlm_secrets/README.md
+++ b/environments/rlm_secrets/README.md
@@ -93,3 +93,9 @@ This environment is specifically designed to test RLM capabilities:
 5. **Tests information flow**: Data must flow: file → sub-LLM → root-LLM → tool → answer
 
 The puzzle is simple enough that models should be able to solve it, while being complex enough to exercise all RLM components.
+
+## Changelog
+
+- v0.1.1 (01 Feb 2026):
+  - add default "rlm-secrets" label to the `sandbox_labels` no matter what the user passes ther in the kwargs
+  - dedupe `sandbox_labels` if passed via the kwargs

--- a/environments/rlm_secrets/pyproject.toml
+++ b/environments/rlm_secrets/pyproject.toml
@@ -2,7 +2,7 @@
 name = "rlm-secrets"
 description = "File puzzle environment for testing RLM capabilities: root tools, sub-LLM tools, file operations"
 tags = ["multi-turn", "rlm", "tools", "eval"]
-version = "0.1.0"
+version = "0.1.1"
 requires-python = ">=3.10"
 dependencies = [
     "verifiers>=0.1.8",

--- a/environments/rlm_secrets/rlm_secrets.py
+++ b/environments/rlm_secrets/rlm_secrets.py
@@ -486,7 +486,7 @@ def load_environment(
     sandbox_labels = kwargs.pop("sandbox_labels", [])
     if not (
         isinstance(sandbox_labels, list)
-        and all(isinstance(l, str) for l in sandbox_labels)
+        and all(isinstance(label, str) for label in sandbox_labels)
     ):
         raise ValueError(
             f"sandbox_labels must be of type list[str]; you provided {sandbox_labels}"

--- a/environments/rlm_secrets/rlm_secrets.py
+++ b/environments/rlm_secrets/rlm_secrets.py
@@ -483,6 +483,16 @@ def load_environment(
         weights=[0.5, 0.5],
     )
 
+    sandbox_labels = kwargs.pop("sandbox_labels", [])
+    if not (
+        isinstance(sandbox_labels, list)
+        and all(isinstance(l, str) for l in sandbox_labels)
+    ):
+        raise ValueError(
+            f"sandbox_labels must be of type list[str]; you provided {sandbox_labels}"
+        )
+    sandbox_labels = list(set(["rlm-secrets"] + sandbox_labels))
+
     return RLMSecretsEnv(
         dataset=train_dataset,
         num_files=num_files,
@@ -492,5 +502,6 @@ def load_environment(
         sub_tool_max_turns=sub_tool_max_turns,
         max_sub_llm_parallelism=max_sub_llm_parallelism,
         code_execution_timeout=code_execution_timeout,
+        sandbox_labels=sandbox_labels,
         **kwargs,
     )


### PR DESCRIPTION
## Description

Add default `sandbox_labels` to the *rlm-secrets* environment.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to environment construction that only affects sandbox labeling and adds input validation; main behavior is unchanged unless callers passed invalid `sandbox_labels`.
> 
> **Overview**
> The `rlm-secrets` environment now always adds a default `"rlm-secrets"` entry to `sandbox_labels`, validates that any provided `sandbox_labels` is `list[str]`, and deduplicates labels before passing them into `RLMSecretsEnv`.
> 
> Bumps the package version to `0.1.1` and documents the change in the README changelog.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9dcf7c3ab30d484a8ac6398c67840f9d60e1e906. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->