### PR TITLE
Capture stdout/stderr for live display

### DIFF
--- a/verifiers/utils/display_utils.py
+++ b/verifiers/utils/display_utils.py
@@ -63,7 +63,10 @@ class DisplayLogHandler(logging.Handler):
 
     def emit(self, record: logging.LogRecord) -> None:
         try:
-            msg = self.format(record)
+            if record.name.endswith(".stdout") or record.name.endswith(".stderr"):
+                msg = record.getMessage()
+            else:
+                msg = self.format(record)
             self.logs.append(msg)
         except Exception:
             pass

--- a/verifiers/utils/display_utils.py
+++ b/verifiers/utils/display_utils.py
@@ -10,9 +10,11 @@ Provides common infrastructure for EvalDisplay and GEPADisplay:
 """
 
 import asyncio
+import io
 import logging
 import os
 import sys
+import threading
 from collections import deque
 from typing import Any
 
@@ -67,6 +69,45 @@ class DisplayLogHandler(logging.Handler):
             pass
 
 
+class _FDToLogger(threading.Thread):
+    """Background reader that forwards a file descriptor's output to a logger."""
+
+    def __init__(
+        self, fd: int, logger: logging.Logger, level: int, encoding: str | None
+    ) -> None:
+        super().__init__(daemon=True)
+        self._fd = fd
+        self._logger = logger
+        self._level = level
+        self._encoding = encoding or "utf-8"
+        self._buffer = ""
+
+    def run(self) -> None:
+        try:
+            while True:
+                try:
+                    data = os.read(self._fd, 1024)
+                except OSError:
+                    break
+                if not data:
+                    break
+                text = data.decode(self._encoding, errors="replace").replace("\r", "\n")
+                combined = f"{self._buffer}{text}"
+                lines = combined.split("\n")
+                self._buffer = lines.pop() if lines else ""
+                for line in lines:
+                    if line:
+                        self._logger.log(self._level, line)
+        finally:
+            if self._buffer:
+                self._logger.log(self._level, self._buffer)
+                self._buffer = ""
+            try:
+                os.close(self._fd)
+            except OSError:
+                pass
+
+
 class BaseDisplay:
     """
     Base class for Rich-based terminal displays.
@@ -90,6 +131,13 @@ class BaseDisplay:
         self._log_handler = DisplayLogHandler(max_lines=3)
         self._old_handler_levels: dict[logging.Handler, int] = {}
         self._old_datasets_level: int | None = None
+        self._old_stdout = None
+        self._old_stderr = None
+        self._old_stdout_fd: int | None = None
+        self._old_stderr_fd: int | None = None
+        self._console_file: io.TextIOWrapper | None = None
+        self._stdout_thread: _FDToLogger | None = None
+        self._stderr_thread: _FDToLogger | None = None
 
     def _render(self) -> Any:
         """
@@ -131,6 +179,18 @@ class BaseDisplay:
 
         # Suppress console output from existing handlers but capture logs for display
         logger = logging.getLogger("verifiers")
+
+        # Preserve original streams for Rich rendering before capturing stdout/stderr
+        self._old_stdout = sys.stdout
+        self._old_stderr = sys.stderr
+        self._old_stdout_fd = os.dup(1)
+        self._old_stderr_fd = os.dup(2)
+        self._console_file = io.TextIOWrapper(
+            os.fdopen(self._old_stdout_fd, "wb", closefd=False),
+            encoding=getattr(self._old_stdout, "encoding", "utf-8"),
+            write_through=True,
+        )
+        self.console = Console(file=self._console_file, force_terminal=True)
         for handler in logger.handlers:
             self._old_handler_levels[handler] = handler.level
             handler.setLevel(logging.CRITICAL)
@@ -143,6 +203,28 @@ class BaseDisplay:
         # Add our handler to capture logs for display panel
         self._log_handler.setLevel(logging.INFO)
         logger.addHandler(self._log_handler)
+
+        # Capture stdout/stderr at the FD level so stray prints don't corrupt the live display
+        stdout_r, stdout_w = os.pipe()
+        stderr_r, stderr_w = os.pipe()
+        os.dup2(stdout_w, 1)
+        os.close(stdout_w)
+        os.dup2(stderr_w, 2)
+        os.close(stderr_w)
+        self._stdout_thread = _FDToLogger(
+            stdout_r,
+            logger.getChild("stdout"),
+            logging.INFO,
+            getattr(self._old_stdout, "encoding", None),
+        )
+        self._stderr_thread = _FDToLogger(
+            stderr_r,
+            logger.getChild("stderr"),
+            logging.ERROR,
+            getattr(self._old_stderr, "encoding", None),
+        )
+        self._stdout_thread.start()
+        self._stderr_thread.start()
 
         # Disable terminal echo in screen mode to prevent scroll/arrow keys from displaying
         if self.screen and HAS_TERMINAL_CONTROL and sys.stdin.isatty():
