### PR TITLE
Allow environments to declare preserved state columns

### DIFF
--- a/docs/environments.md
+++ b/docs/environments.md
@@ -620,6 +620,16 @@ class MyGameEnv(vf.MultiTurnEnv):
         return await super().setup_state(state)
 ```
 
+If you need custom JSON-serializable state fields to be preserved in `RolloutOutput`, declare them with `state_columns` when constructing the environment:
+
+```python
+env = MyGameEnv(
+    dataset=dataset,
+    rubric=rubric,
+    state_columns=["score", "board"],
+)
+```
+
 ### Cleanup and Teardown
 
 For resource management, use `@vf.cleanup` (per-rollout) and `@vf.teardown` (at environment shutdown):

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -275,6 +275,7 @@ class Environment(ABC):
         max_seq_len: int | None = None,
         score_rollouts: bool = True,
         pass_threshold: float = 0.5,
+        state_columns: list[str] | None = None,
         **kwargs,
     ): ...
 ```

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -146,7 +146,7 @@ class Environment(ABC):
         self.max_seq_len = max_seq_len
         self.map_kwargs = map_kwargs
 
-        self.state_columns: list[str] = kwargs.pop("state_columns", [])
+        self.state_columns: list[str] = kwargs.pop("state_columns", None) or []
         self.set_score_rollouts(score_rollouts)
         self.pass_threshold = pass_threshold
 

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -146,6 +146,7 @@ class Environment(ABC):
         self.max_seq_len = max_seq_len
         self.map_kwargs = map_kwargs
 
+        self.state_columns: list[str] = kwargs.pop("state_columns", [])
         self.set_score_rollouts(score_rollouts)
         self.pass_threshold = pass_threshold
 

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -112,6 +112,7 @@ class Environment(ABC):
         max_seq_len: int | None = None,
         score_rollouts: bool = True,
         pass_threshold: float = 0.5,
+        state_columns: list[str] | None = None,
         **kwargs,
     ):
         if message_type is _MESSAGE_TYPE_UNSET:
@@ -146,7 +147,7 @@ class Environment(ABC):
         self.max_seq_len = max_seq_len
         self.map_kwargs = map_kwargs
 
-        self.state_columns: list[str] = kwargs.pop("state_columns", None) or []
+        self.state_columns: list[str] = state_columns or []
         self.set_score_rollouts(score_rollouts)
         self.pass_threshold = pass_threshold
 

--- a/verifiers/envs/tool_env.py
+++ b/verifiers/envs/tool_env.py
@@ -42,6 +42,7 @@ class ToolMonitorRubric(vf.Rubric):
 
     async def total_tool_calls(self, completion: Messages) -> float:
         """Count the total number of tool calls."""
+        assert isinstance(completion, list)
         completion = normalize_messages(completion)
         total = 0
         for msg in completion:
@@ -57,6 +58,7 @@ class ToolMonitorRubric(vf.Rubric):
 
         async def tool_call_count_func(completion: Messages) -> int:
             """Count calls to {tool_name} tool."""
+            assert isinstance(completion, list)
             completion = normalize_messages(completion)
             count = 0
             for msg in completion:

--- a/verifiers/envs/tool_env.py
+++ b/verifiers/envs/tool_env.py
@@ -44,9 +44,10 @@ class ToolMonitorRubric(vf.Rubric):
         total = 0
         assert isinstance(completion, list)
         for msg in completion:
-            if msg.role != "assistant" or not hasattr(msg, "tool_calls"):
+            role = msg.get("role") if isinstance(msg, dict) else getattr(msg, "role", None)
+            if role != "assistant":
                 continue
-            tool_calls = msg.tool_calls
+            tool_calls = msg.get("tool_calls") if isinstance(msg, dict) else getattr(msg, "tool_calls", None)
             if isinstance(tool_calls, list):
                 total += len(tool_calls)
         return float(total)
@@ -59,13 +60,15 @@ class ToolMonitorRubric(vf.Rubric):
             count = 0
             assert isinstance(completion, list)
             for msg in completion:
-                if not isinstance(msg, AssistantMessage):
+                role = msg.get("role") if isinstance(msg, dict) else getattr(msg, "role", None)
+                if role != "assistant":
                     continue
