### PR TITLE
fix tito in cli agent env

### DIFF
--- a/verifiers/envs/experimental/cli_agent_env.py
+++ b/verifiers/envs/experimental/cli_agent_env.py
@@ -28,6 +28,7 @@ from verifiers.utils.interception_utils import (
     deliver_response,
     synthesize_stream,
 )
+from verifiers.utils.message_utils import normalize_messages
 from verifiers.utils.worker_utils import get_free_port
 
 logger = logging.getLogger(__name__)
@@ -297,7 +298,7 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
                 # Got a request, proceed normally
                 state["current_request_id"] = request_id
                 intercept = interception_server.intercepts[request_id]
-                return intercept["messages"]
+                return normalize_messages(intercept["messages"], field_name="messages")
 
             except asyncio.TimeoutError:
                 # No request yet — check tunnel liveness first

--- a/verifiers/envs/multiturn_env.py
+++ b/verifiers/envs/multiturn_env.py
@@ -126,7 +126,7 @@ class MultiTurnEnv(vf.Environment):
             tokens is not None and bool(tokens.get("is_truncated"))
         )
         trajectory_step = TrajectoryStep(
-            prompt=prompt_messages,
+            prompt=normalize_messages(prompt_messages),
             completion=completion_messages,
             response=response,
             tokens=tokens,

--- a/verifiers/envs/multiturn_env.py
+++ b/verifiers/envs/multiturn_env.py
@@ -126,7 +126,7 @@ class MultiTurnEnv(vf.Environment):
             tokens is not None and bool(tokens.get("is_truncated"))
         )
         trajectory_step = TrajectoryStep(
-            prompt=normalize_messages(prompt_messages),
+            prompt=prompt_messages,
             completion=completion_messages,
             response=response,
             tokens=tokens,


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Previously, using `CLIAgentEnv` with TITO client would fail because the intercepted message are not in vf-format and stored as such in trajectory steps. In MITO, we normalize the message-copy that is being sent to the client and so we don't have problems. Because best-effort TITO iterates over messages which are not in vf-format we raise a `ValueError` which falsly aborts any multi-turn rollout.

```bash
uv run vf-eval opencode-math -n1 -r1 -m Qwen/Qwen3-4B-Instruct-2507 -p local --api-client-type openai_chat_completions_token 
```

**Before**

<img width="1392" height="509" alt="Screenshot 2026-03-05 at 11 54 09 AM" src="https://github.com/user-attachments/assets/75767f86-288c-46a0-b779-d6465b5b3237" />

**After**

<img width="1373" height="712" alt="Screenshot 2026-03-05 at 12 21 02 PM" src="https://github.com/user-attachments/assets/297ea882-97df-4b44-be96-65374aec3aab" />

## Claude Summary

- intercept["messages"] in interception_utils.py stores raw dicts from the HTTP request body                                                                                               
  - These get stored as-is in step["prompt"] in the trajectory (the normalize_messages call in environment.get_model_response only normalizes the copy passed to the client, not the one     
  stored in the trajectory)                                                                                                                                                                  
  - On turn ≥ 1, find_largest_prefix_match_tokens rebuilds step messages from the trajectory and calls to_native_prompt directly on them — but from_chat_message only handles typed          
  vf.Message subclasses, not raw dicts                                                                                                                                                       
  - The non-token client never touches trajectory messages, so it never hits this path 

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to message normalization in an experimental environment; minimal surface area and no security/data persistence impact.
> 
> **Overview**
> Fixes `CliAgentEnv` multi-turn rollouts with the TITO token client by normalizing intercepted HTTP request `messages` into vf `Message` objects.
> 
> `get_prompt_messages` now returns `normalize_messages(intercept["messages"])` instead of raw dicts, preventing `ValueError`/type mismatches when trajectory prompts are later reprocessed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e96912fa674fa5976e02ccf2c15d69f97187f7b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->