### PR TITLE
fix math rubric timeout

### DIFF
--- a/verifiers/rubrics/math_rubric.py
+++ b/verifiers/rubrics/math_rubric.py
@@ -1,10 +1,8 @@
 import asyncio
-import logging
 import os
 import sys
 import time
 from concurrent.futures import ProcessPoolExecutor
-from typing import cast
 
 from math_verify import parse, verify
 
@@ -20,6 +18,7 @@ def verify_response(
     response: str,
     answer: str,
     max_verify_chars: int,
+    timeout_seconds: int = 5,
 ) -> tuple[float, float]:
     """
     Verify a response against an answer using math_verify.
@@ -37,11 +36,13 @@ def verify_response(
         return 0.0, elapsed
 
     try:
-        parsed_answer = parse(f"\\boxed{{{answer}}}", parsing_timeout=cast(int, None))
+        parsed_answer = parse(f"\\boxed{{{answer}}}", parsing_timeout=timeout_seconds)
         parsed_response = parse(
-            f"\\boxed{{{response}}}", parsing_timeout=cast(int, None)
+            f"\\boxed{{{response}}}", parsing_timeout=timeout_seconds
         )
-        is_correct = verify(parsed_answer, parsed_response, timeout_seconds=None)
+        is_correct = verify(
+            parsed_answer, parsed_response, timeout_seconds=timeout_seconds
+        )
         elapsed = time.perf_counter() - start
         return float(is_correct), elapsed
     except BaseException:
@@ -82,10 +83,6 @@ class MathRubric(Rubric):
             ),
         )
 
-        # suppress math_verify timeout warnings (we handle timeouts ourselves)
-        logging.getLogger("math_verify.parser").setLevel(logging.ERROR)
-        logging.getLogger("math_verify.grader").setLevel(logging.ERROR)
-
     async def correct_answer(
         self, parser: Parser, completion: Messages, answer: str, **kwargs
     ) -> float:
@@ -113,6 +110,7 @@ class MathRubric(Rubric):
                     response,
                     answer,
                     self.max_verify_chars,
+                    int(self.timeout_seconds),
                 ),
                 timeout=self.HARD_TIMEOUT_SECONDS,
             )


### PR DESCRIPTION
## Summary
- Pass `timeout_seconds` through to `math_verify`'s `parse()` and `verify()` instead of `None`/`cast(int, None)`
- Remove suppressed logging for math_verify timeout warnings (no longer needed since we set proper timeouts)

## Test plan
- [x] Verified fix in hendrycks-sanity IPO run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the math answer verification timeout behavior, which can affect scoring outcomes and runtime characteristics (false negatives vs. runaway verification). Scope is small and localized to `MathRubric` and `verify_response`.
> 
> **Overview**
> Updates `MathRubric` verification to pass an explicit `timeout_seconds` through to `math_verify`’s `parse()` and `verify()` calls (instead of effectively disabling timeouts), and threads that value from the async executor call into `verify_response`.
> 
> Removes the previous suppression of `math_verify` timeout warning logs since timeouts are now intentionally enforced.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 60c7aec62ff764ea97fc37004468176791cc189c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->