### PR TITLE
perf: incremental metrics

### DIFF
--- a/tests/test_save_utils.py
+++ b/tests/test_save_utils.py
@@ -16,7 +16,15 @@ from openai import OpenAI
 from pydantic import BaseModel
 
 from verifiers.types import ClientConfig
-from verifiers.utils.metric_utils import compute_pass_at_k
+from verifiers.utils.metric_utils import (
+    EnvMetrics,
+    ErrorRateMetric,
+    InputTokensMetric,
+    Metric,
+    OutputTokensMetric,
+    PassAtKMetric,
+    RewardMetric,
+)
 from verifiers.utils.save_utils import (
     GenerateOutputsBuilder,
     extract_usage_tokens,
@@ -562,125 +570,8 @@ class TestResumeMetadataValidation:
             )
 
 
-class TestComputePassAtK:
-    @staticmethod
-    def _make_output(example_id: int, reward: float) -> dict:
-        return {"example_id": example_id, "reward": reward}
-
-    def test_single_rollout_returns_empty(self):
-        """rollouts_per_example=1 should return empty dicts."""
-        outputs = [self._make_output(0, 1.0)]
-        pass_at_k, pass_all_k = compute_pass_at_k(outputs, rollouts_per_example=1)
-        assert pass_at_k == {}
-        assert pass_all_k == {}
-
-    def test_all_correct(self):
-        """All rollouts correct → pass@k = 1.0 and pass^k = 1.0 for all k."""
-        outputs = [self._make_output(0, 1.0) for _ in range(8)]
-        pass_at_k, pass_all_k = compute_pass_at_k(outputs, rollouts_per_example=8)
-        assert set(pass_at_k.keys()) == {"1", "2", "4", "8"}
-        for k in pass_at_k:
-            assert pass_at_k[k] == pytest.approx(1.0)
-            assert pass_all_k[k] == pytest.approx(1.0)
-
-    def test_none_correct(self):
-        """No rollouts correct → pass@k = 0.0 and pass^k = 0.0 for all k."""
-        outputs = [self._make_output(0, 0.0) for _ in range(8)]
-        pass_at_k, pass_all_k = compute_pass_at_k(outputs, rollouts_per_example=8)
-        assert set(pass_at_k.keys()) == {"1", "2", "4", "8"}
-        for k in pass_at_k:
-            assert pass_at_k[k] == pytest.approx(0.0)
-            assert pass_all_k[k] == pytest.approx(0.0)
-
-    def test_partial_correctness(self):
-        """Partial correctness: 2 correct out of 4 rollouts."""
-        outputs = [
-            self._make_output(0, 1.0),
-            self._make_output(0, 1.0),
-            self._make_output(0, 0.0),
-            self._make_output(0, 0.0),
-        ]
-        pass_at_k, pass_all_k = compute_pass_at_k(outputs, rollouts_per_example=4)
-        # k values: 1, 2, 4
-        assert set(pass_at_k.keys()) == {"1", "2", "4"}
-        # n=4, c=2: pass@1 = 1 - C(2,1)/C(4,1) = 1 - 2/4 = 0.5
-        assert pass_at_k["1"] == pytest.approx(0.5)
-        # n=4, c=2: pass@2 = 1 - C(2,2)/C(4,2) = 1 - 1/6
-        assert pass_at_k["2"] == pytest.approx(1.0 - 1.0 / 6.0)
-        # n=4, c=2: pass@4 = 1 - C(2,4)/C(4,4) = 1 - 0/1 = 1.0 (n-c < k)
-        assert pass_at_k["4"] == pytest.approx(1.0)
-        # pass^k: C(c,k)/C(n,k)
-        # n=4, c=2: pass^1 = C(2,1)/C(4,1) = 2/4 = 0.5
-        assert pass_all_k["1"] == pytest.approx(0.5)
-        # n=4, c=2: pass^2 = C(2,2)/C(4,2) = 1/6
-        assert pass_all_k["2"] == pytest.approx(1.0 / 6.0)
-        # n=4, c=2: pass^4 = C(2,4)/C(4,4) = 0/1 = 0.0
-        assert pass_all_k["4"] == pytest.approx(0.0)
-
-    def test_multiple_examples_averaged(self):
-        """pass@k and pass^k are averaged across multiple examples."""
-        outputs = [
-            # Example 0: all correct
-            self._make_output(0, 1.0),
-            self._make_output(0, 1.0),
-            self._make_output(0, 1.0),
-            self._make_output(0, 1.0),
-            # Example 1: none correct
-            self._make_output(1, 0.0),
-            self._make_output(1, 0.0),
-            self._make_output(1, 0.0),
-            self._make_output(1, 0.0),
-        ]
-        pass_at_k, pass_all_k = compute_pass_at_k(outputs, rollouts_per_example=4)
-        assert set(pass_at_k.keys()) == {"1", "2", "4"}
-        # pass@1: (1.0 + 0.0) / 2 = 0.5
-        assert pass_at_k["1"] == pytest.approx(0.5)
-        # pass@2: (1.0 + 0.0) / 2 = 0.5
-        assert pass_at_k["2"] == pytest.approx(0.5)
-        # pass@4: (1.0 + 0.0) / 2 = 0.5
-        assert pass_at_k["4"] == pytest.approx(0.5)
-        # pass^1: (1.0 + 0.0) / 2 = 0.5
-        assert pass_all_k["1"] == pytest.approx(0.5)
-        # pass^4: (1.0 + 0.0) / 2 = 0.5
-        assert pass_all_k["4"] == pytest.approx(0.5)
-
-    def test_powers_of_two_k_selection(self):
-        """k values are powers of 2 in [1, n]."""
-        outputs = [self._make_output(0, 1.0) for _ in range(16)]
-        pass_at_k, _ = compute_pass_at_k(outputs, rollouts_per_example=16)
-        assert set(pass_at_k.keys()) == {"1", "2", "4", "8", "16"}
-
-    def test_n3_k_values(self):
-        """n=3 should give k=1,2."""
-        outputs = [self._make_output(0, 1.0) for _ in range(3)]
-        pass_at_k, _ = compute_pass_at_k(outputs, rollouts_per_example=3)
-        assert set(pass_at_k.keys()) == {"1", "2"}
-
-    def test_correctness_threshold(self):
-        """Only reward >= 0.5 counts as correct by default."""
-        outputs = [
-            self._make_output(0, 0.49),  # not correct
-            self._make_output(0, 0.5),  # correct
-            self._make_output(0, 1.0),  # correct
-            self._make_output(0, 0.0),  # not correct
-        ]
-        pass_at_k, _ = compute_pass_at_k(outputs, rollouts_per_example=4)
-        # n=4, c=2
-        assert pass_at_k["1"] == pytest.approx(0.5)
-
-    def test_custom_threshold(self):
-        """Custom threshold changes which rollouts count as correct."""
-        outputs = [
-            self._make_output(0, 0.4),  # not correct at 0.7
-            self._make_output(0, 0.6),  # not correct at 0.7
-            self._make_output(0, 0.8),  # correct at 0.7
-            self._make_output(0, 0.3),  # not correct at 0.7
-        ]
-        pass_at_k, _ = compute_pass_at_k(outputs, rollouts_per_example=4, threshold=0.7)
-        # n=4, c=1: pass@1 = 1 - C(3,1)/C(4,1) = 1 - 3/4 = 0.25
-        assert pass_at_k["1"] == pytest.approx(0.25)
-        # n=4, c=1: pass@2 = 1 - C(3,2)/C(4,2) = 1 - 3/6 = 0.5
-        assert pass_at_k["2"] == pytest.approx(0.5)
+class TestBuilderPassAtK:
+    """Tests for pass@k integration in GenerateOutputsBuilder."""
 
     def test_builder_includes_pass_at_k(self):
         """GenerateOutputsBuilder.build_metadata() includes pass_at_k and pass_all_k."""
