### PR TITLE
perf: math rubric skip overlong answers

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -853,10 +853,10 @@ vf.load_example_dataset(name: str) -> Dataset
 Load a built-in example dataset.
 
 ```python
-vf.extract_boxed_answer(text: str) -> str | None
+vf.extract_boxed_answer(text: str, strict: bool = False) -> str
 ```
 
-Extract answer from LaTeX `\boxed{}` format.
+Extract answer from LaTeX `\boxed{}` format. When `strict=True`, returns `""` if no `\boxed{}` is found (used by `MathRubric` to avoid scoring unformatted responses). When `strict=False` (default), returns the original text as a passthrough.
 
 ```python
 vf.extract_hash_answer(text: str) -> str | None

--- a/tests/test_math_rubric.py
+++ b/tests/test_math_rubric.py
@@ -61,8 +61,8 @@ class TestMathRubric:
     @pytest.mark.parametrize(
         "test_case",
         [
-            {"completion": "1", "answer": "2"},
-            {"completion": "\\frac{1}{3}", "answer": "0.5"},
+            {"completion": "\\boxed{1}", "answer": "2"},
+            {"completion": "\\boxed{\\frac{1}{3}}", "answer": "0.5"},
         ],
         ids=lambda x: f"{x['completion']} != {x['answer']}",
     )

--- a/tests/test_math_rubric.py
+++ b/tests/test_math_rubric.py
@@ -26,9 +26,9 @@ class TestMathRubric:
     @pytest.mark.parametrize(
         "test_case",
         [
-            {"completion": "1", "answer": "1"},
-            {"completion": "x + 1", "answer": "1 + x"},
-            {"completion": "\\frac{1}{2}", "answer": "0.5"},
+            {"completion": "\\boxed{1}", "answer": "1"},
+            {"completion": "\\boxed{x + 1}", "answer": "1 + x"},
+            {"completion": "\\boxed{\\frac{1}{2}}", "answer": "0.5"},
         ],
         ids=lambda x: f"{x['completion']} == {x['answer']}",
     )

--- a/tests/test_math_rubric.py
+++ b/tests/test_math_rubric.py
@@ -98,9 +98,11 @@ class TestMathRubric:
 
         # very large input triggers timeout, takes ~2s to parse and verify
         answer = "1" * int(1e5)
-        completion = "1" * int(1e5)
+        completion = "\\boxed{" + "1" * int(1e5) + "}"
 
-        rubric = vf.MathRubric(max_workers=1, timeout_seconds=timeout_seconds)
+        rubric = vf.MathRubric(
+            max_workers=1, timeout_seconds=timeout_seconds, max_verify_chars=int(2e5)
+        )
 
         state = vf.State(
             input=make_input(

--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -25,7 +25,6 @@ from .utils.config_utils import MissingKeyError, ensure_keys
 from .utils.data_utils import (
     extract_boxed_answer,
     extract_hash_answer,
-    strict_extract_boxed_answer,
     load_example_dataset,
 )
 from .utils.logging_utils import (
@@ -71,7 +70,6 @@ __all__ = [
     "OpenAICompletionsClient",
     "extract_boxed_answer",
     "extract_hash_answer",
-    "strict_extract_boxed_answer",
     "load_example_dataset",
     "setup_logging",
     "log_level",

--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -25,6 +25,7 @@ from .utils.config_utils import MissingKeyError, ensure_keys
 from .utils.data_utils import (
     extract_boxed_answer,
     extract_hash_answer,
+    strict_extract_boxed_answer,
     load_example_dataset,
 )
 from .utils.logging_utils import (
@@ -70,6 +71,7 @@ __all__ = [
     "OpenAICompletionsClient",
     "extract_boxed_answer",
     "extract_hash_answer",
+    "strict_extract_boxed_answer",
     "load_example_dataset",
     "setup_logging",
     "log_level",

--- a/verifiers/rubrics/math_rubric.py
+++ b/verifiers/rubrics/math_rubric.py
@@ -27,7 +27,11 @@ class MathRubric(Rubric):
         timeout_seconds: float = 5,
         max_verify_chars: int = MAX_VERIFY_CHARS,
     ):
-        parser = parser or MaybeThinkParser(extract_fn=extract_boxed_answer)
+        from functools import partial
+
+        parser = parser or MaybeThinkParser(
+            extract_fn=partial(extract_boxed_answer, strict=True)
+        )
         self.max_verify_chars = max_verify_chars
         super().__init__(funcs=funcs, weights=weights, parser=parser)
         self.add_reward_func(self.correct_answer)

--- a/verifiers/rubrics/math_rubric.py
+++ b/verifiers/rubrics/math_rubric.py
@@ -16,6 +16,7 @@ from verifiers.utils.data_utils import extract_boxed_answer
 
 class MathRubric(Rubric):
     HARD_TIMEOUT_SECONDS: float = 120.0
+    MAX_VERIFY_CHARS: int = 50_000
 
     def __init__(
         self,
@@ -24,8 +25,10 @@ class MathRubric(Rubric):
         parser: Parser | None = None,
         max_workers: int = 50,
         timeout_seconds: float = 5,
+        max_verify_chars: int = MAX_VERIFY_CHARS,
     ):
         parser = parser or MaybeThinkParser(extract_fn=extract_boxed_answer)
+        self.max_verify_chars = max_verify_chars
         super().__init__(funcs=funcs, weights=weights, parser=parser)
         self.add_reward_func(self.correct_answer)
         self.timeout_seconds = timeout_seconds
@@ -55,6 +58,14 @@ class MathRubric(Rubric):
             start = time.perf_counter()
             response = parser.parse_answer(completion) or ""
             if response == "":
+                elapsed = time.perf_counter() - start
+                return 0.0, elapsed
+
+            if len(response) > self.max_verify_chars:
+                self.logger.warning(
+                    f"Skipping math verification: parsed response too long "
+                    f"({len(response)} chars > {self.max_verify_chars} limit)"
+                )
                 elapsed = time.perf_counter() - start
                 return 0.0, elapsed
 

--- a/verifiers/utils/data_utils.py
+++ b/verifiers/utils/data_utils.py
@@ -72,7 +72,17 @@ def format_dataset(
     return dataset
 
 
-def extract_boxed_answer(text: str) -> str:
+def extract_boxed_answer(text: str, strict: bool = False) -> str:
+    """Extract the last \\boxed{...} answer from text.
+
+    Args:
+        text: The text to extract from.
+        strict: If True, return "" when no \\boxed{} is found (for reward
+            scoring where format compliance matters). If False, return the
+            original text as a passthrough (for environments that use this
+            as a general text extractor).
+    """
+
     def find_matching_brace(s: str, start: int) -> int:
         count = 1
         i = start
@@ -87,13 +97,13 @@ def extract_boxed_answer(text: str) -> str:
     # Find last \boxed{
     boxed_start = text.rfind("\\boxed{")
     if boxed_start == -1:
-        return text
+        return "" if strict else text
     # Find the content between the braces
     content_start = boxed_start + 7  # len('\\boxed{')
     closing_brace = find_matching_brace(text, content_start)
 
     if closing_brace == -1:
-        return text
+        return "" if strict else text
 
     return text[content_start:closing_brace]
 

--- a/verifiers/utils/data_utils.py
+++ b/verifiers/utils/data_utils.py
@@ -108,14 +108,6 @@ def extract_boxed_answer(text: str, strict: bool = False) -> str:
     return text[content_start:closing_brace]
 
 
-def strict_extract_boxed_answer(text: str) -> str:
-    """Like extract_boxed_answer but returns empty string when no \\boxed{} is found."""
-    result = extract_boxed_answer(text)
-    if result == text:
-        return ""
-    return result
-
-
 def strip_non_numeric(text: str) -> str:
     return "".join(c for c in text if c.isdigit() or c == ".")
 

--- a/verifiers/utils/data_utils.py
+++ b/verifiers/utils/data_utils.py
@@ -98,6 +98,14 @@ def extract_boxed_answer(text: str) -> str:
     return text[content_start:closing_brace]
 
 
+def strict_extract_boxed_answer(text: str) -> str:
+    """Like extract_boxed_answer but returns empty string when no \\boxed{} is found."""
+    result = extract_boxed_answer(text)
+    if result == text:
+        return ""
+    return result
+
+
 def strip_non_numeric(text: str) -> str:
     return "".join(c for c in text if c.isdigit() or c == ".")
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Two fixes to improve the performance of the math rubric at high concurrency:
- Defaults to `extract_boxed_answer` in strict mode to avoid symbolic parsing of the full model response (and also false positives, as mentioned in #1028)
- Explicitly skip verification of answers with >1000 chars

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes `MathRubric` scoring behavior (unboxed answers now score 0 and long parsed responses are skipped), which can affect training/eval metrics; changes are localized and guarded by configurable limits.
> 
> **Overview**
> **MathRubric now enforces boxed-format answers by default and avoids expensive verification on huge outputs.** It switches the default parser extractor to `extract_boxed_answer(strict=True)`, so responses without a `\boxed{}` final answer no longer get passed through to symbolic parsing.
> 
> Adds a configurable `max_verify_chars` (default `50_000`) and skips `math_verify` when the parsed response exceeds this limit (with a warning), improving throughput under high concurrency.
> 
> Updates `extract_boxed_answer` API/docs to support `strict` mode, and adjusts tests to require boxed completions and to cover the new length limit behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d5dbbedef104ec3975ba3446c111ac4ab71651d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->