### PR TITLE
fix: add missing dotenv/config import to CUA server template

### DIFF
--- a/assets/templates/browserbase/cua/index.ts
+++ b/assets/templates/browserbase/cua/index.ts
@@ -16,6 +16,8 @@
  * See README.md for full documentation.
  */
 
+import "dotenv/config";
+
 import { createServer } from "./server";
 import { sessionManager } from "./sessionManager";
 


### PR DESCRIPTION
## Summary
- Add `import "dotenv/config"` to `assets/templates/browserbase/cua/index.ts`
- `dotenv` is listed as a dependency in `package.json` but was never imported, causing `.env` files to be silently ignored
- This led to `modelApiKey is required` errors from Stagehand when users set `OPENAI_API_KEY` in `.env`

## Test plan
- [ ] Verify CUA server picks up env vars from `.env` file after this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line change to a template entrypoint to enable `.env` loading; low risk aside from potential env var precedence differences when `.env` is present.
> 
> **Overview**
> Ensures the CUA server template loads environment variables from local `.env` files by adding `import "dotenv/config"` to `assets/templates/browserbase/cua/index.ts` before reading `process.env` (e.g., `CUA_SERVER_PORT`, `CUA_SERVER_HOST`). This prevents template users from having `.env` values silently ignored at startup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 89c83a2902082e65b6ba9cb1305f2fa5b0125218. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->