### PR TITLE
track vf + env version in metadata

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -197,6 +197,12 @@ Output from `Environment.generate()`. Contains a list of `RolloutOutput` objects
 ### GenerateMetadata
 
 ```python
+class VersionInfo(TypedDict):
+    vf_version: str
+    vf_commit: str | None
+    env_version: str | None
+    env_commit: str | None
+
 class GenerateMetadata(TypedDict):
     env_id: str
     env_args: dict
@@ -209,12 +215,15 @@ class GenerateMetadata(TypedDict):
     time_ms: float
     avg_reward: float
     avg_metrics: dict[str, float]
+    version_info: VersionInfo
     state_columns: list[str]
     path_to_save: Path
     tools: list[ChatCompletionToolParam] | None
 ```
 
 `base_url` is always serialized as a string. For multi-endpoint runs (e.g., using `ClientConfig.endpoint_configs`), it is stored as a comma-separated list of URLs.
+
+`version_info` captures the verifiers framework version/commit and the environment package version/commit at generation time. Populated automatically by `GenerateOutputsBuilder`.
 
 ### RolloutScore / RolloutScores
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -530,10 +530,18 @@ def make_metadata() -> Callable[..., GenerateMetadata]:
         avg_reward: float = 0.0,
         avg_metrics: dict[str, float] = {},
         usage: dict[str, float] | None = None,
+        version_info: dict | None = None,
         state_columns: list[str] = ["foo"],
         path_to_save: Path = Path("test.jsonl"),
         tools: list[ChatCompletionToolParam] | None = None,
     ) -> GenerateMetadata:
