### PR TITLE
feat: human debug mode

### DIFF
--- a/configs/eval/human-debug.toml
+++ b/configs/eval/human-debug.toml
@@ -1,0 +1,7 @@
+save_results = true
+
+[[eval]]
+env_id = "primeintellect/wordle"
+num_examples = 1
+rollouts_per_example = 1
+human_debug = true

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -154,6 +154,7 @@ The `--max-retries` flag enables automatic retry with exponential backoff when r
 | `--verbose` | `-v` | false | Enable debug logging |
 | `--tui` | `-u` | false | Use alternate screen mode (TUI) for display |
 | `--debug` | `-d` | false | Disable Rich display; use normal logging and tqdm progress |
+| `--human-debug` | — | false | Use interactive human input for model responses (text-only) |
 | `--save-results` | `-s` | false | Save results to disk |
 | `--resume [PATH]` | `-R` | — | Resume from a previous run (auto-detect latest matching incomplete run if PATH omitted) |
 | `--state-columns` | `-C` | — | Extra state columns to save (comma-separated) |
@@ -165,6 +166,21 @@ Results are saved to `./outputs/evals/{env_id}--{model}/{run_id}/`, containing:
 
 - `results.jsonl` — rollout outputs, one per line
 - `metadata.json` — evaluation configuration and aggregate metrics
+
+### Human Debug Mode
+
+Use `--human-debug` to replace API model calls with terminal-entered responses:
+
+```bash
+prime eval run my-env --human-debug -n 3 -r 1 -s
+```
+
+In this mode:
+- Responses are entered interactively in the CLI and ended with `:wq` on its own line
+- Only text responses are supported (tool calls are not supported)
+- Exactly one eval config is supported per run
+- Execution is forced to sequential + independent scoring (`max_concurrent=1`, `independent_scoring=true`)
+- TUI display is disabled automatically to avoid stdin/display conflicts
 
 ### Resuming Evaluations
 
@@ -290,6 +306,7 @@ Each `[[eval]]` section must contain an `env_id` field. All other fields are opt
 | `extra_env_kwargs` | table | Arguments passed to environment constructor |
 | `model` | string | Model to evaluate |
 | `endpoint_id` | string | Endpoint registry id (requires TOML `endpoints_path`) |
+| `human_debug` | boolean | Use interactive human-entered model responses (single eval only) |
 
 Example with `env_args`:
 

--- a/tests/test_human_cli_client.py
+++ b/tests/test_human_cli_client.py
@@ -1,0 +1,95 @@
+import builtins
+
+import pytest
+
+from verifiers.clients.human_cli_client import HumanCLIClient
+from verifiers.errors import ModelError
+from verifiers.types import SystemMessage, Tool, UserMessage
+
+
+@pytest.mark.asyncio
+async def test_human_cli_client_returns_multiline_response(monkeypatch):
+    responses = iter(["first line", "second line", ":wq"])
+    monkeypatch.setattr(builtins, "input", lambda: next(responses))
+
+    client = HumanCLIClient()
+    response = await client.get_response(
+        prompt=[UserMessage(content="hello")],
+        model="test-model",
+        sampling_args={},
+    )
+
+    assert response.model == "test-model"
+    assert response.message.content == "first line\nsecond line"
+    assert response.message.finish_reason == "stop"
+    assert response.message.tool_calls is None
+
+
+@pytest.mark.asyncio
+async def test_human_cli_client_reprompts_on_empty_response(monkeypatch):
+    responses = iter(["", ":wq", "final answer", ":wq"])
+    monkeypatch.setattr(builtins, "input", lambda: next(responses))
+
+    client = HumanCLIClient()
+    response = await client.get_response(
+        prompt=[UserMessage(content="hello")],
+        model="test-model",
+        sampling_args={},
+    )
+
+    assert response.message.content == "final answer"
+
+
+@pytest.mark.asyncio
+async def test_human_cli_client_rejects_tool_calls(monkeypatch):
+    responses = iter(["answer", ":wq"])
+    monkeypatch.setattr(builtins, "input", lambda: next(responses))
+
+    client = HumanCLIClient()
+    with pytest.raises(ModelError, match="text-only"):
+        await client.get_response(
+            prompt=[UserMessage(content="hello")],
+            model="test-model",
+            sampling_args={},
+            tools=[
+                Tool(
+                    name="my_tool",
+                    description="test tool",
+                    parameters={"type": "object", "properties": {}},
+                )
+            ],
+        )
+
+
+@pytest.mark.asyncio
+async def test_human_cli_client_propagates_keyboard_interrupt(monkeypatch):
+    def raise_interrupt():
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(builtins, "input", raise_interrupt)
+
+    client = HumanCLIClient()
+    with pytest.raises(KeyboardInterrupt):
+        await client.get_response(
+            prompt=[UserMessage(content="hello")],
+            model="test-model",
+            sampling_args={},
+        )
+
+
+@pytest.mark.asyncio
+async def test_human_cli_client_renders_prompt_without_crashing(monkeypatch):
+    responses = iter(["done", ":wq"])
+    monkeypatch.setattr(builtins, "input", lambda: next(responses))
+
+    client = HumanCLIClient()
+    response = await client.get_response(
+        prompt=[
+            SystemMessage(content="You are helpful"),
+            UserMessage(content="Solve this"),
+        ],
+        model="test-model",
+        sampling_args={},
+    )
+
+    assert response.message.content == "done"

