### PR TITLE
fix: store sandbox_id in state before waiting to prevent orphaned sandboxes

### DIFF
--- a/verifiers/envs/integrations/browser_env/modes/cua_mode.py
+++ b/verifiers/envs/integrations/browser_env/modes/cua_mode.py
@@ -822,7 +822,9 @@ class CUAMode:
                 raise vf.BrowserSandboxError(e)
         else:
             # Sandbox mode: create sandbox, set up server, create session
-            # Wrap in try-except to ensure errors trigger cleanup via stop_errors
+            # Wrap in try-except to ensure errors trigger cleanup via stop_errors.
+            # Store sandbox_id in state immediately after creation so cleanup_session
+            # can delete it even if later steps (wait_for_ready, wait_for_server) fail.
             try:
                 if self.use_prebuilt_image:
                     if self.logger:
@@ -833,8 +835,8 @@ class CUAMode:
                     async for attempt in self.retrying:  # type: ignore[union-attr]
                         with attempt:
                             sandbox_id = await self._create_sandbox()
-                    await self._wait_for_sandbox_ready(sandbox_id)
                     state["cua_sandbox_id"] = sandbox_id
+                    await self._wait_for_sandbox_ready(sandbox_id)
                     await self._wait_for_server(sandbox_id)
                 else:
                     if self.use_binary:
@@ -843,8 +845,8 @@ class CUAMode:
                     async for attempt in self.retrying:  # type: ignore[union-attr]
                         with attempt:
                             sandbox_id = await self._create_sandbox()
-                    await self._wait_for_sandbox_ready(sandbox_id)
                     state["cua_sandbox_id"] = sandbox_id
+                    await self._wait_for_sandbox_ready(sandbox_id)
                     await self._upload_server_files(sandbox_id)
                     await self._start_server(sandbox_id)
                     await self._wait_for_server(sandbox_id)


### PR DESCRIPTION
## Summary
- Move `state["cua_sandbox_id"] = sandbox_id` to immediately after `_create_sandbox()`, before `_wait_for_sandbox_ready()` and `_wait_for_server()`
- This ensures `cleanup_session()` can always find the sandbox_id to delete it, even when later setup steps fail

## Problem
PR #958 fixed sandbox leaks by wrapping errors in `BrowserSandboxError` so `cleanup_session` gets called. But `cleanup_session` looks up the sandbox via `state.get("cua_sandbox_id")`, which was only set *after* `_wait_for_sandbox_ready()`. If that call (or any later step) failed, the sandbox_id was never stored in state, so cleanup silently skipped deletion — leaking the sandbox.

This caused cascading failures during batch training: leaked sandboxes accumulated storage, eventually hitting the 10TB BrowserBase limit, which then caused all subsequent sandbox creations to fail with HTTP 429.

## Test plan
- [ ] Verify `state["cua_sandbox_id"]` is set before any post-creation steps that could fail
- [ ] Confirm cleanup_session deletes sandbox even when `_wait_for_sandbox_ready` fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 30a7c99e219cbf631aff221028ea01382fe0dab7. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->