### PR TITLE
fix: RubricGroup scoring_ms should be the time to score all rubrics

### DIFF
--- a/tests/test_rubric_group.py
+++ b/tests/test_rubric_group.py
@@ -419,7 +419,7 @@ class TestRubricGroup:
         assert recorded_parsers == [xml_parser]
 
     @pytest.mark.asyncio
-    async def test_rubric_group_score_rollout_timing_invariant(self):
+    async def test_rubric_group_score_rollout_timing(self):
         """Test that generation_ms + scoring_ms == total_ms after score_rollout."""
 
         def func1(completion, **kwargs):
@@ -457,7 +457,7 @@ class TestRubricGroup:
         assert state["timing"]["total_ms"] == 100.0 + state["timing"]["scoring_ms"]
 
     @pytest.mark.asyncio
-    async def test_rubric_group_score_group_timing_invariant(self):
+    async def test_rubric_group_score_group_timing(self):
         """Test that generation_ms + scoring_ms == total_ms after score_group."""
 
         def func1(completion, **kwargs):


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Measure total scoring time once at the `RubricGroup` level. `scoring_ms` was previously the last rubric's `scoring_ms` in a `RubricGroup`.

Fixes https://github.com/PrimeIntellect-ai/verifiers/issues/952.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [x] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: isolated change to timing bookkeeping in `RubricGroup`, plus tests validating `scoring_ms`/`total_ms` consistency.
> 
> **Overview**
> Fixes `RubricGroup` timing so `scoring_ms` reflects the **total** time spent scoring across all rubrics (rather than whatever the last rubric wrote). `score_rollout` and `score_group` now measure wall-clock time once at the group level, restore each state’s original `timing` between rubric evaluations, and then update `scoring_ms` and increment `total_ms` after aggregation.
> 
> Adds async tests asserting `generation_ms + scoring_ms == total_ms` for both `score_rollout` and `score_group`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67c3e20fc5ffd4911e10a16b6d682a64d84cdd70. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->