### PR TITLE
remove RLM branding from model-visible prompts and messages

### DIFF
--- a/tests/test_rlm_env.py
+++ b/tests/test_rlm_env.py
@@ -223,7 +223,7 @@ class TestGenerateSubToolsDocumentation:
 
     def test_generate_docs_for_tools(self, rlm_env_with_sub_tools):
         docs = rlm_env_with_sub_tools.prompt_builder.build_sub_tools_documentation()
-        assert "Sub-LLM Tools" in docs
+        assert "Sub-Model Tools" in docs
         assert "sample_tool" in docs
         assert "another_tool" in docs
         assert "Add two numbers" in docs
@@ -445,8 +445,8 @@ class TestBashPrompt:
         result = await env.setup_state(state)
         try:
             prompt = result["rlm_system_prompt"]
-            assert "RLM_READY" in prompt
-            assert "RLM_CONTENT" in prompt
+            assert "ANSWER_READY" in prompt
+            assert "ANSWER_CONTENT" in prompt
         finally:
             await env.cleanup_rlm_state(result)
 
@@ -460,10 +460,10 @@ class TestPromptVerbosity:
                 "light",
                 [
                     "You have the `call_python_repl` tool and a filesystem available to you.",
-                    "Make use of sub-LLMs via `llm_batch`",
+                    "Make use of sub-models via `llm_batch`",
                 ],
                 [
-                    "## Sub-LLM Usage",
+                    "## llm_batch Usage",
                 ],
             ),
             (
@@ -473,14 +473,14 @@ class TestPromptVerbosity:
                     "prefer calling them in parallel",
                 ],
                 [
-                    "## Sub-LLM Usage",
+                    "## llm_batch Usage",
                 ],
             ),
             (
                 "heavy",
                 [
                     "You have the `call_python_repl` tool and a filesystem available to you.",
-                    "## Sub-LLM Usage",
+                    "## llm_batch Usage",
                     "Pass a list of strings only",
                 ],
                 [],
@@ -535,6 +535,7 @@ class TestPromptVerbosity:
             prompt = result["rlm_system_prompt"]
             assert "llm_batch" not in prompt
             assert "sub-LLM" not in prompt
+            assert "sub-model" not in prompt.lower()
             assert "You have the `call_python_repl` tool" in prompt
         finally:
             await env.cleanup_rlm_state(result)
@@ -969,10 +970,10 @@ class TestToolSplitConfiguration:
         try:
             prompt = result["rlm_system_prompt"]
             assert "REPL Tools" in prompt
-            assert "Sub-LLM Tools" in prompt
+            assert "Sub-Model Tools" in prompt
 
             repl_index = prompt.find("REPL Tools")
-            sub_index = prompt.find("Sub-LLM Tools")
+            sub_index = prompt.find("Sub-Model Tools")
             assert repl_index != -1
             assert sub_index != -1
             assert repl_index < sub_index
@@ -1096,7 +1097,7 @@ class TestContextLimitWarning:
         assert "8,000" in output
         assert "10,000" in output
         assert "80%" in output
-        assert "RLM_READY=1" in output
+        assert "ANSWER_READY=1" in output
         assert state["context_warning_sent"] is True
 
 
@@ -2239,7 +2240,7 @@ class TestSubLLMCompletionTokenBudget:
             _, summary_lines = await rlm_env._root_llm_batch(context, ["prompt1"])
 
         # Summary should include budget info
-        budget_line = [s for s in summary_lines if "sub-LLM completion tokens" in s]
+        budget_line = [s for s in summary_lines if "llm_batch completion tokens" in s]
         assert len(budget_line) == 1
         assert "/10000" in budget_line[0]
 
@@ -2276,7 +2277,7 @@ class TestSubLLMCompletionTokenBudget:
         ):
             _, summary_lines = await rlm_env._root_llm_batch(context, ["prompt1"])
 
-        budget_lines = [s for s in summary_lines if "sub-LLM completion tokens" in s]
+        budget_lines = [s for s in summary_lines if "llm_batch completion tokens" in s]
         assert len(budget_lines) == 0
 
     @pytest.mark.asyncio

