### PR TITLE
perf: executor autoscaling

### DIFF
--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -60,6 +60,22 @@ The `--extra-env-kwargs` flag passes arguments directly to the environment const
 prime eval run my-env -x '{"max_turns": 20}'
 ```
 
+#### Executor autoscaling
+
+Thread-pool executors are automatically sized to match the evaluation concurrency. During `prime eval run`, if `max_workers` is not explicitly provided via `--extra-env-kwargs`, it is computed from the concurrency level (`max_concurrent`, or `num_examples * rollouts_per_example` when unlimited) using `recommended_max_workers()`. This value is passed to `Environment.set_max_workers()`, which resizes both the default event-loop executor and all registered executors.
+
+To override the automatic value:
+
+```bash
+prime eval run my-env -x '{"max_workers": 256}'
+```
+
+You can also call `set_max_workers()` directly at runtime:
+
+```python
+env.set_max_workers(256)
+```
+
 ### Model Configuration
 
 | Flag | Short | Default | Description |

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -314,6 +314,7 @@ Abstract base class for all environments.
 | Method | Description |
 |--------|-------------|
 | `set_kwargs(**kwargs)` | Set attributes using setter methods when available |
+| `set_max_workers(max_workers)` | Set `max_workers` and scale all registered thread-pool executors to match |
 | `add_rubric(rubric)` | Add or merge rubric |
 | `set_max_seq_len(max_seq_len)` | Set maximum sequence length |
 | `set_score_rollouts(bool)` | Enable/disable scoring |

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import atexit
-from verifiers.decorators import discover_decorated
 import json
 import logging
 import multiprocessing as mp
@@ -29,12 +28,14 @@ from typing import (
 )
 
 from verifiers.clients import Client, resolve_client
+from verifiers.decorators import discover_decorated
 from verifiers.utils.client_utils import (
     resolve_client_config,
     resolve_client_configs,
 )
 from verifiers.utils.eval_utils import filter_inputs
 from verifiers.utils.path_utils import is_valid_eval_results_path
+from verifiers.utils.thread_utils import scale_executors
 from verifiers.utils.worker_utils import get_free_port_pair
 from verifiers.workers.client.zmq_env_client import ZMQEnvClient
 from verifiers.workers.server.zmq_env_server import ZMQEnvServer
@@ -1237,8 +1238,6 @@ class Environment(ABC):
 
     def set_max_workers(self, max_workers: int) -> None:
         """Set max_workers and scale all registered thread-pool executors to match."""
-        from verifiers.utils.thread_utils import scale_executors
-
         self.max_workers = max_workers
         scale_executors(max_workers=max_workers)
 

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -1235,6 +1235,13 @@ class Environment(ABC):
         else:
             self.rubric = vf.RubricGroup(rubrics=[self.rubric, rubric])
 
+    def set_max_workers(self, max_workers: int) -> None:
+        """Set max_workers and scale all registered thread-pool executors to match."""
+        from verifiers.utils.thread_utils import scale_executors
+
+        self.max_workers = max_workers
+        scale_executors(max_workers=max_workers)
+
     def set_max_seq_len(self, max_seq_len: int | None) -> None:
         """Set the maximum sequence length for this environment."""
         self.max_seq_len = max_seq_len

--- a/verifiers/rubrics/math_rubric.py
+++ b/verifiers/rubrics/math_rubric.py
@@ -10,6 +10,7 @@ from verifiers.parsers.maybe_think_parser import MaybeThinkParser
 from verifiers.parsers.parser import Parser
 from verifiers.rubrics.rubric import Rubric
 from verifiers.types import Messages, RewardFunc
+from verifiers.utils.thread_utils import register_executor, unregister_executor
 from verifiers.utils.data_utils import extract_boxed_answer
 
 
@@ -33,6 +34,8 @@ class MathRubric(Rubric):
             max_workers=max_workers,
             thread_name_prefix="math-verify",
         )
+        self.executor_name = f"math-verify-{id(self)}"
+        register_executor(self.executor_name, self.executor)
 
         # suppress math_verify timeout warnings (we handle timeouts ourselves)
         logging.getLogger("math_verify.parser").setLevel(logging.ERROR)
@@ -98,5 +101,7 @@ class MathRubric(Rubric):
 
     def __del__(self):
         """Shutdown the thread pool executor when the object is garbage collected."""
+        if hasattr(self, "executor_name"):
+            unregister_executor(self.executor_name)
         if hasattr(self, "executor"):
             self.executor.shutdown(wait=False)

--- a/verifiers/utils/async_utils.py
+++ b/verifiers/utils/async_utils.py
@@ -33,6 +33,14 @@ async def maybe_await(func: Callable, *args, **kwargs):
     return result
 
 
+class NullContext:
+    def __enter__(self):
+        return None
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return False
+
+
 class NullAsyncContext:
     async def __aenter__(self):
         return None

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -35,9 +35,14 @@ from verifiers.types import (
 )
 from verifiers.utils.async_utils import EventLoopLagMonitor
 from verifiers.utils.import_utils import load_toml
-from verifiers.utils.logging_utils import print_prompt_completions_sample, print_time
+from verifiers.utils.logging_utils import (
+    log_level,
+    print_prompt_completions_sample,
+    print_time,
+)
 from verifiers.utils.metric_utils import compute_pass_at_k
 from verifiers.utils.path_utils import get_eval_results_path
+from verifiers.utils.thread_utils import recommended_max_workers
 
 logger = logging.getLogger(__name__)
 
@@ -709,6 +714,14 @@ def quiet_datasets():
         enable_progress_bar()
 
 
+class NullContext:
+    def __enter__(self):
+        return None
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return False
+
+
 async def run_evaluation(
     config: EvalConfig,
     on_start: StartCallback | None = None,
@@ -717,7 +730,11 @@ async def run_evaluation(
     on_log: LogCallback | None = None,
 ) -> GenerateOutputs:
     # load environment
-    vf_env = vf.load_environment(env_id=config.env_id, **config.env_args)
+    maybe_suppress_logs = (
+        log_level(logging.CRITICAL) if not config.disable_env_server else NullContext()
+    )
+    with maybe_suppress_logs:
+        vf_env = vf.load_environment(env_id=config.env_id, **config.env_args)
 
     # set extra environment kwargs
     if config.extra_env_kwargs:
@@ -728,16 +745,29 @@ async def run_evaluation(
 
     try:
         if not config.disable_env_server:
+            extra_env_kwargs = dict(config.extra_env_kwargs)
+            if "max_workers" not in extra_env_kwargs:
+                if config.max_concurrent <= 0:
+                    concurrency = config.num_examples * config.rollouts_per_example
+                else:
+                    concurrency = config.max_concurrent
+
+                max_workers = recommended_max_workers(concurrency)
+                logger.info(
+                    f"Automatically determined {max_workers=} for {concurrency=}"
+                )
+                extra_env_kwargs["max_workers"] = max_workers
+
             if config.debug:
                 await vf_env.start_server(
-                    extra_env_kwargs=config.extra_env_kwargs,
+                    extra_env_kwargs=extra_env_kwargs,
                     log_level=get_log_level(config.verbose),
                 )
             else:
                 log_file = results_path / "eval.log"
                 log_file.parent.mkdir(parents=True, exist_ok=True)
                 await vf_env.start_server(
-                    extra_env_kwargs=config.extra_env_kwargs,
+                    extra_env_kwargs=extra_env_kwargs,
                     log_level="CRITICAL",  # disable console logging
                     log_file=str(log_file),
                     log_file_level=get_log_level(config.verbose),

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -10,7 +10,7 @@ import threading
 import time
 from collections import Counter, defaultdict
 from collections.abc import Mapping
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from pathlib import Path
 from typing import Callable, cast
 
@@ -714,14 +714,6 @@ def quiet_datasets():
         enable_progress_bar()
 
 
-class NullContext:
-    def __enter__(self):
-        return None
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        return False
-
-
 async def run_evaluation(
     config: EvalConfig,
     on_start: StartCallback | None = None,
@@ -731,7 +723,7 @@ async def run_evaluation(
 ) -> GenerateOutputs:
     # load environment
     maybe_suppress_logs = (
-        log_level(logging.CRITICAL) if not config.disable_env_server else NullContext()
+        log_level(logging.CRITICAL) if not config.disable_env_server else nullcontext()
     )
     with maybe_suppress_logs:
         vf_env = vf.load_environment(env_id=config.env_id, **config.env_args)

--- a/verifiers/utils/thread_utils.py
+++ b/verifiers/utils/thread_utils.py
@@ -85,8 +85,10 @@ def recommended_max_workers(concurrency: int, cap: int = 4096) -> int:
 def scale_executors(max_workers: int) -> int:
     """Scale the default event-loop executor **and** all registered executors.
 
-    The default event-loop executor is *always* set (it does not need to be
-    registered).  Registered executors are resized in-place.
+    If a running event loop exists, the default executor is bound to it
+    immediately.  Otherwise the executor is only created/resized and the
+    caller must call :func:`install_default_executor` once inside the real
+    loop (e.g. at the start of ``async def run()``).
 
     Returns *max_workers*.
     """
@@ -99,10 +101,17 @@ def scale_executors(max_workers: int) -> int:
         _default_executor = ThreadPoolExecutor(
             max_workers=max_workers, thread_name_prefix="vf-default"
         )
-        loop = asyncio.get_event_loop()
-        loop.set_default_executor(_default_executor)
     else:
         _resize(_default_executor, max_workers)
+
+    # If there is already a running loop, bind immediately. When called
+    # outside of an async context (e.g. during __init__ before asyncio.run),
+    # this is a no-op and the caller must use install_default_executor() later.
+    try:
+        loop = asyncio.get_running_loop()
+        loop.set_default_executor(_default_executor)
+    except RuntimeError:
+        pass  # no running loop yet — caller must call install_default_executor()
 
     # explicitly registered executors
     for name, executor in _executor_registry.items():
@@ -113,6 +122,23 @@ def scale_executors(max_workers: int) -> int:
         f"scale_executors({max_workers}): default + {len(_executor_registry)} registered executor(s)"
     )
     return max_workers
+
+
+def install_default_executor() -> None:
+    """Bind the default executor to the **currently running** event loop.
+
+    Call this early inside an ``async`` function (after ``asyncio.run()`` has
+    created the real loop) so that ``run_in_executor(None, ...)`` uses the
+    scaled thread pool.  Safe to call multiple times — it is a no-op if no
+    default executor has been created yet.
+    """
+    if _default_executor is not None:
+        loop = asyncio.get_running_loop()
+        loop.set_default_executor(_default_executor)
+        logger.debug(
+            f"Installed default executor (max_workers={_default_executor._max_workers}) "
+            f"on loop {id(loop)}"
+        )
 
 
 def shutdown_executors() -> None:

--- a/verifiers/utils/thread_utils.py
+++ b/verifiers/utils/thread_utils.py
@@ -1,6 +1,5 @@
 import asyncio
 import logging
-import os
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Callable
@@ -58,12 +57,12 @@ def register_executor(name: str, executor: ThreadPoolExecutor) -> None:
     if _target_max_workers is not None and executor._max_workers != _target_max_workers:
         _resize(executor, _target_max_workers)
         logger.debug(
-            f"Registered executor '{name}' and immediately scaled to "
+            f"Registered executor {name} and immediately scaled to "
             f"max_workers={_target_max_workers}"
         )
     else:
         logger.debug(
-            f"Registered executor '{name}' (max_workers={executor._max_workers})"
+            f"Registered executor {name} (max_workers={executor._max_workers})"
         )
 
 
@@ -72,45 +71,30 @@ def unregister_executor(name: str) -> None:
     _executor_registry.pop(name, None)
 
 
-def recommended_max_workers(concurrency: int) -> int:
-    """Return a max_workers value scaled to *concurrency*, capped only by OS/CPU
-    physical limits rather than Python's default cap of 32.
+def recommended_max_workers(concurrency: int, cap: int = 4096) -> int:
+    """Return a max_workers value scaled to *concurrency*.
 
-    For I/O-bound workloads the thread count can safely exceed the CPU count.
-    We allow up to ``os.cpu_count() * 8`` as an upper bound (a conservative
-    proxy for OS thread limits) while still honouring the caller's requested
-    concurrency.
+    For I/O-bound workloads (API calls, sandbox RPCs) the thread count can
+    safely far exceed the CPU count since threads spend most of their time
+    blocked on network I/O.  The *cap* is a sanity limit to prevent
+    misconfiguration from exhausting memory (~8 MB stack per thread).
     """
-    cpu_count = os.cpu_count() or 4
-    physical_cap = cpu_count * 8
-    return max(1, min(concurrency, physical_cap))
+    return max(1, min(concurrency, cap))
 
 
-def scale_executors(
-    max_workers: int | None = None,
-    *,
-    concurrency: int | None = None,
-) -> int:
+def scale_executors(max_workers: int) -> int:
     """Scale the default event-loop executor **and** all registered executors.
 
     The default event-loop executor is *always* set (it does not need to be
     registered).  Registered executors are resized in-place.
 
-    Either supply an explicit *max_workers* or a *concurrency* hint (from
-    which :func:`recommended_max_workers` derives the value).
-
-    Returns the resolved *max_workers*.
+    Returns *max_workers*.
     """
     global _default_executor, _target_max_workers
 
-    if max_workers is None:
-        if concurrency is None:
-            raise ValueError("Provide either max_workers or concurrency")
-        max_workers = recommended_max_workers(concurrency)
-
     _target_max_workers = max_workers
 
-    # 1. Default event-loop executor (always tracked)
+    # default event-loop executor (always tracked)
     if _default_executor is None:
         _default_executor = ThreadPoolExecutor(
             max_workers=max_workers, thread_name_prefix="vf-default"
@@ -120,10 +104,10 @@ def scale_executors(
     else:
         _resize(_default_executor, max_workers)
 
-    # 2. All explicitly registered executors
+    # explicitly registered executors
     for name, executor in _executor_registry.items():
         _resize(executor, max_workers)
-        logger.debug(f"Scaled executor '{name}' to max_workers={max_workers}")
+        logger.debug(f"Scaled executor {name} to max_workers={max_workers}")
 
     logger.info(
         f"scale_executors({max_workers}): default + {len(_executor_registry)} registered executor(s)"

--- a/verifiers/utils/thread_utils.py
+++ b/verifiers/utils/thread_utils.py
@@ -1,6 +1,11 @@
 import asyncio
+import logging
+import os
 import threading
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
 
 THREAD_LOCAL_STORAGE = threading.local()
 
@@ -27,3 +32,112 @@ def get_or_create_thread_loop() -> asyncio.AbstractEventLoop:
     thread_local_loop = get_or_create_thread_attr("loop", asyncio.new_event_loop)
     asyncio.set_event_loop(thread_local_loop)
     return thread_local_loop
+
+
+# --- Executor registry & scaling ---
+
+_executor_registry: dict[str, ThreadPoolExecutor] = {}
+_default_executor: ThreadPoolExecutor | None = None
+_target_max_workers: int | None = None  # sticky target from last scale_executors call
+
+
+def _resize(executor: ThreadPoolExecutor, max_workers: int) -> None:
+    """Resize a ThreadPoolExecutor in-place. Threads are spawned lazily so
+    raising the limit simply allows more threads on the next submit."""
+    executor._max_workers = max_workers
+
+
+def register_executor(name: str, executor: ThreadPoolExecutor) -> None:
+    """Register an executor so it is resized by future :func:`scale_executors` calls.
+
+    If :func:`scale_executors` was already called, the executor is immediately
+    resized to match the active target.
+    """
+    _executor_registry[name] = executor
+
+    if _target_max_workers is not None and executor._max_workers != _target_max_workers:
+        _resize(executor, _target_max_workers)
+        logger.debug(
+            f"Registered executor '{name}' and immediately scaled to "
+            f"max_workers={_target_max_workers}"
+        )
+    else:
+        logger.debug(
+            f"Registered executor '{name}' (max_workers={executor._max_workers})"
+        )
+
+
+def unregister_executor(name: str) -> None:
+    """Remove a previously registered executor (does **not** shut it down)."""
+    _executor_registry.pop(name, None)
+
+
+def recommended_max_workers(concurrency: int) -> int:
+    """Return a max_workers value scaled to *concurrency*, capped only by OS/CPU
+    physical limits rather than Python's default cap of 32.
+
+    For I/O-bound workloads the thread count can safely exceed the CPU count.
+    We allow up to ``os.cpu_count() * 8`` as an upper bound (a conservative
+    proxy for OS thread limits) while still honouring the caller's requested
+    concurrency.
+    """
+    cpu_count = os.cpu_count() or 4
+    physical_cap = cpu_count * 8
+    return max(1, min(concurrency, physical_cap))
+
+
+def scale_executors(
+    max_workers: int | None = None,
+    *,
+    concurrency: int | None = None,
+) -> int:
+    """Scale the default event-loop executor **and** all registered executors.
+
+    The default event-loop executor is *always* set (it does not need to be
+    registered).  Registered executors are resized in-place.
+
+    Either supply an explicit *max_workers* or a *concurrency* hint (from
+    which :func:`recommended_max_workers` derives the value).
+
+    Returns the resolved *max_workers*.
+    """
+    global _default_executor, _target_max_workers
+
+    if max_workers is None:
+        if concurrency is None:
+            raise ValueError("Provide either max_workers or concurrency")
+        max_workers = recommended_max_workers(concurrency)
+
+    _target_max_workers = max_workers
+
+    # 1. Default event-loop executor (always tracked)
+    if _default_executor is None:
+        _default_executor = ThreadPoolExecutor(
+            max_workers=max_workers, thread_name_prefix="vf-default"
+        )
+        loop = asyncio.get_event_loop()
+        loop.set_default_executor(_default_executor)
+    else:
+        _resize(_default_executor, max_workers)
+
+    # 2. All explicitly registered executors
+    for name, executor in _executor_registry.items():
+        _resize(executor, max_workers)
+        logger.debug(f"Scaled executor '{name}' to max_workers={max_workers}")
+
+    logger.info(
+        f"scale_executors({max_workers}): default + {len(_executor_registry)} registered executor(s)"
+    )
+    return max_workers
+
+
+def shutdown_executors() -> None:
+    """Shut down the default executor and all registered executors."""
+    global _default_executor, _target_max_workers
+    _target_max_workers = None
+    if _default_executor is not None:
+        _default_executor.shutdown(wait=False)
+        _default_executor = None
+    for executor in _executor_registry.values():
+        executor.shutdown(wait=False)
+    _executor_registry.clear()

--- a/verifiers/utils/threaded_sandbox_client.py
+++ b/verifiers/utils/threaded_sandbox_client.py
@@ -9,6 +9,8 @@ from prime_sandboxes import AsyncSandboxClient
 from verifiers.utils.thread_utils import (
     get_or_create_thread_attr,
     get_or_create_thread_loop,
+    register_executor,
+    unregister_executor,
 )
 
 
@@ -32,6 +34,8 @@ class ThreadedAsyncSandboxClient:
             max_workers=max_workers,
             thread_name_prefix="sandbox-client-executor",
         )
+        self.executor_name = f"sandbox-client-{id(self)}"
+        register_executor(self.executor_name, self.executor)
         self.client_kwargs = {
             "max_connections": max_connections,
             "max_keepalive_connections": max_keepalive_connections,
@@ -60,4 +64,5 @@ class ThreadedAsyncSandboxClient:
 
     def teardown(self, wait: bool = True) -> None:
         """Teardown the thread pool executor."""
+        unregister_executor(self.executor_name)
         self.executor.shutdown(wait=wait)

--- a/verifiers/workers/server/env_server.py
+++ b/verifiers/workers/server/env_server.py
@@ -109,6 +109,13 @@ class EnvServer(ABC):
         """Run the server with signal-based graceful shutdown and cleanup."""
         request_parent_death_signal()
 
+        # Bind the scaled default executor to the *running* event loop.
+        # scale_executors() may have been called during __init__ (before
+        # asyncio.run() created this loop), so we install it here.
+        from verifiers.utils.thread_utils import install_default_executor
+
+        install_default_executor()
+
         stop_event = asyncio.Event()
 
         def signal_handler(sig, frame):


### PR DESCRIPTION
## Summary
- Add executor registry in `thread_utils` with `register_executor` / `scale_executors` / `shutdown_executors`
- `Environment.set_max_workers(n)` scales all registered executors in-place (no swap/shutdown), triggered automatically via `set_kwargs(max_workers=N)` 
- `ThreadedAsyncSandboxClient` and `MathRubric` register their executors on init; late registrations are auto-scaled to the sticky target
- `recommended_max_workers(concurrency)` caps at `cpu_count * 8` instead of Python's default 32

## Test plan
- [ ] Run eval with `extra_env_kwargs: {max_workers: N}` and verify executor thread counts scale
- [ ] Verify event loop lag metrics with scaled executors vs default

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches concurrency infrastructure by dynamically resizing the asyncio default executor and other thread pools (including via private `ThreadPoolExecutor._max_workers`), which could impact runtime stability/perf under load. Scope is contained to evaluation/server execution paths and docs.
> 
> **Overview**
> Adds *executor autoscaling* so evaluation runs size thread pools to match configured concurrency.
> 
> Introduces an executor registry in `thread_utils` (`register_executor`, `scale_executors`, `recommended_max_workers`, `install_default_executor`) and wires it through `Environment.set_max_workers()` so the asyncio default executor and registered `ThreadPoolExecutor`s are resized in-place.
> 
> `prime eval run` now auto-computes `max_workers` from concurrency when not provided, passes it into the env server startup, and the env server installs the scaled default executor on the running loop. `MathRubric` and `ThreadedAsyncSandboxClient` register/unregister their executors so they participate in scaling, and docs/API reference are updated to describe the new behavior and override options.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1544ab8a0c4a877d95e2f622b50b1d2feccf96a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->