### PR TITLE
Codex-generated pull request

### DIFF
--- a/verifiers/envs/integrations/browser_env/browser_env.py
+++ b/verifiers/envs/integrations/browser_env/browser_env.py
@@ -115,6 +115,9 @@ class BrowserEnv(vf.StatefulToolEnv):
             prebuilt_image: Docker image to use (default: deepdream19/cua-server:latest)
             **kwargs: Additional arguments passed to StatefulToolEnv
         """
+        if mode == "cua" and "stop_errors" not in kwargs:
+            kwargs["stop_errors"] = [vf.SandboxError]
+
         super().__init__(**kwargs)
         self.mode = mode
         browserbase_api_key = os.getenv(browserbase_api_key_var)

--- a/verifiers/envs/integrations/browser_env/modes/cua_mode.py
+++ b/verifiers/envs/integrations/browser_env/modes/cua_mode.py
@@ -37,6 +37,12 @@ except ImportError:
     APIClient = None  # type: ignore[misc, assignment]
 
 
+class BrowserSessionSetupError(vf.Error): ...
+
+
+class BrowserSandboxSetupError(vf.SandboxError): ...
+
+
 class CUAMode:
     """
     CUA-based browser mode supporting both local HTTP and sandbox execution.
@@ -801,62 +807,71 @@ class CUAMode:
 
     async def setup_state(self, state: vf.State, **kwargs: Any) -> vf.State:
         """Create a browser session (and sandbox if in sandbox mode)."""
-        if self._execution_mode == "local":
-            # Local mode: create session via HTTP
-            async for attempt in self.retrying:  # type: ignore[union-attr]
-                with attempt:
-                    result = await self._create_session_http()
-            session_id = result.get("sessionId")
-            if not session_id:
-                raise RuntimeError("Failed to get session ID from server response")
-
-            with self._sessions_lock:
-                self.active_sessions.add(session_id)
-
-            state["session_id"] = session_id
-            state["browser_state"] = result.get("state", {})
-        else:
-            # Sandbox mode: create sandbox, set up server, create session
-            if self.use_prebuilt_image:
-                if self.logger:
-                    self.logger.debug(f"Using prebuilt image: {self.prebuilt_image}")
-
+        try:
+            if self._execution_mode == "local":
+                # Local mode: create session via HTTP
                 async for attempt in self.retrying:  # type: ignore[union-attr]
                     with attempt:
-                        sandbox_id = await self._create_sandbox()
-                await self._wait_for_sandbox_ready(sandbox_id)
-                state["cua_sandbox_id"] = sandbox_id
-                await self._wait_for_server(sandbox_id)
+                        result = await self._create_session_http()
+                session_id = result.get("sessionId")
+                if not session_id:
+                    raise RuntimeError("Failed to get session ID from server response")
+
+                with self._sessions_lock:
+                    self.active_sessions.add(session_id)
+
+                state["session_id"] = session_id
+                state["browser_state"] = result.get("state", {})
             else:
-                if self.use_binary:
-                    await self._ensure_binary_exists()
+                # Sandbox mode: create sandbox, set up server, create session
+                if self.use_prebuilt_image:
+                    if self.logger:
+                        self.logger.debug(
+                            f"Using prebuilt image: {self.prebuilt_image}"
+                        )
+
+                    async for attempt in self.retrying:  # type: ignore[union-attr]
+                        with attempt:
+                            sandbox_id = await self._create_sandbox()
+                    await self._wait_for_sandbox_ready(sandbox_id)
+                    state["cua_sandbox_id"] = sandbox_id
+                    await self._wait_for_server(sandbox_id)
+                else:
+                    if self.use_binary:
+                        await self._ensure_binary_exists()
+
+                    async for attempt in self.retrying:  # type: ignore[union-attr]
+                        with attempt:
+                            sandbox_id = await self._create_sandbox()
+                    await self._wait_for_sandbox_ready(sandbox_id)
+                    state["cua_sandbox_id"] = sandbox_id
+                    await self._upload_server_files(sandbox_id)
+                    await self._start_server(sandbox_id)
+                    await self._wait_for_server(sandbox_id)
 
                 async for attempt in self.retrying:  # type: ignore[union-attr]
                     with attempt:
-                        sandbox_id = await self._create_sandbox()
-                await self._wait_for_sandbox_ready(sandbox_id)
-                state["cua_sandbox_id"] = sandbox_id
-                await self._upload_server_files(sandbox_id)
-                await self._start_server(sandbox_id)
-                await self._wait_for_server(sandbox_id)
+                        result = await self._create_session_curl(sandbox_id)
+                session_id = result.get("sessionId")
+                if not session_id:
+                    raise RuntimeError(
+                        f"Failed to get session ID from server response. "
+                        f"Response keys: {list(result.keys())}, Response: {str(result)[:500]}"
+                    )
 
-            async for attempt in self.retrying:  # type: ignore[union-attr]
-                with attempt:
-                    result = await self._create_session_curl(sandbox_id)
-            session_id = result.get("sessionId")
-            if not session_id:
-                raise RuntimeError(
-                    f"Failed to get session ID from server response. "
-                    f"Response keys: {list(result.keys())}, Response: {str(result)[:500]}"
-                )
+                with self._sessions_lock:
+                    self.active_sessions.add(session_id)
 
-            with self._sessions_lock:
-                self.active_sessions.add(session_id)
+                state["session_id"] = session_id
+                state["browser_state"] = result.get("state", {})
 
-            state["session_id"] = session_id
-            state["browser_state"] = result.get("state", {})
-
-        return state
+            return state
+        except vf.Error:
+            raise
+        except Exception as e:
+            if self._execution_mode == "sandbox":
+                raise BrowserSandboxSetupError(e) from e
+            raise BrowserSessionSetupError(e) from e
 
     def update_tool_args(
         self,


### PR DESCRIPTION
Codex generated this pull request, but encountered an unexpected error after generation. This is a placeholder PR message.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699366ed9de4832c91a9220db8347db0)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session/sandbox setup and error classification, which can change how rollouts terminate and how failures are reported. Logic is straightforward but could alter behavior in edge cases where callers relied on raw exceptions or custom `stop_errors` defaults.
> 
> **Overview**
> **Improves error semantics for CUA mode.** `CUAMode.setup_state` now wraps unexpected exceptions into new verifier error types (`BrowserSessionSetupError` for local HTTP setup and `BrowserSandboxSetupError` for sandbox setup), while rethrowing existing `vf.Error` unchanged.
> 
> **Adjusts rollout stopping behavior.** `BrowserEnv` now defaults `stop_errors` to include `vf.SandboxError` when `mode="cua"` (unless explicitly provided), and adds tests covering both the new exception wrapping and the default `stop_errors` behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da5366f3bfd35e945dd8e0835b21f0d2d099219b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->