### PR TITLE
fix math rubric timeouts

### DIFF
--- a/tests/test_math_rubric.py
+++ b/tests/test_math_rubric.py
@@ -92,13 +92,13 @@ class TestMathRubric:
         assert state["metrics"]["correct_answer"] == 0.0
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("timeout_seconds", [0.1, 1, 10])
+    @pytest.mark.parametrize("timeout_seconds", [0.1, 10])
     async def test_timeout(self, timeout_seconds, make_input):
         """Test scoring a single rollout."""
 
         # very large input triggers timeout, takes ~2s to parse and verify
-        answer = "1" * int(1e6)
-        completion = "1" * int(1e6)
+        answer = "1" * int(1e5)
+        completion = "1" * int(1e5)
 
         rubric = vf.MathRubric(max_workers=1, timeout_seconds=timeout_seconds)
 

--- a/tests/test_math_rubric.py
+++ b/tests/test_math_rubric.py
@@ -1,7 +1,5 @@
 """Tests for the MathRubric class."""
 
-import time
-
 import pytest
 
 import verifiers as vf
@@ -98,8 +96,8 @@ class TestMathRubric:
     async def test_timeout(self, timeout_seconds, make_input):
         """Test scoring a single rollout."""
 
-        answer = "1"
         # very large input triggers timeout, takes ~2s to parse and verify
+        answer = "1" * int(1e6)
         completion = "1" * int(1e6)
 
         rubric = vf.MathRubric(max_workers=1, timeout_seconds=timeout_seconds)
@@ -120,15 +118,10 @@ class TestMathRubric:
             "start_time": 0.0,
         }
 
-        start_time = time.time()
         await rubric.score_rollout(state)
-        end_time = time.time()
-        elapsed_time = end_time - start_time
-        assert state["metrics"]["correct_answer"] == 0.0
 
-        # Entire function should timeout within timeout + small overhead
-        print(f"Time taken: {elapsed_time:.2f}s")
-        overhead_seconds = 1
-        assert elapsed_time < timeout_seconds + overhead_seconds, (
-            f"Time taken: {elapsed_time:.2f}s (expected < {timeout_seconds + overhead_seconds}s)"
-        )
+        # rollout should only pass for large timeout
+        if timeout_seconds == 10:
+            assert state["metrics"]["correct_answer"] == 1.0
+        else:
+            assert state["metrics"]["correct_answer"] == 0.0

--- a/verifiers/rubrics/math_rubric.py
+++ b/verifiers/rubrics/math_rubric.py
@@ -51,7 +51,7 @@ class MathRubric(Rubric):
         funcs: list[RewardFunc] | None = None,
         weights: list[float] | None = None,
         parser: Parser | None = None,
-        max_workers: int = 4,
+        max_workers: int = 50,
         timeout_seconds: float = 5,
     ):
         parser = parser or MaybeThinkParser(extract_fn=extract_boxed_answer)

--- a/verifiers/rubrics/math_rubric.py
+++ b/verifiers/rubrics/math_rubric.py
@@ -75,7 +75,7 @@ class MathRubric(Rubric):
 
         response = parser.parse_answer(completion) or ""
         if response == "":
-            self.logger.warning("Parsed response is empty")
+            self.logger.debug("Parsed response is empty")
             return 0.0
 
         loop = asyncio.get_running_loop()
@@ -87,11 +87,9 @@ class MathRubric(Rubric):
             )
         except asyncio.TimeoutError:
             self.logger.warning(
-                f"Math verification hard timeout after {self.HARD_TIMEOUT_SECONDS:.0f}s. Worker may be hung or main event loop experiences severe lag."
+                f"Math verification hit hard timeout after {self.HARD_TIMEOUT_SECONDS:.0f}s. Worker may be hung or main event loop experiences severe lag."
             )
             return 0.0
-        except asyncio.CancelledError:
-            raise
 
         if result.error is not None:
             self.logger.warning(f"Math verification failed: {result.error}")
@@ -99,8 +97,7 @@ class MathRubric(Rubric):
         # Enforce timeout based on actual verification wall-clock time (measured in worker)
         if result.elapsed > self.timeout:
             self.logger.debug(
-                f"Math verification exceeded time limit: "
-                f"{result.elapsed:.2f}s > {self.timeout:.1f}s"
+                f"Math verification exceeded time limit after {result.elapsed:.2f}s (>{self.timeout:.1f}s)"
             )
             return 0.0
 

--- a/verifiers/rubrics/math_rubric.py
+++ b/verifiers/rubrics/math_rubric.py
@@ -1,7 +1,9 @@
 import asyncio
 import logging
