### PR TITLE
Replace remove_conversation_turns with summarize_turns standard tool

### DIFF
--- a/tests/test_rlm_env.py
+++ b/tests/test_rlm_env.py
@@ -2888,38 +2888,17 @@ class TestSummarizeTurns:
             interception_url="http://test.invalid",
         )
 
-    def _make_state(
-        self,
-        main_turns: int,
-        dropped: int = 0,
-        *,
-        per_turn_prompt_tokens: list[int] | None = None,
-    ) -> dict:
-        """Build a minimal state with the given number of main turns.
-
-        If *per_turn_prompt_tokens* is provided it is used directly;
-        otherwise a default list is generated with 100-token increments
-        so that token-delta calculations work predictably.
-        """
+    def _make_state(self, main_turns: int, dropped: int = 0) -> dict:
+        """Build a minimal state with the given number of main turns."""
         trajectory_id = "main_id"
         trajectory = []
-        if per_turn_prompt_tokens is None:
-            per_turn_prompt_tokens = [100 * (i + 1) for i in range(main_turns)]
         for i in range(main_turns):
-            prompt_tokens = (
-                per_turn_prompt_tokens[i] if i < len(per_turn_prompt_tokens) else 0
-            )
-            usage = MagicMock()
-            usage.prompt_tokens = prompt_tokens
-            usage.completion_tokens = 50
-            response = MagicMock()
-            response.usage = usage
             trajectory.append(
                 {
                     "trajectory_id": trajectory_id,
                     "prompt": [{"role": "user", "content": f"turn {i}"}],
                     "completion": [vf.AssistantMessage(content=f"response {i}")],
-                    "response": response,
+                    "response": None,
                     "tokens": None,
                     "reward": None,
                     "advantage": None,
@@ -2934,7 +2913,6 @@ class TestSummarizeTurns:
             "_keep_from_assistant_index": dropped,
             "_drop_sequence": 0,
             "_summary_text": "",
-            "_per_turn_prompt_tokens": list(per_turn_prompt_tokens[:main_turns]),
             "rollout_id": "test_rollout",
         }
         rlm_module._ensure_rlm_metric_state(state)
@@ -3355,17 +3333,12 @@ class TestSummarizeTurns:
 
         # Simulate 3 more main turns (total 13 in trajectory)
         for i in range(3):
-            usage = MagicMock()
-            usage.prompt_tokens = 100 * (10 + i + 1)
-            usage.completion_tokens = 50
-            response = MagicMock()
-            response.usage = usage
             state["trajectory"].append(
                 {
                     "trajectory_id": state["trajectory_id"],
                     "prompt": [{"role": "user", "content": f"extra {i}"}],
                     "completion": [vf.AssistantMessage(content=f"extra resp {i}")],
-                    "response": response,
+                    "response": None,
                     "tokens": None,
                     "reward": None,
                     "advantage": None,
@@ -3373,7 +3346,6 @@ class TestSummarizeTurns:
                     "extras": None,
                 }
             )
-            state["_per_turn_prompt_tokens"].append(usage.prompt_tokens)
 
         # Drop 3 at turn 13: 13-2=11 visible -> 8 remaining
         await env_with_summarize.summarize_turns(
@@ -3416,119 +3388,6 @@ class TestSummarizeTurns:
             state["summarize_total_chars_dropped"]
             / state["summarize_summary_length_chars"]
         )
-
-    @pytest.mark.asyncio
-    async def test_tokens_dropped_tracking(self, env_with_summarize):
-        # Explicit token schedule: turns have prompt_tokens [100, 200, 300, 400, 500, 600]
-        token_schedule = [100, 200, 300, 400, 500, 600]
-        state = self._make_state(main_turns=6, per_turn_prompt_tokens=token_schedule)
-
-        # Drop turns 1-2 (indices 0-1): tokens = prompt_tokens[2] - prompt_tokens[0] = 300 - 100 = 200
-        await env_with_summarize.summarize_turns(
-            n_turns=2, summary="first two", state=state
-        )
-
-        assert state["summarize_total_tokens_dropped"] == 200
-        assert state["summarize_mean_tokens_dropped_per_call"] == 200.0
-
-    @pytest.mark.asyncio
-    async def test_mean_tokens_dropped_per_call(self, env_with_summarize):
-        token_schedule = [100, 200, 300, 400, 500, 600, 700, 800]
-        state = self._make_state(main_turns=8, per_turn_prompt_tokens=token_schedule)
-
-        # Drop 1 turn: tokens = prompt_tokens[1] - prompt_tokens[0] = 100
-        await env_with_summarize.summarize_turns(
-            n_turns=1, summary="first", state=state
-        )
-        assert state["summarize_total_tokens_dropped"] == 100
-        assert state["summarize_mean_tokens_dropped_per_call"] == 100.0
-
-        # Drop 2 more turns: tokens = prompt_tokens[3] - prompt_tokens[1] = 200
-        await env_with_summarize.summarize_turns(
-            n_turns=2, summary="second", state=state
-        )
-        assert state["summarize_total_tokens_dropped"] == 300
-        assert state["summarize_mean_tokens_dropped_per_call"] == 150.0
-
-    # =====================================================================
-    # Per-turn prompt token tracking
-    # =====================================================================
-
-    @pytest.mark.asyncio
-    async def test_per_turn_prompt_tokens_recorded(self, env_with_summarize):
-        """After adding a main-model trajectory step, _per_turn_prompt_tokens is appended."""
-        usage = MagicMock()
-        usage.prompt_tokens = 42
-        usage.completion_tokens = 10
-        usage.reasoning_tokens = 0
-        usage.total_tokens = 52
-        response = MagicMock()
-        response.usage = usage
-        response.message = MagicMock()
-        response.message.content = "hello"
-        response.message.tool_calls = None
-        response.message.is_truncated = False
-
-        state = {
-            "trajectory_id": "main",
-            "trajectory": [],
-            "_per_turn_prompt_tokens": [],
-        }
-        rlm_module._ensure_rlm_metric_state(state)
-
-        step = {
-            "prompt": [UserMessage(content="q")],
-            "completion": [vf.AssistantMessage(content="a")],
-            "response": response,
-            "tokens": None,
-            "reward": None,
-            "advantage": None,
-            "is_truncated": False,
-            "trajectory_id": "main",
-            "extras": {},
-        }
-        await env_with_summarize.add_trajectory_step(state, step)
-
-        assert state["_per_turn_prompt_tokens"] == [42]
-
-    @pytest.mark.asyncio
-    async def test_sub_llm_steps_not_tracked_in_per_turn_tokens(
-        self, env_with_summarize
-    ):
-        """Sub-LLM trajectory steps should NOT append to _per_turn_prompt_tokens."""
-        usage = MagicMock()
-        usage.prompt_tokens = 99
-        usage.completion_tokens = 10
-        usage.reasoning_tokens = 0
-        usage.total_tokens = 109
-        response = MagicMock()
-        response.usage = usage
-        response.message = MagicMock()
-        response.message.content = "sub response"
-        response.message.tool_calls = None
-        response.message.is_truncated = False
-
-        state = {
-            "trajectory_id": "main",
-            "trajectory": [],
-            "_per_turn_prompt_tokens": [],
-        }
-        rlm_module._ensure_rlm_metric_state(state)
-
-        sub_step = {
-            "prompt": [UserMessage(content="sub q")],
-            "completion": [vf.AssistantMessage(content="sub a")],
-            "response": response,
-            "tokens": None,
-            "reward": None,
-            "advantage": None,
-            "is_truncated": False,
-            "trajectory_id": "sub_batch_123",  # different from main
-            "extras": {"is_sub_llm_call": True},
-        }
-        await env_with_summarize.add_trajectory_step(state, sub_step)
-
-        assert state["_per_turn_prompt_tokens"] == []
 
     # =====================================================================
     # Edge cases

--- a/tests/test_rlm_env.py
+++ b/tests/test_rlm_env.py
@@ -3194,8 +3194,8 @@ class TestSummarizeTurns:
         assert "<SUMMARY>" in result[2].content
         assert "response 1" in result[2].content
 
-    def test_summary_injection_idempotent(self, env_with_summarize):
-        """Applying context dropping twice doesn't double-inject the summary."""
+    def test_summary_injection_replaces_stale_summary(self, env_with_summarize):
+        """A second call with updated summary replaces the old <SUMMARY> block."""
         messages = [
             UserMessage(content="scaffolded prompt"),
             vf.AssistantMessage(content="response 0"),
@@ -3206,18 +3206,24 @@ class TestSummarizeTurns:
             vf.ToolMessage(tool_call_id="t2", content="tool 2"),
         ]
 
-        summary_text = "[Turns 1-2] summary"
+        # First call: inject summary v1
         result1 = env_with_summarize._apply_context_dropping(
-            messages, 2, summary_text=summary_text
+            messages, 2, summary_text="[Turns 1-2] old summary"
         )
-        # Apply again on already-truncated result (same index >= remaining count)
+        assert "<SUMMARY>" in result1[1].content
+        assert "old summary" in result1[1].content
+
+        # Second call on already-truncated result with updated summary
         result2 = env_with_summarize._apply_context_dropping(
-            result1, 2, summary_text=summary_text
+            result1, 2, summary_text="[Turns 1-2] old summary\n[Turns 3-4] new summary"
         )
 
-        # Should not double-inject
-        content = result2[1].content if len(result2) > 1 else ""
-        assert content.count("<SUMMARY>") <= 1
+        # Should have exactly one <SUMMARY> block with the updated content
+        content = result2[1].content
+        assert content.count("<SUMMARY>") == 1
+        assert "new summary" in content
+        # Old-only text should not appear separately (it's part of the cumulative)
+        assert "response 2" in content
 
     def test_summary_injection_with_list_content(self, env_with_summarize):
         """If assistant message content is a list, summary is prepended as text block."""

--- a/tests/test_rlm_env.py
+++ b/tests/test_rlm_env.py
@@ -2856,13 +2856,15 @@ class TestFilesystemProvisioning:
 
 
 # =============================================================================
-# Context Dropping
+# Summarize Turns (context dropping overhaul)
 # =============================================================================
 
 
-class TestContextDropping:
+class TestSummarizeTurns:
+    """Tests for the summarize_turns tool (replaces old remove_conversation_turns)."""
+
     @pytest.fixture
-    def env_with_dropping(self) -> RLMEnv:
+    def env_with_summarize(self) -> RLMEnv:
         dataset = make_dataset({})
         import warnings
 
@@ -2877,7 +2879,7 @@ class TestContextDropping:
             )
 
     @pytest.fixture
-    def env_without_dropping(self) -> RLMEnv:
+    def env_without_summarize(self) -> RLMEnv:
         dataset = make_dataset({})
         return build_env(
             dataset,
@@ -2886,20 +2888,105 @@ class TestContextDropping:
             interception_url="http://test.invalid",
         )
 
-    # -- Tool registration --
+    def _make_state(
+        self,
+        main_turns: int,
+        dropped: int = 0,
+        *,
+        per_turn_prompt_tokens: list[int] | None = None,
+    ) -> dict:
+        """Build a minimal state with the given number of main turns.
 
-    def test_tool_registered_when_enabled(self, env_with_dropping):
-        assert "remove_conversation_turns" in env_with_dropping.root_tool_names
+        If *per_turn_prompt_tokens* is provided it is used directly;
+        otherwise a default list is generated with 100-token increments
+        so that token-delta calculations work predictably.
+        """
+        trajectory_id = "main_id"
+        trajectory = []
+        if per_turn_prompt_tokens is None:
+            per_turn_prompt_tokens = [100 * (i + 1) for i in range(main_turns)]
+        for i in range(main_turns):
+            prompt_tokens = (
+                per_turn_prompt_tokens[i] if i < len(per_turn_prompt_tokens) else 0
+            )
+            usage = MagicMock()
+            usage.prompt_tokens = prompt_tokens
+            usage.completion_tokens = 50
+            response = MagicMock()
+            response.usage = usage
+            trajectory.append(
+                {
+                    "trajectory_id": trajectory_id,
+                    "prompt": [{"role": "user", "content": f"turn {i}"}],
+                    "completion": [vf.AssistantMessage(content=f"response {i}")],
+                    "response": response,
+                    "tokens": None,
+                    "reward": None,
+                    "advantage": None,
+                    "is_truncated": False,
+                    "extras": None,
+                }
+            )
+        state = {
+            "trajectory_id": trajectory_id,
+            "trajectory": trajectory,
+            "_dropped_turns_count": dropped,
+            "_keep_from_assistant_index": dropped,
+            "_drop_sequence": 0,
+            "_summary_text": "",
+            "_per_turn_prompt_tokens": list(per_turn_prompt_tokens[:main_turns]),
+            "rollout_id": "test_rollout",
+        }
+        rlm_module._ensure_rlm_metric_state(state)
+        return state
 
