### PR TITLE
fix: remove content rstrip in normalize_response to preserve TITO prefix match

### DIFF
--- a/verifiers/envs/experimental/opencode_env.py
+++ b/verifiers/envs/experimental/opencode_env.py
@@ -294,8 +294,6 @@ class OpenCodeEnv(CliAgentEnv):
             content = message.content
             if content is None:
                 content = ""
-            elif isinstance(content, str):
-                content = content.rstrip()
             reasoning_content = message.reasoning_content or None
             normalized_message = message.model_copy(
                 update={


### PR DESCRIPTION
## Summary
- Removes the `content.rstrip()` call in `normalize_response` that was stripping trailing whitespace from message content, which broke TITO (think-in-turn-out) prefix matching downstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to response normalization that only affects how assistant content is stored/compared; main risk is slightly different cache/prefix-hit behavior due to preserved trailing whitespace.
> 
> **Overview**
> Stops stripping trailing whitespace from assistant `message.content` in `OpenCodeEnv.normalize_response`, so the stored trajectory matches the agent’s original output for TITO prefix cache hits.
> 
> Tool-call normalization (lowercasing tool names and compacting JSON arguments) remains unchanged; only the content trimming behavior is removed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5197334a809f1f7fe6bfba641667cf861d9ffcfc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->