### PR TITLE
vf-tui: fixes & features

### DIFF
--- a/tests/test_tui_info_formatting.py
+++ b/tests/test_tui_info_formatting.py
@@ -325,6 +325,10 @@ async def test_browse_run_screen_moves_browser_shortcuts_to_footer(tmp_path) -> 
             if isinstance(label.content, Text)
         ]
 
+        assert bindings["left"].show is True
+        assert bindings["left"].description == "Parent folder"
+        assert bindings["right"].show is True
+        assert bindings["right"].description == "Expand/next folder"
         assert bindings["enter"].show is True
         assert bindings["enter"].description == "Open/toggle"
         assert bindings["space"].show is True
@@ -363,6 +367,223 @@ async def test_browse_run_screen_offsets_details_content_from_scrollbar(
         assert scroll.styles.padding.right == 1
         assert scroll.styles.scrollbar_gutter == "stable"
         assert details.styles.margin.right == 8
+
+
+@pytest.mark.asyncio
+async def test_browse_run_tree_left_arrow_moves_to_visible_parent(tmp_path) -> None:
+    run_dir = tmp_path / "demo-run"
+    run_dir.mkdir()
+    (run_dir / "metadata.json").write_text(
+        json.dumps({"avg_reward": 0.75}),
+        encoding="utf-8",
+    )
+    (run_dir / "results.jsonl").write_text("{}\n", encoding="utf-8")
+
+    run = RunInfo(
+        env_id="demo-env",
+        model="openai/gpt-5",
+        run_id="run-1",
+        path=run_dir,
+    )
+
+    async with VerifiersTUI({"demo-env": {"openai/gpt-5": [run]}}).run_test() as pilot:
+        await pilot.pause()
+
+        tree = pilot.app.screen.query_one("#run-browser-tree", RunBrowserTree)
+
+        assert tree.cursor_node is not None
+        assert tree.cursor_node.data.kind == "run"
+
+        await pilot.press("left")
+        await pilot.pause()
+        assert tree.cursor_node is not None
+        assert tree.cursor_node.data.kind == "model"
+
+        await pilot.press("left")
+        await pilot.pause()
+        assert tree.cursor_node is not None
+        assert tree.cursor_node.data.kind == "env"
+
+        await pilot.press("left")
+        await pilot.pause()
+        assert tree.cursor_node is not None
+        assert tree.cursor_node.data.kind == "env"
+
+
+@pytest.mark.asyncio
+async def test_browse_run_tree_space_collapses_parent_folder_from_run_leaf(
+    tmp_path,
+) -> None:
+    run_dir = tmp_path / "demo-run"
+    run_dir.mkdir()
+    (run_dir / "metadata.json").write_text(
+        json.dumps({"avg_reward": 0.75}),
+        encoding="utf-8",
+    )
+    (run_dir / "results.jsonl").write_text("{}\n", encoding="utf-8")
+
+    run = RunInfo(
+        env_id="demo-env",
+        model="openai/gpt-5",
+        run_id="run-1",
+        path=run_dir,
+    )
+
+    async with VerifiersTUI({"demo-env": {"openai/gpt-5": [run]}}).run_test() as pilot:
+        await pilot.pause()
+
+        tree = pilot.app.screen.query_one("#run-browser-tree", RunBrowserTree)
+        assert tree.cursor_node is not None
+        model_node = tree.cursor_node.parent
+
+        assert model_node is not None
+        assert model_node.allow_expand is True
+        assert model_node.is_expanded is True
+
+        await pilot.press("space")
+        await pilot.pause()
+
+        assert tree.cursor_node is model_node
+        assert tree.cursor_node.data.kind == "model"
+        assert model_node.is_expanded is False
+
+
+@pytest.mark.asyncio
+async def test_browse_run_tree_right_arrow_moves_leaf_to_next_parent_folder(
+    tmp_path,
+) -> None:
+    first_run_dir = tmp_path / "run-a"
+    first_run_dir.mkdir()
+    (first_run_dir / "metadata.json").write_text(
+        json.dumps({"avg_reward": 0.25}),
+        encoding="utf-8",
+    )
+    (first_run_dir / "results.jsonl").write_text("{}\n", encoding="utf-8")
+
+    second_run_dir = tmp_path / "run-b"
+    second_run_dir.mkdir()
+    (second_run_dir / "metadata.json").write_text(
+        json.dumps({"avg_reward": 0.75}),
+        encoding="utf-8",
+    )
+    (second_run_dir / "results.jsonl").write_text("{}\n", encoding="utf-8")
+
+    first_run = RunInfo(
+        env_id="demo-env",
+        model="a/model",
+        run_id="run-1",
+        path=first_run_dir,
+    )
+    second_run = RunInfo(
+        env_id="demo-env",
+        model="b/model",
+        run_id="run-2",
+        path=second_run_dir,
+    )
+
+    async with VerifiersTUI(
+        {"demo-env": {"a/model": [first_run], "b/model": [second_run]}}
+    ).run_test() as pilot:
+        await pilot.pause()
+
+        tree = pilot.app.screen.query_one("#run-browser-tree", RunBrowserTree)
+
+        assert tree.cursor_node is not None
+        assert tree.cursor_node.data.kind == "run"
+        assert tree.cursor_node.data.model == "a/model"
+
+        await pilot.press("right")
+        await pilot.pause()
+
+        assert tree.cursor_node is not None
+        assert tree.cursor_node.data.kind == "model"
+        assert tree.cursor_node.data.model == "b/model"
+
+
+@pytest.mark.asyncio
+async def test_browse_run_tree_right_arrow_expands_collapsed_folder(tmp_path) -> None:
+    first_run_dir = tmp_path / "run-a"
+    first_run_dir.mkdir()
+    (first_run_dir / "metadata.json").write_text(
+        json.dumps({"avg_reward": 0.25}),
+        encoding="utf-8",
+    )
+    (first_run_dir / "results.jsonl").write_text("{}\n", encoding="utf-8")
+
+    second_run_dir = tmp_path / "run-b"
+    second_run_dir.mkdir()
+    (second_run_dir / "metadata.json").write_text(
+        json.dumps({"avg_reward": 0.75}),
+        encoding="utf-8",
+    )
+    (second_run_dir / "results.jsonl").write_text("{}\n", encoding="utf-8")
+
+    first_run = RunInfo(
+        env_id="alpha-env",
+        model="model-a",
+        run_id="run-1",
+        path=first_run_dir,
+    )
+    second_run = RunInfo(
+        env_id="beta-env",
+        model="model-b",
+        run_id="run-2",
+        path=second_run_dir,
+    )
+
+    async with VerifiersTUI(
+        {"alpha-env": {"model-a": [first_run]}, "beta-env": {"model-b": [second_run]}}
+    ).run_test() as pilot:
+        await pilot.pause()
+
+        tree = pilot.app.screen.query_one("#run-browser-tree", RunBrowserTree)
+        collapsed_env = tree.root.children[1]
+
+        assert collapsed_env.data.kind == "env"
+        assert collapsed_env.is_expanded is False
+
+        tree.move_cursor(collapsed_env)
+        await pilot.pause()
+        await pilot.press("right")
+        await pilot.pause()
+
+        assert tree.cursor_node is collapsed_env
+        assert collapsed_env.is_expanded is True
+
+
+@pytest.mark.asyncio
+async def test_browse_run_tree_clips_long_labels_without_horizontal_scrollbar(
+    tmp_path,
+) -> None:
+    run_dir = tmp_path / "demo-run"
+    run_dir.mkdir()
+    (run_dir / "metadata.json").write_text(
+        json.dumps({"avg_reward": 0.75}),
+        encoding="utf-8",
+    )
+    (run_dir / "results.jsonl").write_text("{}\n", encoding="utf-8")
+
+    long_model = "openai/" + ("very-long-model-name-" * 8)
+    long_run_id = "run-" + ("1234567890" * 12)
+    run = RunInfo(
+        env_id="demo-env",
+        model=long_model,
+        run_id=long_run_id,
+        path=run_dir,
+    )
+
+    async with VerifiersTUI({"demo-env": {long_model: [run]}}).run_test() as pilot:
+        await pilot.pause()
+
+        tree = pilot.app.screen.query_one("#run-browser-tree", RunBrowserTree)
+        model_line = tree.render_line(1).text
+
+        assert tree.size.width > 0
+        assert tree.virtual_size.width <= tree.size.width
+        assert tree.styles.overflow_x == "hidden"
+        assert tree.show_horizontal_scrollbar is False
+        assert "…" in model_line
+        assert "1 runs" in model_line
 
 
 @pytest.mark.asyncio

--- a/tests/test_tui_info_formatting.py
+++ b/tests/test_tui_info_formatting.py
@@ -12,6 +12,9 @@ from verifiers.scripts.tui import (
     BrowseRunsScreen,
     CopyScreen,
     LazyRunResults,
+    MathDisplayBlock,
+    MathMarkdown,
+    MathParagraph,
     RolloutCopyScreen,
     RunBrowserTree,
     RunInfo,
@@ -20,6 +23,9 @@ from verifiers.scripts.tui import (
     _compute_run_overview_stats,
     _extract_numeric_metric_values,
     format_info_for_details,
+    make_math_parser,
+    render_block_math,
+    render_inline_math,
 )
 
 
@@ -135,6 +141,50 @@ def test_extract_numeric_metric_values_includes_metrics_and_reward_signals() -> 
         "format_reward": 1.0,
         "sub_llm_completion_tokens": 144.0,
     }
+
+
+def test_make_math_parser_parses_inline_block_and_amsmath_tokens() -> None:
+    parser = make_math_parser()
+    tokens = parser.parse(
+        r"""
+Inline $E = mc^2$
+
+$$
+\sum_x p(x)
+$$
+
+\begin{align}
+f(x) &= x^2 + 1 \\
+g(x) &= \frac{1}{1 + e^{-x}}
+\end{align}
+"""
+    )
+
+    inline_token = next(token for token in tokens if token.type == "inline")
+
+    assert any(child.type == "math_inline" for child in inline_token.children or [])
+    assert any(token.type == "math_block" for token in tokens)
+    assert any(token.type == "amsmath" for token in tokens)
+
+
+def test_latex_renderers_convert_common_math_to_plain_text() -> None:
+    inline = render_inline_math(r"\alpha = \frac{1}{2}")
+    block = render_block_math(
+        r"""
+\begin{align}
+f(x) &= x^2 + 1 \\
+g(x) &= \frac{1}{1 + e^{-x}}
+\end{align}
+""".strip()
+    )
+
+    assert "α" in inline
+    assert "1/2" in inline
+    assert "\\begin" not in block
+    assert "\\end" not in block
+    assert "\\frac" not in block
+    assert "f(x)" in block
+    assert "g(x)" in block
 
 
 def test_build_run_details_includes_rollout_metric_stats(tmp_path) -> None:
@@ -450,6 +500,81 @@ async def test_view_run_screen_ignores_metadata_rollout_count_when_file_is_short
         assert "only sample" in first_text
 
 
+@pytest.mark.asyncio
+async def test_view_run_screen_renders_history_sections_with_math_markdown(
+    tmp_path,
+) -> None:
+    run_dir = tmp_path / "demo-run"
+    run_dir.mkdir()
+    (run_dir / "metadata.json").write_text(
+        json.dumps(
+            {
+                "avg_reward": 0.5,
+                "num_examples": 1,
+                "rollouts_per_example": 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+    (run_dir / "results.jsonl").write_text(
+        json.dumps(
+            {
+                "reward": 0.5,
+                "prompt": [
+                    {
+                        "role": "user",
+                        "content": "Solve $E = mc^2$",
+                    }
+                ],
+                "completion": [
+                    {
+                        "role": "assistant",
+                        "content": (
+                            "Fraction $\\alpha = \\frac{1}{2}$\n\n$$\n\\sum_x p(x)\n$$"
+                        ),
+                    }
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    run = RunInfo(
+        env_id="demo-env",
+        model="openai/gpt-5",
+        run_id="run-1",
+        path=run_dir,
+    )
+    screen = ViewRunScreen(run)
+
+    async with ViewRunHarness(screen).run_test() as pilot:
+        await pilot.pause()
+        markdown_widgets = list(screen.query(MathMarkdown))
+        math_widget = next(
+            widget
+            for widget in markdown_widgets
+            if "\\alpha = \\frac{1}{2}" in widget.source
+        )
+        paragraphs = list(math_widget.query(MathParagraph))
+        display = math_widget.query_one(MathDisplayBlock)
+
+        assert any(
+            "α" in paragraph._content.plain and "1/2" in paragraph._content.plain
+            for paragraph in paragraphs
+        )
+        assert "sum" in display._content.plain
+        assert "\\" not in display._content.plain
+
+        await pilot.press("m")
+        await pilot.pause()
+        assert not list(screen.query(MathMarkdown))
+
+        await pilot.press("m")
+        await pilot.pause()
+        assert list(screen.query(MathMarkdown))
+
+
 def test_record_preview_uses_error_when_completion_is_empty_payload(tmp_path) -> None:
     run_dir = tmp_path / "demo-run"
     run_dir.mkdir()
@@ -504,6 +629,105 @@ def test_format_prompt_or_completion_handles_non_dict_entries(tmp_path) -> None:
     )
 
     assert rendered.plain == "raw message\n\nassistant: structured message\n\n"
+
+
+def test_format_prompt_or_completion_includes_reasoning_traces(tmp_path) -> None:
+    run_dir = tmp_path / "demo-run"
+    run_dir.mkdir()
+    (run_dir / "metadata.json").write_text("{}", encoding="utf-8")
+    (run_dir / "results.jsonl").write_text("{}\n", encoding="utf-8")
+
+    screen = ViewRunScreen(
+        RunInfo(
+            env_id="demo-env",
+            model="openai/gpt-5",
+            run_id="run-1",
+            path=run_dir,
+        )
+    )
+
+    rendered = screen._format_prompt_or_completion(
+        [
+            {
+                "role": "assistant",
+                "reasoning_content": "hidden chain",
+                "content": "final answer",
+            },
+            {
+                "role": "assistant",
+                "thinking_blocks": [
+                    {
+                        "type": "thinking",
+                        "thinking": "tool plan",
+                        "signature": "sig_1",
+                    },
+                    {
+                        "type": "redacted_thinking",
+                        "data": "opaque",
+                    },
+                ],
+                "content": [
+                    {"type": "thinking", "thinking": "tool plan"},
+                    {"type": "text", "text": "after thought"},
+                ],
+            },
+        ]
+    )
+
+    assert "reasoning:\nhidden chain" in rendered.plain
+    assert "final answer" in rendered.plain
+    assert rendered.plain.count("tool plan") == 1
+    assert "[reasoning redacted]" in rendered.plain
+    assert "after thought" in rendered.plain
+
+
+def test_history_section_data_includes_reasoning_traces(tmp_path) -> None:
+    run_dir = tmp_path / "demo-run"
+    run_dir.mkdir()
+    (run_dir / "metadata.json").write_text("{}", encoding="utf-8")
+    (run_dir / "results.jsonl").write_text("{}\n", encoding="utf-8")
+
+    screen = ViewRunScreen(
+        RunInfo(
+            env_id="demo-env",
+            model="openai/gpt-5",
+            run_id="run-1",
+            path=run_dir,
+        )
+    )
+
+    sections = screen._history_section_data(
+        {
+            "prompt": [{"role": "user", "content": "start"}],
+            "completion": [
+                {
+                    "role": "assistant",
+                    "reasoning_content": "step 1",
+                    "content": "final answer",
+                },
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "thinking", "thinking": "step 2"},
+                        {"type": "text", "text": "another answer"},
+                    ],
+                },
+            ],
+        }
+    )
+
+    assert sections[1].body == "final answer"
+    assert sections[1].body_first is False
+    assert sections[1].nested_sections[0].title == "Reasoning"
+    assert sections[1].nested_sections[0].body == "step 1"
+    assert sections[2].body == "another answer"
+    assert sections[2].body_first is False
+    assert sections[2].nested_sections[0].title == "Reasoning"
+    assert sections[2].nested_sections[0].body == "step 2"
+    assert (
+        screen._render_history_section_copy_text(sections[1])
+        == "1. assistant  final answer\n\n  Reasoning\n\n    step 1\n\n  final answer"
+    )
 
 
 def test_view_run_screen_builds_rollout_copy_items_from_viewer_sections(

--- a/tests/test_tui_info_formatting.py
+++ b/tests/test_tui_info_formatting.py
@@ -587,6 +587,45 @@ async def test_browse_run_screen_offsets_details_content_from_scrollbar(
 
 
 @pytest.mark.asyncio
+async def test_browse_run_screen_highlights_details_pane_when_focused(
+    tmp_path,
+) -> None:
+    run_dir = tmp_path / "demo-run"
+    run_dir.mkdir()
+    (run_dir / "metadata.json").write_text(
+        json.dumps({"avg_reward": 0.75}),
+        encoding="utf-8",
+    )
+    (run_dir / "results.jsonl").write_text("{}\n", encoding="utf-8")
+
+    run = RunInfo(
+        env_id="demo-env",
+        model="openai/gpt-5",
+        run_id="run-1",
+        path=run_dir,
+    )
+
+    async with VerifiersTUI({"demo-env": {"openai/gpt-5": [run]}}).run_test() as pilot:
+        await pilot.pause()
+
+        tree = pilot.app.screen.query_one("#run-browser-tree", RunBrowserTree)
+        scroll = pilot.app.screen.query_one(
+            "#run-browser-details-scroll", VerticalScroll
+        )
+
+        assert pilot.app.focused is tree
+        assert tree.styles.background_tint.a > 0
+        assert scroll.styles.background_tint.a == 0
+
+        await pilot.press("tab")
+        await pilot.pause()
+
+        assert pilot.app.focused is scroll
+        assert tree.styles.background_tint.a == 0
+        assert scroll.styles.background_tint.a > 0
+
+
+@pytest.mark.asyncio
 async def test_browse_run_screen_opens_compare_mode_for_model(tmp_path) -> None:
     first_run_dir = tmp_path / "run-a"
     first_run_dir.mkdir()

--- a/tests/test_tui_info_formatting.py
+++ b/tests/test_tui_info_formatting.py
@@ -10,6 +10,7 @@ from textual.widgets import Label, OptionList, Static, TextArea, Tree
 
 from verifiers.scripts.tui import (
     BrowseRunsScreen,
+    CompareRunsScreen,
     CopyScreen,
     LazyRunResults,
     MathDisplayBlock,
@@ -20,6 +21,7 @@ from verifiers.scripts.tui import (
     RunInfo,
     VerifiersTUI,
     ViewRunScreen,
+    _build_reward_distribution_table,
     _compute_run_overview_stats,
     _extract_numeric_metric_values,
     format_info_for_details,
@@ -250,6 +252,217 @@ def test_build_run_details_includes_rollout_metric_stats(tmp_path) -> None:
     assert "Distribution" in rendered
 
 
+def test_reward_distribution_uses_exact_zero_and_one_buckets() -> None:
+    rendered = _render_to_text(
+        _build_reward_distribution_table(
+            [0.0, 0.0, 0.1, 0.4, 0.8, 1.0],
+            "Rollout rewards",
+        )
+    )
+    lines = [line.strip() for line in rendered.splitlines()]
+
+    assert "=0" in rendered
+    assert "=1" in rendered
+    assert "0-<0.25" in rendered
+    assert "<0" not in lines
+    assert ">=1.0" not in lines
+
+
+def test_build_run_details_includes_run_settings(tmp_path) -> None:
+    run_dir = tmp_path / "demo-run"
+    run_dir.mkdir()
+    (run_dir / "metadata.json").write_text(
+        json.dumps(
+            {
+                "base_url": "https://api.example/v1",
+                "num_examples": 12,
+                "rollouts_per_example": 4,
+                "pass_threshold": 0.7,
+                "sampling_args": {
+                    "temperature": 0.2,
+                    "max_tokens": 512,
+                },
+                "env_args": {
+                    "difficulty": "hard",
+                    "split": "validation",
+                },
+                "state_columns": ["judge_response"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (run_dir / "results.jsonl").write_text(
+        json.dumps({"reward": 1.0, "metrics": {}}) + "\n",
+        encoding="utf-8",
+    )
+
+    run = RunInfo(
+        env_id="demo-env",
+        model="openai/gpt-5",
+        run_id="run-1",
+        path=run_dir,
+    )
+
+    rendered = _render_to_text(
+        BrowseRunsScreen({})._build_run_details(run, _compute_run_overview_stats(run))
+    )
+
+    assert "Run settings" in rendered
+    assert "endpoint" in rendered
+    assert "https://api.example/v1" in rendered
+    assert "examples" in rendered
+    assert "rollouts/example" in rendered
+    assert "pass threshold" in rendered
+    assert "sampling.temperature" in rendered
+    assert "sampling.max_tokens" in rendered
+    assert "env.difficulty" in rendered
+    assert "env.split" in rendered
+    assert "state columns" in rendered
+
+
+def test_model_details_include_setting_variations(tmp_path) -> None:
+    first_run_dir = tmp_path / "run-a"
+    first_run_dir.mkdir()
+    (first_run_dir / "metadata.json").write_text(
+        json.dumps(
+            {
+                "avg_reward": 0.25,
+                "sampling_args": {"temperature": 0.2},
+                "env_args": {"split": "train"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (first_run_dir / "results.jsonl").write_text("{}\n", encoding="utf-8")
+
+    second_run_dir = tmp_path / "run-b"
+    second_run_dir.mkdir()
+    (second_run_dir / "metadata.json").write_text(
+        json.dumps(
+            {
+                "avg_reward": 0.75,
+                "sampling_args": {"temperature": 0.8},
+                "env_args": {"split": "validation"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (second_run_dir / "results.jsonl").write_text("{}\n", encoding="utf-8")
+
+    first_run = RunInfo(
+        env_id="demo-env",
+        model="openai/gpt-5",
+        run_id="run-1",
+        path=first_run_dir,
+    )
+    second_run = RunInfo(
+        env_id="demo-env",
+        model="openai/gpt-5",
+        run_id="run-2",
+        path=second_run_dir,
+    )
+
+    rendered = _render_to_text(
+        BrowseRunsScreen(
+            {"demo-env": {"openai/gpt-5": [first_run, second_run]}}
+        )._build_model_details("demo-env", "openai/gpt-5")
+    )
+
+    assert "Setting variations" in rendered
+    assert "sampling.temperature" in rendered
+    assert "env.split" in rendered
+    assert "0.2 (1 run)" in rendered
+    assert "0.8 (1 run)" in rendered
+    assert "train (1 run)" in rendered
+    assert "validation (1 run)" in rendered
+
+
+def test_compare_runs_screen_renders_settings_and_reward_buckets(tmp_path) -> None:
+    first_run_dir = tmp_path / "run-a"
+    first_run_dir.mkdir()
+    (first_run_dir / "metadata.json").write_text(
+        json.dumps(
+            {
+                "avg_reward": 0.25,
+                "sampling_args": {"temperature": 0.2, "max_tokens": 256},
+                "env_args": {"split": "train"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (first_run_dir / "results.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps({"reward": 0.0, "metrics": {}}),
+                json.dumps({"reward": 0.5, "metrics": {}}),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    second_run_dir = tmp_path / "run-b"
+    second_run_dir.mkdir()
+    (second_run_dir / "metadata.json").write_text(
+        json.dumps(
+            {
+                "avg_reward": 0.75,
+                "sampling_args": {"temperature": 0.8, "max_tokens": 512},
+                "env_args": {"split": "validation"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (second_run_dir / "results.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps({"reward": 1.0, "metrics": {}}),
+                json.dumps({"reward": 1.0, "metrics": {}}),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    first_run = RunInfo(
+        env_id="demo-env",
+        model="openai/gpt-5",
+        run_id="run-1",
+        path=first_run_dir,
+    )
+    second_run = RunInfo(
+        env_id="demo-env",
+        model="openai/gpt-5",
+        run_id="run-2",
+        path=second_run_dir,
+    )
+    screen = CompareRunsScreen(
+        "demo-env",
+        "openai/gpt-5",
+        [first_run, second_run],
+    )
+    stats = {
+        first_run.path: _compute_run_overview_stats(first_run),
+        second_run.path: _compute_run_overview_stats(second_run),
+    }
+
+    rendered = _render_to_text(screen._build_comparison_content(stats), width=220)
+
+    assert "Ablation summary" in rendered
+    assert "Ablation axes" in rendered
+    assert "Outcome groups" in rendered
+    assert "temperature" in rendered
+    assert "max_tokens" in rendered
+    assert "split" in rendered
+    assert "run-1" in rendered
+    assert "run-2" in rendered
+    assert "=0" in rendered
+    assert "=1" in rendered
+    assert "█" in rendered
+    assert "50%" in rendered
+    assert "100%" in rendered
+
+
 def test_copy_screen_uses_custom_labels() -> None:
     copy_screen = CopyScreen(
         "run-1 reward 0.75",
@@ -333,6 +546,10 @@ async def test_browse_run_screen_moves_browser_shortcuts_to_footer(tmp_path) -> 
         assert bindings["enter"].description == "Open/toggle"
         assert bindings["space"].show is True
         assert bindings["space"].description == "Toggle folder"
+        assert any(
+            binding.key == "v" and binding.description == "Compare"
+            for binding in pilot.app.screen.BINDINGS
+        )
         assert "Enter opens runs  Space toggles folders  c copies" not in labels
 
 
@@ -367,6 +584,57 @@ async def test_browse_run_screen_offsets_details_content_from_scrollbar(
         assert scroll.styles.padding.right == 1
         assert scroll.styles.scrollbar_gutter == "stable"
         assert details.styles.margin.right == 8
+
+
+@pytest.mark.asyncio
+async def test_browse_run_screen_opens_compare_mode_for_model(tmp_path) -> None:
+    first_run_dir = tmp_path / "run-a"
+    first_run_dir.mkdir()
+    (first_run_dir / "metadata.json").write_text(
+        json.dumps({"avg_reward": 0.25, "sampling_args": {"temperature": 0.2}}),
+        encoding="utf-8",
+    )
+    (first_run_dir / "results.jsonl").write_text("{}\n", encoding="utf-8")
+
+    second_run_dir = tmp_path / "run-b"
+    second_run_dir.mkdir()
+    (second_run_dir / "metadata.json").write_text(
+        json.dumps({"avg_reward": 0.75, "sampling_args": {"temperature": 0.8}}),
+        encoding="utf-8",
+    )
+    (second_run_dir / "results.jsonl").write_text("{}\n", encoding="utf-8")
+
+    first_run = RunInfo(
+        env_id="demo-env",
+        model="openai/gpt-5",
+        run_id="run-1",
+        path=first_run_dir,
+    )
+    second_run = RunInfo(
+        env_id="demo-env",
+        model="openai/gpt-5",
+        run_id="run-2",
+        path=second_run_dir,
+    )
+
+    async with VerifiersTUI(
+        {"demo-env": {"openai/gpt-5": [first_run, second_run]}}
+    ).run_test() as pilot:
+        await pilot.pause()
+
+        tree = pilot.app.screen.query_one("#run-browser-tree", RunBrowserTree)
+        assert tree.cursor_node is not None
+        assert tree.cursor_node.data.kind == "run"
+
+        await pilot.press("left")
+        await pilot.pause()
+        assert tree.cursor_node is not None
+        assert tree.cursor_node.data.kind == "model"
+
+        await pilot.press("v")
+        await pilot.pause()
+
+        assert isinstance(pilot.app.screen, CompareRunsScreen)
 
 
 @pytest.mark.asyncio
@@ -949,6 +1217,73 @@ def test_history_section_data_includes_reasoning_traces(tmp_path) -> None:
         screen._render_history_section_copy_text(sections[1])
         == "1. assistant  final answer\n\n  Reasoning\n\n    step 1\n\n  final answer"
     )
+
+
+def test_view_run_screen_sorts_pass_metrics_numerically(tmp_path) -> None:
+    run_dir = tmp_path / "demo-run"
+    run_dir.mkdir()
+    (run_dir / "metadata.json").write_text(
+        json.dumps(
+            {
+                "pass_at_k": {"1": 0.1, "10": 1.0, "2": 0.2},
+                "pass_all_k": {"1": 0.01, "10": 0.1, "2": 0.02},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (run_dir / "results.jsonl").write_text("{}\n", encoding="utf-8")
+
+    screen = ViewRunScreen(
+        RunInfo(
+            env_id="demo-env",
+            model="openai/gpt-5",
+            run_id="run-1",
+            path=run_dir,
+        )
+    )
+
+    rendered = screen._build_header_metric_text().plain
+    labels = [token for token in rendered.split() if token.startswith("pass")]
+
+    assert labels == [
+        "pass@1",
+        "pass@2",
+        "pass@10",
+        "pass-all@1",
+        "pass-all@2",
+        "pass-all@10",
+    ]
+
+
+def test_view_run_screen_history_summary_omits_inline_hints(tmp_path) -> None:
+    run_dir = tmp_path / "demo-run"
+    run_dir.mkdir()
+    (run_dir / "metadata.json").write_text("{}", encoding="utf-8")
+    (run_dir / "results.jsonl").write_text("{}\n", encoding="utf-8")
+
+    screen = ViewRunScreen(
+        RunInfo(
+            env_id="demo-env",
+            model="openai/gpt-5",
+            run_id="run-1",
+            path=run_dir,
+        )
+    )
+
+    rendered = screen._build_history_summary_text(
+        {
+            "completion": [
+                {"role": "assistant", "content": "first"},
+                {"role": "user", "content": "question"},
+                {"role": "assistant", "content": "second"},
+            ]
+        }
+    ).plain
+
+    assert "3 events" in rendered
+    assert "1 user turns" in rendered
+    assert "Enter toggles" not in rendered
+    assert "PgUp/PgDn scroll" not in rendered
 
 
 def test_view_run_screen_builds_rollout_copy_items_from_viewer_sections(

--- a/tests/test_tui_info_formatting.py
+++ b/tests/test_tui_info_formatting.py
@@ -24,6 +24,7 @@ from verifiers.scripts.tui import (
     _build_reward_distribution_table,
     _compute_run_overview_stats,
     _extract_numeric_metric_values,
+    _varying_run_setting_keys,
     format_info_for_details,
     make_math_parser,
     render_block_math,
@@ -446,7 +447,23 @@ def test_compare_runs_screen_renders_settings_and_reward_buckets(tmp_path) -> No
         second_run.path: _compute_run_overview_stats(second_run),
     }
 
-    rendered = _render_to_text(screen._build_comparison_content(stats), width=220)
+    # Simulate _finish_loading_comparison_stats setup
+    screen._stats_by_path = stats
+    screen._setting_keys, screen._run_settings = _varying_run_setting_keys(screen.runs)
+    (
+        screen._display_maps,
+        screen._style_maps,
+        screen._legend_rows,
+    ) = screen._build_setting_display_maps(screen._setting_keys, screen._run_settings)
+    from rich.console import Group
+
+    rendered = _render_to_text(
+        Group(
+            screen._build_comparison_header(),
+            screen._build_comparison_outcomes(screen._setting_keys),
+        ),
+        width=220,
+    )
 
     assert "Ablation summary" in rendered
     assert "Ablation axes" in rendered

--- a/tests/test_tui_info_formatting.py
+++ b/tests/test_tui_info_formatting.py
@@ -460,7 +460,7 @@ def test_compare_runs_screen_renders_settings_and_reward_buckets(tmp_path) -> No
     rendered = _render_to_text(
         Group(
             screen._build_comparison_header(),
-            screen._build_comparison_outcomes(screen._setting_keys),
+            screen._build_comparison_outcomes(),
         ),
         width=220,
     )

--- a/verifiers/scripts/tui.py
+++ b/verifiers/scripts/tui.py
@@ -1981,6 +1981,7 @@ class BrowseRunsScreen(Screen):
 
     BINDINGS = [
         Binding("q", "quit", "Quit"),
+        Binding("enter", "enter_selected", "Open/toggle", priority=True),
         Binding("tab", "focus_next_pane", "Next pane"),
         Binding("shift+tab", "focus_prev_pane", show=False),
         Binding("v", "compare_selected", "Compare"),
@@ -1992,7 +1993,7 @@ class BrowseRunsScreen(Screen):
         super().__init__()
         self.index = index
         self._run_overview_cache: Dict[Path, RunOverviewStats] = {}
-        self._highlight_just_changed: bool = False
+        self._click_selected_node: object | None = None
 
     def compose(self) -> ComposeResult:
         with Container():
@@ -2171,22 +2172,36 @@ class BrowseRunsScreen(Screen):
 
     @on(Tree.NodeHighlighted, "#run-browser-tree")
     def on_tree_highlighted(self, event: Tree.NodeHighlighted) -> None:
-        self._highlight_just_changed = True
         self.query_one("#run-browser-details", Static).update(
             self._details_for(getattr(event.node, "data", None))
         )
 
+    def action_enter_selected(self) -> None:
+        """Enter key: immediately open the highlighted run or toggle folder."""
+        tree = self.query_one("#run-browser-tree", Tree)
+        node = tree.cursor_node
+        if node is None:
+            return
+        payload = node.data
+        if not isinstance(payload, BrowserNodeData):
+            return
+        if payload.kind == "run" and payload.run is not None:
+            self.app.push_screen(ViewRunScreen(payload.run))
+            return
+        if node.allow_expand:
+            node.toggle()
+
     @on(Tree.NodeSelected, "#run-browser-tree")
     def on_tree_selected(self, event: Tree.NodeSelected) -> None:
+        """Click: first click selects, second click enters rollout view."""
         payload = event.node.data
         if not isinstance(payload, BrowserNodeData):
             return
         if payload.kind == "run" and payload.run is not None:
-            # First click selects (highlights) the run; second click enters rollout view.
-            if self._highlight_just_changed:
-                self._highlight_just_changed = False
-                return
-            self.app.push_screen(ViewRunScreen(payload.run))
+            if self._click_selected_node is event.node:
+                self.app.push_screen(ViewRunScreen(payload.run))
+            else:
+                self._click_selected_node = event.node
             return
         if event.node.allow_expand:
             event.node.toggle()

--- a/verifiers/scripts/tui.py
+++ b/verifiers/scripts/tui.py
@@ -9,7 +9,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 from io import StringIO
 from pathlib import Path
-from typing import Any, Dict, List, Literal, Optional, Tuple, cast
+from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, cast
 
 from markdown_it import MarkdownIt
 from mdit_py_plugins.amsmath import amsmath_plugin
@@ -52,6 +52,7 @@ from textual.widgets._markdown import (
     MarkdownTH,
 )
 from textual.widgets._option_list import Option
+from textual.widgets._tree import TreeNode
 
 from verifiers.utils.display_utils import format_numeric
 
@@ -153,7 +154,7 @@ class RunBrowserTree(Tree[BrowserNodeData]):
 
         if max_width <= 0:
             label.truncate(1, overflow="ellipsis")
-            label.stylize(style)
+            label.stylize(cast(Any, style))
             return label
 
         suffix = Text()
@@ -167,10 +168,15 @@ class RunBrowserTree(Tree[BrowserNodeData]):
         else:
             label.truncate(max_width, overflow="ellipsis")
 
-        label.stylize(style)
+        label.stylize(cast(Any, style))
         return label
 
-    def render_label(self, node: Any, base_style: Style, style: Style) -> Text:
+    def render_label(  # ty: ignore[invalid-method-override]
+        self,
+        node: TreeNode[Any],
+        base_style: Style,
+        style: Style,
+    ) -> Text:
         payload = node.data
         available_width = self.size.width - (
             self._visible_depth(node) * self.guide_depth
@@ -188,10 +194,10 @@ class RunBrowserTree(Tree[BrowserNodeData]):
             label = self._render_browser_label(payload, style, content_width)
         else:
             label = node._label.copy()
-            label.stylize(style)
+            label.stylize(cast(Any, style))
             label.truncate(content_width, overflow="ellipsis")
 
-        return Text.assemble((prefix_text, base_style), label)
+        return Text.assemble((prefix_text, cast(Any, base_style)), label)
 
     def action_cursor_parent(self) -> None:
         """Move the cursor to the nearest visible parent folder."""
@@ -1312,7 +1318,7 @@ _LATEX_COMMAND_REPLACEMENTS = {
 def _replace_latex_groups(
     text: str,
     pattern: re.Pattern[str],
-    replacement: str | re.Pattern[str] | Any,
+    replacement: str | Callable[[re.Match[str]], str],
 ) -> str:
     while True:
         updated = pattern.sub(replacement, text)

--- a/verifiers/scripts/tui.py
+++ b/verifiers/scripts/tui.py
@@ -3093,14 +3093,25 @@ class ViewRunScreen(Screen):
         completion_lines: List[Tuple[int, int, str]] = []
         for idx, section in enumerate(sections):
             target = prompt_lines if section.column == "prompt" else completion_lines
-            for line in section.body.splitlines():
-                target.append((idx, -1, line))
-            for nested_idx, nested in enumerate(section.nested_sections):
-                nested_target = (
-                    prompt_lines if nested.column == "prompt" else completion_lines
-                )
-                for line in nested.body.splitlines():
-                    nested_target.append((idx, nested_idx, line))
+
+            def _append_body(tgt: List[Tuple[int, int, str]], body: str) -> None:
+                for line in body.splitlines():
+                    tgt.append((idx, -1, line))
+
+            def _append_nested() -> None:
+                for nested_idx, nested in enumerate(section.nested_sections):
+                    nested_target = (
+                        prompt_lines if nested.column == "prompt" else completion_lines
+                    )
+                    for line in nested.body.splitlines():
+                        nested_target.append((idx, nested_idx, line))
+
+            if section.body_first:
+                _append_body(target, section.body)
+                _append_nested()
+            else:
+                _append_nested()
+                _append_body(target, section.body)
         return prompt_lines, completion_lines
 
     def action_search(self) -> None:

--- a/verifiers/scripts/tui.py
+++ b/verifiers/scripts/tui.py
@@ -1740,48 +1740,26 @@ class CompareRunsScreen(Screen):
     def action_copy(self) -> None:
         if not self._stats_by_path:
             return
-        items: List[RolloutCopyItem] = []
-        items.append(
-            RolloutCopyItem(
-                key="summary",
-                label="Summary",
-                body=self._renderable_to_text(self._build_comparison_header()),
-            )
-        )
-        items.append(
-            RolloutCopyItem(
-                key="outcomes",
-                label="Outcome groups",
-                body=self._renderable_to_text(
-                    self._build_grouped_outcomes_table(
-                        self._stats_by_path,
-                        self._setting_keys,
-                        self._run_settings,
-                        self._display_maps,
-                        self._style_maps,
-                        group_by_key=self._grouped_by_key,
-                    )
-                ),
-            )
-        )
+        parts: List[str] = [
+            self._renderable_to_text(self._build_comparison_header()),
+            self._renderable_to_text(
+                self._build_grouped_outcomes_table(
+                    self._stats_by_path,
+                    self._setting_keys,
+                    self._run_settings,
+                    self._display_maps,
+                    self._style_maps,
+                    group_by_key=self._grouped_by_key,
+                )
+            ),
+        ]
         legend = self._build_value_legend(self._legend_rows)
         if isinstance(legend, Group) or (isinstance(legend, Text) and legend.plain):
-            items.append(
-                RolloutCopyItem(
-                    key="legend",
-                    label="Value legend",
-                    body=self._renderable_to_text(legend),
-                )
-            )
-        # "All" section combining everything.
-        all_body = "\n\n".join(item.body for item in items)
-        items.insert(
-            0,
-            RolloutCopyItem(key="all", label="All", body=all_body),
-        )
+            parts.append(self._renderable_to_text(legend))
+        all_body = "\n\n".join(parts)
         self.app.push_screen(
             CompactCopyScreen(
-                items,
+                [RolloutCopyItem(key="all", label="Comparison", body=all_body)],
                 start_key="all",
                 title="Copy Comparison",
             )
@@ -2311,8 +2289,6 @@ class BrowseRunsScreen(Screen):
         payload = getattr(node, "data", None)
         if not isinstance(payload, BrowserNodeData):
             return
-        label = getattr(node, "label", "")
-        label_text = label.plain if isinstance(label, Text) else str(label)
         buffer = StringIO()
         Console(
             file=buffer,
@@ -2321,12 +2297,13 @@ class BrowseRunsScreen(Screen):
             width=180,
         ).print(self._details_for(payload))
         self.app.push_screen(
-            CopyScreen(
-                label_text,
-                buffer.getvalue().rstrip(),
-                "completion",
-                prompt_label="Selection",
-                completion_label="Details",
+            CompactCopyScreen(
+                [
+                    RolloutCopyItem(
+                        key="details", label="Details", body=buffer.getvalue().rstrip()
+                    )
+                ],
+                start_key="details",
                 title="Copy Details",
             )
         )
@@ -2979,7 +2956,7 @@ class ViewRunScreen(Screen):
         out.append(f"{heading}\n", style="bold dim")
         out.append(_format_reward_value(reward), style=_reward_style(reward))
 
-        breakdown = self._extract_reward_metrics(record)
+        breakdown = sorted(_extract_numeric_metric_values(record).items())
         if breakdown:
             breakdown = breakdown[:limit] if limit is not None else breakdown
             if multiline:
@@ -3227,7 +3204,9 @@ class ViewRunScreen(Screen):
         self.query_one("#score-content", Static).update(score_text)
         self.query_one("#usage-content", Static).update(usage_text)
         self.query_one("#info-content", Static).update(info_text)
-        self._update_rollout_summary(record)
+        self.query_one("#rollout-summary", Label).update(
+            self._build_rollout_summary_text(record)
+        )
         self._rebuild_completion_sections(record, focus_history)
 
     def action_back(self) -> None:
@@ -3264,7 +3243,7 @@ class ViewRunScreen(Screen):
         self.app.push_screen(
             RolloutCopyScreen(
                 self._build_rollout_copy_items(record),
-                start_key=self._rollout_copy_start_key(),
+                start_key="snapshot",
                 title=f"Copy Rollout #{self.current_record_idx}",
             )
         )
@@ -3414,11 +3393,6 @@ class ViewRunScreen(Screen):
                 _format_reward_value(record.get("reward")),
                 _reward_style(record.get("reward")),
             ),
-        )
-
-    def _update_rollout_summary(self, record: Dict[str, Any]) -> None:
-        self.query_one("#rollout-summary", Label).update(
-            self._build_rollout_summary_text(record)
         )
 
     def _update_responsive_layout(self, width: int) -> None:
@@ -3668,24 +3642,6 @@ class ViewRunScreen(Screen):
         if focus_history:
             self.call_after_refresh(self._focus_primary_content)
 
-    def _rollout_copy_start_key(self) -> str:
-        if self.is_mounted and self.query_one("#details-panel", Panel).has_focus_within:
-            return f"details:{self._active_details_tab_id()}"
-        if self.is_mounted and self.query_one("#history-panel", Panel).has_focus_within:
-            return "history"
-        if (
-            self.is_mounted
-            and self.query_one("#rollouts-panel", Panel).has_focus_within
-        ):
-            return "rollout"
-        return "snapshot"
-
-    def _active_details_tab_id(self) -> str:
-        if not self.is_mounted:
-            return "details-task"
-        active = self.query_one("#details-tabs", TabbedContent).active
-        return active or "details-task"
-
     def _detail_copy_sections(
         self, record: Dict[str, Any]
     ) -> List[Tuple[str, str, str]]:
@@ -3772,7 +3728,12 @@ class ViewRunScreen(Screen):
             history_parts.append(history_text)
         blocks.append("\n\n".join(history_parts))
 
-        active_tab_id = self._active_details_tab_id()
+        if self.is_mounted:
+            active_tab_id = (
+                self.query_one("#details-tabs", TabbedContent).active or "details-task"
+            )
+        else:
+            active_tab_id = "details-task"
         active_tab_label = next(
             (
                 label
@@ -4027,9 +3988,6 @@ class ViewRunScreen(Screen):
                 out.append("\n")
 
         return out
-
-    def _extract_reward_metrics(self, record: Dict[str, Any]) -> List[Tuple[str, Any]]:
-        return sorted(_extract_numeric_metric_values(record).items())
 
     def _build_task_text(self, record: Dict[str, Any]) -> Text:
         out = Text()
@@ -4738,13 +4696,14 @@ class RolloutCopyScreen(ModalScreen[None]):
     """Modal screen for copying rollout viewer sections."""
 
     BINDINGS = [
-        Binding("escape,b,backspace", "close", "Close"),
-        Binding("tab", "focus_next_pane", "Next pane"),
-        Binding("shift+tab", "focus_prev_pane", show=False),
-        Binding("enter", "copy", "Copy"),
+        Binding("q", "quit", "Quit"),
+        Binding("escape", "close", "Back (esc/b)"),
+        Binding("b,backspace", "close", show=False),
         Binding("c", "copy", "Copy"),
-        Binding("ctrl+c", "copy", show=False),
     ]
+
+    async def action_quit(self) -> None:
+        self.app.exit()
 
     def __init__(
         self,
@@ -4756,27 +4715,19 @@ class RolloutCopyScreen(ModalScreen[None]):
         super().__init__()
         self._items = items
         self._items_by_key = {item.key: item for item in items}
-        self._start_key = (
-            start_key
-            if start_key in self._items_by_key
-            else (items[0].key if items else None)
-        )
         self._title = title
-        self._current_key = self._start_key
+        self._current_idx = 0
+        if start_key:
+            for i, item in enumerate(items):
+                if item.key == start_key:
+                    self._current_idx = i
+                    break
         self._last_copied_selection = ""
 
     def compose(self) -> ComposeResult:
         with Container():
             with Panel(classes="modal-header"):
                 yield Label(Text(self._title, style="bold"))
-                yield Label(
-                    Text(
-                        "Choose a viewer section on the left. Tab switches panes; enter or c copies the current target.",
-                        style="dim",
-                    ),
-                    id="rollout-copy-hint",
-                    classes="copy-hint",
-                )
                 yield Label("", id="rollout-copy-status", classes="subtitle")
 
             with Horizontal(classes="modal-columns"):
@@ -4796,25 +4747,12 @@ class RolloutCopyScreen(ModalScreen[None]):
 
     def on_mount(self) -> None:
         option_list = self.query_one("#rollout-copy-targets", OptionList)
+        option_list.can_focus = False
         for item in self._items:
             option_list.add_option(Option(Text(item.label), id=item.key))
-
-        if self._start_key is not None:
-            for idx, item in enumerate(self._items):
-                if item.key == self._start_key:
-                    option_list.highlighted = idx
-                    option_list.scroll_to_highlight()
-                    break
-
+        option_list.highlighted = self._current_idx
         self._sync_preview()
-        option_list.focus()
-
-    @on(OptionList.OptionHighlighted, "#rollout-copy-targets")
-    def _on_target_highlighted(self, event: OptionList.OptionHighlighted) -> None:
-        if event.option_id is None:
-            return
-        self._current_key = event.option_id
-        self._sync_preview()
+        self.query_one("#rollout-copy-preview", TextArea).focus()
 
     @on(TextArea.SelectionChanged)
     def _on_selection_changed(self, event: TextArea.SelectionChanged) -> None:
@@ -4827,31 +4765,33 @@ class RolloutCopyScreen(ModalScreen[None]):
             self.query_one("#rollout-copy-status", Label).update(
                 Text(f"Copied selection ({len(selected):,} chars).", style="dim")
             )
-        self._update_hint()
 
-    def on_key(self, event) -> None:
-        if event.key in ("tab", "shift+tab", "backtab"):
-            if event.key == "tab":
-                self.action_focus_next_pane()
-            else:
-                self.action_focus_prev_pane()
+    def on_key(self, event: events.Key) -> None:
+        if event.key == "left":
+            self._move_section(-1)
             event.prevent_default()
             event.stop()
+        elif event.key == "right":
+            self._move_section(1)
+            event.prevent_default()
+            event.stop()
+
+    def _move_section(self, delta: int) -> None:
+        if not self._items:
+            return
+        self._current_idx = (self._current_idx + delta) % len(self._items)
+        self.query_one(
+            "#rollout-copy-targets", OptionList
+        ).highlighted = self._current_idx
+        self._sync_preview()
 
     def action_close(self) -> None:
         self.dismiss(None)
 
-    def action_focus_next_pane(self) -> None:
-        self.focus_next()
-
-    def action_focus_prev_pane(self) -> None:
-        self.focus_previous()
-
     def action_copy(self) -> None:
-        item = self._current_item()
-        if item is None:
+        if not self._items:
             return
-
+        item = self._items[self._current_idx]
         preview = self.query_one("#rollout-copy-preview", TextArea)
         selected = preview.selected_text or ""
         copied_text = selected or item.body
@@ -4859,63 +4799,38 @@ class RolloutCopyScreen(ModalScreen[None]):
             self.query_one("#rollout-copy-status", Label).update(
                 Text("Nothing to copy.", style="dim")
             )
-            self._update_hint()
             return
-
         self.app.copy_to_clipboard(copied_text)
         self._last_copied_selection = copied_text
-        if selected:
-            message = f"Copied selection ({len(copied_text):,} chars)."
-        else:
-            message = f"Copied {item.label} ({len(copied_text):,} chars)."
-        self.query_one("#rollout-copy-status", Label).update(Text(message, style="dim"))
-        self._update_hint()
-
-    def _current_item(self) -> Optional[RolloutCopyItem]:
-        if self._current_key is None:
-            return self._items[0] if self._items else None
-        return self._items_by_key.get(self._current_key)
+        label = "selection" if selected else item.label.lower()
+        self.query_one("#rollout-copy-status", Label).update(
+            Text(f"Copied {label} ({len(copied_text):,} chars).", style="dim")
+        )
 
     def _sync_preview(self) -> None:
-        item = self._current_item()
-        preview_label = self.query_one("#rollout-copy-preview-label", Label)
-        preview = self.query_one("#rollout-copy-preview", TextArea)
-        if item is None:
-            preview_label.update(Text("Preview", style="bold"))
-            preview.load_text("")
-            self._update_hint()
+        if not self._items:
             return
-
-        preview_label.update(
+        item = self._items[self._current_idx]
+        self.query_one("#rollout-copy-preview-label", Label).update(
             Text(f"{item.label}  ({len(item.body):,} chars)", style="bold")
         )
-        preview.load_text(item.body)
-        self._update_hint()
-
-    def _update_hint(self) -> None:
-        item = self._current_item()
-        preview = self.query_one("#rollout-copy-preview", TextArea)
-        selected = preview.selected_text or ""
-        if selected:
-            hint = f"Enter/c copies the selection ({len(selected):,} chars)."
-        elif item is not None:
-            hint = f"Enter/c copies {item.label.lower()}. Tab switches panes."
-        else:
-            hint = "Choose a copy target. Tab switches panes."
-        self.query_one("#rollout-copy-hint", Label).update(Text(hint, style="dim"))
+        self.query_one("#rollout-copy-preview", TextArea).load_text(item.body)
 
 
 class CompactCopyScreen(ModalScreen[None]):
     """Compact copy screen with section tabs above a preview area."""
 
     BINDINGS = [
-        Binding("escape,b,backspace", "close", "Close"),
+        Binding("q", "quit", "Quit"),
+        Binding("escape", "close", "Back (esc/b)"),
+        Binding("b,backspace", "close", show=False),
         Binding("tab", "next_section", "Next section"),
-        Binding("shift+tab", "prev_section", "Prev section", show=False),
-        Binding("enter", "copy", "Copy"),
+        Binding("shift+tab", "prev_section", "Prev section"),
         Binding("c", "copy", "Copy"),
-        Binding("ctrl+c", "copy", show=False),
     ]
+
+    async def action_quit(self) -> None:
+        self.app.exit()
 
     def __init__(
         self,
@@ -4940,8 +4855,6 @@ class CompactCopyScreen(ModalScreen[None]):
         with Container():
             with Panel(classes="modal-header"):
                 yield Label(Text(self._title, style="bold"))
-                yield Label("", id="compact-copy-tabs", classes="copy-hint")
-                yield Label("", id="compact-copy-hint", classes="copy-hint")
                 yield Label("", id="compact-copy-status", classes="subtitle")
             with Panel(classes="compact-copy-body"):
                 preview = TextArea(
@@ -4966,7 +4879,6 @@ class CompactCopyScreen(ModalScreen[None]):
             self.query_one("#compact-copy-status", Label).update(
                 Text(f"Copied selection ({len(selected):,} chars).", style="dim")
             )
-        self._update_hint()
 
     def action_close(self) -> None:
         self.dismiss(None)
@@ -5008,50 +4920,29 @@ class CompactCopyScreen(ModalScreen[None]):
         self.query_one("#compact-copy-status", Label).update(
             Text(f"Copied {label} ({len(copied_text):,} chars).", style="dim")
         )
-        self._update_hint()
 
     def _sync(self) -> None:
         if not self._items:
             return
         item = self._items[self._current_idx]
-        # Update tab bar.
-        tabs = Text()
-        for i, it in enumerate(self._items):
-            if i:
-                tabs.append("  ")
-            if i == self._current_idx:
-                tabs.append(f"[{it.label}]", style="bold")
-            else:
-                tabs.append(f" {it.label} ", style="dim")
-        self.query_one("#compact-copy-tabs", Label).update(tabs)
-        # Update preview.
         preview = self.query_one("#compact-copy-preview", TextArea)
         preview.load_text(item.body)
-        self._update_hint()
-
-    def _update_hint(self) -> None:
-        if not self._items:
-            return
-        item = self._items[self._current_idx]
-        preview = self.query_one("#compact-copy-preview", TextArea)
-        selected = preview.selected_text or ""
-        if selected:
-            hint = f"Enter/c copies selection ({len(selected):,} chars). Tab switches section."
-        else:
-            hint = f"Enter/c copies {item.label.lower()}. Tab switches section."
-        self.query_one("#compact-copy-hint", Label).update(Text(hint, style="dim"))
 
 
 class CopyScreen(ModalScreen[None]):
     """Modal screen for selecting and copying prompt/completion text."""
 
     BINDINGS = [
-        Binding("escape,b,backspace", "close", "Close"),
+        Binding("q", "quit", "Quit"),
+        Binding("escape", "close", "Back (esc/b)"),
+        Binding("b,backspace", "close", show=False),
         Binding("tab", "cycle_column", "Next column"),
-        Binding("shift+tab", "cycle_column", show=False),
+        Binding("shift+tab", "cycle_column", "Prev column"),
         Binding("c", "copy", "Copy"),
-        Binding("ctrl+c", "copy", show=False),
     ]
+
+    async def action_quit(self) -> None:
+        self.app.exit()
 
     def __init__(
         self,
@@ -5186,14 +5077,14 @@ class CopyScreen(ModalScreen[None]):
         if selected:
             count = len(selected)
             unit = "char" if count == 1 else "chars"
-            copy_text = f"c / ctrl+c: copy selection ({count} {unit})"
+            copy_text = f"c: copy selection ({count} {unit})"
         else:
             active_label = (
                 self._prompt_label
                 if self._active_column == "prompt"
                 else self._completion_label
             ).lower()
-            copy_text = f"c / ctrl+c: copy {active_label}"
+            copy_text = f"c: copy {active_label}"
         self.query_one("#copy-hint", Label).update(Text(copy_text, style="dim"))
 
 

--- a/verifiers/scripts/tui.py
+++ b/verifiers/scripts/tui.py
@@ -1992,6 +1992,7 @@ class BrowseRunsScreen(Screen):
         super().__init__()
         self.index = index
         self._run_overview_cache: Dict[Path, RunOverviewStats] = {}
+        self._highlight_just_changed: bool = False
 
     def compose(self) -> ComposeResult:
         with Container():
@@ -2170,6 +2171,7 @@ class BrowseRunsScreen(Screen):
 
     @on(Tree.NodeHighlighted, "#run-browser-tree")
     def on_tree_highlighted(self, event: Tree.NodeHighlighted) -> None:
+        self._highlight_just_changed = True
         self.query_one("#run-browser-details", Static).update(
             self._details_for(getattr(event.node, "data", None))
         )
@@ -2180,6 +2182,10 @@ class BrowseRunsScreen(Screen):
         if not isinstance(payload, BrowserNodeData):
             return
         if payload.kind == "run" and payload.run is not None:
+            # First click selects (highlights) the run; second click enters rollout view.
+            if self._highlight_just_changed:
+                self._highlight_just_changed = False
+                return
             self.app.push_screen(ViewRunScreen(payload.run))
             return
         if event.node.allow_expand:

--- a/verifiers/scripts/tui.py
+++ b/verifiers/scripts/tui.py
@@ -606,7 +606,7 @@ def _compact_json_or_str(value: Any) -> str:
 def _format_setting_value(value: Any) -> str:
     if isinstance(value, bool):
         return "true" if value else "false"
-    if isinstance(value, (int, float)) and not isinstance(value, bool):
+    if isinstance(value, (int, float)):
         return _format_compact_metric(value)
     if isinstance(value, str):
         return value

--- a/verifiers/scripts/tui.py
+++ b/verifiers/scripts/tui.py
@@ -19,6 +19,7 @@ from rich.console import Console, Group
 from rich.table import Table
 from rich.text import Text
 from textual import events, on, work
+from textual.message import Message
 from textual.dom import DOMNode
 from textual.widget import Widget
 from textual.app import App, ComposeResult
@@ -1226,6 +1227,100 @@ class TabbedScrollPane(VerticalScroll):
             tc.query_one(ContentTabs).action_next_tab()
 
 
+class GroupByBar(Widget):
+    """Interactive bar of toggleable axis chips for group-by selection."""
+
+    can_focus = True
+
+    BINDINGS = [
+        Binding("left", "cursor_left", show=False),
+        Binding("right", "cursor_right", show=False),
+        Binding("space,enter", "toggle_chip", show=False),
+        Binding("escape,g", "blur_bar", show=False),
+    ]
+
+    class Changed(Message):
+        def __init__(self, active_keys: List[str]) -> None:
+            super().__init__()
+            self.active_keys = active_keys
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._all_keys: List[str] = []
+        self._active: set[str] = set()
+        self._cursor: int = 0
+        self._chip_ranges: List[Tuple[int, int]] = []
+        self._short_key_fn: Callable[[str], str] = lambda k: k
+
+    def set_keys(self, keys: List[str], short_key_fn: Callable[[str], str]) -> None:
+        self._all_keys = list(keys)
+        self._active: set[str] = set()
+        self._short_key_fn = short_key_fn
+        self._cursor = min(self._cursor, max(0, len(keys) - 1))
+        self.refresh()
+
+    def render(self) -> Text:
+        text = Text()
+        text.append("Group by  ", style="bold dim")
+        if not self._active:
+            text.append("(all)  ", style="dim italic")
+        self._chip_ranges = []
+        for idx, key in enumerate(self._all_keys):
+            if idx:
+                text.append("  ")
+            start = len(text.plain)
+            label = self._short_key_fn(key)
+            is_active = key in self._active
+            is_cursor = idx == self._cursor and self.has_focus
+            if is_active:
+                style = "bold reverse" if is_cursor else "bold"
+                text.append(f"[{label}]", style=style)
+            else:
+                style = "dim reverse" if is_cursor else "dim"
+                text.append(f" {label} ", style=style)
+            end = len(text.plain)
+            self._chip_ranges.append((start, end))
+        if not self._all_keys:
+            text.append("(no varying axes)", style="dim")
+        return text
+
+    def on_click(self, event: events.Click) -> None:
+        x = event.x
+        for idx, (start, end) in enumerate(self._chip_ranges):
+            if start <= x < end:
+                self._cursor = idx
+                self.focus()
+                self._toggle(idx)
+                return
+
+    def action_cursor_left(self) -> None:
+        if self._all_keys:
+            self._cursor = (self._cursor - 1) % len(self._all_keys)
+            self.refresh()
+
+    def action_cursor_right(self) -> None:
+        if self._all_keys:
+            self._cursor = (self._cursor + 1) % len(self._all_keys)
+            self.refresh()
+
+    def action_toggle_chip(self) -> None:
+        if self._all_keys:
+            self._toggle(self._cursor)
+
+    def action_blur_bar(self) -> None:
+        self.screen.focus_next()
+
+    def _toggle(self, idx: int) -> None:
+        key = self._all_keys[idx]
+        if key in self._active:
+            self._active.discard(key)
+        else:
+            self._active.add(key)
+        self.refresh()
+        active_ordered = [k for k in self._all_keys if k in self._active]
+        self.post_message(self.Changed(active_ordered))
+
+
 # ----------------------------
 # Search helpers
 # ----------------------------
@@ -1573,6 +1668,7 @@ class CompareRunsScreen(Screen):
     BINDINGS = [
         Binding("q", "quit", "Quit"),
         Binding("b,backspace", "back", "Back"),
+        Binding("g", "focus_group_by", "Group by"),
         Binding("c", "copy", "Copy"),
         Binding("ctrl+c", "copy", show=False),
     ]
@@ -1583,6 +1679,11 @@ class CompareRunsScreen(Screen):
         self.model = model
         self.runs = list(runs)
         self._stats_by_path: Dict[Path, RunOverviewStats] = {}
+        self._setting_keys: List[str] = []
+        self._run_settings: List[Tuple[RunInfo, Dict[str, str]]] = []
+        self._display_maps: Dict[str, Dict[str, str]] = {}
+        self._style_maps: Dict[str, Dict[str, str]] = {}
+        self._legend_rows: List[Tuple[str, str, str]] = []
 
     def compose(self) -> ComposeResult:
         with Container():
@@ -1590,7 +1691,9 @@ class CompareRunsScreen(Screen):
                 Label(Text("Run Comparison", style="bold"), classes="title"),
                 Static("", id="compare-subtitle", classes="subtitle", markup=False),
                 VerticalScroll(
-                    Static("", id="compare-content", markup=False),
+                    Static("", id="compare-header", markup=False),
+                    GroupByBar(id="group-by-bar"),
+                    Static("", id="compare-outcomes", markup=False),
                     id="compare-scroll",
                     classes="surface-scroll",
                 ),
@@ -1604,12 +1707,19 @@ class CompareRunsScreen(Screen):
         subtitle.append("\n")
         subtitle.append(f"{self.env_id}   {len(self.runs)} runs", style="dim")
         self.query_one("#compare-subtitle", Static).update(subtitle)
-        self.query_one("#compare-content", Static).update(
+        self.query_one("#compare-header", Static).update(
             Text("Loading comparison…", style="dim")
         )
         self._load_comparison_stats()
 
     def action_back(self) -> None:
+        bar = self.query_one("#group-by-bar", GroupByBar)
+        if bar.has_focus or bar._active:
+            bar._active.clear()
+            bar.refresh()
+            bar.post_message(bar.Changed([]))
+            self.query_one("#compare-scroll", VerticalScroll).focus()
+            return
         self.app.pop_screen()
 
     def action_copy(self) -> None:
@@ -1651,14 +1761,43 @@ class CompareRunsScreen(Screen):
         if not self.is_mounted:
             return
         self._stats_by_path = stats_by_path
-        self.query_one("#compare-content", Static).update(
-            self._build_comparison_content(stats_by_path)
+        self._setting_keys, self._run_settings = _varying_run_setting_keys(self.runs)
+        (
+            self._display_maps,
+            self._style_maps,
+            self._legend_rows,
+        ) = self._build_setting_display_maps(self._setting_keys, self._run_settings)
+        bar = self.query_one("#group-by-bar", GroupByBar)
+        bar.set_keys(self._setting_keys, self._short_setting_key)
+        self.query_one("#compare-header", Static).update(
+            self._build_comparison_header()
         )
+        self.query_one("#compare-outcomes", Static).update(
+            self._build_comparison_outcomes(self._setting_keys)
+        )
+
+    def action_focus_group_by(self) -> None:
+        self.query_one("#group-by-bar", GroupByBar).focus()
+
+    def _active_or_all_keys(self, active_keys: List[str]) -> List[str]:
+        return active_keys if active_keys else self._setting_keys
+
+    def on_group_by_bar_changed(self, event: GroupByBar.Changed) -> None:
+        if self._stats_by_path:
+            self.query_one("#compare-outcomes", Static).update(
+                self._build_comparison_outcomes(
+                    self._active_or_all_keys(event.active_keys)
+                )
+            )
 
     def _render_comparison_content(self) -> Any:
         if not self._stats_by_path:
             return Text("Loading comparison…", style="dim")
-        return self._build_comparison_content(self._stats_by_path)
+        bar = self.query_one("#group-by-bar", GroupByBar)
+        active = [k for k in self._setting_keys if k in bar._active]
+        header = self._build_comparison_header()
+        outcomes = self._build_comparison_outcomes(self._active_or_all_keys(active))
+        return Group(header, outcomes)
 
     def _short_setting_key(self, key: str) -> str:
         replacements = {
@@ -1969,38 +2108,37 @@ class CompareRunsScreen(Screen):
             table.add_row(Text(alias, style=style), Text(preview, style="dim"))
         return Group(Text("Value legend", style="bold dim"), table)
 
-    def _build_comparison_content(
-        self, stats_by_path: Dict[Path, RunOverviewStats]
-    ) -> Group:
-        setting_keys, run_settings = _varying_run_setting_keys(self.runs)
-        display_maps, style_maps, legend_rows = self._build_setting_display_maps(
-            setting_keys, run_settings
-        )
+    def _build_comparison_header(self) -> Group:
         summary = Text()
         summary.append("Ablation summary\n", style="bold dim")
         summary.append(self.model, style="bold")
         summary.append("\n")
         summary.append(f"{self.env_id}   {len(self.runs)} runs", style="dim")
-
-        items: List[Any] = [
+        return Group(
             summary,
             Text(""),
             self._build_axes_table(
-                setting_keys, run_settings, display_maps, style_maps
+                self._setting_keys,
+                self._run_settings,
+                self._display_maps,
+                self._style_maps,
             ),
-            Text(""),
+        )
+
+    def _build_comparison_outcomes(self, active_keys: List[str]) -> Group:
+        items: List[Any] = [
             Group(
                 Text("Outcome groups", style="bold dim"),
                 self._build_grouped_outcomes_table(
-                    stats_by_path,
-                    setting_keys,
-                    run_settings,
-                    display_maps,
-                    style_maps,
+                    self._stats_by_path,
+                    active_keys,
+                    self._run_settings,
+                    self._display_maps,
+                    self._style_maps,
                 ),
             ),
         ]
-        legend = self._build_value_legend(legend_rows)
+        legend = self._build_value_legend(self._legend_rows)
         if isinstance(legend, Group) or (isinstance(legend, Text) and legend.plain):
             items.extend([Text(""), legend])
         return Group(*items)
@@ -4202,7 +4340,17 @@ class VerifiersTUI(App):
     .compare-panel {
         height: 1fr;
     }
-    
+
+    GroupByBar {
+        height: auto;
+        margin: 1 0;
+        padding: 0 0;
+    }
+
+    GroupByBar:focus {
+        background-tint: $foreground 4%;
+    }
+
     Footer {
         background: $panel;
     }

--- a/verifiers/scripts/tui.py
+++ b/verifiers/scripts/tui.py
@@ -1729,23 +1729,60 @@ class CompareRunsScreen(Screen):
             return
         self.app.pop_screen()
 
+    @staticmethod
+    def _renderable_to_text(renderable: Any, width: int = 220) -> str:
+        buf = StringIO()
+        Console(file=buf, force_terminal=False, color_system=None, width=width).print(
+            renderable
+        )
+        return buf.getvalue().rstrip()
+
     def action_copy(self) -> None:
-        if not self.runs:
+        if not self._stats_by_path:
             return
-        buffer = StringIO()
-        Console(
-            file=buffer,
-            force_terminal=False,
-            color_system=None,
-            width=220,
-        ).print(self._render_comparison_content())
+        items: List[RolloutCopyItem] = []
+        items.append(
+            RolloutCopyItem(
+                key="summary",
+                label="Summary",
+                body=self._renderable_to_text(self._build_comparison_header()),
+            )
+        )
+        items.append(
+            RolloutCopyItem(
+                key="outcomes",
+                label="Outcome groups",
+                body=self._renderable_to_text(
+                    self._build_grouped_outcomes_table(
+                        self._stats_by_path,
+                        self._setting_keys,
+                        self._run_settings,
+                        self._display_maps,
+                        self._style_maps,
+                        group_by_key=self._grouped_by_key,
+                    )
+                ),
+            )
+        )
+        legend = self._build_value_legend(self._legend_rows)
+        if isinstance(legend, Group) or (isinstance(legend, Text) and legend.plain):
+            items.append(
+                RolloutCopyItem(
+                    key="legend",
+                    label="Value legend",
+                    body=self._renderable_to_text(legend),
+                )
+            )
+        # "All" section combining everything.
+        all_body = "\n\n".join(item.body for item in items)
+        items.insert(
+            0,
+            RolloutCopyItem(key="all", label="All", body=all_body),
+        )
         self.app.push_screen(
-            CopyScreen(
-                f"{self.env_id} / {self.model}",
-                buffer.getvalue().rstrip(),
-                "completion",
-                prompt_label="Selection",
-                completion_label="Comparison",
+            CompactCopyScreen(
+                items,
+                start_key="all",
                 title="Copy Comparison",
             )
         )
@@ -4427,6 +4464,11 @@ class VerifiersTUI(App):
         layout: vertical;
     }
 
+    .compact-copy-body {
+        height: 1fr;
+        layout: vertical;
+    }
+
     .search-input {
         background: $surface;
         color: $text;
@@ -4696,7 +4738,7 @@ class RolloutCopyScreen(ModalScreen[None]):
     """Modal screen for copying rollout viewer sections."""
 
     BINDINGS = [
-        Binding("escape", "close", "Close"),
+        Binding("escape,b,backspace", "close", "Close"),
         Binding("tab", "focus_next_pane", "Next pane"),
         Binding("shift+tab", "focus_prev_pane", show=False),
         Binding("enter", "copy", "Copy"),
@@ -4863,11 +4905,148 @@ class RolloutCopyScreen(ModalScreen[None]):
         self.query_one("#rollout-copy-hint", Label).update(Text(hint, style="dim"))
 
 
+class CompactCopyScreen(ModalScreen[None]):
+    """Compact copy screen with section tabs above a preview area."""
+
+    BINDINGS = [
+        Binding("escape,b,backspace", "close", "Close"),
+        Binding("tab", "next_section", "Next section"),
+        Binding("shift+tab", "prev_section", "Prev section", show=False),
+        Binding("enter", "copy", "Copy"),
+        Binding("c", "copy", "Copy"),
+        Binding("ctrl+c", "copy", show=False),
+    ]
+
+    def __init__(
+        self,
+        items: List[RolloutCopyItem],
+        *,
+        start_key: Optional[str] = None,
+        title: str = "Copy",
+    ):
+        super().__init__()
+        self._items = items
+        self._items_by_key = {item.key: item for item in items}
+        self._title = title
+        self._current_idx = 0
+        if start_key:
+            for i, item in enumerate(items):
+                if item.key == start_key:
+                    self._current_idx = i
+                    break
+        self._last_copied_selection = ""
+
+    def compose(self) -> ComposeResult:
+        with Container():
+            with Panel(classes="modal-header"):
+                yield Label(Text(self._title, style="bold"))
+                yield Label("", id="compact-copy-tabs", classes="copy-hint")
+                yield Label("", id="compact-copy-hint", classes="copy-hint")
+                yield Label("", id="compact-copy-status", classes="subtitle")
+            with Panel(classes="compact-copy-body"):
+                preview = TextArea(
+                    "", id="compact-copy-preview", classes="copy-textarea"
+                )
+                preview.read_only = True
+                yield preview
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self._sync()
+        self.query_one("#compact-copy-preview", TextArea).focus()
+
+    @on(TextArea.SelectionChanged)
+    def _on_selection_changed(self, event: TextArea.SelectionChanged) -> None:
+        if event.text_area.id != "compact-copy-preview":
+            return
+        selected = event.text_area.selected_text or ""
+        if selected and selected != self._last_copied_selection:
+            self.app.copy_to_clipboard(selected)
+            self._last_copied_selection = selected
+            self.query_one("#compact-copy-status", Label).update(
+                Text(f"Copied selection ({len(selected):,} chars).", style="dim")
+            )
+        self._update_hint()
+
+    def action_close(self) -> None:
+        self.dismiss(None)
+
+    def on_key(self, event: events.Key) -> None:
+        if event.key in ("tab", "shift+tab", "backtab"):
+            if event.key == "tab":
+                self.action_next_section()
+            else:
+                self.action_prev_section()
+            event.prevent_default()
+            event.stop()
+
+    def action_prev_section(self) -> None:
+        if self._items:
+            self._current_idx = (self._current_idx - 1) % len(self._items)
+            self._sync()
+
+    def action_next_section(self) -> None:
+        if self._items:
+            self._current_idx = (self._current_idx + 1) % len(self._items)
+            self._sync()
+
+    def action_copy(self) -> None:
+        if not self._items:
+            return
+        item = self._items[self._current_idx]
+        preview = self.query_one("#compact-copy-preview", TextArea)
+        selected = preview.selected_text or ""
+        copied_text = selected or item.body
+        if not copied_text:
+            self.query_one("#compact-copy-status", Label).update(
+                Text("Nothing to copy.", style="dim")
+            )
+            return
+        self.app.copy_to_clipboard(copied_text)
+        self._last_copied_selection = copied_text
+        label = "selection" if selected else item.label.lower()
+        self.query_one("#compact-copy-status", Label).update(
+            Text(f"Copied {label} ({len(copied_text):,} chars).", style="dim")
+        )
+        self._update_hint()
+
+    def _sync(self) -> None:
+        if not self._items:
+            return
+        item = self._items[self._current_idx]
+        # Update tab bar.
+        tabs = Text()
+        for i, it in enumerate(self._items):
+            if i:
+                tabs.append("  ")
+            if i == self._current_idx:
+                tabs.append(f"[{it.label}]", style="bold")
+            else:
+                tabs.append(f" {it.label} ", style="dim")
+        self.query_one("#compact-copy-tabs", Label).update(tabs)
+        # Update preview.
+        preview = self.query_one("#compact-copy-preview", TextArea)
+        preview.load_text(item.body)
+        self._update_hint()
+
+    def _update_hint(self) -> None:
+        if not self._items:
+            return
+        item = self._items[self._current_idx]
+        preview = self.query_one("#compact-copy-preview", TextArea)
+        selected = preview.selected_text or ""
+        if selected:
+            hint = f"Enter/c copies selection ({len(selected):,} chars). Tab switches section."
+        else:
+            hint = f"Enter/c copies {item.label.lower()}. Tab switches section."
+        self.query_one("#compact-copy-hint", Label).update(Text(hint, style="dim"))
+
+
 class CopyScreen(ModalScreen[None]):
     """Modal screen for selecting and copying prompt/completion text."""
 
     BINDINGS = [
-        Binding("escape", "close", "Close"),
+        Binding("escape,b,backspace", "close", "Close"),
         Binding("tab", "cycle_column", "Next column"),
         Binding("shift+tab", "cycle_column", show=False),
         Binding("c", "copy", "Copy"),

--- a/verifiers/scripts/tui.py
+++ b/verifiers/scripts/tui.py
@@ -3343,11 +3343,20 @@ class ViewRunScreen(Screen):
         """Flatten all section bodies (including nested) in DOM order."""
         bodies: List[str] = []
         for section in sections:
-            if section.body or not section.nested_sections:
-                bodies.append(section.body)
-            for nested in section.nested_sections:
-                if nested.body or not nested.nested_sections:
-                    bodies.append(nested.body)
+            parent_body = (
+                [section.body] if section.body or not section.nested_sections else []
+            )
+            nested_bodies = [
+                nested.body
+                for nested in section.nested_sections
+                if nested.body or not nested.nested_sections
+            ]
+            if section.body_first:
+                bodies.extend(parent_body)
+                bodies.extend(nested_bodies)
+            else:
+                bodies.extend(nested_bodies)
+                bodies.extend(parent_body)
         return bodies
 
     def action_toggle_markdown_math(self) -> None:

--- a/verifiers/scripts/tui.py
+++ b/verifiers/scripts/tui.py
@@ -2647,8 +2647,6 @@ class ViewRunScreen(Screen):
         self.records = LazyRunResults(run)
         self._record_count = self.records.count_hint()
         self.current_record_idx = 0
-        self._prompt_lines: List[str] = []
-        self._completion_lines: List[str] = []
         self._prompt_text: str = ""
         self._completion_text: str = ""
         self._highlight_regex: Optional[re.Pattern] = None
@@ -3045,8 +3043,6 @@ class ViewRunScreen(Screen):
 
         self._prompt_text = prompt_text.plain
         self._completion_text = completion_text.plain
-        self._prompt_lines = prompt_text.plain.split("\n")
-        self._completion_lines = completion_text.plain.split("\n")
 
     def update_display(self, *, focus_history: bool = False) -> None:
         if not self.records:

--- a/verifiers/scripts/tui.py
+++ b/verifiers/scripts/tui.py
@@ -70,6 +70,14 @@ def _binding_key(binding: TreeBinding) -> str:
     return binding[0]
 
 
+def _int_like_sort_key(value: Any) -> Tuple[int, int, str]:
+    text = str(value)
+    try:
+        return (0, int(text), text)
+    except (TypeError, ValueError):
+        return (1, 0, text)
+
+
 # ----------------------------
 # Discovery and data loading
 # ----------------------------
@@ -583,6 +591,235 @@ def _pretty_json_or_str(value: Any) -> str:
         return str(value)
 
 
+def _compact_json_or_str(value: Any) -> str:
+    try:
+        return json.dumps(value, ensure_ascii=False, sort_keys=True)
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def _format_setting_value(value: Any) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return _format_compact_metric(value)
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        if not value:
+            return "[]"
+        if all(
+            isinstance(item, (str, int, float, bool)) and not isinstance(item, dict)
+            for item in value
+        ):
+            return ", ".join(_format_setting_value(item) for item in value)
+    return _compact_json_or_str(value)
+
+
+def _tool_name(tool: Any) -> str:
+    if not isinstance(tool, dict):
+        return str(getattr(tool, "name", "") or "")
+    function = tool.get("function")
+    if isinstance(function, dict):
+        name = function.get("name")
+        if isinstance(name, str):
+            return name
+    name = tool.get("name")
+    return name if isinstance(name, str) else ""
+
+
+def _run_setting_rows(meta: Dict[str, Any]) -> List[Tuple[str, str]]:
+    rows: List[Tuple[str, str]] = []
+
+    ordered_settings: List[Tuple[str, Any]] = []
+    if meta.get("base_url") not in (None, ""):
+        ordered_settings.append(("endpoint", meta["base_url"]))
+    if meta.get("num_examples") not in (None, ""):
+        ordered_settings.append(("examples", meta["num_examples"]))
+    if meta.get("rollouts_per_example") not in (None, ""):
+        ordered_settings.append(("rollouts/example", meta["rollouts_per_example"]))
+    if meta.get("pass_threshold") not in (None, ""):
+        ordered_settings.append(("pass threshold", meta["pass_threshold"]))
+
+    sampling_args = meta.get("sampling_args")
+    if isinstance(sampling_args, dict):
+        for key in sorted(sampling_args):
+            value = sampling_args[key]
+            if value not in (None, ""):
+                ordered_settings.append((f"sampling.{key}", value))
+
+    env_args = meta.get("env_args")
+    if isinstance(env_args, dict):
+        for key in sorted(env_args):
+            value = env_args[key]
+            if value not in (None, ""):
+                ordered_settings.append((f"env.{key}", value))
+
+    state_columns = meta.get("state_columns")
+    if isinstance(state_columns, list) and state_columns:
+        ordered_settings.append(("state columns", state_columns))
+
+    tools = meta.get("tools")
+    if isinstance(tools, list):
+        tool_names = sorted(
+            name for name in (_tool_name(tool) for tool in tools) if name
+        )
+        if tool_names:
+            ordered_settings.append(("tools", tool_names))
+
+    for label, value in ordered_settings:
+        rows.append((label, _format_setting_value(value)))
+
+    return rows
+
+
+def _build_settings_table(
+    rows: List[Tuple[str, str]],
+    heading: str,
+    *,
+    value_header: str = "Value",
+) -> Group | Text:
+    if not rows:
+        return Text()
+
+    title = Text()
+    title.append(heading, style="bold dim")
+
+    table = Table(
+        box=box.SIMPLE_HEAD,
+        expand=True,
+        show_edge=False,
+        pad_edge=False,
+        padding=(0, 1),
+        collapse_padding=True,
+        row_styles=["none", "dim"],
+    )
+    table.add_column("Setting", style="dim", width=20, no_wrap=True)
+    table.add_column(value_header, ratio=1)
+
+    for setting, value in rows:
+        table.add_row(setting, value)
+
+    return Group(title, table)
+
+
+def _run_setting_variation_rows(
+    runs: List[RunInfo], *, max_rows: int = 8
+) -> Tuple[List[Tuple[str, str]], int]:
+    if not runs:
+        return [], 0
+
+    setting_maps = [dict(_run_setting_rows(run.load_metadata())) for run in runs]
+
+    ordered_keys: List[str] = []
+    for setting_map in setting_maps:
+        for key in setting_map:
+            if key not in ordered_keys:
+                ordered_keys.append(key)
+
+    rows: List[Tuple[str, str]] = []
+    for key in ordered_keys:
+        counts: Dict[str, int] = defaultdict(int)
+        for setting_map in setting_maps:
+            counts[setting_map.get(key, "(unset)")] += 1
+        if len(counts) <= 1:
+            continue
+        parts = [
+            f"{value} ({count} run{'s' if count != 1 else ''})"
+            for value, count in sorted(
+                counts.items(),
+                key=lambda item: (-item[1], item[0]),
+            )
+        ]
+        rows.append((key, ", ".join(parts)))
+
+    hidden_rows = max(0, len(rows) - max_rows)
+    return rows[:max_rows], hidden_rows
+
+
+def _varying_run_setting_keys(
+    runs: List[RunInfo],
+) -> Tuple[List[str], List[Tuple[RunInfo, Dict[str, str]]]]:
+    if not runs:
+        return [], []
+
+    run_settings = [(run, dict(_run_setting_rows(run.load_metadata()))) for run in runs]
+    ordered_keys: List[str] = []
+    for _, settings in run_settings:
+        for key in settings:
+            if key not in ordered_keys:
+                ordered_keys.append(key)
+
+    if len(run_settings) == 1:
+        return ordered_keys, run_settings
+
+    varying_keys = [
+        key
+        for key in ordered_keys
+        if len({settings.get(key, "(unset)") for _, settings in run_settings}) > 1
+    ]
+    return varying_keys, run_settings
+
+
+def _reward_bucket_counts(values: List[float]) -> List[Tuple[str, int, str]]:
+    bucket_counts = [
+        ("=0", 0, "bold red"),
+        ("0-<0.25", 0, "red"),
+        ("0.25-<0.5", 0, "yellow"),
+        ("0.5-<0.75", 0, "yellow"),
+        ("0.75-<1", 0, "green"),
+        ("=1", 0, "bold green"),
+    ]
+
+    for reward in values:
+        if reward <= 0:
+            bucket_idx = 0
+        elif reward < 0.25:
+            bucket_idx = 1
+        elif reward < 0.5:
+            bucket_idx = 2
+        elif reward < 0.75:
+            bucket_idx = 3
+        elif reward < 1.0:
+            bucket_idx = 4
+        else:
+            bucket_idx = 5
+        label, count, style = bucket_counts[bucket_idx]
+        bucket_counts[bucket_idx] = (label, count + 1, style)
+
+    return bucket_counts
+
+
+def _build_reward_share_bars(values: List[float], bar_width: int = 16) -> Text:
+    if not values:
+        return Text("No rollout rewards", style="dim")
+
+    total = len(values)
+    out = Text()
+    for idx, (label, count, style) in enumerate(_reward_bucket_counts(values)):
+        share = count / total if total else 0.0
+        filled = round(max(0.0, min(1.0, share)) * bar_width)
+        if idx:
+            out.append("\n")
+        out.append(f"{label:<9}", style="dim")
+        if filled:
+            out.append("█" * filled, style=style)
+        if filled < bar_width:
+            out.append("░" * (bar_width - filled), style="dim")
+        out.append(f" {share:>4.0%}")
+    return out
+
+
+_COMPARE_ALIAS_PALETTE: Tuple[str, ...] = (
+    "#61afef",
+    "#98c379",
+    "#e5c07b",
+    "#c678dd",
+    "#56b6c2",
+    "#e06c75",
+)
+
+
 def _tool_call_parts(tool_call: Any) -> Tuple[str, str, Optional[str]]:
     if not isinstance(tool_call, dict):
         return str(tool_call), "", None
@@ -756,18 +993,7 @@ def _build_reward_distribution_table(values: List[float], heading: str) -> Group
     summary.append("   max ", style="bold")
     summary.append(f"{max(values):.3f}", style=_reward_style(max(values)))
 
-    buckets = [
-        ("<0", lambda reward: reward < 0, "bold red"),
-        ("0-0.25", lambda reward: 0 <= reward < 0.25, "red"),
-        ("0.25-0.5", lambda reward: 0.25 <= reward < 0.5, "yellow"),
-        ("0.5-0.75", lambda reward: 0.5 <= reward < 0.75, "yellow"),
-        ("0.75-1.0", lambda reward: 0.75 <= reward < 1.0, "green"),
-        (">=1.0", lambda reward: reward >= 1.0, "bold green"),
-    ]
-    bucket_counts = [
-        (label, sum(1 for reward in values if predicate(reward)), style)
-        for label, predicate, style in buckets
-    ]
+    bucket_counts = _reward_bucket_counts(values)
     peak_count = max(count for _, count, _ in bucket_counts) or 1
 
     table = Table(
@@ -1313,6 +1539,445 @@ class MathMarkdown(BaseMarkdown):
 # ----------------------------
 # Screens
 # ----------------------------
+class CompareRunsScreen(Screen):
+    """Dedicated comparison view for runs from a single model."""
+
+    BINDINGS = [
+        Binding("q", "quit", "Quit"),
+        Binding("b,backspace", "back", "Back"),
+        Binding("c", "copy", "Copy"),
+        Binding("ctrl+c", "copy", show=False),
+    ]
+
+    def __init__(self, env_id: str, model: str, runs: List[RunInfo]):
+        super().__init__()
+        self.env_id = env_id
+        self.model = model
+        self.runs = list(runs)
+        self._stats_by_path: Dict[Path, RunOverviewStats] = {}
+
+    def compose(self) -> ComposeResult:
+        with Container():
+            yield Panel(
+                Label(Text("Run Comparison", style="bold"), classes="title"),
+                Static("", id="compare-subtitle", classes="subtitle", markup=False),
+                VerticalScroll(
+                    Static("", id="compare-content", markup=False),
+                    id="compare-scroll",
+                    classes="surface-scroll",
+                ),
+                classes="compare-panel",
+            )
+        yield Footer()
+
+    def on_mount(self) -> None:
+        subtitle = Text()
+        subtitle.append(self.model, style="bold")
+        subtitle.append("\n")
+        subtitle.append(f"{self.env_id}   {len(self.runs)} runs", style="dim")
+        self.query_one("#compare-subtitle", Static).update(subtitle)
+        self.query_one("#compare-content", Static).update(
+            Text("Loading comparison…", style="dim")
+        )
+        self._load_comparison_stats()
+
+    def action_back(self) -> None:
+        self.app.pop_screen()
+
+    def action_copy(self) -> None:
+        if not self.runs:
+            return
+        buffer = StringIO()
+        Console(
+            file=buffer,
+            force_terminal=False,
+            color_system=None,
+            width=220,
+        ).print(self._render_comparison_content())
+        self.app.push_screen(
+            CopyScreen(
+                f"{self.env_id} / {self.model}",
+                buffer.getvalue().rstrip(),
+                "completion",
+                prompt_label="Selection",
+                completion_label="Comparison",
+                title="Copy Comparison",
+            )
+        )
+
+    @work(
+        thread=True,
+        group="run-comparison",
+        exclusive=True,
+        exit_on_error=False,
+    )
+    def _load_comparison_stats(self) -> None:
+        stats_by_path = {
+            run.path: _compute_run_overview_stats(run) for run in self.runs
+        }
+        self.app.call_from_thread(self._finish_loading_comparison_stats, stats_by_path)
+
+    def _finish_loading_comparison_stats(
+        self, stats_by_path: Dict[Path, RunOverviewStats]
+    ) -> None:
+        if not self.is_mounted:
+            return
+        self._stats_by_path = stats_by_path
+        self.query_one("#compare-content", Static).update(
+            self._build_comparison_content(stats_by_path)
+        )
+
+    def _render_comparison_content(self) -> Any:
+        if not self._stats_by_path:
+            return Text("Loading comparison…", style="dim")
+        return self._build_comparison_content(self._stats_by_path)
+
+    def _short_setting_key(self, key: str) -> str:
+        replacements = {
+            "rollouts/example": "r/ex",
+            "sampling.": "",
+            "env.": "",
+        }
+        short = key
+        for source, target in replacements.items():
+            short = short.replace(source, target)
+        return short
+
+    def _alias_style(self, label: str) -> str:
+        match = re.fullmatch(r"v(\d+)", label)
+        if match is None:
+            return ""
+        alias_idx = int(match.group(1)) - 1
+        return f"bold {_COMPARE_ALIAS_PALETTE[alias_idx % len(_COMPARE_ALIAS_PALETTE)]}"
+
+    def _share_style(self, share: float, positive: bool) -> str:
+        if share <= 0:
+            return "dim"
+        if positive:
+            return "bold green" if share >= 0.5 else "green"
+        return "bold red" if share >= 0.5 else "red"
+
+    def _build_setting_display_maps(
+        self,
+        setting_keys: List[str],
+        run_settings: List[Tuple[RunInfo, Dict[str, str]]],
+    ) -> Tuple[
+        Dict[str, Dict[str, str]],
+        Dict[str, Dict[str, str]],
+        List[Tuple[str, str, str]],
+    ]:
+        display_maps: Dict[str, Dict[str, str]] = {}
+        style_maps: Dict[str, Dict[str, str]] = {}
+        legend_rows: List[Tuple[str, str, str]] = []
+
+        for key in setting_keys:
+            ordered_values: List[str] = []
+            for _, settings in run_settings:
+                value = settings.get(key, "(unset)")
+                if value not in ordered_values:
+                    ordered_values.append(value)
+
+            previews = [
+                _truncate_preview(" ".join(value.split()), 20)
+                for value in ordered_values
+            ]
+            needs_alias = len(set(previews)) != len(previews) or any(
+                len(" ".join(value.split())) > 20 for value in ordered_values
+            )
+
+            if needs_alias:
+                display_maps[key] = {}
+                style_maps[key] = {}
+                for idx, value in enumerate(ordered_values):
+                    alias = f"v{idx + 1}"
+                    display_maps[key][value] = alias
+                    style_maps[key][value] = self._alias_style(alias)
+                    legend_rows.append(
+                        (
+                            f"{self._short_setting_key(key)} {alias}",
+                            _truncate_preview(" ".join(value.split()), 120),
+                            style_maps[key][value],
+                        )
+                    )
+                continue
+
+            display_maps[key] = {
+                value: preview for value, preview in zip(ordered_values, previews)
+            }
+            style_maps[key] = {value: "" for value in ordered_values}
+
+        return display_maps, style_maps, legend_rows
+
+    def _build_reward_mix_bar(self, values: List[float], width: int = 18) -> Text:
+        if not values:
+            return Text("—", style="dim")
+
+        counts = _reward_bucket_counts(values)
+        total = len(values)
+        raw_widths = [
+            (count / total) * width if total else 0.0 for _, count, _ in counts
+        ]
+        segment_widths = [int(raw) for raw in raw_widths]
+        used = sum(segment_widths)
+
+        remainders = sorted(
+            [
+                (raw - int(raw), idx)
+                for idx, ((_, count, _), raw) in enumerate(zip(counts, raw_widths))
+                if count > 0
+            ],
+            reverse=True,
+        )
+        for _, idx in remainders:
+            if used >= width:
+                break
+            segment_widths[idx] += 1
+            used += 1
+
+        out = Text()
+        for (_, count, style), segment_width in zip(counts, segment_widths):
+            if count <= 0 or segment_width <= 0:
+                continue
+            out.append("█" * segment_width, style=style)
+        if used < width:
+            out.append("░" * (width - used), style="dim")
+        return out
+
+    def _build_axes_table(
+        self,
+        setting_keys: List[str],
+        run_settings: List[Tuple[RunInfo, Dict[str, str]]],
+        display_maps: Dict[str, Dict[str, str]],
+        style_maps: Dict[str, Dict[str, str]],
+    ) -> Group | Text:
+        if not setting_keys:
+            return Text("All saved settings match across these runs", style="dim")
+
+        table = Table(
+            box=box.SIMPLE_HEAD,
+            expand=True,
+            show_edge=False,
+            pad_edge=False,
+            padding=(0, 1),
+            collapse_padding=True,
+            row_styles=["none", "dim"],
+        )
+        table.add_column(
+            "Axis", style="bold", header_style="bold dim", width=18, no_wrap=True
+        )
+        table.add_column("Values", header_style="bold dim", ratio=1)
+
+        for key in setting_keys:
+            counts: Dict[str, int] = defaultdict(int)
+            ordered_values: List[str] = []
+            for _, settings in run_settings:
+                value = settings.get(key, "(unset)")
+                counts[value] += 1
+                if value not in ordered_values:
+                    ordered_values.append(value)
+
+            value_text = Text()
+            for idx, value in enumerate(ordered_values):
+                if idx:
+                    value_text.append("   ")
+                label = display_maps[key][value]
+                value_text.append(label, style=style_maps[key][value] or "")
+                value_text.append(f" ({counts[value]})", style="dim")
+            axis_label = Text(self._short_setting_key(key), style="bold")
+            table.add_row(axis_label, value_text)
+
+        return Group(Text("Ablation axes", style="bold dim"), table)
+
+    def _build_grouped_outcomes_table(
+        self,
+        stats_by_path: Dict[Path, RunOverviewStats],
+        setting_keys: List[str],
+        run_settings: List[Tuple[RunInfo, Dict[str, str]]],
+        display_maps: Dict[str, Dict[str, str]],
+        style_maps: Dict[str, Dict[str, str]],
+    ) -> Table:
+        grouped: Dict[Tuple[str, ...], Dict[str, Any]] = {}
+
+        for run, settings in run_settings:
+            group_key = tuple(settings.get(key, "(unset)") for key in setting_keys)
+            group = grouped.setdefault(
+                group_key,
+                {"runs": [], "rewards": [], "avg_rewards": []},
+            )
+            cast(List[RunInfo], group["runs"]).append(run)
+            stats = stats_by_path.get(run.path, RunOverviewStats([], []))
+            if stats.rewards:
+                cast(List[float], group["rewards"]).extend(stats.rewards)
+            avg_reward = _numeric_reward(run.load_metadata().get("avg_reward"))
+            if avg_reward is not None:
+                cast(List[float], group["avg_rewards"]).append(avg_reward)
+
+        rows = list(grouped.items())
+        rows.sort(
+            key=lambda item: (
+                -(
+                    sum(cast(List[float], item[1]["rewards"]))
+                    / len(cast(List[float], item[1]["rewards"]))
+                    if cast(List[float], item[1]["rewards"])
+                    else (
+                        sum(cast(List[float], item[1]["avg_rewards"]))
+                        / len(cast(List[float], item[1]["avg_rewards"]))
+                        if cast(List[float], item[1]["avg_rewards"])
+                        else float("-inf")
+                    )
+                ),
+                -len(cast(List[RunInfo], item[1]["runs"])),
+            )
+        )
+
+        table = Table(
+            box=box.SIMPLE_HEAD,
+            expand=True,
+            show_edge=False,
+            pad_edge=False,
+            padding=(0, 1),
+            collapse_padding=True,
+            row_styles=["none", "dim"],
+        )
+        for key in setting_keys:
+            table.add_column(
+                self._short_setting_key(key),
+                header_style="bold dim",
+                ratio=1,
+                no_wrap=True,
+            )
+        table.add_column("runs", justify="right", width=5, header_style="bold dim")
+        table.add_column("avg", justify="right", width=7, header_style="bold #e5c07b")
+        table.add_column("=0", justify="right", width=5, header_style="bold red")
+        table.add_column("=1", justify="right", width=5, header_style="bold green")
+        table.add_column("mix", width=20, header_style="bold dim")
+        table.add_column("ids", ratio=1, header_style="bold dim")
+
+        for raw_values, group in rows:
+            rewards = cast(List[float], group["rewards"])
+            avg_rewards = cast(List[float], group["avg_rewards"])
+            avg_reward = (
+                (sum(rewards) / len(rewards))
+                if rewards
+                else ((sum(avg_rewards) / len(avg_rewards)) if avg_rewards else None)
+            )
+            total = len(rewards)
+            zero_count = next(
+                (
+                    count
+                    for label, count, _ in _reward_bucket_counts(rewards)
+                    if label == "=0"
+                ),
+                0,
+            )
+            one_count = next(
+                (
+                    count
+                    for label, count, _ in _reward_bucket_counts(rewards)
+                    if label == "=1"
+                ),
+                0,
+            )
+            run_ids = ", ".join(
+                run.run_id for run in cast(List[RunInfo], group["runs"])[:3]
+            )
+            hidden_ids = max(0, len(cast(List[RunInfo], group["runs"])) - 3)
+            if hidden_ids:
+                run_ids += f" +{hidden_ids}"
+
+            table.add_row(
+                *(
+                    Text(
+                        display_maps[key][raw_value],
+                        style=style_maps[key][raw_value] or "",
+                    )
+                    for key, raw_value in zip(setting_keys, raw_values)
+                ),
+                str(len(cast(List[RunInfo], group["runs"]))),
+                Text(
+                    _format_reward_value(avg_reward) if avg_reward is not None else "—",
+                    style=_reward_style(avg_reward)
+                    if avg_reward is not None
+                    else "dim",
+                ),
+                Text(
+                    f"{(zero_count / total):.0%}" if total else "—",
+                    style=self._share_style(
+                        (zero_count / total) if total else 0.0, False
+                    ),
+                ),
+                Text(
+                    f"{(one_count / total):.0%}" if total else "—",
+                    style=self._share_style(
+                        (one_count / total) if total else 0.0, True
+                    ),
+                ),
+                self._build_reward_mix_bar(rewards),
+                Text(run_ids or "—", style="dim"),
+            )
+
+        return table
+
+    def _build_value_legend(
+        self, legend_rows: List[Tuple[str, str, str]]
+    ) -> Group | Text:
+        if not legend_rows:
+            return Text()
+
+        table = Table(
+            box=box.SIMPLE_HEAD,
+            expand=True,
+            show_edge=False,
+            pad_edge=False,
+            padding=(0, 1),
+            collapse_padding=True,
+            row_styles=["none", "dim"],
+        )
+        table.add_column(
+            "Alias", style="bold", header_style="bold dim", width=18, no_wrap=True
+        )
+        table.add_column("Preview", header_style="bold dim", ratio=1)
+        for alias, preview, style in legend_rows:
+            table.add_row(Text(alias, style=style), Text(preview, style="dim"))
+        return Group(Text("Value legend", style="bold dim"), table)
+
+    def _build_comparison_content(
+        self, stats_by_path: Dict[Path, RunOverviewStats]
+    ) -> Group:
+        setting_keys, run_settings = _varying_run_setting_keys(self.runs)
+        display_maps, style_maps, legend_rows = self._build_setting_display_maps(
+            setting_keys, run_settings
+        )
+        summary = Text()
+        summary.append("Ablation summary\n", style="bold dim")
+        summary.append(self.model, style="bold")
+        summary.append("\n")
+        summary.append(f"{self.env_id}   {len(self.runs)} runs", style="dim")
+
+        items: List[Any] = [
+            summary,
+            Text(""),
+            self._build_axes_table(
+                setting_keys, run_settings, display_maps, style_maps
+            ),
+            Text(""),
+            Group(
+                Text("Outcome groups", style="bold dim"),
+                self._build_grouped_outcomes_table(
+                    stats_by_path,
+                    setting_keys,
+                    run_settings,
+                    display_maps,
+                    style_maps,
+                ),
+            ),
+        ]
+        legend = self._build_value_legend(legend_rows)
+        if isinstance(legend, Group) or (isinstance(legend, Text) and legend.plain):
+            items.extend([Text(""), legend])
+        return Group(*items)
+
+
 class BrowseRunsScreen(Screen):
     """Single-screen browser for environments, models, and runs."""
 
@@ -1320,6 +1985,7 @@ class BrowseRunsScreen(Screen):
         Binding("q", "quit", "Quit"),
         Binding("tab", "focus_next_pane", "Next pane"),
         Binding("shift+tab", "focus_prev_pane", show=False),
+        Binding("v", "compare_selected", "Compare"),
         Binding("c", "copy", "Copy"),
         Binding("ctrl+c", "copy", show=False),
     ]
@@ -1396,6 +2062,25 @@ class BrowseRunsScreen(Screen):
                 title="Copy Details",
             )
         )
+
+    def action_compare_selected(self) -> None:
+        tree = self.query_one("#run-browser-tree", Tree)
+        payload = getattr(getattr(tree, "cursor_node", None), "data", None)
+        if not isinstance(payload, BrowserNodeData):
+            return
+
+        env_id = payload.env_id
+        model = payload.model
+        if payload.kind == "run" and payload.run is not None:
+            env_id = payload.run.env_id
+            model = payload.run.model
+        elif payload.kind != "model":
+            return
+
+        runs = _sorted_runs(self.index.get(env_id, {}).get(model, []))
+        if not runs:
+            return
+        self.app.push_screen(CompareRunsScreen(env_id, model, runs))
 
     def _populate_tree(self, tree: Tree) -> Any:
         root = tree.root
@@ -1645,6 +2330,36 @@ class BrowseRunsScreen(Screen):
                 recent.append("\n")
             items.extend([Text(""), recent])
 
+            variation_rows, hidden_variations = _run_setting_variation_rows(runs)
+            if variation_rows:
+                items.extend(
+                    [
+                        Text(""),
+                        _build_settings_table(
+                            variation_rows,
+                            "Setting variations",
+                            value_header="Across runs",
+                        ),
+                    ]
+                )
+                if hidden_variations:
+                    items.extend(
+                        [
+                            Text(""),
+                            Text(
+                                f"{hidden_variations} more varied settings not shown",
+                                style="dim",
+                            ),
+                        ]
+                    )
+
+            items.extend(
+                [
+                    Text(""),
+                    Text("Press v to open compare mode for these runs", style="dim"),
+                ]
+            )
+
         return Group(*items)
 
     def _build_run_details(
@@ -1654,6 +2369,7 @@ class BrowseRunsScreen(Screen):
     ) -> Group:
         meta = run.load_metadata()
         rewards = stats.rewards if stats is not None else []
+        setting_rows = _run_setting_rows(meta)
 
         summary = Text()
         summary.append("Run\n", style="bold dim")
@@ -1687,7 +2403,7 @@ class BrowseRunsScreen(Screen):
             values = meta.get(key)
             if isinstance(values, dict):
                 for bucket, value in sorted(
-                    values.items(), key=lambda item: str(item[0])
+                    values.items(), key=lambda item: _int_like_sort_key(item[0])
                 ):
                     numeric = _numeric_reward(value)
                     if numeric is None:
@@ -1705,6 +2421,13 @@ class BrowseRunsScreen(Screen):
                 pass_rate_text.append(f"{value:.3f}", style=_reward_style(value))
 
         items: List[Any] = [summary, Text("")]
+        if setting_rows:
+            items.extend(
+                [
+                    _build_settings_table(setting_rows, "Run settings"),
+                    Text(""),
+                ]
+            )
         if stats is None:
             loading = Text("Loading rollout metrics…", style="dim")
             loading.append(
@@ -1884,7 +2607,7 @@ class ViewRunScreen(Screen):
         return Text("\n").join(lines)
 
     def _build_history_summary_text(
-        self, record: Dict[str, Any], *, include_hints: bool = True
+        self, record: Dict[str, Any], *, include_hints: bool = False
     ) -> Text:
         completion = record.get("completion")
         if not isinstance(completion, list) or not completion:
@@ -1907,15 +2630,6 @@ class ViewRunScreen(Screen):
             ("  ", ""),
             (f"{user_messages} user turns", "dim"),
         ]
-        if include_hints:
-            parts.extend(
-                [
-                    ("  ", ""),
-                    ("Enter toggles", "dim"),
-                    ("  ", ""),
-                    ("PgUp/PgDn scroll", "dim"),
-                ]
-            )
         return Text.assemble(*parts)
 
     def _build_header_metric_text(self) -> Text:
@@ -1924,12 +2638,12 @@ class ViewRunScreen(Screen):
 
         pass_at_k = meta.get("pass_at_k")
         if isinstance(pass_at_k, dict):
-            for key in sorted(pass_at_k.keys(), key=lambda item: str(item)):
+            for key in sorted(pass_at_k.keys(), key=_int_like_sort_key):
                 stats.append((f"pass@{key}", pass_at_k[key]))
 
         pass_all_k = meta.get("pass_all_k")
         if isinstance(pass_all_k, dict):
-            for key in sorted(pass_all_k.keys(), key=lambda item: str(item)):
+            for key in sorted(pass_all_k.keys(), key=_int_like_sort_key):
                 stats.append((f"pass-all@{key}", pass_all_k[key]))
 
         avg_metrics = meta.get("avg_metrics")
@@ -3324,13 +4038,23 @@ class VerifiersTUI(App):
         margin-right: 8;
     }
 
+    #compare-scroll {
+        padding: 0 1 0 2;
+        scrollbar-size-vertical: 2;
+        scrollbar-gutter: stable;
+    }
+
+    #compare-content {
+        margin-right: 8;
+    }
+
     .browser-columns {
         height: 1fr;
         layout: horizontal;
     }
 
     .browser-tree-panel {
-        width: 48;
+        width: 56;
         height: 1fr;
         layout: vertical;
     }
@@ -3349,6 +4073,10 @@ class VerifiersTUI(App):
     .browser-details-panel {
         height: 1fr;
         width: 1fr;
+    }
+
+    .compare-panel {
+        height: 1fr;
     }
     
     Footer {

--- a/verifiers/scripts/tui.py
+++ b/verifiers/scripts/tui.py
@@ -2868,8 +2868,8 @@ class ViewRunScreen(Screen):
         self._previous_animation_level = app.animation_level
         app.animation_level = "none"
         self._populate_rollout_list()
-        self.query_one("#rollout-list", OptionList).focus()
         self.update_display()
+        self.call_after_refresh(self._focus_primary_content)
         self._update_responsive_layout(self.size.width)
 
     def on_resize(self, event: events.Resize) -> None:

--- a/verifiers/scripts/tui.py
+++ b/verifiers/scripts/tui.py
@@ -19,6 +19,8 @@ from rich.console import Console, Group
 from rich.table import Table
 from rich.text import Text
 from textual import events, on, work
+from textual.dom import DOMNode
+from textual.widget import Widget
 from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.content import Content, Span
@@ -3013,11 +3015,34 @@ class ViewRunScreen(Screen):
             section.collapsed = True
         self._focus_primary_content(prefer_expanded=False)
 
+    def _should_skip_focus(self, widget: Widget) -> bool:
+        """Return True for widgets that should be skipped during tab cycling."""
+        # Skip the scroll container itself — only its children should get focus.
+        if widget.id == "completion-scroll":
+            return True
+        # Skip widgets inside hidden (compact-layout) panels.
+        node: DOMNode | None = widget
+        while node is not None:
+            if isinstance(node, Panel) and not node.display:
+                return True
+            node = node.parent
+        return False
+
     def action_focus_next_pane(self) -> None:
+        starting = self.focused
         self.focus_next()
+        while self.focused is not None and self.focused is not starting:
+            if not self._should_skip_focus(self.focused):
+                break
+            self.focus_next()
 
     def action_focus_prev_pane(self) -> None:
+        starting = self.focused
         self.focus_previous()
+        while self.focused is not None and self.focused is not starting:
+            if not self._should_skip_focus(self.focused):
+                break
+            self.focus_previous()
 
     def action_history_page_up(self) -> None:
         self.query_one("#completion-scroll", VerticalScroll).scroll_page_up(

--- a/verifiers/scripts/tui.py
+++ b/verifiers/scripts/tui.py
@@ -3257,12 +3257,10 @@ class ViewRunScreen(Screen):
                 result.extend(parent)
         return result
 
-    def action_toggle_markdown_math(self) -> None:
-        self._render_markdown_math = not self._render_markdown_math
+    def _swap_section_bodies(self) -> None:
+        """Re-render all .section-body widgets in-place (preserves collapsed state)."""
         if not (self.records and self.is_mounted):
             return
-        # Swap each .section-body widget in-place, preserving collapsed
-        # state, scroll position, and focus.
         record = self.records[self.current_record_idx]
         section_data = self._history_section_data(record)
         body_entries = self._collect_section_bodies(section_data)
@@ -3276,6 +3274,10 @@ class ViewRunScreen(Screen):
             replacement = self._make_body_widget(body, column)
             parent.mount(replacement, after=body_widget)
             body_widget.remove()
+
+    def action_toggle_markdown_math(self) -> None:
+        self._render_markdown_math = not self._render_markdown_math
+        self._swap_section_bodies()
 
     def _handle_search_result(self, result: Optional[SearchResult]) -> None:
         if result is not None:
@@ -3307,24 +3309,11 @@ class ViewRunScreen(Screen):
             )
 
         if repaint and self.is_mounted and (had_highlight or result is not None):
-            # Swap body widgets in place to apply or remove highlight
-            # styling without rebuilding (preserves collapsed state).
-            record = self.records[self.current_record_idx]
-            section_data = self._history_section_data(record)
-            body_entries = self._collect_section_bodies(section_data)
-            container = self.query_one("#completion-scroll", VerticalScroll)
-            body_widgets = list(container.query(".section-body"))
-            for i, widget in enumerate(body_widgets):
-                parent = widget.parent
-                if not isinstance(parent, Widget) or i >= len(body_entries):
-                    continue
-                body, column = body_entries[i]
-                replacement = self._make_body_widget(body, column)
-                parent.mount(replacement, after=widget)
-                widget.remove()
+            self._swap_section_bodies()
 
             # For new searches, expand the target section and scroll to it.
             if result is not None:
+                container = self.query_one("#completion-scroll", VerticalScroll)
                 self._expand_and_scroll_to_match(container)
 
     def _build_rollout_summary_text(self, record: Dict[str, Any]) -> Text:

--- a/verifiers/scripts/tui.py
+++ b/verifiers/scripts/tui.py
@@ -54,6 +54,7 @@ from textual.widgets._markdown import (
     MarkdownTH,
 )
 from textual.widgets._option_list import Option
+from textual.widgets._tabbed_content import ContentTabs
 from textual.widgets._tree import TreeNode
 
 from verifiers.utils.display_utils import format_numeric
@@ -1196,6 +1197,33 @@ class Panel(Container):
     """A rounded panel container."""
 
     pass
+
+
+class TabbedScrollPane(VerticalScroll):
+    """A VerticalScroll that switches sibling tabs with left/right arrows."""
+
+    BINDINGS = [
+        Binding("left", "prev_tab", "Prev tab", show=False),
+        Binding("right", "next_tab", "Next tab", show=False),
+    ]
+
+    def _get_tabbed_content(self) -> TabbedContent | None:
+        node = self.parent
+        while node is not None:
+            if isinstance(node, TabbedContent):
+                return node
+            node = node.parent
+        return None
+
+    def action_prev_tab(self) -> None:
+        tc = self._get_tabbed_content()
+        if tc is not None:
+            tc.query_one(ContentTabs).action_previous_tab()
+
+    def action_next_tab(self) -> None:
+        tc = self._get_tabbed_content()
+        if tc is not None:
+            tc.query_one(ContentTabs).action_next_tab()
 
 
 # ----------------------------
@@ -2545,22 +2573,22 @@ class ViewRunScreen(Screen):
                     yield Label(Text("Details", style="bold"), classes="column-header")
                     with TabbedContent(initial="details-task", id="details-tabs"):
                         with TabPane("Task", id="details-task"):
-                            yield VerticalScroll(
+                            yield TabbedScrollPane(
                                 Static("", id="task-content", markup=False),
                                 classes="details-scroll surface-scroll",
                             )
                         with TabPane("Score", id="details-score"):
-                            yield VerticalScroll(
+                            yield TabbedScrollPane(
                                 Static("", id="score-content", markup=False),
                                 classes="details-scroll surface-scroll",
                             )
                         with TabPane("Usage", id="details-usage"):
-                            yield VerticalScroll(
+                            yield TabbedScrollPane(
                                 Static("", id="usage-content", markup=False),
                                 classes="details-scroll surface-scroll",
                             )
                         with TabPane("Info", id="details-info"):
-                            yield VerticalScroll(
+                            yield TabbedScrollPane(
                                 Static("", id="info-content", markup=False),
                                 classes="details-scroll surface-scroll",
                             )
@@ -3015,15 +3043,27 @@ class ViewRunScreen(Screen):
             section.collapsed = True
         self._focus_primary_content(prefer_expanded=False)
 
+    @on(TabbedContent.TabActivated, "#details-tabs")
+    def on_details_tab_activated(self, event: TabbedContent.TabActivated) -> None:
+        """Focus the scroll pane in the newly active details tab."""
+        for child in event.pane.children:
+            if isinstance(child, TabbedScrollPane):
+                child.focus()
+                break
+
     def _should_skip_focus(self, widget: Widget) -> bool:
         """Return True for widgets that should be skipped during tab cycling."""
         # Skip the scroll container itself — only its children should get focus.
         if widget.id == "completion-scroll":
             return True
-        # Skip widgets inside hidden (compact-layout) panels.
-        node: DOMNode | None = widget
+        # Skip the details tab bar — the TabbedScrollPane handles tab switching.
+        if isinstance(widget, ContentTabs):
+            return True
+        # Skip widgets inside hidden ancestors (compact-layout panels,
+        # inactive tab panes, etc.).
+        node: DOMNode | None = widget.parent
         while node is not None:
-            if isinstance(node, Panel) and not node.display:
+            if isinstance(node, Widget) and not node.display:
                 return True
             node = node.parent
         return False

--- a/verifiers/scripts/tui.py
+++ b/verifiers/scripts/tui.py
@@ -4073,6 +4073,10 @@ class VerifiersTUI(App):
         width: 1fr;
     }
 
+    #run-browser-details-scroll:focus {
+        background-tint: $foreground 4%;
+    }
+
     .compare-panel {
         height: 1fr;
     }

--- a/verifiers/scripts/tui.py
+++ b/verifiers/scripts/tui.py
@@ -1668,7 +1668,11 @@ class CompareRunsScreen(Screen):
     BINDINGS = [
         Binding("q", "quit", "Quit"),
         Binding("b,backspace", "back", "Back"),
-        Binding("g", "focus_group_by", "Group by"),
+        Binding("g", "enter_group_mode", "Group by"),
+        Binding("left", "group_cursor_left", show=False),
+        Binding("right", "group_cursor_right", show=False),
+        Binding("enter", "group_select", show=False),
+        Binding("escape", "exit_group_mode", show=False),
         Binding("c", "copy", "Copy"),
         Binding("ctrl+c", "copy", show=False),
     ]
@@ -1684,6 +1688,9 @@ class CompareRunsScreen(Screen):
         self._display_maps: Dict[str, Dict[str, str]] = {}
         self._style_maps: Dict[str, Dict[str, str]] = {}
         self._legend_rows: List[Tuple[str, str, str]] = []
+        self._group_mode: bool = False
+        self._group_cursor: int = 0
+        self._grouped_by_key: str | None = None
 
     def compose(self) -> ComposeResult:
         with Container():
@@ -1692,7 +1699,6 @@ class CompareRunsScreen(Screen):
                 Static("", id="compare-subtitle", classes="subtitle", markup=False),
                 VerticalScroll(
                     Static("", id="compare-header", markup=False),
-                    GroupByBar(id="group-by-bar"),
                     Static("", id="compare-outcomes", markup=False),
                     id="compare-scroll",
                     classes="surface-scroll",
@@ -1713,12 +1719,13 @@ class CompareRunsScreen(Screen):
         self._load_comparison_stats()
 
     def action_back(self) -> None:
-        bar = self.query_one("#group-by-bar", GroupByBar)
-        if bar.has_focus or bar._active:
-            bar._active.clear()
-            bar.refresh()
-            bar.post_message(bar.Changed([]))
-            self.query_one("#compare-scroll", VerticalScroll).focus()
+        if self._grouped_by_key is not None:
+            self._grouped_by_key = None
+            self._refresh_outcomes()
+            return
+        if self._group_mode:
+            self._group_mode = False
+            self._refresh_outcomes()
             return
         self.app.pop_screen()
 
@@ -1767,36 +1774,55 @@ class CompareRunsScreen(Screen):
             self._style_maps,
             self._legend_rows,
         ) = self._build_setting_display_maps(self._setting_keys, self._run_settings)
-        bar = self.query_one("#group-by-bar", GroupByBar)
-        bar.set_keys(self._setting_keys, self._short_setting_key)
         self.query_one("#compare-header", Static).update(
             self._build_comparison_header()
         )
+        self._refresh_outcomes()
+
+    def _refresh_outcomes(self) -> None:
+        if not self._stats_by_path:
+            return
         self.query_one("#compare-outcomes", Static).update(
-            self._build_comparison_outcomes(self._setting_keys)
+            self._build_comparison_outcomes()
         )
 
-    def action_focus_group_by(self) -> None:
-        self.query_one("#group-by-bar", GroupByBar).focus()
+    def action_enter_group_mode(self) -> None:
+        if not self._setting_keys:
+            return
+        self._group_mode = True
+        self._group_cursor = 0
+        self._grouped_by_key = None
+        self._refresh_outcomes()
 
-    def _active_or_all_keys(self, active_keys: List[str]) -> List[str]:
-        return active_keys if active_keys else self._setting_keys
+    def action_group_cursor_left(self) -> None:
+        if not self._group_mode or not self._setting_keys:
+            return
+        self._group_cursor = (self._group_cursor - 1) % len(self._setting_keys)
+        self._refresh_outcomes()
 
-    def on_group_by_bar_changed(self, event: GroupByBar.Changed) -> None:
-        if self._stats_by_path:
-            self.query_one("#compare-outcomes", Static).update(
-                self._build_comparison_outcomes(
-                    self._active_or_all_keys(event.active_keys)
-                )
-            )
+    def action_group_cursor_right(self) -> None:
+        if not self._group_mode or not self._setting_keys:
+            return
+        self._group_cursor = (self._group_cursor + 1) % len(self._setting_keys)
+        self._refresh_outcomes()
+
+    def action_group_select(self) -> None:
+        if not self._group_mode or not self._setting_keys:
+            return
+        self._grouped_by_key = self._setting_keys[self._group_cursor]
+        self._refresh_outcomes()
+
+    def action_exit_group_mode(self) -> None:
+        if self._group_mode:
+            self._group_mode = False
+            self._grouped_by_key = None
+            self._refresh_outcomes()
 
     def _render_comparison_content(self) -> Any:
         if not self._stats_by_path:
             return Text("Loading comparison…", style="dim")
-        bar = self.query_one("#group-by-bar", GroupByBar)
-        active = [k for k in self._setting_keys if k in bar._active]
         header = self._build_comparison_header()
-        outcomes = self._build_comparison_outcomes(self._active_or_all_keys(active))
+        outcomes = self._build_comparison_outcomes()
         return Group(header, outcomes)
 
     def _short_setting_key(self, key: str) -> str:
@@ -1962,16 +1988,27 @@ class CompareRunsScreen(Screen):
         run_settings: List[Tuple[RunInfo, Dict[str, str]]],
         display_maps: Dict[str, Dict[str, str]],
         style_maps: Dict[str, Dict[str, str]],
+        group_by_key: str | None = None,
+        highlight_col: int | None = None,
     ) -> Table:
+        # Determine which keys to actually group by.
+        group_keys = [group_by_key] if group_by_key else setting_keys
+
         grouped: Dict[Tuple[str, ...], Dict[str, Any]] = {}
 
         for run, settings in run_settings:
-            group_key = tuple(settings.get(key, "(unset)") for key in setting_keys)
+            group_key_val = tuple(settings.get(key, "(unset)") for key in group_keys)
             group = grouped.setdefault(
-                group_key,
-                {"runs": [], "rewards": [], "avg_rewards": []},
+                group_key_val,
+                {
+                    "runs": [],
+                    "rewards": [],
+                    "avg_rewards": [],
+                    "run_settings": [],
+                },
             )
             cast(List[RunInfo], group["runs"]).append(run)
+            group["run_settings"].append(settings)
             stats = stats_by_path.get(run.path, RunOverviewStats([], []))
             if stats.rewards:
                 cast(List[float], group["rewards"]).extend(stats.rewards)
@@ -2006,10 +2043,11 @@ class CompareRunsScreen(Screen):
             collapse_padding=True,
             row_styles=["none", "dim"],
         )
-        for key in setting_keys:
+        for idx, key in enumerate(setting_keys):
+            header_style = "bold reverse" if highlight_col == idx else "bold dim"
             table.add_column(
                 self._short_setting_key(key),
-                header_style="bold dim",
+                header_style=header_style,
                 ratio=1,
                 no_wrap=True,
             )
@@ -2020,7 +2058,7 @@ class CompareRunsScreen(Screen):
         table.add_column("mix", width=20, header_style="bold dim")
         table.add_column("ids", ratio=1, header_style="bold dim")
 
-        for raw_values, group in rows:
+        for _group_key_val, group in rows:
             rewards = cast(List[float], group["rewards"])
             avg_rewards = cast(List[float], group["avg_rewards"])
             avg_reward = (
@@ -2052,14 +2090,36 @@ class CompareRunsScreen(Screen):
             if hidden_ids:
                 run_ids += f" +{hidden_ids}"
 
-            table.add_row(
-                *(
-                    Text(
-                        display_maps[key][raw_value],
-                        style=style_maps[key][raw_value] or "",
+            # Build setting cells.
+            setting_cells: List[Text] = []
+            for key in setting_keys:
+                if group_by_key is None or key == group_by_key:
+                    # Show actual value — find it from any run in the group.
+                    value = group["run_settings"][0].get(key, "(unset)")
+                    setting_cells.append(
+                        Text(
+                            display_maps[key][value],
+                            style=style_maps[key][value] or "",
+                        )
                     )
-                    for key, raw_value in zip(setting_keys, raw_values)
-                ),
+                else:
+                    # Non-grouped column: show "N values" or the value if uniform.
+                    distinct = {s.get(key, "(unset)") for s in group["run_settings"]}
+                    if len(distinct) == 1:
+                        value = next(iter(distinct))
+                        setting_cells.append(
+                            Text(
+                                display_maps[key][value],
+                                style=style_maps[key][value] or "dim",
+                            )
+                        )
+                    else:
+                        setting_cells.append(
+                            Text(f"{len(distinct)} values", style="dim italic")
+                        )
+
+            table.add_row(
+                *setting_cells,
                 str(len(cast(List[RunInfo], group["runs"]))),
                 Text(
                     _format_reward_value(avg_reward) if avg_reward is not None else "—",
@@ -2125,16 +2185,19 @@ class CompareRunsScreen(Screen):
             ),
         )
 
-    def _build_comparison_outcomes(self, active_keys: List[str]) -> Group:
+    def _build_comparison_outcomes(self) -> Group:
+        highlight_col = self._group_cursor if self._group_mode else None
         items: List[Any] = [
             Group(
                 Text("Outcome groups", style="bold dim"),
                 self._build_grouped_outcomes_table(
                     self._stats_by_path,
-                    active_keys,
+                    self._setting_keys,
                     self._run_settings,
                     self._display_maps,
                     self._style_maps,
+                    group_by_key=self._grouped_by_key,
+                    highlight_col=highlight_col,
                 ),
             ),
         ]
@@ -4339,16 +4402,6 @@ class VerifiersTUI(App):
 
     .compare-panel {
         height: 1fr;
-    }
-
-    GroupByBar {
-        height: auto;
-        margin: 1 0;
-        padding: 0 0;
-    }
-
-    GroupByBar:focus {
-        background-tint: $foreground 4%;
     }
 
     Footer {

--- a/verifiers/scripts/tui.py
+++ b/verifiers/scripts/tui.py
@@ -768,31 +768,42 @@ def _varying_run_setting_keys(
 
 def _reward_bucket_counts(values: List[float]) -> List[Tuple[str, int, str]]:
     bucket_counts = [
+        ("<0", 0, "bold red"),
         ("=0", 0, "bold red"),
         ("0-<0.25", 0, "red"),
         ("0.25-<0.5", 0, "yellow"),
         ("0.5-<0.75", 0, "yellow"),
         ("0.75-<1", 0, "green"),
         ("=1", 0, "bold green"),
+        (">1", 0, "bold green"),
     ]
 
     for reward in values:
-        if reward <= 0:
+        if reward < 0:
             bucket_idx = 0
-        elif reward < 0.25:
+        elif reward == 0:
             bucket_idx = 1
-        elif reward < 0.5:
+        elif reward < 0.25:
             bucket_idx = 2
-        elif reward < 0.75:
+        elif reward < 0.5:
             bucket_idx = 3
-        elif reward < 1.0:
+        elif reward < 0.75:
             bucket_idx = 4
-        else:
+        elif reward < 1.0:
             bucket_idx = 5
+        elif reward == 1.0:
+            bucket_idx = 6
+        else:
+            bucket_idx = 7
         label, count, style = bucket_counts[bucket_idx]
         bucket_counts[bucket_idx] = (label, count + 1, style)
 
-    return bucket_counts
+    # Only include <0 and >1 buckets if they have values.
+    return [
+        (label, count, style)
+        for label, count, style in bucket_counts
+        if not (label in ("<0", ">1") and count == 0)
+    ]
 
 
 def _build_reward_share_bars(values: List[float], bar_width: int = 16) -> Text:
@@ -3352,7 +3363,7 @@ class ViewRunScreen(Screen):
         body_widgets = list(container.query(".section-body"))
         for i, body_widget in enumerate(body_widgets):
             parent = body_widget.parent
-            if parent is None or i >= len(bodies):
+            if not isinstance(parent, Widget) or i >= len(bodies):
                 continue
             replacement = self._make_body_widget(bodies[i], "completion")
             parent.mount(replacement, after=body_widget)

--- a/verifiers/scripts/tui.py
+++ b/verifiers/scripts/tui.py
@@ -1555,7 +1555,7 @@ class MathMarkdown(BaseMarkdown):
 # Screens
 # ----------------------------
 class CompareRunsScreen(Screen):
-    """Dedicated comparison view for runs from a single model."""
+    """Dedicated comparison view for runs, optionally across models."""
 
     BINDINGS = [
         Binding("q", "quit", "Quit"),
@@ -1569,7 +1569,7 @@ class CompareRunsScreen(Screen):
         Binding("ctrl+c", "copy", show=False),
     ]
 
-    def __init__(self, env_id: str, model: str, runs: List[RunInfo]):
+    def __init__(self, env_id: str, model: Optional[str], runs: List[RunInfo]):
         super().__init__()
         self.env_id = env_id
         self.model = model
@@ -1601,7 +1601,7 @@ class CompareRunsScreen(Screen):
 
     def on_mount(self) -> None:
         subtitle = Text()
-        subtitle.append(self.model, style="bold")
+        subtitle.append(self.model or "all models", style="bold")
         subtitle.append("\n")
         subtitle.append(f"{self.env_id}   {len(self.runs)} runs", style="dim")
         self.query_one("#compare-subtitle", Static).update(subtitle)
@@ -1676,6 +1676,12 @@ class CompareRunsScreen(Screen):
             return
         self._stats_by_path = stats_by_path
         self._setting_keys, self._run_settings = _varying_run_setting_keys(self.runs)
+        if self.model is None:
+            # Cross-model comparison: inject "model" as a setting axis
+            for run, settings in self._run_settings:
+                settings["model"] = run.model
+            if "model" not in self._setting_keys:
+                self._setting_keys.insert(0, "model")
         (
             self._display_maps,
             self._style_maps,
@@ -2071,7 +2077,7 @@ class CompareRunsScreen(Screen):
     def _build_comparison_header(self) -> Group:
         summary = Text()
         summary.append("Ablation summary\n", style="bold dim")
-        summary.append(self.model, style="bold")
+        summary.append(self.model or "all models", style="bold")
         summary.append("\n")
         summary.append(f"{self.env_id}   {len(self.runs)} runs", style="dim")
         return Group(
@@ -2205,6 +2211,15 @@ class BrowseRunsScreen(Screen):
         if payload.kind == "run" and payload.run is not None:
             env_id = payload.run.env_id
             model = payload.run.model
+        elif payload.kind == "env":
+            all_runs: List[RunInfo] = []
+            for model_runs in self.index.get(env_id, {}).values():
+                all_runs.extend(model_runs)
+            runs = _sorted_runs(all_runs)
+            if not runs:
+                return
+            self.app.push_screen(CompareRunsScreen(env_id, None, runs))
+            return
         elif payload.kind != "model":
             return
 

--- a/verifiers/scripts/tui.py
+++ b/verifiers/scripts/tui.py
@@ -3060,10 +3060,46 @@ class ViewRunScreen(Screen):
     def action_history_end(self) -> None:
         self.query_one("#completion-scroll", VerticalScroll).scroll_end(animate=False)
 
+    def _make_body_widget(self, body: str, column: str) -> Widget:
+        """Create the appropriate body widget based on render mode."""
+        if self._render_markdown_math and not (
+            self._highlight_regex and self._highlight_column == column
+        ):
+            return MathMarkdown(body, classes="section-body")
+        text = Text(body)
+        if self._highlight_regex and self._highlight_column == column:
+            _stylize_matches(text, self._highlight_regex, "reverse")
+        return Static(text, classes="section-body", markup=False)
+
+    def _collect_section_bodies(self, sections: List[HistorySectionData]) -> List[str]:
+        """Flatten all section bodies (including nested) in DOM order."""
+        bodies: List[str] = []
+        for section in sections:
+            if section.body or not section.nested_sections:
+                bodies.append(section.body)
+            for nested in section.nested_sections:
+                if nested.body or not nested.nested_sections:
+                    bodies.append(nested.body)
+        return bodies
+
     def action_toggle_markdown_math(self) -> None:
         self._render_markdown_math = not self._render_markdown_math
-        if self.records and self.is_mounted:
-            self._rebuild_completion_sections(self.records[self.current_record_idx])
+        if not (self.records and self.is_mounted):
+            return
+        # Swap each .section-body widget in-place, preserving collapsed
+        # state, scroll position, and focus.
+        record = self.records[self.current_record_idx]
+        section_data = self._history_section_data(record)
+        bodies = self._collect_section_bodies(section_data)
+        container = self.query_one("#completion-scroll", VerticalScroll)
+        body_widgets = list(container.query(".section-body"))
+        for i, body_widget in enumerate(body_widgets):
+            parent = body_widget.parent
+            if parent is None or i >= len(bodies):
+                continue
+            replacement = self._make_body_widget(bodies[i], "completion")
+            parent.mount(replacement, after=body_widget)
+            body_widget.remove()
 
     def _handle_search_result(self, result: Optional[SearchResult]) -> None:
         if result is not None:

--- a/verifiers/scripts/tui.py
+++ b/verifiers/scripts/tui.py
@@ -3393,6 +3393,8 @@ class ViewRunScreen(Screen):
         if self._highlight_timer is not None:
             self._highlight_timer.stop()
             self._highlight_timer = None
+
+        had_highlight = self._highlight_regex is not None
         self._highlight_regex = None
         self._highlight_column = None
 
@@ -3405,9 +3407,23 @@ class ViewRunScreen(Screen):
             self._highlight_timer = self.set_timer(
                 3.0, lambda: self._set_highlight(None)
             )
-
-        if repaint and self.is_mounted:
-            self.update_display()
+            # New search: full rebuild to expand matching sections.
+            if repaint and self.is_mounted:
+                self.update_display()
+        elif had_highlight and self.is_mounted:
+            # Clear highlight styling in place — update Static body widgets
+            # with unstyled text, no layout change.
+            record = self.records[self.current_record_idx]
+            section_data = self._history_section_data(record)
+            body_entries = self._collect_section_bodies(section_data)
+            container = self.query_one("#completion-scroll", VerticalScroll)
+            body_widgets = list(container.query(".section-body"))
+            for i, widget in enumerate(body_widgets):
+                if i >= len(body_entries):
+                    break
+                if isinstance(widget, Static) and not isinstance(widget, MathMarkdown):
+                    body, _column = body_entries[i]
+                    widget.update(Text(body))
 
     def _build_rollout_summary_text(self, record: Dict[str, Any]) -> Text:
         return Text.assemble(
@@ -3664,8 +3680,23 @@ class ViewRunScreen(Screen):
         container = self.query_one("#completion-scroll", VerticalScroll)
         container.remove_children()
         container.mount(*self._completion_sections(record))
-        if focus_history:
+        if self._highlight_regex:
+            self.call_after_refresh(self._scroll_to_first_match)
+        elif focus_history:
             self.call_after_refresh(self._focus_primary_content)
+
+    def _scroll_to_first_match(self) -> None:
+        """Scroll to the first expanded section that matches the highlight."""
+        container = self.query_one("#completion-scroll", VerticalScroll)
+        for section in container.query(Collapsible):
+            if not section.collapsed:
+                section.scroll_visible(animate=False)
+                title_widget = next(iter(section.children), None)
+                if title_widget is not None and getattr(
+                    title_widget, "can_focus", False
+                ):
+                    title_widget.focus()
+                return
 
     def _detail_copy_sections(
         self, record: Dict[str, Any]

--- a/verifiers/scripts/tui.py
+++ b/verifiers/scripts/tui.py
@@ -3339,25 +3339,29 @@ class ViewRunScreen(Screen):
             _stylize_matches(text, self._highlight_regex, "reverse")
         return Static(text, classes="section-body", markup=False)
 
-    def _collect_section_bodies(self, sections: List[HistorySectionData]) -> List[str]:
-        """Flatten all section bodies (including nested) in DOM order."""
-        bodies: List[str] = []
+    def _collect_section_bodies(
+        self, sections: List[HistorySectionData]
+    ) -> List[Tuple[str, str]]:
+        """Flatten all section (body, column) pairs in DOM order."""
+        result: List[Tuple[str, str]] = []
         for section in sections:
-            parent_body = (
-                [section.body] if section.body or not section.nested_sections else []
+            parent = (
+                [(section.body, section.column)]
+                if section.body or not section.nested_sections
+                else []
             )
-            nested_bodies = [
-                nested.body
-                for nested in section.nested_sections
-                if nested.body or not nested.nested_sections
+            nested = [
+                (n.body, n.column)
+                for n in section.nested_sections
+                if n.body or not n.nested_sections
             ]
             if section.body_first:
-                bodies.extend(parent_body)
-                bodies.extend(nested_bodies)
+                result.extend(parent)
+                result.extend(nested)
             else:
-                bodies.extend(nested_bodies)
-                bodies.extend(parent_body)
-        return bodies
+                result.extend(nested)
+                result.extend(parent)
+        return result
 
     def action_toggle_markdown_math(self) -> None:
         self._render_markdown_math = not self._render_markdown_math
@@ -3367,14 +3371,15 @@ class ViewRunScreen(Screen):
         # state, scroll position, and focus.
         record = self.records[self.current_record_idx]
         section_data = self._history_section_data(record)
-        bodies = self._collect_section_bodies(section_data)
+        body_entries = self._collect_section_bodies(section_data)
         container = self.query_one("#completion-scroll", VerticalScroll)
         body_widgets = list(container.query(".section-body"))
         for i, body_widget in enumerate(body_widgets):
             parent = body_widget.parent
-            if not isinstance(parent, Widget) or i >= len(bodies):
+            if not isinstance(parent, Widget) or i >= len(body_entries):
                 continue
-            replacement = self._make_body_widget(bodies[i], "completion")
+            body, column = body_entries[i]
+            replacement = self._make_body_widget(body, column)
             parent.mount(replacement, after=body_widget)
             body_widget.remove()
 

--- a/verifiers/scripts/tui.py
+++ b/verifiers/scripts/tui.py
@@ -11,6 +11,9 @@ from io import StringIO
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Tuple, cast
 
+from markdown_it import MarkdownIt
+from mdit_py_plugins.amsmath import amsmath_plugin
+from mdit_py_plugins.dollarmath import dollarmath_plugin
 from rich import box
 from rich.console import Console, Group
 from rich.table import Table
@@ -18,8 +21,10 @@ from rich.text import Text
 from textual import events, on, work
 from textual.app import App, ComposeResult
 from textual.binding import Binding
+from textual.content import Content, Span
 from textual.containers import Container, Horizontal, VerticalScroll
 from textual.screen import ModalScreen, Screen
+from textual.style import Style
 from textual.theme import Theme
 from textual.widgets import (
     Collapsible,
@@ -33,9 +38,27 @@ from textual.widgets import (
     TextArea,
     Tree,
 )
+from textual.widgets._markdown import (
+    Markdown as BaseMarkdown,
+    MarkdownBlock,
+    MarkdownH1,
+    MarkdownH2,
+    MarkdownH3,
+    MarkdownH4,
+    MarkdownH5,
+    MarkdownH6,
+    MarkdownParagraph,
+    MarkdownTD,
+    MarkdownTH,
+)
 from textual.widgets._option_list import Option
 
 from verifiers.utils.display_utils import format_numeric
+
+try:
+    from pylatexenc.latex2text import LatexNodes2Text
+except ModuleNotFoundError:
+    LatexNodes2Text = None
 
 AnimationLevel = Literal["none", "basic", "full"]
 TreeBinding = Binding | tuple[str, str] | tuple[str, str, str]
@@ -259,8 +282,15 @@ def _stringify_message_content(content: Any) -> str:
         chunks: List[str] = []
         for item in content:
             if isinstance(item, dict):
-                if item.get("type") == "text":
+                item_type = item.get("type")
+                if item_type == "text":
                     chunks.append(str(item.get("text", "")))
+                elif item_type in {"input_audio", "audio"}:
+                    chunks.append("[audio]")
+                elif item_type in {"image", "image_url"}:
+                    chunks.append("[image]")
+                elif item_type in {"thinking", "redacted_thinking"}:
+                    continue
                 else:
                     chunks.append(_pretty_json_or_str(item))
             else:
@@ -269,6 +299,66 @@ def _stringify_message_content(content: Any) -> str:
     if isinstance(content, dict):
         return _pretty_json_or_str(content)
     return str(content)
+
+
+def _thinking_block_to_text(block: Any) -> str:
+    if isinstance(block, dict):
+        block_type = block.get("type")
+        if block_type == "thinking":
+            thinking = block.get("thinking")
+            return str(thinking).strip() if thinking else ""
+        if block_type == "redacted_thinking":
+            return "[reasoning redacted]"
+        return ""
+
+    block_type = getattr(block, "type", None)
+    if block_type == "thinking":
+        thinking = getattr(block, "thinking", None)
+        return str(thinking).strip() if thinking else ""
+    if block_type == "redacted_thinking":
+        return "[reasoning redacted]"
+    return ""
+
+
+def _stringify_message_reasoning(message: Any) -> str:
+    if not isinstance(message, dict):
+        return ""
+
+    parts: List[str] = []
+
+    def add_part(value: str) -> None:
+        text = value.strip()
+        if text and text not in parts:
+            parts.append(text)
+
+    reasoning_content = message.get("reasoning_content")
+    if isinstance(reasoning_content, str):
+        add_part(reasoning_content)
+
+    thinking_blocks = message.get("thinking_blocks")
+    if isinstance(thinking_blocks, list):
+        for block in thinking_blocks:
+            add_part(_thinking_block_to_text(block))
+
+    content = message.get("content")
+    if isinstance(content, list):
+        for item in content:
+            add_part(_thinking_block_to_text(item))
+
+    return "\n\n".join(parts)
+
+
+def _stringify_message(message: Any) -> str:
+    if not isinstance(message, dict):
+        return _stringify_message_content(message)
+
+    content = _stringify_message_content(message.get("content", "")).strip()
+    reasoning = _stringify_message_reasoning(message)
+    if reasoning and content:
+        return f"Reasoning\n{reasoning}\n\n{content}"
+    if reasoning:
+        return f"Reasoning\n{reasoning}"
+    return content
 
 
 def _parse_tool_calls(tool_calls: Any) -> List[Any]:
@@ -332,9 +422,12 @@ def _format_message_preview(message: Any) -> str:
     if not isinstance(message, dict):
         return ""
     content = _stringify_message_content(message.get("content", ""))
+    reasoning = _stringify_message_reasoning(message)
     tool_calls = _parse_tool_calls(message.get("tool_calls"))
     if content:
         return _truncate_preview(content, 56)
+    if reasoning:
+        return f"reasoning: {_truncate_preview(reasoning, 45)}"
     if tool_calls:
         first = tool_calls[0]
         if isinstance(first, dict):
@@ -410,7 +503,7 @@ def _tool_call_parts(tool_call: Any) -> Tuple[str, str, Optional[str]]:
 def _tool_output_preview(message: Any) -> str:
     if not isinstance(message, dict):
         return _truncate_preview(str(message), 44)
-    content = _stringify_message_content(message.get("content", ""))
+    content = _stringify_message(message)
     for line in content.splitlines():
         if line.strip():
             return _truncate_preview(line.strip(), 44)
@@ -442,6 +535,9 @@ def _raw_preview(value: Any, *, limit: int = 56) -> str:
         content = _stringify_message_content(value.get("content", ""))
         if content:
             return _truncate_preview(content, limit)
+        reasoning = _stringify_message_reasoning(value)
+        if reasoning:
+            return _truncate_preview(reasoning, limit)
         for key in ("text", "message", "error", "detail", "details", "type", "name"):
             candidate = value.get(key)
             if isinstance(candidate, str) and candidate.strip():
@@ -791,6 +887,7 @@ class HistorySectionData:
     collapsed: bool
     classes: str
     nested_sections: Tuple["HistorySectionData", ...] = ()
+    body_first: bool = True
 
 
 @dataclass(frozen=True)
@@ -821,6 +918,290 @@ def _text_to_plain(text: Text) -> str:
 
 def _indent_block(text: str, prefix: str) -> str:
     return "\n".join(f"{prefix}{line}" if line else "" for line in text.splitlines())
+
+
+# ----------------------------
+# Markdown rendering
+# ----------------------------
+_LATEX_TO_TEXT = LatexNodes2Text() if LatexNodes2Text is not None else None
+_LATEX_BEGIN_END_RE = re.compile(r"\\(?:begin|end)\{[^}]+\}")
+_LATEX_BRACED_SCRIPT_RE = re.compile(r"([_^])\{([^{}]+)\}")
+_LATEX_WRAPPER_RE = re.compile(
+    r"\\(?:mathrm|mathbf|mathit|mathsf|mathtt|operatorname|text)\{([^{}]+)\}"
+)
+_LATEX_FRACTION_RE = re.compile(r"\\(?:d|t)?frac\{([^{}]+)\}\{([^{}]+)\}")
+_LATEX_SQRT_RE = re.compile(r"\\sqrt\{([^{}]+)\}")
+_LATEX_COMMAND_RE = re.compile(r"\\([A-Za-z]+|.)")
+_LATEX_COMMAND_REPLACEMENTS = {
+    "alpha": "α",
+    "beta": "β",
+    "gamma": "γ",
+    "delta": "δ",
+    "epsilon": "ε",
+    "theta": "θ",
+    "lambda": "λ",
+    "mu": "μ",
+    "pi": "π",
+    "sigma": "σ",
+    "phi": "φ",
+    "psi": "ψ",
+    "omega": "ω",
+    "Gamma": "Γ",
+    "Delta": "Δ",
+    "Theta": "Θ",
+    "Lambda": "Λ",
+    "Pi": "Π",
+    "Sigma": "Σ",
+    "Phi": "Φ",
+    "Psi": "Ψ",
+    "Omega": "Ω",
+    "cdot": "·",
+    "times": "×",
+    "pm": "±",
+    "neq": "!=",
+    "leq": "<=",
+    "geq": ">=",
+    "approx": "~",
+    "to": "->",
+    "rightarrow": "->",
+    "leftarrow": "<-",
+    "infty": "∞",
+    "ldots": "...",
+    "cdots": "...",
+    "sum": "sum",
+    "prod": "prod",
+    "log": "log",
+    "ln": "ln",
+    "exp": "exp",
+    "sin": "sin",
+    "cos": "cos",
+    "tan": "tan",
+    "|": "||",
+    ",": " ",
+    ";": " ",
+    "!": "",
+}
+
+
+def _replace_latex_groups(
+    text: str,
+    pattern: re.Pattern[str],
+    replacement: str | re.Pattern[str] | Any,
+) -> str:
+    while True:
+        updated = pattern.sub(replacement, text)
+        if updated == text:
+            return updated
+        text = updated
+
+
+def _replace_latex_fraction(match: re.Match[str]) -> str:
+    numerator, denominator = (part.strip() for part in match.groups())
+    if re.search(r"\s|[+\-*/]", numerator):
+        numerator = f"({numerator})"
+    if re.search(r"\s|[+\-*/]", denominator):
+        denominator = f"({denominator})"
+    return f"{numerator}/{denominator}"
+
+
+def _replace_latex_command(match: re.Match[str]) -> str:
+    command = match.group(1)
+    if command in _LATEX_COMMAND_REPLACEMENTS:
+        return _LATEX_COMMAND_REPLACEMENTS[command]
+    if len(command) == 1 and not command.isalpha():
+        return command
+    return command
+
+
+def _fallback_latex_to_text(latex: str, *, preserve_newlines: bool) -> str:
+    text = _LATEX_BEGIN_END_RE.sub("", latex)
+    text = text.replace("&", " ")
+    text = text.replace("\\\\", "\n" if preserve_newlines else " ")
+    text = _replace_latex_groups(text, _LATEX_WRAPPER_RE, r"\1")
+    text = _replace_latex_groups(text, _LATEX_BRACED_SCRIPT_RE, r"\1\2")
+    text = _replace_latex_groups(text, _LATEX_FRACTION_RE, _replace_latex_fraction)
+    text = _replace_latex_groups(text, _LATEX_SQRT_RE, r"sqrt(\1)")
+    text = _LATEX_COMMAND_RE.sub(_replace_latex_command, text)
+    text = text.replace("{", "").replace("}", "").replace("~", " ")
+    if preserve_newlines:
+        lines = [re.sub(r"\s+", " ", line).strip() for line in text.splitlines()]
+        return "\n".join(line for line in lines if line)
+    return " ".join(text.split())
+
+
+def _latex_to_text(latex: str, *, preserve_newlines: bool) -> str:
+    if _LATEX_TO_TEXT is not None:
+        return _LATEX_TO_TEXT.latex_to_text(latex)
+    return _fallback_latex_to_text(latex, preserve_newlines=preserve_newlines)
+
+
+def render_inline_math(latex: str) -> str:
+    return " ".join(_latex_to_text(latex, preserve_newlines=False).split())
+
+
+def render_block_math(latex: str) -> str:
+    return _latex_to_text(latex, preserve_newlines=True).strip()
+
+
+def make_math_parser() -> MarkdownIt:
+    parser = MarkdownIt("gfm-like")
+    parser.use(
+        dollarmath_plugin,
+        allow_space=False,
+        allow_digits=False,
+    )
+    parser.use(amsmath_plugin)
+    return parser
+
+
+class MathInlineMixin:
+    """Teach Textual's Markdown blocks how to render inline math tokens."""
+
+    def _token_to_content(self, token: Any) -> Content:
+        if token.children is None:
+            return Content("")
+
+        parts: List[str] = []
+        spans: List[Span] = []
+        style_stack: List[Tuple[Style | str, int]] = []
+        position = 0
+
+        def add_text(text: str) -> None:
+            nonlocal position
+            parts.append(text)
+            position += len(text)
+
+        def push_style(style: Style | str) -> None:
+            style_stack.append((style, position))
+
+        def pop_style() -> None:
+            if not style_stack:
+                return
+            style, start = style_stack.pop()
+            spans.append(Span(start, position, style))
+
+        for child in token.children:
+            child_type = child.type
+            attrs = child.attrs or {}
+
+            if child_type == "text":
+                add_text(re.sub(r"\s+", " ", child.content))
+            elif child_type == "hardbreak":
+                add_text("\n")
+            elif child_type == "softbreak":
+                add_text(" ")
+            elif child_type == "code_inline":
+                push_style(".code_inline")
+                add_text(child.content)
+                pop_style()
+            elif child_type in {"math_inline", "math_inline_double"}:
+                push_style("italic")
+                add_text(render_inline_math(child.content))
+                pop_style()
+            elif child_type == "em_open":
+                push_style(".em")
+            elif child_type == "strong_open":
+                push_style(".strong")
+            elif child_type == "s_open":
+                push_style(".s")
+            elif child_type == "link_open":
+                href = attrs.get("href", "")
+                action = f"link({href!r})"
+                push_style(Style.from_meta({"@click": action}))
+            elif child_type == "image":
+                href = attrs.get("src", "")
+                alt = attrs.get("alt", "")
+                action = f"link({href!r})"
+                push_style(Style.from_meta({"@click": action}))
+                add_text(" ")
+                if alt:
+                    add_text(f"({alt})")
+                if child.children is not None:
+                    for grandchild in child.children:
+                        add_text(grandchild.content)
+                pop_style()
+            elif child_type.endswith("_close"):
+                pop_style()
+
+        return Content("".join(parts), spans=spans)
+
+
+class MathParagraph(MathInlineMixin, MarkdownParagraph):
+    pass
+
+
+class MathH1(MathInlineMixin, MarkdownH1):
+    pass
+
+
+class MathH2(MathInlineMixin, MarkdownH2):
+    pass
+
+
+class MathH3(MathInlineMixin, MarkdownH3):
+    pass
+
+
+class MathH4(MathInlineMixin, MarkdownH4):
+    pass
+
+
+class MathH5(MathInlineMixin, MarkdownH5):
+    pass
+
+
+class MathH6(MathInlineMixin, MarkdownH6):
+    pass
+
+
+class MathTH(MathInlineMixin, MarkdownTH):
+    pass
+
+
+class MathTD(MathInlineMixin, MarkdownTD):
+    pass
+
+
+class MathDisplayBlock(MarkdownBlock):
+    DEFAULT_CSS = """
+    MathDisplayBlock {
+        width: 1fr;
+        height: auto;
+        margin: 0 0 1 0;
+        padding: 0 1;
+        background: $boost;
+        border-left: outer $primary 60%;
+    }
+    """
+
+    def __init__(self, markdown: "MathMarkdown", token: Any):
+        super().__init__(markdown, token)
+        text = render_block_math(token.content)
+        if token.type == "math_block_label" and getattr(token, "info", ""):
+            text = f"[{token.info}]\n{text}"
+        self.set_content(Content(text))
+
+
+class MathMarkdown(BaseMarkdown):
+    BLOCKS = BaseMarkdown.BLOCKS | {
+        "paragraph_open": MathParagraph,
+        "h1": MathH1,
+        "h2": MathH2,
+        "h3": MathH3,
+        "h4": MathH4,
+        "h5": MathH5,
+        "h6": MathH6,
+        "th_open": MathTH,
+        "td_open": MathTD,
+    }
+
+    def __init__(self, markdown: str | None = None, **kwargs: Any) -> None:
+        super().__init__(markdown, parser_factory=make_math_parser, **kwargs)
+
+    def unhandled_token(self, token: Any) -> MarkdownBlock | None:
+        if token.type in {"math_block", "math_block_label", "amsmath"}:
+            return MathDisplayBlock(self, token)
+        return None
 
 
 # ----------------------------
@@ -1233,6 +1614,7 @@ class ViewRunScreen(Screen):
         Binding("e", "expand_all", "Expand all"),
         Binding("x", "collapse_all", "Collapse all"),
         Binding("s", "search", "Search"),
+        Binding("m", "toggle_markdown_math", "Toggle markdown"),
         Binding("c", "copy", "Copy"),
         Binding("ctrl+c", "copy", show=False),
     ]
@@ -1251,6 +1633,7 @@ class ViewRunScreen(Screen):
         self._highlight_column: Optional[str] = None
         self._highlight_timer = None
         self._previous_animation_level: Optional[AnimationLevel] = None
+        self._render_markdown_math = True
         if self.records:
             self._set_record_text_state(self.records[self.current_record_idx])
 
@@ -1636,12 +2019,20 @@ class ViewRunScreen(Screen):
                 continue
             role = str(message.get("role", ""))
             content = _stringify_message_content(message.get("content", ""))
+            reasoning = _stringify_message_reasoning(message)
             if role == "assistant":
                 out.append("assistant: ", style="bold")
             elif role == "tool":
                 out.append("tool result: ", style="bold dim")
             else:
                 out.append(f"{role}: ", style="bold dim")
+            if reasoning:
+                out.append("\n")
+                out.append("reasoning:\n", style="dim")
+                out.append(reasoning, style="dim")
+                out.append("\n")
+                if content:
+                    out.append("\n")
             out.append(content)
             out.append("\n")
 
@@ -1777,6 +2168,11 @@ class ViewRunScreen(Screen):
     def action_history_end(self) -> None:
         self.query_one("#completion-scroll", VerticalScroll).scroll_end(animate=False)
 
+    def action_toggle_markdown_math(self) -> None:
+        self._render_markdown_math = not self._render_markdown_math
+        if self.records and self.is_mounted:
+            self._rebuild_completion_sections(self.records[self.current_record_idx])
+
     def _handle_search_result(self, result: Optional[SearchResult]) -> None:
         if result is not None:
             self._set_highlight(result)
@@ -1857,6 +2253,25 @@ class ViewRunScreen(Screen):
             return
         self._set_current_record(int(event.option_id), focus_history=True)
 
+    def _reasoning_section_data(
+        self,
+        message: Dict[str, Any],
+        *,
+        collapsed: bool = True,
+    ) -> Tuple[HistorySectionData, ...]:
+        reasoning = _stringify_message_reasoning(message)
+        if not reasoning:
+            return ()
+        return (
+            HistorySectionData(
+                title="Reasoning",
+                body=reasoning,
+                column="completion",
+                collapsed=collapsed,
+                classes="history-section reasoning-section nested-section",
+            ),
+        )
+
     def _history_section_data(self, record: Dict[str, Any]) -> List[HistorySectionData]:
         sections: List[HistorySectionData] = [
             HistorySectionData(
@@ -1888,6 +2303,7 @@ class ViewRunScreen(Screen):
                 preview = _format_message_preview(message)
                 if preview:
                     title += f"  {preview}"
+                reasoning_sections = self._reasoning_section_data(message)
 
                 sections.append(
                     HistorySectionData(
@@ -1906,6 +2322,8 @@ class ViewRunScreen(Screen):
                                 else "history-section assistant-section"
                             )
                         ),
+                        nested_sections=reasoning_sections,
+                        body_first=not reasoning_sections,
                     )
                 )
                 continue
@@ -1934,7 +2352,7 @@ class ViewRunScreen(Screen):
                 if collapsed:
                     for output in tool_outputs:
                         output_text = (
-                            _stringify_message_content(output.get("content", ""))
+                            _stringify_message(output)
                             if isinstance(output, dict)
                             else str(output)
                         )
@@ -1942,7 +2360,9 @@ class ViewRunScreen(Screen):
                             collapsed = False
                             break
 
-            nested_sections: List[HistorySectionData] = []
+            nested_sections: List[HistorySectionData] = list(
+                self._reasoning_section_data(message)
+            )
             used_output_indexes: set[int] = set()
             for tool_idx, tool_call in enumerate(tool_calls, start=1):
                 name, arguments, call_id = _tool_call_parts(tool_call)
@@ -1964,7 +2384,7 @@ class ViewRunScreen(Screen):
                             break
 
                 output_text = (
-                    _stringify_message_content(matched_output.get("content", ""))
+                    _stringify_message(matched_output)
                     if isinstance(matched_output, dict)
                     else (str(matched_output) if matched_output is not None else "")
                 )
@@ -1993,7 +2413,7 @@ class ViewRunScreen(Screen):
                 if (extra_idx - 1) in used_output_indexes:
                     continue
                 output_text = (
-                    _stringify_message_content(output_message.get("content", ""))
+                    _stringify_message(output_message)
                     if isinstance(output_message, dict)
                     else str(output_message)
                 )
@@ -2018,6 +2438,7 @@ class ViewRunScreen(Screen):
                     collapsed=collapsed,
                     classes="history-section assistant-section",
                     nested_sections=tuple(nested_sections),
+                    body_first=False if nested_sections else True,
                 )
             )
 
@@ -2078,12 +2499,17 @@ class ViewRunScreen(Screen):
     ) -> str:
         indent = "  " * depth
         parts = [f"{indent}{section.title}"]
-        if section.body:
-            parts.append(_indent_block(section.body, f"{indent}  "))
-        parts.extend(
+        body = [_indent_block(section.body, f"{indent}  ")] if section.body else []
+        nested = [
             self._render_history_section_copy_text(child, depth=depth + 1)
             for child in section.nested_sections
-        )
+        ]
+        if section.body_first:
+            parts.extend(body)
+            parts.extend(nested)
+        else:
+            parts.extend(nested)
+            parts.extend(body)
         return "\n\n".join(part for part in parts if part)
 
     def _render_history_copy_text(self, sections: List[HistorySectionData]) -> str:
@@ -2277,28 +2703,54 @@ class ViewRunScreen(Screen):
             idx += 1
         return groups
 
+    def _section_matches_highlight(self, section: HistorySectionData) -> bool:
+        if not (self._highlight_regex and self._highlight_column == section.column):
+            return False
+        if self._highlight_regex.search(section.title) or self._highlight_regex.search(
+            section.body
+        ):
+            return True
+        return any(
+            self._section_matches_highlight(nested_section)
+            for nested_section in section.nested_sections
+        )
+
     def _make_section(self, section: HistorySectionData) -> Collapsible:
         collapsed = section.collapsed
-        if (
-            self._highlight_regex
-            and self._highlight_column == section.column
-            and self._highlight_regex.search(section.body)
-        ):
+        if self._section_matches_highlight(section):
             collapsed = False
-        children: List[Any] = []
-        if section.body or not section.nested_sections:
+        body_children: List[Any] = []
+        if section.body:
+            if not self._render_markdown_math or (
+                self._highlight_regex and self._highlight_column == section.column
+            ):
+                text = Text(section.body)
+                if self._highlight_regex and self._highlight_column == section.column:
+                    _stylize_matches(text, self._highlight_regex, "reverse")
+                content = Static(
+                    text,
+                    classes="section-body",
+                    markup=False,
+                )
+            else:
+                content = MathMarkdown(section.body, classes="section-body")
+            body_children.append(content)
+        elif not section.nested_sections:
             text = Text(section.body)
-            if self._highlight_regex and self._highlight_column == section.column:
-                _stylize_matches(text, self._highlight_regex, "reverse")
             content = Static(
                 text,
                 classes="section-body",
                 markup=False,
             )
-            children.append(content)
-        children.extend(
+            body_children.append(content)
+        nested_children = [
             self._make_section(nested_section)
             for nested_section in section.nested_sections
+        ]
+        children = (
+            [*body_children, *nested_children]
+            if section.body_first
+            else [*nested_children, *body_children]
         )
         return Collapsible(
             *children,

--- a/verifiers/scripts/tui.py
+++ b/verifiers/scripts/tui.py
@@ -55,11 +55,6 @@ from textual.widgets._option_list import Option
 
 from verifiers.utils.display_utils import format_numeric
 
-try:
-    from pylatexenc.latex2text import LatexNodes2Text
-except ModuleNotFoundError:
-    LatexNodes2Text = None
-
 AnimationLevel = Literal["none", "basic", "full"]
 TreeBinding = Binding | tuple[str, str] | tuple[str, str, str]
 
@@ -1255,7 +1250,6 @@ def _indent_block(text: str, prefix: str) -> str:
 # ----------------------------
 # Markdown rendering
 # ----------------------------
-_LATEX_TO_TEXT = LatexNodes2Text() if LatexNodes2Text is not None else None
 _LATEX_BEGIN_END_RE = re.compile(r"\\(?:begin|end)\{[^}]+\}")
 _LATEX_BRACED_SCRIPT_RE = re.compile(r"([_^])\{([^{}]+)\}")
 _LATEX_WRAPPER_RE = re.compile(
@@ -1362,8 +1356,6 @@ def _fallback_latex_to_text(latex: str, *, preserve_newlines: bool) -> str:
 
 
 def _latex_to_text(latex: str, *, preserve_newlines: bool) -> str:
-    if _LATEX_TO_TEXT is not None:
-        return _LATEX_TO_TEXT.latex_to_text(latex)
     return _fallback_latex_to_text(latex, preserve_newlines=preserve_newlines)
 
 

--- a/verifiers/scripts/tui.py
+++ b/verifiers/scripts/tui.py
@@ -1217,12 +1217,16 @@ class SearchHit:
     column: str
     line_index: int
     line_text: str
+    section_index: int = 0
+    nested_index: int = -1  # -1 = parent body, 0+ = nested section index
 
 
 @dataclass(frozen=True)
 class SearchResult:
     column: str
     pattern: str
+    section_index: int = 0
+    nested_index: int = -1
 
 
 @dataclass(frozen=True)
@@ -2084,6 +2088,7 @@ class CompareRunsScreen(Screen):
     def _build_comparison_outcomes(self) -> Group:
         highlight_col = self._group_cursor if self._group_mode else None
         items: List[Any] = [
+            Text(""),
             Group(
                 Text("Outcome groups", style="bold dim"),
                 self._build_grouped_outcomes_table(
@@ -3079,11 +3084,32 @@ class ViewRunScreen(Screen):
         rollout_list.scroll_to_highlight()
         self._set_current_record(new_index)
 
+    def _build_search_lines(
+        self, record: Dict[str, Any]
+    ) -> Tuple[List[Tuple[int, int, str]], List[Tuple[int, int, str]]]:
+        """Build tagged (section_index, nested_index, line) lists for search."""
+        sections = self._history_section_data(record)
+        prompt_lines: List[Tuple[int, int, str]] = []
+        completion_lines: List[Tuple[int, int, str]] = []
+        for idx, section in enumerate(sections):
+            target = prompt_lines if section.column == "prompt" else completion_lines
+            for line in section.body.splitlines():
+                target.append((idx, -1, line))
+            for nested_idx, nested in enumerate(section.nested_sections):
+                nested_target = (
+                    prompt_lines if nested.column == "prompt" else completion_lines
+                )
+                for line in nested.body.splitlines():
+                    nested_target.append((idx, nested_idx, line))
+        return prompt_lines, completion_lines
+
     def action_search(self) -> None:
         if not self.records:
             return
+        record = self.records[self.current_record_idx]
+        prompt_lines, completion_lines = self._build_search_lines(record)
         self.app.push_screen(
-            SearchScreen(self._prompt_lines, self._completion_lines),
+            SearchScreen(prompt_lines, completion_lines),
             self._handle_search_result,
         )
 
@@ -3243,6 +3269,8 @@ class ViewRunScreen(Screen):
         had_highlight = self._highlight_regex is not None
         self._highlight_regex = None
         self._highlight_column = None
+        self._highlight_section_index: int = 0
+        self._highlight_nested_index: int = -1
 
         if result is not None:
             try:
@@ -3250,26 +3278,32 @@ class ViewRunScreen(Screen):
             except re.error:
                 return
             self._highlight_column = result.column
+            self._highlight_section_index = result.section_index
+            self._highlight_nested_index = result.nested_index
             self._highlight_timer = self.set_timer(
                 3.0, lambda: self._set_highlight(None)
             )
-            # New search: full rebuild to expand matching sections.
-            if repaint and self.is_mounted:
-                self.update_display()
-        elif had_highlight and self.is_mounted:
-            # Clear highlight styling in place — update Static body widgets
-            # with unstyled text, no layout change.
+
+        if repaint and self.is_mounted and (had_highlight or result is not None):
+            # Swap body widgets in place to apply or remove highlight
+            # styling without rebuilding (preserves collapsed state).
             record = self.records[self.current_record_idx]
             section_data = self._history_section_data(record)
             body_entries = self._collect_section_bodies(section_data)
             container = self.query_one("#completion-scroll", VerticalScroll)
             body_widgets = list(container.query(".section-body"))
             for i, widget in enumerate(body_widgets):
-                if i >= len(body_entries):
-                    break
-                if isinstance(widget, Static) and not isinstance(widget, MathMarkdown):
-                    body, _column = body_entries[i]
-                    widget.update(Text(body))
+                parent = widget.parent
+                if not isinstance(parent, Widget) or i >= len(body_entries):
+                    continue
+                body, column = body_entries[i]
+                replacement = self._make_body_widget(body, column)
+                parent.mount(replacement, after=widget)
+                widget.remove()
+
+            # For new searches, expand the target section and scroll to it.
+            if result is not None:
+                self._expand_and_scroll_to_match(container)
 
     def _build_rollout_summary_text(self, record: Dict[str, Any]) -> Text:
         return Text.assemble(
@@ -3526,23 +3560,42 @@ class ViewRunScreen(Screen):
         container = self.query_one("#completion-scroll", VerticalScroll)
         container.remove_children()
         container.mount(*self._completion_sections(record))
-        if self._highlight_regex:
-            self.call_after_refresh(self._scroll_to_first_match)
-        elif focus_history:
+        if focus_history:
             self.call_after_refresh(self._focus_primary_content)
 
-    def _scroll_to_first_match(self) -> None:
-        """Scroll to the first expanded section that matches the highlight."""
-        container = self.query_one("#completion-scroll", VerticalScroll)
-        for section in container.query(Collapsible):
-            if not section.collapsed:
-                section.scroll_visible(animate=False)
-                title_widget = next(iter(section.children), None)
-                if title_widget is not None and getattr(
-                    title_widget, "can_focus", False
-                ):
-                    title_widget.focus()
-                return
+    def _expand_and_scroll_to_match(self, container: VerticalScroll) -> None:
+        """Expand the target section (and nested subsection) and scroll to it."""
+        # Get top-level sections only (direct children of the scroll container).
+        sections = [
+            child for child in container.children if isinstance(child, Collapsible)
+        ]
+        idx = self._highlight_section_index
+        if not (0 <= idx < len(sections)):
+            return
+        parent = sections[idx]
+        if parent.collapsed:
+            parent.collapsed = False
+
+        # If the hit is in a nested section, expand that too.
+        scroll_target = parent
+        nested_idx = self._highlight_nested_index
+        if nested_idx >= 0:
+            nested_collapsibles = [
+                child for child in parent.query(Collapsible) if child is not parent
+            ]
+            if 0 <= nested_idx < len(nested_collapsibles):
+                nested = nested_collapsibles[nested_idx]
+                if nested.collapsed:
+                    nested.collapsed = False
+                scroll_target = nested
+
+        self.call_after_refresh(lambda t=scroll_target: self._scroll_to_section(t))
+
+    def _scroll_to_section(self, section: Collapsible) -> None:
+        section.scroll_visible(animate=False)
+        title_widget = next(iter(section.children), None)
+        if title_widget is not None and getattr(title_widget, "can_focus", False):
+            title_widget.focus()
 
     def _detail_copy_sections(
         self, record: Dict[str, Any]
@@ -4379,9 +4432,13 @@ class SearchScreen(ModalScreen[Optional[SearchResult]]):
         Binding("enter", "select", "Select"),
     ]
 
-    def __init__(self, prompt_lines: List[str], completion_lines: List[str]):
+    def __init__(
+        self,
+        prompt_lines: List[Tuple[int, int, str]],
+        completion_lines: List[Tuple[int, int, str]],
+    ):
         super().__init__()
-        self._lines: Dict[str, List[str]] = {
+        self._tagged_lines: Dict[str, List[Tuple[int, int, str]]] = {
             "prompt": prompt_lines,
             "completion": completion_lines,
         }
@@ -4463,7 +4520,14 @@ class SearchScreen(ModalScreen[Optional[SearchResult]]):
         if selection is None:
             return
         pattern = self.query_one("#search-input", Input).value
-        self.dismiss(SearchResult(column=selection.column, pattern=pattern))
+        self.dismiss(
+            SearchResult(
+                column=selection.column,
+                pattern=pattern,
+                section_index=selection.section_index,
+                nested_index=selection.nested_index,
+            )
+        )
 
     def _set_active_hit(
         self, column: str, option_id: Optional[str], *, select: bool = False
@@ -4509,13 +4573,21 @@ class SearchScreen(ModalScreen[Optional[SearchResult]]):
             return
 
         error_label.update("")
-        for column, lines in self._lines.items():
+        for column, tagged_lines in self._tagged_lines.items():
             hits: List[SearchHit] = []
-            for line_index, line in enumerate(lines):
+            for line_index, (section_index, nested_index, line) in enumerate(
+                tagged_lines
+            ):
                 if not compiled.search(line):
                     continue
                 hits.append(
-                    SearchHit(column=column, line_index=line_index, line_text=line)
+                    SearchHit(
+                        column=column,
+                        line_index=line_index,
+                        line_text=line,
+                        section_index=section_index,
+                        nested_index=nested_index,
+                    )
                 )
                 content = Text(line)
                 _stylize_matches(content, compiled, "reverse")
@@ -4646,11 +4718,24 @@ class RolloutCopyScreen(ModalScreen[None]):
 
     def on_mount(self) -> None:
         option_list = self.query_one("#rollout-copy-targets", OptionList)
-        option_list.can_focus = False
         for item in self._items:
             option_list.add_option(Option(Text(item.label), id=item.key))
         option_list.highlighted = self._current_idx
         self._sync_preview()
+        self.query_one("#rollout-copy-preview", TextArea).focus()
+
+    @on(OptionList.OptionHighlighted, "#rollout-copy-targets")
+    def _on_target_highlighted(self, event: OptionList.OptionHighlighted) -> None:
+        if event.option_index is not None and event.option_index != self._current_idx:
+            self._current_idx = event.option_index
+            self._sync_preview()
+
+    @on(OptionList.OptionSelected, "#rollout-copy-targets")
+    def _on_target_selected(self, event: OptionList.OptionSelected) -> None:
+        """Click on a target: update preview and return focus to TextArea."""
+        if event.option_index is not None:
+            self._current_idx = event.option_index
+            self._sync_preview()
         self.query_one("#rollout-copy-preview", TextArea).focus()
 
     @on(TextArea.SelectionChanged)
@@ -4666,11 +4751,16 @@ class RolloutCopyScreen(ModalScreen[None]):
             )
 
     def on_key(self, event: events.Key) -> None:
-        if event.key == "left":
+        # Only intercept arrow keys when the OptionList has focus;
+        # let all keys pass through to the TextArea normally.
+        option_list = self.query_one("#rollout-copy-targets", OptionList)
+        if self.focused is not option_list:
+            return
+        if event.key in ("left", "up"):
             self._move_section(-1)
             event.prevent_default()
             event.stop()
-        elif event.key == "right":
+        elif event.key in ("right", "down"):
             self._move_section(1)
             event.prevent_default()
             event.stop()

--- a/verifiers/scripts/tui.py
+++ b/verifiers/scripts/tui.py
@@ -4312,6 +4312,10 @@ class VerifiersTUI(App):
         height: 1fr;
     }
 
+    .details-scroll:focus {
+        background-tint: $foreground 4%;
+    }
+
     #details-tabs {
         height: 1fr;
     }

--- a/verifiers/scripts/tui.py
+++ b/verifiers/scripts/tui.py
@@ -19,7 +19,6 @@ from rich.console import Console, Group
 from rich.table import Table
 from rich.text import Text
 from textual import events, on, work
-from textual.message import Message
 from textual.dom import DOMNode
 from textual.widget import Widget
 from textual.app import App, ComposeResult
@@ -493,14 +492,6 @@ def _truncate_preview(text: str, limit: int = 72) -> str:
     return collapsed[: limit - 1].rstrip() + "…"
 
 
-def _count_result_records(path: Path) -> int:
-    try:
-        with path.open("r", encoding="utf-8") as handle:
-            return sum(1 for _ in handle)
-    except OSError:
-        return 0
-
-
 def _compute_run_overview_stats(run: RunInfo) -> RunOverviewStats:
     rewards: List[float] = []
     metric_values: Dict[str, List[float]] = defaultdict(list)
@@ -804,26 +795,6 @@ def _reward_bucket_counts(values: List[float]) -> List[Tuple[str, int, str]]:
         for label, count, style in bucket_counts
         if not (label in ("<0", ">1") and count == 0)
     ]
-
-
-def _build_reward_share_bars(values: List[float], bar_width: int = 16) -> Text:
-    if not values:
-        return Text("No rollout rewards", style="dim")
-
-    total = len(values)
-    out = Text()
-    for idx, (label, count, style) in enumerate(_reward_bucket_counts(values)):
-        share = count / total if total else 0.0
-        filled = round(max(0.0, min(1.0, share)) * bar_width)
-        if idx:
-            out.append("\n")
-        out.append(f"{label:<9}", style="dim")
-        if filled:
-            out.append("█" * filled, style=style)
-        if filled < bar_width:
-            out.append("░" * (bar_width - filled), style="dim")
-        out.append(f" {share:>4.0%}")
-    return out
 
 
 _COMPARE_ALIAS_PALETTE: Tuple[str, ...] = (
@@ -1236,100 +1207,6 @@ class TabbedScrollPane(VerticalScroll):
         tc = self._get_tabbed_content()
         if tc is not None:
             tc.query_one(ContentTabs).action_next_tab()
-
-
-class GroupByBar(Widget):
-    """Interactive bar of toggleable axis chips for group-by selection."""
-
-    can_focus = True
-
-    BINDINGS = [
-        Binding("left", "cursor_left", show=False),
-        Binding("right", "cursor_right", show=False),
-        Binding("space,enter", "toggle_chip", show=False),
-        Binding("escape,g", "blur_bar", show=False),
-    ]
-
-    class Changed(Message):
-        def __init__(self, active_keys: List[str]) -> None:
-            super().__init__()
-            self.active_keys = active_keys
-
-    def __init__(self, **kwargs: Any) -> None:
-        super().__init__(**kwargs)
-        self._all_keys: List[str] = []
-        self._active: set[str] = set()
-        self._cursor: int = 0
-        self._chip_ranges: List[Tuple[int, int]] = []
-        self._short_key_fn: Callable[[str], str] = lambda k: k
-
-    def set_keys(self, keys: List[str], short_key_fn: Callable[[str], str]) -> None:
-        self._all_keys = list(keys)
-        self._active: set[str] = set()
-        self._short_key_fn = short_key_fn
-        self._cursor = min(self._cursor, max(0, len(keys) - 1))
-        self.refresh()
-
-    def render(self) -> Text:
-        text = Text()
-        text.append("Group by  ", style="bold dim")
-        if not self._active:
-            text.append("(all)  ", style="dim italic")
-        self._chip_ranges = []
-        for idx, key in enumerate(self._all_keys):
-            if idx:
-                text.append("  ")
-            start = len(text.plain)
-            label = self._short_key_fn(key)
-            is_active = key in self._active
-            is_cursor = idx == self._cursor and self.has_focus
-            if is_active:
-                style = "bold reverse" if is_cursor else "bold"
-                text.append(f"[{label}]", style=style)
-            else:
-                style = "dim reverse" if is_cursor else "dim"
-                text.append(f" {label} ", style=style)
-            end = len(text.plain)
-            self._chip_ranges.append((start, end))
-        if not self._all_keys:
-            text.append("(no varying axes)", style="dim")
-        return text
-
-    def on_click(self, event: events.Click) -> None:
-        x = event.x
-        for idx, (start, end) in enumerate(self._chip_ranges):
-            if start <= x < end:
-                self._cursor = idx
-                self.focus()
-                self._toggle(idx)
-                return
-
-    def action_cursor_left(self) -> None:
-        if self._all_keys:
-            self._cursor = (self._cursor - 1) % len(self._all_keys)
-            self.refresh()
-
-    def action_cursor_right(self) -> None:
-        if self._all_keys:
-            self._cursor = (self._cursor + 1) % len(self._all_keys)
-            self.refresh()
-
-    def action_toggle_chip(self) -> None:
-        if self._all_keys:
-            self._toggle(self._cursor)
-
-    def action_blur_bar(self) -> None:
-        self.screen.focus_next()
-
-    def _toggle(self, idx: int) -> None:
-        key = self._all_keys[idx]
-        if key in self._active:
-            self._active.discard(key)
-        else:
-            self._active.add(key)
-        self.refresh()
-        active_ordered = [k for k in self._all_keys if k in self._active]
-        self.post_message(self.Changed(active_ordered))
 
 
 # ----------------------------
@@ -1843,13 +1720,6 @@ class CompareRunsScreen(Screen):
             self._group_mode = False
             self._grouped_by_key = None
             self._refresh_outcomes()
-
-    def _render_comparison_content(self) -> Any:
-        if not self._stats_by_path:
-            return Text("Loading comparison…", style="dim")
-        header = self._build_comparison_header()
-        outcomes = self._build_comparison_outcomes()
-        return Group(header, outcomes)
 
     def _short_setting_key(self, key: str) -> str:
         replacements = {
@@ -2881,9 +2751,7 @@ class ViewRunScreen(Screen):
 
         return Text("\n").join(lines)
 
-    def _build_history_summary_text(
-        self, record: Dict[str, Any], *, include_hints: bool = False
-    ) -> Text:
+    def _build_history_summary_text(self, record: Dict[str, Any]) -> Text:
         completion = record.get("completion")
         if not isinstance(completion, list) or not completion:
             return Text()
@@ -3023,14 +2891,6 @@ class ViewRunScreen(Screen):
         total = "?" if self._record_count is None else str(self._record_count)
         return f"{self.current_record_idx + 1}/{total}"
 
-    def _set_rollout_option_count(self, count: int) -> None:
-        rollout_list = self.query_one("#rollout-list", OptionList)
-        while rollout_list.option_count < count:
-            idx = rollout_list.option_count
-            rollout_list.add_option(
-                Option(self._build_rollout_prompt(idx), id=str(idx))
-            )
-
     def _hydrate_rollout_option(self, index: int) -> None:
         rollout_list = self.query_one("#rollout-list", OptionList)
         if not (0 <= index < rollout_list.option_count):
@@ -3039,26 +2899,6 @@ class ViewRunScreen(Screen):
             index,
             self._build_rollout_prompt(index, self.records[index]),
         )
-
-    @work(
-        thread=True,
-        group="rollout-count",
-        exclusive=True,
-        exit_on_error=False,
-    )
-    def _load_record_count(self) -> None:
-        count = _count_result_records(self.run.path / "results.jsonl")
-        self.app.call_from_thread(self._finish_loading_record_count, count)
-
-    def _finish_loading_record_count(self, count: int) -> None:
-        self._record_count = count
-        if not self.is_mounted:
-            return
-        self._set_rollout_option_count(count)
-        rollout_list = self.query_one("#rollout-list", OptionList)
-        rollout_list.highlighted = self.current_record_idx
-        rollout_list.scroll_to_highlight()
-        self.update_display()
 
     def _populate_rollout_list(self) -> None:
         rollout_list = self.query_one("#rollout-list", OptionList)
@@ -3299,18 +3139,24 @@ class ViewRunScreen(Screen):
     def action_focus_next_pane(self) -> None:
         starting = self.focused
         self.focus_next()
+        first_candidate = self.focused
         while self.focused is not None and self.focused is not starting:
             if not self._should_skip_focus(self.focused):
                 break
             self.focus_next()
+            if self.focused is first_candidate:
+                break
 
     def action_focus_prev_pane(self) -> None:
         starting = self.focused
         self.focus_previous()
+        first_candidate = self.focused
         while self.focused is not None and self.focused is not starting:
             if not self._should_skip_focus(self.focused):
                 break
             self.focus_previous()
+            if self.focused is first_candidate:
+                break
 
     def action_history_page_up(self) -> None:
         self.query_one("#completion-scroll", VerticalScroll).scroll_page_up(
@@ -3773,9 +3619,7 @@ class ViewRunScreen(Screen):
             f"Current Rollout\n{self._build_rollout_prompt(self.current_record_idx, record).plain}",
         ]
 
-        history_summary = _text_to_plain(
-            self._build_history_summary_text(record, include_hints=False)
-        )
+        history_summary = _text_to_plain(self._build_history_summary_text(record))
         history_text = self._render_history_copy_text(history_sections)
         history_parts = ["Completion History"]
         if history_summary:
@@ -4770,7 +4614,6 @@ class RolloutCopyScreen(ModalScreen[None]):
     ):
         super().__init__()
         self._items = items
-        self._items_by_key = {item.key: item for item in items}
         self._title = title
         self._current_idx = 0
         if start_key:
@@ -4897,7 +4740,6 @@ class CompactCopyScreen(ModalScreen[None]):
     ):
         super().__init__()
         self._items = items
-        self._items_by_key = {item.key: item for item in items}
         self._title = title
         self._current_idx = 0
         if start_key:

--- a/verifiers/scripts/tui.py
+++ b/verifiers/scripts/tui.py
@@ -98,6 +98,8 @@ class BrowserNodeData:
     env_id: str = ""
     model: str = ""
     run: Optional[RunInfo] = None
+    tree_name: str = ""
+    tree_suffix: Tuple[Tuple[str, str], ...] = ()
 
 
 @dataclass(frozen=True)
@@ -124,9 +126,113 @@ class RunBrowserTree(Tree[BrowserNodeData]):
             for binding in Tree.BINDINGS
             if _binding_key(binding) not in {"enter", "space"}
         ),
+        Binding("left", "cursor_parent", "Parent folder", show=True),
+        Binding("right", "cursor_right", "Expand/next folder", show=True),
         Binding("enter", "select_cursor", "Open/toggle", show=True),
         Binding("space", "toggle_node", "Toggle folder", show=True),
     ]
+
+    def _visible_depth(self, node: Any) -> int:
+        depth = 0
+        parent = node.parent
+        while parent is not None and (self.show_root or not parent.is_root):
+            depth += 1
+            parent = parent.parent
+        return depth
+
+    def _render_browser_label(
+        self, payload: BrowserNodeData, style: Style, max_width: int
+    ) -> Text:
+        label = Text()
+        label.append(payload.tree_name or "", style="bold")
+        for text, segment_style in payload.tree_suffix:
+            label.append(text, style=segment_style or None)
+
+        if max_width <= 0:
+            label.truncate(1, overflow="ellipsis")
+            label.stylize(style)
+            return label
+
+        suffix = Text()
+        for text, segment_style in payload.tree_suffix:
+            suffix.append(text, style=segment_style or None)
+
+        if suffix.cell_len < max_width:
+            name = Text(payload.tree_name or "", style="bold")
+            name.truncate(max_width - suffix.cell_len, overflow="ellipsis")
+            label = Text.assemble(name, suffix)
+        else:
+            label.truncate(max_width, overflow="ellipsis")
+
+        label.stylize(style)
+        return label
+
+    def render_label(self, node: Any, base_style: Style, style: Style) -> Text:
+        payload = node.data
+        available_width = self.size.width - (
+            self._visible_depth(node) * self.guide_depth
+        )
+        prefix_text = (
+            self.ICON_NODE_EXPANDED
+            if node.allow_expand and node.is_expanded
+            else self.ICON_NODE
+            if node.allow_expand
+            else ""
+        )
+        content_width = max(1, available_width - len(prefix_text))
+
+        if isinstance(payload, BrowserNodeData) and payload.tree_name:
+            label = self._render_browser_label(payload, style, content_width)
+        else:
+            label = node._label.copy()
+            label.stylize(style)
+            label.truncate(content_width, overflow="ellipsis")
+
+        return Text.assemble((prefix_text, base_style), label)
+
+    def action_cursor_parent(self) -> None:
+        """Move the cursor to the nearest visible parent folder."""
+        cursor_node = self.cursor_node
+        if cursor_node is None:
+            return
+        parent = cursor_node.parent
+        if parent is None or (not self.show_root and parent.parent is None):
+            return
+        self.move_cursor(parent, animate=True)
+
+    def action_cursor_right(self) -> None:
+        """Expand the current folder or move to the next visible parent folder."""
+        cursor_node = self.cursor_node
+        if cursor_node is None:
+            return
+        if cursor_node.allow_expand:
+            if cursor_node.is_collapsed:
+                cursor_node.expand()
+                return
+            if cursor_node.children:
+                self.move_cursor(cursor_node.children[0], animate=True)
+                return
+
+        node = cursor_node.parent if not cursor_node.allow_expand else cursor_node
+        while node is not None:
+            next_sibling = node.next_sibling
+            if next_sibling is not None:
+                self.move_cursor(next_sibling, animate=True)
+                return
+            node = node.parent
+            if node is not None and not self.show_root and node.is_root:
+                return
+
+    def action_toggle_node(self) -> None:
+        """Toggle the current folder, or the nearest ancestor folder for a leaf."""
+        node = self.cursor_node
+        while node is not None and not node.allow_expand:
+            node = node.parent
+        if node is None or (not self.show_root and node.parent is None):
+            return
+        if node is not self.cursor_node:
+            self.move_cursor(node, animate=False)
+        self._toggle_node(node)
 
 
 def discover_results(
@@ -1312,7 +1418,17 @@ class BrowseRunsScreen(Screen):
             env_label.append(f"{total_runs} runs", style="dim")
             env_node = root.add(
                 env_label,
-                data=BrowserNodeData(kind="env", env_id=env_id),
+                data=BrowserNodeData(
+                    kind="env",
+                    env_id=env_id,
+                    tree_name=env_id,
+                    tree_suffix=(
+                        ("  ", ""),
+                        (f"{len(models)} models", "dim"),
+                        ("  ", ""),
+                        (f"{total_runs} runs", "dim"),
+                    ),
+                ),
                 expand=env_idx == 0,
             )
             for model_idx, model in enumerate(sorted(models.keys())):
@@ -1323,7 +1439,16 @@ class BrowseRunsScreen(Screen):
                 model_label.append(f"{len(runs)} runs", style="dim")
                 model_node = env_node.add(
                     model_label,
-                    data=BrowserNodeData(kind="model", env_id=env_id, model=model),
+                    data=BrowserNodeData(
+                        kind="model",
+                        env_id=env_id,
+                        model=model,
+                        tree_name=model,
+                        tree_suffix=(
+                            ("  ", ""),
+                            (f"{len(runs)} runs", "dim"),
+                        ),
+                    ),
                     expand=env_idx == 0 and model_idx == 0,
                 )
                 for run in runs:
@@ -1344,6 +1469,15 @@ class BrowseRunsScreen(Screen):
                             env_id=env_id,
                             model=model,
                             run=run,
+                            tree_name=run.run_id,
+                            tree_suffix=(
+                                (
+                                    f"  {_format_reward_value(avg_reward)}",
+                                    _reward_style(avg_reward),
+                                ),
+                            )
+                            if avg_reward is not None
+                            else (),
                         ),
                         allow_expand=False,
                     )
@@ -3205,6 +3339,7 @@ class VerifiersTUI(App):
         height: 1fr;
         background: $surface;
         color: $text;
+        overflow-x: hidden;
     }
 
     #run-browser-tree:focus {


### PR DESCRIPTION
## Description

- Improve the copy-sections
- Add toggle-able markdown rendering and reasoning blocks
- Add a comparison mode activated by `v` that allows for direct comparisons between runs of the same env & model
- Multiple subtle user-interaction improvements (see commits)

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large set of TUI behavior changes plus new markdown/math parsing dependencies; risk is mainly UX regressions (navigation/focus/search/copy) rather than data/security concerns.
> 
> **Overview**
> Adds a dedicated `CompareRunsScreen` (opened via `v` from env/model/run) that summarizes *setting axes* and groups outcomes across runs, including exact `=0`/`=1` reward buckets, reward-mix bars, and copyable comparison output.
> 
> Enhances the run viewer with toggleable math-aware markdown rendering (`m`), explicit nested “Reasoning” sections extracted from `reasoning_content`/`thinking_blocks`, improved search that jumps to the matched (nested) section, and numeric sorting for pass@k metrics.
> 
> Improves browse/run UX: tree left/right/space behaviors for parent navigation/expand/collapse, clipped long labels without horizontal scroll, focus highlighting for details panes, and richer details panels showing run settings + model setting variations.
> 
> Revamps copy flows by introducing `CompactCopyScreen` (used for details/comparison) and simplifying `RolloutCopyScreen`/`CopyScreen` bindings and focus behavior; updates tests extensively to cover new screens, rendering, and interactions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aa56ecda8f4777b1ac61fcffd7b0ce1de7cbeba1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->