### PR TITLE
feat: MCP tool channel for composable TaskSet → Harness

### DIFF
--- a/verifiers/envs/experimental/composable/__init__.py
+++ b/verifiers/envs/experimental/composable/__init__.py
@@ -1,4 +1,5 @@
 from verifiers.envs.experimental.composable.task import (
+    MCPServerSpec,
     SandboxSpec,
     Task,
     TaskSet,
@@ -8,6 +9,7 @@ from verifiers.envs.experimental.composable.harness import Harness
 from verifiers.envs.experimental.composable.composable_env import ComposableEnv
 
 __all__ = [
+    "MCPServerSpec",
     "SandboxSpec",
     "Task",
     "TaskSet",

--- a/verifiers/envs/experimental/composable/composable_env.py
+++ b/verifiers/envs/experimental/composable/composable_env.py
@@ -181,10 +181,15 @@ class ComposableEnv(CliAgentEnv):
                         )
                         await self.upload_content(sandbox_id, content, sandbox_path)
             mcp_config = self.harness.format_mcp_config(mcp_servers)
-            if mcp_config:
-                await self.upload_content(
-                    sandbox_id, mcp_config, "/task/mcp_config.json"
+            if mcp_config is None:
+                raise NotImplementedError(
+                    f"TaskSet provides MCP servers {list(mcp_servers)} but "
+                    f"harness {type(self.harness).__name__} does not implement "
+                    f"format_mcp_config"
                 )
+            await self.upload_content(
+                sandbox_id, mcp_config, "/task/mcp_config.json"
+            )
 
         # 6. Install agent binary
         if self.harness.install_script:

--- a/verifiers/envs/experimental/composable/composable_env.py
+++ b/verifiers/envs/experimental/composable/composable_env.py
@@ -168,18 +168,10 @@ class ComposableEnv(CliAgentEnv):
                 sandbox_id, self.harness.system_prompt, self.harness.system_prompt_path
             )
 
-        # 5. Upload MCP server files and pass configs to harness
+        # 5. Wire MCP servers from taskset into harness
         mcp_servers = self.taskset.get_mcp_servers()
         if mcp_servers:
             self.harness.mcp_servers = mcp_servers
-            for name, spec in mcp_servers.items():
-                if spec.files:
-                    for sandbox_path, content in spec.files.items():
-                        parent = sandbox_path.rsplit("/", 1)[0]
-                        await self.sandbox_client.execute_command(
-                            sandbox_id, f"mkdir -p {parent}", timeout=10
-                        )
-                        await self.upload_content(sandbox_id, content, sandbox_path)
             mcp_config = self.harness.format_mcp_config(mcp_servers)
             if mcp_config is None:
                 raise NotImplementedError(

--- a/verifiers/envs/experimental/composable/composable_env.py
+++ b/verifiers/envs/experimental/composable/composable_env.py
@@ -179,9 +179,7 @@ class ComposableEnv(CliAgentEnv):
                     f"harness {type(self.harness).__name__} does not implement "
                     f"format_mcp_config"
                 )
-            await self.upload_content(
-                sandbox_id, mcp_config, "/task/mcp_config.json"
-            )
+            await self.upload_content(sandbox_id, mcp_config, "/task/mcp_config.json")
 
         # 6. Install agent binary
         if self.harness.install_script:

--- a/verifiers/envs/experimental/composable/composable_env.py
+++ b/verifiers/envs/experimental/composable/composable_env.py
@@ -15,6 +15,7 @@ The task and harness each own different concerns.  ComposableEnv connects them:
 - Sandbox setup: ``setup(sandbox_client, sandbox_id, state)``
 - Evaluation: ``evaluate(...)``
 - Environment variables: ``get_env_vars() -> dict``
+- MCP tool servers: ``get_mcp_servers() -> dict[str, MCPServerSpec]``
 
 **Harness owns** (via Harness dataclass):
 - How to install the agent: ``install_script``
@@ -27,7 +28,8 @@ The task and harness each own different concerns.  ComposableEnv connects them:
 **ComposableEnv connects them**:
 1. Writes task's instruction text → harness's instruction_path
 2. Writes harness's system prompt → harness's system_prompt_path
-3. Harness's ``run_command`` reads from these paths
+3. Uploads MCP server files and passes specs to harness via ``format_mcp_config``
+4. Harness's ``run_command`` reads from these paths
 
 ComposableEnv exports the task's working directory as ``AGENT_WORKDIR`` for
 harnesses that need a per-instance workdir while still using a static
@@ -166,7 +168,25 @@ class ComposableEnv(CliAgentEnv):
                 sandbox_id, self.harness.system_prompt, self.harness.system_prompt_path
             )
 
