### PR TITLE
add json_logging support to env server

### DIFF
--- a/verifiers/utils/logging_utils.py
+++ b/verifiers/utils/logging_utils.py
@@ -100,6 +100,9 @@ def setup_logging(
     # using logging.getLogger(__name__) emits JSON too
     if json_logging:
         root = logging.getLogger()
+        root.handlers = [
+            h for h in root.handlers if not isinstance(h.formatter, JsonFormatter)
+        ]
         root.setLevel(console_level)
         root_handler = logging.StreamHandler(sys.stderr)
         root_handler.setFormatter(formatter)

--- a/verifiers/utils/logging_utils.py
+++ b/verifiers/utils/logging_utils.py
@@ -1,6 +1,8 @@
+import json
 import logging
 import sys
 from contextlib import contextmanager
+from datetime import datetime, timezone
 
 from rich.console import Console
 from rich.panel import Panel
@@ -15,12 +17,30 @@ from verifiers.utils.message_utils import format_messages
 LOGGER_NAME = "verifiers"
 
 
+class JsonFormatter(logging.Formatter):
+    """JSON formatter for structured logging."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        log_entry = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "level": record.levelname,
+            "message": record.getMessage(),
+            "module": record.module,
+            "function": record.funcName,
+            "line": record.lineno,
+        }
+        if record.exc_info:
+            log_entry["exception"] = self.formatException(record.exc_info)
+        return json.dumps(log_entry)
+
+
 def setup_logging(
     level: str | None = "INFO",
     log_format: str | None = None,
     date_format: str | None = None,
     log_file: str | None = None,
     log_file_level: str | None = None,
+    json_logging: bool = False,
 ) -> None:
     """
     Setup basic logging configuration for the verifiers package.
@@ -30,13 +50,17 @@ def setup_logging(
         log_format: Custom log format string. If None, uses default format.
         date_format: Custom date format string. If None, uses default format.
         log_file: Optional path to a log file. If specified, logs will be written to this file.
+        log_file_level: The logging level for the file handler. If None, uses the same level as console.
+        json_logging: If True, output logs as JSON. Defaults to False.
     """
-    if log_format is None:
-        log_format = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-    if date_format is None:
-        date_format = "%Y-%m-%d %H:%M:%S"
-
-    formatter = logging.Formatter(fmt=log_format, datefmt=date_format)
+    if json_logging:
+        formatter = JsonFormatter()
+    else:
+        if log_format is None:
+            log_format = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        if date_format is None:
+            date_format = "%Y-%m-%d %H:%M:%S"
+        formatter = logging.Formatter(fmt=log_format, datefmt=date_format)
 
     logger = logging.getLogger(LOGGER_NAME)
 
@@ -70,6 +94,17 @@ def setup_logging(
 
     # prevent the logger from propagating messages to the root logger
     logger.propagate = False
+
+    # when json_logging, also configure the root logger so environment code
+    # using logging.getLogger(__name__) emits JSON too
+    if json_logging:
+        root = logging.getLogger()
+        root.handlers.clear()
+        root.setLevel(console_level)
+        root_handler = logging.StreamHandler(sys.stderr)
+        root_handler.setFormatter(formatter)
+        root_handler.setLevel(console_level)
+        root.addHandler(root_handler)
 
 
 @contextmanager

--- a/verifiers/utils/logging_utils.py
+++ b/verifiers/utils/logging_utils.py
@@ -24,6 +24,7 @@ class JsonFormatter(logging.Formatter):
         log_entry = {
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "level": record.levelname,
+            "name": record.name,
             "message": record.getMessage(),
             "module": record.module,
             "function": record.funcName,
@@ -99,7 +100,6 @@ def setup_logging(
     # using logging.getLogger(__name__) emits JSON too
     if json_logging:
         root = logging.getLogger()
-        root.handlers.clear()
         root.setLevel(console_level)
         root_handler = logging.StreamHandler(sys.stderr)
         root_handler.setFormatter(formatter)

--- a/verifiers/workers/server/env_server.py
+++ b/verifiers/workers/server/env_server.py
@@ -31,15 +31,23 @@ class EnvServer(ABC):
         log_level: str | None = None,
         log_file: str | None = None,
         log_file_level: str | None = None,
+        json_logging: bool = False,
     ):
         # setup logging
         log_file = log_file or f"logs/{env_id}.log"
         Path(log_file).parent.mkdir(parents=True, exist_ok=True)
         if log_level is None:
-            vf.setup_logging(log_file=log_file, log_file_level=log_file_level)
+            vf.setup_logging(
+                log_file=log_file,
+                log_file_level=log_file_level,
+                json_logging=json_logging,
+            )
         else:
             vf.setup_logging(
-                level=log_level, log_file=log_file, log_file_level=log_file_level
+                level=log_level,
+                log_file=log_file,
+                log_file_level=log_file_level,
+                json_logging=json_logging,
             )
 
         self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")


### PR DESCRIPTION
- add `JsonFormatter` and `json_logging` param to `setup_logging()`
- thread `json_logging` through `EnvServer.__init__`
- when `json_logging=True`, configure root logger with JSON formatter so environment code using `logging.getLogger(__name__)` also emits JSON

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches global logging configuration (including the root logger), which can change log output/handlers and affect integrations that rely on existing formatting.
> 
> **Overview**
> Adds optional **structured JSON logging** via a new `JsonFormatter` and a `json_logging` flag on `setup_logging()`.
> 
> When enabled, `setup_logging()` also configures the *root logger* with the JSON formatter so third-party/environment code using standard `logging.getLogger(__name__)` emits JSON as well. `EnvServer.__init__` now accepts and forwards `json_logging` to logging setup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dfa95c8f9037ac150d69839d949258f4e5d1749d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->