### PR TITLE
deprecate interleaved_rollouts

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -308,7 +308,6 @@ Abstract base class for all environments.
 | `set_kwargs(**kwargs)` | Set attributes using setter methods when available |
 | `add_rubric(rubric)` | Add or merge rubric |
 | `set_max_seq_len(max_seq_len)` | Set maximum sequence length |
-| `set_interleaved_rollouts(bool)` | Enable/disable interleaved rollouts |
 | `set_score_rollouts(bool)` | Enable/disable scoring |
 
 #### SingleTurnEnv

--- a/tests/test_rlm_env.py
+++ b/tests/test_rlm_env.py
@@ -14,19 +14,19 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from datasets import Dataset
+
+import verifiers as vf
 from verifiers.envs.experimental import rlm_env as rlm_module
 from verifiers.envs.experimental.rlm_env import (
-    RLMEnv,
-    RLMWorkerPaths,
     RLMCodeExecutionTimeout,
+    RLMEnv,
     RLMSessionError,
     RLMSetupError,
     RLMWorkerError,
+    RLMWorkerPaths,
     RLMWorkerRecoveryError,
     SubLLMEmptyModelResponseError,
 )
-import verifiers as vf
-
 
 # =============================================================================
 # Helpers
@@ -1198,7 +1198,6 @@ class TestSubLLMRequestPaths:
             )
         )
 
-        rlm_env.interleaved_rollouts = True
         messages = [{"role": "user", "content": "hi"}]
         state = {"sampling_args": {"max_tokens": 7}}
 
@@ -1381,10 +1380,8 @@ class TestSubLLMTrajectorySteps:
         env = build_env(
             dataset,
             include_sub_llm_in_trajectory=True,
-            interleaved_rollouts=True,
         )
         assert env.include_sub_llm_in_trajectory is True
-        assert env.interleaved_rollouts is True
 
     @pytest.mark.asyncio
     async def test_sub_llm_steps_added_to_trajectory(self, rlm_env):

--- a/verifiers/envs/env_group.py
+++ b/verifiers/envs/env_group.py
@@ -328,12 +328,6 @@ class EnvGroup(vf.Environment):
         for env in self.envs:
             env.set_max_seq_len(max_seq_len)
 
-    def set_interleaved_rollouts(self, interleaved_rollouts: bool) -> None:
-        """Set the interleaved_rollouts flag for this environment group and all sub-environments."""
-        self.interleaved_rollouts = interleaved_rollouts
-        for env in self.envs:
-            env.set_interleaved_rollouts(interleaved_rollouts)
-
     def set_score_rollouts(self, score_rollouts: bool) -> None:
         """Set the score_rollouts flag for this environment group and all sub-environments."""
         self.score_rollouts = score_rollouts

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -108,7 +108,6 @@ class Environment(ABC):
         env_args: dict | None = None,
         map_kwargs: dict = {},
         max_seq_len: int | None = None,
-        interleaved_rollouts: bool = False,
         score_rollouts: bool = True,
         **kwargs,
     ):
@@ -144,7 +143,6 @@ class Environment(ABC):
         self.max_seq_len = max_seq_len
         self.map_kwargs = map_kwargs
 
-        self.set_interleaved_rollouts(interleaved_rollouts)
         self.set_score_rollouts(score_rollouts)
 
         self.env_client: EnvClient | None = None
@@ -1228,7 +1226,7 @@ class Environment(ABC):
 
         For each kwarg, checks if a `set_{key}` method exists and calls it,
         otherwise falls back to setattr. This ensures proper propagation for
-        attributes like `interleaved_rollouts` in EnvGroup.
+        attributes like `score_rollouts` in EnvGroup.
         """
         for key, value in kwargs.items():
             setter_name = f"set_{key}"
@@ -1250,13 +1248,9 @@ class Environment(ABC):
         """Set the maximum sequence length for this environment."""
         self.max_seq_len = max_seq_len
 
-    def set_interleaved_rollouts(self, interleaved_rollouts: bool) -> None:
-        """Set the interleaved rollouts flag for this environment."""
-        self.interleaved_rollouts = interleaved_rollouts
-        if self.interleaved_rollouts:
-            self.logger.warning(
-                f"{self.__class__.__name__} is configured to use interleaved rollouts. All model responses after the first turn will be pre-tokenized before being sent to the model. Currently, this is a hand-crafted feature for PRIME-RL's vLLM server extension."
-            )
+    def set_score_rollouts(self, score_rollouts: bool) -> None:
+        """Set the score rollouts flag for this environment."""
+        self.score_rollouts = score_rollouts
 
     async def start_server(
         self,
@@ -1308,10 +1302,6 @@ class Environment(ABC):
                 self.env_server_process.kill()
                 self.env_server_process.join(timeout=5)
             self.env_server_process = None
-
-    def set_score_rollouts(self, score_rollouts: bool) -> None:
-        """Set the score rollouts flag for this environment."""
-        self.score_rollouts = score_rollouts
 
     make_dataset = staticmethod(make_dataset)
 

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -3147,9 +3147,6 @@ class RLMEnv(vf.StatefulToolEnv):
     # State Management
     # =========================================================================
 
-    def set_interleaved_rollouts(self, interleaved_rollouts: bool) -> None:
-        super().set_interleaved_rollouts(interleaved_rollouts)
-
     def update_tool_args(
         self,
         tool_name: str,
@@ -3684,7 +3681,8 @@ class RLMEnv(vf.StatefulToolEnv):
         step with incompatible tokens.  We temporarily move trailing sub-LLM
         steps out of the trajectory for the duration of the super call.
         """
-        if not (self.include_sub_llm_in_trajectory and self.interleaved_rollouts):
+
+        if not self.include_sub_llm_in_trajectory:
             return await super().get_model_response(state, prompt, **kwargs)
 
         trajectory = state.get("trajectory", [])


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

it has no effect anymore. to get tito use `client_type="openai_chat_completions_token"`

@snimu im not sure why rlm was using this before? it should usually not be env builder's concern to set this

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This removes a previously accepted configuration/constructor argument (`interleaved_rollouts`), which may break downstream callers still passing it. Runtime behavior also changes in `RLMEnv.get_model_response` for cases where sub-LLM steps are included in trajectories.
> 
> **Overview**
> **Removes the deprecated `interleaved_rollouts` configuration path across the env stack.** `Environment` and `EnvGroup` no longer accept/propagate `interleaved_rollouts` (setter and constructor wiring removed), and `docs/reference.md` drops it from the public API.
> 
> `RLMEnv` eliminates its `set_interleaved_rollouts` override and updates `get_model_response` to apply the “hide trailing sub-LLM trajectory steps” logic whenever `include_sub_llm_in_trajectory` is enabled (no longer gated by `interleaved_rollouts`). Tests are updated accordingly to stop setting/asserting `interleaved_rollouts` and to reflect the new behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1cb1a7a2581e5fe25ef50d13da856e69cfdb308. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->