### PR TITLE
Fix for dir resolutions

### DIFF
--- a/tests/test_prime_plugin.py
+++ b/tests/test_prime_plugin.py
@@ -1,0 +1,87 @@
+from pathlib import Path
+
+import verifiers.cli.plugins.prime as prime_plugin
+
+
+def _make_workspace(tmp_path: Path) -> tuple[Path, Path]:
+    workspace = tmp_path / "workspace"
+    env_dir = workspace / "environments" / "my_env"
+    env_dir.mkdir(parents=True)
+    (workspace / "verifiers").mkdir()
+    (workspace / "pyproject.toml").write_text(
+        '[project]\nname = "workspace"\nversion = "0.1.0"\n',
+        encoding="utf-8",
+    )
+    return workspace, env_dir
+
+
+def _touch_python(venv_root: Path) -> Path:
+    python_bin = prime_plugin._venv_python(venv_root)
+    python_bin.parent.mkdir(parents=True, exist_ok=True)
+    python_bin.write_text("", encoding="utf-8")
+    return python_bin
+
+
+def test_find_workspace_root_from_nested_environment_dir(tmp_path: Path):
+    workspace, env_dir = _make_workspace(tmp_path)
+
+    assert prime_plugin._find_workspace_root(env_dir) == workspace
+
+
+def test_resolve_workspace_python_prefers_workspace_venv_over_uv_env(
+    tmp_path: Path, monkeypatch
+):
+    workspace, env_dir = _make_workspace(tmp_path)
+    workspace_python = _touch_python(workspace / ".venv")
+    _touch_python(env_dir / ".venv")
+
+    monkeypatch.setattr(prime_plugin, "_python_can_import_module", lambda *_: True)
+    monkeypatch.setenv("UV_PROJECT_ENVIRONMENT", str(env_dir / ".venv"))
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+
+    assert prime_plugin._resolve_workspace_python(env_dir) == str(workspace_python)
+
+
+def test_build_module_command_install_adds_workspace_env_path(
+    tmp_path: Path, monkeypatch
+):
+    workspace, env_dir = _make_workspace(tmp_path)
+    plugin = prime_plugin.PrimeCLIPlugin()
+
+    monkeypatch.setattr(prime_plugin, "_current_cwd", lambda: env_dir)
+    monkeypatch.setattr(prime_plugin, "_resolve_workspace_python", lambda *_: "python")
+
+    command = plugin.build_module_command(plugin.install_module, ["my-env"])
+
+    assert command == [
+        "python",
+        "-m",
+        plugin.install_module,
+        "my-env",
+        "--path",
+        str((workspace / "environments").resolve()),
+    ]
+
+
+def test_build_module_command_eval_rewrites_relative_env_dir_path(
+    tmp_path: Path, monkeypatch
+):
+    workspace, env_dir = _make_workspace(tmp_path)
+    plugin = prime_plugin.PrimeCLIPlugin()
+
+    monkeypatch.setattr(prime_plugin, "_current_cwd", lambda: env_dir)
+    monkeypatch.setattr(prime_plugin, "_resolve_workspace_python", lambda *_: "python")
+
+    command = plugin.build_module_command(
+        plugin.eval_module,
+        ["my-env", "--env-dir-path", "./environments"],
+    )
+
+    assert command == [
+        "python",
+        "-m",
+        plugin.eval_module,
+        "my-env",
+        "--env-dir-path",
+        str((workspace / "environments").resolve()),
+    ]

--- a/tests/test_prime_plugin.py
+++ b/tests/test_prime_plugin.py
@@ -85,3 +85,66 @@ def test_build_module_command_eval_rewrites_relative_env_dir_path(
         "--env-dir-path",
         str((workspace / "environments").resolve()),
     ]
