### PR TITLE
fix: validate tool args are dict in ToolEnv.env_response

### DIFF
--- a/verifiers/envs/tool_env.py
+++ b/verifiers/envs/tool_env.py
@@ -152,7 +152,12 @@ class ToolEnv(vf.MultiTurnEnv):
             tool_call_id: str = tool_call.id
             try:
                 tool_name: str = tool_call.name
-                tool_args: dict = json.loads(tool_call.arguments)
+                parsed_args = json.loads(tool_call.arguments)
+                if not isinstance(parsed_args, dict):
+                    raise ValueError(
+                        f"Expected tool arguments to be a dict, got {type(parsed_args).__name__}: {parsed_args}"
+                    )
+                tool_args: dict = parsed_args
             except Exception as e:
                 if self._should_stop_for_error(e):
                     raise vf.ToolParseError from e


### PR DESCRIPTION
While training a tool-calling agent with ToolEnv, I hit a crash mid-rollout caused by a model (Qwen3-4B) producing double-encoded JSON tool arguments. json.loads succeeds but returns a str instead of a dict, which then crashes when unpacked as **kwargs in call_tool.

StatefulToolEnv.env_response already guards against this (lines 141-147), but ToolEnv.env_response was missing the same check. This aligns both methods.

Changes:
- Add isinstance(parsed_args, dict) validation in ToolEnv.env_response, matching the existing StatefulToolEnv pattern
- Non-dict args raise ValueError, caught by the existing error handler (returned to model or stops rollout via stop_errors)
- Add two tests: stop-on-error path and graceful-fallback path

Closes #562

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
- [x] All existing tests pass when running `uv run pytest` locally.
- [x] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized input-validation change in tool-call parsing plus tests; behavior only differs for malformed/non-dict tool arguments.
> 
> **Overview**
> Prevents `ToolEnv.env_response` from crashing when a model returns double-encoded JSON tool arguments by validating that `json.loads(tool_call.arguments)` produces a `dict` and treating non-dicts as a parse error.
> 
> Adds coverage for this case with two new tests: one verifying rollouts stop with `ToolParseError` when `ValueError` is in `stop_errors`, and another ensuring the env returns a tool error message and continues when it is not.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d5da8cac6887b42545995739176553c09efb306. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->