### PR TITLE
feat: `NullClient` for inference-free task solving

### DIFF
--- a/verifiers/clients/__init__.py
+++ b/verifiers/clients/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from verifiers.clients.anthropic_messages_client import AnthropicMessagesClient
 from verifiers.clients.client import Client
+from verifiers.clients.null_client import NullClient
 from verifiers.clients.openai_chat_completions_client import OpenAIChatCompletionsClient
 from verifiers.clients.openai_chat_completions_token_client import (
     OpenAIChatCompletionsTokenClient,
@@ -32,6 +33,7 @@ def resolve_client(client_or_config: Client | ClientConfig) -> Client:
 
 __all__ = [
     "AnthropicMessagesClient",
+    "NullClient",
     "OpenAICompletionsClient",
     "OpenAIChatCompletionsClient",
     "OpenAIChatCompletionsTokenClient",

--- a/verifiers/clients/null_client.py
+++ b/verifiers/clients/null_client.py
@@ -1,0 +1,50 @@
+"""NullClient for environments that don't require LLM inference."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from verifiers.clients.client import Client
+from verifiers.types import ClientConfig, Messages, Response, SamplingArgs, Tool
+
+
+class NullClient(Client):
+    """A no-op client for environments that don't use LLM inference.
+
+    Satisfies the Client ABC so it can pass through resolve_client() unchanged.
+    All inference methods raise NotImplementedError — they should never be called.
+    """
+
+    def __init__(self) -> None:
+        self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
+        self._config = None
+        self._client = None
+
+    def setup_client(self, config: ClientConfig) -> Any:
+        raise NotImplementedError("NullClient does not support inference")
+
+    async def to_native_tool(self, tool: Tool) -> Any:
+        raise NotImplementedError("NullClient does not support inference")
+
+    async def to_native_prompt(self, messages: Messages) -> tuple[Any, dict]:
+        raise NotImplementedError("NullClient does not support inference")
+
+    async def get_native_response(
+        self,
+        prompt: Any,
+        model: str,
+        sampling_args: SamplingArgs,
+        tools: list[Any] | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        raise NotImplementedError("NullClient does not support inference")
+
+    async def raise_from_native_response(self, response: Any) -> None:
+        raise NotImplementedError("NullClient does not support inference")
+
+    async def from_native_response(self, response: Any) -> Response:
+        raise NotImplementedError("NullClient does not support inference")
+
+    async def close(self) -> None:
+        pass

--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -130,6 +130,10 @@ def get_env_eval_defaults(env_id: str) -> dict[str, Any]:
             defaults["num_examples"] = eval_config["num_examples"]
         if "rollouts_per_example" in eval_config:
             defaults["rollouts_per_example"] = eval_config["rollouts_per_example"]
+        if eval_config.get("no_inference"):
+            defaults["no_inference"] = True
+            if "model" in eval_config:
+                defaults["model"] = eval_config["model"]
 
         if defaults:
             logger.debug(
@@ -430,180 +434,210 @@ def main():
                 f"Using rollouts_per_example={rollouts_per_example} from {source}"
             )
 
-        # Resolve model and endpoint config
-        endpoints_path = raw.get("endpoints_path", DEFAULT_ENDPOINTS_PATH)
-        endpoints = load_endpoints(endpoints_path)
-
-        raw_endpoint_id = raw.get("endpoint_id")
-        raw_model_field = raw.get("model")
-        if raw_endpoint_id is not None and raw_model_field is not None:
-            raise ValueError(
-                "Cannot set both 'endpoint_id' and 'model' in eval config; choose one."
-            )
-        if raw_endpoint_id is not None and not isinstance(raw_endpoint_id, str):
-            raise ValueError("'endpoint_id' must be a string when provided.")
-        if isinstance(raw_endpoint_id, str) and not raw_endpoint_id:
-            raise ValueError("'endpoint_id' must be a non-empty string when provided.")
-        resolved_endpoints_file = resolve_endpoints_file(str(endpoints_path))
-        if raw_endpoint_id is not None and (
-            resolved_endpoints_file is None or resolved_endpoints_file.suffix != ".toml"
-        ):
-            raise ValueError(
-                "'endpoint_id' is only supported with TOML endpoint registries. "
-                "Set endpoints_path to an endpoints.toml file."
+        # No-inference environments (e.g. gold-patch solve) skip model/endpoint resolution
+        no_inference = env_defaults.get("no_inference", False)
+        if no_inference:
+            model = env_defaults.get("model", "solve")
+            logger.info(
+                f"No-inference environment '{env_id}' — skipping endpoint resolution (model={model})"
             )
 
-        raw_model = raw_model_field if raw_model_field is not None else DEFAULT_MODEL
-        endpoint_lookup_id = (
-            raw_endpoint_id if raw_endpoint_id is not None else raw_model
-        )
-        raw_client_type = raw.get("api_client_type")
-        raw_api_key_var = raw.get("api_key_var")
-        raw_api_base_url = raw.get("api_base_url")
-        if isinstance(raw_api_base_url, list):
-            raise ValueError(
-                "api_base_url lists are no longer supported. "
-                "Use endpoint_id + endpoints.toml for multi-endpoint configuration."
+        # Resolve model, endpoint, and client config
+        if no_inference:
+            resolved_endpoint_id = None
+            client_config = ClientConfig(
+                client_type=cast(ClientType, DEFAULT_CLIENT_TYPE),
+                api_key_var="NONE",
+                api_base_url="http://localhost",
             )
-
-        # Provider resolution:
-        #   - model IN registry:  registry -> provider overrides -> CLI overrides
-        #   - model NOT in registry: provider (default: prime) -> CLI overrides
-        raw_provider = raw.get("provider")
-        api_key_override = raw_api_key_var is not None
-        api_base_url_override = raw_api_base_url is not None
-        client_type_override = raw_client_type is not None
-        endpoint_group: list[dict[str, str]] | None = None
-        resolved_endpoint_id: str | None = None
-
-        if endpoint_lookup_id in endpoints:
-            endpoint_group = endpoints[endpoint_lookup_id]
-            resolved_endpoint_id = endpoint_lookup_id
-            endpoint = endpoint_group[0]
-
-            # Start from registry values
-            api_key_var = endpoint["key"]
-            api_base_url = endpoint["url"]
-            client_type = endpoint.get("api_client_type", DEFAULT_CLIENT_TYPE)
-
-            endpoint_models = {entry["model"] for entry in endpoint_group}
-            if len(endpoint_models) > 1:
-                raise ValueError(
-                    f"Endpoint alias '{endpoint_lookup_id}' maps to multiple model ids {sorted(endpoint_models)}, "
-                    "which is not yet supported by EvalConfig."
-                )
-            model = endpoint["model"]
-
-            # Provider overrides registry
-            if raw_provider is not None:
-                provider_cfg = PROVIDER_CONFIGS[raw_provider]
-                api_key_var = provider_cfg["key"]
-                api_base_url = provider_cfg["url"]
-                if "client_type" in provider_cfg:
-                    client_type = provider_cfg["client_type"]
-
-            # CLI overrides provider / registry
-            if api_key_override:
-                api_key_var = raw_api_key_var
-            if api_base_url_override:
-                api_base_url = raw_api_base_url
-            if client_type_override:
-                client_type = raw_client_type
-
-            if (
-                api_key_override
-                or api_base_url_override
-                or client_type_override
-                or raw_provider is not None
-            ):
-                logger.debug(
-                    "Using endpoint registry for model '%s' with overrides (key: %s, url: %s, api_client_type: %s)",
-                    model,
-                    "override" if api_key_override or raw_provider else "registry",
-                    "override" if api_base_url_override or raw_provider else "registry",
-                    "override" if client_type_override or raw_provider else "registry",
-                )
-            else:
-                logger.debug(
-                    "Using endpoint configuration for model '%s' from registry (%d endpoint variant(s))",
-                    model,
-                    len(endpoint_group),
-                )
+            merged_sampling_args: dict = {}
         else:
-            if raw_endpoint_id is not None:
+            endpoints_path = raw.get("endpoints_path", DEFAULT_ENDPOINTS_PATH)
+            endpoints = load_endpoints(endpoints_path)
+
+            raw_endpoint_id = raw.get("endpoint_id")
+            raw_model_field = raw.get("model")
+            if raw_endpoint_id is not None and raw_model_field is not None:
                 raise ValueError(
-                    f"Endpoint id '{raw_endpoint_id}' not found in endpoint registry at {endpoints_path}"
+                    "Cannot set both 'endpoint_id' and 'model' in eval config; choose one."
                 )
-            # Fall back to provider (default: prime)
-            provider_cfg = PROVIDER_CONFIGS[raw_provider or DEFAULT_PROVIDER]
-            logger.debug(
-                "Model '%s' not found in endpoint registry, using provider '%s'",
-                raw_model,
-                raw_provider or DEFAULT_PROVIDER,
-            )
-            model = raw_model
-            api_key_var = raw_api_key_var if api_key_override else provider_cfg["key"]
-            api_base_url = (
-                raw_api_base_url if api_base_url_override else provider_cfg["url"]
-            )
-            client_type = (
-                raw_client_type
-                if client_type_override
-                else provider_cfg.get("client_type", DEFAULT_CLIENT_TYPE)
-            )
-
-        # Merge sampling args
-        merged_sampling_args: dict = {}
-        if raw.get("sampling_args") is not None:
-            merged_sampling_args.update(raw["sampling_args"])
-        if "max_tokens" not in merged_sampling_args:
-            merged_sampling_args["max_tokens"] = raw.get("max_tokens")
-        raw_temp = raw.get("temperature")
-        if raw_temp is not None and "temperature" not in merged_sampling_args:
-            merged_sampling_args["temperature"] = raw_temp
-        # Build headers
-        merged_headers: dict[str, str] = {}
-        for h in raw.get("header") or []:
-            if ":" not in h:
-                raise ValueError(f"--header must be 'Name: Value', got: {h!r}")
-            k, v = h.split(":", 1)
-            k, v = k.strip(), v.strip()
-            if not k:
-                raise ValueError("--header name cannot be empty")
-            merged_headers[k] = v
-
-        primary_api_base_url = api_base_url
-        if not isinstance(primary_api_base_url, str):
-            raise ValueError("api_base_url must be a single string URL")
-        assert api_key_var is not None
-        resolved_api_key_var = api_key_var
-
-        endpoint_configs: list[EndpointClientConfig] = []
-        if (
-            endpoint_group is not None
-            and not api_base_url_override
-            and raw_provider is None
-            and len(endpoint_group) > 1
-        ):
-            endpoint_configs = [
-                EndpointClientConfig(
-                    api_key_var=(
-                        resolved_api_key_var if api_key_override else endpoint["key"]
-                    ),
-                    api_base_url=endpoint["url"],
-                    extra_headers=merged_headers,
+            if raw_endpoint_id is not None and not isinstance(raw_endpoint_id, str):
+                raise ValueError("'endpoint_id' must be a string when provided.")
+            if isinstance(raw_endpoint_id, str) and not raw_endpoint_id:
+                raise ValueError(
+                    "'endpoint_id' must be a non-empty string when provided."
                 )
-                for endpoint in endpoint_group
-            ]
+            resolved_endpoints_file = resolve_endpoints_file(str(endpoints_path))
+            if raw_endpoint_id is not None and (
+                resolved_endpoints_file is None
+                or resolved_endpoints_file.suffix != ".toml"
+            ):
+                raise ValueError(
+                    "'endpoint_id' is only supported with TOML endpoint registries. "
+                    "Set endpoints_path to an endpoints.toml file."
+                )
 
-        assert primary_api_base_url is not None
-        client_config = ClientConfig(
-            client_type=cast(ClientType, client_type),
-            api_key_var=resolved_api_key_var,
-            api_base_url=primary_api_base_url,
-            endpoint_configs=endpoint_configs,
-            extra_headers=merged_headers,
-        )
+            raw_model = (
+                raw_model_field if raw_model_field is not None else DEFAULT_MODEL
+            )
+            endpoint_lookup_id = (
+                raw_endpoint_id if raw_endpoint_id is not None else raw_model
+            )
+            raw_client_type = raw.get("api_client_type")
+            raw_api_key_var = raw.get("api_key_var")
+            raw_api_base_url = raw.get("api_base_url")
+            if isinstance(raw_api_base_url, list):
+                raise ValueError(
+                    "api_base_url lists are no longer supported. "
+                    "Use endpoint_id + endpoints.toml for multi-endpoint configuration."
+                )
+
+            # Provider resolution:
+            #   - model IN registry:  registry -> provider overrides -> CLI overrides
+            #   - model NOT in registry: provider (default: prime) -> CLI overrides
+            raw_provider = raw.get("provider")
+            api_key_override = raw_api_key_var is not None
+            api_base_url_override = raw_api_base_url is not None
+            client_type_override = raw_client_type is not None
+            endpoint_group: list[dict[str, str]] | None = None
+            resolved_endpoint_id = None
+
+            if endpoint_lookup_id in endpoints:
+                endpoint_group = endpoints[endpoint_lookup_id]
+                resolved_endpoint_id = endpoint_lookup_id
+                endpoint = endpoint_group[0]
+
+                # Start from registry values
+                api_key_var = endpoint["key"]
+                api_base_url = endpoint["url"]
+                client_type = endpoint.get("api_client_type", DEFAULT_CLIENT_TYPE)
+
+                endpoint_models = {entry["model"] for entry in endpoint_group}
+                if len(endpoint_models) > 1:
+                    raise ValueError(
+                        f"Endpoint alias '{endpoint_lookup_id}' maps to multiple model ids {sorted(endpoint_models)}, "
+                        "which is not yet supported by EvalConfig."
+                    )
+                model = endpoint["model"]
+
+                # Provider overrides registry
+                if raw_provider is not None:
+                    provider_cfg = PROVIDER_CONFIGS[raw_provider]
+                    api_key_var = provider_cfg["key"]
+                    api_base_url = provider_cfg["url"]
+                    if "client_type" in provider_cfg:
+                        client_type = provider_cfg["client_type"]
+
+                # CLI overrides provider / registry
+                if api_key_override:
+                    api_key_var = raw_api_key_var
+                if api_base_url_override:
+                    api_base_url = raw_api_base_url
+                if client_type_override:
+                    client_type = raw_client_type
+
+                if (
+                    api_key_override
+                    or api_base_url_override
+                    or client_type_override
+                    or raw_provider is not None
+                ):
+                    logger.debug(
+                        "Using endpoint registry for model '%s' with overrides (key: %s, url: %s, api_client_type: %s)",
+                        model,
+                        "override" if api_key_override or raw_provider else "registry",
+                        "override"
+                        if api_base_url_override or raw_provider
+                        else "registry",
+                        "override"
+                        if client_type_override or raw_provider
+                        else "registry",
+                    )
+                else:
+                    logger.debug(
+                        "Using endpoint configuration for model '%s' from registry (%d endpoint variant(s))",
+                        model,
+                        len(endpoint_group),
+                    )
+            else:
+                if raw_endpoint_id is not None:
+                    raise ValueError(
+                        f"Endpoint id '{raw_endpoint_id}' not found in endpoint registry at {endpoints_path}"
+                    )
+                # Fall back to provider (default: prime)
+                provider_cfg = PROVIDER_CONFIGS[raw_provider or DEFAULT_PROVIDER]
+                logger.debug(
+                    "Model '%s' not found in endpoint registry, using provider '%s'",
+                    raw_model,
+                    raw_provider or DEFAULT_PROVIDER,
+                )
+                model = raw_model
+                api_key_var = (
+                    raw_api_key_var if api_key_override else provider_cfg["key"]
+                )
+                api_base_url = (
+                    raw_api_base_url if api_base_url_override else provider_cfg["url"]
+                )
+                client_type = (
+                    raw_client_type
+                    if client_type_override
+                    else provider_cfg.get("client_type", DEFAULT_CLIENT_TYPE)
+                )
+
+            # Merge sampling args
+            merged_sampling_args = {}
+            if raw.get("sampling_args") is not None:
+                merged_sampling_args.update(raw["sampling_args"])
+            if "max_tokens" not in merged_sampling_args:
+                merged_sampling_args["max_tokens"] = raw.get("max_tokens")
+            raw_temp = raw.get("temperature")
+            if raw_temp is not None and "temperature" not in merged_sampling_args:
+                merged_sampling_args["temperature"] = raw_temp
+            # Build headers
+            merged_headers: dict[str, str] = {}
+            for h in raw.get("header") or []:
+                if ":" not in h:
+                    raise ValueError(f"--header must be 'Name: Value', got: {h!r}")
+                k, v = h.split(":", 1)
+                k, v = k.strip(), v.strip()
+                if not k:
+                    raise ValueError("--header name cannot be empty")
+                merged_headers[k] = v
+
+            primary_api_base_url = api_base_url
+            if not isinstance(primary_api_base_url, str):
+                raise ValueError("api_base_url must be a single string URL")
+            assert api_key_var is not None
+            resolved_api_key_var = api_key_var
+
+            endpoint_configs: list[EndpointClientConfig] = []
+            if (
+                endpoint_group is not None
+                and not api_base_url_override
+                and raw_provider is None
+                and len(endpoint_group) > 1
+            ):
+                endpoint_configs = [
+                    EndpointClientConfig(
+                        api_key_var=(
+                            resolved_api_key_var
+                            if api_key_override
+                            else endpoint["key"]
+                        ),
+                        api_base_url=endpoint["url"],
+                        extra_headers=merged_headers,
+                    )
+                    for endpoint in endpoint_group
+                ]
+
+            assert primary_api_base_url is not None
+            client_config = ClientConfig(
+                client_type=cast(ClientType, client_type),
+                api_key_var=resolved_api_key_var,
+                api_base_url=primary_api_base_url,
+                endpoint_configs=endpoint_configs,
+                extra_headers=merged_headers,
+            )
 
         # Backward-compatible TOML field: resume_path
         if raw.get("resume") is None and raw.get("resume_path") is not None:
@@ -651,16 +685,21 @@ def main():
             client_config=client_config,
             sampling_args=merged_sampling_args,
             num_examples=num_examples,
-            rollouts_per_example=rollouts_per_example,
+            rollouts_per_example=1 if no_inference else rollouts_per_example,
             max_concurrent=raw.get("max_concurrent", DEFAULT_MAX_CONCURRENT),
             max_retries=raw.get("max_retries", 0),
-            disable_env_server=raw.get("disable_env_server", False),
+            disable_env_server=True
+            if no_inference
+            else raw.get("disable_env_server", False),
             verbose=raw.get("verbose", False),
             debug=raw.get("debug", False),
             state_columns=raw.get("state_columns", []),
             save_results=raw.get("save_results", False),
             resume_path=resume_path,
-            independent_scoring=raw.get("independent_scoring", False),
+            independent_scoring=True
+            if no_inference
+            else raw.get("independent_scoring", False),
+            no_inference=no_inference,
             save_to_hf_hub=raw.get("save_to_hf_hub", False),
             hf_hub_dataset_name=raw.get("hf_hub_dataset_name", ""),
         )

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -504,6 +504,7 @@ class EvalConfig(BaseModel):
     extra_env_kwargs: dict = {}
     max_retries: int = 0
     disable_env_server: bool = False
+    no_inference: bool = False
     # logging
     verbose: bool = False
     debug: bool = False

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -786,8 +786,15 @@ async def run_evaluation(
                     effective_group_max_concurrent, config.num_examples
                 )
 
+        if config.no_inference:
+            from verifiers.clients import NullClient
+
+            eval_client = NullClient()
+        else:
+            eval_client = config.client_config
+
         outputs = await vf_env.evaluate(
-            client=config.client_config,
+            client=eval_client,
             model=config.model,
             sampling_args=config.sampling_args,
             num_examples=config.num_examples,


### PR DESCRIPTION
## Description
introduces a `NullClient` and `no_inference` eval config to solve tasks without involving inference, e.g. applying gold patches to validate swe tasks.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes `eval.py` configuration/build logic and alters runtime evaluation behavior (skipping endpoint resolution, forcing rollouts/server/scoring settings) when `no_inference` is enabled.
> 
> **Overview**
> Adds an inference-free evaluation mode driven by a new `EvalConfig.no_inference` flag.
> 
> When enabled (via an environment’s `[tool.verifiers.eval] no_inference = true`), `verifiers/scripts/eval.py` skips endpoint/model/provider resolution, uses placeholder client settings, forces `rollouts_per_example=1`, disables env servers, and enables independent scoring.
> 
> Introduces a `NullClient` (exported from `verifiers.clients`) and updates `run_evaluation` to pass `NullClient()` into `vf_env.evaluate` instead of a real `ClientConfig` when `no_inference` is set.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c2c56391afb81db6b198b7c7c6eef92a6024443. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->