### PR TITLE
Add team billing headers to JudgeRubric default client

### DIFF
--- a/tests/test_judge_rubric.py
+++ b/tests/test_judge_rubric.py
@@ -1,0 +1,103 @@
+"""Tests for JudgeRubric team header propagation."""
+
+import os
+from unittest.mock import patch
+
+from openai import AsyncOpenAI
+
+from verifiers.rubrics.judge_rubric import JudgeRubric
+from verifiers.utils.client_utils import build_prime_headers
+
+CLEAN_ENV = {
+    k: v for k, v in os.environ.items() if k not in ("PRIME_API_KEY", "PRIME_TEAM_ID")
+}
+
+
+class TestBuildPrimeHeaders:
+    """Test build_prime_headers — same logic as _build_headers_and_api_key but
+    usable without a ClientConfig (for judge clients, GEPA, etc.)."""
+
+    def test_non_prime_key_returns_empty_headers(self):
+        headers, api_key = build_prime_headers("SOME_OTHER_KEY")
+        assert headers == {}
+        assert api_key is None
+
+    @patch.dict(
+        os.environ,
+        {"PRIME_API_KEY": "pit_test123", "PRIME_TEAM_ID": "team_abc"},
+        clear=False,
+    )
+    def test_prime_key_with_team_id(self):
+        headers, api_key = build_prime_headers("PRIME_API_KEY")
+        assert headers == {"X-Prime-Team-ID": "team_abc"}
+        assert api_key == "pit_test123"
+
+    def test_prime_key_without_team_id(self):
+        env = {**CLEAN_ENV, "PRIME_API_KEY": "pit_test123"}
+        with patch.dict(os.environ, env, clear=True):
+            with patch(
+                "verifiers.utils.client_utils.load_prime_config", return_value={}
+            ):
+                headers, api_key = build_prime_headers("PRIME_API_KEY")
+                assert "X-Prime-Team-ID" not in headers
+                assert api_key == "pit_test123"
+
+    def test_prime_key_missing_falls_back_to_config(self):
+        with patch.dict(
+            os.environ, {**CLEAN_ENV, "PRIME_TEAM_ID": "team_abc"}, clear=True
+        ):
+            with patch(
+                "verifiers.utils.client_utils.load_prime_config",
+                return_value={"api_key": "pit_from_config"},
+            ):
+                headers, api_key = build_prime_headers("PRIME_API_KEY")
+                assert api_key == "pit_from_config"
+                assert headers == {"X-Prime-Team-ID": "team_abc"}
+
+    def test_team_id_from_config_file(self):
+        with patch.dict(
+            os.environ, {**CLEAN_ENV, "PRIME_API_KEY": "pit_test"}, clear=True
+        ):
+            with patch(
+                "verifiers.utils.client_utils.load_prime_config",
+                return_value={"team_id": "team_from_file"},
+            ):
+                headers, _ = build_prime_headers("PRIME_API_KEY")
+                assert headers == {"X-Prime-Team-ID": "team_from_file"}
+
+
+class TestJudgeRubricTeamHeaders:
+    """Test that JudgeRubric propagates team headers when no explicit client is given."""
+
+    def test_default_client_gets_team_header(self):
+        with patch.dict(
+            os.environ,
+            {**CLEAN_ENV, "PRIME_API_KEY": "pit_test", "PRIME_TEAM_ID": "team_xyz"},
+            clear=True,
+        ):
+            with patch(
+                "verifiers.utils.client_utils.load_prime_config", return_value={}
+            ):
+                rubric = JudgeRubric()
+                assert (
+                    rubric.judge_client._custom_headers.get("X-Prime-Team-ID")
+                    == "team_xyz"
+                )
+
+    def test_explicit_client_not_overridden(self):
+        custom_client = AsyncOpenAI(
+            api_key="sk-custom", base_url="http://localhost:1234/v1"
+        )
+        rubric = JudgeRubric(judge_client=custom_client)
+        assert rubric.judge_client is custom_client
+
+    def test_no_team_id_no_header(self):
+        with patch.dict(os.environ, {**CLEAN_ENV}, clear=True):
+            with patch(
+                "verifiers.utils.client_utils.load_prime_config", return_value={}
+            ):
+                rubric = JudgeRubric()
+                assert rubric.judge_client is not None
+                assert "X-Prime-Team-ID" not in (
+                    rubric.judge_client._custom_headers or {}
+                )

