### PR TITLE
Make eval `--resume` optional and auto-detect latest incomplete run

### DIFF
--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -139,7 +139,7 @@ The `--max-retries` flag enables automatic retry with exponential backoff when r
 | `--tui` | `-u` | false | Use alternate screen mode (TUI) for display |
 | `--debug` | `-d` | false | Disable Rich display; use normal logging and tqdm progress |
 | `--save-results` | `-s` | false | Save results to disk |
-| `--resume-path` | — | — | Resume from a previous run |
+| `--resume [PATH]` | — | — | Resume from a previous run (auto-detect latest matching incomplete run if PATH omitted) |
 | `--state-columns` | `-C` | — | Extra state columns to save (comma-separated) |
 | `--save-to-hf-hub` | `-H` | false | Push results to Hugging Face Hub |
 | `--hf-hub-dataset-name` | `-D` | — | Dataset name for HF Hub |
@@ -151,7 +151,7 @@ Results are saved to `./outputs/evals/{env_id}--{model}/{run_id}/`, containing:
 
 ### Resuming Evaluations
 
-Long-running evaluations can be interrupted and resumed using checkpointing. When `--save-results` is enabled, results are saved incrementally after each completed group of rollouts. Use `--resume-path` to continue from where you left off.
+Long-running evaluations can be interrupted and resumed using checkpointing. When `--save-results` is enabled, results are saved incrementally after each completed group of rollouts. Use `--resume` to continue from where you left off. Pass a path to resume a specific run, or omit the path to auto-detect the latest incomplete matching run.
 
 **Running with checkpoints:**
 
@@ -164,10 +164,10 @@ With `-s` (save results) enabled, partial results are written to disk after each
 **Resuming from a checkpoint:**
 
 ```bash
-prime eval run my-env -n 1000 -s --resume-path ./environments/my_env/outputs/evals/my-env--openai--gpt-4.1-mini/abc12345
+prime eval run my-env -n 1000 -s --resume ./environments/my_env/outputs/evals/my-env--openai--gpt-4.1-mini/abc12345
 ```
 
-The resume path must point to a valid evaluation results directory containing both `results.jsonl` and `metadata.json`. When resuming:
+When a resume path is provided, it must point to a valid evaluation results directory containing both `results.jsonl` and `metadata.json`. With `--resume` and no path, verifiers scans the environment/model output directory and picks the most recent incomplete run matching `env_id`, `model`, and `rollouts_per_example` where saved `num_examples` is less than or equal to the current run. When resuming:
 
 1. Existing completed rollouts are loaded from the checkpoint
 2. Remaining rollouts are computed based on the example ids and group size
@@ -191,7 +191,7 @@ ls ./environments/math_python/outputs/evals/math-python--openai--gpt-4.1-mini/
 
 # Resume from the checkpoint
 prime eval run math-python -n 500 -r 3 -s \
