### PR TITLE
docs: fix env init template to avoid parser-first guidance

### DIFF
--- a/environments/README.md
+++ b/environments/README.md
@@ -10,16 +10,16 @@ This folder contains installable example environments that showcase common usage
 ## Common usage patterns and examples
 
 ### SingleTurnEnv (prompt → single response)
-- **gsm8k**: Classic QA with exact-match reward; toggles `ThinkParser` vs `Parser` and format reward.
+- **gsm8k**: Classic QA with exact-match reward and optional response-format reward.
 - **reverse_text**: XML formatting with non-binary LCS reward + format reward.
 - **continuation_quality**: Completion-style generation (`message_type="completion"`) judged for prose quality with `JudgeRubric`.
 - **mmmu**: Multimodal inputs (image + text) packed in chat content; single-turn boxed-answer check.
 
 ### SingleTurnEnv subclass (custom dataset/scoring wrappers)
-- **reasoning_gym_env**: Wraps `reasoning_gym` procedural datasets, converts to HF datasets, uses `XMLParser` and task-specific scoring.
+- **reasoning_gym_env**: Wraps `reasoning_gym` procedural datasets, converts to HF datasets, and applies task-specific scoring.
 
 ### MultiTurnEnv (custom interaction protocols)
-- **alphabet_sort**: Multi-turn task requiring the model to maintain and update an alphabetically sorted list of names across turns; uses `XMLParser` with per-turn sequence similarity rewards.
+- **alphabet_sort**: Multi-turn task requiring the model to maintain and update an alphabetically sorted list of names across turns; uses per-turn sequence similarity rewards.
 - **doublecheck**: Simple follow-up turn ("Are you sure?") with math rewards; minimal `is_completed`/`env_response` implementation.
 - **sentence_repeater**: Multi-turn Q/A over a paragraph; rewards compare assistant messages to expected answers.
 - **wordle**: Game-style interaction via `TextArenaEnv`; multiple rewards (correctness, partial credit, few-turn bonus) and XML formatting.
@@ -59,10 +59,6 @@ This folder contains installable example environments that showcase common usage
 - **continuation_quality**: Judge rubric extracts `<grade>` and maps A–F to a continuous score.
 - **toxicity_explanation**: Judge rubric returns 0–10 normalized score for both classification correctness and explanation quality.
 - **self_reward**: Pattern for `SingleTurnEnv` with only a `JudgeRubric` over a dataset that supplies `question`/`answer`; intended for online RL where model acts as its own judge.
-
-### Parsers and formatting
-- **ThinkParser**: Used in `gsm8k`, `wiki_search` to separate reasoning from final answers.
-- **XMLParser**: Used in `reverse_text`, `wordle`, `alphabet_sort`, `reasoning_gym_env` to enforce structured outputs and enable format rewards.
 
 ### Multimodal inputs
 - **mmmu**: Demonstrates passing images via chat `content` items with `{type: "image_url", image_url: {url: ...}}` and standard answer parsing.

--- a/environments/alphabet_sort/README.md
+++ b/environments/alphabet_sort/README.md
@@ -16,7 +16,6 @@
 
 ### Task
 - **Type**: multi-turn
-- **Parser**: `XMLParser(["alphabetical_sorted"])` on turn 1; `XMLParser(["combined_alphabetical_sorted"])` on later turns
 - **Rubric overview**: The reward function uses difflib to calculate sequence similarity between predicted and expected outputs, with the final score raised to the nth power (similarity_power, defaults to 4) to emphasize precision.
 
 ### Quickstart

--- a/environments/continuation_quality/README.md
+++ b/environments/continuation_quality/README.md
@@ -16,7 +16,6 @@
 
 ### Task
 - **Type**: single-turn
-- **Parser**: custom
 - **Rubric overview**: Judge model letter grade (gpt-4.1-mini-based by default)
 
 ### Quickstart

--- a/environments/doublecheck/README.md
+++ b/environments/doublecheck/README.md
@@ -16,7 +16,6 @@
 
 ### Task
 - **Type**: multi-turn
-- **Parser**: XMLParser with fields `think`, `answer` (from `MathRubric`)
 - **Rubric overview**: `MathRubric` combining exact/equivalence math grading and a small format component
 
 ### Quickstart

