### PR TITLE
fix: prevent CUA sandbox leaks during setup

### DIFF
--- a/verifiers/envs/integrations/browser_env/modes/cua_mode.py
+++ b/verifiers/envs/integrations/browser_env/modes/cua_mode.py
@@ -370,6 +370,20 @@ class CUAMode:
             self.logger.debug(f"Created sandbox {sandbox.id}")
         return sandbox.id
 
+    async def _create_sandbox_with_retry(self) -> str:
+        """Create a sandbox with retry, cleaning up orphaned sandboxes from failed attempts."""
+        previous_sandbox_id: str | None = None
+        async for attempt in self.retrying:  # type: ignore[union-attr]
+            with attempt:
+                if previous_sandbox_id is not None:
+                    try:
+                        await self._delete_sandbox(previous_sandbox_id)
+                    except Exception:
+                        pass
+                sandbox_id = await self._create_sandbox()
+                previous_sandbox_id = sandbox_id
+        return sandbox_id
+
     async def _wait_for_sandbox_ready(self, sandbox_id: str) -> None:
         """Wait for sandbox to be ready."""
         client = await self._get_sandbox_client()
@@ -830,21 +844,17 @@ class CUAMode:
                             f"Using prebuilt image: {self.prebuilt_image}"
                         )
 
-                    async for attempt in self.retrying:  # type: ignore[union-attr]
-                        with attempt:
-                            sandbox_id = await self._create_sandbox()
-                    await self._wait_for_sandbox_ready(sandbox_id)
+                    sandbox_id = await self._create_sandbox_with_retry()
                     state["cua_sandbox_id"] = sandbox_id
+                    await self._wait_for_sandbox_ready(sandbox_id)
                     await self._wait_for_server(sandbox_id)
                 else:
                     if self.use_binary:
                         await self._ensure_binary_exists()
 
-                    async for attempt in self.retrying:  # type: ignore[union-attr]
-                        with attempt:
-                            sandbox_id = await self._create_sandbox()
-                    await self._wait_for_sandbox_ready(sandbox_id)
+                    sandbox_id = await self._create_sandbox_with_retry()
                     state["cua_sandbox_id"] = sandbox_id
+                    await self._wait_for_sandbox_ready(sandbox_id)
                     await self._upload_server_files(sandbox_id)
                     await self._start_server(sandbox_id)
                     await self._wait_for_server(sandbox_id)


### PR DESCRIPTION
## Summary
- Set `state["cua_sandbox_id"]` immediately after sandbox creation, before `_wait_for_sandbox_ready`/`_wait_for_server`. Previously if anything failed between creation and the state assignment, `cleanup_session` couldn't find the sandbox_id so the sandbox leaked until teardown at the end of the run.
- Add `_create_sandbox_with_retry` that cleans up orphaned sandboxes from failed retry attempts. Previously if `_create_sandbox` succeeded but the retry loop retried, the first sandbox was orphaned in `active_sandboxes` but never referenced by any state.

## Test plan
- [ ] Run CUA mode browser env training and verify sandbox count stays bounded to inflight rollouts
- [ ] Verify sandboxes are cleaned up after each rollout, not just at teardown

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 1b23e33b531da75fe6a920c607aa56820bcec998. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->