### PR TITLE
make multimodal detection more robust

### DIFF
--- a/verifiers/clients/openai_chat_completions_token_client.py
+++ b/verifiers/clients/openai_chat_completions_token_client.py
@@ -23,10 +23,10 @@ def _has_multimodal_content(messages) -> bool:
         content = msg.get("content") if hasattr(msg, "get") else None
         if isinstance(content, list):
             for part in content:
-                if (hasattr(part, "get") and part.get("type") in (
+                if hasattr(part, "get") and part.get("type") in (
                     "image_url",
                     "input_audio",
-                )):
+                ):
                     return True
     return False
 

--- a/verifiers/clients/openai_chat_completions_token_client.py
+++ b/verifiers/clients/openai_chat_completions_token_client.py
@@ -1,4 +1,3 @@
-from collections.abc import Mapping
 from typing import Optional, cast
 
 from openai import AsyncOpenAI, BaseModel
@@ -14,16 +13,20 @@ from verifiers.clients.openai_chat_completions_client import (
 from verifiers.types import SamplingArgs, State
 
 
-def _has_multimodal_content(messages: OpenAIChatMessages) -> bool:
-    """Check if any message contains multimodal content (images, audio)."""
+def _has_multimodal_content(messages) -> bool:
+    """Check if any message contains multimodal content (images, audio).
+
+    Works with both plain dicts (OpenAIChatMessages) and Pydantic models
+    (Messages stored in trajectory steps) since both support .get().
+    """
     for msg in messages:
-        content = msg.get("content") if isinstance(msg, Mapping) else None
+        content = msg.get("content") if hasattr(msg, "get") else None
         if isinstance(content, list):
             for part in content:
-                if isinstance(part, Mapping) and part.get("type") in (
+                if (hasattr(part, "get") and part.get("type") in (
                     "image_url",
                     "input_audio",
-                ):
+                )):
                     return True
     return False
 

--- a/verifiers/clients/openai_chat_completions_token_client.py
+++ b/verifiers/clients/openai_chat_completions_token_client.py
@@ -73,14 +73,17 @@ class OpenAIChatCompletionsTokenClient(OpenAIChatCompletionsClient):
 
         sampling_args = normalize_sampling_args(sampling_args)
         state = cast(State, kwargs.pop("state"))
-        # Use standard /chat/completions for: (1) first turn (no prior tokens to
-        # stitch), or (2) multimodal conversations.  VLM image-placeholder
-        # expansion happens inside the engine during generation but NOT in the
-        # /tokenize endpoint, so token-stitching (TITO) operates in a different
-        # coordinate system than /tokenize and produces broken prompts.  Falling
-        # back to message-based inference (MITO) lets vLLM handle expansion
+        # Use standard /chat/completions for: (1) first turn (no prior tokens
+        # to stitch), or (2) conversations that contain multimodal content in
+        # any turn.  vLLM ≤0.16's /tokenize doesn't run the multimodal
+        # processor, so image placeholders stay collapsed (1 token instead of
+        # N) and token-stitching (TITO) produces broken prompts.  Falling back
+        # to message-based inference (MITO) lets vLLM handle expansion
         # correctly on every turn.
-        if len(state["trajectory"]) == 0 or _has_multimodal_content(prompt):
+        has_multimodal = _has_multimodal_content(prompt) or any(
+            _has_multimodal_content(step["prompt"]) for step in state["trajectory"]
+        )
+        if len(state["trajectory"]) == 0 or has_multimodal:
             return await super().get_native_response(
                 prompt, model, sampling_args, tools
             )


### PR DESCRIPTION
## Description
fall back to MITO for entire conversation when any turn contains multimodal content, not just the current on

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes routing logic between token-stitching and message-based inference; if multimodal detection is too broad/narrow it can affect prompt formatting and output quality across conversations.
> 
> **Overview**
> Ensures conversations with *any* multimodal content (images/audio) bypass token-stitching and always use standard `/chat/completions`, preventing broken prompts caused by vLLM’s `/tokenize` not expanding multimodal placeholders.
> 
> Makes multimodal detection more robust by handling both dict-based messages and Pydantic-model message objects (used in stored trajectory steps) via `.get`-capability checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ae1ac91e42bd9757a8ef2ddcd79bee8324adcf9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->