### PR TITLE
Add overview panel and collapse non-running envs in vf-eval display

### DIFF
--- a/verifiers/utils/eval_display.py
+++ b/verifiers/utils/eval_display.py
@@ -546,10 +546,11 @@ class EvalDisplay(BaseDisplay):
                 if env_state.total > 0
                 else 0
             )
+            total_str = "..." if env_state.total <= 0 else str(env_state.total)
             line.append(" \u25b8 ", style="bold yellow")
             line.append(config.env_id, style="yellow")
             line.append(f"  {pct:.0f}%", style="bold")
-            line.append(f" ({env_state.progress}/{env_state.total})", style="dim")
+            line.append(f" ({env_state.progress}/{total_str})", style="dim")
             line.append("  reward ", style="dim")
             line.append(format_numeric(env_state.reward), style="bold")
             color = self._get_error_rate_color(env_state.error_rate)

--- a/verifiers/utils/eval_display.py
+++ b/verifiers/utils/eval_display.py
@@ -512,15 +512,98 @@ class EvalDisplay(BaseDisplay):
             padding=(0, 1),
         )
 
+    def _make_compact_env_row(self, env_idx: int) -> Text:
+        """Create a compact single-line summary for any env status."""
+        config = self.configs[env_idx]
+        env_state = self.state.envs[env_idx]
+
+        line = Text()
+        if env_state.status == "completed":
+            line.append(" \u2713 ", style="bold green")
+            line.append(config.env_id, style="green")
+            line.append("  reward ", style="dim")
+            line.append(format_numeric(env_state.reward), style="bold")
+            color = self._get_error_rate_color(env_state.error_rate)
+            line.append("  error rate ", style="dim")
+            line.append(f"{env_state.error_rate:.3f}", style=f"bold {color}")
+            elapsed = env_state.elapsed_time
+            mins, secs = divmod(int(elapsed), 60)
+            time_str = f"{mins}m {secs:02d}s" if mins > 0 else f"{secs}s"
+            line.append(f"  {time_str}", style="dim")
+        elif env_state.status == "failed":
+            line.append(" \u2717 ", style="bold red")
+            line.append(config.env_id, style="red")
+            if env_state.error:
+                line.append("  ", style="dim")
+                line.append(env_state.error[:80], style="red")
+            elapsed = env_state.elapsed_time
+            mins, secs = divmod(int(elapsed), 60)
+            time_str = f"{mins}m {secs:02d}s" if mins > 0 else f"{secs}s"
+            line.append(f"  {time_str}", style="dim")
+        elif env_state.status == "running":
+            pct = (
+                (env_state.progress / env_state.total * 100)
+                if env_state.total > 0
+                else 0
+            )
+            line.append(" \u25b8 ", style="bold yellow")
+            line.append(config.env_id, style="yellow")
+            line.append(f"  {pct:.0f}%", style="bold")
+            line.append(f" ({env_state.progress}/{env_state.total})", style="dim")
+            line.append("  reward ", style="dim")
+            line.append(format_numeric(env_state.reward), style="bold")
+            color = self._get_error_rate_color(env_state.error_rate)
+            line.append("  error rate ", style="dim")
+            line.append(f"{env_state.error_rate:.3f}", style=f"bold {color}")
+            elapsed = env_state.elapsed_time
+            mins, secs = divmod(int(elapsed), 60)
+            time_str = f"{mins}m {secs:02d}s" if mins > 0 else f"{secs}s"
+            line.append(f"  {time_str}", style="dim")
+        else:
+            line.append(" \u25cb ", style="dim")
+            line.append(config.env_id, style="dim")
+            line.append("  pending", style="dim")
+
+        return line
+
     def _make_env_stack(self) -> Group:
-        """Create a vertical stack of environment panels."""
+        """Create a vertical stack of environment panels.
+
+        A persistent overview panel at the top shows every env's status on one line.
+        Below it, only running envs get full detail panels with progress bars,
+        metrics, and logs. This prevents overflow when many environments are evaluated.
+        """
         if not self.configs:
             return Group()
 
-        # create panels for each environment by index
-        panels = [self._make_env_panel(idx) for idx in range(len(self.configs))]
+        # Overview panel: one compact line per env, always visible
+        overview_rows = [
+            self._make_compact_env_row(idx) for idx in range(len(self.configs))
+        ]
 
-        return Group(*panels)
+        n_total = len(self.configs)
+        n_completed = sum(
+            1 for s in self.state.envs.values() if s.status in ("completed", "failed")
+        )
+        title = Text(f"Overview ({n_completed}/{n_total} done)", style="dim")
+
+        items: list[Panel | Group] = [
+            Panel(
+                Group(*overview_rows),
+                title=title,
+                title_align="left",
+                border_style="dim",
+                padding=(0, 1),
+                expand=True,
+            )
+        ]
+
+        # Full detail panels for running envs only
+        for idx in range(len(self.configs)):
+            if self.state.envs[idx].status == "running":
+                items.append(self._make_env_panel(idx))
+
+        return Group(*items)
 
     def _make_footer(self) -> Panel:
         """Create the footer panel with instructions."""


### PR DESCRIPTION
## Description

When evaluating many environments from a TOML file, the progress display overflowed the terminal. Now a persistent overview panel at the top shows every env's status (reward, error rate, time) on one compact line, and only running envs get full detail panels below it.

This is what the overview panel looks like:

<img width="927" height="911" alt="image" src="https://github.com/user-attachments/assets/af2f3be5-7603-4879-a764-d9fcb3d15dbc" />

The original motivation was that in some runs, the envs with a visible progress bar finished, but others were still running invisibly, which was very confusing. The two solutions were to only show the progress bars of environments that were still progressing, and giving the overview.

A few open questions:

- Should finished environments show all the metrics? The reason that they currently don't is that it's a bit too much, but it might also be nice to see everything at once; and since it doesn't show the logs, it's still much more compact than with individual progress bars
- Should the progress bar of finished envs actually be hidden? The final summary is still shown, and they are likely not visible anyway, so I would vote no, but I'm also not completely certain

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change to terminal rendering; main risk is minor regressions in how per-environment progress/status is presented (e.g., indexing/status visibility) during multi-env runs.
> 
> **Overview**
> Adds a persistent **overview panel** to `EvalDisplay` that renders one compact status line per environment (status icon, reward, error rate, elapsed time, and brief failure message).
> 
> Changes the live stack rendering so that only *running* environments get full detail panels (progress bar, metrics, logs) below the overview, preventing terminal overflow when many envs are evaluated.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6e75132c7e42ac1861a736c3cbcdd23e8847f81. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->