### PR TITLE
do not set strict oai tool call mode by default

### DIFF
--- a/verifiers/clients/openai_chat_completions_client.py
+++ b/verifiers/clients/openai_chat_completions_client.py
@@ -211,7 +211,7 @@ class OpenAIChatCompletionsClient(
                 name=tool.name,
                 description=tool.description,
                 parameters=tool.parameters,
-                strict=tool.strict if tool.strict is not None else True,
+                strict=tool.strict,
             ),
         )
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

previously we would set `strict=True` by default which is not the default behavior of the oai api and creates footguns in envs that define custom tools. we now just set `None` which is our default and the oai default which is backwards compatible

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-parameter behavior change limited to OpenAI tool serialization; could affect tool-calling strictness but is small and localized.
> 
> **Overview**
> Stops forcing OpenAI tool `FunctionDefinition.strict` to `True` by default when serializing `Tool`s in `OpenAIChatCompletionsClient.to_native_tool`, and instead forwards `tool.strict` directly (allowing `None` to use the OpenAI API default behavior).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad0291c882a7c1a29ba7a3acbb9213e886513b47. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->