### PR TITLE
Fix vf-tui Info rendering for JSON strings and large payloads

### DIFF
--- a/tests/test_tui_info_formatting.py
+++ b/tests/test_tui_info_formatting.py
@@ -1,0 +1,29 @@
+import json
+
+from verifiers.scripts.tui import format_info_for_details
+
+
+def test_format_info_for_details_handles_dict() -> None:
+    info = {"status": "ok", "attempt": 2}
+
+    rendered = format_info_for_details(info)
+
+    assert rendered == json.dumps(info, ensure_ascii=False, indent=2)
+
+
+def test_format_info_for_details_parses_json_string() -> None:
+    info = '{"status":"ok","nested":{"value":1}}'
+
+    rendered = format_info_for_details(info)
+
+    assert '"status": "ok"' in rendered
+    assert '"nested": {' in rendered
+
+
+def test_format_info_for_details_truncates_large_content() -> None:
+    info = {"payload": [f"line-{i}" for i in range(50)]}
+
+    rendered = format_info_for_details(info, max_chars=120, max_lines=3)
+
+    assert "(truncated;" in rendered
+    assert rendered.count("\n") <= 4


### PR DESCRIPTION
### Motivation
- The TUI details panel rendered `info` fields poorly when they were JSON-encoded strings or very large, causing broken output or the details pane to dominate the UI. 
- The goal is to reliably display `info` whether it's a dict/list or a JSON string and keep the details panel compact and readable.

### Description
- Added `_coerce_info_value` to parse JSON-encoded `info` strings into Python objects when appropriate. 
- Added `format_info_for_details(info, *, max_chars=..., max_lines=...)` which pretty-prints structured `info`, and truncates long outputs with a clear truncation summary. 
- Updated the rollout details rendering to use `format_info_for_details`, append a dim hint `(full info available in results.jsonl)`, and preserve spacing so `Task` displays cleanly after `Info`. 
- Modified `verifiers/scripts/tui.py` and added unit tests in `tests/test_tui_info_formatting.py` to cover dict rendering, JSON-string parsing, and truncation behavior.

### Testing
- Ran the focused unit tests with `uv run pytest tests/test_tui_info_formatting.py`, which passed (`3 passed`).
- Ran lint/format checks with `uv run ruff check verifiers/scripts/tui.py tests/test_tui_info_formatting.py`, which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69844f81c4a88326ba63d93d5d9a090b)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only formatting changes limited to TUI display logic with small, well-tested helpers; minimal risk beyond potential edge-case formatting differences.
> 
> **Overview**
> Improves the rollout details panel `Info` rendering by parsing JSON-encoded strings into structured objects, pretty-printing dict/list values, and truncating large outputs to keep the panel compact with a clear truncation footer.
> 
> Updates the details view to use the new formatter, adds a dim note that full `info` is in `results.jsonl`, and fixes spacing so `Task` renders cleanly after `Info`. Adds unit tests covering dict formatting, JSON-string parsing, and truncation behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 056464acac0e2ff666af6f0c46dcb4a4a63db1d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->