### PR TITLE
feat: SolveEnv for composable SandboxTaskSet validation

### DIFF
--- a/verifiers/envs/experimental/__init__.py
+++ b/verifiers/envs/experimental/__init__.py
@@ -8,6 +8,7 @@ __all__ = [
     "TaskSet",
     "Harness",
     "ComposableEnv",
+    "SolveEnv",
 ]
 
 
@@ -19,6 +20,7 @@ def __getattr__(name: str):
         "TaskSet": "verifiers.envs.experimental.composable:TaskSet",
         "Harness": "verifiers.envs.experimental.composable:Harness",
         "ComposableEnv": "verifiers.envs.experimental.composable:ComposableEnv",
+        "SolveEnv": "verifiers.envs.experimental.composable:SolveEnv",
     }
     if name in _lazy:
         import importlib

--- a/verifiers/envs/experimental/composable/__init__.py
+++ b/verifiers/envs/experimental/composable/__init__.py
@@ -6,6 +6,7 @@ from verifiers.envs.experimental.composable.task import (
 )
 from verifiers.envs.experimental.composable.harness import Harness
 from verifiers.envs.experimental.composable.composable_env import ComposableEnv
+from verifiers.envs.experimental.composable.solve_env import SolveEnv
 
 __all__ = [
     "SandboxSpec",
@@ -14,4 +15,5 @@ __all__ = [
     "SandboxTaskSet",
     "Harness",
     "ComposableEnv",
+    "SolveEnv",
 ]

--- a/verifiers/envs/experimental/composable/solve_env.py
+++ b/verifiers/envs/experimental/composable/solve_env.py
@@ -1,0 +1,129 @@
+"""SolveEnv — gold-patch validation for any SandboxTaskSet.
+
+Creates sandboxes, calls ``taskset.validate_instance(state)`` (which applies
+the gold patch + runs tests), and reports the result as a reward.
+
+No agent, no inference — just infrastructure validation.
+
+::
+
+    from verifiers.envs.experimental.composable import SolveEnv
+    from swe_tasksets import R2EGymTaskSet
+
+    taskset = R2EGymTaskSet()
+    env = SolveEnv(taskset=taskset)
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import Any
+
+import verifiers as vf
+from prime_sandboxes import CreateSandboxRequest
+from verifiers.envs.experimental.sandbox_mixin import SandboxMixin, SandboxMonitorRubric
+from verifiers.types import Messages, State
+
+from .task import SandboxTaskSet
+
+logger = logging.getLogger(__name__)
+
+
+class SolveRubric(SandboxMonitorRubric):
+    """Reads ``state["reward"]`` set during setup. Inherits OOM/timeout metrics."""
+
+    def __init__(self, **kwargs: Any):
+        super().__init__(**kwargs)
+        self.add_reward_func(self.solve_reward, weight=1.0)
+
+    async def solve_reward(self, state: vf.State, **kwargs: Any) -> float:
+        return state.get("reward", 0.0)
+
+
+class SolveEnv(SandboxMixin, vf.MultiTurnEnv):
+    """Gold-patch solve: create sandbox, validate instance, score.
+
+    Lifecycle:
+    - setup_state(): create sandbox + taskset.setup + validate_instance
+    - @vf.stop: immediately complete (no multi-turn loop)
+    - @vf.cleanup: delete sandbox
+    """
+
+    def __init__(
+        self,
+        taskset: SandboxTaskSet,
+        dataset: Any = None,
+        test_timeout: int = 900,
+        cpu_cores: int | None = None,
+        memory_gb: int | None = None,
+        disk_size_gb: int | None = None,
+        labels: list[str] | None = None,
+        timeout_seconds: float = 1800.0,
+        **sandbox_kwargs: Any,
+    ):
+        self.taskset = taskset
+        self.test_timeout = test_timeout
+        self._cpu_cores = cpu_cores
+        self._memory_gb = memory_gb
+        self._disk_size_gb = disk_size_gb
+        self.labels = labels or ["solve"]
+        self.timeout_seconds = timeout_seconds
+
+        dataset = dataset or taskset.get_dataset()
+        rubric = SolveRubric()
+        super().__init__(dataset=dataset, rubric=rubric)
+        self.init_sandbox_client(**sandbox_kwargs)
+
+    async def env_response(
+        self, messages: Messages, state: State, **kwargs: Any
+    ) -> Messages:
+        raise NotImplementedError("SolveEnv does not use multi-turn interaction")
+
+    # --- Lifecycle ---
+
+    async def setup_state(self, state: State) -> State:
+        state = await super().setup_state(state)
+        info = state["info"]
+        spec = self.taskset.get_sandbox_spec(info)
+
+        request = CreateSandboxRequest(
+            name=f"solve-{state.get('example_id', 'unknown')}",
+            docker_image=spec.image,
+            cpu_cores=self._cpu_cores or spec.cpu_cores,
+            memory_gb=self._memory_gb or spec.memory_gb,
+            disk_size_gb=self._disk_size_gb or spec.disk_size_gb,
+            gpu_count=spec.gpu_count,
+            gpu_type=spec.gpu_type,
+            vm=spec.gpu_count > 0,
+            timeout_minutes=math.ceil(self.timeout_seconds / 60),
+            labels=self.labels,
+        )
+        await self.create_sandbox(state, request)
+
+        try:
+            valid = await self.taskset.validate_instance(state)
+            state["reward"] = float(valid)
+            state["completion"] = f"reward={float(valid)}"
+        except Exception as e:
+            state["error"] = vf.SandboxError(f"Validation failed: {repr(e)}")
+            state["reward"] = 0.0
+
+        return state
+
+    async def post_sandbox_setup(self, state: State) -> None:
+        """Inject sandbox context into state, then run taskset setup."""
+        state["sandbox_client"] = self.sandbox_client
+        state["test_timeout"] = self.test_timeout
+        state["run_background_job"] = self.run_background_job
+        await self.taskset.setup(state)
+
+    @vf.stop
+    async def solve_completed(self, state: State) -> bool:
+        return True
+
+    @vf.cleanup
+    async def destroy_sandbox(self, state: State) -> None:
+        sandbox_id = state.get("sandbox_id")
+        if sandbox_id:
+            await self.delete_sandbox(sandbox_id)


### PR DESCRIPTION
## Summary

- Lightweight gold-patch validation environment for any `SandboxTaskSet`
- Creates sandbox, calls `taskset.validate_instance(state)` (gold patch + tests), reports reward
- No agent, no inference — pure infrastructure validation
- Same `SandboxMixin + MultiTurnEnv` pattern as the existing SolveEnv in research-environments, but generic

## Files

- `verifiers/envs/experimental/composable/solve_env.py` — `SolveEnv` + `SolveRubric`
- `verifiers/envs/experimental/composable/__init__.py` — export
- `verifiers/envs/experimental/__init__.py` — lazy import

## Verified E2E

Tested with `R2EGymTaskSet` from #1067's composable architecture (via research-environments PR #221):

```
Reward: 1.0
Error: None
```

## Usage

```python
from swe_tasksets import make_r2e_taskset
from verifiers.envs.experimental.composable import SolveEnv

taskset = make_r2e_taskset()
env = SolveEnv(taskset=taskset, test_timeout=900)
```

Resource params (`cpu_cores`, `memory_gb`, `disk_size_gb`) default to `None` — falls back to `SandboxSpec` from taskset. Non-None values override for all instances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new sandbox lifecycle code that creates and tears down sandboxes and runs taskset validation, so failures could leak resources or misreport rewards if state/error handling is wrong.
> 
> **Overview**
> Adds a new `SolveEnv` in `verifiers.envs.experimental.composable` to run **single-shot** “gold patch + tests” validation for any `SandboxTaskSet`: it creates a sandbox from the taskset’s `SandboxSpec`, runs `taskset.setup()` and `taskset.validate_instance(state)`, and records the boolean result as `state["reward"]` via a small `SolveRubric`.
> 
> Exports `SolveEnv` from both `verifiers.envs.experimental.composable` and the top-level `verifiers.envs.experimental` module (via lazy import), and ensures the sandbox is cleaned up with a `@vf.cleanup` handler even though the env immediately stops (no multi-turn interaction).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 153a8dadbc76417e5bd4f361171b5205834e7f37. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->