### PR TITLE
Fix vf-eval concurrent rollouts label to show effective capped value

### DIFF
--- a/tests/test_eval_display.py
+++ b/tests/test_eval_display.py
@@ -1,0 +1,39 @@
+from verifiers.types import ClientConfig, EvalConfig
+from verifiers.utils.eval_display import EvalDisplay
+
+
+def make_config(
+    *, max_concurrent: int, rollouts_per_example: int = 1, independent_scoring: bool = False
+) -> EvalConfig:
+    return EvalConfig(
+        env_id="dummy-env",
+        env_args={},
+        env_dir_path="./environments",
+        model="gpt-4.1-mini",
+        client_config=ClientConfig(),
+        sampling_args={},
+        num_examples=5,
+        rollouts_per_example=rollouts_per_example,
+        max_concurrent=max_concurrent,
+        independent_scoring=independent_scoring,
+    )
+
+
+def test_display_max_concurrent_caps_to_total_rollouts() -> None:
+    config = make_config(max_concurrent=32)
+
+    assert EvalDisplay._display_max_concurrent(config, total_rollouts=8) == 8
+
+
+def test_display_max_concurrent_uses_effective_concurrency() -> None:
+    config = make_config(max_concurrent=9, rollouts_per_example=4)
+
+    assert EvalDisplay._display_max_concurrent(config, total_rollouts=10) == 3
+
+
+def test_display_max_concurrent_does_not_scale_independent_scoring() -> None:
+    config = make_config(
+        max_concurrent=9, rollouts_per_example=4, independent_scoring=True
+    )
+
+    assert EvalDisplay._display_max_concurrent(config, total_rollouts=10) == 9

--- a/verifiers/utils/eval_display.py
+++ b/verifiers/utils/eval_display.py
@@ -6,6 +6,7 @@ Provides a visual progress display that works in two modes:
 - TUI mode (screen=True): Alternate screen buffer with echo handling
 """
 
+import math
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -166,6 +167,22 @@ class EvalDisplay(BaseDisplay):
                 rollouts_per_example=config.rollouts_per_example,
             )
 
+    @staticmethod
+    def _display_max_concurrent(config: EvalConfig, total_rollouts: int) -> int:
+        """Return the effective concurrency shown in the UI."""
+        max_concurrent = config.max_concurrent
+        if (
+            not config.independent_scoring
+            and max_concurrent > 0
+            and config.rollouts_per_example > 1
+        ):
+            max_concurrent = math.ceil(max_concurrent / config.rollouts_per_example)
+
+        if max_concurrent > 0 and total_rollouts > 0:
+            return min(max_concurrent, total_rollouts)
+
+        return max_concurrent
+
     def update_env_state(
         self,
         env_idx: int,
@@ -303,8 +320,11 @@ class EvalDisplay(BaseDisplay):
         def fmt_concurrency(val: int) -> str:
             return "∞" if val == -1 else str(val)
 
+        display_max_concurrent = self._display_max_concurrent(
+            config, env_state.total
+        )
         config_line.append("  |  ", style="dim")
-        config_line.append(fmt_concurrency(config.max_concurrent), style="white")
+        config_line.append(fmt_concurrency(display_max_concurrent), style="white")
         config_line.append(" concurrent rollouts", style="dim")
 
         if config.sampling_args and any(config.sampling_args.values()):


### PR DESCRIPTION
### Motivation
- The eval UI could display a `concurrent rollouts` value larger than the actual work or runtime concurrency because it showed `config.max_concurrent` directly instead of the effective concurrency used at runtime and did not cap by total rollouts.
- The intent is to make the display reflect the same effective concurrency calculation used by `evaluate(...)` (respecting `rollouts_per_example` and `independent_scoring`) and avoid inflated labels.

### Description
- Add a static helper `EvalDisplay._display_max_concurrent(config, total_rollouts)` that computes the effective concurrency by applying rollout-per-example scaling (when `independent_scoring` is False), using `math.ceil` for division, and capping the result to `total_rollouts` when appropriate.
- Use the new helper in `_make_env_panel` to render the `concurrent rollouts` label instead of showing `config.max_concurrent` directly, and import `math` for the calculation.
- Add focused unit tests in `tests/test_eval_display.py` that assert capping to `total_rollouts`, correct scaling by `rollouts_per_example`, and that `independent_scoring=True` preserves the unscaled value.

### Testing
- Ran `uv run pytest tests/test_eval_display.py` and the tests passed (`3 passed`).
- Ran `uv run ruff check verifiers/utils/eval_display.py tests/test_eval_display.py` and style checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985ba23fe708326b30c9922126d2fbd)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only display logic change with small, well-covered arithmetic adjustments; no runtime evaluation behavior is modified.
> 
> **Overview**
> Fixes the eval UI’s `concurrent rollouts` label to reflect *effective* runtime concurrency rather than raw `config.max_concurrent`.
> 
> Adds `EvalDisplay._display_max_concurrent()` to scale concurrency by `rollouts_per_example` when `independent_scoring` is disabled (using `ceil`) and to cap the displayed value to `total_rollouts`, and wires this value into the panel rendering. Includes unit tests covering capping, scaling, and the `independent_scoring=True` exception.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c31ec0d2ced9ec1e25c70f312d38708dfd01e2ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->