### PR TITLE
fix: catch Exception instead of BaseException in MathRubric.verify_response

### DIFF
--- a/verifiers/rubrics/math_rubric.py
+++ b/verifiers/rubrics/math_rubric.py
@@ -43,7 +43,7 @@ def verify_response(
         is_correct = verify(parsed_answer, parsed_response, timeout_seconds=None)
         elapsed = time.perf_counter() - start
         return float(is_correct), elapsed
-    except BaseException:
+    except Exception:
         elapsed = time.perf_counter() - start
         return 0.0, elapsed
 


### PR DESCRIPTION
## Problem

`verify_response()` in `verifiers/rubrics/math_rubric.py` (line 46) catches `BaseException`, which intercepts `KeyboardInterrupt`, `SystemExit`, and `GeneratorExit` in addition to regular exceptions. This makes worker processes that are running math verification effectively unkillable via `Ctrl+C` or `SIGTERM` — the signal is silently swallowed and the function returns `0.0` as if verification simply failed.

## Fix

Replace `except BaseException` with `except Exception`. This still catches all regular exceptions (parsing errors, timeouts, value errors, etc.) but allows the three critical `BaseException` subclasses to propagate normally so processes can be interrupted and terminated as expected.

## Testing

Existing math rubric tests continue to pass (`pytest tests/ -k "math"`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line change to exception handling that only affects how interruptions/termination signals propagate out of math verification workers.
> 
> **Overview**
> Stops `verifiers/rubrics/math_rubric.py::verify_response` from catching `BaseException` and instead catches only `Exception`, so `KeyboardInterrupt`/`SystemExit`/`GeneratorExit` can propagate rather than being silently converted into a failed verification score.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 625394faafa56d8bd41a9cee96d2e14d2792719a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->