### PR TITLE
fix empty SandboxError message in RLM executor

### DIFF
--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -1364,7 +1364,7 @@ class RLMExecutor(SandboxMixin):
         except RLMCodeExecutionTimeout:
             raise
         except Exception as e:
-            raise vf.SandboxError() from e
+            raise vf.SandboxError(f"Sandbox command failed: {e}") from e
 
         return RLMExecResult(stdout=raw, stderr="")
 


### PR DESCRIPTION
## Description

`SandboxError` was raised with no message, causing the error formatter to produce an empty string. The model would then see empty tool responses for every subsequent call against the dead sandbox, with no indication of what went wrong. This is fixed now.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 43c31ba983a9b3e5038197af50a967b691207666. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->