### PR TITLE
use spawn multiprocessing method for sidecar env server

### DIFF
--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -14,7 +14,8 @@ from collections import defaultdict
 from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
-from multiprocessing import Process
+import multiprocessing
+from multiprocessing.process import BaseProcess
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -146,7 +147,7 @@ class Environment(ABC):
         self.set_score_rollouts(score_rollouts)
 
         self.env_client: EnvClient | None = None
-        self.env_server_process: Process | None = None
+        self.env_server_process: BaseProcess | None = None
 
         # Dataset sources (builders) and built datasets
         # Use get_dataset()/get_eval_dataset() for access; build_dataset() to trigger build
@@ -1268,7 +1269,10 @@ class Environment(ABC):
             depending on it directly.
         """
         address = address or f"tcp://127.0.0.1:{get_free_port()}"
-        self.env_server_process = Process(
+        # Use spawn to avoid inheriting file descriptors (e.g. sockets) from
+        # the parent process, which has caused hangs when multiple env server
+        # subprocesses share the same fds.
+        self.env_server_process = multiprocessing.get_context("spawn").Process(
             target=ZMQEnvServer.run_server,
             args=(
                 self.env_id,

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -14,7 +14,7 @@ from collections import defaultdict
 from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
-import multiprocessing
+import multiprocessing as mp
 from multiprocessing.process import BaseProcess
 from pathlib import Path
 from typing import (
@@ -1272,7 +1272,7 @@ class Environment(ABC):
         # Use spawn to avoid inheriting file descriptors (e.g. sockets) from
         # the parent process, which has caused hangs when multiple env server
         # subprocesses share the same fds.
-        self.env_server_process = multiprocessing.get_context("spawn").Process(
+        self.env_server_process = mp.get_context("spawn").Process(
             target=ZMQEnvServer.run_server,
             args=(
                 self.env_id,


### PR DESCRIPTION
Switch from the default fork method to spawn when creating the env server subprocess. Fork inherits all file descriptors from the parent, which means multiple env server subprocesses can share sockets and other fds, leading to hangs. Spawn starts a fresh interpreter and avoids this class of issues.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes process creation semantics for the env server, which can affect startup behavior and platform-specific multiprocessing quirks even though the diff is small.
> 
> **Overview**
> Switches `Environment.start_server()` to create the ZMQ env server subprocess via `mp.get_context("spawn").Process(...)` instead of the default `multiprocessing.Process`, preventing the child from inheriting parent file descriptors that previously led to hangs when multiple servers were started.
> 
> Updates typing/imports to track the process as `BaseProcess` and adds an inline comment documenting the rationale; shutdown behavior remains the same.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05fbf0688b556feaceadccf61320e6f8be890f4f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->