### PR TITLE
fix: EnvGroup nested routing silently misroutes to envs[0]

### DIFF
--- a/docs/environments.md
+++ b/docs/environments.md
@@ -780,7 +780,9 @@ combined = vf.EnvGroup(
 )
 ```
 
-The group concatenates all sub-environment datasets, tagging each row with a `task` column that routes rollouts to the appropriate environment for generation and scoring. Metrics from all environments are tracked together. 
+The group concatenates all sub-environment datasets, tagging each row with a `task` column that routes rollouts to the appropriate environment for generation and scoring. Metrics from all environments are tracked together.
+
+Nested `EnvGroup`s are supported — when an `EnvGroup` is used as a sub-environment, the inner group's task names are preserved and routed correctly through the nesting chain. Requesting a task that doesn't exist in any sub-environment raises a `ValueError` with the list of available tasks.
 
 ## Performance
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -452,7 +452,7 @@ env_group = vf.EnvGroup(
 )
 ```
 
-Combines multiple environments for mixed-task training.
+Combines multiple environments for mixed-task training. Nested `EnvGroup`s are supported — inner task names are preserved for correct routing. Requesting an unknown task raises `ValueError`.
 
 ---
 

--- a/tests/test_env_group.py
+++ b/tests/test_env_group.py
@@ -651,3 +651,28 @@ class TestEnvGroup:
         # Routing goes to the correct intermediate group
         assert outer_group.get_env_for_task("a") == mid_group
         assert outer_group.get_env_for_task("b") == mid_group
+
+    def test_nested_env_group_outer_name_matches_inner_task(self, mock_client):
+        """Test that outer name matching an inner task name is not removed from env_map."""
+        env_math = SingleTurnEnv(
+            client=mock_client,
+            model="test-model",
+            dataset=Dataset.from_dict({"question": ["q1"], "answer": ["a1"]}),
+            rubric=Rubric(),
+        )
+
+        env_code = SingleTurnEnv(
+            client=mock_client,
+            model="test-model",
+            dataset=Dataset.from_dict({"question": ["q2"], "answer": ["a2"]}),
+            rubric=Rubric(),
+        )
+
+        inner_group = EnvGroup(envs=[env_math, env_code], env_names=["math", "code"])
+
+        # Outer name "math" intentionally matches an inner task name
+        outer_group = EnvGroup(envs=[inner_group], env_names=["math"])
+
+        # "math" should still be routable since it's a valid inner task
+        assert outer_group.get_env_for_task("math") == inner_group
+        assert outer_group.get_env_for_task("code") == inner_group

--- a/tests/test_env_group.py
+++ b/tests/test_env_group.py
@@ -584,3 +584,66 @@ class TestEnvGroup:
         assert outer_group.get_env_for_task("math") == inner_group
         assert outer_group.get_env_for_task("code") == inner_group
         assert outer_group.get_env_for_task("writing") == env_writing
+
+    def test_nested_env_group_eval_only(self, mock_client):
+        """Test nested EnvGroup with eval-only datasets registers inner task names."""
+        env_math = SingleTurnEnv(
+            client=mock_client,
+            model="test-model",
+            eval_dataset=Dataset.from_dict({"question": ["q1"], "answer": ["a1"]}),
+            rubric=Rubric(),
+        )
+
+        env_code = SingleTurnEnv(
+            client=mock_client,
+            model="test-model",
+            eval_dataset=Dataset.from_dict({"question": ["q2"], "answer": ["a2"]}),
+            rubric=Rubric(),
+        )
+
+        inner_group = EnvGroup(envs=[env_math, env_code], env_names=["math", "code"])
+
+        outer_group = EnvGroup(envs=[inner_group], env_names=["my_envs"])
+
+        # Inner task names should be registered even though there's no train dataset
+        assert outer_group.get_env_for_task("math") == inner_group
+        assert outer_group.get_env_for_task("code") == inner_group
+
+        # Eval dataset should preserve inner task names
+        eval_dataset = outer_group.get_eval_dataset()
+        assert eval_dataset is not None
+        tasks = eval_dataset["task"]
+        assert "math" in tasks
+        assert "code" in tasks
+
+    def test_deeply_nested_env_group(self, mock_client):
+        """Test 3+ levels of nesting routes to the correct intermediate EnvGroup."""
+        env_a = SingleTurnEnv(
+            client=mock_client,
+            model="test-model",
+            dataset=Dataset.from_dict({"question": ["q1"], "answer": ["a1"]}),
+            rubric=Rubric(),
+        )
+
+        env_b = SingleTurnEnv(
+            client=mock_client,
+            model="test-model",
+            dataset=Dataset.from_dict({"question": ["q2"], "answer": ["a2"]}),
+            rubric=Rubric(),
+        )
+
+        inner_group = EnvGroup(envs=[env_a, env_b], env_names=["a", "b"])
+        mid_group = EnvGroup(envs=[inner_group], env_names=["inner"])
+        outer_group = EnvGroup(envs=[mid_group], env_names=["mid"])
+
+        # Task names from the leaf level should propagate through all nesting levels
+        dataset = outer_group.get_dataset()
+        tasks = dataset["task"]
+        assert "a" in tasks
+        assert "b" in tasks
+        assert "inner" not in tasks
+        assert "mid" not in tasks
+
+        # Routing goes to the correct intermediate group
+        assert outer_group.get_env_for_task("a") == mid_group
+        assert outer_group.get_env_for_task("b") == mid_group

