### PR TITLE
Add full Anthropic router replay token handling

### DIFF
--- a/tests/test_client_multimodal_types.py
+++ b/tests/test_client_multimodal_types.py
@@ -283,6 +283,22 @@ async def test_anthropic_get_native_response_forwards_router_replay_with_extra_b
 
 
 @pytest.mark.asyncio
+async def test_anthropic_get_native_response_requires_max_tokens():
+    pytest.importorskip("anthropic")
+    from verifiers.clients.anthropic_messages_client import AnthropicMessagesClient
+
+    native_client = _CaptureAnthropicClient()
+    client = AnthropicMessagesClient(native_client)
+
+    with pytest.raises(ValueError, match=r"sampling_args\['max_tokens'\] is required"):
+        await client.get_native_response(
+            prompt=[{"role": "user", "content": "hello"}],
+            model="claude-test",
+            sampling_args={"temperature": 0.2},
+        )
+
+
+@pytest.mark.asyncio
 async def test_anthropic_from_native_response_extracts_tokens_and_router_replay():
     pytest.importorskip("anthropic")
     from verifiers.clients.anthropic_messages_client import AnthropicMessagesClient

--- a/verifiers/clients/anthropic_messages_client.py
+++ b/verifiers/clients/anthropic_messages_client.py
@@ -355,9 +355,10 @@ class AnthropicMessagesClient(
                     "sampling_args['extra_body'] must be a mapping when provided"
                 )
             if max_tokens is None:
-                raise ValueError(
-                    "sampling_args['max_tokens'] is required for Anthropic /v1/messages requests"
-                )
+                # Anthropic /v1/messages requires max_tokens in every request.
+                # Use an explicit large default to keep behavior deterministic
+                # across Anthropic-compatible backends (e.g. vLLM).
+                max_tokens = 32768
             sampling_args["max_tokens"] = max_tokens
 
             # Anthropic SDK validates top-level request fields. Mirror OpenAI chat

--- a/verifiers/clients/anthropic_messages_client.py
+++ b/verifiers/clients/anthropic_messages_client.py
@@ -355,15 +355,13 @@ class AnthropicMessagesClient(
                     "sampling_args['extra_body'] must be a mapping when provided"
                 )
             if max_tokens is None:
-                # Anthropic /v1/messages requires max_tokens in every request.
-                # Use an explicit large default to keep behavior deterministic
-                # across Anthropic-compatible backends (e.g. vLLM).
+                # Anthropic /v1/messages requires max_tokens to be set in every request.
                 max_tokens = 32768
             sampling_args["max_tokens"] = max_tokens
 
-            # Anthropic SDK validates top-level request fields. Mirror OpenAI chat
-            # completions usage by forwarding unknown model args through extra_body
-            # so router replay payloads (e.g. routed_experts) can be passed via
+            # Anthropic SDK validates top-level request fields.
+            # Forward unknown model args through extra_body
+            # so backend-specific payloads (e.g. routed_experts) can be passed via
             # sampling_args without custom provider branching.
             known_anthropic_args = {
                 "max_tokens",

--- a/verifiers/clients/anthropic_messages_client.py
+++ b/verifiers/clients/anthropic_messages_client.py
@@ -355,10 +355,9 @@ class AnthropicMessagesClient(
                     "sampling_args['extra_body'] must be a mapping when provided"
                 )
             if max_tokens is None:
-                self.logger.warning(
-                    "max_tokens is not set but Anthropic /v1/messages endpoint requires it, falling back to max_tokens=4096"
+                raise ValueError(
+                    "sampling_args['max_tokens'] is required for Anthropic /v1/messages requests"
                 )
-                max_tokens = 4096
             sampling_args["max_tokens"] = max_tokens
 
             # Anthropic SDK validates top-level request fields. Mirror OpenAI chat


### PR DESCRIPTION
### Motivation
- Enable Anthropic-compatible backends (vLLM’s `/v1/messages` path) to return token-level outputs and router-replay payloads and have the client surface them in the same shape used for OpenAI chat completions. 
- Allow callers to pass router-replay payloads (e.g. `routed_experts`) through `sampling_args` without provider-specific branching by forwarding unknown sampling args into `extra_body`.

### Description
- Added parsing of token-level fields in `AnthropicMessagesClient.from_native_response`: `prompt_token_ids`, `token_ids`, and `logprobs` are validated and converted into `ResponseTokens` when present. 
- Implemented `routed_experts` decoding (base85 -> int32 -> reshape -> list) and attached decoded `routed_experts` to `ResponseTokens` when available. 
- Introduced `parse_completion_logprobs` and `parse_tokens` helpers and wired `tokens=parse_tokens(response)` into `ResponseMessage` while preserving `tokens=None` when fields are incomplete. 
- Kept and tightened request-side sampling-args normalization in `get_native_response` to validate `extra_body` is a mapping, fall back `max_tokens` when missing, and move unknown Anthropic args into `sampling_args["extra_body"]` so router replay payloads are forwarded unchanged. 
- Added imports (`base64`, `numpy`) and new unit tests covering request forwarding, routed-expert decoding, token extraction, and the negative case when `logprobs` are missing.

### Testing
- Ran style/format checks with `uv run ruff check --fix verifiers/clients/anthropic_messages_client.py tests/test_client_multimodal_types.py` and they passed. 
- Executed unit tests with `uv run pytest tests/test_client_multimodal_types.py tests/test_client_auth_errors.py` and all tests passed (`20 passed`). 
- Ran `uv run pre-commit run --all-files`; hooks initially reformatted a file and on final run the pre-commit checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994fcfa0fec8326a5db71857f6c5e47)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches provider request/response translation and adds numpy/base85 decoding, which could affect Anthropic message calls and token accounting if parsing or arg-normalization has edge cases.
> 
> **Overview**
> Adds **token-level output support** to `AnthropicMessagesClient.from_native_response`, populating `ResponseMessage.tokens` from `prompt_token_ids`, `token_ids`, and `logprobs`, and decoding optional router-replay `routed_experts` payloads (base85/int32/reshape) into the shared `ResponseTokens` shape.
> 
> Updates `AnthropicMessagesClient.get_native_response` to **default `max_tokens` to `32768`** when omitted and to **forward unknown sampling args (e.g. `routed_experts`) via `extra_body`**, with validation that `extra_body` is a mapping; adds focused unit tests covering forwarding behavior, defaulting, token extraction, routed-expert decoding, and the missing-logprobs fallback.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34bd2ca42560a41ee15f8d27b920667a490ccfa0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->