@@ -737,30 +628,262 @@ class TestComputePassAtK:
         # 1 of 4 correct at threshold=0.7: pass^1 = C(1,1)/C(4,1) = 0.25
         assert metadata["pass_all_k"]["1"] == pytest.approx(0.25)
 
-    def test_incomplete_groups_excluded(self):
-        """Examples with fewer outputs than rollouts_per_example are excluded."""
-        outputs = [
-            # Example 0: complete group (4 rollouts), all correct
-            self._make_output(0, 1.0),
-            self._make_output(0, 1.0),
-            self._make_output(0, 1.0),
-            self._make_output(0, 1.0),
-            # Example 1: incomplete group (only 2 of 4 rollouts)
-            self._make_output(1, 0.0),
-            self._make_output(1, 0.0),
-        ]
-        pass_at_k, pass_all_k = compute_pass_at_k(outputs, rollouts_per_example=4)
-        # Only example 0 contributes; example 1 is excluded entirely
+
+class TestMetricProtocol:
+    def test_all_metrics_satisfy_protocol(self):
+        """All metric classes satisfy the Metric protocol."""
+        assert isinstance(RewardMetric(), Metric)
+        assert isinstance(ErrorRateMetric(), Metric)
+        assert isinstance(InputTokensMetric(), Metric)
+        assert isinstance(OutputTokensMetric(), Metric)
+        assert isinstance(EnvMetrics(), Metric)
+        assert isinstance(PassAtKMetric(rollouts_per_example=4), Metric)
+
+
+class TestRewardMetric:
+    def test_basic(self):
+        m = RewardMetric()
+        m.add_output({"reward": 0.3})
+        m.add_output({"reward": 0.7})
+        assert m.compute() == pytest.approx(0.5)
+        assert m.count == 2
+
+    def test_missing_reward_defaults_to_zero(self):
+        m = RewardMetric()
+        m.add_output({})
+        assert m.compute() == pytest.approx(0.0)
+
+    def test_add_outputs(self):
+        m = RewardMetric()
+        m.add_outputs([{"reward": 1.0}, {"reward": 0.0}])
+        assert m.compute() == pytest.approx(0.5)
+
+    def test_reset(self):
+        m = RewardMetric()
+        m.add_output({"reward": 1.0})
+        m.reset()
+        assert m.compute() == 0.0
+        assert m.count == 0
+
+
+class TestErrorRateMetric:
+    def test_basic(self):
+        m = ErrorRateMetric()
+        m.add_output({"error": "some error"})
+        m.add_output({})
+        m.add_output({"error": None})
+        m.add_output({"error": "another"})
+        assert m.compute() == pytest.approx(0.5)
+
+
+class TestInputTokensMetric:
+    def test_skips_outputs_without_usage(self):
+        m = InputTokensMetric()
+        m.add_output({"token_usage": {"input_tokens": 100.0, "output_tokens": 50.0}})
+        m.add_output({})  # skipped
+        m.add_output({"token_usage": {"input_tokens": 200.0, "output_tokens": 100.0}})
+        assert m.compute() == pytest.approx(150.0)
+        assert m.count == 2
+
+
+class TestOutputTokensMetric:
+    def test_skips_outputs_without_usage(self):
+        m = OutputTokensMetric()
+        m.add_output({"token_usage": {"input_tokens": 100.0, "output_tokens": 50.0}})
+        m.add_output({})  # skipped
+        m.add_output({"token_usage": {"input_tokens": 200.0, "output_tokens": 100.0}})
+        assert m.compute() == pytest.approx(75.0)
+        assert m.count == 2
+
+
+class TestEnvMetrics:
+    def test_basic(self):
+        m = EnvMetrics()
+        m.add_output({"metrics": {"accuracy": 1.0, "f1": 0.8}})
+        m.add_output({"metrics": {"accuracy": 0.0, "f1": 0.6}})
+        result = m.compute()
+        assert result["accuracy"] == pytest.approx(0.5)
+        assert result["f1"] == pytest.approx(0.7)
+
+    def test_sparse_keys(self):
+        m = EnvMetrics()
+        m.add_output({"metrics": {"accuracy": 1.0, "f1": 0.8}})
+        m.add_output({"metrics": {"accuracy": 0.0}})
+        m.add_output({"metrics": {"accuracy": 0.0, "f1": 0.4}})
+        result = m.compute()
+        assert result["accuracy"] == pytest.approx(1.0 / 3)
+        assert result["f1"] == pytest.approx(0.6)
+
+    def test_empty(self):
+        m = EnvMetrics()
+        assert m.compute() == {}
+
+    def test_reset(self):
+        m = EnvMetrics()
+        m.add_output({"metrics": {"acc": 1.0}})
+        m.reset()
+        assert m.compute() == {}
+
+
+class TestPassAtKMetric:
+    @staticmethod
+    def _make_output(example_id: int, reward: float) -> dict:
+        return {"example_id": example_id, "reward": reward}
+
+    def test_incremental_matches_batch(self):
+        """Incremental add_output matches batch compute_pass_at_k."""
+        import random
+
+        random.seed(42)
+        rollouts_per_example = 8
+
+        all_outputs = []
+        for eid in range(10):
+            for _ in range(rollouts_per_example):
+                reward = random.choice([0.0, 0.5, 1.0])
+                all_outputs.append(self._make_output(eid, reward))
+
+        random.shuffle(all_outputs)
+
+        # Incremental: one-by-one
+        m1 = PassAtKMetric(rollouts_per_example)
+        for output in all_outputs:
+            m1.add_output(output)
+            m1.compute()  # verify O(1) doesn't crash
+        inc_pass_at_k, inc_pass_all_k = m1.compute()
+
+        # Batch: add_outputs all at once
+        m2 = PassAtKMetric(rollouts_per_example)
+        m2.add_outputs(all_outputs)
+        batch_pass_at_k, batch_pass_all_k = m2.compute()
+
+        assert inc_pass_at_k == pytest.approx(batch_pass_at_k)
+        assert inc_pass_all_k == pytest.approx(batch_pass_all_k)
+
+    def test_add_outputs(self):
+        m = PassAtKMetric(rollouts_per_example=2)
+        m.add_outputs([self._make_output(0, 1.0), self._make_output(0, 0.0)])
+        pass_at_k, _ = m.compute()
+        assert pass_at_k["1"] == pytest.approx(0.5)
+
+    def test_incomplete_examples_excluded(self):
+        m = PassAtKMetric(rollouts_per_example=4)
+        for _ in range(4):
+            m.add_output(self._make_output(0, 1.0))
+        for _ in range(2):
+            m.add_output(self._make_output(1, 0.0))
+        pass_at_k, pass_all_k = m.compute()
         assert pass_at_k["1"] == pytest.approx(1.0)
         assert pass_all_k["1"] == pytest.approx(1.0)
 
