### PR TITLE
Add robust token usage tracking

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,7 +161,6 @@ asyncio_mode = "auto"
 norecursedirs = [".git", ".tox", "dist", "build", "*.egg", "__pycache__"]
 
 [tool.ty.rules]
-unresolved-import = "warn"
 unknown-argument = "warn"
 redundant-cast = "ignore"
 

--- a/tests/test_eval_utils.py
+++ b/tests/test_eval_utils.py
@@ -116,3 +116,23 @@ def test_print_results_three_rollouts(capsys, make_metadata, make_state, make_in
     assert "r2: [0.2, 0.5]" in captured.out
     # r3 should have [0.3, 0.6] (third rollout of each example)
     assert "r3: [0.3, 0.6]" in captured.out
+
+
+def test_print_results_includes_usage(capsys, make_metadata, make_output):
+    from verifiers.utils.eval_utils import print_results
+
+    outputs = [
+        make_output(example_id=0, reward=1.0, metrics={"test_metric": 1.0}),
+        make_output(example_id=1, reward=0.0, metrics={"test_metric": 2.0}),
+    ]
+    outputs[0]["token_usage"] = {"input_tokens": 10.0, "output_tokens": 4.0}
+    outputs[1]["token_usage"] = {"input_tokens": 6.0, "output_tokens": 2.0}
+    metadata = make_metadata(num_examples=2, rollouts_per_example=1, usage=None)
+
+    results = GenerateOutputs(outputs=outputs, metadata=metadata)
+    print_results(results)
+    captured = capsys.readouterr()
+
+    assert "Usage:" in captured.out
+    assert "input_tokens (avg): 8.000" in captured.out
+    assert "output_tokens (avg): 3.000" in captured.out

--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -144,6 +144,8 @@ def __getattr__(name: str):
 
 
 if TYPE_CHECKING:
+    from typing import Any
+
     from .envs.experimental.cli_agent_env import CliAgentEnv  # noqa: F401
     from .envs.experimental.gym_env import GymEnv  # noqa: F401
     from .envs.experimental.harbor_env import HarborEnv  # noqa: F401
@@ -155,15 +157,13 @@ if TYPE_CHECKING:
     from .envs.python_env import PythonEnv  # noqa: F401
     from .envs.sandbox_env import SandboxEnv  # noqa: F401
     from .rubrics.math_rubric import MathRubric  # noqa: F401
-    from verifiers_rl.rl.trainer import (  # noqa: F401
-        GRPOConfig,
-        GRPOTrainer,
-        RLConfig,
-        RLTrainer,
-        grpo_defaults,
-        lora_defaults,
-    )
-    from verifiers_rl.rl.trainer.utils import (  # noqa: F401
-        get_model,
-        get_model_and_tokenizer,
-    )
+
+    # Optional verifiers-rl exports. Keep type-checking clean when extra is absent.
+    RLConfig: Any
+    RLTrainer: Any
+    GRPOTrainer: Any
+    GRPOConfig: Any
+    grpo_defaults: Any
+    lora_defaults: Any
+    get_model: Any
+    get_model_and_tokenizer: Any

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -164,6 +164,8 @@ class State(dict):
     metrics: dict[str, float] | None
     timing: RolloutTiming | None
     error: Error | None
+    usage: TokenUsage | None
+    usage_tracker: object
 
     def __getitem__(self, key: str) -> Any:
         # forward to input if exists

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -429,6 +429,35 @@ def print_timing(results: GenerateOutputs):
     )
 
 
+def print_usage(results: GenerateOutputs):
+    usage_count = 0
+    input_tokens_total = 0.0
+    output_tokens_total = 0.0
+    for output in results["outputs"]:
+        token_usage = output.get("token_usage")
+        if not isinstance(token_usage, Mapping):
+            continue
+        usage_count += 1
+        input_tokens_total += float(token_usage.get("input_tokens", 0.0))
+        output_tokens_total += float(token_usage.get("output_tokens", 0.0))
+
+    usage = None
+    if usage_count > 0:
+        usage = {
+            "input_tokens": input_tokens_total / usage_count,
+            "output_tokens": output_tokens_total / usage_count,
+        }
+    elif results["metadata"].get("usage") is not None:
+        usage = results["metadata"]["usage"]
+
+    if usage is None:
+        return
+
+    print("Usage:")
+    print(f"input_tokens (avg): {usage['input_tokens']:.3f}")
+    print(f"output_tokens (avg): {usage['output_tokens']:.3f}")
+
+
 def print_results(results: GenerateOutputs, num_samples: int = 1):
     assert results["metadata"] is not None
     print("--- Evaluation ---")
@@ -458,6 +487,7 @@ def print_results(results: GenerateOutputs, num_samples: int = 1):
     print_rewards(results)
     print_info(results)
     print_timing(results)
+    print_usage(results)
 
     tasks = set([o["task"] for o in results["outputs"]])
     if len(tasks) > 1:
@@ -467,6 +497,7 @@ def print_results(results: GenerateOutputs, num_samples: int = 1):
             print_rewards(task_results)
             print_info(task_results)
             print_timing(task_results)
