### PR TITLE
feat(model-specific-tools): Add model-specific tool selection from TOML config

### DIFF
--- a/environments/tool_test/tool_test.py
+++ b/environments/tool_test/tool_test.py
@@ -94,11 +94,15 @@ def load_environment(
     if tools is None:
         tools = DEFAULT_TOOL_LIST
 
+    # Extract tool names from ACTUAL tools being used (not hardcoded list)
+    actual_tool_names = [tool.__name__ for tool in tools]
+
     train_rows = []
     eval_rows = []
     for i in range(num_train_examples + num_eval_examples):
+        # Sample from actual available tools only
         tool_names = random.sample(
-            tool_name_list, random.randint(1, len(tool_name_list))
+            actual_tool_names, random.randint(1, len(actual_tool_names))
         )
         prompt = [
             {

--- a/environments/tool_test/tool_test.py
+++ b/environments/tool_test/tool_test.py
@@ -95,6 +95,21 @@ def load_environment(
     # Extract tool names from ACTUAL tools being used (not hardcoded list)
     actual_tool_names = [tool.__name__ for tool in tools]
 
+    # Handle empty tools case
+    if not actual_tool_names:
+        # Create empty datasets when no tools available
+        dataset = Dataset.from_list([])
+        eval_dataset = Dataset.from_list([])
+        rubric = vf.Rubric(funcs=[tool_call_reward_func])
+        vf_env = vf.ToolEnv(
+            dataset=dataset,
+            eval_dataset=eval_dataset,
+            rubric=rubric,
+            tools=tools,
+            max_turns=1,
+        )
+        return vf_env
+
     train_rows = []
     eval_rows = []
     for i in range(num_train_examples + num_eval_examples):

--- a/environments/tool_test/tool_test.py
+++ b/environments/tool_test/tool_test.py
@@ -3,9 +3,11 @@ import random
 from datasets import Dataset
 
 import verifiers as vf
+from verifiers.utils.tool_registry import register_tool
 
 
 # dummy tools for sanity checking parallel tool calls
+@register_tool("tool-test", "tool_A")
 async def tool_A(x: int) -> int:
     """
     Tool for adding 1 to an integer.
@@ -19,6 +21,7 @@ async def tool_A(x: int) -> int:
     return x + 1
 
 
+@register_tool("tool-test", "tool_B")
 async def tool_B(x: str) -> str:
     """
     Tool for concatenating a string with "2".
@@ -32,6 +35,7 @@ async def tool_B(x: str) -> str:
     return x + "2"
 
 
+@register_tool("tool-test", "tool_C")
 async def tool_C(x: float) -> float:
     """
     Tool for adding 3.0 to a float.
@@ -45,6 +49,7 @@ async def tool_C(x: float) -> float:
     return x + 3.0
 
 
+@register_tool("tool-test", "tool_D")
 async def tool_D(x: bool) -> bool:
     """
     Tool for negating a boolean.
@@ -59,6 +64,7 @@ async def tool_D(x: bool) -> bool:
 
 
 tool_list = [tool_A, tool_B, tool_C, tool_D]
+DEFAULT_TOOL_LIST = [tool_A, tool_B, tool_C, tool_D]
 tool_name_list = [tool.__name__ for tool in tool_list]
 
 
@@ -76,11 +82,17 @@ def tool_call_reward_func(completion, info):
 
 
 def load_environment(
-    num_train_examples: int = 1000, num_eval_examples: int = 100
+    num_train_examples: int = 1000,
+    num_eval_examples: int = 100,
+    tools: list | None = None,
 ) -> vf.ToolEnv:
     """
     Loads tool-test environment.
     """
+
+    # Use provided tools or fall back to default
+    if tools is None:
+        tools = DEFAULT_TOOL_LIST
 
     train_rows = []
     eval_rows = []
@@ -107,7 +119,7 @@ def load_environment(
         dataset=dataset,
         eval_dataset=eval_dataset,
         rubric=rubric,
-        tools=tool_list,
+        tools=tools,
         max_turns=1,
     )
     return vf_env

--- a/environments/tool_test/tool_test.py
+++ b/environments/tool_test/tool_test.py
@@ -63,9 +63,7 @@ async def tool_D(x: bool) -> bool:
     return not x
 
 
-tool_list = [tool_A, tool_B, tool_C, tool_D]
 DEFAULT_TOOL_LIST = [tool_A, tool_B, tool_C, tool_D]
-tool_name_list = [tool.__name__ for tool in tool_list]
 
 
 def tool_call_reward_func(completion, info):

--- a/packages/verifiers-rl/verifiers_rl/scripts/train.py
+++ b/packages/verifiers-rl/verifiers_rl/scripts/train.py
@@ -1,4 +1,5 @@
 import argparse
+import logging
 from pathlib import Path
 
 try:
@@ -8,6 +9,8 @@ except ImportError:
 
 import verifiers as vf
 from verifiers_rl.rl.trainer import RLConfig, RLTrainer
+
+logger = logging.getLogger("verifiers_rl.scripts.train")
 
 
 def main() -> None:
@@ -29,7 +32,33 @@ def main() -> None:
     model = config["model"]
     env_id = config["env"]["id"]
     env_args = config["env"].get("args", {})
-    env = vf.load_environment(env_id=env_id, **env_args)
+
+    # Resolve tools from config
+    if "tools" in config["env"]:
+        from verifiers.utils.tool_registry import (
+            get_tools as registry_get_tools,
+            validate_tools,
+        )
+
+        tool_names = config["env"]["tools"]
+        if not isinstance(tool_names, list):
+            raise ValueError(
+                f"env.tools must be list of tool names, got {type(tool_names).__name__}"
+            )
+
+        logger.info(f"Loading tools from config: {tool_names}")
+
+        # Validate before loading
+        try:
+            validate_tools(env_id, tool_names)
+        except ValueError as e:
+            raise ValueError(f"Tool validation failed for env '{env_id}': {e}") from e
+
+        tools = registry_get_tools(env_id, tool_names)
+    else:
+        tools = None
+
+    env = vf.load_environment(env_id=env_id, tools=tools, **env_args)
     rl_config = RLConfig(**config["trainer"].get("args", {}))
     trainer = RLTrainer(model=model, env=env, args=rl_config)
     trainer.train()

--- a/tests/test_env_utils_tools.py
+++ b/tests/test_env_utils_tools.py
@@ -1,0 +1,183 @@
+"""
+Integration tests for env_utils tool resolution functionality
+
+Tests cover:
+- Loading environment with string tools (resolved via registry)
+- Loading environment with callable tools (passed through)
+- Loading environment with no tools (backward compatibility)
+- Error handling for mixed tool types
+"""
+
+import pytest
+
+from verifiers.utils.env_utils import load_environment
+from verifiers.utils.tool_registry import register_tool
+
+
+@pytest.fixture(autouse=True)
+def clear_registry():
+    """Clear the registry before and after each test."""
+    from verifiers.utils import tool_registry
+
+    # Clear before test
+    tool_registry._tool_registry.clear()
+    yield
+    # Clear after test
+    tool_registry._tool_registry.clear()
+
+
+def test_load_environment_with_string_tools(clear_registry):
+    """Test loading environment with string tool names (registry resolution)."""
+
+    # Register test tools
+    @register_tool("tool-test", "test_tool_a")
+    async def test_tool_a(x: int) -> int:
+        return x + 1
+
+    @register_tool("tool-test", "test_tool_b")
+    async def test_tool_b(x: str) -> str:
+        return x + "suffix"
+
+    # Load environment with string tools
+    env = load_environment("tool-test", tools=["test_tool_a", "test_tool_b"])
+
+    # Verify tools were resolved and attached
+    assert hasattr(env, "tools")
+    assert len(env.tools) == 2
+    assert test_tool_a in env.tools
+    assert test_tool_b in env.tools
+
+
+def test_load_environment_with_callable_tools(clear_registry):
+    """Test loading environment with callable tools (direct pass-through)."""
+
+    # Define test tools
+    async def direct_tool_a(x: int) -> int:
+        return x + 1
+
+    async def direct_tool_b(x: str) -> str:
+        return x + "suffix"
+
+    # Load environment with callable tools
+    env = load_environment(
+        "tool-test", tools=[direct_tool_a, direct_tool_b]
+    )
+
+    # Verify tools were passed through
+    assert hasattr(env, "tools")
+    assert len(env.tools) == 2
+    assert direct_tool_a in env.tools
+    assert direct_tool_b in env.tools
+
+
+def test_load_environment_no_tools(clear_registry):
+    """Test loading environment without tools parameter (backward compatibility)."""
+
+    # Load environment without tools parameter
+    env = load_environment("tool-test")
+
+    # Verify environment loaded with default tools
+    assert hasattr(env, "tools")
+    # tool-test environment has 4 default tools
+    assert len(env.tools) == 4
+
+
+def test_load_environment_empty_tool_list(clear_registry):
+    """Test loading environment with empty tool list."""
+
+    # Load environment with empty tools list
+    env = load_environment("tool-test", tools=[])
+
+    # Verify environment has no tools
+    assert hasattr(env, "tools")
+    assert len(env.tools) == 0
+
+
+def test_mixed_tool_types_error(clear_registry):
+    """Test that mixing Callable and str tools raises TypeError."""
+
+    # Define a callable tool
+    async def my_tool(x: int) -> int:
+        return x + 1
+
+    # Register a string tool
+    @register_tool("tool-test", "registered_tool")
+    async def registered_tool() -> str:
+        return "registered"
+
+    # Attempt to load with mixed types - should raise TypeError
+    with pytest.raises(TypeError, match="tools must be all Callable or all str"):
+        load_environment("tool-test", tools=[my_tool, "registered_tool"])
+
+    with pytest.raises(TypeError, match="tools must be all Callable or all str"):
+        load_environment("tool-test", tools=["registered_tool", my_tool])
+
+
+def test_invalid_tool_name_in_registry(clear_registry):
+    """Test that unregistered tool name raises KeyError from registry."""
+
+    # Register one tool so environment exists in registry
+    @register_tool("tool-test", "valid_tool")
+    async def valid_tool(x: int) -> int:
+        return x + 1
+
+    # Try to load with a different, unregistered tool name
+    with pytest.raises(KeyError, match=r"Tools \['nonexistent_tool'\] not found"):
+        load_environment("tool-test", tools=["valid_tool", "nonexistent_tool"])
+
+
+def test_invalid_tool_type_error(clear_registry):
+    """Test that invalid tool type raises TypeError."""
+
+    # Load with invalid tool type (int, not Callable or str)
+    with pytest.raises(TypeError, match="tools must be list of Callable or list of str"):
+        load_environment("tool-test", tools=[123, 456])
+
+
+def test_environment_with_other_args(clear_registry):
+    """Test that tools parameter works alongside other environment arguments."""
+
+    # Register a tool
+    @register_tool("tool-test", "custom_tool")
+    async def custom_tool() -> str:
+        return "custom"
+
+    # Load environment with tools and other args
+    env = load_environment(
+        "tool-test",
+        tools=["custom_tool"],
+        num_train_examples=50,
+        num_eval_examples=10,
+    )
+
+    # Verify both tools and other args were applied
+    assert hasattr(env, "tools")
+    assert len(env.tools) >= 1
+    assert custom_tool in env.tools
+    # num_train_examples should affect dataset size
+    # (actual value depends on tool-test env implementation)
+
+
+def test_single_string_tool(clear_registry):
+    """Test loading environment with single string tool."""
+
+    @register_tool("tool-test", "single_tool")
+    async def single_tool(x: int) -> int:
+        return x * 2
+
+    env = load_environment("tool-test", tools=["single_tool"])
+
+    assert hasattr(env, "tools")
+    assert single_tool in env.tools
+
+
+def test_single_callable_tool(clear_registry):
+    """Test loading environment with single callable tool."""
+
+    async def my_tool() -> str:
+        return "result"
+
+    env = load_environment("tool-test", tools=[my_tool])
+
+    assert hasattr(env, "tools")
+    assert my_tool in env.tools

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -10,7 +10,9 @@ Tests cover:
 """
 
 import pytest
+
 from verifiers.utils.tool_registry import (
+    clear_registry,
     get_tool,
     get_tools,
     list_tools,
@@ -18,3 +20,164 @@ from verifiers.utils.tool_registry import (
     register_tool,
     validate_tools,
 )
+
+
+@pytest.fixture(autouse=True)
+def clear_registry_before_and_after_test():
+    """Clear the registry before and after each test."""
+    clear_registry()
+    yield
+    clear_registry()
+
+
+def test_registration_and_retrieval():
+    """Test registering a tool and retrieving it."""
+    # Register a test tool
+    @register_tool("test-env", "test_tool")
+    async def test_tool(x: int) -> int:
+        return x + 1
+
+    # Retrieve the tool
+    retrieved = get_tool("test-env", "test_tool")
+
+    # Verify it's the same function
+    assert retrieved == test_tool
+    assert retrieved.__name__ == "test_tool"
+
+
+def test_batch_retrieval():
+    """Test retrieving multiple tools at once."""
+    # Register multiple tools
+    @register_tool("test-env", "tool_a")
+    async def tool_a(x: int) -> int:
+        return x + 1
+
+    @register_tool("test-env", "tool_b")
+    async def tool_b(x: str) -> str:
+        return x + "suffix"
+
+    # Retrieve both tools
+    tools = get_tools("test-env", ["tool_a", "tool_b"])
+
+    # Verify both were retrieved
+    assert len(tools) == 2
+    assert tool_a in tools
+    assert tool_b in tools
+
+
+def test_validation():
+    """Test tool validation."""
+    # Register tools
+    @register_tool("test-env", "tool_a")
+    async def tool_a(x: int) -> int:
+        return x + 1
+
+    @register_tool("test-env", "tool_b")
+    async def tool_b(x: str) -> str:
+        return x + "suffix"
+
+    # Valid tools should pass validation
+    validate_tools("test-env", ["tool_a", "tool_b"])  # Should not raise
+
+    # Invalid tool should raise ValueError
+    with pytest.raises(ValueError, match="Unregistered tools"):
+        validate_tools("test-env", ["tool_a", "nonexistent_tool"])
+
+
+def test_clear_registry():
+    """Test clearing the registry."""
+    # Register a tool
+    @register_tool("test-env", "test_tool")
+    async def test_tool(x: int) -> int:
+        return x + 1
+
+    # Verify it's registered
+    assert get_tool("test-env", "test_tool") == test_tool
+
+    # Clear registry
+    clear_registry()
+
+    # Verify it's gone
+    with pytest.raises(KeyError):
+        get_tool("test-env", "test_tool")
+
+
+def test_multiple_environments():
+    """Test that tools from different environments don't interfere."""
+    # Register tools in different environments
+    @register_tool("env-a", "shared_name")
+    async def env_a_tool(x: int) -> int:
+        return x + 1
+
+    @register_tool("env-b", "shared_name")
+    async def env_b_tool(x: int) -> int:
+        return x + 2
+
+    # Retrieve from each environment
+    tool_from_a = get_tool("env-a", "shared_name")
+    tool_from_b = get_tool("env-b", "shared_name")
+
+    # Verify they're different functions
+    assert tool_from_a == env_a_tool
+    assert tool_from_b == env_b_tool
+    assert tool_from_a != tool_from_b
+    assert tool_from_a.__name__ == "shared_name"
+    assert tool_from_b.__name__ == "shared_name"
+
+
+def test_list_tools():
+    """Test listing all tools in an environment."""
+    # Register tools
+    @register_tool("test-env", "tool_a")
+    async def tool_a(x: int) -> int:
+        return x + 1
+
+    @register_tool("test-env", "tool_b")
+    async def tool_b(x: str) -> str:
+        return x + "suffix"
+
+    # List tools
+    tools = list_tools("test-env")
+
+    # Verify both tools are listed
+    assert len(tools) == 2
+    assert "tool_a" in tools
+    assert "tool_b" in tools
+
+
+def test_list_environments():
+    """Test listing all environments with registered tools."""
+    # Register tools in different environments
+    @register_tool("env-a", "tool_a")
+    async def tool_a(x: int) -> int:
+        return x + 1
+
+    @register_tool("env-b", "tool_b")
+    async def tool_b(x: str) -> str:
+        return x + "suffix"
+
+    # List environments
+    envs = list_environments()
+
+    # Verify both environments are listed
+    assert len(envs) == 2
+    assert "env-a" in envs
+    assert "env-b" in envs
+
+
+def test_error_get_nonexistent_tool():
+    """Test error when retrieving a nonexistent tool."""
+    with pytest.raises(KeyError, match="not found"):
+        get_tool("test-env", "nonexistent_tool")
+
+
+def test_error_get_tools_partial_match():
+    """Test error when some tools don't exist."""
+    # Register only one tool
+    @register_tool("test-env", "tool_a")
+    async def tool_a(x: int) -> int:
+        return x + 1
+
+    # Try to retrieve multiple tools where one doesn't exist
+    with pytest.raises(KeyError, match="not found"):
+        get_tools("test-env", ["tool_a", "nonexistent_tool"])

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -1,0 +1,20 @@
+"""
+Unit tests for tool_registry module
+
+Tests cover:
+- Tool registration and retrieval
+- Batch tool retrieval
+- Tool validation
+- Listing tools and environments
+- Error cases and edge conditions
+"""
+
+import pytest
+from verifiers.utils.tool_registry import (
+    get_tool,
+    get_tools,
+    list_tools,
+    list_environments,
+    register_tool,
+    validate_tools,
+)

--- a/verifiers/utils/env_utils.py
+++ b/verifiers/utils/env_utils.py
@@ -18,6 +18,13 @@ def load_environment(
     tool_names_to_resolve = None
 
     if tools is not None:
+        # Check if tools is actually a list (not a string or other type)
+        if not isinstance(tools, list):
+            raise TypeError(
+                f"tools must be a list, got {type(tools).__name__}. "
+                f"If passing tool names, use tools=['tool_name'] not tools='tool_name'"
+            )
+
         if tools:
             # Check for mixed types (both Callable and str in same list)
             first_is_callable = callable(tools[0])
@@ -29,11 +36,19 @@ def load_environment(
                     f"got list containing {type(tools[0]).__name__}"
                 )
 
-            # Verify all tools are same type
+            # Verify all tools are same type AND are valid types (callable or str)
             for i, tool in enumerate(tools):
                 is_callable = callable(tool)
                 is_str = isinstance(tool, str)
 
+                # Check if element is neither callable nor string
+                if not is_callable and not is_str:
+                    raise TypeError(
+                        f"tools list elements must be Callable or str, "
+                        f"got {type(tool).__name__} at index {i}"
+                    )
+
+                # Check for mixed types
                 if is_callable and first_is_str:
                     raise TypeError(
                         f"tools must be all Callable or all str, got mixed types "

--- a/verifiers/utils/env_utils.py
+++ b/verifiers/utils/env_utils.py
@@ -99,12 +99,9 @@ def load_environment(
                 tools = get_tools(env_id, tool_names_to_resolve)
                 env_args["tools"] = tools
                 logger.info(f"Successfully resolved {len(tools)} tools")
-            except KeyError as e:
-                logger.error(
-                    f"Failed to resolve tools for env '{env_id}': {str(e)}\n"
-                    f"Note: Tools must be registered with @register_tool decorator "
-                    f"in the environment module before load_environment() is called."
-                )
+            except KeyError:
+                # Re-raise KeyError to preserve original error type
+                # The error message from get_tools() is already descriptive
                 raise
         sig = inspect.signature(env_load_func)
         defaults_info = []
@@ -163,6 +160,10 @@ def load_environment(
         raise ValueError(
             f"Could not import '{env_id}' environment. Ensure the package for the '{env_id}' environment is installed."
         ) from e
+    except KeyError:
+        # KeyError from tool resolution should propagate as-is
+        # The error message from get_tools() is already descriptive
+        raise
     except Exception as e:
         logger.error(
             f"Failed to load environment {env_id} with args {env_args}: {str(e)}"

--- a/verifiers/utils/tool_registry.py
+++ b/verifiers/utils/tool_registry.py
@@ -1,0 +1,220 @@
+"""
+Tool Registry for Environment-Specific Tool Management
+
+This module provides a centralized registry system for managing tools across different
+environments. Tools are registered by environment ID and can be retrieved by name.
+
+Core Functions:
+    register_tool: Decorator to register tools in the registry
+    get_tool: Retrieve a single tool by environment ID and tool name
+    get_tools: Retrieve multiple tools by environment ID and tool names
+    validate_tools: Validate that all specified tools are registered
+    list_tools: List all available tools for an environment
+
+Example:
+    @register_tool("tool-test", "tool_A")
+    async def tool_A(x: int) -> int:
+        return x + 1
+
+    tools = get_tools("tool-test", ["tool_A", "tool_B"])
+"""
+
+import logging
+import threading
+from collections import defaultdict
+from typing import Callable
+
+# Global tool registry: {env_id: {tool_name: tool_function}}
+_tool_registry: dict[str, dict[str, Callable]] = defaultdict(dict)
+
+# Thread-safe lock for registry operations
+_registry_lock = threading.RLock()
+
+logger = logging.getLogger("verifiers.utils.tool_registry")
+
+
+def register_tool(env_id: str, tool_name: str):
+    """
+    Decorator to register a tool function in the global registry.
+
+    Args:
+        env_id: Environment identifier (e.g., "tool-test", "wiki-search")
+        tool_name: Name to register the tool under (typically function.__name__)
+
+    Returns:
+        Decorator function that registers the tool and returns it unchanged
+
+    Example:
+        @register_tool("tool-test", "my_tool")
+        async def my_tool(x: int) -> int:
+            return x + 1
+    """
+    def decorator(tool_func: Callable) -> Callable:
+        with _registry_lock:
+            _tool_registry[env_id][tool_name] = tool_func
+            logger.debug(
+                f"Registered tool '{tool_name}' for environment '{env_id}': "
+                f"{tool_func.__module__}.{tool_func.__name__}"
+            )
+        return tool_func
+
+    return decorator
+
+
+def get_tool(env_id: str, tool_name: str) -> Callable:
+    """
+    Retrieve a single tool function from the registry.
+
+    Args:
+        env_id: Environment identifier
+        tool_name: Name of the tool to retrieve
+
+    Returns:
+        The tool function
+
+    Raises:
+        KeyError: If environment or tool not found
+
+    Example:
+        tool = get_tool("tool-test", "tool_A")
+    """
+    with _registry_lock:
+        if env_id not in _tool_registry:
+            available_envs = sorted(_tool_registry.keys())
+            raise KeyError(
+                f"Environment '{env_id}' not found in tool registry. "
+                f"Available environments: {available_envs}"
+            )
+
+        if tool_name not in _tool_registry[env_id]:
+            available_tools = sorted(_tool_registry[env_id].keys())
+            raise KeyError(
+                f"Tool '{tool_name}' not found for environment '{env_id}'. "
+                f"Available tools: {available_tools}"
+            )
+
+        return _tool_registry[env_id][tool_name]
+
+
+def get_tools(env_id: str, tool_names: list[str]) -> list[Callable]:
+    """
+    Retrieve multiple tool functions from the registry.
+
+    Args:
+        env_id: Environment identifier
+        tool_names: List of tool names to retrieve
+
+    Returns:
+        List of tool functions in the same order as tool_names
+
+    Raises:
+        KeyError: If any tool not found (includes list of available tools)
+
+    Example:
+        tools = get_tools("tool-test", ["tool_A", "tool_B", "tool_C"])
+    """
+    with _registry_lock:
+        if env_id not in _tool_registry:
+            available_envs = sorted(_tool_registry.keys())
+            raise KeyError(
+                f"Environment '{env_id}' not found in tool registry. "
+                f"Available environments: {available_envs}"
+            )
+
+        tools = []
+        missing_tools = []
+
+        for tool_name in tool_names:
+            if tool_name not in _tool_registry[env_id]:
+                missing_tools.append(tool_name)
+            else:
+                tools.append(_tool_registry[env_id][tool_name])
+
+        if missing_tools:
+            available_tools = sorted(_tool_registry[env_id].keys())
+            raise KeyError(
+                f"Tools {missing_tools} not found for environment '{env_id}'. "
+                f"Available tools: {available_tools}"
+            )
+
+        return tools
+
+
+def validate_tools(env_id: str, tool_names: list[str]) -> None:
+    """
+    Validate that all specified tools are registered for the environment.
+
+    Args:
+        env_id: Environment identifier
+        tool_names: List of tool names to validate
+
+    Raises:
+        ValueError: If any tool is not registered (includes helpful context)
+
+    Example:
+        try:
+            validate_tools("tool-test", ["tool_A", "tool_B"])
+        except ValueError as e:
+            print(f"Invalid tools: {e}")
+    """
+    with _registry_lock:
+        if env_id not in _tool_registry:
+            available_envs = sorted(_tool_registry.keys())
+            raise ValueError(
+                f"Environment '{env_id}' not found in tool registry. "
+                f"Available environments: {available_envs}"
+            )
+
+        missing_tools = [
+            tool_name for tool_name in tool_names if tool_name not in _tool_registry[env_id]
+        ]
+
+        if missing_tools:
+            available_tools = sorted(_tool_registry[env_id].keys())
+            raise ValueError(
+                f"Unregistered tools found: {missing_tools}. "
+                f"Available tools for '{env_id}': {available_tools}"
+            )
+
+
+def list_tools(env_id: str) -> list[str]:
+    """
+    List all available tool names for a specific environment.
+
+    Args:
+        env_id: Environment identifier
+
+    Returns:
+        Sorted list of tool names registered for this environment
+
+    Raises:
+        KeyError: If environment not found in registry
+
+    Example:
+        tools = list_tools("tool-test")
+        # Returns: ["tool_A", "tool_B", "tool_C", "tool_D"]
+    """
+    with _registry_lock:
+        if env_id not in _tool_registry:
+            available_envs = sorted(_tool_registry.keys())
+            raise KeyError(
+                f"Environment '{env_id}' not found in tool registry. "
+                f"Available environments: {available_envs}"
+            )
+
+        return sorted(_tool_registry[env_id].keys())
+
+
+def list_environments() -> list[str]:
+    """
+    List all environment IDs that have registered tools.
+
+    Returns:
+        Sorted list of environment IDs
+
+    Example:
+        envs = list_environments()
+        # Returns: ["tool-test", "wiki-search", ...]
+    """
+    with _registry_lock:
+        return sorted(_tool_registry.keys())

--- a/verifiers/utils/tool_registry.py
+++ b/verifiers/utils/tool_registry.py
@@ -218,3 +218,17 @@ def list_environments() -> list[str]:
     """
     with _registry_lock:
         return sorted(_tool_registry.keys())
+
+
+def clear_registry() -> None:
+    """
+    Clear all tools from the registry.
+
+    This is primarily useful for testing to ensure a clean state between tests.
+
+    Example:
+        clear_registry()
+    """
+    with _registry_lock:
+        _tool_registry.clear()
+        logger.debug("Tool registry cleared")


### PR DESCRIPTION
## Summary
Add model-specific tool selection from TOML config files. Enables different models to use different tool sets from the same environment.

## Changes
- **verifiers/utils/tool_registry.py** (new): Tool registry with `@register_tool(env_id, tool_name)` decorator
- **verifiers/utils/env_utils.py**: Add `tools` parameter to `load_environment()`
- **packages/verifiers-rl/verifiers_rl/scripts/train.py**: Config tool loading and validation
- **environments/tool_test/tool_test.py**: Backward compatibility with tools parameter
- **tests/test_env_utils_tools.py** (new): Integration tests
- **tests/test_tool_registry.py** (new): Unit tests

## Usage
```toml
[[env]]
id = "tool-test"
tools = ["tool_A", "tool_B"]  # Use only these tools
```

## Testing
- ✅ All 10 tests passing
- ✅ Backward compatible (uses DEFAULT_TOOL_LIST when tools=None)
- ✅ String tool resolution via registry
- ✅ Proper error handling

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the environment loading path and introduces dynamic tool resolution based on strings, which could impact training/runtime behavior if configs or registrations are incorrect, though covered by new tests.
> 
> **Overview**
> Adds a global, thread-safe tool registry (`@register_tool`, `get_tools`, etc.) and extends `load_environment` to accept `tools` as either callables or tool-name strings that are resolved *after* importing the environment module.
> 
> Updates `vf-train` to read optional `env.tools` from TOML (supporting both `[[env]]` and `[env]` formats) and pass it through, and updates the `tool-test` environment to register its tools, honor a provided tool subset (including empty list), and generate prompts based on the selected tools. Adds unit/integration tests covering tool registration, resolution, and error cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1d92159416207e2281a7efe9f66f6312c1586b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->