### PR TITLE
perf: offload file i/o to thread pool

### DIFF
--- a/environments/terminus_harbor/terminus_harbor.py
+++ b/environments/terminus_harbor/terminus_harbor.py
@@ -1,9 +1,10 @@
+import asyncio
 import logging
-import tempfile
 from pathlib import Path
 
 import verifiers as vf
 from verifiers.envs.experimental.harbor_env import HarborEnv
+from verifiers.utils.path_utils import write_temp_file
 
 logger = logging.getLogger(__name__)
 
@@ -80,9 +81,7 @@ class TerminusHarborEnv(HarborEnv):
 
         # Upload the run_agent.py script
         script_content = self._get_run_agent_script()
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
-            f.write(script_content)
-            temp_path = f.name
+        temp_path = await asyncio.to_thread(write_temp_file, script_content, ".py")
 
         try:
             await self.sandbox_client.upload_file(
@@ -91,7 +90,7 @@ class TerminusHarborEnv(HarborEnv):
                 temp_path,
             )
         finally:
-            Path(temp_path).unlink(missing_ok=True)
+            await asyncio.to_thread(Path(temp_path).unlink, True)
 
     def _get_run_agent_script(self) -> str:
         return """#!/usr/bin/env python3

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -1046,10 +1046,10 @@ class Environment(ABC):
                     for cb in extra_on_progress:
                         cb(builder.outputs, new_outputs, metadata)
 
-                    # incrementally save outputs
+                    # incrementally save outputs (offloaded to thread to avoid blocking the event loop)
                     if save_results:
-                        save_new_outputs(new_outputs, builder.results_path)
-                        save_metadata(metadata, builder.results_path)
+                        await asyncio.to_thread(save_new_outputs, new_outputs, builder.results_path)
+                        await asyncio.to_thread(save_metadata, metadata, builder.results_path)
             finally:
                 # cancel all outstanding tasks and await their completion
                 pending = [task for task in tasks.keys() if not task.done()]
@@ -1063,8 +1063,8 @@ class Environment(ABC):
 
             # save if requested
             if save_results:
-                save_outputs(results["outputs"], builder.results_path)
-                save_metadata(results["metadata"], builder.results_path)
+                await asyncio.to_thread(save_outputs, results["outputs"], builder.results_path)
+                await asyncio.to_thread(save_metadata, results["metadata"], builder.results_path)
                 if push_to_hf_hub:
                     push_results_to_hf_hub(results, hf_hub_dataset_name)
                 if on_log is not None:

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -1048,8 +1048,12 @@ class Environment(ABC):
 
                     # incrementally save outputs (offloaded to thread to avoid blocking the event loop)
                     if save_results:
-                        await asyncio.to_thread(save_new_outputs, new_outputs, builder.results_path)
-                        await asyncio.to_thread(save_metadata, metadata, builder.results_path)
+                        await asyncio.to_thread(
+                            save_new_outputs, new_outputs, builder.results_path
+                        )
+                        await asyncio.to_thread(
+                            save_metadata, metadata, builder.results_path
+                        )
             finally:
                 # cancel all outstanding tasks and await their completion
                 pending = [task for task in tasks.keys() if not task.done()]
@@ -1063,8 +1067,12 @@ class Environment(ABC):
 
             # save if requested
             if save_results:
-                await asyncio.to_thread(save_outputs, results["outputs"], builder.results_path)
-                await asyncio.to_thread(save_metadata, results["metadata"], builder.results_path)
+                await asyncio.to_thread(
+                    save_outputs, results["outputs"], builder.results_path
+                )
+                await asyncio.to_thread(
+                    save_metadata, results["metadata"], builder.results_path
+                )
                 if push_to_hf_hub:
                     push_results_to_hf_hub(results, hf_hub_dataset_name)
                 if on_log is not None:

--- a/verifiers/envs/experimental/opencode_env.py
+++ b/verifiers/envs/experimental/opencode_env.py
@@ -221,9 +221,7 @@ class OpenCodeEnv(CliAgentEnv):
         prompt = self.build_prompt(state)
 
         # Upload prompt as file (temp file I/O offloaded to thread)
-        local_prompt_path = await asyncio.to_thread(
-            write_temp_file, prompt
-        )
+        local_prompt_path = await asyncio.to_thread(write_temp_file, prompt)
 
         try:
             logger.debug(

--- a/verifiers/envs/experimental/opencode_env.py
+++ b/verifiers/envs/experimental/opencode_env.py
@@ -231,7 +231,7 @@ class OpenCodeEnv(CliAgentEnv):
                 sandbox_id, self.remote_prompt_path, local_prompt_path
             )
         finally:
-            await asyncio.to_thread(Path(local_prompt_path).unlink, True)
+            await asyncio.to_thread(Path(local_prompt_path).unlink, missing_ok=True)
 
         # Upload system prompt as file, if provided
         if self.system_prompt:
@@ -247,7 +247,7 @@ class OpenCodeEnv(CliAgentEnv):
                     sandbox_id, self.remote_system_prompt_path, local_system_prompt_path
                 )
             finally:
-                await asyncio.to_thread(Path(local_system_prompt_path).unlink, True)
+                await asyncio.to_thread(Path(local_system_prompt_path).unlink, missing_ok=True)
 
     async def build_env_vars(self, state: vf.State) -> dict[str, str]:
         """Build environment variables for the sandbox. Override to add custom vars."""

--- a/verifiers/envs/experimental/opencode_env.py
+++ b/verifiers/envs/experimental/opencode_env.py
@@ -1,6 +1,6 @@
+import asyncio
 import json
 import logging
-import tempfile
 from collections import Counter
 from pathlib import Path
 from typing import Callable
@@ -10,6 +10,7 @@ from datasets import Dataset
 import verifiers as vf
 from verifiers.envs.experimental.cli_agent_env import CliAgentEnv
 from verifiers.types import AssistantMessage, Messages, ToolCall
+from verifiers.utils.path_utils import write_temp_file
 from verifiers.utils.logging_utils import truncate
 
 logger = logging.getLogger(__name__)
@@ -219,10 +220,10 @@ class OpenCodeEnv(CliAgentEnv):
 
         prompt = self.build_prompt(state)
 
-        # Upload prompt as file
-        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".txt") as f:
-            f.write(prompt)
-            local_prompt_path = f.name
+        # Upload prompt as file (temp file I/O offloaded to thread)
+        local_prompt_path = await asyncio.to_thread(
+            write_temp_file, prompt
+        )
 
         try:
             logger.debug(
@@ -232,15 +233,13 @@ class OpenCodeEnv(CliAgentEnv):
                 sandbox_id, self.remote_prompt_path, local_prompt_path
             )
         finally:
-            Path(local_prompt_path).unlink(missing_ok=True)
+            await asyncio.to_thread(Path(local_prompt_path).unlink, True)
 
         # Upload system prompt as file, if provided
         if self.system_prompt:
-            with tempfile.NamedTemporaryFile(
-                mode="w", delete=False, suffix=".txt"
-            ) as f:
-                f.write(self.system_prompt)
-                local_system_prompt_path = f.name
+            local_system_prompt_path = await asyncio.to_thread(
+                write_temp_file, self.system_prompt
+            )
 
             try:
                 logger.debug(
@@ -250,7 +249,7 @@ class OpenCodeEnv(CliAgentEnv):
                     sandbox_id, self.remote_system_prompt_path, local_system_prompt_path
                 )
             finally:
-                Path(local_system_prompt_path).unlink(missing_ok=True)
+                await asyncio.to_thread(Path(local_system_prompt_path).unlink, True)
 
     async def build_env_vars(self, state: vf.State) -> dict[str, str]:
         """Build environment variables for the sandbox. Override to add custom vars."""

--- a/verifiers/envs/experimental/opencode_env.py
+++ b/verifiers/envs/experimental/opencode_env.py
@@ -247,7 +247,9 @@ class OpenCodeEnv(CliAgentEnv):
                     sandbox_id, self.remote_system_prompt_path, local_system_prompt_path
                 )
             finally:
-                await asyncio.to_thread(Path(local_system_prompt_path).unlink, missing_ok=True)
+                await asyncio.to_thread(
+                    Path(local_system_prompt_path).unlink, missing_ok=True
+                )
 
     async def build_env_vars(self, state: vf.State) -> dict[str, str]:
         """Build environment variables for the sandbox. Override to add custom vars."""

--- a/verifiers/envs/experimental/sandbox_mixin.py
+++ b/verifiers/envs/experimental/sandbox_mixin.py
@@ -7,6 +7,8 @@ import tempfile
 from pathlib import Path
 from typing import Any, Callable, cast
 
+from verifiers.utils.path_utils import write_temp_file
+
 import httpx
 import tenacity as tc
 from prime_sandboxes import (
@@ -255,13 +257,11 @@ class SandboxMixin:
         remote_path: str,
     ) -> None:
         """Upload a string as a file to the sandbox."""
-        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".txt") as f:
-            f.write(content)
-            local_path = f.name
+        local_path = await asyncio.to_thread(write_temp_file, content)
         try:
             await self.upload_file(sandbox_id, remote_path, local_path)
         finally:
-            Path(local_path).unlink(missing_ok=True)
+            await asyncio.to_thread(Path(local_path).unlink, True)
 
     async def read_file(
         self,
@@ -312,7 +312,7 @@ class SandboxMixin:
         try:
             await self.upload_file(sandbox_id, archive_remote, tmp_path)
         finally:
-            Path(tmp_path).unlink(missing_ok=True)
+            await asyncio.to_thread(Path(tmp_path).unlink, True)
 
         extract_cmd = (
             f"mkdir -p {dest_dir} && "

--- a/verifiers/envs/experimental/sandbox_mixin.py
+++ b/verifiers/envs/experimental/sandbox_mixin.py
@@ -261,7 +261,7 @@ class SandboxMixin:
         try:
             await self.upload_file(sandbox_id, remote_path, local_path)
         finally:
-            await asyncio.to_thread(Path(local_path).unlink, True)
+            await asyncio.to_thread(Path(local_path).unlink, missing_ok=True)
 
     async def read_file(
         self,
@@ -312,7 +312,7 @@ class SandboxMixin:
         try:
             await self.upload_file(sandbox_id, archive_remote, tmp_path)
         finally:
-            await asyncio.to_thread(Path(tmp_path).unlink, True)
+            await asyncio.to_thread(Path(tmp_path).unlink, missing_ok=True)
 
         extract_cmd = (
             f"mkdir -p {dest_dir} && "

--- a/verifiers/utils/path_utils.py
+++ b/verifiers/utils/path_utils.py
@@ -1,11 +1,23 @@
 import json
 import logging
+import tempfile
 import uuid
 from pathlib import Path
 
 from verifiers.types import EvalConfig
 
 logger = logging.getLogger(__name__)
+
+
+def write_temp_file(content: str, suffix: str = ".txt") -> str:
+    """Write content to a named temporary file and return its path.
+
+    Intended to be called via ``await asyncio.to_thread(write_temp_file, ...)``
+    so that file I/O does not block the event loop.
+    """
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=suffix) as f:
+        f.write(content)
+        return f.name
 
 
 def _get_outputs_base_path(env_id: str, env_dir_path: str = "./environments") -> Path:


### PR DESCRIPTION
## Summary 

- Offload synchronous file I/O (`tempfile` writes, `Path.unlink`) to threads via `asyncio.to_thread()` so they don't block the event loop
- Extract shared `write_temp_file()` helper into `verifiers/utils/path_utils.py`
- Applies to: `environment.py` (save results/metadata), `sandbox_mixin.py`, `opencode_env.py`, `terminus_harbor.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moves multiple sync filesystem operations (temp file creation, unlink, and results/metadata saving) onto `asyncio.to_thread`, which changes execution timing and introduces thread-safety/ordering considerations around incremental saves and cleanup.
> 
> **Overview**
> Reduces event-loop blocking by offloading synchronous filesystem I/O to the thread pool across sandbox-based envs and evaluation output saving.
> 
> This introduces a shared `write_temp_file()` helper in `verifiers/utils/path_utils.py` and updates `terminus_harbor.py`, `opencode_env.py`, and `sandbox_mixin.py` to create/delete temp files via `asyncio.to_thread`. `Environment.generate()` also offloads incremental and final `save_*` writes to threads when `save_results` is enabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c8307657159e9154d41b21814e9773c6c2bdbe6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->