-    def test_all_groups_incomplete_returns_empty(self):
-        """If no example has a complete group, return empty dicts."""
-        outputs = [
+    def test_empty(self):
+        m = PassAtKMetric(rollouts_per_example=4)
+        assert m.compute() == ({}, {})
+
+    def test_single_rollout(self):
+        m = PassAtKMetric(rollouts_per_example=1)
+        m.add_output(self._make_output(0, 1.0))
+        assert m.compute() == ({}, {})
+
+    def test_reset(self):
+        m = PassAtKMetric(rollouts_per_example=2)
+        m.add_output(self._make_output(0, 1.0))
+        m.add_output(self._make_output(0, 1.0))
+        pass_at_k, _ = m.compute()
+        assert pass_at_k["1"] == pytest.approx(1.0)
+
+        m.reset()
+        m.add_output(self._make_output(0, 0.0))
+        m.add_output(self._make_output(0, 0.0))
+        pass_at_k, _ = m.compute()
+        assert pass_at_k["1"] == pytest.approx(0.0)
+
+    def test_custom_threshold(self):
+        m = PassAtKMetric(rollouts_per_example=4, threshold=0.7)
+        for o in [
+            self._make_output(0, 0.4),
+            self._make_output(0, 0.6),
+            self._make_output(0, 0.8),
+            self._make_output(0, 0.3),
+        ]:
+            m.add_output(o)
+        pass_at_k, _ = m.compute()
+        # 1 of 4 correct at threshold=0.7: pass@1 = 1 - C(3,1)/C(4,1) = 0.25
+        assert pass_at_k["1"] == pytest.approx(0.25)
+        # pass@2 = 1 - C(3,2)/C(4,2) = 1 - 3/6 = 0.5
+        assert pass_at_k["2"] == pytest.approx(0.5)
+
+    def test_all_correct(self):
+        """All rollouts correct → pass@k = 1.0 and pass^k = 1.0 for all k."""
+        m = PassAtKMetric(rollouts_per_example=8)
+        m.add_outputs([self._make_output(0, 1.0) for _ in range(8)])
+        pass_at_k, pass_all_k = m.compute()
+        assert set(pass_at_k.keys()) == {"1", "2", "4", "8"}
+        for k in pass_at_k:
+            assert pass_at_k[k] == pytest.approx(1.0)
+            assert pass_all_k[k] == pytest.approx(1.0)
+
+    def test_none_correct(self):
+        """No rollouts correct → pass@k = 0.0 and pass^k = 0.0 for all k."""
+        m = PassAtKMetric(rollouts_per_example=8)
+        m.add_outputs([self._make_output(0, 0.0) for _ in range(8)])
+        pass_at_k, pass_all_k = m.compute()
+        for k in pass_at_k:
+            assert pass_at_k[k] == pytest.approx(0.0)
+            assert pass_all_k[k] == pytest.approx(0.0)
+
+    def test_partial_correctness(self):
+        """Partial correctness: 2 correct out of 4 rollouts."""
+        m = PassAtKMetric(rollouts_per_example=4)
+        m.add_outputs([
             self._make_output(0, 1.0),
             self._make_output(0, 1.0),
-            self._make_output(1, 1.0),
-        ]
-        pass_at_k, pass_all_k = compute_pass_at_k(outputs, rollouts_per_example=4)
-        assert pass_at_k == {}
-        assert pass_all_k == {}
+            self._make_output(0, 0.0),
+            self._make_output(0, 0.0),
+        ])
+        pass_at_k, pass_all_k = m.compute()
+        assert pass_at_k["1"] == pytest.approx(0.5)
+        assert pass_at_k["2"] == pytest.approx(1.0 - 1.0 / 6.0)
+        assert pass_at_k["4"] == pytest.approx(1.0)
+        assert pass_all_k["1"] == pytest.approx(0.5)
+        assert pass_all_k["2"] == pytest.approx(1.0 / 6.0)
+        assert pass_all_k["4"] == pytest.approx(0.0)
+
+    def test_multiple_examples_averaged(self):
+        """pass@k and pass^k are averaged across multiple examples."""
+        m = PassAtKMetric(rollouts_per_example=4)
+        m.add_outputs([
+            self._make_output(0, 1.0), self._make_output(0, 1.0),
+            self._make_output(0, 1.0), self._make_output(0, 1.0),
+            self._make_output(1, 0.0), self._make_output(1, 0.0),
+            self._make_output(1, 0.0), self._make_output(1, 0.0),
+        ])
+        pass_at_k, pass_all_k = m.compute()
+        assert pass_at_k["1"] == pytest.approx(0.5)
+        assert pass_all_k["1"] == pytest.approx(0.5)
+
+    def test_powers_of_two_k_selection(self):
+        """k values are powers of 2 in [1, n]."""
+        m = PassAtKMetric(rollouts_per_example=16)
+        m.add_outputs([self._make_output(0, 1.0) for _ in range(16)])
+        pass_at_k, _ = m.compute()
+        assert set(pass_at_k.keys()) == {"1", "2", "4", "8", "16"}
+
+    def test_n3_k_values(self):
+        """n=3 should give k=1,2."""
+        m = PassAtKMetric(rollouts_per_example=3)
+        m.add_outputs([self._make_output(0, 1.0) for _ in range(3)])
+        pass_at_k, _ = m.compute()
+        assert set(pass_at_k.keys()) == {"1", "2"}
+
+    def test_correctness_threshold_boundary(self):
+        """Only reward >= 0.5 counts as correct by default."""
+        m = PassAtKMetric(rollouts_per_example=4)
+        m.add_outputs([
+            self._make_output(0, 0.49),  # not correct
+            self._make_output(0, 0.5),   # correct
+            self._make_output(0, 1.0),   # correct
+            self._make_output(0, 0.0),   # not correct
+        ])
+        pass_at_k, _ = m.compute()
+        assert pass_at_k["1"] == pytest.approx(0.5)