-                tool_calls = msg.tool_calls
+                tool_calls = msg.get("tool_calls") if isinstance(msg, dict) else getattr(msg, "tool_calls", None)
                 if not isinstance(tool_calls, list):
                     continue
                 for tool_call in tool_calls:
-                    if isinstance(tool_call, ToolCall) and tool_call.name == tool_name:
+                    name = tool_call.get("name") if isinstance(tool_call, dict) else getattr(tool_call, "name", None)
+                    if name == tool_name:
                         count += 1
 
             return count

--- a/verifiers/envs/tool_env.py
+++ b/verifiers/envs/tool_env.py
@@ -2,7 +2,7 @@ import json
 from typing import Callable, cast
 
 import verifiers as vf
-from verifiers.types import AssistantMessage, Messages, ToolCall, ToolMessage
+from verifiers.types import Messages, ToolMessage
 from verifiers.utils.async_utils import maybe_await
 from verifiers.utils.tool_utils import (
     convert_func_to_tool_def,
@@ -44,10 +44,16 @@ class ToolMonitorRubric(vf.Rubric):
         total = 0
         assert isinstance(completion, list)
         for msg in completion:
-            role = msg.get("role") if isinstance(msg, dict) else getattr(msg, "role", None)
+            role = (
+                msg.get("role") if isinstance(msg, dict) else getattr(msg, "role", None)
+            )
             if role != "assistant":
                 continue
-            tool_calls = msg.get("tool_calls") if isinstance(msg, dict) else getattr(msg, "tool_calls", None)
+            tool_calls = (
+                msg.get("tool_calls")
+                if isinstance(msg, dict)
+                else getattr(msg, "tool_calls", None)
+            )
             if isinstance(tool_calls, list):
                 total += len(tool_calls)
         return float(total)
@@ -60,14 +66,26 @@ class ToolMonitorRubric(vf.Rubric):
             count = 0
             assert isinstance(completion, list)
             for msg in completion:
-                role = msg.get("role") if isinstance(msg, dict) else getattr(msg, "role", None)
+                role = (
+                    msg.get("role")
+                    if isinstance(msg, dict)
+                    else getattr(msg, "role", None)
+                )
                 if role != "assistant":
                     continue
-                tool_calls = msg.get("tool_calls") if isinstance(msg, dict) else getattr(msg, "tool_calls", None)
+                tool_calls = (
+                    msg.get("tool_calls")
+                    if isinstance(msg, dict)
+                    else getattr(msg, "tool_calls", None)
+                )
                 if not isinstance(tool_calls, list):
                     continue
                 for tool_call in tool_calls:
-                    name = tool_call.get("name") if isinstance(tool_call, dict) else getattr(tool_call, "name", None)
+                    name = (
+                        tool_call.get("name")
+                        if isinstance(tool_call, dict)
+                        else getattr(tool_call, "name", None)
+                    )
                     if name == tool_name:
                         count += 1
 

--- a/verifiers/envs/tool_env.py
+++ b/verifiers/envs/tool_env.py
@@ -2,8 +2,9 @@ import json
 from typing import Callable, cast
 
 import verifiers as vf
-from verifiers.types import Messages, ToolMessage
+from verifiers.types import AssistantMessage, Messages, ToolCall, ToolMessage
 from verifiers.utils.async_utils import maybe_await
+from verifiers.utils.message_utils import normalize_messages
 from verifiers.utils.tool_utils import (
     convert_func_to_tool_def,
     is_valid_tool_content_parts,
@@ -41,19 +42,12 @@ class ToolMonitorRubric(vf.Rubric):
 
     async def total_tool_calls(self, completion: Messages) -> float:
         """Count the total number of tool calls."""
+        completion = normalize_messages(completion)
         total = 0
-        assert isinstance(completion, list)
         for msg in completion:
-            role = (
-                msg.get("role") if isinstance(msg, dict) else getattr(msg, "role", None)
-            )
-            if role != "assistant":
+            if msg.role != "assistant" or not hasattr(msg, "tool_calls"):
                 continue
-            tool_calls = (
-                msg.get("tool_calls")
-                if isinstance(msg, dict)
-                else getattr(msg, "tool_calls", None)
-            )
+            tool_calls = msg.tool_calls
             if isinstance(tool_calls, list):
                 total += len(tool_calls)
         return float(total)
@@ -63,30 +57,16 @@ class ToolMonitorRubric(vf.Rubric):
 
         async def tool_call_count_func(completion: Messages) -> int:
             """Count calls to {tool_name} tool."""
+            completion = normalize_messages(completion)
             count = 0
-            assert isinstance(completion, list)
             for msg in completion:
-                role = (
-                    msg.get("role")
-                    if isinstance(msg, dict)
-                    else getattr(msg, "role", None)
-                )
-                if role != "assistant":
+                if not isinstance(msg, AssistantMessage):
                     continue
-                tool_calls = (
-                    msg.get("tool_calls")
-                    if isinstance(msg, dict)
-                    else getattr(msg, "tool_calls", None)
-                )
+                tool_calls = msg.tool_calls
                 if not isinstance(tool_calls, list):
                     continue
                 for tool_call in tool_calls:
-                    name = (
-                        tool_call.get("name")
-                        if isinstance(tool_call, dict)
-                        else getattr(tool_call, "name", None)
-                    )
-                    if name == tool_name:
+                    if isinstance(tool_call, ToolCall) and tool_call.name == tool_name:
                         count += 1
 
             return count

--- a/verifiers/envs/tool_env.py
+++ b/verifiers/envs/tool_env.py
@@ -42,9 +42,9 @@ class ToolMonitorRubric(vf.Rubric):
 
     async def total_tool_calls(self, completion: Messages) -> float:
         """Count the total number of tool calls."""
+        total = 0
         assert isinstance(completion, list)
         completion = normalize_messages(completion)
-        total = 0
         for msg in completion:
             if msg.role != "assistant" or not hasattr(msg, "tool_calls"):
                 continue
@@ -58,9 +58,9 @@ class ToolMonitorRubric(vf.Rubric):
 
         async def tool_call_count_func(completion: Messages) -> int:
             """Count calls to {tool_name} tool."""
+            count = 0
             assert isinstance(completion, list)
             completion = normalize_messages(completion)
-            count = 0
             for msg in completion:
                 if not isinstance(msg, AssistantMessage):
                     continue


### PR DESCRIPTION
Two fixes for deferred group scoring compatibility.

## Description

### 1. Allow environments to declare preserved state columns

When environments write custom fields into `vf.State` during `post_rollout` (e.g. `state["eval_score"]`), those fields are dropped during `state_to_output()` serialization unless explicitly requested via `state_columns`. Currently, the only way to preserve them is for the orchestrator to hardcode environment-specific field names in `REQUIRED_STATE_COLUMNS`, which couples the orchestrator to individual environment implementations.

This adds an optional `state_columns` parameter to `Environment.__init__` so environments can declare their own required state columns at construction time:

```python
return MyEnv(
    dataset=dataset,
    rubric=rubric,
    state_columns=["eval_score", "eval_error"],
)
```

The orchestrator (e.g. `prime-rl`) can then read `env.state_columns` and include them automatically, without needing to know the field names itself.

Defaults to `[]`.

### 2. Handle serialized messages in tool monitor rubrics

`ToolMonitorRubric` used attribute access (`msg.role`) which fails when completion messages are serialized to plain dicts during deferred group scoring. Added `normalize_messages()` to convert any serialized dicts back to `Message` objects before processing, using the existing `message_utils` helper.

Fixes:

<img width="589" height="202" alt="image" src="https://github.com/user-attachments/assets/39f080f6-ef80-4e9a-a7ad-d30d8e8864ab" />

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing

- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist

- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes

Companion PR: [PrimeIntellect-ai/prime-rl#2057](https://github.com/PrimeIntellect-ai/prime-rl/pull/2057)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, backwards-compatible additions: `state_columns` is optional and defaults to empty, and message normalization only broadens accepted input shapes for tool-monitor metrics.
> 
> **Overview**
> Adds an optional `state_columns` parameter to `Environment` construction and stores it on `env.state_columns`, so environments can declare which JSON-serializable `State` fields should be preserved into `RolloutOutput` without orchestrator hardcoding.
> 
> Fixes deferred/group scoring compatibility for `ToolMonitorRubric` by normalizing `completion` messages (e.g., serialized dicts) before counting tool calls. Documentation and API reference are updated to reflect both changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd016db0366ad4650a66350d850e149b593caa68. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->