-    def test_tool_not_registered_when_disabled(self, env_without_dropping):
-        assert "remove_conversation_turns" not in env_without_dropping.root_tool_names
+    # =====================================================================
+    # Tool registration
+    # =====================================================================
 
-    def test_tool_name_reserved(self):
-        from verifiers.envs.experimental.rlm_env import _FIXED_REPL_TOOL_NAMES
+    def test_tool_registered_as_standard_tool_when_enabled(self, env_with_summarize):
+        """summarize_turns should be a standard tool, not a root-REPL tool."""
+        tool_names = [t.__name__ for t in env_with_summarize.standard_tools]
+        # It's added via add_tool, so check the env's tool definitions
+        tool_def_names = [td.name for td in env_with_summarize.tool_defs]
+        assert "summarize_turns" in tool_def_names
 
-        assert "remove_conversation_turns" in _FIXED_REPL_TOOL_NAMES
+    def test_tool_not_in_root_tools(self, env_with_summarize):
+        """summarize_turns must NOT appear in root_tool_names (REPL tools)."""
+        assert "summarize_turns" not in env_with_summarize.root_tool_names
 
-    # -- Default changes --
+    def test_tool_not_registered_when_disabled(self, env_without_summarize):
+        tool_def_names = [td.name for td in env_without_summarize.tool_defs]
+        assert "summarize_turns" not in tool_def_names
+
+    def test_repl_tool_still_registered(self, env_with_summarize):
+        """The REPL tool must still be present alongside summarize_turns."""
+        tool_def_names = [td.name for td in env_with_summarize.tool_defs]
+        assert any(
+            name in tool_def_names for name in ("call_python_repl", "call_bash_repl")
+        )
+
+    def test_old_tool_name_not_registered(self, env_with_summarize):
+        """remove_conversation_turns should no longer exist anywhere."""
+        tool_def_names = [td.name for td in env_with_summarize.tool_defs]
+        assert "remove_conversation_turns" not in tool_def_names
+        assert "remove_conversation_turns" not in env_with_summarize.root_tool_names
+
+    # =====================================================================
+    # State injection
+    # =====================================================================
+
+    def test_update_tool_args_injects_state(self, env_with_summarize):
+        state = self._make_state(main_turns=3)
+        args = {"n_turns": 1, "summary": "test"}
+        result = env_with_summarize.update_tool_args("summarize_turns", args, [], state)
+        assert result["state"] is state
+        assert result["n_turns"] == 1
+        assert result["summary"] == "test"
+
+    # =====================================================================
+    # Default configuration
+    # =====================================================================
 
     def test_expose_message_history_defaults_to_true(self):
         dataset = make_dataset({})
@@ -2929,114 +3016,128 @@ class TestContextDropping:
                 interception_url="http://test.invalid",
             )
 
-    # -- System prompt --
+    # =====================================================================
+    # System prompt
+    # =====================================================================
 
-    def test_system_prompt_includes_note_when_enabled(self, env_with_dropping):
-        prompt = env_with_dropping.prompt_builder.build_system_prompt()
-        assert "remove_conversation_turns" in prompt
-        assert "min_turns_in_context" not in prompt or "3" in prompt
+    def test_system_prompt_includes_note_when_enabled(self, env_with_summarize):
+        prompt = env_with_summarize.prompt_builder.build_system_prompt()
+        assert "summarize_turns" in prompt
+        assert "<SUMMARY>" in prompt
 
-    def test_system_prompt_excludes_note_when_disabled(self, env_without_dropping):
-        prompt = env_without_dropping.prompt_builder.build_system_prompt()
-        assert "remove_conversation_turns" not in prompt
+    def test_system_prompt_excludes_note_when_disabled(self, env_without_summarize):
+        prompt = env_without_summarize.prompt_builder.build_system_prompt()
+        assert "summarize_turns" not in prompt
 
-    # -- _handle_remove_conversation_turns --
-
-    def _make_state(self, main_turns: int, dropped: int = 0) -> dict:
-        """Build a minimal state with the given number of main turns."""
-        trajectory_id = "main_id"
-        trajectory = []
-        for i in range(main_turns):
-            trajectory.append(
-                {
-                    "trajectory_id": trajectory_id,
-                    "prompt": [{"role": "user", "content": f"turn {i}"}],
-                    "completion": [{"role": "assistant", "content": f"response {i}"}],
-                    "response": None,
-                    "tokens": None,
-                    "reward": None,
-                    "advantage": None,
-                    "is_truncated": False,
-                    "extras": None,
-                }
-            )
-        return {
-            "trajectory_id": trajectory_id,
-            "trajectory": trajectory,
-            "_dropped_turns_count": dropped,
-            "_keep_from_assistant_index": dropped,
-            "_drop_sequence": 0,
-            "rollout_id": "test_rollout",
-        }
+    # =====================================================================
+    # Basic summarize_turns behavior
+    # =====================================================================
 
     @pytest.mark.asyncio
-    async def test_basic_drop(self, env_with_dropping):
+    async def test_basic_summarize(self, env_with_summarize):
         state = self._make_state(main_turns=6)
-        env_with_dropping._upload_summary = AsyncMock()
 
