### PR TITLE
remove redundant msg normalization + align `env_response` api

### DIFF
--- a/environments/alphabet_sort/alphabet_sort.py
+++ b/environments/alphabet_sort/alphabet_sort.py
@@ -224,7 +224,7 @@ def load_environment(
             assistant_count = len([m for m in messages if m["role"] == "assistant"])
             follow_ups = state["info"]["follow_ups"]
             follow_up_idx = assistant_count - 1
-            return [{"role": "user", "content": follow_ups[follow_up_idx]}]
+            return [vf.UserMessage(content=follow_ups[follow_up_idx])]
 
     def score_response(
         predicted: List[str], expected: List[str], apply_power: bool = True

--- a/environments/doublecheck/doublecheck.py
+++ b/environments/doublecheck/doublecheck.py
@@ -27,7 +27,7 @@ class DoubleCheckEnv(vf.MultiTurnEnv):
         self, messages: Messages, state: State, **kwargs
     ) -> Messages:
         """Generate a response from the environment."""
-        return [{"role": "user", "content": "Are you sure?"}]
+        return [vf.UserMessage(content="Are you sure?")]
 
 
 def load_environment(

--- a/environments/sentence_repeater/sentence_repeater.py
+++ b/environments/sentence_repeater/sentence_repeater.py
@@ -83,12 +83,7 @@ class SentenceRepeaterEnv(vf.MultiTurnEnv):
         self, messages: Messages, state: State, **kwargs
     ) -> Messages:
         num_turn = len(state["trajectory"])
-        return [
-            {
-                "role": "user",
-                "content": state["info"]["questions"][num_turn],
-            }
-        ]
+        return [vf.UserMessage(content=state["info"]["questions"][num_turn])]
 
 
 def load_environment(**kwargs) -> vf.Environment:

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -494,7 +494,7 @@ class Environment(ABC):
     async def get_model_response(
         self,
         state: State,
-        prompt: Messages,
+        prompt: Messages | str,
         client: Client | None = None,
         model: str | None = None,
         tool_defs: list[Tool] | None = None,
@@ -540,6 +540,18 @@ class Environment(ABC):
         )
 
         self._get_usage_tracker(state, create_if_missing=True)
+
+        if not isinstance(prompt, list) or not all(
+            isinstance(m, vf.Message) for m in prompt
+        ):
+            self.logger.warning(
+                "get_model_response() received raw dicts/strings instead of "
+                "vf.Message objects. This triggers normalize_messages() on every "
+                "call, which can cause unnecessary Pydantic validation overhaead. "
+                "Return vf.Message types (e.g. vf.UserMessage, vf.AssistantMessage) "
+                "from get_prompt_messages() to avoid this overhead."
+            )
+            prompt = normalize_messages(prompt)
 
         response = await client.get_response(
             prompt=prompt,

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -494,7 +494,7 @@ class Environment(ABC):
     async def get_model_response(
         self,
         state: State,
-        prompt: Messages | str,
+        prompt: Messages,
         client: Client | None = None,
         model: str | None = None,
         tool_defs: list[Tool] | None = None,
@@ -540,18 +540,6 @@ class Environment(ABC):
         )
 
         self._get_usage_tracker(state, create_if_missing=True)
-
-        if not isinstance(prompt, list) or not all(
-            isinstance(m, vf.Message) for m in prompt
-        ):
-            self.logger.warning(
-                "get_model_response() received raw dicts/strings instead of "
-                "vf.Message objects. This triggers normalize_messages() on every "
-                "call, which can cause unnecessary Pydantic validation overhaead. "
-                "Return vf.Message types (e.g. vf.UserMessage, vf.AssistantMessage) "
-                "from get_prompt_messages() to avoid this overhead."
-            )
-            prompt = normalize_messages(prompt)
 
         response = await client.get_response(
             prompt=prompt,

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -539,12 +539,10 @@ class Environment(ABC):
             client, model, tool_defs, sampling_args
         )
 
-        normalized_prompt = normalize_messages(prompt, field_name="prompt")
-
         self._get_usage_tracker(state, create_if_missing=True)
 
         response = await client.get_response(
-            prompt=normalized_prompt,
+            prompt=prompt,
             model=model,
             tools=tool_defs,
             sampling_args=sampling_args,

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -494,7 +494,7 @@ class Environment(ABC):
     async def get_model_response(
         self,
         state: State,
-        prompt: Messages | str,
+        prompt: Messages,
         client: Client | None = None,
         model: str | None = None,
         tool_defs: list[Tool] | None = None,

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -539,10 +539,12 @@ class Environment(ABC):
             client, model, tool_defs, sampling_args
         )
 
+        normalized_prompt = normalize_messages(prompt, field_name="prompt")
+
         self._get_usage_tracker(state, create_if_missing=True)
 
         response = await client.get_response(
-            prompt=prompt,
+            prompt=normalized_prompt,
             model=model,
             tools=tool_defs,
             sampling_args=sampling_args,

--- a/verifiers/envs/experimental/cli_agent_env.py
+++ b/verifiers/envs/experimental/cli_agent_env.py
@@ -436,7 +436,7 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
     async def get_model_response(
         self,
         state: State,
-        prompt: Messages,
+        prompt: Messages | str,
         client: Client | None = None,
         model: str | None = None,
         tool_defs: list[Tool] | None = None,

--- a/verifiers/envs/experimental/cli_agent_env.py
+++ b/verifiers/envs/experimental/cli_agent_env.py
@@ -436,7 +436,7 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
     async def get_model_response(
         self,
         state: State,
-        prompt: Messages | str,
+        prompt: Messages,
         client: Client | None = None,
         model: str | None = None,
         tool_defs: list[Tool] | None = None,

--- a/verifiers/envs/experimental/gym_env.py
+++ b/verifiers/envs/experimental/gym_env.py
@@ -142,12 +142,12 @@ class GymEnv(vf.MultiTurnEnv):
             return self.obs_to_text_fn(obs)
         return str(obs)
 
-    def wrap_response(self, text: str) -> vf.Messages | str:
-        return cast(vf.Messages, [{"role": "user", "content": text}])
+    def wrap_response(self, text: str) -> vf.Messages:
+        return [vf.UserMessage(content=text)]
 
     async def env_response(
         self, messages: vf.Messages, state: State, **kwargs: Any
-    ) -> vf.Messages | str:
+    ) -> vf.Messages:
         if "gym_env" not in state:
             env = self.env_cls(**self.env_kwargs)
             seed = int(state["answer"])

--- a/verifiers/envs/multiturn_env.py
+++ b/verifiers/envs/multiturn_env.py
@@ -71,13 +71,9 @@ class MultiTurnEnv(vf.Environment):
     async def get_prompt_messages(self, state: State) -> Messages:
         """Override for rollouts with non-linear message sequences."""
         if len(state["trajectory"]) == 0:
-            return normalize_messages(state["prompt"], field_name="state.prompt")
-        prev_turn_prompt = normalize_messages(
-            state["trajectory"][-1]["prompt"], field_name="trajectory.prompt"
-        )
-        prev_turn_completion = normalize_messages(
-            state["trajectory"][-1]["completion"], field_name="trajectory.completion"
-        )
+            return state["prompt"]
+        prev_turn_prompt = state["trajectory"][-1]["prompt"]
+        prev_turn_completion = state["trajectory"][-1]["completion"]
         messages = concat_messages([prev_turn_prompt, prev_turn_completion])
         env_response = await self.env_response(messages, state)
         env_response_messages = normalize_messages(
@@ -90,23 +86,21 @@ class MultiTurnEnv(vf.Environment):
         if len(state["trajectory"]) == 0:
             state["completion"] = []
             return
-        last_prompt = normalize_messages(
-            state["trajectory"][-1]["prompt"], field_name="trajectory.prompt"
-        )
-        last_completion = normalize_messages(
-            state["trajectory"][-1]["completion"], field_name="trajectory.completion"
-        )
+        last_prompt = state["trajectory"][-1]["prompt"]
+        last_completion = state["trajectory"][-1]["completion"]
         full_conversation = concat_messages([last_prompt, last_completion])
         if state.get("final_env_response"):
-            full_conversation = concat_messages(
-                [
-                    full_conversation,
-                    normalize_messages(
-                        state["final_env_response"], field_name="final_env_response"
-                    ),
-                ]
-            )
-        prompt_messages = normalize_messages(state["prompt"], field_name="state.prompt")
+            final_resp = state["final_env_response"]
+            if isinstance(final_resp, str) or (
+                isinstance(final_resp, list)
+                and final_resp
+                and isinstance(final_resp[0], dict)
+            ):
+                final_resp = normalize_messages(
+                    final_resp, field_name="final_env_response"
+                )
+            full_conversation = concat_messages([full_conversation, final_resp])
+        prompt_messages = state["prompt"]
         state["completion"] = full_conversation[len(prompt_messages) :]
 
     async def add_trajectory_step(self, state: State, trajectory_step: TrajectoryStep):

--- a/verifiers/envs/multiturn_env.py
+++ b/verifiers/envs/multiturn_env.py
@@ -13,7 +13,11 @@ from verifiers.types import (
     State,
     TrajectoryStep,
 )
-from verifiers.utils.message_utils import concat_messages, normalize_messages
+from verifiers.utils.message_utils import (
+    concat_messages,
+    normalize_messages,
+    requires_normalize_messages,
+)
 from verifiers.utils.response_utils import (
     parse_response_message,
     parse_response_tokens,
@@ -91,11 +95,14 @@ class MultiTurnEnv(vf.Environment):
         full_conversation = concat_messages([last_prompt, last_completion])
         if state.get("final_env_response"):
             final_resp = state["final_env_response"]
-            if isinstance(final_resp, str) or (
-                isinstance(final_resp, list)
-                and final_resp
-                and isinstance(final_resp[0], dict)
-            ):
+            if requires_normalize_messages(final_resp):
+                self.logger.warning(
+                    "final_env_response returned raw dicts/strings instead of "
+                    "vf.Message objects. This triggers normalize_messages() on every "
+                    "turn, which can cause unnecessary Pydantic validation overhead. "
+                    "Return vf.Message types (e.g. vf.UserMessage, vf.AssistantMessage) "
+                    "from env_response() to avoid this overhead."
+                )
                 final_resp = normalize_messages(
                     final_resp, field_name="final_env_response"
                 )
@@ -150,6 +157,17 @@ class MultiTurnEnv(vf.Environment):
             while not await self.is_completed(state):
                 try:
                     prompt_messages = await self.get_prompt_messages(state)
+                    if requires_normalize_messages(prompt_messages):
+                        self.logger.warning(
+                            "get_prompt_messages() returned raw dicts/strings instead of "
+                            "vf.Message objects. This triggers normalize_messages() on every "
+                            "turn, which can cause unnecessary Pydantic validation overhead. "
+                            "Return vf.Message types (e.g. vf.UserMessage, vf.AssistantMessage) "
+                            "from get_prompt_messages() to avoid this overhead."
+                        )
+                        prompt_messages = normalize_messages(
+                            prompt_messages, field_name="prompt_messages"
+                        )
                     if state.get("final_env_response") is not None:
                         continue
                     response = await self.get_model_response(state, prompt_messages)

--- a/verifiers/envs/multiturn_env.py
+++ b/verifiers/envs/multiturn_env.py
@@ -79,10 +79,8 @@ class MultiTurnEnv(vf.Environment):
         prev_turn_completion = state["trajectory"][-1]["completion"]
         messages = concat_messages([prev_turn_prompt, prev_turn_completion])
         env_response = await self.env_response(messages, state)
-        env_response_messages = maybe_normalize_messages(
-            env_response, field_name="env_response"
-        )
-        return concat_messages([messages, env_response_messages])
+        env_response = maybe_normalize_messages(env_response, field_name="env_response")
+        return concat_messages([messages, env_response])
 
     async def render_completion(self, state: State):
         """Override for rollouts with non-linear message sequences."""
@@ -149,8 +147,7 @@ class MultiTurnEnv(vf.Environment):
                 try:
                     prompt_messages = await self.get_prompt_messages(state)
                     prompt_messages = maybe_normalize_messages(
-                        prompt_messages,
-                        field_name="prompt_messages",
+                        prompt_messages, field_name="prompt_messages"
                     )
                     if state.get("final_env_response") is not None:
                         continue

--- a/verifiers/envs/multiturn_env.py
+++ b/verifiers/envs/multiturn_env.py
@@ -15,8 +15,7 @@ from verifiers.types import (
 )
 from verifiers.utils.message_utils import (
     concat_messages,
-    normalize_messages,
-    requires_normalize_messages,
+    maybe_normalize_messages,
 )
 from verifiers.utils.response_utils import (
     parse_response_message,
@@ -45,7 +44,7 @@ class MultiTurnEnv(vf.Environment):
     @abstractmethod
     async def env_response(
         self, messages: Messages, state: State, **kwargs
-    ) -> Messages | str:
+    ) -> Messages:
         """
         Generate a response from the environment.
         """
@@ -80,7 +79,7 @@ class MultiTurnEnv(vf.Environment):
         prev_turn_completion = state["trajectory"][-1]["completion"]
         messages = concat_messages([prev_turn_prompt, prev_turn_completion])
         env_response = await self.env_response(messages, state)
-        env_response_messages = normalize_messages(
+        env_response_messages = maybe_normalize_messages(
             env_response, field_name="env_response"
         )
         return concat_messages([messages, env_response_messages])
@@ -95,17 +94,9 @@ class MultiTurnEnv(vf.Environment):
         full_conversation = concat_messages([last_prompt, last_completion])
         if state.get("final_env_response"):
             final_resp = state["final_env_response"]
-            if requires_normalize_messages(final_resp):
-                self.logger.warning(
-                    "final_env_response returned raw dicts/strings instead of "
-                    "vf.Message objects. This triggers normalize_messages() on every "
-                    "turn, which can cause unnecessary Pydantic validation overhead. "
-                    "Return vf.Message types (e.g. vf.UserMessage, vf.AssistantMessage) "
-                    "from env_response() to avoid this overhead."
-                )
-                final_resp = normalize_messages(
-                    final_resp, field_name="final_env_response"
-                )
+            final_resp = maybe_normalize_messages(
+                final_resp, field_name="final_env_response"
+            )
             full_conversation = concat_messages([full_conversation, final_resp])
         prompt_messages = state["prompt"]
         state["completion"] = full_conversation[len(prompt_messages) :]
@@ -157,17 +148,10 @@ class MultiTurnEnv(vf.Environment):
             while not await self.is_completed(state):
                 try:
                     prompt_messages = await self.get_prompt_messages(state)
-                    if requires_normalize_messages(prompt_messages):
-                        self.logger.warning(
-                            "get_prompt_messages() returned raw dicts/strings instead of "
-                            "vf.Message objects. This triggers normalize_messages() on every "
-                            "turn, which can cause unnecessary Pydantic validation overhead. "
-                            "Return vf.Message types (e.g. vf.UserMessage, vf.AssistantMessage) "
-                            "from get_prompt_messages() to avoid this overhead."
-                        )
-                        prompt_messages = normalize_messages(
-                            prompt_messages, field_name="prompt_messages"
-                        )
+                    prompt_messages = maybe_normalize_messages(
+                        prompt_messages,
+                        field_name="prompt_messages",
+                    )
                     if state.get("final_env_response") is not None:
                         continue
                     response = await self.get_model_response(state, prompt_messages)

--- a/verifiers/utils/logging_utils.py
+++ b/verifiers/utils/logging_utils.py
@@ -12,9 +12,32 @@ from rich.text import Text
 from verifiers.errors import Error
 from verifiers.types import ErrorInfo, Messages
 from verifiers.utils.error_utils import ErrorChain
-from verifiers.utils.message_utils import format_messages
 
 LOGGER_NAME = "verifiers"
+
+_seen_once_keys: set[tuple[str, str]] = set()
+
+
+def log_once(
+    logger: logging.Logger,
+    level: int,
+    msg: str,
+    *args: object,
+    **kwargs: object,
+) -> None:
+    """Log a message only once per (logger name, message) pair for the process lifetime."""
+    key = (logger.name, msg)
+    if key in _seen_once_keys:
+        return
+    _seen_once_keys.add(key)
+    logger.log(level, msg, *args, **kwargs)
+
+
+def warning_once(
+    logger: logging.Logger, msg: str, *args: object, **kwargs: object
+) -> None:
+    """Shorthand for ``log_once(logger, logging.WARNING, ...)``."""
+    log_once(logger, logging.WARNING, msg, *args, **kwargs)
 
 
 class JsonFormatter(logging.Formatter):
@@ -144,6 +167,8 @@ def print_prompt_completions_sample(
     step: int,
     num_samples: int = 1,
 ) -> None:
+    from verifiers.utils.message_utils import format_messages
+
     def format_error(error: ErrorInfo | BaseException) -> Text:
         out = Text()
         if isinstance(error, BaseException):

--- a/verifiers/utils/logging_utils.py
+++ b/verifiers/utils/logging_utils.py
@@ -18,26 +18,18 @@ LOGGER_NAME = "verifiers"
 _seen_once_keys: set[tuple[str, str]] = set()
 
 
-def log_once(
-    logger: logging.Logger,
-    level: int,
-    msg: str,
-    *args: object,
-    **kwargs: object,
-) -> None:
+def log_once(logger: logging.Logger, level: int, msg: str) -> None:
     """Log a message only once per (logger name, message) pair for the process lifetime."""
     key = (logger.name, msg)
     if key in _seen_once_keys:
         return
     _seen_once_keys.add(key)
-    logger.log(level, msg, *args, **kwargs)
+    logger.log(level, msg)
 
 
-def warning_once(
-    logger: logging.Logger, msg: str, *args: object, **kwargs: object
-) -> None:
+def warning_once(logger: logging.Logger, msg: str) -> None:
     """Shorthand for ``log_once(logger, logging.WARNING, ...)``."""
-    log_once(logger, logging.WARNING, msg, *args, **kwargs)
+    log_once(logger, logging.WARNING, msg)
 
 
 class JsonFormatter(logging.Formatter):

--- a/verifiers/utils/message_utils.py
+++ b/verifiers/utils/message_utils.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import re
 from collections.abc import Mapping
 from typing import Any, cast
@@ -18,6 +19,8 @@ from verifiers.types import (
     ToolMessage,
     UserMessage,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def from_raw_content_part(part: dict[str, Any]) -> ContentPart:
@@ -139,9 +142,25 @@ def normalize_messages(
     return normalized
 
 
-def requires_normalize_messages(value: list | str) -> bool:
-    """Check if a message list requires normalization into a list of Message objects."""
-    return not isinstance(value, list) or not all(isinstance(m, Message) for m in value)
+def maybe_normalize_messages(
+    value: Messages | str,
+    *,
+    field_name: str = "messages",
+) -> Messages:
+    """Normalize messages only if needed, logging a warning on first occurrence."""
+    requires_normalize = not isinstance(value, list) or not all(
+        isinstance(m, Message) for m in value
+    )
+    if not requires_normalize:
+        return cast(Messages, value)
+    logger.warning(
+        "%s returned raw dicts/strings instead of vf.Messages. This"
+        " repeatedly triggers normalize_messages(), causing unnecessary"
+        " Pydantic validation overhead. Return vf.Message types (e.g."
+        " vf.UserMessage, vf.AssistantMessage) to avoid this.",
+        field_name,
+    )
+    return normalize_messages(value, field_name=field_name)
 
 
 def concat_messages(messages_list: list[Messages]) -> Messages:

--- a/verifiers/utils/message_utils.py
+++ b/verifiers/utils/message_utils.py
@@ -157,11 +157,10 @@ def maybe_normalize_messages(
         return cast(Messages, value)
     warning_once(
         logger,
-        "%s returned raw dicts/strings instead of vf.Messages. This"
+        f"{field_name} returned raw dicts/strings instead of vf.Messages. This"
         " repeatedly triggers normalize_messages(), causing unnecessary"
         " Pydantic validation overhead. Return vf.Message types (e.g."
         " vf.UserMessage, vf.AssistantMessage) to avoid this.",
-        field_name,
     )
     return normalize_messages(value, field_name=field_name)
 

--- a/verifiers/utils/message_utils.py
+++ b/verifiers/utils/message_utils.py
@@ -139,6 +139,11 @@ def normalize_messages(
     return normalized
 
 
+def requires_normalize_messages(value: list | str) -> bool:
+    """Check if a message list requires normalization into a list of Message objects."""
+    return not isinstance(value, list) or not all(isinstance(m, Message) for m in value)
+
+
 def concat_messages(messages_list: list[Messages]) -> Messages:
     """Concatenate multiple Messages lists into one."""
     result = []

--- a/verifiers/utils/message_utils.py
+++ b/verifiers/utils/message_utils.py
@@ -148,12 +148,15 @@ def maybe_normalize_messages(
     field_name: str = "messages",
 ) -> Messages:
     """Normalize messages only if needed, logging a warning on first occurrence."""
+    from verifiers.utils.logging_utils import warning_once
+
     requires_normalize = not isinstance(value, list) or not all(
         isinstance(m, Message) for m in value
     )
     if not requires_normalize:
         return cast(Messages, value)
-    logger.warning(
+    warning_once(
+        logger,
         "%s returned raw dicts/strings instead of vf.Messages. This"
         " repeatedly triggers normalize_messages(), causing unnecessary"
         " Pydantic validation overhead. Return vf.Message types (e.g."

--- a/verifiers/utils/response_utils.py
+++ b/verifiers/utils/response_utils.py
@@ -9,14 +9,12 @@ from verifiers.types import (
 async def parse_response_message(response: Response) -> Messages:
     """Parse a vf.Response into a vf.Messages list (single vf.AssistantMessage)."""
     response_message = response.message
-    message_payload = {
-        "role": "assistant",
-        "content": response_message.content,
-        "reasoning_content": response_message.reasoning_content,
-        "thinking_blocks": response_message.thinking_blocks,
-        "tool_calls": response_message.tool_calls,
-    }
-    message = AssistantMessage.model_validate(message_payload)
+    message = AssistantMessage(
+        content=response_message.content,
+        reasoning_content=response_message.reasoning_content,
+        thinking_blocks=response_message.thinking_blocks,
+        tool_calls=response_message.tool_calls,
+    )
     return [message]
 
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Reduces calls to `normalize_messages` to minimal set: 
- Once and unconditionally in `init_state` (this is safe, because not on hot path)
- Then for all other call sites (e.g. after `get_prompt_messages` or `env_response`) we use `maybe_normalize_messages` which emits a warning before normalizing the message to nudge users towards using the types directly to avoid potential performance bottlenecks
- Changed the `env_response` return type from `Messages | str` to just `Messages` to be consistent with the rest of the API (e.g. `get_model_response`, `rollout`, etc just operate on `Messages` and `str -> vf.Messages` conversion is an example of (undesired) conversion to custom types) and thus be handled the same way as list of dicts
- Also fixes all our envs to use those patterns

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens the core `MultiTurnEnv`/`Environment.get_model_response` APIs to require `Messages` and introduces conditional normalization, which could break downstream custom envs/providers that still return raw dicts/strings or pass string prompts.
> 
> **Overview**
> Standardizes environment and model prompting to operate on typed `vf.Messages` only: `env_response()` and `get_model_response()` now take/return `Messages` (no more `str`), and built-in envs (`alphabet_sort`, `doublecheck`, `sentence_repeater`, `GymEnv`) were updated to emit `vf.UserMessage` objects instead of raw dicts.
> 
> To cut hot-path Pydantic overhead, `MultiTurnEnv` now uses `maybe_normalize_messages()` (new helper) to only normalize when needed and logs a **warning once** when callers still return raw dicts/strings; supporting `log_once`/`warning_once` utilities were added, and `parse_response_message()` now constructs `AssistantMessage` directly instead of round-tripping through `model_validate`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd87b2c5ce14ea8b396844fea2220cf9eb78c6ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->