### PR TITLE
Add cleanup and teardown lifecycle hooks to Rubric

### DIFF
--- a/tests/test_decorator_ranks.py
+++ b/tests/test_decorator_ranks.py
@@ -365,6 +365,100 @@ class TestTeardownPriorityOrdering:
         ) < env.teardown_order.index("default_teardown")
 
 
+class TestRubricCleanupTeardown:
+    """Test cleanup/teardown on Rubric and RubricGroup."""
+
+    def test_rubric_cleanup_handlers(self):
+        """Test that @vf.cleanup decorated methods on a Rubric subclass are invoked."""
+        import asyncio
+
+        class MyRubric(vf.Rubric):
+            def __init__(self, **kwargs):
+                super().__init__(**kwargs)
+                self.cleaned = []
+
+            @vf.cleanup
+            async def do_cleanup(self, state: State):
+                self.cleaned.append(state.get("id"))
+
+        rubric = MyRubric()
+        asyncio.run(rubric.cleanup({"id": "a"}))
+        assert rubric.cleaned == ["a"]
+
+    def test_rubric_teardown_handlers(self):
+        """Test that @vf.teardown decorated methods on a Rubric subclass are invoked."""
+        import asyncio
+
+        class MyRubric(vf.Rubric):
+            def __init__(self, **kwargs):
+                super().__init__(**kwargs)
+                self.torn_down = False
+
+            @vf.teardown
+            async def do_teardown(self):
+                self.torn_down = True
+
+        rubric = MyRubric()
+        asyncio.run(rubric.teardown())
+        assert rubric.torn_down
+
+    def test_rubric_group_runs_own_and_child_cleanup(self):
+        """Test that RubricGroup.cleanup runs both its own and child handlers."""
+        import asyncio
+
+        class ChildRubric(vf.Rubric):
+            def __init__(self, **kwargs):
+                super().__init__(**kwargs)
+                self.order = []
+
+            @vf.cleanup
+            async def child_cleanup(self, state: State):
+                self.order.append("child")
+
+        class MyGroup(vf.RubricGroup):
+            def __init__(self, **kwargs):
+                super().__init__(**kwargs)
+                self.order = []
+
+            @vf.cleanup
+            async def group_cleanup(self, state: State):
+                self.order.append("group")
+
+        child = ChildRubric()
+        group = MyGroup(rubrics=[child])
+        asyncio.run(group.cleanup({"id": "x"}))
+        assert "group" in group.order
+        assert "child" in child.order
+
+    def test_rubric_group_runs_own_and_child_teardown(self):
+        """Test that RubricGroup.teardown runs both its own and child handlers."""
+        import asyncio
+
+        class ChildRubric(vf.Rubric):
+            def __init__(self, **kwargs):
+                super().__init__(**kwargs)
+                self.torn_down = False
+
+            @vf.teardown
+            async def child_teardown(self):
+                self.torn_down = True
+
+        class MyGroup(vf.RubricGroup):
+            def __init__(self, **kwargs):
+                super().__init__(**kwargs)
+                self.torn_down = False
+
+            @vf.teardown
+            async def group_teardown(self):
+                self.torn_down = True
+
+        child = ChildRubric()
+        group = MyGroup(rubrics=[child])
+        asyncio.run(group.teardown())
+        assert group.torn_down
+        assert child.torn_down
+
+
 class TestDecoratorPriorityEdgeCases:
     """Test edge cases for decorator priority functionality."""
 

--- a/verifiers/decorators.py
+++ b/verifiers/decorators.py
@@ -2,7 +2,7 @@ import inspect
 from typing import Any, Awaitable, Callable
 
 