+
+
+def test_build_module_command_gepa_adds_workspace_env_dir_path(
+    tmp_path: Path, monkeypatch
+):
+    workspace, env_dir = _make_workspace(tmp_path)
+    plugin = prime_plugin.PrimeCLIPlugin()
+
+    monkeypatch.setattr(prime_plugin, "_current_cwd", lambda: env_dir)
+    monkeypatch.setattr(prime_plugin, "_resolve_workspace_python", lambda *_: "python")
+
+    command = plugin.build_module_command(plugin.gepa_module, ["my-env"])
+
+    assert command == [
+        "python",
+        "-m",
+        plugin.gepa_module,
+        "my-env",
+        "--env-dir-path",
+        str((workspace / "environments").resolve()),
+    ]
+
+
+def test_build_module_command_build_adds_workspace_env_path(
+    tmp_path: Path, monkeypatch
+):
+    workspace, env_dir = _make_workspace(tmp_path)
+    plugin = prime_plugin.PrimeCLIPlugin()
+
+    monkeypatch.setattr(prime_plugin, "_current_cwd", lambda: env_dir)
+    monkeypatch.setattr(prime_plugin, "_resolve_workspace_python", lambda *_: "python")
+
+    command = plugin.build_module_command(plugin.build_module, ["my-env"])
+
+    assert command == [
+        "python",
+        "-m",
+        plugin.build_module,
+        "my-env",
+        "--path",
+        str((workspace / "environments").resolve()),
+    ]
+
+
+def test_build_module_command_init_adds_workspace_env_path(
+    tmp_path: Path, monkeypatch
+):
+    workspace, env_dir = _make_workspace(tmp_path)
+    plugin = prime_plugin.PrimeCLIPlugin()
+
+    monkeypatch.setattr(prime_plugin, "_current_cwd", lambda: env_dir)
+    monkeypatch.setattr(prime_plugin, "_resolve_workspace_python", lambda *_: "python")
+
+    command = plugin.build_module_command(plugin.init_module, ["my-env"])
+
+    assert command == [
+        "python",
+        "-m",
+        plugin.init_module,
+        "my-env",
+        "--path",
+        str((workspace / "environments").resolve()),
+    ]

--- a/tests/test_prime_plugin.py
+++ b/tests/test_prime_plugin.py
@@ -129,9 +129,7 @@ def test_build_module_command_build_adds_workspace_env_path(
     ]
 
 
-def test_build_module_command_init_adds_workspace_env_path(
-    tmp_path: Path, monkeypatch
-):
+def test_build_module_command_init_adds_workspace_env_path(tmp_path: Path, monkeypatch):
     workspace, env_dir = _make_workspace(tmp_path)
     plugin = prime_plugin.PrimeCLIPlugin()
 

--- a/verifiers/cli/plugins/prime.py
+++ b/verifiers/cli/plugins/prime.py
@@ -11,6 +11,8 @@ from functools import lru_cache
 from typing import Sequence
 
 PRIME_PLUGIN_API_VERSION = 1
+WORKSPACE_ENV_DIR = "environments"
+WORKSPACE_ROOT_MARKERS = ("pyproject.toml", "verifiers", "environments")
 
 
 def _venv_python(venv_root: Path) -> Path:
