### PR TITLE
stop rollouts on incomplete responses (no content or tools)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ __pycache__/
 
 # libraries
 /prime-rl
+/packages/tasksets
+/packages/harnesses
 
 # outputs
 wandb/

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ __pycache__/
 /packages/tasksets
 /packages/harnesses
 
+
 # outputs
 wandb/
 outputs/

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -567,7 +567,7 @@ class MyGameEnv(vf.MultiTurnEnv):
         return state.get("lives", 1) <= 0
 ```
 
-`MultiTurnEnv` includes built-in stop conditions for errors, prompt length limits, and `max_turns` by default.
+`MultiTurnEnv` includes built-in stop conditions for errors, prompt length limits, `max_turns`, and incomplete response detection by default.
 
 Execution order can be controlled with `priority` (higher runs first). This is useful for checking cheap conditions before expensive ones:
 

--- a/environments/wiki_search/pyproject.toml
+++ b/environments/wiki_search/pyproject.toml
@@ -3,9 +3,9 @@ name = "wiki-search"
 description = "Agentic RAG over Wikipedia pages for trivia Q&A"
 tags = ["wikipedia", "multi-turn", "agentic-search", "rag", "train", "eval", "llm-judge"]
 requires-python = ">=3.11"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
-    "verifiers>=0.1.9",
+    "verifiers>=0.1.11.dev0",
     "chromadb",
     "datasets",
     "openai",

--- a/environments/wiki_search/wiki_search.py
+++ b/environments/wiki_search/wiki_search.py
@@ -260,7 +260,10 @@ def load_environment(
     )
 
     async def judge_reward_func(judge, prompt, completion, answer, state) -> float:
-        judge_response = await judge(prompt, completion, answer, state)
+        cleaned_completion = [
+            {x["role"]: x["content"].split("</think>")[-1] for x in completion}
+        ]
+        judge_response = await judge(prompt, cleaned_completion, answer, state)
         if "yes" in judge_response.lower():
             return 1.0
         else:

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -156,7 +156,9 @@ class Environment(ABC):
 
         if dataset is not None:
             if callable(dataset):
-                self.dataset_source: DatasetBuilder | None = dataset
+                self.dataset_source: DatasetBuilder | None = cast(
+                    DatasetBuilder, dataset
+                )
             else:
                 self.dataset_source = lambda ds=dataset: ds
                 self.build_dataset()  # Eagerly build for raw datasets (backwards compat)
@@ -165,7 +167,9 @@ class Environment(ABC):
 
         if eval_dataset is not None:
             if callable(eval_dataset):
-                self.eval_dataset_source: DatasetBuilder | None = eval_dataset
+                self.eval_dataset_source: DatasetBuilder | None = cast(
+                    DatasetBuilder, eval_dataset
+                )
             else:
                 self.eval_dataset_source = lambda ds=eval_dataset: ds
                 self.build_eval_dataset()  # Eagerly build for raw datasets (backwards compat)


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core rollout termination/truncation behavior in `MultiTurnEnv`, which can alter evaluation/training outcomes when providers emit empty responses.
> 
> **Overview**
> **Multi-turn rollouts now terminate when the model returns an “incomplete” response** (no message content and no tool calls). This is implemented as a new `@vf.stop` condition (`has_incomplete_response`) and by marking such trajectory steps as truncated in `MultiTurnEnv.add_model_response`.
> 
> Docs are updated to mention incomplete-response detection as a default stop condition, the `wiki-search` environment strips `<think>` content before LLM judging, and dataset builder fields in `Environment` are explicitly `cast()` for type safety; `.gitignore` also ignores `packages/tasksets` and `packages/harnesses`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92a8da88ecf9537bd6b0828a62a3f831ded88d21. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->