### PR TITLE
Show env_args in detail panel header

### DIFF
--- a/verifiers/utils/display_utils.py
+++ b/verifiers/utils/display_utils.py
@@ -34,6 +34,24 @@ def make_aligned_row(left: Text, right: Text) -> Table:
     return table
 
 
+def make_kv_line(
+    items: dict[str, object], prefix: str = "╰─ ", prefix_style: str = "dim"
+) -> Text:
+    """Create a key-value line like: ╰─ name value   name value
+
+    Keys are dim, values are bold, separated by 3 spaces.
+    """
+    text = Text()
+    text.append(prefix, style=prefix_style)
+    for i, (name, value) in enumerate(items.items()):
+        text.append(name, style="dim")
+        text.append(" ", style="dim")
+        text.append(str(value), style="bold")
+        if i < len(items) - 1:
+            text.append("   ")
+    return text
+
+
 def format_numeric(value: float | int | str) -> str:
     if isinstance(value, float):
         if value == int(value):

--- a/verifiers/utils/eval_display.py
+++ b/verifiers/utils/eval_display.py
@@ -349,19 +349,12 @@ class EvalDisplay(BaseDisplay):
 
     def _make_tokens_row(self, usage: TokenUsage) -> Table | None:
         """Create a tokens row with input/output values."""
-        tokens_text = Text()
-        tokens_text.append("╰─ ", style="dim")
-        token_items = [
-            ("input", usage.get("input_tokens", 0.0)),
-            ("output", usage.get("output_tokens", 0.0)),
-        ]
-        for i, (name, value) in enumerate(token_items):
-            value_str = format_numeric(value)
-            tokens_text.append(name, style="dim")
-            tokens_text.append(" ", style="dim")
-            tokens_text.append(value_str, style="bold")
-            if i < len(token_items) - 1:
-                tokens_text.append("   ")
+        tokens_text = make_kv_line(
+            {
+                "input": format_numeric(usage.get("input_tokens", 0.0)),
+                "output": format_numeric(usage.get("output_tokens", 0.0)),
+            }
+        )
         return make_aligned_row(tokens_text, Text())
 
     @staticmethod

--- a/verifiers/utils/eval_display.py
+++ b/verifiers/utils/eval_display.py
@@ -25,7 +25,12 @@ from rich.table import Table
 from rich.text import Text
 
 from verifiers.types import EvalConfig, GenerateOutputs, TokenUsage
-from verifiers.utils.display_utils import BaseDisplay, format_numeric, make_aligned_row
+from verifiers.utils.display_utils import (
+    BaseDisplay,
+    format_numeric,
+    make_aligned_row,
+    make_kv_line,
+)
 from verifiers.utils.message_utils import format_messages
 
 
@@ -330,22 +335,7 @@ class EvalDisplay(BaseDisplay):
         """Create a metrics row with metrics left-aligned and error_rate right-aligned."""
         metrics = {"reward": reward, **metrics}
 
-        # build the left-aligned metrics text
-        metrics_text = Text()
-        metrics_text.append("╰─ ", style="dim")
-
-        for i, (name, value) in enumerate(metrics.items()):
-            # format value
-            value_str = format_numeric(value)
-
-            # add metric with dotted leader
-            metrics_text.append(name, style="dim")
-            metrics_text.append(" ", style="dim")
-            metrics_text.append(value_str, style="bold")
-
-            # add separator between metrics
-            if i < len(metrics) - 1:
-                metrics_text.append("   ")  # 3 spaces between metrics
+        metrics_text = make_kv_line({k: format_numeric(v) for k, v in metrics.items()})
 
         # build the right-aligned error_rate text
         error_text = Text()
@@ -489,7 +479,25 @@ class EvalDisplay(BaseDisplay):
 
         # combine all content
         space = Text("  ")
-        content_items: list[RenderableType] = [config_line, space, progress]
+        content_items: list[RenderableType] = []
+
+        # Show env_args and sampling_args above config line
+        args_dict: dict[str, object] = {}
+        if config.env_args:
+            args_dict.update(config.env_args)
+        if config.sampling_args and any(
+            v is not None for v in config.sampling_args.values()
+        ):
+            args_dict.update(
+                {k: v for k, v in config.sampling_args.items() if v is not None}
+            )
+        if args_dict:
+            content_items.append(
+                make_kv_line(args_dict, prefix="args: ", prefix_style="white")
+            )
+            content_items.append(space)
+
+        content_items.extend([config_line, space, progress])
         if metrics_content:
             content_items.append(metrics_content)
         else:
