### PR TITLE
assert types for ty to be happy

### DIFF
--- a/verifiers/utils/interception_utils.py
+++ b/verifiers/utils/interception_utils.py
@@ -259,9 +259,6 @@ async def synthesize_stream(
     chunk_queue = intercept.get("chunk_queue")
     future = intercept.get("response_future")
 
-    assert isinstance(response, ChatCompletion)
-    assert isinstance(chunk_queue, asyncio.Queue)
-
     # Error / no-response: unblock queue reader, fail/resolve future
     if error is not None or response is None:
         if chunk_queue is not None:
@@ -275,6 +272,9 @@ async def synthesize_stream(
             else:
                 future.set_result(None)
         return
+
+    assert isinstance(response, ChatCompletion)
+    assert isinstance(chunk_queue, asyncio.Queue)
 
     choice = response.choices[0]
     message = choice.message

--- a/verifiers/utils/interception_utils.py
+++ b/verifiers/utils/interception_utils.py
@@ -15,10 +15,12 @@ from openai.types.chat import (
 from openai.types.chat.chat_completion import Choice
 from openai.types.chat.chat_completion_chunk import (
     ChatCompletionChunk,
-    Choice as ChunkChoice,
     ChoiceDelta,
     ChoiceDeltaToolCall,
     ChoiceDeltaToolCallFunction,
+)
+from openai.types.chat.chat_completion_chunk import (
+    Choice as ChunkChoice,
 )
 
 from verifiers.types import ModelResponse
@@ -256,6 +258,9 @@ async def synthesize_stream(
     """
     chunk_queue = intercept.get("chunk_queue")
     future = intercept.get("response_future")
+
+    assert isinstance(response, ChatCompletion)
+    assert isinstance(chunk_queue, asyncio.Queue)
 
     # Error / no-response: unblock queue reader, fail/resolve future
     if error is not None or response is None:


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, type-safety-focused change limited to streaming response synthesis; low likelihood of affecting runtime behavior except for failing fast if unexpected types are passed.
> 
> **Overview**
> Tightens `synthesize_stream` type expectations by adding runtime `assert` checks that `response` is a `ChatCompletion` and `chunk_queue` is an `asyncio.Queue` before constructing synthetic SSE chunks.
> 
> Also adjusts `ChunkChoice` import style to appease type checkers, without changing behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d5a619f03c8de25db07455b24fccdffeb657c96. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->