### PR TITLE
Pin uv <0.11.0 to fix flash-attn resolution

### DIFF
--- a/.github/workflows/publish-envs.yml
+++ b/.github/workflows/publish-envs.yml
@@ -51,7 +51,7 @@ jobs:
           submodules: true
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"

--- a/.github/workflows/publish-verifiers-rl.yml
+++ b/.github/workflows/publish-verifiers-rl.yml
@@ -66,7 +66,7 @@ jobs:
 
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v7
 
       - name: Build verifiers-rl
         run: uv build packages/verifiers-rl

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -35,9 +35,7 @@ jobs:
         with:
           python-version: "3.13"
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
-        with:
-          version: "latest"
+        uses: astral-sh/setup-uv@v7
       - name: Install dependencies
         run: uv sync
       - name: Run ty

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -110,7 +110,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v7
 
       - name: Build sdist and wheel
         run: uv build
@@ -201,7 +201,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v7
 
       - name: Build sdist and wheel
         run: uv build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,9 +32,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
-        with:
-          version: "latest"
+        uses: astral-sh/setup-uv@v7
 
       - name: Install dependencies
         run: uv sync
@@ -66,9 +64,7 @@ jobs:
           dir_names_max_depth: 1
           separator: ","
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
-        with:
-          version: "latest"
+        uses: astral-sh/setup-uv@v7
       - name: Install dependencies
         run: uv sync
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,7 @@ rl = [
 
 [tool.uv]
 preview = true
+required-version = "<0.11.0"
 
 [tool.uv.extra-build-dependencies]
 flash-attn = [{ requirement = "torch", match-runtime = true }]


### PR DESCRIPTION
## Summary
- uv 0.11.0 fails to resolve `flash-attn` with `match-runtime=true` when `flash-attn` has no static metadata, even when the `rl` extra is not selected
- Previously worked on CI with uv 0.10.12; broke when `setup-uv@latest` picked up 0.11.0
- Pin `required-version = "<0.11.0"` in `pyproject.toml` until fixed upstream

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the dependency-management tool version used across CI/release pipelines; could affect builds/publishing if the pin or action behavior differs from previous uv versions.
> 
> **Overview**
> Pins `uv` to `<0.11.0` via `pyproject.toml` (`[tool.uv].required-version`) to avoid resolution issues with `flash-attn` extra build metadata.
> 
> Updates all GitHub Actions workflows that install `uv` to use `astral-sh/setup-uv@v7`, removing explicit `version: latest` configuration where present so CI uses a consistent, pinned-compatible installer across tests, style checks, and release/publish jobs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49c86d8a45457ecd19baf573663166cdfd8c2317. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->