### PR TITLE
fix: task cancelation race + RLM sandbox workers

### DIFF
--- a/tests/test_env_server.py
+++ b/tests/test_env_server.py
@@ -370,7 +370,6 @@ class TestTaskCancellation:
             )
 
             await asyncio.wait_for(process_request_blocked.wait(), timeout=5)
-            assert len(server.pending_tasks) == 1
             assert len(server.request_tasks) == 1
             assert not original_process_request_entered.is_set()
 
@@ -408,7 +407,7 @@ class TestTaskCancellation:
 
             # Wait for the server to actually start processing
             await asyncio.wait_for(server_task_started.wait(), timeout=5)
-            assert len(server.pending_tasks) == 1
+            assert len(server.request_tasks) == 1
 
             # Cancel on the client side
             client_task.cancel()
@@ -453,7 +452,7 @@ class TestTaskCancellation:
 
             # Confirm the server started processing
             await asyncio.wait_for(server_task_started.wait(), timeout=5)
-            assert len(server.pending_tasks) == 1
+            assert len(server.request_tasks) == 1
 
             # Give the system time to propagate
             await asyncio.sleep(0.5)

--- a/tests/test_env_server.py
+++ b/tests/test_env_server.py
@@ -332,6 +332,56 @@ class TestTaskCancellation:
     """
 
     @pytest.mark.asyncio
+    async def test_cancelled_client_task_should_cancel_server_task_before_request_processing(
+        self,
+    ):
+        """Cancellation should still propagate before process_request enters its body."""
+        process_request_blocked = asyncio.Event()
+        original_process_request_entered = asyncio.Event()
+        server_task_cancelled = asyncio.Event()
+
+        async with run_server_and_client() as (server, client):
+            original_process_request = server.process_request
+
+            async def delayed_process_request(
+                client_id,
+                request_id_bytes,
+                payload_bytes,
+            ):
+                process_request_blocked.set()
+                try:
+                    await asyncio.Event().wait()
+                    original_process_request_entered.set()
+                    return await original_process_request(
+                        client_id,
+                        request_id_bytes,
+                        payload_bytes,
+                    )
+                except asyncio.CancelledError:
+                    server_task_cancelled.set()
+                    raise
+
+            server.process_request = delayed_process_request  # type: ignore[assignment]
+
+            client_task = asyncio.create_task(
+                client.send_request(
+                    make_rollout_request(), RunRolloutResponse, timeout=30
+                )
+            )
+
+            await asyncio.wait_for(process_request_blocked.wait(), timeout=5)
+            assert len(server.pending_tasks) == 1
+            assert len(server.request_tasks) == 1
+            assert not original_process_request_entered.is_set()
+
+            client_task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await client_task
+
+            await asyncio.wait_for(server_task_cancelled.wait(), timeout=5)
+            assert not original_process_request_entered.is_set()
+
+    @pytest.mark.asyncio
     async def test_cancelled_client_task_should_cancel_server_task(self):
         """When the asyncio task awaiting send_request() is cancelled on the
         client, the corresponding server-side task should also be cancelled

--- a/tests/test_rlm_env.py
+++ b/tests/test_rlm_env.py
@@ -2793,7 +2793,11 @@ class TestFilesystemProvisioning:
     @pytest.mark.asyncio
     async def test_write_sandbox_files_retries_upload_timeout(self):
         dataset = make_dataset({})