--- a/tests/test_env_group.py
+++ b/tests/test_env_group.py
@@ -353,8 +353,9 @@ class TestEnvGroup:
 
         assert env_group.get_env_for_task("math") == env1
         assert env_group.get_env_for_task("code") == env2
-        # Unknown task returns first environment as fallback
-        assert env_group.get_env_for_task("unknown") == env1
+        # Unknown task raises ValueError instead of silently falling back
+        with pytest.raises(ValueError, match="No environment found for task 'unknown'"):
+            env_group.get_env_for_task("unknown")
 
     @pytest.mark.asyncio
     async def test_env_group_generate(self, mock_client, make_input):
@@ -509,3 +510,77 @@ class TestEnvGroup:
         assert tasks_from_iteration[1] == "math"
         assert tasks_from_iteration[2] == "code"
         assert tasks_from_iteration[3] == "code"
+
+    def test_nested_env_group_preserves_inner_tasks(self, mock_client):
+        """Test that wrapping an EnvGroup inside another preserves inner task names."""
+        env_math = SingleTurnEnv(
+            client=mock_client,
+            model="test-model",
+            dataset=Dataset.from_dict({"question": ["q1"], "answer": ["a1"]}),
+            rubric=Rubric(),
+        )
+
+        env_code = SingleTurnEnv(
+            client=mock_client,
+            model="test-model",
+            dataset=Dataset.from_dict({"question": ["q2"], "answer": ["a2"]}),
+            rubric=Rubric(),
+        )
+
+        inner_group = EnvGroup(envs=[env_math, env_code], env_names=["math", "code"])
+
+        outer_group = EnvGroup(envs=[inner_group], env_names=["my_envs"])
+
+        # Inner task names should be preserved in the dataset
+        dataset = outer_group.get_dataset()
+        tasks = dataset["task"]
+        assert "math" in tasks
+        assert "code" in tasks
+        assert "my_envs" not in tasks
+
+        # Outer env_map should route inner task names to the inner group
+        assert outer_group.get_env_for_task("math") == inner_group
+        assert outer_group.get_env_for_task("code") == inner_group
+
+    def test_nested_env_group_with_flat_env(self, mock_client):
+        """Test EnvGroup with a mix of nested EnvGroup and flat environments."""
+        env_math = SingleTurnEnv(
+            client=mock_client,
+            model="test-model",
+            dataset=Dataset.from_dict({"question": ["q1"], "answer": ["a1"]}),
+            rubric=Rubric(),
+        )
+
+        env_code = SingleTurnEnv(
+            client=mock_client,
+            model="test-model",
+            dataset=Dataset.from_dict({"question": ["q2"], "answer": ["a2"]}),
+            rubric=Rubric(),
+        )
+
+        env_writing = SingleTurnEnv(
+            client=mock_client,
+            model="test-model",
+            dataset=Dataset.from_dict({"question": ["q3"], "answer": ["a3"]}),
+            rubric=Rubric(),
+        )
+
+        inner_group = EnvGroup(envs=[env_math, env_code], env_names=["math", "code"])
+
+        outer_group = EnvGroup(
+            envs=[inner_group, env_writing], env_names=["grouped", "writing"]
+        )
+
+        dataset = outer_group.get_dataset()
+        tasks = dataset["task"]
+
+        # Inner group tasks preserved, flat env gets its outer name
+        assert "math" in tasks
+        assert "code" in tasks
+        assert "writing" in tasks
+        assert "grouped" not in tasks
+
+        # Routing works for all tasks
+        assert outer_group.get_env_for_task("math") == inner_group
+        assert outer_group.get_env_for_task("code") == inner_group
+        assert outer_group.get_env_for_task("writing") == env_writing

--- a/tests/test_env_group.py
+++ b/tests/test_env_group.py
@@ -542,6 +542,10 @@ class TestEnvGroup:
         assert outer_group.get_env_for_task("math") == inner_group
         assert outer_group.get_env_for_task("code") == inner_group
 
