### PR TITLE
fix browser sandbox leak by wrapping errors in vf.Error subclass

### DIFF
--- a/verifiers/envs/integrations/browser_env/browser_env.py
+++ b/verifiers/envs/integrations/browser_env/browser_env.py
@@ -79,6 +79,8 @@ class BrowserEnv(vf.StatefulToolEnv):
         # Pre-built image configuration (default - fastest startup, skips binary upload)
         use_prebuilt_image: bool = True,
         prebuilt_image: str = "deepdream19/cua-server:latest",
+        # Error handling
+        stop_errors: list[type[Exception]] | None = None,
         # Common
         **kwargs: Any,
     ):
@@ -113,9 +115,13 @@ class BrowserEnv(vf.StatefulToolEnv):
             use_binary: Use pre-built SEA binary when use_prebuilt_image=False (default: True)
             use_prebuilt_image: Use pre-built Docker image for fastest startup (default: True)
             prebuilt_image: Docker image to use (default: deepdream19/cua-server:latest)
+            stop_errors: List of exception types that should trigger cleanup (default: [vf.SandboxError])
             **kwargs: Additional arguments passed to StatefulToolEnv
         """
-        super().__init__(**kwargs)
+        super().__init__(
+            stop_errors=stop_errors if stop_errors is not None else [vf.SandboxError],
+            **kwargs,
+        )
         self.mode = mode
         browserbase_api_key = os.getenv(browserbase_api_key_var)
         model_api_key = os.getenv(model_api_key_var)

--- a/verifiers/errors.py
+++ b/verifiers/errors.py
@@ -54,3 +54,9 @@ class SandboxError(InfraError):
     """Used to catch errors while interacting with sandboxes."""
 
     pass
+
+
+class BrowserSandboxError(SandboxError):
+    """Used to catch errors while interacting with browser sandboxes."""
+
+    pass


### PR DESCRIPTION
CUA mode's setup_state raised plain RuntimeError on failures, which bypassed the rollout error handler (only catches vf.Error). This caused cleanup_session to never run, orphaning sandboxes. With batch training and retries, this compounded to thousands of leaked sandboxes.

Changes:
- Add BrowserSandboxError class (inherits from vf.SandboxError)
- Pass stop_errors=[vf.SandboxError] in BrowserEnv.__init__
- Wrap setup_state exceptions in BrowserSandboxError

Now errors trigger has_error() -> is_completed() -> cleanup_session() -> sandbox deletion before retry.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->