--- a/verifiers/rubrics/judge_rubric.py
+++ b/verifiers/rubrics/judge_rubric.py
@@ -6,6 +6,7 @@ from verifiers.parsers.parser import Parser
 from verifiers.rubrics.rubric import Rubric
 from verifiers.types import Messages, State
 from verifiers.utils.async_utils import maybe_await
+from verifiers.utils.client_utils import build_prime_headers
 
 DEFAULT_JUDGE_PROMPT = """Given a ground truth answer \
 and a response, determine if the response is correct.
@@ -39,7 +40,14 @@ class JudgeRubric(Rubric):
         judge_prompt: str = DEFAULT_JUDGE_PROMPT,
     ):
         super().__init__(parser=parser)
-        self.judge_client = judge_client if judge_client is not None else AsyncOpenAI()
+        if judge_client is not None:
+            self.judge_client = judge_client
+        else:
+            headers, api_key = build_prime_headers()
+            self.judge_client = AsyncOpenAI(
+                api_key=api_key or "EMPTY",
+                default_headers=headers if headers else None,
+            )
         self.judge_model = judge_model
         self.judge_prompt = judge_prompt
         self.judge_sampling_args = judge_sampling_args or {}

--- a/verifiers/utils/client_utils.py
+++ b/verifiers/utils/client_utils.py
@@ -58,13 +58,20 @@ def load_prime_config() -> dict:
     return {}
 
 
-def _build_headers_and_api_key(
-    config: ClientConfig,
+def build_prime_headers(
+    api_key_var: str = "PRIME_API_KEY",
 ) -> tuple[dict[str, str], str | None]:
-    headers = dict(config.extra_headers)
-    api_key = os.getenv(config.api_key_var)
+    """Build headers and resolve API key for Prime API calls.
 
-    if config.api_key_var == "PRIME_API_KEY":
+    When api_key_var is "PRIME_API_KEY", loads team context from PRIME_TEAM_ID
+    env var or ~/.prime/config.json and adds X-Prime-Team-ID header for team
+    billing (see client_utils._build_headers_and_api_key for the ClientConfig
+    equivalent used by generation clients).
+    """
+    headers: dict[str, str] = {}
+    api_key = os.getenv(api_key_var)
+
+    if api_key_var == "PRIME_API_KEY":
         prime_config = load_prime_config()
         if not api_key:
             api_key = prime_config.get("api_key", "")
@@ -72,6 +79,14 @@ def _build_headers_and_api_key(
         if team_id:
             headers["X-Prime-Team-ID"] = team_id
 
+    return headers, api_key
+
+
+def _build_headers_and_api_key(
+    config: ClientConfig,
+) -> tuple[dict[str, str], str | None]:
+    extra_headers, api_key = build_prime_headers(config.api_key_var)
+    headers = {**dict(config.extra_headers), **extra_headers}
     return headers, api_key
 
 


### PR DESCRIPTION
Judge clients were missing the `X-Prime-Team-ID` header when created without an explicit `AsyncOpenAI` instance — this caused judge API calls (e.g., to `api.pinference.ai`) to bill the user's personal account instead of the team, even when `PRIME_TEAM_ID` was set in the environment.

Generation clients already handle this correctly via `_build_headers_and_api_key` in `client_utils.py` — this PR extracts that logic into a reusable `build_prime_headers()` helper and wires it into `JudgeRubric`'s default client.

### Note

Environments that create their own judge `AsyncOpenAI` clients directly still need to pass the header themselves, this PR only fixes the default path in `JudgeRubric`. Those environments could switch to passing no `judge_client` and letting the default handle it, or use `build_prime_headers()` directly.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `JudgeRubric` constructs its default `AsyncOpenAI` client by injecting Prime API key resolution and `X-Prime-Team-ID` headers, which can affect request routing/billing and potentially authentication if misconfigured.
> 
> **Overview**
> Fixes missing Prime team billing context for judge calls by extracting Prime API key/header resolution into reusable `build_prime_headers()` and reusing it across clients.
> 
> When `JudgeRubric` creates its own default `AsyncOpenAI` client (no explicit `judge_client` provided), it now sets `default_headers` to include `X-Prime-Team-ID` (from `PRIME_TEAM_ID` or `~/.prime/config.json`) and resolves `PRIME_API_KEY` consistently. Adds tests covering `build_prime_headers()` behavior and verifying `JudgeRubric` header propagation and non-overriding of explicitly provided clients.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd4eae95dc673d8826737b7fe1eb15dd36081172. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->