### PR TITLE
Add EndpointClientConfig and forbid recursive endpoint_configs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ These points are direct restatements of Verifiers docs so agents can follow the 
 
 Use this guidance when contributing to the `verifiers` repository itself.
 
+- Always run `uv run pre-commit install` before making any changes.
 - Run the documented contributor checks for touched areas: `uv run ruff check --fix .`, `uv run pytest tests/`, and `uv run pre-commit run --all-files` as needed. (See `docs/development.md`.)
 - Keep changes aligned with documented architecture (`verifiers/`, `environments/`, `configs/`, `tests/`, `docs/`) and update docs when behavior changes. (See `docs/development.md`.)
 - Prefer a single clear path over maintaining parallel approaches by default; if two options exist, preserve both only when there is an explicit long-term reason.

--- a/assets/agents/repo_development_best_practices.md
+++ b/assets/agents/repo_development_best_practices.md
@@ -2,6 +2,7 @@
 
 Use this guidance when contributing to the `verifiers` repository itself.
 
+- Always run `uv run pre-commit install` before making any changes.
 - Run the documented contributor checks for touched areas: `uv run ruff check --fix .`, `uv run pytest tests/`, and `uv run pre-commit run --all-files` as needed. (See `docs/development.md`.)
 - Keep changes aligned with documented architecture (`verifiers/`, `environments/`, `configs/`, `tests/`, `docs/`) and update docs when behavior changes. (See `docs/development.md`.)
 - Prefer a single clear path over maintaining parallel approaches by default; if two options exist, preserve both only when there is an explicit long-term reason.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -572,7 +572,7 @@ class ClientConfig(BaseModel):
     client_idx: int = 0
     api_key_var: str = "PRIME_API_KEY"
     api_base_url: str = "https://api.pinference.ai/api/v1"
-    endpoint_configs: list[ClientConfig] = []
+    endpoint_configs: list[EndpointClientConfig] = []
     timeout: float = 3600.0
     max_connections: int = 28000
     max_keepalive_connections: int = 28000
@@ -587,6 +587,22 @@ When `api_key_var` is `"PRIME_API_KEY"` (the default), credentials are loaded wi
 - **Team ID**: `PRIME_TEAM_ID` env var > `~/.prime/config.json` > not set
 
 This allows seamless use after running `prime login`.
+
+### EndpointClientConfig
+
+```python
+class EndpointClientConfig(BaseModel):
+    client_idx: int = 0
+    api_key_var: str = "PRIME_API_KEY"
+    api_base_url: str = "https://api.pinference.ai/api/v1"
+    timeout: float = 3600.0
+    max_connections: int = 28000
+    max_keepalive_connections: int = 28000
+    max_retries: int = 10
+    extra_headers: dict[str, str] = {}
+```
+
+Leaf endpoint configuration used inside `ClientConfig.endpoint_configs`. Has the same fields as `ClientConfig` except `endpoint_configs` itself, preventing recursive nesting.
 
 ### EvalConfig
 

--- a/tests/test_client_config.py
+++ b/tests/test_client_config.py
@@ -26,7 +26,9 @@ def test_client_config_rejects_recursive_endpoint_configs():
                 "endpoint_configs": [
                     {
                         "api_base_url": "http://localhost:8001/v1",
-                        "endpoint_configs": [{"api_base_url": "http://localhost:8002/v1"}],
+                        "endpoint_configs": [
+                            {"api_base_url": "http://localhost:8002/v1"}
+                        ],
                     }
                 ],
             }

