### PR TITLE
Fix get_free_port_pair() TOCTOU race condition

### DIFF
--- a/verifiers/utils/worker_utils.py
+++ b/verifiers/utils/worker_utils.py
@@ -49,8 +49,12 @@ _reserved_sockets: list[socket.socket] = []
 def _make_reusable_socket(port: int = 0) -> socket.socket:
     """Create a TCP socket with SO_REUSEADDR bound to the given port."""
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    s.bind(("localhost", port))
+    try:
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        s.bind(("localhost", port))
+    except OSError:
+        s.close()
+        raise
     return s
 
 


### PR DESCRIPTION
## Description
Hold port reservation sockets open to prevent the OS from reassigning ports between discovery and ZMQ bind. Fixes #1012.

  Changes

  - Keep sockets alive in a module-level list instead of closing them on return
  - Set SO_REUSEADDR so child ZMQ processes can still bind the same ports

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes low-level socket/port allocation behavior and intentionally holds sockets open, which could cause port exhaustion or unexpected reuse semantics if called repeatedly.
> 
> **Overview**
> Fixes a TOCTOU race in `get_free_port_pair()` by *reserving* the discovered ports: it now creates sockets with `SO_REUSEADDR`, binds both `port` and `port+1`, and keeps those sockets alive in a module-level `_reserved_sockets` list instead of closing them immediately.
> 
> Adds `_make_reusable_socket()` helper to centralize reusable/bind logic and updates retry behavior to explicitly close partially-acquired sockets on failure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 21d6f13a4e3f1ede0b0037f87319313076d75e36. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->