### PR TITLE
Fix uncacheable dataset.map calls 

### DIFF
--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -87,6 +87,35 @@ from verifiers.workers.client.env_client import EnvClient
 
 _MESSAGE_TYPE_UNSET = object()
 
+def _format_prompt_fn(
+    prompt_str: str,
+    system_prompt: str | None = None,
+    few_shot: Messages | None = None,
+) -> Messages:
+    messages = []
+    if system_prompt:
+        messages.append({"role": "system", "content": system_prompt})
+    if few_shot:
+        messages.extend(few_shot)
+    messages.append({"role": "user", "content": prompt_str})
+    return messages
+
+def _prepend_system_prompt(prompt: list[Any], system_prompt: str) -> list[Any]:
+    assert isinstance(prompt, list), (
+        f"prompt must be a list of messages when system_prompt is provided, got {type(prompt)}"
+    )
+    # Check if a system message already exists (first message)
+    first = prompt[0] if prompt else None
+    first_role = (
+        first.get("role")
+        if isinstance(first, dict)
+        else getattr(first, "role", None)
+    )
+    if first_role == "system":
+        return prompt
+    # Prepend as a plain dict so Arrow/HuggingFace can serialize.
+    # Normalization to Pydantic happens later in init_state.
+    return [{"role": "system", "content": system_prompt}, *prompt]
 
 class Environment(ABC):
     """
@@ -282,14 +311,14 @@ class Environment(ABC):
         )
         signal.signal(signal.SIGTERM, lambda _, __: (_sync_teardown(), exit(143)))
 
-    def _ensure_example_id(self, dataset: Dataset) -> Dataset:
+    def _ensure_example_id(self, dataset: Dataset, map_kwargs: dict = {}) -> Dataset:
         """Ensure example_id column exists and is integer type."""
         if "example_id" in dataset.column_names and not isinstance(
             dataset["example_id"][0], int
         ):
             dataset = dataset.rename_column("example_id", "src_id")
         if "example_id" not in dataset.column_names:
-            dataset = dataset.add_column("example_id", range(len(dataset)))
+            dataset = dataset.map(lambda _, i: {"example_id": i}, with_indices=True, **map_kwargs)
         return dataset
 
     def _ensure_prompt(
@@ -303,27 +332,17 @@ class Environment(ABC):
     ) -> Dataset:
         """Ensure prompt column exists."""
         if "prompt" not in dataset.column_names:
-
-            def format_prompt_fn(prompt_str: str) -> Messages:
-                messages = []
-                if system_prompt:
-                    messages.append({"role": "system", "content": system_prompt})
-                if few_shot:
-                    messages.extend(few_shot)
-                messages.append({"role": "user", "content": prompt_str})
-                return messages
-
             if answer_key == "answer":
                 dataset = dataset.map(
                     lambda x: {
-                        "prompt": format_prompt_fn(x[question_key]),
+                        "prompt": _format_prompt_fn(x[question_key], system_prompt, few_shot),
                     },
                     **map_kwargs,
                 )
             else:
                 dataset = dataset.map(
                     lambda x: {
-                        "prompt": format_prompt_fn(x[question_key]),
+                        "prompt": _format_prompt_fn(x[question_key], system_prompt, few_shot),
                         "answer": x[answer_key],
                     },
                     **map_kwargs,
@@ -332,25 +351,8 @@ class Environment(ABC):
         else:
             if system_prompt is not None:
 
-                def prepend_system_prompt(prompt: list[Any]) -> list[Any]:
-                    assert isinstance(prompt, list), (
-                        f"prompt must be a list of messages when system_prompt is provided, got {type(prompt)}"
-                    )
-                    # Check if a system message already exists (first message)
-                    first = prompt[0] if prompt else None
-                    first_role = (
-                        first.get("role")
-                        if isinstance(first, dict)
-                        else getattr(first, "role", None)
-                    )
-                    if first_role == "system":
-                        return prompt
-                    # Prepend as a plain dict so Arrow/HuggingFace can serialize.
-                    # Normalization to Pydantic happens later in init_state.
-                    return [{"role": "system", "content": system_prompt}, *prompt]
-
                 dataset = dataset.map(
-                    lambda x: {"prompt": prepend_system_prompt(x["prompt"])},
+                    lambda x: {"prompt": _prepend_system_prompt(x["prompt"], system_prompt)},
                     **map_kwargs,
                 )
             if few_shot is not None:
@@ -383,7 +385,7 @@ class Environment(ABC):
         """
         Format dataset by creating example_id and prompt columns, and setting task column.
         """
-        dataset = self._ensure_example_id(dataset)
+        dataset = self._ensure_example_id(dataset, map_kwargs)
         dataset = self._ensure_prompt(
             dataset, system_prompt, few_shot, question_key, answer_key, map_kwargs
         )
@@ -396,7 +398,7 @@ class Environment(ABC):
         """
         Format dataset by creating example_id and prompt columns, and setting task column.
         """
-        dataset = self._ensure_example_id(dataset)
+        dataset = self._ensure_example_id(dataset, map_kwargs)
         dataset = self._ensure_task(dataset, map_kwargs)
         return dataset
 


### PR DESCRIPTION
## Description
Datasets loaded via Environment weren't using the huggingface cache, because the caching hash is consistent on locally defined functions. 

Made the utility functions into module level functions
## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized changes to dataset preprocessing; main risk is subtle differences in `example_id` generation or prompt message structure affecting downstream consumers.
> 
> **Overview**
> Fixes HuggingFace `Dataset.map` caching in `Environment` dataset formatting by moving prompt-building helpers into module-level functions (stable hashing) and reusing them when creating/prepending system prompts.
> 
> Updates `_ensure_example_id` to use `dataset.map(..., with_indices=True, **map_kwargs)` (instead of `add_column`) and threads `map_kwargs` through the dataset formatting pipeline so caller-provided map settings are consistently applied.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1679cdf89682d5cb0f79a8fad94785b719ce65bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->