-        result = await env_with_dropping._handle_remove_conversation_turns(
-            state, 2, "dropped first two"
+        result = await env_with_summarize.summarize_turns(
+            n_turns=2, summary="explored dataset", state=state
         )
 
         assert state["_dropped_turns_count"] == 2
         assert state["_keep_from_assistant_index"] == 2
         assert state["_drop_sequence"] == 1
-        assert "Dropped 2" in result
-        assert "dropped first two" in result
+        assert "[Turns 1-2]" in result
+        assert "explored dataset" in result
+        assert state["_summary_text"] == result
 
     @pytest.mark.asyncio
-    async def test_drop_minus_one(self, env_with_dropping):
+    async def test_summarize_minus_one(self, env_with_summarize):
         state = self._make_state(main_turns=6)
-        env_with_dropping._upload_summary = AsyncMock()
 
-        result = await env_with_dropping._handle_remove_conversation_turns(
-            state, -1, ""
+        result = await env_with_summarize.summarize_turns(
+            n_turns=-1, summary="everything so far", state=state
         )
 
         # 6 visible - 3 min = 3 droppable
         assert state["_dropped_turns_count"] == 3
         assert state["_keep_from_assistant_index"] == 3
-        assert "Dropped 3" in result
+        assert "[Turns 1-3]" in result
 
     @pytest.mark.asyncio
-    async def test_drop_exceeds_limit(self, env_with_dropping):
+    async def test_summarize_exceeds_limit(self, env_with_summarize):
         state = self._make_state(main_turns=5)
-        env_with_dropping._upload_summary = AsyncMock()
 
-        result = await env_with_dropping._handle_remove_conversation_turns(state, 4, "")
+        result = await env_with_summarize.summarize_turns(
+            n_turns=4, summary="too many", state=state
+        )
 
         assert state["_dropped_turns_count"] == 0
         assert "Cannot drop" in result
-        env_with_dropping._upload_summary.assert_not_awaited()
+        assert state["_summary_text"] == ""
 
     @pytest.mark.asyncio
-    async def test_drop_zero(self, env_with_dropping):
+    async def test_summarize_zero(self, env_with_summarize):
         state = self._make_state(main_turns=5)
-        env_with_dropping._upload_summary = AsyncMock()
 
-        result = await env_with_dropping._handle_remove_conversation_turns(state, 0, "")
+        result = await env_with_summarize.summarize_turns(
+            n_turns=0, summary="nothing", state=state
+        )
 
         assert state["_dropped_turns_count"] == 0
         assert "Nothing to drop" in result
+        assert state["_summary_text"] == ""
+
+    # =====================================================================
+    # Cumulative summary
+    # =====================================================================
 
     @pytest.mark.asyncio
-    async def test_cumulative_drops(self, env_with_dropping):
+    async def test_cumulative_summary_text(self, env_with_summarize):
         state = self._make_state(main_turns=8)
-        env_with_dropping._upload_summary = AsyncMock()
 
-        await env_with_dropping._handle_remove_conversation_turns(state, 1, "first")
-        assert state["_dropped_turns_count"] == 1
-        assert state["_keep_from_assistant_index"] == 1
-        assert state["_drop_sequence"] == 1
+        result1 = await env_with_summarize.summarize_turns(
+            n_turns=1, summary="first batch", state=state
+        )
+        assert "[Turns 1-1]" in result1
+        assert "first batch" in result1
 
-        await env_with_dropping._handle_remove_conversation_turns(state, 2, "second")
-        assert state["_dropped_turns_count"] == 3
-        assert state["_keep_from_assistant_index"] == 3
-        assert state["_drop_sequence"] == 2
+        result2 = await env_with_summarize.summarize_turns(
+            n_turns=2, summary="second batch", state=state
+        )
+        # Cumulative: contains both sections
+        assert "[Turns 1-1]" in result2
+        assert "first batch" in result2
+        assert "[Turns 2-3]" in result2
+        assert "second batch" in result2
+        assert state["_summary_text"] == result2
 
-    # -- _apply_context_dropping --
+    @pytest.mark.asyncio
+    async def test_summary_returned_as_tool_output(self, env_with_summarize):
+        state = self._make_state(main_turns=6)
 
-    def test_apply_preserves_scaffolded_message(self, env_with_dropping):
+        result = await env_with_summarize.summarize_turns(
+            n_turns=2, summary="my summary", state=state
+        )
+
+        # Return value IS the full cumulative summary
+        assert result == state["_summary_text"]
+
+    @pytest.mark.asyncio
+    async def test_multiline_summary(self, env_with_summarize):
+        state = self._make_state(main_turns=6)
+
+        multiline = "explored the dataset\nfound 3 CSV files\neach has ~10k rows"
+        result = await env_with_summarize.summarize_turns(
+            n_turns=2, summary=multiline, state=state
+        )
+
+        assert "explored the dataset" in result
+        assert "found 3 CSV files" in result
+        assert "each has ~10k rows" in result
+
+    # =====================================================================
+    # Summary injection into messages (_apply_context_dropping)
+    # =====================================================================
+
+    def test_summary_prepended_to_first_assistant_message(self, env_with_summarize):
         messages = [
             UserMessage(content="scaffolded prompt"),
             vf.AssistantMessage(content="response 0"),
@@ -3047,54 +3148,56 @@ class TestContextDropping:
             vf.ToolMessage(tool_call_id="t2", content="tool 2"),
         ]
 
-        result = env_with_dropping._apply_context_dropping(messages, 2)
+        summary_text = "[Turns 1-2] explored dataset"
+        result = env_with_summarize._apply_context_dropping(
+            messages, 2, summary_text=summary_text
+        )
 
+        # preamble (user) + asst_2 + tool_2
         assert result[0].content == "scaffolded prompt"
-        assert len(result) == 3  # scaffolded + asst_2 + tool_2
-        assert result[1].content == "response 2"
+        assert len(result) == 3
+        # First remaining assistant message should have summary prepended
+        assert result[1].content.startswith("<SUMMARY>")
+        assert "[Turns 1-2] explored dataset" in result[1].content
+        assert "</SUMMARY>" in result[1].content
+        assert "response 2" in result[1].content
 
-    def test_apply_zero_is_noop(self, env_with_dropping):
+    def test_summary_not_injected_when_empty(self, env_with_summarize):
         messages = [
-            UserMessage(content="scaffolded"),
-            vf.AssistantMessage(content="r0"),
+            UserMessage(content="scaffolded prompt"),
+            vf.AssistantMessage(content="response 0"),
+            vf.ToolMessage(tool_call_id="t0", content="tool 0"),
         ]
-        result = env_with_dropping._apply_context_dropping(messages, 0)
-        assert result == messages
 
-    def test_apply_drop_all_returns_unchanged(self, env_with_dropping):
-        """Dropping more than available turns returns messages unchanged."""
-        messages = [
-            UserMessage(content="scaffolded"),
-            vf.AssistantMessage(content="r0"),
-            vf.ToolMessage(tool_call_id="t0", content="t0"),
-        ]
-        result = env_with_dropping._apply_context_dropping(messages, 5)
-        assert result == messages
+        result = env_with_summarize._apply_context_dropping(
+            messages, 0, summary_text=""
+        )
 
-    def test_apply_is_idempotent(self, env_with_dropping):
-        """Applying the same keep_from_assistant_index twice gives the same result."""
+        assert result == messages
+        # No SUMMARY tags anywhere
+        for msg in result:
+            content = msg.content if isinstance(msg.content, str) else str(msg.content)
+            assert "<SUMMARY>" not in content
+
+    def test_summary_injection_preserves_preamble(self, env_with_summarize):
         messages = [
             UserMessage(content="scaffolded prompt"),
             vf.AssistantMessage(content="response 0"),
             vf.ToolMessage(tool_call_id="t0", content="tool 0"),
             vf.AssistantMessage(content="response 1"),
             vf.ToolMessage(tool_call_id="t1", content="tool 1"),
-            vf.AssistantMessage(content="response 2"),
-            vf.ToolMessage(tool_call_id="t2", content="tool 2"),
         ]
 
-        # First application: drop first 2 turns
-        result1 = env_with_dropping._apply_context_dropping(messages, 2)
-        assert len(result1) == 3  # scaffolded + asst_2 + tool_2
+        summary_text = "[Turns 1-1] first turn summary"
+        result = env_with_summarize._apply_context_dropping(
+            messages, 1, summary_text=summary_text
+        )
 
-        # Second application on already-truncated result: same index, no further dropping
-        result2 = env_with_dropping._apply_context_dropping(result1, 2)
-        assert len(result2) == 3  # unchanged — only 1 assistant msg, index 2 >= count
-        assert result2[0].content == "scaffolded prompt"
-        assert result2[1].content == "response 2"
+        assert len(result) == 3  # user + asst_1 + tool_1
+        assert result[0].content == "scaffolded prompt"
+        assert "<SUMMARY>" not in result[0].content
 
-    def test_apply_preserves_system_message_preamble(self, env_with_dropping):
-        """System message + scaffolded user message are both preserved."""
+    def test_summary_injection_with_system_message_preamble(self, env_with_summarize):
         messages = [
             vf.SystemMessage(content="system instructions"),
             UserMessage(content="scaffolded prompt"),
@@ -3104,65 +3207,167 @@ class TestContextDropping:
             vf.ToolMessage(tool_call_id="t1", content="tool 1"),
         ]
 
-        result = env_with_dropping._apply_context_dropping(messages, 1)
+        summary_text = "[Turns 1-1] summary"
+        result = env_with_summarize._apply_context_dropping(
+            messages, 1, summary_text=summary_text
+        )
 
         assert len(result) == 4  # system + user + asst_1 + tool_1
         assert result[0].content == "system instructions"
         assert result[1].content == "scaffolded prompt"
-        assert result[2].content == "response 1"
+        assert "<SUMMARY>" in result[2].content
+        assert "response 1" in result[2].content
 
-    # -- _upload_summary --
+    def test_summary_injection_idempotent(self, env_with_summarize):
+        """Applying context dropping twice doesn't double-inject the summary."""
+        messages = [
+            UserMessage(content="scaffolded prompt"),
+            vf.AssistantMessage(content="response 0"),
+            vf.ToolMessage(tool_call_id="t0", content="tool 0"),
+            vf.AssistantMessage(content="response 1"),
+            vf.ToolMessage(tool_call_id="t1", content="tool 1"),
+            vf.AssistantMessage(content="response 2"),
+            vf.ToolMessage(tool_call_id="t2", content="tool 2"),
+        ]
+
+        summary_text = "[Turns 1-2] summary"
+        result1 = env_with_summarize._apply_context_dropping(
+            messages, 2, summary_text=summary_text
+        )
+        # Apply again on already-truncated result (same index >= remaining count)
+        result2 = env_with_summarize._apply_context_dropping(
+            result1, 2, summary_text=summary_text
+        )
+
+        # Should not double-inject
+        content = result2[1].content if len(result2) > 1 else ""
+        assert content.count("<SUMMARY>") <= 1
+
+    def test_summary_injection_with_list_content(self, env_with_summarize):
+        """If assistant message content is a list, summary is prepended as text block."""
+        messages = [
+            UserMessage(content="scaffolded prompt"),
+            vf.AssistantMessage(content=[{"type": "text", "text": "response 0"}]),
+            vf.ToolMessage(tool_call_id="t0", content="tool 0"),
+            vf.AssistantMessage(content=[{"type": "text", "text": "response 1"}]),
+            vf.ToolMessage(tool_call_id="t1", content="tool 1"),
+        ]
+
+        summary_text = "[Turns 1-1] summary"
+        result = env_with_summarize._apply_context_dropping(
+            messages, 1, summary_text=summary_text
+        )
+
+        # First remaining assistant message content should be a list
+        # with summary prepended as a text block
+        asst_content = result[1].content
+        assert isinstance(asst_content, list)
+        assert asst_content[0]["type"] == "text"
+        assert "<SUMMARY>" in asst_content[0]["text"]
+        assert "summary" in asst_content[0]["text"]
+
+    def test_apply_zero_is_noop(self, env_with_summarize):
+        messages = [
+            UserMessage(content="scaffolded"),
+            vf.AssistantMessage(content="r0"),
+        ]
+        result = env_with_summarize._apply_context_dropping(
+            messages, 0, summary_text=""
+        )
+        assert result == messages
+
+    def test_apply_drop_all_returns_unchanged(self, env_with_summarize):
+        """Dropping more than available turns returns messages unchanged."""
+        messages = [
+            UserMessage(content="scaffolded"),
+            vf.AssistantMessage(content="r0"),
+            vf.ToolMessage(tool_call_id="t0", content="t0"),
+        ]
+        result = env_with_summarize._apply_context_dropping(
+            messages, 5, summary_text="[Turns 1-5] summary"
+        )
+        assert result == messages
+
+    # =====================================================================
+    # .messages file unaffected
+    # =====================================================================
+
+    def test_message_history_excludes_summaries(self, env_with_summarize):
+        """_build_message_history returns uncompacted history without <SUMMARY> tags."""
+        trajectory_id = "main_traj"
+        state = {
+            "trajectory_id": trajectory_id,
+            "trajectory": [
+                {
+                    "prompt": [
+                        UserMessage(content="scaffolded prompt"),
+                    ],
+                    "completion": [
+                        vf.AssistantMessage(content="response 0"),
+                        vf.ToolMessage(tool_call_id="t0", content="tool 0"),
+                        vf.AssistantMessage(content="response 1"),
+                    ],
+                    "response": None,
+                    "tokens": None,
+                    "reward": None,
+                    "advantage": None,
+                    "is_truncated": False,
+                    "trajectory_id": trajectory_id,
+                    "extras": {},
+                }
+            ],
+            "_summary_text": "[Turns 1-1] some summary",
+            "_keep_from_assistant_index": 1,
+        }
+
+        history = env_with_summarize._build_message_history(state)
+
+        for entry in history:
+            content = entry.get("content", "")
+            if isinstance(content, str):
+                assert "<SUMMARY>" not in content
+
+    # =====================================================================
+    # Metrics
+    # =====================================================================
 
     @pytest.mark.asyncio
-    async def test_upload_summary(self, env_with_dropping):
-        state = self._make_state(main_turns=5)
-
-        session = MagicMock()
-        session.sandbox_id = "sbx_test"
-        session.sandbox_fs_root = "/tmp/rlm_test/rlm_fs"
-        env_with_dropping._executor._get_session = MagicMock(return_value=session)
-        env_with_dropping._executor._execute_sandbox_command = AsyncMock()
-
-        await env_with_dropping._upload_summary(state, 2, "test summary", 3)
-
-        env_with_dropping._executor._execute_sandbox_command.assert_awaited_once()
-        cmd = env_with_dropping._executor._execute_sandbox_command.call_args[0][1]
-        assert ".summaries" in cmd
-        assert "base64" in cmd
-
-    # -- Metrics --
-
-    @pytest.mark.asyncio
-    async def test_basic_drop_metrics(self, env_with_dropping):
+    async def test_basic_metrics(self, env_with_summarize):
         state = self._make_state(main_turns=6)
-        env_with_dropping._upload_summary = AsyncMock()
 
-        await env_with_dropping._handle_remove_conversation_turns(state, 2, "")
+        await env_with_summarize.summarize_turns(n_turns=2, summary="test", state=state)
 
-        assert state["compaction_count"] == 1
-        assert state["compaction_total_turns_dropped"] == 2
-        assert state["compaction_mean_remaining_turns"] == 4.0  # 6 - 2
-        assert state["compaction_mean_turns_between"] == 0.0  # only 1 drop
+        assert state["summarize_count"] == 1
+        assert state["summarize_total_turns_dropped"] == 2
+        assert state["summarize_mean_remaining_turns"] == 4.0  # 6 - 2
+        assert state["summarize_mean_turns_between"] == 0.0  # only 1 call
+        assert state["summarize_mean_turns_per_call"] == 2.0
 
     @pytest.mark.asyncio
-    async def test_cumulative_drop_metrics(self, env_with_dropping):
+    async def test_cumulative_metrics(self, env_with_summarize):
         # 10 turns, min_turns_in_context=3
         state = self._make_state(main_turns=10)
-        env_with_dropping._upload_summary = AsyncMock()
 
         # Drop 2 at turn 10: 10 visible -> 8 remaining
-        await env_with_dropping._handle_remove_conversation_turns(state, 2, "")
-        assert state["compaction_count"] == 1
-        assert state["compaction_mean_remaining_turns"] == 8.0
+        await env_with_summarize.summarize_turns(
+            n_turns=2, summary="batch 1", state=state
+        )
+        assert state["summarize_count"] == 1
+        assert state["summarize_mean_remaining_turns"] == 8.0
 
         # Simulate 3 more main turns (total 13 in trajectory)
         for i in range(3):
+            usage = MagicMock()
+            usage.prompt_tokens = 100 * (10 + i + 1)
+            usage.completion_tokens = 50
+            response = MagicMock()
+            response.usage = usage
             state["trajectory"].append(
                 {
                     "trajectory_id": state["trajectory_id"],
                     "prompt": [{"role": "user", "content": f"extra {i}"}],
-                    "completion": [{"role": "assistant", "content": f"extra resp {i}"}],
-                    "response": None,
+                    "completion": [vf.AssistantMessage(content=f"extra resp {i}")],
+                    "response": response,
                     "tokens": None,
                     "reward": None,
                     "advantage": None,
@@ -3170,23 +3375,203 @@ class TestContextDropping:
                     "extras": None,
                 }
             )
+            state["_per_turn_prompt_tokens"].append(usage.prompt_tokens)
 
         # Drop 3 at turn 13: 13-2=11 visible -> 8 remaining
-        await env_with_dropping._handle_remove_conversation_turns(state, 3, "")
-        assert state["compaction_count"] == 2
-        assert state["compaction_total_turns_dropped"] == 5
+        await env_with_summarize.summarize_turns(
+            n_turns=3, summary="batch 2", state=state
+        )
+        assert state["summarize_count"] == 2
+        assert state["summarize_total_turns_dropped"] == 5
         # mean remaining: (8 + 8) / 2 = 8.0
-        assert state["compaction_mean_remaining_turns"] == 8.0
+        assert state["summarize_mean_remaining_turns"] == 8.0
         # turns between: [13 - 10] = [3], mean = 3.0
-        assert state["compaction_mean_turns_between"] == 3.0
+        assert state["summarize_mean_turns_between"] == 3.0
+        # mean turns per call: (2 + 3) / 2 = 2.5
+        assert state["summarize_mean_turns_per_call"] == 2.5
 
     @pytest.mark.asyncio
-    async def test_failed_drop_does_not_update_metrics(self, env_with_dropping):
+    async def test_failed_summarize_no_metrics(self, env_with_summarize):
         state = self._make_state(main_turns=4)
-        env_with_dropping._upload_summary = AsyncMock()
 
         # Try to drop 5 (exceeds limit)
-        await env_with_dropping._handle_remove_conversation_turns(state, 5, "")
+        await env_with_summarize.summarize_turns(
+            n_turns=5, summary="too many", state=state
+        )
 
-        assert state.get("compaction_count", 0) == 0
-        assert state.get("compaction_total_turns_dropped", 0) == 0
+        assert state.get("summarize_count", 0) == 0
+        assert state.get("summarize_total_turns_dropped", 0) == 0
+
+    @pytest.mark.asyncio
+    async def test_char_compression_ratio(self, env_with_summarize):
+        state = self._make_state(main_turns=6)
+
+        # The dropped messages have known content lengths (from _make_state:
+        # completion content is "response 0", "response 1" etc.)
+        await env_with_summarize.summarize_turns(
+            n_turns=2, summary="short", state=state
+        )
+
+        assert state["summarize_total_chars_dropped"] > 0
+        assert state["summarize_summary_length_chars"] == len(state["_summary_text"])
+        assert state["summarize_char_compression_ratio"] == pytest.approx(
+            state["summarize_total_chars_dropped"]
+            / state["summarize_summary_length_chars"]
+        )
+
+    @pytest.mark.asyncio
+    async def test_tokens_dropped_tracking(self, env_with_summarize):
+        # Explicit token schedule: turns have prompt_tokens [100, 200, 300, 400, 500, 600]
+        token_schedule = [100, 200, 300, 400, 500, 600]
+        state = self._make_state(main_turns=6, per_turn_prompt_tokens=token_schedule)
+
+        # Drop turns 1-2 (indices 0-1): tokens = prompt_tokens[2] - prompt_tokens[0] = 300 - 100 = 200
+        await env_with_summarize.summarize_turns(
+            n_turns=2, summary="first two", state=state
+        )
+
+        assert state["summarize_total_tokens_dropped"] == 200
+        assert state["summarize_mean_tokens_dropped_per_call"] == 200.0
+
+    @pytest.mark.asyncio
+    async def test_mean_tokens_dropped_per_call(self, env_with_summarize):
+        token_schedule = [100, 200, 300, 400, 500, 600, 700, 800]
+        state = self._make_state(main_turns=8, per_turn_prompt_tokens=token_schedule)
+
+        # Drop 1 turn: tokens = prompt_tokens[1] - prompt_tokens[0] = 100
+        await env_with_summarize.summarize_turns(
+            n_turns=1, summary="first", state=state
+        )
+        assert state["summarize_total_tokens_dropped"] == 100
+        assert state["summarize_mean_tokens_dropped_per_call"] == 100.0
+
+        # Drop 2 more turns: tokens = prompt_tokens[3] - prompt_tokens[1] = 200
+        await env_with_summarize.summarize_turns(
+            n_turns=2, summary="second", state=state
+        )
+        assert state["summarize_total_tokens_dropped"] == 300
+        assert state["summarize_mean_tokens_dropped_per_call"] == 150.0
+
+    # =====================================================================
+    # Per-turn prompt token tracking
+    # =====================================================================
+
+    @pytest.mark.asyncio
+    async def test_per_turn_prompt_tokens_recorded(self, env_with_summarize):
+        """After adding a main-model trajectory step, _per_turn_prompt_tokens is appended."""
+        usage = MagicMock()
+        usage.prompt_tokens = 42
+        usage.completion_tokens = 10
+        usage.reasoning_tokens = 0
+        usage.total_tokens = 52
+        response = MagicMock()
+        response.usage = usage
+        response.message = MagicMock()
+        response.message.content = "hello"
+        response.message.tool_calls = None
+        response.message.is_truncated = False
+
+        state = {
+            "trajectory_id": "main",
+            "trajectory": [],
+            "_per_turn_prompt_tokens": [],
+        }
+        rlm_module._ensure_rlm_metric_state(state)
+
+        step = {
+            "prompt": [UserMessage(content="q")],
+            "completion": [vf.AssistantMessage(content="a")],
+            "response": response,
+            "tokens": None,
+            "reward": None,
+            "advantage": None,
+            "is_truncated": False,
+            "trajectory_id": "main",
+            "extras": {},
+        }
+        await env_with_summarize.add_trajectory_step(state, step)
+
+        assert state["_per_turn_prompt_tokens"] == [42]
+
+    @pytest.mark.asyncio
+    async def test_sub_llm_steps_not_tracked_in_per_turn_tokens(
+        self, env_with_summarize
+    ):
+        """Sub-LLM trajectory steps should NOT append to _per_turn_prompt_tokens."""
+        usage = MagicMock()
+        usage.prompt_tokens = 99
+        usage.completion_tokens = 10
+        usage.reasoning_tokens = 0
+        usage.total_tokens = 109
+        response = MagicMock()
+        response.usage = usage
+        response.message = MagicMock()
+        response.message.content = "sub response"
+        response.message.tool_calls = None
+        response.message.is_truncated = False
+
+        state = {
+            "trajectory_id": "main",
+            "trajectory": [],
+            "_per_turn_prompt_tokens": [],
+        }
+        rlm_module._ensure_rlm_metric_state(state)
+
+        sub_step = {
+            "prompt": [UserMessage(content="sub q")],
+            "completion": [vf.AssistantMessage(content="sub a")],
+            "response": response,
+            "tokens": None,
+            "reward": None,
+            "advantage": None,
+            "is_truncated": False,
+            "trajectory_id": "sub_batch_123",  # different from main
+            "extras": {"is_sub_llm_call": True},
+        }
+        await env_with_summarize.add_trajectory_step(state, sub_step)
+
+        assert state["_per_turn_prompt_tokens"] == []
+
+    # =====================================================================
+    # Edge cases
+    # =====================================================================
+
+    def test_summary_with_no_remaining_assistant_messages(self, env_with_summarize):
+        """If no assistant messages remain after dropping, summary is not injected
+        (graceful degradation — shouldn't happen with min_turns_in_context)."""
+        messages = [
+            UserMessage(content="scaffolded"),
+        ]
+
+        summary_text = "[Turns 1-1] summary"
+        result = env_with_summarize._apply_context_dropping(
+            messages, 0, summary_text=summary_text
+        )
+
+        # No assistant message to inject into — messages returned as-is
+        assert len(result) == 1
+        assert result[0].content == "scaffolded"
+
+    def test_apply_context_dropping_zero_keep_from_no_summary(self, env_with_summarize):
+        """No dropping + no summary = messages unchanged."""
+        messages = [
+            UserMessage(content="scaffolded"),
+            vf.AssistantMessage(content="r0"),
+            vf.ToolMessage(tool_call_id="t0", content="t0"),
+        ]
+        result = env_with_summarize._apply_context_dropping(
+            messages, 0, summary_text=""
+        )
+        assert result == messages
+
+    def test_warn_when_dropping_without_message_history(self):
+        """Warning still fires when allow_context_dropping=True
+        but expose_message_history=False."""
+        dataset = make_dataset({})
+        with pytest.warns(UserWarning, match="allow_context_dropping=True"):
+            build_env(
+                dataset,
+                allow_context_dropping=True,
+                expose_message_history=False,
+                interception_url="http://test.invalid",
+            )

--- a/tests/test_rlm_env.py
+++ b/tests/test_rlm_env.py
@@ -2946,8 +2946,6 @@ class TestSummarizeTurns:
 
     def test_tool_registered_as_standard_tool_when_enabled(self, env_with_summarize):
         """summarize_turns should be a standard tool, not a root-REPL tool."""
-        tool_names = [t.__name__ for t in env_with_summarize.standard_tools]
-        # It's added via add_tool, so check the env's tool definitions
         tool_def_names = [td.name for td in env_with_summarize.tool_defs]
         assert "summarize_turns" in tool_def_names
 

--- a/tests/test_rlm_env.py
+++ b/tests/test_rlm_env.py
@@ -3252,8 +3252,9 @@ class TestSummarizeTurns:
         )
         assert result == messages
 
-    def test_apply_drop_all_returns_unchanged(self, env_with_summarize):
-        """Dropping more than available turns returns messages unchanged."""
+    def test_apply_drop_all_still_injects_summary(self, env_with_summarize):
+        """When keep_from exceeds available turns, no further dropping occurs
+        but the summary is still injected into the first assistant message."""
         messages = [
             UserMessage(content="scaffolded"),
             vf.AssistantMessage(content="r0"),
@@ -3262,7 +3263,10 @@ class TestSummarizeTurns:
         result = env_with_summarize._apply_context_dropping(
             messages, 5, summary_text="[Turns 1-5] summary"
         )
-        assert result == messages
+        assert len(result) == 3
+        assert result[0].content == "scaffolded"
+        assert "<SUMMARY>" in result[1].content
+        assert "r0" in result[1].content
 
     # =====================================================================
     # .messages file unaffected

--- a/tests/test_rlm_env.py
+++ b/tests/test_rlm_env.py
@@ -2909,9 +2909,7 @@ class TestSummarizeTurns:
         state = {
             "trajectory_id": trajectory_id,
             "trajectory": trajectory,
-            "_dropped_turns_count": dropped,
             "_keep_from_assistant_index": dropped,
-            "_drop_sequence": 0,
             "_summary_text": "",
             "rollout_id": "test_rollout",
         }
@@ -3017,9 +3015,8 @@ class TestSummarizeTurns:
             n_turns=2, summary="explored dataset", state=state
         )
 
-        assert state["_dropped_turns_count"] == 2
+        assert state["summarize_total_turns_dropped"] == 2
         assert state["_keep_from_assistant_index"] == 2
-        assert state["_drop_sequence"] == 1
         assert "[Turns 1-2]" in result
         assert "explored dataset" in result
         assert state["_summary_text"] == result
@@ -3033,7 +3030,7 @@ class TestSummarizeTurns:
         )
 
         # 6 visible - 3 min = 3 droppable
