### PR TITLE
Fix tag-and-release trigger so auto-created tags publish correctly

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -19,6 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      created: ${{ steps.tag.outputs.created }}
+      tag: ${{ steps.tag.outputs.tag }}
+      version: ${{ steps.tag.outputs.version }}
     steps:
       - name: Checkout main
         uses: actions/checkout@v4
@@ -26,32 +30,41 @@ jobs:
           fetch-depth: 0
 
       - name: Detect version bump and create tag
+        id: tag
         env:
           BEFORE_SHA: ${{ github.event.before }}
-          AFTER_SHA: ${{ github.sha }}
         run: |
+          echo "created=false" >> "$GITHUB_OUTPUT"
+
           if [ "$BEFORE_SHA" = "0000000000000000000000000000000000000000" ]; then
             echo "No valid base commit available; skipping auto-tag."
             exit 0
           fi
 
-          if ! git diff "$BEFORE_SHA" "$AFTER_SHA" -- verifiers/__init__.py | grep -q '__version__'; then
-            echo "No __version__ change detected in verifiers/__init__.py; skipping auto-tag."
-            exit 0
+          OLD_VERSION=$(git show "$BEFORE_SHA:verifiers/__init__.py" | sed -n 's/^__version__ = "\([^"]*\)"$/\1/p')
+          if [ -z "$OLD_VERSION" ]; then
+            echo "Could not find __version__ in previous verifiers/__init__.py" >&2
+            exit 1
           fi
 
-          VERSION=$(python - <<'PY'
+          NEW_VERSION=$(python - <<'PY'
           from pathlib import Path
           import re
           import sys
 
           match = re.search(r'__version__\s*=\s*"([^"]+)"', Path("verifiers/__init__.py").read_text())
           if not match:
-              sys.exit("Could not find __version__ in verifiers/__init__.py")
+              sys.exit("Could not find __version__ in current verifiers/__init__.py")
           print(match.group(1))
           PY
           )
-          TAG="v${VERSION}"
+
+          if [ "$OLD_VERSION" = "$NEW_VERSION" ]; then
+            echo "No __version__ change detected in verifiers/__init__.py; skipping auto-tag."
+            exit 0
+          fi
+
+          TAG="v${NEW_VERSION}"
 
           if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
             echo "Tag ${TAG} already exists locally; skipping."
@@ -67,6 +80,53 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag -a "$TAG" -m "Release $TAG"
           git push origin "$TAG"
+
+          echo "created=true" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+
+  release-from-auto-tag:
+    needs: auto-tag-on-main
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.auto-tag-on-main.outputs.created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout auto-created tag
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: refs/tags/${{ needs.auto-tag-on-main.outputs.tag }}
+
+      - name: Set release metadata
+        id: release
+        run: |
+          echo "tag=${{ needs.auto-tag-on-main.outputs.tag }}" >> "$GITHUB_OUTPUT"
+          echo "version=${{ needs.auto-tag-on-main.outputs.version }}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Build sdist and wheel
+        run: uv build
+
+      - name: Publish to PyPI
+        env:
+          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        run: uv publish --token "$PYPI_TOKEN"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.release.outputs.tag }}
+          body_path: assets/release/RELEASE_${{ steps.release.outputs.tag }}.md
+          files: |
+            dist/*
 
   tag-and-release:
     if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v')
@@ -149,7 +209,7 @@ jobs:
       - name: Publish to PyPI
         env:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-        run: uv publish --token "$PYPI_TOKEN" 
+        run: uv publish --token "$PYPI_TOKEN"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -2,6 +2,8 @@ name: Tag and Release
 
 on:
   push:
+    branches:
+      - main
     tags:
       - 'v*'
   workflow_dispatch:
@@ -12,7 +14,62 @@ on:
         type: string
 
 jobs:
+  auto-tag-on-main:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect version bump and create tag
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.sha }}
+        run: |
+          if [ "$BEFORE_SHA" = "0000000000000000000000000000000000000000" ]; then
+            echo "No valid base commit available; skipping auto-tag."
+            exit 0
+          fi
+
+          if ! git diff "$BEFORE_SHA" "$AFTER_SHA" -- verifiers/__init__.py | grep -q '__version__'; then
+            echo "No __version__ change detected in verifiers/__init__.py; skipping auto-tag."
+            exit 0
+          fi
+
+          VERSION=$(python - <<'PY'
+          from pathlib import Path
+          import re
+          import sys
+
+          match = re.search(r'__version__\s*=\s*"([^"]+)"', Path("verifiers/__init__.py").read_text())
+          if not match:
+              sys.exit("Could not find __version__ in verifiers/__init__.py")
+          print(match.group(1))
+          PY
+          )
+          TAG="v${VERSION}"
+
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            echo "Tag ${TAG} already exists locally; skipping."
+            exit 0
+          fi
+
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "Tag ${TAG} already exists on origin; skipping."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "Release $TAG"
+          git push origin "$TAG"
+
   tag-and-release:
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
### Motivation
- Ensure that when `auto-tag-on-main` creates a `vX.Y.Z` tag after a version bump, the existing publish and GitHub Release job reliably runs for that tag. 
- Remove the `push` `paths` filter which can prevent tag pushes from triggering workflows, while preserving the safety check that only runs auto-tagging for commits that changed `verifiers/__init__.py`.
- Preserve the current release-notes flow so any `assets/release/RELEASE_<tag>.md` files are still used for release bodies.

### Description
- Removed the `paths: - verifiers/__init__.py` filter from the `push` trigger in `.github/workflows/tag-and-release.yml` so tag pushes reliably trigger the workflow. 
- Added an `auto-tag-on-main` job that runs on `push` to `main` and detects `__version__` changes in `verifiers/__init__.py`, creates an annotated `v<version>` tag, and pushes it if the tag does not already exist. 
- Kept and gated the existing `tag-and-release` job to run on `workflow_dispatch` or `refs/tags/v*` and verify that the tag matches the `__version__` in `verifiers/__init__.py`. 
- The `Create GitHub Release` step still uses `body_path: assets/release/RELEASE_${{ steps.release.outputs.tag }}.md`, so existing release notes in `assets/release` are used unchanged. 

### Testing
- Ran `git diff -- .github/workflows/tag-and-release.yml` to view changes and it completed successfully. 
- Parsed the workflow YAML with `python -c "import yaml; yaml.safe_load(open('.github/workflows/tag-and-release.yml'))"` which printed `YAML parse OK`. 
- Printed the updated workflow with `nl -ba .github/workflows/tag-and-release.yml | sed -n '1,220p'` to inspect the final content and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986a6a87ac083269e6ba4879f875bd3)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the automated release pipeline and introduces tag creation/publishing from CI; misconfiguration could cause missed or unintended releases and publish failures.
> 
> **Overview**
> On pushes to `main`, the workflow now **auto-detects `verifiers/__init__.py` `__version__` bumps** and, when changed, **creates/pushes an annotated `v<version>` tag**.
> 
> When an auto-tag is created, a new job **checks out that tag and runs the full release pipeline** (build, PyPI publish, GitHub Release using `assets/release/RELEASE_<tag>.md`). The existing `tag-and-release` job is now **explicitly gated** to run only for manual dispatch or `v*` tag refs, improving trigger reliability for tag pushes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 326d5d5e97089bb3141f634b78ad2745b4939337. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->