### PR TITLE
refactor: rename RLM metrics for consistency

### DIFF
--- a/tests/test_rlm_env.py
+++ b/tests/test_rlm_env.py
@@ -2445,25 +2445,25 @@ class TestRootLLMMaxCompletionTokens:
     @pytest.mark.asyncio
     async def test_is_root_budget_exhausted_false_when_none(self, rlm_env):
         assert rlm_env.root_max_completion_tokens is None
-        state = {"main_rlm_completion_tokens": 999999}
+        state = {"root_llm_completion_tokens": 999999}
         assert rlm_env._is_root_budget_exhausted(state) is False
 
     @pytest.mark.asyncio
     async def test_is_root_budget_exhausted_false_when_under(self, rlm_env):
         rlm_env.root_max_completion_tokens = 1000
-        state = {"main_rlm_completion_tokens": 500}
+        state = {"root_llm_completion_tokens": 500}
         assert rlm_env._is_root_budget_exhausted(state) is False
 
     @pytest.mark.asyncio
     async def test_is_root_budget_exhausted_true_when_at(self, rlm_env):
         rlm_env.root_max_completion_tokens = 1000
-        state = {"main_rlm_completion_tokens": 1000}
+        state = {"root_llm_completion_tokens": 1000}
         assert rlm_env._is_root_budget_exhausted(state) is True
 
     @pytest.mark.asyncio
     async def test_is_root_budget_exhausted_true_when_over(self, rlm_env):
         rlm_env.root_max_completion_tokens = 1000
-        state = {"main_rlm_completion_tokens": 1500}
+        state = {"root_llm_completion_tokens": 1500}
         assert rlm_env._is_root_budget_exhausted(state) is True
 
     @pytest.mark.asyncio
@@ -2483,7 +2483,7 @@ class TestRootLLMMaxCompletionTokens:
         state = {
             "trajectory": [],
             "context_warning_sent": False,
-            "main_rlm_completion_tokens": 1200,
+            "root_llm_completion_tokens": 1200,
         }
         output = await rlm_env.call_python_repl("print('test')", state)
 
@@ -2506,7 +2506,7 @@ class TestRootLLMMaxCompletionTokens:
         state = {
             "trajectory": [],
             "context_warning_sent": False,
-            "main_rlm_completion_tokens": 1200,
+            "root_llm_completion_tokens": 1200,
         }
         output = await rlm_env.call_python_repl("print('test')", state)
 
@@ -2565,7 +2565,7 @@ class TestRootLLMMaxCompletionTokens:
         rlm_env.root_max_completion_tokens = 1000
         rlm_env._executor.read_answer = AsyncMock(return_value="my answer")
 
