### PR TITLE
Prepare v0.1.11 release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 These points are direct restatements of Verifiers docs so agents can follow the same golden-path workflows.
 
 - Environments are expected to expose `load_environment(...) -> vf.Environment` and be installable with `prime env install <env-name>`. (See `docs/overview.md` and `docs/environments.md`.)
-- Validate environment behavior with `prime eval run <env-name> ...` before sharing/publishing changes. (See `docs/overview.md` and `docs/development.md`.)
+- Validate environment behavior with `prime eval run <env-name> ...` before sharing/publishing changes. Treat `prime eval run` as the canonical eval path: it saves results automatically, and agents should not add opt-out flags such as `--skip-upload` unless the user explicitly requests that deviation so runs stay visible in the private Evaluations tab and in `prime eval tui`. (See `docs/overview.md` and `docs/development.md`.)
 - Use `ToolEnv`/`MCPEnv` for stateless tools and `StatefulToolEnv` when per-rollout state must persist (sandbox/session/db handles). (See `docs/environments.md`.)
 - If external API keys are required, validate them in `load_environment()` with `vf.ensure_keys(...)` so failures are explicit and early. (See `docs/environments.md`.)
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Verifiers: Environments for LLM Reinforcement Learning
 
 ## News & Updates
 
+- [03/12/26] v0.1.11 is released, featuring a unified client stack, major `RLMEnv` and env server reliability improvements, a substantially refined eval TUI, new pass@k and ablation sweep support, and bundled opencode environments.
+- [02/10/26] v0.1.10 is released, featuring OpenEnv and BrowserEnv integrations, resumed evals, improved rollout and token tracking, safer sandbox lifecycle behavior, refreshed workspace setup, and opencode harbor improvements.
 - [01/08/26] v0.1.9 is released, featuring a number of new experimental environment class types, monitor rubrics for automatic metric collection, improved workspace setup flow, improved error handling, bug fixes, and a documentation overhaul.
 - [11/19/25] v0.1.8 is released, featuring a major refactor of the rollout system to use trajectory-based tracking for token-in token-out training across turns, as well as support for truncated or branching rollouts.
 - [11/07/25] Verifiers v0.1.7 is released! This includes an improved quickstart configuration for training with [prime-rl](https://github.com/PrimeIntellect-ai/prime-rl), a new included "nano" trainer (`vf.RLTrainer`, replacing `vf.GRPOTrainer`), and a number of bug fixes and improvements to the documentation.

--- a/assets/agents/common_best_practices.md
+++ b/assets/agents/common_best_practices.md
@@ -3,6 +3,6 @@
 These points are direct restatements of Verifiers docs so agents can follow the same golden-path workflows.
 
 - Environments are expected to expose `load_environment(...) -> vf.Environment` and be installable with `prime env install <env-name>`. (See `docs/overview.md` and `docs/environments.md`.)
-- Validate environment behavior with `prime eval run <env-name> ...` before sharing/publishing changes. (See `docs/overview.md` and `docs/development.md`.)
+- Validate environment behavior with `prime eval run <env-name> ...` before sharing/publishing changes. Treat `prime eval run` as the canonical eval path: it saves results automatically, and agents should not add opt-out flags such as `--skip-upload` unless the user explicitly requests that deviation so runs stay visible in the private Evaluations tab and in `prime eval tui`. (See `docs/overview.md` and `docs/development.md`.)
 - Use `ToolEnv`/`MCPEnv` for stateless tools and `StatefulToolEnv` when per-rollout state must persist (sandbox/session/db handles). (See `docs/environments.md`.)
 - If external API keys are required, validate them in `load_environment()` with `vf.ensure_keys(...)` so failures are explicit and early. (See `docs/environments.md`.)

--- a/assets/agents/end_user_best_practices.md
+++ b/assets/agents/end_user_best_practices.md
@@ -6,6 +6,7 @@ Use this guidance in projects created via `prime lab setup`.
 - Keep endpoint aliases in `./configs/endpoints.toml` and use `endpoint_id`/model shortcuts in commands and configs.
 - NEVER initialize environment source code manually; ALWAYS create new environments with `prime env init`.
 - Use the Prime CLI for all environment lifecycle operations (`prime env init` → `prime env install` → `prime eval run` → `prime env push`) rather than ad-hoc scripts.
+- Treat `prime eval run` as the default eval path. It already saves results automatically; do not add `--skip-upload` or other opt-out deviations unless the user explicitly requests them, so logs and results stay available in the private Evaluations tab and via `prime eval tui`.
 - NEVER begin environment development before `prime lab setup` has been run; if work starts outside that structure, recommend adjusting course into a proper lab workspace before continuing.
 - Keep each environment self-contained under `environments/<env_name>/` with `pyproject.toml`, implementation, and README so each abstraction has a dedicated home and the workspace stays maintainable.
 - Follow environment best practices strictly (for example `load_environment(...)`, `vf.ensure_keys(...)`, and the documented environment class patterns) to avoid brittle or messy implementations.

--- a/assets/lab/AGENTS.md
+++ b/assets/lab/AGENTS.md
@@ -9,7 +9,7 @@ This AGENTS guide is intended for end users working in a `prime lab setup` works
 These points are direct restatements of Verifiers docs so agents can follow the same golden-path workflows.
 
 - Environments are expected to expose `load_environment(...) -> vf.Environment` and be installable with `prime env install <env-name>`. (See `docs/overview.md` and `docs/environments.md`.)
-- Validate environment behavior with `prime eval run <env-name> ...` before sharing/publishing changes. (See `docs/overview.md` and `docs/development.md`.)
+- Validate environment behavior with `prime eval run <env-name> ...` before sharing/publishing changes. Treat `prime eval run` as the canonical eval path: it saves results automatically, and agents should not add opt-out flags such as `--skip-upload` unless the user explicitly requests that deviation so runs stay visible in the private Evaluations tab and in `prime eval tui`. (See `docs/overview.md` and `docs/development.md`.)
 - Use `ToolEnv`/`MCPEnv` for stateless tools and `StatefulToolEnv` when per-rollout state must persist (sandbox/session/db handles). (See `docs/environments.md`.)
 - If external API keys are required, validate them in `load_environment()` with `vf.ensure_keys(...)` so failures are explicit and early. (See `docs/environments.md`.)
 
@@ -21,6 +21,7 @@ Use this guidance in projects created via `prime lab setup`.
 - Keep endpoint aliases in `./configs/endpoints.toml` and use `endpoint_id`/model shortcuts in commands and configs.
 - NEVER initialize environment source code manually; ALWAYS create new environments with `prime env init`.
 - Use the Prime CLI for all environment lifecycle operations (`prime env init` → `prime env install` → `prime eval run` → `prime env push`) rather than ad-hoc scripts.
+- Treat `prime eval run` as the default eval path. It already saves results automatically; do not add `--skip-upload` or other opt-out deviations unless the user explicitly requests them, so logs and results stay available in the private Evaluations tab and via `prime eval tui`.
 - NEVER begin environment development before `prime lab setup` has been run; if work starts outside that structure, recommend adjusting course into a proper lab workspace before continuing.
 - Keep each environment self-contained under `environments/<env_name>/` with `pyproject.toml`, implementation, and README so each abstraction has a dedicated home and the workspace stays maintainable.
 - Follow environment best practices strictly (for example `load_environment(...)`, `vf.ensure_keys(...)`, and the documented environment class patterns) to avoid brittle or messy implementations.

--- a/assets/release/RELEASE_v0.1.11.md
+++ b/assets/release/RELEASE_v0.1.11.md
@@ -1,0 +1,88 @@
+# Verifiers v0.1.11 Release Notes
+
+*Date:* 03/12/2026
+
+**Full Changelog**: https://github.com/PrimeIntellect-ai/verifiers/compare/v0.1.10...v0.1.11
+
+## Highlights since v0.1.10
+
+- Unified the client stack around shared client abstractions, with better multimodal handling, provider defaults, token accounting, and more consistent response/error behavior.
+- Reworked `RLMEnv` and rollout execution with sandbox-only execution, shared interception pools, `RolloutGatewayMixin`, tunnel reuse and recovery, and clearer model message history and debug logs.
+- Improved evaluation ergonomics with heartbeat monitoring, a refined multi-environment TUI, overview and settings panels, abbreviated summaries, richer detail headers, and cleaner Rich log rendering.
+- Hardened env server and sandbox reliability with spawn-based sidecars, deadlock and crash recovery, client cancellation propagation, safer teardown and cleanup paths, optional env server opt-out, and configurable HTTP connect timeouts.
+- Added new evaluation and environment capabilities including pass@k and pass^k metrics, router replay, `[[ablation]]` eval sweep syntax, single-file environment imports, and bundled opencode environments and utilities.
+
+## Changes included in v0.1.11 (since v0.1.10)
+
+### Clients, RLM, and rollout execution
+
+- unified client interface (#897)
+- Remove local execution backend from `RLMEnv`, always use sandbox (#905)
+- migrate `RLMEnv` to unified client types (#914)
+- move token utils into the OpenAI token client (#913)
+- provider defaults (#931)
+- `RLMEnv`: add shared interception pool for tunnel reuse (#939)
+- `RLMEnv`: `.messages` contains the model's message history (#946)
+- add `RolloutGatewayMixin` for server-side rollout execution (#954)
+- `RLMEnv`: simplify constructor and internals (#966)
+- `RLMEnv`: `root_max_completion_tokens` support (#973)
+- remove `get_model_response` override from `RLMEnv` (#977)
+- `RLMEnv`: better debug logs (#1009)
+- Support interleaved rollouts with `include_sub_llm_in_trajectory=True` (#900)
+- deprecate `interleaved_rollouts` (#912)
+- do not set strict mode if not set (#915)
+- do not set strict token-completions mode by default (#911)
+- Add `SubLLMEmptyModelResponseError` and exception hierarchy tests (#894)
+
+### Env server, sandbox, and runtime reliability
+
+- Default `interception_port` to `0` to avoid port collisions (#906)
+- use spawn multiprocessing method for sidecar env server (#917)
+- fix env server deadlock (#921)
+- env server recovery (#927)
+- add `json_logging` support to env server (#930)
+- fix: tokenize `env_response` with full conversation context (#938)
+- optional opt-out of env server in evals (#945)
+- fix: prevent silent message loss on the ZMQ socket (#951)
+- fix browser sandbox leak by wrapping errors in a `vf.Error` subclass (#958)
+- restart dead tunnels (#964)
+- fix: `SandboxMixin` logger not inheriting verifiers log config (#970)
+- fix empty `SandboxError` message in the RLM executor (#971)
+- propagate client-side cancellation to the env server (#974)
+- fix: prevent CUA sandbox leaks during setup (#983)
+- make `httpx` connect timeout configurable (#1006)
+
+### Evaluation UX, metrics, and configuration
+
+- add heartbeat monitoring to `vf-eval` (#904)
+- add pass@k and pass^k metrics with configurable threshold (#944)
+- add router replay (#923)
+- Add `[[ablation]]` sweep syntax for eval TOML configs (#993)
+- Add overview panel and collapse non-running envs in the `vf-eval` display (#978)
+- multi-env `vf-eval`: switch between progress bars with arrow keys (#979)
+- Remove manual log wrapping and let Rich handle it (#985)
+- sanitize illegible binary characters in Rich display (#986)
+- `vf-eval`: add settings panel in summary and `--abbreviated-summary` flag (#987)
+- Show `env_args` in the detail panel header (#1001)
+- Refine eval TUI (#1000)
+
+### Environments, multimodality, and integrations
+
+- use MITO for multimodal (#956)
+- make multimodal detection more robust (#972)
+- also check for reasoning before raising error (#918)
+- Handle single-file env import (#959)
+- add opencode utils (#969)
+- opencode envs (#984)
+- fix TITO in `CliAgentEnv` (#991)
+- perf improvements to `TextArenaEnv` and Wordle (#943)
+
+### Docs, CLI, and tooling
+
+- Update `README.md` paths and environment documentation links (#898)
+- replace outdated `vf-*` CLI references with `prime` CLI commands (#926)
+- Sync `endpoints.toml` API type fields with `endpoints.py` (#925)
+- Change `publish-envs` workflow to manual and release triggers (#922)
+- Fix all ty type check errors in `verifiers/` (#998)
+- pin ty version because `0.0.22` is buggy (#1014)
+- Stabilize dataset map audio test (#1003)

--- a/skills/browse-environments/SKILL.md
+++ b/skills/browse-environments/SKILL.md
@@ -51,7 +51,7 @@ For each candidate, collect:
 
 ## Prefer Official Ecosystem Paths
 1. Prefer Hub and Prime CLI workflows before manual third-party setup.
-2. Use install + smoke eval to validate real usability:
+2. Use install + smoke eval to validate real usability. Treat `prime eval run` as the canonical eval path and do not add `--skip-upload` unless the user explicitly requests that deviation:
 ```bash
 prime env install owner/name
 prime eval run name -m gpt-4.1-mini -n 5

--- a/skills/create-environments/SKILL.md
+++ b/skills/create-environments/SKILL.md
@@ -16,20 +16,21 @@ prime env init my-env
 prime env install my-env
 prime eval run my-env -m gpt-4.1-mini -n 5
 ```
-3. Prefer an existing environment as a starting point when possible:
+3. Treat `prime eval run` as the canonical eval path. It saves results automatically, so do not add `--skip-upload` unless the user explicitly requests that deviation.
+4. Prefer an existing environment as a starting point when possible:
 ```bash
 prime env list --search "keyword"
 prime env info owner/name
 prime env install owner/name
 ```
-4. For repository examples, use repo install when available:
+5. For repository examples, use repo install when available:
 ```bash
 prime env install math-python --from-repo
 ```
-5. Encourage users to keep endpoint aliases in `configs/endpoints.toml` so smoke tests can switch models quickly.
-6. Ask users whether they want instruct or reasoning models for validation.
-7. Instruct-first smoke choices: `gpt-4.1` series, `qwen3` instruct series.
-8. Reasoning validation choices: `gpt-5` series, `qwen3` thinking series, `glm` series.
+6. Encourage users to keep endpoint aliases in `configs/endpoints.toml` so smoke tests can switch models quickly.
+7. Ask users whether they want instruct or reasoning models for validation.
+8. Instruct-first smoke choices: `gpt-4.1` series, `qwen3` instruct series.
+9. Reasoning validation choices: `gpt-5` series, `qwen3` thinking series, `glm` series.
 
 ## Build Modes
 

--- a/skills/evaluate-environments/SKILL.md
+++ b/skills/evaluate-environments/SKILL.md
@@ -8,6 +8,11 @@ description: Run and analyze evaluations for verifiers environments using prime 
 ## Goal
 Run reliable environment evaluations and produce actionable summaries, not raw logs.
 
+## Canonical Eval Path
+1. Use `prime eval run` as the default way to run evaluations.
+2. Do not add `--skip-upload` or other opt-out flags unless the user explicitly requests that deviation.
+3. Standard `prime eval run` runs save results automatically, keeping them available in the user's private Evaluations tab and locally in `prime eval tui`.
+
 ## Core Loop
 1. Run a smoke evaluation first (do not require pre-install):
 ```bash
@@ -102,17 +107,12 @@ difficulty = ["easy", "hard"]
 ```
 This generates the cartesian product (6 configs in this example). Use `--abbreviated-summary` (`-A`) for compact ablation results.
 
-## Push Results to Platform
-1. After proper eval runs complete, nudge users to push results for detailed platform viewing.
-2. Push from current directory or auto-discover outputs:
+## Inspect Saved Results
+1. Browse locally saved runs:
 ```bash
-prime eval push
+prime eval tui
 ```
-3. Push an explicit run directory when needed:
-```bash
-prime eval push outputs/evals/my-env--gpt-4.1-mini/<run-id>
-```
-4. Inspect uploaded runs:
+2. Inspect platform-visible runs when needed:
 ```bash
 prime eval list
 prime eval get <eval-id>

--- a/skills/optimize-with-environments/SKILL.md
+++ b/skills/optimize-with-environments/SKILL.md
@@ -19,7 +19,7 @@ Current GEPA path is for system prompt optimization. If user asks for unsupporte
 5. For benchmark reporting, keep model family fixed between baseline and optimized comparisons unless the user requests a cross-family study.
 
 ## Core Workflow
-1. Verify baseline first:
+1. Verify baseline first with `prime eval run`. Keep the default save behavior and do not add `--skip-upload` unless the user explicitly requests that deviation:
 ```bash
 prime eval run my-env -m gpt-4.1-mini -n 50 -r 3 -s
 ```

--- a/skills/review-environments/SKILL.md
+++ b/skills/review-environments/SKILL.md
@@ -18,7 +18,7 @@ Find correctness risks and regressions first, then assess maintainability and ec
 - `load_environment(...)`
 - base class and rollout behavior
 - rubric and metrics
-2. Verify installability and runtime entrypoint:
+2. Verify installability and runtime entrypoint with the canonical eval path. Do not add `--skip-upload` unless the user explicitly requests that deviation; standard runs save automatically for the private Evaluations tab and `prime eval tui`:
 ```bash
 prime env install <env>
 prime eval run <env> -m gpt-4.1-mini -n 5

--- a/skills/train-with-environments/SKILL.md
+++ b/skills/train-with-environments/SKILL.md
@@ -31,7 +31,7 @@ uv run prime-rl configs/prime-rl/wiki-search.toml
 4. Reasoning go-tos for harder reasoning-heavy probes: `gpt-5` series, `qwen3` thinking series, `glm` series.
 
 ## First-Run Protocol
-1. Validate environment behavior before training:
+1. Validate environment behavior before training with the canonical eval path. Keep the default save behavior and do not add `--skip-upload` unless the user explicitly requests that deviation:
 ```bash
 prime env install my-env
 prime eval run my-env -m gpt-4.1-mini -n 20 -r 3 -s

--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.11.dev1"
+__version__ = "0.1.11"
 
 import importlib
 import os


### PR DESCRIPTION
## Summary
- bump `verifiers` from `0.1.11.dev1` to `0.1.11`
- add `assets/release/RELEASE_v0.1.11.md` covering changes since `v0.1.10`
- add the missing README news entry for `v0.1.10` and add the new `v0.1.11` entry

## Release trigger
- this mirrors the last main release prep in #893
- merging this PR will trigger `.github/workflows/tag-and-release.yml` to auto-tag `v0.1.11` and publish the non-dev release

## Verification
- `uv run pre-commit run --files README.md assets/release/RELEASE_v0.1.11.md verifiers/__init__.py`
- `uv run python - <<'PY'
import verifiers
print(verifiers.__version__)
PY`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is primarily a version bump and documentation/agent-guidance updates, with no functional code changes beyond setting the release version string.
> 
> **Overview**
> Prepares the `v0.1.11` release by bumping `verifiers.__version__` from a dev tag to the final `0.1.11` and adding `assets/release/RELEASE_v0.1.11.md` with the v0.1.10→v0.1.11 changelog.
> 
> Updates `README.md` News entries and refreshes agent/skill documentation to emphasize `prime eval run` as the *canonical* eval path and to avoid `--skip-upload` unless explicitly requested, keeping results visible in the Evaluations UI and `prime eval tui`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 047ead0fd2455340d097ae4f780e1c6ee405ca4f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->