### PR TITLE
Add dual-segment progress bar for in-progress vs completed rollouts

### DIFF
--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -1144,7 +1144,9 @@ class Environment(ABC):
                 on_log(f"Saving results to {builder.results_path}")
 
             tasks: dict[asyncio.Task, int] = {}
-            started_count = 0
+            # Initialize to already-completed count so that in_progress
+            # (= started - progress) is correct when resuming evaluations.
+            started_count = len(builder.outputs)
 
             def _make_on_acquire(num_rollouts: int):
                 """Create an on_acquire callback that counts the right number of rollouts.

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -1144,22 +1144,17 @@ class Environment(ABC):
                 on_log(f"Saving results to {builder.results_path}")
 
             tasks: dict[asyncio.Task, int] = {}
-            # Initialize to already-completed count so that in_progress
-            # (= started - progress) is correct when resuming evaluations.
-            started_count = len(builder.outputs)
 
             def _make_on_acquire(num_rollouts: int):
-                """Create an on_acquire callback that counts the right number of rollouts.
+                """Create an on_acquire callback for a task.
 
-                For independent scoring each task is 1 rollout; for grouped scoring
-                each task covers len(group_input) rollouts.
+                Calls on_rollout_start with the number of rollouts that just
+                began executing (1 for independent scoring, len(group) for grouped).
                 """
 
                 def _on_acquire() -> None:
-                    nonlocal started_count
-                    started_count += num_rollouts
                     if on_rollout_start is not None:
-                        on_rollout_start(started_count)
+                        on_rollout_start(num_rollouts)
 
                 return _on_acquire
 

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -1145,18 +1145,18 @@ class Environment(ABC):
 
             tasks: dict[asyncio.Task, int] = {}
 
-            def _make_on_acquire(num_rollouts: int):
+            def make_on_acquire(num_rollouts: int):
                 """Create an on_acquire callback for a task.
 
                 Calls on_rollout_start with the number of rollouts that just
                 began executing (1 for independent scoring, len(group) for grouped).
                 """
 
-                def _on_acquire() -> None:
+                def on_acquire() -> None:
                     if on_rollout_start is not None:
                         on_rollout_start(num_rollouts)
 
-                return _on_acquire
+                return on_acquire
 
             try:
                 # create tasks based on mode
@@ -1174,7 +1174,7 @@ class Environment(ABC):
                                     max_retries=max_retries,
                                     state_columns=state_columns,
                                 ),
-                                on_acquire=_make_on_acquire(1),
+                                on_acquire=make_on_acquire(1),
                             ),
                         )
                         tasks[task] = i
@@ -1203,7 +1203,7 @@ class Environment(ABC):
                                     max_retries=max_retries,
                                     state_columns=state_columns,
                                 ),
-                                on_acquire=_make_on_acquire(len(group_input)),
+                                on_acquire=make_on_acquire(len(group_input)),
                             ),
                         )
                         tasks[task] = i

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -61,9 +61,9 @@ from verifiers.types import (
     Messages,
     MessageType,
     ModelResponse,
-    ProgressCallback,
+    TaskDoneCallback,
     RolloutInput,
-    RolloutStartCallback,
+    TaskStartCallback,
     RolloutOutput,
     RolloutTiming,
     SamplingArgs,
@@ -976,9 +976,9 @@ class Environment(ABC):
         independent_scoring: bool = False,
         max_retries: int = 0,
         on_start: StartCallback | None = None,
-        on_progress: ProgressCallback | None = None,
+        on_task_done: TaskDoneCallback | None = None,
         on_log: LogCallback | None = None,
-        on_rollout_start: RolloutStartCallback | None = None,
+        on_task_start: TaskStartCallback | None = None,
     ) -> GenerateOutputs:
         """
         Generate rollouts for a set of inputs.
@@ -1031,7 +1031,7 @@ class Environment(ABC):
                     postfix=dict(reward="?"),
                 )
 
-        def default_on_progress(
+        def default_on_task_done(
             all_outputs: list[RolloutOutput],
             new_outputs: list[RolloutOutput],
             new_metadata: GenerateMetadata,
@@ -1047,7 +1047,7 @@ class Environment(ABC):
             self.logger.info(message)
 
         on_start = on_start or cast(StartCallback, default_on_start)
-        on_progress = on_progress or cast(ProgressCallback, default_on_progress)
+        on_task_done = on_task_done or cast(TaskDoneCallback, default_on_task_done)
         on_log = on_log or cast(LogCallback, default_on_log)
 
         if isinstance(inputs, Dataset):
@@ -1148,13 +1148,13 @@ class Environment(ABC):
             def make_on_acquire(num_rollouts: int):
                 """Create an on_acquire callback for a task.
 
