### PR TITLE
re-raise auth errs + fix overlong prompt err for openrouter

### DIFF
--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -502,6 +502,7 @@ class Environment(ABC):
                     if any(phrase in error_text for phrase in context_length_phrases):
                         self.logger.debug("Caught overlong prompt.")
                         raise vf.OverlongPromptError from e
+                except Exception as e:
                     # in all other case we raise a generic model error
                     raise vf.ModelError from e
 

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -502,6 +502,7 @@ class Environment(ABC):
                     if any(phrase in error_text for phrase in context_length_phrases):
                         self.logger.debug("Caught overlong prompt.")
                         raise vf.OverlongPromptError from e
+                    raise vf.ModelError from e
                 except Exception as e:
                     # in all other case we raise a generic model error
                     raise vf.ModelError from e

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -492,7 +492,7 @@ class Environment(ABC):
                     # we raise a special overlong prompt error
                     error_text = e.response.text.lower()
                     context_length_phrases = [
-                        "this model's maximum context length is",
+                        "maximum context length is",
                         "is longer than the model's context length",
                         "exceeds the model's context length",
                         "exceed the configured limit",

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -1177,6 +1177,12 @@ class Environment(ABC):
         log_file: str | None = None,
         startup_timeout: float = 10.0,
     ) -> None:
+        """Start a ZMQ server process for this environment.
+
+        .. warning::
+            This method is subject to change. External users should avoid
+            depending on it directly.
+        """
         address = address or f"tcp://127.0.0.1:{get_free_port()}"
         self.env_server_process = Process(
             target=ZMQEnvServer.run_server,
@@ -1195,6 +1201,12 @@ class Environment(ABC):
         await self.env_client.health(timeout=startup_timeout)
 
     async def stop_server(self) -> None:
+        """Stop the ZMQ server process for this environment.
+
+        .. warning::
+            This method is subject to change. External users should avoid
+            depending on it directly.
+        """
         if self.env_client is not None:
             await self.env_client.close()
             self.env_client = None


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

one small convenience feature + buf fix:
1. we now reraise OAI's `AuthenticationError` which will immediately kill the environment process (e.g. in vf-eval the server exits) which is the more desirable "fail" loudly behavior as its completely unrecoverable. currently, we run through all rollouts requests and mark an authentication in each
2. fix the string matching of `vf.OverlongPromptError` to also work for OpenRouter which had `this endpoint's context [...]` instead of `this model's context [...]` which we were matching before

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: localized error-handling changes around model API calls; primary impact is different exception propagation/typing on auth and bad-request failures.
> 
> **Overview**
> Model-call error handling in `Environment.get_model_response` is adjusted to **fail fast** on `openai.AuthenticationError` by re-raising it instead of wrapping it, so unrecoverable auth failures terminate immediately.
> 
> Overlong-prompt detection is broadened by matching more generic context-length phrases (not tied to "this model's" wording), and `BadRequestError`s that aren’t context-length related are now consistently wrapped as `vf.ModelError`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d4b766080d89862624d61223a497dad3d0afbb1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->