### PR TITLE
vf-eval: Add settings panel in summary and --abbreviated-summary flag

### DIFF
--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -158,6 +158,7 @@ When evaluating multiple environments, the display shows an overview panel at th
 | `--verbose` | `-v` | false | Enable debug logging |
 | `--tui` | `-u` | false | Use alternate screen mode (TUI) for display |
 | `--debug` | `-d` | false | Disable Rich display; use normal logging and tqdm progress |
+| `--abbreviated-summary` | `-A` | false | Abbreviated summary: show settings and stats, skip example prompts |
 | `--save-results` | `-s` | false | Save results to disk |
 | `--resume [PATH]` | `-R` | — | Resume from a previous run (auto-detect latest matching incomplete run if PATH omitted) |
 | `--state-columns` | `-C` | — | Extra state columns to save (comma-separated) |

--- a/tests/test_eval_cli.py
+++ b/tests/test_eval_cli.py
@@ -57,6 +57,7 @@ def run_cli(make_metadata, make_state, make_input):
             "max_retries": 0,
             "tui": False,
             "debug": False,
+            "abbreviated_summary": False,
             "heartbeat_url": None,
         }
         base_args.update(overrides)

--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -345,6 +345,13 @@ def main():
         help="Do not start env servers when evaluating environments",
     )
     parser.add_argument(
+        "--abbreviated-summary",
+        "-A",
+        default=False,
+        action="store_true",
+        help="Abbreviated summary: show settings and stats only, skip example prompts/completions",
+    )
+    parser.add_argument(
         "--heartbeat-url",
         type=str,
         default=None,
@@ -660,7 +667,13 @@ def main():
     if args.debug:
         asyncio.run(run_evaluations(eval_run_config))
     else:
-        asyncio.run(run_evaluations_tui(eval_run_config, tui_mode=args.tui))
+        asyncio.run(
+            run_evaluations_tui(
+                eval_run_config,
+                tui_mode=args.tui,
+                compact=args.abbreviated_summary,
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/verifiers/utils/eval_display.py
+++ b/verifiers/utils/eval_display.py
@@ -156,9 +156,12 @@ class EvalDisplay(BaseDisplay):
                 If False (default), refresh in-place without screen hijacking.
     """
 
-    def __init__(self, configs: list[EvalConfig], screen: bool = False) -> None:
+    def __init__(
+        self, configs: list[EvalConfig], screen: bool = False, compact: bool = False
+    ) -> None:
         super().__init__(screen=screen, refresh_per_second=4)
         self.state = EvalDisplayState()
+        self.compact = compact
 
         # store configs by index to handle duplicate env_ids
         self.configs: list[EvalConfig] = list(configs)
@@ -988,15 +991,63 @@ class EvalDisplay(BaseDisplay):
         self.console.print(table)
         self.console.print()
 
+    def _make_settings_panel(
+        self, config: EvalConfig, env_state: EnvEvalState
+    ) -> Panel:
+        """Create a panel showing key eval settings for this environment."""
+        text = Text()
+        text.append("model: ", style="dim")
+        text.append(config.model, style="bold")
+        text.append("\n")
+        text.append("endpoint: ", style="dim")
+        text.append(self._format_client_target(config))
+        text.append("\n")
+        text.append("examples: ", style="dim")
+        text.append(str(env_state.num_examples), style="bold")
+        text.append("  rollouts/example: ", style="dim")
+        text.append(str(config.rollouts_per_example), style="bold")
+        text.append("  concurrent: ", style="dim")
+
+        def fmt_concurrency(val: int) -> str:
+            return "\u221e" if val == -1 else str(val)
+
+        display_max = self._display_max_concurrent(config, env_state.total)
+        text.append(fmt_concurrency(display_max), style="bold")
+        if config.sampling_args and any(config.sampling_args.values()):
+            text.append("\n")
+            text.append("sampling: ", style="dim")
+            parts = [
+                f"{k}={v}" for k, v in config.sampling_args.items() if v is not None
+            ]
+            text.append(", ".join(parts))
+        if config.env_args:
+            text.append("\n")
+            text.append("env args: ", style="dim")
+            parts = [f"{k}={v}" for k, v in config.env_args.items()]
+            text.append(", ".join(parts))
+        return Panel(
+            text,
+            title="[dim]settings[/dim]",
+            border_style="dim",
+        )
+
     def _make_env_detail(
         self, config: EvalConfig, env_state: EnvEvalState, results: GenerateOutputs
     ) -> Group:
         """Create detailed content for a single environment's summary."""
         items: list[Panel] = []
 
-        # Example 0 prompt/completion (already in printable format from state_to_output)
+        # Settings panel (always shown)
+        items.append(self._make_settings_panel(config, env_state))
+
+        # Example 0 prompt/completion (skip in compact mode)
         outputs = results["outputs"]
-        if outputs and outputs[0]["prompt"] and outputs[0]["completion"]:
+        if (
+            not self.compact
+            and outputs
+            and outputs[0]["prompt"]
+            and outputs[0]["completion"]
+        ):
             prompt = outputs[0]["prompt"]
             completion = outputs[0]["completion"]
             reward_0 = outputs[0]["reward"] if outputs[0]["reward"] else 0.0

--- a/verifiers/utils/eval_display.py
+++ b/verifiers/utils/eval_display.py
@@ -422,7 +422,9 @@ class EvalDisplay(BaseDisplay):
         config_line.append(fmt_concurrency(display_max_concurrent), style="white")
         config_line.append(" concurrent rollouts", style="dim")
 
-        if config.sampling_args and any(config.sampling_args.values()):
+        if config.sampling_args and any(
+            v is not None for v in config.sampling_args.values()
+        ):
             config_line.append("  |  ", style="dim")
             config_line.append("custom sampling ", style="white")
             config_line.append("(", style="dim")
@@ -1013,7 +1015,9 @@ class EvalDisplay(BaseDisplay):
 
         display_max = self._display_max_concurrent(config, env_state.total)
         text.append(fmt_concurrency(display_max), style="bold")
-        if config.sampling_args and any(config.sampling_args.values()):
+        if config.sampling_args and any(
+            v is not None for v in config.sampling_args.values()
+        ):
             text.append("\n")
             text.append("sampling: ", style="dim")
             parts = [

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -709,12 +709,15 @@ async def run_evaluations(config: EvalRunConfig) -> None:
         )
 
 
-async def run_evaluations_tui(config: EvalRunConfig, tui_mode: bool = True) -> None:
+async def run_evaluations_tui(
+    config: EvalRunConfig, tui_mode: bool = True, compact: bool = False
+) -> None:
     """Run multi-environment evaluation with a Rich display.
 
     Args:
         config: Evaluation run configuration.
         tui_mode: If True, use alternate screen (--tui flag). If False, refresh in-place.
+        compact: If True, show compact summary (settings + stats, skip example prompts).
     """
     from verifiers.utils.eval_display import EvalDisplay, is_tty
 
@@ -730,7 +733,7 @@ async def run_evaluations_tui(config: EvalRunConfig, tui_mode: bool = True) -> N
 
         heart = Heartbeat(config.heartbeat_url)
 
-    display = EvalDisplay(config.evals, screen=tui_mode)
+    display = EvalDisplay(config.evals, screen=tui_mode, compact=compact)
 
     async def run_with_progress(
         env_config: EvalConfig, env_idx: int


### PR DESCRIPTION
## Description

- New settings panel in final summary showing model, endpoint, examples/rollouts/concurrency, sampling args, and env args
- --abbreviated-summary (-A) flag skips example prompts/completions in the summary, showing only settings and stats for quick ablation comparison

Here is the summary of a single environment with the -A flag set:

<img width="934" height="696" alt="image" src="https://github.com/user-attachments/assets/0aaf4b95-ccac-4f22-b431-d458e7b6ebf4" />

The motivation for the --abbreviated-summary flag is that in multi-env evals it's often difficult to get a quick overview over the results, because the examples take up so much space that it's hard to move between the different environments. The settings panel is there because ablations with different settings of the same environment are common, and it was previously impossible to distinguish which summary of the same environment was achieved with which setting.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only and CLI-flag plumbing changes; no changes to evaluation execution, scoring, or persistence logic beyond how results are summarized/rendered.
> 
> **Overview**
> Adds an always-on **settings panel** to each environment’s final evaluation summary, surfacing model/endpoint, example+rollout counts, effective concurrency, sampling args, and env args.
> 
> Introduces `--abbreviated-summary` (`-A`) to run the Rich/TUI evaluation display with a *compact* final summary that omits the example 0 prompt/completion panels (settings + stats only), and wires this flag through `prime eval` → `run_evaluations_tui` → `EvalDisplay`.
> 
> Also tightens sampling-args display logic to only show “custom sampling” when at least one sampling arg is non-`None`, and updates docs/tests to include the new flag.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e372d6c485a38f27c31ad2341f75e59f072621a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->