### PR TITLE
Sync endpoints.toml API type fields with endpoints.py

### DIFF
--- a/configs/endpoints.toml
+++ b/configs/endpoints.toml
@@ -3,213 +3,277 @@ endpoint_id = "olmo3-32b-t"
 model = "allenai/olmo-3-32b-think"
 url = "https://api.pinference.ai/api/v1"
 key = "PRIME_API_KEY"
+type = "openai_chat_completions"
 
 [[endpoint]]
 endpoint_id = "olmo3-7b-i"
 model = "allenai/olmo-3-7b-instruct"
 url = "https://api.pinference.ai/api/v1"
 key = "PRIME_API_KEY"
+type = "openai_chat_completions"
 
 [[endpoint]]
 endpoint_id = "olmo3-7b-t"
 model = "allenai/olmo-3-7b-think"
 url = "https://api.pinference.ai/api/v1"
 key = "PRIME_API_KEY"
+type = "openai_chat_completions"
 
 [[endpoint]]
 endpoint_id = "trinity-mini"
 model = "arcee/trinity-mini"
 url = "https://api.pinference.ai/api/v1"
 key = "PRIME_API_KEY"
+type = "openai_chat_completions"
 
 [[endpoint]]
 endpoint_id = "haiku"
-model = "anthropic/claude-4.5-haiku"
-url = "https://api.pinference.ai/api/v1"
-key = "PRIME_API_KEY"
+model = "claude-haiku-4-5"
+url = "https://api.anthropic.com"
+key = "ANTHROPIC_API_KEY"
+type = "anthropic_messages"
 
 [[endpoint]]
 endpoint_id = "sonnet"
-model = "anthropic/claude-4.5-sonnet"
-url = "https://api.pinference.ai/api/v1"
-key = "PRIME_API_KEY"
+model = "claude-sonnet-4-5"
+url = "https://api.anthropic.com"
+key = "ANTHROPIC_API_KEY"
+type = "anthropic_messages"
 
 [[endpoint]]
 endpoint_id = "opus"
-model = "anthropic/claude-4.5-opus"
-url = "https://api.pinference.ai/api/v1"
-key = "PRIME_API_KEY"
+model = "claude-opus-4-5"
+url = "https://api.anthropic.com"
+key = "ANTHROPIC_API_KEY"
+type = "anthropic_messages"
+
+[[endpoint]]
+endpoint_id = "deepseek-chat"
+model = "deepseek-chat"
+url = "https://api.deepseek.com/v1"
+key = "DEEPSEEK_API_KEY"
+type = "openai_chat_completions"
+
+[[endpoint]]
+endpoint_id = "deepseek-reasoner"
+model = "deepseek-reasoner"
+url = "https://api.deepseek.com/v1"
+key = "DEEPSEEK_API_KEY"
+type = "openai_chat_completions"
+
+[[endpoint]]
+endpoint_id = "deepseek-chat-anth"
+model = "deepseek-chat"
+url = "https://api.deepseek.com/anthropic"
+key = "DEEPSEEK_API_KEY"
+type = "anthropic_messages"
+
+[[endpoint]]
+endpoint_id = "deepseek-reasoner-anth"
+model = "deepseek-reasoner"
+url = "https://api.deepseek.com/anthropic"
+key = "DEEPSEEK_API_KEY"
+type = "anthropic_messages"
 
 [[endpoint]]
 endpoint_id = "gemini-2.5-flash"
 model = "google/gemini-2.5-flash"
 url = "https://api.pinference.ai/api/v1"
 key = "PRIME_API_KEY"
+type = "openai_chat_completions"
 
 [[endpoint]]
 endpoint_id = "gemini-2.5-pro"
 model = "google/gemini-2.5-pro"
 url = "https://api.pinference.ai/api/v1"
 key = "PRIME_API_KEY"
+type = "openai_chat_completions"
 
 [[endpoint]]
 endpoint_id = "gemini-3-flash"
 model = "google/gemini-3-flash"
 url = "https://api.pinference.ai/api/v1"
 key = "PRIME_API_KEY"
+type = "openai_chat_completions"
 
 [[endpoint]]
 endpoint_id = "gemini-3-pro"
 model = "google/gemini-3-pro-preview"
 url = "https://api.pinference.ai/api/v1"
 key = "PRIME_API_KEY"
