### PR TITLE
tune GC on env server before accepting requests

### DIFF
--- a/verifiers/workers/server/zmq_env_server.py
+++ b/verifiers/workers/server/zmq_env_server.py
@@ -1,4 +1,5 @@
 import asyncio
+import gc
 import multiprocessing as mp
 from typing import cast
 
@@ -89,6 +90,14 @@ class ZMQEnvServer(EnvServer):
         )
         self.health_process.start()
         self.logger.info(f"Health check responder started on {self.health_address}")
+
+        gc.collect()
+        gc.freeze()
+        gc.set_threshold(150_000, 10, 10)
+        self.logger.info(
+            f"GC tuned: frozen {gc.get_freeze_count()} objects, "
+            f"threshold={gc.get_threshold()}"
+        )
 
         lag_monitor_task = self.lag_monitor.run_in_background()
 


### PR DESCRIPTION
Freeze the init-time object graph (env, rubric, tools, dataset) and raise gen0 threshold from 700 to 150K so the collector runs less often and never scans long-lived init objects.

Some before/after from local testing. Total GC pauses are less at least. 

<img width="740" height="212" alt="image" src="https://github.com/user-attachments/assets/f495d606-c79d-4263-92f2-7562f6ed0899" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk performance tweak that changes Python GC behavior at server startup; potential risk is altered memory/latency characteristics under load.
> 
> **Overview**
> Tunes Python GC in `ZMQEnvServer.serve()` before accepting requests by forcing a collection, freezing the init-time object graph, and raising GC thresholds (with an info log of the new settings). This aims to reduce GC frequency/pauses during steady-state request handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 441bba58a4cf06b52b794ae16fb839fa445ca990. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->