### PR TITLE
make output_dir configurable in evals

### DIFF
--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -619,6 +619,7 @@ def main():
                 num_examples=num_examples,
                 rollouts_per_example=rollouts_per_example,
                 env_dir_path=raw.get("env_dir_path", DEFAULT_ENV_DIR_PATH),
+                output_dir=raw.get("output_dir"),
             )
             if auto_resume_path is not None:
                 resume_path = auto_resume_path
@@ -636,6 +637,7 @@ def main():
             env_id=env_id,
             env_args=raw.get("env_args", {}),
             env_dir_path=raw.get("env_dir_path", DEFAULT_ENV_DIR_PATH),
+            output_dir=raw.get("output_dir"),
             extra_env_kwargs=raw.get("extra_env_kwargs", {}),
             endpoint_id=resolved_endpoint_id,
             model=model,

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -501,6 +501,7 @@ class EvalConfig(BaseModel):
     verbose: bool = False
     debug: bool = False
     # saving
+    output_dir: str | None = None
     state_columns: list[str] | None = None
     save_results: bool = False
     resume_path: Path | None = None

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -428,6 +428,7 @@ def load_toml_config(path: Path) -> list[dict]:
         "verbose",
         "debug",
         # saving
+        "output_dir",
         "state_columns",
         "save_results",
         "resume",

--- a/verifiers/utils/path_utils.py
+++ b/verifiers/utils/path_utils.py
@@ -36,7 +36,9 @@ def get_results_path(
 
 
 def get_eval_results_path(config: EvalConfig) -> Path:
-    base_path = _get_outputs_base_path(config.env_id, config.env_dir_path, config.output_dir)
+    base_path = _get_outputs_base_path(
+        config.env_id, config.env_dir_path, config.output_dir
+    )
     return get_results_path(config.env_id, config.model, base_path)
 
 
@@ -96,7 +98,9 @@ def find_latest_incomplete_eval_results_path(
     output_dir: str | None = None,
 ) -> Path | None:
     """Find the newest resumable, incomplete eval run for the provided config."""
-    runs_dir = get_eval_runs_dir(env_id=env_id, model=model, env_dir_path=env_dir_path, output_dir=output_dir)
+    runs_dir = get_eval_runs_dir(
+        env_id=env_id, model=model, env_dir_path=env_dir_path, output_dir=output_dir
+    )
     if not runs_dir.exists():
         return None
 

--- a/verifiers/utils/path_utils.py
+++ b/verifiers/utils/path_utils.py
@@ -8,8 +8,14 @@ from verifiers.types import EvalConfig
 logger = logging.getLogger(__name__)
 
 
-def _get_outputs_base_path(env_id: str, env_dir_path: str = "./environments") -> Path:
+def _get_outputs_base_path(
+    env_id: str,
+    env_dir_path: str = "./environments",
+    output_dir: str | None = None,
+) -> Path:
     """Resolve where outputs should be stored for an environment."""
+    if output_dir is not None:
+        return Path(output_dir)
     module_name = env_id.replace("-", "_")
     local_env_dir = Path(env_dir_path) / module_name
 
@@ -30,15 +36,18 @@ def get_results_path(
 
 
 def get_eval_results_path(config: EvalConfig) -> Path:
-    base_path = _get_outputs_base_path(config.env_id, config.env_dir_path)
+    base_path = _get_outputs_base_path(config.env_id, config.env_dir_path, config.output_dir)
     return get_results_path(config.env_id, config.model, base_path)
 
 
 def get_eval_runs_dir(
-    env_id: str, model: str, env_dir_path: str = "./environments"
+    env_id: str,
+    model: str,
+    env_dir_path: str = "./environments",
+    output_dir: str | None = None,
 ) -> Path:
     """Return directory containing all eval run directories for env/model."""
-    base_path = _get_outputs_base_path(env_id, env_dir_path)
+    base_path = _get_outputs_base_path(env_id, env_dir_path, output_dir)
     env_model_str = f"{env_id}--{model.replace('/', '--')}"
     return base_path / "evals" / env_model_str
 
@@ -84,9 +93,10 @@ def find_latest_incomplete_eval_results_path(
     num_examples: int,
     rollouts_per_example: int,
     env_dir_path: str = "./environments",
+    output_dir: str | None = None,
 ) -> Path | None:
     """Find the newest resumable, incomplete eval run for the provided config."""
-    runs_dir = get_eval_runs_dir(env_id=env_id, model=model, env_dir_path=env_dir_path)
+    runs_dir = get_eval_runs_dir(env_id=env_id, model=model, env_dir_path=env_dir_path, output_dir=output_dir)
     if not runs_dir.exists():
         return None
 
@@ -131,6 +141,7 @@ def get_gepa_results_path(
     env_id: str,
     model: str,
     env_dir_path: str = "./environments",
+    output_dir: str | None = None,
 ) -> Path:
     """Generate path for GEPA optimization run.
 
@@ -139,5 +150,5 @@ def get_gepa_results_path(
     Otherwise saves to:
         ./outputs/gepa/{env_id}--{model}/{uuid8}/
     """
-    base_path = _get_outputs_base_path(env_id, env_dir_path)
+    base_path = _get_outputs_base_path(env_id, env_dir_path, output_dir)
     return get_results_path(env_id, model, base_path, subdir="gepa")


### PR DESCRIPTION
Adds an `output_dir` field to EvalConfig that overrides the default `./outputs` fallback in path resolution. Can be set via `output_dir` in eval TOML configs.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an optional `output_dir` override to evaluation path resolution without changing default behavior when unset. Main risk is misconfiguration leading to results/resume lookup writing to or scanning an unexpected directory.
> 
> **Overview**
> Adds a new optional `output_dir` field to `EvalConfig` and allows it to be set from eval TOML/CLI configs.
> 
> Updates output path resolution in `path_utils` so eval/GEPA results (and `--resume` auto-detection via `find_latest_incomplete_eval_results_path`) use `output_dir` when provided, otherwise preserving the existing environment-local `outputs/` or `./outputs` fallback behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 756059d8f0700968c99d71723f79a78315c3f7f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->