### PR TITLE
sanitize illegible binary characters in Rich display

### DIFF
--- a/verifiers/utils/message_utils.py
+++ b/verifiers/utils/message_utils.py
@@ -1,4 +1,5 @@
 import json
+import re
 from collections.abc import Mapping
 from typing import Any, cast
 
@@ -207,6 +208,17 @@ def messages_to_printable(messages: Any) -> Any:
 # --- Legacy utilities (still used by save_utils, trainer, logging) ---
 
 
+# Matches control chars (except \n \t), surrogates, and private-use/non-characters
+_NON_PRINTABLE_RE = re.compile(
+    r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f\ud800-\udfff\ufffe\uffff]"
+)
+
+
+def _sanitize_for_display(text: str) -> str:
+    """Replace non-printable / binary characters that crash Rich's grapheme splitter."""
+    return _NON_PRINTABLE_RE.sub("\ufffd", text)
+
+
 def format_messages(messages: Any) -> Text:
     """Format messages for display. Works with both Pydantic messages and legacy dicts."""
 
@@ -232,7 +244,7 @@ def format_messages(messages: Any) -> Text:
         return {"name": name, "args": args}
 
     if isinstance(messages, str):
-        return Text(messages)
+        return Text(_sanitize_for_display(messages))
 
     out = Text()
     for idx, msg in enumerate(messages):
@@ -249,19 +261,22 @@ def format_messages(messages: Any) -> Text:
         if isinstance(reasoning_content, str) and reasoning_content.strip():
             out.append("\n")
             out.append("[reasoning]\n", style="dim")
-            out.append(reasoning_content, style="dim")
+            out.append(_sanitize_for_display(reasoning_content), style="dim")
             out.append("\n")
 
         if content:
             if isinstance(reasoning_content, str) and reasoning_content.strip():
                 out.append("\n")
-            out.append(str(content), style=style)
+            out.append(_sanitize_for_display(str(content)), style=style)
 
         tool_calls = _attr_or_key(msg, "tool_calls")
         for tc in tool_calls or []:
             payload = _normalize_tool_call(tc)
             out.append(
-                "\n\n[tool call]\n" + json.dumps(payload, indent=2, ensure_ascii=False),
+                "\n\n[tool call]\n"
+                + _sanitize_for_display(
+                    json.dumps(payload, indent=2, ensure_ascii=False)
+                ),
                 style=style,
             )
 


### PR DESCRIPTION
## Description
replaces illegible characters from e.g. binary PDF output with � in Rich display

crashes Rich display otherwise.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to display-only formatting; main risk is minor log/output differences from replacing characters during rendering.
> 
> **Overview**
> Prevents Rich rendering crashes when messages contain illegible/binary characters (e.g., PDF output) by sanitizing display output in `format_messages`.
> 
> Adds a regex-based `_sanitize_for_display` helper and applies it to raw string messages, `reasoning_content`, main `content`, and JSON-rendered tool-call payloads so non-printable/surrogate characters are replaced with `` replacement characters before building `rich.text.Text`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f4150a7e75ca6e11cf3be417420c712d0810a6b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->