-        env = build_env(dataset, repl_language="python")
+        env = build_env(
+            dataset,
+            repl_language="python",
+            sandbox_transfer_max_retries=1,
+        )
         state = {
             "rollout_id": "rlm_test",
             "rlm_fs_root": "/tmp/rlm_rlm_test/rlm_fs",

--- a/tests/test_rlm_env.py
+++ b/tests/test_rlm_env.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from datasets import Dataset
+from prime_sandboxes import UploadTimeoutError
 
 import verifiers as vf
 from verifiers.envs.experimental import rlm_env as rlm_module
@@ -2707,6 +2708,28 @@ class TestCleanupSemantics:
 
 
 class TestFilesystemProvisioning:
+    def test_rlm_env_threads_sandbox_client_pool_settings_to_executor(self):
+        dataset = make_dataset({})
+        with (
+            patch("verifiers.envs.environment.signal.signal"),
+            patch(
+                "verifiers.envs.experimental.sandbox_mixin.ThreadedAsyncSandboxClient"
+            ) as mock_client_cls,
+        ):
+            mock_client_cls.return_value = MagicMock()
+            RLMEnv(
+                dataset=dataset,
+                sandbox_client_max_workers=123,
+                sandbox_client_max_connections=234,
+                sandbox_client_max_keepalive_connections=56,
+            )
+
+        mock_client_cls.assert_called_with(
+            max_workers=123,
+            max_connections=234,
+            max_keepalive_connections=56,
+        )
+
     @pytest.mark.asyncio
     async def test_prepare_filesystem_uploads_and_sets_paths(self, tmp_path: Path):
         dataset = make_dataset({})
@@ -2766,3 +2789,37 @@ class TestFilesystemProvisioning:
         await executor._write_sandbox_files(session, state)
 
         assert executor.sandbox_client.upload_file.await_count == 3
+
+    @pytest.mark.asyncio
+    async def test_write_sandbox_files_retries_upload_timeout(self):
+        dataset = make_dataset({})
+        env = build_env(dataset, repl_language="python")
+        state = {
+            "rollout_id": "rlm_test",
+            "rlm_fs_root": "/tmp/rlm_rlm_test/rlm_fs",
+            "model": "m",
+            "client": MagicMock(),
+            "interception_url": "http://example.invalid",
+            "root_tool_url": "http://example.invalid",
+        }
+
+        executor = env._executor
+        executor._sessions.clear()
+        session = executor._get_or_create_session(state)
+        session.sandbox_id = "sbx_1"
+        session.sandbox_control_dir = "/tmp/rlm_rlm_test/rlm_control"
+        session.sandbox_fs_root = "/tmp/rlm_rlm_test/rlm_fs"
+        session.paths = rlm_module._build_worker_paths(session.sandbox_control_dir)
+
+        executor.sandbox_client.upload_file = AsyncMock(
+            side_effect=[
+                UploadTimeoutError("sbx_1", session.paths.context_file, 300),
+                MagicMock(),
+                MagicMock(),
+                MagicMock(),
+            ]
+        )
+
+        await executor._write_sandbox_files(session, state)
+
+        assert executor.sandbox_client.upload_file.await_count == 4

--- a/tests/test_sandbox_mixin.py
+++ b/tests/test_sandbox_mixin.py
@@ -100,6 +100,19 @@ def test_create_sandbox_creation_fails(mixin):
         asyncio.run(mixin.create_sandbox({}, request=MagicMock()))
 
 
+def test_create_sandbox_max_retries_is_true_retry_count():
+    obj = ConcreteMixin(max_retries=1, base_delay=0.01)
+    obj.logger = MagicMock()
+    sandbox_obj = MagicMock(id="sb-retry")
+    obj.sandbox_client.create = AsyncMock(side_effect=[Exception("boom"), sandbox_obj])
+    obj.sandbox_client.wait_for_creation = AsyncMock()
+
+    result = asyncio.run(obj.create_sandbox({}, request=MagicMock()))
+
+    assert result == "sb-retry"
+    assert obj.sandbox_client.create.await_count == 2
+
+
 def test_create_sandbox_not_ready(mixin):
     sandbox_obj = MagicMock(id="sb-2")
     mixin.sandbox_client.create = AsyncMock(return_value=sandbox_obj)

--- a/tests/test_sandbox_mixin.py
+++ b/tests/test_sandbox_mixin.py
@@ -2,7 +2,15 @@ import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from prime_sandboxes import CommandTimeoutError, SandboxOOMError, SandboxTimeoutError
+import httpx
+from prime_sandboxes import (
+    APIError,
+    CommandTimeoutError,
+    DownloadTimeoutError,
+    SandboxOOMError,
+    SandboxTimeoutError,
+    UploadTimeoutError,
+)
 
 import verifiers as vf
 from verifiers.envs.experimental.sandbox_mixin import (
@@ -11,6 +19,8 @@ from verifiers.envs.experimental.sandbox_mixin import (
     SandboxNotReadyError,
     SandboxSetupError,
     ThreadedAsyncSandboxClient,
+    is_retryable_sandbox_api_error,
+    is_retryable_sandbox_read_error,
 )
 
 MODULE = "verifiers.envs.experimental.sandbox_mixin"
@@ -39,6 +49,28 @@ def test_init_creates_client_and_retry():
     assert isinstance(obj.active_sandboxes, set) and len(obj.active_sandboxes) == 0
     assert isinstance(obj.sandbox_client, ThreadedAsyncSandboxClient)
     assert callable(obj.with_retry)
+
+
+@pytest.mark.parametrize(
+    "exception",
+    [
+        UploadTimeoutError("sb", "/tmp/file", 300),
+        DownloadTimeoutError("sb", "/tmp/file", 300),
+        CommandTimeoutError("sb", "echo hi", 30),
+        httpx.ReadTimeout("timed out"),
+        APIError("Upload failed: HTTP 503: retry me"),
+        APIError("Upload failed: ConnectError at POST /upload: boom"),
+    ],
+)
+def test_retryable_sandbox_read_error_matches_current_sdk_exceptions(exception):
+    assert is_retryable_sandbox_read_error(exception) is True
+
+
+def test_retryable_sandbox_api_error_ignores_non_retryable_api_error():
+    assert (
+        is_retryable_sandbox_api_error(APIError("Upload failed: HTTP 400: nope"))
+        is False
+    )
 
 
 # ── create_sandbox ───────────────────────────────────────────────────

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -1602,21 +1602,24 @@ class RLMExecutor(SandboxMixin):
         )
         worker_script = self.env.customize_worker_script(worker_script, state)
         worker_path.write_text(worker_script, encoding="utf-8")
+        sandbox_id = session.sandbox_id
+        if sandbox_id is None:
+            raise RLMSessionError("Sandbox not initialized")
 
         await self._upload_file_with_retry(
-            session.sandbox_id,
+            sandbox_id,
             session.paths.context_file,
             str(context_path),
             "context file upload",
         )
         await self._upload_file_with_retry(
-            session.sandbox_id,
+            sandbox_id,
             session.paths.answer_file,
             str(answer_path),
             "answer file upload",
         )
         await self._upload_file_with_retry(
-            session.sandbox_id,
+            sandbox_id,
             session.paths.worker_path,
             str(worker_path),
             "worker file upload",
@@ -2158,7 +2161,7 @@ class RLMEnv(vf.StatefulToolEnv):
             retry=tc.retry_if_exception(is_retryable_sandbox_read_error),
             stop=tc.stop_after_attempt(sandbox_transfer_max_retries),
             wait=tc.wait_exponential_jitter(initial=1, max=30),
-            before_sleep=tc.before_sleep_log(logger, logging.WARNING),
+            before_sleep=tc.before_sleep_log(cast(Any, logger), logging.WARNING),
             reraise=True,
         ).wraps
         fixed_root_tools = self._build_fixed_root_tools()

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -47,13 +47,17 @@ else:
     from typing import TypedDict
 
 from aiohttp import web
+import tenacity as tc
 from prime_sandboxes import CommandTimeoutError, SandboxClient
 from prime_sandboxes.core import APIClient
 from prime_tunnel import Tunnel
 
 import verifiers as vf
 from verifiers.clients import Client
-from verifiers.envs.experimental.sandbox_mixin import SandboxMixin
+from verifiers.envs.experimental.sandbox_mixin import (
+    SandboxMixin,
+    is_retryable_sandbox_read_error,
+)
 from verifiers.envs.sandbox_env import CreateSandboxRequest
 from verifiers.types import (
     AssistantMessage,
@@ -1287,9 +1291,11 @@ class RLMExecutor(SandboxMixin):
         self._sessions: dict[str, SandboxRLMReplSession] = {}
         self._retained_dirs: set[str] = set()
         self.init_sandbox_client(
-            sandbox_client_max_workers=50,
-            sandbox_client_max_connections=100,
-            sandbox_client_max_keepalive_connections=50,
+            sandbox_client_max_workers=env.sandbox_client_max_workers,
+            sandbox_client_max_connections=env.sandbox_client_max_connections,
+            sandbox_client_max_keepalive_connections=(
+                env.sandbox_client_max_keepalive_connections
+            ),
         )
 
     def create_rollout_dirs(self, state: State) -> None:
@@ -1597,14 +1603,23 @@ class RLMExecutor(SandboxMixin):
         worker_script = self.env.customize_worker_script(worker_script, state)
         worker_path.write_text(worker_script, encoding="utf-8")
 
-        await self.sandbox_client.upload_file(
-            session.sandbox_id, session.paths.context_file, str(context_path)
+        await self._upload_file_with_retry(
+            session.sandbox_id,
+            session.paths.context_file,
+            str(context_path),
+            "context file upload",
         )
-        await self.sandbox_client.upload_file(
-            session.sandbox_id, session.paths.answer_file, str(answer_path)
+        await self._upload_file_with_retry(
+            session.sandbox_id,
+            session.paths.answer_file,
+            str(answer_path),
+            "answer file upload",
         )
-        await self.sandbox_client.upload_file(
-            session.sandbox_id, session.paths.worker_path, str(worker_path)
+        await self._upload_file_with_retry(
+            session.sandbox_id,
+            session.paths.worker_path,
+            str(worker_path),
+            "worker file upload",
         )
 
     async def _start_worker(self, session: SandboxRLMReplSession, state: State) -> None:
@@ -1834,7 +1849,12 @@ class RLMExecutor(SandboxMixin):
             with tarfile.open(tar_path, "w:gz") as tar:
                 tar.add(local_path, arcname=".")
             remote_tar = f"/tmp/rlm_upload_{uuid.uuid4().hex}.tar.gz"
-            await self.sandbox_client.upload_file(sandbox_id, remote_tar, str(tar_path))
+            await self._upload_file_with_retry(
+                sandbox_id,
+                remote_tar,
+                str(tar_path),
+                "directory archive upload",
+            )
             extract_cmd = (
                 "bash -lc '"
                 f'mkdir -p "{remote_dir}"; '
@@ -1869,8 +1889,11 @@ class RLMExecutor(SandboxMixin):
             tmp = tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False)
             tar_path = Path(tmp.name)
             tmp.close()
-            await self.sandbox_client.download_file(
-                sandbox_id, remote_tar, str(tar_path)
+            await self._download_file_with_retry(
+                sandbox_id,
+                remote_tar,
+                str(tar_path),
+                "directory archive download",
             )
             if local_path.exists():
                 shutil.rmtree(local_path, True)
@@ -1909,6 +1932,36 @@ class RLMExecutor(SandboxMixin):
                     tar_path.unlink()
                 except Exception:
                     pass
+
+    async def _upload_file_with_retry(
+        self,
+        sandbox_id: str,
+        remote_path: str,
+        local_path: str,
+        context: str,
+    ) -> None:
+        upload = self.env.with_retry_on_read_errors(self.sandbox_client.upload_file)
+        try:
+            await upload(sandbox_id, remote_path, local_path)
+        except Exception as e:
+            raise vf.SandboxError(
+                f"{context} failed for sandbox {sandbox_id}: {repr(e)}"
+            ) from e
+
+    async def _download_file_with_retry(
+        self,
+        sandbox_id: str,
+        remote_path: str,
+        local_path: str,
+        context: str,
+    ) -> None:
+        download = self.env.with_retry_on_read_errors(self.sandbox_client.download_file)
+        try:
+            await download(sandbox_id, remote_path, local_path)
+        except Exception as e:
+            raise vf.SandboxError(
+                f"{context} failed for sandbox {sandbox_id}: {repr(e)}"
+            ) from e
 
 
 class RLMEnv(vf.StatefulToolEnv):
@@ -2004,6 +2057,9 @@ class RLMEnv(vf.StatefulToolEnv):
         sandbox_timeout_minutes: Sandbox timeout in minutes (default: 60)
         sandbox_environment_vars: Extra environment vars for sandbox (default: None)
         sandbox_labels: Optional labels for sandbox (default: None)
+        sandbox_client_max_workers: Max worker threads for the sandbox client
+        sandbox_client_max_connections: Max HTTP connections for the sandbox client
+        sandbox_client_max_keepalive_connections: Max keepalive connections for the sandbox client
         **kwargs: Additional arguments passed to StatefulToolEnv
     """
 
@@ -2039,6 +2095,10 @@ class RLMEnv(vf.StatefulToolEnv):
         sandbox_timeout_minutes: int = 60,
         sandbox_environment_vars: dict[str, str] | None = None,
         sandbox_labels: list[str] | None = None,
+        sandbox_client_max_workers: int = 50,
+        sandbox_client_max_connections: int = 100,
+        sandbox_client_max_keepalive_connections: int = 50,
+        sandbox_transfer_max_retries: int = 3,
         **kwargs,
     ):
         if repl_language not in {"bash", "python"}:
@@ -2087,8 +2147,20 @@ class RLMEnv(vf.StatefulToolEnv):
         self.sandbox_timeout_minutes = sandbox_timeout_minutes
         self.sandbox_environment_vars = sandbox_environment_vars
         self.sandbox_labels = sandbox_labels
+        self.sandbox_client_max_workers = sandbox_client_max_workers
+        self.sandbox_client_max_connections = sandbox_client_max_connections
+        self.sandbox_client_max_keepalive_connections = (
+            sandbox_client_max_keepalive_connections
+        )
+        self.sandbox_transfer_max_retries = sandbox_transfer_max_retries
         self.sub_llm_timeout = max(1, code_execution_timeout - 5)
-
+        self.with_retry_on_read_errors = tc.AsyncRetrying(
+            retry=tc.retry_if_exception(is_retryable_sandbox_read_error),
+            stop=tc.stop_after_attempt(sandbox_transfer_max_retries),
+            wait=tc.wait_exponential_jitter(initial=1, max=30),
+            before_sleep=tc.before_sleep_log(logger, logging.WARNING),
+            reraise=True,
+        ).wraps
         fixed_root_tools = self._build_fixed_root_tools()
         self.root_tools, self.root_tool_map = _merge_tool_lists(
             fixed_tools=fixed_root_tools,

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -2159,7 +2159,7 @@ class RLMEnv(vf.StatefulToolEnv):
         self.sub_llm_timeout = max(1, code_execution_timeout - 5)
         self.with_retry_on_read_errors = tc.AsyncRetrying(
             retry=tc.retry_if_exception(is_retryable_sandbox_read_error),
-            stop=tc.stop_after_attempt(sandbox_transfer_max_retries),
+            stop=tc.stop_after_attempt(sandbox_transfer_max_retries + 1),
             wait=tc.wait_exponential_jitter(initial=1, max=30),
             before_sleep=tc.before_sleep_log(cast(Any, logger), logging.WARNING),
             reraise=True,

--- a/verifiers/envs/experimental/sandbox_mixin.py
+++ b/verifiers/envs/experimental/sandbox_mixin.py
@@ -133,7 +133,7 @@ class SandboxMixin:
             max_keepalive_connections=sandbox_client_max_keepalive_connections,
         )
         self.with_retry = tc.AsyncRetrying(
-            stop=tc.stop_after_attempt(max_retries),
+            stop=tc.stop_after_attempt(max_retries + 1),
             wait=tc.wait_exponential_jitter(
                 initial=base_delay,
                 exp_base=backoff_factor,

--- a/verifiers/envs/experimental/sandbox_mixin.py
+++ b/verifiers/envs/experimental/sandbox_mixin.py
@@ -13,9 +13,11 @@ from prime_sandboxes import (
     APIError,
     CommandTimeoutError,
     CreateSandboxRequest,
+    DownloadTimeoutError,
     SandboxClient,
     SandboxOOMError,
     SandboxTimeoutError,
+    UploadTimeoutError,
 )
 from prime_sandboxes.core import APIClient
 
@@ -55,6 +57,37 @@ class SandboxMonitorRubric(vf.Rubric):
     async def sandbox_timeout(self, state: vf.State) -> float:
         """Whether the sandbox timed out."""
         return float(bool(state.get("sandbox_timeout")))
+
+
+# The SDK handles some transient transport retries internally, but upload/download
+# timeouts still surface as typed exceptions. Keep the env-level helpers here so
+# sandbox environments can share one policy for those cases.
+def is_retryable_sandbox_api_error(exception: Exception) -> bool:
+    """Return True for transient sandbox API failures that are safe to retry."""
+    if not isinstance(exception, APIError):
+        return False
+
+    error_str = str(exception)
+    retry_tokens = (
+        "502",
+        "503",
+        "ConnectError",
+        "Temporary failure in name resolution",
+    )
+    return any(token in error_str for token in retry_tokens)
+
+
+def is_retryable_sandbox_read_error(exception: Exception) -> bool:
+    """Return True for retryable read/transfer timeouts and transient API errors."""
+    return isinstance(
+        exception,
+        (
+            httpx.ReadTimeout,
+            CommandTimeoutError,
+            UploadTimeoutError,
+            DownloadTimeoutError,
+        ),
+    ) or is_retryable_sandbox_api_error(exception)
 
 
 class SandboxMixin:

--- a/verifiers/envs/experimental/sandbox_mixin.py
+++ b/verifiers/envs/experimental/sandbox_mixin.py
@@ -62,7 +62,7 @@ class SandboxMonitorRubric(vf.Rubric):
 # The SDK handles some transient transport retries internally, but upload/download
 # timeouts still surface as typed exceptions. Keep the env-level helpers here so
 # sandbox environments can share one policy for those cases.
-def is_retryable_sandbox_api_error(exception: Exception) -> bool:
+def is_retryable_sandbox_api_error(exception: BaseException) -> bool:
     """Return True for transient sandbox API failures that are safe to retry."""
     if not isinstance(exception, APIError):
         return False
@@ -77,7 +77,7 @@ def is_retryable_sandbox_api_error(exception: Exception) -> bool:
     return any(token in error_str for token in retry_tokens)
 
 
-def is_retryable_sandbox_read_error(exception: Exception) -> bool:
+def is_retryable_sandbox_read_error(exception: BaseException) -> bool:
     """Return True for retryable read/transfer timeouts and transient API errors."""
     return isinstance(
         exception,

--- a/verifiers/workers/server/env_server.py
+++ b/verifiers/workers/server/env_server.py
@@ -76,7 +76,6 @@ class EnvServer(ABC):
         self.extra_env_kwargs = extra_env_kwargs or {}
 
         self.clients: dict[str, Client] = {}
-        self.pending_tasks: set[asyncio.Task] = set()
 
         # load environment
         self.logger.info(f"Loading environment {env_id} with {env_args=}")

--- a/verifiers/workers/server/zmq_env_server.py
+++ b/verifiers/workers/server/zmq_env_server.py
@@ -77,6 +77,11 @@ class ZMQEnvServer(EnvServer):
         self.stop_health = mp.Event()
         self.health_process: mp.Process | None = None
 
+    def _cleanup_request_task(self, frame_request_id: str, task: asyncio.Task) -> None:
+        self.pending_tasks.discard(task)
+        if self.request_tasks.get(frame_request_id) is task:
+            self.request_tasks.pop(frame_request_id, None)
+
     async def serve(self, stop_event: asyncio.Event | None = None) -> None:
         self.logger.info(f"{self.__class__.__name__} started on {self.address}")
 
@@ -135,11 +140,16 @@ class ZMQEnvServer(EnvServer):
                         continue
 
                     # Process in background, tracking the task for cleanup
+                    frame_request_id = request_id.decode()
                     task = asyncio.create_task(
                         self.process_request(client_id, request_id, payload_bytes)
                     )
+                    self.request_tasks[frame_request_id] = task
                     self.pending_tasks.add(task)
-                    task.add_done_callback(self.pending_tasks.discard)
+                    task.add_done_callback(
+                        lambda done_task,
+                        rid=frame_request_id: self._cleanup_request_task(rid, done_task)
+                    )
 
                 except asyncio.CancelledError:
                     break
@@ -203,47 +213,42 @@ class ZMQEnvServer(EnvServer):
         payload_bytes: bytes,
     ):
         request_id = request_id_bytes.decode()
-        frame_request_id = request_id
-        current_task = asyncio.current_task()
-        if current_task is not None:
-            self.request_tasks[frame_request_id] = current_task
         response: BaseResponse
 
         try:
-            try:
-                # deserialize request
-                raw = msgpack.unpackb(payload_bytes, raw=False)
-                request_type = raw.get("request_type")
-                request_id = raw.get("request_id", request_id)
+            # deserialize request
+            raw = msgpack.unpackb(payload_bytes, raw=False)
+            request_type = raw.get("request_type")
+            request_id = raw.get("request_id", request_id)
 
-                # Health requests are handled by the dedicated health process,
-                # so they should not arrive here.
-                if request_type == "run_rollout":
-                    request = RunRolloutRequest.model_validate(raw)
-                    response = await self.handle_run_rollout(request)
-                elif request_type == "run_group":
-                    request = RunGroupRequest.model_validate(raw)
-                    response = await self.handle_run_group(request)
-                else:
-                    self.logger.warning(f"Got unknown request type: {request_type}")
-                    response = BaseResponse(
-                        success=False, error=f"Unknown request type: {request_type}"
-                    )
-
-            except asyncio.CancelledError:
-                return
-
-            except Exception as e:
-                self.logger.error(
-                    f"Error processing request {request_id}: {e}", exc_info=True
-                )
+            # Health requests are handled by the dedicated health process,
+            # so they should not arrive here.
+            if request_type == "run_rollout":
+                request = RunRolloutRequest.model_validate(raw)
+                response = await self.handle_run_rollout(request)
+            elif request_type == "run_group":
+                request = RunGroupRequest.model_validate(raw)
+                response = await self.handle_run_group(request)
+            else:
+                self.logger.warning(f"Got unknown request type: {request_type}")
                 response = BaseResponse(
-                    success=False,
-                    error=repr(e),
+                    success=False, error=f"Unknown request type: {request_type}"
                 )
 
-            # serialize response using Pydantic
-            response_bytes = cast(
+        except asyncio.CancelledError:
+            return
+
+        except Exception as e:
+            self.logger.error(
+                f"Error processing request {request_id}: {e}", exc_info=True
+            )
+            response = BaseResponse(
+                success=False,
+                error=repr(e),
+            )
+
+        def serialize_response() -> bytes:
+            return cast(
                 bytes,
                 msgpack.packb(
                     response.model_dump(mode="python", warnings=False),
@@ -252,15 +257,15 @@ class ZMQEnvServer(EnvServer):
                 ),
             )
 
-            # send response: [client_id, request_id, response]
-            try:
-                await self.socket.send_multipart(
-                    [client_id, request_id.encode(), response_bytes]
-                )
-            except zmq.ZMQError as e:
-                self.logger.warning(
-                    f"Failed to send response for request {request_id[:7]}: {e} "
-                    f"(client likely disconnected)"
-                )
-        finally:
-            self.request_tasks.pop(frame_request_id, None)
+        response_bytes = await asyncio.to_thread(serialize_response)
+
+        # send response: [client_id, request_id, response]
+        try:
+            await self.socket.send_multipart(
+                [client_id, request_id.encode(), response_bytes]
+            )
+        except zmq.ZMQError as e:
+            self.logger.warning(
+                f"Failed to send response for request {request_id[:7]}: {e} "
+                f"(client likely disconnected)"
+            )

--- a/verifiers/workers/server/zmq_env_server.py
+++ b/verifiers/workers/server/zmq_env_server.py
@@ -72,7 +72,8 @@ class ZMQEnvServer(EnvServer):
         self.socket.setsockopt(zmq.LINGER, 0)  # discard msgs on socket close
         self.socket.bind(self.address)
 
-        # Map frame request-id -> asyncio.Task so we can cancel on demand
+        # Map frame request-id -> asyncio.Task so we can cancel on demand and
+        # track in-flight work from a single source of truth.
         self.request_tasks: dict[str, asyncio.Task] = {}
 
         # Health check runs in a separate process (immune to env workload)
@@ -80,7 +81,6 @@ class ZMQEnvServer(EnvServer):
         self.health_process: mp.Process | None = None
 
     def _cleanup_request_task(self, frame_request_id: str, task: asyncio.Task) -> None:
-        self.pending_tasks.discard(task)
         if self.request_tasks.get(frame_request_id) is task:
             self.request_tasks.pop(frame_request_id, None)
 
@@ -155,7 +155,6 @@ class ZMQEnvServer(EnvServer):
                         self.process_request(client_id, request_id, payload_bytes)
                     )
                     self.request_tasks[frame_request_id] = task
-                    self.pending_tasks.add(task)
                     task.add_done_callback(
                         lambda done_task,
                         rid=frame_request_id: self._cleanup_request_task(rid, done_task)
@@ -184,12 +183,12 @@ class ZMQEnvServer(EnvServer):
             self.health_process = None
 
         # Cancel and await all pending tasks
-        if self.pending_tasks:
-            self.logger.info(f"Cancelling {len(self.pending_tasks)} pending tasks")
-            for task in self.pending_tasks:
+        if self.request_tasks:
+            tasks = list(self.request_tasks.values())
+            self.logger.info(f"Cancelling {len(tasks)} pending tasks")
+            for task in tasks:
                 task.cancel()
-            await asyncio.gather(*self.pending_tasks, return_exceptions=True)
-            self.pending_tasks.clear()
+            await asyncio.gather(*tasks, return_exceptions=True)
 
         self.request_tasks.clear()
 
@@ -203,7 +202,7 @@ class ZMQEnvServer(EnvServer):
         """Periodically log statistics."""
         while True:
             await asyncio.sleep(interval)
-            pending = len(self.pending_tasks)
+            pending = len(self.request_tasks)
             message = f"Pending tasks: {pending}"
 
             lags = self.lag_monitor.lags

--- a/verifiers/workers/server/zmq_env_server.py
+++ b/verifiers/workers/server/zmq_env_server.py
@@ -156,8 +156,9 @@ class ZMQEnvServer(EnvServer):
                     )
                     self.request_tasks[frame_request_id] = task
                     task.add_done_callback(
-                        lambda done_task,
-                        rid=frame_request_id: self._cleanup_request_task(rid, done_task)
+                        lambda done_task, rid=frame_request_id: (
+                            self._cleanup_request_task(rid, done_task)
+                        )
                     )
 
                 except asyncio.CancelledError:


### PR DESCRIPTION
## Description                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                               
  Fix a missed-cancel race in the ZMQ env server and make RLM sandbox upload+download failures fail as vf.SandboxError.                                               
                                                                               
  ## Changes                                                                                                                                                   
                                                                               
  - register request tasks at creation time so cancels cannot miss the pre-registration window
  - add a regression test for that cancel race                           
  - add shared retry predicates for current sandbox timeout/error types                                                                                        
  - wire RLM sandbox client pool knobs through to the real executor client
  - add sandbox_transfer_max_retries to RLMEnv                                                                                                                                                                                                                                                                                 
  - wrap exhausted RLM upload/download retries as vf.SandboxError              
                                                                                                                                                               
  ## Why                                                                                                                                                                                                                                                                                                                       
                                                                               
  This stops stale cancelled rollouts from continuing invisibly and makes exhausted sandbox transfer failures follow the normal rescheduleable sandbox-error path.
                                                                                                                                                                                                                                                                                                                               
  ## Testing                                                                   
                                                                                                                                                                                                                                                                                                                               
  - added targeted unit tests                                                  
  - uv run ruff check passed 

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches request lifecycle/cancellation in the ZMQ env server and adds retry logic around sandbox uploads/downloads, which can affect rollout execution and resource cleanup. Changes are scoped and covered by new regression tests but impact core worker infrastructure.
> 
> **Overview**
> Prevents missed client-side cancels in the ZMQ env server by tracking request tasks from creation time (single source of truth via `request_tasks`) and cleaning them up reliably, including during shutdown.
> 
> Improves RLM sandbox robustness by threading sandbox client pool settings through `RLMEnv`/`RLMExecutor`, adding `sandbox_transfer_max_retries`, and retrying upload/download operations on retryable SDK/transport errors while converting exhausted failures into `vf.SandboxError`.
> 
> Adds targeted tests covering the pre-processing cancellation race, retryable sandbox error predicates, true retry-count semantics, and RLM upload retry behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19c6ffd73cfdba990a5a8de372b216cd506ba9e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->