--- a/environments/gem_wordle/README.md
+++ b/environments/gem_wordle/README.md
@@ -16,7 +16,6 @@
 
 ### Task
 - **Type**: multi-turn (gym environment interaction)
-- **Parser**: Identity (GEM environment parses `\boxed{GUESS}` internally via regex; the env passes raw model text through so format/validity penalties remain part of the training signal)
 - **Rubric overview**: Sum of per-step rewards returned by GEM (includes shaping + terminal success reward, plus small negative penalties for format/invalid actions; commonly `-0.1`)
 
 ### Quickstart

--- a/environments/gsm8k/README.md
+++ b/environments/gsm8k/README.md
@@ -16,7 +16,6 @@
 
 ### Task
 - **Type**: single-turn
-- **Parser**: `ThinkParser` with boxed answer extraction
 - **Rubric overview**: Exact match on parsed boxed answer; optional format check
 
 ### Quickstart

--- a/environments/math_group/README.md
+++ b/environments/math_group/README.md
@@ -6,7 +6,7 @@
 
 ### Overview
 - **Environment ID**: `math-group`
-- **Short description**: Groups GSM8K and MATH single-turn sub-environments into one evaluation with a shared math CoT parser.
+- **Short description**: Groups GSM8K and MATH single-turn sub-environments into one evaluation with a shared math reasoning-and-answer format.
 - **Tags**: math, group, single-turn, gsm8k, math, think
 
 ### Datasets
@@ -16,7 +16,6 @@
 
 ### Task
 - **Type**: single-turn (EnvGroup of two SingleTurnEnv instances)
-- **Parser**: `ThinkParser` with boxed answer extraction
 - **Rubric overview**: Exact numeric/equivalent match per sub-environment plus optional format check
 
 ### Quickstart

--- a/environments/math_python/README.md
+++ b/environments/math_python/README.md
@@ -16,7 +16,6 @@
 
 ### Task
 - **Type**: tool use (single-turn ToolEnv)
