### PR TITLE
ergonomic message constructors

### DIFF
--- a/assets/lab/environments/AGENTS.md
+++ b/assets/lab/environments/AGENTS.md
@@ -123,6 +123,29 @@ Together, these construct the full prompt:
 
 If your dataset already has a `prompt` column, `question` is ignored. However, if a `system_prompt` is provided, it will be prepended to existing prompts that don't already start with a system message.
 
+You can also build prompts using typed message constructors instead of raw dicts:
+
+```python
+dataset = Dataset.from_list([
+    {"prompt": [vf.UserMessage("What is 2+2?")], "answer": "4"},
+])
+```
+
+For multimodal prompts (e.g. images), use content part types:
+
+```python
+dataset = Dataset.from_list([
+    {
+        "prompt": [
+            vf.UserMessage("Describe this image:", vf.Image("https://example.com/photo.png")),
+        ],
+        "answer": "A sunset over the ocean.",
+    },
+])
+```
+
+See the [Content Part Types](reference.md#content-part-types) and [Message Constructors](reference.md#message-constructors) reference for all available types.
+
 ### Evaluation Datasets
 
 Environments can be initialized with a separate `eval_dataset` for evaluation, distinct from the training dataset:
@@ -440,6 +463,17 @@ vf_env = vf.ToolEnv(
 ```
 
 During rollouts, the model can call tools, receive results, and continue reasoning until it produces a response without tool calls (or hits `max_turns`). Each turn consists of a model response followed by the environment's tool execution. Tool call counts are tracked automatically via monitor rubrics (see above).
+
+Tools can return multimodal content by returning a list of content parts instead of a plain string:
+
+```python
+async def screenshot_tool(url: str) -> list:
+    """Take a screenshot of a webpage."""
+    screenshot_b64 = await capture_screenshot(url)
+    return [vf.Text(f"Screenshot of {url}"), vf.Image.from_b64(screenshot_b64)]
+```
+
+When a tool returns a `list` of content parts (with `type` equal to `"text"` or `"image_url"`), `ToolEnv` preserves the structured content in the tool message. Otherwise, the return value is converted to a string.
 
 ### MCP Tool Environments
 

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -117,6 +117,29 @@ Together, these construct the full prompt:
 
 If your dataset already has a `prompt` column, `question` is ignored. However, if a `system_prompt` is provided, it will be prepended to existing prompts that don't already start with a system message.
 
+You can also build prompts using typed message constructors instead of raw dicts:
+
+```python
+dataset = Dataset.from_list([
+    {"prompt": [vf.UserMessage("What is 2+2?")], "answer": "4"},
+])
+```
+
+For multimodal prompts (e.g. images), use content part types:
+
+```python
+dataset = Dataset.from_list([
+    {
+        "prompt": [
+            vf.UserMessage("Describe this image:", vf.Image("https://example.com/photo.png")),
+        ],
+        "answer": "A sunset over the ocean.",
+    },
+])
+```
+
+See the [Content Part Types](reference.md#content-part-types) and [Message Constructors](reference.md#message-constructors) reference for all available types.
+
 ### Evaluation Datasets
 
 Environments can be initialized with a separate `eval_dataset` for evaluation, distinct from the training dataset:
@@ -434,6 +457,17 @@ vf_env = vf.ToolEnv(
 ```
 
 During rollouts, the model can call tools, receive results, and continue reasoning until it produces a response without tool calls (or hits `max_turns`). Each turn consists of a model response followed by the environment's tool execution. Tool call counts are tracked automatically via monitor rubrics (see above).
+
+Tools can return multimodal content by returning a list of content parts instead of a plain string:
+
+```python
+async def screenshot_tool(url: str) -> list:
+    """Take a screenshot of a webpage."""
+    screenshot_b64 = await capture_screenshot(url)
+    return [vf.Text(f"Screenshot of {url}"), vf.Image.from_b64(screenshot_b64)]
+```
+
+When a tool returns a `list` of content parts (with `type` equal to `"text"` or `"image_url"`), `ToolEnv` preserves the structured content in the tool message. Otherwise, the return value is converted to a string.
 
 ### MCP Tool Environments
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -34,6 +34,65 @@ ChatMessage = ChatCompletionMessageParam  # from openai.types.chat
 
 OpenAI's chat message type with `role`, `content`, and optional `tool_calls` / `tool_call_id` fields.
 
+### Content Part Types
+
+Typed content parts for building multimodal message content. These are Pydantic models exported as `vf.Text`, `vf.Image`, and `vf.Audio`.
+
+```python
+Text = TextContentPart    # type: "text"
+Image = ImageUrlContentPart  # type: "image_url"
+Audio = InputAudioContentPart  # type: "input_audio"
+```
+
+**`vf.Text`** — text content:
+```python
+vf.Text("Hello, world!")
+```
+
+**`vf.Image`** — image content with factory methods:
+```python
+vf.Image("https://example.com/image.png")       # from URL
+vf.Image.from_b64(b64_string)                   # from base64 string
+vf.Image.from_b64(b64_string, "image/jpeg")     # with media type
+vf.Image.from_bytes(png_bytes)                   # from raw bytes
+vf.Image.from_pil(pil_image)                     # from PIL Image
+```
+
+**`vf.Audio`** — audio content:
+```python
+vf.Audio(data=b64_audio, format="wav")
+```
+
+### Message Constructors
+
+Typed message constructors for building prompts and tool results. These are Pydantic models that accept both simple strings and multipart content.
+
+**`vf.SystemMessage`** / **`vf.UserMessage`** — accept a string or content parts as positional args:
+```python
+vf.SystemMessage("You are a helpful assistant.")
+vf.UserMessage("What is this?", vf.Image.from_b64(screenshot_b64))
+```
+
+**`vf.ToolCall`** — represents a tool invocation:
+```python
+vf.ToolCall(id="call_123", name="calculate", arguments='{"expression": "2+2"}')
+vf.ToolCall(id="call_123", name="calculate", arguments={"expression": "2+2"})  # dict auto-serialized
+```
+
+**`vf.ToolMessage`** — tool result, accepts a `ToolCall` for `tool_call_id`:
+```python
+vf.ToolMessage(tool_call_id="call_123", content="4")
+vf.ToolMessage(tool_call_id=tool_call, content=[vf.Text("Result"), vf.Image.from_b64(b64)])
+```
+
+**`vf.AssistantMessage`** — assistant response with optional tool calls:
+```python
+vf.AssistantMessage(content="Here's the answer.")
+vf.AssistantMessage(tool_calls=[vf.ToolCall(...)])
+```
+
+These constructors are interchangeable with raw dicts in all APIs that accept `Messages`.
+
 ### Info
 
 ```python

--- a/environments/AGENTS.md
+++ b/environments/AGENTS.md
@@ -123,6 +123,29 @@ Together, these construct the full prompt:
 
 If your dataset already has a `prompt` column, `question` is ignored. However, if a `system_prompt` is provided, it will be prepended to existing prompts that don't already start with a system message.
 
+You can also build prompts using typed message constructors instead of raw dicts:
+
+```python
+dataset = Dataset.from_list([
+    {"prompt": [vf.UserMessage("What is 2+2?")], "answer": "4"},
+])
+```
+
+For multimodal prompts (e.g. images), use content part types:
+
+```python
+dataset = Dataset.from_list([
+    {
+        "prompt": [
+            vf.UserMessage("Describe this image:", vf.Image("https://example.com/photo.png")),
+        ],
+        "answer": "A sunset over the ocean.",
+    },
+])
+```
+
+See the [Content Part Types](reference.md#content-part-types) and [Message Constructors](reference.md#message-constructors) reference for all available types.
+
 ### Evaluation Datasets
 
 Environments can be initialized with a separate `eval_dataset` for evaluation, distinct from the training dataset:
@@ -440,6 +463,17 @@ vf_env = vf.ToolEnv(
 ```
 
 During rollouts, the model can call tools, receive results, and continue reasoning until it produces a response without tool calls (or hits `max_turns`). Each turn consists of a model response followed by the environment's tool execution. Tool call counts are tracked automatically via monitor rubrics (see above).
+
+Tools can return multimodal content by returning a list of content parts instead of a plain string:
+
+```python
+async def screenshot_tool(url: str) -> list:
+    """Take a screenshot of a webpage."""
+    screenshot_b64 = await capture_screenshot(url)
+    return [vf.Text(f"Screenshot of {url}"), vf.Image.from_b64(screenshot_b64)]
+```
+
+When a tool returns a `list` of content parts (with `type` equal to `"text"` or `"image_url"`), `ToolEnv` preserves the structured content in the tool message. Otherwise, the return value is converted to a string.
 
 ### MCP Tool Environments
 

--- a/skills/create-environments/SKILL.md
+++ b/skills/create-environments/SKILL.md
@@ -35,19 +35,20 @@ prime env install math-python --from-repo
 
 ### 1. Build From Scratch
 1. Define task contract first: prompt shape, allowed tools, stop conditions, rubric outputs, metrics.
-2. Select the smallest correct base class:
+2. Build prompts with typed message constructors (`vf.UserMessage`, `vf.SystemMessage`, etc.) instead of raw dicts. For multimodal prompts, compose content parts: `vf.UserMessage("Describe:", vf.Image(url))`. See `docs/reference.md#message-constructors` and `docs/reference.md#content-part-types`.
+3. Select the smallest correct base class:
 - `SingleTurnEnv` for one-response tasks.
 - `MultiTurnEnv` for custom interaction loops.
 - `ToolEnv` or `MCPEnv` for stateless tools.
 - `StatefulToolEnv` for per-rollout resources.
-3. Implement `load_environment(...) -> vf.Environment` with explicit arguments.
-4. Add `pyproject.toml` defaults in `[tool.verifiers.eval]` only when stable.
+4. Implement `load_environment(...) -> vf.Environment` with explicit arguments.
+5. Add `pyproject.toml` defaults in `[tool.verifiers.eval]` only when stable.
 
 ### 2. Port From Another Library, Project, or Paper
 1. Create a strict source-to-target mapping before coding:
 - dataset rows and splits
 - prompt rendering and role ordering
-- tool I/O schema and stop logic
+- tool I/O schema and stop logic (tools can return multimodal content as `list` of parts, e.g. `[vf.Text(...), vf.Image.from_b64(...)]`)
 - scoring math and aggregation
 - pass/fail thresholds and special cases
 2. Preserve one-to-one logical equivalence for what the model sees and what gets scored.

--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -12,7 +12,7 @@ from .decorators import (  # noqa # isort: skip
     stop,
     teardown,
 )
-from .types import DatasetBuilder  # noqa # isort: skip
+from .types import Audio, DatasetBuilder, Image, Text  # noqa # isort: skip
 from .parsers.parser import Parser  # noqa # isort: skip
 from .rubrics.rubric import Rubric  # noqa # isort: skip
 from .envs.environment import Environment  # noqa # isort: skip
@@ -85,6 +85,9 @@ __all__ = [
     "OpenAIChatCompletionsClient",
     "OpenAIChatCompletionsTokenClient",
     "OpenAICompletionsClient",
+    "Text",
+    "Image",
+    "Audio",
     "extract_boxed_answer",
     "extract_hash_answer",
     "load_example_dataset",

--- a/verifiers/envs/experimental/gym_env.py
+++ b/verifiers/envs/experimental/gym_env.py
@@ -143,7 +143,7 @@ class GymEnv(vf.MultiTurnEnv):
         return str(obs)
 
     def wrap_response(self, text: str) -> vf.Messages | str:
-        return cast(vf.Messages, [{"role": "user", "content": text}])
+        return [vf.UserMessage(text)]
 
     async def env_response(
         self, messages: vf.Messages, state: State, **kwargs: Any

--- a/verifiers/envs/experimental/mcp_env.py
+++ b/verifiers/envs/experimental/mcp_env.py
@@ -233,31 +233,19 @@ class MCPEnv(vf.ToolEnv):
             tool_wrapper = self.tool_map[tool_name]
             try:
                 result = await tool_wrapper(**tool_args)
-                return cast(
-                    ToolMessage,
-                    {
-                        "role": "tool",
-                        "content": str(result),
-                        "tool_call_id": tool_call_id,
-                    },
+                return ToolMessage(
+                    tool_call_id=tool_call_id,
+                    content=str(result),
                 )
             except Exception as e:
-                return cast(
-                    ToolMessage,
-                    {
-                        "role": "tool",
-                        "content": self.error_formatter(e),
-                        "tool_call_id": tool_call_id,
-                    },
+                return ToolMessage(
+                    tool_call_id=tool_call_id,
+                    content=self.error_formatter(e),
                 )
         else:
-            return cast(
-                ToolMessage,
-                {
-                    "role": "tool",
-                    "content": f"Error: Tool '{tool_name}' not found",
-                    "tool_call_id": tool_call_id,
-                },
+            return ToolMessage(
+                tool_call_id=tool_call_id,
+                content=f"Error: Tool '{tool_name}' not found",
             )
 
     async def cleanup(self):

--- a/verifiers/envs/integrations/browser_env/modes/cua_mode.py
+++ b/verifiers/envs/integrations/browser_env/modes/cua_mode.py
@@ -763,20 +763,13 @@ class CUAMode:
                 f"Viewport: {viewport.get('width', 0)}x{viewport.get('height', 0)}"
             )
 
-        content: list[dict[str, str | dict[str, str]]] = [
-            {"type": "text", "text": "\n".join(text_parts)}
-        ]
+        content: list = [vf.Text("\n".join(text_parts))]
 
         if screenshot_b64 and session_id:
             self._save_screenshot(session_id, screenshot_b64, url)
 
         if screenshot_b64:
-            content.append(
-                {
-                    "type": "image_url",
-                    "image_url": {"url": f"data:image/png;base64,{screenshot_b64}"},
-                }
-            )
+            content.append(vf.Image.from_b64(screenshot_b64))
 
         return content
 
@@ -790,7 +783,9 @@ class CUAMode:
             content = msg.get("content")
             if isinstance(content, list):
                 for content_idx, item in enumerate(content):
-                    if isinstance(item, dict) and item.get("type") == "image_url":
+                    if (isinstance(item, vf.Image)) or (
+                        isinstance(item, dict) and item.get("type") == "image_url"
+                    ):
                         screenshot_positions.append((msg_idx, content_idx))
 
         if len(screenshot_positions) <= self.keep_recent_screenshots:
@@ -806,10 +801,9 @@ class CUAMode:
         for msg_idx, content_idx in positions_to_replace:
             content_list = filtered_messages[msg_idx]["content"]
             if isinstance(content_list, list) and content_idx < len(content_list):
-                content_list[content_idx] = {
-                    "type": "text",
-                    "text": "[Screenshot removed to save context]",
-                }
+                content_list[content_idx] = vf.Text(
+                    "[Screenshot removed to save context]"
+                )
 
         return filtered_messages
 

--- a/verifiers/envs/integrations/browser_env/modes/cua_mode.py
+++ b/verifiers/envs/integrations/browser_env/modes/cua_mode.py
@@ -741,7 +741,7 @@ class CUAMode:
                 self.logger.warning(f"Failed to save screenshot: {e}")
             return None
 
-    def _format_response(self, response: dict, session_id: str = "") -> list[dict]:
+    def _format_response(self, response: dict, session_id: str = "") -> list:
         """Format action response as multipart content with text and image."""
         success = response.get("success", False)
         error = response.get("error")
@@ -1029,7 +1029,7 @@ class CUAMode:
         session_id: str = "",
         sandbox_id: str = "",
         tool_call_id: str = "",
-    ) -> list[dict]:
+    ) -> list:
         """Click at coordinates (x, y) on the page."""
         response = await self._execute_action(
             session_id,
@@ -1046,7 +1046,7 @@ class CUAMode:
         session_id: str = "",
         sandbox_id: str = "",
         tool_call_id: str = "",
-    ) -> list[dict]:
+    ) -> list:
         """Double-click at coordinates (x, y) on the page."""
         response = await self._execute_action(
             session_id,
@@ -1062,7 +1062,7 @@ class CUAMode:
         session_id: str = "",
         sandbox_id: str = "",
         tool_call_id: str = "",
-    ) -> list[dict]:
+    ) -> list:
         """Type text into the currently focused element."""
         response = await self._execute_action(
             session_id,
@@ -1078,7 +1078,7 @@ class CUAMode:
         session_id: str = "",
         sandbox_id: str = "",
         tool_call_id: str = "",
-    ) -> list[dict]:
+    ) -> list:
         """Press keyboard key(s)."""
         response = await self._execute_action(
             session_id,
@@ -1097,7 +1097,7 @@ class CUAMode:
         session_id: str = "",
         sandbox_id: str = "",
         tool_call_id: str = "",
-    ) -> list[dict]:
+    ) -> list:
         """Scroll the page at a specific position."""
         response = await self._execute_action(
             session_id,
@@ -1119,7 +1119,7 @@ class CUAMode:
         session_id: str = "",
         sandbox_id: str = "",
         tool_call_id: str = "",
-    ) -> list[dict]:
+    ) -> list:
         """Navigate to a URL."""
         try:
             response = await self._execute_action(
@@ -1141,7 +1141,7 @@ class CUAMode:
         session_id: str = "",
         sandbox_id: str = "",
         tool_call_id: str = "",
-    ) -> list[dict]:
+    ) -> list:
         """Navigate back in browser history."""
         response = await self._execute_action(
             session_id,
@@ -1156,7 +1156,7 @@ class CUAMode:
         session_id: str = "",
         sandbox_id: str = "",
         tool_call_id: str = "",
-    ) -> list[dict]:
+    ) -> list:
         """Navigate forward in browser history."""
         response = await self._execute_action(
             session_id,
@@ -1172,7 +1172,7 @@ class CUAMode:
         session_id: str = "",
         sandbox_id: str = "",
         tool_call_id: str = "",
-    ) -> list[dict]:
+    ) -> list:
         """Wait for a specified amount of time."""
         try:
             response = await self._execute_action(
@@ -1194,7 +1194,7 @@ class CUAMode:
         session_id: str = "",
         sandbox_id: str = "",
         tool_call_id: str = "",
-    ) -> list[dict]:
+    ) -> list:
         """Capture a screenshot of the current page state."""
         response = await self._execute_action(
             session_id,

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import base64
+import json
 import sys
 from collections.abc import Mapping
 from pathlib import Path
@@ -14,7 +16,7 @@ from typing import (
 
 from anthropic.types import RedactedThinkingBlock
 from anthropic.types import ThinkingBlock as AnthropicThinkingBlock
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 if TYPE_CHECKING:
     from datasets import Dataset
@@ -67,6 +69,18 @@ class TextContentPart(CustomBaseModel):
     type: Literal["text"] = "text"
     text: str
 
+    def __init__(self, text: str | None = None, /, **data):
+        if text is not None and "text" not in data:
+            data["text"] = text
+        super().__init__(**data)
+
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_text(cls, value: Any):
+        if isinstance(value, str):
+            return {"text": value}
+        return value
+
 
 class ImageUrlSource(CustomBaseModel):
     url: str
@@ -75,6 +89,54 @@ class ImageUrlSource(CustomBaseModel):
 class ImageUrlContentPart(CustomBaseModel):
     type: Literal["image_url"] = "image_url"
     image_url: ImageUrlSource
+
+    def __init__(self, url: str | None = None, /, **data):
+        if url is not None and "url" not in data and "image_url" not in data:
+            data["url"] = url
+        super().__init__(**data)
+
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_image_url(cls, value: Any):
+        if isinstance(value, str):
+            return {"image_url": {"url": value}}
+        if isinstance(value, Mapping) and "url" in value and "image_url" not in value:
+            return {"image_url": {"url": value["url"]}}
+        return value
+
+    @classmethod
+    def from_b64(cls, data: str, media_type: str = "image/png") -> ImageUrlContentPart:
+        """Create from a base64-encoded string.
+
+        >>> vf.Image.from_b64(b64_string, "image/png")
+        """
+        return cls(url=f"data:{media_type};base64,{data}")
+
+    @classmethod
+    def from_bytes(
+        cls, data: bytes, media_type: str = "image/png"
+    ) -> ImageUrlContentPart:
+        """Create from raw bytes (e.g. PNG file contents).
+
+        >>> vf.Image.from_bytes(png_bytes)
+        """
+        b64 = base64.b64encode(data).decode()
+        return cls(url=f"data:{media_type};base64,{b64}")
+
+    @classmethod
+    def from_pil(cls, image: Any, format: str = "PNG") -> ImageUrlContentPart:
+        """Create from a PIL/Pillow Image.
+
+        >>> vf.Image.from_pil(pil_image)
+        >>> vf.Image.from_pil(pil_image, format="JPEG")
+        """
+        from io import BytesIO
+
+        media_type = f"image/{format.lower()}"
+        buf = BytesIO()
+        image.save(buf, format=format)
+        b64 = base64.b64encode(buf.getvalue()).decode()
+        return cls(url=f"data:{media_type};base64,{b64}")
 
 
 class InputAudioSource(CustomBaseModel):
@@ -85,6 +147,34 @@ class InputAudioSource(CustomBaseModel):
 class InputAudioContentPart(CustomBaseModel):
     type: Literal["input_audio"] = "input_audio"
     input_audio: InputAudioSource
+
+    def __init__(
+        self,
+        data: str | None = None,
+        /,
+        *,
+        format: str | None = None,
+        **kwargs,
+    ):
+        if data is not None and "data" not in kwargs and "input_audio" not in kwargs:
+            kwargs["data"] = data
+        if (
+            format is not None
+            and "format" not in kwargs
+            and "input_audio" not in kwargs
+        ):
+            kwargs["format"] = format
+        super().__init__(**kwargs)
+
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_input_audio(cls, value: Any):
+        if isinstance(value, Mapping) and "input_audio" not in value:
+            if "data" in value and "format" in value:
+                return {
+                    "input_audio": {"data": value["data"], "format": value["format"]}
+                }
+        return value
 
 
 class GenericContentPart(CustomBaseModel):
@@ -100,21 +190,69 @@ ContentPart: TypeAlias = (
 )
 MessageContent: TypeAlias = str | list[ContentPart]
 
+Text = TextContentPart
+Image = ImageUrlContentPart
+Audio = InputAudioContentPart
+
+
+def _build_content_list(
+    parts: tuple[str | ContentPart, ...],
+) -> list[ContentPart]:
+    """Convert varargs of strings and content parts into a content list."""
+    result: list[ContentPart] = []
+    for part in parts:
+        if isinstance(part, str):
+            result.append(TextContentPart(text=part))
+        else:
+            result.append(part)
+    return result
+
 
 class SystemMessage(CustomBaseModel):
     role: Literal["system"] = "system"
     content: MessageContent
+
+    def __init__(
+        self, *parts: str | ContentPart, content: MessageContent | None = None, **data
+    ):
+        if content is not None:
+            super().__init__(content=content, **data)
+        elif len(parts) == 1 and isinstance(parts[0], str):
+            super().__init__(content=parts[0], **data)
+        elif parts:
+            super().__init__(content=_build_content_list(parts), **data)
+        else:
+            super().__init__(**data)
 
 
 class UserMessage(CustomBaseModel):
     role: Literal["user"] = "user"
     content: MessageContent
 
+    def __init__(
+        self, *parts: str | ContentPart, content: MessageContent | None = None, **data
+    ):
+        if content is not None:
+            super().__init__(content=content, **data)
+        elif len(parts) == 1 and isinstance(parts[0], str):
+            super().__init__(content=parts[0], **data)
+        elif parts:
+            super().__init__(content=_build_content_list(parts), **data)
+        else:
+            super().__init__(**data)
+
 
 class ToolCall(CustomBaseModel):
     id: str
     name: str
     arguments: str
+
+    @field_validator("arguments", mode="before")
+    @classmethod
+    def serialize_arguments(cls, v: Any) -> str:
+        if isinstance(v, str):
+            return v
+        return json.dumps(v)
 
 
 ThinkingBlock: TypeAlias = AnthropicThinkingBlock | RedactedThinkingBlock
@@ -132,6 +270,13 @@ class ToolMessage(CustomBaseModel):
     role: Literal["tool"] = "tool"
     tool_call_id: str
     content: MessageContent
+
+    @field_validator("tool_call_id", mode="before")
+    @classmethod
+    def extract_tool_call_id(cls, v: Any) -> str:
+        if isinstance(v, ToolCall):
+            return v.id
+        return v
 
 
 Message: TypeAlias = (

--- a/verifiers/utils/tool_utils.py
+++ b/verifiers/utils/tool_utils.py
@@ -11,13 +11,18 @@ def is_valid_tool_content_parts(value: Any) -> bool:
     """Check if value is a valid list of tool content parts.
 
     Valid content parts have a "type" field with value "text" or "image_url".
+    Accepts both plain dicts and Pydantic model instances (e.g. vf.Text, vf.Image).
     """
     if not isinstance(value, list):
         return False
     for item in value:
-        if not isinstance(item, dict):
+        if isinstance(item, dict):
+            item_type = item.get("type")
+        elif hasattr(item, "type"):
+            item_type = getattr(item, "type")
+        else:
             return False
-        if item.get("type") not in VALID_TOOL_CONTENT_PART_TYPES:
+        if item_type not in VALID_TOOL_CONTENT_PART_TYPES:
             return False
     return True
 


### PR DESCRIPTION
## Description
Env authors no longer need raw dicts to build messages. UserMessage("describe", Image.from_pil(img)) just works. ToolCall accepts dict arguments, ToolMessage accepts a ToolCall for tool_call_id. Migrated browser env, mcp env, and gym env.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core message/tool typing and serialization paths plus multiple environment integrations; subtle provider formatting or JSON-serialization regressions are possible without broad test coverage.
> 
> **Overview**
> Adds typed, ergonomic constructors for building prompts and tool results: `vf.SystemMessage`/`vf.UserMessage` now accept either a plain string or multipart content via `vf.Text`/`vf.Image`/`vf.Audio`, `vf.ToolCall` auto-serializes dict `arguments`, and `vf.ToolMessage` accepts a `ToolCall` for `tool_call_id`.
> 
> Updates `ToolEnv`/tool utilities and integrations to handle structured tool outputs: tools may return a `list` of content parts (text/image) that is preserved, and the browser CUA mode, `MCPEnv`, and `GymEnv` are migrated off raw message dicts to these constructors. Public exports and docs are expanded to document and expose the new types (`vf.Text`, `vf.Image`, `vf.Audio`) and usage patterns.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 778b1e955d87d9f228a7d45c4f0b597ac792390c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->