### PR TITLE
Support api_base_url/api_key_var aliases in endpoints.toml parsing

### DIFF
--- a/tests/test_endpoint_registry.py
+++ b/tests/test_endpoint_registry.py
@@ -47,6 +47,76 @@ def test_load_endpoints_toml_groups_variants_by_endpoint_id(tmp_path: Path):
     assert endpoints["gpt-5-mini"][1]["url"] == "https://api.openai.com/v1"
 
 
+def test_load_endpoints_toml_accepts_long_field_names(tmp_path: Path):
+    registry_path = tmp_path / "endpoints.toml"
+    registry_path.write_text(
+        "[[endpoint]]\n"
+        'endpoint_id = "gpt-5-mini"\n'
+        'model = "openai/gpt-5-mini"\n'
+        'api_base_url = "https://api.pinference.ai/api/v1"\n'
+        'api_key_var = "PRIME_API_KEY"\n',
+        encoding="utf-8",
+    )
+
+    endpoints = load_endpoints(str(registry_path))
+
+    assert endpoints["gpt-5-mini"][0]["url"] == "https://api.pinference.ai/api/v1"
+    assert endpoints["gpt-5-mini"][0]["key"] == "PRIME_API_KEY"
+
+
+def test_load_endpoints_toml_accepts_matching_short_and_long_fields(tmp_path: Path):
+    registry_path = tmp_path / "endpoints.toml"
+    registry_path.write_text(
+        "[[endpoint]]\n"
+        'endpoint_id = "gpt-5-mini"\n'
+        'model = "openai/gpt-5-mini"\n'
+        'url = "https://api.pinference.ai/api/v1"\n'
+        'api_base_url = "https://api.pinference.ai/api/v1"\n'
+        'key = "PRIME_API_KEY"\n'
+        'api_key_var = "PRIME_API_KEY"\n',
+        encoding="utf-8",
+    )
+
+    endpoints = load_endpoints(str(registry_path))
+
+    assert endpoints["gpt-5-mini"][0]["url"] == "https://api.pinference.ai/api/v1"
+    assert endpoints["gpt-5-mini"][0]["key"] == "PRIME_API_KEY"
+
+
+def test_load_endpoints_toml_rejects_conflicting_url_fields(tmp_path: Path):
+    registry_path = tmp_path / "endpoints.toml"
+    registry_path.write_text(
+        "[[endpoint]]\n"
+        'endpoint_id = "gpt-5-mini"\n'
+        'model = "openai/gpt-5-mini"\n'
+        'url = "https://a.example/v1"\n'
+        'api_base_url = "https://b.example/v1"\n'
+        'key = "PRIME_API_KEY"\n',
+        encoding="utf-8",
+    )
+
+    endpoints = load_endpoints(str(registry_path))
+
+    assert endpoints == {}
+
+
+def test_load_endpoints_toml_rejects_conflicting_key_fields(tmp_path: Path):
+    registry_path = tmp_path / "endpoints.toml"
+    registry_path.write_text(
+        "[[endpoint]]\n"
+        'endpoint_id = "gpt-5-mini"\n'
+        'model = "openai/gpt-5-mini"\n'
+        'url = "https://a.example/v1"\n'
+        'key = "A_KEY"\n'
+        'api_key_var = "B_KEY"\n',
+        encoding="utf-8",
+    )
+
+    endpoints = load_endpoints(str(registry_path))
+
+    assert endpoints == {}
+
+
 def test_load_endpoints_python_registry_supports_list_variants(tmp_path: Path):
     registry_path = tmp_path / "endpoints.py"
     registry_path.write_text(

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -129,9 +129,25 @@ def _normalize_toml_endpoints(raw_toml: object, source: Path) -> Endpoints:
                 f"Each [[endpoint]] entry must include non-empty string 'endpoint_id' in {entry_source}"
             )
 
+        url = raw_entry_dict.get("url")
+        api_base_url = raw_entry_dict.get("api_base_url")
+        if url is not None and api_base_url is not None and url != api_base_url:
+            raise ValueError(
+                f"Conflicting values for 'url' and 'api_base_url' in {entry_source}"
+            )
+
+        key = raw_entry_dict.get("key")
+        api_key_var = raw_entry_dict.get("api_key_var")
+        if key is not None and api_key_var is not None and key != api_key_var:
+            raise ValueError(
+                f"Conflicting values for 'key' and 'api_key_var' in {entry_source}"
+            )
+
         endpoint_payload = {
             k: v for k, v in raw_entry_dict.items() if k != "endpoint_id"
         }
+        endpoint_payload["url"] = url if url is not None else api_base_url
+        endpoint_payload["key"] = key if key is not None else api_key_var
         endpoint = _coerce_endpoint(
             endpoint_payload,
             source=f"{entry_source} (endpoint_id={endpoint_id!r})",


### PR DESCRIPTION
### Motivation
- Make TOML endpoint registries ergonomic by accepting both shorthand (`url`/`key`) and long-form (`api_base_url`/`api_key_var`) field names while keeping the internal `Endpoint` shape consistent.
- Detect and fail fast when a single `[[endpoint]]` entry contains conflicting short and long-field values to avoid ambiguous configurations.

### Description
- Updated `_normalize_toml_endpoints` in `verifiers/utils/eval_utils.py` to read `api_base_url` and `api_key_var` and resolve them to canonical `url` and `key` prior to coercion. 
- Added validation to raise `ValueError` when both `url` and `api_base_url` are present with different values, or when `key` and `api_key_var` conflict. 
- Ensured the normalized payload always contains `url` and `key` for downstream `_coerce_endpoint` usage. 
- Added unit tests in `tests/test_endpoint_registry.py` covering long-form-only entries, matching short+long pairs, and conflicting short+long URL/key cases.

### Testing
- Ran `uv run pytest tests/test_endpoint_registry.py` and the test suite for the file completed successfully (`9 passed`).
- Ran `uv run ruff check verifiers/utils/eval_utils.py tests/test_endpoint_registry.py` and lint checks passed with no violations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987e0570bf88326b09b500d7d60a7a2)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, well-tested parsing change limited to TOML endpoint registry normalization; main risk is stricter validation causing previously-tolerated ambiguous configs to be ignored (empty registry) due to `ValueError` handling in `load_endpoints`.
> 
> **Overview**
> Updates TOML endpoint registry normalization (`_normalize_toml_endpoints`) to accept long-form fields `api_base_url`/`api_key_var` as aliases for `url`/`key`, always emitting canonical `url` and `key` before coercion.
> 
> Adds validation to fail fast when both short and long forms are provided with different values, and extends `tests/test_endpoint_registry.py` with coverage for long-form-only, matching short+long, and conflicting URL/key cases (which result in an empty registry via `load_endpoints` error handling).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1312d72f71b680d3f38e186ec78b06c0699cc460. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->