### PR TITLE
Add reasoning content normalization middleware

### DIFF
--- a/tests/test_reasoning_utils.py
+++ b/tests/test_reasoning_utils.py
@@ -1,0 +1,415 @@
+"""Tests for reasoning content normalization utilities."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from verifiers.utils.reasoning_utils import (
+    detect_reasoning_format,
+    extract_reasoning_from_response,
+    normalize_reasoning_content,
+    prepare_messages_for_provider,
+    strip_reasoning_from_content,
+)
+
+
+# ---------------------------------------------------------------------------
+# TestExtractReasoningFromResponse
+# ---------------------------------------------------------------------------
+class TestExtractReasoningFromResponse:
+    def test_reasoning_content_present(self):
+        msg = SimpleNamespace(reasoning_content="step by step", reasoning=None)
+        assert extract_reasoning_from_response(msg) == "step by step"
+
+    def test_reasoning_present(self):
+        msg = SimpleNamespace(reasoning="my reasoning")
+        assert extract_reasoning_from_response(msg) == "my reasoning"
+
+    def test_both_prefers_reasoning_content(self):
+        msg = SimpleNamespace(reasoning_content="rc value", reasoning="r value")
+        assert extract_reasoning_from_response(msg) == "rc value"
+
+    def test_neither(self):
+        msg = SimpleNamespace()
+        assert extract_reasoning_from_response(msg) is None
+
+    def test_empty_string(self):
+        msg = SimpleNamespace(reasoning_content="", reasoning="")
+        assert extract_reasoning_from_response(msg) is None
+
+    def test_whitespace_only(self):
+        msg = SimpleNamespace(reasoning_content="   ", reasoning="  \n  ")
+        assert extract_reasoning_from_response(msg) is None
+
+    def test_none_values(self):
+        msg = SimpleNamespace(reasoning_content=None, reasoning=None)
+        assert extract_reasoning_from_response(msg) is None
+
+    def test_reasoning_content_none_reasoning_present(self):
+        msg = SimpleNamespace(reasoning_content=None, reasoning="fallback")
+        assert extract_reasoning_from_response(msg) == "fallback"
+
+    def test_reasoning_content_empty_reasoning_present(self):
+        msg = SimpleNamespace(reasoning_content="", reasoning="fallback")
+        assert extract_reasoning_from_response(msg) == "fallback"
+
+
+# ---------------------------------------------------------------------------
+# TestDetectReasoningFormat
+# ---------------------------------------------------------------------------
+class TestDetectReasoningFormat:
+    def test_detects_reasoning_content(self):
+        msg = SimpleNamespace(reasoning_content="thinking...")
+        assert detect_reasoning_format(msg, "answer") == "reasoning_content"
+
+    def test_detects_reasoning(self):
+        msg = SimpleNamespace(reasoning="thinking...")
+        assert detect_reasoning_format(msg, "answer") == "reasoning"
+
+    def test_detects_think_tags(self):
+        msg = SimpleNamespace()
+        assert (
+            detect_reasoning_format(msg, "<think>thinking</think>\nanswer")
+            == "think_tags"
+        )
+
+    def test_detects_think_tags_with_leading_whitespace(self):
+        msg = SimpleNamespace()
+        assert (
+            detect_reasoning_format(msg, "  <think>thinking</think>\nanswer")
+            == "think_tags"
+        )
+
+    def test_returns_none_for_vanilla(self):
+        msg = SimpleNamespace()
+        assert detect_reasoning_format(msg, "just an answer") == "none"
+
+    def test_returns_none_for_empty_content(self):
+        msg = SimpleNamespace()
+        assert detect_reasoning_format(msg, "") == "none"
+
+    def test_returns_none_for_none_content(self):
+        msg = SimpleNamespace()
+        assert detect_reasoning_format(msg, None) == "none"
+
+    def test_prefers_reasoning_content_over_think_tags(self):
+        msg = SimpleNamespace(reasoning_content="rc")
+        assert (
+            detect_reasoning_format(msg, "<think>tags</think>\ncontent")
+            == "reasoning_content"
+        )
+
+    def test_empty_reasoning_content_falls_through(self):
+        msg = SimpleNamespace(reasoning_content="")
+        assert (
+            detect_reasoning_format(msg, "<think>tags</think>\ncontent") == "think_tags"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestNormalizeReasoningContent
+# ---------------------------------------------------------------------------
+class TestNormalizeReasoningContent:
+    def test_both_present(self):
+        result = normalize_reasoning_content("thinking", "answer")
+        assert result == "<think>\nthinking\n</think>\nanswer"
+
+    def test_reasoning_only(self):
+        result = normalize_reasoning_content("thinking", None)
+        assert result == "<think>\nthinking\n</think>"
+
+    def test_reasoning_only_empty_content(self):
+        result = normalize_reasoning_content("thinking", "")
+        assert result == "<think>\nthinking\n</think>"
+
+    def test_content_only(self):
+        result = normalize_reasoning_content(None, "answer")
+        assert result == "answer"
+
+    def test_neither(self):
+        result = normalize_reasoning_content(None, None)
+        assert result == ""
+
+    def test_neither_empty_strings(self):
+        result = normalize_reasoning_content("", "")
+        assert result == ""
+
+    def test_avoids_duplication(self):
+        content = "<think>\nalready tagged\n</think>\nanswer"
+        result = normalize_reasoning_content("new reasoning", content)
+        assert result == content  # unchanged
+
+    def test_avoids_duplication_with_whitespace(self):
+        content = "  <think>\nalready tagged\n</think>\nanswer"
+        result = normalize_reasoning_content("new reasoning", content)
+        assert result == content  # unchanged
+
+    def test_whitespace_reasoning_skipped(self):
+        result = normalize_reasoning_content("   ", "answer")
+        assert result == "answer"
+
+    def test_multiline_reasoning(self):
+        reasoning = "step 1\nstep 2\nstep 3"
+        result = normalize_reasoning_content(reasoning, "final answer")
+        assert result == "<think>\nstep 1\nstep 2\nstep 3\n</think>\nfinal answer"
+
+
+# ---------------------------------------------------------------------------
+# TestStripReasoningFromContent
+# ---------------------------------------------------------------------------
+class TestStripReasoningFromContent:
+    def test_with_tags(self):
+        reasoning, content = strip_reasoning_from_content(
+            "<think>\nmy reasoning\n</think>\nmy answer"
+        )
+        assert reasoning == "my reasoning"
+        assert content == "my answer"
+
+    def test_without_tags(self):
+        reasoning, content = strip_reasoning_from_content("just an answer")
+        assert reasoning is None
+        assert content == "just an answer"
+
+    def test_truncated_no_closing(self):
+        reasoning, content = strip_reasoning_from_content(
+            "<think>reasoning without closing tag"
+        )
+        assert reasoning is None
+        assert content == "<think>reasoning without closing tag"
+
+    def test_empty_reasoning(self):
+        reasoning, content = strip_reasoning_from_content("<think></think>\nanswer")
+        assert reasoning is None
+        assert content == "answer"
+
+    def test_empty_content(self):
+        reasoning, content = strip_reasoning_from_content("")
+        assert reasoning is None
+        assert content == ""
+
+    def test_only_think_tags(self):
+        reasoning, content = strip_reasoning_from_content(
+            "<think>some reasoning</think>"
+        )
+        assert reasoning == "some reasoning"
+        assert content == ""
+
+    def test_round_trip_with_normalize(self):
+        original_reasoning = "step by step"
+        original_content = "the answer is 42"
+        normalized = normalize_reasoning_content(original_reasoning, original_content)
+        reasoning, content = strip_reasoning_from_content(normalized)
+        assert reasoning == original_reasoning
+        assert content == original_content
+
+    def test_whitespace_before_think(self):
+        reasoning, content = strip_reasoning_from_content(
+            "  <think>\nmy reasoning\n</think>\nmy answer"
+        )
+        assert reasoning == "my reasoning"
+        assert content == "my answer"
+
+
+# ---------------------------------------------------------------------------
+# TestPrepareMessagesForProvider
+# ---------------------------------------------------------------------------
+class TestPrepareMessagesForProvider:
+    def _make_messages(self):
+        return [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "What is 2+2?"},
+            {
+                "role": "assistant",
+                "content": "<think>\nlet me think\n</think>\n4",
+            },
+            {"role": "user", "content": "<think>user think tags</think>\nfollow up"},
+        ]
+
+    def test_strips_think_from_assistant_for_reasoning_content(self):
+        messages = self._make_messages()
+        result = prepare_messages_for_provider(messages, "reasoning_content")
+        # assistant message should have think tags stripped
+        assert result[2]["content"] == "4"
+        # user message should be untouched
+        assert result[3]["content"] == "<think>user think tags</think>\nfollow up"
+        # system message untouched
+        assert result[0]["content"] == "You are helpful."
+
+    def test_strips_think_from_assistant_for_reasoning(self):
+        messages = self._make_messages()
+        result = prepare_messages_for_provider(messages, "reasoning")
+        assert result[2]["content"] == "4"
+
+    def test_noop_for_think_tags(self):
+        messages = self._make_messages()
+        result = prepare_messages_for_provider(messages, "think_tags")
+        assert result is messages  # same object, not copied
+
+    def test_noop_for_none_format(self):
+        messages = self._make_messages()
+        result = prepare_messages_for_provider(messages, "none")
+        assert result is messages
+
+    def test_noop_for_auto(self):
+        messages = self._make_messages()
+        result = prepare_messages_for_provider(messages, "auto")
+        assert result is messages
+
+    def test_assistant_without_think_tags_unchanged(self):
+        messages = [
+            {"role": "assistant", "content": "plain answer"},
+        ]
+        result = prepare_messages_for_provider(messages, "reasoning_content")
+        assert result[0]["content"] == "plain answer"
+
+    def test_does_not_mutate_original(self):
+        messages = [
+            {
+                "role": "assistant",
+                "content": "<think>\nthinking\n</think>\nanswer",
+            },
+        ]
+        original_content = messages[0]["content"]
+        prepare_messages_for_provider(messages, "reasoning_content")
+        assert messages[0]["content"] == original_content
+
+    def test_tool_message_untouched(self):
+        messages = [
+            {
+                "role": "tool",
+                "content": "<think>tool output</think>\nresult",
+                "tool_call_id": "123",
+            },
+        ]
+        result = prepare_messages_for_provider(messages, "reasoning_content")
+        assert result[0]["content"] == "<think>tool output</think>\nresult"
+
+
+# ---------------------------------------------------------------------------
+# TestParseResponseMessagesIntegration
+# ---------------------------------------------------------------------------
+class TestParseResponseMessagesIntegration:
+    @pytest.mark.asyncio
+    async def test_reasoning_content_appears_in_parsed_messages(self):
+        """Mock a ChatCompletion with reasoning_content field and verify <think> tags."""
+        from openai.types.chat.chat_completion import ChatCompletion
+
+        from verifiers.utils.response_utils import parse_response_messages
+
+        message = MagicMock()
+        message.content = "the answer is 42"
+        message.reasoning_content = "let me work through this"
+        message.reasoning = None
+        message.tool_calls = None
+
+        choice = MagicMock()
+        choice.message = message
+
+        response = MagicMock(spec=ChatCompletion)
+        response.choices = [choice]
+
+        result = await parse_response_messages(response, "chat")
+        assert isinstance(result, list)
+        assert len(result) == 1
+        content = result[0]["content"]
+        assert content.startswith("<think>")
+        assert "let me work through this" in content
+        assert "the answer is 42" in content
+
+    @pytest.mark.asyncio
+    async def test_no_reasoning_field_works_as_before(self):
+        """Response without reasoning fields should work identically to before."""
+        from openai.types.chat.chat_completion import ChatCompletion
+
+        from verifiers.utils.response_utils import parse_response_messages
+
+        message = MagicMock()
+        message.content = "plain answer"
+        message.tool_calls = None
+        # No reasoning_content or reasoning attributes
+        del message.reasoning_content
+        del message.reasoning
+
+        choice = MagicMock()
+        choice.message = message
+
+        response = MagicMock(spec=ChatCompletion)
+        response.choices = [choice]
+
+        result = await parse_response_messages(response, "chat")
+        assert isinstance(result, list)
+        assert result[0]["content"] == "plain answer"
+
+    @pytest.mark.asyncio
+    async def test_reasoning_only_no_content(self):
+        """Response with reasoning but no content should produce <think> block only."""
+        from openai.types.chat.chat_completion import ChatCompletion
+
+        from verifiers.utils.response_utils import parse_response_messages
+
+        message = MagicMock()
+        message.content = None
+        message.reasoning_content = "thinking deeply"
+        message.reasoning = None
+        message.tool_calls = None
+
+        choice = MagicMock()
+        choice.message = message
+
+        response = MagicMock(spec=ChatCompletion)
+        response.choices = [choice]
+
+        result = await parse_response_messages(response, "chat")
+        content = result[0]["content"]
+        assert content == "<think>\nthinking deeply\n</think>"
+
+
+# ---------------------------------------------------------------------------
+# TestValidationIntegration
+# ---------------------------------------------------------------------------
+class TestValidationIntegration:
+    """Test that reasoning-only responses are not rejected by validation."""
+
+    def test_reasoning_only_response_not_rejected(self):
+        """A response with content=None but reasoning_content='...' should not raise."""
+        from openai.types.chat.chat_completion import Choice
+
+        # Build a mock Choice that has reasoning_content but no content
+        message = MagicMock()
+        message.content = None
+        message.tool_calls = None
+        message.reasoning_content = "deep reasoning here"
+        message.reasoning = None
+
+        choice = MagicMock(spec=Choice)
+        choice.message = message
+
+        # The validation logic we added
+        has_content = bool(choice.message.content)
+        has_tool_calls = bool(choice.message.tool_calls)
+        has_reasoning = bool(
+            getattr(choice.message, "reasoning_content", None)
+            or getattr(choice.message, "reasoning", None)
+        )
+        # Should pass - has_reasoning is True
+        assert has_reasoning is True
+        assert not has_content
+        assert not has_tool_calls
+        assert has_content or has_tool_calls or has_reasoning
+
+    def test_truly_empty_response_still_rejected(self):
+        """A response with no content, no tool_calls, and no reasoning should fail."""
+        message = MagicMock()
+        message.content = None
+        message.tool_calls = None
+        message.reasoning_content = None
+        message.reasoning = None
+
+        has_content = bool(message.content)
+        has_tool_calls = bool(message.tool_calls)
+        has_reasoning = bool(
+            getattr(message, "reasoning_content", None)
+            or getattr(message, "reasoning", None)
+        )
+        assert not (has_content or has_tool_calls or has_reasoning)

--- a/verifiers/utils/reasoning_utils.py
+++ b/verifiers/utils/reasoning_utils.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import re
+from typing import Literal
+
+from verifiers.types import ChatMessage
+
+ReasoningFormat = Literal[
+    "auto", "think_tags", "reasoning_content", "reasoning", "none"
+]
+
+
+def extract_reasoning_from_response(message_obj: object) -> str | None:
+    """Extract reasoning from response message's provider-specific fields.
+
+    Checks reasoning_content (vLLM/DeepSeek) then reasoning (OpenRouter).
+    Returns None if no reasoning found or if the value is empty/whitespace.
+    """
+    for attr in ("reasoning_content", "reasoning"):
+        value = getattr(message_obj, attr, None)
+        if isinstance(value, str) and value.strip():
+            return value
+    return None
+
+
+def detect_reasoning_format(
+    message_obj: object, content: str | None
+) -> ReasoningFormat:
+    """Detect reasoning format from a response message.
+
+    Returns "reasoning_content", "reasoning", "think_tags", or "none".
+    """
+    rc = getattr(message_obj, "reasoning_content", None)
+    if isinstance(rc, str) and rc.strip():
+        return "reasoning_content"
+
+    r = getattr(message_obj, "reasoning", None)
+    if isinstance(r, str) and r.strip():
+        return "reasoning"
+
+    if isinstance(content, str) and content.lstrip().startswith("<think>"):
+        return "think_tags"
+
+    return "none"
+
+
+def normalize_reasoning_content(reasoning: str | None, content: str | None) -> str:
+    """Prepend reasoning as <think> tags to content string.
+
+    Edge cases:
+    - reasoning + content → "<think>\\n{reasoning}\\n</think>\\n{content}"
+    - reasoning + no content → "<think>\\n{reasoning}\\n</think>"
+    - no reasoning → content as-is
+    - content already starts with <think> → content as-is (avoid duplication)
+    """
+    if not reasoning or not reasoning.strip():
+        return content or ""
+
+    if isinstance(content, str) and content.lstrip().startswith("<think>"):
+        return content
+
+    think_block = f"<think>\n{reasoning}\n</think>"
+    if content:
+        return f"{think_block}\n{content}"
+    return think_block
+
+
+def strip_reasoning_from_content(content: str) -> tuple[str | None, str]:
+    """Split <think>...</think> prefix from content.
+
+    Returns (reasoning_text_or_None, remaining_content).
+    Handles: no tags, truncated tags (no </think>), empty reasoning.
+    """
+    if not content.lstrip().startswith("<think>"):
+        return None, content
+
+    match = re.match(r"^\s*<think>(.*?)</think>\s*(.*)", content, re.DOTALL)
+    if match is None:
+        # Truncated: <think> present but no </think>
+        return None, content
+
+    reasoning = match.group(1).strip()
+    remaining = match.group(2)
+
+    return (reasoning if reasoning else None), remaining
+
+
+def prepare_messages_for_provider(
+    messages: list[ChatMessage],
+    reasoning_format: ReasoningFormat,
+) -> list[ChatMessage]:
+    """Convert internal messages to provider format before sending.
+
+    For "reasoning_content"/"reasoning" formats: strips <think> tags from
+    assistant message content (provider doesn't expect them in input).
+    For "think_tags"/"none"/"auto": returns messages unchanged.
+    Only modifies assistant messages; user/system/tool messages pass through.
+    """
+    if reasoning_format not in ("reasoning_content", "reasoning"):
+        return messages
+
+    result: list[ChatMessage] = []
+    for msg in messages:
+        if msg.get("role") != "assistant":
+            result.append(msg)
+            continue
+
+        content = msg.get("content")
+        if not isinstance(content, str) or not content.lstrip().startswith("<think>"):
+            result.append(msg)
+            continue
+
+        _reasoning, remaining = strip_reasoning_from_content(content)
+        new_msg = dict(msg)
+        new_msg["content"] = remaining
+        result.append(new_msg)  # type: ignore[arg-type]
+
+    return result

--- a/verifiers/utils/response_utils.py
+++ b/verifiers/utils/response_utils.py
@@ -9,6 +9,10 @@ from verifiers.types import (
     ModelResponse,
     TrajectoryStepTokens,
 )
+from verifiers.utils.reasoning_utils import (
+    extract_reasoning_from_response,
+    normalize_reasoning_content,
+)
 
 
 async def parse_response_tokens(
@@ -105,6 +109,8 @@ async def parse_response_messages(
         assert isinstance(response, ChatCompletion)
         if response.choices and response.choices[0].message:
             response_text = response.choices[0].message.content or ""
+            reasoning = extract_reasoning_from_response(response.choices[0].message)
+            response_text = normalize_reasoning_content(reasoning, response_text)
         response_message: dict[str, object] = {
             "role": "assistant",
             "content": response_text,


### PR DESCRIPTION
## Description

Quick fix for missing reasoning content in GLM 4.7-Flash.

Normalize reasoning from provider-specific fields (reasoning_content, reasoning) into <think> tags in content, and strip them on outbound requests to providers that use separate reasoning fields.

- New verifiers/utils/reasoning_utils.py with pure utility functions
- Inbound: extract reasoning from responses, prepend as <think> tags
- Outbound: strip <think> tags from assistant messages for providers that use reasoning_content/reasoning fields
- Auto-detect reasoning format from first response
- Accept reasoning-only responses in validation (no EmptyModelResponseError)

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [x] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core request/response handling and validation for model calls; behavior changes depend on provider response shape and could affect prompts or error handling if detection/stripping misfires.
> 
> **Overview**
> Normalizes provider-specific reasoning fields into a consistent `<think>...</think>` prefix on inbound chat responses, so models that return `reasoning_content`/`reasoning` no longer drop reasoning.
> 
> Adds `reasoning_format` handling to `Environment`: strips `<think>` blocks from outbound assistant messages for providers that expect separate reasoning fields, auto-detects the format from the first response, and relaxes response validation to accept reasoning-only replies. Includes a new `reasoning_utils` module and comprehensive unit/integration tests covering extraction, normalization, stripping, and provider message prep.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fcf95fa8297b09eb8a2d34848ff48141a4e3d53f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->