### PR TITLE
Support interleaved rollouts with include_sub_llm_in_trajectory=True

### DIFF
--- a/tests/test_rlm_env.py
+++ b/tests/test_rlm_env.py
@@ -1338,14 +1338,15 @@ class TestSubLLMTrajectorySteps:
     async def test_include_sub_llm_in_trajectory_default(self, rlm_env):
         assert rlm_env.include_sub_llm_in_trajectory is False
 
-    def test_interleaved_disallowed_when_sub_llm_in_trajectory(self):
+    def test_interleaved_allowed_when_sub_llm_in_trajectory(self):
         dataset = make_dataset({})
-        with pytest.raises(ValueError, match="include_sub_llm_in_trajectory=True"):
-            build_env(
-                dataset,
-                include_sub_llm_in_trajectory=True,
-                interleaved_rollouts=True,
-            )
+        env = build_env(
+            dataset,
+            include_sub_llm_in_trajectory=True,
+            interleaved_rollouts=True,
+        )
+        assert env.include_sub_llm_in_trajectory is True
+        assert env.interleaved_rollouts is True
 
     @pytest.mark.asyncio
     async def test_sub_llm_steps_added_to_trajectory(self, rlm_env):


### PR DESCRIPTION
## Description

When sub-LLM trajectory steps are stored alongside main-model steps, several base-class methods that read `state["trajectory"][-1]` would see a sub-LLM step instead of the last main-model step.  This adds `RLMEnv` overrides that filter by `trajectory_id` so that `get_prompt_messages`, `get_model_response` (`get_prompt_ids`), `max_turns_reached`, and `no_tools_called` always reference the correct step.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core rollout sequencing (prompt construction, tokenization path, and stop conditions) and relies on correct trajectory filtering; mistakes could cause subtle prompt/termination bugs under interleaving.
> 
> **Overview**
> **Interleaved rollouts are now supported when `include_sub_llm_in_trajectory=True`.** The previous guardrails that raised `ValueError` in `set_interleaved_rollouts`/`setup_state` were removed and the docs were updated to reflect the new supported behavior.
> 
> To make this safe, `RLMEnv` now consistently targets the last *main-model* trajectory step (matching `state["trajectory_id"]`) when building follow-up prompts, computing token-level prompt IDs during `get_model_response`, and evaluating stop conditions. The tests were updated to assert interleaving is allowed in this configuration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d1a88a7c13cf6d96f504d146c48f4d49eb4b7d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->