### PR TITLE
Use SDK read-file endpoint and bg job handling in SandboxMixin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,8 @@ dependencies = [
     "nest-asyncio>=1.6.0", # for jupyter notebooks
     "openai>=1.108.1",
     "openai-agents>=0.0.7",
-    "prime-tunnel>=0.1.4",
-    "prime-sandboxes>=0.2.16",
+    "prime-tunnel>=0.1.5",
+    "prime-sandboxes>=0.2.19",
     "pydantic>=2.11.9",
     "requests",
     "rich",

--- a/tests/test_sandbox_mixin.py
+++ b/tests/test_sandbox_mixin.py
@@ -229,10 +229,8 @@ def test_bulk_delete_failure(mixin):
 
 
 def test_run_background_job_success(mixin):
-    job = MagicMock()
     results = MagicMock(completed=True)
-    mixin.sandbox_client.start_background_job = AsyncMock(return_value=job)
-    mixin.sandbox_client.get_background_job = AsyncMock(return_value=results)
+    mixin.sandbox_client.run_background_job = AsyncMock(return_value=results)
 
     state = {"sandbox_id": "sb-1"}
     ret = asyncio.run(mixin.run_background_job(state, command="echo hi", timeout=10))
@@ -240,74 +238,35 @@ def test_run_background_job_success(mixin):
 
 
 def test_run_background_job_command_timeout(mixin):
-    mixin.sandbox_client.start_background_job = AsyncMock(
+    mixin.sandbox_client.run_background_job = AsyncMock(
         side_effect=CommandTimeoutError(sandbox_id="sb-1", command="cmd", timeout=5)
     )
 
     state = {"sandbox_id": "sb-1"}
-    with pytest.raises(vf.SandboxError):
-        asyncio.run(mixin.run_background_job(state, command="cmd", timeout=10))
-
-
-def test_run_background_job_oom_on_start(mixin):
-    mixin.sandbox_client.start_background_job = AsyncMock(
-        side_effect=SandboxOOMError(sandbox_id="sb-1")
-    )
-
-    state = {"sandbox_id": "sb-1"}
-    with pytest.raises(vf.SandboxError):
-        asyncio.run(mixin.run_background_job(state, command="cmd", timeout=10))
-    assert state["sandbox_oom"] is True
-
-
-def test_run_background_job_timeout_on_start(mixin):
-    mixin.sandbox_client.start_background_job = AsyncMock(
-        side_effect=SandboxTimeoutError(sandbox_id="sb-1")
-    )
-
-    state = {"sandbox_id": "sb-1"}
-    with pytest.raises(vf.SandboxError):
-        asyncio.run(mixin.run_background_job(state, command="cmd", timeout=10))
-    assert state["sandbox_timeout"] is True
-
-
-def test_run_background_job_oom_during_poll(mixin):
-    job = MagicMock()
-    mixin.sandbox_client.start_background_job = AsyncMock(return_value=job)
-    mixin.sandbox_client.get_background_job = AsyncMock(
-        side_effect=SandboxOOMError(sandbox_id="sb-1")
-    )
-
-    state = {"sandbox_id": "sb-1"}
-    with pytest.raises(vf.SandboxError):
-        asyncio.run(mixin.run_background_job(state, command="cmd", timeout=10))
-    assert state["sandbox_oom"] is True
-
-
-def test_run_background_job_timeout_during_poll(mixin):
-    job = MagicMock()
-    mixin.sandbox_client.start_background_job = AsyncMock(return_value=job)
-    mixin.sandbox_client.get_background_job = AsyncMock(
-        side_effect=SandboxTimeoutError(sandbox_id="sb-1")
-    )
-
-    state = {"sandbox_id": "sb-1"}
-    with pytest.raises(vf.SandboxError):
-        asyncio.run(mixin.run_background_job(state, command="cmd", timeout=10))
-    assert state["sandbox_timeout"] is True
-
-
-def test_run_background_job_poll_timeout(mixin):
-    job = MagicMock()
-    not_done = MagicMock(completed=False)
-    mixin.sandbox_client.start_background_job = AsyncMock(return_value=job)
-    mixin.sandbox_client.get_background_job = AsyncMock(return_value=not_done)
-
-    state = {"sandbox_id": "sb-1"}
     with pytest.raises(CommandTimeoutError):
-        asyncio.run(
-            mixin.run_background_job(state, command="cmd", timeout=0, poll_interval=1)
-        )
+        asyncio.run(mixin.run_background_job(state, command="cmd", timeout=10))
+
+
+def test_run_background_job_oom(mixin):
+    mixin.sandbox_client.run_background_job = AsyncMock(
+        side_effect=SandboxOOMError(sandbox_id="sb-1")
+    )
+
+    state = {"sandbox_id": "sb-1"}
+    with pytest.raises(vf.SandboxError):
+        asyncio.run(mixin.run_background_job(state, command="cmd", timeout=10))
+    assert state["sandbox_oom"] is True
+
+
+def test_run_background_job_sandbox_timeout(mixin):
+    mixin.sandbox_client.run_background_job = AsyncMock(
+        side_effect=SandboxTimeoutError(sandbox_id="sb-1")
+    )
+
+    state = {"sandbox_id": "sb-1"}
+    with pytest.raises(vf.SandboxError):
+        asyncio.run(mixin.run_background_job(state, command="cmd", timeout=10))
+    assert state["sandbox_timeout"] is True
 
 
 # ── teardown_sandboxes ──────────────────────────────────────────────

--- a/verifiers/envs/experimental/sandbox_mixin.py
+++ b/verifiers/envs/experimental/sandbox_mixin.py
@@ -16,6 +16,7 @@ from prime_sandboxes import (
     CreateSandboxRequest,
     DownloadTimeoutError,
     SandboxClient,
+    SandboxFileNotFoundError,
     SandboxOOMError,
     SandboxTimeoutError,
     UploadTimeoutError,
@@ -233,16 +234,14 @@ class SandboxMixin:
     ):
         """Run a command as a background job and poll until completion or timeout."""
         sandbox_id = state["sandbox_id"]
-        start_job = self.with_retry(self.sandbox_client.start_background_job)
-        get_job = self.with_retry(self.sandbox_client.get_background_job)
-
         try:
-            job = await start_job(
-                sandbox_id=sandbox_id, command=command, working_dir=working_dir
+            return await self.sandbox_client.run_background_job(
+                sandbox_id=sandbox_id,
+                command=command,
+                timeout=timeout,
+                working_dir=working_dir,
+                poll_interval=poll_interval,
             )
-        except (CommandTimeoutError, httpx.ReadTimeout) as e:
-            self.logger.error(f"Failed to start background job: {repr(e)}")
-            raise vf.SandboxError() from e
         except SandboxOOMError as e:
             state["sandbox_oom"] = True
             self.logger.error(f"Sandbox OOM during background job: {repr(e)}")
@@ -251,28 +250,6 @@ class SandboxMixin:
             state["sandbox_timeout"] = True
             self.logger.error(f"Sandbox timeout during background job: {repr(e)}")
             raise vf.SandboxError() from e
-
-        try:
-            for elapsed in range(0, timeout + poll_interval, poll_interval):
-                results = await get_job(sandbox_id, job)
-                if results.completed:
-                    return results
-                self.logger.debug(
-                    f"{sandbox_id=}: Polling job... {elapsed} / {timeout} seconds elapsed"
-                )
-                await asyncio.sleep(poll_interval)
-        except SandboxOOMError as e:
-            state["sandbox_oom"] = True
-            self.logger.error(f"Sandbox OOM during polling: {repr(e)}")
-            raise vf.SandboxError() from e
-        except SandboxTimeoutError as e:
-            state["sandbox_timeout"] = True
-            self.logger.error(f"Sandbox timeout during polling: {repr(e)}")
-            raise vf.SandboxError() from e
-
-        raise CommandTimeoutError(
-            sandbox_id=sandbox_id, command=command, timeout=timeout
-        )
 
     async def upload_file(
         self,
@@ -317,13 +294,11 @@ class SandboxMixin:
     ) -> str | None:
         """Read a file from the sandbox, returning its contents or None on failure."""
         try:
-            result = await self.sandbox_client.execute_command(
-                sandbox_id,
-                f"cat {remote_path}",
-                timeout=timeout,
+            result = await self.sandbox_client.read_file(
+                sandbox_id, remote_path, timeout=timeout
             )
-            if result.exit_code == 0:
-                return result.stdout or ""
+            return result.content
+        except SandboxFileNotFoundError:
             return None
         except Exception as e:
             self.logger.warning(


### PR DESCRIPTION
note: max file size for read_file() right now is 10MB

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavioral changes in sandbox execution and file IO (notably timeout/exception propagation) could affect callers that depended on the previous polling and error-wrapping semantics; dependency bumps also shift runtime behavior to the new SDK implementations.
> 
> **Overview**
> Switches `SandboxMixin.run_background_job` from manual start/poll logic to the `prime_sandboxes` SDK’s `run_background_job`, changing timeout behavior to let `CommandTimeoutError` propagate while still mapping OOM/timeout to `vf.SandboxError` and setting state flags.
> 
> Updates `SandboxMixin.read_file` to call the SDK `read_file` endpoint (returning `result.content`) and treat `SandboxFileNotFoundError` as a clean `None` result, and refreshes unit tests plus bumps `prime-tunnel`/`prime-sandboxes` dependency versions to match the new SDK APIs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e10d90095d33187afda57e24efabedee5d819008. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->