### PR TITLE
chore: reuse math rubric in hybrid math rubric

### DIFF
--- a/verifiers/rubrics/experimental/hybrid_math_rubric.py
+++ b/verifiers/rubrics/experimental/hybrid_math_rubric.py
@@ -2,12 +2,11 @@ from __future__ import annotations
 
 import asyncio
 
-from math_verify import parse, verify
 from openai import AsyncOpenAI
 from verifiers.envs.experimental.sandbox_mixin import SandboxMixin
 from verifiers.parsers.parser import Parser
+from verifiers.rubrics.math_rubric import MathRubric
 from verifiers.utils.data_utils import extract_boxed_answer
-from verifiers.utils.logging_utils import truncate
 
 import verifiers as vf
 
@@ -88,7 +87,12 @@ Analysis step by step and Final Judgment:
 
 
 class HybridMathRubric(vf.JudgeRubric):
-    """Runs rule-based math verification first, with optional LLM judge fallback."""
+    """Runs rule-based math verification first, with optional LLM judge fallback.
+
+    Delegates math verification to an internal :class:`MathRubric` instance so
+    the executor-based, non-blocking verification logic is reused rather than
+    duplicated.
+    """
 
     DEFAULT_JUDGE_PARSER = None
     DEFAULT_JUDGE_MODEL = "gpt-5-nano"
@@ -105,6 +109,8 @@ class HybridMathRubric(vf.JudgeRubric):
         judge_model: str = DEFAULT_JUDGE_MODEL,
         judge_prompt: str = DEFAULT_JUDGE_PROMPT,
         judge_sampling_args: dict | None = None,
+        timeout_seconds: float = 5,
+        max_workers: int = 50,
         **kwargs,
     ):
         judge_sampling_args = judge_sampling_args or self.DEFAULT_JUDGE_SAMPLING_ARGS
@@ -125,32 +131,23 @@ class HybridMathRubric(vf.JudgeRubric):
         self.judge_model = judge_model if use_judge_fallback else None
         self.class_objects["judge_model"] = self.judge_model
 
+        # Delegate math verification to MathRubric (executor-based, non-blocking).
+        # We clear its auto-registered reward func since we manage scoring ourselves.
+        self._math_rubric = MathRubric(
+            parser=self.parser,
+            max_workers=max_workers,
+            timeout_seconds=timeout_seconds,
+        )
+        self._math_rubric.funcs.clear()
+        self._math_rubric.weights.clear()
+
     async def math_verify_score(
         self, completion: vf.Messages, answer: str, state: vf.State, **kwargs
     ) -> float:
-        """Basic rule-based math verification."""
-        response = self.parser.parse_answer(completion) or ""
-        if response == "":
-            self.logger.debug("Parsed response is empty.")
-            state["math_verify_score"] = 0.0
-            return 0.0
-
-        try:
-            score = float(
-                verify(
-                    parse(f"\\boxed{{{answer}}}", parsing_timeout=5),
-                    parse(f"\\boxed{{{response}}}", parsing_timeout=5),
-                    timeout_seconds=5,
-                )
-            )
-            answer_str = truncate(answer.strip(), 20)
-            response_str = truncate(response.strip(), 20)
-            self.logger.debug(
-                f"Local math_verify {score} (answer={answer_str}, response={response_str})"
-            )
-        except BaseException as e:
-            self.logger.warning(f"Math verification failed: {e!r}")
-            score = 0.0
+        """Basic rule-based math verification (delegated to MathRubric)."""
+        score = await self._math_rubric.correct_answer(
+            parser=self.parser, completion=completion, answer=answer,
+        )
         state["math_verify_score"] = score
         return score
 

--- a/verifiers/rubrics/experimental/hybrid_math_rubric.py
+++ b/verifiers/rubrics/experimental/hybrid_math_rubric.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 import asyncio
 
 from openai import AsyncOpenAI
+
+import verifiers as vf
 from verifiers.envs.experimental.sandbox_mixin import SandboxMixin
 from verifiers.parsers.parser import Parser
 from verifiers.rubrics.math_rubric import MathRubric
 from verifiers.utils.data_utils import extract_boxed_answer
