### PR TITLE
Remove deprecated --vf-rl handling and refine setup tests

### DIFF
--- a/tests/test_setup_script.py
+++ b/tests/test_setup_script.py
@@ -28,7 +28,7 @@ def test_run_setup_downloads_endpoints_toml_and_rl_plus_gepa_configs(
     assert config_batches == [setup.GEPA_CONFIGS, setup.RL_CONFIGS]
 
 
-def test_run_setup_vf_rl_is_deprecated_and_does_not_download_vf_rl_configs(
+def test_run_setup_with_prime_rl_downloads_prime_configs_only(
     tmp_path: Path, monkeypatch
 ) -> None:
     monkeypatch.chdir(tmp_path)
@@ -44,8 +44,10 @@ def test_run_setup_vf_rl_is_deprecated_and_does_not_download_vf_rl_configs(
         "download_configs",
         lambda configs: config_batches.append(list(configs)),
     )
+    monkeypatch.setattr(setup, "install_prime_rl", lambda: None)
+    monkeypatch.setattr(setup, "install_environments_to_prime_rl", lambda: None)
 
-    setup.run_setup(skip_install=True, skip_agents_md=True, vf_rl=True)
+    setup.run_setup(skip_install=True, skip_agents_md=True, prime_rl=True)
 
     assert downloaded == [(setup.ENDPOINTS_SRC, setup.ENDPOINTS_DST)]
-    assert config_batches == [setup.GEPA_CONFIGS]
+    assert config_batches == [setup.PRIME_RL_CONFIGS, setup.GEPA_CONFIGS]

--- a/verifiers/scripts/setup.py
+++ b/verifiers/scripts/setup.py
@@ -227,7 +227,6 @@ def ensure_uv_project():
 
 def run_setup(
     prime_rl: bool = False,
-    vf_rl: bool = False,
     skip_agents_md: bool = False,
     skip_install: bool = False,
 ) -> None:
@@ -235,7 +234,6 @@ def run_setup(
 
     Args:
         prime_rl: Install prime-rl and download prime-rl configs.
-        vf_rl: Deprecated. Kept for backward compatibility; no configs are downloaded.
         skip_agents_md: Skip downloading AGENTS.md, CLAUDE.md, and environments/AGENTS.md.
         skip_install: Skip uv project initialization and verifiers installation.
     """
@@ -273,18 +271,12 @@ def run_setup(
     else:
         print(f"{ENDPOINTS_DST} already exists")
 
-    if vf_rl:
-        print(
-            "Warning: --vf-rl is deprecated and will be removed in a future release. "
-            "Install verifiers-rl and use configs from that package instead."
-        )
-
     if prime_rl:
         download_configs(PRIME_RL_CONFIGS)
 
     download_configs(GEPA_CONFIGS)
 
-    if not prime_rl and not vf_rl:
+    if not prime_rl:
         download_configs(RL_CONFIGS)
 
 
@@ -296,11 +288,6 @@ def main():
         "--prime-rl",
         action="store_true",
         help="Install prime-rl and download prime-rl configs",
-    )
-    parser.add_argument(
-        "--vf-rl",
-        action="store_true",
-        help="[DEPRECATED] vf-rl configs are no longer bundled by vf-setup",
     )
     parser.add_argument(
         "--skip-agents-md",
@@ -316,7 +303,6 @@ def main():
 
     run_setup(
         prime_rl=args.prime_rl,
-        vf_rl=args.vf_rl,
         skip_agents_md=args.skip_agents_md,
         skip_install=args.skip_install,
     )


### PR DESCRIPTION
### Motivation
- Hard-deprecate the old `--vf-rl` flag so it no longer affects setup control flow or test expectations.
- Make the setup tests reflect the new behavior and cover the `--prime-rl` branch explicitly.
- Ensure default RL configs continue to be downloaded in normal setup runs unless `--prime-rl` is used.

### Description
- Removed the `vf_rl` parameter, the `--vf-rl` CLI argument, the deprecation warning, and the code path guarded by `vf_rl` from `verifiers/scripts/setup.py`.
- Kept the RL-download logic such that `download_configs(RL_CONFIGS)` runs when `prime_rl` is not requested and `download_configs(PRIME_RL_CONFIGS)` runs when `prime_rl` is true.
- Updated `tests/test_setup_script.py` by renaming the legacy test to avoid mentioning legacy flags and replacing the duplicate default-flow assertion with a `prime_rl=True` case that stubs `install_prime_rl` and `install_environments_to_prime_rl` and asserts `PRIME_RL_CONFIGS` + `GEPA_CONFIGS` are downloaded.
- Adjusted monkeypatching in the tests to capture `wget.download` and `download_configs` calls for deterministic assertions.

### Testing
- Ran `uv run pytest tests/test_setup_script.py` and the tests passed (`2 passed`).
- Ran `uv run ruff check tests/test_setup_script.py verifiers/scripts/setup.py` and lint checks passed (`All checks passed!`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69881d8b4d3083269ad39b3cdffd0127)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Removes a deprecated CLI flag and adjusts config-download branching; limited impact to developer setup flow and covered by focused tests.
> 
> **Overview**
> Removes the deprecated `--vf-rl` CLI flag and the associated `vf_rl` code path from `verifiers/scripts/setup.py`, simplifying `run_setup` to branch only on `prime_rl`.
> 
> Updates setup tests to explicitly cover the `prime_rl` path by stubbing `install_prime_rl`/`install_environments_to_prime_rl` and asserting that `PRIME_RL_CONFIGS` + `GEPA_CONFIGS` are downloaded, while the default path continues to download `GEPA_CONFIGS` + `RL_CONFIGS`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b4dc03f916ac9acfd3762e36a4f8303b6677a4f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->