### PR TITLE
RLMEnv: change `tools` arg to pass standard tools to root LLM

### DIFF
--- a/tests/test_rlm_env.py
+++ b/tests/test_rlm_env.py
@@ -899,7 +899,7 @@ class TestRLMEnvInitialization:
 
 
 class TestToolSplitConfiguration:
-    def test_tool_name_collision_raises(self):
+    def test_repl_tool_name_collision_raises(self):
         def tool_a() -> str:
             return "a"
 
@@ -910,7 +910,7 @@ class TestToolSplitConfiguration:
 
         dataset = make_dataset({})
         with pytest.raises(ValueError, match="collision"):
-            build_env(dataset, tools=[tool_a, tool_b])
+            build_env(dataset, root_tools=[tool_a, tool_b])
 
     def test_fixed_tool_override_raises(self):
         def llm_batch() -> str:  # pragma: no cover - name collision test
@@ -918,37 +918,36 @@ class TestToolSplitConfiguration:
 
         dataset = make_dataset({})
         with pytest.raises(ValueError, match="llm_batch"):
-            build_env(dataset, tools=[llm_batch])
+            build_env(dataset, root_tools=[llm_batch])
 
-    def test_tools_not_exposed_as_environment_tool_defs(self):
-        def shared_tool() -> str:
-            return "shared"
+    def test_standard_tools_exposed_repl_tools_not(self):
+        def standard_tool() -> str:
+            return "standard"
 
-        def root_tool() -> str:
-            return "root"
+        def repl_tool() -> str:
+            return "repl"
 
         def sub_tool() -> str:
             return "sub"
 
         dataset = make_dataset({})
         env = build_env(
-            dataset, tools=[shared_tool], root_tools=[root_tool], sub_tools=[sub_tool]
+            dataset,
+            tools=[standard_tool],
+            root_tools=[repl_tool],
+            sub_tools=[sub_tool],
         )
 
         tool_names = {tool.name for tool in env.tool_defs}
-        assert "shared_tool" not in tool_names
-        assert "root_tool" not in tool_names
+        assert "standard_tool" in tool_names
+        assert "repl_tool" not in tool_names
         assert "sub_tool" not in tool_names
 
     @pytest.mark.asyncio
-    async def test_root_and_sub_tools_documented_and_ordered(self):
-        def shared_tool() -> str:
-            """Shared tool."""
-            return "shared"
-
-        def root_tool() -> str:
-            """Root-only tool."""
-            return "root"
+    async def test_repl_and_sub_tools_documented_and_ordered(self):
+        def repl_tool() -> str:
+            """REPL-only tool."""
+            return "repl"
 
         def sub_tool() -> str:
             """Sub-only tool."""
@@ -957,8 +956,7 @@ class TestToolSplitConfiguration:
         dataset = make_dataset({})
         env = build_env(
             dataset,
-            tools=[shared_tool],
-            root_tools=[root_tool],
+            root_tools=[repl_tool],
             sub_tools=[sub_tool],
             interception_url="http://test.invalid",
         )
@@ -973,31 +971,26 @@ class TestToolSplitConfiguration:
             assert "REPL Tools" in prompt
             assert "Sub-LLM Tools" in prompt
 
-            root_index = prompt.find("REPL Tools")
+            repl_index = prompt.find("REPL Tools")
             sub_index = prompt.find("Sub-LLM Tools")
-            assert root_index != -1
+            assert repl_index != -1
             assert sub_index != -1
-            assert root_index < sub_index
+            assert repl_index < sub_index
 
-            root_section = prompt[root_index:sub_index]
+            repl_section = prompt[repl_index:sub_index]
             sub_section = prompt[sub_index:]
 
-            assert "llm_batch" in root_section
-            assert root_section.find("llm_batch") < root_section.find("shared_tool")
-            assert root_section.find("shared_tool") < root_section.find("root_tool")
+            assert "llm_batch" in repl_section
+            assert repl_section.find("llm_batch") < repl_section.find("repl_tool")
 
-            assert "shared_tool" in sub_section
             assert "sub_tool" in sub_section
-            assert "root_tool" not in sub_section
-            assert sub_section.find("shared_tool") < sub_section.find("sub_tool")
+            assert "repl_tool" not in sub_section
 
-            assert result["rlm_shared_tools"] == ["shared_tool"]
             assert result["rlm_root_tools"] == [
                 "llm_batch",
-                "shared_tool",
-                "root_tool",
+                "repl_tool",
             ]
