### PR TITLE
keep images in tool responses

### DIFF
--- a/verifiers/clients/openai_chat_completions_client.py
+++ b/verifiers/clients/openai_chat_completions_client.py
@@ -209,7 +209,7 @@ class OpenAIChatCompletionsClient(
                 return ChatCompletionToolMessageParam(
                     role="tool",
                     tool_call_id=message.tool_call_id,
-                    content=content_to_text(message.content),
+                    content=cast(Any, normalize_content(message.content)),
                 )
             elif isinstance(message, TextMessage):
                 return ChatCompletionUserMessageParam(


### PR DESCRIPTION
## Description
we were stripping images from tool responses. this fixes that
## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `ToolMessage` content is serialized for the OpenAI Chat Completions API; if any downstream model/provider expects tool content to be plain text, this could cause request validation or behavior differences.
> 
> **Overview**
> Stops coercing `ToolMessage` content to plain text when building Chat Completions prompts, and instead passes through normalized structured content (e.g., image parts) just like other message roles.
> 
> This fixes tool responses losing non-text payloads during prompt serialization in `OpenAIChatCompletionsClient.to_native_prompt`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f971ffa305154f58c427c0ad5d7b5381746c11c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->