--- a/tests/test_save_utils.py
+++ b/tests/test_save_utils.py
@@ -835,12 +835,14 @@ class TestPassAtKMetric:
     def test_partial_correctness(self):
         """Partial correctness: 2 correct out of 4 rollouts."""
         m = PassAtKMetric(rollouts_per_example=4)
-        m.add_outputs([
-            self._make_output(0, 1.0),
-            self._make_output(0, 1.0),
-            self._make_output(0, 0.0),
-            self._make_output(0, 0.0),
-        ])
+        m.add_outputs(
+            [
+                self._make_output(0, 1.0),
+                self._make_output(0, 1.0),
+                self._make_output(0, 0.0),
+                self._make_output(0, 0.0),
+            ]
+        )
         pass_at_k, pass_all_k = m.compute()
         assert pass_at_k["1"] == pytest.approx(0.5)
         assert pass_at_k["2"] == pytest.approx(1.0 - 1.0 / 6.0)
@@ -852,12 +854,18 @@ class TestPassAtKMetric:
     def test_multiple_examples_averaged(self):
         """pass@k and pass^k are averaged across multiple examples."""
         m = PassAtKMetric(rollouts_per_example=4)
-        m.add_outputs([
-            self._make_output(0, 1.0), self._make_output(0, 1.0),
-            self._make_output(0, 1.0), self._make_output(0, 1.0),
-            self._make_output(1, 0.0), self._make_output(1, 0.0),
-            self._make_output(1, 0.0), self._make_output(1, 0.0),
-        ])
+        m.add_outputs(
+            [
+                self._make_output(0, 1.0),
+                self._make_output(0, 1.0),
+                self._make_output(0, 1.0),
+                self._make_output(0, 1.0),
+                self._make_output(1, 0.0),
+                self._make_output(1, 0.0),
+                self._make_output(1, 0.0),
+                self._make_output(1, 0.0),
+            ]
+        )
         pass_at_k, pass_all_k = m.compute()
         assert pass_at_k["1"] == pytest.approx(0.5)
         assert pass_all_k["1"] == pytest.approx(0.5)
