### PR TITLE
env server recovery

### DIFF
--- a/tests/test_env_crash_recovery.py
+++ b/tests/test_env_crash_recovery.py
@@ -1,0 +1,446 @@
+"""Tests for environment server crash detection and recovery."""
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from verifiers.workers.client.zmq_env_client import ZMQEnvClient
+from verifiers.workers.types import (
+    HealthRequest,
+    HealthResponse,
+    PendingTaskInfo,
+    ServerState,
+)
+
+
+class TestCancelAllPending:
+    """Tests for cancel_all_pending functionality."""
+
+    @pytest.mark.asyncio
+    async def test_cancel_all_pending_returns_metadata(self):
+        """Test that cancel_all_pending returns correct PendingTaskInfo objects."""
+        client = ZMQEnvClient(
+            address="tcp://127.0.0.1:5555",
+            health_check_interval=0,  # Disable health checks
+        )
+
+        # Manually add some pending tasks
+        request1 = HealthRequest()
+        request2 = HealthRequest()
+
+        async with client._pending_lock:
+            client.pending["req1"] = asyncio.Future()
+            client.pending["req2"] = asyncio.Future()
+            client.pending_tasks["req1"] = PendingTaskInfo(
+                request_id="req1",
+                request=request1,
+                submitted_at=time.time(),
+                timeout=10.0,
+            )
+            client.pending_tasks["req2"] = PendingTaskInfo(
+                request_id="req2",
+                request=request2,
+                submitted_at=time.time(),
+                timeout=20.0,
+            )
+
+        # Cancel all pending
+        cancelled_tasks = await client.cancel_all_pending("Test cancellation")
+
+        # Verify return value
+        assert len(cancelled_tasks) == 2
+        assert all(isinstance(task, PendingTaskInfo) for task in cancelled_tasks)
+        assert {task.request_id for task in cancelled_tasks} == {"req1", "req2"}
+
+        # Verify internal state is cleaned up
+        assert len(client.pending) == 0
+        assert len(client.pending_tasks) == 0
+
+        # Verify futures are cancelled
+        for task in cancelled_tasks:
+            # The futures should have been failed with RuntimeError
+            pass
+
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_cancel_all_pending_empty(self):
+        """Test cancel_all_pending when there are no pending tasks."""
+        client = ZMQEnvClient(
+            address="tcp://127.0.0.1:5555",
+            health_check_interval=0,  # Disable health checks
+        )
+
+        cancelled_tasks = await client.cancel_all_pending("Test cancellation")
+
+        assert len(cancelled_tasks) == 0
+        assert len(client.pending) == 0
+        assert len(client.pending_tasks) == 0
+
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_cancel_all_pending_fails_futures(self):
+        """Test that cancel_all_pending fails all pending futures."""
+        client = ZMQEnvClient(
+            address="tcp://127.0.0.1:5555",
+            health_check_interval=0,  # Disable health checks
+        )
+
+        # Create futures
+        future1 = asyncio.Future()
+        future2 = asyncio.Future()
+
+        async with client._pending_lock:
+            client.pending["req1"] = future1
+            client.pending["req2"] = future2
+            client.pending_tasks["req1"] = PendingTaskInfo(
+                request_id="req1",
+                request=HealthRequest(),
+                submitted_at=time.time(),
+                timeout=10.0,
+            )
+            client.pending_tasks["req2"] = PendingTaskInfo(
+                request_id="req2",
+                request=HealthRequest(),
+                submitted_at=time.time(),
+                timeout=10.0,
+            )
+
+        # Cancel all
+        await client.cancel_all_pending("Test error")
+
+        # Verify futures are failed
+        assert future1.done()
+        assert future2.done()
+        with pytest.raises(RuntimeError, match="Test error"):
+            future1.result()
+        with pytest.raises(RuntimeError, match="Test error"):
+            future2.result()
+
+        await client.close()
+
+
+class TestHealthCheck:
+    """Tests for health check functionality."""
+
+    @pytest.mark.asyncio
+    async def test_health_check_disabled(self):
+        """Test that health checks don't start when interval=0."""
+        client = ZMQEnvClient(address="tcp://127.0.0.1:5555", health_check_interval=0)
+
+        # Start the receiver (which would normally start health checks)
+        await client._start()
+        await asyncio.sleep(0.1)
+
+        # Verify health check task is not running
+        assert client._health_check_task is None
+
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_health_check_starts_automatically(self):
+        """Test that health check task starts on first request."""
+        client = ZMQEnvClient(
+            address="tcp://127.0.0.1:5555",
+            health_check_interval=5.0,  # 5 seconds
+        )
+
+        # Mock the health method to avoid actual network calls
+        client.health = AsyncMock(return_value=True)
+
+        # Mock socket operations - send_multipart needs to return a coroutine
+        async def mock_send(*args, **kwargs):
+            pass
+
+        with (
+            patch.object(client.socket, "connect"),
+            patch.object(client.socket, "send_multipart", new=mock_send),
+        ):
+            # Manually start the client
+            await client._start()
+
+            # Simulate sending a request (this should start health check)
+            try:
+                # This will timeout, but should start health check
+                await asyncio.wait_for(
+                    client._send_request(HealthRequest(), HealthResponse, timeout=0.1),
+                    timeout=0.2,
+                )
+            except (asyncio.TimeoutError, TimeoutError):
+                pass
+
+            # Give it a moment to start the health check task
+            await asyncio.sleep(0.1)
+
+            # Verify health check task is running
+            assert client._health_check_task is not None
+            assert not client._health_check_task.done()
+
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_health_check_marks_unhealthy_after_failures(self):
+        """Test that consecutive health check failures mark server as unhealthy."""
+        client = ZMQEnvClient(
+            address="tcp://127.0.0.1:5555",
+            health_check_interval=0.5,  # Fast checks for testing
+            health_check_timeout=0.2,
+        )
+
+        # Mock health to fail
+        client.health = AsyncMock(side_effect=RuntimeError("Connection failed"))
+
+        # Start the health check loop
+        client._health_check_task = asyncio.create_task(client._health_check_loop())
+
+        # Wait for health checks to run and fail
+        await asyncio.sleep(1.5)  # Should have 2-3 failed checks
+
+        # Verify state is now unhealthy
+        async with client._state_lock:
+            assert client._server_state == ServerState.UNHEALTHY
+
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_health_check_recovers_from_unhealthy(self):
+        """Test that health check can recover from unhealthy state."""
+        client = ZMQEnvClient(
+            address="tcp://127.0.0.1:5555",
+            health_check_interval=0.5,  # Fast checks for testing
+        )
+
+        # Start with unhealthy state
+        async with client._state_lock:
+            client._server_state = ServerState.UNHEALTHY
+            client._failed_health_checks = 3
+
+        # Mock health to succeed
+        client.health = AsyncMock(return_value=True)
+
+        # Start the health check loop
+        client._health_check_task = asyncio.create_task(client._health_check_loop())
+
+        # Wait for health check to run
+        await asyncio.sleep(1.0)
+
+        # Verify state is now healthy
+        async with client._state_lock:
+            assert client._server_state == ServerState.HEALTHY
+            assert client._failed_health_checks == 0
+
+        await client.close()
+
+
+class TestWaitForRecovery:
+    """Tests for wait_for_recovery functionality."""
+
+    @pytest.mark.asyncio
+    async def test_wait_for_recovery_success(self):
+        """Test that wait_for_recovery succeeds when server recovers."""
+        client = ZMQEnvClient(address="tcp://127.0.0.1:5555", health_check_interval=0)
+
+        # Mock health to succeed
+        client.health = AsyncMock(return_value=True)
+
+        # Should return quickly
+        await client.wait_for_recovery(timeout=5.0, check_interval=0.5)
+
+        # Verify state is healthy
+        async with client._state_lock:
+            assert client._server_state == ServerState.HEALTHY
+
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_wait_for_recovery_timeout(self):
+        """Test that wait_for_recovery raises TimeoutError on timeout."""
+        client = ZMQEnvClient(address="tcp://127.0.0.1:5555", health_check_interval=0)
+
+        # Mock health to always fail
+        client.health = AsyncMock(side_effect=RuntimeError("Server down"))
+
+        # Should timeout
+        with pytest.raises(TimeoutError, match="Server did not recover within"):
+            await client.wait_for_recovery(timeout=1.0, check_interval=0.3)
+
+        # Verify state is unhealthy
+        async with client._state_lock:
+            assert client._server_state == ServerState.UNHEALTHY
+
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_wait_for_recovery_delayed_success(self):
+        """Test recovery after initial failures."""
+        client = ZMQEnvClient(address="tcp://127.0.0.1:5555", health_check_interval=0)
+
+        # Mock health to fail first 2 times, then succeed
+        call_count = 0
+
+        async def mock_health(timeout: float | None = 10):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 2:
+                raise RuntimeError("Server down")
+            return True
+
+        client.health = mock_health
+
+        # Should eventually succeed
+        await client.wait_for_recovery(timeout=3.0, check_interval=0.5)
+
+        # Verify state is healthy
+        async with client._state_lock:
+            assert client._server_state == ServerState.HEALTHY
+
+        await client.close()
+
+
+class TestAutoRetry:
+    """Tests for automatic retry on server failure."""
+
+    @pytest.mark.asyncio
+    async def test_send_request_caches_metadata(self):
+        """Test that _send_request caches task metadata."""
+        client = ZMQEnvClient(address="tcp://127.0.0.1:5555", health_check_interval=0)
+
+        request = HealthRequest()
+
+        # Mock socket operations - send_multipart needs to return a coroutine
+        async def mock_send(*args, **kwargs):
+            pass
+
+        with (
+            patch.object(client.socket, "connect"),
+            patch.object(client.socket, "send_multipart", new=mock_send),
+        ):
+            # Start receiver
+            await client._start()
+
+            # Send a request that will timeout
+            try:
+                await asyncio.wait_for(
+                    client._send_request(request, HealthResponse, timeout=0.1),
+                    timeout=0.2,
+                )
+            except (asyncio.TimeoutError, TimeoutError):
+                pass
+
+            # The metadata should have been cleaned up on timeout
+            assert len(client.pending_tasks) == 0
+
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_send_request_cleans_metadata_on_success(self):
+        """Test that metadata is cleaned up on successful response."""
+        client = ZMQEnvClient(address="tcp://127.0.0.1:5555", health_check_interval=0)
+
+        request = HealthRequest()
+
+        # Mock socket operations - send_multipart needs to return a coroutine
+        async def mock_send(*args, **kwargs):
+            pass
+
+        with (
+            patch.object(client.socket, "connect"),
+            patch.object(client.socket, "send_multipart", new=mock_send),
+        ):
+            await client._start()
+
+            # Create a task to send response after a delay
+            async def send_response():
+                await asyncio.sleep(0.1)
+                # Get the request_id from pending
+                if client.pending:
+                    request_id = list(client.pending.keys())[0]
+                    future = client.pending.get(request_id)
+                    if future and not future.done():
+                        # Simulate a successful response
+                        future.set_result({"success": True, "error": None})
+
+            response_task = asyncio.create_task(send_response())
+
+            try:
+                response = await asyncio.wait_for(
+                    client._send_request(request, HealthResponse, timeout=1.0),
+                    timeout=2.0,
+                )
+                # Verify metadata is cleaned up
+                assert len(client.pending_tasks) == 0
+                assert response.success
+            except asyncio.TimeoutError:
+                pass
+            finally:
+                response_task.cancel()
+                try:
+                    await response_task
+                except asyncio.CancelledError:
+                    pass
+
+            await client.close()
+
+
+class TestCloseCleanup:
+    """Tests for client close and cleanup."""
+
+    @pytest.mark.asyncio
+    async def test_close_cancels_health_check_task(self):
+        """Test that close() cancels the health check task."""
+        client = ZMQEnvClient(
+            address="tcp://127.0.0.1:5555",
+            health_check_interval=10.0,  # Long interval
+        )
+
+        # Mock health to avoid network calls
+        client.health = AsyncMock(return_value=True)
+
+        # Mock socket operations - send_multipart needs to return a coroutine
+        async def mock_send(*args, **kwargs):
+            pass
+
+        # Start the client (which starts health checks)
+        with (
+            patch.object(client.socket, "connect"),
+            patch.object(client.socket, "send_multipart", new=mock_send),
+        ):
+            await client._start()
+            # Manually start health check
+            client._health_check_task = asyncio.create_task(client._health_check_loop())
+            await asyncio.sleep(0.1)
+
+            # Verify health check is running
+            assert client._health_check_task is not None
+            assert not client._health_check_task.done()
+
+            # Close the client
+            await client.close()
+
+            # Verify health check task is cancelled
+            assert client._health_check_task is None
+
+    @pytest.mark.asyncio
+    async def test_close_cancels_pending_tasks(self):
+        """Test that close() cancels all pending tasks."""
+        client = ZMQEnvClient(address="tcp://127.0.0.1:5555", health_check_interval=0)
+
+        # Add some pending tasks
+        async with client._pending_lock:
+            client.pending["req1"] = asyncio.Future()
+            client.pending_tasks["req1"] = PendingTaskInfo(
+                request_id="req1",
+                request=HealthRequest(),
+                submitted_at=time.time(),
+                timeout=10.0,
+            )
+
+        # Close
+        await client.close()
+
+        # Verify cleanup
+        assert len(client.pending) == 0
+        assert len(client.pending_tasks) == 0