--- a/tests/test_rlm_env.py
+++ b/tests/test_rlm_env.py
@@ -223,7 +223,7 @@ class TestGenerateSubToolsDocumentation:
 
     def test_generate_docs_for_tools(self, rlm_env_with_sub_tools):
         docs = rlm_env_with_sub_tools.prompt_builder.build_sub_tools_documentation()
-        assert "Sub-Model Tools" in docs
+        assert "Sub-LLM Tools" in docs
         assert "sample_tool" in docs
         assert "another_tool" in docs
         assert "Add two numbers" in docs
@@ -460,10 +460,10 @@ class TestPromptVerbosity:
                 "light",
                 [
                     "You have the `call_python_repl` tool and a filesystem available to you.",
-                    "Make use of sub-models via `llm_batch`",
+                    "Make use of sub-LLMs via `llm_batch`",
                 ],
                 [
-                    "## llm_batch Usage",
+                    "## Sub-LLM Usage",
                 ],
             ),
             (
@@ -473,14 +473,14 @@ class TestPromptVerbosity:
                     "prefer calling them in parallel",
                 ],
                 [
-                    "## llm_batch Usage",
+                    "## Sub-LLM Usage",
                 ],
             ),
             (
                 "heavy",
                 [
                     "You have the `call_python_repl` tool and a filesystem available to you.",
-                    "## llm_batch Usage",
+                    "## Sub-LLM Usage",
                     "Pass a list of strings only",
                 ],
                 [],
@@ -535,7 +535,6 @@ class TestPromptVerbosity:
             prompt = result["rlm_system_prompt"]
             assert "llm_batch" not in prompt
             assert "sub-LLM" not in prompt
-            assert "sub-model" not in prompt.lower()
             assert "You have the `call_python_repl` tool" in prompt
         finally:
             await env.cleanup_rlm_state(result)
@@ -970,10 +969,10 @@ class TestToolSplitConfiguration:
         try:
             prompt = result["rlm_system_prompt"]
             assert "REPL Tools" in prompt
-            assert "Sub-Model Tools" in prompt
+            assert "Sub-LLM Tools" in prompt
 
             repl_index = prompt.find("REPL Tools")
-            sub_index = prompt.find("Sub-Model Tools")
+            sub_index = prompt.find("Sub-LLM Tools")
             assert repl_index != -1
             assert sub_index != -1
             assert repl_index < sub_index

--- a/tests/test_rlm_env.py
+++ b/tests/test_rlm_env.py
@@ -223,7 +223,7 @@ class TestGenerateSubToolsDocumentation:
 
     def test_generate_docs_for_tools(self, rlm_env_with_sub_tools):
         docs = rlm_env_with_sub_tools.prompt_builder.build_sub_tools_documentation()
-        assert "Sub-LLM Tools" in docs
+        assert "llm_batch Tools" in docs
         assert "sample_tool" in docs
         assert "another_tool" in docs
         assert "Add two numbers" in docs
@@ -460,27 +460,27 @@ class TestPromptVerbosity:
                 "light",
                 [
                     "You have the `call_python_repl` tool and a filesystem available to you.",
-                    "Make use of sub-LLMs via `llm_batch`",
+                    "Make use of `llm_batch`",
                 ],
                 [
-                    "## Sub-LLM Usage",
+                    "## llm_batch Usage",
                 ],
             ),
             (
                 "medium",
                 [
                     "You have the `call_python_repl` tool and a filesystem available to you.",
-                    "prefer calling them in parallel",
+                    "prefer calling in parallel",
                 ],
                 [
-                    "## Sub-LLM Usage",
+                    "## llm_batch Usage",
                 ],
             ),
             (
                 "heavy",
                 [
                     "You have the `call_python_repl` tool and a filesystem available to you.",
-                    "## Sub-LLM Usage",
+                    "## llm_batch Usage",
                     "Pass a list of strings only",
                 ],
                 [],
@@ -969,10 +969,10 @@ class TestToolSplitConfiguration:
         try:
             prompt = result["rlm_system_prompt"]
             assert "REPL Tools" in prompt
-            assert "Sub-LLM Tools" in prompt
+            assert "llm_batch Tools" in prompt
 
             repl_index = prompt.find("REPL Tools")
-            sub_index = prompt.find("Sub-LLM Tools")
+            sub_index = prompt.find("llm_batch Tools")
             assert repl_index != -1
             assert sub_index != -1
             assert repl_index < sub_index

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -1215,19 +1215,17 @@ In the end, the `ANSWER_CONTENT` environment variable must contain your answer. 
 """
 
     SUB_LLM_ROOT_INSTRUCTION_STORE: dict[str, str] = {
-        "light": (
-            "Make use of sub-LLMs via `llm_batch` whenever they could be useful."
-        ),
+        "light": ("Make use of `llm_batch` whenever it could be useful."),
         "medium": (
-            "Make use of sub-LLMs via `llm_batch` whenever they could be useful;"
-            " prefer calling them in parallel to calling them sequentially."
+            "Make use of `llm_batch` whenever it could be useful;"
+            " prefer calling in parallel to calling sequentially."
         ),
         "heavy": (
-            "\n## Sub-LLM Usage\n\n"
+            "\n## llm_batch Usage\n\n"
             "- Use `llm_batch()` for semantic tasks — summarization,"
             " understanding text, classification, etc.\n"
             "- Pass a list of strings only (no message dicts).\n"
-            "- Prefer calling sub-LLMs in parallel to calling them sequentially."
+            "- Prefer parallel calls to sequential ones."
         ),
     }
 
@@ -1346,16 +1344,14 @@ In the end, the `ANSWER_CONTENT` environment variable must contain your answer. 
         if not self.enable_sub_llms or not self.sub_tool_defs:
             return ""
 
-        lines = ["\n## Sub-LLM Tools\n"]
-        lines.append(
-            "The sub-LLMs called via `llm_batch()` have access to the following tools:\n"
-        )
+        lines = ["\n## llm_batch Tools\n"]
+        lines.append("The `llm_batch()` calls have access to the following tools:\n")
 
         self._format_tool_docs_into(lines, self.sub_tool_defs)
 
         lines.append(
-            "When delegating tasks to sub-LLMs via `llm_batch()`, they can use these "
-            "tools autonomously."
+            "When delegating tasks via `llm_batch()`, these tools are used "
+            "autonomously."
         )
         lines.append(
             "You do NOT need to manage tool calls yourself - just describe the task "
@@ -2556,11 +2552,13 @@ class RLMEnv(vf.StatefulToolEnv):
 
             async def llm_batch(prompts: list[str]) -> list[str]:
                 """
-                Call the sub-LLM on multiple prompts in parallel.
+                Dispatch prompts to fresh instances of your own model in parallel.
+                Each call gets an independent context window — they cannot see
+                your conversation or each other's responses.
 
                 - Input: a list of prompt strings.
                 - Output: a list of responses in the same order as the input prompts.
-                - Use this inside the REPL to get help on sub-tasks.
+                - Use this inside the REPL to delegate sub-tasks.
                 """
                 # Context is injected only when called via the REPL root-tool endpoint.
                 context = self._root_tool_context_var.get()

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -1028,16 +1028,16 @@ _RLM_BASH_WORKER_SCRIPT_TEMPLATE = textwrap.dedent(
         pwd_marker = f"__RLM_PWD__{marker}__"
 
         bash_script = (
-            f'cd "${{RLM_PWD:-$PWD}}"\\n'
-            f'export RLM_READY="${{RLM_READY:-}}"\\n'
-            f'export RLM_CONTENT="${{RLM_CONTENT-}}"\\n'
+            f'cd "${{REPL_PWD:-$PWD}}"\\n'
+            f'export ANSWER_READY="${{ANSWER_READY:-}}"\\n'
+            f'export ANSWER_CONTENT="${{ANSWER_CONTENT-}}"\\n'
             f"{TOOL_DEF_SCRIPT}\\n"
             f"(\\n"
             f"trap '"
             f'__RLM_STATUS=$?; '
             f'printf "\\n{end_marker}__%s\\n" "$__RLM_STATUS"; '
-            f'printf "{env_marker}__%s__" "${{RLM_READY:-}}"; '
-            f'printf "%s" "${{RLM_CONTENT-}}" | base64 | tr -d "\\n"; '
+            f'printf "{env_marker}__%s__" "${{ANSWER_READY:-}}"; '
+            f'printf "%s" "${{ANSWER_CONTENT-}}" | base64 | tr -d "\\n"; '
             f'printf "\\n{pwd_marker}__%s\\n" "$PWD"'
             f"' EXIT\\n"
             f"{code}\\n"
@@ -1047,9 +1047,9 @@ _RLM_BASH_WORKER_SCRIPT_TEMPLATE = textwrap.dedent(
         env = os.environ.copy()
         env.update(
             {
-                "RLM_READY": "1" if state.get("ready") else "",
-                "RLM_CONTENT": state.get("content", ""),
-                "RLM_PWD": state.get("cwd", ""),
+                "ANSWER_READY": "1" if state.get("ready") else "",
+                "ANSWER_CONTENT": state.get("content", ""),
+                "REPL_PWD": state.get("cwd", ""),
                 "RLM_ROOT_TOOL_HELPER": helper_path,
                 "RLM_ROOT_TOOL_PYTHON": sys.executable,
             }
@@ -1211,23 +1211,23 @@ There exists an `answer` variable, which is a dict. `answer["content"]` must con
 
     BASH_BASE_PROMPT: str = """You have the `call_bash_repl` tool and a filesystem available to you.
 
-In the end, the `RLM_CONTENT` environment variable must contain your answer. When the final answer is set, call `export RLM_READY=1`.
+In the end, the `ANSWER_CONTENT` environment variable must contain your answer. When the final answer is set, call `export ANSWER_READY=1`.
 """
 
     SUB_LLM_ROOT_INSTRUCTION_STORE: dict[str, str] = {
         "light": (
-            "Make use of sub-LLMs via `llm_batch` whenever they could be useful."
+            "Make use of sub-models via `llm_batch` whenever they could be useful."
         ),
         "medium": (
-            "Make use of sub-LLMs via `llm_batch` whenever they could be useful;"
+            "Make use of sub-models via `llm_batch` whenever they could be useful;"
             " prefer calling them in parallel to calling them sequentially."
         ),
         "heavy": (
-            "\n## Sub-LLM Usage\n\n"
+            "\n## llm_batch Usage\n\n"
             "- Use `llm_batch()` for semantic tasks — summarization,"
             " understanding text, classification, etc.\n"
             "- Pass a list of strings only (no message dicts).\n"
-            "- Prefer calling sub-LLMs in parallel to calling them sequentially."
+            "- Prefer calling sub-models in parallel to calling them sequentially."
         ),
     }
 
@@ -1346,15 +1346,15 @@ In the end, the `RLM_CONTENT` environment variable must contain your answer. Whe
         if not self.enable_sub_llms or not self.sub_tool_defs:
             return ""
 
-        lines = ["\n## Sub-LLM Tools\n"]
+        lines = ["\n## Sub-Model Tools\n"]
         lines.append(
-            "The sub-LLMs called via `llm_batch()` have access to the following tools:\n"
+            "The sub-models called via `llm_batch()` have access to the following tools:\n"
         )
 
         self._format_tool_docs_into(lines, self.sub_tool_defs)
 
         lines.append(
-            "When delegating tasks to sub-LLMs via `llm_batch()`, they can use these "
+            "When delegating tasks to sub-models via `llm_batch()`, they can use these "
             "tools autonomously."
         )
         lines.append(
@@ -1404,7 +1404,7 @@ In the end, the `RLM_CONTENT` environment variable must contain your answer. Whe
         return (
             f"\nYou have a total budget of "
             f"{self.sub_max_completion_tokens} completion tokens "
-            f"across all sub-LLM calls via llm_batch().\n"
+            f"across all llm_batch() calls.\n"
         )
 
     def build_system_prompt(self) -> str:
@@ -1420,7 +1420,7 @@ In the end, the `RLM_CONTENT` environment variable must contain your answer. Whe
             + self.build_message_history_note()
             + self.build_context_dropping_note()
         )
-        return "<RLM_SCAFFOLDING>\n" + body + "\n</RLM_SCAFFOLDING>\n\n"
+        return "<SCAFFOLDING>\n" + body + "\n</SCAFFOLDING>\n\n"
 
     def build_sub_llm_system_prompt(self) -> str:
         """Build the system prompt prepended to every sub-LLM call."""
@@ -1445,7 +1445,7 @@ In the end, the `RLM_CONTENT` environment variable must contain your answer. Whe
             content = msg_mut.get("content")
             if isinstance(content, str) or content is None:
                 text = content or ""
-                if text.startswith("<RLM_SCAFFOLDING>"):
+                if text.startswith("<SCAFFOLDING>"):
                     return
                 msg_mut["content"] = scaffold + text
             elif isinstance(content, list):
@@ -1453,7 +1453,7 @@ In the end, the `RLM_CONTENT` environment variable must contain your answer. Whe
                     content
                     and isinstance(content[0], dict)
                     and content[0].get("type") == "text"
-                    and str(content[0].get("text", "")).startswith("<RLM_SCAFFOLDING>")
+                    and str(content[0].get("text", "")).startswith("<SCAFFOLDING>")
                 ):
                     return
                 msg_mut["content"] = [{"type": "text", "text": scaffold}, *content]
@@ -2556,7 +2556,7 @@ class RLMEnv(vf.StatefulToolEnv):
 
             async def llm_batch(prompts: list[str]) -> list[str]:
                 """
-                Call the sub-LLM on multiple prompts in parallel.
+                Call a sub-model on multiple prompts in parallel.
 
                 - Input: a list of prompt strings.
                 - Output: a list of responses in the same order as the input prompts.
@@ -3035,9 +3035,9 @@ class RLMEnv(vf.StatefulToolEnv):
         used = state_ref.get("sub_llm_completion_tokens", 0)
         budget = self.sub_max_completion_tokens
         return (
-            f"Sub-LLM token budget exhausted "
+            f"llm_batch token budget exhausted "
             f"(used {used}/{budget} completion tokens). "
-            f"No further sub-LLM calls are available. "
+            f"No further llm_batch calls are available. "
             f"Finalize your answer with the information you have."
         )
 
@@ -3065,7 +3065,7 @@ class RLMEnv(vf.StatefulToolEnv):
                 contents = [msg] * len(prompts)
                 summary_lines = [
                     f"llm_batch: {len(prompts)} call(s) skipped — "
-                    f"sub-LLM token budget exhausted "
+                    f"llm_batch token budget exhausted "
                     f"({used}/{self.sub_max_completion_tokens} "
                     f"completion tokens used)"
                 ]
@@ -3173,7 +3173,9 @@ class RLMEnv(vf.StatefulToolEnv):
         if self.sub_max_completion_tokens is not None:
             used = state_ref.get("sub_llm_completion_tokens", 0)
             budget = self.sub_max_completion_tokens
-            summary_lines.append(f"  [{used}/{budget} sub-LLM completion tokens used]")
+            summary_lines.append(
+                f"  [{used}/{budget} llm_batch completion tokens used]"
+            )
 
         return contents, summary_lines
 
@@ -3258,9 +3260,9 @@ class RLMEnv(vf.StatefulToolEnv):
                         {
                             "message": {
                                 "content": (
-                                    f"Sub-LLM token budget exhausted "
+                                    f"llm_batch token budget exhausted "
                                     f"(used {used}/{budget} completion tokens). "
-                                    f"No further sub-LLM calls are available. "
+                                    f"No further llm_batch calls are available. "
                                     f"Finalize your answer with the information you have."
                                 )
                             }
@@ -3980,7 +3982,7 @@ class RLMEnv(vf.StatefulToolEnv):
         return await self._call_repl(
             code,
             state,
-            ready_instruction="Please finalize your answer soon by setting RLM_READY=1.",
+            ready_instruction="Please finalize your answer soon by setting ANSWER_READY=1.",
             append_execution_time=False,
         )
 

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -1216,18 +1216,18 @@ In the end, the `ANSWER_CONTENT` environment variable must contain your answer. 
 
     SUB_LLM_ROOT_INSTRUCTION_STORE: dict[str, str] = {
         "light": (
-            "Make use of sub-models via `llm_batch` whenever they could be useful."
+            "Make use of sub-LLMs via `llm_batch` whenever they could be useful."
         ),
         "medium": (
-            "Make use of sub-models via `llm_batch` whenever they could be useful;"
+            "Make use of sub-LLMs via `llm_batch` whenever they could be useful;"
             " prefer calling them in parallel to calling them sequentially."
         ),
         "heavy": (
-            "\n## llm_batch Usage\n\n"
+            "\n## Sub-LLM Usage\n\n"
             "- Use `llm_batch()` for semantic tasks — summarization,"
             " understanding text, classification, etc.\n"
             "- Pass a list of strings only (no message dicts).\n"
-            "- Prefer calling sub-models in parallel to calling them sequentially."
+            "- Prefer calling sub-LLMs in parallel to calling them sequentially."
         ),
     }
 
@@ -1346,15 +1346,15 @@ In the end, the `ANSWER_CONTENT` environment variable must contain your answer. 
         if not self.enable_sub_llms or not self.sub_tool_defs:
             return ""
 
-        lines = ["\n## Sub-Model Tools\n"]
+        lines = ["\n## Sub-LLM Tools\n"]
         lines.append(
-            "The sub-models called via `llm_batch()` have access to the following tools:\n"
+            "The sub-LLMs called via `llm_batch()` have access to the following tools:\n"
         )
 
         self._format_tool_docs_into(lines, self.sub_tool_defs)
 
         lines.append(
-            "When delegating tasks to sub-models via `llm_batch()`, they can use these "
+            "When delegating tasks to sub-LLMs via `llm_batch()`, they can use these "
             "tools autonomously."
         )
         lines.append(
@@ -2556,7 +2556,7 @@ class RLMEnv(vf.StatefulToolEnv):
 
             async def llm_batch(prompts: list[str]) -> list[str]:
                 """
-                Call a sub-model on multiple prompts in parallel.
+                Call the sub-LLM on multiple prompts in parallel.
 
                 - Input: a list of prompt strings.
                 - Output: a list of responses in the same order as the input prompts.


### PR DESCRIPTION
## Description

Rename model-facing references so the scaffolding is generic:
- <RLM_SCAFFOLDING> → <SCAFFOLDING>
- RLM_READY → ANSWER_READY, RLM_CONTENT → ANSWER_CONTENT, RLM_PWD → REPL_PWD
- "sub-LLM" → "sub-model" / "llm_batch" in prompt text and budget messages
- "Sub-LLM Tools" → "Sub-Model Tools"

Internal variable names, log messages, and class names are unchanged.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the wire protocol between the Bash worker and host (`ANSWER_*`/`REPL_PWD` env vars and scaffold tags), which could break integrations if any callers still expect the old `RLM_*` markers.
> 
> **Overview**
> Removes RLM-specific branding from model-visible prompts by renaming the scaffolding wrapper from `RLM_SCAFFOLDING` to `SCAFFOLDING` (and updating injection/idempotency checks).
> 
> Updates the Bash REPL answer handoff protocol to use `ANSWER_READY`/`ANSWER_CONTENT` and `REPL_PWD` instead of `RLM_READY`/`RLM_CONTENT`/`RLM_PWD`, including the worker-side export/serialization and the host-side guidance string.
> 
> Rewrites sub-LLM prompt copy to be explicitly about `llm_batch` (section headers, tool docs, delegation guidance, and token budget/“budget exhausted” messages), and adjusts tests accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c9880fe5d61704f625aa077b8218bb8b76ec5ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->