### PR TITLE
fix output dir logging

### DIFF
--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -176,6 +176,7 @@ When evaluating multiple environments, the display shows an overview panel at th
 | `--tui` | `-u` | false | Use alternate screen mode (TUI) for display |
 | `--debug` | `-d` | false | Disable Rich display; use normal logging and tqdm progress |
 | `--abbreviated-summary` | `-A` | false | Abbreviated summary: show settings and stats, skip example prompts |
+| `--output-dir` | `-o` | — | Custom output directory for evaluation results and logs |
 | `--save-results` | `-s` | false | Save results to disk |
 | `--resume [PATH]` | `-R` | — | Resume from a previous run (auto-detect latest matching incomplete run if PATH omitted) |
 | `--state-columns` | `-C` | — | Extra state columns to save (comma-separated) |
@@ -183,7 +184,7 @@ When evaluating multiple environments, the display shows an overview panel at th
 | `--hf-hub-dataset-name` | `-D` | — | Dataset name for HF Hub |
 | `--heartbeat-url` | — | — | Heartbeat URL for uptime monitoring |
 
-Results are saved to `./outputs/evals/{env_id}--{model}/{run_id}/`, containing:
+By default, results are saved to `./outputs/evals/{env_id}--{model}/{run_id}/`. Use `--output-dir` to override the base output directory — when set, results (and logs) are saved under `{output_dir}/evals/{env_id}--{model}/{run_id}/` instead. The directory contains:
 
 - `results.jsonl` — rollout outputs, one per line
 - `metadata.json` — evaluation configuration and aggregate metrics

--- a/skills/evaluate-environments/SKILL.md
+++ b/skills/evaluate-environments/SKILL.md
@@ -90,11 +90,15 @@ prime eval run my-env -s -C "judge_response,parsed_answer"
 ```bash
 prime eval run my-env -n 1000 -s --resume
 ```
-5. Run multi-environment TOML suites:
+5. Save results to a custom output directory:
+```bash
+prime eval run my-env -s -o /path/to/output
+```
+6. Run multi-environment TOML suites:
 ```bash
 prime eval run configs/eval/my-benchmark.toml
 ```
-6. Run ablation sweeps using `[[ablation]]` blocks in TOML configs:
+7. Run ablation sweeps using `[[ablation]]` blocks in TOML configs:
 ```toml
 [[ablation]]
 env_id = "my-env"

--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -267,6 +267,13 @@ def main():
         ),
     )
     parser.add_argument(
+        "--output-dir",
+        "-o",
+        type=str,
+        default=None,
+        help="Custom output directory for evaluation results and logs",
+    )
+    parser.add_argument(
         "--verbose", "-v", default=False, action="store_true", help="Verbose output"
     )
     parser.add_argument(

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -750,22 +750,24 @@ async def run_evaluation(
                 )
                 extra_env_kwargs["max_workers"] = max_workers
 
+            log_file = results_path / "eval.log"
+            log_file.parent.mkdir(parents=True, exist_ok=True)
             if config.debug:
                 await vf_env.start_server(
                     extra_env_kwargs=extra_env_kwargs,
                     log_level=get_log_level(config.verbose),
+                    log_file=str(log_file),
+                    log_file_level=get_log_level(config.verbose),
                 )
             else:
-                log_file = results_path / "eval.log"
-                log_file.parent.mkdir(parents=True, exist_ok=True)
                 await vf_env.start_server(
                     extra_env_kwargs=extra_env_kwargs,
                     log_level="CRITICAL",  # disable console logging
                     log_file=str(log_file),
                     log_file_level=get_log_level(config.verbose),
                 )
-                if on_log_file is not None:
-                    on_log_file(log_file)
+            if on_log_file is not None:
+                on_log_file(log_file)
 
         logger.debug(f"Starting evaluation with model: {config.model}")
         logger.debug(

--- a/verifiers/workers/server/env_server.py
+++ b/verifiers/workers/server/env_server.py
@@ -56,21 +56,15 @@ class EnvServer(ABC):
         json_logging: bool = False,
     ):
         # setup logging
-        log_file = log_file or f"logs/{env_id}.log"
-        Path(log_file).parent.mkdir(parents=True, exist_ok=True)
-        if log_level is None:
-            vf.setup_logging(
-                log_file=log_file,
-                log_file_level=log_file_level,
-                json_logging=json_logging,
-            )
-        else:
-            vf.setup_logging(
-                level=log_level,
-                log_file=log_file,
-                log_file_level=log_file_level,
-                json_logging=json_logging,
-            )
+        logger_kwargs: dict[str, Any] = {"json_logging": json_logging}
+        if log_level is not None:
+            logger_kwargs["level"] = log_level
+        if log_file is not None:
+            Path(log_file).parent.mkdir(parents=True, exist_ok=True)
+            logger_kwargs["log_file"] = log_file
+            logger_kwargs["log_file_level"] = log_file_level
+
+        vf.setup_logging(**logger_kwargs)
 
         self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
         self.logger.info(


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

two small fixes to `output_dir` in `vf-eval`:
- logging dir is also relative to `output_dir`
- can be set via cli (not only toml)

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes evaluation output/log path wiring and env-server logging initialization, which could affect where logs are written or whether logging is configured as expected across debug/non-debug runs.
> 
> **Overview**
> Adds `--output-dir` (`-o`) to `prime eval run` so CLI-only evaluations can override the base directory used for saved results and logs, and documents the new flag/behavior.
> 
> Fixes env-server logging to consistently write `eval.log` under the computed `results_path` (including in debug mode) and always register the log file callback, and refactors `EnvServer` logging setup to only configure file logging when `log_file` is explicitly provided (removing the implicit `logs/{env_id}.log` default).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc038eec849fdf02936d8ba3356a6ff2205014a1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->