--- a/tests/test_client_config.py
+++ b/tests/test_client_config.py
@@ -1,0 +1,50 @@
+import pytest
+from pydantic import ValidationError
+
+from verifiers.types import ClientConfig, EndpointClientConfig
+
+
+def test_client_config_allows_leaf_endpoint_configs():
+    config = ClientConfig(
+        api_base_url="http://localhost:8000/v1",
+        endpoint_configs=[
+            EndpointClientConfig(api_base_url="http://localhost:8001/v1"),
+            {"api_base_url": "http://localhost:8002/v1"},
+        ],
+    )
+
+    assert len(config.endpoint_configs) == 2
+    assert config.endpoint_configs[0].api_base_url == "http://localhost:8001/v1"
+    assert config.endpoint_configs[1].api_base_url == "http://localhost:8002/v1"
+
+
+def test_client_config_rejects_recursive_endpoint_configs():
+    with pytest.raises(ValidationError, match="cannot include endpoint_configs"):
+        ClientConfig.model_validate(
+            {
+                "api_base_url": "http://localhost:8000/v1",
+                "endpoint_configs": [
+                    {
+                        "api_base_url": "http://localhost:8001/v1",
+                        "endpoint_configs": [{"api_base_url": "http://localhost:8002/v1"}],
+                    }
+                ],
+            }
+        )
+
+
+def test_client_config_accepts_empty_nested_endpoint_configs_key():
+    config = ClientConfig.model_validate(
+        {
+            "api_base_url": "http://localhost:8000/v1",
+            "endpoint_configs": [
+                {
+                    "api_base_url": "http://localhost:8001/v1",
+                    "endpoint_configs": [],
+                }
+            ],
+        }
+    )
+
+    assert len(config.endpoint_configs) == 1
+    assert config.endpoint_configs[0].api_base_url == "http://localhost:8001/v1"

--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -17,7 +17,12 @@ from pathlib import Path
 from typing import Any
 
 from verifiers import setup_logging
