### PR TITLE
fix: handle None prompt/completion token ids in parse_tokens

### DIFF
--- a/verifiers/clients/openai_chat_completions_client.py
+++ b/verifiers/clients/openai_chat_completions_client.py
@@ -441,8 +441,12 @@ class OpenAIChatCompletionsClient(
             if not (has_logprobs_obj or has_logprobs_dict):
                 return None
             prompt_ids = getattr(response, "prompt_token_ids")
-            prompt_mask = [0] * len(prompt_ids)
+            if prompt_ids is None:
+                return None
             completion_ids = getattr(response.choices[0], "token_ids")
+            if completion_ids is None:
+                return None
+            prompt_mask = [0] * len(prompt_ids)
             completion_mask = [1] * len(completion_ids)
             if has_logprobs_obj:
                 assert response.choices[0].logprobs.content is not None

--- a/verifiers/clients/openai_completions_client.py
+++ b/verifiers/clients/openai_completions_client.py
@@ -158,8 +158,12 @@ class OpenAICompletionsClient(
             if not hasattr(response.choices[0].logprobs, "token_logprobs"):
                 return None
             prompt_ids = getattr(response.choices[0], "prompt_token_ids")
-            prompt_mask = [0] * len(prompt_ids)
+            if prompt_ids is None:
+                return None
             completion_ids = getattr(response.choices[0], "token_ids")
+            if completion_ids is None:
+                return None
+            prompt_mask = [0] * len(prompt_ids)
             completion_mask = [1] * len(completion_ids)
             completion_logprobs = getattr(
                 response.choices[0].logprobs, "token_logprobs"

--- a/verifiers/clients/openai_completions_client.py
+++ b/verifiers/clients/openai_completions_client.py
@@ -168,6 +168,8 @@ class OpenAICompletionsClient(
             completion_logprobs = getattr(
                 response.choices[0].logprobs, "token_logprobs"
             )
+            if completion_logprobs is None:
+                return None
             return ResponseTokens(
                 prompt_ids=prompt_ids,
                 prompt_mask=prompt_mask,


### PR DESCRIPTION
## Summary
- `parse_tokens` in both `openai_chat_completions_client.py` and `openai_completions_client.py` checks for attribute existence via `hasattr` but not for `None` values
- When `prompt_token_ids` or `token_ids` attributes are present but `None`, `len(None)` raises a `TypeError`
- Added early `return None` guards after `getattr` calls, consistent with the existing pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: narrow, defensive changes that only cause `parse_tokens` to return `None` instead of raising when OpenAI SDK fields are unexpectedly `None`.
> 
> **Overview**
> Prevents crashes in `parse_tokens` for both chat and completions clients when OpenAI responses include `prompt_token_ids`/`token_ids` (and, for completions, `token_logprobs`) attributes that are present but `None`.
> 
> The parsing now **early-returns `None`** in these cases instead of calling `len(None)`, keeping token/logprob extraction behavior unchanged when fields are populated.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7daeebfa553f73f6ad5de3d80ae431959bf7eae0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->