### PR TITLE
Stabilize dataset map audio test

### DIFF
--- a/tests/test_message_utils_audio.py
+++ b/tests/test_message_utils_audio.py
@@ -86,15 +86,11 @@ def test_dataset_map_may_introduce_none_fields_and_stripping_fixes():
     # Older/newer datasets versions differ here: some inject missing keys as None,
     # others leave them absent. Normalize to the problematic shape before testing
     # the stripping logic that production code relies on.
-    if "image_url" in content[0]:
-        assert content[0]["image_url"] is None, "text item should have image_url=None"
-    else:
-        content[0]["image_url"] = None
+    assert content[0].get("image_url") is None, "text item should have image_url=None"
+    content[0]["image_url"] = None
 
-    if "text" in content[1]:
-        assert content[1]["text"] is None, "image_url item should have text=None"
-    else:
-        content[1]["text"] = None
+    assert content[1].get("text") is None, "image_url item should have text=None"
+    content[1]["text"] = None
 
     # Strip None values (same logic as in get_model_response)
     for msg in prompt:

--- a/tests/test_message_utils_audio.py
+++ b/tests/test_message_utils_audio.py
@@ -45,10 +45,12 @@ def test_messages_to_printable_order_and_joining():
     assert "[audio]" in printable and "describe" in printable
 
 
-def test_dataset_map_introduces_none_fields_and_stripping_fixes():
+def test_dataset_map_may_introduce_none_fields_and_stripping_fixes():
     """
-    Demonstrates that HuggingFace Dataset.map() introduces None values
-    when content items have different schemas, and stripping Nones fixes this.
+    HuggingFace Dataset.map() may materialize missing fields as None when
+    content items have different schemas. Regardless of whether that happens
+    in the installed datasets version, stripping None values should preserve
+    the expected multimodal content shape.
     """
     from datasets import Dataset
 
@@ -76,13 +78,23 @@ def test_dataset_map_introduces_none_fields_and_stripping_fixes():
     prompt = ds[0]["prompt"]
     content = prompt[0]["content"]
 
-    # Dataset.map() unifies schemas, adding None for missing keys
-    assert "image_url" in content[0], (
-        "Dataset.map should add image_url key to text item"
-    )
-    assert content[0]["image_url"] is None, "text item should have image_url=None"
-    assert "text" in content[1], "Dataset.map should add text key to image_url item"
-    assert content[1]["text"] is None, "image_url item should have text=None"
+    assert content[0]["type"] == "text"
+    assert content[0]["text"] == "What is this?"
+    assert content[1]["type"] == "image_url"
+    assert content[1]["image_url"] == {"url": "data:image/png;base64,abc123"}
+
+    # Older/newer datasets versions differ here: some inject missing keys as None,
+    # others leave them absent. Normalize to the problematic shape before testing
+    # the stripping logic that production code relies on.
+    if "image_url" in content[0]:
+        assert content[0]["image_url"] is None, "text item should have image_url=None"
+    else:
+        content[0]["image_url"] = None
+
+    if "text" in content[1]:
+        assert content[1]["text"] is None, "image_url item should have text=None"
+    else:
+        content[1]["text"] = None
 
     # Strip None values (same logic as in get_model_response)
     for msg in prompt:


### PR DESCRIPTION
## Description

Fix tests bug stemming from `datasets` version breaking test assumptions.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that relaxes a version-dependent assumption; no production logic is modified.
> 
> **Overview**
> Updates the `Dataset.map()` multimodal prompt test to no longer assume missing keys are always injected as `None`, making it pass across `datasets` versions.
> 
> The test now first asserts the expected `text`/`image_url` content shape, then explicitly normalizes items to the problematic `None`-filled schema before verifying the production-style “strip `None` values” cleanup behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c395fb48062b537b7258203ec646a16b556988f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->