### PR TITLE
release v0.1.11.dev1

### DIFF
--- a/assets/release/RELEASE_v0.1.11.dev1.md
+++ b/assets/release/RELEASE_v0.1.11.dev1.md
@@ -1,0 +1,5 @@
+# Verifiers v0.1.11.dev1 Release Notes
+
+*Date:* 03/02/2026
+
+**Full Changelog**: https://github.com/PrimeIntellect-ai/verifiers/compare/v0.1.11.dev0...v0.1.11.dev1

--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.11.dev0"
+__version__ = "0.1.11.dev1"
 
 import importlib
 import os
@@ -162,10 +162,12 @@ if TYPE_CHECKING:
     from typing import Any
 
     from .envs.experimental.cli_agent_env import CliAgentEnv  # noqa: F401
-    from .envs.experimental.rollout_gateway_mixin import RolloutGatewayMixin  # noqa: F401
     from .envs.experimental.gym_env import GymEnv  # noqa: F401
     from .envs.experimental.harbor_env import HarborEnv  # noqa: F401
     from .envs.experimental.mcp_env import MCPEnv  # noqa: F401
+    from .envs.experimental.rollout_gateway_mixin import (
+        RolloutGatewayMixin,  # noqa: F401
+    )
     from .envs.integrations.browser_env import BrowserEnv  # noqa: F401
     from .envs.integrations.openenv_env import OpenEnvEnv  # noqa: F401
     from .envs.integrations.reasoninggym_env import ReasoningGymEnv  # noqa: F401

--- a/verifiers/envs/experimental/cli_agent_env.py
+++ b/verifiers/envs/experimental/cli_agent_env.py
@@ -97,6 +97,18 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
         self.advanced_configs = advanced_configs
         self.labels = labels
 
+        self._interception_server: InterceptionServer | None = None
+        self._tunnel: Tunnel | None = None
+        self._tunnel_lock = asyncio.Lock()
+
+        self.init_interception(interception_port, interception_url)
+
+    def init_interception(
+        self,
+        interception_port: int = 8765,
+        interception_url: str | None = None,
+    ):
+        """Initialize interception server and tunnel resources. Call from __init__."""
         self.interception_port = interception_port
         self.interception_url = interception_url
         self._tunnel: Tunnel | None = None

--- a/verifiers/envs/experimental/cli_agent_env.py
+++ b/verifiers/envs/experimental/cli_agent_env.py
@@ -115,11 +115,16 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
         self._tunnel_lock = asyncio.Lock()
         self._interception_server = InterceptionServer(port=interception_port)
 
+    @property
+    def _server(self) -> InterceptionServer:
+        assert self._interception_server is not None
+        return self._interception_server
+
     async def get_tunnel_url(self) -> str:
         """Get tunnel URL, starting the tunnel if needed."""
         async with self._tunnel_lock:
             if self._tunnel is None:
-                port = self._interception_server.port
+                port = self._server.port
                 if logger.isEnabledFor(logging.DEBUG):
                     self._tunnel = Tunnel(
                         local_port=port,
@@ -141,7 +146,7 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
         rollout_id = f"rollout_{uuid.uuid4().hex[:8]}"
         state["rollout_id"] = rollout_id
 
-        await self._interception_server.start()
+        await self._server.start()
 
         if self.interception_url is None:
             tunnel_url = await self.get_tunnel_url()
@@ -175,7 +180,7 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
         await self.create_sandbox(state, sandbox_request)
 
         # Register rollout for interception
-        request_id_queue = self._interception_server.register_rollout(rollout_id)
+        request_id_queue = self._server.register_rollout(rollout_id)
         state["request_id_queue"] = request_id_queue
         state["agent_completed"] = False
 
@@ -276,7 +281,7 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
                 )
                 # Got a request, proceed normally
                 state["current_request_id"] = request_id
-                intercept = self._interception_server.intercepts[request_id]
+                intercept = self._server.intercepts[request_id]
                 return intercept["messages"]
 
             except asyncio.TimeoutError:
@@ -362,9 +367,7 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
             )
 
         request_id = state.get("current_request_id")
-        intercept = (
-            self._interception_server.intercepts.get(request_id) if request_id else None
-        )
+        intercept = self._server.intercepts.get(request_id) if request_id else None
 
         if intercept:
             # Always use the configured model from state, not the intercepted model

--- a/verifiers/envs/experimental/cli_agent_env.py
+++ b/verifiers/envs/experimental/cli_agent_env.py
@@ -97,18 +97,6 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
         self.advanced_configs = advanced_configs
         self.labels = labels
 
-        self._interception_server: InterceptionServer | None = None
-        self._tunnel: Tunnel | None = None
-        self._tunnel_lock = asyncio.Lock()
-
-        self.init_interception(interception_port, interception_url)
-
-    def init_interception(
-        self,
-        interception_port: int = 8765,
-        interception_url: str | None = None,
-    ):
-        """Initialize interception server and tunnel resources. Call from __init__."""
         self.interception_port = interception_port
         self.interception_url = interception_url
         self._tunnel: Tunnel | None = None


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

dev release to unblock some stuff in research-environments

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release housekeeping plus a small refactor in `CliAgentEnv` to centralize access to the interception server; behavior should be unchanged aside from earlier failure if the server is unexpectedly unset.
> 
> **Overview**
> Bumps `verifiers` version to `0.1.11.dev1` and adds `RELEASE_v0.1.11.dev1.md` release notes.
> 
> Refactors `CliAgentEnv` to use a `_server` property (asserting the interception server is initialized) and routes tunnel startup, server start, rollout registration, and intercept lookups through it, reducing direct nullable access to `_interception_server`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f7254f1ab585b4161e15ab0903b301687b797da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->