### PR TITLE
Add hosted evaluations section to eval docs

### DIFF
--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -4,6 +4,7 @@ This section explains how to run evaluations with Verifiers environments. See [E
 
 ## Table of Contents
 - [Basic Usage](#basic-usage)
+- [Hosted Evaluations](#hosted-evaluations)
 - [Command Reference](#command-reference)
   - [Environment Selection](#environment-selection)
   - [Model Configuration](#model-configuration)
@@ -30,6 +31,24 @@ prime eval run my-env -m gpt-4.1-mini -n 10
 ```
 
 `prime eval` imports the environment module using Python's import system, calls its `load_environment()` function, runs 5 examples with 3 rollouts each (the default), scores them using the environment's rubric, and prints aggregate metrics.
+
+## Hosted Evaluations
+
+You can also run evaluations on Prime-managed infrastructure with `prime eval run --hosted`. Hosted evaluations require an environment that has already been published to the Environments Hub, and they are useful when you want Prime to manage execution, monitor logs remotely, or run against a shared Hub environment slug instead of a local package.
+
+```bash
+prime env push my-env
+prime eval run my-team/my-env --hosted
+prime eval run my-team/my-env --hosted --follow
+```
+
+Hosted runs also support TOML configs:
+
+```bash
+prime eval run configs/eval/benchmark-hosted.toml --hosted
+```
+
+For the full hosted workflow and hosted-only flags such as `--follow`, `--timeout-minutes`, `--allow-sandbox-access`, and `--custom-secrets`, see the official [Hosted Evaluations](https://docs.primeintellect.ai/tutorials-environments/hosted-evaluations) guide.
 
 ## Command Reference
 

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -38,8 +38,8 @@ You can also run evaluations on Prime-managed infrastructure with `prime eval ru
 
 ```bash
 prime env push my-env
-prime eval run my-team/my-env --hosted
-prime eval run my-team/my-env --hosted --follow
+prime eval run my-env --hosted
+prime eval run my-env --hosted --follow
 ```
 
 Hosted runs also support TOML configs:

--- a/skills/evaluate-environments/SKILL.md
+++ b/skills/evaluate-environments/SKILL.md
@@ -60,7 +60,7 @@ or
 ```bash
 prime env push my-env --visibility PRIVATE
 ```
-4. For hosted eval workflows, prefer running large jobs against the Hub slug:
+4. For hosted environment workflows, prefer running large jobs against the Hub slug:
 ```bash
 prime eval run owner/my-env -m gpt-4.1-mini -n 200 -r 3 -s
 ```


### PR DESCRIPTION
## Summary
- add a short Hosted Evaluations section near the top of `docs/evaluation.md`
- link the new section from the table of contents
- document the basic `prime eval run --hosted` flow, including publishing first, `--follow`, TOML config usage, and the official hosted eval guide

## Testing
- Not run (not requested)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no runtime behavior or APIs are modified.
> 
> **Overview**
> Adds a new **Hosted Evaluations** section to `docs/evaluation.md`, links it from the TOC, and documents the basic `prime eval run --hosted` flow (including publishing to Hub first, `--follow`, TOML config usage, and a link to the official hosted guide).
> 
> Updates the `evaluate-environments` skill doc wording to refer to *hosted environment workflows* when recommending running large jobs against a Hub slug.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65fe4522367602987b58748c918846d99999b500. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->