-                Calls on_rollout_start with the number of rollouts that just
+                Calls on_task_start with the number of rollouts that just
                 began executing (1 for independent scoring, len(group) for grouped).
                 """
 
                 def on_acquire() -> None:
-                    if on_rollout_start is not None:
-                        on_rollout_start(num_rollouts)
+                    if on_task_start is not None:
+                        on_task_start(num_rollouts)
 
                 return on_acquire
 
@@ -1216,7 +1216,7 @@ class Environment(ABC):
                     builder.add_outputs(new_outputs)
                     metadata = builder.build_metadata()
 
-                    on_progress(builder.outputs, new_outputs, metadata)
+                    on_task_done(builder.outputs, new_outputs, metadata)
 
                     # incrementally save outputs
                     if save_results:
@@ -1317,9 +1317,9 @@ class Environment(ABC):
         independent_scoring: bool = False,
         max_retries: int = 0,
         on_start: StartCallback | None = None,
-        on_progress: ProgressCallback | None = None,
+        on_task_done: TaskDoneCallback | None = None,
         on_log: LogCallback | None = None,
-        on_rollout_start: RolloutStartCallback | None = None,
+        on_task_start: TaskStartCallback | None = None,
         **kwargs,
     ) -> GenerateOutputs:
         """
@@ -1340,9 +1340,9 @@ class Environment(ABC):
             independent_scoring=independent_scoring,
             max_retries=max_retries,
             on_start=on_start,
-            on_progress=on_progress,
+            on_task_done=on_task_done,
             on_log=on_log,
-            on_rollout_start=on_rollout_start,
+            on_task_start=on_task_start,
             **kwargs,
         )
 

--- a/verifiers/gepa/adapter.py
+++ b/verifiers/gepa/adapter.py
@@ -100,7 +100,7 @@ class VerifiersGEPAAdapter:
                 max_concurrent=self.max_concurrent,
                 state_columns=self.state_columns,
                 on_start=do_nothing,
