### PR TITLE
fix: SandboxMixin logger not inheriting verifiers log config

### DIFF
--- a/verifiers/envs/experimental/sandbox_mixin.py
+++ b/verifiers/envs/experimental/sandbox_mixin.py
@@ -56,9 +56,7 @@ class SandboxMixin:
         sandbox_wait_for_creation_max_attempts: int = 120,
     ):
         """Initialize sandbox client and retry wrapper. Call from subclass __init__."""
-        self.logger = logging.getLogger(
-            f"{self.__class__.__module__}.{self.__class__.__name__}"
-        )
+        self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
         self.active_sandboxes = set()
         self.sandbox_wait_for_creation_max_attempts = (
             sandbox_wait_for_creation_max_attempts


### PR DESCRIPTION
## Summary
- `SandboxMixin.init_sandbox_client()` was creating a logger using `self.__class__.__module__` (e.g. `opencode_math.OpenCodeMathEnv`), which is not a child of the `"verifiers"` logger
- Since `setup_logging()` only configures handlers on the `"verifiers"` logger, log messages from any environment using `SandboxMixin` were silently dropped
- Changed to use `__name__` (i.e. `verifiers.envs.experimental.sandbox_mixin`), matching the pattern in `Environment.__init__`, so the logger stays under the `verifiers.*` hierarchy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only the logger name used by `SandboxMixin`, affecting log routing/visibility but not sandbox lifecycle logic or data handling.
> 
> **Overview**
> Fixes `SandboxMixin.init_sandbox_client()` to create its logger using `__name__` (module path) rather than `self.__class__.__module__`, keeping logs under the `verifiers.*` hierarchy.
> 
> This ensures sandbox-related log messages inherit the configured `verifiers` logging handlers instead of being silently dropped when environments live outside the package namespace.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4e05b115affe088c82d41c7616adc339662d402. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->