### PR TITLE
add opencode utils

### DIFF
--- a/tests/test_cli_agent_env.py
+++ b/tests/test_cli_agent_env.py
@@ -56,6 +56,7 @@ class TestCliAgentEnv:
         env = vf.CliAgentEnv(
             run_command="python agent.py",
             dataset=sample_dataset,
+            interception_port=8765,
             rubric=vf.Rubric(),
         )
         assert env.run_command == "python agent.py"

--- a/verifiers/envs/experimental/cli_agent_env.py
+++ b/verifiers/envs/experimental/cli_agent_env.py
@@ -28,6 +28,7 @@ from verifiers.utils.interception_utils import (
     deliver_response,
     synthesize_stream,
 )
+from verifiers.utils.worker_utils import get_free_port
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +44,7 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
     def __init__(
         self,
         run_command: str,
-        interception_port: int = 8765,
+        interception_port: int | None = None,
         interception_url: str | None = None,
         max_turns: int = -1,
         timeout_seconds: float = 3600.0,
@@ -101,6 +102,9 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
         self._tunnel: Tunnel | None = None
         self._tunnel_lock = asyncio.Lock()
 
+        interception_port = (
+            get_free_port() if interception_port is None else interception_port
+        )
         self.init_interception(interception_port, interception_url)
 
     def init_interception(

--- a/verifiers/envs/experimental/opencode_env.py
+++ b/verifiers/envs/experimental/opencode_env.py
@@ -1,0 +1,296 @@
+import json
+import logging
+import tempfile
+from collections import Counter
+from pathlib import Path
+from typing import Callable
+
+from datasets import Dataset
+
+import verifiers as vf
+from verifiers.envs.experimental.cli_agent_env import CliAgentEnv
+from verifiers.types import AssistantMessage, Messages, ToolCall
+from verifiers.utils.interception_utils import _truncate as truncate
+
+logger = logging.getLogger(__name__)
+
+# Default OpenCode tools to track individually
+OPENCODE_TOOLS = [
+    "bash",
+    "glob",
+    "grep",
+    "read",
+    "edit",
+    "write",
+    "todowrite",
+    "todoread",
+    "webfetch",
+    "question",
+    "task",
+]
+
+
+DEFAULT_OPENCODE_SYSTEM_PROMPT = """\
+You are OpenCode, the best coding agent on the planet.
+
+You are an interactive CLI tool that helps users with software engineering tasks. Use the instructions below and the tools available to you to assist the user.
+
+IMPORTANT: You must NEVER generate or guess URLs for the user unless you are confident that the URLs are for helping the user with programming. You may use URLs provided by the user in their messages or local files.
+
+If the user asks for help or wants to give feedback inform them of the following:
+- ctrl+p to list available actions
+- To give feedback, users should report the issue at
+  https://github.com/anomalyco/opencode
+
+# Tone and style
+- Only use emojis if the user explicitly requests it. Avoid using emojis in all communication unless asked.
+- Your output will be displayed on a command line interface. Your responses should be short and concise. You can use Github-flavored markdown for formatting, and will be rendered in a monospace font using the CommonMark specification.
+- Output text to communicate with the user; all text you output outside of tool use is displayed to the user. Only use tools to complete tasks. Never use tools like Bash or code comments as means to communicate with the user during the session.
+- NEVER create files unless they're absolutely necessary for achieving your goal. ALWAYS prefer editing an existing file to creating a new one. This includes markdown files.
+
+# Professional objectivity
+Prioritize technical accuracy and truthfulness over validating the user's beliefs. Focus on facts and problem-solving, providing direct, objective technical info without any unnecessary superlatives, praise, or emotional validation. It is best for the user if OpenCode honestly applies the same rigorous standards to all ideas and disagrees when necessary, even if it may not be what the user wants to hear. Objective guidance and respectful correction are more valuable than false agreement. Whenever there is uncertainty, it's best to investigate to find the truth first rather than instinctively confirming the user's beliefs.
+
+# Task Management
+You have access to the TodoWrite tools to help you manage and plan tasks. Use these tools VERY frequently to ensure that you are tracking your tasks and giving the user visibility into your progress.
+These tools are also EXTREMELY helpful for planning tasks, and for breaking down larger complex tasks into smaller steps. If you do not use this tool when planning, you may forget to do important tasks - and that is unacceptable.
+
+It is critical that you mark todos as completed as soon as you are done with a task. Do not batch up multiple tasks before marking them as completed.
+"""
+
+DEFAULT_OPENCODE_RUN_COMMAND_TEMPLATE = """\
+set -e
+
+apt-get update && apt-get install -y curl
+
+curl -fsSL https://opencode.ai/install | bash
+export PATH="$HOME/.opencode/bin:$PATH"
+
+mkdir -p ~/.config/opencode
+
+SCHEMA_DOLLAR='$'
+
+cat > ~/.config/opencode/opencode.json << EOFCONFIG
+{config_json}
+EOFCONFIG
+
+cd {agent_workdir}
+cat {prompt_path} | opencode run 2>&1 | tee {logs_path}
+"""
+
+
+class OpenCodeMonitorRubric(vf.Rubric):
+    """Monitor rubric that tracks OpenCode tool usage."""
+
+    def __init__(self, tool_names: list[str] | None = None, **kwargs):
+        super().__init__(**kwargs)
+        self.tool_names = list(tool_names or OPENCODE_TOOLS)
+
+        self.add_metric(self.total_tool_calls)
+        self.add_metric(self.unique_tools_used)
+        self.add_metric(self.has_tool_calls)
+        for tool_name in self.tool_names:
+            self.add_metric(self._make_tool_count_metric(tool_name))
+
+    @staticmethod
+    def _count_tool_calls(completion: Messages) -> Counter:
+        """Count tool calls by name across all assistant messages."""
+        counts: Counter = Counter()
+        assert isinstance(completion, list)
+        for msg in completion:
+            if not isinstance(msg, AssistantMessage):
+                continue
+            tool_calls = msg.tool_calls
+            if not isinstance(tool_calls, list):
+                continue
+            for tc in tool_calls:
+                if isinstance(tc, ToolCall):
+                    counts[tc.name] += 1
+        return counts
+
+    async def total_tool_calls(self, completion: Messages) -> float:
+        """Total number of tool calls across all turns."""
+        return float(sum(self._count_tool_calls(completion).values()))
+
+    async def unique_tools_used(self, completion: Messages) -> float:
+        """Number of distinct tools used."""
+        return float(len(self._count_tool_calls(completion)))
+
+    async def has_tool_calls(self, completion: Messages) -> float:
+        """Whether the completion has any tool calls (0 or 1)."""
+        return float(bool(self._count_tool_calls(completion)))
+
+    def _make_tool_count_metric(self, tool_name: str) -> Callable:
+        """Create a metric function that counts calls to a specific tool."""
+
+        async def tool_count(completion: Messages) -> float:
+            counts = self._count_tool_calls(completion)
+            return float(counts.get(tool_name, 0))
+
+        tool_count.__name__ = f"{tool_name}_calls"
+        return tool_count
+
+
+class OpenCodeEnv(CliAgentEnv):
+    """OpenCode environment."""
+
+    DEFAULT_AGENT_WORKDIR = "/app"
+    DEFAULT_ASSET_DIR = "/opencode"
+    DEFAULT_DISABLED_TOOLS = ["webfetch", "question"]
+    DEFAULT_RUN_COMMAND_TEMPLATE = DEFAULT_OPENCODE_RUN_COMMAND_TEMPLATE
+    DEFAULT_SYSTEM_PROMPT = DEFAULT_OPENCODE_SYSTEM_PROMPT
+
+    def __init__(
+        self,
+        dataset: Dataset,
+        asset_dir: str = DEFAULT_ASSET_DIR,
+        agent_workdir: str = DEFAULT_AGENT_WORKDIR,
+        disabled_tools: list[str] | None = DEFAULT_DISABLED_TOOLS,
+        system_prompt: str | None = DEFAULT_SYSTEM_PROMPT,
+        run_command_template: str = DEFAULT_RUN_COMMAND_TEMPLATE,
+        **kwargs,
+    ):
+        self.asset_dir = asset_dir
+        self.agent_workdir = agent_workdir
+        self.disabled_tools = disabled_tools
+
+        run_command = self.build_run_command(
+            run_command_template,
+            agent_workdir,
+            disabled_tools=disabled_tools,
+            system_prompt=system_prompt,
+        )
+
+        super().__init__(
+            run_command=run_command,
+            dataset=dataset,
+            system_prompt=system_prompt,
+            **kwargs,
+        )
+        self.add_rubric(OpenCodeMonitorRubric())
+
+    @property
+    def remote_system_prompt_path(self) -> str:
+        return f"{self.asset_dir}/system.txt"
+
+    @property
+    def remote_prompt_path(self) -> str:
+        return f"{self.asset_dir}/prompt.txt"
+
+    @property
+    def remote_logs_path(self) -> str:
+        return f"{self.asset_dir}/logs.txt"
+
+    async def post_sandbox_setup(self, state: vf.State) -> None:
+        """Upload prompt and optional system prompt after sandbox creation."""
+        sandbox_id = state.get("sandbox_id")
+        if not sandbox_id:
+            return
+
+        # Create working directories
+        dirs = [self.asset_dir, self.agent_workdir]
+        self.logger.debug(f"Creating working directories ({', '.join(dirs)})")
+        await self.sandbox_client.execute_command(
+            sandbox_id, f"mkdir -p {' '.join(dirs)}", working_dir=None
+        )
+
+        prompt = self.build_prompt(state)
+
+        # Upload prompt as file
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".txt") as f:
+            f.write(prompt)
+            local_prompt_path = f.name
+
+        try:
+            logger.debug(
+                f"Uploading prompt '{truncate(prompt, 50)}' from {local_prompt_path} to {self.remote_prompt_path}"
+            )
+            await self.sandbox_client.upload_file(
+                sandbox_id, self.remote_prompt_path, local_prompt_path
+            )
+        finally:
+            Path(local_prompt_path).unlink(missing_ok=True)
+
+        # Upload system prompt as file, if provided
+        if self.system_prompt:
+            with tempfile.NamedTemporaryFile(
+                mode="w", delete=False, suffix=".txt"
+            ) as f:
+                f.write(self.system_prompt)
+                local_system_prompt_path = f.name
+
+            try:
+                logger.debug(
+                    f"Uploading system prompt '{truncate(self.system_prompt, 20)}' from {local_system_prompt_path} to {self.remote_system_prompt_path}"
+                )
+                await self.sandbox_client.upload_file(
+                    sandbox_id, self.remote_system_prompt_path, local_system_prompt_path
+                )
+            finally:
+                Path(local_system_prompt_path).unlink(missing_ok=True)
+
+    def build_prompt(self, state: vf.State) -> str:
+        """Build the prompt to be uploaded to OpenCode."""
+        return state["prompt"][-1]["content"]
+
+    def build_opencode_config(
+        self,
+        disabled_tools: list[str] | None = None,
+        system_prompt_path: str | None = None,
+    ) -> str:
+        """Build OpenCode config."""
+        config: dict = {
+            "${SCHEMA_DOLLAR}schema": "https://opencode.ai/config.json",
+            "provider": {
+                "intercepted": {
+                    "npm": "@ai-sdk/openai-compatible",
+                    "name": "Intercepted",
+                    "options": {
+                        "baseURL": "$OPENAI_BASE_URL",
+                        "apiKey": "intercepted",
+                        "timeout": 600000,
+                    },
+                    "models": {
+                        "model": {
+                            "name": "Intercepted Model",
+                            "modalities": {
+                                "input": ["text", "image"],
+                                "output": ["text"],
+                            },
+                        }
+                    },
+                }
+            },
+            "model": "intercepted/model",
+        }
+
+        if system_prompt_path or disabled_tools:
+            build_config: dict = {}
+            if system_prompt_path:
+                build_config["prompt"] = "{file:" + system_prompt_path + "}"
+            if disabled_tools:
+                build_config["tools"] = {tool: False for tool in disabled_tools}
+            config["agent"] = {"build": build_config}
+
+        return json.dumps(config, indent=2)
+
+    def build_run_command(
+        self,
+        run_command_template: str,
+        agent_workdir: str,
+        disabled_tools: list[str] | None = None,
+        system_prompt: str | None = None,
+    ) -> str:
+        """Build bash script to install and run OpenCode."""
+
+        config_json = self.build_opencode_config(
+            disabled_tools,
+            self.remote_system_prompt_path if system_prompt else None,
+        )
+
+        return run_command_template.format(
+            config_json=config_json,
+            agent_workdir=agent_workdir,
+            prompt_path=self.remote_prompt_path,
+            logs_path=self.remote_logs_path,
+        )

--- a/verifiers/envs/experimental/opencode_qa_env.py
+++ b/verifiers/envs/experimental/opencode_qa_env.py
@@ -1,6 +1,6 @@
-import verifiers as vf
 from datasets import Dataset, load_dataset
 
+import verifiers as vf
 from verifiers.envs.experimental.opencode_env import OpenCodeEnv
 
 

--- a/verifiers/envs/experimental/opencode_qa_env.py
+++ b/verifiers/envs/experimental/opencode_qa_env.py
@@ -1,0 +1,72 @@
+import verifiers as vf
+from datasets import Dataset, load_dataset
+
+from verifiers.envs.experimental.opencode_env import OpenCodeEnv
+
+
+class OpenCodeQAEnv(OpenCodeEnv):
+    """Solve general QA problems in OpenCode."""
+
+    DEFAULT_QUESTION_KEY = "question"
+    DEFAULT_ANSWER_KEY = "answer"
+    DEFAULT_INSTRUCTION_PROMPT = ""
+    DEFAULT_INSTRUCTION_PROMPT_POST = ""
+
+    def __init__(
+        self,
+        rubric: vf.Rubric,
+        dataset_name: str,
+        dataset_subset: str,
+        dataset_split: str,
+        question_key: str = DEFAULT_QUESTION_KEY,
+        answer_key: str = DEFAULT_ANSWER_KEY,
+        instruction_prompt: str = DEFAULT_INSTRUCTION_PROMPT,
+        instruction_prompt_post: str = DEFAULT_INSTRUCTION_PROMPT_POST,
+        **kwargs,
+    ):
+        dataset = self.construct_dataset(
+            dataset_name,
+            dataset_subset,
+            dataset_split,
+            question_key,
+            answer_key,
+            instruction_prompt,
+            instruction_prompt_post,
+        )
+
+        super().__init__(dataset=dataset, rubric=rubric, **kwargs)
+
+    def construct_dataset(
+        self,
+        dataset_name: str,
+        dataset_subset: str,
+        dataset_split: str,
+        question_key: str,
+        answer_key: str,
+        instruction_prompt: str,
+        instruction_prompt_post: str,
+    ) -> Dataset:
+        """Constructs a general QA dataset."""
+
+        dataset = load_dataset(dataset_name, dataset_subset, split=dataset_split)
+
+        if question_key not in dataset.column_names:
+            raise ValueError(
+                f"Column '{question_key}' not found in dataset: {dataset.column_names}"
+            )
+        if answer_key not in dataset.column_names:
+            raise ValueError(
+                f"Column '{answer_key}' not found in dataset: {dataset.column_names}"
+            )
+
+        def process_example(example):
+            question = example[question_key]
+            answer = example[answer_key]
+            return {
+                "question": instruction_prompt + question + instruction_prompt_post,
+                "answer": answer,
+            }
+
+        dataset = dataset.map(process_example)
+
+        return dataset

--- a/verifiers/rubrics/experimental/hybrid_math_rubric.py
+++ b/verifiers/rubrics/experimental/hybrid_math_rubric.py
@@ -1,0 +1,171 @@
+from math_verify import parse, verify  # type: ignore[unresolved-import]
+from openai import AsyncOpenAI
+
+import verifiers as vf
+from verifiers.parsers.parser import Parser
+from verifiers.utils.data_utils import extract_boxed_answer
+
+# https://github.com/open-compass/CompassVerifier/blob/2d7cba6df0b21f9c6121786ac1e5770c68473598/src/prompts.py#L28
+DEFAULT_JUDGE_PROMPT = """\
+As a grading expert, your task is to determine whether the candidate's final answer matches the provided standard answer. Follow these evaluation guidelines precisely:
+
+Evaluation Protocol:
+1. Reference Standard:
+   - The standard answer is definitive and always correct
+   - The question is perfectly valid - never question them
+   - Do not regenerate answers; only compare with the given standard
+
+2. Comparison Method:
+   - Carefully analyze the question's requirements and the standard answer's structure
+     * Determine whether the question expects exact matching of the entire standard answer or allows partial matching of its components.
+     * This determination must be made based on the question's phrasing and the nature of the standard answer.
+   - Compare ONLY the candidate's final answer (ignore all reasoning/explanation errors)
+   - Disregard any differences in formatting or presentation style
+   - For mathematical expressions: calculate step by step whether the two formulas are equivalent
+   - For multiple-choice questions: compare only the final choice and corresponding option content
+
+3. Multi-part Answers:
+   - For questions requiring multiple responses (e.g., multi-select):
+   - All parts must match the standard answer exactly.
+   - Compare each sub-answer step by step. Partial matches are considered incorrect.
+
+4. Validity Check:
+   - Reject answers that are:
+     * Incomplete (cut off mid-sentence in the final sentence, lacking a complete response) → Label as INCOMPLETE
+     * Repetitive (repetition of words or phrases in a loop) → Label as REPETITIVE
+     * Explicit refusals (e.g., directly return "I cannot answer/provide/access ...") → Label as REFUSAL
+   - For invalid answers, specify the type in the judgment (e.g., \\boxed{{C}} - INCOMPLETE).
+
+Grading Scale:
+\\boxed{{A}} - CORRECT:
+   - Answer matches standard exactly (including equivalent expressions)
+   - For numerical answers: consider as equivalent if values match when rounded appropriately
+   - Semantically equivalent responses
+
+\\boxed{{B}} - INCORRECT:
+   - Any deviation from standard answer
+   - Partial matches for multi-part questions
+
+\\boxed{{C}} - INCOMPLETE/REPETITIVE/REFUSAL:
+   - Fails validity criteria above (must specify: INCOMPLETE/REPETITIVE/REFUSAL)
+
+Execution Steps and Output Formats:
+
+Analysis step by step: [
+Thoroughly evaluate the candidate's answer including:
+(1) First check if the answer is INCOMPLETE (cut off mid-sentence), REPETITIVE (looping repetition), or a REFUSAL (explicit denial) - if so, immediately classify as \\boxed{{C}} with the corresponding type.
+(2) Analyze the question's core requirements and the standard answer's structure, for example:
+- Strict requirements: Identify mandatory constraints (e.g., simplification, answer order, multi-part completeness)
+- Tolerant allowances: Ignore non-critical deviations (e.g., missing option labels in MCQs, equivalent but unformatted expressions)
+- Required answer type, precision level, etc.
+(3) Perform a detailed comparison between the candidate's final answer and the standard answer, for example:
+- Content equivalence
+- Permitted variations in numerical precision
+- Allowed expression formats]
+Final Judgment: \\boxed{{A/B/C}} - <CORRECT/INCORRECT/INCOMPLETE/REPETITIVE/REFUSAL>
+
+Here is your task.
+<Original Question Begin>
+{question}
+<Original Question End>
+
+<Standard Answer Begin>
+{answer}
+<Standard Answer End>
+
+<Candidate's Answer Begin>
+{response}
+<Candidate's Answer End>
+
+Analysis step by step and Final Judgment:
+"""
+
+
+class HybridMathRubric(vf.JudgeRubric):
+    """Runs rule-based math verification first, with optional LLM judge fallback."""
+
+    def __init__(
+        self,
+        judge_parser: Parser | None = None,
+        judge_model: str | None = None,
+        judge_client: AsyncOpenAI | None = None,
+        judge_sampling_args: dict = {},
+        judge_prompt: str = DEFAULT_JUDGE_PROMPT,
+        timeout_seconds: float = 5,
+        **kwargs,
+    ):
+        super().__init__(
+            judge_client=judge_client,
+            judge_sampling_args=judge_sampling_args,
+            judge_prompt=judge_prompt,
+            parser=judge_parser,
+            **kwargs,
+        )
+        # Reward functions
+        self.add_reward_func(self.math_verify_score, weight=0)
+        self.add_reward_func(self.judge_score, weight=0)
+        self.add_reward_func(self.correct_answer, weight=1)
+
+        self.timeout_seconds = timeout_seconds
+        self.judge_model = judge_model
+
+    async def math_verify_score(
+        self, completion: vf.Messages, answer: str, state: vf.State, **kwargs
+    ) -> float:
+        """Basic rule-based math verification."""
+        response = self.parser.parse_answer(completion) or ""
+        if response == "":
+            math_verify_score = 0.0
+            self.logger.debug("Parsed response is empty.")
+        else:
+            try:
+                math_verify_score = float(
+                    verify(
+                        parse(
+                            f"\\boxed{{{answer}}}",
+                            parsing_timeout=int(self.timeout_seconds),
+                        ),
+                        parse(
+                            f"\\boxed{{{response}}}",
+                            parsing_timeout=int(self.timeout_seconds),
+                        ),
+                        timeout_seconds=int(self.timeout_seconds),
+                    )
+                )
+            except BaseException as e:
+                self.logger.warning(
+                    f"Math verification failed with {type(e).__name__}: {e!r}"
+                )
+                math_verify_score = 0.0
+        state["math_verify_score"] = math_verify_score
+        return math_verify_score
+
+    async def judge_score(
+        self,
+        prompt: vf.Messages,
+        completion: vf.Messages,
+        answer: str,
+        state: vf.State,
+        **kwargs,
+    ) -> float:
+        """Calls judge model if math verification did not pass and a judge model is set, else returns math verification score."""
+        if state.get("math_verify_score", 0) == 1 or self.judge_model is None:
+            return state.get("math_verify_score", 0)
+
+        judge_response = await self.judge(prompt, completion, answer, state)
+        judge_result = (
+            extract_boxed_answer(judge_response)
+            if len(judge_response) != 1
+            else judge_response
+        )
+        judge_score = 1.0 if judge_result == "A" else 0.0
+        self.logger.debug(f"{judge_score=} ({judge_result=})")
+        state["judge_result"] = judge_result
+        state["judge_score"] = judge_score
+        return judge_score
+
+    async def correct_answer(self, state: vf.State, **kwargs) -> float:
+        """Whether either math verification or judge passed."""
+        return float(
+            state.get("math_verify_score", 0.0) or state.get("judge_score", 0.0)
+        )

--- a/verifiers/rubrics/experimental/hybrid_math_rubric.py
+++ b/verifiers/rubrics/experimental/hybrid_math_rubric.py
@@ -108,6 +108,7 @@ class HybridMathRubric(vf.JudgeRubric):
 
         self.timeout_seconds = timeout_seconds
         self.judge_model = judge_model
+        self.class_objects["judge_model"] = judge_model
 
     async def math_verify_score(
         self, completion: vf.Messages, answer: str, state: vf.State, **kwargs

--- a/verifiers/utils/interception_utils.py
+++ b/verifiers/utils/interception_utils.py
@@ -432,24 +432,28 @@ def _truncate(s: str, limit: int = 200) -> str:
 
 
 def _log_request(rollout_id: str, body: dict) -> None:
-    logger.debug(f"[{rollout_id}] <- INTERCEPTED REQUEST")
+    """Log an intercepted request."""
+    log_msg = f"[{rollout_id}] <- INTERCEPTED REQUEST"
+    log_msg += f" ({len(body.get('tools', []))} tool(s))"
     for msg in body.get("messages", []):
         content = msg.get("content", "")
         if isinstance(content, str):
-            logger.debug(f"  [{msg.get('role', '?')}] {_truncate(content)}")
+            log_msg += f"\n[{msg.get('role', '?')}] {_truncate(content)}"
         else:
-            logger.debug(f"  [{msg.get('role', '?')}] <complex content>")
-    if body.get("tools"):
-        logger.debug(f"  [tools] {len(body['tools'])} tool(s)")
+            log_msg += f"\n[{msg.get('role', '?')}] <complex content>"
+        for tc in msg.get("tool_calls") or []:
+            func = tc.get("function", {})
+            log_msg += f"\n[tool_call]\n{func.get('name')}({_truncate(func.get('arguments', ''), 100)})"
+    logger.debug(log_msg)
 
 
 def _log_response(rollout_id: str, response: dict) -> None:
-    logger.debug(f"[{rollout_id}] -> RESPONSE")
+    """Log the response from the model."""
+    log_msg = f"[{rollout_id}] -> RESPONSE"
     msg = response.get("choices", [{}])[0].get("message", {})
     if msg.get("content"):
-        logger.debug(f"  [assistant] {_truncate(msg['content'])}")
+        log_msg += f"\n[assistant]\n{_truncate(msg['content'])}"
     for tc in msg.get("tool_calls") or []:
         func = tc.get("function", {})
-        logger.debug(
-            f"  [tool_call] {func.get('name')}({_truncate(func.get('arguments', ''), 100)})"
-        )
+        log_msg += f"\n[tool_call]\n{func.get('name')}({_truncate(func.get('arguments', ''), 100)})"
+    logger.debug(log_msg)


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

- Small updates to logging utils in `interception_utils.py`
- Auto-setup port on `InterceptionServer` by default
- Add `OpenCodeEnv` and `OpenCodeQAEnv`

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default interception port selection in `CliAgentEnv` (now auto-allocates a free port), which can affect setups that assumed a fixed port, and adds new sandbox execution paths (OpenCode install/run) plus new grading logic that may need validation in real runs.
> 
> **Overview**
> Adds new experimental OpenCode integrations: `OpenCodeEnv` runs the OpenCode CLI inside a sandbox (installs via script, writes config, uploads prompt/system prompt, and captures logs) and `OpenCodeQAEnv` builds a QA dataset wrapper around it, plus an `OpenCodeMonitorRubric` that records per-tool usage metrics.
> 
> Updates `CliAgentEnv` to choose an available interception port by default (via `get_free_port`) rather than hard-coding `8765`, and tweaks interception logging to emit a single structured debug message including tool counts and tool call details. Adds `HybridMathRubric` that first does rule-based `math_verify` checking and optionally falls back to an LLM judge, exposing both signals in `state` and a final correctness reward.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a03aadc636fab47684a483a9a7343b6fc6a0c4c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->