### PR TITLE
Prepare v0.1.12.dev0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Verifiers: Environments for LLM Reinforcement Learning
 
 ## News & Updates
 
+- [03/22/26] v0.1.12.dev0 release prep is up, featuring opencode RLM environments, performance and autoscaling improvements, stronger cancellation/runtime handling, multimodal save fidelity, and updated development docs.
 - [03/12/26] v0.1.11 is released, featuring a unified client stack, major `RLMEnv` and env server reliability improvements, a substantially refined eval TUI, new pass@k and ablation sweep support, and bundled opencode environments.
 - [02/10/26] v0.1.10 is released, featuring OpenEnv and BrowserEnv integrations, resumed evals, improved rollout and token tracking, safer sandbox lifecycle behavior, refreshed workspace setup, and opencode harbor improvements.
 - [01/08/26] v0.1.9 is released, featuring a number of new experimental environment class types, monitor rubrics for automatic metric collection, improved workspace setup flow, improved error handling, bug fixes, and a documentation overhaul.

--- a/assets/release/RELEASE_v0.1.12.dev0.md
+++ b/assets/release/RELEASE_v0.1.12.dev0.md
@@ -1,0 +1,47 @@
+# Verifiers v0.1.12.dev0 Release Notes
+
+*Date:* 03/22/2026
+
+## Highlights since v0.1.11
+
+- Added the new `opencode_rlm_env` plus broader opencode environment cleanups and performance work, including executor autoscaling and incremental metrics for better throughput under load.
+- Improved runtime reliability with more robust cancellation handling, env server startup tuning, safer port allocation, and better event loop lag monitoring.
+- Expanded configuration and lifecycle ergonomics with `Rubric` cleanup/teardown hooks, configurable eval `output_dir`, preserved multimodal media in saved eval results, and `ClientConfig.extra_headers_from_state`.
+- Refined rubric and environment performance with lazy imports, faster file I/O, math-rubric optimizations, and follow-up fixes to logging and response normalization.
+- Added fresh docs for BrowserEnv integration and a new environment performance guide.
+
+## Changes included in v0.1.12.dev0 (since v0.1.11)
+
+### Environments, execution, and performance
+
+- deprecate `RolloutGatewayMixin` (#1017)
+- Lazily import packages (#1019)
+- Add BrowserEnv integration README (#1020)
+- tune GC on env server before accepting requests (#1022)
+- opencode_rlm_env (#1023)
+- Preserve multimodal media in saved eval results (#1015)
+- Add cleanup and teardown lifecycle hooks to Rubric (#1026)
+- remove redundant msg normalization + align `env_response` api (#1027)
+- make `output_dir` configurable in evals (#1029)
+- misc improvements to opencode envs (#999)
+- perf improvs for opencode envs + math rubric (#1034)
+- fix: task cancelation race + RLM sandbox workers (#1035)
+- perf: incremental metrics (#1036)
+- perf: offload file i/o to thread pool (#1037)
+- feat: improve event loop lag monitor (#1038)
+- perf: executor autoscaling (#1039)
+
+### Reliability, cancellation, and bug fixes
+
+- Fix get_free_port_pair() TOCTOU race condition (#1013)
+- fix display of custom sampling args (#1025)
+- fix output dir logging (#1041)
+- fix: revert opencode_env config regression and move RLM logic out of cli_agent_env (#1042)
+- chore: reuse math rubric in hybrid math rubric (#1043)
+- fix cancelled + serialize error (#1044)
+- docs: add performance guide for environments (#1045)
+- perf: math rubric skip overlong answers (#1046)
+- fix: call uncancel() after catching `CancelledError` in `process_request` (#1047)
+- feat: add `extra_headers_from_state` to `ClientConfig` (#1048)
+
+**Full Changelog**: https://github.com/PrimeIntellect-ai/verifiers/compare/v0.1.11...v0.1.12.dev0

--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.11"
+__version__ = "0.1.12.dev0"
 
 import importlib
 import os


### PR DESCRIPTION
### Motivation
- Cut a new development pre-release (`0.1.12.dev0`) so the release workflow and downstream tooling can reference the next dev version and publish release notes for the interim changes.

### Description
- Bump package version to `0.1.12.dev0` by updating `verifiers/__init__.py`.
- Add `assets/release/RELEASE_v0.1.12.dev0.md` containing dev0 release notes summarizing changes since `v0.1.11` and pointing to the full compare link.
- Add a README news entry announcing the `v0.1.12.dev0` release prep.
- Commit created with message `Prepare v0.1.12.dev0 release` and a PR payload was generated for review.

### Testing
- Ran `uv run ruff check --fix verifiers/__init__.py README.md assets/release/RELEASE_v0.1.12.dev0.md` and it passed.
- Ran `uv run pytest tests/test_install_utils.py` and `27 passed` was reported.
- Ran `uv run pre-commit run --files verifiers/__init__.py README.md assets/release/RELEASE_v0.1.12.dev0.md` and all configured pre-commit checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf53dedea483269232d2247c93f7da)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a version bump plus documentation/release-note additions, with no functional code changes beyond updating `__version__`. Main risk is downstream tooling expecting the new pre-release version string.
> 
> **Overview**
> Prepares the `v0.1.12.dev0` development pre-release by bumping `verifiers.__version__` from `0.1.11` to `0.1.12.dev0`.
> 
> Adds `RELEASE_v0.1.12.dev0.md` with release notes/changelog links and updates the README *News & Updates* with a `v0.1.12.dev0` release-prep entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4f990127afb20befa4259066a41679fcba13edf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->