--- a/verifiers/clients/__init__.py
+++ b/verifiers/clients/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from verifiers.clients.anthropic_messages_client import AnthropicMessagesClient
 from verifiers.clients.client import Client
+from verifiers.clients.human_cli_client import HumanCLIClient
 from verifiers.clients.openai_chat_completions_client import OpenAIChatCompletionsClient
 from verifiers.clients.openai_chat_completions_token_client import (
     OpenAIChatCompletionsTokenClient,
@@ -35,5 +36,6 @@ __all__ = [
     "OpenAICompletionsClient",
     "OpenAIChatCompletionsClient",
     "OpenAIChatCompletionsTokenClient",
+    "HumanCLIClient",
     "Client",
 ]

--- a/verifiers/clients/human_cli_client.py
+++ b/verifiers/clients/human_cli_client.py
@@ -1,0 +1,111 @@
+import time
+import uuid
+
+from rich.console import Console
+
+from verifiers.clients.client import Client
+from verifiers.errors import EmptyModelResponseError, ModelError
+from verifiers.types import (
+    ClientConfig,
+    Messages,
+    Response,
+    ResponseMessage,
+    SamplingArgs,
+    Tool,
+)
+from verifiers.utils.logging_utils import format_messages
+
+
+class HumanCLIClient(Client[None, Messages, Response, Tool]):
+    """Client that captures assistant responses from a human in the terminal."""
+
+    def __init__(self, sentinel: str = ":wq") -> None:
+        self.sentinel = sentinel
+        self._console = Console()
+        super().__init__(None)
+
+    def setup_client(self, config: ClientConfig) -> None:
+        return None
+
+    async def to_native_tool(self, tool: Tool) -> Tool:
+        return tool
+
+    async def to_native_prompt(self, messages: Messages) -> tuple[Messages, dict]:
+        return messages, {}
+
+    async def get_native_response(
+        self,
+        prompt: Messages,
+        model: str,
+        sampling_args: SamplingArgs,
+        tools: list[Tool] | None = None,
+        **kwargs,
+    ) -> Response:
+        raise NotImplementedError(
+            "HumanCLIClient.get_native_response is not used. Call get_response()."
+        )
+
+    async def raise_from_native_response(self, response: Response) -> None:
+        return None
+
+    async def from_native_response(self, response: Response) -> Response:
+        return response
+
+    async def close(self) -> None:
+        return None
+
+    def _read_human_response(self, prompt: Messages) -> str:
+        self._console.rule("Human Debug")
+        self._console.print(format_messages(prompt))
+        self._console.print(
+            f"\nEnter assistant response. End input with `{self.sentinel}` on its own line."
+        )
+
+        while True:
+            lines: list[str] = []
+            while True:
+                try:
+                    line = input()
+                except EOFError as e:
+                    raise EmptyModelResponseError(
+                        "Reached EOF while waiting for human input"
+                    ) from e
+
+                if line.strip() == self.sentinel:
+                    break
+                lines.append(line)
+
+            response_text = "\n".join(lines).strip()
+            if response_text:
+                return "\n".join(lines)
+
+            self._console.print("Empty response. Please enter a non-empty response.")
+
+    async def get_response(
+        self,
+        prompt: Messages,
+        model: str,
+        sampling_args: SamplingArgs,
+        tools: list[Tool] | None = None,
+        **kwargs,
+    ) -> Response:
+        if tools:
+            raise ModelError(
+                "Human debug mode is text-only and does not support tool calls."
+            )
+
+        content = self._read_human_response(prompt)
+        return Response(
+            id=f"human-{uuid.uuid4().hex}",
+            created=int(time.time()),
+            model=model,
+            usage=None,
+            message=ResponseMessage(
+                content=content,
+                reasoning_content=None,
+                finish_reason="stop",
+                is_truncated=False,
+                tokens=None,
+                tool_calls=None,
+            ),
+        )

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -486,6 +486,7 @@ class EvalConfig(BaseModel):
     rollouts_per_example: int
     max_concurrent: int
     independent_scoring: bool = False
+    human_debug: bool = False
     extra_env_kwargs: dict = {}
     max_retries: int = 0
     # logging


### PR DESCRIPTION
## Description
This PR adds a simple way to quickly test text-based environments with human input, instead of having to wait for a hosted run to fail/reach the edge-case we want to test/...

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [x] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the eval execution path and client selection, so regressions could affect how evaluations run (especially concurrency/TUI behavior), though the new mode is opt-in and well-tested.
> 
> **Overview**
> Adds a new *human debug mode* for `prime eval run` (via `--human-debug` or `human_debug=true` in eval TOML) that replaces model API calls with terminal-entered assistant responses using a new `HumanCLIClient`.
> 
> When enabled, the CLI enforces a safer runtime (single-eval only, forces `max_concurrent=1` and `independent_scoring=true`), disables TUI execution, and handles Ctrl-C cleanly; docs, an example config (`configs/eval/human-debug.toml`), and tests are updated to cover the new flag/client behavior and TOML validation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6aa99cafaee7e46bb0405287c70e58317c229cce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->