### PR TITLE
fix: don't swallow `SIGTERM`+ `SIGINT` in env server

### DIFF
--- a/verifiers/workers/server/env_server.py
+++ b/verifiers/workers/server/env_server.py
@@ -123,12 +123,8 @@ class EnvServer(ABC):
         try:
             await self.serve(stop_event=stop_event)
         finally:
-            try:
-                await self.env._teardown()
-            except Exception:
-                self.logger.exception("Error during environment teardown")
-            finally:
-                await self.close()
+            await self.env._teardown()
+            await self.close()
 
     @classmethod
     def run_server(cls, *args, **kwargs):

--- a/verifiers/workers/server/env_server.py
+++ b/verifiers/workers/server/env_server.py
@@ -123,8 +123,12 @@ class EnvServer(ABC):
         try:
             await self.serve(stop_event=stop_event)
         finally:
-            await self.env._teardown()
-            await self.close()
+            try:
+                await self.env._teardown()
+            except Exception:
+                self.logger.exception("Error during environment teardown")
+            finally:
+                await self.close()
 
     @classmethod
     def run_server(cls, *args, **kwargs):

--- a/verifiers/workers/server/env_server.py
+++ b/verifiers/workers/server/env_server.py
@@ -124,6 +124,7 @@ class EnvServer(ABC):
         try:
             await self.serve(stop_event=stop_event)
         finally:
+            await self.env._teardown()
             await self.close()
 
     @classmethod

--- a/verifiers/workers/server/env_server.py
+++ b/verifiers/workers/server/env_server.py
@@ -111,15 +111,14 @@ class EnvServer(ABC):
 
         stop_event = asyncio.Event()
 
-        def signal_handler(sig):
-            self.logger.info(
-                f"Received signal {sig.name}, initiating graceful shutdown"
-            )
+        def signal_handler(sig, frame):
             stop_event.set()
+            if sig == signal.SIGTERM:
+                raise SystemExit(143)
+            raise KeyboardInterrupt()
 
-        loop = asyncio.get_running_loop()
-        for sig in (signal.SIGTERM, signal.SIGINT):
-            loop.add_signal_handler(sig, lambda s=sig: signal_handler(s))
+        signal.signal(signal.SIGTERM, signal_handler)
+        signal.signal(signal.SIGINT, signal_handler)
 
         try:
             await self.serve(stop_event=stop_event)


### PR DESCRIPTION
## Description
`EnvServer.run()` registers asyncio signal handlers that override the classic signal.signal() handlers set by `Environment.__post_init__`. The asyncio handlers gracefully stop the serve loop and call `server.close()`, but `close()` only tears down ZMQ/network resources — it never invokes `env._teardown()`, so @vf.teardown handlers (notably teardown_sandboxes) never run. This causes sandbox leaks.
You can reproduce with Ctrl+C.

Adds await self.env._teardown() to the server's finally block before close().

second fix: https://github.com/PrimeIntellect-ai/verifiers/pull/947#issuecomment-3938005156

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches process signal handling and shutdown sequencing; mistakes here can cause hangs or premature exits, but the change is localized and aims to make cleanup more reliable.
> 
> **Overview**
> Fixes `EnvServer.run()` shutdown behavior so environment teardown hooks reliably run and signals aren’t swallowed.
> 
> This switches from `asyncio` loop signal handlers to `signal.signal` handlers (raising `SystemExit(143)` on `SIGTERM` and `KeyboardInterrupt` on `SIGINT`) and adds `await self.env._teardown()` in the `finally` block before `close()` to prevent resource/sandbox leaks on graceful shutdown.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f229d18e71d1ef16c7e738941c69c81e95862b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->