### PR TITLE
fix CI for datasets v4.7.0

### DIFF
--- a/verifiers/utils/message_utils.py
+++ b/verifiers/utils/message_utils.py
@@ -37,21 +37,16 @@ def _normalize_raw_message_content(message: dict[str, Any]) -> dict[str, Any]:
     if isinstance(content, list):
         normalized_parts = []
         for part in content:
-            if isinstance(part, dict):
-                normalized_parts.append(from_raw_content_part(part))
-            elif isinstance(part, str):
+            if isinstance(part, str):
                 # HuggingFace datasets may serialize content-part dicts to JSON
                 # strings when storing heterogeneous lists in Arrow tables.
                 try:
-                    decoded = json.loads(part)
+                    part = json.loads(part)
                 except (json.JSONDecodeError, TypeError):
-                    decoded = None
-                if isinstance(decoded, dict) and "type" in decoded:
-                    normalized_parts.append(from_raw_content_part(decoded))
-                else:
-                    normalized_parts.append(part)
-            else:
-                normalized_parts.append(part)
+                    pass
+            if isinstance(part, dict) and "type" in part:
+                part = from_raw_content_part(part)
+            normalized_parts.append(part)
         message = dict(message)
         message["content"] = normalized_parts
     return message

--- a/verifiers/utils/message_utils.py
+++ b/verifiers/utils/message_utils.py
@@ -39,6 +39,17 @@ def _normalize_raw_message_content(message: dict[str, Any]) -> dict[str, Any]:
         for part in content:
             if isinstance(part, dict):
                 normalized_parts.append(from_raw_content_part(part))
+            elif isinstance(part, str):
+                # HuggingFace datasets may serialize content-part dicts to JSON
+                # strings when storing heterogeneous lists in Arrow tables.
+                try:
+                    decoded = json.loads(part)
+                except (json.JSONDecodeError, TypeError):
+                    decoded = None
+                if isinstance(decoded, dict) and "type" in decoded:
+                    normalized_parts.append(from_raw_content_part(decoded))
+                else:
+                    normalized_parts.append(part)
             else:
                 normalized_parts.append(part)
         message = dict(message)


### PR DESCRIPTION
## Description

Starting with v4.7.0, HuggingFace datasets serialize heterogeneous content-part dicts (e.g. text + image_url) to JSON strings when storing in Arrow tables. Recover these by attempting `json.loads` on string content parts during message normalization.

This is a quick and dirty fix for now. #1002 could be an opportunity for a more general fix.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized normalization change with best-effort JSON parsing; main risk is subtle behavior changes if arbitrary string content happens to be valid JSON.
> 
> **Overview**
> Fixes message normalization for HuggingFace `datasets` v4.7+ where heterogeneous `content` part dicts may be persisted as JSON strings.
> 
> During `_normalize_raw_message_content`, string parts are now best-effort `json.loads`-decoded and only dict parts with a `type` field are converted via `from_raw_content_part`, improving robustness when reading dataset-backed messages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5817f8cc646c1a5b343b11f3c915951bf7268e92. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->