### PR TITLE
fix: replace mutable default arguments with None defaults

### DIFF
--- a/verifiers/clients/openai_chat_completions_token_client.py
+++ b/verifiers/clients/openai_chat_completions_token_client.py
@@ -270,10 +270,11 @@ class OpenAIChatCompletionsTokenClient(OpenAIChatCompletionsClient):
         messages: str | OpenAIChatMessages,
         tools: list[OpenAITool] | None,
         model: str,
-        extra_kwargs: dict = {},
+        extra_kwargs: dict | None = None,
         **kwargs,
     ) -> list[int]:
         """Tokenize messages using the vLLM /tokenize API."""
+        extra_kwargs = extra_kwargs or {}
         if isinstance(messages, str):
             body = dict(
                 model=model,

--- a/verifiers/envs/env_group.py
+++ b/verifiers/envs/env_group.py
@@ -134,7 +134,7 @@ class EnvGroup(vf.Environment):
         self,
         envs: list[vf.Environment],
         env_names: list[str] | None = None,
-        map_kwargs: dict = {},
+        map_kwargs: dict | None = None,
         **kwargs,
     ):
         """
@@ -148,6 +148,7 @@ class EnvGroup(vf.Environment):
         """
         from datasets import concatenate_datasets
 
+        map_kwargs = map_kwargs or {}
         if not envs:
             raise ValueError("EnvGroup requires at least one environment")
 
@@ -219,11 +220,12 @@ class EnvGroup(vf.Environment):
         few_shot: Messages | None = None,
         question_key: str = "question",
         answer_key: str = "answer",
-        map_kwargs: dict = {},
+        map_kwargs: dict | None = None,
     ) -> Dataset:
         """
         Ensure unique example_ids and mapped tasks across concatenated datasets.
         """
+        map_kwargs = map_kwargs or {}
         # use parent's prompt handling
         dataset = self._ensure_prompt(
             dataset, system_prompt, few_shot, question_key, answer_key, map_kwargs
@@ -248,11 +250,12 @@ class EnvGroup(vf.Environment):
         return dataset
 
     def _format_completion_dataset(
-        self, dataset: Dataset, map_kwargs: dict = {}
+        self, dataset: Dataset, map_kwargs: dict | None = None
     ) -> Dataset:
         """
         Ensure unique example_ids and mapped tasks across concatenated datasets.
         """
+        map_kwargs = map_kwargs or {}
         # ensure unique example_ids across concatenated datasets
         if "example_id" in dataset.column_names:
             dataset = dataset.remove_columns(["example_id"])

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -108,7 +108,7 @@ class Environment(ABC):
         max_workers: int = 512,
         env_id: str | None = None,
         env_args: dict | None = None,
-        map_kwargs: dict = {},
+        map_kwargs: dict | None = None,
         max_seq_len: int | None = None,
         score_rollouts: bool = True,
         pass_threshold: float = 0.5,
@@ -144,7 +144,7 @@ class Environment(ABC):
         self.env_id = env_id or ""
         self.env_args = env_args or {}
         self.max_seq_len = max_seq_len
-        self.map_kwargs = map_kwargs
+        self.map_kwargs = map_kwargs or {}
 
         self.set_score_rollouts(score_rollouts)
         self.pass_threshold = pass_threshold
@@ -283,9 +283,10 @@ class Environment(ABC):
         few_shot: Messages | None = None,
         question_key: str = "question",
         answer_key: str = "answer",
-        map_kwargs: dict = {},
+        map_kwargs: dict | None = None,
     ) -> Dataset:
         """Ensure prompt column exists."""
+        map_kwargs = map_kwargs or {}
         if "prompt" not in dataset.column_names:
 
             def format_prompt_fn(prompt_str: str) -> Messages:
@@ -343,8 +344,9 @@ class Environment(ABC):
                 )
         return dataset
 
-    def _ensure_task(self, dataset: Dataset, map_kwargs: dict = {}) -> Dataset:
+    def _ensure_task(self, dataset: Dataset, map_kwargs: dict | None = None) -> Dataset:
         """Ensure task column exists, set to env_id."""
+        map_kwargs = map_kwargs or {}
         if "task" not in dataset.column_names:
             task_value = self.env_id or "default"
 
@@ -362,7 +364,7 @@ class Environment(ABC):
         few_shot: Messages | None = None,
         question_key: str = "question",
         answer_key: str = "answer",