-def discover_decorated(obj: Any, attr: str) -> list[Callable]:
+def discover_decorated(obj: Any, attr: str) -> list:
     """Discover methods decorated with a given attribute, sorted by priority.
 
     Returns bound methods on *obj* that have ``attr`` set, ordered by

--- a/verifiers/decorators.py
+++ b/verifiers/decorators.py
@@ -1,4 +1,21 @@
-from typing import Awaitable, Callable
+import inspect
+from typing import Any, Awaitable, Callable
+
+
+def discover_decorated(obj: Any, attr: str) -> list[Callable]:
+    """Discover methods decorated with a given attribute, sorted by priority.
+
+    Returns bound methods on *obj* that have ``attr`` set, ordered by
+    descending ``{attr}_priority`` then ascending ``__name__``.
+    """
+    methods = [
+        method
+        for _, method in inspect.getmembers(obj, predicate=inspect.ismethod)
+        if hasattr(method, attr) and callable(method)
+    ]
+    priority_attr = f"{attr}_priority"
+    methods.sort(key=lambda m: (-getattr(m, priority_attr, 0), m.__name__))
+    return methods
 
 
 def stop(

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -667,6 +667,7 @@ class Environment(ABC):
         """
         Tear down environment resources.
         """
+        await self.rubric.teardown()
         for handler in self._teardown_handlers:
             await handler()
 

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -747,6 +747,8 @@ class Environment(ABC):
             else:
                 await self.rubric.dummy_score_rollout(state)
 
+            await self.rubric.cleanup(state)
+
             return state
 
         state = await maybe_retry(run_rollout_attempt, max_retries=max_retries)()
@@ -804,6 +806,10 @@ class Environment(ABC):
                 await self.rubric.score_group(group_states)
             else:
                 await self.rubric.dummy_score_group(group_states)
+
+            for state in group_states:
+                await self.rubric.cleanup(state)
+
             return group_states
 
         group_states = await maybe_retry(run_group_attempt, max_retries=max_retries)()

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import atexit
-import inspect
+from verifiers.decorators import discover_decorated
 import json
 import logging
 import multiprocessing as mp
@@ -241,32 +241,9 @@ class Environment(ABC):
         return normalized
 
     def __post_init__(self):
-        self._stop_conditions = [
-            method
-            for _, method in inspect.getmembers(self, predicate=inspect.ismethod)
-            if hasattr(method, "stop") and callable(method)
-        ]
-        self._stop_conditions.sort(
-            key=lambda m: (-getattr(m, "stop_priority", 0), m.__name__)
-        )
-
-        self._cleanup_handlers = [
-            method
-            for _, method in inspect.getmembers(self, predicate=inspect.ismethod)
-            if hasattr(method, "cleanup") and callable(method)
-        ]
-        self._cleanup_handlers.sort(
-            key=lambda m: (-getattr(m, "cleanup_priority", 0), m.__name__)
-        )
-
-        self._teardown_handlers = [
-            method
-            for _, method in inspect.getmembers(self, predicate=inspect.ismethod)
-            if hasattr(method, "teardown") and callable(method)
-        ]
-        self._teardown_handlers.sort(
-            key=lambda m: (-getattr(m, "teardown_priority", 0), m.__name__)
-        )
+        self._stop_conditions = discover_decorated(self, "stop")
+        self._cleanup_handlers = discover_decorated(self, "cleanup")
+        self._teardown_handlers = discover_decorated(self, "teardown")
 
         def _sync_teardown():
             try:

--- a/verifiers/rubrics/rubric.py
+++ b/verifiers/rubrics/rubric.py
@@ -63,6 +63,16 @@ class Rubric:
             key=lambda m: (-getattr(m, "cleanup_priority", 0), m.__name__)
         )
 
+        # Discover @vf.teardown-decorated methods
+        self._teardown_handlers: list[Callable[[], Awaitable[None]]] = [
+            method
+            for _, method in inspect.getmembers(self, predicate=inspect.ismethod)
+            if hasattr(method, "teardown") and callable(method)
+        ]
+        self._teardown_handlers.sort(
+            key=lambda m: (-getattr(m, "teardown_priority", 0), m.__name__)
+        )
+
     # public helpers
     def add_reward_func(self, func: RewardFunc, weight: float = 1.0):
         self.funcs.append(func)
@@ -227,6 +237,11 @@ class Rubric:
         """Run all @vf.cleanup-decorated methods on this rubric."""
         for handler in self._cleanup_handlers:
             await handler(state)
+
+    async def teardown(self):
+        """Run all @vf.teardown-decorated methods on this rubric."""
+        for handler in self._teardown_handlers:
+            await handler()
 
     async def dummy_score_rollout(self, state: State):
         """Score a single rollout with dummy rewards."""

--- a/verifiers/rubrics/rubric.py
+++ b/verifiers/rubrics/rubric.py
@@ -2,7 +2,7 @@ import asyncio
 import inspect
 import logging
 import time
-from typing import Any, Awaitable, Callable, cast
+from typing import Any, cast
 
 import verifiers as vf
 from verifiers.decorators import discover_decorated

--- a/verifiers/rubrics/rubric.py
+++ b/verifiers/rubrics/rubric.py
@@ -5,6 +5,7 @@ import time
 from typing import Any, Awaitable, Callable, cast
 
 import verifiers as vf
+from verifiers.decorators import discover_decorated
 from verifiers.types import (
     GroupRewardFunc,
     RewardFunc,
@@ -53,25 +54,8 @@ class Rubric:
         if self.parser:
             self.class_objects["parser"] = self.parser
 
-        # Discover @vf.cleanup-decorated methods
-        self._cleanup_handlers: list[Callable[[State], Awaitable[None]]] = [
-            method
-            for _, method in inspect.getmembers(self, predicate=inspect.ismethod)
-            if hasattr(method, "cleanup") and callable(method)
-        ]
-        self._cleanup_handlers.sort(
-            key=lambda m: (-getattr(m, "cleanup_priority", 0), m.__name__)
-        )
-
-        # Discover @vf.teardown-decorated methods
-        self._teardown_handlers: list[Callable[[], Awaitable[None]]] = [
-            method
-            for _, method in inspect.getmembers(self, predicate=inspect.ismethod)
-            if hasattr(method, "teardown") and callable(method)
-        ]
-        self._teardown_handlers.sort(
-            key=lambda m: (-getattr(m, "teardown_priority", 0), m.__name__)
-        )
+        self._cleanup_handlers = discover_decorated(self, "cleanup")
+        self._teardown_handlers = discover_decorated(self, "teardown")
 
     # public helpers
     def add_reward_func(self, func: RewardFunc, weight: float = 1.0):

--- a/verifiers/rubrics/rubric.py
+++ b/verifiers/rubrics/rubric.py
@@ -2,7 +2,7 @@ import asyncio
 import inspect
 import logging
 import time
-from typing import Any, cast
+from typing import Any, Awaitable, Callable, cast
 
 import verifiers as vf
 from verifiers.types import (
@@ -52,6 +52,16 @@ class Rubric:
         self.class_objects = {}
         if self.parser:
             self.class_objects["parser"] = self.parser
+
+        # Discover @vf.cleanup-decorated methods
+        self._cleanup_handlers: list[Callable[[State], Awaitable[None]]] = [
+            method
+            for _, method in inspect.getmembers(self, predicate=inspect.ismethod)
+            if hasattr(method, "cleanup") and callable(method)
+        ]
+        self._cleanup_handlers.sort(
+            key=lambda m: (-getattr(m, "cleanup_priority", 0), m.__name__)
+        )
 
     # public helpers
     def add_reward_func(self, func: RewardFunc, weight: float = 1.0):
@@ -212,6 +222,11 @@ class Rubric:
                 )
                 ans = [0.0] * len(states)
         return ans
+
+    async def cleanup(self, state: State):
+        """Run all @vf.cleanup-decorated methods on this rubric."""
+        for handler in self._cleanup_handlers:
+            await handler(state)
 
     async def dummy_score_rollout(self, state: State):
         """Score a single rollout with dummy rewards."""

--- a/verifiers/rubrics/rubric_group.py
+++ b/verifiers/rubrics/rubric_group.py
@@ -82,6 +82,11 @@ class RubricGroup(Rubric):
         for rubric in self.rubrics:
             await rubric.cleanup(state)
 
+    async def teardown(self):
+        """Run teardown for all rubrics in the group."""
+        for rubric in self.rubrics:
+            await rubric.teardown()
+
     async def score_group(self, states: list[State]):
         """
         Evaluate all reward functions in-place for a group of rollouts.

