### PR TITLE
Preserve image content in tool messages

### DIFF
--- a/verifiers/clients/openai_chat_completions_client.py
+++ b/verifiers/clients/openai_chat_completions_client.py
@@ -209,7 +209,7 @@ class OpenAIChatCompletionsClient(
                 return ChatCompletionToolMessageParam(
                     role="tool",
                     tool_call_id=message.tool_call_id,
-                    content=content_to_text(message.content),
+                    content=cast(Any, normalize_content(message.content)),
                 )
             elif isinstance(message, TextMessage):
                 return ChatCompletionUserMessageParam(


### PR DESCRIPTION
\`content_to_text()\` in \`OpenAIChatCompletionsClient.to_native_prompt\` was stripping \`image_url\` parts from \`ToolMessage\` content before sending to the API. This meant VLM models never saw screenshots returned by browser tools (CUA mode).

Uses \`normalize_content()\` instead, consistent with how system, user, and assistant messages already handle multipart content.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small change to prompt serialization so `ToolMessage` content is no longer flattened to text, but it could alter what gets sent to the OpenAI API for tool responses.
> 
> **Overview**
> Ensures `ToolMessage` content passed to the Chat Completions API preserves multipart payloads (e.g., `image_url` parts) by switching from `content_to_text()` to `normalize_content()` in `OpenAIChatCompletionsClient.to_native_prompt`.
> 
> This aligns tool-message serialization with system/user/assistant handling so non-text tool outputs are no longer dropped before reaching vision-capable models.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2404c42f39da88fb3cee03b6c0d444a4d39f3707. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->