-        map_kwargs: dict = {},
+        map_kwargs: dict | None = None,
     ) -> Dataset:
         """
         Format dataset by creating example_id and prompt columns, and setting task column.
@@ -375,7 +377,7 @@ class Environment(ABC):
         return dataset
 
     def _format_completion_dataset(
-        self, dataset: Dataset, map_kwargs: dict = {}
+        self, dataset: Dataset, map_kwargs: dict | None = None
     ) -> Dataset:
         """
         Format dataset by creating example_id and prompt columns, and setting task column.

--- a/verifiers/envs/stateful_tool_env.py
+++ b/verifiers/envs/stateful_tool_env.py
@@ -66,7 +66,7 @@ class StatefulToolEnv(vf.ToolEnv):
         self.skipped_args: dict[str, list[str]] = {}
         self.max_turns: int = max_turns
 
-    def add_tool(self, tool: Callable, args_to_skip: list[str] = []):
+    def add_tool(self, tool: Callable, args_to_skip: list[str] | None = None):
         """Add a tool, optionally hiding arguments from the agent's view.
 
         Skipped args are removed from the schema shown to the agent but can be
@@ -75,6 +75,7 @@ class StatefulToolEnv(vf.ToolEnv):
 
         Assumes all non-skipped args use standard JSON types (no remaining $ref/$defs).
         """
+        args_to_skip = args_to_skip or []
         self.tools.append(tool)
         tool_def = convert_func_to_tool_def(filter_signature(tool, args_to_skip))
         params = tool_def.parameters

--- a/verifiers/utils/data_utils.py
+++ b/verifiers/utils/data_utils.py
@@ -28,11 +28,12 @@ def format_dataset(
     few_shot: Messages | None = None,
     question_key: str = "question",
     answer_key: str = "answer",
-    map_kwargs: dict = {},
+    map_kwargs: dict | None = None,
 ) -> Dataset:
     """
     Create `example_id` and `prompt` columns if not present.
     """
+    map_kwargs = map_kwargs or {}
     # if "id" column is present and not int, rename it to "src_id"
     if "example_id" in dataset.column_names and not isinstance(
         dataset["example_id"][0], int


### PR DESCRIPTION
## Summary

Replace mutable default arguments (`dict = {}`, `list = []`) with `None` defaults in core library files. This is a well-known Python bug where mutable defaults are shared across all calls to a function — if the object is stored as an instance attribute or mutated, it silently corrupts state across unrelated callers.

### Changed functions

- **`Environment.__init__`**: `map_kwargs` is stored as `self.map_kwargs`, meaning all instances using the default share the same dict
- **`Environment._ensure_prompt`, `_ensure_task`, `_format_dataset`, `_format_completion_dataset`**: `map_kwargs` spread via `**` — safe today but fragile if any caller later stores or mutates it
- **`EnvGroup.__init__`, `_format_dataset`, `_format_completion_dataset`**: same pattern as Environment
- **`StatefulToolEnv.add_tool`**: `args_to_skip` is stored in `self.skipped_args[tool_name]` — all tools added without explicit `args_to_skip` share the same list
- **`format_dataset`** in `data_utils.py`: `map_kwargs` spread via `**`
- **`OpenAIChatCompletionsTokenClient.tokenize`**: `extra_kwargs` spread via `**`

### Pattern applied

```python
# Before
def foo(param: dict = {}):
    ...

# After  
def foo(param: dict | None = None):
    param = param or {}
    ...
```

## Test plan

- [x] `ruff check` passes on all changed files
- [x] `ruff format` reports no changes needed
- [x] Full test suite passes: `pytest tests/ --ignore=tests/test_envs --ignore=tests/test_envs.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, behavior-preserving change that prevents shared mutable defaults from leaking state across calls/instances. Minor risk that callers relied on mutating the passed-in default object (now always a fresh dict/list when omitted).
> 
> **Overview**
> Fixes several functions that previously used mutable default arguments (e.g. `dict = {}` / `list = []`) by switching them to `None` defaults and initializing locally.
> 
> This affects dataset mapping kwargs plumbing (`map_kwargs`) across `Environment`, `EnvGroup`, and `format_dataset`, tool registration in `StatefulToolEnv.add_tool` (`args_to_skip`), and extra request parameters in `OpenAIChatCompletionsTokenClient.tokenize` (`extra_kwargs`), preventing accidental state sharing between calls or instances.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e9b80548b691350c912e9bfd6c2fa2b0f2a6d09b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->