+        if version_info is None:
+            version_info = {
+                "vf_version": "0.0.0-test",
+                "vf_commit": None,
+                "env_version": None,
+                "env_commit": None,
+            }
         return GenerateMetadata(
             env_id=env_id,
             env_args=env_args,
@@ -547,6 +555,7 @@ def make_metadata() -> Callable[..., GenerateMetadata]:
             avg_reward=avg_reward,
             avg_metrics=avg_metrics,
             usage=usage,
+            version_info=version_info,
             state_columns=state_columns,
             path_to_save=path_to_save,
             tools=tools,

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -73,6 +73,15 @@ class TokenUsage(TypedDict):
     output_tokens: float
 
 
+class VersionInfo(TypedDict):
+    """Version and commit metadata for the verifiers framework and environment."""
+
+    vf_version: str
+    vf_commit: str | None
+    env_version: str | None
+    env_commit: str | None
+
+
 class TrajectoryStep(TypedDict):
     prompt: Messages
     completion: Messages
@@ -202,15 +211,6 @@ ProgressCallback = Callable[
     [list[RolloutOutput], list[RolloutOutput], "GenerateMetadata"], None
 ]  # all_outputs, new_outputs, new_metadata
 LogCallback = Callable[[str], None]  # log messages
-
-
-class VersionInfo(TypedDict):
-    """Version and commit metadata for the verifiers framework and environment."""
-
-    vf_version: str
-    vf_commit: str | None
-    env_version: str | None
-    env_commit: str | None
 
 
 class GenerateMetadata(TypedDict):

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -74,8 +74,6 @@ class TokenUsage(TypedDict):
 
 
 class VersionInfo(TypedDict):
-    """Version and commit metadata for the verifiers framework and environment."""
-
     vf_version: str
     vf_commit: str | None
     env_version: str | None

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -204,6 +204,15 @@ ProgressCallback = Callable[
 LogCallback = Callable[[str], None]  # log messages
 
 
+class VersionInfo(TypedDict):
+    """Version and commit metadata for the verifiers framework and environment."""
+
+    vf_version: str
+    vf_commit: str | None
+    env_version: str | None
+    env_commit: str | None
+
+
 class GenerateMetadata(TypedDict):
     """Pydantic model for generation metadata."""
 
@@ -220,6 +229,7 @@ class GenerateMetadata(TypedDict):
     avg_metrics: dict[str, float]
     avg_error: float
     usage: TokenUsage | None
+    version_info: VersionInfo
     state_columns: list[str]
     path_to_save: Path
     tools: list[ChatCompletionToolParam] | None

--- a/verifiers/utils/save_utils.py
+++ b/verifiers/utils/save_utils.py
@@ -21,6 +21,7 @@ from verifiers.types import (
     SamplingArgs,
     State,
     TokenUsage,
+    VersionInfo,
 )
 from verifiers.utils.error_utils import ErrorChain
 from verifiers.utils.message_utils import messages_to_printable, sanitize_tool_calls
@@ -29,7 +30,12 @@ from verifiers.utils.usage_utils import (
     StateUsageTracker,
     extract_usage_tokens as extract_usage_tokens_from_response,
 )
-from verifiers.utils.version_utils import get_version_info
+from verifiers.utils.version_utils import (
+    get_env_commit,
+    get_env_version,
+    get_vf_commit,
+    get_vf_version,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -259,7 +265,12 @@ class GenerateOutputsBuilder:
         self.results_path = results_path or get_results_path(env_id, model)
         self.start_time = time.time()
         self.base_url = self._compute_base_url(self.client)
-        self.version_info = get_version_info(env_id)
+        self.version_info = VersionInfo(
+            vf_version=get_vf_version(),
+            vf_commit=get_vf_commit(),
+            env_version=get_env_version(env_id),
+            env_commit=get_env_commit(env_id),
+        )
 
         # Accumulated outputs
         self.outputs: list[RolloutOutput] = []

--- a/verifiers/utils/save_utils.py
+++ b/verifiers/utils/save_utils.py
@@ -29,6 +29,7 @@ from verifiers.utils.usage_utils import (
     StateUsageTracker,
     extract_usage_tokens as extract_usage_tokens_from_response,
 )
+from verifiers.utils.version_utils import get_version_info
 
 logger = logging.getLogger(__name__)
 
@@ -258,6 +259,7 @@ class GenerateOutputsBuilder:
         self.results_path = results_path or get_results_path(env_id, model)
         self.start_time = time.time()
         self.base_url = self._compute_base_url(self.client)
+        self.version_info = get_version_info(env_id)
 
         # Accumulated outputs
         self.outputs: list[RolloutOutput] = []
@@ -352,6 +354,7 @@ class GenerateOutputsBuilder:
             avg_metrics=avg_metrics,
             avg_error=avg_error,
             usage=usage,
+            version_info=self.version_info,
             state_columns=self.state_columns,
             path_to_save=self.results_path,
             tools=tools,

--- a/verifiers/utils/save_utils.py
+++ b/verifiers/utils/save_utils.py
@@ -21,7 +21,6 @@ from verifiers.types import (
     SamplingArgs,
     State,
     TokenUsage,
-    VersionInfo,
 )
 from verifiers.utils.error_utils import ErrorChain
 from verifiers.utils.message_utils import messages_to_printable, sanitize_tool_calls
@@ -30,12 +29,7 @@ from verifiers.utils.usage_utils import (
     StateUsageTracker,
     extract_usage_tokens as extract_usage_tokens_from_response,
 )
-from verifiers.utils.version_utils import (
-    get_env_commit,
-    get_env_version,
-    get_vf_commit,
-    get_vf_version,
-)
+from verifiers.utils.version_utils import get_version_info
 
 logger = logging.getLogger(__name__)
 
@@ -265,12 +259,7 @@ class GenerateOutputsBuilder:
         self.results_path = results_path or get_results_path(env_id, model)
         self.start_time = time.time()
         self.base_url = self._compute_base_url(self.client)
-        self.version_info = VersionInfo(
-            vf_version=get_vf_version(),
-            vf_commit=get_vf_commit(),
-            env_version=get_env_version(env_id),
-            env_commit=get_env_commit(env_id),
-        )
+        self.version_info = get_version_info(env_id=env_id)
 
         # Accumulated outputs
         self.outputs: list[RolloutOutput] = []

--- a/verifiers/utils/version_utils.py
+++ b/verifiers/utils/version_utils.py
@@ -1,0 +1,111 @@
+"""Utilities for detecting verifiers and environment version/commit info."""
+
+from __future__ import annotations
+
+import importlib.metadata
+import logging
+import subprocess
+import sys
+from pathlib import Path
+
+if sys.version_info < (3, 12):
+    from typing_extensions import TypedDict
+else:
+    from typing import TypedDict
+
+logger = logging.getLogger(__name__)
+
+
+class VersionInfo(TypedDict):
+    """Version and commit metadata for the verifiers framework and environment."""
+
+    vf_version: str
+    vf_commit: str | None
+    env_version: str | None
+    env_commit: str | None
+
+
+def _git_commit_for_path(path: Path) -> str | None:
+    """Get the git commit hash for a file or directory path.
+
+    Walks up the directory tree to find a git repository and returns the
+    HEAD commit hash.
+    """
+    try:
+        directory = path if path.is_dir() else path.parent
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            cwd=str(directory),
+            timeout=5,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except Exception:
+        pass
+    return None
+
+
+def _get_package_source_path(package_name: str) -> Path | None:
+    """Get the source directory for an installed package."""
+    try:
+        module = importlib.import_module(package_name)
+        if hasattr(module, "__file__") and module.__file__:
+            return Path(module.__file__).parent
+    except Exception:
+        pass
+    return None
+
+
+def get_vf_version() -> str:
+    """Return the verifiers framework version."""
+    import verifiers
+
+    return verifiers.__version__
+
+
+def get_vf_commit() -> str | None:
+    """Return the git commit hash of the verifiers package, or None."""
+    source = _get_package_source_path("verifiers")
+    if source is None:
+        return None
+    return _git_commit_for_path(source)
+
+
+def _env_module_name(env_id: str) -> str | None:
+    """Derive the importable module name from an env_id, or None if empty."""
+    name = env_id.replace("-", "_").split("/")[-1]
+    return name if name else None
+
+
+def get_env_version(env_id: str) -> str | None:
+    """Return the installed version of an environment package, or None."""
+    module_name = _env_module_name(env_id)
+    if not module_name:
+        return None
+    try:
+        return importlib.metadata.version(module_name)
+    except (importlib.metadata.PackageNotFoundError, ValueError):
+        return None
+
+
+def get_env_commit(env_id: str) -> str | None:
+    """Return the git commit hash of an environment package, or None."""
+    module_name = _env_module_name(env_id)
+    if not module_name:
+        return None
+    source = _get_package_source_path(module_name)
+    if source is None:
+        return None
+    return _git_commit_for_path(source)
+
+
+def get_version_info(env_id: str) -> VersionInfo:
+    """Build a VersionInfo dict for the current verifiers + environment."""
+    return VersionInfo(
+        vf_version=get_vf_version(),
+        vf_commit=get_vf_commit(),
+        env_version=get_env_version(env_id),
+        env_commit=get_env_commit(env_id),
+    )

--- a/verifiers/utils/version_utils.py
+++ b/verifiers/utils/version_utils.py
@@ -25,8 +25,9 @@ class VersionInfo(TypedDict):
     env_commit: str | None
 
 
-def _git_commit_for_path(path: Path) -> str | None:
-    """Get the git commit hash for a file or directory path.
+def get_commit_for_path(path: Path) -> str | None:
+    """
+    Get the git commit hash for a file or directory path.
 
     Walks up the directory tree to find a git repository and returns the
     HEAD commit hash.
@@ -47,7 +48,7 @@ def _git_commit_for_path(path: Path) -> str | None:
     return None
 
 
-def _get_package_source_path(package_name: str) -> Path | None:
+def get_package_source_path(package_name: str) -> Path | None:
     """Get the source directory for an installed package."""
     try:
         module = importlib.import_module(package_name)
@@ -67,21 +68,15 @@ def get_vf_version() -> str:
 
 def get_vf_commit() -> str | None:
     """Return the git commit hash of the verifiers package, or None."""
-    source = _get_package_source_path("verifiers")
+    source = get_package_source_path("verifiers")
     if source is None:
         return None
-    return _git_commit_for_path(source)
-
-
-def _env_module_name(env_id: str) -> str | None:
-    """Derive the importable module name from an env_id, or None if empty."""
-    name = env_id.replace("-", "_").split("/")[-1]
-    return name if name else None
+    return get_commit_for_path(source)
 
 
 def get_env_version(env_id: str) -> str | None:
     """Return the installed version of an environment package, or None."""
-    module_name = _env_module_name(env_id)
+    module_name = env_id.replace("-", "_").split("/")[-1]
     if not module_name:
         return None
     try:
@@ -92,20 +87,10 @@ def get_env_version(env_id: str) -> str | None:
 
 def get_env_commit(env_id: str) -> str | None:
     """Return the git commit hash of an environment package, or None."""
-    module_name = _env_module_name(env_id)
+    module_name = env_id.replace("-", "_").split("/")[-1]
     if not module_name:
         return None
-    source = _get_package_source_path(module_name)
+    source = get_package_source_path(module_name)
     if source is None:
         return None
-    return _git_commit_for_path(source)
-
-
-def get_version_info(env_id: str) -> VersionInfo:
-    """Build a VersionInfo dict for the current verifiers + environment."""
-    return VersionInfo(
-        vf_version=get_vf_version(),
-        vf_commit=get_vf_commit(),
-        env_version=get_env_version(env_id),
-        env_commit=get_env_commit(env_id),
-    )
+    return get_commit_for_path(source)

--- a/verifiers/utils/version_utils.py
+++ b/verifiers/utils/version_utils.py
@@ -8,21 +8,14 @@ import subprocess
 import sys
 from pathlib import Path
 
+from verifiers.types import VersionInfo
+
 if sys.version_info < (3, 12):
     from typing_extensions import TypedDict
 else:
     from typing import TypedDict
 
 logger = logging.getLogger(__name__)
-
-
-class VersionInfo(TypedDict):
-    """Version and commit metadata for the verifiers framework and environment."""
-
-    vf_version: str
-    vf_commit: str | None
-    env_version: str | None
-    env_commit: str | None
 
 
 def get_commit_for_path(path: Path) -> str | None:
@@ -94,3 +87,13 @@ def get_env_commit(env_id: str) -> str | None:
     if source is None:
         return None
     return get_commit_for_path(source)
+
+
+def get_version_info(env_id: str) -> VersionInfo:
+    """Get version and commit info for the verifiers framework and an environment."""
+    return VersionInfo(
+        vf_version=get_vf_version(),
+        vf_commit=get_vf_commit(),
+        env_version=get_env_version(env_id),
+        env_commit=get_env_commit(env_id),
+    )

--- a/verifiers/utils/version_utils.py
+++ b/verifiers/utils/version_utils.py
@@ -5,15 +5,9 @@ from __future__ import annotations
 import importlib.metadata
 import logging
 import subprocess
-import sys
 from pathlib import Path
 
 from verifiers.types import VersionInfo
-
-if sys.version_info < (3, 12):
-    from typing_extensions import TypedDict
-else:
-    from typing import TypedDict
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

saves vf version commit + env version and commit into the metadata of an eval run. useful to show on platform for y reasons and to match an eval run to env versions

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low-impact API extension, but it introduces `subprocess` calls to `git` during metadata construction which could behave differently across runtime environments and affect performance/timeouts.
> 
> **Overview**
> Eval run metadata now includes a new `version_info` block containing the verifiers framework version/commit and the environment package version/commit.
> 
> This adds a `VersionInfo` type, populates it automatically in `GenerateOutputsBuilder` via a new `version_utils` helper (using package metadata and `git rev-parse` when available), updates test fixtures to include defaults, and documents the new metadata field in the reference docs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d9f2580142cd0dd51dc895a1c0486dc612a9e0e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->