### PR TITLE
Add [[ablation]] sweep syntax for eval TOML configs

### DIFF
--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -337,7 +337,7 @@ difficulty = ["easy", "hard"]
 - **Fixed `env_args`** can be set alongside swept ones (e.g. `env_args = {split = "test"}` keeps `split` fixed while sweeping other env args). The same key cannot appear in both fixed and swept env_args.
 - Multiple `[[ablation]]` blocks are independent (no cross-product between blocks)
 - `[[ablation]]` and `[[eval]]` blocks can coexist in the same config file
-- `env_id` can be a fixed field or a sweep key (e.g. `env_id = ["env-a", "env-b"]`)
+- `env_id` can be a fixed field or a sweep key (e.g. `env_id = ["env-a", "env-b"]`), but note that all swept envs must accept the same `env_args` — use separate `[[ablation]]` blocks for envs with different argument schemas
 
 Use `--abbreviated-summary` (`-A`) to get a compact summary focused on settings and stats, which is useful when comparing many ablation runs.
 

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -15,6 +15,7 @@ This section explains how to run evaluations with Verifiers environments. See [E
 - [Environment Defaults](#environment-defaults)
 - [Multi-Environment Evaluation](#multi-environment-evaluation)
   - [TOML Configuration](#toml-configuration)
+  - [Ablation Sweeps](#ablation-sweeps)
   - [Configuration Precedence](#configuration-precedence)
 
 Use `prime eval` to execute rollouts against any supported model provider and report aggregate metrics. Supported providers include OpenAI-compatible APIs (the default) and the Anthropic Messages API (via `--api-client-type anthropic_messages`).
@@ -307,6 +308,38 @@ num_examples = 50
 difficulty = "hard"
 split = "test"
 ```
+
+### Ablation Sweeps
+
+Use `[[ablation]]` blocks to automatically generate eval configs from a cartesian product of parameter values. This is useful for hyperparameter sweeps and ablation studies without manually writing each combination.
+
+```toml
+# Global defaults apply to all evals and ablations
+model = "openai/gpt-4.1-mini"
+num_examples = 50
+
+# Sweep temperature × difficulty → 6 eval configs
+# split is fixed across all combinations
+[[ablation]]
+env_id = "my-env"
+env_args = {split = "test"}
+
+[ablation.sweep]
+temperature = [0.0, 0.5, 1.0]
+
+[ablation.sweep.env_args]
+difficulty = ["easy", "hard"]
+```
+
+- **Fixed fields** in the `[[ablation]]` block (like `env_id`) apply to all expanded configs
+- **`[ablation.sweep]`** keys are lists of values crossed as a cartesian product
+- **`[ablation.sweep.env_args]`** keys are swept and merged into the `env_args` dict
+- **Fixed `env_args`** can be set alongside swept ones (e.g. `env_args = {split = "test"}` keeps `split` fixed while sweeping other env args). The same key cannot appear in both fixed and swept env_args.
+- Multiple `[[ablation]]` blocks are independent (no cross-product between blocks)
+- `[[ablation]]` and `[[eval]]` blocks can coexist in the same config file
+- `env_id` can be a fixed field or a sweep key (e.g. `env_id = ["env-a", "env-b"]`)
+
+Use `--abbreviated-summary` (`-A`) to get a compact summary focused on settings and stats, which is useful when comparing many ablation runs.
 
 ### Configuration Precedence
 

--- a/skills/evaluate-environments/SKILL.md
+++ b/skills/evaluate-environments/SKILL.md
@@ -89,6 +89,18 @@ prime eval run my-env -n 1000 -s --resume
 ```bash
 prime eval run configs/eval/my-benchmark.toml
 ```
+6. Run ablation sweeps using `[[ablation]]` blocks in TOML configs:
+```toml
+[[ablation]]
+env_id = "my-env"
+
+[ablation.sweep]
+temperature = [0.0, 0.5, 1.0]
+
+[ablation.sweep.env_args]
+difficulty = ["easy", "hard"]
+```
+This generates the cartesian product (6 configs in this example). Use `--abbreviated-summary` (`-A`) for compact ablation results.
 
 ## Push Results to Platform
 1. After proper eval runs complete, nudge users to push results for detailed platform viewing.

--- a/tests/test_eval_cli.py
+++ b/tests/test_eval_cli.py
@@ -903,3 +903,190 @@ def test_cli_toml_resume_false_disables_global_resume(monkeypatch, run_cli):
     assert configs[0].resume_path is None
     assert configs[1].env_id == "env-b"
     assert configs[1].resume_path is None
+
+
+# --- Ablation tests ---
+
+
+def test_ablation_basic_expansion():
+    """Single sweep key expands to correct number of configs."""
+    with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
+        f.write(
+            '[[ablation]]\nenv_id = "my-env"\n\n'
+            "[ablation.sweep]\n"
+            "temperature = [0.0, 0.5, 1.0]\n"
+        )
+        f.flush()
+        configs = load_toml_config(Path(f.name))
+
+    assert len(configs) == 3
+    assert all(c["env_id"] == "my-env" for c in configs)
+    assert [c["temperature"] for c in configs] == [0.0, 0.5, 1.0]
+
+
+def test_ablation_cartesian_product():
+    """Multiple sweep keys produce cartesian product."""
+    with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
+        f.write(
+            '[[ablation]]\nenv_id = "my-env"\n\n'
+            "[ablation.sweep]\n"
+            "temperature = [0.0, 1.0]\n"
+            'model = ["gpt-4.1-mini", "gpt-4.1"]\n'
+        )
+        f.flush()
+        configs = load_toml_config(Path(f.name))
+
+    assert len(configs) == 4  # 2 × 2
+    temps = [c["temperature"] for c in configs]
+    models = [c["model"] for c in configs]
+    assert 0.0 in temps and 1.0 in temps
+    assert "gpt-4.1-mini" in models and "gpt-4.1" in models
+
+
+def test_ablation_env_args_sweep():
+    """sweep.env_args keys are merged into env_args dict."""
+    with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
+        f.write(
+            '[[ablation]]\nenv_id = "my-env"\n'
+            'env_args = {fixed_key = "fixed"}\n\n'
+            "[ablation.sweep]\n"
+            "temperature = [0.0, 1.0]\n\n"
+            "[ablation.sweep.env_args]\n"
+            'difficulty = ["easy", "hard"]\n'
+        )
+        f.flush()
+        configs = load_toml_config(Path(f.name))
+
+    assert len(configs) == 4  # 2 × 2
+    for c in configs:
+        assert c["env_args"]["fixed_key"] == "fixed"
+        assert c["env_args"]["difficulty"] in ("easy", "hard")
+
+
+def test_ablation_global_defaults_apply():
+    """Global defaults are applied to ablation configs."""
+    with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
+        f.write(
+            "num_examples = 100\n\n"
+            '[[ablation]]\nenv_id = "my-env"\n\n'
+            "[ablation.sweep]\n"
+            "temperature = [0.0, 1.0]\n"
+        )
+        f.flush()
+        configs = load_toml_config(Path(f.name))
+
+    assert len(configs) == 2
+    assert all(c["num_examples"] == 100 for c in configs)
+
+
+def test_ablation_with_eval_blocks():
+    """Ablation and eval blocks can coexist."""
+    with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
+        f.write(
+            '[[eval]]\nenv_id = "plain-env"\n\n'
+            '[[ablation]]\nenv_id = "sweep-env"\n\n'
+            "[ablation.sweep]\n"
+            "temperature = [0.0, 0.5, 1.0]\n"
+        )
+        f.flush()
+        configs = load_toml_config(Path(f.name))
+
+    assert len(configs) == 4  # 1 eval + 3 ablation
+    assert configs[0]["env_id"] == "plain-env"
+    assert all(c["env_id"] == "sweep-env" for c in configs[1:])
+
+
+def test_ablation_multiple_blocks():
+    """Multiple [[ablation]] blocks are independent."""
+    with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
+        f.write(
+            '[[ablation]]\nenv_id = "env-a"\n\n'
+            "[ablation.sweep]\n"
+            "temperature = [0.0, 1.0]\n\n"
+            '[[ablation]]\nenv_id = "env-b"\n\n'
+            "[ablation.sweep]\n"
+            'model = ["m1", "m2", "m3"]\n'
+        )
+        f.flush()
+        configs = load_toml_config(Path(f.name))
+
+    assert len(configs) == 5  # 2 + 3
+    assert sum(1 for c in configs if c["env_id"] == "env-a") == 2
+    assert sum(1 for c in configs if c["env_id"] == "env-b") == 3
+
+
+def test_ablation_env_id_in_sweep():
+    """env_id can be a sweep key itself."""
+    with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
+        f.write(
+            "[[ablation]]\n\n"
+            "[ablation.sweep]\n"
+            'env_id = ["env-a", "env-b"]\n'
+            "temperature = [0.0, 1.0]\n"
+        )
+        f.flush()
+        configs = load_toml_config(Path(f.name))
+
+    assert len(configs) == 4  # 2 × 2
+    env_ids = [c["env_id"] for c in configs]
+    assert "env-a" in env_ids and "env-b" in env_ids
+
+
+def test_ablation_empty_sweep_raises():
+    """Ablation without sweep section raises ValueError."""
+    with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
+        f.write('[[ablation]]\nenv_id = "my-env"\n')
+        f.flush()
+        with pytest.raises(ValueError, match="non-empty"):
+            load_toml_config(Path(f.name))
+
+
+def test_ablation_invalid_field_raises():
+    """Ablation with invalid fixed field raises ValueError."""
+    with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
+        f.write(
+            '[[ablation]]\nenv_id = "my-env"\nbogus = true\n\n'
+            "[ablation.sweep]\n"
+            "temperature = [0.0]\n"
+        )
+        f.flush()
+        with pytest.raises(ValueError, match="Invalid"):
+            load_toml_config(Path(f.name))
+
+
+def test_ablation_invalid_sweep_field_raises():
+    """Ablation with invalid sweep key raises ValueError."""
+    with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
+        f.write(
+            '[[ablation]]\nenv_id = "my-env"\n\n'
+            "[ablation.sweep]\n"
+            "bogus_field = [1, 2]\n"
+        )
+        f.flush()
+        with pytest.raises(ValueError, match="Invalid sweep"):
+            load_toml_config(Path(f.name))
+
+
+def test_ablation_missing_env_id_raises():
+    """Ablation without env_id (fixed or swept) raises ValueError."""
+    with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
+        f.write("[[ablation]]\n\n[ablation.sweep]\ntemperature = [0.0, 1.0]\n")
+        f.flush()
+        with pytest.raises(ValueError, match="env_id"):
+            load_toml_config(Path(f.name))
+
+
+def test_ablation_overlapping_env_args_raises():
+    """Same key in fixed env_args and sweep.env_args raises ValueError."""
+    with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
+        f.write(
+            '[[ablation]]\nenv_id = "my-env"\n'
+            'env_args = {difficulty = "easy"}\n\n'
+            "[ablation.sweep]\n"
+            "temperature = [0.0, 1.0]\n\n"
+            "[ablation.sweep.env_args]\n"
+            'difficulty = ["easy", "hard"]\n'
+        )
+        f.flush()
+        with pytest.raises(ValueError, match="difficulty"):
+            load_toml_config(Path(f.name))

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import importlib.util
+import itertools
 import logging
 import math
 import os
@@ -257,10 +258,88 @@ def load_endpoints(endpoints_path: str):
     return endpoints
 
 
+def _expand_ablation(ablation: dict, global_defaults: dict) -> list[dict]:
+    """Expand an [[ablation]] block into eval configs via cartesian product.
+
+    Sweep keys are lists of values under [ablation.sweep]. Environment args
+    can be swept via [ablation.sweep.env_args]. All sweep dimensions are
+    crossed to produce one eval config per combination.
+
+    Example TOML:
+        [[ablation]]
+        env_id = "my-env"
+
+        [ablation.sweep]
+        temperature = [0.0, 0.5]
+
+        [ablation.sweep.env_args]
+        difficulty = ["easy", "hard"]
+
+    This produces 4 eval configs (2 temperatures × 2 difficulties).
+    """
+    ablation = dict(ablation)  # don't mutate caller's dict
+    sweep = ablation.pop("sweep", {})
+    sweep = dict(sweep)  # copy before mutating
+    env_args_sweep = sweep.pop("env_args", {})
+
+    # Collect all sweep dimensions: [(key, [values]), ...]
+    dimensions: list[tuple[str, list]] = []
+    for key, values in sweep.items():
+        if not isinstance(values, list):
+            raise ValueError(
+                f"Ablation sweep values must be lists, got {type(values).__name__} "
+                f"for '{key}'"
+            )
+        dimensions.append((key, values))
+    for key, values in env_args_sweep.items():
+        if not isinstance(values, list):
+            raise ValueError(
+                f"Ablation sweep.env_args values must be lists, got "
+                f"{type(values).__name__} for '{key}'"
+            )
+        dimensions.append((f"env_args.{key}", values))
+
+    if not dimensions:
+        raise ValueError(
+            "[[ablation]] block must have a non-empty [ablation.sweep] section"
+        )
+
+    # Guard against same key in both fixed env_args and sweep.env_args
+    fixed_env_args = ablation.get("env_args", {})
+    if fixed_env_args and env_args_sweep:
+        overlap = set(fixed_env_args.keys()) & set(env_args_sweep.keys())
+        if overlap:
+            raise ValueError(
+                f"env_args key(s) {overlap} appear in both fixed env_args and "
+                f"sweep.env_args — use one or the other"
+            )
+
+    # Fixed fields: global defaults overridden by ablation-level fields
+    fixed = {**global_defaults, **ablation}
+
+    # Expand cartesian product
+    keys = [k for k, _ in dimensions]
+    value_lists = [v for _, v in dimensions]
+
+    expanded = []
+    for combo in itertools.product(*value_lists):
+        config = dict(fixed)
+        for key, value in zip(keys, combo):
+            if key.startswith("env_args."):
+                env_key = key[len("env_args.") :]
+                config["env_args"] = {**config.get("env_args", {}), env_key: value}
+            else:
+                config[key] = value
+        expanded.append(config)
+
+    return expanded
+
+
 def load_toml_config(path: Path) -> list[dict]:
     """Loads and validates a TOML config file.
 
-    Config format supports global defaults at the top level, with per-eval overrides:
+    Config format supports global defaults at the top level, with per-eval overrides
+    and ablation sweeps:
 
         # Global defaults (optional)
         model = "openai/gpt-4.1-mini"
@@ -273,10 +352,16 @@ def load_toml_config(path: Path) -> list[dict]:
         env_id = "math-python"
         num_examples = 5  # overrides global default
 
-    Minimal config (just a single eval):
+        # Ablation: cartesian product of sweep values
+        [[ablation]]
+        env_id = "my-env"
 
-        [[eval]]
-        env_id = "gsm8k"
+        [ablation.sweep]
+        temperature = [0.0, 0.5, 1.0]
+
+        [ablation.sweep.env_args]
+        difficulty = ["easy", "hard"]
+        # → 6 eval configs
     """
     if not path.exists():
         raise FileNotFoundError(f"Config file not found: {path}")
@@ -286,21 +371,30 @@ def load_toml_config(path: Path) -> list[dict]:
 
     # validate schema
     eval_list = raw_config.get("eval", [])
+    ablation_list = raw_config.get("ablation", [])
+
     if not isinstance(eval_list, list):
         raise ValueError(
             f"Config file uses [eval] but should use [[eval]] (double brackets) "
             f"for array of tables: {path}"
         )
-    if not eval_list:
+    if not isinstance(ablation_list, list):
         raise ValueError(
-            f"Config file must contain at least one [[eval]] section: {path}"
+            f"Config file uses [ablation] but should use [[ablation]] (double brackets) "
+            f"for array of tables: {path}"
+        )
+    if not eval_list and not ablation_list:
+        raise ValueError(
+            f"Config file must contain at least one [[eval]] or [[ablation]] section: {path}"
         )
 
     if not all("env_id" in e for e in eval_list):
         raise ValueError(f"All [[eval]] sections must contain an env_id field: {path}")
 
-    # extract global defaults (everything except 'eval' key)
-    global_defaults = {k: v for k, v in raw_config.items() if k != "eval"}
+    # extract global defaults (everything except 'eval' and 'ablation' keys)
+    global_defaults = {
+        k: v for k, v in raw_config.items() if k not in ("eval", "ablation")
+    }
 
     # valid fields mirror cli args, not evalconfig
     # TODO: properly tie EvalConfig to CLI
@@ -362,7 +456,38 @@ def load_toml_config(path: Path) -> list[dict]:
             )
         # global defaults, then per-eval overrides
         merged = {**global_defaults, **eval_config}
-        # Resolve endpoints_path relative to the config file location.
+        merged_eval_list.append(merged)
+
+    # expand [[ablation]] blocks into eval configs
+    for ablation in ablation_list:
+        # Validate fixed fields (everything except 'sweep')
+        ablation_fixed_keys = set(ablation.keys()) - {"sweep"}
+        invalid_fields = ablation_fixed_keys - valid_fields
+        if invalid_fields:
+            raise ValueError(
+                f"Invalid field(s) {invalid_fields} in [[ablation]] block. "
+                f"Valid fields are: {sorted(valid_fields)}"
+            )
+        # Validate sweep keys (except env_args which has freeform sub-keys)
+        sweep = ablation.get("sweep", {})
+        invalid_sweep = set(sweep.keys()) - valid_fields - {"env_args"}
+        if invalid_sweep:
+            raise ValueError(
+                f"Invalid sweep field(s) {invalid_sweep} in [[ablation]] block. "
+                f"Valid fields are: {sorted(valid_fields)}"
+            )
+        expanded = _expand_ablation(ablation, global_defaults)
+        merged_eval_list.extend(expanded)
+
+    # Validate all expanded configs have env_id
+    for config in merged_eval_list:
+        if "env_id" not in config:
+            raise ValueError(
+                "All eval configs (including expanded ablations) must have an env_id"
+            )
+
+    # Resolve endpoints_path relative to the config file location
+    for merged in merged_eval_list:
         endpoints_path = merged.get("endpoints_path")
         if isinstance(endpoints_path, str):
             endpoints_path_obj = Path(endpoints_path)
@@ -370,7 +495,6 @@ def load_toml_config(path: Path) -> list[dict]:
                 merged["endpoints_path"] = str(
                     (path.parent / endpoints_path_obj).resolve()
                 )
-        merged_eval_list.append(merged)
 
     return merged_eval_list
 

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -323,7 +323,7 @@ def _expand_ablation(ablation: dict, global_defaults: dict) -> list[dict]:
 
     expanded = []
     for combo in itertools.product(*value_lists):
-        config = dict(fixed)
+        config = {k: (dict(v) if isinstance(v, dict) else v) for k, v in fixed.items()}
         for key, value in zip(keys, combo):
             if key.startswith("env_args."):
                 env_key = key[len("env_args.") :]


### PR DESCRIPTION
Expand cartesian products of parameter values into eval configs automatically. Supports top-level sweep keys and env_args sweep keys, fixed env_args alongside swept ones (with overlap guard), multiple independent ablation blocks, and coexistence with [[eval]].

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [x] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core config-loading logic used by `prime eval`, so schema/validation mistakes could break existing TOML workflows, though changes are well-scoped and covered by new tests.
> 
> **Overview**
> Adds support for `[[ablation]]` blocks in eval TOML configs, expanding a cartesian product of `[ablation.sweep]` (and `[ablation.sweep.env_args]`) values into multiple concrete eval configs alongside existing `[[eval]]` entries.
> 
> Updates `load_toml_config` to parse/validate `ablation` sections, apply global defaults to generated configs, guard against invalid fields and overlapping fixed vs swept `env_args`, and continue resolving `endpoints_path` relative to the config. Documentation and the eval skill guide now describe the new syntax, and the test suite adds comprehensive coverage for expansion behavior and error cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d8dd11e1d908e3b67e87b116c40db5417d8f024. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->