### PR TITLE
Allow string info in RolloutInput typing

### DIFF
--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -95,7 +95,7 @@ class RolloutInput(BaseRolloutInput, total=False):
     # required: prompt, example_id, task
     # optional: answer, info
     answer: str
-    info: Info
+    info: Info | str
 
 
 class RolloutTiming(TypedDict, total=False):


### PR DESCRIPTION
### Motivation
- Pydantic emits serialization warnings when `RolloutInput.info` is a JSON string because the schema only accepted a `dict`, while `Environment.init_state` already accepts JSON-string `info`, so the input typing should accept both to avoid spurious warnings.

### Description
- Change `RolloutInput` in `verifiers/types.py` so `info` is typed as `Info | str` (previously `Info`) to allow either a dict or JSON string for rollout inputs.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983177dad848326a35411a7aa5987d0)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only change that broadens accepted input shape for `info`; low risk aside from possibly masking malformed JSON strings that will still fail when parsed later.
> 
> **Overview**
> Updates the `RolloutInput` `TypedDict` so `info` can be either an `Info` dict or a `str` (`Info | str`), aligning the input schema with existing code paths that pass JSON-serialized `info`.
> 
> This reduces Pydantic serialization warnings when rollouts provide `info` as a JSON string, without changing runtime behavior elsewhere.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec2d0429f00bf312b97eb7ec1ed0654df755649b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->