### PR TITLE
Fix broken documentation links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,17 +147,17 @@ prime eval run primeintellect/math-python
 
 ## Documentation
 
-**[Environments](environments.md)** — Create datasets, rubrics, and custom multi-turn interaction protocols.
+**[Environments](docs/environments.md)** — Create datasets, rubrics, and custom multi-turn interaction protocols.
 
-**[Evaluation](evaluation.md)** - Evaluate models using your environments.
+**[Evaluation](docs/evaluation.md)** - Evaluate models using your environments.
 
-**[Training](training.md)** — Train models in your environments with reinforcement learning.
+**[Training](docs/training.md)** — Train models in your environments with reinforcement learning.
 
-**[Development](development.md)** — Contributing to verifiers
+**[Development](docs/development.md)** — Contributing to verifiers
 
-**[API Reference](reference.md)** — Understanding the API and data structures
+**[API Reference](docs/reference.md)** — Understanding the API and data structures
 
-**[FAQs](faqs.md)** - Other frequently asked questions.
+**[FAQs](docs/faqs.md)** - Other frequently asked questions.
 
 
 ## Citation


### PR DESCRIPTION
This PR fixes broken documentation links in the README file. The links were pointing to files in the root directory (e.g., `environments.md`) but the actual documentation files are located in the `docs/` directory.

**Changes:**
- Updated all documentation links to point to `docs/` directory
- Fixed links for: Environments, Evaluation, Training, Development, API Reference, and FAQs

All documentation files exist in the `docs/` directory, so these links should now work correctly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adjusts README markdown links; no runtime or behavioral code changes.
> 
> **Overview**
> Fixes broken README documentation links by updating them to point to the `docs/` directory (Environments, Evaluation, Training, Development, API Reference, FAQs) instead of root-level `*.md` paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41cd9c8a6b5fda556706381f6deb19d976ccc4d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->