### PR TITLE
provider defaults

### DIFF
--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -310,6 +310,7 @@ def load_toml_config(path: Path) -> list[dict]:
         "endpoints_path",
         "extra_env_kwargs",
         # model/client
+        "provider",
         "endpoint_id",
         "model",
         "api_client_type",


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

adds the `--provider` (`-p`) eval config arg which resolves the api base url and key (optionally also client type) for common providers, such as `prime`, `openrouter`, `openai`, `deepseek`, `vllm`/`local`, etc.

we distinguish these two cases of precedence:
1. model not in registry, cli > provider > default provider (prime)
2. model is in registry: cli > provider > registry (endpoints)

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how API base URL/key/client type are resolved for eval runs, which could silently reroute traffic if provider/registry/CLI precedence is misunderstood; scope is limited to eval configuration.
> 
> **Overview**
> Adds a new `--provider`/`-p` option to `verifiers/scripts/eval.py` that selects common inference providers (base URL, API key env var, and sometimes client type) via a built-in `PROVIDER_CONFIGS` map.
> 
> Updates endpoint/client resolution precedence so **CLI overrides provider overrides endpoint registry**, and for models not found in the registry it now falls back to a default provider (`prime`) instead of hardcoded URL/key defaults; multi-endpoint variants are disabled when a provider override is used. TOML config validation is extended to allow the new `provider` field.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bec394badc5a207d032f2fec7ae5c2ccea2b3c39. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->