### PR TITLE
docs: de-emphasize Parser objects in environment README files

### DIFF
--- a/environments/README.md
+++ b/environments/README.md
@@ -10,16 +10,16 @@ This folder contains installable example environments that showcase common usage
 ## Common usage patterns and examples
 
 ### SingleTurnEnv (prompt → single response)
-- **gsm8k**: Classic QA with exact-match reward; toggles `ThinkParser` vs `Parser` and format reward.
+- **gsm8k**: Classic QA with exact-match reward and optional response-format reward.
 - **reverse_text**: XML formatting with non-binary LCS reward + format reward.
 - **continuation_quality**: Completion-style generation (`message_type="completion"`) judged for prose quality with `JudgeRubric`.
 - **mmmu**: Multimodal inputs (image + text) packed in chat content; single-turn boxed-answer check.
 
 ### SingleTurnEnv subclass (custom dataset/scoring wrappers)
-- **reasoning_gym_env**: Wraps `reasoning_gym` procedural datasets, converts to HF datasets, uses `XMLParser` and task-specific scoring.
+- **reasoning_gym_env**: Wraps `reasoning_gym` procedural datasets, converts to HF datasets, and applies task-specific scoring.
 
 ### MultiTurnEnv (custom interaction protocols)
-- **alphabet_sort**: Multi-turn task requiring the model to maintain and update an alphabetically sorted list of names across turns; uses `XMLParser` with per-turn sequence similarity rewards.
+- **alphabet_sort**: Multi-turn task requiring the model to maintain and update an alphabetically sorted list of names across turns; uses per-turn sequence similarity rewards.
 - **doublecheck**: Simple follow-up turn ("Are you sure?") with math rewards; minimal `is_completed`/`env_response` implementation.
 - **sentence_repeater**: Multi-turn Q/A over a paragraph; rewards compare assistant messages to expected answers.
 - **wordle**: Game-style interaction via `TextArenaEnv`; multiple rewards (correctness, partial credit, few-turn bonus) and XML formatting.
@@ -59,10 +59,6 @@ This folder contains installable example environments that showcase common usage
 - **continuation_quality**: Judge rubric extracts `<grade>` and maps A–F to a continuous score.
 - **toxicity_explanation**: Judge rubric returns 0–10 normalized score for both classification correctness and explanation quality.
 - **self_reward**: Pattern for `SingleTurnEnv` with only a `JudgeRubric` over a dataset that supplies `question`/`answer`; intended for online RL where model acts as its own judge.
-
-### Parsers and formatting
-- **ThinkParser**: Used in `gsm8k`, `wiki_search` to separate reasoning from final answers.
-- **XMLParser**: Used in `reverse_text`, `wordle`, `alphabet_sort`, `reasoning_gym_env` to enforce structured outputs and enable format rewards.
 
 ### Multimodal inputs
 - **mmmu**: Demonstrates passing images via chat `content` items with `{type: "image_url", image_url: {url: ...}}` and standard answer parsing.

--- a/environments/alphabet_sort/README.md
+++ b/environments/alphabet_sort/README.md
@@ -16,7 +16,6 @@
 
 ### Task
 - **Type**: multi-turn
-- **Parser**: `XMLParser(["alphabetical_sorted"])` on turn 1; `XMLParser(["combined_alphabetical_sorted"])` on later turns
 - **Rubric overview**: The reward function uses difflib to calculate sequence similarity between predicted and expected outputs, with the final score raised to the nth power (similarity_power, defaults to 4) to emphasize precision.
 
 ### Quickstart

--- a/environments/continuation_quality/README.md
+++ b/environments/continuation_quality/README.md
@@ -16,7 +16,6 @@
 
 ### Task
 - **Type**: single-turn
-- **Parser**: custom
 - **Rubric overview**: Judge model letter grade (gpt-4.1-mini-based by default)
 
 ### Quickstart

--- a/environments/doublecheck/README.md
+++ b/environments/doublecheck/README.md
@@ -16,7 +16,6 @@
 
 ### Task
 - **Type**: multi-turn
