### PR TITLE
use MITO for multimodal

### DIFF
--- a/verifiers/clients/openai_chat_completions_token_client.py
+++ b/verifiers/clients/openai_chat_completions_token_client.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from typing import Optional, cast
 
 from openai import AsyncOpenAI, BaseModel
@@ -11,6 +12,20 @@ from verifiers.clients.openai_chat_completions_client import (
     handle_openai_overlong_prompt,
 )
 from verifiers.types import SamplingArgs, State
+
+
+def _has_multimodal_content(messages: OpenAIChatMessages) -> bool:
+    """Check if any message contains multimodal content (images, audio)."""
+    for msg in messages:
+        content = msg.get("content") if isinstance(msg, Mapping) else None
+        if isinstance(content, list):
+            for part in content:
+                if isinstance(part, Mapping) and part.get("type") in (
+                    "image_url",
+                    "input_audio",
+                ):
+                    return True
+    return False
 
 
 # copy from vllm/entrypoints/openai/protocol.py
@@ -58,8 +73,14 @@ class OpenAIChatCompletionsTokenClient(OpenAIChatCompletionsClient):
 
         sampling_args = normalize_sampling_args(sampling_args)
         state = cast(State, kwargs.pop("state"))
-        # use /v1/chat/completions for first turn to avoid redundant tokenization
-        if len(state["trajectory"]) == 0:
+        # Use standard /chat/completions for: (1) first turn (no prior tokens to
+        # stitch), or (2) multimodal conversations.  VLM image-placeholder
+        # expansion happens inside the engine during generation but NOT in the
+        # /tokenize endpoint, so token-stitching (TITO) operates in a different
+        # coordinate system than /tokenize and produces broken prompts.  Falling
+        # back to message-based inference (MITO) lets vLLM handle expansion
+        # correctly on every turn.
+        if len(state["trajectory"]) == 0 or _has_multimodal_content(prompt):
             return await super().get_native_response(
                 prompt, model, sampling_args, tools
             )


### PR DESCRIPTION
## Description
VLM image placeholder tokens (e.g. `<|image_pad|>`) get expanded inside vLLM's engine during generation (1 token → N tokens based on image resolution), but the `/tokenize` endpoint does **not** run this expansion. TITO's `get_prompt_ids()` uses the expanded token count from the generation response as a slice offset against the unexpanded token array from `/tokenize`, producing broken prompts on turns 1+.

MITO lets vLLM handle tokenization and image expansion correctly on every turn with no extra round-trips.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request routing in the chat client based on prompt content, which could alter behavior/performance for multimodal and mixed-content conversations but is localized to client logic.
> 
> **Overview**
> Prevents broken follow-up turns in multimodal (image/audio) conversations by disabling token-stitching (TITO) when prompts contain multimodal content.
> 
> `OpenAIChatCompletionsTokenClient.get_native_response` now detects multimodal message parts and falls back to the standard `/chat/completions` (MITO) path for those requests (and still for the first turn), leaving the token-based `/chat/completions/tokens` route for text-only multi-turn chats.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5099bf3ce689130a80901e23e42f96a7a1f4682. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->