### PR TITLE
Prioritize primeintellect envs and add freshness/CI/version criteria to browse-environments skill

### DIFF
--- a/skills/browse-environments/SKILL.md
+++ b/skills/browse-environments/SKILL.md
@@ -11,7 +11,7 @@ Use Prime ecosystem commands to discover environments quickly, inspect quality s
 ## Primary Discovery Workflow
 1. List candidate environments:
 ```bash
-prime env list --search "math" --sort stars --show-actions
+prime env list --search "math" --owner primeintellect --show-actions
 ```
 2. Narrow results with owner, tags, mine, or starred filters:
 ```bash
@@ -19,12 +19,17 @@ prime env list --owner primeintellect --tag tools --tag sandbox
 prime env list --mine
 prime env list --starred
 ```
-3. Inspect details for shortlisted candidates:
+3. Prioritize quality and freshness signals:
+   - Prefer environments published by `primeintellect` first.
+   - Keep only candidates with passing latest action/CI status from `--show-actions` or `prime env status`.
+   - Prefer candidates updated in roughly the last 2 months.
+   - Prefer candidates on version `v0.1.8` or newer.
+4. Inspect details for shortlisted candidates:
 ```bash
 prime env info owner/name
 prime env status owner/name
 ```
-4. Pull source for deep inspection when needed:
+5. Pull source for deep inspection when needed:
 ```bash
 prime env pull owner/name -t ./tmp-env
 ```
@@ -35,7 +40,8 @@ For each candidate, collect:
 2. Reward type: binary, continuous, judge-based, mixed.
 3. Dependencies and secrets requirements.
 4. Latest action status and version signal.
-5. Fit to user goal: eval-only, GEPA, RL, or benchmark migration.
+5. Recency signal: last updated date (target within ~2 months).
+6. Fit to user goal: eval-only, GEPA, RL, or benchmark migration.
 
 ## Endpoint And Model Selection Nudge
 1. Encourage users to configure endpoint aliases in `configs/endpoints.toml` before comparison evals.


### PR DESCRIPTION
### Motivation
- Improve discovery quality by preferring official `primeintellect` environments as the first-pass results. 
- Emphasize actionable signals (CI/actions, recency, and explicit version) to avoid stale or broken environments. 
- Make the shortlist selection more deterministic for downstream evals, installs, and migrations. 

### Description
- Update `skills/browse-environments/SKILL.md` to change the primary `prime env list` example to include `--owner primeintellect` by default. 
- Add explicit shortlist filtering guidance to prefer `primeintellect`-published environments with passing latest actions/CI, updated within ~2 months, and on version `v0.1.8` or newer. 
- Move and expand the inspect/pull steps and add a `Recency` line to the candidate comparison checklist. 

### Testing
- Ran `uv run pre-commit install` which completed successfully. 
- Ran `uv run pre-commit run --all-files` which passed all configured checks. 
- Ran `uv run pytest tests/ -q --maxfail=1` which reported a failure in `tests/test_envs.py::test_env[gsm8k]` attributable to an environment/API evaluation issue unrelated to this docs-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989ae534d7c83269634ff41e6dab80a)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes that adjust recommended CLI usage and evaluation criteria; no runtime or security-sensitive code paths are modified.
> 
> **Overview**
> Updates `skills/browse-environments/SKILL.md` to **prioritize official `primeintellect` environments** in the primary `prime env list` example and to make the discovery workflow more deterministic.
> 
> Adds explicit shortlisting guidance to filter by **passing latest actions/CI**, **recent updates (~2 months)**, and **minimum version (`v0.1.8+`)**, and expands the comparison checklist with an explicit recency signal while renumbering the inspect/pull steps accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 518a7669a38669ce641917cadc6724d6cedbfed9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->