### PR TITLE
RLM: Make FIFO IO non-blocking

### DIFF
--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -2360,6 +2360,7 @@ class SandboxRLMExecutor(BaseRLMExecutor, SandboxExecutorMixin):
     command_fifo = '{session.paths.command_fifo}'
     response_fifo = '{session.paths.response_fifo}'
     timeout_seconds = {timeout_seconds}
+    deadline = time.time() + timeout_seconds
 
     try:
         cmd_fd = os.open(command_fifo, os.O_WRONLY | os.O_NONBLOCK)
@@ -2395,7 +2396,6 @@ class SandboxRLMExecutor(BaseRLMExecutor, SandboxExecutorMixin):
             sys.exit(0)
         raise
     chunks = []
-    deadline = time.time() + timeout_seconds
     try:
         while True:
             now = time.time()

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -23,12 +23,14 @@ Key features:
 import asyncio
 import base64
 import contextvars
+import errno
 import json
 import logging
 import os
 import pickle
 import random
 import re
+import select
 import shutil
 import signal
 import shlex
@@ -1565,14 +1567,54 @@ class LocalRLMExecutor(BaseRLMExecutor):
 
         def _do_io() -> str:
             payload_json = json.dumps(payload)
-            with open(
-                session.paths.command_fifo, "w", encoding="utf-8"
-            ) as command_file:
-                command_file.write(payload_json)
-            with open(
-                session.paths.response_fifo, "r", encoding="utf-8"
-            ) as response_file:
-                return response_file.read()
+            payload_bytes = payload_json.encode("utf-8")
+            deadline = time.monotonic() + self.env.code_execution_timeout
+
+            try:
+                cmd_fd = os.open(
+                    session.paths.command_fifo, os.O_WRONLY | os.O_NONBLOCK
+                )
+            except OSError as exc:
+                if exc.errno in (errno.ENXIO, errno.ENOENT):
+                    raise RLMCodeExecutionTimeout from exc
+                raise
+            try:
+                remaining = payload_bytes
+                while remaining:
+                    written = os.write(cmd_fd, remaining)
+                    remaining = remaining[written:]
+            finally:
+                os.close(cmd_fd)
+
+            try:
+                res_fd = os.open(
+                    session.paths.response_fifo, os.O_RDONLY | os.O_NONBLOCK
+                )
+            except OSError as exc:
+                if exc.errno in (errno.ENOENT,):
+                    raise RLMCodeExecutionTimeout from exc
+                raise
+            chunks: list[bytes] = []
+            try:
+                while True:
+                    now = time.monotonic()
+                    if now >= deadline:
+                        raise RLMCodeExecutionTimeout
+                    timeout = min(0.05, deadline - now)
+                    ready, _, _ = select.select([res_fd], [], [], timeout)
+                    if not ready:
+                        continue
+                    chunk = os.read(res_fd, 4096)
+                    if chunk:
+                        chunks.append(chunk)
+                        continue
+                    break
+            finally:
+                os.close(res_fd)
+
+            if not chunks:
+                raise RLMCodeExecutionTimeout
+            return b"".join(chunks).decode("utf-8", errors="replace")
 
         try:
             raw = await asyncio.wait_for(
@@ -1585,6 +1627,10 @@ class LocalRLMExecutor(BaseRLMExecutor):
             )
             self._unblock_response_fifo(session, payload.get("seq", 0))
             raise RLMCodeExecutionTimeout from e
+        except RLMCodeExecutionTimeout as e:
+            logger.warning("RLM worker did not respond in time")
+            self._unblock_response_fifo(session, payload.get("seq", 0))
+            raise
         except Exception as e:
             raise vf.SandboxError() from e
 
@@ -1880,9 +1926,7 @@ class SandboxRLMExecutor(BaseRLMExecutor, SandboxExecutorMixin):
                 # Allow environments to run repo/tool setup before the worker starts.
                 await self.env.on_sandbox_ready(state, sandbox.id)
             except Exception as exc:
-                raise vf.SandboxError(
-                    f"Sandbox setup hook failed: {exc}"
-                ) from exc
+                raise vf.SandboxError(f"Sandbox setup hook failed: {exc}") from exc
 
         if not session.sandbox_id:
             raise vf.SandboxError() from Exception("Sandbox not initialized")
@@ -1935,6 +1979,8 @@ class SandboxRLMExecutor(BaseRLMExecutor, SandboxExecutorMixin):
             raw = await self._send_worker_request(session, payload)
         except CommandTimeoutError as e:
             raise RLMCodeExecutionTimeout from e
+        except RLMCodeExecutionTimeout:
+            raise
         except Exception as e:
             raise vf.SandboxError() from e
 
@@ -2280,6 +2326,7 @@ class SandboxRLMExecutor(BaseRLMExecutor, SandboxExecutorMixin):
             raise vf.SandboxError() from Exception("Sandbox not initialized")
         payload_json = json.dumps(payload)
         payload_b64 = base64.b64encode(payload_json.encode("utf-8")).decode("utf-8")
