### PR TITLE
Bump version to v0.1.12.dev2 and add release notes

### DIFF
--- a/assets/release/RELEASE_v0.1.12.dev2.md
+++ b/assets/release/RELEASE_v0.1.12.dev2.md
@@ -1,0 +1,28 @@
+# Verifiers v0.1.12.dev2 Release Notes
+
+*Date:* 04/01/2026
+
+## Highlights since v0.1.12.dev1
+
+- Added major composability improvements for task/agent/environment architecture.
+- Improved execution ergonomics by routing standard tools through the root LLM via the `tools` argument.
+- Strengthened TUI observability with saved-state column visibility updates.
+- Removed RLM branding from model-visible prompts/messages and aligned RLM metrics naming for consistency.
+- Hardened token parsing behavior for `None` prompt/completion token IDs.
+
+## Changes included in v0.1.12.dev2 (since v0.1.12.dev1)
+
+### Features and architecture
+
+- feat: composable Task/Agent/Environment architecture (#1067)
+- feat: change `tools` arg to pass standard tools to root LLM (#1087)
+- Show saved state columns in TUI info view (#1091)
+
+### Fixes and maintenance
+
+- fix: handle None prompt/completion token ids in parse_tokens (#1066)
+- refactor: rename RLM metrics for consistency (#1086)
+- remove RLM branding from model-visible prompts and messages (#1089)
+- feat: add enable_sub_llms toggle to RLMEnv (#1085)
+
+**Full Changelog**: https://github.com/PrimeIntellect-ai/verifiers/compare/v0.1.12.dev1...v0.1.12.dev2

--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.12.dev1"
+__version__ = "0.1.12.dev2"
 
 import importlib
 import os


### PR DESCRIPTION
### Motivation
- Bump package version and add release notes for `v0.1.12.dev2` to record recent changes including composability improvements, routing standard tools via the `tools` arg, TUI saved-state visibility updates, RLM naming/branding fixes, and token parsing hardening.

### Description
- Update `__version__` in `verifiers/__init__.py` to `0.1.12.dev2` and add `assets/release/RELEASE_v0.1.12.dev2.md` containing the release notes and a changelog link.

### Testing
- Ran the project test suite with `pytest` locally and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd8a323ad88326af05cb07f3bfbfd7)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only bumps the package version constant and adds release notes; no runtime logic changes beyond the version string.
> 
> **Overview**
> Bumps `verifiers` version from `0.1.12.dev1` to `0.1.12.dev2`.
> 
> Adds `assets/release/RELEASE_v0.1.12.dev2.md` documenting highlights and the changelog link for the `v0.1.12.dev2` release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eee8a7c84d4a1bfa59a6b9cabb737f433ffb779c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->