### PR TITLE
enforce integer, dims handling

### DIFF
--- a/assets/templates/browserbase/cua/actionExecutor.ts
+++ b/assets/templates/browserbase/cua/actionExecutor.ts
@@ -1,5 +1,9 @@
 import type { Page } from "@browserbasehq/stagehand";
-import { ActionRequest, ActionExecutionResult } from "./types";
+import {
+  ActionRequest,
+  ActionExecutionResult,
+  ValidationErrorDetail,
+} from "./types";
 
 /**
  * Logger interface for structured logging (compatible with Fastify logger)
@@ -7,6 +11,17 @@ import { ActionRequest, ActionExecutionResult } from "./types";
 export interface ActionLogger {
   info: (obj: object, msg?: string) => void;
   error: (obj: object, msg?: string) => void;
+}
+
+export class ActionValidationError extends Error {
+  readonly code = "INVALID_ACTION_ARGS";
+  readonly details: ValidationErrorDetail[];
+
+  constructor(actionType: string, details: ValidationErrorDetail[]) {
+    super(`Invalid arguments for ${actionType}`);
+    this.name = "ActionValidationError";
+    this.details = details;
+  }
 }
 
 /**
@@ -61,6 +76,75 @@ function mapKeyToPlaywright(key: string): string {
   return KEY_MAP[upperKey] || key;
 }
 
+function describeValueType(value: unknown): string {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  return typeof value;
+}
+
+function integerFieldError(
+  field: string,
+  value: unknown,
+  expected = "an integer"
+): ValidationErrorDetail {
+  return {
+    field,
+    expected,
+    receivedType: describeValueType(value),
+    receivedValue: value,
+    message: `${field} must be ${expected}, received ${JSON.stringify(value)} (${describeValueType(value)})`,
+  };
+}
+
+function stringFieldError(
+  field: string,
+  value: unknown,
+  expected = "a string"
+): ValidationErrorDetail {
+  return {
+    field,
+    expected,
+    receivedType: describeValueType(value),
+    receivedValue: value,
+    message: `${field} must be ${expected}, received ${JSON.stringify(value)} (${describeValueType(value)})`,
+  };
+}
+
+function validateClickLikeArgs(
+  actionType: string,
+  x: unknown,
+  y: unknown
+): { x: number; y: number } {
+  const details: ValidationErrorDetail[] = [];
+  if (!Number.isInteger(x)) {
+    details.push(integerFieldError("x", x, "an integer pixel coordinate"));
+  }
+  if (!Number.isInteger(y)) {
+    details.push(integerFieldError("y", y, "an integer pixel coordinate"));
+  }
+  if (details.length > 0) {
+    throw new ActionValidationError(actionType, details);
+  }
+  return { x: x as number, y: y as number };
+}
+
+function validateOptionalInteger(
+  field: string,
+  value: unknown,
+  defaultValue: number,
+  expected = "an integer"
+): number {
+  if (value === undefined) {
+    return defaultValue;
+  }
+  if (!Number.isInteger(value)) {
+    throw new ActionValidationError("scroll", [
+      integerFieldError(field, value, expected),
+    ]);
+  }
+  return value as number;
+}
+
 /**
  * ActionExecutor
  *
@@ -90,14 +174,8 @@ export async function executeAction(
     switch (action.type) {
       case "click": {
         const { x, y, button = "left", clickCount = 1 } = action;
-        if (typeof x !== "number" || typeof y !== "number") {
-          result = {
-            success: false,
-            error: "click requires x and y coordinates",
-          };
-          break;
-        }
-        await page.click(x, y, {
+        const coords = validateClickLikeArgs("click", x, y);
+        await page.click(coords.x, coords.y, {
           button: button as "left" | "right" | "middle",
           clickCount,
         });
@@ -108,14 +186,8 @@ export async function executeAction(
       case "double_click":
       case "doubleClick": {
         const { x, y } = action;
-        if (typeof x !== "number" || typeof y !== "number") {
-          result = {
-            success: false,
-            error: "double_click requires x and y coordinates",
-          };
-          break;
-        }
-        await page.click(x, y, {
+        const coords = validateClickLikeArgs("double_click", x, y);
+        await page.click(coords.x, coords.y, {
           button: "left",
           clickCount: 2,
         });
@@ -125,14 +197,8 @@ export async function executeAction(
 
       case "tripleClick": {
         const { x, y } = action;
-        if (typeof x !== "number" || typeof y !== "number") {
-          result = {
-            success: false,
-            error: "tripleClick requires x and y coordinates",
-          };
-          break;
-        }
-        await page.click(x, y, {
+        const coords = validateClickLikeArgs("tripleClick", x, y);
+        await page.click(coords.x, coords.y, {
           button: "left",
           clickCount: 3,
         });
@@ -143,8 +209,9 @@ export async function executeAction(
       case "type": {
         const { text } = action;
         if (typeof text !== "string") {
-          result = { success: false, error: "type requires text parameter" };
-          break;
+          throw new ActionValidationError("type", [
+            stringFieldError("text", text, "a string to type"),
+          ]);
         }
         await page.type(text);
         result = { success: true };
@@ -154,8 +221,17 @@ export async function executeAction(
       case "keypress": {
         const { keys } = action;
         if (!keys) {
-          result = { success: false, error: "keypress requires keys parameter" };
-          break;
+          throw new ActionValidationError("keypress", [
+            stringFieldError("keys", keys, "a string or array of strings"),
+          ]);
+        }
+        if (
+          typeof keys !== "string" &&
+          (!Array.isArray(keys) || keys.some((key) => typeof key !== "string"))
+        ) {
+          throw new ActionValidationError("keypress", [
+            stringFieldError("keys", keys, "a string or array of strings"),
+          ]);
         }
         const keyList = Array.isArray(keys) ? keys : [keys];
         for (const rawKey of keyList) {
@@ -167,12 +243,15 @@ export async function executeAction(
       }
 
       case "scroll": {
-        const { x = 0, y = 0, scroll_x = 0, scroll_y = 0 } = action;
+        const x = validateOptionalInteger("x", action.x, 0, "an integer pixel coordinate");
+        const y = validateOptionalInteger("y", action.y, 0, "an integer pixel coordinate");
+        const scroll_x = validateOptionalInteger("scroll_x", action.scroll_x, 0, "an integer pixel delta");
+        const scroll_y = validateOptionalInteger("scroll_y", action.scroll_y, 0, "an integer pixel delta");
         await page.scroll(
-          x as number,
-          y as number,
-          scroll_x as number,
-          scroll_y as number,
+          x,
+          y,
+          scroll_x,
+          scroll_y,
         );
         result = { success: true };
         break;
@@ -206,6 +285,11 @@ export async function executeAction(
 
       case "wait": {
         const time = action.timeMs ?? 1000;
+        if (!Number.isInteger(time) || time < 0) {
+          throw new ActionValidationError("wait", [
+            integerFieldError("timeMs", time, "a non-negative integer number of milliseconds"),
+          ]);
+        }
         await new Promise((r) => setTimeout(r, time));
         result = { success: true };
         break;
@@ -221,8 +305,9 @@ export async function executeAction(
       case "goto": {
         const { url } = action;
         if (typeof url !== "string") {
-          result = { success: false, error: "goto requires url parameter" };
-          break;
+          throw new ActionValidationError("goto", [
+            stringFieldError("url", url, "a URL string"),
+          ]);
         }
         await page.goto(url, { waitUntil: "load" });
         result = { success: true };

--- a/assets/templates/browserbase/cua/server.ts
+++ b/assets/templates/browserbase/cua/server.ts
@@ -9,6 +9,79 @@ import {
   SessionCreateResponse,
   ErrorResponse,
 } from "./types";
+import { ActionValidationError } from "./actionExecutor";
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isRateLimitError(error: unknown): boolean {
+  const message = getErrorMessage(error).toLowerCase();
+  return (
+    message.includes("rate limit") ||
+    message.includes("too many requests") ||
+    message.includes("status code 429") ||
+    message.includes("http 429")
+  );
+}
+
+function isTimeoutError(error: unknown): boolean {
+  const message = getErrorMessage(error).toLowerCase();
+  return (
+    message.includes("timeout") ||
+    message.includes("timed out") ||
+    message.includes("etimedout")
+  );
+}
+
+function buildErrorResponse(
+  error: unknown,
+  fallbackCode: string,
+): { statusCode: number; body: ErrorResponse } {
+  if (error instanceof ActionValidationError) {
+    return {
+      statusCode: 400,
+      body: {
+        error: error.message,
+        code: error.code,
+        retryable: false,
+        details: error.details,
+      },
+    };
+  }
+
+  const errorMessage = getErrorMessage(error);
+  if (isRateLimitError(error)) {
+    return {
+      statusCode: 429,
+      body: {
+        error: errorMessage,
+        code: "RATE_LIMITED",
+        retryable: true,
+      },
+    };
+  }
+
+  if (isTimeoutError(error)) {
+    return {
+      statusCode: 504,
+      body: {
+        error: errorMessage,
+        code: `${fallbackCode}_TIMEOUT`,
+        retryable: true,
+      },
+    };
+  }
+
+  return {
+    statusCode: 500,
+    body: {
+      error: errorMessage,
+      code: fallbackCode,
+      retryable: false,
+    },
+  };
+}
 
 /**
  * Create and configure the Fastify server with CUA primitive routes
@@ -46,9 +119,9 @@ export function createServer(): FastifyInstance {
         state,
       };
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      reply.status(500);
-      return { error: errorMessage, code: "SESSION_CREATE_FAILED" };
+      const { statusCode, body } = buildErrorResponse(error, "SESSION_CREATE_FAILED");
+      reply.status(statusCode);
+      return body;
     }
   });
 
@@ -140,8 +213,6 @@ export function createServer(): FastifyInstance {
         state,
       };
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-
       // Try to capture state even on error
       let state;
       try {
@@ -154,15 +225,12 @@ export function createServer(): FastifyInstance {
         };
       }
 
-      reply.status(500);
-      return {
-        success: false,
-        error: errorMessage,
-        state,
-      };
+      const { statusCode, body } = buildErrorResponse(error, "ACTION_EXECUTION_FAILED");
+      body.state = state;
+      reply.status(statusCode);
+      return body;
     }
   });
 
   return server;
 }
-

--- a/assets/templates/browserbase/cua/types.ts
+++ b/assets/templates/browserbase/cua/types.ts
@@ -79,6 +79,17 @@ export interface ActionResponse {
 }
 
 /**
+ * Structured validation detail for action argument errors
+ */
+export interface ValidationErrorDetail {
+  field: string;
+  expected: string;
+  receivedType: string;
+  receivedValue?: unknown;
+  message: string;
+}
+
+/**
  * Session Create Request
  */
 export interface SessionCreateRequest {
@@ -113,4 +124,7 @@ export interface BrowserSession {
 export interface ErrorResponse {
   error: string;
   code: string;
+  retryable?: boolean;
+  details?: ValidationErrorDetail[];
+  state?: BrowserState;
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,11 @@ flash-attn = [{ requirement = "torch", match-runtime = true }]
 [tool.uv.extra-build-variables]
 flash-attn = { FLASH_ATTENTION_SKIP_CUDA_BUILD = "TRUE" }
 
+[tool.uv.workspace]
+members = [
+    "sample-rl-run",
+]
+
 [project.scripts]
 vf-eval = "verifiers.scripts.eval:main"
 vf-gepa = "verifiers.scripts.gepa:main"

--- a/tests/test_browser_env.py
+++ b/tests/test_browser_env.py
@@ -97,6 +97,75 @@ class TestCUAModeInit:
                 assert isinstance(env._mode_impl, CUAMode)
                 assert env._mode_impl._execution_mode == "local"
 
+    def test_cua_default_system_prompt_uses_configured_viewport(self):
+        """Test that BrowserEnv injects a default CUA prompt with viewport dimensions."""
+        from verifiers.envs.integrations.browser_env.browser_env import BrowserEnv
+
+        with patch.dict(os.environ, {}, clear=True):
+            with patch(
+                "verifiers.envs.integrations.browser_env.modes.cua_mode.CUAMode.verify_server_connection"
+            ):
+                env = BrowserEnv(
+                    mode="cua",
+                    use_sandbox=False,
+                    env="LOCAL",
+                    viewport_width=800,
+                    viewport_height=600,
+                    dataset=Dataset.from_dict(
+                        {"question": ["test"], "answer": ["test"]}
+                    ),
+                )
+
+        assert env.system_prompt is not None
+        assert "800x600" in env.system_prompt
+
+    def test_cua_custom_system_prompt_is_preserved(self):
+        """Test that custom CUA prompts override the default prompt injection."""
+        from verifiers.envs.integrations.browser_env.browser_env import BrowserEnv
+
+        with patch.dict(os.environ, {}, clear=True):
+            with patch(
+                "verifiers.envs.integrations.browser_env.modes.cua_mode.CUAMode.verify_server_connection"
+            ):
+                env = BrowserEnv(
+                    mode="cua",
+                    use_sandbox=False,
+                    env="LOCAL",
+                    system_prompt="custom prompt",
+                    dataset=Dataset.from_dict(
+                        {"question": ["test"], "answer": ["test"]}
+                    ),
+                )
+
+        assert env.system_prompt == "custom prompt"
+
+
+class TestCUAToolDescriptions:
+    """Tests for CUA tool schema descriptions."""
+
+    def test_tool_descriptions_include_viewport_dimensions(self):
+        """Test that coordinate tools include configured viewport dimensions."""
+        from verifiers.envs.integrations.browser_env.browser_env import BrowserEnv
+
+        with patch.dict(os.environ, {}, clear=True):
+            with patch(
+                "verifiers.envs.integrations.browser_env.modes.cua_mode.CUAMode.verify_server_connection"
+            ):
+                env = BrowserEnv(
+                    mode="cua",
+                    use_sandbox=False,
+                    env="LOCAL",
+                    viewport_width=800,
+                    viewport_height=600,
+                    dataset=Dataset.from_dict(
+                        {"question": ["test"], "answer": ["test"]}
+                    ),
+                )
+
+        tool_descriptions = {tool.name: tool.description for tool in env.tool_defs}
+        assert "800x600" in tool_descriptions["click"]
+        assert "800x600" in tool_descriptions["scroll"]
+
 
 class TestCUASandboxModeBackwardsCompat:
     """Tests for backwards compatibility with CUASandboxMode."""
@@ -379,6 +448,46 @@ class TestCUAModeResponseFormat:
 
         assert len(formatted) == 1
         assert formatted[0]["type"] == "text"
+
+
+class TestCUAModeErrorHelpers:
+    """Tests for structured CUA error parsing and retry classification."""
+
+    def test_format_error_message_includes_validation_details(self):
+        """Test validation details are rendered in a model-repairable format."""
+        from verifiers.envs.integrations.browser_env.modes.cua_mode import CUAMode
+
+        mode = CUAMode(execution_mode="local", save_screenshots=False)
+        message = mode._format_error_message(
+            400,
+            {
+                "error": "Invalid arguments for click",
+                "details": [
+                    {
+                        "field": "x",
+                        "expected": "an integer pixel coordinate",
+                        "receivedType": "string",
+                        "receivedValue": "512",
+                    }
+                ],
+            },
+            "",
+        )
+
+        assert "Invalid arguments for click" in message
+        assert "x must be an integer pixel coordinate" in message
+        assert '"512"' not in message
+        assert "512" in message
+        assert "string" in message
+
+    def test_retryable_response_detects_rate_limit_payload(self):
+        """Test that retryable payloads are classified for internal retry."""
+        from verifiers.envs.integrations.browser_env.modes.cua_mode import CUAMode
+
+        mode = CUAMode(execution_mode="local", save_screenshots=False)
+
+        assert mode._is_retryable_response(429, {"retryable": True}) is True
+        assert mode._is_retryable_response(400, {"retryable": False}) is False
 
 
 # ============================================================================

--- a/verifiers/envs/integrations/README.md
+++ b/verifiers/envs/integrations/README.md
@@ -100,6 +100,12 @@ env = BrowserEnv(
 )
 ```
 
+When you do not pass a custom `system_prompt`, BrowserEnv now injects a default CUA prompt that includes the configured viewport resolution and tells the model to use integer pixel coordinates from the top-left corner of the page.
+
+The generated CUA tool descriptions also include the configured display dimensions, so runs with custom args such as `viewport_width=800` and `viewport_height=600` surface that context directly to the model.
+
+If you need to smooth bursty traffic to the CUA server, set `cua_max_concurrent_requests` on `BrowserEnv` to limit concurrent CUA session/action requests per environment instance.
+
 #### Manual Server Mode (Optional)
 
 For local development or debugging, you can disable sandbox mode and run the CUA server manually:

--- a/verifiers/envs/integrations/browser_env/browser_env.py
+++ b/verifiers/envs/integrations/browser_env/browser_env.py
@@ -15,6 +15,18 @@ logger = logging.getLogger(__name__)
 ModeType = Literal["dom", "cua"]
 
 
+def _build_default_cua_system_prompt(viewport_width: int, viewport_height: int) -> str:
+    """Build the default system prompt used for CUA mode when none is provided."""
+    return (
+        "You are a browser automation agent. Use the provided tools to interact with the current browser screenshot.\n\n"
+        f"The display resolution is {viewport_width}x{viewport_height} pixels.\n"
+        "Use integer pixel coordinates measured from the top-left corner of the page. "
+        "Center clicks on targets and rely on the latest screenshot after each action before choosing the next step.\n"
+        "If a tool call fails because of invalid arguments, repair the arguments and try again. "
+        "If the task is infeasible from the current page state, explain the failure clearly."
+    )
+
+
 class BrowserEnv(vf.StatefulToolEnv):
     """
     Unified browser environment supporting both DOM-based and CUA-based modes.
@@ -63,6 +75,7 @@ class BrowserEnv(vf.StatefulToolEnv):
         viewport_height: int = 768,
         save_screenshots: bool = True,
         keep_recent_screenshots: int | None = 2,
+        cua_max_concurrent_requests: int | None = 8,
         proxies: bool = False,
         advanced_stealth: bool = False,
         # CUA sandbox mode specific
@@ -101,6 +114,7 @@ class BrowserEnv(vf.StatefulToolEnv):
             viewport_height: Browser viewport height (default: 768)
             save_screenshots: Save screenshots to disk (default: True)
             keep_recent_screenshots: Number of recent screenshots to keep in context (default: 2)
+            cua_max_concurrent_requests: Maximum number of concurrent CUA session/action requests per environment (default: 8)
             proxies: Enable Browserbase proxies (default: False)
             advanced_stealth: Enable Browserbase Advanced Stealth mode for anti-bot detection (default: False)
             server_port: Port for CUA server in sandbox mode (default: 3000)
@@ -118,6 +132,10 @@ class BrowserEnv(vf.StatefulToolEnv):
             stop_errors: List of exception types that should trigger cleanup (default: [vf.SandboxError])
             **kwargs: Additional arguments passed to StatefulToolEnv
         """
+        if mode == "cua" and "system_prompt" not in kwargs:
+            kwargs["system_prompt"] = _build_default_cua_system_prompt(
+                viewport_width, viewport_height
+            )
         super().__init__(
             stop_errors=stop_errors if stop_errors is not None else [vf.SandboxError],
             **kwargs,
@@ -145,6 +163,7 @@ class BrowserEnv(vf.StatefulToolEnv):
                 browserbase_project_id=project_id,
                 viewport_width=viewport_width,
                 viewport_height=viewport_height,
+                cua_max_concurrent_requests=cua_max_concurrent_requests,
                 save_screenshots=save_screenshots,
                 keep_recent_screenshots=keep_recent_screenshots,
                 proxies=proxies,

--- a/verifiers/envs/integrations/browser_env/modes/cua_mode.py
+++ b/verifiers/envs/integrations/browser_env/modes/cua_mode.py
@@ -3,12 +3,14 @@
 import asyncio
 import base64
 import copy
+import inspect
 import json
 import logging
 import os
 import tarfile
 import tempfile
 import threading
+from contextlib import asynccontextmanager
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Literal
@@ -35,6 +37,21 @@ except ImportError:
     CreateSandboxRequest = None  # type: ignore[misc, assignment]
     SandboxClient = None  # type: ignore[misc, assignment]
     APIClient = None  # type: ignore[misc, assignment]
+
+
+class CUATransientError(RuntimeError):
+    """Retryable CUA request error."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int | None = None,
+        code: str | None = None,
+    ):
+        super().__init__(message)
+        self.status_code = status_code
+        self.code = code
 
 
 class CUAMode:
@@ -80,6 +97,7 @@ class CUAMode:
         backoff_factor: float = 2.0,
         max_backoff_seconds: float = 30.0,
         jitter: float = 1e-3,
+        cua_max_concurrent_requests: int | None = 8,
         screenshot_dir: str | None = None,
         save_screenshots: bool = True,
         keep_recent_screenshots: int | None = 2,
@@ -110,6 +128,8 @@ class CUAMode:
         self._execution_mode = execution_mode
         self.keep_recent_screenshots = keep_recent_screenshots
         self.logger = None  # Will be set when register_tools is called
+        self.viewport_width = viewport_width
+        self.viewport_height = viewport_height
 
         # Resolve API keys
         resolved_api_key = browserbase_api_key or os.getenv("BROWSERBASE_API_KEY")
@@ -150,6 +170,13 @@ class CUAMode:
         self.max_backoff_seconds = max_backoff_seconds
         self.jitter = jitter
         self.retrying: AsyncRetrying | None = None
+        self.request_retrying: AsyncRetrying | None = None
+        self.cua_max_concurrent_requests = cua_max_concurrent_requests
+        self._request_semaphore = (
+            asyncio.Semaphore(cua_max_concurrent_requests)
+            if cua_max_concurrent_requests and cua_max_concurrent_requests > 0
+            else None
+        )
 
         # Local mode specific
         self.server_url = server_url.rstrip("/")
@@ -218,7 +245,7 @@ class CUAMode:
         """Register CUA mode tools with the environment."""
         self.logger = env.logger
 
-        # Set up retry now that we have logger
+        # Resource lifecycle retry: broad by design for sandbox/session setup and cleanup.
         self.retrying = tc.AsyncRetrying(
             stop=tc.stop_after_attempt(self.max_retries),
             wait=tc.wait_exponential_jitter(
@@ -230,23 +257,223 @@ class CUAMode:
             before_sleep=tc.before_sleep_log(self.logger, logging.ERROR),
             reraise=True,
         )
+        self.request_retrying = tc.AsyncRetrying(
+            stop=tc.stop_after_attempt(self.max_retries),
+            wait=tc.wait_exponential_jitter(
+                initial=self.base_delay,
+                exp_base=self.backoff_factor,
+                max=self.max_backoff_seconds,
+                jitter=self.jitter,
+            ),
+            retry=tc.retry_if_exception_type(
+                (CUATransientError, aiohttp.ClientError, asyncio.TimeoutError)
+            ),
+            before_sleep=tc.before_sleep_log(self.logger, logging.WARNING),
+            reraise=True,
+        )
 
         # Hide internal args from tool schema
         _skip = ["session_id", "sandbox_id", "tool_call_id"]
-        env.add_tool(self.click, args_to_skip=_skip)
-        env.add_tool(self.double_click, args_to_skip=_skip)
-        env.add_tool(self.type_text, args_to_skip=_skip)
-        env.add_tool(self.keypress, args_to_skip=_skip)
-        env.add_tool(self.scroll, args_to_skip=_skip)
-        env.add_tool(self.goto, args_to_skip=_skip)
-        env.add_tool(self.back, args_to_skip=_skip)
-        env.add_tool(self.forward, args_to_skip=_skip)
-        env.add_tool(self.wait, args_to_skip=_skip)
-        env.add_tool(self.screenshot, args_to_skip=_skip)
+        env.add_tool(
+            self._wrap_tool(
+                self.click,
+                (
+                    "Click at pixel coordinates (x, y) on the page. "
+                    f"The display resolution is {self.viewport_width}x{self.viewport_height} pixels. "
+                    "Use integer pixel coordinates measured from the top-left corner and center clicks on the target."
+                ),
+            ),
+            args_to_skip=_skip,
+        )
+        env.add_tool(
+            self._wrap_tool(
+                self.double_click,
+                (
+                    "Double-click at pixel coordinates (x, y). "
+                    f"The display resolution is {self.viewport_width}x{self.viewport_height} pixels. "
+                    "Use integer pixel coordinates measured from the top-left corner."
+                ),
+            ),
+            args_to_skip=_skip,
+        )
+        env.add_tool(
+            self._wrap_tool(
+                self.type_text,
+                "Type text into the currently focused element.",
+            ),
+            args_to_skip=_skip,
+        )
+        env.add_tool(
+            self._wrap_tool(
+                self.keypress,
+                "Press one key or a list of keys using Playwright-style key names.",
+            ),
+            args_to_skip=_skip,
+        )
+        env.add_tool(
+            self._wrap_tool(
+                self.scroll,
+                (
+                    "Scroll the page. x and y are integer pixel cursor coordinates, "
+                    "and scroll_x/scroll_y are integer pixel deltas. "
+                    f"The display resolution is {self.viewport_width}x{self.viewport_height} pixels."
+                ),
+            ),
+            args_to_skip=_skip,
+        )
+        env.add_tool(
+            self._wrap_tool(self.goto, "Navigate the browser to a URL."),
+            args_to_skip=_skip,
+        )
+        env.add_tool(
+            self._wrap_tool(self.back, "Navigate back in browser history."),
+            args_to_skip=_skip,
+        )
+        env.add_tool(
+            self._wrap_tool(self.forward, "Navigate forward in browser history."),
+            args_to_skip=_skip,
+        )
+        env.add_tool(
+            self._wrap_tool(
+                self.wait,
+                "Wait for a specified non-negative integer number of milliseconds.",
+            ),
+            args_to_skip=_skip,
+        )
+        env.add_tool(
+            self._wrap_tool(
+                self.screenshot,
+                (
+                    "Capture a screenshot of the current page state. "
+                    f"The display resolution is {self.viewport_width}x{self.viewport_height} pixels."
+                ),
+            ),
+            args_to_skip=_skip,
+        )
 
         # For local mode, verify server is reachable
         if self._execution_mode == "local":
             self.verify_server_connection()
+
+    @staticmethod
+    def _wrap_tool(tool, description: str):
+        """Return a callable wrapper with the original signature and a custom description."""
+
+        async def wrapper(*args, **kwargs):
+            return await tool(*args, **kwargs)
+
+        setattr(wrapper, "__name__", getattr(tool, "__name__", "unknown"))
+        setattr(wrapper, "__doc__", description)
+        setattr(wrapper, "__signature__", inspect.signature(tool))
+        setattr(wrapper, "__annotations__", getattr(tool, "__annotations__", {}))
+        return wrapper
+
+    @staticmethod
+    def _parse_json_payload(body: str) -> dict[str, Any] | None:
+        try:
+            payload = json.loads(body)
+        except json.JSONDecodeError:
+            return None
+        return payload if isinstance(payload, dict) else None
+
+    @staticmethod
+    def _coerce_http_status(http_code: str | int) -> int | None:
+        if isinstance(http_code, int):
+            return http_code
+        if isinstance(http_code, str) and http_code.isdigit():
+            return int(http_code)
+        return None
+
+    @staticmethod
+    def _describe_value_type(value: Any) -> str:
+        if value is None:
+            return "null"
+        if isinstance(value, bool):
+            return "boolean"
+        if isinstance(value, (int, float)):
+            return "number"
+        if isinstance(value, list):
+            return "array"
+        if isinstance(value, dict):
+            return "object"
+        return type(value).__name__
+
+    def _format_error_message(
+        self,
+        status_code: int | None,
+        payload: dict[str, Any] | None,
+        raw_body: str,
+    ) -> str:
+        if payload:
+            error = str(
+                payload.get("error") or f"CUA request failed (HTTP {status_code})"
+            )
+            details = payload.get("details")
+            if isinstance(details, list) and details:
+                formatted_details = []
+                for detail in details:
+                    if not isinstance(detail, dict):
+                        continue
+                    message = detail.get("message")
+                    if isinstance(message, str) and message.strip():
+                        formatted_details.append(message)
+                        continue
+                    field = detail.get("field", "field")
+                    expected = detail.get("expected", "the expected type")
+                    received_value = detail.get("receivedValue")
+                    received_type = detail.get(
+                        "receivedType", self._describe_value_type(received_value)
+                    )
+                    formatted_details.append(
+                        f"{field} must be {expected}, received {received_value!r} ({received_type})"
+                    )
+                if formatted_details:
+                    return f"{error}: {'; '.join(formatted_details)}"
+            return error
+
+        if status_code is not None:
+            return f"CUA request failed (HTTP {status_code}): {raw_body[:500]}"
+        return raw_body[:500]
+
+    def _is_retryable_response(
+        self,
+        status_code: int | None,
+        payload: dict[str, Any] | None,
+    ) -> bool:
+        if payload and payload.get("retryable") is True:
+            return True
+        return status_code in {429, 502, 503, 504}
+
+    def _build_error_result(
+        self,
+        status_code: int | None,
+        payload: dict[str, Any] | None,
+        raw_body: str,
+    ) -> dict[str, Any]:
+        state = payload.get("state", {}) if payload else {}
+        if not isinstance(state, dict):
+            state = {}
+        return {
+            "success": False,
+            "error": self._format_error_message(status_code, payload, raw_body),
+            "state": state,
+        }
+
+    @asynccontextmanager
+    async def _request_slot(self):
+        if self._request_semaphore is None:
+            yield
+            return
+        async with self._request_semaphore:
+            yield
+
+    async def _run_request_with_retry(self, func, *args, **kwargs):
+        """Run a CUA session/action request with transient-error retry and concurrency control."""
+        async for attempt in self.request_retrying:  # type: ignore[union-attr]
+            with attempt:
+                async with self._request_slot():
+                    return await func(*args, **kwargs)
+        raise RuntimeError("CUA request retry loop exhausted")
 
     # ==================== Server Health Check (Local Mode) ====================
 
@@ -314,10 +541,21 @@ class CUAMode:
         async with client.post(
             f"{self.server_url}/sessions",
             json=self.session_config,
+            timeout=aiohttp.ClientTimeout(total=60),
         ) as resp:
             if resp.status != 200:
                 error_text = await resp.text()
-                raise RuntimeError(f"Failed to create browser session: {error_text}")
+                payload = self._parse_json_payload(error_text)
+                error_message = self._format_error_message(
+                    resp.status, payload, error_text
+                )
+                if self._is_retryable_response(resp.status, payload):
+                    raise CUATransientError(
+                        f"Failed to create browser session: {error_message}",
+                        status_code=resp.status,
+                        code=payload.get("code") if payload else None,
+                    )
+                raise RuntimeError(f"Failed to create browser session: {error_message}")
             return await resp.json()
 
     async def _destroy_session_http(self, session_id: str) -> None:
@@ -343,14 +581,25 @@ class CUAMode:
         async with client.post(
             f"{self.server_url}/sessions/{session_id}/action",
             json=payload,
+            timeout=aiohttp.ClientTimeout(total=60),
         ) as resp:
             if resp.status != 200:
                 error_text = await resp.text()
+                error_payload = self._parse_json_payload(error_text)
+                error_message = self._format_error_message(
+                    resp.status, error_payload, error_text
+                )
+                if self._is_retryable_response(resp.status, error_payload):
+                    raise CUATransientError(
+                        f"Action failed for session {session_id}: {error_message}",
+                        status_code=resp.status,
+                        code=error_payload.get("code") if error_payload else None,
+                    )
                 if self.logger:
                     self.logger.warning(
-                        f"Action failed for session {session_id}: {error_text}"
+                        f"Action failed for session {session_id}: {error_message}"
                     )
-                return {"success": False, "error": error_text, "state": {}}
+                return self._build_error_result(resp.status, error_payload, error_text)
             return await resp.json()
 
     # ==================== Sandbox Client Methods ====================
@@ -632,6 +881,17 @@ class CUAMode:
         )
 
         body, http_code = self._parse_curl_response(stdout)
+        status_code = self._coerce_http_status(http_code)
+        if status_code != 200:
+            payload_dict = self._parse_json_payload(body)
+            error_message = self._format_error_message(status_code, payload_dict, body)
+            if self._is_retryable_response(status_code, payload_dict):
+                raise CUATransientError(
+                    f"Failed to create browser session: {error_message}",
+                    status_code=status_code,
+                    code=payload_dict.get("code") if payload_dict else None,
+                )
+            raise RuntimeError(f"Failed to create browser session: {error_message}")
 
         try:
             return json.loads(body)
@@ -676,6 +936,17 @@ class CUAMode:
         )
 
         body, http_code = self._parse_curl_response(stdout)
+        status_code = self._coerce_http_status(http_code)
+        if status_code != 200:
+            payload_dict = self._parse_json_payload(body)
+            error_message = self._format_error_message(status_code, payload_dict, body)
+            if self._is_retryable_response(status_code, payload_dict):
+                raise CUATransientError(
+                    f"Action failed for session {session_id}: {error_message}",
+                    status_code=status_code,
+                    code=payload_dict.get("code") if payload_dict else None,
+                )
+            return self._build_error_result(status_code, payload_dict, body)
 
         try:
             return json.loads(body)
@@ -696,14 +967,28 @@ class CUAMode:
         sandbox_id: str | None = None,
     ) -> dict:
         """Execute a browser action using the appropriate method based on mode."""
-        if self._execution_mode == "local":
-            return await self._execute_action_http(session_id, action, tool_call_id)
-        else:
+        try:
+            if self._execution_mode == "local":
+                return await self._run_request_with_retry(
+                    self._execute_action_http,
+                    session_id,
+                    action,
+                    tool_call_id,
+                )
+
             if sandbox_id is None:
                 raise ValueError("sandbox_id is required for sandbox mode")
-            return await self._execute_action_curl(
-                session_id, action, sandbox_id, tool_call_id
+            return await self._run_request_with_retry(
+                self._execute_action_curl,
+                session_id,
+                action,
+                sandbox_id,
+                tool_call_id,
             )
+        except (CUATransientError, aiohttp.ClientError, asyncio.TimeoutError) as e:
+            if self.logger:
+                self.logger.warning(f"CUA action retries exhausted: {e}")
+            return {"success": False, "error": str(e), "state": {}}
 
     # ==================== Screenshot Methods ====================
 
@@ -818,9 +1103,7 @@ class CUAMode:
         if self._execution_mode == "local":
             # Local mode: create session via HTTP
             try:
-                async for attempt in self.retrying:  # type: ignore[union-attr]
-                    with attempt:
-                        result = await self._create_session_http()
+                result = await self._run_request_with_retry(self._create_session_http)
                 session_id = result.get("sessionId")
                 if not session_id:
                     raise RuntimeError("Failed to get session ID from server response")
@@ -859,9 +1142,9 @@ class CUAMode:
                     await self._start_server(sandbox_id)
                     await self._wait_for_server(sandbox_id)
 
-                async for attempt in self.retrying:  # type: ignore[union-attr]
-                    with attempt:
-                        result = await self._create_session_curl(sandbox_id)
+                result = await self._run_request_with_retry(
+                    self._create_session_curl, sandbox_id
+                )
                 session_id = result.get("sessionId")
                 if not session_id:
                     raise RuntimeError(


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the CUA request/response contract and adds new retry/concurrency logic around session/action calls, which could change error handling behavior and load patterns under failure conditions.
> 
> **Overview**
> **CUA server now validates action arguments as strict integers/strings and emits structured 400s** via `ActionValidationError` + `ValidationErrorDetail`, with `ErrorResponse` extended to include `retryable`, `details`, and optional `state`.
> 
> **CUA client integration is updated to use viewport-aware prompting and more resilient request handling.** `BrowserEnv` injects a default CUA `system_prompt` (unless overridden) and `CUAMode` tool descriptions embed the configured viewport dimensions; `CUAMode` also adds per-request timeouts, transient-error retries, and an optional `cua_max_concurrent_requests` semaphore to smooth bursty traffic. Tests and docs are updated accordingly, and `pyproject.toml` adds a `uv` workspace member.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d291c1bc22484f3ce9fc00da1c2eed62adccf94. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->