+type = "openai_chat_completions"
 
 [[endpoint]]
 endpoint_id = "gemini-3-pro-exp"
 model = "google/gemini-3-pro-preview"
 url = "https://api.pinference.ai/api/v1"
 key = "PRIME_API_KEY"
+type = "openai_chat_completions"
 
 [[endpoint]]
 endpoint_id = "qwen3-30b-i"
 model = "qwen/qwen3-30b-a3b-instruct-2507"
 url = "https://api.pinference.ai/api/v1"
 key = "PRIME_API_KEY"
+type = "openai_chat_completions"
 
 [[endpoint]]
 endpoint_id = "qwen3-30b-t"
 model = "qwen/qwen3-30b-a3b-thinking-2507"
 url = "https://api.pinference.ai/api/v1"
 key = "PRIME_API_KEY"
+type = "openai_chat_completions"
 
 [[endpoint]]
 endpoint_id = "qwen3-235b-i"
 model = "qwen/qwen3-235b-a22b-instruct-2507"
 url = "https://api.pinference.ai/api/v1"
 key = "PRIME_API_KEY"
+type = "openai_chat_completions"
 
 [[endpoint]]
 endpoint_id = "qwen3-235b-t"
 model = "qwen/qwen3-235b-a22b-thinking-2507"
 url = "https://api.pinference.ai/api/v1"
 key = "PRIME_API_KEY"
+type = "openai_chat_completions"
 
 [[endpoint]]
 endpoint_id = "qwen3-vl-30b-i"
 model = "qwen/qwen3-vl-30b-a3b-instruct"
 url = "https://api.pinference.ai/api/v1"
 key = "PRIME_API_KEY"
+type = "openai_chat_completions"
 
 [[endpoint]]
 endpoint_id = "qwen3-vl-30b-t"
 model = "qwen/qwen3-vl-30b-a3b-thinking"
 url = "https://api.pinference.ai/api/v1"
 key = "PRIME_API_KEY"
+type = "openai_chat_completions"
 
 [[endpoint]]
 endpoint_id = "qwen3-vl-235b-i"
 model = "qwen/qwen3-vl-235b-a22b-instruct"
 url = "https://api.pinference.ai/api/v1"
 key = "PRIME_API_KEY"
+type = "openai_chat_completions"
 
 [[endpoint]]
 endpoint_id = "qwen3-vl-235b-t"
 model = "qwen/qwen3-vl-235b-a22b-thinking"
 url = "https://api.pinference.ai/api/v1"
 key = "PRIME_API_KEY"
+type = "openai_chat_completions"
 
 [[endpoint]]
 endpoint_id = "kimi-k2"
 model = "moonshotai/kimi-k2-0905"
 url = "https://api.pinference.ai/api/v1"
 key = "PRIME_API_KEY"
+type = "openai_chat_completions"
 
 [[endpoint]]
 endpoint_id = "kimi-k2-t"
 model = "moonshotai/kimi-k2-thinking"
 url = "https://api.pinference.ai/api/v1"
 key = "PRIME_API_KEY"
+type = "openai_chat_completions"
 
 [[endpoint]]
 endpoint_id = "gpt-oss-120b"
 model = "openai/gpt-oss-120b"
 url = "https://api.pinference.ai/api/v1"
 key = "PRIME_API_KEY"
+type = "openai_chat_completions"
 
 [[endpoint]]
 endpoint_id = "gpt-oss-20b"
 model = "openai/gpt-oss-20b"
 url = "https://api.pinference.ai/api/v1"
 key = "PRIME_API_KEY"
+type = "openai_chat_completions"
 
 [[endpoint]]
 endpoint_id = "gpt-4.1-nano"
 model = "gpt-4.1-nano"
 url = "https://api.openai.com/v1"
 key = "OPENAI_API_KEY"
+type = "openai_chat_completions"
 
 [[endpoint]]
 endpoint_id = "gpt-4.1-mini"
 model = "gpt-4.1-mini"
 url = "https://api.openai.com/v1"
 key = "OPENAI_API_KEY"
+type = "openai_chat_completions"
 
 [[endpoint]]
 endpoint_id = "gpt-4.1"
 model = "gpt-4.1"
 url = "https://api.openai.com/v1"
 key = "OPENAI_API_KEY"
