### PR TITLE
feat: dataset builder pattern for lazy loading in all environments

### DIFF
--- a/environments/alphabet_sort/alphabet_sort.py
+++ b/environments/alphabet_sort/alphabet_sort.py
@@ -346,5 +346,4 @@ def load_environment(
         dataset_split=dataset_split,
         seed=seed,
     )
-    dataset = dataset_builder()
-    return SortingEnv(dataset=dataset, rubric=rubric, max_turns=max_turns)
+    return SortingEnv(dataset=dataset_builder, rubric=rubric, max_turns=max_turns)

--- a/environments/continuation_quality/continuation_quality.py
+++ b/environments/continuation_quality/continuation_quality.py
@@ -30,16 +30,17 @@ def load_environment(
     judge_base_url: str = "https://api.openai.com/v1",
     judge_api_key_var: str = "OPENAI_API_KEY",
 ) -> vf.Environment:
-    vf.ensure_keys([judge_api_key_var])
 
-    dataset = load_dataset(dataset_name, split=dataset_split)
-    # only accept examples with >~100 words or so
-    dataset = dataset.filter(lambda x: x[dataset_key].count(" ") > 100)
-    dataset = dataset.map(lambda x: make_cut(x[dataset_key]))
-    dataset = dataset.shuffle(seed=777)
+    def build_dataset():
+        dataset = load_dataset(dataset_name, split=dataset_split)
+        # only accept examples with >~100 words or so
+        dataset = dataset.filter(lambda x: x[dataset_key].count(" ") > 100)
+        dataset = dataset.map(lambda x: make_cut(x[dataset_key]))
+        dataset = dataset.shuffle(seed=777)
+        return dataset
 
     judge_client = AsyncOpenAI(
-        base_url=judge_base_url, api_key=os.environ[judge_api_key_var]
+        base_url=judge_base_url, api_key=os.getenv(judge_api_key_var, "")
     )
     judge_prompt = """Evaluate this base model continuation from a prefix, compared to the true continuation from Wikipedia.
 
@@ -91,7 +92,7 @@ Think aloud in a <scratchpad> for a few lines, then respond with the letter grad
 
     return vf.SingleTurnEnv(
         message_type="completion",
-        dataset=dataset,
+        dataset=build_dataset,
         parser=vf.Parser(),
         rubric=rubric,
         sampling_args={

--- a/environments/doublecheck/doublecheck.py
+++ b/environments/doublecheck/doublecheck.py
@@ -35,10 +35,12 @@ def load_environment(
     dataset_split: str = "train",
     num_train_examples: int = -1,
 ):
-    dataset = load_example_dataset(dataset_name, dataset_split, n=num_train_examples)
+    def build_dataset():
+        return load_example_dataset(dataset_name, dataset_split, n=num_train_examples)
+
     rubric = MathRubric()
     vf_env = DoubleCheckEnv(
-        dataset=dataset,
+        dataset=build_dataset,
         system_prompt=SIMPLE_PROMPT,
         few_shot=[],
         parser=rubric.parser,

--- a/environments/gsm8k/gsm8k.py
+++ b/environments/gsm8k/gsm8k.py
@@ -10,17 +10,22 @@ def load_environment(
     num_train_examples=-1,
     num_eval_examples=-1,
 ):
-    dataset = load_example_dataset("gsm8k", split="train")
-    if num_train_examples != -1:
-        dataset = dataset.select(range(num_train_examples))
-    eval_dataset = load_example_dataset("gsm8k", split="test")
-    if num_eval_examples != -1:
-        eval_dataset = eval_dataset.select(range(num_eval_examples))
+    def build_dataset():
+        dataset = load_example_dataset("gsm8k", split="train")
+        if num_train_examples != -1:
+            dataset = dataset.select(range(num_train_examples))
+        return dataset
+
+    def build_eval_dataset():
+        eval_dataset = load_example_dataset("gsm8k", split="test")
+        if num_eval_examples != -1:
+            eval_dataset = eval_dataset.select(range(num_eval_examples))
+        return eval_dataset
 
     rubric = vf.MathRubric()
     vf_env = vf.SingleTurnEnv(
-        dataset=dataset,
-        eval_dataset=eval_dataset,
+        dataset=build_dataset,
+        eval_dataset=build_eval_dataset,
         system_prompt=system_prompt,
         parser=rubric.parser,
         rubric=rubric,

--- a/environments/math_group/math_group.py
+++ b/environments/math_group/math_group.py
@@ -19,9 +19,12 @@ def load_environment(**kwargs):
         funcs=[gsm8k_answer_reward_func, parser.get_format_reward_func()],
         weights=[1.0, 0.0],
     )
-    dataset1 = load_example_dataset("gsm8k", split="train").select(range(1000))
+
+    def build_gsm8k_dataset():
+        return load_example_dataset("gsm8k", split="train").select(range(1000))
+
     env1 = vf.SingleTurnEnv(
-        dataset=dataset1,
+        dataset=build_gsm8k_dataset,
         system_prompt=BOXED_SYSTEM_PROMPT,
         parser=parser,
         rubric=rubric1,
@@ -37,9 +40,12 @@ def load_environment(**kwargs):
         funcs=[math_answer_reward_func, parser.get_format_reward_func()],
         weights=[1.0, 0.2],
     )
-    dataset2 = load_example_dataset("math", split="train").select(range(1000))
+
+    def build_math_dataset():
+        return load_example_dataset("math", split="train").select(range(1000))
+
     env2 = vf.SingleTurnEnv(
-        dataset=dataset2,
+        dataset=build_math_dataset,
         system_prompt=BOXED_SYSTEM_PROMPT,
         parser=parser,
         rubric=rubric2,

--- a/environments/math_python/math_python.py
+++ b/environments/math_python/math_python.py
@@ -18,7 +18,9 @@ def load_environment(
     sandbox_client_max_workers: int = 50,
     **kwargs,
 ):
-    dataset = load_example_dataset(dataset_name, dataset_split, n=num_train_examples)
+    def build_dataset():
+        return load_example_dataset(dataset_name, dataset_split, n=num_train_examples)
+
     pip_install_prompt = (
         f"In addition to the Python standard library, you have access to: {pip_install_packages}."
         if pip_install_packages.strip()
@@ -32,7 +34,7 @@ def load_environment(
     parser = vf.Parser(extract_fn=extract_boxed_answer)
     math_rubric = vf.MathRubric(parser=parser)
     return vf.PythonEnv(
-        dataset=dataset,
+        dataset=build_dataset,
         system_prompt=system_prompt,
         parser=parser,
         rubric=math_rubric,

--- a/environments/mcp_search_env/mcp_search_env.py
+++ b/environments/mcp_search_env/mcp_search_env.py
@@ -11,13 +11,12 @@ def load_environment(
 ) -> vf.Environment:
     """Load an MCPEnv environment with fetch server for testing."""
     if mcp_servers is None:
-        vf.ensure_keys(["EXA_API_KEY"])
         mcp_servers = [
             {
                 "name": "exa",
                 "command": "npx",
                 "args": ["-y", "exa-mcp-server"],
-                "env": {"EXA_API_KEY": os.environ["EXA_API_KEY"]},
+                "env": {"EXA_API_KEY": os.getenv("EXA_API_KEY", "")},
                 "description": "Exa MCP server",
             },
             {

--- a/environments/mmmu/mmmu.py
+++ b/environments/mmmu/mmmu.py
@@ -92,19 +92,20 @@ def load_environment(
     else:
         tasks.append(subset)
 
-    task_datasets = []
-    for task in tasks:
-        # load MMMU dataset
-        task_dataset = load_dataset("MMMU/MMMU", task, split=split).map(
-            lambda x: {"prompt": format_prompt(x), "answer": x["answer"]}
-        )
-        assert isinstance(task_dataset, Dataset)
-        cols = task_dataset.column_names
-        cols_to_remove = [col for col in cols if col not in ["prompt", "answer"]]
-        task_dataset = task_dataset.remove_columns(cols_to_remove)
-        task_datasets.append(task_dataset)
+    def build_dataset():
+        task_datasets = []
+        for task in tasks:
+            # load MMMU dataset
+            task_dataset = load_dataset("MMMU/MMMU", task, split=split).map(
+                lambda x: {"prompt": format_prompt(x), "answer": x["answer"]}
+            )
+            assert isinstance(task_dataset, Dataset)
+            cols = task_dataset.column_names
+            cols_to_remove = [col for col in cols if col not in ["prompt", "answer"]]
+            task_dataset = task_dataset.remove_columns(cols_to_remove)
+            task_datasets.append(task_dataset)
 
-    dataset = concatenate_datasets(task_datasets)
+        return concatenate_datasets(task_datasets)
 
     parser = vf.Parser(extract_fn=extract_boxed_answer)
 
@@ -115,7 +116,7 @@ def load_environment(
     rubric = vf.Rubric(funcs=[correct_answer], parser=parser)
 
     vf_env = vf.SingleTurnEnv(
-        dataset=dataset,
+        dataset=build_dataset,
         parser=parser,
         rubric=rubric,
     )

--- a/environments/reverse_text/reverse_text.py
+++ b/environments/reverse_text/reverse_text.py
@@ -9,15 +9,17 @@ def load_environment(
     system_prompt: str
     | None = "Reverse the text character-by-character. Put your answer in <reversed_text> tags.",
 ) -> vf.Environment:
-    train_dataset = load_dataset(dataset_name, split=dataset_split).map(
-        lambda x: {
-            "question": x["prompt"],
-            "answer": x["prompt"][::-1],
-            "info": {},
-            "task": "reverse-text",
-        }
-    )
-    train_dataset = train_dataset.remove_columns(["prompt"])
+    def build_dataset():
+        train_dataset = load_dataset(dataset_name, split=dataset_split).map(
+            lambda x: {
+                "question": x["prompt"],
+                "answer": x["prompt"][::-1],
+                "info": {},
+                "task": "reverse-text",
+            }
+        )
+        train_dataset = train_dataset.remove_columns(["prompt"])
+        return train_dataset
 
     parser = vf.XMLParser(["reversed_text"], answer_field="reversed_text")
 
@@ -45,7 +47,7 @@ def load_environment(
     )
 
     vf_env = vf.SingleTurnEnv(
-        dataset=train_dataset,
+        dataset=build_dataset,
         system_prompt=system_prompt,
         parser=parser,
         rubric=rubric,

--- a/environments/self_reward/self_reward.py
+++ b/environments/self_reward/self_reward.py
@@ -14,7 +14,9 @@ def load_environment(
     base_url: str = "http://0.0.0.0:8000/v1",
     api_key_var: str = "JUDGE_API_KEY",
 ):
-    dataset = load_dataset(dataset_name, dataset_subset, split=dataset_split)
+    def build_dataset():
+        return load_dataset(dataset_name, dataset_subset, split=dataset_split)
+
     judge_prompt = "Q: {question}\nA: {answer}\nGiven: {response}\nRespond with a score between 0.0 and 1.0."
     judge_client = AsyncOpenAI(
         base_url=base_url, api_key=os.getenv(api_key_var, "EMPTY")
@@ -25,7 +27,7 @@ def load_environment(
         judge_prompt=judge_prompt,
     )
     vf_env = vf.SingleTurnEnv(
-        dataset=dataset,
+        dataset=build_dataset,
         system_prompt="You are a helpful assistant.",
         rubric=rubric,
     )

--- a/environments/sentence_repeater/sentence_repeater.py
+++ b/environments/sentence_repeater/sentence_repeater.py
@@ -87,10 +87,13 @@ class SentenceRepeaterEnv(vf.MultiTurnEnv):
 
 
 def load_environment(**kwargs) -> vf.Environment:
-    dataset: Dataset = load_dataset("agentlans/wikipedia-paragraphs", split="train")  # type: ignore
-    dataset = dataset.map(lambda x: {"sentences": get_sentences(x["text"])})
-    dataset = dataset.filter(lambda x: len(x["sentences"]) == 5)
-    dataset = dataset.map(get_sentence_questions)
+    def build_dataset():
+        dataset: Dataset = load_dataset("agentlans/wikipedia-paragraphs", split="train")  # type: ignore
+        dataset = dataset.map(lambda x: {"sentences": get_sentences(x["text"])})
+        dataset = dataset.filter(lambda x: len(x["sentences"]) == 5)
+        dataset = dataset.map(get_sentence_questions)
+        return dataset
+
     parser = vf.Parser()
 
     def compare_answers_reward_func(parser, completion, info, **kwargs) -> float:
@@ -113,7 +116,7 @@ def load_environment(**kwargs) -> vf.Environment:
     rubric = vf.Rubric(parser=parser, funcs=[compare_answers_reward_func])
 
     vf_env = SentenceRepeaterEnv(
-        dataset=dataset, parser=parser, rubric=rubric, **kwargs
+        dataset=build_dataset, parser=parser, rubric=rubric, **kwargs
     )
 
     return vf_env

--- a/environments/tool_test/tool_test.py
+++ b/environments/tool_test/tool_test.py
@@ -82,30 +82,36 @@ def load_environment(
     Loads tool-test environment.
     """
 