-        # 5. Install agent binary
+        # 5. Upload MCP server files and pass configs to harness
+        mcp_servers = self.taskset.get_mcp_servers()
+        if mcp_servers:
+            self.harness.mcp_servers = mcp_servers
+            for name, spec in mcp_servers.items():
+                if spec.files:
+                    for sandbox_path, content in spec.files.items():
+                        parent = sandbox_path.rsplit("/", 1)[0]
+                        await self.sandbox_client.execute_command(
+                            sandbox_id, f"mkdir -p {parent}", timeout=10
+                        )
+                        await self.upload_content(sandbox_id, content, sandbox_path)
+            mcp_config = self.harness.format_mcp_config(mcp_servers)
+            if mcp_config:
+                await self.upload_content(
+                    sandbox_id, mcp_config, "/task/mcp_config.json"
+                )
+
+        # 6. Install agent binary
         if self.harness.install_script:
             self.logger.debug(f"Installing agent in sandbox {sandbox_id}")
             result = await self.sandbox_client.execute_command(

--- a/verifiers/envs/experimental/composable/harness.py
+++ b/verifiers/envs/experimental/composable/harness.py
@@ -16,11 +16,11 @@ connects them.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from verifiers.envs.experimental.composable.task import SandboxSpec
+    from verifiers.envs.experimental.composable.task import MCPServerSpec, SandboxSpec
 
 
 @dataclass
@@ -47,6 +47,9 @@ class Harness:
         Default sandbox resources when the task doesn't provide a
         SandboxSpec (e.g. math + OpenCode — the agent needs a sandbox
         but the task doesn't specify one).
+    mcp_servers:
+        MCP servers merged from the TaskSet.  Populated by ComposableEnv
+        at setup time — do not set manually.
     """
 
     install_script: str | None = None
@@ -56,3 +59,25 @@ class Harness:
     instruction_path: str = "/task/instruction.md"
     log_path: str | None = None
     sandbox_spec: SandboxSpec | None = None
+    mcp_servers: dict[str, MCPServerSpec] = field(default_factory=dict)
+
+    def format_mcp_config(self, servers: dict[str, MCPServerSpec]) -> str | None:
+        """Format MCP server specs into agent-native config.
+
+        Override in harness factories to produce agent-specific config.
+        For example, an OpenCode harness would write the ``mcp`` section
+        of ``opencode.json``.
+
+        Parameters
+        ----------
+        servers:
+            Mapping of server name → MCPServerSpec from the TaskSet.
+
+        Returns
+        -------
+        str or None:
+            Config content to write into the sandbox, or None if the
+            harness handles MCP servers through other means (e.g. by
+            regenerating its run_command).
+        """
+        return None

--- a/verifiers/envs/experimental/composable/task.py
+++ b/verifiers/envs/experimental/composable/task.py
@@ -36,10 +36,12 @@ from verifiers.types import Messages, State
 class MCPServerSpec:
     """An MCP server that a TaskSet provides to the agent.
 
-    The server script is uploaded into the sandbox and spawned by the
-    agent harness via stdio transport.  The harness is responsible for
-    mapping this spec to its own config format (e.g. OpenCode's ``mcp``
-    section, Claude Code's ``--mcp-server`` flag, etc.).
+    The server is spawned by the agent harness via stdio transport.
+    The harness maps this spec to its own config format (e.g. OpenCode's
+    ``mcp`` section, Claude Code's ``--mcp-server`` flag, etc.).
+
+    The taskset is responsible for getting the server binary/script into
+    the sandbox (e.g. via ``setup()``, docker image, or install script).
 
     Attributes
     ----------
@@ -48,14 +50,10 @@ class MCPServerSpec:
         e.g. ``["python", "/task/tools/serper_search.py"]``.
     env_vars:
         Environment variables the server needs (e.g. API keys).
-    files:
-        Files to upload into the sandbox before the server starts.
-        Mapping of sandbox path → file content.
     """
 
     command: list[str]
     env_vars: dict[str, str] | None = None
-    files: dict[str, str] | None = None
 
 
 @dataclass

--- a/verifiers/envs/experimental/composable/task.py
+++ b/verifiers/envs/experimental/composable/task.py
@@ -33,6 +33,32 @@ from verifiers.types import Messages, State
 
 
 @dataclass
+class MCPServerSpec:
+    """An MCP server that a TaskSet provides to the agent.
+
+    The server script is uploaded into the sandbox and spawned by the
+    agent harness via stdio transport.  The harness is responsible for
+    mapping this spec to its own config format (e.g. OpenCode's ``mcp``
+    section, Claude Code's ``--mcp-server`` flag, etc.).
+
+    Attributes
+    ----------
+    command:
+        Command to start the server inside the sandbox,
+        e.g. ``["python", "/task/tools/serper_search.py"]``.
+    env_vars:
+        Environment variables the server needs (e.g. API keys).
+    files:
+        Files to upload into the sandbox before the server starts.
+        Mapping of sandbox path → file content.
+    """
+
+    command: list[str]
+    env_vars: dict[str, str] | None = None
+    files: dict[str, str] | None = None
+
+
+@dataclass
 class SandboxSpec:
     """Sandbox requirements for a task instance."""
 
@@ -132,6 +158,18 @@ class TaskSet:
         return "/app"
 
     def get_env_vars(self) -> dict[str, str]:
+        return {}
+
+    def get_mcp_servers(self) -> dict[str, MCPServerSpec]:
+        """MCP servers this task provides to the agent.
+
+        Returns a mapping of server name → MCPServerSpec.  The ComposableEnv
+        uploads any declared files into the sandbox and passes the server
+        configs to the Harness, which maps them to the agent's native MCP
+        configuration format.
+
+        Default: no MCP servers.
+        """
         return {}
 
     async def setup(self, state: State) -> None:


### PR DESCRIPTION
## Summary

- **MCPServerSpec** dataclass for declaring MCP servers (command, env_vars, files to upload)
- **TaskSet.get_mcp_servers()** hook — tasks declare what tools they need
- **Harness.format_mcp_config()** hook — each harness maps MCP specs to its agent's native config format
- **ComposableEnv** wiring — uploads server files into sandbox, calls format_mcp_config at setup

This enables tasksets to bring their own tools via the MCP standard protocol, without requiring fork-specific agent modifications. The harness stays generic — it just connects whatever MCP servers the task provides.

## Motivation

Environments like DeepDive and BrowseComp need task-specific tools (web search via Serper/Exa, web fetch). Currently these are baked into a custom OpenCode fork as built-in TypeScript tools. With this change, a DeepDive taskset can ship a Python MCP server wrapping the Serper API, and any harness (OpenCode, Claude Code, etc.) can connect to it.

## Design

```
TaskSet                    ComposableEnv              Harness
  get_mcp_servers()  →  uploads files to sandbox  →  format_mcp_config()
  (what tools)           (wiring layer)              (agent-native config)
```

- **stdio transport** inside the sandbox — the MCP server is a script that the agent spawns as a subprocess
- **Harness-agnostic** — each harness implementation maps MCPServerSpec to its own config (OpenCode's `mcp` JSON section, Claude Code's `--mcp-server` flags, etc.)
- **No changes needed for existing tasksets** — `get_mcp_servers()` defaults to empty dict

## Next steps

- Implement `format_mcp_config()` in the OpenCode harness (research-environments PR)
- Port DeepDive as the first MCP-enabled taskset
- Port BrowseComp

## Test plan

- [x] All 15 existing composable env tests pass
- [x] Ruff check + format clean
- [ ] E2E test with a DeepDive MCP taskset (followup PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `ComposableEnv` sandbox setup sequence to inject task-provided MCP server configuration, which can break existing harnesses if tasks start declaring MCP servers without a corresponding `format_mcp_config` implementation.
> 
> **Overview**
> Adds a new TaskSet→Harness “MCP tool server” channel so tasks can declare MCP servers and have the environment pass them to the agent.
> 
> This introduces `MCPServerSpec` plus a `TaskSet.get_mcp_servers()` hook, extends `Harness` with `mcp_servers` and an overridable `format_mcp_config()` method, and updates `ComposableEnv.post_sandbox_setup()` to call the hook, require a harness config formatter, and upload the generated config to `/task/mcp_config.json` before installing the agent.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b9d22808a298551b60032f593a8eee22aeeb1c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->