### PR TITLE
fix rlm bash timeout

### DIFF
--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -663,6 +663,7 @@ _RLM_BASH_TOOL_HELPER_SCRIPT = textwrap.dedent(
     ROOT_TOOL_USER_AGENT = os.environ.get(
         "RLM_ROOT_TOOL_USER_AGENT", "python-requests/2.32.3"
     )
+    SUB_LLM_TIMEOUT = int(os.environ.get("RLM_SUB_LLM_TIMEOUT", "300"))
 
 
     def _decode_arg(raw: str):
@@ -696,7 +697,7 @@ _RLM_BASH_TOOL_HELPER_SCRIPT = textwrap.dedent(
             method="POST",
         )
         try:
-            with urllib.request.urlopen(req, timeout=300) as resp:
+            with urllib.request.urlopen(req, timeout=SUB_LLM_TIMEOUT) as resp:
                 resp_body = resp.read().decode("utf-8")
         except urllib.error.HTTPError as e:
             try:


### PR DESCRIPTION
## Description

The sub-LLM call timeout for bash (but not for python) was hardcoded; this PR changes it to respect the user settings.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small change that replaces a hardcoded HTTP timeout with an environment-configured value, affecting only sub-LLM/root-tool calls from the Bash worker helper.
> 
> **Overview**
> Fixes the Bash RLM worker’s root-tool HTTP proxy call to **respect the configured sub-LLM timeout** instead of using a hardcoded 300s.
> 
> `_RLM_BASH_TOOL_HELPER_SCRIPT` now reads `RLM_SUB_LLM_TIMEOUT` into `SUB_LLM_TIMEOUT` and uses it for `urllib.request.urlopen(..., timeout=SUB_LLM_TIMEOUT)`, aligning Bash behavior with the Python worker’s configurable timeout.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 428107843540dd84ff91827bc06a4dd8f4faa44a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->