-                on_progress=do_nothing,
+                on_task_done=do_nothing,
             )
         )
 

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -211,7 +211,7 @@ ProgressCallback = Callable[
 LogCallback = Callable[[str], None]  # log messages
 RolloutStartCallback = Callable[
     [int], None
-]  # called with rollout count when a rollout starts executing
+]  # called with number of rollouts that just began executing
 
 
 class GenerateMetadata(TypedDict):

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -205,11 +205,11 @@ JsonPrimitive = Literal["string", "number", "integer", "boolean", "array", "obje
 StartCallback = Callable[
     [list[RolloutInput], list[RolloutInput] | list[list[RolloutInput]]], None
 ]
-ProgressCallback = Callable[
+TaskDoneCallback = Callable[
     [list[RolloutOutput], list[RolloutOutput], "GenerateMetadata"], None
 ]  # all_outputs, new_outputs, new_metadata
 LogCallback = Callable[[str], None]  # log messages
-RolloutStartCallback = Callable[
+TaskStartCallback = Callable[
     [int], None
 ]  # called with number of rollouts that just began executing
 

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -209,6 +209,9 @@ ProgressCallback = Callable[
     [list[RolloutOutput], list[RolloutOutput], "GenerateMetadata"], None
 ]  # all_outputs, new_outputs, new_metadata
 LogCallback = Callable[[str], None]  # log messages
+RolloutStartCallback = Callable[
+    [int], None
+]  # called with rollout count when a rollout starts executing
 
 
 class GenerateMetadata(TypedDict):

--- a/verifiers/utils/eval_display.py
+++ b/verifiers/utils/eval_display.py
@@ -130,6 +130,8 @@ class DualBarColumn(ProgressColumn):
         in_progress_style: StyleType = COLOR_RUNNING,
         table_column: Column | None = None,
     ) -> None:
+        if table_column is None:
+            table_column = Column(no_wrap=True, ratio=2)
         super().__init__(table_column=table_column)
         self.bar_width = bar_width
         self.style = style

--- a/verifiers/utils/eval_display.py
+++ b/verifiers/utils/eval_display.py
@@ -516,11 +516,7 @@ class EvalDisplay(BaseDisplay):
         # show "..." for total if not yet known
         total_str = "..." if total_rollouts <= 0 else str(total_rollouts)
 
-        # build rollout count text with in-progress indicator
-        rollout_count_text = f"({completed_rollouts}/{total_str} rollouts"
-        if in_progress_rollouts > 0:
-            rollout_count_text += f", {in_progress_rollouts} active"
-        rollout_count_text += ")"
+        rollout_count_text = f"({completed_rollouts}/{total_str} rollouts)"
 
         progress = Progress(
             SpinnerColumn() if env_state.status == "running" else TextColumn(""),

--- a/verifiers/utils/eval_display.py
+++ b/verifiers/utils/eval_display.py
@@ -20,7 +20,7 @@ from rich.panel import Panel
 from rich.progress import Progress, ProgressColumn, SpinnerColumn, Task, TextColumn
 from rich.progress_bar import ProgressBar
 from rich.segment import Segment
-from rich.style import Style, StyleType
+from rich.style import StyleType
 from rich.table import Column, Table
 from rich.text import Text
 
@@ -28,8 +28,11 @@ from verifiers.types import EvalConfig, GenerateOutputs, TokenUsage
 from verifiers.utils.display_utils import BaseDisplay, format_numeric, make_aligned_row
 from verifiers.utils.message_utils import format_messages
 
-# Default style for the in-progress bar segment (warm amber)
-DEFAULT_IN_PROGRESS_STYLE = Style(color="rgb(240,198,116)")
+# Status colors — used for panel borders and progress bar segments
+COLOR_PENDING = "dim"
+COLOR_RUNNING = "yellow"
+COLOR_COMPLETED = "green"
+COLOR_FAILED = "red"
 
 
 class _DualBar(ProgressBar):
@@ -42,7 +45,7 @@ class _DualBar(ProgressBar):
     def __init__(
         self,
         in_progress: float = 0,
-        in_progress_style: StyleType = DEFAULT_IN_PROGRESS_STYLE,
+        in_progress_style: StyleType = COLOR_RUNNING,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -121,9 +124,9 @@ class DualBarColumn(ProgressColumn):
     def __init__(
         self,
         bar_width: int | None = None,
-        style: StyleType = "bar.back",
-        complete_style: StyleType = "bar.complete",
-        in_progress_style: StyleType = DEFAULT_IN_PROGRESS_STYLE,
+        style: StyleType = COLOR_PENDING,
+        complete_style: StyleType = COLOR_COMPLETED,
+        in_progress_style: StyleType = COLOR_RUNNING,
         table_column: Column | None = None,
     ) -> None:
         super().__init__(table_column=table_column)
@@ -602,12 +605,12 @@ class EvalDisplay(BaseDisplay):
 
         # border style based on status
         border_styles = {
-            "pending": "dim",
-            "running": "yellow",
-            "completed": "green",
-            "failed": "red",
+            "pending": COLOR_PENDING,
+            "running": COLOR_RUNNING,
+            "completed": COLOR_COMPLETED,
+            "failed": COLOR_FAILED,
         }
-        border_style = border_styles.get(env_state.status, "dim")
+        border_style = border_styles.get(env_state.status, COLOR_PENDING)
 
         # build title with env name only
         title = Text()

--- a/verifiers/utils/eval_display.py
+++ b/verifiers/utils/eval_display.py
@@ -35,7 +35,6 @@ COLOR_COMPLETED = "green"
 COLOR_FAILED = "red"
 
 
-
 class _DualBar(ProgressBar):
     """Three-segment progress bar extending Rich's ProgressBar.
 

--- a/verifiers/utils/eval_display.py
+++ b/verifiers/utils/eval_display.py
@@ -35,6 +35,7 @@ COLOR_COMPLETED = "green"
 COLOR_FAILED = "red"
 
 
+
 class _DualBar(ProgressBar):
     """Three-segment progress bar extending Rich's ProgressBar.
 
@@ -124,7 +125,7 @@ class DualBarColumn(ProgressColumn):
     def __init__(
         self,
         bar_width: int | None = None,
-        style: StyleType = COLOR_PENDING,
+        style: StyleType = "bar.back",
         complete_style: StyleType = COLOR_COMPLETED,
         in_progress_style: StyleType = COLOR_RUNNING,
         table_column: Column | None = None,

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -32,6 +32,7 @@ from verifiers.types import (
     ProgressCallback,
     RolloutInput,
     RolloutOutput,
+    RolloutStartCallback,
     StartCallback,
 )
 from verifiers.utils.async_utils import EventLoopLagMonitor
@@ -539,6 +540,7 @@ async def run_evaluation(
     on_log_file: Callable[[Path], None] | None = None,
     on_progress: ProgressCallback | None = None,
     on_log: LogCallback | None = None,
+    on_rollout_start: RolloutStartCallback | None = None,
 ) -> GenerateOutputs:
     # load environment
     vf_env = vf.load_environment(env_id=config.env_id, **config.env_args)
@@ -606,6 +608,7 @@ async def run_evaluation(
             on_start=on_start,
             on_progress=on_progress,
             on_log=on_log,
+            on_rollout_start=on_rollout_start,
         )
     finally:
         await vf_env.stop_server()
@@ -697,6 +700,9 @@ async def run_evaluations_tui(config: EvalRunConfig, tui_mode: bool = True) -> N
         def on_log(message: str) -> None:
             display.update_env_state(env_idx, log_message=message)
 
+        def on_rollout_start(started_count: int) -> None:
+            display.update_env_state(env_idx, started=started_count)
+
         def register_log_file(log_file: Path) -> None:
             display.add_log_file_for_env(env_idx, log_file)
 
@@ -708,6 +714,7 @@ async def run_evaluations_tui(config: EvalRunConfig, tui_mode: bool = True) -> N
                 on_progress=on_progress,
                 on_log=on_log,
                 on_log_file=register_log_file,
+                on_rollout_start=on_rollout_start,
             )
 
             # get save path if results were saved


### PR DESCRIPTION
## Summary

- Adds a **dual-segment progress bar** that visually distinguishes between completed rollouts (green) and actively executing rollouts (amber), with remaining rollouts shown in dark gray
- Adds an `on_acquire` callback to `with_sem()` that fires when a rollout acquires the semaphore and starts executing, enabling accurate tracking of in-flight work
- Wires a new `RolloutStartCallback` through the `generate()` → `evaluate()` → `run_evaluation()` callback chain so the display knows how many rollouts are currently active
- Shows an "active" count in the progress text (e.g., `(5/100 rollouts, 8 active)`) when rollouts are in flight

### How it works

The bar has three visual segments:
```
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  completed (green)   active (amber)   remaining (gray)
```

`in_progress = started - completed`, where `started` is incremented each time a rollout acquires the concurrency semaphore and `completed` comes from the existing `on_progress` callback.

### Files changed

| File | Change |
|------|--------|
| `verifiers/utils/async_utils.py` | Add optional `on_acquire` callback to `with_sem()` |
| `verifiers/types.py` | Add `RolloutStartCallback` type alias |
| `verifiers/envs/environment.py` | Wire `on_rollout_start` through `generate()` and `evaluate()` |
| `verifiers/utils/eval_utils.py` | Wire `on_rollout_start` through `run_evaluation()` and `run_with_progress()` |
| `verifiers/utils/eval_display.py` | Add `DualBarColumn` / `_DualBar` renderable, track `started` count in `EnvEvalState` |

## Test plan

- [x] All existing tests pass (`uv run pytest tests/` - 608 tests)
- [x] `uv run pre-commit run --all-files` passes (ruff check + format)
- [ ] Manual verification: run `prime eval run` with a real environment and observe the dual-segment bar during execution
- [ ] Verify the bar correctly shows active rollouts ramping up when the evaluation starts, and draining to zero as it finishes

Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the public callback surface (`on_progress` -> `on_task_done` plus new `on_task_start`) and adds semaphore-acquire hooks, which could affect integrations and progress accounting under concurrency/resume scenarios.
> 
> **Overview**
> Adds rollout *in-flight* tracking and a new Rich UI to visualize it: the evaluation display now renders a three-segment progress bar (completed vs running vs remaining) and maintains a `started` counter to compute `in_progress`.
> 
> Refactors the generation/evaluation callback API by replacing `on_progress` with `on_task_done` and introducing `on_task_start`; `Environment.generate()` now triggers `on_task_start` when a task acquires the concurrency semaphore via a new `with_sem(..., on_acquire=...)` hook, and this signal is threaded through `evaluate()`, `run_evaluation()`, and the GEPA adapter.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad1f6738e1cf2f515e380ecaca81553e0fcb6697. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->