-    train_rows = []
-    eval_rows = []
-    for i in range(num_train_examples + num_eval_examples):
-        tool_names = random.sample(
-            tool_name_list, random.randint(1, len(tool_name_list))
-        )
-        prompt = [
-            {
-                "role": "user",
-                "content": f"Call the following tools with arguments of your choice: {tool_names}",
-            }
-        ]
-        info = {"tool_names": tool_names}
-        if i < num_train_examples:
-            train_rows.append({"prompt": prompt, "info": info})
-        else:
-            eval_rows.append({"prompt": prompt, "info": info})
+    def build_datasets():
+        train_rows = []
+        eval_rows = []
+        for i in range(num_train_examples + num_eval_examples):
+            tool_names = random.sample(
+                tool_name_list, random.randint(1, len(tool_name_list))
+            )
+            prompt = [
+                {
+                    "role": "user",
+                    "content": f"Call the following tools with arguments of your choice: {tool_names}",
+                }
+            ]
+            info = {"tool_names": tool_names}
+            if i < num_train_examples:
+                train_rows.append({"prompt": prompt, "info": info})
+            else:
+                eval_rows.append({"prompt": prompt, "info": info})
+        return Dataset.from_list(train_rows), Dataset.from_list(eval_rows)
 
-    dataset = Dataset.from_list(train_rows)
-    eval_dataset = Dataset.from_list(eval_rows)
+    def build_train_dataset():
+        return build_datasets()[0]
+
+    def build_eval_dataset():
+        return build_datasets()[1]
+
     rubric = vf.Rubric(funcs=[tool_call_reward_func])
     vf_env = vf.ToolEnv(
-        dataset=dataset,
-        eval_dataset=eval_dataset,
+        dataset=build_train_dataset,
+        eval_dataset=build_eval_dataset,
         rubric=rubric,
         tools=tool_list,
         max_turns=1,

--- a/environments/tool_test/tool_test.py
+++ b/environments/tool_test/tool_test.py
@@ -82,7 +82,7 @@ def load_environment(
     Loads tool-test environment.
     """
 
-    def _build_rows(count, seed_offset=0):
+    def build_dataset(count, seed_offset=0):
         rng = random.Random(42 + seed_offset)
         rows = []
         for _ in range(count):
@@ -98,10 +98,10 @@ def load_environment(
         return Dataset.from_list(rows)
 
     def build_train_dataset():
-        return _build_rows(num_train_examples, seed_offset=0)
+        return build_dataset(num_train_examples, seed_offset=0)
 
     def build_eval_dataset():
-        return _build_rows(num_eval_examples, seed_offset=1)
+        return build_dataset(num_eval_examples, seed_offset=1)
 
     rubric = vf.Rubric(funcs=[tool_call_reward_func])
     vf_env = vf.ToolEnv(

--- a/environments/tool_test/tool_test.py
+++ b/environments/tool_test/tool_test.py
@@ -65,7 +65,7 @@ tool_name_list = [tool.__name__ for tool in tool_list]
 def tool_call_reward_func(completion: vf.Messages, info: dict) -> float:
     # check if completion tool calls exactly matches info tool calls
     tool_calls = (
-        completion[-1].tool_calls or [] if completion[-1].role == "assistant" else []
+        (completion[-1].tool_calls or []) if completion[-1].role == "assistant" else []
     )
     called_tool_names = sorted([call.name for call in tool_calls])
     expected_tool_names = sorted(info["tool_names"])

--- a/environments/tool_test/tool_test.py
+++ b/environments/tool_test/tool_test.py
@@ -82,13 +82,11 @@ def load_environment(
     Loads tool-test environment.
     """
 
-    def build_datasets():
-        train_rows = []
-        eval_rows = []
-        for i in range(num_train_examples + num_eval_examples):
-            tool_names = random.sample(
-                tool_name_list, random.randint(1, len(tool_name_list))
-            )
+    def _build_rows(count, seed_offset=0):
+        rng = random.Random(42 + seed_offset)
+        rows = []
+        for _ in range(count):
+            tool_names = rng.sample(tool_name_list, rng.randint(1, len(tool_name_list)))
             prompt = [
                 {
                     "role": "user",
@@ -96,17 +94,14 @@ def load_environment(
                 }
             ]
             info = {"tool_names": tool_names}
-            if i < num_train_examples:
-                train_rows.append({"prompt": prompt, "info": info})
-            else:
-                eval_rows.append({"prompt": prompt, "info": info})
-        return Dataset.from_list(train_rows), Dataset.from_list(eval_rows)
+            rows.append({"prompt": prompt, "info": info})
+        return Dataset.from_list(rows)
 
     def build_train_dataset():
-        return build_datasets()[0]
+        return _build_rows(num_train_examples, seed_offset=0)
 
     def build_eval_dataset():
-        return build_datasets()[1]
+        return _build_rows(num_eval_examples, seed_offset=1)
 
     rubric = vf.Rubric(funcs=[tool_call_reward_func])
     vf_env = vf.ToolEnv(

--- a/environments/tool_test/tool_test.py
+++ b/environments/tool_test/tool_test.py
@@ -62,17 +62,14 @@ tool_list = [tool_A, tool_B, tool_C, tool_D]
 tool_name_list = [tool.__name__ for tool in tool_list]
 
 
-def tool_call_reward_func(completion, info):
+def tool_call_reward_func(completion: vf.Messages, info: dict) -> float:
     # check if completion tool calls exactly matches info tool calls
-    tool_calls = completion[-1].get("tool_calls", [])
-    called_tool_names = sorted(
-        [call.get("function", {}).get("name", "") for call in tool_calls]
+    tool_calls = (
+        completion[-1].tool_calls or [] if completion[-1].role == "assistant" else []
     )
+    called_tool_names = sorted([call.name for call in tool_calls])
     expected_tool_names = sorted(info["tool_names"])
-    if called_tool_names == expected_tool_names:
-        return 1.0
-    else:
-        return 0.0
+    return 1.0 if called_tool_names == expected_tool_names else 0.0
 
 
 def load_environment(

--- a/environments/toxicity_explanation/toxicity_explanation.py
+++ b/environments/toxicity_explanation/toxicity_explanation.py
@@ -26,42 +26,45 @@ def load_environment(
     Args:
         max_examples: Maximum number of examples to load (-1 for all examples)
     """
-    vf.ensure_keys([judge_api_key_var])
 
-    dataset = load_dataset("google/civil_comments", split="train")
+    def build_dataset():
+        dataset = load_dataset("google/civil_comments", split="train[:10%]")
 
-    if max_examples > 0:
-        dataset = dataset.select(range(max_examples))  # type: ignore
+        if max_examples > 0:
+            dataset = dataset.select(range(max_examples))  # type: ignore
 
-    def transform_example(example):
-        is_toxic = example["toxicity"] >= 0.5
+        def transform_example(example):
+            is_toxic = example["toxicity"] >= 0.5
 
-        toxicity_details = []
-        threshold = 0.5
+            toxicity_details = []
+            threshold = 0.5
 
-        if example.get("severe_toxicity", 0) >= threshold:
-            toxicity_details.append("severely toxic")
-        if example.get("obscene", 0) >= threshold:
-            toxicity_details.append("obscene")
-        if example.get("threat", 0) >= threshold:
-            toxicity_details.append("threatening")
-        if example.get("insult", 0) >= threshold:
-            toxicity_details.append("insulting")
-        if example.get("identity_attack", 0) >= threshold:
-            toxicity_details.append("identity attack")
+            if example.get("severe_toxicity", 0) >= threshold:
+                toxicity_details.append("severely toxic")
+            if example.get("obscene", 0) >= threshold:
+                toxicity_details.append("obscene")
+            if example.get("threat", 0) >= threshold:
+                toxicity_details.append("threatening")
+            if example.get("insult", 0) >= threshold:
+                toxicity_details.append("insulting")
+            if example.get("identity_attack", 0) >= threshold:
+                toxicity_details.append("identity attack")
 
-        return {
-            "question": f"Analyze the following text for toxicity and explain your reasoning:\n\n{example['text']}",
-            "answer": "toxic" if is_toxic else "non-toxic",  # For JudgeRubric
-            "info": {
-                "is_toxic": is_toxic,
-                "categories": toxicity_details if toxicity_details else ["non-toxic"],
-                "text": example["text"],
-                "label": "toxic" if is_toxic else "non-toxic",
-            },
-        }
+            return {
+                "question": f"Analyze the following text for toxicity and explain your reasoning:\n\n{example['text']}",
+                "answer": "toxic" if is_toxic else "non-toxic",  # For JudgeRubric
+                "info": {
+                    "is_toxic": is_toxic,
+                    "categories": toxicity_details
+                    if toxicity_details
+                    else ["non-toxic"],
+                    "text": example["text"],
+                    "label": "toxic" if is_toxic else "non-toxic",
+                },
+            }
 
-    dataset = dataset.map(transform_example, remove_columns=dataset.column_names)  # type: ignore
+        dataset = dataset.map(transform_example, remove_columns=dataset.column_names)  # type: ignore
+        return dataset
 
     system_prompt = """You are a content moderation assistant. For each text, you must:
 
@@ -75,7 +78,7 @@ Respond in the following format:
 
     parser = vf.Parser()
     judge_client = AsyncOpenAI(
-        api_key=os.environ[judge_api_key_var], base_url=judge_base_url
+        api_key=os.getenv(judge_api_key_var, ""), base_url=judge_base_url
     )
 
     judge_prompt = """Evaluate this toxicity classification task.
@@ -121,7 +124,7 @@ Respond with ONLY a single number from 0 to 10."""
     rubric.add_reward_func(comprehensive_evaluation, weight=1.0)
 
     env = vf.SingleTurnEnv(
-        dataset=dataset,
+        dataset=build_dataset,
         system_prompt=system_prompt,
         parser=parser,
         rubric=rubric,

--- a/environments/wiki_search/wiki_search.py
+++ b/environments/wiki_search/wiki_search.py
@@ -34,22 +34,28 @@ def load_environment(
     corpus_split: str = "train",
     chroma_db_dir: str = CHROMA_DB_DIR,
 ) -> vf.Environment:
-    # load corpus into memory and build page_id -> row index
-    corpus = load_dataset(corpus_dataset, split=corpus_split)
-    page_id_to_title: dict[str, str] = {}
-    page_id_to_content: dict[str, str] = {}
-    for row in corpus:
-        row = cast(dict, row)
-        pid = row["id"]
-        title = row["title"]
-        content = row["content"]
-        page_id_to_title[pid] = title
-        page_id_to_content[pid] = content
+    # lazy corpus loading and chroma initialization
+    _corpus_state: dict = {
+        "loaded": False,
+        "page_id_to_title": {},
+        "page_id_to_content": {},
+    }
 
-    # lazy chroma initialization (once across all env instances)
+    def _load_corpus():
+        if _corpus_state["loaded"]:
+            return
+        corpus = load_dataset(corpus_dataset, split=corpus_split)
+        for row in corpus:
+            row = cast(dict, row)
+            pid = row["id"]
+            _corpus_state["page_id_to_title"][pid] = row["title"]
+            _corpus_state["page_id_to_content"][pid] = row["content"]
+        _corpus_state["loaded"] = True
+
     _chroma_state: dict = {"collection": None}
 
     def _get_collection():
+        _load_corpus()
         if _chroma_state["collection"] is None:
             openai_ef = embedding_functions.OpenAIEmbeddingFunction(
                 model_name=embed_model,
@@ -66,6 +72,7 @@ def load_environment(
 
     def _init_chroma(collection) -> None:
         # upsert missing pages
+        page_id_to_title = _corpus_state["page_id_to_title"]
         all_ids = list(page_id_to_title.keys())
         existing: set[str] = set()
         for i in range(0, len(all_ids), 500):
@@ -77,7 +84,7 @@ def load_environment(
             documents = []
             metadatas = []
             for pid in missing:
-                title = str(page_id_to_title[pid]).strip()
+                title = str(_corpus_state["page_id_to_title"][pid]).strip()
                 if not title:
                     raise ValueError(f"Empty title for page_id {pid}")
                 documents.append(title)
@@ -143,7 +150,8 @@ def load_environment(
         example:
             "basketball" -> [{"section_id": "basketball:history", "section_name": "History"}, ...]
         """
-        content = page_id_to_content[page_id]
+        _load_corpus()
+        content = _corpus_state["page_id_to_content"][page_id]
         sections = []
         lines = content.split("\n")
         for i, line in enumerate(lines):
@@ -192,7 +200,8 @@ def load_environment(
         page_id, section_name_id = section_id.split(":", 1)
 
         # get Markdown content
-        content = page_id_to_content[page_id]
+        _load_corpus()
+        content = _corpus_state["page_id_to_content"][page_id]
         lines = content.split("\n")
 
         # special case for "full" section
@@ -225,7 +234,9 @@ def load_environment(
         read_section,
     ]
     parser = vf.Parser()
-    dataset = load_dataset("willcb/wiki-trivia-questions-v4", split="train")
+
+    def build_dataset():
+        return load_dataset("willcb/wiki-trivia-questions-v4", split="train")
 
     JUDGE_PROMPT = """Given a ground truth answer \
     and a response, determine if the response is both correct and coherent.
@@ -250,7 +261,7 @@ def load_environment(
     If a response contains incoherent text, respond with "no" even if the correct answer is also present.
     """
     judge_client = AsyncOpenAI(
-        base_url=judge_base_url, api_key=os.environ[judge_api_key_var]
+        base_url=judge_base_url, api_key=os.getenv(judge_api_key_var, "")
     )
     judge_rubric = JudgeRubric(
         judge_client=judge_client,
@@ -269,7 +280,7 @@ def load_environment(
     system_prompt = "Use the provided Wikipedia search tools to help answer questions."
     judge_rubric.add_reward_func(judge_reward_func, weight=1.0)
     vf_env = vf.ToolEnv(
-        dataset=dataset,
+        dataset=build_dataset,
         system_prompt=system_prompt,
         parser=parser,
         rubric=judge_rubric,

--- a/verifiers/utils/env_utils.py
+++ b/verifiers/utils/env_utils.py
@@ -4,6 +4,7 @@ import logging
 from typing import Callable
 
 from verifiers.envs.environment import Environment
+from verifiers.utils.config_utils import MissingKeyError
 
 
 def load_environment(env_id: str, **env_args) -> Environment:
@@ -81,6 +82,8 @@ def load_environment(env_id: str, **env_args) -> Environment:
         raise ValueError(
             f"Could not import '{env_id}' environment. Ensure the package for the '{env_id}' environment is installed."
         ) from e
+    except MissingKeyError:
+        raise
     except Exception as e:
         logger.error(
             f"Failed to load environment {env_id} with args {env_args}: {str(e)}"


### PR DESCRIPTION
## Summary
- Convert all 14 environment `load_environment()` functions to use the `DatasetBuilder` pattern (pass callables instead of raw `Dataset` objects), deferring dataset downloads to eval time
- Defer API key validation (`ensure_keys`) and use `os.getenv()` with fallback for `AsyncOpenAI` client creation so `load_environment()` never fails on missing keys
- Load only 10% of `google/civil_comments` in toxicity_explanation via `split="train[:10%]"` to avoid downloading 1.8M rows
- Propagate `MissingKeyError` directly in `env_utils.py` instead of wrapping in `RuntimeError`
- Lazy-load wiki_search corpus data on first tool call instead of at environment load time
- Also fixes rubric in `tool-test` env

## Test plan
- [x] Verified `vf.load_environment('toxicity-explanation')` succeeds instantly without `OPENAI_API_KEY` set
- [x] Verified `vf.load_environment('gsm8k')` succeeds without downloading dataset
- [x] Verified `env.dataset is None` and `env.dataset_source is not None` after loading (lazy)
- [x] Run full eval to confirm datasets build correctly on first access

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes when/where datasets and external dependencies (HuggingFace downloads, Chroma/wiki corpus, OpenAI API keys) are initialized, which can shift runtime failures from load time to eval time and affect reproducibility/perf.
> 
> **Overview**
> **Moves environments to a lazy `DatasetBuilder` pattern.** Most `load_environment()` functions now pass callables (and for some, separate train/eval builders) instead of eagerly materializing HuggingFace datasets, deferring downloads/work until the dataset is first accessed.
> 
> **Reduces load-time hard failures and heavy initialization.** OpenAI/MCP envs stop enforcing `ensure_keys` at environment load and use `os.getenv(..., "")` for client/server config; `toxicity_explanation` loads only `train[:10%]`; `wiki_search` defers loading the wiki corpus (and related Chroma setup) until the first tool/dataset access.
> 
> **Small correctness/robustness fixes.** `tool_test` now builds deterministic train/eval datasets with separate seeds and updates `tool_call_reward_func` to read structured `tool_calls`; `verifiers/utils/env_utils.py` now re-raises `MissingKeyError` instead of wrapping it in `RuntimeError`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0bd6f62721b419e3fda1ff78b5abb1a8f5b82cb4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->