### PR TITLE
Prepare v0.1.10.dev5 release bump and notes

### DIFF
--- a/assets/release/RELEASE_v0.1.10.dev5.md
+++ b/assets/release/RELEASE_v0.1.10.dev5.md
@@ -1,0 +1,24 @@
+# Verifiers v0.1.10.dev5 Release Notes
+
+*Date:* 02/10/2026
+
+**Full Changelog**: https://github.com/PrimeIntellect-ai/verifiers/compare/v0.1.10.dev4...v0.1.10.dev5
+
+## Highlights since v0.1.10.dev4
+
+- Improved environment worker reliability and metadata tracking by migrating sandbox execution internals and recording verifiers/environment versions in rollout metadata.
+- Polished evaluation UX with a fix for non-TUI live overflow rendering and broader logging improvements.
+- Added and refined developer-facing guidance for skills and agent workflows, including clearer skill handling and browse-environment quality priorities.
+- Extended opencode harbor support with TITO support, tunnel sync stop behavior, and a terminal-bench task addition.
+
+## Incremental changes since v0.1.10.dev4
+
+- env worker integration (#832)
+- track vf + env version in metadata (#881)
+- misc logging improvs (#882)
+- rlm: migrate sandbox executor to SandboxMixin (#875)
+- opencode env: TITO support, tunnel sync stop, add terminal-bench (#874)
+- Fix vf-eval non-TUI live overflow rendering (#883)
+- Fix for dir resolutions (#879)
+- Update browse-environments freshness and quality priorities (#884)
+- Clarify agent skill handling (#886)

--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.10.dev4"
+__version__ = "0.1.10.dev5"
 
 import importlib
 import os


### PR DESCRIPTION
### Motivation
- Cut a new development release by incrementing the package version and adding formal release notes for v0.1.10.dev5.

### Description
- Bumped `__version__` in `verifiers/__init__.py` to `0.1.10.dev5` and added `assets/release/RELEASE_v0.1.10.dev5.md` containing the release date, compare link, highlights, and incremental changelog.

### Testing
- Ran `uv run pre-commit install`, `uv run ruff check --fix verifiers/__init__.py assets/release/RELEASE_v0.1.10.dev5.md`, and `uv run pre-commit run --all-files`, and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698add3cca148326ba374e6a845f13a2)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates version metadata and adds a markdown release-notes file; no runtime behavior changes beyond the version string.
> 
> **Overview**
> Bumps the library version from `0.1.10.dev4` to `0.1.10.dev5`.
> 
> Adds `RELEASE_v0.1.10.dev5.md` with the release date, compare link, and a curated list of highlights/incremental changes included in this dev release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 892be624ee523701ad9621119e2f3d8be32324a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->