### PR TITLE
chore: enforce ruff formatting and improve dev tooling docs

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -18,8 +18,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
-      - name: Run ruff
+      - name: Lint
         uses: astral-sh/ruff-action@v3
+      - name: Format
+        uses: astral-sh/ruff-action@v3
+        with:
+          args: "format --check"
   ty:
     name: Ty
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,16 @@
 repos:
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.3
-    hooks:
-      # Run the linter.
-      - id: ruff
-        args: [--fix, --config=pyproject.toml]
-      # Run the formatter.
-      - id: ruff-format
-        args: [--config=pyproject.toml]
   - repo: local
     hooks:
+      - id: ruff-check
+        name: ruff check
+        entry: uv run ruff check --fix
+        language: system
+        types_or: [python, pyi]
+      - id: ruff-format
+        name: ruff format
+        entry: uv run ruff format
+        language: system
+        types_or: [python, pyi]
       - id: sync-agents-md
         name: Sync AGENTS.md from docs
         entry: uv run python scripts/sync_agents_md.py

--- a/docs/development.md
+++ b/docs/development.md
@@ -243,9 +243,14 @@ uv run pytest tests/ --cov=verifiers  # With coverage
 uv run pytest tests/test_envs.py -vv              # All environments
 uv run pytest tests/test_envs.py -k math_python   # Specific environment
 
-# Linting
-uv run ruff check --fix .             # Fix lint errors
-uv run pre-commit run --all-files     # Run all pre-commit hooks
+# Linting & formatting & type checking
+uv run ruff check .                                     # Check lint errors
+uv run ruff check --fix .                               # Fix lint errors
+uv run ruff format --check .                            # Check formatting
+uv run ruff format .                                    # Format code
+uv run ty check verifiers/                              # Type check
+uv run ty check verifiers/ --ignore unresolved-import   # Type check (CPU-only)
+uv run pre-commit run --all-files                       # Run all pre-commit hooks
 
 # Environment tools
 prime env init new-env                       # Create environment

--- a/docs/development.md
+++ b/docs/development.md
@@ -16,6 +16,7 @@ This guide covers setup, testing, and contributing to the verifiers package.
 ## Setup
 
 ### Prerequisites
