### PR TITLE
Default interception_port to 0 (ephemeral) to avoid port collisions

### DIFF
--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -1950,7 +1950,7 @@ class RLMEnv(vf.StatefulToolEnv):
         repl_language: REPL language to use: "bash" or "python" (default: "bash")
         execution_backend: Deprecated, has no effect. Sandbox execution is always used.
         interception_host: Optional hostname/IP for interception server (default: 127.0.0.1)
-        interception_port: Port for interception server (default: 8766)
+        interception_port: Port for interception server (default: 0, i.e. ephemeral)
         interception_url: Optional base URL for interception (sandbox only). If set,
                    tunnel startup is skipped.
         pip_install_packages: Space-separated packages to install in addition to requests
@@ -2011,7 +2011,7 @@ class RLMEnv(vf.StatefulToolEnv):
         repl_language: Literal["bash", "python"] = "bash",
         execution_backend: Literal["local", "sandbox"] | None = None,
         interception_host: str | None = None,
-        interception_port: int = 8766,
+        interception_port: int = 0,
         interception_url: str | None = None,
         pip_install_packages: str = "",
         include_sub_llm_in_trajectory: bool = False,


### PR DESCRIPTION
## Description

With sandbox-only execution, the interception server port is only used locally and tunneled to the sandbox. Using an ephemeral port avoids collisions when multiple workers run on the same machine.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small configuration-default change in the local interception server; low risk aside from any callers that implicitly relied on the fixed port `8766`.
> 
> **Overview**
> Updates `RLMEnv` to default the interception server port to `0` (ephemeral) instead of `8766`, and adjusts the inline docs accordingly.
> 
> This avoids local port collisions when multiple RLM workers are started on the same host; the server already detects `port==0` and records the actual bound port for tunnel usage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2fbcc5d57890e0148cf9b791023ab34d5185b131. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->