### PR TITLE
docs: revert /tmp guidance in README and overview, keep brainstorm SKILL update

### DIFF
--- a/skills/brainstorm/SKILL.md
+++ b/skills/brainstorm/SKILL.md
@@ -28,8 +28,9 @@ Run structured, interactive ideation that turns ambiguous research goals into co
 
 ## Required Grounding Sources
 1. Read local source before proposing workflows:
-- `~/dev/prime-cli`
-- `~/dev/prime-rl` (clone to `/tmp` only if needed)
+- optionally clone Prime Intellect repositories to `/tmp` only when needed, e.g.
+  - `git clone https://github.com/PrimeIntellect-ai/prime-cli /tmp/prime-cli`
+  - `git clone https://github.com/PrimeIntellect-ai/prime-rl /tmp/prime-rl`
 - current verifiers workspace docs/configs
 2. For literature and external eval ideas, browse web sources and prioritize mid-2025 onward unless the user asks otherwise.
 3. Include dates when discussing recent papers or benchmarks.


### PR DESCRIPTION
### Motivation
- The `/tmp` clone guidance added to `README.md` and `docs/overview.md` is not relevant to the repository's primary docs and should be reverted. 
- The `skills/brainstorm/SKILL.md` change providing optional `/tmp` clone instructions for Prime Intellect repos is useful and should be retained.

### Description
- Restored `README.md` to its original workspace snippet (`# ~/dev/my-lab`) and removed the `/tmp` clone suggestion. 
- Restored `docs/overview.md` to its original workspace snippet (`# ~/dev/my-lab`) and removed the `/tmp` clone suggestion. 
- Left `skills/brainstorm/SKILL.md` updated to include the optional `/tmp` clone examples for `prime-cli` and `prime-rl`.

### Testing
- Ran `uv run pre-commit run --all-files`, which completed successfully (noting a TOML parse warning during settings discovery). 
- `ruff check` was run as part of pre-commit hooks and passed. 
- `ruff format` was run as part of pre-commit hooks and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69953fcea0f8832686af52e7359e96a1)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit a94c8275b771f90f9e9317616df26fa223d48c6c. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->