### PR TITLE
Clarify agent skill handling

### DIFF
--- a/docs/training.md
+++ b/docs/training.md
@@ -99,7 +99,7 @@ This will clone and install the `prime-rl` trainer and its dependencies, and set
 
 Then, you can start training with:
 ```bash
-uv run prime-rl @ configs/prime-rl/wiki-search.toml
+uv run prime-rl configs/prime-rl/wiki-search.toml
 ```
 
 This will launch a tmux session with separate panes for the trainer, orchestrator, and inference server. For further configuration options, see the [prime-rl documentation](https://docs.primeintellect.ai/prime-rl). 

--- a/skills/create-environments/SKILL.md
+++ b/skills/create-environments/SKILL.md
@@ -99,6 +99,13 @@ prime env push --path ./environments/my_env --visibility PRIVATE
 prime eval run owner/my-env -m gpt-4.1-mini -n 200 -r 3 -s
 ```
 
+## Synthetic Data
+1. Ask users for preferences on which LLMs to use for synthetic data generation and curation before implementation.
+2. Prefer generating synthetic data from raw source documents whenever possible instead of relying only on hand-authored prompts.
+3. Use LLM orchestration (planner/generator/validator loops) to improve sample quality and diversity.
+4. Use back-translation: start from complete materials and decompose them into incomplete tasks, criteria, or partial artifacts that the model must reconstruct.
+5. Use fan-out subtopic sampling from LLMs to expand coverage and avoid overfitting to a narrow slice of the domain.
+
 ## Deliverable Format
 Report:
 1. Environment ID and path.

--- a/skills/train-with-environments/SKILL.md
+++ b/skills/train-with-environments/SKILL.md
@@ -9,16 +9,18 @@ description: Train models with verifiers environments using hosted RL or prime-r
 Run stable RL training loops with environment-aware hyperparameter choices and clear diagnostics.
 
 ## Preferred Training Paths
-1. Hosted Training service path from lab setup:
+1. By default, assume users intend to use Hosted Training unless they explicitly ask for self-managed training.
+2. Hosted Training service path from lab setup:
 ```bash
 prime lab setup
 ```
-2. Self-managed `prime-rl` workflow:
+3. Self-managed `prime-rl` workflow:
 ```bash
 prime lab setup --prime-rl
-uv run prime-rl @ configs/prime-rl/wiki-search.toml
+uv run prime-rl configs/prime-rl/wiki-search.toml
 ```
-3. Runtime expectation:
+4. Treat `prime-rl` as a power-user path and assume users are comfortable working with GPU infrastructure and troubleshooting.
+5. Runtime expectation:
 - Hosted Training is intended to be launched from a CPU machine.
 - Local `prime-rl` training requires local GPU access.
 

--- a/tests/test_setup_script.py
+++ b/tests/test_setup_script.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+import os
 from pathlib import Path
 
 from verifiers.scripts import setup
@@ -101,3 +103,186 @@ def test_sync_prime_skills_creates_dot_prime_tree(tmp_path: Path, monkeypatch) -
             ".prime/skills/brainstorm/SKILL.md",
         ),
     ]
+
+
+def test_prepare_agent_skill_dirs_materializes_skills_from_prime(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(setup, "LAB_SKILLS", ["create-environments", "brainstorm"])
+
+    for skill_name in setup.LAB_SKILLS:
+        skill_dir = tmp_path / ".prime" / "skills" / skill_name
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        (skill_dir / "SKILL.md").write_text(f"{skill_name}\n")
+
+    setup._prepare_agent_skill_dirs(["codex"])
+
+    for skill_name in setup.LAB_SKILLS:
+        source = tmp_path / ".prime" / "skills" / skill_name
+        target = tmp_path / ".codex" / "skills" / skill_name
+        assert target.exists()
+        assert (target / "SKILL.md").exists()
+        if target.is_symlink():
+            assert target.resolve() == source.resolve()
+
+
+def test_prepare_agent_skill_dirs_is_safe_with_existing_links(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(setup, "LAB_SKILLS", ["create-environments"])
+
+    source = tmp_path / ".prime" / "skills" / "create-environments"
+    source.mkdir(parents=True, exist_ok=True)
+    (source / "SKILL.md").write_text("create-environments\n")
+
+    target = tmp_path / ".codex" / "skills" / "create-environments"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.symlink_to(
+        os.path.relpath(source, start=target.parent),
+        target_is_directory=True,
+    )
+
+    setup._prepare_agent_skill_dirs(["codex"])
+
+    assert target.is_symlink()
+    assert target.resolve() == source.resolve()
+    assert (target / "SKILL.md").exists()
+
+
+def test_prepare_agent_skill_dirs_uses_mapped_root_for_amp(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(setup, "LAB_SKILLS", ["create-environments"])
+
+    source = tmp_path / ".prime" / "skills" / "create-environments"
+    source.mkdir(parents=True, exist_ok=True)
+    (source / "SKILL.md").write_text("create-environments\n")
+
+    setup._prepare_agent_skill_dirs(["amp"])
+
+    assert (
+        tmp_path / ".agents" / "skills" / "create-environments" / "SKILL.md"
+    ).exists()
+    assert not (tmp_path / ".amp" / "skills").exists()
+
+
+def test_prepare_agent_skill_dirs_supports_skill_name_mapping(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(setup, "LAB_SKILLS", ["create-environments"])
+    monkeypatch.setattr(
+        setup,
+        "AGENT_SKILL_NAME_MAP",
+        {"amp": {"create-environments": "create-envs"}},
+    )
+
+    source = tmp_path / ".prime" / "skills" / "create-environments"
+    source.mkdir(parents=True, exist_ok=True)
+    (source / "SKILL.md").write_text("create-environments\n")
+
+    setup._prepare_agent_skill_dirs(["amp"])
+
+    assert (tmp_path / ".agents" / "skills" / "create-envs" / "SKILL.md").exists()
+    assert not (tmp_path / ".agents" / "skills" / "create-environments").exists()
+
+
+def test_run_setup_prints_post_setup_call_to_action(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    monkeypatch.setattr(setup.wget, "download", _fake_download_factory([]))
+    monkeypatch.setattr(setup, "download_configs", lambda *_: None)
+    monkeypatch.setattr(setup, "sync_prime_skills", lambda: None)
+
+    setup.run_setup(skip_install=True, skip_agents_md=True)
+
+    output = capsys.readouterr().out
+    assert "Prepared .codex/skills" in output
+    assert output.index("Prepared .codex/skills") < output.index("get started")
+    assert "get started" in output
+    assert "quick commands" in output
+    assert "ask codex" in output
+    assert "example prompt" not in output
+    assert 'ask codex: "I want to train a model for my task domain.' not in output
+    assert "idea -> environment -> eval -> training" in output
+    assert "prime env init my-env" in output
+    assert "prime env install my-env" not in output
+    assert "prime eval run my-env -m gpt-5-nano -n 5" in output
+    assert "prime eval tui" in output
+    assert "prime rl run configs/rl/wiki-search.toml" in output
+    assert "prime gepa run my-env -m gpt-5-nano" in output
+
+
+def test_run_setup_prints_prime_rl_post_setup_call_to_action(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    monkeypatch.setattr(setup.wget, "download", _fake_download_factory([]))
+    monkeypatch.setattr(setup, "download_configs", lambda *_: None)
+    monkeypatch.setattr(setup, "sync_prime_skills", lambda: None)
+    monkeypatch.setattr(setup, "install_prime_rl", lambda: None)
+    monkeypatch.setattr(setup, "install_environments_to_prime_rl", lambda: None)
+
+    setup.run_setup(skip_install=True, skip_agents_md=True, prime_rl=True)
+
+    output = capsys.readouterr().out
+    assert "get started" in output
+    assert "quick commands" in output
+    assert "ask codex" in output
+    assert "example prompt" not in output
+    assert "prime env install my-env" not in output
+    assert "uv run prime-rl configs/prime-rl/wiki-search.toml" in output
+    assert "prime rl run configs/rl/wiki-search.toml" not in output
+
+
+def test_run_setup_persists_lab_choices_metadata(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    monkeypatch.setattr(setup.wget, "download", _fake_download_factory([]))
+    monkeypatch.setattr(setup, "download_configs", lambda *_: None)
+    monkeypatch.setattr(setup, "sync_prime_skills", lambda: None)
+
+    setup.run_setup(
+        skip_install=True,
+        skip_agents_md=True,
+        agents="codex,cursor,codex",
+        no_interactive=True,
+    )
+
+    metadata_path = tmp_path / ".prime" / "lab.json"
+    assert metadata_path.exists()
+    metadata = json.loads(metadata_path.read_text())
+    assert metadata["setup_source"] == "prime lab setup"
+    assert metadata["choices"] == {
+        "agents": ["codex", "cursor"],
+        "primary_agent": "codex",
+        "use_multiple_agents": True,
+    }
+
+
+def test_run_setup_persists_default_lab_choices_metadata(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    monkeypatch.setattr(setup.wget, "download", _fake_download_factory([]))
+    monkeypatch.setattr(setup, "download_configs", lambda *_: None)
+    monkeypatch.setattr(setup, "sync_prime_skills", lambda: None)
+
+    setup.run_setup(skip_install=True, skip_agents_md=True, no_interactive=True)
+
+    metadata_path = tmp_path / ".prime" / "lab.json"
+    assert metadata_path.exists()
+    metadata = json.loads(metadata_path.read_text())
+    assert metadata["setup_source"] == "prime lab setup"
+    assert metadata["choices"] == {
+        "agents": ["codex"],
+        "primary_agent": "codex",
+        "use_multiple_agents": False,
+    }

--- a/verifiers/scripts/prime_rl.py
+++ b/verifiers/scripts/prime_rl.py
@@ -3,7 +3,7 @@
 Wrapper script to run prime-rl rl command from the current working directory.
 
 Usage:
-    uv run prime-rl @ configs/prime-rl/config.toml
+    uv run prime-rl configs/prime-rl/config.toml
 """
 
 import argparse
@@ -147,7 +147,6 @@ def main():
     parser = argparse.ArgumentParser(
         description="Create a tmux session and run prime-rl rl command from a TOML config."
     )
-    parser.add_argument("at", type=str)
     parser.add_argument("config_path", type=str)
     parser.add_argument(
         "--session",
@@ -167,9 +166,6 @@ def main():
 
     if not tmux_exists():
         raise SystemExit("tmux not found in PATH. Please install tmux.")
-
-    if args.at != "@":
-        raise SystemExit("Usage: prime-rl @ path/to/file.toml")
 
     cwd = Path.cwd()
     prime_rl_dir = cwd / "prime-rl"

--- a/verifiers/scripts/setup.py
+++ b/verifiers/scripts/setup.py
@@ -1,8 +1,16 @@
 import argparse
+import json
 import os
+from pathlib import Path
+import shutil
 import subprocess
 import sys
 
+from rich import box
+from rich.console import Console, Group
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
 import wget
 
 VERIFIERS_REPO = "primeintellect-ai/verifiers"
@@ -36,7 +44,14 @@ LAB_SKILLS = [
     "train-with-environments",
     "brainstorm",
 ]
+AGENT_SKILLS_DIR_MAP: dict[str, str] = {
+    "amp": ".agents/skills",
+}
+AGENT_SKILL_NAME_MAP: dict[str, dict[str, str]] = {}
+SUPPORTED_AGENTS = ("codex", "claude", "cursor", "opencode", "amp")
 PRIME_SKILLS_DIR = ".prime/skills"
+PRIME_DIR = ".prime"
+LAB_METADATA_PATH = os.path.join(PRIME_DIR, "lab.json")
 
 ConfigSpec = tuple[str, str, str]
 
@@ -271,6 +286,8 @@ def run_setup(
     prime_rl: bool = False,
     skip_agents_md: bool = False,
     skip_install: bool = False,
+    agents: str | None = None,
+    no_interactive: bool = False,
 ) -> None:
     """Run verifiers setup with the specified options.
 
@@ -278,13 +295,26 @@ def run_setup(
         prime_rl: Install prime-rl and download prime-rl configs.
         skip_agents_md: Skip downloading AGENTS.md, CLAUDE.md, and environments/AGENTS.md.
         skip_install: Skip uv project initialization and verifiers installation.
+        agents: Comma-separated coding agents to scaffold.
+        no_interactive: Disable interactive coding agent prompts.
     """
+    primary_agent, selected_agents, use_multiple_agents = _resolve_setup_agents(
+        agents=agents,
+        no_interactive=no_interactive,
+    )
+
     if not skip_install:
         ensure_uv_project()
 
     os.makedirs("configs", exist_ok=True)
     os.makedirs("environments", exist_ok=True)
     sync_prime_skills()
+    _prepare_agent_skill_dirs(selected_agents)
+    _sync_lab_metadata(
+        primary_agent=primary_agent,
+        selected_agents=selected_agents,
+        use_multiple_agents=use_multiple_agents,
+    )
 
     if not skip_agents_md:
         if os.path.exists(AGENTS_MD_DST):
@@ -319,6 +349,223 @@ def run_setup(
         configs_to_download.extend(RL_CONFIGS)
 
     download_configs(_dedupe_config_destinations(configs_to_download))
+    print_post_setup_call_to_action(prime_rl=prime_rl, primary_agent=primary_agent)
+
+
+def print_post_setup_call_to_action(prime_rl: bool, primary_agent: str) -> None:
+    """Print practical next steps after setup."""
+    prompt_heading = f"ask {primary_agent}"
+    prompt_body = (
+        "I want to train a model for <my task domain>. Propose an initial environment "
+        "scaffold including relevant tools, and come up with a good method to generate "
+        "a small sample synthetic dataset. Run a quick eval baseline, inspect the "
+        "results, and then decide how we should iterate on refining the implementation."
+    )
+    prompt_text = Text(
+        prompt_body,
+        style="italic",
+    )
+
+    command_table = Table.grid(padding=(0, 1))
+    command_table.add_row("[bold green]$[/bold green]", "prime env init my-env")
+    command_table.add_row(
+        "[bold green]$[/bold green]", "prime eval run my-env -m gpt-5-nano -n 5"
+    )
+    command_table.add_row("[bold green]$[/bold green]", "prime eval tui")
+    if prime_rl:
+        command_table.add_row(
+            "[bold green]$[/bold green]",
+            "uv run prime-rl configs/prime-rl/wiki-search.toml",
+        )
+    else:
+        command_table.add_row(
+            "[bold green]$[/bold green]", "prime rl run configs/rl/wiki-search.toml"
+        )
+    command_table.add_row(
+        "[bold green]$[/bold green]", "prime gepa run my-env -m gpt-5-nano"
+    )
+
+    header_text = Text.assemble(
+        ("idea -> environment -> eval -> training", "dim"),
+    )
+
+    content = Group(
+        header_text,
+        Panel(
+            prompt_text,
+            title=prompt_heading,
+            border_style="magenta",
+            box=box.ROUNDED,
+            padding=(1, 2),
+            expand=False,
+        ),
+        Panel(
+            command_table,
+            title="quick commands",
+            border_style="green",
+            box=box.ROUNDED,
+            padding=(0, 1),
+            expand=False,
+        ),
+    )
+
+    console = Console()
+    console.print()
+    console.print(
+        Panel(
+            content,
+            title="[bold white]get started[/bold white]",
+            border_style="bright_blue",
+            box=box.DOUBLE,
+            padding=(1, 2),
+            expand=False,
+        )
+    )
+
+
+def _load_lab_metadata() -> dict[str, object]:
+    """Load persisted lab metadata from .prime directory."""
+    metadata_path = Path(LAB_METADATA_PATH)
+    if not metadata_path.exists():
+        return {}
+    try:
+        raw = json.loads(metadata_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if not isinstance(raw, dict):
+        return {}
+    return raw
+
+
+def _normalize_agent(value: str) -> str:
+    normalized = value.strip().lower()
+    if normalized not in SUPPORTED_AGENTS:
+        allowed = ", ".join(SUPPORTED_AGENTS)
+        raise ValueError(
+            f"Unsupported coding agent '{value}'. Supported values: {allowed}"
+        )
+    return normalized
+
+
+def _parse_agents_csv(value: str | None) -> list[str] | None:
+    if value is None:
+        return None
+    parsed = [token.strip() for token in value.split(",") if token.strip()]
+    if not parsed:
+        return None
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for token in parsed:
+        normalized = _normalize_agent(token)
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        deduped.append(normalized)
+    return deduped
+
+
+def _prompt_for_agents() -> list[str]:
+    print(f"Supported coding agents: {', '.join(SUPPORTED_AGENTS)}")
+    while True:
+        raw_primary = input("Primary coding agent [codex]: ").strip()
+        primary = raw_primary if raw_primary else "codex"
+        try:
+            normalized_primary = _normalize_agent(primary)
+            break
+        except ValueError as exc:
+            print(exc)
+
+    selected = [normalized_primary]
+    use_multiple_raw = input("Using multiple coding agents? [y/N]: ").strip().lower()
+    if use_multiple_raw in {"y", "yes"}:
+        while True:
+            additional_raw = input("Additional agents (comma-separated): ").strip()
+            try:
+                additional = _parse_agents_csv(additional_raw) or []
+            except ValueError as exc:
+                print(exc)
+                continue
+            for agent in additional:
+                if agent not in selected:
+                    selected.append(agent)
+            break
+    return selected
+
+
+def _resolve_setup_agents(
+    agents: str | None, no_interactive: bool
+) -> tuple[str, list[str], bool]:
+    if agents is not None:
+        selected = _parse_agents_csv(agents)
+        if selected is None:
+            raise RuntimeError(
+                "No valid coding agents provided. Supported values: "
+                + ", ".join(SUPPORTED_AGENTS)
+            )
+    elif not no_interactive and sys.stdin.isatty():
+        selected = _prompt_for_agents()
+    else:
+        selected = ["codex"]
+
+    primary_agent = selected[0]
+    use_multiple_agents = len(selected) > 1
+    return primary_agent, selected, use_multiple_agents
+
+
+def _prepare_agent_skill_dirs(agents: list[str]) -> None:
+    prime_skills_dir = Path(PRIME_SKILLS_DIR)
+    for agent in agents:
+        skills_dir = _resolve_agent_skills_dir(agent)
+        skills_dir.mkdir(parents=True, exist_ok=True)
+        for skill_name in LAB_SKILLS:
+            source_skill_dir = prime_skills_dir / skill_name
+            if not source_skill_dir.exists():
+                continue
+            target_skill_name = _resolve_agent_skill_name(agent, skill_name)
+            target_skill_dir = skills_dir / target_skill_name
+            _safe_link_or_copy_skill_dir(source_skill_dir, target_skill_dir)
+        print(f"Prepared {skills_dir}")
+
+
+def _safe_link_or_copy_skill_dir(source: Path, target: Path) -> None:
+    if target.exists() or target.is_symlink():
+        return
+
+    try:
+        relative_source = os.path.relpath(source, start=target.parent)
+        target.symlink_to(relative_source, target_is_directory=True)
+        return
+    except OSError:
+        shutil.copytree(source, target, dirs_exist_ok=True)
+
+
+def _resolve_agent_skills_dir(agent: str) -> Path:
+    mapped_dir = AGENT_SKILLS_DIR_MAP.get(agent)
+    if mapped_dir is not None:
+        return Path(mapped_dir)
+    return Path(f".{agent}") / "skills"
+
+
+def _resolve_agent_skill_name(agent: str, skill_name: str) -> str:
+    return AGENT_SKILL_NAME_MAP.get(agent, {}).get(skill_name, skill_name)
+
+
+def _sync_lab_metadata(
+    *, primary_agent: str, selected_agents: list[str], use_multiple_agents: bool
+) -> None:
+    """Persist lab setup metadata in .prime/."""
+    os.makedirs(PRIME_DIR, exist_ok=True)
+
+    metadata = _load_lab_metadata()
+    metadata["setup_source"] = "prime lab setup"
+    metadata["choices"] = {
+        "agents": selected_agents,
+        "primary_agent": primary_agent,
+        "use_multiple_agents": use_multiple_agents,
+    }
+
+    metadata_path = Path(LAB_METADATA_PATH)
+    metadata_path.write_text(json.dumps(metadata, indent=2, sort_keys=True) + "\n")
 
 
 def main():
@@ -340,12 +587,23 @@ def main():
         action="store_true",
         help="Skip uv project initialization and verifiers installation",
     )
+    parser.add_argument(
+        "--agents",
+        help="Comma-separated coding agents to scaffold (codex,claude,cursor,opencode,amp)",
+    )
+    parser.add_argument(
+        "--no-interactive",
+        action="store_true",
+        help="Disable interactive coding agent prompts",
+    )
     args = parser.parse_args()
 
     run_setup(
         prime_rl=args.prime_rl,
         skip_agents_md=args.skip_agents_md,
         skip_install=args.skip_install,
+        agents=args.agents,
+        no_interactive=args.no_interactive,
     )
 
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes `prime lab setup` behavior (new prompts/flags, filesystem symlinks/copies, and metadata writes) and adds output formatting that could affect automation or existing workflows.
> 
> **Overview**
> Updates the Lab setup flow to **scaffold coding-agent skill directories** from `.prime/skills` (via symlink when possible, with per-agent root and name mapping) and adds `--agents`/`--no-interactive` options plus an interactive prompt to choose agents.
> 
> `prime lab setup` now **persists user choices** to `.prime/lab.json` and prints a new Rich “get started” call-to-action panel with quick commands; tests were expanded to cover skill dir preparation, output text, and metadata persistence. Documentation/usage was aligned by dropping the `prime-rl @` CLI placeholder and clarifying Hosted Training vs self-managed `prime-rl`, plus adding synthetic-data guidance to the create-environment skill.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24f0288e50da9f99f252e1aedc1ca757e2c3341d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->