@@ -171,6 +253,20 @@ class BaseDisplay:
             self._live.stop()
             self._live = None
 
+        # Restore stdout/stderr file descriptors (ends pipe, unblocks readers)
+        if self._old_stdout_fd is not None:
+            os.dup2(self._old_stdout_fd, 1)
+        if self._old_stderr_fd is not None:
+            os.dup2(self._old_stderr_fd, 2)
+
+        # Join reader threads
+        if self._stdout_thread is not None:
+            self._stdout_thread.join(timeout=0.5)
+            self._stdout_thread = None
+        if self._stderr_thread is not None:
+            self._stderr_thread.join(timeout=0.5)
+            self._stderr_thread = None
+
         # Restore datasets progress bar
         from datasets import enable_progress_bar
 
@@ -188,6 +284,26 @@ class BaseDisplay:
             datasets_logger = logging.getLogger("datasets")
             datasets_logger.setLevel(self._old_datasets_level)
             self._old_datasets_level = None
+
+        # Restore stdout/stderr
+        if self._old_stdout is not None:
+            sys.stdout = self._old_stdout  # type: ignore[assignment]
+            self._old_stdout = None
+        if self._old_stderr is not None:
+            sys.stderr = self._old_stderr  # type: ignore[assignment]
+            self._old_stderr = None
+        if self._console_file is not None:
+            try:
+                self._console_file.flush()
+                self._console_file.close()
+            finally:
+                self._console_file = None
+        if self._old_stdout_fd is not None:
+            os.close(self._old_stdout_fd)
+            self._old_stdout_fd = None
+        if self._old_stderr_fd is not None:
+            os.close(self._old_stderr_fd)
+            self._old_stderr_fd = None
 
         # Restore terminal settings
         if self._old_terminal_settings is not None:

--- a/verifiers/utils/display_utils.py
+++ b/verifiers/utils/display_utils.py
@@ -293,6 +293,8 @@ class BaseDisplay:
             sys.stderr = self._old_stderr  # type: ignore[assignment]
             self._old_stderr = None
         if self._console_file is not None:
+            # Redirect console back to original stdout before closing temp stream
+            self.console = Console(file=sys.stdout, force_terminal=sys.stdout.isatty())
             try:
                 self._console_file.flush()
                 self._console_file.close()


### PR DESCRIPTION
## Description

Add fd-level stdout/stderr capture during Rich live eval to prevent stray output from corrupting the TUI; route it into the existing Logs panel and restore fds/terminal state on exit.

Cause of the error: non‑verifiers output (prints, warnings, tracebacks, subprocess stderr) was writing to the terminal while Rich Live was drawing. That moves the cursor, so the next refresh paints at the wrong location and you get overlapping panels. The fix intercepts fd 1/2 during the live display, so those writes no longer hit the terminal.

Turns a hot mess like this:

<img width="911" height="894" alt="image" src="https://github.com/user-attachments/assets/46604500-d2f1-4d14-b511-5b38b667a735" />

Into something nice like this (notice that the logs actually capture the outputs that previously caused the display issues):

<img width="911" height="317" alt="2026-02-03_17-23-37" src="https://github.com/user-attachments/assets/b89ffacb-7e45-49bd-b048-4c3e08c01318" />

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches low-level process I/O redirection and thread lifecycle; mistakes could hang or lose output or fail to restore terminal state on exit.
> 
> **Overview**
> Prevents Rich `Live` TUI corruption by **capturing fd-level `stdout`/`stderr` during `BaseDisplay.start()`** and routing that output into the existing Logs panel instead of letting stray prints/warnings write to the terminal.
> 
> Adds a background `_FDToLogger` reader thread per stream, adjusts `DisplayLogHandler` formatting for these new `verifiers.*.(stdout|stderr)` loggers, and ensures `BaseDisplay.stop()` restores original fds/streams and joins threads/cleans up the temporary console file.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da3f6a4df4da5d2eb5024d7a3b6e75259596f8b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->