### PR TITLE
perf improvements to textarena env + wordle

### DIFF
--- a/verifiers/envs/integrations/textarena_env.py
+++ b/verifiers/envs/integrations/textarena_env.py
@@ -101,7 +101,7 @@ class TextArenaEnv(vf.MultiTurnEnv):
         return memo
 
     async def setup_state(self, state: vf.State, **kwargs) -> vf.State:
-        ta_env = await asyncio.to_thread(deepcopy, self.ta_env, self.shared_memo.copy())
+        ta_env = await asyncio.to_thread(deepcopy, self.ta_env, self.shared_memo.copy())  # type: ignore[unresolved-attribute]
         ta_env.state.game_state["secret_word"] = state["answer"]
         state["ta_env"] = ta_env
         return state

--- a/verifiers/envs/integrations/textarena_env.py
+++ b/verifiers/envs/integrations/textarena_env.py
@@ -101,8 +101,8 @@ class TextArenaEnv(vf.MultiTurnEnv):
         return memo
 
     async def setup_state(self, state: vf.State, **kwargs) -> vf.State:
-        ta_env = await asyncio.to_thread(deepcopy, self.ta_env, self.shared_memo.copy())  # type: ignore[unresolved-attribute]
-        ta_env.state.game_state["secret_word"] = state["answer"]
+        ta_env = await asyncio.to_thread(deepcopy, self.ta_env, self.shared_memo.copy())
+        ta_env.state.game_state["secret_word"] = state["answer"]  # type: ignore[unresolved-attribute]
         state["ta_env"] = ta_env
         return state
 

--- a/verifiers/envs/integrations/textarena_env.py
+++ b/verifiers/envs/integrations/textarena_env.py
@@ -121,7 +121,7 @@ class TextArenaEnv(vf.MultiTurnEnv):
         if ta_env.state.done:
             self.logger.debug(f"Game completed! {ta_env.state.game_info=}")
             response = vf.UserMessage(content=ta_env.state.game_info[0]["reason"])
-            state["final_env_response"] = response
+            state["final_env_response"] = [response]
             return [response]
         else:
             _, observation = await asyncio.to_thread(ta_env.get_observation)


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

the textarena env (which `worlde` uses) has extreme event loop lag at high concurrency. this pr offloads the sync ops from the textarena package into the default asyncio thread pool executor.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core rollout execution paths (`setup_state`/`env_response`) and changes sync-to-async behavior plus deepcopy semantics, which could introduce subtle concurrency or state-sharing bugs under load.
> 
> **Overview**
> Improves `TextArenaEnv` concurrency performance by offloading blocking TextArena calls (`deepcopy` during `setup_state`, `step`, and `get_observation`) to the default asyncio thread pool via `asyncio.to_thread`.
> 
> Adds a `build_shared_memo` helper and uses it when cloning the underlying env so large immutable dictionary/word-list data can be shared across deep copies, and standardizes env responses to return `vf.UserMessage` objects (including the stored `final_env_response`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b0e02d5d4fa3feb9b0c20380759165dae693d7bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->