### PR TITLE
Disable aiohttp access logging for interception servers

### DIFF
--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -2808,7 +2808,7 @@ class RLMEnv(vf.StatefulToolEnv):
                 self._handle_root_tool_request,
             )
 
-            runner = web.AppRunner(app)
+            runner = web.AppRunner(app, access_log=None)
             await runner.setup()
             site = web.TCPSite(
                 runner, self._interception_bind_host, self.interception_port

--- a/verifiers/utils/interception_utils.py
+++ b/verifiers/utils/interception_utils.py
@@ -63,7 +63,7 @@ class InterceptionServer:
                 lambda _: web.json_response({"status": "ok"}),
             )
 
-            runner = web.AppRunner(app)
+            runner = web.AppRunner(app, access_log=None)
             await runner.setup()
             site = web.TCPSite(runner, "0.0.0.0", self.port)
             await site.start()


### PR DESCRIPTION
## Summary
- Disables aiohttp access logging for the interception HTTP servers
- Fixes noisy `aiohttp.access - INFO` logs like:
  ```
  aiohttp.access - INFO - 127.0.0.1 [18/Feb/2026:22:19:34 +0000] "POST /rollout/rlm_00e7c8a3/v1/rlm/tools
  ```

## Changes
- Added `access_log=None` to `web.AppRunner()` in:
  - `verifiers/utils/interception_utils.py` (InterceptionServer)
  - `verifiers/envs/experimental/rlm_env.py` (RLMEnv)

## Test plan
- [x] Verify aiohttp access logs no longer appear during rollouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change affecting only HTTP access logging configuration; no functional request/response logic is modified.
> 
> **Overview**
> Disables aiohttp access logging on the internal aiohttp interception servers by constructing `web.AppRunner` with `access_log=None` in both `RLMEnv`’s `_ensure_interception_server` and `InterceptionServer.start`.
> 
> This reduces rollout log noise (e.g., `aiohttp.access` INFO lines) without changing request routing or handler behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 29c26471a559b2fed72662843caab1364b5154df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->