### PR TITLE
feat: set process titles on env server and workers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dependencies = [
     "pyzmq>=27.1.0",
     "msgpack>=1.1.2",
     "aiolimiter>=1.2.1",
+    "setproctitle>=1.3.0",
 ]
 
 [dependency-groups]

--- a/verifiers/serve/server/env_server.py
+++ b/verifiers/serve/server/env_server.py
@@ -41,6 +41,7 @@ class EnvServer(ABC):
         stats_log_interval: float = 10.0,
         death_pipe: Connection | None = None,
     ):
+        set_proc_title("EnvServer")
         self.death_pipe = death_pipe
 
         logger_kwargs: dict[str, Any] = {
@@ -85,8 +86,6 @@ class EnvServer(ABC):
 
     async def run(self) -> None:
         """Run the server with signal-based graceful shutdown."""
-        set_proc_title("EnvServer")
-
         if self.death_pipe is not None:
             monitor_death_pipe(self.death_pipe)
 

--- a/verifiers/serve/server/env_server.py
+++ b/verifiers/serve/server/env_server.py
@@ -15,7 +15,7 @@ from typing import Any
 
 import verifiers as vf
 from verifiers.serve.server.env_router import EnvRouter
-from verifiers.utils.process_utils import monitor_death_pipe
+from verifiers.utils.process_utils import monitor_death_pipe, set_proc_title
 
 
 class EnvServer(ABC):
@@ -85,6 +85,8 @@ class EnvServer(ABC):
 
     async def run(self) -> None:
         """Run the server with signal-based graceful shutdown."""
+        set_proc_title("EnvServer")
+
         if self.death_pipe is not None:
             monitor_death_pipe(self.death_pipe)
 

--- a/verifiers/serve/server/env_worker.py
+++ b/verifiers/serve/server/env_worker.py
@@ -32,7 +32,7 @@ from verifiers.serve.types import (
 from verifiers.types import ClientConfig
 from verifiers.utils.async_utils import EventLoopLagMonitor, EventLoopLagStats
 from verifiers.utils.client_utils import resolve_client_config
-from verifiers.utils.process_utils import monitor_death_pipe
+from verifiers.utils.process_utils import monitor_death_pipe, set_proc_title
 from verifiers.utils.serve_utils import msgpack_encoder
 
 
@@ -355,6 +355,8 @@ class EnvWorker:
         self.logger.info(f"Shut down worker {self.worker_name}")
 
     async def run(self) -> None:
+        set_proc_title(f"EnvWorker{self.worker_id}")
+
         if self.death_pipe is not None:
             monitor_death_pipe(self.death_pipe)
 

--- a/verifiers/serve/server/env_worker.py
+++ b/verifiers/serve/server/env_worker.py
@@ -68,6 +68,7 @@ class EnvWorker:
         stats_address: str,
         death_pipe: Connection | None = None,
     ):
+        set_proc_title(f"EnvWorker{worker_id}")
         self.death_pipe = death_pipe
         self.env_id = env_id
         self.worker_id = worker_id
@@ -355,8 +356,6 @@ class EnvWorker:
         self.logger.info(f"Shut down worker {self.worker_name}")
 
     async def run(self) -> None:
-        set_proc_title(f"EnvWorker{self.worker_id}")
-
         if self.death_pipe is not None:
             monitor_death_pipe(self.death_pipe)
 

--- a/verifiers/utils/process_utils.py
+++ b/verifiers/utils/process_utils.py
@@ -7,7 +7,23 @@ import threading
 from multiprocessing.connection import Connection
 from multiprocessing.process import BaseProcess
 
+import setproctitle
+
 logger = logging.getLogger(__name__)
+
+VERIFIERS_PROC_PREFIX = "Verifiers"
+
+
+def set_proc_title(name: str) -> None:
+    """Set the process title for visibility in tools like ``ps`` and ``htop``.
+
+    Args:
+        name: A short, descriptive label (e.g. ``EnvServer``, ``EnvWorker0``).
+              The process title is set to ``{VERIFIERS_PROC_PREFIX}::{name}``.
+    """
+    title = f"{VERIFIERS_PROC_PREFIX}::{name}"
+    setproctitle.setproctitle(title)
+    logger.info(f"Process title set to {title!r}")
 
 
 def monitor_death_pipe(death_pipe: Connection) -> None:

--- a/verifiers/utils/process_utils.py
+++ b/verifiers/utils/process_utils.py
@@ -23,7 +23,6 @@ def set_proc_title(name: str) -> None:
     """
     title = f"{VERIFIERS_PROC_PREFIX}::{name}"
     setproctitle.setproctitle(title)
-    logger.info(f"Process title set to {title!r}")
 
 
 def monitor_death_pipe(death_pipe: Connection) -> None:


### PR DESCRIPTION
## Summary
- Adds `setproctitle` dependency and `set_proc_title` utility to `process_utils.py`
- Labels env server process as `Verifiers::EnvServer` and worker processes as `Verifiers::EnvWorker{N}`
- Makes verifiers processes identifiable in `ps`, `htop`, and `pstree` for easier debugging

<img width="669" height="65" alt="Screenshot 2026-04-01 at 1 35 27 AM" src="https://github.com/user-attachments/assets/8f823097-9231-45e5-8fc5-55a1748ba4b3" />

Companion to PrimeIntellect-ai/prime-rl#2159 which sets titles on all prime-rl entrypoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to setting process titles and adding a small runtime dependency, with no impact on request handling or shutdown logic.
> 
> **Overview**
> Adds the `setproctitle` dependency and a new `set_proc_title` helper in `process_utils` to standardize process naming as `Verifiers::{name}`.
> 
> The env server and each env worker now set their process titles at startup (e.g., `Verifiers::EnvServer`, `Verifiers::EnvWorker{N}`) to make spawned processes easier to identify in `ps`/`htop`/`pstree`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 53f8238d6bafa763f17b847f17df95e7f76e21ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->