### PR TITLE
Add subtle `--debug` hint beneath Logs panel

### DIFF
--- a/verifiers/gepa/display.py
+++ b/verifiers/gepa/display.py
@@ -107,6 +107,9 @@ class GEPADisplay(BaseDisplay):
         if self.log_file:
             self.log_file.parent.mkdir(parents=True, exist_ok=True)
 
+    def get_log_hint(self) -> Text | None:
+        return None
+
     def set_valset_info(self, valset_size: int, valset_example_ids: list[int]) -> None:
         """Update valset info after environment is loaded."""
         self.valset_size = valset_size

--- a/verifiers/utils/display_utils.py
+++ b/verifiers/utils/display_utils.py
@@ -181,10 +181,14 @@ class BaseDisplay:
             else:
                 log_text.append(" ", style="dim")  # placeholder line
 
-        log_text.append("\n")
-        log_text.append("full logs: --debug", style="dim")
-
-        return Panel(log_text, title="[dim]Logs[/dim]", border_style="dim")
+        subtitle = Text("full logs: --debug", style="dim")
+        return Panel(
+            log_text,
+            title="[dim]Logs[/dim]",
+            subtitle=subtitle,
+            subtitle_align="center",
+            border_style="dim",
+        )
 
     def start(self) -> None:
         """Start the live display."""

--- a/verifiers/utils/display_utils.py
+++ b/verifiers/utils/display_utils.py
@@ -181,6 +181,9 @@ class BaseDisplay:
             else:
                 log_text.append(" ", style="dim")  # placeholder line
 
+        log_text.append("\n")
+        log_text.append("full logs: --debug", style="dim")
+
         return Panel(log_text, title="[dim]Logs[/dim]", border_style="dim")
 
     def start(self) -> None:

--- a/verifiers/utils/display_utils.py
+++ b/verifiers/utils/display_utils.py
@@ -166,6 +166,10 @@ class BaseDisplay:
         if self._live:
             self._live.update(self._render())
 
+    def get_log_hint(self) -> Text | None:
+        """Return an optional hint for viewing full logs."""
+        return Text("full logs: --debug", style="dim")
+
     def _make_log_panel(self) -> Panel:
         """Create a panel showing recent log messages with placeholder lines."""
         max_lines = self._log_handler.logs.maxlen or 3
@@ -181,7 +185,9 @@ class BaseDisplay:
             else:
                 log_text.append(" ", style="dim")  # placeholder line
 
-        subtitle = Text("full logs: --debug", style="dim")
+        subtitle = self.get_log_hint()
+        if subtitle is None:
+            return Panel(log_text, title="[dim]Logs[/dim]", border_style="dim")
         return Panel(
             log_text,
             title="[dim]Logs[/dim]",


### PR DESCRIPTION
### Motivation
- Provide a minimal, tasteful hint in the eval display UI that `--debug` can be used to view full logs so users discover the option without cluttering the interface.

### Description
- Append a dim hint line (`full logs: --debug`) to the Logs panel in `_make_log_panel()` in `verifiers/utils/display_utils.py` to show the `--debug` hint beneath the log lines.

### Testing
- No automated tests were run because this is a UI-only tweak.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69831ecfa0ac832688ac743984d2e109)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change to Rich rendering; main risk is minor formatting/layout issues in the terminal display.
> 
> **Overview**
> Adds an optional *log hint* beneath the Logs panel by introducing `BaseDisplay.get_log_hint()` (defaulting to a dim `full logs: --debug` message) and wiring it into `_make_log_panel()` as a Rich `Panel` subtitle.
> 
> Allows displays to suppress the hint by overriding `get_log_hint()`; `GEPADisplay` overrides it to return `None`, keeping its Logs panel unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8cde7a753f1e1d4a1ba7224c40a20ea31ce26cbf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->