### PR TITLE
ci: skip terminus_harbor in test-envs

### DIFF
--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -21,6 +21,8 @@ SKIPPED_ENVS = [
     "browser_dom_example",
     # Requires BROWSERBASE_API_KEY, BROWSERBASE_PROJECT_ID, and running CUA server
     "browser_cua_example",
+    # Uses prime-tunnel which is still experimental and has low usage limits
+    "terminus_harbor",
 ]
 
 SKIPPED_ENV_LOADING_ENVS = [


### PR DESCRIPTION
## Summary
- Skip `terminus_harbor` environment in `test-envs` CI job since it uses `prime-tunnel` which is still experimental and has low usage limits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that excludes one environment from CI; no production code or runtime behavior is modified.
> 
> **Overview**
> Updates the `test-envs` CI checks to **skip the `terminus_harbor` environment** by adding it to `SKIPPED_ENVS` in `tests/test_envs.py`, since it depends on the experimental `prime-tunnel` with low usage limits.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4db80219847da2ed9195380f1b245ff65c379bc6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->