@@ -879,11 +887,13 @@ class TestPassAtKMetric:
     def test_correctness_threshold_boundary(self):
         """Only reward >= 0.5 counts as correct by default."""
         m = PassAtKMetric(rollouts_per_example=4)
-        m.add_outputs([
-            self._make_output(0, 0.49),  # not correct
-            self._make_output(0, 0.5),   # correct
-            self._make_output(0, 1.0),   # correct
-            self._make_output(0, 0.0),   # not correct
-        ])
+        m.add_outputs(
+            [
+                self._make_output(0, 0.49),  # not correct
+                self._make_output(0, 0.5),  # correct
+                self._make_output(0, 1.0),  # correct
+                self._make_output(0, 0.0),  # not correct
+            ]
+        )
         pass_at_k, _ = m.compute()
         assert pass_at_k["1"] == pytest.approx(0.5)

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -36,7 +36,7 @@ from verifiers.types import (
 from verifiers.utils.async_utils import EventLoopLagMonitor
 from verifiers.utils.import_utils import load_toml
 from verifiers.utils.logging_utils import print_prompt_completions_sample, print_time
-from verifiers.utils.metric_utils import PassAtKMetric
+
 from verifiers.utils.path_utils import get_eval_results_path
 
 logger = logging.getLogger(__name__)
@@ -550,10 +550,8 @@ def print_rewards(results: GenerateOutputs):
         out = f"r{i + 1}: {trials}"
         print(out)
 
-    threshold = results["metadata"].get("pass_threshold", 0.5)
-    pass_at_k_metric = PassAtKMetric(r, threshold=threshold)
-    pass_at_k_metric.add_outputs(results["outputs"])
-    pass_at_k, pass_all_k = pass_at_k_metric.compute()
+    pass_at_k = results["metadata"].get("pass_at_k", {})
+    pass_all_k = results["metadata"].get("pass_all_k", {})
     if pass_at_k:
         parts = [
             f"{k}={v:.3f}"

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -36,7 +36,7 @@ from verifiers.types import (
 from verifiers.utils.async_utils import EventLoopLagMonitor
 from verifiers.utils.import_utils import load_toml
 from verifiers.utils.logging_utils import print_prompt_completions_sample, print_time
-from verifiers.utils.metric_utils import compute_pass_at_k
+from verifiers.utils.metric_utils import PassAtKMetric
 from verifiers.utils.path_utils import get_eval_results_path
 
 logger = logging.getLogger(__name__)
@@ -551,7 +551,9 @@ def print_rewards(results: GenerateOutputs):
         print(out)
 
     threshold = results["metadata"].get("pass_threshold", 0.5)
-    pass_at_k, pass_all_k = compute_pass_at_k(results["outputs"], r, threshold)
+    pass_at_k_metric = PassAtKMetric(r, threshold=threshold)
+    pass_at_k_metric.add_outputs(results["outputs"])
+    pass_at_k, pass_all_k = pass_at_k_metric.compute()
     if pass_at_k:
         parts = [
             f"{k}={v:.3f}"

--- a/verifiers/utils/metric_utils.py
+++ b/verifiers/utils/metric_utils.py
@@ -1,69 +1,193 @@
 import math
+from abc import ABC, abstractmethod
 from collections import defaultdict
+from typing import Any, Protocol, runtime_checkable
 
 from verifiers.types import RolloutOutput
 
 
-def compute_pass_at_k(
-    outputs: list[RolloutOutput],
-    rollouts_per_example: int,
-    threshold: float = 0.5,
-) -> tuple[dict[str, float], dict[str, float]]:
-    """Compute pass@k and pass^k metrics using unbiased estimators.
+@runtime_checkable
+class Metric(Protocol):
+    """Protocol for incremental eval metrics over rollout outputs."""
+
+    def add_output(self, output: RolloutOutput) -> None: ...
+    def add_outputs(self, outputs: list[RolloutOutput]) -> None: ...
+    def compute(self) -> Any: ...
+    def reset(self) -> None: ...
+
+
+class MeanMetric(ABC):
+    """Abstract running mean over a value extracted from each RolloutOutput.
+
+    Subclasses override ``extract`` to select which value to average.
+    Return ``None`` from ``extract`` to skip an output.
+    """
+
+    __slots__ = ("_sum", "_count")
+
+    def __init__(self) -> None:
+        self.reset()
+
+    @abstractmethod
+    def extract(self, output: RolloutOutput) -> float | None:
+        """Extract the value to accumulate, or None to skip this output."""
+
+    def add_output(self, output: RolloutOutput) -> None:
+        value = self.extract(output)
+        if value is not None:
+            self._sum += value
+            self._count += 1
+
+    def add_outputs(self, outputs: list[RolloutOutput]) -> None:
+        for output in outputs:
+            self.add_output(output)
+
+    def reset(self) -> None:
+        self._sum = 0.0
+        self._count = 0
+
+    def compute(self) -> float:
+        return self._sum / self._count if self._count else 0.0
+
+    @property
+    def count(self) -> int:
+        return self._count
+
+
+class RewardMetric(MeanMetric):
+    """Mean reward across outputs."""
+
+    def extract(self, output: RolloutOutput) -> float:
+        return output.get("reward", 0.0)
+
+
+class ErrorRateMetric(MeanMetric):
+    """Fraction of outputs with a non-None error."""
+
+    def extract(self, output: RolloutOutput) -> float:
+        return 1.0 if output.get("error") is not None else 0.0
+
+
+class InputTokensMetric(MeanMetric):
+    """Mean input tokens per output (skips outputs without token_usage)."""
+
+    def extract(self, output: RolloutOutput) -> float | None:
+        usage = output.get("token_usage")
+        if isinstance(usage, dict):
+            return float(usage.get("input_tokens", 0.0))
+        return None
+
+
+class OutputTokensMetric(MeanMetric):
+    """Mean output tokens per output (skips outputs without token_usage)."""
+
+    def extract(self, output: RolloutOutput) -> float | None:
+        usage = output.get("token_usage")
+        if isinstance(usage, dict):
+            return float(usage.get("output_tokens", 0.0))
+        return None
+
+
+class EnvMetrics:
+    """Per-key running means for environment-defined metrics.
+
+    Dynamically creates accumulators for each metric key seen in
+    ``output["metrics"]``. Non-numeric values are skipped.
+    """
+
+    def __init__(self) -> None:
+        self.reset()
+
+    def add_output(self, output: RolloutOutput) -> None:
+        output_metrics = output.get("metrics", {})
+        if output_metrics:
+            for name, value in output_metrics.items():
+                if isinstance(value, (int, float)):
+                    if name not in self._sums:
+                        self._sums[name] = 0.0
+                        self._counts[name] = 0
+                    self._sums[name] += value
+                    self._counts[name] += 1
+
+    def add_outputs(self, outputs: list[RolloutOutput]) -> None:
+        for output in outputs:
+            self.add_output(output)
+
+    def reset(self) -> None:
+        self._sums: dict[str, float] = {}
+        self._counts: dict[str, int] = {}
+
+    def compute(self) -> dict[str, float]:
+        return {k: self._sums[k] / self._counts[k] for k in self._sums}
+
+
+class PassAtKMetric:
+    """Incremental pass@k and pass^k using unbiased estimators.
 
     pass@k = 1 - C(n-c, k) / C(n, k)  (at least one correct in k samples)
     pass^k = C(c, k) / C(n, k)         (all k samples correct)
 
-    Both averaged across examples.
-    n = rollouts per example, c = correct rollouts (reward >= threshold).
-    k values: all powers of 2 in [1, n].
-    Returns (empty, empty) if rollouts_per_example <= 1.
+    Both averaged across complete examples.
+    n = rollouts_per_example, c = correct rollouts (reward >= threshold).
+    k values: powers of 2 in [1, n].
     """
-    if rollouts_per_example <= 1:
-        return {}, {}
 
-    # Determine k values: powers of 2 in [1, n]
-    k_values: list[int] = []
-    k = 1
-    while k <= rollouts_per_example:
-        k_values.append(k)
-        k *= 2
+    def __init__(self, rollouts_per_example: int, threshold: float = 0.5) -> None:
+        self.rollouts_per_example = rollouts_per_example
+        self.threshold = threshold
 
-    if not k_values:
-        return {}, {}
+        self._k_values: list[int] = []
+        if rollouts_per_example > 1:
+            k = 1
+            while k <= rollouts_per_example:
+                self._k_values.append(k)
+                k *= 2
 
-    # Group outputs by example_id
-    examples: dict[int, list[RolloutOutput]] = defaultdict(list)
-    for output in outputs:
-        examples[output.get("example_id", 0)].append(output)
+        self.reset()
 
-    # Only include examples with complete rollout groups
-    complete_examples = {
-        eid: outs for eid, outs in examples.items() if len(outs) == rollouts_per_example
-    }
-    num_complete = len(complete_examples)
+    def add_output(self, output: RolloutOutput) -> None:
+        if not self._k_values:
+            return
 
-    if num_complete == 0:
-        return {}, {}
+        example_id = output.get("example_id", 0)
+        self._example_counts[example_id] += 1
+        if output.get("reward", 0.0) >= self.threshold:
+            self._example_correct[example_id] += 1
 
-    # Compute pass@k and pass^k for each complete example, then average
-    pass_at_k_sums: dict[str, float] = {str(kv): 0.0 for kv in k_values}
-    pass_all_k_sums: dict[str, float] = {str(kv): 0.0 for kv in k_values}
+        if self._example_counts[example_id] == self.rollouts_per_example:
+            self._num_complete += 1
+            n = self.rollouts_per_example
+            c = self._example_correct[example_id]
+            for kv in self._k_values:
+                kv_str = str(kv)
+                n_choose_k = math.comb(n, kv)
+                if n - c < kv:
+                    self._pass_at_k_sums[kv_str] += 1.0
+                else:
+                    self._pass_at_k_sums[kv_str] += (
+                        1.0 - math.comb(n - c, kv) / n_choose_k
+                    )
+                self._pass_all_k_sums[kv_str] += math.comb(c, kv) / n_choose_k
 
-    for example_outputs in complete_examples.values():
-        n = len(example_outputs)
-        c = sum(1 for o in example_outputs if o.get("reward", 0.0) >= threshold)
-        for kv in k_values:
+    def add_outputs(self, outputs: list[RolloutOutput]) -> None:
+        for output in outputs:
+            self.add_output(output)
+
+    def reset(self) -> None:
+        self._example_counts: dict[int, int] = defaultdict(int)
+        self._example_correct: dict[int, int] = defaultdict(int)
+        self._num_complete = 0
+        self._pass_at_k_sums: dict[str, float] = defaultdict(float)
+        self._pass_all_k_sums: dict[str, float] = defaultdict(float)
+
+    def compute(self) -> tuple[dict[str, float], dict[str, float]]:
+        """Return (pass_at_k, pass_all_k) dicts. Empty if no complete examples."""
+        if self._num_complete == 0:
+            return {}, {}
+        pass_at_k: dict[str, float] = {}
+        pass_all_k: dict[str, float] = {}
+        for kv in self._k_values:
             kv_str = str(kv)
-            n_choose_k = math.comb(n, kv)
-            # pass@k: P(at least one correct)
-            if n - c < kv:
-                pass_at_k_sums[kv_str] += 1.0
-            else:
-                pass_at_k_sums[kv_str] += 1.0 - math.comb(n - c, kv) / n_choose_k
-            # pass^k: P(all correct)
-            pass_all_k_sums[kv_str] += math.comb(c, kv) / n_choose_k
-
-    pass_at_k = {str(kv): pass_at_k_sums[str(kv)] / num_complete for kv in k_values}
-    pass_all_k = {str(kv): pass_all_k_sums[str(kv)] / num_complete for kv in k_values}
-    return pass_at_k, pass_all_k
+            pass_at_k[kv_str] = self._pass_at_k_sums[kv_str] / self._num_complete
+            pass_all_k[kv_str] = self._pass_all_k_sums[kv_str] / self._num_complete
+        return pass_at_k, pass_all_k

--- a/verifiers/utils/save_utils.py
+++ b/verifiers/utils/save_utils.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import time
-from collections import defaultdict
 from collections.abc import Mapping
 from datetime import date, datetime
 from pathlib import Path
@@ -27,7 +26,14 @@ from verifiers.utils.message_utils import (
     sanitize_tool_calls,
     serialize_messages_for_output,
 )
-from verifiers.utils.metric_utils import compute_pass_at_k
+from verifiers.utils.metric_utils import (
+    EnvMetrics,
+    ErrorRateMetric,
+    InputTokensMetric,
+    OutputTokensMetric,
+    PassAtKMetric,
+    RewardMetric,
+)
 from verifiers.utils.path_utils import get_results_path
 from verifiers.utils.usage_utils import (
     StateUsageTracker,
@@ -273,82 +279,47 @@ class GenerateOutputsBuilder:
         self.results_path = results_path or get_results_path(env_id, model)
         self.pass_threshold = pass_threshold
         self.start_time = time.time()
-        self.base_url = self._compute_base_url(self.client)
+        self.base_url = self.compute_base_url(self.client)
         self.version_info = get_version_info(env_id=env_id)
 
         # Accumulated outputs
         self.outputs: list[RolloutOutput] = []
         self.tools_list: list[list[Tool] | None] = []
 
+        # Incremental metric accumulators (avoid O(n) rescan in build_metadata)
+        self.reward = RewardMetric()
+        self.error_rate = ErrorRateMetric()
+        self.env_metrics = EnvMetrics()
+        self.input_tokens = InputTokensMetric()
+        self.output_tokens = OutputTokensMetric()
+        self.pass_at_k = PassAtKMetric(rollouts_per_example, threshold=pass_threshold)
+
+        # Tools tracking
+        self.unique_tools_keys: set[str] = set()
+        self.first_tools: list[Tool] | None = None
+
     @staticmethod
-    def _format_base_url(url: str) -> str:
+    def format_base_url(url: str) -> str:
         return url
 
-    def _compute_base_url(self, client: AsyncOpenAI | ClientConfig | object) -> str:
+    def compute_base_url(self, client: AsyncOpenAI | ClientConfig | object) -> str:
         if isinstance(client, ClientConfig):
             if client.endpoint_configs:
                 endpoint_urls = [cfg.api_base_url for cfg in client.endpoint_configs]
                 if endpoint_urls:
                     return ",".join(endpoint_urls)
-            return self._format_base_url(client.api_base_url)
+            return self.format_base_url(client.api_base_url)
 
         if hasattr(client, "base_url"):
             return str(getattr(client, "base_url"))
         return ""
 
-    def add_outputs(self, new_outputs: list[RolloutOutput]) -> None:
-        """Accumulate new outputs."""
-        self.outputs.extend(new_outputs)
-        for output in new_outputs:
-            self.tools_list.append(output.get("tool_defs"))
+    @staticmethod
+    def tools_key(tools: list[Tool] | None) -> str:
+        if not tools:
+            return ""
 
-    def build_metadata(self) -> GenerateMetadata:
-        """Build metadata from accumulated outputs."""
-        # compute reward stats from accumulated outputs
-        rewards = [o.get("reward", 0.0) for o in self.outputs]
-        avg_reward = sum(rewards) / len(rewards) if rewards else 0.0
-
-        # compute metrics stats from accumulated outputs
-        metrics: dict[str, list[float]] = defaultdict(list)
-        for output in self.outputs:
-            output_metrics = output.get("metrics", {})
-            if output_metrics:
-                for metric_name, metric_value in output_metrics.items():
-                    if isinstance(metric_value, (int, float)):
-                        metrics[metric_name].append(metric_value)
-        avg_metrics = {k: sum(v) / len(v) if v else 0.0 for k, v in metrics.items()}
-
-        # compute error rate from accumulated outputs
-        errors = [o.get("error") for o in self.outputs]
-        has_errors = [e is not None for e in errors]
-        avg_error = sum(has_errors) / len(has_errors) if has_errors else 0.0
-
-        # compute pass@k and pass^k from accumulated outputs
-        pass_at_k, pass_all_k = compute_pass_at_k(
-            self.outputs, self.rollouts_per_example, self.pass_threshold
-        )
-
-        input_tokens_total = 0.0
-        output_tokens_total = 0.0
-        usage_seen = False
-        usage_count = 0
-        for output in self.outputs:
-            token_usage = output.get("token_usage")
-            if not isinstance(token_usage, dict):
-                continue
-            usage_seen = True
-            usage_count += 1
-            input_tokens_total += float(token_usage.get("input_tokens", 0.0))
-            output_tokens_total += float(token_usage.get("output_tokens", 0.0))
-        usage: TokenUsage | None = None
-        if usage_seen and usage_count > 0:
-            usage = {
-                "input_tokens": input_tokens_total / usage_count,
-                "output_tokens": output_tokens_total / usage_count,
-            }
-
-        # Determine tools (use first non-None if all same)
-        def tool_name(tool: Tool | dict[str, Any]) -> str:
+        def _tool_name(tool: Tool | dict[str, Any]) -> str:
             if isinstance(tool, dict):
                 function = tool.get("function")
                 if isinstance(function, dict):
@@ -359,17 +330,39 @@ class GenerateOutputsBuilder:
                 return name if isinstance(name, str) else ""
             return tool.name
 
-        def tools_key(tools: list[Tool] | None) -> str:
-            if not tools:
-                return ""
-            return str(sorted(tool_name(t) for t in tools))
+        return str(sorted(_tool_name(t) for t in tools))
 
-        unique_tools = set(tools_key(t) for t in self.tools_list)
-        tools = (
-            next((t for t in self.tools_list if t), None)
-            if len(unique_tools) == 1
-            else None
-        )
+    def add_outputs(self, new_outputs: list[RolloutOutput]) -> None:
+        """Accumulate new outputs and update incremental accumulators."""
+        self.outputs.extend(new_outputs)
+        self.reward.add_outputs(new_outputs)
+        self.error_rate.add_outputs(new_outputs)
+        self.env_metrics.add_outputs(new_outputs)
+        self.input_tokens.add_outputs(new_outputs)
+        self.output_tokens.add_outputs(new_outputs)
+        self.pass_at_k.add_outputs(new_outputs)
+
+        for output in new_outputs:
+            tool_defs = output.get("tool_defs")
+            self.tools_list.append(tool_defs)
+
+            # Tools tracking
+            tk = self.tools_key(tool_defs)
+            self.unique_tools_keys.add(tk)
+            if self.first_tools is None and tool_defs:
+                self.first_tools = tool_defs
+
+    def build_metadata(self) -> GenerateMetadata:
+        """Build metadata from incremental accumulators. O(1) per call."""
+        pass_at_k_result, pass_all_k_result = self.pass_at_k.compute()
+        tools = self.first_tools if len(self.unique_tools_keys) == 1 else None
+
+        usage: TokenUsage | None = None
+        if self.input_tokens.count > 0:
+            usage = {
+                "input_tokens": self.input_tokens.compute(),
+                "output_tokens": self.output_tokens.compute(),
+            }
 
         return GenerateMetadata(
             env_id=self.env_id,
@@ -381,11 +374,11 @@ class GenerateOutputsBuilder:
             sampling_args=self.sampling_args,
             date=datetime.now().isoformat(),
             time_ms=(time.time() - self.start_time) * 1000.0,
-            avg_reward=avg_reward,
-            avg_metrics=avg_metrics,
-            avg_error=avg_error,
-            pass_at_k=pass_at_k,
-            pass_all_k=pass_all_k,
+            avg_reward=self.reward.compute(),
+            avg_metrics=self.env_metrics.compute(),
+            avg_error=self.error_rate.compute(),
+            pass_at_k=pass_at_k_result,
+            pass_all_k=pass_all_k_result,
             pass_threshold=self.pass_threshold,
             usage=usage,
             version_info=self.version_info,

--- a/verifiers/utils/save_utils.py
+++ b/verifiers/utils/save_utils.py
@@ -284,7 +284,6 @@ class GenerateOutputsBuilder:
 
         # Accumulated outputs
         self.outputs: list[RolloutOutput] = []
-        self.tools_list: list[list[Tool] | None] = []
 
         # Incremental metric accumulators (avoid O(n) rescan in build_metadata)
         self.reward = RewardMetric()
@@ -344,7 +343,6 @@ class GenerateOutputsBuilder:
 
         for output in new_outputs:
             tool_defs = output.get("tool_defs")
-            self.tools_list.append(tool_defs)
 
             # Tools tracking
             tk = self.tools_key(tool_defs)


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Replace O(n²) metric recomputation in GenerateOutputsBuilder with incremental update/compute pattern. Introduces a Metric protocol and concrete classes (RewardMetric, ErrorRateMetric, InputTokensMetric, OutputTokensMetric, EnvMetrics, PassAtKMetric) in `metric_utils.py`. Each metric handles its own value extraction from RolloutOutput, making the builder a thin coordinator. Removes the compute_pass_at_k helper in favor of using PassAtKMetric directly.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors core evaluation metadata computation (reward/error/usage/pass@k) to incremental accumulators, which can subtly change aggregation semantics and affect reported metrics. Low security risk but impacts correctness/performance of evaluation reporting.
> 
> **Overview**
> Replaces the one-shot `compute_pass_at_k` helper and ad-hoc metadata aggregation with an incremental metric system (`Metric` protocol plus `RewardMetric`, `ErrorRateMetric`, `EnvMetrics`, token metrics, and `PassAtKMetric`). `GenerateOutputsBuilder` now updates these accumulators as outputs arrive and builds metadata in O(1) without rescanning all outputs.
> 
> Updates result printing to read `pass_at_k`/`pass_all_k` directly from saved metadata (instead of recomputing), and rewrites tests to validate the new metric classes, reset behavior, and `GenerateOutputsBuilder` pass@k integration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 18f14d6ea4dd8c659b3083a61953f99ac254bd6a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->