### PR TITLE
Clarify MCPEnv usage for global read-only MCP servers

### DIFF
--- a/verifiers/envs/experimental/mcp_env.py
+++ b/verifiers/envs/experimental/mcp_env.py
@@ -165,10 +165,16 @@ class MCPToolWrapper:
 
 
 class MCPEnv(vf.ToolEnv):
-    """Environment for MCP-based tools using the official MCP SDK."""
+    """Environment for MCP-based tools using the official MCP SDK.
+
+    MCPEnv is intended for globally available, read-only MCP servers where the
+    same toolset can be shared across all rollouts.
+    """
 
     def __init__(
         self,
+        # MCPEnv is designed for global server processes, not per-rollout,
+        # stateful server instances with mutable task-specific data.
         mcp_servers: List[MCPServerConfig | dict] = [],
         max_turns: int = 10,
         error_formatter: Callable[[Exception], str] = lambda e: f"Error: {str(e)}",


### PR DESCRIPTION
### Motivation
- Make the intended usage of `MCPEnv` explicit so users know it expects globally available, read-only MCP servers rather than per-rollout mutable/stateful server processes.

### Description
- Update `MCPEnv` documentation and constructor comments in `verifiers/envs/experimental/mcp_env.py` to state that the class is intended for global, read-only MCP servers and not per-rollout stateful servers.

### Testing
- Ran `uv run ruff check verifiers/envs/experimental/mcp_env.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985caa8f0088326b637cb62fc56b387)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment/docstring-only change with no runtime behavior impact.
> 
> **Overview**
> Clarifies `MCPEnv`’s intended usage by expanding its docstring and adding constructor comments to emphasize it is meant for **globally available, read-only MCP servers** whose toolsets are shared across rollouts, *not* per-rollout/stateful server instances.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 769f306daae5054794b52bf404f814068da509ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->