### PR TITLE
Fix vf-eval non-TUI live overflow rendering

### DIFF
--- a/verifiers/utils/display_utils.py
+++ b/verifiers/utils/display_utils.py
@@ -263,13 +263,17 @@ class BaseDisplay:
             new_settings[3] = new_settings[3] & ~termios.ECHO
             termios.tcsetattr(fd, termios.TCSADRAIN, new_settings)
 
+        # In non-TUI mode, clamp vertical overflow so oversized renders don't
+        # scroll and smear repeated frames in-place.
+        vertical_overflow = "visible" if self.screen else "ellipsis"
+
         self._live = Live(
             self._render(),
             console=self.console,
             refresh_per_second=self.refresh_per_second,
             screen=self.screen,
             transient=False,  # Keep final display visible in scrollback
-            vertical_overflow="visible",
+            vertical_overflow=vertical_overflow,
         )
         self._live.start()
 


### PR DESCRIPTION
## Description

When the terminal window wasn't high enough, the progress bar would render very poorly:

<img width="921" height="482" alt="image" src="https://github.com/user-attachments/assets/1a2cd239-3440-485c-b1b4-dc9ca658bd6a" />

After this pr it looks good again:

<img width="921" height="482" alt="image" src="https://github.com/user-attachments/assets/9fae7e50-d18f-4e04-b3b4-82a9d82f9eed" />

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to terminal rendering configuration; main risk is minor formatting/visibility differences in edge-case terminal sizes.
> 
> **Overview**
> Fixes Rich `Live` rendering in non-TUI mode by clamping `vertical_overflow` to `"ellipsis"` when `screen=False`, preventing oversized frames from scrolling and smearing repeated refreshes in small terminals. TUI/alternate-screen mode keeps `vertical_overflow="visible"` so full content can still render when space permits.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 524141c4b9b89e65be34521637c811b8b473a57b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->