+
 - Python 3.10, 3.11, 3.12, or 3.13
 - [uv](https://docs.astral.sh/uv/) package manager
 
@@ -44,7 +45,7 @@ verifiers/
 │   ├── envs/           # Environment classes
 │   │   ├── integrations/   # Third-party wrappers (TextArena, ReasoningGym)
 │   │   └── experimental/   # Newer environments (MCP, Harbor, etc.)
-│   ├── parsers/        # Parser classes  
+│   ├── parsers/        # Parser classes
 │   ├── rubrics/        # Rubric classes
 │   ├── rl/             # Training infrastructure
 │   │   ├── inference/  # vLLM server utilities
@@ -94,18 +95,18 @@ The test suite includes 380+ tests covering parsers, rubrics, environments, and 
 ```python
 class TestFeature:
     """Test the feature functionality."""
-    
+
     def test_basic_functionality(self):
         """Test normal operation."""
         # Arrange
         feature = Feature()
-        
+
         # Act
         result = feature.process("input")
-        
+
         # Assert
         assert result == "expected"
-    
+
     def test_error_handling(self):
         """Test error cases."""
         with pytest.raises(ValueError):
@@ -164,25 +165,22 @@ def test_with_mock(mock_client):
 ## Common Issues
 
 ### Import Errors
+
 ```bash
 # Ensure package is installed in development mode
 uv sync
 ```
 
 ### Integration Tests
+
 ```bash
 # Install optional dependencies for specific integrations
 uv sync --extra ta   # for TextArenaEnv
 uv sync --extra rg   # for ReasoningGymEnv
 ```
 
-### Type Checking on CPU-Only Machines
-If you're on a CPU-only machine and can't install all dependencies (e.g. `torch`, `vllm`), `ty` will report unresolved-import warnings for those packages. You can suppress these and still check the rest of the codebase:
-```bash
-uv run ty check verifiers/ --ignore unresolved-import
-```
-
 ### Test Failures
+
 ```bash
 # Debug specific test
 uv run pytest tests/test_file.py::test_name -vvs --pdb
@@ -213,16 +211,16 @@ def load_environment(**kwargs):
     """Load the environment."""
     dataset = vf.load_example_dataset("dataset_name")
     parser = vf.XMLParser(fields=["reasoning", "answer"])
-    
+
     def reward_func(parser, completion, answer, **kwargs):
         return 1.0 if parser.parse_answer(completion) == answer else 0.0
-    
+
     rubric = vf.Rubric(
         funcs=[reward_func, parser.get_format_reward_func()],
         weights=[1.0, 0.2],
         parser=parser
     )
-    
+
     return vf.SingleTurnEnv(
         dataset=dataset,
         parser=parser,
@@ -264,15 +262,15 @@ prime eval tui                               # Browse eval results
 
 ### CLI Tools
 
- | Command | Description |
-|---------|-------------|
-| `prime eval run` | Run evaluations on environments |
-| `prime env init` | Initialize new environment from template |
-| `prime env install` | Install environment module |
-| `prime lab setup` | Set up training workspace |
-| `prime eval tui` | Terminal UI for browsing eval results |
-| `prime rl run` | Launch Hosted Training |
-| `uv run prime-rl` | Launch prime-rl training |
+| Command             | Description                              |
+| ------------------- | ---------------------------------------- |
+| `prime eval run`    | Run evaluations on environments          |
+| `prime env init`    | Initialize new environment from template |
+| `prime env install` | Install environment module               |
+| `prime lab setup`   | Set up training workspace                |
+| `prime eval tui`    | Terminal UI for browsing eval results    |
+| `prime rl run`      | Launch Hosted Training                   |
+| `uv run prime-rl`   | Launch prime-rl training                 |
 
 ### Project Guidelines
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -16,7 +16,6 @@ This guide covers setup, testing, and contributing to the verifiers package.
 ## Setup
 
 ### Prerequisites
-
 - Python 3.10, 3.11, 3.12, or 3.13
 - [uv](https://docs.astral.sh/uv/) package manager
 
@@ -45,7 +44,7 @@ verifiers/
 │   ├── envs/           # Environment classes
 │   │   ├── integrations/   # Third-party wrappers (TextArena, ReasoningGym)
 │   │   └── experimental/   # Newer environments (MCP, Harbor, etc.)
-│   ├── parsers/        # Parser classes
+│   ├── parsers/        # Parser classes  
 │   ├── rubrics/        # Rubric classes
 │   ├── rl/             # Training infrastructure
 │   │   ├── inference/  # vLLM server utilities
@@ -95,18 +94,18 @@ The test suite includes 380+ tests covering parsers, rubrics, environments, and 
 ```python
 class TestFeature:
     """Test the feature functionality."""
-
+    
     def test_basic_functionality(self):
         """Test normal operation."""
         # Arrange
         feature = Feature()
-
+        
         # Act
         result = feature.process("input")
-
+        
         # Assert
         assert result == "expected"
-
+    
     def test_error_handling(self):
         """Test error cases."""
         with pytest.raises(ValueError):
@@ -165,14 +164,12 @@ def test_with_mock(mock_client):
 ## Common Issues
 
 ### Import Errors
-
 ```bash
 # Ensure package is installed in development mode
 uv sync
 ```
 
 ### Integration Tests
-
 ```bash
 # Install optional dependencies for specific integrations
 uv sync --extra ta   # for TextArenaEnv
@@ -180,7 +177,6 @@ uv sync --extra rg   # for ReasoningGymEnv
 ```
 
 ### Test Failures
-
 ```bash
 # Debug specific test
 uv run pytest tests/test_file.py::test_name -vvs --pdb
@@ -211,16 +207,16 @@ def load_environment(**kwargs):
     """Load the environment."""
     dataset = vf.load_example_dataset("dataset_name")
     parser = vf.XMLParser(fields=["reasoning", "answer"])
-
+    
     def reward_func(parser, completion, answer, **kwargs):
         return 1.0 if parser.parse_answer(completion) == answer else 0.0
-
+    
     rubric = vf.Rubric(
         funcs=[reward_func, parser.get_format_reward_func()],
         weights=[1.0, 0.2],
         parser=parser
     )
-
+    
     return vf.SingleTurnEnv(
         dataset=dataset,
         parser=parser,
@@ -247,11 +243,9 @@ uv run pytest tests/ --cov=verifiers  # With coverage
 uv run pytest tests/test_envs.py -vv              # All environments
 uv run pytest tests/test_envs.py -k math_python   # Specific environment
 
-# Linting & type checking
+# Linting
 uv run ruff check --fix .             # Fix lint errors
 uv run pre-commit run --all-files     # Run all pre-commit hooks
-uv run ty check verifiers/            # Type check (needs all deps)
-uv run ty check verifiers/ --ignore unresolved-import  # Type check (CPU-only)
 
 # Environment tools
 prime env init new-env                       # Create environment
@@ -262,15 +256,15 @@ prime eval tui                               # Browse eval results
 
 ### CLI Tools
 
-| Command             | Description                              |
-| ------------------- | ---------------------------------------- |
-| `prime eval run`    | Run evaluations on environments          |
-| `prime env init`    | Initialize new environment from template |
-| `prime env install` | Install environment module               |
-| `prime lab setup`   | Set up training workspace                |
-| `prime eval tui`    | Terminal UI for browsing eval results    |
-| `prime rl run`      | Launch Hosted Training                   |
-| `uv run prime-rl`   | Launch prime-rl training                 |
+ | Command | Description |
+|---------|-------------|
+| `prime eval run` | Run evaluations on environments |
+| `prime env init` | Initialize new environment from template |
+| `prime env install` | Install environment module |
+| `prime lab setup` | Set up training workspace |
+| `prime eval tui` | Terminal UI for browsing eval results |
+| `prime rl run` | Launch Hosted Training |
+| `uv run prime-rl` | Launch prime-rl training |
 
 ### Project Guidelines
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -176,6 +176,12 @@ uv sync --extra ta   # for TextArenaEnv
 uv sync --extra rg   # for ReasoningGymEnv
 ```
 
+### Type Checking on CPU-Only Machines
+If you're on a CPU-only machine and can't install all dependencies (e.g. `torch`, `vllm`), `ty` will report unresolved-import warnings for those packages. You can suppress these and still check the rest of the codebase:
+```bash
+uv run ty check verifiers/ --ignore unresolved-import
+```
+
 ### Test Failures
 ```bash
 # Debug specific test
@@ -243,9 +249,11 @@ uv run pytest tests/ --cov=verifiers  # With coverage
 uv run pytest tests/test_envs.py -vv              # All environments
 uv run pytest tests/test_envs.py -k math_python   # Specific environment
 
-# Linting
+# Linting & type checking
 uv run ruff check --fix .             # Fix lint errors
 uv run pre-commit run --all-files     # Run all pre-commit hooks
+uv run ty check verifiers/            # Type check (needs all deps)
+uv run ty check verifiers/ --ignore unresolved-import  # Type check (CPU-only)
 
 # Environment tools
 prime env init new-env                       # Create environment

--- a/environments/terminus_harbor/terminus_harbor.py
+++ b/environments/terminus_harbor/terminus_harbor.py
@@ -84,22 +84,19 @@ class TerminusHarborEnv(HarborEnv):
 
         # Upload the run_agent.py script
         script_content = self._get_run_agent_script()
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.py', delete=False) as f:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
             f.write(script_content)
             temp_path = f.name
 
         try:
             await sandbox_client.upload_file(
-                sandbox_id,
-                f"{self.agent_workdir}/run_agent.py",
-                temp_path
+                sandbox_id, f"{self.agent_workdir}/run_agent.py", temp_path
             )
         finally:
             Path(temp_path).unlink(missing_ok=True)
 
-
     def _get_run_agent_script(self) -> str:
-        return '''#!/usr/bin/env python3
+        return """#!/usr/bin/env python3
 import sys
 import asyncio
 import os
@@ -255,7 +252,7 @@ if __name__ == "__main__":
     print("Starting asyncio.run(main())...", flush=True)
     asyncio.run(main())
     print("=== run_agent.py finished ===", flush=True)
-'''
+"""
 
 
 def load_environment(

--- a/tests/test_path_utils.py
+++ b/tests/test_path_utils.py
@@ -12,12 +12,7 @@ def test_find_latest_incomplete_eval_results_path_picks_newest_matching(
 ):
     env_id = "dummy-env"
     model = "openai/gpt-4.1-mini"
-    runs_dir = (
-        tmp_path
-        / "outputs"
-        / "evals"
-        / f"{env_id}--{model.replace('/', '--')}"
-    )
+    runs_dir = tmp_path / "outputs" / "evals" / f"{env_id}--{model.replace('/', '--')}"
 
     old_run = runs_dir / "11111111"
     new_run = runs_dir / "22222222"

--- a/tests/test_tool_env.py
+++ b/tests/test_tool_env.py
@@ -356,7 +356,10 @@ class TestToolEnv:
         def mixed_tool() -> list:
             return [
                 {"type": "text", "text": "Here's the screenshot"},
-                {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "data:image/png;base64,abc"},
+                },
             ]
 
         env = vf.ToolEnv(

--- a/verifiers/envs/experimental/cli_agent_env.py
+++ b/verifiers/envs/experimental/cli_agent_env.py
@@ -580,16 +580,12 @@ class CliAgentEnv(vf.MultiTurnEnv):
         rollout_id = request.match_info["rollout_id"]
         context = self.active_rollouts.get(rollout_id)
         if not context:
-            return web.json_response(
-                {"error": "Rollout not found"}, status=404
-            )
+            return web.json_response({"error": "Rollout not found"}, status=404)
 
         try:
             request_body = await request.json()
         except Exception as e:
-            return web.json_response(
-                {"error": f"Invalid JSON: {e}"}, status=400
-            )
+            return web.json_response({"error": f"Invalid JSON: {e}"}, status=400)
 
         self.log_request(rollout_id, request_body)
 
@@ -622,14 +618,10 @@ class CliAgentEnv(vf.MultiTurnEnv):
                 )
                 response = await response_future
             except asyncio.CancelledError:
-                return web.json_response(
-                    {"error": "Rollout cancelled"}, status=499
-                )
+                return web.json_response({"error": "Rollout cancelled"}, status=499)
             except Exception as e:
                 logger.error(f"Error processing intercepted request: {e}")
-                return web.json_response(
-                    {"error": str(e)}, status=500
-                )
+                return web.json_response({"error": str(e)}, status=500)
 
             response_dict = (
                 response.model_dump()

--- a/verifiers/envs/integrations/textarena_env.py
+++ b/verifiers/envs/integrations/textarena_env.py
@@ -18,8 +18,10 @@ except ImportError as e:
 # monkey-patch nltk.download to always be quiet before importing textarena
 _original_nltk_download = nltk.download
 
+
 def _quiet_download(*args: Any, **kwargs: Any) -> Any:
     return _original_nltk_download(*args, **{**kwargs, "quiet": True})
+
 
 cast(Any, nltk).download = _quiet_download
 

--- a/verifiers/envs/tool_env.py
+++ b/verifiers/envs/tool_env.py
@@ -6,7 +6,10 @@ from openai.types.chat import ChatCompletionAssistantMessageParam
 import verifiers as vf
 from verifiers.types import Messages
 from verifiers.utils.async_utils import maybe_await
-from verifiers.utils.tool_utils import convert_func_to_oai_tool, is_valid_tool_content_parts
+from verifiers.utils.tool_utils import (
+    convert_func_to_oai_tool,
+    is_valid_tool_content_parts,
+)
 
 
 class ToolMonitorRubric(vf.Rubric):

--- a/verifiers/gepa/gepa_utils.py
+++ b/verifiers/gepa/gepa_utils.py
@@ -81,12 +81,14 @@ def save_gepa_results(
                 if score == best_score
             ]
 
-            records.append({
-                "valset_row": row_idx,
-                "best_score": best_score,
-                "num_best_prompts": len(best_prompts),
-                "best_prompts": best_prompts,
-            })
+            records.append(
+                {
+                    "valset_row": row_idx,
+                    "best_score": best_score,
+                    "num_best_prompts": len(best_prompts),
+                    "best_prompts": best_prompts,
+                }
+            )
 
     # Save frontier as JSONL
     if records:
@@ -102,7 +104,9 @@ def save_gepa_results(
     metadata = {
         "num_candidates": len(candidates),
         "best_idx": best_idx,
-        "best_score": float(val_scores[best_idx]) if val_scores and best_idx < len(val_scores) else None,
+        "best_score": float(val_scores[best_idx])
+        if val_scores and best_idx < len(val_scores)
+        else None,
         "total_metric_calls": getattr(result, "total_metric_calls", None),
         "completed_at": datetime.now().isoformat(),
     }

--- a/verifiers/rl/trainer/trainer.py
+++ b/verifiers/rl/trainer/trainer.py
@@ -453,8 +453,7 @@ class RLTrainer(Trainer):
                     for c in textual_logs["completion"]
                 ]
                 table = {
-                    "step": [str(self.state.global_step)]
-                    * len(textual_logs["prompt"]),
+                    "step": [str(self.state.global_step)] * len(textual_logs["prompt"]),
                     "prompt": prompts_clean,
                     "completion": completions_clean,
                     **{k: list(v) for k, v in rewards_map.items()},

--- a/verifiers/rubrics/rubric.py
+++ b/verifiers/rubrics/rubric.py
@@ -93,7 +93,11 @@ class Rubric:
 
     # individual-level reward helpers
     def _get_individual_reward_func_names(self) -> list[str]:
-        return [getattr(func, "__name__", repr(func)) for func in self.funcs if not self._is_group_func(func)]
+        return [
+            getattr(func, "__name__", repr(func))
+            for func in self.funcs
+            if not self._is_group_func(func)
+        ]
 
     def _get_individual_reward_funcs(self) -> list[RewardFunc]:
         return [func for func in self.funcs if not self._is_group_func(func)]
@@ -152,10 +156,17 @@ class Rubric:
 
     # group-level reward helpers
     def _get_group_reward_func_names(self) -> list[str]:
-        return [getattr(func, "__name__", repr(func)) for func in self.funcs if self._is_group_func(func)]
+        return [
+            getattr(func, "__name__", repr(func))
+            for func in self.funcs
+            if self._is_group_func(func)
+        ]
 
     def _get_group_reward_funcs(self) -> list[GroupRewardFunc]:
-        return cast(list[GroupRewardFunc], [func for func in self.funcs if self._is_group_func(func)])
+        return cast(
+            list[GroupRewardFunc],
+            [func for func in self.funcs if self._is_group_func(func)],
+        )
 
     def _get_group_reward_weights(self) -> list[float]:
         return [

--- a/verifiers/utils/message_utils.py
+++ b/verifiers/utils/message_utils.py
@@ -96,7 +96,6 @@ def format_messages(messages: Any) -> Text:
             return obj.get(key, default)
         return default
 
-
     def _normalize_tool_call(tc: Any) -> dict[str, str]:
         if isinstance(tc, str):
             tc = json.loads(tc)

--- a/verifiers/utils/path_utils.py
+++ b/verifiers/utils/path_utils.py
@@ -34,7 +34,9 @@ def get_eval_results_path(config: EvalConfig) -> Path:
     return get_results_path(config.env_id, config.model, base_path)
 
 
-def get_eval_runs_dir(env_id: str, model: str, env_dir_path: str = "./environments") -> Path:
+def get_eval_runs_dir(
+    env_id: str, model: str, env_dir_path: str = "./environments"
+) -> Path:
     """Return directory containing all eval run directories for env/model."""
     base_path = _get_outputs_base_path(env_id, env_dir_path)
     env_model_str = f"{env_id}--{model.replace('/', '--')}"


### PR DESCRIPTION
## Summary
- Document ruff (lint + format) and ty (type-check) commands in development docs, including CPU-only `--ignore unresolved-import` flag
- Run `ruff format` across the codebase (11 files reformatted)
- Add `ruff format --check` step to the CI style workflow so formatting is enforced in CI

## Test plan
- [x] `uv run pre-commit run ruff-format --all-files` passes
- [x] `uv run ruff format --check .` passes (no unformatted files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily CI/tooling and code formatting changes; functional behavior should be unchanged aside from potential edge cases from automated reformatting.
> 
> **Overview**
> **Formatting is now enforced in automation.** The style GitHub Action splits Ruff into a lint step plus a new `ruff format --check` step so PRs fail on unformatted code.
> 
> Pre-commit is updated to run Ruff via local `uv run` hooks (`ruff check --fix` and `ruff format`) instead of the `ruff-pre-commit` repo, and `docs/development.md` is expanded to document separate linting, formatting, and `ty check` commands (including a CPU-only flag).
> 
> The remaining code changes are repo-wide Ruff formatting cleanups across multiple Python modules/tests with no intended logic changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc062a0090c084822efc5a686f4119f7eff0e52d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->