### PR TITLE
remove get_model_response override from RLMEnv

### DIFF
--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -3723,47 +3723,6 @@ class RLMEnv(vf.StatefulToolEnv):
         used = state.get("main_rlm_completion_tokens", 0)
         return used >= self.root_max_completion_tokens
 
-    async def get_model_response(  # type: ignore[override]
-        self, state: State, prompt: Messages, **kwargs: Any
-    ) -> Response:
-        """Ensure get_prompt_ids sees the last main trajectory step, not a sub-LLM step.
-
-        In interleaved mode, get_prompt_ids (called from super) reads
-        state["trajectory"][-1] to build token-level prompts.  After
-        env_response adds sub-LLM steps, trajectory[-1] may be a sub-LLM
-        step with incompatible tokens.  We temporarily move trailing sub-LLM
-        steps out of the trajectory for the duration of the super call.
-        """
-
-        if not self.include_sub_llm_in_trajectory:
-            return await super().get_model_response(state, prompt, **kwargs)
-
-        trajectory = state.get("trajectory", [])
-        if not trajectory:
-            return await super().get_model_response(state, prompt, **kwargs)
-
-        main_id = state["trajectory_id"]
-        if trajectory[-1].get("trajectory_id") == main_id:
-            return await super().get_model_response(state, prompt, **kwargs)
-
-        # Find last main step and temporarily move trailing sub-LLM steps aside
-        last_main_idx = None
-        for i in range(len(trajectory) - 1, -1, -1):
-            if trajectory[i].get("trajectory_id") == main_id:
-                last_main_idx = i
-                break
-
-        if last_main_idx is None:
-            return await super().get_model_response(state, prompt, **kwargs)
-
-        trailing = trajectory[last_main_idx + 1 :]
-        del trajectory[last_main_idx + 1 :]
-        try:
-            result = await super().get_model_response(state, prompt, **kwargs)
-        finally:
-            trajectory.extend(trailing)
-        return result
-
     # =========================================================================
     # Stop Conditions
     # =========================================================================


### PR DESCRIPTION
## Description

This override temporarily hid trailing sub-LLM trajectory steps so the old get_prompt_ids() (which blindly read trajectory[-1]) would find a main-model step. PR #955 introduced best-effort backward scanning with message-prefix matching in get_prompt_ids(), which automatically skips non-matching sub-LLM steps. The override is now unnecessary.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 331e47a0b349ba8ffda1007d7675108e9865ea29. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->