### PR TITLE
also check for reasoning before raising error

### DIFF
--- a/verifiers/clients/openai_chat_completions_client.py
+++ b/verifiers/clients/openai_chat_completions_client.py
@@ -120,6 +120,19 @@ DEFAULT_REASONING_FIELDS = [
     "reasoning_details",  # OpenRouter, MiniMax
 ]
 
+
+def parse_reasoning_content(message: Any) -> str | None:
+    message_dict = message.model_dump()
+    if not isinstance(message_dict, dict):
+        return None
+
+    for field in DEFAULT_REASONING_FIELDS:
+        value = message_dict.get(field)
+        if isinstance(value, str):
+            return value
+    return None
+
+
 OpenAIChatMessage: TypeAlias = ChatCompletionMessageParam
 OpenAIChatMessages: TypeAlias = list[OpenAIChatMessage]
 OpenAIChatResponse: TypeAlias = ChatCompletion
@@ -282,12 +295,13 @@ class OpenAIChatCompletionsClient(
             raise InvalidModelResponseError(
                 f"Model returned {len(response.choices)} choices, expected 1"
             )
-        if not (
-            response.choices[0].message.content
-            or response.choices[0].message.tool_calls
-        ):
+        message = response.choices[0].message
+        has_content = bool(content_to_text(getattr(message, "content", None)))
+        has_tool_calls = bool(getattr(message, "tool_calls", None))
+        has_reasoning = bool(parse_reasoning_content(message))
+        if not (has_content or has_tool_calls or has_reasoning):
             raise EmptyModelResponseError(
-                "Model returned no content and did not call any tools"
+                "Model returned no content, reasoning, and did not call any tools"
             )
 
     async def from_native_response(self, response: OpenAIChatResponse) -> Response:
@@ -439,15 +453,10 @@ class OpenAIChatCompletionsClient(
                 completion_logprobs=completion_logprobs,
             )
 
-        def parse_reasoning_content(response: OpenAIChatResponse) -> str | None:
-            message_dict = response.choices[0].message.model_dump()
-            if not isinstance(message_dict, dict):
-                return None
-            for field in DEFAULT_REASONING_FIELDS:
-                value = message_dict.get(field)
-                if isinstance(value, str):
-                    return value
-            return None
+        def parse_reasoning_content_from_response(
+            response: OpenAIChatResponse,
+        ) -> str | None:
+            return parse_reasoning_content(response.choices[0].message)
 
         response_id = getattr(response, "id", "")
         if not isinstance(response_id, str):
@@ -466,7 +475,7 @@ class OpenAIChatCompletionsClient(
             usage=parse_usage(response),
             message=ResponseMessage(
                 content=response.choices[0].message.content,
-                reasoning_content=parse_reasoning_content(response),
+                reasoning_content=parse_reasoning_content_from_response(response),
                 finish_reason=parse_finish_reason(response),
                 is_truncated=parse_is_truncated(response),
                 tokens=parse_tokens(response),


### PR DESCRIPTION
## Description
We still were throwing an error when OAI client response had no content or tool calls without checking for reasoning. Returning reasoning with no content or tool calls would be a valid response for a thinking model with a very low max tokens, for example. 

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small validation change in `OpenAIChatCompletionsClient` response handling; low blast radius and no auth/data flow changes, but could slightly alter when empty-response errors are raised.
> 
> **Overview**
> Updates `OpenAIChatCompletionsClient.raise_from_native_response` to consider extracted `reasoning`/`reasoning_content`/`reasoning_details` as valid output, preventing `EmptyModelResponseError` when a model returns reasoning without text content or tool calls.
> 
> Refactors reasoning extraction into a shared `parse_reasoning_content(message)` helper and wires `from_native_response` to populate `ResponseMessage.reasoning_content` via that helper.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19db283dd041b55d4fc54e50e910b58217367cde. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->