### PR TITLE
fix display of custom sampling args

### DIFF
--- a/verifiers/utils/eval_display.py
+++ b/verifiers/utils/eval_display.py
@@ -411,9 +411,13 @@ class EvalDisplay(BaseDisplay):
             config_line.append("  |  ", style="dim")
             config_line.append("custom sampling ", style="white")
             config_line.append("(", style="dim")
-            for key, value in config.sampling_args.items():
-                if value is not None:
-                    config_line.append(f"{key}={value}", style="dim")
+            non_none_items = [
+                (k, v) for k, v in config.sampling_args.items() if v is not None
+            ]
+            for i, (key, value) in enumerate(non_none_items):
+                if i > 0:
+                    config_line.append(", ", style="dim")
+                config_line.append(f"{key}={value}", style="dim")
             config_line.append(")", style="dim")
         if config.save_results:
             config_line.append("  |  ", style="dim")


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change: adjusts how `sampling_args` are rendered in the Rich eval progress display, with no impact on evaluation logic or data handling.
> 
> **Overview**
> Fixes the live eval Rich UI so `custom sampling` arguments are displayed as a clean comma-separated list, rather than concatenating values without separators when multiple non-`None` `sampling_args` are present.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb66eafc47f6afdfd1981510fe4ab0cd0dd6d7c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->