-- **Parser**: Basic `Parser` with boxed answer extraction
 - **Rubric overview**: Correctness by `math_verify.parse` + `verify`; logs auxiliary metrics (#turns, #tool calls, #errors)
 
 ### Quickstart

--- a/environments/mcp_search_env/README.md
+++ b/environments/mcp_search_env/README.md
@@ -21,7 +21,6 @@ This environment demonstrates how to use the first-class `MCPEnv` from `verifier
 ### Task
 
 - **Type**: <multi-turn | tool use>
-- **Parser**: N/A
 - **Rubric overview**: N/A
 
 ### Quickstart

--- a/environments/mmmu/README.md
+++ b/environments/mmmu/README.md
@@ -16,7 +16,6 @@
 
 ### Task
 - **Type**: <single-turn | multi-turn | tool use>
-- **Parser**: <e.g., ThinkParser, XMLParser, custom>
 - **Rubric overview**: <briefly list reward functions and key metrics>
 
 ### Quickstart

--- a/environments/opencode_harbor/README.md
+++ b/environments/opencode_harbor/README.md
@@ -12,7 +12,6 @@
 
 ### Task
 - **Type**: multiturn, cli_agent
-- **Parser**: N/A
 - **Rubric overview**: Binary, returned by running task tests
 
 ### Quickstart

--- a/environments/reasoning_gym_env/README.md
+++ b/environments/reasoning_gym_env/README.md
@@ -16,7 +16,6 @@
 
 ### Task
 - **Type**: single-turn
-- **Parser**: `XMLParser(["answer"])`
 - **Rubric overview**: Score computed via `reasoning_gym` task-specific scorer; optional format component
 
 ### Quickstart

--- a/environments/reverse_text/README.md
+++ b/environments/reverse_text/README.md
@@ -16,7 +16,6 @@
 
 ### Task
 - **Type**: single-turn
-- **Parser**: `XMLParser(["reversed_text"], answer_field="reversed_text")`
 - **Rubric overview**: LCS ratio between parsed answer and target reversed text
 
 ### Quickstart

--- a/environments/self_reward/README.md
+++ b/environments/self_reward/README.md
@@ -16,7 +16,6 @@
 
 ### Task
 - **Type**: single-turn
-- **Parser**: default `Parser`
 - **Rubric overview**: `JudgeRubric` uses a judge client/model/prompt to produce a 0–1 score
 
 ### Quickstart

--- a/environments/sentence_repeater/README.md
+++ b/environments/sentence_repeater/README.md
@@ -16,7 +16,6 @@
 
 ### Task
 - **Type**: multi-turn
-- **Parser**: default `Parser`
 - **Rubric overview**: Sequence similarity against the 5 target answers across turns
 
 ### Quickstart

--- a/environments/terminus_harbor/README.md
+++ b/environments/terminus_harbor/README.md
@@ -12,7 +12,6 @@
 
 ### Task
 - **Type**: multiturn, cli_agent
-- **Parser**: N/A
 - **Rubric overview**: Binary, returned by running task tests
 
 ### Quickstart

--- a/environments/tool_test/README.md
+++ b/environments/tool_test/README.md
@@ -16,7 +16,6 @@
 
 ### Task
 - **Type**: tool use (single-turn ToolEnv)
-- **Parser**: default `Parser`
 - **Rubric overview**: ToolRubric checks tool execution and adds exact match on the required tool set
 
 ### Quickstart

--- a/environments/toxicity_explanation/README.md
+++ b/environments/toxicity_explanation/README.md
@@ -16,7 +16,6 @@
 
 ### Task
 - **Type**: single-turn
-- **Parser**: default `Parser`
 - **Rubric overview**: `JudgeRubric` with a numeric (0–10) rubric normalized to 0–1; evaluates correctness and explanation quality
 
 ### Quickstart

--- a/environments/wordle/README.md
+++ b/environments/wordle/README.md
@@ -16,7 +16,6 @@
 
 ### Task
 - **Type**: multi-turn (game interaction)
-- **Parser**: `XMLParser` with `think`/`guess`
 - **Rubric overview**: Exact guess match, partial credit from feedback, length bonus, and format check
 
 ### Quickstart

--- a/verifiers/scripts/init.py
+++ b/verifiers/scripts/init.py
@@ -20,7 +20,7 @@ README_TEMPLATE = """\
 
 ### Task
 - **Type**: <single-turn | multi-turn | tool use>
-- **Parser**: <e.g., ThinkParser, XMLParser, custom>
+- **Output format expectations (optional)**: <e.g., plain text, XML tags, JSON schema>
 - **Rubric overview**: <briefly list reward functions and key metrics>
 
 ### Quickstart


### PR DESCRIPTION
### Motivation
- Reduce parser-centric guidance surfaced to authors when scaffolding new environments so docs focus on task/rubric behavior rather than parser internals.
- Ensure the `prime env init` README template matches the prior cleanup of per-environment `README.md` files and does not encourage using `Parser` objects by default.

### Description
- Rewrote the environment README templates under `environments/*/README.md` to remove explicit `- **Parser**:` metadata lines and to reword parser-heavy phrasing in example summaries (various environment READMEs updated). 
- Updated the generator template in `verifiers/scripts/init.py` to replace the `- **Parser**:` line with a neutral `- **Output format expectations (optional)**:` line so newly-created READMEs no longer prompt parser-first documentation.
- Minor whitespace/format fixes applied to several `README.md` files as part of the cleanup.

### Testing
- Searched repository README templates with ripgrep to confirm the `**Parser**` template line was removed from `verifiers/scripts/init.py` using `rg` (search for parser-related phrases). The search showed the new `Output format expectations` line present and no `**Parser**` template line in the init template.
- Ran a local smoke test by calling `init_environment('demo-env', path=<tmpdir>)` from `verifiers.scripts.init` and inspected the generated `README.md` to verify it does not contain `**Parser**` and does contain `**Output format expectations (optional)**` (test succeeded).
- Verified the file change applied cleanly with a local commit and the follow-up PR metadata was created.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985cb3e8cfc8326aae517b07ace24ab)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only/template changes with no runtime behavior impact beyond the text generated by `prime env init`.
> 
> **Overview**
> Updates the environment documentation to **remove parser-centric guidance**: per-environment `README.md` files and the top-level `environments/README.md` drop explicit `**Parser**` metadata lines and reword a few descriptions to focus on task/rubric behavior instead of parser internals.
> 
> Adjusts `prime env init`’s `README_TEMPLATE` (`verifiers/scripts/init.py`) to replace the `**Parser**` placeholder with a neutral `**Output format expectations (optional)**` line, and applies minor Markdown/whitespace fixes (including newline-at-EOF cleanup).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 840efc7febf4b0318bef1d381a7ac4e646639081. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->