### PR TITLE
Add AIME 2026 dataset support

### DIFF
--- a/verifiers/utils/data_utils.py
+++ b/verifiers/utils/data_utils.py
@@ -127,6 +127,15 @@ def get_preprocess_fn(name: str) -> Callable[[dict], dict]:
             }
 
         return preprocess_aime2025
+    elif name == "aime2026":
+
+        def preprocess_aime2026(x: dict[str, Any]) -> dict[str, Any]:
+            return {
+                "question": x["problem"],
+                "answer": str(int(x["answer"])),
+            }
+
+        return preprocess_aime2026
     elif name == "amc2023":
 
         def preprocess_amc2023(x: dict[str, Any]) -> dict[str, Any]:
@@ -278,6 +287,10 @@ def load_example_dataset(
             Dataset, load_dataset("opencompass/AIME2025", "AIME2025-II")[split]
         )
         dataset = concatenate_datasets([aime_i, aime_ii])
+    elif name == "aime2026":
+        if split is None:
+            split = "train"
+        dataset = load_dataset("MathArena/aime_2026")[split]
     elif name == "amc2023":
         if split is None:
             split = "train"


### PR DESCRIPTION
## Summary
- Add AIME 2026 dataset loading (`MathArena/aime_2026`) and preprocessing to `data_utils.py`
- 30 problems, integer answers — same schema as AIME 2024

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Testing
- [x] All existing tests pass when running `uv run pytest` locally
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in AGENTS.md
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive change limited to example dataset loading/preprocessing; main risk is minor breakage if the upstream dataset schema or split name differs.
> 
> **Overview**
> Adds AIME 2026 support to the example dataset utilities by wiring `aime2026` into `load_example_dataset` (loads `MathArena/aime_2026`, defaulting to the `train` split).
> 
> Introduces a matching `get_preprocess_fn` handler that maps `problem` → `question` and normalizes answers to integer strings (`str(int(...))`) for consistent `question`/`answer` output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b55563b479ac0032676c622ee0e47a81a5e9b6e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->