+        timeout_seconds = int(self.env.code_execution_timeout)
         alive_check = (
             f'[ -f "{session.paths.worker_pid_file}" ] '
             f'&& [ -d "/proc/$(cat {session.paths.worker_pid_file})" ] '
@@ -2290,14 +2337,64 @@ class SandboxRLMExecutor(BaseRLMExecutor, SandboxExecutorMixin):
             {alive_check}
             python - <<'PY'
     import base64
+    import errno
     import json
+    import os
+    import select
     import sys
+    import time
 
     data = base64.b64decode('{payload_b64}').decode('utf-8')
-    with open('{session.paths.command_fifo}', 'w', encoding='utf-8') as command_file:
-        command_file.write(data)
-    with open('{session.paths.response_fifo}', 'r', encoding='utf-8') as response_file:
-        sys.stdout.write(response_file.read())
+    command_fifo = '{session.paths.command_fifo}'
+    response_fifo = '{session.paths.response_fifo}'
+    timeout_seconds = {timeout_seconds}
+
+    try:
+        cmd_fd = os.open(command_fifo, os.O_WRONLY | os.O_NONBLOCK)
+    except OSError as exc:
+        if exc.errno in (errno.ENXIO, errno.ENOENT):
+            print("WORKER_DEAD")
+            sys.exit(0)
+        raise
+    try:
+        payload_bytes = data.encode("utf-8")
+        remaining = payload_bytes
+        while remaining:
+            written = os.write(cmd_fd, remaining)
+            remaining = remaining[written:]
+    finally:
+        os.close(cmd_fd)
+
+    try:
+        res_fd = os.open(response_fifo, os.O_RDONLY | os.O_NONBLOCK)
+    except OSError as exc:
+        if exc.errno in (errno.ENOENT,):
+            print("WORKER_DEAD")
+            sys.exit(0)
+        raise
+    chunks = []
+    deadline = time.time() + timeout_seconds
+    try:
+        while True:
+            now = time.time()
+            if now >= deadline:
+                print("WORKER_TIMEOUT")
+                sys.exit(0)
+            timeout = min(0.05, deadline - now)
+            ready, _, _ = select.select([res_fd], [], [], timeout)
+            if not ready:
+                continue
+            chunk = os.read(res_fd, 4096)
+            if chunk:
+                chunks.append(chunk)
+                continue
+            break
+    finally:
+        os.close(res_fd)
+    if not chunks:
+        print("WORKER_DEAD")
+        sys.exit(0)
+    sys.stdout.write(b"".join(chunks).decode("utf-8", errors="replace"))
     PY
             """
         )
@@ -2308,7 +2405,9 @@ class SandboxRLMExecutor(BaseRLMExecutor, SandboxExecutorMixin):
         )
         raw_response = result.stdout or ""
         if raw_response and raw_response.strip() == "WORKER_DEAD":
-            raise vf.SandboxError() from RuntimeError("RLM worker not running")
+            raise RLMCodeExecutionTimeout
+        if raw_response and raw_response.strip() == "WORKER_TIMEOUT":
+            raise RLMCodeExecutionTimeout
         return raw_response
 
     async def _upload_directory(

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -1627,7 +1627,7 @@ class LocalRLMExecutor(BaseRLMExecutor):
             )
             self._unblock_response_fifo(session, payload.get("seq", 0))
             raise RLMCodeExecutionTimeout from e
-        except RLMCodeExecutionTimeout as e:
+        except RLMCodeExecutionTimeout:
             logger.warning("RLM worker did not respond in time")
             self._unblock_response_fifo(session, payload.get("seq", 0))
             raise

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -1608,6 +1608,9 @@ class LocalRLMExecutor(BaseRLMExecutor):
                     if chunk:
                         chunks.append(chunk)
                         continue
+                    if not chunks:
+                        time.sleep(0.01)
+                        continue
                     break
             finally:
                 os.close(res_fd)
@@ -2387,6 +2390,9 @@ class SandboxRLMExecutor(BaseRLMExecutor, SandboxExecutorMixin):
             chunk = os.read(res_fd, 4096)
             if chunk:
                 chunks.append(chunk)
+                continue
+            if not chunks:
+                time.sleep(0.01)
                 continue
             break
     finally:


### PR DESCRIPTION
## Description

- Use non‑blocking FIFO read/write with select in local and sandbox workers.
- Fail fast when the worker is dead/missing instead of hanging until timeout.
- Preserve existing timeout/recovery behavior for REPL execution.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ x I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core REPL execution I/O and timeout handling; subtle FIFO/`select` edge cases could cause new timeouts or incomplete reads/writes across local and sandbox backends.
> 
> **Overview**
> Improves RLM REPL worker communication by switching FIFO reads/writes to **non-blocking** `os.open`/`os.read`/`os.write` with `select`, instead of blocking file I/O that could hang.
> 
> Both local and sandbox execution paths now **fail fast** when FIFOs/worker are missing or unresponsive, mapping `WORKER_DEAD`/`WORKER_TIMEOUT` conditions to `RLMCodeExecutionTimeout` and preserving the existing timeout recovery path (including FIFO unblocking) with clearer logging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9fede6ffaf9c6fc7c0c4dcb5a48ce1f0cf1a6491. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->