### PR TITLE
fix: revert opencode_env config regression and move RLM logic out of cli_agent_env

### DIFF
--- a/tests/test_opencode_rlm_env.py
+++ b/tests/test_opencode_rlm_env.py
@@ -118,6 +118,7 @@ class TestOpenCodeConfig:
 
         script = (
             f"OPENAI_BASE_URL=https://example.invalid "
+            f"OPENAI_MODEL=myprovider/mymodel "
             f"SCHEMA_DOLLAR='$' "
             f"bash -lc 'cat <<EOFCONFIG\n{config_block}\nEOFCONFIG'"
         )
@@ -132,10 +133,13 @@ class TestOpenCodeConfig:
         config = json.loads(result.stdout)
         assert config["$schema"] == "https://opencode.ai/config.json"
         assert config["plugin"] == ["file:///tmp/opencode-rlm"]
-        assert config["model"] == "intercepted/model"
+        assert config["model"] == "myprovider/mymodel"
         assert (
-            config["provider"]["intercepted"]["options"]["baseURL"]
+            config["provider"]["myprovider"]["options"]["baseURL"]
             == "https://example.invalid"
+        )
+        assert (
+            config["provider"]["myprovider"]["models"]["mymodel"]["name"] == "mymodel"
         )
 
 

--- a/verifiers/envs/experimental/cli_agent_env.py
+++ b/verifiers/envs/experimental/cli_agent_env.py
@@ -507,14 +507,8 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
         # Skip adding empty "agent completed" step - keeps trajectory clean
         if not prompt_messages:
             return
-        # On first main turn, update state["prompt"] to match the agent's actual prompt.
-        # Check for first *main* step (not sub-LLM) in case sub-LLM steps were
-        # appended to the trajectory before the first main step.
-        has_main_step = any(
-            not (step.get("extras") or {}).get("is_sub_llm_call")
-            for step in state["trajectory"]
-        )
-        if not has_main_step:
+        # On first turn, update state["prompt"] to match the agent's actual prompt
+        if len(state["trajectory"]) == 0:
             state["prompt"] = prompt_messages
         await super().add_model_response(
             state, prompt_messages, self.normalize_response(response)

--- a/verifiers/envs/experimental/opencode_env.py
+++ b/verifiers/envs/experimental/opencode_env.py
@@ -339,33 +339,32 @@ class OpenCodeEnv(CliAgentEnv):
         enable_interleaved: bool = True,
     ) -> str:
         """Build OpenCode config."""
-        interleaved_config: dict | bool = (
-            {"field": "reasoning_content"} if enable_interleaved else False
-        )
         config: dict = {
             "${SCHEMA_DOLLAR}schema": "https://opencode.ai/config.json",
             "provider": {
-                "intercepted": {
+                "${OPENAI_MODEL%%/*}": {
                     "npm": "@ai-sdk/openai-compatible",
-                    "name": "intercepted",
+                    "name": "${OPENAI_MODEL%%/*}",
                     "options": {
                         "baseURL": "$OPENAI_BASE_URL",
                         "apiKey": "intercepted",
                         "timeout": self.provider_timeout_ms,
                     },
                     "models": {
-                        "model": {
-                            "name": "model",
+                        "${OPENAI_MODEL##*/}": {
+                            "name": "${OPENAI_MODEL##*/}",
                             "modalities": {
                                 "input": ["text", "image"],
                                 "output": ["text"],
                             },
-                            "interleaved": interleaved_config,
+                            "interleaved": {"field": "reasoning_content"}
+                            if enable_interleaved
+                            else False,
                         }
                     },
                 }
             },
-            "model": "intercepted/model",
+            "model": "$OPENAI_MODEL",
         }
 
         if disable_compaction:

--- a/verifiers/envs/experimental/opencode_rlm_env.py
+++ b/verifiers/envs/experimental/opencode_rlm_env.py
@@ -15,6 +15,7 @@ import json
 from typing import Any
 
 import verifiers as vf
+from verifiers.envs.experimental.cli_agent_env import CliAgentEnv
 from verifiers.envs.experimental.opencode_env import OpenCodeEnv
 from verifiers.types import (
     Messages,
@@ -374,6 +375,32 @@ class OpenCodeRLMEnv(OpenCodeEnv):
                             },
                         }
                     )
+
+    async def add_model_response(
+        self,
+        state: State,
+        prompt_messages: Messages,
+        response: Response,
+    ):
+        """Add model response and update top-level prompt on first main turn.
+
+        Sub-LLM steps may be appended to the trajectory before the first
+        main-agent step, so we check for the presence of a main step rather
+        than an empty trajectory.
+        """
+        if not prompt_messages:
+            return
+        has_main_step = any(
+            not (step.get("extras") or {}).get("is_sub_llm_call")
+            for step in state["trajectory"]
+        )
+        if not has_main_step:
+            state["prompt"] = prompt_messages
+        # Skip CliAgentEnv.add_model_response (which has its own simpler
+        # first-turn check) and call MultiTurnEnv directly.
+        await super(CliAgentEnv, self).add_model_response(
+            state, prompt_messages, self.normalize_response(response)
+        )
 
     @staticmethod
     def _extract_token_counts(response: Response) -> tuple[int, int]:


### PR DESCRIPTION
## Summary
- Reverts `opencode_env.py` config builder to use shell variable expansion (`${OPENAI_MODEL%%/*}` etc.) instead of hardcoded `"intercepted/model"` to include the correct model name in the native oc system prompt — regression from #1023
- Moves `is_sub_llm_call`-aware first-turn prompt check from `CliAgentEnv.add_model_response` into `OpenCodeRLMEnv`, restoring the simple `len(trajectory) == 0` check in the base class
- `OpenCodeRLMEnv.add_model_response` uses `super(CliAgentEnv, self)` to skip the base class check and call `MultiTurnEnv` directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how OpenCode model/provider config is generated and how first-turn prompts are recorded when sub-LLM calls occur, which can affect model selection and trajectory/prompt correctness during rollouts.
> 
> **Overview**
> Fixes an OpenCode config regression by switching `build_opencode_config` back to shell-expanded `OPENAI_MODEL` parsing so the generated config uses the real provider/model (`$OPENAI_MODEL`, `${OPENAI_MODEL%%/*}`, `${OPENAI_MODEL##*/}`) instead of a hardcoded `intercepted/model`.
> 
> Moves the *sub-LLM aware* “first main turn” prompt update logic out of `CliAgentEnv.add_model_response` into `OpenCodeRLMEnv.add_model_response`, ensuring `state["prompt"]` is set based on the first non-sub call while keeping the base CLI env’s first-turn check simple.
> 
> Updates tests to validate the rendered config after shell expansion (provider key, model name, and baseURL) using an explicit `OPENAI_MODEL=myprovider/mymodel`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b38775c65dd5cfbc3617945dd815d1fb417c1211. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->