-- **Parser**: XMLParser with fields `think`, `answer` (from `MathRubric`)
 - **Rubric overview**: `MathRubric` combining exact/equivalence math grading and a small format component
 
 ### Quickstart

--- a/environments/gem_wordle/README.md
+++ b/environments/gem_wordle/README.md
@@ -16,7 +16,6 @@
 
 ### Task
 - **Type**: multi-turn (gym environment interaction)
-- **Parser**: Identity (GEM environment parses `\boxed{GUESS}` internally via regex; the env passes raw model text through so format/validity penalties remain part of the training signal)
 - **Rubric overview**: Sum of per-step rewards returned by GEM (includes shaping + terminal success reward, plus small negative penalties for format/invalid actions; commonly `-0.1`)
 
 ### Quickstart

--- a/environments/gsm8k/README.md
+++ b/environments/gsm8k/README.md
@@ -16,7 +16,6 @@
 
 ### Task
 - **Type**: single-turn
-- **Parser**: `ThinkParser` with boxed answer extraction
 - **Rubric overview**: Exact match on parsed boxed answer; optional format check
 
 ### Quickstart

--- a/environments/math_group/README.md
+++ b/environments/math_group/README.md
@@ -6,7 +6,7 @@
 
 ### Overview
 - **Environment ID**: `math-group`
-- **Short description**: Groups GSM8K and MATH single-turn sub-environments into one evaluation with a shared math CoT parser.
+- **Short description**: Groups GSM8K and MATH single-turn sub-environments into one evaluation with a shared math reasoning-and-answer format.
 - **Tags**: math, group, single-turn, gsm8k, math, think
 
 ### Datasets
@@ -16,7 +16,6 @@
 
 ### Task
 - **Type**: single-turn (EnvGroup of two SingleTurnEnv instances)
-- **Parser**: `ThinkParser` with boxed answer extraction
 - **Rubric overview**: Exact numeric/equivalent match per sub-environment plus optional format check
 
 ### Quickstart

--- a/environments/math_python/README.md
+++ b/environments/math_python/README.md
@@ -16,7 +16,6 @@
 
 ### Task
 - **Type**: tool use (single-turn ToolEnv)