+        # Stale outer name should be removed from env_map
+        with pytest.raises(ValueError, match="No environment found for task 'my_envs'"):
+            outer_group.get_env_for_task("my_envs")
+
     def test_nested_env_group_with_flat_env(self, mock_client):
         """Test EnvGroup with a mix of nested EnvGroup and flat environments."""
         env_math = SingleTurnEnv(

--- a/verifiers/envs/env_group.py
+++ b/verifiers/envs/env_group.py
@@ -175,11 +175,13 @@ class EnvGroup(vf.Environment):
 
         def _register_inner_tasks(env: EnvGroup, name: str, dataset: Dataset) -> None:
             """Register task names from a nested EnvGroup's dataset in the outer env_map."""
-            for inner_task in set(dataset["task"]):
+            inner_tasks = set(dataset["task"])
+            for inner_task in inner_tasks:
                 self.env_map[inner_task] = env
-            # Remove the stale outer name that was set in the initial env_map
-            # construction — it doesn't correspond to any real task in the dataset.
-            self.env_map.pop(name, None)
+            # Remove the stale outer name only if it isn't also a legitimate
+            # inner task name (e.g. outer name "math" matching inner task "math").
+            if name not in inner_tasks:
+                self.env_map.pop(name, None)
 
         for env, name in zip(self.envs, self.env_names):
             is_nested = isinstance(env, EnvGroup)

--- a/verifiers/envs/env_group.py
+++ b/verifiers/envs/env_group.py
@@ -174,23 +174,33 @@ class EnvGroup(vf.Environment):
             return add_task
 
         for env, name in zip(self.envs, self.env_names):
-            add_task = make_add_task_fn(name)
+            is_nested = isinstance(env, EnvGroup)
 
             # Build dataset if using DatasetBuilder, returns None if not available
             env_dataset = env.build_dataset()
             if env_dataset is not None:
-                # override task column to use env_name for routing
-                if "task" in env_dataset.column_names:
-                    env_dataset = env_dataset.remove_columns(["task"])
-                env_dataset = env_dataset.map(add_task, **map_kwargs)
+                if is_nested and "task" in env_dataset.column_names:
+                    # Preserve inner EnvGroup's task names for correct routing
+                    for inner_name in env.env_names:
+                        self.env_map[inner_name] = env
+                else:
+                    add_task = make_add_task_fn(name)
+                    if "task" in env_dataset.column_names:
+                        env_dataset = env_dataset.remove_columns(["task"])
+                    env_dataset = env_dataset.map(add_task, **map_kwargs)
                 datasets.append(env_dataset)
+
             # Build eval_dataset if using DatasetBuilder, returns None if not available
             env_eval_dataset = env.build_eval_dataset()
             if env_eval_dataset is not None:
-                # override task column to use env_name for routing
-                if "task" in env_eval_dataset.column_names:
-                    env_eval_dataset = env_eval_dataset.remove_columns(["task"])
-                env_eval_dataset = env_eval_dataset.map(add_task, **map_kwargs)
+                if is_nested and "task" in env_eval_dataset.column_names:
+                    # Inner task names already registered above
+                    pass
+                else:
+                    add_task = make_add_task_fn(name)
+                    if "task" in env_eval_dataset.column_names:
+                        env_eval_dataset = env_eval_dataset.remove_columns(["task"])
+                    env_eval_dataset = env_eval_dataset.map(add_task, **map_kwargs)
                 eval_datasets.append(env_eval_dataset)
         dataset = concatenate_datasets(datasets) if datasets else None
         eval_dataset = concatenate_datasets(eval_datasets) if eval_datasets else None
@@ -320,7 +330,13 @@ class EnvGroup(vf.Environment):
         return await env.rollout(input, client, model, sampling_args)
 
     def get_env_for_task(self, task: str) -> vf.Environment:
-        return self.env_map.get(task, self.envs[0])
+        env = self.env_map.get(task)
+        if env is None:
+            available = sorted(self.env_map.keys())
+            raise ValueError(
+                f"No environment found for task '{task}'. Available tasks: {available}"
+            )
+        return env
 
     def set_max_seq_len(self, max_seq_len: int | None) -> None:
         """Set the max_seq_len value for this environment group and all sub-environments."""

--- a/verifiers/envs/env_group.py
+++ b/verifiers/envs/env_group.py
@@ -173,6 +173,11 @@ class EnvGroup(vf.Environment):
 
             return add_task
 
+        def _register_inner_tasks(env: EnvGroup, dataset: Dataset) -> None:
+            """Register task names from a nested EnvGroup's dataset in the outer env_map."""
+            for inner_task in set(dataset["task"]):
+                self.env_map[inner_task] = env
+
         for env, name in zip(self.envs, self.env_names):
             is_nested = isinstance(env, EnvGroup)
 
@@ -180,9 +185,10 @@ class EnvGroup(vf.Environment):
             env_dataset = env.build_dataset()
             if env_dataset is not None:
                 if is_nested and "task" in env_dataset.column_names:
-                    # Preserve inner EnvGroup's task names for correct routing
-                    for inner_name in env.env_names:
-                        self.env_map[inner_name] = env
+                    # Preserve inner EnvGroup's task names for correct routing.
+                    # Uses dataset["task"] values (not env.env_names) to handle
+                    # arbitrary nesting depth correctly.
+                    _register_inner_tasks(env, env_dataset)
                 else:
                     add_task = make_add_task_fn(name)
                     if "task" in env_dataset.column_names:
@@ -194,8 +200,9 @@ class EnvGroup(vf.Environment):
             env_eval_dataset = env.build_eval_dataset()
             if env_eval_dataset is not None:
                 if is_nested and "task" in env_eval_dataset.column_names:
-                    # Inner task names already registered above
-                    pass
+                    # Register inner task names from eval dataset too, in case
+                    # the nested EnvGroup has eval-only datasets.
+                    _register_inner_tasks(env, env_eval_dataset)
                 else:
                     add_task = make_add_task_fn(name)
                     if "task" in env_eval_dataset.column_names:

--- a/verifiers/envs/env_group.py
+++ b/verifiers/envs/env_group.py
@@ -173,10 +173,13 @@ class EnvGroup(vf.Environment):
 
             return add_task
 
-        def _register_inner_tasks(env: EnvGroup, dataset: Dataset) -> None:
+        def _register_inner_tasks(env: EnvGroup, name: str, dataset: Dataset) -> None:
             """Register task names from a nested EnvGroup's dataset in the outer env_map."""
             for inner_task in set(dataset["task"]):
                 self.env_map[inner_task] = env
+            # Remove the stale outer name that was set in the initial env_map
+            # construction — it doesn't correspond to any real task in the dataset.
+            self.env_map.pop(name, None)
 
         for env, name in zip(self.envs, self.env_names):
             is_nested = isinstance(env, EnvGroup)
@@ -188,7 +191,7 @@ class EnvGroup(vf.Environment):
                     # Preserve inner EnvGroup's task names for correct routing.
                     # Uses dataset["task"] values (not env.env_names) to handle
                     # arbitrary nesting depth correctly.
-                    _register_inner_tasks(env, env_dataset)
+                    _register_inner_tasks(env, name, env_dataset)
                 else:
                     add_task = make_add_task_fn(name)
                     if "task" in env_dataset.column_names:
@@ -202,7 +205,7 @@ class EnvGroup(vf.Environment):
                 if is_nested and "task" in env_eval_dataset.column_names:
                     # Register inner task names from eval dataset too, in case
                     # the nested EnvGroup has eval-only datasets.
-                    _register_inner_tasks(env, env_eval_dataset)
+                    _register_inner_tasks(env, name, env_eval_dataset)
                 else:
                     add_task = make_add_task_fn(name)
                     if "task" in env_eval_dataset.column_names:


### PR DESCRIPTION
## Summary

Fixes #1008 — when an `EnvGroup` is wrapped inside another `EnvGroup` (as prime-rl does), the outer group overwrites inner task names, causing:
- All rollouts silently routed to `envs[0]` via `get_env_for_task` fallback
- Scoring returns `reward=0.0` for all unrecognized task names

### Changes
- **`get_env_for_task`**: Raises `ValueError` with available task names instead of silently falling back to `envs[0]`
- **`__init__` dataset loop**: When a sub-env is an `EnvGroup`, preserves its inner task names in the dataset and registers them in `env_map` for correct routing
- **Tests**: Updated existing fallback test, added 2 new tests for nested `EnvGroup` task preservation and mixed nested/flat routing

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Test plan
- [x] All 797 existing tests pass
- [x] `test_get_env_for_task` updated: unknown task now raises `ValueError`
- [x] `test_nested_env_group_preserves_inner_tasks`: inner task names preserved in outer dataset and env_map
- [x] `test_nested_env_group_with_flat_env`: mixed nested EnvGroup + flat env routing works correctly
- [x] `ruff check` and `ruff format` pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `EnvGroup` routing semantics by removing the silent fallback to `envs[0]` and raising a `ValueError` for unknown tasks, which could break callers relying on the previous behavior. Nested task registration touches dataset construction and `env_map` wiring, so mis-registration could affect rollout routing/scoring across tasks.
> 
> **Overview**
> Fixes nested `EnvGroup` task routing so inner `task` labels are preserved through dataset concatenation and registered in the outer `env_map`, preventing misrouting when groups are wrapped inside other groups.
> 
> `get_env_for_task` now raises a `ValueError` listing available tasks instead of silently falling back to `envs[0]`; tests and docs are updated and expanded to cover unknown-task errors, nested groups (including eval-only and deep nesting), and mixed nested/flat configurations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 851174a086f35ece6225b83119eba9af468e547c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->