### PR TITLE
robustify env crash detection

### DIFF
--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -1277,7 +1277,9 @@ class Environment(ABC):
         # Use spawn to avoid inheriting file descriptors (e.g. sockets) from
         # the parent process, which has caused hangs when multiple env server
         # subprocesses share the same fds.
-        self.env_server_process = mp.get_context("spawn").Process(
+        self.env_server_process = mp.get_context(
+            "spawn"
+        ).Process(
             target=ZMQEnvServer.run_server,
             args=(
                 self.env_id,
@@ -1288,7 +1290,7 @@ class Environment(ABC):
                 log_file_level,
             ),
             kwargs=dict(address=address),
-            daemon=True,  # ensure server process is terminated when parent exits
+            daemon=False,  # cannot be daemon because we spawn subprocesses from the env server
         )
         self.env_server_process.start()
         self.env_client = ZMQEnvClient(

--- a/verifiers/scripts/gepa.py
+++ b/verifiers/scripts/gepa.py
@@ -559,7 +559,7 @@ def run_gepa_optimization(
             logger.debug(f"Results saved to {run_dir}")
 
         # Set result info for final summary
-        best_prompt = result.best_candidate.get("system_prompt", "")
+        best_prompt = result.best_candidate.get("system_prompt", "")  # type: ignore[unresolved-attribute]
         display.set_result(best_prompt=best_prompt, save_path=save_path)
 
     return result


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

previously, when running environments with heavy workloads/ high concurrency/ blocking ops, the env server would become unresponsive to the env client's periodic health checks which falsely makes the env client believe the server is dead and reschedules all requests as part of its recovery mechanism. one such example is the `wordle` environment on current main:

```bash
uv run vf-eval wordle -n16 -r64 -c-1 -i -d -m PrimeIntellect/Qwen3-1.7B-Wordle-SFT -p local
```

<img width="1426" height="247" alt="Screenshot 2026-02-20 at 1 05 36 PM" src="https://github.com/user-attachments/assets/cbac6542-623b-4a64-990a-3a779d60bde5" />


this pr makes several changes to avoid such false positives:
- [use subprocess for health responder on zmq env server](https://github.com/PrimeIntellect-ai/verifiers/commit/d9f6b2db730118355b1476c6551b9372ce3f4fa2)
- [run health check loop in dedicated thread](https://github.com/PrimeIntellect-ai/verifiers/commit/14de1c831cfde43b0c26db3810d32d946d0adbfe)

the first change requires that if spawning the env server as a sidecar, it _cannot be spawned as a daemon process_. automatic cleanup is already implemented on the env server, so this should be fine.

after the changes, health checks succeed as expected despite **heavy event loop lag**

<img width="1427" height="578" alt="Screenshot 2026-02-20 at 1 09 01 PM" src="https://github.com/user-attachments/assets/66dc86d5-e0ef-4c23-82b2-5c00758d25c6" />

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core health monitoring and process/thread lifecycle management; mis-wiring the thread→event-loop callbacks or process cleanup could cause missed unhealthy detection or leaked background workers.
> 
> **Overview**
> Makes env crash detection more robust under heavy workload by moving health probing off the main asyncio loop: `ZMQEnvServer` now runs the health responder in a separate process, and `ZMQEnvClient` runs the probe/state machine in a dedicated thread that reports transitions back via `call_soon_threadsafe`.
> 
> Updates lifecycle behavior around this: the client no longer performs health socket I/O from async code (it reports last known state), unhealthy detection now triggers after 5 consecutive probe failures and cancels pending requests via a callback, and `Environment.start_server` spawns the env server as non-daemon while `EnvServer` requests a Linux parent-death SIGTERM for cleanup. Tests are rewritten to exercise the new callback-driven transitions, and a small typing suppression is added in `gepa.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 488bfadf57912df1ed3237827313152ac0307f75. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->