### PR TITLE
move sanitize_metadata out of save_metadata

### DIFF
--- a/verifiers/utils/save_utils.py
+++ b/verifiers/utils/save_utils.py
@@ -488,17 +488,18 @@ def save_new_outputs(new_outputs: list[RolloutOutput], results_path: Path):
     save_outputs(new_outputs, results_path, mode="a")
 
 
+def sanitize_metadata(metadata: GenerateMetadata) -> dict:
+    """Sanitizes metadata before saving to disk."""
+
+    metadata_dict = dict(metadata)
+    metadata_dict.pop("path_to_save")
+    metadata_dict.pop("date")
+
+    return metadata_dict
+
+
 def save_metadata(metadata: GenerateMetadata, result_path: Path):
     """Saves metadata to disk."""
-
-    def sanitize_metadata(metadata: GenerateMetadata) -> dict:
-        """Sanitizes metadata before saving to disk."""
-
-        metadata_dict = dict(metadata)
-        metadata_dict.pop("path_to_save")
-        metadata_dict.pop("date")
-
-        return metadata_dict
 
     result_path.mkdir(parents=True, exist_ok=True)
     metadata_path = result_path / "metadata.json"


### PR DESCRIPTION
## Description

Moves `sanitize_metadata` out of `save_metadata`. The reason is that there's no reason for the function to be defined inside the other function, and that prime-rl tries to import `sanitize_metadata` which it cannot if it's nested in such a way.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor that only changes function scope/visibility; serialization and file-writing behavior remains the same.
> 
> **Overview**
> Moves `sanitize_metadata` out of `save_metadata` in `verifiers/utils/save_utils.py`, making it a top-level helper that can be imported by other packages.
> 
> `save_metadata` now calls the extracted `sanitize_metadata` function, preserving the same metadata filtering (`path_to_save`, `date`) before writing `metadata.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 16b47add589ce9f05231bf46e1f3b74a480348a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->