### PR TITLE
fix cancelled + serialize error

### DIFF
--- a/verifiers/workers/server/zmq_env_server.py
+++ b/verifiers/workers/server/zmq_env_server.py
@@ -242,7 +242,9 @@ class ZMQEnvServer(EnvServer):
                     )
 
             except asyncio.CancelledError:
-                return
+                response = BaseResponse(
+                    success=False, error="Request was cancelled"
+                )
 
             except Exception as e:
                 self.logger.error(
@@ -253,15 +255,32 @@ class ZMQEnvServer(EnvServer):
                     error=repr(e),
                 )
 
-            # serialize response using Pydantic
-            response_bytes = cast(
-                bytes,
-                msgpack.packb(
-                    response.model_dump(mode="python", warnings=False),
-                    default=msgpack_encoder,
-                    use_bin_type=True,
-                ),
-            )
+            # serialize and send response
+            try:
+                response_bytes = cast(
+                    bytes,
+                    msgpack.packb(
+                        response.model_dump(mode="python", warnings=False),
+                        default=msgpack_encoder,
+                        use_bin_type=True,
+                    ),
+                )
+            except Exception as e:
+                self.logger.error(
+                    f"Failed to serialize response for request {request_id}: {e}",
+                    exc_info=True,
+                )
+                response_bytes = cast(
+                    bytes,
+                    msgpack.packb(
+                        BaseResponse(
+                            success=False,
+                            error=f"Response serialization failed: {repr(e)}",
+                        ).model_dump(mode="python", warnings=False),
+                        default=msgpack_encoder,
+                        use_bin_type=True,
+                    ),
+                )
 
             # send response: [client_id, request_id, response]
             try:

--- a/verifiers/workers/server/zmq_env_server.py
+++ b/verifiers/workers/server/zmq_env_server.py
@@ -242,9 +242,7 @@ class ZMQEnvServer(EnvServer):
                     )
 
             except asyncio.CancelledError:
-                response = BaseResponse(
-                    success=False, error="Request was cancelled"
-                )
+                response = BaseResponse(success=False, error="Request was cancelled")
 
             except Exception as e:
                 self.logger.error(


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

- **CancelledError no longer silently drops requests**: Previously, if a `process_request` task was cancelled (e.g. client disconnect, task cancellation), the server returned without sending any ZMQ response — leaving the client hanging until the 10-hour default timeout. Now sends an error response so the client slot is freed immediately.
- **Serialization failures send fallback error response**: If `msgpack.packb(response.model_dump())` throws (e.g. on a malformed or huge response), the exception was unhandled and `socket.send_multipart` was never reached — again leaving the client hanging. Now catches serialization errors and sends a plain error response.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes error-handling in the ZMQ request/response path to avoid dropping replies; a mistake could alter client-visible behavior or mask underlying failures, but scope is limited to response generation.
> 
> **Overview**
> Prevents ZMQ clients from hanging when a `process_request` task is cancelled by returning a `BaseResponse` error instead of silently exiting.
> 
> Hardens response sending by catching exceptions during msgpack serialization and emitting a fallback error payload, ensuring `send_multipart` still runs and the client receives a failure response.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d26f327962a85311a91ec843084bb28be8119063. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->