### PR TITLE
vf-eval: Add mouse click support to eval TUI overview panel

### DIFF
--- a/verifiers/utils/display_utils.py
+++ b/verifiers/utils/display_utils.py
@@ -171,6 +171,7 @@ class BaseDisplay:
         self._stderr_thread: _FDToLogger | None = None
         self._key_listener_thread: threading.Thread | None = None
         self._key_listener_stop: threading.Event | None = None
+        self._mouse_enabled: bool = False
 
     def _render(self) -> Any:
         """
@@ -295,8 +296,25 @@ class BaseDisplay:
         )
         self._live.start()
 
+        # Enable SGR mouse tracking for click-to-select in overview panel
+        if (
+            HAS_TERMINAL_CONTROL
+            and sys.stdin.isatty()
+            and self._old_stdout_fd is not None
+        ):
+            os.write(self._old_stdout_fd, b"\x1b[?1000h\x1b[?1006h")
+            self._mouse_enabled = True
+
     def stop(self) -> None:
         """Stop the live display and restore terminal settings."""
+        # Disable mouse tracking before tearing down
+        if self._mouse_enabled and self._old_stdout_fd is not None:
+            try:
+                os.write(self._old_stdout_fd, b"\x1b[?1006l\x1b[?1000l")
+            except OSError:
+                pass
+            self._mouse_enabled = False
+
         if self._live:
             self._live.stop()
             self._live = None
@@ -377,28 +395,60 @@ class BaseDisplay:
             if not char:  # EOF (e.g. SSH disconnect)
                 break
             if char == b"\x1b":
-                # Parse escape sequences for arrow keys
+                handled = False
                 if select_module.select([fd], [], [], 0.05)[0]:
                     next_char = os.read(fd, 1)
                     if (
                         next_char == b"["
                         and select_module.select([fd], [], [], 0.05)[0]
                     ):
-                        direction = os.read(fd, 1)
-                        key_map = {
-                            b"C": "right",
-                            b"D": "left",
-                            b"A": "up",
-                            b"B": "down",
-                        }
-                        if direction in key_map:
-                            self._on_key(key_map[direction])
-                # Drain any remaining escape sequence chars
-                while select_module.select([fd], [], [], 0.01)[0]:
-                    os.read(fd, 1)
+                        third = os.read(fd, 1)
+                        if third == b"<":
+                            # SGR mouse event: \x1b[<Cb;Cx;CyM (press) or m (release)
+                            buf = b""
+                            while select_module.select([fd], [], [], 0.05)[0]:
+                                c = os.read(fd, 1)
+                                buf += c
+                                if c in (b"M", b"m"):
+                                    break
+                            if buf.endswith(b"M"):  # button press only
+                                try:
+                                    parts = buf[:-1].decode().split(";")
+                                    if len(parts) == 3:
+                                        button = int(parts[0])
+                                        x = int(parts[1])
+                                        y = int(parts[2])
+                                        if button == 0:  # left click
+                                            self._on_mouse_click(x, y)
+                                        elif button == 64:  # wheel up
+                                            self._on_key("up")
+                                        elif button == 65:  # wheel down
+                                            self._on_key("down")
+                                except (ValueError, IndexError):
+                                    pass
+                            handled = True
+                        else:
+                            # Arrow keys or other CSI sequences
+                            key_map = {
+                                b"C": "right",
+                                b"D": "left",
+                                b"A": "up",
+                                b"B": "down",
+                            }
+                            if third in key_map:
+                                self._on_key(key_map[third])
+                                handled = True
+                if not handled:
+                    # Drain any remaining escape sequence chars
+                    while select_module.select([fd], [], [], 0.01)[0]:
+                        os.read(fd, 1)
 
     def _on_key(self, key: str) -> None:
         """Handle a parsed keypress. Override in subclasses."""
+        pass
+
+    def _on_mouse_click(self, x: int, y: int) -> None:
+        """Handle a mouse click at terminal position (x, y), 1-indexed. Override in subclasses."""
         pass
 
     async def wait_for_exit(self) -> None:

--- a/verifiers/utils/eval_display.py
+++ b/verifiers/utils/eval_display.py
@@ -180,6 +180,9 @@ class EvalDisplay(BaseDisplay):
         self._env_log_titles: dict[int, Text] = {}
         self._tail_task: asyncio.Task | None = None
 
+        # Maps overview content row offset (0-based) to env index for click handling
+        self._overview_content_row_to_env: dict[int, int] = {}
+
         # initialize env states by index
         for idx, config in enumerate(configs):
             total = config.num_examples * config.rollouts_per_example
@@ -208,6 +211,20 @@ class EvalDisplay(BaseDisplay):
             self.refresh()
         elif key == "down":
             self._log_scroll_offset = max(0, self._log_scroll_offset - 3)
+            self.refresh()
+
+    def _on_mouse_click(self, x: int, y: int) -> None:
+        if not self.configs or len(self.configs) <= 1:
+            return
+        # Overview panel top border is at terminal row 1 (the frame always starts
+        # at the top of the visible area). Content rows start right after the border.
+        content_start_y = 2  # row 1 = border, row 2 = first content
+
+        content_row = y - content_start_y
+        env_idx = self._overview_content_row_to_env.get(content_row)
+        if env_idx is not None and env_idx != self._selected_env_idx:
+            self._selected_env_idx = env_idx
+            self._log_scroll_offset = 0
             self.refresh()
 
     @staticmethod
@@ -770,14 +787,19 @@ class EvalDisplay(BaseDisplay):
         below_count = n - end
 
         overview_rows: list[Text] = []
+        self._overview_content_row_to_env = {}
+        content_row = 0
         if above_count > 0:
             overview_rows.append(Text(f"  ... {above_count} above", style="dim"))
+            content_row += 1
         for idx in range(start, end):
             is_selected = idx == self._selected_env_idx
             row = self._make_compact_env_row(idx, selected=is_selected)
             if is_selected:
                 row.stylize("bold")
             overview_rows.append(row)
+            self._overview_content_row_to_env[content_row] = idx
+            content_row += 1
         if below_count > 0:
             overview_rows.append(Text(f"  ... and {below_count} more", style="dim"))
 
@@ -813,7 +835,7 @@ class EvalDisplay(BaseDisplay):
         """Create the footer panel with instructions."""
         nav_hint = ""
         if len(self.configs) > 1:
-            nav_hint = "\u25c4 \u25ba switch envs  \u25b2 \u25bc scroll logs"
+            nav_hint = "click or \u25c4 \u25ba switch envs  \u25b2 \u25bc scroll logs"
 
         if self.state.all_completed:
             if self.screen:


### PR DESCRIPTION
## Description

Enable SGR mouse tracking so users can click on env rows in the overview panel to select them, instead of only cycling with arrow keys. Also forwards mouse wheel events as up/down for log scrolling.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches low-level terminal I/O (escape-sequence parsing and terminal mode toggles), so regressions could break input handling or leave mouse tracking enabled in some terminals; scope is otherwise contained to the TUI display.
> 
> **Overview**
> Adds SGR mouse support to the Rich-based displays by enabling/disabling terminal mouse tracking in `BaseDisplay.start()`/`stop()` and extending the stdin key listener to parse SGR mouse events.
> 
> `EvalDisplay` now maps rendered overview rows to env indices and handles left-clicks to select an environment; mouse wheel events are forwarded as up/down for log scrolling, and the footer hint text is updated to advertise click navigation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed4f3dd031f8ff2da25084938beed614f208432c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->