### PR TITLE
Ensure `example_id` exists in `init_state` (default to 0)

### DIFF
--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -595,6 +595,8 @@ class Environment(ABC):
         state_input = cast(RolloutInput, deepcopy(input))
         if "info" in state_input and isinstance(state_input["info"], str):
             state_input["info"] = json.loads(state_input["info"])
+        if "example_id" not in state_input:
+            state_input["example_id"] = 0
         if "task" not in state_input:
             state_input["task"] = self.env_id or "default"
         state = State(input=state_input)


### PR DESCRIPTION
### Motivation
- Prevent missing `example_id` from causing downstream errors by ensuring `init_state` always supplies a valid `example_id` when inputs omit it.

### Description
- Add a guard in `Environment.init_state` to set `state_input["example_id"] = 0` when `example_id` is not present before constructing the `State` (file: `verifiers/envs/environment.py`).

### Testing
- Ran `uv run pytest tests/test_environment.py -k init_state` which passed (`2 passed, 28 deselected`).
- Ran `uv run ruff check verifiers/envs/environment.py` which completed with all checks passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9016455288326a52b4b6f67299e3b)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized defaulting change in state initialization; main risk is minor behavior change for callers that relied on absent `example_id`.
> 
> **Overview**
> Ensures `Environment.init_state` always populates `state_input["example_id"]` by defaulting to `0` when the input row omits it, preventing downstream code from failing on missing IDs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d74f297cc9fb9dddcfa95dc4cd9bf28c8b6d1fd1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->