@@ -544,12 +552,16 @@ class EvalDisplay(BaseDisplay):
         logs_panel = self._make_logs_panel(env_idx, max_lines=log_max_lines)
         content_items.append(logs_panel)
 
+        # No top padding when args are shown (they sit right under the title)
+        has_args = bool(args_dict)
+        top_pad = 0 if has_args else 1
+
         return Panel(
             Group(*content_items),
             title=title,
             title_align="left",
             border_style=border_style,
-            padding=(1, 1),
+            padding=(top_pad, 1, 1, 1),
             expand=True,
         )
 

--- a/verifiers/utils/eval_display.py
+++ b/verifiers/utils/eval_display.py
@@ -474,19 +474,10 @@ class EvalDisplay(BaseDisplay):
         space = Text("  ")
         content_items: list[RenderableType] = []
 
-        # Show env_args and sampling_args above config line
-        args_dict: dict[str, object] = {}
+        # Show env_args above config line (sampling_args shown on config line instead)
         if config.env_args:
-            args_dict.update(config.env_args)
-        if config.sampling_args and any(
-            v is not None for v in config.sampling_args.values()
-        ):
-            args_dict.update(
-                {k: v for k, v in config.sampling_args.items() if v is not None}
-            )
-        if args_dict:
             content_items.append(
-                make_kv_line(args_dict, prefix="args: ", prefix_style="white")
+                make_kv_line(config.env_args, prefix="args: ", prefix_style="white")
             )
             content_items.append(space)
 
@@ -522,7 +513,7 @@ class EvalDisplay(BaseDisplay):
         content_items.append(Text(""))
 
         # No top padding when args are shown (they sit right under the title)
-        has_args = bool(args_dict)
+        has_args = bool(config.env_args)
         top_pad = 0 if has_args else 1
 
         # Compute log lines by measuring the actual rendered height of content.

--- a/verifiers/utils/eval_display.py
+++ b/verifiers/utils/eval_display.py
@@ -528,6 +528,10 @@ class EvalDisplay(BaseDisplay):
 
         content_items.append(Text(""))
 
+        # No top padding when args are shown (they sit right under the title)
+        has_args = bool(args_dict)
+        top_pad = 0 if has_args else 1
+
         # Compute log lines by measuring the actual rendered height of content.
         # We render content_items to a temporary buffer to count lines because
         # items like the metrics row can wrap to multiple terminal lines depending
@@ -543,18 +547,14 @@ class EvalDisplay(BaseDisplay):
             measure_console = Console(file=buf, width=inner_width, highlight=False)
             measure_console.print(Group(*content_items))
             rendered_lines = buf.getvalue().count("\n")
-            # Outer panel: 2 borders + 2 padding; logs panel: 2 borders
-            overhead = rendered_lines + 4 + 2
+            # Outer panel: 2 borders + top_pad + 1 bottom pad; logs panel: 2 borders
+            overhead = rendered_lines + 2 + top_pad + 1 + 2
             log_max_lines = max(3, available_height - overhead)
         else:
             log_max_lines = 20
 
         logs_panel = self._make_logs_panel(env_idx, max_lines=log_max_lines)
         content_items.append(logs_panel)
-
-        # No top padding when args are shown (they sit right under the title)
-        has_args = bool(args_dict)
-        top_pad = 0 if has_args else 1
 
         return Panel(
             Group(*content_items),


### PR DESCRIPTION
## Description

Display args right below the env name in the detail panel:

<img width="934" height="904" alt="image" src="https://github.com/user-attachments/assets/a238aa1a-d3db-4bf3-af87-9f474bd4ddad" />

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only changes to terminal UI layout/formatting with no impact to evaluation logic, persistence, or security; main risk is minor regressions in rendering/wrapping across terminal sizes.
> 
> **Overview**
> Adds a reusable Rich formatting helper `make_kv_line` and refactors the eval detail panel’s metrics/tokens lines to use it for consistent key/value rendering.
> 
> Updates `EvalDisplay` to display `config.env_args` directly under the environment title (separate from sampling args), and adjusts panel padding plus log-height calculations so the new header line doesn’t reduce usable log space or introduce extra top spacing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c1a5da3e77cd5cd5332bcb67a0fa78de42820f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->