### PR TITLE
RLM: handle empty metrics

### DIFF
--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -344,7 +344,8 @@ class RLMMonitorRubric(vf.Rubric):
 
     def _make_state_metric(self, key: str):
         async def metric(state: State):
-            return state[key]
+            value = state.get(key, 0)
+            return 0 if value is None else value
 
         metric.__name__ = key
         return metric


### PR DESCRIPTION
## Description

When the RLM crashes early for some reason, the metrics that it automatically collects are not present in its state. Then, the rollout finishes due to the crash and the metrics are collected, each of which now produces its own error, polluting the output and making it hard to debug the problem. This PR simply sets them to 0 if they are not present or None, which solves the problem.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to metrics reading logic; behavior only changes for missing/`None` metric keys and should reduce errors without affecting core execution.
> 
> **Overview**
> Fixes RLM monitor metric collection to be resilient to early-crash/partial state by making `RLMMonitorRubric._make_state_metric` default missing or `None` values to `0` instead of raising (previously `state[key]`).
> 
> This prevents follow-on metric errors from polluting rollout output when metrics weren’t initialized.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4890f5145e3349bfba72b35d2126776750a866ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->