-from concurrent.futures import ThreadPoolExecutor
-from typing import Any, Callable
+import multiprocessing
+import time
+from concurrent.futures import ProcessPoolExecutor
+from dataclasses import dataclass
 
 from math_verify import parse, verify  # type: ignore[unresolved-import]
 
@@ -12,75 +14,96 @@ from verifiers.types import Messages, RewardFunc
 from verifiers.utils.data_utils import extract_boxed_answer
 
 
+@dataclass
+class MathVerifyResult:
+    """Result of math verification with timing information."""
+
+    reward: float
+    elapsed: float
+    error: str | None = None
+
+
+def verify_response(response: str, answer: str) -> MathVerifyResult:
+    """Verify a response against an answer using math_verify."""
+    start = time.perf_counter()
+    try:
+        parsed_answer = parse(f"\\boxed{{{answer}}}", parsing_timeout=None)  # type: ignore[arg-type]
+        parsed_response = parse(f"\\boxed{{{response}}}", parsing_timeout=None)  # type: ignore[arg-type]
+        is_correct = verify(parsed_answer, parsed_response, timeout_seconds=None)
+        elapsed = time.perf_counter() - start
+
+        return MathVerifyResult(reward=float(is_correct), elapsed=elapsed)
+    except BaseException as e:
+        elapsed = time.perf_counter() - start
+        return MathVerifyResult(
+            reward=0.0, elapsed=elapsed, error=f"{type(e).__name__}: {e!r}"
+        )
+
+
 class MathRubric(Rubric):
+    HARD_TIMEOUT_SECONDS: float = 120.0
+
     def __init__(
         self,
         funcs: list[RewardFunc] | None = None,
         weights: list[float] | None = None,
         parser: Parser | None = None,
-        max_workers: int = 10,
-        timeout_seconds: float = 5,
+        max_workers: int = 1,
+        timeout: float = 5,
     ):
         parser = parser or MaybeThinkParser(extract_fn=extract_boxed_answer)
         super().__init__(funcs=funcs, weights=weights, parser=parser)
         self.add_reward_func(self.correct_answer)