-  --resume-path ./environments/math_python/outputs/evals/math-python--openai--gpt-4.1-mini/abc12345
+  --resume ./environments/math_python/outputs/evals/math-python--openai--gpt-4.1-mini/abc12345
 ```
 
 The `--state-columns` flag allows saving environment-specific state fields that your environment stores during rollouts:

--- a/tests/test_path_utils.py
+++ b/tests/test_path_utils.py
@@ -1,0 +1,71 @@
+import os
+from pathlib import Path
+
+from verifiers.utils.path_utils import find_latest_incomplete_eval_results_path
+
+
+def test_find_latest_incomplete_eval_results_path_picks_newest_matching(
+    tmp_path: Path, monkeypatch
+):
+    env_id = "dummy-env"
+    model = "openai/gpt-4.1-mini"
+    runs_dir = (
+        tmp_path
+        / "outputs"
+        / "evals"
+        / f"{env_id}--{model.replace('/', '--')}"
+    )
+
+    old_run = runs_dir / "11111111"
+    new_run = runs_dir / "22222222"
+    complete_run = runs_dir / "33333333"
+    for run in [old_run, new_run, complete_run]:
+        run.mkdir(parents=True)
+
+    metadata = (
+        '{"env_id":"dummy-env","model":"openai/gpt-4.1-mini",'
+        '"num_examples":4,"rollouts_per_example":1}'
+    )
+    for run in [old_run, new_run, complete_run]:
+        (run / "metadata.json").write_text(metadata, encoding="utf-8")
+
+    (old_run / "results.jsonl").write_text('{"example_id":0}\n', encoding="utf-8")
+    (new_run / "results.jsonl").write_text(
+        '{"example_id":0}\n{"example_id":1}\n', encoding="utf-8"
+    )
+    (complete_run / "results.jsonl").write_text(
+        '{"example_id":0}\n{"example_id":1}\n{"example_id":2}\n{"example_id":3}\n',
+        encoding="utf-8",
+    )
+
+    os.utime(old_run, (1, 1))
+    os.utime(new_run, (2, 2))
+    os.utime(complete_run, (3, 3))
+
+    monkeypatch.chdir(tmp_path)
+
+    result = find_latest_incomplete_eval_results_path(
+        env_id=env_id,
+        model=model,
+        num_examples=4,
+        rollouts_per_example=1,
+        env_dir_path=str(tmp_path / "environments"),
+    )
+
+    assert result is not None
+    assert result.resolve() == new_run.resolve()
+
+
+def test_find_latest_incomplete_eval_results_path_returns_none_when_no_match(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+
+    result = find_latest_incomplete_eval_results_path(
+        env_id="dummy-env",
+        model="openai/gpt-4.1-mini",
+        num_examples=4,
+        rollouts_per_example=1,
+        env_dir_path=str(tmp_path / "environments"),
+    )
+    assert result is None

--- a/tests/test_path_utils.py
+++ b/tests/test_path_utils.py
@@ -1,7 +1,10 @@
 import os
 from pathlib import Path
 
-from verifiers.utils.path_utils import find_latest_incomplete_eval_results_path
+from verifiers.utils.path_utils import (
+    find_latest_incomplete_eval_results_path,
+    is_valid_eval_results_path,
+)
 
 
 def test_find_latest_incomplete_eval_results_path_picks_newest_matching(
@@ -69,3 +72,23 @@ def test_find_latest_incomplete_eval_results_path_returns_none_when_no_match(
         env_dir_path=str(tmp_path / "environments"),
     )
     assert result is None
+
+
+def test_is_valid_eval_results_path_requires_files(tmp_path: Path):
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+
+    (run_dir / "results.jsonl").mkdir()
+    (run_dir / "metadata.json").mkdir()
+
+    assert not is_valid_eval_results_path(run_dir)
+
+
+def test_is_valid_eval_results_path_accepts_expected_layout(tmp_path: Path):
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+
+    (run_dir / "results.jsonl").write_text("", encoding="utf-8")
+    (run_dir / "metadata.json").write_text("{}", encoding="utf-8")
+
+    assert is_valid_eval_results_path(run_dir)

--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -404,31 +404,32 @@ def main():
         # handle resume path resolution
         resume_arg = raw.get("resume")
         resume_path: Path | None = None
-        if resume_arg is not None:
-            if isinstance(resume_arg, str):
-                resume_path = Path(resume_arg)
-                if not is_valid_eval_results_path(resume_path):
-                    raise ValueError(
-                        f"Resume path {resume_path} is not a valid evaluation results path"
-                    )
-                logger.info(f"Resuming from explicit path: {resume_path}")
-            elif resume_arg is True:
-                auto_resume_path = find_latest_incomplete_eval_results_path(
-                    env_id=env_id,
-                    model=model,
-                    num_examples=num_examples,
-                    rollouts_per_example=rollouts_per_example,
-                    env_dir_path=raw.get("env_dir_path", DEFAULT_ENV_DIR_PATH),
+        if isinstance(resume_arg, str):
+            resume_path = Path(resume_arg)
+            if not is_valid_eval_results_path(resume_path):
+                raise ValueError(
+                    f"Resume path {resume_path} is not a valid evaluation results path"
                 )
-                if auto_resume_path is not None:
-                    resume_path = auto_resume_path
-                    logger.info(f"Auto-resuming from: {resume_path}")
-                else:
-                    logger.info(
-                        "No matching incomplete run found for --resume; starting a new run"
-                    )
+            logger.info(f"Resuming from explicit path: {resume_path}")
+        elif resume_arg is True:
+            auto_resume_path = find_latest_incomplete_eval_results_path(
+                env_id=env_id,
+                model=model,
+                num_examples=num_examples,
+                rollouts_per_example=rollouts_per_example,
+                env_dir_path=raw.get("env_dir_path", DEFAULT_ENV_DIR_PATH),
+            )
+            if auto_resume_path is not None:
+                resume_path = auto_resume_path
+                logger.info(f"Auto-resuming from: {resume_path}")
             else:
-                raise ValueError(f"Invalid value for --resume: {resume_arg!r}")
+                logger.info(
+                    "No matching incomplete run found for --resume; starting a new run"
+                )
+        elif resume_arg in (None, False):
+            pass
+        else:
+            raise ValueError(f"Invalid value for --resume: {resume_arg!r}")
 
         return EvalConfig(
             env_id=env_id,

--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -1,6 +1,9 @@
 import os
 
-from verifiers.utils.path_utils import is_valid_eval_results_path
+from verifiers.utils.path_utils import (
+    find_latest_incomplete_eval_results_path,
+    is_valid_eval_results_path,
+)
 
 # Suppress tokenizers parallelism warning (only prints when env var is unset)
 os.environ.setdefault("TOKENIZERS_PARALLELISM", "true")
@@ -214,10 +217,15 @@ def main():
         help="Save results to disk",
     )
     parser.add_argument(
-        "--resume-path",
-        type=str,
+        "--resume",
+        nargs="?",
+        const=True,
         default=None,
-        help="Resume from a previous run.",
+        metavar="PATH",
+        help=(
+            "Resume from a previous run. Optionally provide a PATH; "
+            "if omitted, auto-detect the latest incomplete matching run."
+        ),
     )
     parser.add_argument(
         "--independent-scoring",
@@ -389,15 +397,38 @@ def main():
             extra_headers=merged_headers,
         )
 
+        # Backward-compatible TOML field: resume_path
+        if raw.get("resume") is None and raw.get("resume_path") is not None:
+            raw["resume"] = raw["resume_path"]
+
         # handle resume path resolution
-        resume_path = raw.get("resume_path")
-        if resume_path is not None:
-            resume_path = Path(resume_path)
-            if not is_valid_eval_results_path(resume_path):
-                raise ValueError(
-                    f"Resume path {resume_path} is not a valid evaluation results path"
+        resume_arg = raw.get("resume")
+        resume_path: Path | None = None
+        if resume_arg is not None:
+            if isinstance(resume_arg, str):
+                resume_path = Path(resume_arg)
+                if not is_valid_eval_results_path(resume_path):
+                    raise ValueError(
+                        f"Resume path {resume_path} is not a valid evaluation results path"
+                    )
+                logger.info(f"Resuming from explicit path: {resume_path}")
+            elif resume_arg is True:
+                auto_resume_path = find_latest_incomplete_eval_results_path(
+                    env_id=env_id,
+                    model=model,
+                    num_examples=num_examples,
+                    rollouts_per_example=rollouts_per_example,
+                    env_dir_path=raw.get("env_dir_path", DEFAULT_ENV_DIR_PATH),
                 )
-            logger.info(f"Resuming from: {resume_path}")
+                if auto_resume_path is not None:
+                    resume_path = auto_resume_path
+                    logger.info(f"Auto-resuming from: {resume_path}")
+                else:
+                    logger.info(
+                        "No matching incomplete run found for --resume; starting a new run"
+                    )
+            else:
+                raise ValueError(f"Invalid value for --resume: {resume_arg!r}")
 
         return EvalConfig(
             env_id=env_id,

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -154,6 +154,7 @@ def load_toml_config(path: Path) -> list[dict]:
         # saving
         "state_columns",
         "save_results",
+        "resume",
         "resume_path",
         "save_to_hf_hub",
         "hf_hub_dataset_name",

--- a/verifiers/utils/path_utils.py
+++ b/verifiers/utils/path_utils.py
@@ -1,11 +1,21 @@
-import logging
 import json
+import logging
 import uuid
 from pathlib import Path
 
 from verifiers.types import EvalConfig
 
 logger = logging.getLogger(__name__)
+
+
+def _get_outputs_base_path(env_id: str, env_dir_path: str = "./environments") -> Path:
+    """Resolve where outputs should be stored for an environment."""
+    module_name = env_id.replace("-", "_")
+    local_env_dir = Path(env_dir_path) / module_name
+
+    if local_env_dir.exists():
+        return local_env_dir / "outputs"
+    return Path("./outputs")
 
 
 def get_results_path(
@@ -20,28 +30,13 @@ def get_results_path(
 
 
 def get_eval_results_path(config: EvalConfig) -> Path:
-    module_name = config.env_id.replace("-", "_")
-    local_env_dir = Path(config.env_dir_path) / module_name
-
-    if local_env_dir.exists():
-        base_path = local_env_dir / "outputs"
-        results_path = get_results_path(config.env_id, config.model, base_path)
-    else:
-        base_path = Path("./outputs")
-        results_path = get_results_path(config.env_id, config.model, base_path)
-    return results_path
+    base_path = _get_outputs_base_path(config.env_id, config.env_dir_path)
+    return get_results_path(config.env_id, config.model, base_path)
 
 
 def get_eval_runs_dir(env_id: str, model: str, env_dir_path: str = "./environments") -> Path:
     """Return directory containing all eval run directories for env/model."""
-    module_name = env_id.replace("-", "_")
-    local_env_dir = Path(env_dir_path) / module_name
-
-    if local_env_dir.exists():
-        base_path = local_env_dir / "outputs"
-    else:
-        base_path = Path("./outputs")
-
+    base_path = _get_outputs_base_path(env_id, env_dir_path)
     env_model_str = f"{env_id}--{model.replace('/', '--')}"
     return base_path / "evals" / env_model_str
 
@@ -138,12 +133,5 @@ def get_gepa_results_path(
     Otherwise saves to:
         ./outputs/gepa/{env_id}--{model}/{uuid8}/
     """
-    module_name = env_id.replace("-", "_")
-    local_env_dir = Path(env_dir_path) / module_name
-
-    if local_env_dir.exists():
-        base_path = local_env_dir / "outputs"
-    else:
-        base_path = Path("./outputs")
-
+    base_path = _get_outputs_base_path(env_id, env_dir_path)
     return get_results_path(env_id, model, base_path, subdir="gepa")

--- a/verifiers/utils/path_utils.py
+++ b/verifiers/utils/path_utils.py
@@ -1,4 +1,5 @@
 import logging
+import json
 import uuid
 from pathlib import Path
 
@@ -31,6 +32,20 @@ def get_eval_results_path(config: EvalConfig) -> Path:
     return results_path
 
 
+def get_eval_runs_dir(env_id: str, model: str, env_dir_path: str = "./environments") -> Path:
+    """Return directory containing all eval run directories for env/model."""
+    module_name = env_id.replace("-", "_")
+    local_env_dir = Path(env_dir_path) / module_name
+
+    if local_env_dir.exists():
+        base_path = local_env_dir / "outputs"
+    else:
+        base_path = Path("./outputs")
+
+    env_model_str = f"{env_id}--{model.replace('/', '--')}"
+    return base_path / "evals" / env_model_str
+
+
 def is_valid_eval_results_path(path: Path) -> bool:
     """Checks if a path is a valid evaluation results path."""
     return (
@@ -39,6 +54,76 @@ def is_valid_eval_results_path(path: Path) -> bool:
         and Path(path / "results.jsonl").exists()
         and Path(path / "metadata.json").exists()
     )
+
+
+def _count_saved_rollouts(results_path: Path) -> int:
+    """Count completed rollout rows in results.jsonl."""
+    outputs_path = results_path / "results.jsonl"
+    count = 0
+    with open(outputs_path, "r") as f:
+        for line_idx, line in enumerate(f, start=1):
+            if not line.strip():
+                continue
+            try:
+                json.loads(line)
+            except json.JSONDecodeError:
+                logger.warning(
+                    "Ignoring malformed trailing line in %s at line %s",
+                    outputs_path,
+                    line_idx,
+                )
+                break
+            count += 1
+    return count
+
+
+def find_latest_incomplete_eval_results_path(
+    env_id: str,
+    model: str,
+    num_examples: int,
+    rollouts_per_example: int,
+    env_dir_path: str = "./environments",
+) -> Path | None:
+    """Find the newest resumable, incomplete eval run for the provided config."""
+    runs_dir = get_eval_runs_dir(env_id=env_id, model=model, env_dir_path=env_dir_path)
+    if not runs_dir.exists():
+        return None
+
+    total_rollouts = num_examples * rollouts_per_example
+    candidates: list[Path] = []
+    for run_dir in runs_dir.iterdir():
+        if run_dir.is_dir() and is_valid_eval_results_path(run_dir):
+            candidates.append(run_dir)
+
+    candidates.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+
+    for candidate in candidates:
+        metadata_path = candidate / "metadata.json"
+        try:
+            with open(metadata_path, "r") as f:
+                metadata = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            continue
+
+        if not isinstance(metadata, dict):
+            continue
+
+        if metadata.get("env_id") != env_id:
+            continue
+        if metadata.get("model") != model:
+            continue
+        if metadata.get("rollouts_per_example") != rollouts_per_example:
+            continue
+
+        saved_num_examples = metadata.get("num_examples")
+        if not isinstance(saved_num_examples, int) or saved_num_examples > num_examples:
+            continue
+
+        saved_rollouts = _count_saved_rollouts(candidate)
+        if saved_rollouts < total_rollouts:
+            return candidate
+
+    return None
 
 
 def get_gepa_results_path(

--- a/verifiers/utils/path_utils.py
+++ b/verifiers/utils/path_utils.py
@@ -43,11 +43,15 @@ def get_eval_runs_dir(env_id: str, model: str, env_dir_path: str = "./environmen
 
 def is_valid_eval_results_path(path: Path) -> bool:
     """Checks if a path is a valid evaluation results path."""
+    results_file = path / "results.jsonl"
+    metadata_file = path / "metadata.json"
     return (
         path.exists()
         and path.is_dir()
-        and Path(path / "results.jsonl").exists()
-        and Path(path / "metadata.json").exists()
+        and results_file.exists()
+        and results_file.is_file()
+        and metadata_file.exists()
+        and metadata_file.is_file()
     )
 
 


### PR DESCRIPTION
### Motivation
- Allow resuming evaluations without always supplying an explicit results path by making `--resume` accept an optional path and auto-detect the most recent incomplete matching run. 
- Keep existing explicit-path behavior and preserve TOML backward compatibility for `resume_path`.

### Description
- Replace CLI flag `--resume-path` with `--resume [PATH]` so `--resume <path>` validates and resumes the provided directory while `--resume` (no path) triggers auto-detection. 
- Add auto-resume utilities in `verifiers/utils/path_utils.py`: `get_eval_runs_dir`, `_count_saved_rollouts`, and `find_latest_incomplete_eval_results_path` which locate per-env run directories, count completed rollouts, and pick the newest incomplete run matching `env_id`, `model`, `rollouts_per_example`, and `num_examples` compatibility.
- Wire auto-detection into the CLI flow in `verifiers/scripts/eval.py`, including explicit-path validation and logging; keep `resume_path` in the produced `EvalConfig` for downstream code.
- Accept legacy TOML field by allowing `resume` in `load_toml_config` and mapping `resume_path` -> `resume` for backwards compatibility.
- Update docs in `docs/evaluation.md` to document `--resume [PATH]` and the no-path auto-resume behavior.
- Add tests: CLI tests updated in `tests/test_eval_cli.py` (explicit path + auto-detect cases) and new unit tests in `tests/test_path_utils.py` for candidate selection logic.

### Testing
- Ran style checks: `uv run ruff check --fix verifiers/scripts/eval.py verifiers/utils/path_utils.py verifiers/utils/eval_utils.py tests/test_eval_cli.py tests/test_path_utils.py` and the fixes completed successfully.
- Ran unit tests: `uv run pytest tests/test_eval_cli.py tests/test_path_utils.py -q` and both test files passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985d0cfa12c832699ff0bf36ebc45a4)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches evaluation checkpoint/resume and output path selection; incorrect matching or rollout counting could resume the wrong run or skip/redo work, though changes are well-covered by new tests.
> 
> **Overview**
> Adds a new `prime eval` resume mode by replacing `--resume-path` with `--resume [PATH]`: passing a path still validates and resumes that run, while `--resume` with no path now auto-detects the most recent *incomplete* matching run.
> 
> Implements auto-detection in `path_utils` (run directory discovery, rollout counting, newest-incomplete selection) and wires it into `verifiers/scripts/eval.py`, including TOML support (`resume` plus backward-compatible `resume_path`) and stricter results-dir validation. Updates evaluation docs and extends tests to cover explicit resume, auto-detect, and TOML override behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 08d1c160675a8063d998b853f6395a23677b7e29. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->