-        state = {"main_rlm_completion_tokens": 1500, "rollout_id": "test"}
+        state = {"root_llm_completion_tokens": 1500, "rollout_id": "test"}
         fake_tool_messages = [MagicMock()]
 
         with patch(
@@ -2584,7 +2584,7 @@ class TestRootLLMMaxCompletionTokens:
         final_env_response."""
         rlm_env.root_max_completion_tokens = 1000
 
-        state = {"main_rlm_completion_tokens": 500}
+        state = {"root_llm_completion_tokens": 500}
         fake_tool_messages = [MagicMock()]
 
         with patch(
@@ -2603,7 +2603,7 @@ class TestRootLLMMaxCompletionTokens:
         rlm_env.root_max_completion_tokens = 1000
 
         state = {
-            "main_rlm_completion_tokens": 500,
+            "root_llm_completion_tokens": 500,
             "final_answer": "already set",
         }
         fake_tool_messages = [MagicMock()]
@@ -3146,10 +3146,10 @@ class TestContextDropping:
 
         await env_with_dropping._handle_remove_conversation_turns(state, 2, "")
 
-        assert state["context_drop_count"] == 1
-        assert state["context_total_turns_dropped"] == 2
-        assert state["context_drop_mean_remaining_turns"] == 4.0  # 6 - 2
-        assert state["context_drop_mean_turns_between"] == 0.0  # only 1 drop
+        assert state["compaction_count"] == 1
+        assert state["compaction_total_turns_dropped"] == 2
+        assert state["compaction_mean_remaining_turns"] == 4.0  # 6 - 2
+        assert state["compaction_mean_turns_between"] == 0.0  # only 1 drop
 
     @pytest.mark.asyncio
     async def test_cumulative_drop_metrics(self, env_with_dropping):
@@ -3159,8 +3159,8 @@ class TestContextDropping:
 
         # Drop 2 at turn 10: 10 visible -> 8 remaining
         await env_with_dropping._handle_remove_conversation_turns(state, 2, "")
-        assert state["context_drop_count"] == 1
-        assert state["context_drop_mean_remaining_turns"] == 8.0
+        assert state["compaction_count"] == 1
+        assert state["compaction_mean_remaining_turns"] == 8.0
 
         # Simulate 3 more main turns (total 13 in trajectory)
         for i in range(3):
@@ -3180,12 +3180,12 @@ class TestContextDropping:
 
         # Drop 3 at turn 13: 13-2=11 visible -> 8 remaining
         await env_with_dropping._handle_remove_conversation_turns(state, 3, "")
-        assert state["context_drop_count"] == 2
-        assert state["context_total_turns_dropped"] == 5
+        assert state["compaction_count"] == 2
+        assert state["compaction_total_turns_dropped"] == 5
         # mean remaining: (8 + 8) / 2 = 8.0
-        assert state["context_drop_mean_remaining_turns"] == 8.0
+        assert state["compaction_mean_remaining_turns"] == 8.0
         # turns between: [13 - 10] = [3], mean = 3.0
-        assert state["context_drop_mean_turns_between"] == 3.0
+        assert state["compaction_mean_turns_between"] == 3.0
 
     @pytest.mark.asyncio
     async def test_failed_drop_does_not_update_metrics(self, env_with_dropping):
@@ -3195,5 +3195,5 @@ class TestContextDropping:
         # Try to drop 5 (exceeds limit)
         await env_with_dropping._handle_remove_conversation_turns(state, 5, "")
 
-        assert state.get("context_drop_count", 0) == 0
-        assert state.get("context_total_turns_dropped", 0) == 0
+        assert state.get("compaction_count", 0) == 0
+        assert state.get("compaction_total_turns_dropped", 0) == 0

--- a/tests/test_tui_info_formatting.py
+++ b/tests/test_tui_info_formatting.py
@@ -245,11 +245,11 @@ def test_build_run_details_includes_rollout_metric_stats(tmp_path) -> None:
     assert "Average" in rendered
     assert "Min" in rendered
     assert "Max" in rendered
-    assert "sub-LLM completion tokens" in rendered
+    assert "sub llm completion tokens" in rendered
     assert "28,698" in rendered
     assert "877" in rendered
     assert "56,519" in rendered
-    assert "sub-LLM call count" in rendered
+    assert "sub llm call count" in rendered
     assert "Distribution" in rendered
 
 

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -270,9 +270,9 @@ def _ensure_rlm_metric_state(state: State) -> None:
     state.setdefault("sub_llm_max_batch_size", 0)
     state.setdefault("sub_llm_mean_batch_size", 0.0)
 
-    state.setdefault("main_rlm_turns", 0)
-    state.setdefault("main_rlm_prompt_tokens", 0)
-    state.setdefault("main_rlm_completion_tokens", 0)
+    state.setdefault("root_llm_turns", 0)
+    state.setdefault("root_llm_prompt_tokens", 0)
+    state.setdefault("root_llm_completion_tokens", 0)
 
     state.setdefault("repl_total_time_seconds", 0.0)
     state.setdefault("repl_call_count", 0)
@@ -287,12 +287,12 @@ def _ensure_rlm_metric_state(state: State) -> None:
     state.setdefault("_drop_sequence", 0)
     state.setdefault("_keep_from_assistant_index", 0)
 
-    state.setdefault("context_drop_count", 0)
-    state.setdefault("context_total_turns_dropped", 0)
-    state.setdefault("context_drop_mean_remaining_turns", 0.0)
-    state.setdefault("context_drop_mean_turns_between", 0.0)
-    state.setdefault("_context_drop_remaining_turns_list", [])
-    state.setdefault("_context_drop_at_main_turns", [])
+    state.setdefault("compaction_count", 0)
+    state.setdefault("compaction_total_turns_dropped", 0)
+    state.setdefault("compaction_mean_remaining_turns", 0.0)
+    state.setdefault("compaction_mean_turns_between", 0.0)
+    state.setdefault("_compaction_remaining_turns_list", [])
+    state.setdefault("_compaction_at_root_llm_turns", [])
 
 
 def _update_rlm_repl_metrics(state: State, execution_seconds: float) -> None:
@@ -349,9 +349,9 @@ def update_rlm_metrics_from_step(state: State, step: TrajectoryStep) -> None:
             state["sub_llm_max_batch_size"] = 0
             state["sub_llm_mean_batch_size"] = 0.0
     else:
-        state["main_rlm_turns"] += 1
-        state["main_rlm_prompt_tokens"] += prompt_tokens
-        state["main_rlm_completion_tokens"] += completion_tokens
+        state["root_llm_turns"] += 1
+        state["root_llm_prompt_tokens"] += prompt_tokens
+        state["root_llm_completion_tokens"] += completion_tokens
 
 
 def _update_root_tool_metrics(state: State, tool_name: str) -> None:
@@ -372,17 +372,17 @@ class RLMMonitorRubric(vf.Rubric):
         "sub_llm_batch_count",
         "sub_llm_max_batch_size",
         "sub_llm_mean_batch_size",
-        "main_rlm_turns",
-        "main_rlm_prompt_tokens",
-        "main_rlm_completion_tokens",
+        "root_llm_turns",
+        "root_llm_prompt_tokens",
+        "root_llm_completion_tokens",
         "repl_total_time_seconds",
         "repl_call_count",
         "repl_mean_time_seconds",
         "root_tool_call_count",
-        "context_drop_count",
-        "context_total_turns_dropped",
-        "context_drop_mean_remaining_turns",
-        "context_drop_mean_turns_between",
+        "compaction_count",
+        "compaction_total_turns_dropped",
+        "compaction_mean_remaining_turns",
+        "compaction_mean_turns_between",
     ]
 
     def __init__(self, root_tool_names: list[str] | None = None, **kwargs):
@@ -2680,20 +2680,20 @@ class RLMEnv(vf.StatefulToolEnv):
 
         # Update context dropping metrics
         _ensure_rlm_metric_state(state)
-        state["context_drop_count"] += 1
-        state["context_total_turns_dropped"] = state["_dropped_turns_count"]
+        state["compaction_count"] += 1
+        state["compaction_total_turns_dropped"] = state["_dropped_turns_count"]
 
-        remaining_list: list[int] = state["_context_drop_remaining_turns_list"]
+        remaining_list: list[int] = state["_compaction_remaining_turns_list"]
         remaining_list.append(new_visible)
-        state["context_drop_mean_remaining_turns"] = sum(remaining_list) / len(
+        state["compaction_mean_remaining_turns"] = sum(remaining_list) / len(
             remaining_list
         )
 
-        at_turns: list[int] = state["_context_drop_at_main_turns"]
+        at_turns: list[int] = state["_compaction_at_root_llm_turns"]
         at_turns.append(main_turn)
         if len(at_turns) >= 2:
             gaps = [at_turns[i] - at_turns[i - 1] for i in range(1, len(at_turns))]
-            state["context_drop_mean_turns_between"] = sum(gaps) / len(gaps)
+            state["compaction_mean_turns_between"] = sum(gaps) / len(gaps)
 
         await self._upload_summary(state, n_turns, summary, new_visible)
 
@@ -3986,7 +3986,7 @@ class RLMEnv(vf.StatefulToolEnv):
         )
 
         if self.root_max_completion_tokens is not None:
-            used = state.get("main_rlm_completion_tokens", 0)
+            used = state.get("root_llm_completion_tokens", 0)
             budget = self.root_max_completion_tokens
             output += f"\n[{used}/{budget} root completion tokens used]"
 
@@ -4135,7 +4135,7 @@ class RLMEnv(vf.StatefulToolEnv):
         """Check if root model completion token budget is exhausted."""
         if self.root_max_completion_tokens is None:
             return False
-        used = state.get("main_rlm_completion_tokens", 0)
+        used = state.get("root_llm_completion_tokens", 0)
         return used >= self.root_max_completion_tokens
 
     # =========================================================================

--- a/verifiers/scripts/tui.py
+++ b/verifiers/scripts/tui.py
@@ -1235,14 +1235,7 @@ def _build_metric_summary_table(metric_summaries: List[MetricSummary]) -> Table 
         "Scores": 5,
         "Other": 6,
     }
-    replacements = (
-        ("sub llm", "sub-LLM"),
-        ("main rlm", "main RLM"),
-        ("root rlm", "root RLM"),
-        ("llm", "LLM"),
-        ("repl", "REPL"),
-    )
-    prepared: List[Tuple[int, int, str, str, MetricSummary]] = []
+    prepared: List[Tuple[int, str, str, MetricSummary]] = []
     for summary in metric_summaries:
         lowered = summary.name.lower()
         if "token" in lowered:
@@ -1260,23 +1253,10 @@ def _build_metric_summary_table(metric_summaries: List[MetricSummary]) -> Table 
         else:
             category = "Other"
 
-        prefix_rank = 4
-        if lowered.startswith("sub_llm_"):
-            prefix_rank = 0
-        elif lowered.startswith("main_rlm_"):
-            prefix_rank = 1
-        elif lowered.startswith("root_"):
-            prefix_rank = 2
-        elif lowered.startswith("repl_"):
-            prefix_rank = 3
-
         display_name = summary.name.replace("_", " ")
-        for source, target in replacements:
-            display_name = display_name.replace(source, target)
         prepared.append(
             (
                 category_order.get(category, 99),
-                prefix_rank,
                 display_name,
                 category,
                 summary,
@@ -1291,7 +1271,7 @@ def _build_metric_summary_table(metric_summaries: List[MetricSummary]) -> Table 
     count_width = len("N")
 
     previous_category: str | None = None
-    for _, _, display_name, category, summary in sorted(prepared):
+    for _, display_name, category, summary in sorted(prepared):
         avg_text = _format_metric_stat_value(summary.avg)
         min_text = _format_metric_stat_value(summary.min_value)
         max_text = _format_metric_stat_value(summary.max_value)


### PR DESCRIPTION
## Description

- main_rlm_* → root_llm_* (turns, prompt_tokens, completion_tokens)
- context_drop_*/context_total_* → compaction_* metrics
- Remove RLM-specific display formatting from TUI (prefix ranking, name replacements)

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Renames state/metric keys used across `RLMEnv` and the TUI, which can break any downstream consumers expecting the old metric names. Logic changes are mostly mechanical, but missed references would surface as missing/zeroed metrics or budget checks not triggering.
> 
> **Overview**
> Unifies RLM metric naming by renaming `main_rlm_*` to `root_llm_*` (turn/token counters) and `context_drop_*` to `compaction_*` (compaction/drop counters), updating the metric initialization, updates, and the root completion-token budget check/output to use the new keys.
> 
> Simplifies TUI metric rendering by removing RLM-specific display name replacements and prefix-based ordering, so metrics are now grouped/sorted only by broad category and shown with plain underscore-to-space formatting. Tests were updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e08c2a46814c615be1a65119311c022f544b5f76. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->