### PR TITLE
feat: add extra_headers_from_state to ClientConfig

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -683,11 +683,15 @@ class ClientConfig(BaseModel):
     api_base_url: str = "https://api.pinference.ai/api/v1"
     endpoint_configs: list[EndpointClientConfig] = []
     timeout: float = 3600.0
+    connect_timeout: float = 5.0
     max_connections: int = 28000
     max_keepalive_connections: int = 28000
     max_retries: int = 10
     extra_headers: dict[str, str] = {}
+    extra_headers_from_state: dict[str, str] = {}
 ```
+
+`extra_headers_from_state` maps HTTP header names to state field names. For each inference request, the header value is dynamically read from the rollout state dict. For example, `{"X-Session-ID": "example_id"}` adds a `X-Session-ID` header with the value of `state["example_id"]`, enabling sticky routing at the inference router level.
 
 `client_type` selects which `Client` implementation to instantiate (see [Client Classes](#client-classes)). Use `endpoint_configs` for multi-endpoint round-robin. In grouped scoring mode, groups are distributed round-robin across endpoint configs.
 

--- a/tests/test_openai_chat_completions_token_client.py
+++ b/tests/test_openai_chat_completions_token_client.py
@@ -20,7 +20,9 @@ class _RecordingClient(_NoopClient):
     def __init__(self) -> None:
         self.calls: list[dict[str, Any]] = []
 
-    async def post(self, path: str, body: dict[str, Any], cast_to: type) -> Any:
+    async def post(
+        self, path: str, body: dict[str, Any], cast_to: type, **kwargs: Any
+    ) -> Any:
         self.calls.append({"path": path, "body": body, "cast_to": cast_to})
         return {"ok": True, "path": path, "body": body}
 

--- a/verifiers/clients/client.py
+++ b/verifiers/clients/client.py
@@ -40,8 +40,10 @@ class Client(ABC, Generic[ClientT, MessagesT, ResponseT, ToolT]):
     def __init__(self, client_or_config: ClientT | ClientConfig) -> None:
         self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
         if isinstance(client_or_config, ClientConfig):
+            self._config = client_or_config
             self._client = self.setup_client(client_or_config)
         else:
+            self._config = None
             self._client = client_or_config
 
     @property
@@ -97,6 +99,17 @@ class Client(ABC, Generic[ClientT, MessagesT, ResponseT, ToolT]):
             native_tools.append(await self.to_native_tool(tool))
         return native_tools
 
+    def _build_state_headers(self, state) -> dict[str, str] | None:
+        """Build per-request HTTP headers from state using extra_headers_from_state mapping."""
+        if not self._config or not self._config.extra_headers_from_state or not state:
+            return None
+        headers = {}
+        for header_name, state_key in self._config.extra_headers_from_state.items():
+            val = state.get(state_key)
+            if val is not None:
+                headers[header_name] = str(val)
+        return headers or None
+
     async def get_response(
         self,
         prompt: Messages,
@@ -107,6 +120,10 @@ class Client(ABC, Generic[ClientT, MessagesT, ResponseT, ToolT]):
     ) -> Response:
         """Get the response from the client."""
         try:
+            extra_headers = self._build_state_headers(kwargs.get("state"))
+            if extra_headers:
+                kwargs["extra_headers"] = extra_headers
+
             native_prompt, extra_kwargs = await self.to_native_prompt(prompt)
             native_tools = await self.to_native_tools(tools)
             native_response = await self.get_native_response(

--- a/verifiers/clients/openai_chat_completions_client.py
+++ b/verifiers/clients/openai_chat_completions_client.py
@@ -274,17 +274,21 @@ class OpenAIChatCompletionsClient(
         if has_audio and "modalities" not in sampling_args:
             sampling_args = {**sampling_args, "modalities": ["text"]}
 
+        extra_headers = kwargs.pop("extra_headers", None)
+
         if tools:
             response = await self.client.chat.completions.create(
                 model=model,
                 messages=prompt,
                 tools=tools,
+                extra_headers=extra_headers,
                 **normalize_sampling_args(sampling_args),
             )
         else:
             response = await self.client.chat.completions.create(
                 model=model,
                 messages=prompt,
+                extra_headers=extra_headers,
                 **normalize_sampling_args(sampling_args),
             )
         return response

--- a/verifiers/clients/openai_chat_completions_token_client.py
+++ b/verifiers/clients/openai_chat_completions_token_client.py
@@ -77,6 +77,7 @@ class OpenAIChatCompletionsTokenClient(OpenAIChatCompletionsClient):
 
         sampling_args = normalize_sampling_args(sampling_args)
         state = cast(State, kwargs.pop("state"))
+        extra_headers = kwargs.pop("extra_headers", None)
         # Use standard /chat/completions for: (1) first turn (no prior tokens
         # to stitch), or (2) conversations that contain multimodal content in
         # any turn.  vLLM ≤0.16's /tokenize doesn't run the multimodal
@@ -89,12 +90,12 @@ class OpenAIChatCompletionsTokenClient(OpenAIChatCompletionsClient):
         )
         if len(state["trajectory"]) == 0 or has_multimodal:
             return await super().get_native_response(
-                prompt, model, sampling_args, tools
+                prompt, model, sampling_args, tools, extra_headers=extra_headers
             )
         prompt_ids = await self.get_prompt_ids(state, prompt, tools)
         if prompt_ids is None:
             return await super().get_native_response(
-                prompt, model, sampling_args, tools
+                prompt, model, sampling_args, tools, extra_headers=extra_headers
             )
         extra_body = sampling_args.pop("extra_body", {})
         body = dict(
@@ -110,6 +111,7 @@ class OpenAIChatCompletionsTokenClient(OpenAIChatCompletionsClient):
             "/chat/completions/tokens",
             body=body,
             cast_to=ChatCompletion,
+            options={"headers": extra_headers} if extra_headers else {},
         )
 
     async def get_prompt_ids(

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -418,6 +418,13 @@ class ClientConfig(BaseModel):
     max_keepalive_connections: int = 28000
     max_retries: int = 10
     extra_headers: dict[str, str] = Field(default_factory=dict)
+    extra_headers_from_state: dict[str, str] = Field(
+        default_factory=dict,
+        description="Maps HTTP header names to state field names. "
+        "For each request, the header value is read from the state dict. "
+        'e.g. {"X-Session-ID": "example_id"} adds a X-Session-ID header '
+        "with the value of state['example_id'].",
+    )
 
     @field_validator("endpoint_configs", mode="before")
     @classmethod


### PR DESCRIPTION
## Summary
- Adds `extra_headers_from_state` field to `ClientConfig` that maps HTTP header names to state field names
- For each inference request, headers are dynamically built from the rollout state dict
- Enables sticky routing (e.g. `X-Session-ID` from `example_id`) without monkey-patching client classes

## Usage
```python
ClientConfig(extra_headers_from_state={"X-Session-ID": "example_id"})
```

Or in TOML:
```toml
[orchestrator.client]
extra_headers_from_state = {"X-Session-ID" = "example_id"}
```

## Changes
- `types.py`: New `extra_headers_from_state` field on `ClientConfig`
- `clients/client.py`: Store config ref, add `_build_state_headers()`, inject headers in `get_response()`
- `clients/openai_chat_completions_client.py`: Pass `extra_headers` to `chat.completions.create()`
- `clients/openai_chat_completions_token_client.py`: Pass `extra_headers` to both fallback and token paths

## Test plan
- [ ] Verify `ClientConfig(extra_headers_from_state={"X-Session-ID": "example_id"})` works
- [ ] Verify headers appear on outgoing requests when state has the field
- [ ] Verify no headers added when state field is missing
- [ ] Verify no regression for clients without `extra_headers_from_state`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds dynamic HTTP header injection into all `Client.get_response()` calls based on rollout `state`, which can affect routing/auth behavior of outbound model requests. Risk is moderate because it changes request parameters on the hot inference path but is opt-in via config and falls back cleanly when unset.
> 
> **Overview**
> Adds `ClientConfig.extra_headers_from_state`, allowing configured HTTP headers to be **dynamically populated from rollout `state`** on each inference request (documented in `docs/reference.md`).
> 
> Updates the base `Client` to retain the provided config, build headers via `_build_state_headers(state)`, and pass them through `kwargs` as `extra_headers`; OpenAI chat clients now forward those headers to `chat.completions.create()`, and the token client forwards them both on the fallback path and via `options={"headers": ...}` on the `/chat/completions/tokens` route. Tests are adjusted to accept extra `post()` kwargs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f6ff527446ac7d2f3308f85de490731722f209a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->