-- **Parser**: Basic `Parser` with boxed answer extraction
 - **Rubric overview**: Correctness by `math_verify.parse` + `verify`; logs auxiliary metrics (#turns, #tool calls, #errors)
 
 ### Quickstart

--- a/environments/mcp_search_env/README.md
+++ b/environments/mcp_search_env/README.md
@@ -21,7 +21,6 @@ This environment demonstrates how to use the first-class `MCPEnv` from `verifier
 ### Task
 
 - **Type**: <multi-turn | tool use>
-- **Parser**: N/A
 - **Rubric overview**: N/A
 
 ### Quickstart

--- a/environments/mmmu/README.md
+++ b/environments/mmmu/README.md
@@ -16,7 +16,6 @@
 
 ### Task
 - **Type**: <single-turn | multi-turn | tool use>
-- **Parser**: <e.g., ThinkParser, XMLParser, custom>
 - **Rubric overview**: <briefly list reward functions and key metrics>
 
 ### Quickstart

--- a/environments/opencode_harbor/README.md
+++ b/environments/opencode_harbor/README.md
@@ -12,7 +12,6 @@
 
 ### Task
 - **Type**: multiturn, cli_agent
-- **Parser**: N/A
 - **Rubric overview**: Binary, returned by running task tests
 
 ### Quickstart

--- a/environments/reasoning_gym_env/README.md
+++ b/environments/reasoning_gym_env/README.md
@@ -16,7 +16,6 @@
 
 ### Task
 - **Type**: single-turn
-- **Parser**: `XMLParser(["answer"])`
 - **Rubric overview**: Score computed via `reasoning_gym` task-specific scorer; optional format component
 
 ### Quickstart

--- a/environments/reverse_text/README.md
+++ b/environments/reverse_text/README.md
@@ -16,7 +16,6 @@
 
 ### Task
 - **Type**: single-turn
-- **Parser**: `XMLParser(["reversed_text"], answer_field="reversed_text")`
 - **Rubric overview**: LCS ratio between parsed answer and target reversed text
 
 ### Quickstart

--- a/environments/self_reward/README.md
+++ b/environments/self_reward/README.md
@@ -16,7 +16,6 @@
 
 ### Task
 - **Type**: single-turn
-- **Parser**: default `Parser`
 - **Rubric overview**: `JudgeRubric` uses a judge client/model/prompt to produce a 0–1 score
 
 ### Quickstart

--- a/environments/sentence_repeater/README.md
+++ b/environments/sentence_repeater/README.md
@@ -16,7 +16,6 @@
 
 ### Task
 - **Type**: multi-turn
-- **Parser**: default `Parser`
 - **Rubric overview**: Sequence similarity against the 5 target answers across turns
 
 ### Quickstart

--- a/environments/terminus_harbor/README.md
+++ b/environments/terminus_harbor/README.md
@@ -12,7 +12,6 @@
 
 ### Task
 - **Type**: multiturn, cli_agent
-- **Parser**: N/A
 - **Rubric overview**: Binary, returned by running task tests
 
 ### Quickstart

--- a/environments/tool_test/README.md
+++ b/environments/tool_test/README.md
@@ -16,7 +16,6 @@
 
 ### Task
 - **Type**: tool use (single-turn ToolEnv)
-- **Parser**: default `Parser`
 - **Rubric overview**: ToolRubric checks tool execution and adds exact match on the required tool set
 
 ### Quickstart

--- a/environments/toxicity_explanation/README.md
+++ b/environments/toxicity_explanation/README.md
@@ -16,7 +16,6 @@
 
 ### Task
 - **Type**: single-turn
-- **Parser**: default `Parser`
 - **Rubric overview**: `JudgeRubric` with a numeric (0–10) rubric normalized to 0–1; evaluates correctness and explanation quality
 
 ### Quickstart

--- a/environments/wordle/README.md
+++ b/environments/wordle/README.md
@@ -16,7 +16,6 @@
 
 ### Task
 - **Type**: multi-turn (game interaction)
-- **Parser**: `XMLParser` with `think`/`guess`
 - **Rubric overview**: Exact guess match, partial credit from feedback, length bonus, and format check
 
 ### Quickstart


### PR DESCRIPTION
### Motivation
- Parser objects remain supported for legacy cases but should not be presented as the default or recommended pattern in user-facing environment docs.
- The goal is to reduce parser-centric guidance in environment templates and examples so authors and users focus on tasks, rubrics, and workflows instead of parser internals.

### Description
- Removed explicit `- **Parser**:` metadata lines from per-environment `README.md` files across the `environments/` tree so parser internals are no longer foregrounded in example overviews.
- Removed the dedicated “Parsers and formatting” section and parser-heavy phrasing from the top-level `environments/README.md` and adjusted a few summary lines to emphasize task/rubric behavior instead.
- Updated the `mmmu` environment template README to stop prompting authors to document a `Parser` field by default and reworded several per-environment task descriptions to avoid naming specific parser classes.
- Applied the changes to 19 environment README files and committed the edits with the message `docs: remove parser-centric guidance from environment READMEs`.

### Testing
- Ran a targeted search with ripgrep: `rg -n "\bParser\b|ThinkParser|XMLParser|parser" environments -g 'README.md'` and confirmed no remaining parser mentions in the environment README files (scan completed successfully).
- Executed the cleanup script that removed `- **Parser**:` lines from per-environment READMEs and applied a focused patch to `environments/README.md` using `apply_patch`, both of which completed without errors.
- Created a git commit containing the documentation changes and verified the commit succeeded (`git commit` returned success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985cb3e8cfc8326aae517b07ace24ab)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no runtime or API changes; risk is limited to confusing/missing docs details.
> 
> **Overview**
> Updates environment documentation to **stop foregrounding parser internals** and instead describe environments in terms of tasks and rubrics.
> 
> Across the `environments/` README set, this removes per-environment `Parser` metadata lines (and the top-level “Parsers and formatting” section), and lightly rewords several blurbs/templates (including `mmmu`) to avoid naming specific parser classes; also fixes a few minor markdown/newline nits.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b82a6519196ba1b933da4536f7b30c71dce1edae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->