### PR TITLE
add preview true uv

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,9 @@ rl = [
     "flash-attn>=2.8.3",
 ]
 
+[tool.uv]
+preview = true
+
 [tool.uv.extra-build-dependencies]
 flash-attn = [{ requirement = "torch", match-runtime = true }]
 


### PR DESCRIPTION
mini pr to enable preview feature in uv

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single config toggle affecting dependency/build tooling behavior; no runtime code or security-sensitive logic changes.
> 
> **Overview**
> Enables `uv` *preview mode* by adding `[tool.uv] preview = true` to `pyproject.toml`, opting the project into uv’s preview behavior while leaving existing `uv` build dependency/variable configuration unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a93edbda32cffd554673ecdd97c794209cf1df6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->