--- a/verifiers/rubrics/rubric_group.py
+++ b/verifiers/rubrics/rubric_group.py
@@ -79,11 +79,13 @@ class RubricGroup(Rubric):
 
     async def cleanup(self, state: State):
         """Run cleanup for all rubrics in the group."""
+        await super().cleanup(state)
         for rubric in self.rubrics:
             await rubric.cleanup(state)
 
     async def teardown(self):
         """Run teardown for all rubrics in the group."""
+        await super().teardown()
         for rubric in self.rubrics:
             await rubric.teardown()
 

--- a/verifiers/rubrics/rubric_group.py
+++ b/verifiers/rubrics/rubric_group.py
@@ -77,6 +77,11 @@ class RubricGroup(Rubric):
         state["reward"] = total_reward
         state["metrics"] = aggregated_metrics
 
+    async def cleanup(self, state: State):
+        """Run cleanup for all rubrics in the group."""
+        for rubric in self.rubrics:
+            await rubric.cleanup(state)
+
     async def score_group(self, states: list[State]):
         """
         Evaluate all reward functions in-place for a group of rollouts.


### PR DESCRIPTION
Independent rubric cleanup and teardown handlers, following the same pattern as for envs. Concretely enables extending the sandbox lifecycle from rollout to scoring by "transferring" a sandbox from the environment to the rubric for scoring (see #999). Apart from cleaner abstractions this will also enable independently retrying just scoring without having to redo the full rollout.

## Summary
- **Rubric cleanup/teardown**: Add `cleanup(state)` and `teardown()` methods to `Rubric` and `RubricGroup`, allowing rubrics to register `@vf.cleanup` and `@vf.teardown` decorated handlers that run after scoring and at environment shutdown respectively.
- **Environment integration**: Call `rubric.cleanup()` after scoring in both `run_rollout` and `run_group`, and `rubric.teardown()` during environment teardown.
- **Refactor decorator discovery**: Extract repeated `inspect.getmembers` pattern into `discover_decorated()` utility in `verifiers/decorators.py`, used by both `Environment` and `Rubric`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rollout/teardown sequencing by invoking rubric cleanup after scoring and rubric teardown during environment teardown; could surface ordering/async side effects in existing custom rubrics/environments.
> 
> **Overview**
> Adds **lifecycle hooks to rubrics**: `Rubric` and `RubricGroup` now support `@vf.cleanup` and `@vf.teardown` handlers via new `cleanup(state)` / `teardown()` methods, with groups running both their own handlers and each child rubric’s handlers.
> 
> Integrates these hooks into execution flow by calling `rubric.cleanup()` after scoring in `Environment.run_rollout`/`run_group`, and `rubric.teardown()` during environment teardown.
> 
> Refactors decorator scanning into a shared `discover_decorated()` helper in `verifiers/decorators.py` and updates env/rubric code to use it; adds tests covering rubric and rubric-group cleanup/teardown behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f9b1c9aabdb1cdbe91aac6cde89f1634804c6bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->