### PR TITLE
Feat: router replay

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -176,6 +176,7 @@ class TrajectoryStepTokens(TypedDict):
     completion_logprobs: list[float]
     overlong_prompt: bool
     is_truncated: bool
+    routed_experts: list[list[list[int]]] | None  # [seq_len, layers, topk] to enable router replay
 ```
 
 Token-level data for training.

--- a/verifiers/clients/openai_chat_completions_client.py
+++ b/verifiers/clients/openai_chat_completions_client.py
@@ -450,24 +450,19 @@ class OpenAIChatCompletionsClient(
                 completion_logprobs = [token["logprob"] for token in logprobs_content]
 
             has_routed_experts = (
-                isinstance(
-                    routed_experts := getattr(choice, "routed_experts", None), dict
-                )
+                isinstance(routed_experts := getattr(choice, "routed_experts", None), dict)
                 and "data" in routed_experts
                 and "shape" in routed_experts
             )
             if has_routed_experts:
                 routed_experts = cast(dict[str, Any], routed_experts)
-                routed_experts = cast(
-                    list[list[list[int]]],
-                    (
-                        np.frombuffer(
-                            base64.b85decode(routed_experts["data"]), dtype=np.int32
-                        )
-                        .reshape(routed_experts["shape"])
-                        .tolist()
-                    ),
-                )  # [seq_len, layers, topk]
+                routed_experts = cast(list[list[list[int]]], (
+                    np.frombuffer(
+                        base64.b85decode(routed_experts["data"]), dtype=np.int32
+                    )
+                    .reshape(routed_experts["shape"])
+                    .tolist()
+                )) # [seq_len, layers, topk]
             else:
                 routed_experts = None
             return ResponseTokens(

--- a/verifiers/clients/openai_chat_completions_client.py
+++ b/verifiers/clients/openai_chat_completions_client.py
@@ -1,6 +1,9 @@
+import base64
 import functools
 from collections.abc import Iterable, Mapping
 from typing import Any, TypeAlias, cast
+
+import numpy as np
 
 from openai import (
     AsyncOpenAI,
@@ -445,12 +448,31 @@ class OpenAIChatCompletionsClient(
                 assert isinstance(response.choices[0].logprobs, dict)
                 logprobs_content = response.choices[0].logprobs["content"]
                 completion_logprobs = [token["logprob"] for token in logprobs_content]
+
+            has_routed_experts = (
+                hasattr(choice, "routed_experts")
+                and choice.routed_experts is not None
+                and isinstance(choice.routed_experts, dict)
+                and "data" in choice.routed_experts
+                and "shape" in choice.routed_experts
+            )
+            if has_routed_experts:
+                routed_experts = (
+                    np.frombuffer(
+                        base64.b85decode(choice.routed_experts["data"]), dtype=np.int32
+                    )
+                    .reshape(choice.routed_experts["shape"])
+                    .tolist()
+                )
+            else:
+                routed_experts = None
             return ResponseTokens(
                 prompt_ids=prompt_ids,
                 prompt_mask=prompt_mask,
                 completion_ids=completion_ids,
                 completion_mask=completion_mask,
                 completion_logprobs=completion_logprobs,
+                routed_experts=routed_experts,
             )
 
         def parse_reasoning_content_from_response(

--- a/verifiers/clients/openai_chat_completions_client.py
+++ b/verifiers/clients/openai_chat_completions_client.py
@@ -450,19 +450,24 @@ class OpenAIChatCompletionsClient(
                 completion_logprobs = [token["logprob"] for token in logprobs_content]
 
             has_routed_experts = (
-                isinstance(routed_experts := getattr(choice, "routed_experts", None), dict)
+                isinstance(
+                    routed_experts := getattr(choice, "routed_experts", None), dict
+                )
                 and "data" in routed_experts
                 and "shape" in routed_experts
             )
             if has_routed_experts:
                 routed_experts = cast(dict[str, Any], routed_experts)
-                routed_experts = cast(list[list[list[int]]], (
-                    np.frombuffer(
-                        base64.b85decode(routed_experts["data"]), dtype=np.int32
-                    )
-                    .reshape(routed_experts["shape"])
-                    .tolist()
-                )) # [seq_len, layers, topk]
+                routed_experts = cast(
+                    list[list[list[int]]],
+                    (
+                        np.frombuffer(
+                            base64.b85decode(routed_experts["data"]), dtype=np.int32
+                        )
+                        .reshape(routed_experts["shape"])
+                        .tolist()
+                    ),
+                )  # [seq_len, layers, topk]
             else:
                 routed_experts = None
             return ResponseTokens(

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -160,6 +160,7 @@ class ResponseTokens(CustomBaseModel):
     completion_ids: list[int]
     completion_mask: list[int]
     completion_logprobs: list[float]
+    routed_experts: list[list[list[int]]] | None = None  # [seq_len, layers, topk]
 
 
 FinishReason = Literal["stop", "length", "tool_calls"] | None
@@ -196,6 +197,7 @@ class TrajectoryStepTokens(TypedDict):
     completion_logprobs: list[float]
     overlong_prompt: bool
     is_truncated: bool
+    routed_experts: list[list[list[int]]] | None  # [seq_len, layers, topk]
 
 
 class TokenUsage(TypedDict):

--- a/verifiers/utils/response_utils.py
+++ b/verifiers/utils/response_utils.py
@@ -34,6 +34,7 @@ async def parse_response_tokens(
     completion_ids = tokens.completion_ids
     completion_mask = tokens.completion_mask
     completion_logprobs = tokens.completion_logprobs
+    routed_experts = tokens.routed_experts
 
     if max_seq_len is not None:
         prompt_len = len(prompt_ids)
@@ -46,17 +47,14 @@ async def parse_response_tokens(
             completion_ids = []
             completion_mask = []
             completion_logprobs = []
-            routed_experts = [] if tokens.routed_experts else None
+            routed_experts = [] if routed_experts else None
         elif prompt_len + completion_len > max_seq_len:
             is_truncated = True
             completion_ids = tokens.completion_ids[: max_seq_len - prompt_len]
             completion_mask = tokens.completion_mask[: max_seq_len - prompt_len]
             completion_logprobs = tokens.completion_logprobs[: max_seq_len - prompt_len]
-            routed_experts = (
-                tokens.routed_experts[: max_seq_len - prompt_len]
-                if tokens.routed_experts is not None
-                else None
-            )
+            if routed_experts is not None:
+                routed_experts = routed_experts[: max_seq_len - prompt_len]
         else:
             is_truncated = False
     else:

--- a/verifiers/utils/response_utils.py
+++ b/verifiers/utils/response_utils.py
@@ -47,7 +47,7 @@ async def parse_response_tokens(
             completion_ids = []
             completion_mask = []
             completion_logprobs = []
-            routed_experts = [] if routed_experts else None
+            routed_experts = [] if routed_experts is not None else None
         elif prompt_len + completion_len > max_seq_len:
             is_truncated = True
             completion_ids = tokens.completion_ids[: max_seq_len - prompt_len]

--- a/verifiers/utils/response_utils.py
+++ b/verifiers/utils/response_utils.py
@@ -46,11 +46,17 @@ async def parse_response_tokens(
             completion_ids = []
             completion_mask = []
             completion_logprobs = []
+            routed_experts = [] if tokens.routed_experts else None
         elif prompt_len + completion_len > max_seq_len:
             is_truncated = True
             completion_ids = tokens.completion_ids[: max_seq_len - prompt_len]
             completion_mask = tokens.completion_mask[: max_seq_len - prompt_len]
             completion_logprobs = tokens.completion_logprobs[: max_seq_len - prompt_len]
+            routed_experts = (
+                tokens.routed_experts[: max_seq_len - prompt_len]
+                if tokens.routed_experts is not None
+                else None
+            )
         else:
             is_truncated = False
     else:
@@ -65,5 +71,5 @@ async def parse_response_tokens(
         completion_logprobs=completion_logprobs,
         overlong_prompt=overlong_prompt,
         is_truncated=is_truncated,
-        routed_experts=tokens.routed_experts,
+        routed_experts=routed_experts,
     )

--- a/verifiers/utils/response_utils.py
+++ b/verifiers/utils/response_utils.py
@@ -65,4 +65,5 @@ async def parse_response_tokens(
         completion_logprobs=completion_logprobs,
         overlong_prompt=overlong_prompt,
         is_truncated=is_truncated,
+        routed_experts=tokens.routed_experts,
     )


### PR DESCRIPTION
to enable https://github.com/PrimeIntellect-ai/prime-rl/pull/1807 router replay in prime-rl

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches response parsing and token truncation paths; incorrect decoding/shape handling could break token serialization or downstream training consumers.
> 
> **Overview**
> Adds *router replay* support by threading a new optional `routed_experts` tensor through token metadata.
> 
> `OpenAIChatCompletionsClient` now decodes `choice.routed_experts` (base85-encoded int32 buffer + shape) into a `[seq_len, layers, topk]` nested list and stores it on `ResponseTokens`; `parse_response_tokens` propagates/truncates this field alongside token ids/masks. API/reference docs and `TrajectoryStepTokens`/`ResponseTokens` types are updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d015588ba60effecded5a47159e68c2f7529350. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->