-
-import verifiers as vf
 
 # https://github.com/open-compass/CompassVerifier/blob/2d7cba6df0b21f9c6121786ac1e5770c68473598/src/prompts.py#L28
 DEFAULT_JUDGE_PROMPT = """\
@@ -131,21 +131,21 @@ class HybridMathRubric(vf.JudgeRubric):
         self.judge_model = judge_model if use_judge_fallback else None
         self.class_objects["judge_model"] = self.judge_model
 
-        # Delegate math verification to MathRubric (executor-based, non-blocking).
-        # We clear its auto-registered reward func since we manage scoring ourselves.
-        self._math_rubric = MathRubric(
+        # Delegate math verification to default MathRubric
+        # We clear its auto-registered reward func since we manage scoring ourselves
+        self.math_rubric = MathRubric(
             parser=self.parser,
             max_workers=max_workers,
             timeout_seconds=timeout_seconds,
         )
-        self._math_rubric.funcs.clear()
-        self._math_rubric.weights.clear()
+        self.math_rubric.funcs.clear()
+        self.math_rubric.weights.clear()
 
     async def math_verify_score(
         self, completion: vf.Messages, answer: str, state: vf.State, **kwargs
     ) -> float:
-        """Basic rule-based math verification (delegated to MathRubric)."""
-        score = await self._math_rubric.correct_answer(
+        """Basic rule-based math verification."""
+        score = await self.math_rubric.correct_answer(
             parser=self.parser,
             completion=completion,
             answer=answer,
@@ -161,7 +161,7 @@ class HybridMathRubric(vf.JudgeRubric):
         state: vf.State,
         **kwargs,
     ) -> float:
-        """Calls judge model if math verification did not pass and a judge model is set, else returns math verification score."""
+        """Calls judge if math verification failed and a judge model is set."""
         if state.get("math_verify_score", 0) == 1 or self.judge_model is None:
             return state.get("math_verify_score", 0)
 
@@ -178,7 +178,7 @@ class HybridMathRubric(vf.JudgeRubric):
         return judge_score
 
     async def correct_answer(self, state: vf.State, **kwargs) -> float:
-        """Whether either math verification or judge passed."""
+        """Whether math verification or judge succeeded."""
         return float(
             state.get("math_verify_score", 0.0) or state.get("judge_score", 0.0)
         )

--- a/verifiers/rubrics/experimental/hybrid_math_rubric.py
+++ b/verifiers/rubrics/experimental/hybrid_math_rubric.py
@@ -146,7 +146,9 @@ class HybridMathRubric(vf.JudgeRubric):
     ) -> float:
         """Basic rule-based math verification (delegated to MathRubric)."""
         score = await self._math_rubric.correct_answer(
-            parser=self.parser, completion=completion, answer=answer,
+            parser=self.parser,
+            completion=completion,
+            answer=answer,
         )
         state["math_verify_score"] = score
         return score


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

HybridMathRubric now holds an internal MathRubric instance and delegates math_verify calls to it instead of running parse()/verify() itself. This reuses MathRubric's ThreadPoolExecutor-based, non-blocking verification with hard timeout and executor auto-scaling.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core math-scoring behavior by routing `HybridMathRubric` through `MathRubric`’s executor-based verification and new timeout/worker settings, which may alter pass/fail outcomes and performance under load.
> 
> **Overview**
> **Hybrid math grading now reuses `MathRubric` for local rule-based verification instead of calling `math_verify` directly.** `HybridMathRubric` constructs an internal `MathRubric` (with configurable `timeout_seconds`/`max_workers`), clears its auto-registered reward funcs, and delegates `math_verify_score` to `MathRubric.correct_answer`.
> 
> Minor cleanup includes removing direct `math_verify` imports/logging in `HybridMathRubric` and tightening docstrings/behavior around when the LLM judge fallback runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8e2704862a59c554f9c914f1f3aa35c3376a9d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->