-        assert state["_dropped_turns_count"] == 3
+        assert state["summarize_total_turns_dropped"] == 3
         assert state["_keep_from_assistant_index"] == 3
         assert "[Turns 1-3]" in result
 
@@ -3045,7 +3042,7 @@ class TestSummarizeTurns:
             n_turns=4, summary="too many", state=state
         )
 
-        assert state["_dropped_turns_count"] == 0
+        assert state["summarize_total_turns_dropped"] == 0
         assert "Cannot drop" in result
         assert state["_summary_text"] == ""
 
@@ -3057,7 +3054,7 @@ class TestSummarizeTurns:
             n_turns=0, summary="nothing", state=state
         )
 
-        assert state["_dropped_turns_count"] == 0
+        assert state["summarize_total_turns_dropped"] == 0
         assert "Nothing to drop" in result
         assert state["_summary_text"] == ""
 

--- a/tests/test_rlm_env.py
+++ b/tests/test_rlm_env.py
@@ -2872,7 +2872,7 @@ class TestSummarizeTurns:
             warnings.simplefilter("ignore", UserWarning)
             return build_env(
                 dataset,
-                allow_context_dropping=True,
+                enable_summarization=True,
                 min_turns_in_context=3,
                 expose_message_history=False,
                 interception_url="http://test.invalid",
@@ -2883,7 +2883,7 @@ class TestSummarizeTurns:
         dataset = make_dataset({})
         return build_env(
             dataset,
-            allow_context_dropping=False,
+            enable_summarization=False,
             expose_message_history=False,
             interception_url="http://test.invalid",
         )
@@ -2971,10 +2971,10 @@ class TestSummarizeTurns:
 
     def test_warning_when_dropping_without_message_history(self):
         dataset = make_dataset({})
-        with pytest.warns(UserWarning, match="allow_context_dropping=True"):
+        with pytest.warns(UserWarning, match="enable_summarization=True"):
             build_env(
                 dataset,
-                allow_context_dropping=True,
+                enable_summarization=True,
                 expose_message_history=False,
                 interception_url="http://test.invalid",
             )
@@ -2987,7 +2987,7 @@ class TestSummarizeTurns:
             warnings.simplefilter("error")
             build_env(
                 dataset,
-                allow_context_dropping=True,
+                enable_summarization=True,
                 expose_message_history=True,
                 interception_url="http://test.invalid",
             )
@@ -3426,13 +3426,13 @@ class TestSummarizeTurns:
         assert result == messages
 
     def test_warn_when_dropping_without_message_history(self):
-        """Warning still fires when allow_context_dropping=True
+        """Warning still fires when enable_summarization=True
         but expose_message_history=False."""
         dataset = make_dataset({})
-        with pytest.warns(UserWarning, match="allow_context_dropping=True"):
+        with pytest.warns(UserWarning, match="enable_summarization=True"):
             build_env(
                 dataset,
-                allow_context_dropping=True,
+                enable_summarization=True,
                 expose_message_history=False,
                 interception_url="http://test.invalid",
             )

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -3980,29 +3980,61 @@ class RLMEnv(vf.StatefulToolEnv):
         return state["_summary_text"]
 
     def _compute_dropped_chars(self, state: State, keep_from: int, n_turns: int) -> int:
-        """Compute the total character length of messages being dropped."""
-        trajectory = state.get("trajectory", [])
-        main_id = state.get("trajectory_id")
-        # Collect main-model steps
-        main_steps = [s for s in trajectory if s.get("trajectory_id") == main_id]
+        """Compute the total character length of messages being dropped.
+
+        Uses the same assistant-index logic as ``_apply_context_dropping`` to
+        identify which messages would be removed, then sums the char length of
+        all content (including tool call arguments and tool responses).
+        """
+        last_main = self._last_main_trajectory_step(state)
+        if last_main is None:
+            return 0
+        messages = concat_messages([last_main["prompt"], last_main["completion"]])
+
+        assistant_indices = [
+            i
+            for i, msg in enumerate(messages)
+            if getattr(msg, "role", None) == "assistant"
+            or (isinstance(msg, dict) and msg.get("role") == "assistant")
+        ]
+        if not assistant_indices or keep_from >= len(assistant_indices):
+            return 0
+
+        # Messages being dropped: from the first assistant message up to (but
+        # not including) the keep_from-th assistant message.
+        drop_start = assistant_indices[0]
+        new_end = keep_from + n_turns
+        if new_end >= len(assistant_indices):
+            drop_end = len(messages)
+        else:
+            drop_end = assistant_indices[new_end]
+        # But we only want the newly dropped messages (keep_from..new_end),
+        # not previously dropped ones.
+        if keep_from < len(assistant_indices):
+            drop_start = assistant_indices[keep_from]
+        else:
+            return 0
 
         total_chars = 0
-        for i in range(keep_from, min(keep_from + n_turns, len(main_steps))):
-            step = main_steps[i]
-            for msg in step.get("completion", []):
-                content = getattr(msg, "content", None)
-                if content is None:
-                    continue
-                if isinstance(content, str):
-                    total_chars += len(content)
-                elif isinstance(content, list):
-                    for part in content:
-                        if isinstance(part, dict):
-                            total_chars += len(str(part.get("text", "")))
-                        else:
-                            total_chars += len(str(part))
-                else:
-                    total_chars += len(str(content))
+        for msg in messages[drop_start:drop_end]:
+            content = getattr(msg, "content", None)
+            if content is None:
+                # Count tool call arguments for assistant messages
+                tool_calls = getattr(msg, "tool_calls", None)
+                if tool_calls:
+                    for tc in tool_calls:
+                        total_chars += len(getattr(tc, "arguments", "") or "")
+                continue
+            if isinstance(content, str):
+                total_chars += len(content)
+            elif isinstance(content, list):
+                for part in content:
+                    if isinstance(part, dict):
+                        total_chars += len(str(part.get("text", "")))
+                    else:
+                        total_chars += len(str(part))
+            else:
+                total_chars += len(str(content))
         return total_chars
 
     def _last_main_trajectory_step(self, state: State) -> TrajectoryStep | None:

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -276,8 +276,6 @@ def _ensure_rlm_metric_state(state: State) -> None:
     state.setdefault("_rlm_sub_llm_call_ids", {})
     state.setdefault("_rlm_sub_llm_batch_counts", {})
 
-    state.setdefault("_dropped_turns_count", 0)
-    state.setdefault("_drop_sequence", 0)
     state.setdefault("_keep_from_assistant_index", 0)
     state.setdefault("_summary_text", "")
 
@@ -3541,8 +3539,6 @@ class RLMEnv(vf.StatefulToolEnv):
             state["_messages_uploaded_count"] = 0
 
             # Initialize context dropping state
-            state["_dropped_turns_count"] = 0
-            state["_drop_sequence"] = 0
             state["_keep_from_assistant_index"] = 0
 
             _ensure_rlm_metric_state(state)
@@ -3928,17 +3924,14 @@ class RLMEnv(vf.StatefulToolEnv):
 
         # Update state
         state["_keep_from_assistant_index"] = keep_from + n_turns
-        state["_dropped_turns_count"] = state.get("_dropped_turns_count", 0) + n_turns
-        state["_drop_sequence"] = state.get("_drop_sequence", 0) + 1
         new_visible = visible_turns - n_turns
 
         # Append to cumulative summary
         section = f"[Turns {range_start}-{range_end}] {summary}"
         prev_summary = state.get("_summary_text", "")
-        if prev_summary:
-            state["_summary_text"] = prev_summary + "\n" + section
-        else:
-            state["_summary_text"] = section
+        state["_summary_text"] = (
+            f"{prev_summary}\n{section}" if prev_summary else section
+        )
 
         logger.debug(
             "[%s] main turn %d: summarize_turns: %d turn(s) dropped "
@@ -3953,7 +3946,7 @@ class RLMEnv(vf.StatefulToolEnv):
 
         # Update metrics
         state["summarize_count"] += 1
-        state["summarize_total_turns_dropped"] = state["_dropped_turns_count"]
+        state["summarize_total_turns_dropped"] += n_turns
         state["summarize_total_chars_dropped"] += chars_dropped
         state["summarize_summary_length_chars"] = len(state["_summary_text"])
         if state["summarize_summary_length_chars"] > 0:
@@ -4143,20 +4136,15 @@ class RLMEnv(vf.StatefulToolEnv):
         if not assistant_indices:
             return messages
 
-        if keep_from_assistant_index >= len(assistant_indices):
-            # Already truncated past the index — no more turns to drop.
-            # But still inject summary into the first remaining assistant
-            # message if needed (the index may exceed the count because
-            # prior context dropping already removed those turns from the
-            # stored prompt).
-            preamble = list(messages[: assistant_indices[0]])
-            remaining = list(messages[assistant_indices[0] :])
+        # Preserve everything before the first assistant message (system msgs,
+        # scaffolded user msg, etc.), then keep from the target turn onward.
+        # If the index exceeds available assistants (prior dropping already
+        # truncated the stored prompt), keep all remaining messages.
+        preamble = list(messages[: assistant_indices[0]])
+        if keep_from_assistant_index < len(assistant_indices):
+            remaining = list(messages[assistant_indices[keep_from_assistant_index] :])
         else:
-            # Preserve everything before the first assistant message (system msgs,
-            # scaffolded user msg, etc.), then keep from the target turn onward.
-            preamble = list(messages[: assistant_indices[0]])
-            keep_from = assistant_indices[keep_from_assistant_index]
-            remaining = list(messages[keep_from:])
+            remaining = list(messages[assistant_indices[0] :])
 
         # Inject or replace summary in the first remaining assistant message
         if summary_text and remaining:

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -280,15 +280,12 @@ def _ensure_rlm_metric_state(state: State) -> None:
     state.setdefault("_drop_sequence", 0)
     state.setdefault("_keep_from_assistant_index", 0)
     state.setdefault("_summary_text", "")
-    state.setdefault("_per_turn_prompt_tokens", [])
 
     state.setdefault("summarize_count", 0)
     state.setdefault("summarize_total_turns_dropped", 0)
-    state.setdefault("summarize_total_tokens_dropped", 0)
     state.setdefault("summarize_total_chars_dropped", 0)
     state.setdefault("summarize_summary_length_chars", 0)
     state.setdefault("summarize_char_compression_ratio", 0.0)
-    state.setdefault("summarize_mean_tokens_dropped_per_call", 0.0)
     state.setdefault("summarize_mean_turns_per_call", 0.0)
     state.setdefault("summarize_mean_remaining_turns", 0.0)
     state.setdefault("summarize_mean_turns_between", 0.0)
@@ -382,11 +379,9 @@ class RLMMonitorRubric(vf.Rubric):
         "root_tool_call_count",
         "summarize_count",
         "summarize_total_turns_dropped",
-        "summarize_total_tokens_dropped",
         "summarize_total_chars_dropped",
         "summarize_summary_length_chars",
         "summarize_char_compression_ratio",
-        "summarize_mean_tokens_dropped_per_call",
         "summarize_mean_turns_per_call",
         "summarize_mean_remaining_turns",
         "summarize_mean_turns_between",
@@ -3926,9 +3921,6 @@ class RLMEnv(vf.StatefulToolEnv):
         # Compute chars of dropped messages
         chars_dropped = self._compute_dropped_chars(state, keep_from, n_turns)
 
-        # Compute tokens dropped from per-turn prompt_tokens
-        tokens_dropped = self._compute_dropped_tokens(state, keep_from, n_turns)
-
         # Update state
         state["_keep_from_assistant_index"] = keep_from + n_turns
         state["_dropped_turns_count"] = state.get("_dropped_turns_count", 0) + n_turns
@@ -3957,7 +3949,6 @@ class RLMEnv(vf.StatefulToolEnv):
         # Update metrics
         state["summarize_count"] += 1
         state["summarize_total_turns_dropped"] = state["_dropped_turns_count"]
-        state["summarize_total_tokens_dropped"] += tokens_dropped
         state["summarize_total_chars_dropped"] += chars_dropped
         state["summarize_summary_length_chars"] = len(state["_summary_text"])
         if state["summarize_summary_length_chars"] > 0:
@@ -3967,10 +3958,6 @@ class RLMEnv(vf.StatefulToolEnv):
             )
         state["summarize_mean_turns_per_call"] = (
             state["summarize_total_turns_dropped"] / state["summarize_count"]
-        )
-
-        state["summarize_mean_tokens_dropped_per_call"] = (
-            state["summarize_total_tokens_dropped"] / state["summarize_count"]
         )
 
         remaining_list: list[int] = state["_summarize_remaining_turns_list"]
@@ -4013,27 +4000,6 @@ class RLMEnv(vf.StatefulToolEnv):
                     total_chars += len(str(content))
         return total_chars
 
-    def _compute_dropped_tokens(
-        self, state: State, keep_from: int, n_turns: int
-    ) -> int:
-        """Compute tokens dropped using per-turn prompt_tokens deltas.
-
-        ``per_turn[i]`` is the prompt_tokens reported by the API for main turn
-        *i*.  The tokens contributed by turns ``[start, end)`` are approximated
-        as ``per_turn[end] - per_turn[start]`` (the growth in prompt size across
-        those turns).  If ``end`` is out of range we return 0 — this shouldn't
-        happen in practice because ``min_turns_in_context >= 1`` guarantees at
-        least one turn remains after the dropped range.
-        """
-        per_turn = state.get("_per_turn_prompt_tokens", [])
-        if not per_turn:
-            return 0
-        start_idx = keep_from
-        end_idx = keep_from + n_turns
-        if start_idx >= len(per_turn) or end_idx >= len(per_turn):
-            return 0
-        return max(0, per_turn[end_idx] - per_turn[start_idx])
-
     def _last_main_trajectory_step(self, state: State) -> TrajectoryStep | None:
         """Find the last trajectory step belonging to the main (root) model."""
         main_id = state.get("trajectory_id")
@@ -4044,14 +4010,6 @@ class RLMEnv(vf.StatefulToolEnv):
 
     async def add_trajectory_step(self, state: State, trajectory_step: TrajectoryStep):
         update_rlm_metrics_from_step(state, trajectory_step)
-        # Track per-turn prompt_tokens for main-model steps only
-        # Use trajectory_id match (consistent with _main_turn_count)
-        is_main = trajectory_step.get("trajectory_id") == state.get("trajectory_id")
-        if is_main:
-            response = trajectory_step.get("response")
-            usage = getattr(response, "usage", None) if response else None
-            prompt_tokens = int(getattr(usage, "prompt_tokens", 0) or 0)
-            state.setdefault("_per_turn_prompt_tokens", []).append(prompt_tokens)
         await super().add_trajectory_step(state, trajectory_step)
 
     async def add_model_response(

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -88,7 +88,7 @@ from verifiers.utils.tool_utils import convert_func_to_tool_def
 
 logger = logging.getLogger(__name__)
 
-_FIXED_REPL_TOOL_NAMES = frozenset({"llm_batch", "remove_conversation_turns"})
+_FIXED_REPL_TOOL_NAMES = frozenset({"llm_batch"})
 
 
 def _tool_display_name(tool: Callable) -> str:
@@ -279,13 +279,22 @@ def _ensure_rlm_metric_state(state: State) -> None:
     state.setdefault("_dropped_turns_count", 0)
     state.setdefault("_drop_sequence", 0)
     state.setdefault("_keep_from_assistant_index", 0)
+    state.setdefault("_summary_text", "")
+    state.setdefault("_per_turn_prompt_tokens", [])
 
-    state.setdefault("compaction_count", 0)
-    state.setdefault("compaction_total_turns_dropped", 0)
-    state.setdefault("compaction_mean_remaining_turns", 0.0)
-    state.setdefault("compaction_mean_turns_between", 0.0)
-    state.setdefault("_compaction_remaining_turns_list", [])
-    state.setdefault("_compaction_at_root_llm_turns", [])
+    state.setdefault("summarize_count", 0)
+    state.setdefault("summarize_total_turns_dropped", 0)
+    state.setdefault("summarize_total_tokens_dropped", 0)
+    state.setdefault("summarize_total_chars_dropped", 0)
+    state.setdefault("summarize_summary_length_chars", 0)
+    state.setdefault("summarize_char_compression_ratio", 0.0)
+    state.setdefault("summarize_mean_tokens_dropped_per_call", 0.0)
+    state.setdefault("summarize_mean_turns_per_call", 0.0)
+    state.setdefault("summarize_mean_remaining_turns", 0.0)
+    state.setdefault("summarize_mean_turns_between", 0.0)
+    state.setdefault("_summarize_remaining_turns_list", [])
+    state.setdefault("_summarize_at_root_llm_turns", [])
+    state.setdefault("_summarize_tokens_dropped_list", [])
 
 
 def _update_rlm_repl_metrics(state: State, execution_seconds: float) -> None:
@@ -372,10 +381,16 @@ class RLMMonitorRubric(vf.Rubric):
         "repl_call_count",
         "repl_mean_time_seconds",
         "root_tool_call_count",
-        "compaction_count",
-        "compaction_total_turns_dropped",
-        "compaction_mean_remaining_turns",
-        "compaction_mean_turns_between",
+        "summarize_count",
+        "summarize_total_turns_dropped",
+        "summarize_total_tokens_dropped",
+        "summarize_total_chars_dropped",
+        "summarize_summary_length_chars",
+        "summarize_char_compression_ratio",
+        "summarize_mean_tokens_dropped_per_call",
+        "summarize_mean_turns_per_call",
+        "summarize_mean_remaining_turns",
+        "summarize_mean_turns_between",
     ]
 
     def __init__(self, root_tool_names: list[str] | None = None, **kwargs):
@@ -1374,13 +1389,16 @@ In the end, the `ANSWER_CONTENT` environment variable must contain your answer. 
             return ""
         return (
             "\n## Context Management\n\n"
-            "You can drop old conversation turns from context to free up space using "
-            '`remove_conversation_turns(n_turns, summary="")`.\n'
+            "You have a `summarize_turns` tool to drop old conversation turns "
+            "from context and replace them with a summary.\n"
             f"- At least {self.min_turns_in_context} turns must remain in context.\n"
             "- Use `n_turns=-1` to drop the maximum possible.\n"
-            "- Provide a `summary` to record what was in the dropped turns.\n"
+            "- Provide a `summary` describing the key findings and state from "
+            "the dropped turns.\n"
+            "- Summaries are cumulative: each call appends to the previous summary.\n"
+            "- The full summary is returned as the tool output and injected into "
+            "the first assistant message as a `<SUMMARY>` block.\n"
             "- Dropped turns are still accessible via the `.messages` file.\n"
-            "- Summaries are recorded in the `.summaries` file (JSONL).\n"
         )
 
     def build_root_budget_note(self) -> str:
@@ -2503,6 +2521,10 @@ class RLMEnv(vf.StatefulToolEnv):
         else:
             self.add_tool(self.call_python_repl, args_to_skip=["state"])
 
+        # Add summarize_turns as a standard tool (not a REPL tool)
+        if self.allow_context_dropping:
+            self.add_tool(self.summarize_turns, args_to_skip=["state"])
+
     def get_sandbox_request(self, state: State) -> CreateSandboxRequest:
         """Return the sandbox request for this rollout.
 
@@ -2572,158 +2594,7 @@ class RLMEnv(vf.StatefulToolEnv):
             llm_batch.__name__ = "llm_batch"
             tools.append(llm_batch)
 
-        if self.allow_context_dropping:
-
-            async def remove_conversation_turns(n_turns: int, summary: str = "") -> str:
-                """
-                Drop the oldest n_turns from your conversation context.
-
-                Dropped turns remain accessible via the .messages file.
-                Summaries are recorded in the .summaries file.
-
-                Args:
-                    n_turns: Number of oldest turns to drop. Use -1 to drop the
-                             maximum possible.
-                    summary: Optional summary of the dropped context.
-
-                Returns:
-                    Status message with turns dropped, turns remaining, and echoed summary.
-                """
-                context = self._root_tool_context_var.get()
-                if context is None:
-                    raise RuntimeError(
-                        "remove_conversation_turns called outside of a tool request context."
-                    )
-                return await self._handle_remove_conversation_turns(
-                    context["state"], n_turns, summary
-                )
-
-            remove_conversation_turns.__name__ = "remove_conversation_turns"
-            tools.append(remove_conversation_turns)
-
         return tools
-
-    async def _handle_remove_conversation_turns(
-        self, state: State, n_turns: int, summary: str
-    ) -> str:
-        """Core logic for the remove_conversation_turns root tool."""
-        rid = state.get("rollout_id", "?")
-        main_turn = self._main_turn_count(state)
-        keep_from = state.get("_keep_from_assistant_index", 0)
-        visible_turns = main_turn - keep_from
-        max_droppable = max(0, visible_turns - self.min_turns_in_context)
-
-        if n_turns == -1:
-            n_turns = max_droppable
-
-        if n_turns <= 0:
-            logger.debug(
-                "[%s] main turn %d: context drop: nothing to drop "
-                "(n_turns=%d, %d visible)",
-                rid,
-                main_turn,
-                n_turns,
-                visible_turns,
-            )
-            return (
-                f"Nothing to drop (n_turns={n_turns}). "
-                f"Currently {visible_turns} turn(s) visible in context."
-            )
-
-        if n_turns > max_droppable:
-            logger.warning(
-                "[%s] main turn %d: context drop rejected: requested %d turn(s) "
-                "but max droppable is %d (%d visible, min=%d)",
-                rid,
-                main_turn,
-                n_turns,
-                max_droppable,
-                visible_turns,
-                self.min_turns_in_context,
-            )
-            return (
-                f"Cannot drop {n_turns} turn(s). "
-                f"You have {visible_turns} turn(s) visible in context and "
-                f"min_turns_in_context={self.min_turns_in_context}. "
-                f"Maximum droppable: {max_droppable}. No turns were dropped."
-            )
-
-        state["_keep_from_assistant_index"] = keep_from + n_turns
-        state["_dropped_turns_count"] = state.get("_dropped_turns_count", 0) + n_turns
-        state["_drop_sequence"] = state.get("_drop_sequence", 0) + 1
-        new_visible = visible_turns - n_turns
-
-        logger.debug(
-            "[%s] main turn %d: context drop: %d turn(s) dropped "
-            "(%d visible -> %d visible, keep_from=%d, summary=%s)",
-            rid,
-            main_turn,
-            n_turns,
-            visible_turns,
-            new_visible,
-            state["_keep_from_assistant_index"],
-            "yes" if summary.strip() else "no",
-        )
-
-        # Update context dropping metrics
-        _ensure_rlm_metric_state(state)
-        state["compaction_count"] += 1
-        state["compaction_total_turns_dropped"] = state["_dropped_turns_count"]
-
-        remaining_list: list[int] = state["_compaction_remaining_turns_list"]
-        remaining_list.append(new_visible)
-        state["compaction_mean_remaining_turns"] = sum(remaining_list) / len(
-            remaining_list
-        )
-
-        at_turns: list[int] = state["_compaction_at_root_llm_turns"]
-        at_turns.append(main_turn)
-        if len(at_turns) >= 2:
-            gaps = [at_turns[i] - at_turns[i - 1] for i in range(1, len(at_turns))]
-            state["compaction_mean_turns_between"] = sum(gaps) / len(gaps)
-
-        await self._upload_summary(state, n_turns, summary, new_visible)
-
-        parts = [
-            f"Dropped {n_turns} oldest turn(s) from context.",
-            f"Turns now visible: {new_visible}.",
-        ]
-        if summary:
-            parts.append(f"Summary recorded: {summary}")
-        parts.append("Dropped turns are still accessible via .messages.")
-        return "\n".join(parts)
-
-    async def _upload_summary(
-        self, state: State, n_turns: int, summary: str, turns_remaining: int
-    ) -> None:
-        """Append a summary entry to .summaries JSONL in the sandbox."""
-        entry = json.dumps(
-            {
-                "n_turns_dropped": n_turns,
-                "summary": summary,
-                "timestamp": time.time(),
-                "turns_remaining": turns_remaining,
-            },
-            ensure_ascii=False,
-        )
-        entry_line = entry + "\n"
-
-        session = self._executor._get_session(state)
-        if not session.sandbox_id:
-            return
-        fs_root = session.sandbox_fs_root or state.get("rlm_fs_root_remote", "")
-        remote_path = f"{fs_root}/.summaries"
-        delta_b64 = base64.b64encode(entry_line.encode("utf-8")).decode("ascii")
-        cmd = f"echo '{delta_b64}' | base64 -d >> {remote_path}"
-
-        try:
-            await self._executor._execute_sandbox_command(
-                session.sandbox_id,
-                f"bash -lc {shlex.quote(cmd)}",
-                timeout=30,
-            )
-        except Exception as e:
-            logger.warning("Failed to upload summary: %s", e)
 
     def _build_worker_env_vars(self, state: State) -> dict[str, str]:
         return {
@@ -3572,8 +3443,8 @@ class RLMEnv(vf.StatefulToolEnv):
         state: State,
         **kwargs,
     ) -> dict[str, Any]:
-        """Inject state into REPL tool args."""
-        if tool_name in {"call_python_repl", "call_bash_repl"}:
+        """Inject state into REPL and summarize_turns tool args."""
+        if tool_name in {"call_python_repl", "call_bash_repl", "summarize_turns"}:
             updated_args = dict(tool_args)
             updated_args["state"] = state
             return updated_args
@@ -3993,6 +3864,175 @@ class RLMEnv(vf.StatefulToolEnv):
             append_execution_time=True,
         )
 
