### PR TITLE
fix: catch vLLM InternalServerError for overlong prompts

### DIFF
--- a/tests/test_client_auth_errors.py
+++ b/tests/test_client_auth_errors.py
@@ -4,6 +4,7 @@ from anthropic import AuthenticationError as AnthropicAuthenticationError
 from anthropic import BadRequestError as AnthropicBadRequestError
 from openai import AuthenticationError as OpenAIAuthenticationError
 from openai import BadRequestError as OpenAIBadRequestError
+from openai import InternalServerError as OpenAIInternalServerError
 
 from verifiers.clients.anthropic_messages_client import AnthropicMessagesClient
 from verifiers.clients.openai_chat_completions_client import OpenAIChatCompletionsClient
@@ -182,6 +183,72 @@ async def test_openai_overlong_prompt_raises_overlong_error(error_message: str):
     client = OpenAIChatCompletionsClient(_OverlongOpenAIChatClient(error_message))
 
     with pytest.raises(OverlongPromptError):
+        await client.get_response(
+            prompt=[UserMessage(content="test prompt")],
+            model="gpt-test",
+            sampling_args={},
+        )
+
+
+# ---------------------------------------------------------------------------
+# vLLM-style InternalServerError for overlong prompts
+# ---------------------------------------------------------------------------
+
+
+def _make_openai_internal_server_error(message: str) -> OpenAIInternalServerError:
+    response = httpx.Response(
+        status_code=500,
+        request=httpx.Request("POST", "https://api.openai.com/v1/chat/completions"),
+        text=message,
+    )
+    return OpenAIInternalServerError(message, response=response, body=None)
+
+
+class _OverlongVLLMChatCompletions:
+    def __init__(self, message: str) -> None:
+        self._message = message
+
+    async def create(self, *args, **kwargs):  # noqa: ANN002, ANN003
+        raise _make_openai_internal_server_error(self._message)
+
+
+class _OverlongVLLMChatClient:
+    class _Chat:
+        def __init__(self, message: str) -> None:
+            self.completions = _OverlongVLLMChatCompletions(message)
+
+    def __init__(self, message: str) -> None:
+        self.chat = self._Chat(message)
+
+
+@pytest.mark.parametrize(
+    "error_message",
+    [
+        # Real vLLM error format
+        "The prompt is 32769 tokens, which exceeds the model's maximum context length of 32768 tokens.",
+        # Other context-length phrases that might come as 500s
+        "context length exceeded",
+    ],
+)
+@pytest.mark.asyncio
+async def test_vllm_internal_server_error_overlong_prompt(error_message: str):
+    """vLLM returns overlong-prompt errors as 500 InternalServerError, not 400."""
+    client = OpenAIChatCompletionsClient(_OverlongVLLMChatClient(error_message))
+
+    with pytest.raises(OverlongPromptError):
+        await client.get_response(
+            prompt=[UserMessage(content="test prompt")],
+            model="gpt-test",
+            sampling_args={},
+        )
+
+
+@pytest.mark.asyncio
+async def test_vllm_non_overlong_internal_server_error_not_converted():
+    """A 500 that is NOT about context length should propagate as InternalServerError."""
+    client = OpenAIChatCompletionsClient(_OverlongVLLMChatClient("CUDA out of memory"))
+
+    with pytest.raises(OpenAIInternalServerError):
         await client.get_response(
             prompt=[UserMessage(content="test prompt")],
             model="gpt-test",

--- a/verifiers/clients/openai_chat_completions_client.py
+++ b/verifiers/clients/openai_chat_completions_client.py
@@ -9,6 +9,7 @@ from openai import (
     AsyncOpenAI,
     AuthenticationError,
     BadRequestError,
+    InternalServerError,
     PermissionDeniedError,
 )
 from openai.types.chat import (
@@ -71,7 +72,7 @@ def handle_openai_overlong_prompt(func):
             return await func(*args, **kwargs)
         except (AuthenticationError, PermissionDeniedError):
             raise
-        except BadRequestError as e:
+        except (BadRequestError, InternalServerError) as e:
             error_text = e.response.text.lower()
             context_length_phrases = [
                 "this model's maximum context length is",


### PR DESCRIPTION
## Summary
- vLLM returns overlong-prompt errors as HTTP 500 `InternalServerError` instead of 400 `BadRequestError`
- Extended `handle_openai_overlong_prompt` decorator to also catch `InternalServerError` and check for context-length phrases in the error text
- Added tests for both matching (converted to `OverlongPromptError`) and non-matching (passes through) 500 errors

## Test plan
- [x] Verified fix converts vLLM-style 500 with context length message to `OverlongPromptError`
- [x] Verified non-context-length 500 errors still propagate as `InternalServerError`
- [x] All existing error handling behavior unchanged (decorator still catches `BadRequestError`, still re-raises auth errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands exception handling to reinterpret some `InternalServerError` responses as `OverlongPromptError`, which could mask genuine 500s if the message matches the context-length phrases; tests reduce this risk by asserting non-matching 500s still propagate.
> 
> **Overview**
> Extends OpenAI chat-completions overlong-prompt detection to also handle vLLM-style HTTP 500s by catching `InternalServerError` in `handle_openai_overlong_prompt` and mapping context-length messages to `OverlongPromptError`.
> 
> Adds regression tests covering both conversion of vLLM 500 context-length errors and pass-through behavior for unrelated 500s (e.g., "CUDA out of memory").
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f93ca5fc4b80bf06e9a93ade0f748947b73d8e62. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->