--- a/tests/test_env_crash_recovery.py
+++ b/tests/test_env_crash_recovery.py
@@ -121,8 +121,8 @@ class TestRetryOnServerError:
                 asyncio.create_task(succeed())
 
         with (
-            patch.object(client.socket, "connect"),
-            patch.object(client.socket, "send_multipart", new=mock_send),
+            patch.object(client._socket, "connect"),
+            patch.object(client._socket, "send_multipart", new=mock_send),
         ):
             await client._ensure_started()
             response = await client._send_request(
@@ -151,8 +151,8 @@ class TestRetryOnServerError:
             asyncio.create_task(fail())
 
         with (
-            patch.object(client.socket, "connect"),
-            patch.object(client.socket, "send_multipart", new=mock_send),
+            patch.object(client._socket, "connect"),
+            patch.object(client._socket, "send_multipart", new=mock_send),
         ):
             await client._ensure_started()
 
@@ -185,8 +185,8 @@ class TestRetryOnServerError:
             asyncio.create_task(fail())
 
         with (
-            patch.object(client.socket, "connect"),
-            patch.object(client.socket, "send_multipart", new=mock_send),
+            patch.object(client._socket, "connect"),
+            patch.object(client._socket, "send_multipart", new=mock_send),
         ):
             await client._ensure_started()
 
@@ -218,7 +218,7 @@ class TestWaitForServerStartup:
 
         client.health = mock_health
 
-        with patch.object(client.socket, "connect"):
+        with patch.object(client._socket, "connect"):
             await client.wait_for_server_startup(timeout=3.0)
 
         assert client._healthy_event.is_set()
@@ -235,7 +235,7 @@ class TestWaitForServerStartup:
 
         client.health = AsyncMock(return_value=False)
 
-        with patch.object(client.socket, "connect"):
+        with patch.object(client._socket, "connect"):
             with pytest.raises(TimeoutError, match="did not become healthy"):
                 await client.wait_for_server_startup(timeout=1.0)
 

--- a/tests/test_env_crash_recovery.py
+++ b/tests/test_env_crash_recovery.py
@@ -134,7 +134,7 @@ class TestHealthCheck:
         client = ZMQEnvClient(address="tcp://127.0.0.1:5555", health_check_interval=0)
 
         # Start the receiver (which would normally start health checks)
-        await client._start()
+        await client._ensure_started()
         await asyncio.sleep(0.1)
 
         # Verify health check task is not running
@@ -162,7 +162,7 @@ class TestHealthCheck:
             patch.object(client.socket, "send_multipart", new=mock_send),
         ):
             # Manually start the client
-            await client._start()
+            await client._ensure_started()
 
             # Simulate sending a request (this should start health check)
             try:
@@ -316,7 +316,7 @@ class TestRequestMetadata:
             patch.object(client.socket, "send_multipart", new=mock_send),
         ):
             # Start receiver
-            await client._start()
+            await client._ensure_started()
 
             # Send a request that will timeout
             try:
@@ -347,7 +347,7 @@ class TestRequestMetadata:
             patch.object(client.socket, "connect"),
             patch.object(client.socket, "send_multipart", new=mock_send),
         ):
-            await client._start()
+            await client._ensure_started()
 
             # Create a task to send response after a delay
             async def send_response():
@@ -406,9 +406,7 @@ class TestCloseCleanup:
             patch.object(client.socket, "connect"),
             patch.object(client.socket, "send_multipart", new=mock_send),
         ):
-            await client._start()
-            # Manually start health check
-            client._health_check_task = asyncio.create_task(client._health_check_loop())
+            await client._ensure_started()
             await asyncio.sleep(0.1)
 
             # Verify health check is running
@@ -490,7 +488,7 @@ class TestAutomaticRetry:
             patch.object(client.socket, "connect"),
             patch.object(client.socket, "send_multipart", new=mock_send),
         ):
-            await client._start()
+            await client._ensure_started()
 
             # Send request - should retry and succeed
             response = await client._send_request(request, HealthResponse, timeout=5.0)
@@ -524,7 +522,7 @@ class TestAutomaticRetry:
             patch.object(client.socket, "connect"),
             patch.object(client.socket, "send_multipart", new=mock_send),
         ):
-            await client._start()
+            await client._ensure_started()
 
             # Send request - should fail with TimeoutError after recovery_timeout
             with pytest.raises(TimeoutError, match="did not recover"):
@@ -562,7 +560,7 @@ class TestAutomaticRetry:
             patch.object(client.socket, "connect"),
             patch.object(client.socket, "send_multipart", new=mock_send),
         ):
-            await client._start()
+            await client._ensure_started()
 
             # Send request - should NOT retry
             with pytest.raises(RuntimeError, match="Invalid request format"):

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -1256,7 +1256,7 @@ class Environment(ABC):
     async def start_server(
         self,
         address: str | None = None,
-        extra_env_kwargs: dict[str, Any] = {},
+        extra_env_kwargs: dict[str, Any] | None = None,
         # logging configs
         log_level: str | None = None,
         log_file: str | None = None,
@@ -1265,6 +1265,7 @@ class Environment(ABC):
         health_check_interval: float = 10.0,  # 10s
         startup_timeout: float = 600.0,  # 10m
         recovery_timeout: float = 600.0,  # 10m
+        max_auto_retries: int = 3,
     ) -> None:
         """Start a ZMQ server process for this environment.
 
@@ -1273,6 +1274,7 @@ class Environment(ABC):
             depending on it directly.
         """
         address = address or f"tcp://127.0.0.1:{get_free_port()}"
+        extra_env_kwargs = extra_env_kwargs or {}
         # Use spawn to avoid inheriting file descriptors (e.g. sockets) from
         # the parent process, which has caused hangs when multiple env server
         # subprocesses share the same fds.
@@ -1295,6 +1297,7 @@ class Environment(ABC):
             health_check_interval=health_check_interval,
             startup_timeout=startup_timeout,
             recovery_timeout=recovery_timeout,
+            max_auto_retries=max_auto_retries,
         )
         await self.env_client.wait_for_server_startup()
 

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -1293,10 +1293,10 @@ class Environment(ABC):
         self.env_server_process.start()
         self.env_client = ZMQEnvClient(
             address=address,
-            name=self.env_id,
             health_check_interval=health_check_interval,
             startup_timeout=startup_timeout,
             recovery_timeout=recovery_timeout,
+            name=self.env_id,
         )
         await self.env_client.wait_for_server_startup()
 

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -1257,6 +1257,7 @@ class Environment(ABC):
         self,
         address: str | None = None,
         extra_env_kwargs: dict[str, Any] | None = None,
+        max_workers: int = 32,
         # logging configs
         log_level: str | None = None,
         log_file: str | None = None,
@@ -1287,7 +1288,7 @@ class Environment(ABC):
                 log_file,
                 log_file_level,
             ),
-            kwargs=dict(address=address),
+            kwargs=dict(address=address, max_workers=max_workers),
             daemon=True,  # ensure server process is terminated when parent exits
         )
         self.env_server_process.start()

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -1263,7 +1263,7 @@ class Environment(ABC):
         log_file: str | None = None,
         log_file_level: str | None = None,
         # health check configs
-        health_check_interval: float = 10.0,  # 10s
+        health_check_interval: float = 1.0,  # 1s
         startup_timeout: float = 600.0,  # 10m
         recovery_timeout: float = 600.0,  # 10m
     ) -> None:

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -1298,7 +1298,7 @@ class Environment(ABC):
             recovery_timeout=recovery_timeout,
         )
         # Wait for server to be ready using built-in health check
