### PR TITLE
info oaitools fix

### DIFF
--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -682,8 +682,11 @@ class Environment(ABC):
         state["is_completed"] = False
         state["is_truncated"] = False
         state["oai_tools"] = None
-        if "info" in state and hasattr(state["info"], "oai_tools"):
-            state["oai_tools"] = state["info"]["oai_tools"]
+        info = state.get("info")
+        if isinstance(info, dict) and "oai_tools" in info:
+            state["oai_tools"] = info["oai_tools"]
+        elif info is not None and hasattr(info, "oai_tools"):
+            state["oai_tools"] = getattr(info, "oai_tools")
         elif hasattr(self, "oai_tools"):
             state["oai_tools"] = self.oai_tools
         else:


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to state initialization that only affects how `oai_tools` is sourced; low risk aside from potentially changing tool configuration precedence for some callers.
> 
> **Overview**
> Fixes `Environment.init_state` tool discovery by robustly pulling `oai_tools` from `input.info` regardless of whether `info` is a `dict` (key lookup) or an object (attribute access), instead of incorrectly mixing `hasattr` with dict indexing.
> 
> This reduces crashes/incorrect defaults when initializing rollout state with tool configuration embedded in `info`, while preserving the existing fallback to `self.oai_tools` or an empty list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ec5247eac848df2bcd13c4c00fbeaf867242bcf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->