### PR TITLE
RLM: root_max_completion_tokens

### DIFF
--- a/tests/test_rlm_env.py
+++ b/tests/test_rlm_env.py
@@ -2449,6 +2449,57 @@ class TestRootLLMMaxCompletionTokens:
         rlm_env._executor.read_answer.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_stop_defers_when_pending_tool_calls(self, rlm_env):
+        """When over budget but last message has tool calls, defer to let
+        env_response execute the tool before stopping."""
+        from verifiers.types import AssistantMessage, ToolCall
+
+        rlm_env.root_llm_max_completion_tokens = 1000
+        assistant_msg = AssistantMessage(
+            role="assistant",
+            content=None,
+            tool_calls=[ToolCall(id="tc1", name="call_bash_repl", arguments="{}")],
+        )
+        state = {
+            "main_rlm_completion_tokens": 1500,
+            "trajectory_id": "main",
+            "trajectory": [
+                {
+                    "trajectory_id": "main",
+                    "prompt": [],
+                    "completion": [assistant_msg],
+                }
+            ],
+        }
+        assert await rlm_env.root_token_budget_exhausted(state) is False
+
+    @pytest.mark.asyncio
+    async def test_stop_fires_when_no_pending_tool_calls(self, rlm_env):
+        """When over budget and last message has no tool calls, stop fires."""
+        from verifiers.types import AssistantMessage
+
+        rlm_env.root_llm_max_completion_tokens = 1000
+        rlm_env._executor.read_answer = AsyncMock(return_value="answer")
+        assistant_msg = AssistantMessage(
+            role="assistant",
+            content="I'm done",
+            tool_calls=None,
+        )
+        state = {
+            "main_rlm_completion_tokens": 1500,
+            "rollout_id": "test",
+            "trajectory_id": "main",
+            "trajectory": [
+                {
+                    "trajectory_id": "main",
+                    "prompt": [],
+                    "completion": [assistant_msg],
+                }
+            ],
+        }
+        assert await rlm_env.root_token_budget_exhausted(state) is True
+
+    @pytest.mark.asyncio
     async def test_repl_output_includes_budget_when_set(self, rlm_env):
         rlm_env.root_llm_max_completion_tokens = 5000
         rlm_env._execute_code = AsyncMock(
@@ -2537,6 +2588,67 @@ class TestRootLLMMaxCompletionTokens:
             assert "your own responses" not in prompt
         finally:
             await env.cleanup_rlm_state(result)
+
+    @pytest.mark.asyncio
+    async def test_env_response_sets_final_env_response_when_budget_exhausted(
+        self, rlm_env
+    ):
+        """When root budget is exhausted, env_response should execute the tool
+        and set final_env_response so the loop stops after the tool runs."""
+        rlm_env.root_llm_max_completion_tokens = 1000
+        rlm_env._executor.read_answer = AsyncMock(return_value="my answer")
+
+        state = {"main_rlm_completion_tokens": 1500, "rollout_id": "test"}
+        fake_tool_messages = [MagicMock()]
+
+        with patch(
+            "verifiers.envs.stateful_tool_env.StatefulToolEnv.env_response",
+            new=AsyncMock(return_value=fake_tool_messages),
+        ):
+            result = await rlm_env.env_response([], state)
+
+        assert result is fake_tool_messages
+        assert state["final_env_response"] is fake_tool_messages
+        assert state["final_answer"] == "my answer"
+
+    @pytest.mark.asyncio
+    async def test_env_response_no_final_env_response_when_under_budget(self, rlm_env):
+        """When root budget is not exhausted, env_response should not set
+        final_env_response."""
+        rlm_env.root_llm_max_completion_tokens = 1000
+
+        state = {"main_rlm_completion_tokens": 500}
+        fake_tool_messages = [MagicMock()]
+
+        with patch(
+            "verifiers.envs.stateful_tool_env.StatefulToolEnv.env_response",
+            new=AsyncMock(return_value=fake_tool_messages),
+        ):
+            result = await rlm_env.env_response([], state)
+
+        assert result is fake_tool_messages
+        assert "final_env_response" not in state
+
+    @pytest.mark.asyncio
+    async def test_env_response_final_answer_takes_priority_over_budget(self, rlm_env):
+        """When final_answer is already set (answer ready), that path takes
+        priority regardless of budget state."""
+        rlm_env.root_llm_max_completion_tokens = 1000
+
+        state = {
+            "main_rlm_completion_tokens": 500,
+            "final_answer": "already set",
+        }
+        fake_tool_messages = [MagicMock()]
+
+        with patch(
+            "verifiers.envs.stateful_tool_env.StatefulToolEnv.env_response",
+            new=AsyncMock(return_value=fake_tool_messages),
+        ):
+            await rlm_env.env_response([], state)
+
+        assert state["final_env_response"] is fake_tool_messages
+        assert state["final_answer"] == "already set"
 
 
 # =============================================================================

--- a/tests/test_rlm_env.py
+++ b/tests/test_rlm_env.py
@@ -2409,95 +2409,28 @@ class TestRootLLMMaxCompletionTokens:
         assert env.root_llm_max_completion_tokens == 20000
 
     @pytest.mark.asyncio
-    async def test_stop_false_when_none(self, rlm_env):
+    async def test_is_root_budget_exhausted_false_when_none(self, rlm_env):
         assert rlm_env.root_llm_max_completion_tokens is None
         state = {"main_rlm_completion_tokens": 999999}
-        assert await rlm_env.root_token_budget_exhausted(state) is False
+        assert rlm_env._is_root_budget_exhausted(state) is False
 
     @pytest.mark.asyncio
-    async def test_stop_false_when_under_budget(self, rlm_env):
+    async def test_is_root_budget_exhausted_false_when_under(self, rlm_env):
         rlm_env.root_llm_max_completion_tokens = 1000
         state = {"main_rlm_completion_tokens": 500}
-        assert await rlm_env.root_token_budget_exhausted(state) is False
+        assert rlm_env._is_root_budget_exhausted(state) is False
 
     @pytest.mark.asyncio
-    async def test_stop_true_when_at_budget(self, rlm_env):
+    async def test_is_root_budget_exhausted_true_when_at(self, rlm_env):
         rlm_env.root_llm_max_completion_tokens = 1000
-        rlm_env._executor.read_answer = AsyncMock(return_value="my answer")
-        state = {"main_rlm_completion_tokens": 1000, "rollout_id": "test"}
-        assert await rlm_env.root_token_budget_exhausted(state) is True
-        assert state["final_answer"] == "my answer"
+        state = {"main_rlm_completion_tokens": 1000}
+        assert rlm_env._is_root_budget_exhausted(state) is True
 
     @pytest.mark.asyncio
-    async def test_stop_true_when_over_budget(self, rlm_env):
+    async def test_is_root_budget_exhausted_true_when_over(self, rlm_env):
         rlm_env.root_llm_max_completion_tokens = 1000
-        rlm_env._executor.read_answer = AsyncMock(return_value="my answer")
-        state = {"main_rlm_completion_tokens": 1500, "rollout_id": "test"}
-        assert await rlm_env.root_token_budget_exhausted(state) is True
-        assert state["final_answer"] == "my answer"
-
-    @pytest.mark.asyncio
-    async def test_stop_skips_read_when_final_answer_already_set(self, rlm_env):
-        rlm_env.root_llm_max_completion_tokens = 1000
-        rlm_env._executor.read_answer = AsyncMock(return_value="should not be called")
-        state = {
-            "main_rlm_completion_tokens": 2000,
-            "final_answer": "existing answer",
-        }
-        assert await rlm_env.root_token_budget_exhausted(state) is True
-        assert state["final_answer"] == "existing answer"
-        rlm_env._executor.read_answer.assert_not_awaited()
-
-    @pytest.mark.asyncio
-    async def test_stop_defers_when_pending_tool_calls(self, rlm_env):
-        """When over budget but last message has tool calls, defer to let
-        env_response execute the tool before stopping."""
-        from verifiers.types import AssistantMessage, ToolCall
-
-        rlm_env.root_llm_max_completion_tokens = 1000
-        assistant_msg = AssistantMessage(
-            role="assistant",
-            content=None,
-            tool_calls=[ToolCall(id="tc1", name="call_bash_repl", arguments="{}")],
-        )
-        state = {
-            "main_rlm_completion_tokens": 1500,
-            "trajectory_id": "main",
-            "trajectory": [
-                {
-                    "trajectory_id": "main",
-                    "prompt": [],
-                    "completion": [assistant_msg],
-                }
-            ],
-        }
-        assert await rlm_env.root_token_budget_exhausted(state) is False
-
-    @pytest.mark.asyncio
-    async def test_stop_fires_when_no_pending_tool_calls(self, rlm_env):
-        """When over budget and last message has no tool calls, stop fires."""
-        from verifiers.types import AssistantMessage
-
-        rlm_env.root_llm_max_completion_tokens = 1000
-        rlm_env._executor.read_answer = AsyncMock(return_value="answer")
-        assistant_msg = AssistantMessage(
-            role="assistant",
-            content="I'm done",
-            tool_calls=None,
-        )
-        state = {
-            "main_rlm_completion_tokens": 1500,
-            "rollout_id": "test",
-            "trajectory_id": "main",
-            "trajectory": [
-                {
-                    "trajectory_id": "main",
-                    "prompt": [],
-                    "completion": [assistant_msg],
-                }
-            ],
-        }
-        assert await rlm_env.root_token_budget_exhausted(state) is True
+        state = {"main_rlm_completion_tokens": 1500}
+        assert rlm_env._is_root_budget_exhausted(state) is True
 
     @pytest.mark.asyncio
     async def test_repl_output_includes_budget_when_set(self, rlm_env):

--- a/tests/test_rlm_env.py
+++ b/tests/test_rlm_env.py
@@ -2391,6 +2391,154 @@ class TestSubLLMCompletionTokenBudget:
         assert result["total_completion_tokens"] == 110  # 80 + 30
 
 
+class TestRootLLMMaxCompletionTokens:
+    """Tests for the root_llm_max_completion_tokens budget feature."""
+
+    def test_default_is_none(self):
+        dataset = make_dataset({})
+        env = build_env(dataset, interception_url="http://test.invalid")
+        assert env.root_llm_max_completion_tokens is None
+
+    def test_custom_value(self):
+        dataset = make_dataset({})
+        env = build_env(
+            dataset,
+            root_llm_max_completion_tokens=20000,
+            interception_url="http://test.invalid",
+        )
+        assert env.root_llm_max_completion_tokens == 20000
+
+    @pytest.mark.asyncio
+    async def test_stop_false_when_none(self, rlm_env):
+        assert rlm_env.root_llm_max_completion_tokens is None
+        state = {"main_rlm_completion_tokens": 999999}
+        assert await rlm_env.root_token_budget_exhausted(state) is False
+
+    @pytest.mark.asyncio
+    async def test_stop_false_when_under_budget(self, rlm_env):
+        rlm_env.root_llm_max_completion_tokens = 1000
+        state = {"main_rlm_completion_tokens": 500}
+        assert await rlm_env.root_token_budget_exhausted(state) is False
+
+    @pytest.mark.asyncio
+    async def test_stop_true_when_at_budget(self, rlm_env):
+        rlm_env.root_llm_max_completion_tokens = 1000
+        rlm_env._executor.read_answer = AsyncMock(return_value="my answer")
+        state = {"main_rlm_completion_tokens": 1000, "rollout_id": "test"}
+        assert await rlm_env.root_token_budget_exhausted(state) is True
+        assert state["final_answer"] == "my answer"
+
+    @pytest.mark.asyncio
+    async def test_stop_true_when_over_budget(self, rlm_env):
+        rlm_env.root_llm_max_completion_tokens = 1000
+        rlm_env._executor.read_answer = AsyncMock(return_value="my answer")
+        state = {"main_rlm_completion_tokens": 1500, "rollout_id": "test"}
+        assert await rlm_env.root_token_budget_exhausted(state) is True
+        assert state["final_answer"] == "my answer"
+
+    @pytest.mark.asyncio
+    async def test_stop_skips_read_when_final_answer_already_set(self, rlm_env):
+        rlm_env.root_llm_max_completion_tokens = 1000
+        rlm_env._executor.read_answer = AsyncMock(return_value="should not be called")
+        state = {
+            "main_rlm_completion_tokens": 2000,
+            "final_answer": "existing answer",
+        }
+        assert await rlm_env.root_token_budget_exhausted(state) is True
+        assert state["final_answer"] == "existing answer"
+        rlm_env._executor.read_answer.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_repl_output_includes_budget_when_set(self, rlm_env):
+        rlm_env.root_llm_max_completion_tokens = 5000
+        rlm_env._execute_code = AsyncMock(
+            return_value={
+                "status": "ok",
+                "stdout": "output",
+                "stderr": "",
+                "result": None,
+                "execution_count": 1,
+                "answer": {"ready": False, "content": ""},
+            }
+        )
+
+        state = {
+            "trajectory": [],
+            "context_warning_sent": False,
+            "main_rlm_completion_tokens": 1200,
+        }
+        output = await rlm_env.call_python_repl("print('test')", state)
+
+        assert "1200/5000 root completion tokens used" in output
+
+    @pytest.mark.asyncio
+    async def test_repl_output_excludes_budget_when_none(self, rlm_env):
+        assert rlm_env.root_llm_max_completion_tokens is None
+        rlm_env._execute_code = AsyncMock(
+            return_value={
+                "status": "ok",
+                "stdout": "output",
+                "stderr": "",
+                "result": None,
+                "execution_count": 1,
+                "answer": {"ready": False, "content": ""},
+            }
+        )
+
+        state = {
+            "trajectory": [],
+            "context_warning_sent": False,
+            "main_rlm_completion_tokens": 1200,
+        }
+        output = await rlm_env.call_python_repl("print('test')", state)
+
+        assert "root completion tokens" not in output
+
+    @pytest.mark.asyncio
+    async def test_system_prompt_includes_root_budget_when_set(self):
+        dataset = make_dataset({})
+        env = build_env(
+            dataset,
+            root_llm_max_completion_tokens=20000,
+            repl_language="python",
+            interception_url="http://test.invalid",
+        )
+        env._ensure_interception_server = AsyncMock()
+        env._executor.prepare_filesystem = AsyncMock()
+        env._executor.setup = AsyncMock()
+
+        state: dict[str, Any] = {"info": {}, "model": "m", "client": MagicMock()}
+        result = await env.setup_state(state)
+        try:
+            prompt = result["rlm_system_prompt"]
+            assert "20000" in prompt
+            assert "completion tokens" in prompt
+            assert "your own responses" in prompt
+        finally:
+            await env.cleanup_rlm_state(result)
+
+    @pytest.mark.asyncio
+    async def test_system_prompt_excludes_root_budget_when_none(self):
+        dataset = make_dataset({})
+        env = build_env(
+            dataset,
+            repl_language="python",
+            interception_url="http://test.invalid",
+        )
+        assert env.root_llm_max_completion_tokens is None
+        env._ensure_interception_server = AsyncMock()
+        env._executor.prepare_filesystem = AsyncMock()
+        env._executor.setup = AsyncMock()
+
+        state: dict[str, Any] = {"info": {}, "model": "m", "client": MagicMock()}
+        result = await env.setup_state(state)
+        try:
+            prompt = result["rlm_system_prompt"]
+            assert "your own responses" not in prompt
+        finally:
+            await env.cleanup_rlm_state(result)
+
+
 # =============================================================================
 # Sandbox Backend Tests (mocked)
 # =============================================================================

--- a/tests/test_rlm_env.py
+++ b/tests/test_rlm_env.py
@@ -2012,25 +2012,25 @@ class TestMessageHistory:
 
 
 class TestSubLLMCompletionTokenBudget:
-    """Tests for the sub_llm_max_completion_tokens budget feature."""
+    """Tests for the sub_max_completion_tokens budget feature."""
 
     def test_default_is_none(self):
         dataset = make_dataset({})
         env = build_env(dataset, interception_url="http://test.invalid")
-        assert env.sub_llm_max_completion_tokens is None
+        assert env.sub_max_completion_tokens is None
 
     def test_custom_value(self):
         dataset = make_dataset({})
         env = build_env(
             dataset,
-            sub_llm_max_completion_tokens=50000,
+            sub_max_completion_tokens=50000,
             interception_url="http://test.invalid",
         )
-        assert env.sub_llm_max_completion_tokens == 50000
+        assert env.sub_max_completion_tokens == 50000
 
     @pytest.mark.asyncio
     async def test_run_sub_llm_request_blocks_when_budget_exhausted(self, rlm_env):
-        rlm_env.sub_llm_max_completion_tokens = 1000
+        rlm_env.sub_max_completion_tokens = 1000
         state = {
             "trajectory": [],
             "sampling_args": {},
@@ -2054,7 +2054,7 @@ class TestSubLLMCompletionTokenBudget:
 
     @pytest.mark.asyncio
     async def test_run_sub_llm_request_allows_when_under_budget(self, rlm_env):
-        rlm_env.sub_llm_max_completion_tokens = 1000
+        rlm_env.sub_max_completion_tokens = 1000
         state = {
             "trajectory": [],
             "sampling_args": {},
@@ -2103,8 +2103,8 @@ class TestSubLLMCompletionTokenBudget:
 
     @pytest.mark.asyncio
     async def test_run_sub_llm_request_allows_when_no_budget(self, rlm_env):
-        """When sub_llm_max_completion_tokens is None, no budget check occurs."""
-        assert rlm_env.sub_llm_max_completion_tokens is None
+        """When sub_max_completion_tokens is None, no budget check occurs."""
+        assert rlm_env.sub_max_completion_tokens is None
         state = {
             "trajectory": [],
             "sampling_args": {},
@@ -2152,7 +2152,7 @@ class TestSubLLMCompletionTokenBudget:
 
     @pytest.mark.asyncio
     async def test_batch_early_exit_when_budget_exhausted(self, rlm_env):
-        rlm_env.sub_llm_max_completion_tokens = 500
+        rlm_env.sub_max_completion_tokens = 500
         context = {
             "client": MagicMock(),
             "sub_model": "gpt-4",
@@ -2174,7 +2174,7 @@ class TestSubLLMCompletionTokenBudget:
 
     @pytest.mark.asyncio
     async def test_batch_summary_includes_budget_when_set(self, rlm_env):
-        rlm_env.sub_llm_max_completion_tokens = 10000
+        rlm_env.sub_max_completion_tokens = 10000
 
         mock_response = MagicMock()
         mock_response.message.content = "ok"
@@ -2218,7 +2218,7 @@ class TestSubLLMCompletionTokenBudget:
 
     @pytest.mark.asyncio
     async def test_batch_summary_excludes_budget_when_none(self, rlm_env):
-        assert rlm_env.sub_llm_max_completion_tokens is None
+        assert rlm_env.sub_max_completion_tokens is None
 
         state = {
             "trajectory": [],
@@ -2257,7 +2257,7 @@ class TestSubLLMCompletionTokenBudget:
         dataset = make_dataset({})
         env = build_env(
             dataset,
-            sub_llm_max_completion_tokens=50000,
+            sub_max_completion_tokens=50000,
             repl_language="python",
             interception_url="http://test.invalid",
         )
@@ -2283,7 +2283,7 @@ class TestSubLLMCompletionTokenBudget:
             repl_language="python",
             interception_url="http://test.invalid",
         )
-        assert env.sub_llm_max_completion_tokens is None
+        assert env.sub_max_completion_tokens is None
         env._ensure_interception_server = AsyncMock()
         env._executor.prepare_filesystem = AsyncMock()
         env._executor.setup = AsyncMock()
@@ -2302,7 +2302,7 @@ class TestSubLLMCompletionTokenBudget:
         the tool loop breaks and forces a final answer instead of continuing."""
         from verifiers.types import Response, ResponseMessage, ToolCall, Usage
 
-        rlm_env_with_sub_tools.sub_llm_max_completion_tokens = 100
+        rlm_env_with_sub_tools.sub_max_completion_tokens = 100
 
         # Turn 1: tool call that uses 80 completion tokens
         resp1 = Response(
@@ -2392,49 +2392,49 @@ class TestSubLLMCompletionTokenBudget:
 
 
 class TestRootLLMMaxCompletionTokens:
-    """Tests for the root_llm_max_completion_tokens budget feature."""
+    """Tests for the root_max_completion_tokens budget feature."""
 
     def test_default_is_none(self):
         dataset = make_dataset({})
         env = build_env(dataset, interception_url="http://test.invalid")
-        assert env.root_llm_max_completion_tokens is None
+        assert env.root_max_completion_tokens is None
 
     def test_custom_value(self):
         dataset = make_dataset({})
         env = build_env(
             dataset,
-            root_llm_max_completion_tokens=20000,
+            root_max_completion_tokens=20000,
             interception_url="http://test.invalid",
         )
-        assert env.root_llm_max_completion_tokens == 20000
+        assert env.root_max_completion_tokens == 20000
 
     @pytest.mark.asyncio
     async def test_is_root_budget_exhausted_false_when_none(self, rlm_env):
-        assert rlm_env.root_llm_max_completion_tokens is None
+        assert rlm_env.root_max_completion_tokens is None
         state = {"main_rlm_completion_tokens": 999999}
         assert rlm_env._is_root_budget_exhausted(state) is False
 
     @pytest.mark.asyncio
     async def test_is_root_budget_exhausted_false_when_under(self, rlm_env):
-        rlm_env.root_llm_max_completion_tokens = 1000
+        rlm_env.root_max_completion_tokens = 1000
         state = {"main_rlm_completion_tokens": 500}
         assert rlm_env._is_root_budget_exhausted(state) is False
 
     @pytest.mark.asyncio
     async def test_is_root_budget_exhausted_true_when_at(self, rlm_env):
-        rlm_env.root_llm_max_completion_tokens = 1000
+        rlm_env.root_max_completion_tokens = 1000
         state = {"main_rlm_completion_tokens": 1000}
         assert rlm_env._is_root_budget_exhausted(state) is True
 
     @pytest.mark.asyncio
     async def test_is_root_budget_exhausted_true_when_over(self, rlm_env):
-        rlm_env.root_llm_max_completion_tokens = 1000
+        rlm_env.root_max_completion_tokens = 1000
         state = {"main_rlm_completion_tokens": 1500}
         assert rlm_env._is_root_budget_exhausted(state) is True
 
     @pytest.mark.asyncio
     async def test_repl_output_includes_budget_when_set(self, rlm_env):
-        rlm_env.root_llm_max_completion_tokens = 5000
+        rlm_env.root_max_completion_tokens = 5000
         rlm_env._execute_code = AsyncMock(
             return_value={
                 "status": "ok",
@@ -2457,7 +2457,7 @@ class TestRootLLMMaxCompletionTokens:
 
     @pytest.mark.asyncio
     async def test_repl_output_excludes_budget_when_none(self, rlm_env):
-        assert rlm_env.root_llm_max_completion_tokens is None
+        assert rlm_env.root_max_completion_tokens is None
         rlm_env._execute_code = AsyncMock(
             return_value={
                 "status": "ok",
@@ -2483,7 +2483,7 @@ class TestRootLLMMaxCompletionTokens:
         dataset = make_dataset({})
         env = build_env(
             dataset,
-            root_llm_max_completion_tokens=20000,
+            root_max_completion_tokens=20000,
             repl_language="python",
             interception_url="http://test.invalid",
         )
@@ -2509,7 +2509,7 @@ class TestRootLLMMaxCompletionTokens:
             repl_language="python",
             interception_url="http://test.invalid",
         )
-        assert env.root_llm_max_completion_tokens is None
+        assert env.root_max_completion_tokens is None
         env._ensure_interception_server = AsyncMock()
         env._executor.prepare_filesystem = AsyncMock()
         env._executor.setup = AsyncMock()
@@ -2528,7 +2528,7 @@ class TestRootLLMMaxCompletionTokens:
     ):
         """When root budget is exhausted, env_response should execute the tool
         and set final_env_response so the loop stops after the tool runs."""
-        rlm_env.root_llm_max_completion_tokens = 1000
+        rlm_env.root_max_completion_tokens = 1000
         rlm_env._executor.read_answer = AsyncMock(return_value="my answer")
 
         state = {"main_rlm_completion_tokens": 1500, "rollout_id": "test"}
@@ -2548,7 +2548,7 @@ class TestRootLLMMaxCompletionTokens:
     async def test_env_response_no_final_env_response_when_under_budget(self, rlm_env):
         """When root budget is not exhausted, env_response should not set
         final_env_response."""
-        rlm_env.root_llm_max_completion_tokens = 1000
+        rlm_env.root_max_completion_tokens = 1000
 
         state = {"main_rlm_completion_tokens": 500}
         fake_tool_messages = [MagicMock()]
@@ -2566,7 +2566,7 @@ class TestRootLLMMaxCompletionTokens:
     async def test_env_response_final_answer_takes_priority_over_budget(self, rlm_env):
         """When final_answer is already set (answer ready), that path takes
         priority regardless of budget state."""
-        rlm_env.root_llm_max_completion_tokens = 1000
+        rlm_env.root_max_completion_tokens = 1000
 
         state = {
             "main_rlm_completion_tokens": 500,

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -1953,13 +1953,13 @@ class RLMEnv(vf.StatefulToolEnv):
                    Each list is deduplicated by tool name. If two different tools
                    share a name within a list, initialization raises an error.
         sub_llm_max_turns: Maximum tool-calling turns for sub-LLM calls (default: 5)
-        sub_llm_max_completion_tokens: Total completion-token budget shared across all
+        sub_max_completion_tokens: Total completion-token budget shared across all
                    sub-LLM calls in a rollout.  When set, the environment tracks
                    cumulative sub-LLM completion tokens and refuses new calls once
                    the budget is reached.  The root model is informed of the budget
                    in its system prompt and in the per-batch summary printed after
                    each llm_batch() call.  None (default) means unlimited.
-        root_llm_max_completion_tokens: Total completion-token budget for the root
+        root_max_completion_tokens: Total completion-token budget for the root
                    model across the full rollout.  When set, the environment tracks
                    cumulative root-model completion tokens and stops the rollout
                    once the budget is reached, reading the current answer before
@@ -2014,8 +2014,8 @@ class RLMEnv(vf.StatefulToolEnv):
         root_tools: list[Callable] | None = None,
         sub_tools: list[Callable] | None = None,
         sub_llm_max_turns: int = 5,
-        sub_llm_max_completion_tokens: int | None = None,
-        root_llm_max_completion_tokens: int | None = None,
+        sub_max_completion_tokens: int | None = None,
+        root_max_completion_tokens: int | None = None,
         sub_model: str | None = None,
         sub_prompt_verbosity: Literal["light", "medium", "heavy"] = "light",
         root_prompt_verbosity: Literal["light", "medium", "heavy"] = "light",
@@ -2063,8 +2063,8 @@ class RLMEnv(vf.StatefulToolEnv):
         self.root_only_tools = root_tools or []
         self.sub_only_tools = sub_tools or []
         self.sub_llm_max_turns = sub_llm_max_turns
-        self.sub_llm_max_completion_tokens = sub_llm_max_completion_tokens
-        self.root_llm_max_completion_tokens = root_llm_max_completion_tokens
+        self.sub_max_completion_tokens = sub_max_completion_tokens
+        self.root_max_completion_tokens = root_max_completion_tokens
         self.max_output_length = max_output_length
         self.max_sub_llm_parallelism = max_sub_llm_parallelism
         self.custom_system_prompt = system_prompt
@@ -2548,11 +2548,11 @@ class RLMEnv(vf.StatefulToolEnv):
             # Check if the sub-LLM completion token budget is exceeded
             # mid-loop. We combine already-committed tokens (state) with
             # tokens accumulated in this call so far.
-            if self.sub_llm_max_completion_tokens is not None:
+            if self.sub_max_completion_tokens is not None:
                 committed = state.get("sub_llm_completion_tokens", 0)
                 if (
                     committed + total_completion_tokens
-                    >= self.sub_llm_max_completion_tokens
+                    >= self.sub_max_completion_tokens
                 ):
                     break
 
@@ -2614,7 +2614,7 @@ class RLMEnv(vf.StatefulToolEnv):
     def _sub_llm_budget_exhausted_message(self, state_ref: State) -> str:
         """Build a human-readable budget-exhausted message."""
         used = state_ref.get("sub_llm_completion_tokens", 0)
-        budget = self.sub_llm_max_completion_tokens
+        budget = self.sub_max_completion_tokens
         return (
             f"Sub-LLM token budget exhausted "
             f"(used {used}/{budget} completion tokens). "
@@ -2639,15 +2639,15 @@ class RLMEnv(vf.StatefulToolEnv):
             raise RuntimeError("Sub-LLM context is not available.")
 
         # Early exit when budget is already exhausted before starting the batch.
-        if self.sub_llm_max_completion_tokens is not None:
+        if self.sub_max_completion_tokens is not None:
             used = state_ref.get("sub_llm_completion_tokens", 0)
-            if used >= self.sub_llm_max_completion_tokens:
+            if used >= self.sub_max_completion_tokens:
                 msg = self._sub_llm_budget_exhausted_message(state_ref)
                 contents = [msg] * len(prompts)
                 summary_lines = [
                     f"llm_batch: {len(prompts)} call(s) skipped — "
                     f"sub-LLM token budget exhausted "
-                    f"({used}/{self.sub_llm_max_completion_tokens} "
+                    f"({used}/{self.sub_max_completion_tokens} "
                     f"completion tokens used)"
                 ]
                 return contents, summary_lines
@@ -2728,9 +2728,9 @@ class RLMEnv(vf.StatefulToolEnv):
                 f"{tool_calls} tool calls, {elapsed:.2f}s {status}"
             )
 
-        if self.sub_llm_max_completion_tokens is not None:
+        if self.sub_max_completion_tokens is not None:
             used = state_ref.get("sub_llm_completion_tokens", 0)
-            budget = self.sub_llm_max_completion_tokens
+            budget = self.sub_max_completion_tokens
             summary_lines.append(f"  [{used}/{budget} sub-LLM completion tokens used]")
 
         return contents, summary_lines
@@ -2807,10 +2807,10 @@ class RLMEnv(vf.StatefulToolEnv):
         elapsed_seconds: float | None = None,
     ) -> dict[str, Any]:
         # Budget gate: refuse new sub-LLM calls when token budget is exhausted.
-        if self.sub_llm_max_completion_tokens is not None:
+        if self.sub_max_completion_tokens is not None:
             used = state_ref.get("sub_llm_completion_tokens", 0)
-            if used >= self.sub_llm_max_completion_tokens:
-                budget = self.sub_llm_max_completion_tokens
+            if used >= self.sub_max_completion_tokens:
+                budget = self.sub_max_completion_tokens
                 return {
                     "choices": [
                         {
@@ -3209,17 +3209,17 @@ class RLMEnv(vf.StatefulToolEnv):
                 else:
                     message_history_docs = _RLM_MESSAGE_HISTORY_NOTE_PYTHON
             root_budget_docs = ""
-            if self.root_llm_max_completion_tokens is not None:
+            if self.root_max_completion_tokens is not None:
                 root_budget_docs = (
                     f"\nYou have a total budget of "
-                    f"{self.root_llm_max_completion_tokens} completion tokens "
+                    f"{self.root_max_completion_tokens} completion tokens "
                     f"for your own responses across this entire rollout.\n"
                 )
             sub_budget_docs = ""
-            if self.sub_llm_max_completion_tokens is not None:
+            if self.sub_max_completion_tokens is not None:
                 sub_budget_docs = (
                     f"\nYou have a total budget of "
-                    f"{self.sub_llm_max_completion_tokens} completion tokens "
+                    f"{self.sub_max_completion_tokens} completion tokens "
                     f"across all sub-LLM calls via llm_batch().\n"
                 )
             state["rlm_system_prompt"] = (
@@ -3535,9 +3535,9 @@ class RLMEnv(vf.StatefulToolEnv):
             output, state, ready_instruction=ready_instruction
         )
 
-        if self.root_llm_max_completion_tokens is not None:
+        if self.root_max_completion_tokens is not None:
             used = state.get("main_rlm_completion_tokens", 0)
-            budget = self.root_llm_max_completion_tokens
+            budget = self.root_max_completion_tokens
             output += f"\n[{used}/{budget} root completion tokens used]"
 
         return output
@@ -3718,10 +3718,10 @@ class RLMEnv(vf.StatefulToolEnv):
 
     def _is_root_budget_exhausted(self, state: State) -> bool:
         """Check if root model completion token budget is exhausted."""
-        if self.root_llm_max_completion_tokens is None:
+        if self.root_max_completion_tokens is None:
             return False
         used = state.get("main_rlm_completion_tokens", 0)
-        return used >= self.root_llm_max_completion_tokens
+        return used >= self.root_max_completion_tokens
 
     async def get_model_response(  # type: ignore[override]
         self, state: State, prompt: Messages, **kwargs: Any

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -3809,30 +3809,6 @@ class RLMEnv(vf.StatefulToolEnv):
         await self._ensure_final_answer(state)
         return True
 
-    @vf.stop
-    async def root_token_budget_exhausted(self, state: State) -> bool:
-        """Stop when root model's cumulative completion tokens reach the budget.
-
-        When the last assistant message has pending tool calls, this returns
-        False so that env_response can execute the tool first. env_response
-        then sets final_env_response and the has_final_env_response stop
-        condition halts the loop on the next iteration.
-
-        This stop condition only fires directly when the model responds
-        without tool calls while over budget (safety net).
-        """
-        if not self._is_root_budget_exhausted(state):
-            return False
-        # If the last main-model response has pending tool calls, defer
-        # so env_response can execute them before stopping.
-        last_main = self._last_main_trajectory_step(state)
-        if last_main is not None:
-            last_message = cast(AssistantMessage, last_main["completion"][-1])
-            if last_message.role == "assistant" and (last_message.tool_calls or []):
-                return False
-        await self._ensure_final_answer(state)
-        return True
-
     # =========================================================================
     # Cleanup
     # =========================================================================

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -3707,11 +3707,21 @@ class RLMEnv(vf.StatefulToolEnv):
     async def env_response(
         self, messages: Messages, state: State, **kwargs
     ) -> Messages:
-        """Override to set final_env_response when answer is ready to avoid extra model call"""
+        """Override to set final_env_response when answer is ready or root budget is exhausted."""
         tool_messages = await super().env_response(messages, state, **kwargs)
         if "final_answer" in state:
             state["final_env_response"] = tool_messages
+        elif self._is_root_budget_exhausted(state):
+            await self._ensure_final_answer(state)
+            state["final_env_response"] = tool_messages
         return tool_messages
+
+    def _is_root_budget_exhausted(self, state: State) -> bool:
+        """Check if root model completion token budget is exhausted."""
+        if self.root_llm_max_completion_tokens is None:
+            return False
+        used = state.get("main_rlm_completion_tokens", 0)
+        return used >= self.root_llm_max_completion_tokens
 
     async def get_model_response(  # type: ignore[override]
         self, state: State, prompt: Messages, **kwargs: Any
@@ -3801,12 +3811,25 @@ class RLMEnv(vf.StatefulToolEnv):
 
     @vf.stop
     async def root_token_budget_exhausted(self, state: State) -> bool:
-        """Stop when root model's cumulative completion tokens reach the budget."""
-        if self.root_llm_max_completion_tokens is None:
+        """Stop when root model's cumulative completion tokens reach the budget.
+
+        When the last assistant message has pending tool calls, this returns
+        False so that env_response can execute the tool first. env_response
+        then sets final_env_response and the has_final_env_response stop
+        condition halts the loop on the next iteration.
+
+        This stop condition only fires directly when the model responds
+        without tool calls while over budget (safety net).
+        """
+        if not self._is_root_budget_exhausted(state):
             return False
-        used = state.get("main_rlm_completion_tokens", 0)
-        if used < self.root_llm_max_completion_tokens:
-            return False
+        # If the last main-model response has pending tool calls, defer
+        # so env_response can execute them before stopping.
+        last_main = self._last_main_trajectory_step(state)
+        if last_main is not None:
+            last_message = cast(AssistantMessage, last_main["completion"][-1])
+            if last_message.role == "assistant" and (last_message.tool_calls or []):
+                return False
         await self._ensure_final_answer(state)
         return True
 

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -1959,6 +1959,13 @@ class RLMEnv(vf.StatefulToolEnv):
                    the budget is reached.  The root model is informed of the budget
                    in its system prompt and in the per-batch summary printed after
                    each llm_batch() call.  None (default) means unlimited.
+        root_llm_max_completion_tokens: Total completion-token budget for the root
+                   model across the full rollout.  When set, the environment tracks
+                   cumulative root-model completion tokens and stops the rollout
+                   once the budget is reached, reading the current answer before
+                   halting.  The root model is informed of the budget in its system
+                   prompt and in the per-REPL-call footer appended after each code
+                   execution.  None (default) means unlimited.
         sub_model: Model to use for sub-LLM calls (defaults to same as root model)
         sub_prompt_verbosity: The verbosity of the sub-LLMs' system prompt; "light", "medium", or "heavy"
         root_prompt_verbosity: The verbosity of the root-LLM's system prompt; "light", "medium", or "heavy"
@@ -2008,6 +2015,7 @@ class RLMEnv(vf.StatefulToolEnv):
         sub_tools: list[Callable] | None = None,
         sub_llm_max_turns: int = 5,
         sub_llm_max_completion_tokens: int | None = None,
+        root_llm_max_completion_tokens: int | None = None,
         sub_model: str | None = None,
         sub_prompt_verbosity: Literal["light", "medium", "heavy"] = "light",
         root_prompt_verbosity: Literal["light", "medium", "heavy"] = "light",
@@ -2056,6 +2064,7 @@ class RLMEnv(vf.StatefulToolEnv):
         self.sub_only_tools = sub_tools or []
         self.sub_llm_max_turns = sub_llm_max_turns
         self.sub_llm_max_completion_tokens = sub_llm_max_completion_tokens
+        self.root_llm_max_completion_tokens = root_llm_max_completion_tokens
         self.max_output_length = max_output_length
         self.max_sub_llm_parallelism = max_sub_llm_parallelism
         self.custom_system_prompt = system_prompt
@@ -3199,9 +3208,16 @@ class RLMEnv(vf.StatefulToolEnv):
                     message_history_docs = _RLM_MESSAGE_HISTORY_NOTE_BASH
                 else:
                     message_history_docs = _RLM_MESSAGE_HISTORY_NOTE_PYTHON
-            budget_docs = ""
+            root_budget_docs = ""
+            if self.root_llm_max_completion_tokens is not None:
+                root_budget_docs = (
+                    f"\nYou have a total budget of "
+                    f"{self.root_llm_max_completion_tokens} completion tokens "
+                    f"for your own responses across this entire rollout.\n"
+                )
+            sub_budget_docs = ""
             if self.sub_llm_max_completion_tokens is not None:
-                budget_docs = (
+                sub_budget_docs = (
                     f"\nYou have a total budget of "
                     f"{self.sub_llm_max_completion_tokens} completion tokens "
                     f"across all sub-LLM calls via llm_batch().\n"
@@ -3211,7 +3227,8 @@ class RLMEnv(vf.StatefulToolEnv):
                 + packages_docs
                 + root_tools_docs
                 + sub_tools_docs
-                + budget_docs
+                + root_budget_docs
+                + sub_budget_docs
                 + message_history_docs
             )
             state["rlm_packages_docs"] = packages_docs
@@ -3518,6 +3535,11 @@ class RLMEnv(vf.StatefulToolEnv):
             output, state, ready_instruction=ready_instruction
         )
 
+        if self.root_llm_max_completion_tokens is not None:
+            used = state.get("main_rlm_completion_tokens", 0)
+            budget = self.root_llm_max_completion_tokens
+            output += f"\n[{used}/{budget} root completion tokens used]"
+
         return output
 
     async def call_bash_repl(self, code: str, state: Any) -> str:
@@ -3774,6 +3796,17 @@ class RLMEnv(vf.StatefulToolEnv):
         if not state.get("prompt_too_long", False):
             return False
 
+        await self._ensure_final_answer(state)
+        return True
+
+    @vf.stop
+    async def root_token_budget_exhausted(self, state: State) -> bool:
+        """Stop when root model's cumulative completion tokens reach the budget."""
+        if self.root_llm_max_completion_tokens is None:
+            return False
+        used = state.get("main_rlm_completion_tokens", 0)
+        if used < self.root_llm_max_completion_tokens:
+            return False
         await self._ensure_final_answer(state)
         return True
 


### PR DESCRIPTION
## Description

- Add `root_max_completion_tokens` parameter to `RLMEnv` — a per-rollout completion-token budget for the root model, mirroring the existing `sub_max_completion_tokens` pattern
- The root model is informed of its budget in the system prompt and sees running usage (`[used/budget root completion tokens used]`) after each REPL call
- When the budget is exhausted, the last pending tool call still executes before the rollout stops — `env_response` sets `final_env_response` and the loop exits cleanly
- Rename `budget_docs` → `sub_budget_docs` and reorder to match root-then-sub convention used elsewhere

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [x] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rollout stop conditions and `env_response` behavior when the root budget is hit, which could alter termination timing and final-answer handling. Also renames a public constructor parameter for sub-LLM budgeting, which may break downstream callers relying on the old name.
> 
> **Overview**
> Adds `root_max_completion_tokens` to `RLMEnv` to cap total *root-model* completion tokens per rollout, surfaces the budget in the system prompt, and appends a `[used/budget root completion tokens used]` footer after each REPL call.
> 
> When the root budget is exhausted, `env_response` now forces reading the current answer and sets `final_env_response` so the rollout exits cleanly after the pending tool call completes. Separately, renames `sub_llm_max_completion_tokens` to `sub_max_completion_tokens` throughout budget checks, summaries, and tests, and splits system-prompt budget docs into root-then-sub sections.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 737b055390887ac84b5539fd180189f0e270c7a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->