### PR TITLE
remove vf pin in `opencode_harbor`

### DIFF
--- a/environments/opencode_harbor/pyproject.toml
+++ b/environments/opencode_harbor/pyproject.toml
@@ -6,13 +6,10 @@ tags = ["eval", "cli_agent"]
 version = "0.1.1"
 requires-python = ">=3.10"
 dependencies = [
-    "verifiers",
+    "verifiers>=0.1.10.dev2",
     "prime-sandboxes>=0.2.10",
     "tomli>=2.3.0",
 ]
-
-[tool.uv.sources]
-verifiers = { git = "https://github.com/primeintellect-ai/verifiers", branch = "cooper/terminus" }
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

env didn't work before because the pinned vf branch pins `prime` on branch that got deleted. it's in main now tho, so it works without the pin

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->