+    async def summarize_turns(self, n_turns: int, summary: str, state: Any) -> str:
+        """Drop the oldest n_turns from context and record a cumulative summary.
+
+        The summary is appended to previous summaries and injected into the
+        first remaining assistant message as a <SUMMARY> block.
+
+        Args:
+            n_turns: Number of oldest visible turns to drop. Use -1 to drop
+                     the maximum possible.
+            summary: Summary of the content in the dropped turns.
+
+        Returns:
+            The full cumulative summary (all prior summaries + this one).
+        """
+        _ensure_rlm_metric_state(state)
+        rid = state.get("rollout_id", "?")
+        main_turn = self._main_turn_count(state)
+        keep_from = state.get("_keep_from_assistant_index", 0)
+        visible_turns = main_turn - keep_from
+        max_droppable = max(0, visible_turns - self.min_turns_in_context)
+
+        if n_turns == -1:
+            n_turns = max_droppable
+
+        if n_turns <= 0:
+            logger.debug(
+                "[%s] main turn %d: summarize_turns: nothing to drop "
+                "(n_turns=%d, %d visible)",
+                rid,
+                main_turn,
+                n_turns,
+                visible_turns,
+            )
+            return (
+                f"Nothing to drop (n_turns={n_turns}). "
+                f"Currently {visible_turns} turn(s) visible in context."
+            )
+
+        if n_turns > max_droppable:
+            logger.warning(
+                "[%s] main turn %d: summarize_turns rejected: requested %d turn(s) "
+                "but max droppable is %d (%d visible, min=%d)",
+                rid,
+                main_turn,
+                n_turns,
+                max_droppable,
+                visible_turns,
+                self.min_turns_in_context,
+            )
+            return (
+                f"Cannot drop {n_turns} turn(s). "
+                f"You have {visible_turns} turn(s) visible in context and "
+                f"min_turns_in_context={self.min_turns_in_context}. "
+                f"Maximum droppable: {max_droppable}. No turns were dropped."
+            )
+
+        # Compute absolute turn range (1-indexed for display)
+        range_start = keep_from + 1
+        range_end = keep_from + n_turns
+
+        # Compute chars of dropped messages
+        chars_dropped = self._compute_dropped_chars(state, keep_from, n_turns)
+
+        # Compute tokens dropped from per-turn prompt_tokens
+        tokens_dropped = self._compute_dropped_tokens(state, keep_from, n_turns)
+
+        # Update state
+        state["_keep_from_assistant_index"] = keep_from + n_turns
+        state["_dropped_turns_count"] = state.get("_dropped_turns_count", 0) + n_turns
+        state["_drop_sequence"] = state.get("_drop_sequence", 0) + 1
+        new_visible = visible_turns - n_turns
+
+        # Append to cumulative summary
+        section = f"[Turns {range_start}-{range_end}] {summary}"
+        prev_summary = state.get("_summary_text", "")
+        if prev_summary:
+            state["_summary_text"] = prev_summary + "\n" + section
+        else:
+            state["_summary_text"] = section
+
+        logger.debug(
+            "[%s] main turn %d: summarize_turns: %d turn(s) dropped "
+            "(%d visible -> %d visible, keep_from=%d)",
+            rid,
+            main_turn,
+            n_turns,
+            visible_turns,
+            new_visible,
+            state["_keep_from_assistant_index"],
+        )
+
+        # Update metrics
+        state["summarize_count"] += 1
+        state["summarize_total_turns_dropped"] = state["_dropped_turns_count"]
+        state["summarize_total_tokens_dropped"] += tokens_dropped
+        state["summarize_total_chars_dropped"] += chars_dropped
+        state["summarize_summary_length_chars"] = len(state["_summary_text"])
+        if state["summarize_summary_length_chars"] > 0:
+            state["summarize_char_compression_ratio"] = (
+                state["summarize_total_chars_dropped"]
+                / state["summarize_summary_length_chars"]
+            )
+        state["summarize_mean_turns_per_call"] = (
+            state["summarize_total_turns_dropped"] / state["summarize_count"]
+        )
+
+        tokens_list: list[int] = state["_summarize_tokens_dropped_list"]
+        tokens_list.append(tokens_dropped)
+        state["summarize_mean_tokens_dropped_per_call"] = (
+            state["summarize_total_tokens_dropped"] / state["summarize_count"]
+        )
+
+        remaining_list: list[int] = state["_summarize_remaining_turns_list"]
+        remaining_list.append(new_visible)
+        state["summarize_mean_remaining_turns"] = sum(remaining_list) / len(
+            remaining_list
+        )
+
+        at_turns: list[int] = state["_summarize_at_root_llm_turns"]
+        at_turns.append(main_turn)
+        if len(at_turns) >= 2:
+            gaps = [at_turns[i] - at_turns[i - 1] for i in range(1, len(at_turns))]
+            state["summarize_mean_turns_between"] = sum(gaps) / len(gaps)
+
+        return state["_summary_text"]
+
+    def _compute_dropped_chars(self, state: State, keep_from: int, n_turns: int) -> int:
+        """Compute the total character length of messages being dropped."""
+        trajectory = state.get("trajectory", [])
+        main_id = state.get("trajectory_id")
+        # Collect main-model steps
+        main_steps = [s for s in trajectory if s.get("trajectory_id") == main_id]
+
+        total_chars = 0
+        for i in range(keep_from, min(keep_from + n_turns, len(main_steps))):
+            step = main_steps[i]
+            for msg in step.get("completion", []):
+                content = getattr(msg, "content", None)
+                if content is None:
+                    continue
+                if isinstance(content, str):
+                    total_chars += len(content)
+                elif isinstance(content, list):
+                    for part in content:
+                        if isinstance(part, dict):
+                            total_chars += len(str(part.get("text", "")))
+                        else:
+                            total_chars += len(str(part))
+                else:
+                    total_chars += len(str(content))
+        return total_chars
+
+    def _compute_dropped_tokens(
+        self, state: State, keep_from: int, n_turns: int
+    ) -> int:
+        """Compute tokens dropped using per-turn prompt_tokens deltas."""
+        per_turn = state.get("_per_turn_prompt_tokens", [])
+        if not per_turn:
+            return 0
+        # The tokens contributed by turns [keep_from, keep_from+n_turns) is
+        # approximately prompt_tokens[keep_from+n_turns] - prompt_tokens[keep_from].
+        start_idx = keep_from
+        end_idx = keep_from + n_turns
+        if start_idx >= len(per_turn):
+            return 0
+        start_tokens = per_turn[start_idx]
+        end_tokens = per_turn[min(end_idx, len(per_turn) - 1)]
+        return max(0, end_tokens - start_tokens)
+
     def _last_main_trajectory_step(self, state: State) -> TrajectoryStep | None:
         """Find the last trajectory step belonging to the main (root) model."""
         main_id = state.get("trajectory_id")
