### PR TITLE
vf-eval: Use daemon thread for display refresh loop

### DIFF
--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -5,10 +5,11 @@ import importlib.util
 import logging
 import math
 import os
+import threading
 import time
 from collections import Counter, defaultdict
 from collections.abc import Mapping
-from contextlib import contextmanager, suppress
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Callable, cast
 
@@ -814,14 +815,19 @@ async def run_evaluations_tui(
             display.update_env_state(env_idx, status="failed", error=str(e))
             raise
 
-    async def refresh_loop() -> None:
-        while not display.state.all_completed:
+    # Use a daemon thread for the refresh loop so it runs even when the
+    # event loop is blocked by synchronous work (e.g. env installation).
+    refresh_stop = threading.Event()
+
+    def refresh_loop() -> None:
+        while not refresh_stop.is_set() and not display.state.all_completed:
             display.refresh()
-            await asyncio.sleep(1)
+            refresh_stop.wait(1)
 
     try:
         async with display:
-            refresh_task = asyncio.create_task(refresh_loop())
+            refresh_thread = threading.Thread(target=refresh_loop, daemon=True)
+            refresh_thread.start()
             try:
                 await asyncio.gather(
                     *[
@@ -835,9 +841,8 @@ async def run_evaluations_tui(
                 if tui_mode:
                     await display.wait_for_exit()
             finally:
-                refresh_task.cancel()
-                with suppress(asyncio.CancelledError):
-                    await refresh_task
+                refresh_stop.set()
+                refresh_thread.join(timeout=2)
 
     except KeyboardInterrupt:
         pass  # exit on interrupt


### PR DESCRIPTION
## Description

The async refresh task couldn't run when the event loop was blocked by synchronous env installation, causing timers to freeze until all envs started running. A daemon thread now runs independently.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces cross-thread interaction with `EvalDisplay.refresh()`, which could expose thread-safety or shutdown-order issues, but the change is localized to the TUI refresh loop.
> 
> **Overview**
> Prevents the eval TUI from freezing when the asyncio event loop is blocked (e.g., during synchronous env installation) by replacing the async `refresh_loop` task with a daemon `threading.Thread`.
> 
> Adds a `threading.Event` stop signal and ensures the refresh thread is stopped and joined during teardown, removing the previous `asyncio` task cancellation/suppress logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01253763c1071143d1dbbcd0b64d7a89fd9a0089. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->