-        self.timeout_seconds = timeout_seconds
-        self.executor = ThreadPoolExecutor(
+        self.timeout = timeout
+
+        # use 'spawn' for clean process isolation (no inherited state)
+        ctx = multiprocessing.get_context("spawn")
+        self.executor = ProcessPoolExecutor(
             max_workers=max_workers,
-            thread_name_prefix="math-rubric",
+            mp_context=ctx,
         )
 
-        # suppress math_verify timeout warnings (we handle timeouts ourselves via asyncio.wait_for)
+        # suppress math_verify timeout warnings (we handle timeouts ourselves)
         logging.getLogger("math_verify.parser").setLevel(logging.ERROR)
         logging.getLogger("math_verify.grader").setLevel(logging.ERROR)
-
-    async def run_in_executor(self, func: Callable, *args) -> Any:
-        """Run a sync function in the thread pool."""
-        loop = asyncio.get_running_loop()
-        return await loop.run_in_executor(self.executor, func, *args)
 
     async def correct_answer(
         self, parser: Parser, completion: Messages, answer: str, **kwargs
     ) -> float:
         """Reward function that checks if the final answer matches the expected answer."""
 
-        async def _correct_answer() -> float:
-            try:
-                response = (
-                    await self.run_in_executor(lambda: parser.parse_answer(completion))
-                    or ""
-                )
-                if response == "":
-                    self.logger.warning("Parsed response is empty")
-                    return 0.0
+        response = parser.parse_answer(completion) or ""
+        if response == "":
+            self.logger.warning("Parsed response is empty")
+            return 0.0
 
-                parsed_answer = await self.run_in_executor(
-                    lambda: parse(f"\\boxed{{{answer}}}", parsing_timeout=None)  # type: ignore
-                )
-                parsed_response = await self.run_in_executor(
-                    lambda: parse(f"\\boxed{{{response}}}", parsing_timeout=None)  # type: ignore
-                )
-                result = await self.run_in_executor(
-                    lambda: verify(parsed_answer, parsed_response, timeout_seconds=None)
-                )
-                return 1.0 if result else 0.0
-            except asyncio.CancelledError:
-                raise
-            except BaseException as e:
-                self.logger.warning(
-                    f"Math verification failed with {type(e).__name__}: {e!r}"
-                )
-                return 0.0
+        loop = asyncio.get_running_loop()
 
         try:
-            return await asyncio.wait_for(
-                _correct_answer(), timeout=self.timeout_seconds
+            result = await asyncio.wait_for(
+                loop.run_in_executor(self.executor, verify_response, response, answer),
+                timeout=self.HARD_TIMEOUT_SECONDS,
             )
         except asyncio.TimeoutError:
             self.logger.warning(
-                f"Math verification timed out after {self.timeout_seconds:.1f}s"
+                f"Math verification hard timeout after {self.HARD_TIMEOUT_SECONDS:.0f}s. Worker may be hung or main event loop experiences severe lag."
             )
             return 0.0
+        except asyncio.CancelledError:
+            raise
+
+        if result.error is not None:
+            self.logger.warning(f"Math verification failed: {result.error}")
+
+        # Enforce timeout based on actual verification wall-clock time (measured in worker)
+        if result.elapsed > self.timeout:
+            self.logger.debug(
+                f"Math verification exceeded time limit: "
+                f"{result.elapsed:.2f}s > {self.timeout:.1f}s"
+            )
+            return 0.0
+
+        return result.reward
 
     def __del__(self):
         """Shutdown the thread pool executor when the object is garbage collected."""

--- a/verifiers/rubrics/math_rubric.py
+++ b/verifiers/rubrics/math_rubric.py
@@ -52,12 +52,12 @@ class MathRubric(Rubric):
         weights: list[float] | None = None,
         parser: Parser | None = None,
         max_workers: int = 4,
-        timeout: float = 5,
+        timeout_seconds: float = 5,
     ):
         parser = parser or MaybeThinkParser(extract_fn=extract_boxed_answer)
         super().__init__(funcs=funcs, weights=weights, parser=parser)
         self.add_reward_func(self.correct_answer)
-        self.timeout = timeout
+        self.timeout_seconds = timeout_seconds
 
         self.executor = ThreadPoolExecutor(
             max_workers=max_workers,
@@ -95,9 +95,9 @@ class MathRubric(Rubric):
             self.logger.warning(f"Math verification failed: {result.error}")
 
         # Enforce timeout based on actual verification wall-clock time (measured in worker)
-        if result.elapsed > self.timeout:
+        if result.elapsed > self.timeout_seconds:
             self.logger.debug(
-                f"Math verification exceeded time limit after {result.elapsed:.2f}s (>{self.timeout:.1f}s)"
+                f"Math verification exceeded time limit after {result.elapsed:.2f}s (>{self.timeout_seconds:.1f}s)"
             )
             return 0.0
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Currently, the scoring timeout set in `vf.MathRubric` includes eventloop lag (e.g. the time it takes until verification even starts in the thread executor) which results in the rubric falsly marking answers with 0 reward because. 

For example, in `aime2024` with only 200 rollouts we see false timeouts because we get a burst of scoring requests because many rollouts finish simulatenously atfer 4K tokens.

```bash
uv run vf-eval aime2024 -m deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B -b http://localhost:8000/v1 -n 20 -r 10 -c -1 -d -t 4096 -R
```

<img width="1220" height="695" alt="Screenshot 2026-02-05 at 3 00 37 PM" src="https://github.com/user-attachments/assets/df7324f8-737a-4eed-bf85-e9ff36194775" />

This PR fixes this by using asyncio timeouts only as a very high timeout time to prevent infinite hangs, the actual timing logic is thread-internal and only starts when scoring actually starts. I confirmed this work by running `aime2024` at Avg@32 (960 parallel rollouts) at 4K context without any false positives (got the expected score of ~11%)

```bash
uv run vf-eval aime2024 -m deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B -b http://localhost:8000/v1 -n 30 -r 32 -c -1 -d -t 8192 -R
```

<img width="1219" height="157" alt="Screenshot 2026-02-05 at 4 09 26 PM" src="https://github.com/user-attachments/assets/77b94658-1683-4bd9-aefc-458e743653c8" />

It is to be noted that verification that takes actually long, we only cancel the verification after 120s (hard timeout) but this should happen fairly little and given that it is in a thread it should not block the remainder of the env execution.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes scoring behavior and concurrency defaults for math verification; while aimed at reducing false negatives, it can affect throughput and timing/CPU characteristics under load and should be validated in large evaluations.
> 
> **Overview**
> Fixes false timeouts in `MathRubric` by moving parsing/verification and elapsed-time measurement into the executor thread and only enforcing `timeout_seconds` based on that internal duration (so event-loop/executor queueing delay no longer zeros rewards).
> 
> Adds a **hard** `HARD_TIMEOUT_SECONDS` (120s) around the executor call to prevent indefinite hangs, bumps the default `max_workers` (10→50), and updates the timeout test to assert pass/fail behavior by `timeout_seconds` instead of wall-clock timing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 384487b1cf27179efb616bc7853ec4bcf72c6b2b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->