### PR TITLE
Will/misc ty

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -24,7 +24,7 @@ This directory contains automated workflows for the verifiers project.
 - Pushes to `main`, `master`, or `develop` branches with the same file changes
 
 **What it does**:
-- Runs tests on multiple Python versions (3.11, 3.12)
+- Runs tests on multiple Python versions (3.12, 3.13)
 - Generates coverage reports (XML, HTML, and terminal output)
 - Uploads coverage to Codecov (requires `CODECOV_TOKEN` secret)
 - Uploads HTML coverage reports as artifacts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,8 @@ logs/
 .chroma_db/
 
 # development
+packages/harnesses
+packages/tasksets
 scratch/
 .idea/
 .vscode/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
         pass_filenames: false
       - id: ty
         name: ty (ci parity)
-        entry: uv run ty check verifiers
+        entry: uv run --python 3.13 ty check verifiers
         language: system
         pass_filenames: false
         stages: [pre-push]

--- a/docs/development.md
+++ b/docs/development.md
@@ -34,7 +34,7 @@ uv sync
 uv sync --all-extras
 
 # Install pre-commit hooks (including pre-push Ty gate):
-uv run pre-commit install --hook-type pre-commit --hook-type pre-push
+uv run pre-commit install
 ```
 
 ## Project Structure
@@ -172,15 +172,15 @@ def test_with_mock(mock_client):
 3. **Make changes** following existing patterns
 4. **Add tests** for new functionality
 5. **Run tests**: `uv run pytest tests/`
-6. **Run linting/format checks**: `uv run ruff check --fix . && uv run ruff format --check verifiers tests`
-7. **Run CI-parity type checks**: `uv run ty check verifiers`
+6. **Install hooks once per clone**: `uv run pre-commit install`
+7. **Commit and push** (hooks run automatically on each commit/push)
 8. **Update docs** if adding/changing public APIs
 9. **Submit PR** with clear description
 
 ### Code Style
 
-- Strict `ruff` enforcement - all PRs must pass `ruff check --fix .` and `ruff format --check verifiers tests`
-- `ty` must pass via `uv run ty check verifiers` to mirror CI setup (Python 3.13 target)
+- Strict `ruff` enforcement via pre-commit hooks
+- `ty` runs in the pre-push hook via `uv run --python 3.13 ty check verifiers`
 - Use type hints for function parameters and returns
 - Write docstrings for public functions/classes
 - Keep functions focused and modular
@@ -189,9 +189,7 @@ def test_with_mock(mock_client):
 ### PR Checklist
 
 - [ ] Tests pass locally (`uv run pytest tests/`)
-- [ ] Linting/format checks pass (`uv run ruff check --fix . && uv run ruff format --check verifiers tests`)
-- [ ] Type checks pass (`uv run ty check verifiers`)
-- [ ] Pre-commit hooks pass (`uv run pre-commit run --all-files`)
+- [ ] Pre-commit and pre-push hooks pass on latest commit/push
 - [ ] Added tests for new functionality
 - [ ] Updated documentation if needed
 
@@ -267,6 +265,7 @@ def load_environment(**kwargs):
 # Development setup
 uv sync                               # CPU-only
 uv sync --all-extras                  # With RL/training extras
+uv run pre-commit install             # One-time per clone (installs pre-commit + pre-push)
 
 # Run tests
 uv run pytest tests/                  # All tests
@@ -280,8 +279,7 @@ uv run pytest tests/test_envs.py -k math_python   # Specific environment
 # Linting
 uv run ruff check --fix .             # Fix lint errors
 uv run ruff format --check verifiers tests  # Verify Python formatting
-uv run ty check verifiers               # Type check (matches CI Ty target)
-uv run pre-commit run --all-files     # Run all pre-commit hooks
+uv run ty check verifiers             # Type check (matches CI Ty target)
 
 # Environment tools
 prime env init new-env                       # Create environment

--- a/tests/test_rollout_gateway_env.py
+++ b/tests/test_rollout_gateway_env.py
@@ -440,9 +440,9 @@ async def test_poll_job_completion_raises_tunnel_error_on_dead_tunnel(monkeypatc
     await env.get_gateway_tunnel_url(local_addr="10.0.0.1")
     tunnel = FakeTunnel.instances[0]
 
-    # Mock sandbox_client.get_background_job to never complete
-    env.sandbox_client = SimpleNamespace(
-        get_background_job=AsyncMock(return_value=SimpleNamespace(completed=False)),
+    # Mock get_background_job on the real sandbox client
+    env.sandbox_client.get_background_job = AsyncMock(
+        return_value=SimpleNamespace(completed=False)
     )
 
     state = {

--- a/verifiers/envs/experimental/cli_agent_env.py
+++ b/verifiers/envs/experimental/cli_agent_env.py
@@ -119,6 +119,11 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
         self._tunnel_lock = asyncio.Lock()
         self._interception_server = InterceptionServer(port=interception_port)
 
+    def _require_interception_server(self) -> InterceptionServer:
+        if self._interception_server is None:
+            raise RuntimeError("Interception server is not initialized.")
+        return self._interception_server
+
     async def get_tunnel_url(self) -> str:
         """Get tunnel URL, starting the tunnel if needed. Recreates dead tunnels."""
         async with self._tunnel_lock:
@@ -131,7 +136,8 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
                 self._tunnel = None
 
             if self._tunnel is None:
-                port = self._interception_server.port  # ty: ignore[unresolved-attribute]
+                interception_server = self._require_interception_server()
+                port = interception_server.port
                 if logger.isEnabledFor(logging.DEBUG):
                     self._tunnel = Tunnel(
                         local_port=port,
@@ -153,7 +159,8 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
         rollout_id = f"rollout_{uuid.uuid4().hex[:8]}"
         state["rollout_id"] = rollout_id
 
-        await self._interception_server.start()  # ty: ignore[unresolved-attribute]
+        interception_server = self._require_interception_server()
+        await interception_server.start()
 
         if self.interception_url is None:
             tunnel_url = await self.get_tunnel_url()
@@ -187,7 +194,7 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
         await self.create_sandbox(state, sandbox_request)
 
         # Register rollout for interception
-        request_id_queue = self._interception_server.register_rollout(rollout_id)  # ty: ignore[unresolved-attribute]
+        request_id_queue = interception_server.register_rollout(rollout_id)
         state["request_id_queue"] = request_id_queue
         state["agent_completed"] = False
 
@@ -278,6 +285,7 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
     async def get_prompt_messages(self, state: State) -> Messages:
         """Wait for agent to make an API request OR agent completion, whichever comes first."""
         request_id_queue = state["request_id_queue"]
+        interception_server = self._require_interception_server()
 
         while True:
             try:
@@ -288,7 +296,7 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
                 )
                 # Got a request, proceed normally
                 state["current_request_id"] = request_id
-                intercept = self._interception_server.intercepts[request_id]  # ty: ignore[unresolved-attribute]
+                intercept = interception_server.intercepts[request_id]
                 return intercept["messages"]
 
             except asyncio.TimeoutError:
@@ -381,9 +389,9 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
             )
 
         request_id = state.get("current_request_id")
-        intercept = (
-            self._interception_server.intercepts.get(request_id) if request_id else None  # ty: ignore[unresolved-attribute]
-        )
+        intercept = None
+        if request_id:
+            intercept = self._require_interception_server().intercepts.get(request_id)
 
         if intercept:
             # Always use the configured model from state, not the intercepted model

--- a/verifiers/envs/experimental/opencode_qa_env.py
+++ b/verifiers/envs/experimental/opencode_qa_env.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from datasets import Dataset, load_dataset
 
 import verifiers as vf
@@ -48,25 +50,38 @@ class OpenCodeQAEnv(OpenCodeEnv):
     ) -> Dataset:
         """Constructs a general QA dataset."""
 
-        dataset = load_dataset(dataset_name, dataset_subset, split=dataset_split)
-
-        if question_key not in dataset.column_names:
-            raise ValueError(
-                f"Column '{question_key}' not found in dataset: {dataset.column_names}"
+        dataset_obj = load_dataset(dataset_name, dataset_subset, split=dataset_split)
+        if not isinstance(dataset_obj, Dataset):
+            raise TypeError(
+                "Expected a Dataset for the requested split, got a different dataset type."
             )
-        if answer_key not in dataset.column_names:
+        dataset = dataset_obj
+
+        column_names = dataset.column_names
+        if column_names is None:
+            raise ValueError("Dataset has no columns.")
+
+        if question_key not in column_names:
             raise ValueError(
-                f"Column '{answer_key}' not found in dataset: {dataset.column_names}"
+                f"Column '{question_key}' not found in dataset: {column_names}"
+            )
+        if answer_key not in column_names:
+            raise ValueError(
+                f"Column '{answer_key}' not found in dataset: {column_names}"
             )
 
-        def process_example(example):
+        def process_example(example: dict[str, Any]) -> dict[str, Any]:
             question = example[question_key]
             answer = example[answer_key]
+            if not isinstance(question, str):
+                question = str(question)
             return {
                 "question": instruction_prompt + question + instruction_prompt_post,
                 "answer": answer,
             }
 
-        dataset = dataset.map(process_example)
+        mapped_dataset = dataset.map(process_example)
+        if not isinstance(mapped_dataset, Dataset):
+            raise TypeError("Expected mapped dataset to be a Dataset.")
 
-        return dataset
+        return mapped_dataset


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly CI/docs and type-safety cleanup, but it changes runtime behavior in experimental envs by adding stricter validation and new failure modes if interception or dataset shapes are unexpected.
> 
> **Overview**
> Updates CI/dev tooling to target **Python 3.13**: `test.yml` now runs on 3.12/3.13 (dropping 3.11), and the pre-push `ty` hook is forced to run under 3.13; docs are updated accordingly.
> 
> Tightens correctness in a few runtime paths: `CliAgentEnv` now centralizes a `_require_interception_server()` guard instead of relying on `ty` ignores, `OpenCodeQAEnv.construct_dataset()` validates `load_dataset`/`map` return types and column presence (and coerces non-string questions), and `test_rollout_gateway_env` adjusts mocking to patch `get_background_job` on the existing `sandbox_client` rather than replacing it. `.gitignore` also adds `packages/harnesses` and `packages/tasksets`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee190b1efbaa05a20f95e5b5423e7b1477189566. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->