### PR TITLE
Fix all ty type check errors

### DIFF
--- a/verifiers/envs/experimental/mcp_env.py
+++ b/verifiers/envs/experimental/mcp_env.py
@@ -127,7 +127,10 @@ class MCPToolWrapper:
 
     def to_tool_def(self) -> Tool:
         """Convert the MCP tool metadata directly to vf.Tool."""
-        parameters = self.tool.inputSchema or {"type": "object", "properties": {}}
+        parameters = cast(
+            dict[str, object],
+            self.tool.inputSchema or {"type": "object", "properties": {}},
+        )
         return Tool(
             name=self.__name__,
             description=self.__doc__ or "",

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -2654,7 +2654,9 @@ class RLMEnv(vf.StatefulToolEnv):
 
         batch_start = perf_counter()
         batch_id = uuid.uuid4().hex[:8]
-        results: list[dict[str, Any] | None] = [None] * len(prompts)
+        results: list[dict[str, Any] | None] = [
+            cast(dict[str, Any] | None, None)
+        ] * len(prompts)
         semaphore = asyncio.Semaphore(self.max_sub_llm_parallelism)
 
         def _coerce_prompt_messages(prompt: Any, index: int) -> Messages:
@@ -2900,7 +2902,7 @@ class RLMEnv(vf.StatefulToolEnv):
                 )
                 update_rlm_metrics_from_step(state_ref, trajectory_step)
 
-        metadata = {
+        metadata: dict[str, int | float | bool] = {
             "prompt_tokens": prompt_tokens,
             "completion_tokens": completion_tokens,
             "tool_call_count": tool_call_count,

--- a/verifiers/envs/integrations/browser_env/modes/cua_mode.py
+++ b/verifiers/envs/integrations/browser_env/modes/cua_mode.py
@@ -763,7 +763,9 @@ class CUAMode:
                 f"Viewport: {viewport.get('width', 0)}x{viewport.get('height', 0)}"
             )
 
-        content = [{"type": "text", "text": "\n".join(text_parts)}]
+        content: list[dict[str, str | dict[str, str]]] = [
+            {"type": "text", "text": "\n".join(text_parts)}
+        ]
 
         if screenshot_b64 and session_id:
             self._save_screenshot(session_id, screenshot_b64, url)

--- a/verifiers/envs/integrations/openenv_env.py
+++ b/verifiers/envs/integrations/openenv_env.py
@@ -1188,9 +1188,12 @@ class OpenEnvEnv(vf.MultiTurnEnv):
                 Tool(
                     name=tool_dict.get("name", ""),
                     description=tool_dict.get("description", ""),
-                    parameters=tool_dict.get("input_schema")
-                    or tool_dict.get("inputSchema")
-                    or {"type": "object", "properties": {}},
+                    parameters=cast(
+                        dict[str, object],
+                        tool_dict.get("input_schema")
+                        or tool_dict.get("inputSchema")
+                        or {"type": "object", "properties": {}},
+                    ),
                 )
             )
         return tool_defs

--- a/verifiers/utils/eval_display.py
+++ b/verifiers/utils/eval_display.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from typing import Literal
 
 from rich.columns import Columns
-from rich.console import Console, Group
+from rich.console import Console, Group, RenderableType
 from rich.panel import Panel
 from rich.progress import BarColumn, Progress, SpinnerColumn, TextColumn
 from rich.table import Table
@@ -489,7 +489,7 @@ class EvalDisplay(BaseDisplay):
 
         # combine all content
         space = Text("  ")
-        content_items = [config_line, space, progress]
+        content_items: list[RenderableType] = [config_line, space, progress]
         if metrics_content:
             content_items.append(metrics_content)
         else:


### PR DESCRIPTION
## Summary
- Fix 8 `ty` type checker diagnostics across `verifiers/` by adding explicit type annotations, `cast()` calls, and proper import of `RenderableType`
- Files fixed: `mcp_env.py`, `rlm_env.py`, `cua_mode.py`, `openenv_env.py`, `eval_display.py`

## Test plan
- [x] `uv run ty check verifiers` passes with zero diagnostics
- [x] `uv run ruff check` passes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only/annotation changes with no intended runtime behavior changes; risk is limited to potential incorrect casts masking real schema mismatches at runtime.
> 
> **Overview**
> Resolves `ty` type-checker diagnostics across several `verifiers/` modules by tightening type hints and adding `cast()` calls where third-party/loosely-typed data is passed through.
> 
> Key tweaks include casting MCP/OpenEnv tool `parameters` schemas to `dict[str, object]`, making `rlm_env` batch result initialization and `_rlm_metadata` typing explicit, typing CUA browser response `content` as a structured list, and importing/using Rich’s `RenderableType` for display composition in `eval_display.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d50d1f38fa90e307637ab7dfa14e2ae45d2d1b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->