### PR TITLE
fix: extract_boxed_answer returns full text when no \boxed{} found

### DIFF
--- a/tests/test_math_rubric.py
+++ b/tests/test_math_rubric.py
@@ -26,9 +26,9 @@ class TestMathRubric:
     @pytest.mark.parametrize(
         "test_case",
         [
-            {"completion": "1", "answer": "1"},
-            {"completion": "x + 1", "answer": "1 + x"},
-            {"completion": "\\frac{1}{2}", "answer": "0.5"},
+            {"completion": "\\boxed{1}", "answer": "1"},
+            {"completion": "\\boxed{x + 1}", "answer": "1 + x"},
+            {"completion": "\\boxed{\\frac{1}{2}}", "answer": "0.5"},
         ],
         ids=lambda x: f"{x['completion']} == {x['answer']}",
     )

--- a/verifiers/rubrics/math_rubric.py
+++ b/verifiers/rubrics/math_rubric.py
@@ -24,7 +24,11 @@ class MathRubric(Rubric):
         max_workers: int = 50,
         timeout_seconds: float = 5,
     ):
-        parser = parser or MaybeThinkParser(extract_fn=extract_boxed_answer)
+        from functools import partial
+
+        parser = parser or MaybeThinkParser(
+            extract_fn=partial(extract_boxed_answer, strict=True)
+        )
         super().__init__(funcs=funcs, weights=weights, parser=parser)
         self.add_reward_func(self.correct_answer)
         self.timeout_seconds = timeout_seconds

--- a/verifiers/utils/data_utils.py
+++ b/verifiers/utils/data_utils.py
@@ -72,7 +72,16 @@ def format_dataset(
     return dataset
 
 
-def extract_boxed_answer(text: str) -> str:
+def extract_boxed_answer(text: str, strict: bool = False) -> str:
+    """Extract the last \\boxed{...} answer from text.
+
+    Args:
+        text: The text to extract from.
+        strict: If True, return "" when no \\boxed{} is found (for reward
+            scoring where format compliance matters). If False, return the
+            original text as a passthrough (for environments that use this
+            as a general text extractor).
+    """
     def find_matching_brace(s: str, start: int) -> int:
         count = 1
         i = start
@@ -87,13 +96,13 @@ def extract_boxed_answer(text: str) -> str:
     # Find last \boxed{
     boxed_start = text.rfind("\\boxed{")
     if boxed_start == -1:
-        return text
+        return "" if strict else text
     # Find the content between the braces
     content_start = boxed_start + 7  # len('\\boxed{')
     closing_brace = find_matching_brace(text, content_start)
 
     if closing_brace == -1:
-        return text
+        return "" if strict else text
 
     return text[content_start:closing_brace]
 


### PR DESCRIPTION
## Problem

`extract_boxed_answer()` returns the **entire input text** when no `\boxed{}` tag is found. This text is then passed to `math_verify`, which extracts any number it can find — allowing a model to get correct-answer credit by mentioning the answer anywhere in its output without using `\boxed{}`.

### Training impact

We ran [rewardprobe](https://github.com/chopratejas/rewardprobe) simulate on the GSM8K MathRubric. The strategy scoreboard shows:

```
correct_lazy         ████████████████████ 1.00  ← just the answer, no reasoning
shortcut             ████████████████████ 1.00  ← skips computation  
perfect              █████████████░░░░░░░ 0.67  ← full reasoning + boxed answer
```

A model trained against this will learn to skip reasoning entirely — because `correct_lazy` (just outputting the number) scores **higher** than `perfect` (showing work in `\boxed{}`).

## Fix

Add a `strict` parameter to `extract_boxed_answer` (default: `False`).

- `strict=False` (default): returns full text on no match — **backwards compatible**, existing callers unaffected
- `strict=True`: returns `""` on no match — used by MathRubric to enforce `\boxed{}` format

### Changes

1. **`data_utils.py`**: Add `strict` parameter with safe default
2. **`math_rubric.py`**: MathRubric uses `strict=True` via `functools.partial`
3. **`test_math_rubric.py`**: Tests updated to use `\boxed{}` format (reflecting correct behavior)

### Addresses Cursor bot feedback

- **"Sub-LLM responses silently dropped in RLM environment"**: Fixed. `strict` defaults to `False`, so `rlm_env.py` and all other callers get the same passthrough behavior as before.
- **"Change breaks existing valid-answer tests"**: Fixed. Tests now use `\boxed{}` completions, which is the correct format MathRubric should require.

Found using [rewardprobe](https://github.com/chopratejas/rewardprobe), a pre-training QA tool for reward functions.