### PR TITLE
Session start instead of create

### DIFF
--- a/verifiers/envs/integrations/browser_env/modes/dom_mode.py
+++ b/verifiers/envs/integrations/browser_env/modes/dom_mode.py
@@ -93,7 +93,7 @@ class DOMMode:
         browserbase_params = browserbase_params or None
 
         sessions = cast(Any, self.stagehand_client.sessions)
-        session = await sessions.create(
+        session = await sessions.start(
             model_name=self.stagehand_model,
             browserbase_session_create_params=browserbase_params,
         )


### PR DESCRIPTION
## Description

Stagehand api changed to use 'start' instead of 'create' for sessions

Fix for https://github.com/browserbase/stagehand-python/commit/74cb7fb1806d5afa62accdd3889f6a60647c037e

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized API call rename to match an upstream SDK change; risk is limited to session startup failing if the Stagehand SDK version/contract differs.
> 
> **Overview**
> Updates the Stagehand integration in `dom_mode.py` to use `sessions.start()` (new Stagehand API) rather than `sessions.create()` when creating a per-rollout session, keeping the same parameters and state wiring.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c06430a7594a9e65c49d9ddd373ba8ffe7ce5d3b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->