### PR TITLE
docs: replace outdated vf-* CLI references with prime CLI commands

### DIFF
--- a/assets/lab/environments/AGENTS.md
+++ b/assets/lab/environments/AGENTS.md
@@ -659,16 +659,16 @@ This bypasses the normal model response loop and immediately terminates the roll
 
 ## Developing Environments
 
-Environments are packaged as installable Python projects. We recommend developing environments in a workspace with `environments/` and `configs/` folders. The `vf-setup` command initializes this structure:
+Environments are packaged as installable Python projects. We recommend developing environments in a workspace with `environments/` and `configs/` folders. The `prime env setup` command initializes this structure:
 
 ```bash
-vf-setup
+prime env setup
 ```
 
-The `vf-init` command initializes a new environment project:
+The `prime env init` command initializes a new environment project:
 
 ```bash
-vf-init my-env
+prime env init my-env
 ```
 
 This creates the following structure:
@@ -796,7 +796,7 @@ Supported third-party environment integrations include:
 - **`BrowserEnv`** — unified browser automation via [Browserbase](https://browserbase.com) with DOM and CUA modes
 - **`OpenEnvEnv`** — wraps OpenEnv gym and MCP contracts using Prime Sandboxes with prebuilt images referenced from `.build.json`
 
-These require additional dependencies installed via extras (e.g., `uv add 'verifiers[ta]'` for TextArena, `uv add 'verifiers[browser]'` for BrowserEnv, `uv add 'verifiers[openenv]'` for OpenEnvEnv). For OpenEnv environments, build the bundled project image with `uv run vf-build <env-id>` before evaluation or training.
+These require additional dependencies installed via extras (e.g., `uv add 'verifiers[ta]'` for TextArena, `uv add 'verifiers[browser]'` for BrowserEnv, `uv add 'verifiers[openenv]'` for OpenEnvEnv). For OpenEnv environments, build the bundled project image with `prime env build <env-id>` before evaluation or training.
 
 Newer and more experimental environment classes include:
 

--- a/assets/lab/environments/AGENTS.md
+++ b/assets/lab/environments/AGENTS.md
@@ -659,10 +659,10 @@ This bypasses the normal model response loop and immediately terminates the roll
 
 ## Developing Environments
 
-Environments are packaged as installable Python projects. We recommend developing environments in a workspace with `environments/` and `configs/` folders. The `prime env setup` command initializes this structure:
+Environments are packaged as installable Python projects. We recommend developing environments in a workspace with `environments/` and `configs/` folders. The `prime lab setup` command initializes this structure:
 
 ```bash
-prime env setup
+prime lab setup
 ```
 
 The `prime env init` command initializes a new environment project:

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -653,16 +653,16 @@ This bypasses the normal model response loop and immediately terminates the roll
 
 ## Developing Environments
 
-Environments are packaged as installable Python projects. We recommend developing environments in a workspace with `environments/` and `configs/` folders. The `vf-setup` command initializes this structure:
+Environments are packaged as installable Python projects. We recommend developing environments in a workspace with `environments/` and `configs/` folders. The `prime env setup` command initializes this structure:
 
 ```bash
-vf-setup
+prime env setup
 ```
 
-The `vf-init` command initializes a new environment project:
+The `prime env init` command initializes a new environment project:
 
 ```bash
-vf-init my-env
+prime env init my-env
 ```
 
 This creates the following structure:
@@ -790,7 +790,7 @@ Supported third-party environment integrations include:
 - **`BrowserEnv`** — unified browser automation via [Browserbase](https://browserbase.com) with DOM and CUA modes
 - **`OpenEnvEnv`** — wraps OpenEnv gym and MCP contracts using Prime Sandboxes with prebuilt images referenced from `.build.json`
 
-These require additional dependencies installed via extras (e.g., `uv add 'verifiers[ta]'` for TextArena, `uv add 'verifiers[browser]'` for BrowserEnv, `uv add 'verifiers[openenv]'` for OpenEnvEnv). For OpenEnv environments, build the bundled project image with `uv run vf-build <env-id>` before evaluation or training.
+These require additional dependencies installed via extras (e.g., `uv add 'verifiers[ta]'` for TextArena, `uv add 'verifiers[browser]'` for BrowserEnv, `uv add 'verifiers[openenv]'` for OpenEnvEnv). For OpenEnv environments, build the bundled project image with `prime env build <env-id>` before evaluation or training.
 
 Newer and more experimental environment classes include:
 

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -653,10 +653,10 @@ This bypasses the normal model response loop and immediately terminates the roll
 
 ## Developing Environments
 
-Environments are packaged as installable Python projects. We recommend developing environments in a workspace with `environments/` and `configs/` folders. The `prime env setup` command initializes this structure:
+Environments are packaged as installable Python projects. We recommend developing environments in a workspace with `environments/` and `configs/` folders. The `prime lab setup` command initializes this structure:
 
 ```bash
-prime env setup
+prime lab setup
 ```
 
 The `prime env init` command initializes a new environment project:

--- a/docs/training.md
+++ b/docs/training.md
@@ -134,7 +134,7 @@ After optimization, you'll find:
 - `pareto_frontier.jsonl` - Best prompts per validation example
 - `metadata.json` - Run configuration and summary
 
-Use `vf-eval` to verify performance before and after optimization.
+Use `prime eval run` to verify performance before and after optimization.
 
 ## RL Rules of Thumb
 
@@ -185,7 +185,7 @@ The best way to improve training is to ensure appropriate task difficulty for yo
 
 ### `vf.RLTrainer` (Legacy)
 
-The legacy `vf.RLTrainer` still exists for educational and experimental purposes via the optional `verifiers-rl` package and the `vf-rl` entrypoint, but it is not actively maintained. It is a compact single-node async RL trainer with a narrower feature set than production trainers. Its core implementation (`trainer.py` and `orchestrator.py` under `packages/verifiers-rl/verifiers_rl/rl/trainer/`) remains intentionally lightweight for algorithm experimentation. For production training and current guidance, use [`prime-rl`](#training-with-prime-rl).
+The legacy `vf.RLTrainer` still exists for educational and experimental purposes via the optional `verifiers-rl` package and the legacy RL CLI entrypoint, but it is not actively maintained. It is a compact single-node async RL trainer with a narrower feature set than production trainers. Its core implementation (`trainer.py` and `orchestrator.py` under `packages/verifiers-rl/verifiers_rl/rl/trainer/`) remains intentionally lightweight for algorithm experimentation. For production training and current guidance, use [`prime-rl`](#training-with-prime-rl).
 
 ### Tinker
 

--- a/environments/AGENTS.md
+++ b/environments/AGENTS.md
@@ -659,16 +659,16 @@ This bypasses the normal model response loop and immediately terminates the roll
 
 ## Developing Environments
 
-Environments are packaged as installable Python projects. We recommend developing environments in a workspace with `environments/` and `configs/` folders. The `vf-setup` command initializes this structure:
+Environments are packaged as installable Python projects. We recommend developing environments in a workspace with `environments/` and `configs/` folders. The `prime env setup` command initializes this structure:
 
 ```bash
-vf-setup
+prime env setup
 ```
 
-The `vf-init` command initializes a new environment project:
+The `prime env init` command initializes a new environment project:
 
 ```bash
-vf-init my-env
+prime env init my-env
 ```
 
 This creates the following structure:
@@ -796,7 +796,7 @@ Supported third-party environment integrations include:
 - **`BrowserEnv`** — unified browser automation via [Browserbase](https://browserbase.com) with DOM and CUA modes
 - **`OpenEnvEnv`** — wraps OpenEnv gym and MCP contracts using Prime Sandboxes with prebuilt images referenced from `.build.json`
 
-These require additional dependencies installed via extras (e.g., `uv add 'verifiers[ta]'` for TextArena, `uv add 'verifiers[browser]'` for BrowserEnv, `uv add 'verifiers[openenv]'` for OpenEnvEnv). For OpenEnv environments, build the bundled project image with `uv run vf-build <env-id>` before evaluation or training.
+These require additional dependencies installed via extras (e.g., `uv add 'verifiers[ta]'` for TextArena, `uv add 'verifiers[browser]'` for BrowserEnv, `uv add 'verifiers[openenv]'` for OpenEnvEnv). For OpenEnv environments, build the bundled project image with `prime env build <env-id>` before evaluation or training.
 
 Newer and more experimental environment classes include:
 

--- a/environments/AGENTS.md
+++ b/environments/AGENTS.md
@@ -659,10 +659,10 @@ This bypasses the normal model response loop and immediately terminates the roll
 
 ## Developing Environments
 
-Environments are packaged as installable Python projects. We recommend developing environments in a workspace with `environments/` and `configs/` folders. The `prime env setup` command initializes this structure:
+Environments are packaged as installable Python projects. We recommend developing environments in a workspace with `environments/` and `configs/` folders. The `prime lab setup` command initializes this structure:
 
 ```bash
-prime env setup
+prime lab setup
 ```
 
 The `prime env init` command initializes a new environment project:

--- a/verifiers/AGENTS.md
+++ b/verifiers/AGENTS.md
@@ -105,7 +105,7 @@ uv add verifiers            # core
 uv add 'verifiers[all]'     # + training
 
 # Scaffold new environment
-vf-init new-environment
+prime env init new-environment
 
 # Install + test
 prime env install new-environment


### PR DESCRIPTION
### Motivation
- Several docs and generated AGENTS guidance still referenced legacy `vf-*` entrypoints which are outdated and cause confusion for users following the CLI workflow. 
- The repository has standardized on the `prime` CLI for environment lifecycle and evaluation commands, so docs must reflect the current UX. 
- Keep generated AGENTS files consistent with the user-facing docs to avoid divergent guidance for automated agents and contributors. 

### Description
- Replaced `vf-setup` with `prime env setup` and `vf-init` with `prime env init` across environment development docs and AGENTS files. 
- Updated OpenEnv build guidance from `uv run vf-build <env-id>` to `prime env build <env-id>`. 
- Replaced `vf-eval` with `prime eval run` and changed the explicit `vf-rl` CLI mention to a neutral `legacy RL CLI entrypoint` in training docs. 
- Synchronized the same changes into generated AGENTS copies under `environments/AGENTS.md`, `assets/lab/environments/AGENTS.md`, and `verifiers/AGENTS.md`, and updated `docs/environments.md` and `docs/training.md`. 

### Testing
- Ran `uv run pre-commit install` which completed successfully. 
- Ran `uv run pre-commit run --all-files` which completed and passed the included checks. 
- Verified there are no remaining `vf-` command references in the targeted markdown files by running a repository-wide grep, which returned no matches.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699406dc60c48326868fc59d13640808)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that update command examples; no runtime or API behavior is modified.
> 
> **Overview**
> Replaces outdated `vf-*` CLI references across environment and training docs with the standardized `prime` CLI workflow (e.g., `prime lab setup`, `prime env init`, `prime env build`, `prime eval run`).
> 
> Synchronizes the same command updates into generated guidance files (`assets/lab/environments/AGENTS.md`, `environments/AGENTS.md`, `verifiers/AGENTS.md`) and softens the explicit `vf-rl` mention to a generic “legacy RL CLI entrypoint”.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac05d1f508004ea05adf2585f60d5c8b82e1ae31. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->