### PR TITLE
fix: add default writer_batch_size to prevent pyarrow offset overflow

### DIFF
--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -101,6 +101,19 @@ def relative_reward(completions: list, answers: list, **kwargs) -> list[float]:
     return [s / max_score for s in scores]
 ```
 
+## Datasets
+
+### I'm getting a pyarrow `ArrowInvalid: offset overflow` error with large datasets
+
+This happens when dataset rows contain very large strings (e.g., code datasets like DeepCoder's `lcbv5`) that exceed pyarrow's 2 GB per-batch limit during `.map()` calls. Verifiers defaults `writer_batch_size` to `200` in `map_kwargs` to prevent this. If you still see the error, lower the value:
+
+```python
+env = MyEnv(
+    dataset=dataset,
+    map_kwargs={"writer_batch_size": 16},
+)
+```
+
 ## Training
 
 ### How do I use a local vLLM server?

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -144,7 +144,11 @@ class Environment(ABC):
         self.env_id = env_id or ""
         self.env_args = env_args or {}
         self.max_seq_len = max_seq_len
-        self.map_kwargs = map_kwargs
+        # Copy to avoid mutating the shared default and set a default
+        # writer_batch_size to prevent pyarrow offset overflow for datasets
+        # with large strings (e.g. serialized test cases in coding datasets).
+        self.map_kwargs = {**map_kwargs}
+        self.map_kwargs.setdefault("writer_batch_size", 200)
 
         self.set_score_rollouts(score_rollouts)
         self.pass_threshold = pass_threshold

--- a/verifiers/utils/data_utils.py
+++ b/verifiers/utils/data_utils.py
@@ -33,6 +33,10 @@ def format_dataset(
     """
     Create `example_id` and `prompt` columns if not present.
     """
+    # Set a default writer_batch_size to prevent pyarrow offset overflow
+    # for datasets with large strings (e.g. serialized test cases).
+    map_kwargs = {**map_kwargs}
+    map_kwargs.setdefault("writer_batch_size", 200)
     # if "id" column is present and not int, rename it to "src_id"
     if "example_id" in dataset.column_names and not isinstance(
         dataset["example_id"][0], int
@@ -362,6 +366,7 @@ def load_example_dataset(
         preprocess_fn,
         num_proc=10,
         remove_columns=dataset.column_names,
+        writer_batch_size=200,
     )
     if "temp_answer" in dataset.column_names:
         dataset = dataset.rename_column("temp_answer", "answer")


### PR DESCRIPTION
## Summary

Closes #230.

- Datasets with large strings (e.g. serialized test cases in coding datasets like DeepCoder's `lcbv5` subset) cause **pyarrow offset overflow** during `dataset.map()` calls because the default batch size produces Arrow arrays exceeding the 2 GB limit.
- Sets `writer_batch_size=200` as a default in `Environment.__init__` (propagated to all internal `.map()` calls via `map_kwargs`) and in the standalone `format_dataset` / `load_example_dataset` utilities.
- Users can still override `writer_batch_size` by passing it explicitly in `map_kwargs`.

## Changes

- **`verifiers/envs/environment.py`** -- copy `map_kwargs` to avoid mutating the shared mutable default, then `setdefault("writer_batch_size", 200)`.
- **`verifiers/utils/data_utils.py`** -- same default in `format_dataset()`, and explicit `writer_batch_size=200` in `load_example_dataset()`'s `.map()` call.

## Test plan

- [x] Existing tests pass (`uv run pytest tests/test_env_group.py tests/test_message_utils_multimodal.py`)
- [x] `uv run ruff check` and `uv run ruff format` clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default HuggingFace `Dataset.map()` batching across environment dataset formatting and example dataset utilities, which could affect performance/memory and any callers relying on previous implicit defaults.
> 
> **Overview**
> Prevents pyarrow `ArrowInvalid: offset overflow` on datasets with very large string fields by defaulting HuggingFace `.map()` `writer_batch_size` to `200`.
> 
> `Environment` now copies `map_kwargs` (avoiding mutation of the default dict) and applies the default via `setdefault`, while `format_dataset()` and `load_example_dataset()` apply the same default (including an explicit `writer_batch_size=200` on the example preprocessing `.map()`). Documentation adds an FAQ explaining the error and how to override `writer_batch_size` when needed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e08dc65097288c5f00dc5fa39775c8ac6206008f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->