-from verifiers.types import ClientConfig, EvalConfig, EvalRunConfig
+from verifiers.types import (
+    ClientConfig,
+    EndpointClientConfig,
+    EvalConfig,
+    EvalRunConfig,
+)
 from verifiers.utils.eval_utils import (
     load_endpoints,
     load_toml_config,
@@ -441,14 +446,14 @@ def main():
         assert api_key_var is not None
         resolved_api_key_var = api_key_var
 
-        endpoint_configs: list[ClientConfig] = []
+        endpoint_configs: list[EndpointClientConfig] = []
         if (
             endpoint_group is not None
             and not api_base_url_override
             and len(endpoint_group) > 1
         ):
             endpoint_configs = [
-                ClientConfig(
+                EndpointClientConfig(
                     api_key_var=(
                         resolved_api_key_var if api_key_override else endpoint["key"]
                     ),

--- a/verifiers/utils/client_utils.py
+++ b/verifiers/utils/client_utils.py
@@ -12,33 +12,21 @@ from verifiers.types import ClientConfig
 logger = logging.getLogger(__name__)
 
 
-def _resolve_client_config_impl(
-    config: ClientConfig, ancestors: list[ClientConfig] | None = None
-) -> ClientConfig:
-    """Resolve possibly nested endpoint configs to a single concrete client config."""
-    chain = list(ancestors or [])
-    visited = {id(ancestor) for ancestor in chain}
-    resolved = config
-    while resolved.endpoint_configs:
-        resolved_id = id(resolved)
-        if resolved_id in visited:
-            raise ValueError(
-                "Detected cyclic ClientConfig.endpoint_configs while resolving client"
-            )
-        visited.add(resolved_id)
-        chain.append(resolved)
-        endpoint_idx = resolved.client_idx % len(resolved.endpoint_configs)
-        resolved = resolved.endpoint_configs[endpoint_idx]
+def _resolve_client_config_impl(config: ClientConfig) -> ClientConfig:
+    """Resolve endpoint config overrides onto a concrete client config."""
+    if not config.endpoint_configs:
+        return ClientConfig.model_validate(config.model_dump(mode="python"))
 
-    resolved_data = resolved.model_dump(mode="python")
-    resolved_fields = set(resolved.model_fields_set)
-    for parent in reversed(chain):
-        for field_name in ClientConfig.model_fields:
-            if field_name == "endpoint_configs":
-                continue
-            if field_name not in resolved_fields:
-                resolved_data[field_name] = getattr(parent, field_name)
-                resolved_fields.add(field_name)
+    endpoint_idx = config.client_idx % len(config.endpoint_configs)
+    endpoint_config = config.endpoint_configs[endpoint_idx]
+
+    resolved_data = endpoint_config.model_dump(mode="python")
+    resolved_fields = set(endpoint_config.model_fields_set)
+    for field_name in ClientConfig.model_fields:
+        if field_name == "endpoint_configs":
+            continue
+        if field_name not in resolved_fields:
+            resolved_data[field_name] = getattr(config, field_name)
 
     return ClientConfig.model_validate(resolved_data)
 
@@ -50,10 +38,17 @@ def resolve_client_config(config: ClientConfig) -> ClientConfig:
 def resolve_client_configs(config: ClientConfig) -> list[ClientConfig]:
     """Expand a client config into one or more resolved endpoint configs."""
     if config.endpoint_configs:
-        return [
-            _resolve_client_config_impl(endpoint, ancestors=[config])
-            for endpoint in config.endpoint_configs
-        ]
+        expanded_configs: list[ClientConfig] = []
+        for endpoint_config in config.endpoint_configs:
+            expanded_data = endpoint_config.model_dump(mode="python")
+            expanded_fields = set(endpoint_config.model_fields_set)
+            for field_name in ClientConfig.model_fields:
+                if field_name == "endpoint_configs":
+                    continue
+                if field_name not in expanded_fields:
+                    expanded_data[field_name] = getattr(config, field_name)
+            expanded_configs.append(ClientConfig.model_validate(expanded_data))
+        return expanded_configs
     return [resolve_client_config(config)]
 
 

--- a/verifiers/utils/client_utils.py
+++ b/verifiers/utils/client_utils.py
@@ -7,12 +7,14 @@ import httpx
 from httpx import AsyncClient
 from openai import AsyncOpenAI
 
-from verifiers.types import ClientConfig
+from verifiers.types import ClientConfig, EndpointClientConfig
 
 logger = logging.getLogger(__name__)
 
 
-def _merge_endpoint(parent: ClientConfig, endpoint: ClientConfig) -> ClientConfig:
+def _merge_endpoint(
+    parent: ClientConfig, endpoint: EndpointClientConfig
+) -> ClientConfig:
     """Merge parent config fields into an endpoint config, preserving endpoint overrides."""
     merged_data = endpoint.model_dump(mode="python")
     explicitly_set = set(endpoint.model_fields_set)


### PR DESCRIPTION
### Motivation
- Prevent recursive `ClientConfig.endpoint_configs` structures so endpoint lists are single-level and easier to resolve at runtime.
- Make the intent explicit by separating a leaf endpoint entry type from the full `ClientConfig` to avoid accidental recursion and cycles.

### Description
- Introduced a new leaf model `EndpointClientConfig` and changed `ClientConfig.endpoint_configs` to `list[EndpointClientConfig]` so endpoint entries are typed as leaf endpoint configs.
- Added a Pydantic validator on `ClientConfig.endpoint_configs` that rejects entries which include non-empty `endpoint_configs`, while normalizing callers that pass `ClientConfig` leaves into plain endpoint dicts.
- Simplified resolution logic in `resolve_client_config`/`resolve_client_configs` to assume a single-level `endpoint_configs` list and merge parent defaults into selected endpoint overrides (removed recursive traversal/cycle handling).
- Added unit tests `tests/test_client_config.py` to cover valid leaf endpoints, rejection of recursive endpoint entries, and acceptance of an empty nested `endpoint_configs` key.

### Testing
- Ran style checks with `uv run ruff check --fix .` and formatting/pre-commit hooks with `uv run pre-commit run --all-files`, both succeeded.
- Ran unit tests with `uv run pytest tests/test_client_config.py tests/test_worker_client_timeouts.py tests/test_eval_display.py tests/test_environment_extra.py tests/test_eval_cli.py -q`, and all tests passed.
- Added `tests/test_client_config.py` to validate the new behavior and confirmed it passes under the test suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988535ffa3883268fb139872441af04)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches client configuration typing/validation and endpoint resolution used to construct API clients, which could affect multi-endpoint routing and defaults. Changes are contained and covered by new unit tests.
> 
> **Overview**
> **Prevents recursive `ClientConfig.endpoint_configs` by introducing a leaf `EndpointClientConfig` type** and updating `ClientConfig.endpoint_configs` to only accept a single-level list.
> 
> Adds Pydantic validation to reject nested/non-empty `endpoint_configs` (while normalizing leaf `ClientConfig` inputs), simplifies client config resolution/merging logic in `client_utils`, and updates the eval CLI builder to emit `EndpointClientConfig` entries. Documentation is updated and new unit tests cover acceptance/rejection cases; dev docs add a reminder to run `uv run pre-commit install`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ff720626ee8e5c2c00376bbb601383e378e4619. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->