### PR TITLE
do not set strict mode if not set

### DIFF
--- a/verifiers/clients/openai_chat_completions_client.py
+++ b/verifiers/clients/openai_chat_completions_client.py
@@ -205,14 +205,22 @@ class OpenAIChatCompletionsClient(
         return [from_chat_message(message) for message in messages], {}
 
     async def to_native_tool(self, tool: Tool) -> OpenAITool:
-        return OpenAITool(
-            type="function",
-            function=FunctionDefinition(
+        if tool.strict is None:
+            function = FunctionDefinition(
+                name=tool.name,
+                description=tool.description,
+                parameters=tool.parameters,
+            )
+        else:
+            function = FunctionDefinition(
                 name=tool.name,
                 description=tool.description,
                 parameters=tool.parameters,
                 strict=tool.strict,
-            ),
+            )
+        return OpenAITool(
+            type="function",
+            function=function,
         )
 
     @handle_openai_overlong_prompt


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to tool payload construction; risk is limited to minor behavior differences in how strict mode is applied when previously defaulted or passed through.
> 
> **Overview**
> Adjusts OpenAI Chat Completions tool serialization to **only include `FunctionDefinition.strict` when explicitly set**.
> 
> `to_native_tool` now builds the `FunctionDefinition` without `strict` when `tool.strict` is `None`, avoiding sending a null/unspecified strict mode to the OpenAI API.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 93ec834893898d8fb7e809a759f54dd42266c5df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->