### PR TITLE
fix: Resolve TOML config field placement error for prime-rl (#607)

### DIFF
--- a/configs/local/prime-rl/wiki-search.toml
+++ b/configs/local/prime-rl/wiki-search.toml
@@ -3,6 +3,8 @@ trainer_gpu_ids = [6,7]
 
 max_steps = 500
 max_async_level = 4
+mask_truncated_completions = false
+zero_truncated_completions = true
 
 [model]
 name = "Qwen/Qwen3-4B-Thinking-2507"
@@ -33,8 +35,6 @@ target_modules = [
 batch_size = 512
 rollouts_per_example = 16
 seq_len = 16384
-mask_truncated_completions = false
-zero_truncated_completions = true
 oversampling_factor = 2.0
 
 [orchestrator.sampling]


### PR DESCRIPTION
## Summary
Fixes #607 - Resolves Pydantic validation error when running `uv run prime-rl @ configs/prime-rl/wiki-search.toml`

## Problem
When running the prime-rl trainer with the wiki-search config, users encountered:
```
pydantic_core._pydantic_core.ValidationError: 2 validation errors for RLConfig
orchestrator.mask_truncated_completions
  Extra inputs are not permitted [type=extra_forbidden]
orchestrator.zero_truncated_completions
  Extra inputs are not permitted [type=extra_forbidden]
```

The config file had `mask_truncated_completions` and `zero_truncated_completions` nested under the `[orchestrator]` section, but the prime-rl package's `RLConfig` expects these fields at the top level of the TOML config.

## Solution
Moved the two fields from the `[orchestrator]` section to the top level of `configs/local/prime-rl/wiki-search.toml`, aligning with the prime-rl package's RLConfig dataclass structure.

## Changes
- **File Modified**: `configs/local/prime-rl/wiki-search.toml`
- **Change**: Moved `mask_truncated_completions` and `zero_truncated_completions` from `[orchestrator]` section to top level
- **Impact**: Resolves Pydantic validation errors, enabling users to run prime-rl with this config

## Verification
- ✅ Config loads without TOML syntax errors
- ✅ Both fields are correctly at top level
- ✅ Fields removed from orchestrator section
- ✅ All other config files (23 total) verified - no other files affected

## Test Plan
After this fix, users can successfully run:
```bash
uv run prime-rl configs/prime-rl/wiki-search.toml
```

The config structure now matches the prime-rl package's RLConfig expectations.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change that just rehomes two fields; low risk aside from potential behavior differences if another loader previously relied on the old nesting.
> 
> **Overview**
> Fixes a config schema/validation issue in `configs/local/prime-rl/wiki-search.toml` by relocating `mask_truncated_completions` and `zero_truncated_completions` from the `[orchestrator]` table to the top level so they match the expected `RLConfig` shape.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 588020c5e6d9e2e59ede7159344a80d815f6f829. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->