-            assert result["rlm_sub_tools"] == ["shared_tool", "sub_tool"]
+            assert result["rlm_sub_tools"] == ["sub_tool"]
         finally:
             await env.cleanup_rlm_state(result)
 

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -122,7 +122,6 @@ def _dedupe_tools(
 def _merge_tool_lists(
     *,
     fixed_tools: list[Callable],
-    shared_tools: list[Callable],
     role_tools: list[Callable],
     context: str,
     reserved_names: set[str],
@@ -133,12 +132,6 @@ def _merge_tool_lists(
         reserved_names=set(),
     )
     merged = list(fixed)
-    deduped_shared, _ = _dedupe_tools(
-        shared_tools,
-        context=f"{context} shared tools",
-        reserved_names=reserved_names,
-    )
-    merged.extend(deduped_shared)
     deduped_role, _ = _dedupe_tools(
         role_tools,
         context=f"{context} tools",
@@ -2239,16 +2232,14 @@ class RLMEnv(vf.StatefulToolEnv):
 
     Args:
         max_turns: Maximum number of root-model turns (default: 50).
-        tools: List of tools shared by both the root REPL and sub-LLMs.
-                   These are added first in the tool documentation order.
-        root_tools: List of tools available only to the root REPL.
-                   The root model can call these inside the REPL as Python functions.
+        tools: List of standard tools given directly to the root LLM via
+                   normal tool calling (alongside the REPL tool). These are NOT
+                   available inside the REPL or to sub-LLMs.
+        root_tools: List of tools available only inside the REPL. The root
+                   model can call these as Python functions (or shell commands
+                   in bash mode) within REPL code. They are proxied via HTTP.
         sub_tools: List of tools available only to sub-LLMs.
                    Sub-LLMs access these via standard tool calling.
-        (Ordering) The root tool list is: fixed tools (e.g. llm_batch), then `tools`,
-                   then `root_tools`. The sub-LLM tool list is: `tools`, then `sub_tools`.
-                   Each list is deduplicated by tool name. If two different tools
-                   share a name within a list, initialization raises an error.
         sub_llm_max_turns: Maximum tool-calling turns for sub-LLM calls (default: 5)
         sub_max_completion_tokens: Total completion-token budget shared across all
                    sub-LLM calls in a rollout.  When set, the environment tracks
@@ -2372,8 +2363,8 @@ class RLMEnv(vf.StatefulToolEnv):
         self.enable_sub_llms = enable_sub_llms
         self.repl_language = repl_language
         self.sub_model = sub_model
-        self.shared_tools = tools or []
-        self.root_only_tools = root_tools or []
+        self.standard_tools = tools or []
+        self.repl_tools = root_tools or []
         self.sub_only_tools = sub_tools or []
         self.sub_llm_max_turns = sub_llm_max_turns
         self.sub_max_completion_tokens = sub_max_completion_tokens
@@ -2453,14 +2444,12 @@ class RLMEnv(vf.StatefulToolEnv):
         active_reserved = {_tool_display_name(t) for t in fixed_root_tools}
         self.root_tools, self.root_tool_map = _merge_tool_lists(
             fixed_tools=fixed_root_tools,
-            shared_tools=self.shared_tools,
-            role_tools=self.root_only_tools,
+            role_tools=self.repl_tools,
             context="root tools",
             reserved_names=active_reserved,
         )
         self.sub_tools, self.sub_tool_map = _merge_tool_lists(
             fixed_tools=[],
-            shared_tools=self.shared_tools,
             role_tools=self.sub_only_tools,
             context="sub-LLM tools",
             reserved_names=active_reserved,
@@ -2489,7 +2478,7 @@ class RLMEnv(vf.StatefulToolEnv):
         self.active_rollouts: dict[str, dict[str, Any]] = {}
 
         super().__init__(
-            tools=[],
+            tools=self.standard_tools,
             max_turns=max_turns,
             **kwargs,
         )
@@ -3660,12 +3649,6 @@ class RLMEnv(vf.StatefulToolEnv):
                 self.retain_filesystem_after_rollout
             )
             state["rlm_system_prompt"] = self.prompt_builder.build_system_prompt()
-            deduped_shared, _ = _dedupe_tools(
-                self.shared_tools, context="shared tools", reserved_names=set()
-            )
-            state["rlm_shared_tools"] = [
-                _tool_display_name(tool) for tool in deduped_shared
-            ]
             state["rlm_root_tools"] = [
                 _tool_display_name(tool) for tool in self.root_tools
             ]


### PR DESCRIPTION
## Description

Previously `tools` were shared between root REPL and sub-LLMs. Now `tools` are standard tool-calling tools given directly to the root LLM alongside the REPL tool. `root_tools` remains REPL-only, `sub_tools` remains sub-LLM-only. Removes the shared tools concept.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it’s a breaking behavioral change to tool exposure and ordering that can silently alter which tools are available to the root REPL vs sub-LLMs in existing integrations.
> 
> **Overview**
> **RLMEnv tool routing is redefined.** The `tools` argument now registers *standard tool-calling tools for the root LLM only* (alongside the REPL tool), and the previous concept of tools being shared with both the REPL and sub-LLMs is removed.
> 
> `root_tools` is repurposed to mean *REPL-only* tools (proxied via the REPL/HTTP path), `sub_tools` remains *sub-LLM-only*, and initialization/state no longer tracks `rlm_shared_tools`. Tests are updated to reflect the new collision checks, tool exposure in `env.tool_defs`, and prompt documentation/ordering expectations (REPL tools documented separately from sub-LLM tools).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 65c722f9dee3a7da57b3804fd2bdf5dde99a7175. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->