### PR TITLE
Change publish-envs workflow to manual and release triggers

### DIFF
--- a/.github/workflows/publish-envs.yml
+++ b/.github/workflows/publish-envs.yml
@@ -3,8 +3,8 @@ name: Publish Envs
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
-      - 'v[0-9]+.[0-9]+.[0-9]+.post[0-9]+'
+      - 'v*.*.*'
+      - '!v*.*.*.dev*'  # Exclude dev releases
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/publish-envs.yml
+++ b/.github/workflows/publish-envs.yml
@@ -2,7 +2,9 @@ name: Publish Envs
 
 on:
   push:
-    branches: [main]
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+  workflow_dispatch:
 
 jobs:
   detect-changed-envs:

--- a/.github/workflows/publish-envs.yml
+++ b/.github/workflows/publish-envs.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+.post[0-9]+'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/publish-envs.yml
+++ b/.github/workflows/publish-envs.yml
@@ -8,62 +8,39 @@ on:
   workflow_dispatch:
 
 jobs:
-  detect-changed-envs:
-    name: Detect changed envs
+  detect-envs:
+    name: Detect all environments
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
-      has_changes: ${{ steps.set-matrix.outputs.has_changes }}
+      has_envs: ${{ steps.set-matrix.outputs.has_envs }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Detect changed environments
-        id: changed-envs
-        uses: tj-actions/changed-files@v47
-        with:
-          files: environments/**
-          dir_names: true
-          dir_names_max_depth: 2
 
       - name: Set matrix
         id: set-matrix
-        env:
-          CHANGED_ENVS: ${{ steps.changed-envs.outputs.all_changed_files }}
         run: |
-          if [ -z "$CHANGED_ENVS" ]; then
-            echo "has_changes=false" >> $GITHUB_OUTPUT
+          # Get all environment directories
+          ENV_IDS=$(ls -d environments/*/ 2>/dev/null | xargs -n1 basename | jq -R . | jq -sc .)
+
+          if [ "$ENV_IDS" = "[]" ] || [ "$ENV_IDS" = "null" ]; then
+            echo "has_envs=false" >> $GITHUB_OUTPUT
             echo "matrix={\"env_id\":[]}" >> $GITHUB_OUTPUT
           else
-            # Filter to only actual environment directories (not files in environments/)
-            ENV_IDS=$(echo "$CHANGED_ENVS" | tr ' ' '\n' | while read -r path; do
-              dir=$(basename "$path")
-              # Verify it's actually a directory under environments/ and skip empty names
-              if [ -n "$dir" ] && [ -d "environments/$dir" ]; then
-                echo "$dir"
-              fi
-            done | sort -u | jq -R . | jq -sc .)
-            
-            if [ "$ENV_IDS" = "[]" ]; then
-              echo "has_changes=false" >> $GITHUB_OUTPUT
-              echo "matrix={\"env_id\":[]}" >> $GITHUB_OUTPUT
-            else
-              echo "Changed envs: $ENV_IDS"
-              echo "has_changes=true" >> $GITHUB_OUTPUT
-              echo "matrix={\"env_id\":$ENV_IDS}" >> $GITHUB_OUTPUT
-            fi
+            echo "Environments to publish: $ENV_IDS"
+            echo "has_envs=true" >> $GITHUB_OUTPUT
+            echo "matrix={\"env_id\":$ENV_IDS}" >> $GITHUB_OUTPUT
           fi
 
   publish-envs:
     name: Publish ${{ matrix.env_id }}
-    needs: detect-changed-envs
-    if: needs.detect-changed-envs.outputs.has_changes == 'true'
+    needs: detect-envs
+    if: needs.detect-envs.outputs.has_envs == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.detect-changed-envs.outputs.matrix) }}
+      matrix: ${{ fromJson(needs.detect-envs.outputs.matrix) }}
     env:
       PRIME_API_KEY: ${{ secrets.PRIME_API_KEY }}
       PRIME_TEAM_ID: ${{ secrets.PRIME_TEAM_ID }}
@@ -93,11 +70,14 @@ jobs:
           echo "$output"
           set -e
 
-          if [ $exit_code -eq 0 ]; then
+          # Check if this is just an unchanged content hash (not a real failure)
+          if echo "$output" | grep -qi "content hash.*already exists\|already exists with the same content"; then
+            echo "⏭️  Environment $ENV_ID unchanged - skipping (content hash already exists)"
+            exit 0
+          elif [ $exit_code -eq 0 ]; then
             echo "✅ Successfully published $ENV_ID"
-          elif echo "$output" | grep -q "content hash.*already exists"; then
-            echo "::warning::Environment $ENV_ID already exists with the same content hash. Skipping upload."
+            exit 0
           else
-            echo "::error::Failed to publish $ENV_ID"
-            exit $exit_code
+            echo "❌ Failed to publish $ENV_ID"
+            exit 1
           fi


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Change the publish-envs workflow to trigger on non-dev versions (e.g., v0.1.10) and via manual trigger instead of every push to main. This is to avoid pushing environments to the env hub which depend on development versions of verifiers (which are e.g. not yet on the env hub/ hosted

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI behavior changes from incremental-on-main to full publish-on-release, which can increase publish volume and affect release automation if tag filtering or env detection is wrong.
> 
> **Overview**
> The `publish-envs` workflow now triggers only on `v*.*.*` tags (excluding `*.dev*`) and via `workflow_dispatch`, instead of on pushes to `main`.
> 
> It replaces “detect changed envs” logic with publishing **all** directories under `environments/` via a generated matrix, and updates the publish step to treat “content hash already exists / same content” output from `prime env push` as a successful no-op rather than a warning/error.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c52ef905eb72922d5867265794617a7c06ec6fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->