@@ -4003,6 +4043,13 @@ class RLMEnv(vf.StatefulToolEnv):
 
     async def add_trajectory_step(self, state: State, trajectory_step: TrajectoryStep):
         update_rlm_metrics_from_step(state, trajectory_step)
+        # Track per-turn prompt_tokens for main-model steps only
+        is_sub_llm = bool((trajectory_step.get("extras") or {}).get("is_sub_llm_call"))
+        if not is_sub_llm:
+            response = trajectory_step.get("response")
+            usage = getattr(response, "usage", None) if response else None
+            prompt_tokens = int(getattr(usage, "prompt_tokens", 0) or 0)
+            state.setdefault("_per_turn_prompt_tokens", []).append(prompt_tokens)
         await super().add_trajectory_step(state, trajectory_step)
 
     async def add_model_response(
@@ -4066,14 +4113,20 @@ class RLMEnv(vf.StatefulToolEnv):
             messages = concat_messages([prev_turn_prompt, prev_turn_completion])
 
             keep_from = state.get("_keep_from_assistant_index", 0)
-            if keep_from > 0:
-                messages = self._apply_context_dropping(messages, keep_from)
+            summary_text = state.get("_summary_text", "")
+            if keep_from > 0 or summary_text:
+                messages = self._apply_context_dropping(
+                    messages, keep_from, summary_text=summary_text
+                )
 
             env_response = await self.env_response(messages, state)
             return concat_messages([messages, env_response])
 
     def _apply_context_dropping(
-        self, messages: Messages, keep_from_assistant_index: int
+        self,
+        messages: Messages,
+        keep_from_assistant_index: int,
+        summary_text: str = "",
     ) -> Messages:
         """Drop all turns before the *keep_from_assistant_index*-th assistant message.
 
@@ -4081,8 +4134,11 @@ class RLMEnv(vf.StatefulToolEnv):
         the scaffolded user message, etc.). A "turn" is one assistant message plus
         all subsequent tool messages. Idempotent: if the messages are already
         truncated past the index, returns them unchanged.
+
+        If *summary_text* is non-empty, it is prepended as a ``<SUMMARY>`` block
+        to the content of the first remaining assistant message.
         """
-        if keep_from_assistant_index <= 0:
+        if keep_from_assistant_index <= 0 and not summary_text:
             return messages
 
         # Find turn boundaries (each assistant message starts a new turn)
@@ -4093,14 +4149,57 @@ class RLMEnv(vf.StatefulToolEnv):
             or (isinstance(msg, dict) and msg.get("role") == "assistant")
         ]
 
