### PR TITLE
make httpx connect timout configurable

### DIFF
--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -410,6 +410,7 @@ class ClientConfig(BaseModel):
     api_base_url: str = "https://api.pinference.ai/api/v1"
     endpoint_configs: list["EndpointClientConfig"] = Field(default_factory=list)
     timeout: float = 3600.0
+    connect_timeout: float = 5.0
     max_connections: int = 28000
     max_keepalive_connections: int = 28000
     max_retries: int = 10
@@ -464,6 +465,7 @@ class EndpointClientConfig(BaseModel):
     api_key_var: str = "PRIME_API_KEY"
     api_base_url: str = "https://api.pinference.ai/api/v1"
     timeout: float = 3600.0
+    connect_timeout: float = 5.0
     max_connections: int = 28000
     max_keepalive_connections: int = 28000
     max_retries: int = 10

--- a/verifiers/utils/client_utils.py
+++ b/verifiers/utils/client_utils.py
@@ -78,7 +78,7 @@ def _build_headers_and_api_key(
 def _build_http_client(
     config: ClientConfig, headers: dict[str, str]
 ) -> httpx.AsyncClient:
-    timeout = httpx.Timeout(config.timeout, connect=5.0)
+    timeout = httpx.Timeout(config.timeout, connect=config.connect_timeout)
     limits = httpx.Limits(
         max_connections=config.max_connections,
         max_keepalive_connections=config.max_keepalive_connections,


### PR DESCRIPTION
## Description
don't hardcode httpx connect timeout for OAI or any other client anymore.
helps with vLLM or cluster flakiness.

related: https://github.com/PrimeIntellect-ai/prime-rl/pull/2017

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new config field and wires it into `httpx.Timeout` without changing request logic beyond the connect-timeout value.
> 
> **Overview**
> Makes the HTTP connect timeout configurable via `ClientConfig.connect_timeout` and `EndpointClientConfig.connect_timeout` (default `5.0`).
> 
> Updates HTTP client construction to use `config.connect_timeout` instead of a hardcoded connect timeout when building the `httpx.AsyncClient` timeout settings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 555eb2b1a54757d950a8e818f0f6b5f128bced12. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->