-        await self.env_client.wait_for_recovery(
+        await self.env_client.wait_for_server_health(
             timeout=startup_timeout,
             check_interval=1.0,  # Check every second for fast startup
         )

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -1293,6 +1293,7 @@ class Environment(ABC):
         self.env_server_process.start()
         self.env_client = ZMQEnvClient(
             address=address,
+            name=self.env_id,
             health_check_interval=health_check_interval,
             startup_timeout=startup_timeout,
             recovery_timeout=recovery_timeout,

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -35,7 +35,7 @@ from verifiers.utils.client_utils import (
 )
 from verifiers.utils.eval_utils import filter_inputs
 from verifiers.utils.path_utils import is_valid_eval_results_path
-from verifiers.utils.worker_utils import get_free_port
+from verifiers.utils.worker_utils import get_free_port_pair
 from verifiers.workers.client.zmq_env_client import ZMQEnvClient
 from verifiers.workers.server.zmq_env_server import ZMQEnvServer
 
@@ -1272,7 +1272,7 @@ class Environment(ABC):
             This method is subject to change. External users should avoid
             depending on it directly.
         """
-        address = address or f"tcp://127.0.0.1:{get_free_port()}"
+        address = address or f"tcp://127.0.0.1:{get_free_port_pair()}"
         extra_env_kwargs = extra_env_kwargs or {}
         # Use spawn to avoid inheriting file descriptors (e.g. sockets) from
         # the parent process, which has caused hangs when multiple env server

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -1257,14 +1257,13 @@ class Environment(ABC):
         self,
         address: str | None = None,
         extra_env_kwargs: dict[str, Any] = {},
-        startup_timeout: float = 3600,  # 1h
         # logging configs
         log_level: str | None = None,
         log_file: str | None = None,
         log_file_level: str | None = None,
         # health check configs
         health_check_interval: float = 10.0,  # 10s
-        health_check_timeout: float = 1.0,  # 5s
+        startup_timeout: float = 600.0,  # 10m
         recovery_timeout: float = 600.0,  # 10m
     ) -> None:
         """Start a ZMQ server process for this environment.
@@ -1294,14 +1293,10 @@ class Environment(ABC):
         self.env_client = ZMQEnvClient(
             address=address,
             health_check_interval=health_check_interval,
-            health_check_timeout=health_check_timeout,
+            startup_timeout=startup_timeout,
             recovery_timeout=recovery_timeout,
         )
-        # Wait for server to be ready using built-in health check
-        await self.env_client.wait_for_server_health(
-            timeout=startup_timeout,
-            check_interval=1.0,  # Check every second for fast startup
-        )
+        await self.env_client.wait_for_server_startup()
 
     async def stop_server(self) -> None:
         """Stop the ZMQ server process for this environment.

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -35,7 +35,7 @@ from verifiers.utils.client_utils import (
 )
 from verifiers.utils.eval_utils import filter_inputs
 from verifiers.utils.path_utils import is_valid_eval_results_path
-from verifiers.utils.worker_utils import get_free_port, wait_for_env_server
+from verifiers.utils.worker_utils import get_free_port
 from verifiers.workers.client.zmq_env_client import ZMQEnvClient
 from verifiers.workers.server.zmq_env_server import ZMQEnvServer
 
@@ -1297,7 +1297,11 @@ class Environment(ABC):
             health_check_timeout=health_check_timeout,
             recovery_timeout=recovery_timeout,
         )
-        await wait_for_env_server(self.env_client, timeout=startup_timeout)
+        # Wait for server to be ready using built-in health check
+        await self.env_client.wait_for_recovery(
+            timeout=startup_timeout,
+            check_interval=1.0,  # Check every second for fast startup
+        )
 
     async def stop_server(self) -> None:
         """Stop the ZMQ server process for this environment.

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -1265,7 +1265,6 @@ class Environment(ABC):
         health_check_interval: float = 10.0,  # 10s
         startup_timeout: float = 600.0,  # 10m
         recovery_timeout: float = 600.0,  # 10m
-        max_auto_retries: int = 3,
     ) -> None:
         """Start a ZMQ server process for this environment.
 
@@ -1297,7 +1296,6 @@ class Environment(ABC):
             health_check_interval=health_check_interval,
             startup_timeout=startup_timeout,
             recovery_timeout=recovery_timeout,
-            max_auto_retries=max_auto_retries,
         )
         await self.env_client.wait_for_server_startup()
 

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -1257,7 +1257,6 @@ class Environment(ABC):
         self,
         address: str | None = None,
         extra_env_kwargs: dict[str, Any] | None = None,
-        max_workers: int = 32,
         # logging configs
         log_level: str | None = None,
         log_file: str | None = None,
@@ -1288,7 +1287,7 @@ class Environment(ABC):
                 log_file,
                 log_file_level,
             ),
-            kwargs=dict(address=address, max_workers=max_workers),
+            kwargs=dict(address=address),
             daemon=True,  # ensure server process is terminated when parent exits
         )
         self.env_server_process.start()

--- a/verifiers/envs/integrations/openenv_env.py
+++ b/verifiers/envs/integrations/openenv_env.py
@@ -163,10 +163,14 @@ class OpenEnvEnv(vf.MultiTurnEnv):
         self,
         address: str | None = None,
         extra_env_kwargs: dict[str, Any] | None = None,
+        # logging configs
         log_level: str | None = None,
         log_file: str | None = None,
         log_file_level: str | None = None,
-        startup_timeout: float = 120.0,
+        # health check configs
+        health_check_interval: float = 10.0,  # 10s
+        startup_timeout: float = 600.0,  # 10m
+        recovery_timeout: float = 600.0,  # 10m
     ) -> None:
         await super().start_server(
             address=address,

--- a/verifiers/envs/integrations/openenv_env.py
+++ b/verifiers/envs/integrations/openenv_env.py
@@ -178,7 +178,9 @@ class OpenEnvEnv(vf.MultiTurnEnv):
             log_level=log_level,
             log_file=log_file,
             log_file_level=log_file_level,
+            health_check_interval=health_check_interval,
             startup_timeout=startup_timeout,
+            recovery_timeout=recovery_timeout,
         )
 
     def _build_seed_datasets(self) -> tuple[Dataset, Dataset | None]:

--- a/verifiers/envs/integrations/openenv_env.py
+++ b/verifiers/envs/integrations/openenv_env.py
@@ -168,7 +168,7 @@ class OpenEnvEnv(vf.MultiTurnEnv):
         log_file: str | None = None,
         log_file_level: str | None = None,
         # health check configs
-        health_check_interval: float = 10.0,  # 10s
+        health_check_interval: float = 1.0,  # 1s
         startup_timeout: float = 600.0,  # 10m
         recovery_timeout: float = 600.0,  # 10m
     ) -> None:

--- a/verifiers/utils/async_utils.py
+++ b/verifiers/utils/async_utils.py
@@ -122,10 +122,10 @@ class EventLoopLagMonitor:
         max_lag = lags[-1]
         p99_lag = lags[int(len(lags) * 0.99)]
         self.logger.info(
-            f"Event loop lag: mean={print_time(mean_lag)}, "
+            f"Measured event loop lag over the last {len(lags)} measurements ("
+            f"mean={print_time(mean_lag)}, "
             f"p99={print_time(p99_lag)}, "
-            f"max={print_time(max_lag)} "
-            f"(n={len(lags)})"
+            f"max={print_time(max_lag)})"
         )
         self.reset_lags()
 

--- a/verifiers/utils/async_utils.py
+++ b/verifiers/utils/async_utils.py
@@ -122,9 +122,9 @@ class EventLoopLagMonitor:
         max_lag = lags[-1]
         p99_lag = lags[int(len(lags) * 0.99)]
         self.logger.info(
-            f"Event loop lag: mean={mean_lag * 1000:.1f}ms, "
-            f"p99={p99_lag * 1000:.1f}ms, "
-            f"max={max_lag * 1000:.1f}ms "
+            f"Event loop lag: mean={print_time(mean_lag)}, "
+            f"p99={print_time(p99_lag)}, "
+            f"max={print_time(max_lag)} "
             f"(n={len(lags)})"
         )
         self.reset_lags()

--- a/verifiers/utils/async_utils.py
+++ b/verifiers/utils/async_utils.py
@@ -74,7 +74,7 @@ class EventLoopLagMonitor:
         self.logger = logger or logging.getLogger(
             f"{__name__}.{self.__class__.__name__}"
         )
-        self._lags: list[float] = []
+        self.lags: list[float] = []
         self.logger.debug(
             f"Event loop lag monitor initialized with measure_interval={self.measure_interval} and max_measurements={self.max_measurements}"
         )
@@ -87,21 +87,17 @@ class EventLoopLagMonitor:
         lag = now - next_time
         return lag
 
-    @property
-    def lags(self) -> list[float]:
-        return self._lags
-
     def reset(self):
         """Reset the list of measured event loop lags."""
-        self._lags = []
+        self.lags = []
 
     async def run(self):
         """Loop to measure event loop lag. Should be started as background task."""
         while True:
             lag = await self.measure_lag()
-            self._lags.append(lag)
-            if len(self._lags) > self.max_measurements:
-                self._lags.pop(0)
+            self.lags.append(lag)
+            if len(self.lags) > self.max_measurements:
+                self.lags.pop(0)
 
     def run_in_background(self):
         """Run the event loop lag monitor as a background task."""

--- a/verifiers/utils/async_utils.py
+++ b/verifiers/utils/async_utils.py
@@ -74,7 +74,7 @@ class EventLoopLagMonitor:
         self.logger = logger or logging.getLogger(
             f"{__name__}.{self.__class__.__name__}"
         )
-        self.lags = []
+        self._lags: list[float] = []
         self.logger.debug(
             f"Event loop lag monitor initialized with measure_interval={self.measure_interval} and max_measurements={self.max_measurements}"
         )
@@ -87,47 +87,25 @@ class EventLoopLagMonitor:
         lag = now - next_time
         return lag
 
-    def get_lags(self) -> list[float]:
-        """Get the list of measured event loop lags."""
-        return self.lags
+    @property
+    def lags(self) -> list[float]:
+        return self._lags
 
-    def reset_lags(self):
+    def reset(self):
         """Reset the list of measured event loop lags."""
-        self.lags = []
+        self._lags = []
 
-    async def run(self, log_interval: float | None = None):
+    async def run(self):
         """Loop to measure event loop lag. Should be started as background task."""
-        last_log_time = perf_counter()
-
         while True:
             lag = await self.measure_lag()
-            self.lags.append(lag)
-            if len(self.lags) > self.max_measurements:
-                self.lags.pop(0)
+            self._lags.append(lag)
+            if len(self._lags) > self.max_measurements:
+                self._lags.pop(0)
 
-            if log_interval and perf_counter() - last_log_time >= log_interval:
-                self._log_summary()
-                last_log_time = perf_counter()
-
-    def run_in_background(self, log_interval: float | None = None):
+    def run_in_background(self):
         """Run the event loop lag monitor as a background task."""
-        return asyncio.create_task(self.run(log_interval=log_interval))
-
-    def _log_summary(self):
-        """Log a summary of recent event loop lag measurements."""
-        if not self.lags:
-            return
-        lags = sorted(self.lags)
-        mean_lag = sum(lags) / len(lags)
-        max_lag = lags[-1]
-        p99_lag = lags[int(len(lags) * 0.99)]
-        self.logger.info(
-            f"Measured event loop lag over the last {len(lags)} measurements ("
-            f"mean={print_time(mean_lag)}, "
-            f"p99={print_time(p99_lag)}, "
-            f"max={print_time(max_lag)})"
-        )
-        self.reset_lags()
+        return asyncio.create_task(self.run())
 
 
 def maybe_retry(

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -670,7 +670,7 @@ async def run_evaluations(config: EvalRunConfig) -> None:
     if config.heartbeat_url is not None:
         await heart.close()
 
-    event_loop_lags = event_loop_lag_monitor.get_lags()
+    event_loop_lags = event_loop_lag_monitor.lags
     logger.info(f"Evaluation completed in {end_time - start_time:.2f} seconds")
 
     for results in all_results:

--- a/verifiers/utils/worker_utils.py
+++ b/verifiers/utils/worker_utils.py
@@ -3,13 +3,9 @@ import socket
 from datetime import date, datetime
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING
 from uuid import UUID
 
 import numpy as np
-
-if TYPE_CHECKING:
-    pass
 
 logger = logging.getLogger(__name__)
 

--- a/verifiers/utils/worker_utils.py
+++ b/verifiers/utils/worker_utils.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 import socket
 from datetime import date, datetime
@@ -9,10 +8,8 @@ from uuid import UUID
 
 import numpy as np
 
-from verifiers.utils.logging_utils import print_time
-
 if TYPE_CHECKING:
-    from verifiers.workers.client.env_client import EnvClient
+    pass
 
 logger = logging.getLogger(__name__)
 
@@ -48,30 +45,3 @@ def get_free_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind(("localhost", 0))
         return s.getsockname()[1]
-
-
-async def wait_for_env_server(
-    env_client: "EnvClient",
-    interval: float = 1,
-    log_interval: float = 10,
-    timeout: float = 3600,  # 1h
-) -> None:
-    wait_time = 0
-    logger.debug(f"Starting pinging environment server at {env_client.address}")
-    while wait_time < timeout:
-        try:
-            await env_client.health(timeout=1)  # quick timeout
-            logger.debug(
-                f"Environment server at {env_client.address} is ready after {print_time(wait_time)}"
-            )
-            return
-        except Exception as e:
-            if wait_time % log_interval == 0 and wait_time > 0:
-                logger.warning(
-                    f"Environment server at {env_client.address} was not reached after {print_time(wait_time)} (Error: {e})"
-                )
-            await asyncio.sleep(interval)
-            wait_time += interval
-    msg = f"Environment server at {env_client.address} is not ready after {print_time(wait_time)} (>{print_time(timeout)}). Aborting..."
-    logger.error(msg)
-    raise TimeoutError(msg)

--- a/verifiers/utils/worker_utils.py
+++ b/verifiers/utils/worker_utils.py
@@ -41,3 +41,23 @@ def get_free_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind(("localhost", 0))
         return s.getsockname()[1]
+
+
+def get_free_port_pair() -> int:
+    """Get a free port whose successor (port+1) is also free.
+
+    Used when the server needs two adjacent ports (e.g. work + health).
+    """
+    for _ in range(10):
+        with (
+            socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s1,
+            socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s2,
+        ):
+            s1.bind(("localhost", 0))
+            port = s1.getsockname()[1]
+            try:
+                s2.bind(("localhost", port + 1))
+                return port
+            except OSError:
+                continue
+    raise RuntimeError("Could not find a free port pair after 10 attempts")

--- a/verifiers/utils/worker_utils.py
+++ b/verifiers/utils/worker_utils.py
@@ -44,10 +44,7 @@ def get_free_port() -> int:
 
 
 def get_free_port_pair() -> int:
-    """Get a free port whose successor (port+1) is also free.
-
-    Used when the server needs two adjacent ports (e.g. work + health).
-    """
+    """Get a free port whose successor (port+1) is also free."""
     for _ in range(10):
         with (
             socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s1,

--- a/verifiers/workers/client/env_client.py
+++ b/verifiers/workers/client/env_client.py
@@ -133,7 +133,9 @@ class EnvClient(ABC):
         ...
 
     @abstractmethod
-    async def cancel_all_pending(self) -> list[PendingRequest]:
+    async def cancel_all_pending(
+        self, reason: str = "Request cancelled"
+    ) -> list[PendingRequest]:
         """Cancel all pending requests and return their metadata."""
         ...
 

--- a/verifiers/workers/client/env_client.py
+++ b/verifiers/workers/client/env_client.py
@@ -107,16 +107,13 @@ class EnvClient(ABC):
         start_time = time.time()
 
         while time.time() - start_time < timeout:
-            try:
-                is_healthy = await self.health(timeout=interval)
-                if is_healthy:
-                    elapsed = time.time() - start_time
-                    self.logger.info(
-                        f"Server at {self.address} became healthy after {print_time(elapsed)}"
-                    )
-                    return
-            except Exception as e:
-                self.logger.debug(f"Health check failed: {e}")
+            is_healthy = await self.health(timeout=interval)
+            if is_healthy:
+                elapsed = time.time() - start_time
+                self.logger.info(
+                    f"Server at {self.address} became healthy after {print_time(elapsed)}"
+                )
+                return
 
             await asyncio.sleep(interval)
 

--- a/verifiers/workers/client/env_client.py
+++ b/verifiers/workers/client/env_client.py
@@ -24,12 +24,14 @@ class EnvClient(ABC):
     def __init__(
         self,
         address: str,
+        name: str | None = None,
         health_check_interval: float = 1.0,  # 1s
         startup_timeout: float = 600.0,  # 10min
         recovery_timeout: float = 600.0,  # 10min
     ):
         self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
         self.address = address
+        self.name = f"{name} ({address})" if name is not None else address
 
         self.health_check_interval = health_check_interval
         self.startup_timeout = startup_timeout

--- a/verifiers/workers/client/env_client.py
+++ b/verifiers/workers/client/env_client.py
@@ -25,7 +25,7 @@ class EnvClient(ABC):
         self,
         address: str,
         name: str | None = None,
-        health_check_interval: float = 10.0,  # 10s
+        health_check_interval: float = 1.0,  # 1s
         startup_timeout: float = 600.0,  # 10min
         recovery_timeout: float = 600.0,  # 10min
     ):
@@ -37,7 +37,7 @@ class EnvClient(ABC):
         self.startup_timeout = startup_timeout
         self.recovery_timeout = recovery_timeout
 
-    async def health(self, timeout: float | None = 10) -> bool:
+    async def health(self, timeout: float | None = 1) -> bool:
         request = HealthRequest()
         response = await self.handle_health_request(request, timeout=timeout)
         return response.success

--- a/verifiers/workers/client/env_client.py
+++ b/verifiers/workers/client/env_client.py
@@ -32,6 +32,7 @@ class EnvClient(ABC):
         health_check_interval: float = 10.0,  # 10s
         startup_timeout: float = 600.0,  # 10min
         recovery_timeout: float = 600.0,  # 10min
+        max_auto_retries: int = 3,  # Number of times to retry after server failure
     ):
         self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
         self.address = address
@@ -39,6 +40,7 @@ class EnvClient(ABC):
         self.health_check_interval = health_check_interval
         self.startup_timeout = startup_timeout
         self.recovery_timeout = recovery_timeout
+        self.max_auto_retries = max_auto_retries
 
     async def health(self, timeout: float | None = 10) -> bool:
         request = HealthRequest()

--- a/verifiers/workers/client/env_client.py
+++ b/verifiers/workers/client/env_client.py
@@ -11,6 +11,7 @@ from verifiers.utils.client_utils import resolve_client_config
 from verifiers.workers.types import (
     HealthRequest,
     HealthResponse,
+    PendingTaskInfo,
     RunGroupRequest,
     RunGroupResponse,
     RunRolloutRequest,
@@ -91,6 +92,22 @@ class EnvClient(ABC):
         self, request: RunGroupRequest, timeout: float | None
     ) -> RunGroupResponse:
         """Run a group of rollouts on the remote environment server."""
+        ...
+
+    @abstractmethod
+    async def cancel_all_pending(
+        self, reason: str = "Cancelled"
+    ) -> list[PendingTaskInfo]:
+        """Cancel all pending requests and return info about them."""
+        ...
+
+    @abstractmethod
+    async def wait_for_recovery(
+        self,
+        timeout: float = 600.0,  # 10m
+        check_interval: float = 10.0,  # 10s
+    ) -> None:
+        """Wait for server to recover after a failure."""
         ...
 
     @abstractmethod

--- a/verifiers/workers/client/env_client.py
+++ b/verifiers/workers/client/env_client.py
@@ -25,7 +25,7 @@ class EnvClient(ABC):
         self,
         address: str,
         name: str | None = None,
-        health_check_interval: float = 1.0,  # 1s
+        health_check_interval: float = 10.0,  # 10s
         startup_timeout: float = 600.0,  # 10min
         recovery_timeout: float = 600.0,  # 10min
     ):

--- a/verifiers/workers/client/zmq_env_client.py
+++ b/verifiers/workers/client/zmq_env_client.py
@@ -256,10 +256,6 @@ class ZMQEnvClient(EnvClient):
                 self._pending_requests.pop(request_id, None)
             raise
 
-        # Clean up metadata on success (receive loop already popped it, but do it here too for safety)
-        async with self._pending_lock:
-            self._pending_requests.pop(request_id, None)
-
         # validate response with Pydantic
         response = response_type.model_validate(raw_response)
 

--- a/verifiers/workers/client/zmq_env_client.py
+++ b/verifiers/workers/client/zmq_env_client.py
@@ -325,11 +325,6 @@ class ZMQEnvClient(EnvClient):
                     f"Request {request_id[:7]} waiting for env server {self.name} to recover ({e})"
                 )
 
-                # Wait for health check loop to detect recovery.
-                # Don't clear _healthy_event here — the health loop already
-                # cleared it during the UNHEALTHY transition. Clearing again
-                # would race with a recovery that happened between the
-                # transition and this point.
                 try:
                     await asyncio.wait_for(
                         self._healthy_event.wait(),

--- a/verifiers/workers/client/zmq_env_client.py
+++ b/verifiers/workers/client/zmq_env_client.py
@@ -182,7 +182,7 @@ class ZMQEnvClient(EnvClient):
                     except Exception as unpack_error:
                         # Unpacking failed - fail the specific future
                         self.logger.error(
-                            f"Failed to unpack response for request {request_id}: {unpack_error}"
+                            f"Request {request_id[:7]} failed to unpack response: {unpack_error}"
                         )
                         pending_req.future.set_exception(
                             RuntimeError(
@@ -190,10 +190,7 @@ class ZMQEnvClient(EnvClient):
                             )
                         )
                 elif pending_req is None:
-                    self.logger.debug(
-                        f"Received response for unknown request_id={request_id} "
-                        f"(pending={len(self._pending_requests)})"
-                    )
+                    pass  # ignore responses for requests we already popped (e.g. timed out)
 
             except asyncio.CancelledError:
                 break
@@ -273,7 +270,7 @@ class ZMQEnvClient(EnvClient):
                     else self.logger.error
                 )
                 log(
-                    f"Timed out waiting for request_id={request_id} "
+                    f"Request {request_id[:7]} timed out "
                     f"type={request.request_type} "
                     f"after {effective_timeout:.1f}s "
                     f"(pending={len(self._pending_requests)})"
@@ -284,7 +281,7 @@ class ZMQEnvClient(EnvClient):
                 )
             except ServerError as e:
                 self.logger.debug(
-                    f"Request {request_id[:8]} waiting for server recovery: {e}"
+                    f"Request {request_id[:7]} waiting for server recovery: {e}"
                 )
 
                 # Wait for health check loop to detect recovery

--- a/verifiers/workers/client/zmq_env_client.py
+++ b/verifiers/workers/client/zmq_env_client.py
@@ -132,39 +132,6 @@ class ZMQEnvClient(EnvClient):
 
         return cancelled_requests
 
-    async def wait_for_server_health(
-        self,
-        timeout: float = 600.0,
-        check_interval: float = 10.0,
-    ) -> None:
-        """Wait for server to become healthy.
-
-        Universal method for both initial startup and recovery scenarios.
-        """
-        self.logger.info(
-            f"Waiting for server to become healthy (timeout={print_time(timeout)})..."
-        )
-        start_time = time.time()
-
-        while time.time() - start_time < timeout:
-            try:
-                is_healthy = await self.health(timeout=check_interval)
-                if is_healthy:
-                    self._failed_health_checks = 0
-                    self.logger.info(
-                        f"Server is healthy after {print_time(time.time() - start_time)}"
-                    )
-                    return
-            except Exception as e:
-                self.logger.debug(f"Health check failed: {e}")
-
-            await asyncio.sleep(check_interval)
-
-        # Timeout reached
-        raise TimeoutError(
-            f"Server did not become healthy within {print_time(timeout)}"
-        )
-
     def _fail_all_pending(self, reason: str):
         """Fail all pending requests synchronously."""
         pending_count = len(self.pending_requests)

--- a/verifiers/workers/client/zmq_env_client.py
+++ b/verifiers/workers/client/zmq_env_client.py
@@ -190,7 +190,7 @@ class ZMQEnvClient(EnvClient):
                             )
                         )
                 elif pending_req is None:
-                    self.logger.warning(
+                    self.logger.debug(
                         f"Received response for unknown request_id={request_id} "
                         f"(pending={len(self._pending_requests)})"
                     )

--- a/verifiers/workers/client/zmq_env_client.py
+++ b/verifiers/workers/client/zmq_env_client.py
@@ -1,6 +1,7 @@
 import asyncio
 import time
 import uuid
+from asyncio import Future
 from typing import cast
 
 import msgpack
@@ -247,7 +248,7 @@ class ZMQEnvClient(EnvClient):
             )
 
             # Create future and pending request atomically
-            future: asyncio.Future[dict] = asyncio.Future()
+            future: Future = asyncio.Future()
             pending_req = PendingRequest(
                 request_id=request_id,
                 request=request,

--- a/verifiers/workers/client/zmq_env_client.py
+++ b/verifiers/workers/client/zmq_env_client.py
@@ -95,6 +95,8 @@ class ZMQEnvClient(EnvClient):
                             "Server is likely unhealthy as 3 consecutive health checks failed"
                         )
 
+                await asyncio.sleep(self.health_check_interval)
+
             except asyncio.CancelledError:
                 self.logger.debug("Health check loop cancelled")
                 break

--- a/verifiers/workers/client/zmq_env_client.py
+++ b/verifiers/workers/client/zmq_env_client.py
@@ -89,7 +89,7 @@ class ZMQEnvClient(EnvClient):
         timeout = timeout if timeout is not None else self.startup_timeout
         self.logger.info(
             f"Waiting for env server {self.name} to become healthy "
-            f"(timeout={print_time(timeout)})..."
+            f"(timeout={print_time(timeout)})"
         )
         await self._ensure_started()
         try:

--- a/verifiers/workers/client/zmq_env_client.py
+++ b/verifiers/workers/client/zmq_env_client.py
@@ -146,7 +146,6 @@ class ZMQEnvClient(EnvClient):
             except asyncio.CancelledError:
                 break
             except zmq.ZMQError as e:
-                # Socket-level error - cancel all pending requests and exit
                 self.logger.error(f"ZMQ socket error in receive loop: {e}")
                 await self._cancel_all_pending(f"ZMQ socket error: {e}")
                 break
@@ -199,8 +198,6 @@ class ZMQEnvClient(EnvClient):
 
         # Create future and pending request atomically
         future: asyncio.Future[dict] = asyncio.Future()
-        from verifiers.workers.types import PendingRequest
-
         pending_req = PendingRequest(
             request_id=request_id,
             request=request,

--- a/verifiers/workers/client/zmq_env_client.py
+++ b/verifiers/workers/client/zmq_env_client.py
@@ -51,14 +51,18 @@ class ZMQEnvClient(EnvClient):
             zmq.TCP_KEEPALIVE_CNT, 3
         )  # Give up after 3 failed probes
 
-        # Single dict for all pending requests (includes futures)
-        self.pending_requests: dict[str, PendingRequest] = {}
+        self._receiver_lock = asyncio.Lock()
         self._receiver_task: asyncio.Task | None = None
-        self._start_lock = asyncio.Lock()
+
+        # Track pending requests
+        self._pending_requests: dict[str, PendingRequest] = {}
         self._pending_lock = asyncio.Lock()
+
+        # Run health check loop
+        self._server_state = ServerState.STARTUP
+        self._health_check_lock = asyncio.Lock()
         self._health_check_task: asyncio.Task | None = None
         self._failed_health_checks = 0
-        self._server_state = ServerState.STARTUP
 
     async def handle_health_request(
         self, request: HealthRequest, timeout: float | None
@@ -75,103 +79,19 @@ class ZMQEnvClient(EnvClient):
     ) -> RunGroupResponse:
         return await self._send_request(request, RunGroupResponse, timeout=timeout)
 
-    async def wait_for_server_recovery(
-        self,
-        timeout: float | None = None,
-        interval: float | None = None,
-    ) -> None:
-        """Wait for server to recover, managing state transitions."""
-        self.logger.info(
-            "Entering recovery mode - waiting for server to become healthy"
-        )
-        self._server_state = ServerState.RECOVERING
-
-        # Wait for server to become healthy (base class handles the actual waiting)
-        await super().wait_for_server_recovery(timeout=timeout, interval=interval)
-
-        # Recovery successful - transition to HEALTHY
-        self._server_state = ServerState.HEALTHY
-        self._failed_health_checks = 0
-        self.logger.info("Recovery complete - server is healthy")
-
-    async def _health_check_loop(self):
-        """Background task that periodically checks server health."""
-        self.logger.debug(
-            f"Starting health check loop (interval={print_time(self.health_check_interval)})"
-        )
-
-        while True:
-            try:
-                # Skip health checks if we're in RECOVERING state
-                # (wait_for_server_recovery does its own health polling)
-                if self._server_state == ServerState.RECOVERING:
-                    await asyncio.sleep(self.health_check_interval)
-                    continue
-
-                try:
-                    await self.health(timeout=self.health_check_interval)
-                    # Health check passed
-
-                    # Transition from STARTUP or UNHEALTHY to HEALTHY
-                    if self._server_state in (
-                        ServerState.STARTUP,
-                        ServerState.UNHEALTHY,
-                    ):
-                        if self._server_state == ServerState.STARTUP:
-                            self.logger.info(
-                                "Server is healthy - initial startup complete"
-                            )
-                        else:
-                            self.logger.info(
-                                "Server health check passed - server recovered"
-                            )
-                        self._server_state = ServerState.HEALTHY
-
-                    self._failed_health_checks = 0
-
-                except Exception as e:
-                    self._failed_health_checks += 1
-                    self.logger.debug(
-                        f"Health check failed ({self._failed_health_checks} consecutive): {e}"
-                    )
-
-                    # Transition from HEALTHY to UNHEALTHY after 3 consecutive failures
-                    if (
-                        self._server_state == ServerState.HEALTHY
-                        and self._failed_health_checks >= 3
-                    ):
-                        self.logger.warning(
-                            "Server is unhealthy after 3 consecutive health check failures - "
-                            "cancelling pending requests to trigger retry"
-                        )
-                        self._server_state = ServerState.UNHEALTHY
-                        await self.cancel_all_pending(
-                            f"Server unhealthy: {self._failed_health_checks} consecutive health check failures"
-                        )
-
-                await asyncio.sleep(self.health_check_interval)
-
-            except asyncio.CancelledError:
-                self.logger.debug("Health check loop cancelled")
-                break
-            except Exception as e:
-                self.logger.error(
-                    f"Unexpected error in health check loop: {e}", exc_info=True
-                )
-
-    async def cancel_all_pending(
+    async def _cancel_all_pending(
         self, reason: str = "Request cancelled"
     ) -> list[PendingRequest]:
         """Cancel all pending requests and return their metadata."""
         async with self._pending_lock:
-            pending_count = len(self.pending_requests)
+            pending_count = len(self._pending_requests)
             if pending_count:
                 self.logger.warning(
                     f"Cancelling {pending_count} pending request(s): {reason}"
                 )
 
             # Collect metadata before clearing
-            cancelled_requests = list(self.pending_requests.values())
+            cancelled_requests = list(self._pending_requests.values())
 
             # Fail all futures with the provided reason
             for pending_req in cancelled_requests:
@@ -179,7 +99,7 @@ class ZMQEnvClient(EnvClient):
                     pending_req.future.set_exception(RuntimeError(reason))
 
             # Clear tracking dict
-            self.pending_requests.clear()
+            self._pending_requests.clear()
 
         return cancelled_requests
 
@@ -201,7 +121,7 @@ class ZMQEnvClient(EnvClient):
 
                 # Pop pending request atomically
                 async with self._pending_lock:
-                    pending_req = self.pending_requests.pop(request_id, None)
+                    pending_req = self._pending_requests.pop(request_id, None)
 
                 if pending_req is not None and not pending_req.future.done():
                     try:
@@ -220,7 +140,7 @@ class ZMQEnvClient(EnvClient):
                 elif pending_req is None:
                     self.logger.warning(
                         f"Received response for unknown request_id={request_id} "
-                        f"(pending={len(self.pending_requests)})"
+                        f"(pending={len(self._pending_requests)})"
                     )
 
             except asyncio.CancelledError:
@@ -228,7 +148,7 @@ class ZMQEnvClient(EnvClient):
             except zmq.ZMQError as e:
                 # Socket-level error - cancel all pending requests and exit
                 self.logger.error(f"ZMQ socket error in receive loop: {e}")
-                await self.cancel_all_pending(f"ZMQ socket error: {e}")
+                await self._cancel_all_pending(f"ZMQ socket error: {e}")
                 break
             except Exception as e:
                 self.logger.error(
@@ -250,13 +170,13 @@ class ZMQEnvClient(EnvClient):
         """Send request to environment and await response with automatic retry."""
         # auto-start receiver if not already running (with lock to prevent race)
         if self._receiver_task is None:
-            async with self._start_lock:
+            async with self._receiver_lock:
                 if self._receiver_task is None:
                     await self._start()
 
         # Start health check task if enabled and not running
         if self.health_check_interval > 0 and self._health_check_task is None:
-            async with self._start_lock:
+            async with self._health_check_lock:
                 if self._health_check_task is None:
                     self._health_check_task = asyncio.create_task(
                         self._health_check_loop()
@@ -290,7 +210,7 @@ class ZMQEnvClient(EnvClient):
         )
 
         async with self._pending_lock:
-            self.pending_requests[request_id] = pending_req
+            self._pending_requests[request_id] = pending_req
 
         await self.socket.send_multipart([request_id.encode(), payload_bytes])
 
@@ -299,10 +219,10 @@ class ZMQEnvClient(EnvClient):
         except asyncio.TimeoutError:
             # Clean up on timeout
             async with self._pending_lock:
-                self.pending_requests.pop(request_id, None)
+                self._pending_requests.pop(request_id, None)
             self.logger.error(
                 f"Timed out waiting for request_id={request_id} type={request.request_type} "
-                f"after {effective_timeout:.1f}s (pending={len(self.pending_requests)})"
+                f"after {effective_timeout:.1f}s (pending={len(self._pending_requests)})"
             )
             raise TimeoutError(
                 f"Environment timeout for {request.request_type} request after {effective_timeout}s"
@@ -322,8 +242,8 @@ class ZMQEnvClient(EnvClient):
                 )
                 self.logger.info("Waiting for server recovery before retry...")
 
-                # Wait for server to recover (ZMQ handles reconnection automatically)
-                await self.wait_for_server_recovery()
+                # Wait for server to recover
+                await self._wait_for_server_recovery()
 
                 # Retry with incremented attempt counter
                 self.logger.info(
@@ -336,12 +256,12 @@ class ZMQEnvClient(EnvClient):
             # Either not a server error or exceeded max retries
             # Clean up metadata before re-raising
             async with self._pending_lock:
-                self.pending_requests.pop(request_id, None)
+                self._pending_requests.pop(request_id, None)
             raise
 
         # Clean up metadata on success (receive loop already popped it, but do it here too for safety)
         async with self._pending_lock:
-            self.pending_requests.pop(request_id, None)
+            self._pending_requests.pop(request_id, None)
 
         # validate response with Pydantic
         response = response_type.model_validate(raw_response)
@@ -372,7 +292,7 @@ class ZMQEnvClient(EnvClient):
             self._receiver_task = None
 
         # Cancel all pending requests
-        cancelled = await self.cancel_all_pending()
+        cancelled = await self._cancel_all_pending()
         if cancelled:
             self.logger.info(
                 f"Cancelled {len(cancelled)} pending requests during close"
@@ -381,3 +301,65 @@ class ZMQEnvClient(EnvClient):
         # Close socket and terminate context
         self.socket.close()
         self.ctx.term()
+
+    async def _health_check_loop(self):
+        """Background task that periodically checks server health."""
+        self.logger.debug(
+            f"Starting health check loop (interval={print_time(self.health_check_interval)})"
+        )
+
+        while True:
+            try:
+                # Skip health checks if server is recovering
+                if self._server_state == ServerState.RECOVERING:
+                    await asyncio.sleep(self.health_check_interval)
+                    continue
+
+                try:
+                    await self.health(timeout=self.health_check_interval)
+                    self._server_state = ServerState.HEALTHY
+                    self._failed_health_checks = 0
+                except Exception as e:
+                    self._failed_health_checks += 1
+                    self.logger.debug(
+                        f"Health check failed ({self._failed_health_checks} consecutive): {e}"
+                    )
+
+                    # Transition from HEALTHY to UNHEALTHY after 3 consecutive failures
+                    if (
+                        self._server_state == ServerState.HEALTHY
+                        and self._failed_health_checks >= 3
+                    ):
+                        self.logger.warning(
+                            "Server is unhealthy after 3 consecutive health check failures - "
+                            "cancelling pending requests to trigger retry"
+                        )
+                        self._server_state = ServerState.UNHEALTHY
+                        await self._cancel_all_pending(
+                            f"Server unhealthy: {self._failed_health_checks} consecutive health check failures"
+                        )
+
+                await asyncio.sleep(self.health_check_interval)
+
+            except asyncio.CancelledError:
+                self.logger.debug("Health check loop cancelled")
+                break
+            except Exception as e:
+                self.logger.error(
+                    f"Unexpected error in health check loop: {e}", exc_info=True
+                )
+
+    async def _wait_for_server_recovery(
+        self,
+        timeout: float | None = None,
+        interval: float | None = None,
+    ) -> None:
+        """Wait for server to recover, managing state transitions."""
+        self._server_state = ServerState.RECOVERING
+
+        timeout = timeout if timeout is not None else self.recovery_timeout
+        interval = interval if interval is not None else self.health_check_interval
+        await self._wait_for_server_health(timeout=timeout, interval=interval)
+
+        self._server_state = ServerState.HEALTHY
+        self._failed_health_checks = 0

--- a/verifiers/workers/client/zmq_env_client.py
+++ b/verifiers/workers/client/zmq_env_client.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 import uuid
 from typing import cast
 
@@ -6,6 +7,7 @@ import msgpack
 import zmq
 import zmq.asyncio
 
+from verifiers.utils.logging_utils import print_time
 from verifiers.utils.worker_utils import msgpack_encoder
 from verifiers.workers.client.env_client import EnvClient
 from verifiers.workers.types import (
@@ -13,10 +15,12 @@ from verifiers.workers.types import (
     BaseResponseT,
     HealthRequest,
     HealthResponse,
+    PendingTaskInfo,
     RunGroupRequest,
     RunGroupResponse,
     RunRolloutRequest,
     RunRolloutResponse,
+    ServerState,
 )
 
 
@@ -25,7 +29,13 @@ class ZMQEnvClient(EnvClient):
 
     DEFAULT_REQUEST_TIMEOUT = 36_000  # 10h
 
-    def __init__(self, address: str = "tcp://127.0.0.1:5000"):
+    def __init__(
+        self,
+        address: str = "tcp://127.0.0.1:5000",
+        health_check_interval: float = 60.0,  # 1m, 0 to disable
+        health_check_timeout: float = 1.0,  # 1s
+        recovery_timeout: float = 600.0,  # 10m
+    ):
         super().__init__(address=address)
 
         # DEALER socket for async request/response
@@ -45,9 +55,25 @@ class ZMQEnvClient(EnvClient):
             zmq.TCP_KEEPALIVE_CNT, 3
         )  # Give up after 3 failed probes
 
+        # Existing state
         self.pending: dict[str, asyncio.Future] = {}
         self._receiver_task: asyncio.Task | None = None
         self._start_lock = asyncio.Lock()
+
+        # Task metadata cache for rescheduling
+        self.pending_tasks: dict[str, PendingTaskInfo] = {}
+        self._pending_lock = asyncio.Lock()
+
+        # Health check configuration
+        self.health_check_interval = health_check_interval
+        self.health_check_timeout = health_check_timeout
+        self.recovery_timeout = recovery_timeout
+
+        # Server state management
+        self._server_state = ServerState.HEALTHY
+        self._state_lock = asyncio.Lock()
+        self._health_check_task: asyncio.Task | None = None
+        self._failed_health_checks = 0
 
     async def handle_health_request(
         self, request: HealthRequest, timeout: float | None
@@ -64,15 +90,139 @@ class ZMQEnvClient(EnvClient):
     ) -> RunGroupResponse:
         return await self._send_request(request, RunGroupResponse, timeout=timeout)
 
+    async def _health_check_loop(self):
+        """Background task that periodically checks server health."""
+        self.logger.debug(
+            f"Starting health check loop (interval={print_time(self.health_check_interval)})"
+        )
+
+        while True:
+            try:
+                await asyncio.sleep(self.health_check_interval)
+
+                # Skip if we're already recovering
+                async with self._state_lock:
+                    if self._server_state == ServerState.RECOVERING:
+                        continue
+
+                # Perform health check
+                try:
+                    is_healthy = await self.health(timeout=self.health_check_timeout)
+                    if is_healthy:
+                        async with self._state_lock:
+                            if self._server_state != ServerState.HEALTHY:
+                                self.logger.info("Server recovered")
+                                self._server_state = ServerState.HEALTHY
+                            self._failed_health_checks = 0
+                    else:
+                        # Health check returned False (shouldn't happen but handle it)
+                        self._failed_health_checks += 1
+                        self.logger.warning(
+                            f"Health check failed ({self._failed_health_checks} consecutive)"
+                        )
+
+                except Exception as e:
+                    self._failed_health_checks += 1
+                    self.logger.warning(
+                        f"Health check error ({self._failed_health_checks} consecutive): {e}"
+                    )
+
+                    # Mark as unhealthy after 2 consecutive failures
+                    if self._failed_health_checks >= 2:
+                        async with self._state_lock:
+                            if self._server_state == ServerState.HEALTHY:
+                                self.logger.error("Server found to be unhealthy")
+                                self._server_state = ServerState.UNHEALTHY
+
+            except asyncio.CancelledError:
+                self.logger.debug("Health check loop cancelled")
+                break
+            except Exception as e:
+                self.logger.error(
+                    f"Unexpected error in health check loop: {e}", exc_info=True
+                )
+
+    async def cancel_all_pending(
+        self, reason: str = "Cancelled"
+    ) -> list[PendingTaskInfo]:
+        """Cancel all pending requests and return their metadata."""
+        async with self._pending_lock:
+            pending_count = len(self.pending)
+            if pending_count:
+                self.logger.warning(
+                    f"Cancelling {pending_count} pending request(s): {reason}"
+                )
+
+            # Collect metadata before clearing
+            cancelled_tasks = list(self.pending_tasks.values())
+
+            # Fail all futures
+            for request_id, future in list(self.pending.items()):
+                if not future.done():
+                    future.set_exception(RuntimeError(reason))
+
+            # Clear both tracking dicts
+            self.pending.clear()
+            self.pending_tasks.clear()
+
+        return cancelled_tasks
+
+    async def wait_for_recovery(
+        self,
+        timeout: float = 600.0,
+        check_interval: float = 10.0,
+    ) -> None:
+        """Wait for server to recover after a failure."""
+        async with self._state_lock:
+            self._server_state = ServerState.RECOVERING
+
+        self.logger.info(f"Waiting for server recovery (timeout={timeout}s)...")
+        start_time = time.time()
+
+        while time.time() - start_time < timeout:
+            try:
+                is_healthy = await self.health(timeout=check_interval)
+                if is_healthy:
+                    async with self._state_lock:
+                        self._server_state = ServerState.HEALTHY
+                        self._failed_health_checks = 0
+                    self.logger.info("Server has recovered")
+                    return
+            except Exception as e:
+                self.logger.debug(f"Recovery check failed: {e}")
+
+            await asyncio.sleep(check_interval)
+
+        # Timeout reached
+        async with self._state_lock:
+            self._server_state = ServerState.UNHEALTHY
+        raise TimeoutError(f"Server did not recover within {print_time(timeout)}")
+
+    async def _cancel_and_maybe_recover(self, reason: str):
+        """Cancel all pending and mark server as unhealthy."""
+        await self.cancel_all_pending(reason)
+        async with self._state_lock:
+            self._server_state = ServerState.UNHEALTHY
+
     def _fail_all_pending(self, reason: str):
-        """Fail all pending futures with the given reason."""
-        pending_count = len(self.pending)
-        if pending_count:
-            self.logger.warning(f"Failing {pending_count} pending request(s): {reason}")
-        for _, future in list(self.pending.items()):
-            if not future.done():
-                future.set_exception(RuntimeError(reason))
-        self.pending.clear()
+        """Synchronous wrapper for failing all pending requests."""
+        # Schedule the async cancel method
+        try:
+            loop = asyncio.get_running_loop()
+            # Fire and forget - don't await
+            loop.create_task(self._cancel_and_maybe_recover(reason))
+        except RuntimeError:
+            # No event loop running, fail synchronously
+            pending_count = len(self.pending)
+            if pending_count:
+                self.logger.warning(
+                    f"Failing {pending_count} pending request(s): {reason}"
+                )
+            for request_id, future in list(self.pending.items()):
+                if not future.done():
+                    future.set_exception(RuntimeError(reason))
+            self.pending.clear()
+            self.pending_tasks.clear()
 
     async def _receive_loop(self):
         """Continuously receive responses from environment servers."""
@@ -90,23 +240,26 @@ class ZMQEnvClient(EnvClient):
                 request_id_bytes, response_data = msg[0], msg[1]
                 request_id = request_id_bytes.decode()
 
-                if request_id in self.pending:
-                    future = self.pending.pop(request_id)
-                    if not future.done():
-                        try:
-                            response = msgpack.unpackb(response_data, raw=False)
-                            future.set_result(response)
-                        except Exception as unpack_error:
-                            # Unpacking failed - fail the specific future
-                            self.logger.error(
-                                f"Failed to unpack response for request {request_id}: {unpack_error}"
+                # Pop both future and metadata atomically
+                async with self._pending_lock:
+                    future = self.pending.pop(request_id, None)
+                    self.pending_tasks.pop(request_id, None)  # Clean up metadata
+
+                if future is not None and not future.done():
+                    try:
+                        response = msgpack.unpackb(response_data, raw=False)
+                        future.set_result(response)
+                    except Exception as unpack_error:
+                        # Unpacking failed - fail the specific future
+                        self.logger.error(
+                            f"Failed to unpack response for request {request_id}: {unpack_error}"
+                        )
+                        future.set_exception(
+                            RuntimeError(
+                                f"Failed to deserialize response: {unpack_error}"
                             )
-                            future.set_exception(
-                                RuntimeError(
-                                    f"Failed to deserialize response: {unpack_error}"
-                                )
-                            )
-                else:
+                        )
+                elif future is None:
                     self.logger.warning(
                         f"Received response for unknown request_id={request_id} (pending={len(self.pending)})"
                     )
@@ -134,12 +287,20 @@ class ZMQEnvClient(EnvClient):
         response_type: type[BaseResponseT],
         timeout: float | None = None,
     ) -> BaseResponseT:
-        """Send request to environment and await response"""
+        """Send request to environment and await response."""
         # auto-start receiver if not already running (with lock to prevent race)
         if self._receiver_task is None:
             async with self._start_lock:
                 if self._receiver_task is None:
                     await self._start()
+
+        # Start health check task if enabled and not running
+        if self.health_check_interval > 0 and self._health_check_task is None:
+            async with self._start_lock:
+                if self._health_check_task is None:
+                    self._health_check_task = asyncio.create_task(
+                        self._health_check_loop()
+                    )
 
         effective_timeout = self.DEFAULT_REQUEST_TIMEOUT if timeout is None else timeout
 
@@ -157,19 +318,49 @@ class ZMQEnvClient(EnvClient):
         )
 
         future: asyncio.Future[dict] = asyncio.Future()
-        self.pending[request_id] = future
+
+        # Store future and metadata atomically
+        async with self._pending_lock:
+            self.pending[request_id] = future
+            # Cache metadata for potential rescheduling
+            self.pending_tasks[request_id] = PendingTaskInfo(
+                request_id=request_id,
+                request=request,
+                submitted_at=time.time(),
+                timeout=effective_timeout,
+            )
+
         await self.socket.send_multipart([request_id.encode(), payload_bytes])
 
         try:
             raw_response = await asyncio.wait_for(future, timeout=effective_timeout)
         except asyncio.TimeoutError:
-            self.pending.pop(request_id, None)
+            # Clean up on timeout
+            async with self._pending_lock:
+                self.pending.pop(request_id, None)
+                self.pending_tasks.pop(request_id, None)
             self.logger.error(
-                f"Timed out waiting for request_id={request_id} type={request.request_type} after {effective_timeout:.1f}s (pending={len(self.pending)})"
+                f"Timed out waiting for request_id={request_id} type={request.request_type} "
+                f"after {effective_timeout:.1f}s (pending={len(self.pending)})"
             )
             raise TimeoutError(
                 f"Environment timeout for {request.request_type} request after {effective_timeout}s"
             )
+        except RuntimeError as e:
+            # Check if this is a server crash and we should retry
+            if "ZMQ socket error" in str(e) or "Client closed" in str(e):
+                self.logger.warning(
+                    "Request failed due to server error. Will retry after recovery..."
+                )
+                # Wait for server to recover
+                await self.wait_for_recovery(timeout=self.recovery_timeout)
+                # Retry with incremented attempt counter
+                return await self._send_request(request, response_type, timeout)
+            raise
+
+        # Clean up metadata on success
+        async with self._pending_lock:
+            self.pending_tasks.pop(request_id, None)
 
         # validate response with Pydantic
         response = response_type.model_validate(raw_response)
@@ -181,7 +372,16 @@ class ZMQEnvClient(EnvClient):
 
     async def close(self) -> None:
         """Close the client and clean up ZMQ resources."""
-        # Cancel the receiver task
+        # Cancel health check task
+        if self._health_check_task is not None:
+            self._health_check_task.cancel()
+            try:
+                await self._health_check_task
+            except asyncio.CancelledError:
+                pass
+            self._health_check_task = None
+
+        # Cancel receiver task
         if self._receiver_task is not None:
             self._receiver_task.cancel()
             try:
@@ -190,8 +390,10 @@ class ZMQEnvClient(EnvClient):
                 pass
             self._receiver_task = None
 
-        # Fail any pending futures
-        self._fail_all_pending("Client closed")
+        # Cancel all pending requests
+        cancelled = await self.cancel_all_pending("Client closed")
+        if cancelled:
+            self.logger.info(f"Cancelled {len(cancelled)} pending tasks during close")
 
         # Close socket and terminate context
         self.socket.close()

--- a/verifiers/workers/server/env_server.py
+++ b/verifiers/workers/server/env_server.py
@@ -100,13 +100,13 @@ class EnvServer(ABC):
 
         return asyncio.run(run_with_graceful_shutdown())
 
-    async def _handle_health(self, _request: HealthRequest) -> HealthResponse:
+    async def handle_health(self, _request: HealthRequest) -> HealthResponse:
         return HealthResponse()
 
-    async def _handle_run_rollout(
+    async def handle_run_rollout(
         self, request: RunRolloutRequest
     ) -> RunRolloutResponse:
-        client = await self._resolve_client(request.client_config)
+        client = await self.resolve_client(request.client_config)
         output = await self.env.run_rollout(
             input=request.input,
             client=client,
@@ -117,8 +117,8 @@ class EnvServer(ABC):
         )
         return RunRolloutResponse(output=output)
 
-    async def _handle_run_group(self, request: RunGroupRequest) -> RunGroupResponse:
-        client = await self._resolve_client(request.client_config)
+    async def handle_run_group(self, request: RunGroupRequest) -> RunGroupResponse:
+        client = await self.resolve_client(request.client_config)
         outputs = await self.env.run_group(
             group_inputs=request.group_inputs,
             client=client,
@@ -129,7 +129,7 @@ class EnvServer(ABC):
         )
         return RunGroupResponse(outputs=outputs)
 
-    async def _resolve_client(self, client_config: ClientConfig) -> Client:
+    async def resolve_client(self, client_config: ClientConfig) -> Client:
         resolved_client_config = resolve_client_config(client_config)
         client_key = resolved_client_config.model_dump_json()
         if client_key in self.clients:
@@ -138,7 +138,7 @@ class EnvServer(ABC):
         self.clients[client_key] = client
         return client
 
-    async def _close_cached_clients(self) -> None:
+    async def close_cached_clients(self) -> None:
         for client in self.clients.values():
             await client.close()
         self.clients.clear()

--- a/verifiers/workers/server/env_server.py
+++ b/verifiers/workers/server/env_server.py
@@ -8,6 +8,7 @@ from typing import Any
 import verifiers as vf
 from verifiers.clients import Client, resolve_client
 from verifiers.types import ClientConfig
+from verifiers.utils.async_utils import EventLoopLagMonitor
 from verifiers.utils.client_utils import resolve_client_config
 from verifiers.workers.types import (
     HealthRequest,
@@ -62,6 +63,9 @@ class EnvServer(ABC):
                 f"Setting extra environment kwargs: {self.extra_env_kwargs}"
             )
             self.env.set_kwargs(**self.extra_env_kwargs)
+
+        # Start event loop lag monitor
+        self.lag_monitor = EventLoopLagMonitor(logger=self.logger)
 
     @abstractmethod
     async def run(self, stop_event: asyncio.Event | None = None):

--- a/verifiers/workers/server/env_server.py
+++ b/verifiers/workers/server/env_server.py
@@ -9,7 +9,6 @@ import verifiers as vf
 from verifiers.clients import Client, resolve_client
 from verifiers.types import ClientConfig
 from verifiers.utils.client_utils import resolve_client_config
-from verifiers.utils.thread_utils import get_thread_local_storage
 from verifiers.workers.types import (
     HealthRequest,
     HealthResponse,
@@ -52,6 +51,7 @@ class EnvServer(ABC):
         self.env_args = env_args or {}
         self.extra_env_kwargs = extra_env_kwargs or {}
 
+        self.clients: dict[str, Client] = {}
         self.pending_tasks: set[asyncio.Task] = set()
 
         # load environment
@@ -126,22 +126,15 @@ class EnvServer(ABC):
         return RunGroupResponse(outputs=outputs)
 
     async def _resolve_client(self, client_config: ClientConfig) -> Client:
-        """Resolve a client from config, caching per thread."""
-        tls = get_thread_local_storage()
-        if not hasattr(tls, "clients"):
-            tls.clients = {}
-
         resolved_client_config = resolve_client_config(client_config)
         client_key = resolved_client_config.model_dump_json()
-        if client_key in tls.clients:
-            return tls.clients[client_key]
+        if client_key in self.clients:
+            return self.clients[client_key]
         client = resolve_client(resolved_client_config)
-        tls.clients[client_key] = client
+        self.clients[client_key] = client
         return client
 
     async def _close_cached_clients(self) -> None:
-        tls = get_thread_local_storage()
-        if hasattr(tls, "clients"):
-            for client in tls.clients.values():
-                await client.close()
-            tls.clients.clear()
+        for client in self.clients.values():
+            await client.close()
+        self.clients.clear()

--- a/verifiers/workers/server/zmq_env_server.py
+++ b/verifiers/workers/server/zmq_env_server.py
@@ -42,9 +42,7 @@ class ZMQEnvServer(EnvServer):
         self.socket.setsockopt(zmq.LINGER, 0)
         self.socket.bind(self.address)
 
-        # Health check runs on a dedicated thread with its own ZMQ socket,
-        # completely decoupled from the main event loop so it always responds
-        # even when rollout work saturates the loop.
+        # Health check runs completely decoupled (dedicated thread and ZMQ socket)
         self._stop_health = threading.Event()
         self._health_thread: threading.Thread | None = None
 

--- a/verifiers/workers/server/zmq_env_server.py
+++ b/verifiers/workers/server/zmq_env_server.py
@@ -25,12 +25,7 @@ def derive_health_address(address: str) -> str:
 class ZMQEnvServer(EnvServer):
     """ZMQ-based environment server."""
 
-    def __init__(
-        self,
-        *args,
-        address: str = "tcp://127.0.0.1:5000",
-        **kwargs,
-    ):
+    def __init__(self, *args, address: str = "tcp://127.0.0.1:5000", **kwargs):
         super().__init__(*args, **kwargs)
         self.address = address
         self.health_address = derive_health_address(address)

--- a/verifiers/workers/server/zmq_env_server.py
+++ b/verifiers/workers/server/zmq_env_server.py
@@ -67,7 +67,7 @@ class ZMQEnvServer(EnvServer):
         ctx.term()
         self.logger.debug("Health check responder stopped")
 
-    async def run(self, stop_event: asyncio.Event | None = None) -> None:
+    async def serve(self, stop_event: asyncio.Event | None = None) -> None:
         self.logger.info(f"{self.__class__.__name__} started on {self.address}")
 
         # Start health responder thread

--- a/verifiers/workers/types.py
+++ b/verifiers/workers/types.py
@@ -1,4 +1,5 @@
 import asyncio
+from enum import Enum
 from typing import Annotated, Literal, TypeVar
 
 from pydantic import BaseModel, BeforeValidator, ConfigDict, SkipValidation
@@ -73,6 +74,13 @@ class RunGroupResponse(BaseResponse):
 
 BaseRequestT = TypeVar("BaseRequestT", bound=BaseRequest)
 BaseResponseT = TypeVar("BaseResponseT", bound=BaseResponse)
+
+
+class ServerState(str, Enum):
+    STARTUP = "startup"  # Initial state, before first successful health check
+    HEALTHY = "healthy"  # Server is responsive and working normally
+    UNHEALTHY = "unhealthy"  # Server failed health checks
+    RECOVERING = "recovering"  # Actively waiting for server to recover
 
 
 class PendingRequest(BaseModel):

--- a/verifiers/workers/types.py
+++ b/verifiers/workers/types.py
@@ -90,6 +90,6 @@ class PendingRequest(BaseModel):
 
     request_id: str
     request: BaseRequest
-    future: Future[BaseResponse]
+    future: Future[dict]
     timeout: float | None = None
     submitted_at: float  # timestamp

--- a/verifiers/workers/types.py
+++ b/verifiers/workers/types.py
@@ -1,4 +1,4 @@
-from enum import Enum
+import asyncio
 from typing import Annotated, Literal, TypeVar
 
 from pydantic import BaseModel, BeforeValidator, ConfigDict, SkipValidation
@@ -13,14 +13,6 @@ from verifiers.types import (
 CoercedRolloutOutput = Annotated[
     RolloutOutput, BeforeValidator(lambda v: RolloutOutput(v))
 ]
-
-
-class ServerState(str, Enum):
-    """State of the environment server connection."""
-
-    HEALTHY = "healthy"
-    UNHEALTHY = "unhealthy"
-    RECOVERING = "recovering"
 
 
 class BaseRequest(BaseModel):
@@ -83,10 +75,11 @@ BaseRequestT = TypeVar("BaseRequestT", bound=BaseRequest)
 BaseResponseT = TypeVar("BaseResponseT", bound=BaseResponse)
 
 
-class PendingTaskInfo(BaseModel):
-    """Information about a pending task."""
+class PendingRequest(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     request_id: str
     request: BaseRequest
     timeout: float | None = None
     submitted_at: float  # timestamp
+    future: "asyncio.Future[dict]"  # Response future

--- a/verifiers/workers/types.py
+++ b/verifiers/workers/types.py
@@ -1,4 +1,4 @@
-import asyncio
+from asyncio import Future
 from enum import Enum
 from typing import Annotated, Literal, TypeVar
 
@@ -90,6 +90,6 @@ class PendingRequest(BaseModel):
 
     request_id: str
     request: BaseRequest
+    future: Future[BaseResponse]
     timeout: float | None = None
     submitted_at: float  # timestamp
-    future: "asyncio.Future[dict]"  # Response future

--- a/verifiers/workers/types.py
+++ b/verifiers/workers/types.py
@@ -80,7 +80,6 @@ class ServerState(str, Enum):
     STARTUP = "startup"  # Initial state, before first successful health check
     HEALTHY = "healthy"  # Server is responsive and working normally
     UNHEALTHY = "unhealthy"  # Server failed health checks
-    RECOVERING = "recovering"  # Actively waiting for server to recover
 
 
 class PendingRequest(BaseModel):

--- a/verifiers/workers/types.py
+++ b/verifiers/workers/types.py
@@ -82,6 +82,9 @@ class ServerState(str, Enum):
     UNHEALTHY = "unhealthy"  # Server failed health checks
 
 
+class ServerError(RuntimeError): ...
+
+
 class PendingRequest(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 

--- a/verifiers/workers/types.py
+++ b/verifiers/workers/types.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing import Annotated, Literal, TypeVar
 
 from pydantic import BaseModel, BeforeValidator, ConfigDict, SkipValidation
@@ -12,6 +13,14 @@ from verifiers.types import (
 CoercedRolloutOutput = Annotated[
     RolloutOutput, BeforeValidator(lambda v: RolloutOutput(v))
 ]
+
+
+class ServerState(str, Enum):
+    """State of the environment server connection."""
+
+    HEALTHY = "healthy"
+    UNHEALTHY = "unhealthy"
+    RECOVERING = "recovering"
 
 
 class BaseRequest(BaseModel):
@@ -72,3 +81,12 @@ class RunGroupResponse(BaseResponse):
 
 BaseRequestT = TypeVar("BaseRequestT", bound=BaseRequest)
 BaseResponseT = TypeVar("BaseResponseT", bound=BaseResponse)
+
+
+class PendingTaskInfo(BaseModel):
+    """Information about a pending task."""
+
+    request_id: str
+    request: BaseRequest
+    timeout: float | None = None
+    submitted_at: float  # timestamp


### PR DESCRIPTION
## Description

Enables env server crash detection and recovery in the ZMQ client. Uses a health check loop to keep track of server state. Upon server crash, cancels pending requests and reschedules them once the server is back up. 

Also fixes the public `health` method which now correctly returns `False` if the health check is unsuccessful within the given timeout. Further misc fixes to logging on env client, as well as using a dedicated thread to responding to health requests independently on the event loop pressure on the server, as well as periodic logging of pending tasks and lag for improved observability.
 
## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- [x] All existing tests pass when running `uv run pytest` locally.
- [x] New tests have been added to cover the changes

19 tests in `test_env_crash_recovery.py` covering health loop transitions, pending request cancellation, retry-after-recovery, timeout behavior, and close cleanup.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core request/response plumbing and process startup behavior for env servers; while well-tested, new background loops/threads and retry semantics can introduce subtle hangs or misclassified failures under load.
> 
> **Overview**
> Adds crash detection and recovery to the ZMQ env worker stack by introducing a dedicated health-check channel (port+1) and a client-side health loop that tracks `ServerState`, cancels in-flight requests on repeated failures, and retries `send_request` once the server becomes healthy again (with a bounded recovery timeout).
> 
> Server startup now waits on an event-driven `wait_for_server_startup` (with configurable `health_check_interval`/timeouts), and env server port allocation switches to `get_free_port_pair()` to reserve the work+health ports. The server now runs a separate health responder thread plus periodic observability logging (pending tasks + event loop lag), and new tests cover state transitions, pending cancellation, retry/recovery timeout, and shutdown cleanup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d002593fc6f7e72c889902c8717113b584e70d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->