+type = "openai_chat_completions"
 
 [[endpoint]]
 endpoint_id = "gpt-5-nano"
 model = "gpt-5-nano"
 url = "https://api.openai.com/v1"
 key = "OPENAI_API_KEY"
+type = "openai_chat_completions"
 
 [[endpoint]]
 endpoint_id = "gpt-5-mini"
 model = "gpt-5-mini"
 url = "https://api.openai.com/v1"
 key = "OPENAI_API_KEY"
+type = "openai_chat_completions"
 
 [[endpoint]]
 endpoint_id = "gpt-5"
 model = "gpt-5"
 url = "https://api.openai.com/v1"
 key = "OPENAI_API_KEY"
+type = "openai_chat_completions"
 
 [[endpoint]]
 endpoint_id = "gpt-5.1"
 model = "gpt-5.1"
 url = "https://api.openai.com/v1"
 key = "OPENAI_API_KEY"
+type = "openai_chat_completions"
 
 [[endpoint]]
 endpoint_id = "gpt-5.2"
 model = "gpt-5.2"
 url = "https://api.openai.com/v1"
 key = "OPENAI_API_KEY"
+type = "openai_chat_completions"
 
 [[endpoint]]
 endpoint_id = "glm-4.5"
 model = "z-ai/glm-4.5"
 url = "https://api.pinference.ai/api/v1"
 key = "PRIME_API_KEY"
+type = "openai_chat_completions"
 
 [[endpoint]]
 endpoint_id = "glm-4.5-air"
 model = "z-ai/glm-4.5-air"
 url = "https://api.pinference.ai/api/v1"
 key = "PRIME_API_KEY"
+type = "openai_chat_completions"
 
 [[endpoint]]
 endpoint_id = "glm-4.6"
 model = "z-ai/glm-4.6"
 url = "https://api.pinference.ai/api/v1"
 key = "PRIME_API_KEY"
+type = "openai_chat_completions"
 
 [[endpoint]]
 endpoint_id = "glm-4.7"
 model = "z-ai/glm-4.7"
 url = "https://api.pinference.ai/api/v1"
 key = "PRIME_API_KEY"
+type = "openai_chat_completions"


### PR DESCRIPTION
### Motivation
- The TOML endpoint registry omitted explicit API client `type` fields, while `configs/endpoints.py` uses `type` to determine the client implementation; the TOML registry must mirror the Python registry to avoid mismatches.
- Some provider entries (Anthropic / DeepSeek) had different `model`/`url`/`key` representations in TOML compared to the Python registry, so alignment is needed for consistent behavior across tools that read the TOML registry.

### Description
- Added a `type` field to every `[[endpoint]]` entry in `configs/endpoints.toml`, using the same client types present in `configs/endpoints.py` (e.g., `openai_chat_completions`, `anthropic_messages`).
- Updated Anthropic entries to use the Anthropic `model`, `url`, and `key` values present in the Python registry.
- Added DeepSeek endpoint variants to `configs/endpoints.toml` so the TOML and Python registries contain the same `endpoint_id`, `model`, `url`, `key`, and `type` sets.

### Testing
- Ran `uv run pre-commit install` which completed successfully.
- Ran `uv run pre-commit run --files configs/endpoints.toml` which completed successfully for the changed file.
- Ran a Python consistency check that loaded `configs/endpoints.py` and `configs/endpoints.toml` and asserted `endpoint_id`, `model`, `url`, `key`, and `type` match for all entries, and the script completed with `ok`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993a0a5f4308326940d4ffdea850fad)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only changes that adjust provider routing/keys/URLs; risk is limited to potential misconfiguration causing requests to hit the wrong backend or fail at runtime.
> 
> **Overview**
> Aligns `configs/endpoints.toml` with `configs/endpoints.py` by adding an explicit `type` to every endpoint so tooling can choose the correct client (`openai_chat_completions` vs `anthropic_messages`).
> 
> Updates the Anthropic endpoints (`haiku`/`sonnet`/`opus`) to use native Anthropic `model` names, `https://api.anthropic.com` URLs, and `ANTHROPIC_API_KEY` instead of the previous Pinference values, and adds DeepSeek endpoints (including Anthropic-compatible variants) with the appropriate URLs/keys/types.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1c785bd534c55852417892c27d7efe395b93a26. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->