### PR TITLE
misc logging improvs

### DIFF
--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -43,7 +43,7 @@ from .utils.logging_utils import (
 )
 
 # Setup default logging configuration
-setup_logging(os.getenv("VF_LOG_LEVEL", "INFO"))
+setup_logging(os.getenv("VF_LOG_LEVEL"))
 
 __all__ = [
     "DatasetBuilder",

--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -24,6 +24,7 @@ from verifiers.types import (
     EvalRunConfig,
 )
 from verifiers.utils.eval_utils import (
+    get_log_level,
     load_endpoints,
     load_toml_config,
     resolve_endpoints_file,
@@ -279,7 +280,8 @@ def main():
     )
     args = parser.parse_args()
 
-    setup_logging("DEBUG" if args.verbose else os.getenv("VF_LOG_LEVEL", "INFO"))
+    if args.debug:  # only set up console logging in debug mode
+        setup_logging(get_log_level(args.verbose))
 
     # Build raw configs: both paths produce list[dict]
     if args.env_id_or_config.endswith(".toml"):
@@ -519,6 +521,7 @@ def main():
             max_concurrent=raw.get("max_concurrent", DEFAULT_MAX_CONCURRENT),
             max_retries=raw.get("max_retries", 0),
             verbose=raw.get("verbose", False),
+            debug=raw.get("debug", False),
             state_columns=raw.get("state_columns", []),
             save_results=raw.get("save_results", False),
             resume_path=resume_path,

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -341,6 +341,7 @@ class EvalConfig(BaseModel):
     max_retries: int = 0
     # logging
     verbose: bool = False
+    debug: bool = False
     # saving
     state_columns: list[str] | None = None
     save_results: bool = False

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -4,17 +4,17 @@ import asyncio
 import importlib.util
 import logging
 import math
+import os
 import time
 from collections import Counter, defaultdict
 from collections.abc import Mapping
 from contextlib import contextmanager, suppress
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
-
-from datasets import disable_progress_bar, enable_progress_bar
-from datasets.utils import logging as ds_logging
+from typing import TYPE_CHECKING, Callable, cast
 
 import numpy as np
+from datasets import disable_progress_bar, enable_progress_bar
+from datasets.utils import logging as ds_logging
 
 import verifiers as vf
 from verifiers.utils.import_utils import load_toml
@@ -295,6 +295,7 @@ def load_toml_config(path: Path) -> list[dict]:
         "max_retries",
         # logging
         "verbose",
+        "debug",
         # saving
         "state_columns",
         "save_results",
@@ -516,6 +517,10 @@ def print_results(results: GenerateOutputs, num_samples: int = 1):
             print_usage(task_results)
 
 
+def get_log_level(verbose: bool) -> str:
+    return "DEBUG" if verbose else os.getenv("VF_LOG_LEVEL", "INFO")
+
+
 @contextmanager
 def quiet_datasets():
     prev_level = ds_logging.get_verbosity()
@@ -531,6 +536,7 @@ def quiet_datasets():
 async def run_evaluation(
     config: EvalConfig,
     on_start: StartCallback | None = None,
+    on_log_file: Callable[[Path], None] | None = None,
     on_progress: ProgressCallback | None = None,
     on_log: LogCallback | None = None,
 ) -> GenerateOutputs:
@@ -542,12 +548,26 @@ async def run_evaluation(
         logger.info(f"Setting extra environment kwargs: {config.extra_env_kwargs}")
         vf_env.set_kwargs(**config.extra_env_kwargs)
 
-    # start env server as sidecar process
-    try:
-        await vf_env.start_server(extra_env_kwargs=config.extra_env_kwargs)
+    results_path = config.resume_path or get_eval_results_path(config)
 
-        # run evaluation
-        results_path = config.resume_path or get_eval_results_path(config)
+    if config.debug:
+        await vf_env.start_server(
+            extra_env_kwargs=config.extra_env_kwargs,
+            log_level=get_log_level(config.verbose),
+        )
+    else:
+        log_file = results_path / "eval.log"
+        log_file.parent.mkdir(parents=True, exist_ok=True)
+        await vf_env.start_server(
+            extra_env_kwargs=config.extra_env_kwargs,
+            log_level="CRITICAL",  # disable console logging
+            log_file=str(log_file),
+            log_file_level=get_log_level(config.verbose),
+        )
+        if on_log_file is not None:
+            on_log_file(log_file)
+
+    try:
         logger.debug(f"Starting evaluation with model: {config.model}")
         logger.debug(
             f"Configuration: num_examples={config.num_examples}, rollouts_per_example={config.rollouts_per_example}, max_concurrent={config.max_concurrent}"
@@ -676,6 +696,9 @@ async def run_evaluations_tui(config: EvalRunConfig, tui_mode: bool = True) -> N
         def on_log(message: str) -> None:
             display.update_env_state(env_idx, log_message=message)
 
+        def register_log_file(log_file: Path) -> None:
+            display.add_log_file_for_env(env_idx, log_file)
+
         display.update_env_state(env_idx, status="running")
         try:
             result = await run_evaluation(
@@ -683,6 +706,7 @@ async def run_evaluations_tui(config: EvalRunConfig, tui_mode: bool = True) -> N
                 on_start=on_start,
                 on_progress=on_progress,
                 on_log=on_log,
+                on_log_file=register_log_file,
             )
 
             # get save path if results were saved

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -567,10 +567,11 @@ async def run_evaluation(
             )
             if on_log_file is not None:
                 on_log_file(log_file)
-            logger.debug(f"Starting evaluation with model: {config.model}")
-            logger.debug(
-                f"Configuration: num_examples={config.num_examples}, rollouts_per_example={config.rollouts_per_example}, max_concurrent={config.max_concurrent}"
-            )
+
+        logger.debug(f"Starting evaluation with model: {config.model}")
+        logger.debug(
+            f"Configuration: num_examples={config.num_examples}, rollouts_per_example={config.rollouts_per_example}, max_concurrent={config.max_concurrent}"
+        )
 
         effective_group_max_concurrent = config.max_concurrent
         if (

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -550,28 +550,28 @@ async def run_evaluation(
 
     results_path = config.resume_path or get_eval_results_path(config)
 
-    if config.debug:
-        await vf_env.start_server(
-            extra_env_kwargs=config.extra_env_kwargs,
-            log_level=get_log_level(config.verbose),
-        )
-    else:
-        log_file = results_path / "eval.log"
-        log_file.parent.mkdir(parents=True, exist_ok=True)
-        await vf_env.start_server(
-            extra_env_kwargs=config.extra_env_kwargs,
-            log_level="CRITICAL",  # disable console logging
-            log_file=str(log_file),
-            log_file_level=get_log_level(config.verbose),
-        )
-        if on_log_file is not None:
-            on_log_file(log_file)
-
     try:
-        logger.debug(f"Starting evaluation with model: {config.model}")
-        logger.debug(
-            f"Configuration: num_examples={config.num_examples}, rollouts_per_example={config.rollouts_per_example}, max_concurrent={config.max_concurrent}"
-        )
+        if config.debug:
+            await vf_env.start_server(
+                extra_env_kwargs=config.extra_env_kwargs,
+                log_level=get_log_level(config.verbose),
+            )
+        else:
+            log_file = results_path / "eval.log"
+            log_file.parent.mkdir(parents=True, exist_ok=True)
+            await vf_env.start_server(
+                extra_env_kwargs=config.extra_env_kwargs,
+                log_level="CRITICAL",  # disable console logging
+                log_file=str(log_file),
+                log_file_level=get_log_level(config.verbose),
+            )
+            if on_log_file is not None:
+                on_log_file(log_file)
+            logger.debug(f"Starting evaluation with model: {config.model}")
+            logger.debug(
+                f"Configuration: num_examples={config.num_examples}, rollouts_per_example={config.rollouts_per_example}, max_concurrent={config.max_concurrent}"
+            )
+
         effective_group_max_concurrent = config.max_concurrent
         if (
             not config.independent_scoring

--- a/verifiers/utils/logging_utils.py
+++ b/verifiers/utils/logging_utils.py
@@ -16,7 +16,7 @@ LOGGER_NAME = "verifiers"
 
 
 def setup_logging(
-    level: str = "INFO",
+    level: str | None = "INFO",
     log_format: str | None = None,
     date_format: str | None = None,
     log_file: str | None = None,
@@ -26,11 +26,10 @@ def setup_logging(
     Setup basic logging configuration for the verifiers package.
 
     Args:
-        level: The logging level to use for console output. Defaults to "INFO".
+        level: The logging level to use. If None, logging is disabled. Defaults to "INFO".
         log_format: Custom log format string. If None, uses default format.
         date_format: Custom date format string. If None, uses default format.
         log_file: Optional path to a log file. If specified, logs will be written to this file.
-        log_file_level: The logging level for the file handler. If None, uses the same level as console.
     """
     if log_format is None:
         log_format = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
@@ -43,6 +42,9 @@ def setup_logging(
 
     # remove any existing handlers to avoid duplicates
     logger.handlers.clear()
+
+    if level is None:
+        return
 
     # set logger level to the minimum of console and file levels
     # so messages can reach the more permissive handler

--- a/verifiers/utils/logging_utils.py
+++ b/verifiers/utils/logging_utils.py
@@ -44,6 +44,7 @@ def setup_logging(
     logger.handlers.clear()
 
     if level is None:
+        logger.propagate = False
         return
 
     # set logger level to the minimum of console and file levels


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

a couple of improvements to verifiers' logging behavior:
1. by default, logging is disabled (e.g. no logger is set up upon `import verifiers`). however, the module-wide log level can be set with `VF_LOG_LEVEL` as before
2. in `vf-eval` we discriminate between non-rich (`--debug` ) and rich mode:
    - in debug mode: all logs (main process + env server) go to the console + env server logs to file
    - in rich mode: all console logs are disabled + env server logs to file and eval display streams from there
in both cases, the log level is `INFO` by default but can be turned into `DEBUG` via `--verbose`

## Example

```bash
# info console logs
uv run vf-eval gsm8k -d

# debug console logs
uv run vf-eval gsm8k -d -v

# info streamed env server logs
uv run vf-eval gsm8k

# debug streamed env server logs
uv run vf-eval gsm8k -v
```

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default logging behavior and eval runtime log routing (console vs file/tailing), which may affect observability or hide logs if misconfigured, but does not touch core scoring/data logic.
> 
> **Overview**
> Disables package-wide logging by default on `import verifiers` by allowing `setup_logging(None)` when `VF_LOG_LEVEL` is unset, while keeping env-var control for opting into logs.
> 
> Refactors `vf-eval` logging to split **debug mode** (`--debug`) vs Rich display mode: debug configures console logging; non-debug runs env servers with console logging suppressed, writes env logs to per-run `eval.log`, and streams/tails those logs into the Rich per-environment panels.
> 
> Extends `EvalConfig`/TOML config to include a `debug` flag and threads it through evaluation execution, including passing log level/file settings into `start_server`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f2a8dafdd41f49b6d4f61ef47260b81a98893a5f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->