-        if not assistant_indices or keep_from_assistant_index >= len(assistant_indices):
+        if not assistant_indices:
+            return messages
+
+        if keep_from_assistant_index >= len(assistant_indices):
             return messages
 
         # Preserve everything before the first assistant message (system msgs,
         # scaffolded user msg, etc.), then keep from the target turn onward.
         preamble = list(messages[: assistant_indices[0]])
         keep_from = assistant_indices[keep_from_assistant_index]
-        return preamble + list(messages[keep_from:])
+        remaining = list(messages[keep_from:])
+
+        # Inject summary into the first remaining assistant message
+        if summary_text and remaining:
+            first_asst = remaining[0]
+            summary_block = f"<SUMMARY>\n{summary_text}\n</SUMMARY>\n\n"
+            content = getattr(first_asst, "content", None)
+            if isinstance(content, str):
+                # Skip injection if summary is already present (idempotency)
+                if "<SUMMARY>" not in content:
+                    remaining[0] = AssistantMessage(
+                        content=summary_block + content,
+                        tool_calls=getattr(first_asst, "tool_calls", None),
+                        reasoning_content=getattr(
+                            first_asst, "reasoning_content", None
+                        ),
+                        thinking_blocks=getattr(first_asst, "thinking_blocks", None),
+                    )
+            elif isinstance(content, list):
+                # Check idempotency for list content
+                has_summary = any(
+                    isinstance(part, dict)
+                    and part.get("type") == "text"
+                    and "<SUMMARY>" in str(part.get("text", ""))
+                    for part in content
+                )
+                if not has_summary:
+                    new_content = [
+                        {"type": "text", "text": summary_block},
+                        *content,
+                    ]
+                    remaining[0] = AssistantMessage(
+                        content=new_content,
+                        tool_calls=getattr(first_asst, "tool_calls", None),
+                        reasoning_content=getattr(
+                            first_asst, "reasoning_content", None
+                        ),
+                        thinking_blocks=getattr(first_asst, "thinking_blocks", None),
+                    )
+
+        return preamble + remaining
 
     async def env_response(
         self, messages: Messages, state: State, **kwargs

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -4030,7 +4030,7 @@ class RLMEnv(vf.StatefulToolEnv):
             return 0
         start_idx = keep_from
         end_idx = keep_from + n_turns
-        if start_idx >= len(per_turn) or end_idx > len(per_turn):
+        if start_idx >= len(per_turn) or end_idx >= len(per_turn):
             return 0
         return max(0, per_turn[end_idx] - per_turn[start_idx])
 

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -294,7 +294,6 @@ def _ensure_rlm_metric_state(state: State) -> None:
     state.setdefault("summarize_mean_turns_between", 0.0)
     state.setdefault("_summarize_remaining_turns_list", [])
     state.setdefault("_summarize_at_root_llm_turns", [])
-    state.setdefault("_summarize_tokens_dropped_list", [])
 
 
 def _update_rlm_repl_metrics(state: State, execution_seconds: float) -> None:
@@ -3970,8 +3969,6 @@ class RLMEnv(vf.StatefulToolEnv):
             state["summarize_total_turns_dropped"] / state["summarize_count"]
         )
 
-        tokens_list: list[int] = state["_summarize_tokens_dropped_list"]
-        tokens_list.append(tokens_dropped)
         state["summarize_mean_tokens_dropped_per_call"] = (
             state["summarize_total_tokens_dropped"] / state["summarize_count"]
         )
@@ -4044,8 +4041,9 @@ class RLMEnv(vf.StatefulToolEnv):
     async def add_trajectory_step(self, state: State, trajectory_step: TrajectoryStep):
         update_rlm_metrics_from_step(state, trajectory_step)
         # Track per-turn prompt_tokens for main-model steps only
-        is_sub_llm = bool((trajectory_step.get("extras") or {}).get("is_sub_llm_call"))
-        if not is_sub_llm:
+        # Use trajectory_id match (consistent with _main_turn_count)
+        is_main = trajectory_step.get("trajectory_id") == state.get("trajectory_id")
+        if is_main:
             response = trajectory_step.get("response")
             usage = getattr(response, "usage", None) if response else None
             prompt_tokens = int(getattr(usage, "prompt_tokens", 0) or 0)

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -4016,19 +4016,23 @@ class RLMEnv(vf.StatefulToolEnv):
     def _compute_dropped_tokens(
         self, state: State, keep_from: int, n_turns: int
     ) -> int:
-        """Compute tokens dropped using per-turn prompt_tokens deltas."""
+        """Compute tokens dropped using per-turn prompt_tokens deltas.
+
+        ``per_turn[i]`` is the prompt_tokens reported by the API for main turn
+        *i*.  The tokens contributed by turns ``[start, end)`` are approximated
+        as ``per_turn[end] - per_turn[start]`` (the growth in prompt size across
+        those turns).  If ``end`` is out of range we return 0 — this shouldn't
+        happen in practice because ``min_turns_in_context >= 1`` guarantees at
+        least one turn remains after the dropped range.
+        """
         per_turn = state.get("_per_turn_prompt_tokens", [])
         if not per_turn:
             return 0
-        # The tokens contributed by turns [keep_from, keep_from+n_turns) is
-        # approximately prompt_tokens[keep_from+n_turns] - prompt_tokens[keep_from].
         start_idx = keep_from
         end_idx = keep_from + n_turns
-        if start_idx >= len(per_turn):
+        if start_idx >= len(per_turn) or end_idx > len(per_turn):
             return 0
-        start_tokens = per_turn[start_idx]
-        end_tokens = per_turn[min(end_idx, len(per_turn) - 1)]
-        return max(0, end_tokens - start_tokens)
+        return max(0, per_turn[end_idx] - per_turn[start_idx])
 
     def _last_main_trajectory_step(self, state: State) -> TrajectoryStep | None:
         """Find the last trajectory step belonging to the main (root) model."""

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -4158,43 +4158,47 @@ class RLMEnv(vf.StatefulToolEnv):
             keep_from = assistant_indices[keep_from_assistant_index]
             remaining = list(messages[keep_from:])
 
-        # Inject summary into the first remaining assistant message
+        # Inject or replace summary in the first remaining assistant message
         if summary_text and remaining:
             first_asst = remaining[0]
             summary_block = f"<SUMMARY>\n{summary_text}\n</SUMMARY>\n\n"
             content = getattr(first_asst, "content", None)
             if isinstance(content, str):
