### PR TITLE
Align auto-tag version parsing and clarify review severity

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -2,6 +2,8 @@ name: Tag and Release
 
 on:
   push:
+    branches:
+      - main
     tags:
       - 'v*'
   workflow_dispatch:
@@ -12,7 +14,128 @@ on:
         type: string
 
 jobs:
+  auto-tag-on-main:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      created: ${{ steps.tag.outputs.created }}
+      tag: ${{ steps.tag.outputs.tag }}
+      version: ${{ steps.tag.outputs.version }}
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect version bump and create tag
+        id: tag
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          echo "created=false" >> "$GITHUB_OUTPUT"
+
+          if [ "$BEFORE_SHA" = "0000000000000000000000000000000000000000" ]; then
+            echo "No valid base commit available; skipping auto-tag."
+            exit 0
+          fi
+
+          OLD_VERSION=$(git show "$BEFORE_SHA:verifiers/__init__.py" | python - <<'PY'
+          import re
+          import sys
+
+          text = sys.stdin.read()
+          match = re.search(r'__version__\s*=\s*"([^"]+)"', text)
+          if not match:
+              sys.exit("Could not find __version__ in previous verifiers/__init__.py")
+          print(match.group(1))
+          PY
+          )
+
+          NEW_VERSION=$(python - <<'PY'
+          from pathlib import Path
+          import re
+          import sys
+
+          match = re.search(r'__version__\s*=\s*"([^"]+)"', Path("verifiers/__init__.py").read_text())
+          if not match:
+              sys.exit("Could not find __version__ in current verifiers/__init__.py")
+          print(match.group(1))
+          PY
+          )
+
+          if [ "$OLD_VERSION" = "$NEW_VERSION" ]; then
+            echo "No __version__ change detected in verifiers/__init__.py; skipping auto-tag."
+            exit 0
+          fi
+
+          TAG="v${NEW_VERSION}"
+
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            echo "Tag ${TAG} already exists locally; skipping."
+            exit 0
+          fi
+
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "Tag ${TAG} already exists on origin; skipping."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "Release $TAG"
+          git push origin "$TAG"
+
+          echo "created=true" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+
+  release-from-auto-tag:
+    needs: auto-tag-on-main
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.auto-tag-on-main.outputs.created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout auto-created tag
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: refs/tags/${{ needs.auto-tag-on-main.outputs.tag }}
+
+      - name: Set release metadata
+        id: release
+        run: |
+          echo "tag=${{ needs.auto-tag-on-main.outputs.tag }}" >> "$GITHUB_OUTPUT"
+          echo "version=${{ needs.auto-tag-on-main.outputs.version }}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Build sdist and wheel
+        run: uv build
+
+      - name: Publish to PyPI
+        env:
+          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        run: uv publish --token "$PYPI_TOKEN"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.release.outputs.tag }}
+          body_path: assets/release/RELEASE_${{ steps.release.outputs.tag }}.md
+          files: |
+            dist/*
+
   tag-and-release:
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -92,7 +215,7 @@ jobs:
       - name: Publish to PyPI
         env:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-        run: uv publish --token "$PYPI_TOKEN" 
+        run: uv publish --token "$PYPI_TOKEN"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
### Motivation
- Fix a medium-severity bug where the `OLD_VERSION` extraction used a rigid `sed` pattern and could fail on legitimate version-bump commits with different whitespace around `__version__ = ...`.
- Keep release semantics unchanged while addressing only the parsing fragility in the auto-tagging path.

### Description
- Update `.github/workflows/tag-and-release.yml` to replace the `sed`-based `OLD_VERSION` extraction with the same Python/`re` extraction used for `NEW_VERSION`, using `__version__\s*=\s*"([^"]+)"` for both.
- Preserve existing `release-from-auto-tag` and `tag-and-release` steps and behavior, leaving the duplicated publish/build steps intact for this targeted fix.

### Testing
- Parsed the updated workflow YAML with `python -c "import yaml; yaml.safe_load(open('.github/workflows/tag-and-release.yml'))"` which returned `YAML parse OK`.
- Ran `git diff --check` to validate there are no whitespace/patch problems and it completed successfully.
- Inspected the final workflow file with `nl -ba .github/workflows/tag-and-release.yml` to confirm the `OLD_VERSION`/`NEW_VERSION` extraction blocks were updated as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986a6a87ac083269e6ba4879f875bd3)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Automates tagging and publishing on `main` based on `__version__` changes; mistakes in parsing or tagging could unintentionally publish releases to PyPI/GitHub, though the logic is straightforward and gated by tag existence checks.
> 
> **Overview**
> Adds an automated release path on `main`: when `verifiers/__init__.py`’s `__version__` changes, the workflow now creates and pushes an annotated `v{version}` tag, then builds and publishes the package and creates a GitHub Release from that auto-created tag.
> 
> Hardens version detection by extracting `OLD_VERSION` with the same Python regex used for `NEW_VERSION` (instead of a fragile pattern), and adjusts the existing `tag-and-release` job to run only for manual dispatches or `v*` tag pushes (plus a small whitespace fix in the publish step).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d87aef8289ce8fab19b68137279a459c6f1beaed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->