+            print_usage(task_results)
 
 
 @contextmanager

--- a/verifiers/utils/save_utils.py
+++ b/verifiers/utils/save_utils.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import time
+from collections.abc import Mapping
 from collections import defaultdict
 from datetime import date, datetime
 from pathlib import Path
@@ -24,6 +25,10 @@ from verifiers.types import (
 from verifiers.utils.error_utils import ErrorChain
 from verifiers.utils.message_utils import messages_to_printable, sanitize_tool_calls
 from verifiers.utils.path_utils import get_results_path
+from verifiers.utils.usage_utils import (
+    StateUsageTracker,
+    extract_usage_tokens as extract_usage_tokens_from_response,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +45,7 @@ def is_json_serializable(value: object) -> bool:
         return True
     if isinstance(value, (list, tuple)):
         return all(is_json_serializable(item) for item in value)
-    if isinstance(value, dict):
+    if isinstance(value, Mapping):
         return all(
             isinstance(k, str) and is_json_serializable(v) for k, v in value.items()
         )
@@ -64,26 +69,44 @@ def make_serializable(value: object) -> str | int | float | bool | list | dict |
         return value.as_posix()
     elif isinstance(value, (BaseException)):
         return repr(value)
+    elif isinstance(value, Mapping):
+        return dict(value)
     else:
         return str(value)
 
 
 def extract_usage_tokens(response: object) -> tuple[int, int]:
-    usage = getattr(response, "usage", None)
-    if usage is None:
-        return 0, 0
+    return extract_usage_tokens_from_response(response)
 
-    def get_usage_value(usage_obj: object, key: str) -> int | float:
-        if isinstance(usage_obj, dict):
-            return cast(dict[str, Any], usage_obj).get(key, 0)
-        return getattr(usage_obj, key, 0)
 
-    prompt_tokens = get_usage_value(usage, "prompt_tokens")
-    completion_tokens = get_usage_value(usage, "completion_tokens")
-    if not prompt_tokens and not completion_tokens:
-        prompt_tokens = get_usage_value(usage, "input_tokens")
-        completion_tokens = get_usage_value(usage, "output_tokens")
-    return int(prompt_tokens or 0), int(completion_tokens or 0)
+def _coerce_token_usage(value: object) -> TokenUsage | None:
+    if not isinstance(value, Mapping):
+        return None
+    try:
+        input_tokens = float(value.get("input_tokens", 0.0))
+        output_tokens = float(value.get("output_tokens", 0.0))
+    except (TypeError, ValueError):
+        return None
+    return {
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+    }
+
+
+def _extract_state_token_usage(state: State) -> TokenUsage | None:
+    tracker = state.get("usage_tracker")
+    if isinstance(tracker, StateUsageTracker):
+        usage = tracker.snapshot()
+        coerced = _coerce_token_usage(usage)
+        if coerced is not None:
+            return coerced
+
+    for key in ("token_usage", "usage"):
+        usage = _coerce_token_usage(state.get(key))
+        if usage is not None:
+            return usage
+
+    return None
 
 
 def get_hf_hub_dataset_name(outputs: GenerateOutputs) -> str:
@@ -131,24 +154,29 @@ def state_to_output(state: State, state_columns: list[str] = []) -> RolloutOutpu
         metrics=state.get("metrics", {}),
         oai_tools=state.get("oai_tools", None),
     )
-    trajectory = state.get("trajectory", [])
-    input_tokens = 0
-    output_tokens = 0
-    usage_seen = False
-    for step in trajectory:
-        response = step.get("response")
-        if response is None:
-            continue
-        if getattr(response, "usage", None) is not None:
-            usage_seen = True
-        step_input_tokens, step_output_tokens = extract_usage_tokens(response)
-        input_tokens += step_input_tokens
-        output_tokens += step_output_tokens
-    if usage_seen:
-        output["token_usage"] = {
-            "input_tokens": input_tokens,
-            "output_tokens": output_tokens,
-        }
+    usage = _extract_state_token_usage(state)
+    if usage is None:
+        # Legacy fallback for states that do not use state-level usage tracking.
+        trajectory = state.get("trajectory", [])
+        input_tokens = 0
+        output_tokens = 0
+        usage_seen = False
+        for step in trajectory:
+            response = step.get("response")
+            if response is None:
+                continue
+            if getattr(response, "usage", None) is not None:
+                usage_seen = True
+            step_input_tokens, step_output_tokens = extract_usage_tokens(response)
+            input_tokens += step_input_tokens
+            output_tokens += step_output_tokens
+        if usage_seen:
+            usage = {
+                "input_tokens": float(input_tokens),
+                "output_tokens": float(output_tokens),
+            }
+    if usage is not None:
+        output["token_usage"] = usage
     # sanitize messages (handle None for error cases)
     prompt = state.get("prompt")
     if prompt is not None:

--- a/verifiers/utils/save_utils.py
+++ b/verifiers/utils/save_utils.py
@@ -103,6 +103,12 @@ def _extract_state_token_usage(state: State) -> TokenUsage | None:
         coerced = _coerce_token_usage(usage)
         if coerced is not None:
             return coerced
+        # Tracker exists but has not seen usage yet. Avoid falling through to
+        # state["usage"], which is a zeroed live tracker view.
+        token_usage = _coerce_token_usage(state.get("token_usage"))
+        if token_usage is not None:
+            return token_usage
+        return None
 
     for key in ("token_usage", "usage"):
         usage = _coerce_token_usage(state.get(key))

--- a/verifiers/utils/save_utils.py
+++ b/verifiers/utils/save_utils.py
@@ -82,9 +82,12 @@ def extract_usage_tokens(response: object) -> tuple[int, int]:
 def _coerce_token_usage(value: object) -> TokenUsage | None:
     if not isinstance(value, Mapping):
         return None
+    mapping_value = cast(Mapping[str, Any], value)
     try:
-        input_tokens = float(value.get("input_tokens", 0.0))
-        output_tokens = float(value.get("output_tokens", 0.0))
+        input_raw = mapping_value.get("input_tokens")
+        output_raw = mapping_value.get("output_tokens")
+        input_tokens = float(0.0 if input_raw is None else input_raw)
+        output_tokens = float(0.0 if output_raw is None else output_raw)
     except (TypeError, ValueError):
         return None
     return {

--- a/verifiers/utils/usage_utils.py
+++ b/verifiers/utils/usage_utils.py
@@ -1,0 +1,71 @@
+from collections.abc import Mapping
+from types import MappingProxyType
+
+from verifiers.types import TokenUsage
+
+
+def _get_usage_value(usage_obj: object, key: str) -> int | float:
+    if isinstance(usage_obj, Mapping):
+        return usage_obj.get(key, 0)  # type: ignore[return-value]
+    return getattr(usage_obj, key, 0)
+
+
+def extract_usage_tokens(response: object) -> tuple[int, int]:
+    usage = getattr(response, "usage", None)
+    if usage is None:
+        return 0, 0
+
+    prompt_tokens = _get_usage_value(usage, "prompt_tokens")
+    completion_tokens = _get_usage_value(usage, "completion_tokens")
+    if not prompt_tokens and not completion_tokens:
+        prompt_tokens = _get_usage_value(usage, "input_tokens")
+        completion_tokens = _get_usage_value(usage, "output_tokens")
+    return int(prompt_tokens or 0), int(completion_tokens or 0)
+
+
+class StateUsageTracker:
+    """Accumulates token usage and exposes a read-only live usage mapping."""
+
+    __slots__ = ("_usage_seen", "_usage_totals", "_usage_view")
+
+    def __init__(self) -> None:
+        self._usage_seen = False
+        self._usage_totals: dict[str, float] = {
+            "input_tokens": 0.0,
+            "output_tokens": 0.0,
+        }
+        self._usage_view = MappingProxyType(self._usage_totals)
+
+    @property
+    def usage(self) -> Mapping[str, float]:
+        return self._usage_view
+
+    def increment(
+        self,
+        input_tokens: int | float = 0,
+        output_tokens: int | float = 0,
+        *,
+        mark_seen: bool = True,
+    ) -> None:
+        input_delta = float(input_tokens or 0.0)
+        output_delta = float(output_tokens or 0.0)
+        if input_delta < 0 or output_delta < 0:
+            raise ValueError("Token usage increments must be non-negative.")
+        if mark_seen:
+            self._usage_seen = True
+        self._usage_totals["input_tokens"] += input_delta
+        self._usage_totals["output_tokens"] += output_delta
+
+    def increment_from_response(self, response: object) -> None:
+        if getattr(response, "usage", None) is None:
+            return
+        input_tokens, output_tokens = extract_usage_tokens(response)
+        self.increment(input_tokens, output_tokens, mark_seen=True)
+
+    def snapshot(self) -> TokenUsage | None:
+        if not self._usage_seen:
+            return None
+        return {
+            "input_tokens": self._usage_totals["input_tokens"],
+            "output_tokens": self._usage_totals["output_tokens"],
+        }


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core rollout generation (`Environment.get_model_response`) and output serialization, so incorrect usage parsing could affect all evaluations/saved results, but changes are additive with legacy fallbacks and test coverage.
> 
> **Overview**
> Adds state-level token usage tracking via a new `StateUsageTracker`, accumulating usage directly in `Environment.get_model_response` and exposing a read-only `state["usage"]` plus `Environment.get_state_usage()`.
> 
> Updates `state_to_output`/`states_to_outputs` to prefer tracked state usage (with legacy trajectory fallback) and hardens token extraction/serialization against invalid provider `usage` payloads. Evaluation output now prints average token usage, and new tests cover tracking behavior, output emission rules, and invalid usage values; `verifiers.__init__` TYPE_CHECKING stubs are adjusted for optional `verifiers-rl` exports.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 455850e16a4e000a34f28d3522c4b2c01e1cb120. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->