-                # Skip injection if summary is already present (idempotency)
-                if "<SUMMARY>" not in content:
-                    remaining[0] = AssistantMessage(
-                        content=summary_block + content,
-                        tool_calls=getattr(first_asst, "tool_calls", None),
-                        reasoning_content=getattr(
-                            first_asst, "reasoning_content", None
-                        ),
-                        thinking_blocks=getattr(first_asst, "thinking_blocks", None),
-                    )
-            elif isinstance(content, list):
-                # Check idempotency for list content
-                has_summary = any(
-                    isinstance(part, dict)
-                    and part.get("type") == "text"
-                    and "<SUMMARY>" in str(part.get("text", ""))
-                    for part in content
+                # Strip any existing summary block before prepending the new one
+                content = re.sub(
+                    r"<SUMMARY>\n.*?\n</SUMMARY>\n\n",
+                    "",
+                    content,
+                    count=1,
+                    flags=re.DOTALL,
                 )
-                if not has_summary:
-                    new_content = [
-                        {"type": "text", "text": summary_block},
-                        *content,
-                    ]
-                    remaining[0] = AssistantMessage(
-                        content=new_content,
-                        tool_calls=getattr(first_asst, "tool_calls", None),
-                        reasoning_content=getattr(
-                            first_asst, "reasoning_content", None
-                        ),
-                        thinking_blocks=getattr(first_asst, "thinking_blocks", None),
+                remaining[0] = AssistantMessage(
+                    content=summary_block + content,
+                    tool_calls=getattr(first_asst, "tool_calls", None),
+                    reasoning_content=getattr(first_asst, "reasoning_content", None),
+                    thinking_blocks=getattr(first_asst, "thinking_blocks", None),
+                )
+            elif isinstance(content, list):
+                # Remove any existing summary text block, then prepend new one
+                filtered = [
+                    part
+                    for part in content
+                    if not (
+                        isinstance(part, dict)
+                        and part.get("type") == "text"
+                        and "<SUMMARY>" in str(part.get("text", ""))
                     )
+                ]
+                new_content = [
+                    {"type": "text", "text": summary_block},
+                    *filtered,
+                ]
+                remaining[0] = AssistantMessage(
+                    content=new_content,
+                    tool_calls=getattr(first_asst, "tool_calls", None),
+                    reasoning_content=getattr(first_asst, "reasoning_content", None),
+                    thinking_blocks=getattr(first_asst, "thinking_blocks", None),
+                )
 
         return preamble + remaining
 

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -3924,7 +3924,7 @@ class RLMEnv(vf.StatefulToolEnv):
         range_end = keep_from + n_turns
 
         # Compute chars of dropped messages
-        chars_dropped = self._compute_dropped_chars(state, keep_from, n_turns)
+        chars_dropped = self._compute_dropped_chars(state, n_turns)
 
         # Update state
         state["_keep_from_assistant_index"] = keep_from + n_turns
@@ -3979,12 +3979,13 @@ class RLMEnv(vf.StatefulToolEnv):
 
         return state["_summary_text"]
 
-    def _compute_dropped_chars(self, state: State, keep_from: int, n_turns: int) -> int:
+    def _compute_dropped_chars(self, state: State, n_turns: int) -> int:
         """Compute the total character length of messages being dropped.
 
-        Uses the same assistant-index logic as ``_apply_context_dropping`` to
-        identify which messages would be removed, then sums the char length of
-        all content (including tool call arguments and tool responses).
+        The last trajectory step's prompt already has prior context dropping
+        applied, so the first ``n_turns`` assistant messages (and their
+        following tool messages) in that prompt are exactly the ones being
+        removed by this call.
         """
         last_main = self._last_main_trajectory_step(state)
         if last_main is None:
@@ -3997,23 +3998,16 @@ class RLMEnv(vf.StatefulToolEnv):
             if getattr(msg, "role", None) == "assistant"
             or (isinstance(msg, dict) and msg.get("role") == "assistant")
         ]
-        if not assistant_indices or keep_from >= len(assistant_indices):
+        if not assistant_indices or n_turns <= 0:
             return 0
 
-        # Messages being dropped: from the first assistant message up to (but
-        # not including) the keep_from-th assistant message.
+        # Drop the first n_turns assistant messages (relative to the current
+        # already-truncated view).
         drop_start = assistant_indices[0]
-        new_end = keep_from + n_turns
-        if new_end >= len(assistant_indices):
+        if n_turns >= len(assistant_indices):
             drop_end = len(messages)
         else:
-            drop_end = assistant_indices[new_end]
-        # But we only want the newly dropped messages (keep_from..new_end),
-        # not previously dropped ones.
-        if keep_from < len(assistant_indices):
-            drop_start = assistant_indices[keep_from]
-        else:
-            return 0
+            drop_end = assistant_indices[n_turns]
 
         total_chars = 0
         for msg in messages[drop_start:drop_end]:

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -3540,6 +3540,7 @@ class RLMEnv(vf.StatefulToolEnv):
 
             # Initialize context dropping state
             state["_keep_from_assistant_index"] = 0
+            state["_summary_text"] = ""
 
             _ensure_rlm_metric_state(state)
 

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -3723,8 +3723,16 @@ class RLMEnv(vf.StatefulToolEnv):
     # Message History Upload
     # =========================================================================
 
+    _SUMMARY_BLOCK_RE = re.compile(r"<SUMMARY>\n.*?\n</SUMMARY>\n\n", re.DOTALL)
+
     def _build_message_history(self, state: State) -> list[dict[str, Any]]:
-        """Build the full serialized message history from the trajectory."""
+        """Build the serialized message history from the trajectory.
+
+        Reads from the last main trajectory step (which has the full
+        cumulative conversation in its prompt) and strips any injected
+        ``<SUMMARY>`` blocks so that ``.messages`` reflects the raw
+        conversation without summarization artifacts.
+        """
         last_main = self._last_main_trajectory_step(state)
         if last_main is None:
             return []
@@ -3732,9 +3740,15 @@ class RLMEnv(vf.StatefulToolEnv):
         serialized: list[dict[str, Any]] = []
         for msg in messages:
             if hasattr(msg, "model_dump"):
-                serialized.append(msg.model_dump(exclude_none=True))
+                entry = msg.model_dump(exclude_none=True)
             elif isinstance(msg, dict):
-                serialized.append(dict(msg))
+                entry = dict(msg)
+            else:
+                continue
+            content = entry.get("content")
+            if isinstance(content, str) and "<SUMMARY>" in content:
+                entry["content"] = self._SUMMARY_BLOCK_RE.sub("", content)
+            serialized.append(entry)
         return serialized
 
     async def _upload_message_history(self, state: State) -> None:

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -4113,13 +4113,19 @@ class RLMEnv(vf.StatefulToolEnv):
             return messages
 
         if keep_from_assistant_index >= len(assistant_indices):
-            return messages
-
-        # Preserve everything before the first assistant message (system msgs,
-        # scaffolded user msg, etc.), then keep from the target turn onward.
-        preamble = list(messages[: assistant_indices[0]])
-        keep_from = assistant_indices[keep_from_assistant_index]
-        remaining = list(messages[keep_from:])
+            # Already truncated past the index — no more turns to drop.
+            # But still inject summary into the first remaining assistant
+            # message if needed (the index may exceed the count because
+            # prior context dropping already removed those turns from the
+            # stored prompt).
+            preamble = list(messages[: assistant_indices[0]])
+            remaining = list(messages[assistant_indices[0] :])
+        else:
+            # Preserve everything before the first assistant message (system msgs,
+            # scaffolded user msg, etc.), then keep from the target turn onward.
+            preamble = list(messages[: assistant_indices[0]])
+            keep_from = assistant_indices[keep_from_assistant_index]
+            remaining = list(messages[keep_from:])
 
         # Inject summary into the first remaining assistant message
         if summary_text and remaining:

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -1253,7 +1253,7 @@ In the end, the `ANSWER_CONTENT` environment variable must contain your answer. 
         root_tool_defs: list[vf.Tool],
         sub_tool_defs: list[vf.Tool],
         enable_sub_llms: bool = True,
-        allow_context_dropping: bool = False,
+        enable_summarization: bool = False,
         min_turns_in_context: int = 3,
     ) -> None:
         self.repl_language = repl_language
@@ -1268,7 +1268,7 @@ In the end, the `ANSWER_CONTENT` environment variable must contain your answer. 
         self.root_tool_defs = root_tool_defs
         self.sub_tool_defs = sub_tool_defs
         self.enable_sub_llms = enable_sub_llms
-        self.allow_context_dropping = allow_context_dropping
+        self.enable_summarization = enable_summarization
         self.min_turns_in_context = min_turns_in_context
 
     def build_base_system_prompt(self) -> str:
@@ -1379,7 +1379,7 @@ In the end, the `ANSWER_CONTENT` environment variable must contain your answer. 
 
     def build_context_dropping_note(self) -> str:
         """Return context-dropping documentation note, or empty string."""
-        if not self.allow_context_dropping:
+        if not self.enable_summarization:
             return ""
         return (
             "\n## Context Management\n\n"
@@ -2270,6 +2270,11 @@ class RLMEnv(vf.StatefulToolEnv):
         enable_sub_llms: If True (default), the root model can call sub-LLMs via
                    ``llm_batch()``. If False, ``llm_batch`` is not registered as a
                    tool and all sub-LLM-related prompt sections are omitted.
+        enable_summarization: If True, the root model gets a ``summarize_turns``
+                   tool to drop old conversation turns and replace them with a
+                   cumulative summary. Defaults to False.
+        min_turns_in_context: Minimum turns that must remain after summarization
+                   (default: 3). Only has effect when enable_summarization=True.
         max_output_length: Maximum length of code execution output
         max_sub_llm_parallelism: Maximum number of concurrent sub-LLM calls
         system_prompt: Custom system prompt (default: RLM standard prompt)
@@ -2324,6 +2329,8 @@ class RLMEnv(vf.StatefulToolEnv):
         sub_prompt_verbosity: Literal["light", "medium", "heavy"] = "light",
         root_prompt_verbosity: Literal["light", "medium", "heavy"] = "light",
         enable_sub_llms: bool = True,
+        enable_summarization: bool = False,
+        min_turns_in_context: int = 3,
         max_output_length: int = 8192,
         max_sub_llm_parallelism: int = 5,
         system_prompt: str | None = None,
@@ -2335,8 +2342,6 @@ class RLMEnv(vf.StatefulToolEnv):
         code_execution_timeout: int = 120,
         abort_on_code_timeout: bool = False,
         expose_message_history: bool = True,
-        allow_context_dropping: bool = False,
-        min_turns_in_context: int = 3,
         retain_filesystem_after_rollout: bool = False,
         sandbox_docker_image: str = "python:3.11-slim",
         sandbox_cpu_cores: int = 1,
@@ -2389,13 +2394,13 @@ class RLMEnv(vf.StatefulToolEnv):
         self.code_execution_timeout = code_execution_timeout
         self.abort_on_code_timeout = abort_on_code_timeout
         self.expose_message_history = expose_message_history
-        self.allow_context_dropping = allow_context_dropping
+        self.enable_summarization = enable_summarization
         self.min_turns_in_context = min_turns_in_context
-        if self.allow_context_dropping and not self.expose_message_history:
+        if self.enable_summarization and not self.expose_message_history:
             import warnings
 
             warnings.warn(
-                "allow_context_dropping=True but expose_message_history=False. "
+                "enable_summarization=True but expose_message_history=False. "
                 "The model won't be able to read dropped context from .messages. "
                 "Consider setting expose_message_history=True.",
                 UserWarning,
@@ -2505,7 +2510,7 @@ class RLMEnv(vf.StatefulToolEnv):
             root_tool_defs=self.root_tool_defs,
             sub_tool_defs=self.sub_tool_defs,
             enable_sub_llms=self.enable_sub_llms,
-            allow_context_dropping=self.allow_context_dropping,
+            enable_summarization=self.enable_summarization,
             min_turns_in_context=self.min_turns_in_context,
         )
 
@@ -2516,7 +2521,7 @@ class RLMEnv(vf.StatefulToolEnv):
             self.add_tool(self.call_python_repl, args_to_skip=["state"])
 
         # Add summarize_turns as a standard tool (not a REPL tool)
-        if self.allow_context_dropping:
+        if self.enable_summarization:
             self.add_tool(self.summarize_turns, args_to_skip=["state"])
 
     def get_sandbox_request(self, state: State) -> CreateSandboxRequest:


### PR DESCRIPTION
## Description

Overhaul context dropping in RLMEnv:
- Rename r`emove_conversation_turns` → `summarize_turns` and move from root-REPL tool to standard tool (called via normal tool calling)
- Summaries are cumulative: each call appends [Turns X-Y] section
- Summary injected as <SUMMARY> block into first remaining assistant message instead of being written to .summaries file
- .messages file remains unaffected (full uncompacted history)
- Replace `compaction_*` metrics with `summarize_*` metrics including char/token compression tracking
- Track per-turn prompt_tokens for accurate token-drop measurement
- 38 new tests replacing 16 old ones

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [x] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how conversation context is truncated and re-injected into prompts, which can affect model behavior and any downstream consumers of stored messages/metrics. Also renames/removes previous tool and metrics, so integrations relying on `remove_conversation_turns` or `compaction_*` will break if not updated.
> 
> **Overview**
> Replaces the root-only `remove_conversation_turns` mechanism with an opt-in standard tool, `summarize_turns`, controlled by `enable_summarization`, which drops older turns while maintaining a **cumulative** summary in state.
> 
> Summaries are now injected into the first remaining assistant message as a `<SUMMARY>` block (handling both string and list message content) and `.messages` serialization is updated to strip these injected blocks so message history remains clean.
> 
> Removes `.summaries` uploading and `compaction_*` state/metrics, replacing them with `summarize_*` metrics including dropped character tracking and a compression ratio; tests are overhauled to cover tool registration, prompt notes, injection behavior, edge cases, and the new metrics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 042d6a4744d208c72b66c128c6f428b1ad6a32e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->