@@ -42,13 +44,20 @@ def _python_can_import_module(
 
 def _resolve_workspace_python(cwd: Path | None = None) -> str:
     workspace = (cwd or Path.cwd()).resolve()
-    workspace_str = str(workspace)
+    workspace_root = _find_workspace_root(workspace)
+    workspace_for_probe = workspace_root or workspace
+    workspace_str = str(workspace_for_probe)
     module = "verifiers.cli.commands.eval"
 
     def _usable(candidate: Path) -> bool:
         return candidate.exists() and _python_can_import_module(
             str(candidate), module, workspace_str
         )
+
+    if workspace_root is not None:
+        candidate = _venv_python(workspace_root / ".venv")
+        if _usable(candidate):
+            return str(candidate)
 
     uv_project_env = os.environ.get("UV_PROJECT_ENVIRONMENT")
     if uv_project_env:
@@ -71,6 +80,68 @@ def _resolve_workspace_python(cwd: Path | None = None) -> str:
     return sys.executable
 
 
+def _find_workspace_root(start: Path) -> Path | None:
+    for directory in [start, *start.parents]:
+        marker_paths = [directory / marker for marker in WORKSPACE_ROOT_MARKERS]
+        if (
+            marker_paths[0].is_file()
+            and marker_paths[1].is_dir()
+            and marker_paths[2].is_dir()
+        ):
+            return directory
+    return None
+
+
+def _current_cwd() -> Path:
+    return Path.cwd().resolve()
+
+
+def _resolve_dir_arg(value: str, cwd: Path) -> str:
+    path = Path(value)
+    if path.is_absolute():
+        return str(path)
+
+    for directory in [cwd, *cwd.parents]:
+        candidate = (directory / path).resolve()
+        if candidate.exists() and candidate.is_dir():
+            return str(candidate)
+
+    return str((cwd / path).resolve())
+
+
+def _normalize_or_append_dir_option(
+    args: Sequence[str] | None,
+    *,
+    long_flag: str,
+    short_flag: str,
+    fallback_value: str | None,
+    cwd: Path,
+) -> list[str]:
+    normalized = list(args or [])
+    found_flag = False
+    i = 0
+    while i < len(normalized):
+        token = normalized[i]
+        if token in (long_flag, short_flag):
+            found_flag = True
+            if i + 1 < len(normalized):
+                normalized[i + 1] = _resolve_dir_arg(normalized[i + 1], cwd)
+                i += 1
+        elif token.startswith(f"{long_flag}="):
+            found_flag = True
+            _, raw_value = token.split("=", 1)
+            normalized[i] = f"{long_flag}={_resolve_dir_arg(raw_value, cwd)}"
+        elif token.startswith(short_flag) and token != short_flag:
+            found_flag = True
+            raw_value = token[len(short_flag) :]
+            normalized[i] = f"{short_flag}{_resolve_dir_arg(raw_value, cwd)}"
+        i += 1
+
+    if not found_flag and fallback_value is not None:
+        normalized.extend([long_flag, fallback_value])
+    return normalized
+
+
 @dataclass(frozen=True)
 class PrimeCLIPlugin:
     """Declarative command surface consumed by prime-cli."""
@@ -86,9 +157,35 @@ class PrimeCLIPlugin:
     def build_module_command(
         self, module_name: str, args: Sequence[str] | None = None
     ) -> list[str]:
-        command = [_resolve_workspace_python(), "-m", module_name]
-        if args:
-            command.extend(args)
+        cwd = _current_cwd()
+        workspace_root = _find_workspace_root(cwd)
+        workspace_env_dir: str | None = None
+        if workspace_root is not None:
+            env_dir = workspace_root / WORKSPACE_ENV_DIR
+            if env_dir.is_dir():
+                workspace_env_dir = str(env_dir.resolve())
+
+        normalized_args = list(args or [])
+        if module_name == self.install_module:
+            normalized_args = _normalize_or_append_dir_option(
+                normalized_args,
+                long_flag="--path",
+                short_flag="-p",
+                fallback_value=workspace_env_dir,
+                cwd=cwd,
+            )
+        elif module_name == self.eval_module:
+            normalized_args = _normalize_or_append_dir_option(
+                normalized_args,
+                long_flag="--env-dir-path",
+                short_flag="-p",
+                fallback_value=workspace_env_dir,
+                cwd=cwd,
+            )
+
+        command = [_resolve_workspace_python(cwd), "-m", module_name]
+        if normalized_args:
+            command.extend(normalized_args)
         return command
 
 

--- a/verifiers/cli/plugins/prime.py
+++ b/verifiers/cli/plugins/prime.py
@@ -12,7 +12,6 @@ from typing import Sequence
 
 PRIME_PLUGIN_API_VERSION = 1
 WORKSPACE_ENV_DIR = "environments"
-WORKSPACE_ROOT_MARKERS = ("pyproject.toml", "verifiers", "environments")
 
 
 def _venv_python(venv_root: Path) -> Path:
@@ -82,11 +81,10 @@ def _resolve_workspace_python(cwd: Path | None = None) -> str:
 
 def _find_workspace_root(start: Path) -> Path | None:
     for directory in [start, *start.parents]:
-        marker_paths = [directory / marker for marker in WORKSPACE_ROOT_MARKERS]
         if (
-            marker_paths[0].is_file()
-            and marker_paths[1].is_dir()
-            and marker_paths[2].is_dir()
+            (directory / "pyproject.toml").is_file()
+            and (directory / "verifiers").is_dir()
+            and (directory / WORKSPACE_ENV_DIR).is_dir()
         ):
             return directory
     return None

--- a/verifiers/cli/plugins/prime.py
+++ b/verifiers/cli/plugins/prime.py
@@ -164,7 +164,7 @@ class PrimeCLIPlugin:
                 workspace_env_dir = str(env_dir.resolve())
 
         normalized_args = list(args or [])
-        if module_name == self.install_module:
+        if module_name in (self.install_module, self.build_module, self.init_module):
             normalized_args = _normalize_or_append_dir_option(
                 normalized_args,
                 long_flag="--path",
@@ -172,7 +172,7 @@ class PrimeCLIPlugin:
                 fallback_value=workspace_env_dir,
                 cwd=cwd,
             )
-        elif module_name == self.eval_module:
+        elif module_name in (self.eval_module, self.gepa_module):
             normalized_args = _normalize_or_append_dir_option(
                 normalized_args,
                 long_flag="--env-dir-path",


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes command construction and python interpreter selection based on workspace discovery; may affect how `prime-cli` runs modules in different directory layouts and virtualenv setups.
> 
> **Overview**
> Improves workspace detection for the Prime CLI plugin by introducing `_find_workspace_root()` (requires `pyproject.toml`, `verifiers/`, and `environments/`) and preferring the workspace’s `.venv` when resolving the Python executable, even when `UV_PROJECT_ENVIRONMENT` is set.
> 
> Updates `PrimeCLIPlugin.build_module_command()` to normalize/resolve directory arguments and to auto-inject the workspace `environments` directory for commands that need it (adds `--path` for `install`/`build`/`init`, and `--env-dir-path` for `eval`/`gepa`), including rewriting relative paths to absolute ones. Adds a new `tests/test_prime_plugin.py` suite covering workspace root discovery, interpreter preference, and argument normalization/injection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6040bd08c8cb31ae2628ec4aa9ce6bb670fb61c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->