### PR TITLE
Pass usage_signature through to RolloutOutput

### DIFF
--- a/verifiers/clients/openai_chat_completions_client.py
+++ b/verifiers/clients/openai_chat_completions_client.py
@@ -498,11 +498,16 @@ class OpenAIChatCompletionsClient(
         if not isinstance(model, str):
             model = ""
 
+        usage_signature = getattr(response, "usage_signature", None)
+        if usage_signature is None and hasattr(response, "model_extra") and response.model_extra:
+            usage_signature = response.model_extra.get("usage_signature")
+
         return Response(
             id=response_id,
             created=created,
             model=model,
             usage=parse_usage(response),
+            usage_signature=usage_signature if isinstance(usage_signature, str) else None,
             message=ResponseMessage(
                 content=response.choices[0].message.content,
                 reasoning_content=parse_reasoning_content_from_response(response),

--- a/verifiers/clients/openai_chat_completions_client.py
+++ b/verifiers/clients/openai_chat_completions_client.py
@@ -499,7 +499,11 @@ class OpenAIChatCompletionsClient(
             model = ""
 
         usage_signature = getattr(response, "usage_signature", None)
-        if usage_signature is None and hasattr(response, "model_extra") and response.model_extra:
+        if (
+            usage_signature is None
+            and hasattr(response, "model_extra")
+            and response.model_extra
+        ):
             usage_signature = response.model_extra.get("usage_signature")
 
         return Response(
@@ -507,7 +511,9 @@ class OpenAIChatCompletionsClient(
             created=created,
             model=model,
             usage=parse_usage(response),
-            usage_signature=usage_signature if isinstance(usage_signature, str) else None,
+            usage_signature=usage_signature
+            if isinstance(usage_signature, str)
+            else None,
             message=ResponseMessage(
                 content=response.choices[0].message.content,
                 reasoning_content=parse_reasoning_content_from_response(response),

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -180,6 +180,7 @@ class Response(CustomBaseModel):
     created: int
     model: str
     usage: Usage | None = None
+    usage_signature: str | None = None
     message: ResponseMessage  # can call tools
 
 
@@ -206,6 +207,7 @@ class TrajectoryStepTokens(TypedDict):
 class TokenUsage(TypedDict):
     input_tokens: float
     output_tokens: float
+    usage_signature: NotRequired[str]
 
 
 class VersionInfo(TypedDict):

--- a/verifiers/utils/save_utils.py
+++ b/verifiers/utils/save_utils.py
@@ -109,6 +109,16 @@ def _coerce_token_usage(value: object) -> TokenUsage | None:
     }
 
 
+def _extract_last_usage_signature(state: "State") -> str | None:
+    """Extract the usage_signature from the last trajectory response, if present."""
+    trajectory = state.get("trajectory", [])
+    for step in reversed(trajectory):
+        response = step.get("response")
+        if response is not None and getattr(response, "usage_signature", None):
+            return response.usage_signature
+    return None
+
+
 def _extract_state_token_usage(state: State) -> TokenUsage | None:
     tracker = state.get("usage_tracker")
     if isinstance(tracker, StateUsageTracker):
@@ -200,6 +210,9 @@ def state_to_output(
                 "output_tokens": float(output_tokens),
             }
     if usage is not None:
+        sig = _extract_last_usage_signature(state)
+        if sig is not None:
+            usage["usage_signature"] = sig
         output["token_usage"] = usage
 
     # sanitize messages (handle None for error cases)

--- a/verifiers/utils/save_utils.py
+++ b/verifiers/utils/save_utils.py
@@ -205,7 +205,7 @@ def state_to_output(
             input_tokens += step_input_tokens
             output_tokens += step_output_tokens
         if usage_seen:
-            usage = {
+            usage: TokenUsage = {
                 "input_tokens": float(input_tokens),
                 "output_tokens": float(output_tokens),
             }


### PR DESCRIPTION
## Summary

Small change to pass the HMAC usage signature from vLLM responses through to the orchestrator for tamper detection.

When the vLLM ASGI middleware signs token usage data (added in the prime-rl companion PR), the signature is injected as `usage_signature` in the chat completion response JSON. This PR ensures that field survives the verifiers pipeline:

- `types.py` — add optional `usage_signature` field to `Response` and `TokenUsage`
- `openai_chat_completions_client.py` — extract `usage_signature` from the OpenAI SDK response's `model_extra`
- `save_utils.py` — forward the last trajectory response's signature into `RolloutOutput.token_usage`

3 files, 20 lines. No behavior change when the middleware isn't active (field is simply absent).

Companion PRs: [platform#913](https://github.com/PrimeIntellect-ai/platform/pull/913) · [prime-rl#2042](https://github.com/PrimeIntellect-ai/prime-rl/pull/2042) · [hosted-rl#862](https://github.com/PrimeIntellect-ai/hosted-rl/pull/862)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: additive optional fields and passthrough logic only; behavior is unchanged when `usage_signature` is absent, with minimal chance of breaking consumers that strictly validate output schemas.
> 
> **Overview**
> Propagates an optional `usage_signature` (HMAC for token usage tamper detection) through the verifiers pipeline into saved rollout outputs.
> 
> Adds `usage_signature` to `Response` and `TokenUsage` types, extracts it from OpenAI SDK responses (including `model_extra`) in `OpenAIChatCompletionsClient`, and forwards the last trajectory response’s signature into `RolloutOutput.token_usage` during `state_to_output` serialization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8384e3e13b8cd8020ee445cf1bd531fc3ce331d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->