### PR TITLE
RLM: Remove token/timing info from llm_batch output and add max_turns metric

### DIFF
--- a/tests/test_rlm_env.py
+++ b/tests/test_rlm_env.py
@@ -811,29 +811,21 @@ class TestBashToolHelper:
         assert "Invalid JSON payload" in stderr
         assert captured is None
 
-    def test_llm_batch_output_headers_with_metadata(self):
+    def test_llm_batch_output_json(self):
         payload = json.dumps({"prompts": ["one", "two"]})
         response_data = {
             "result": base64.b64encode(pickle.dumps(["first", "second"])).decode(
                 "ascii"
             ),
             "error": None,
-            "print_lines": [
-                "llm_batch: 2 call(s) in 0.10s",
-                "  [0]: 5 tokens, 0 tool calls, 0.01s ✓",
-                "  [1]: 6 tokens, 1 tool calls, 0.02s ✓",
-            ],
         }
         stdout, stderr, code, captured = self._run_helper(
             ["--tool", "llm_batch", "--json", payload], response_data=response_data
         )
         assert code == 0
         assert stderr == ""
-        assert "llm_batch: 2 call(s) in 0.10s" in stdout
-        assert "----- llm_batch[0]" in stdout
-        assert "----- llm_batch[1]" in stdout
-        assert "first" in stdout
-        assert "second" in stdout
+        parsed = json.loads(stdout.strip())
+        assert parsed == ["first", "second"]
 
 
 # =============================================================================
@@ -1261,12 +1253,12 @@ class TestLLMBatchPromptValidation:
             "state": {"trajectory": []},
         }
 
-        contents, _ = await rlm_env._root_llm_batch(
+        contents = await rlm_env._root_llm_batch(
             context, [{"role": "user", "content": "hi"}]
         )
         assert "must be a string" in contents[0]
 
-        contents, _ = await rlm_env._root_llm_batch(
+        contents = await rlm_env._root_llm_batch(
             context, [[{"role": "user", "content": "hi"}]]
         )
         assert "must be a string" in contents[0]
@@ -2125,7 +2117,6 @@ class TestSubLLMCompletionTokenBudget:
                 parent_turn=0,
             )
 
-        assert result["_rlm_metadata"].get("budget_exhausted") is not True
         assert result["choices"][0]["message"]["content"] == "ok"
 
     @pytest.mark.asyncio
@@ -2175,7 +2166,7 @@ class TestSubLLMCompletionTokenBudget:
                 parent_turn=0,
             )
 
-        assert result["_rlm_metadata"].get("budget_exhausted") is not True
+        assert result["choices"][0]["message"]["content"] == "ok"
 
     @pytest.mark.asyncio
     async def test_batch_early_exit_when_budget_exhausted(self, rlm_env):
@@ -2189,95 +2180,11 @@ class TestSubLLMCompletionTokenBudget:
             },
         }
 
-        contents, summary_lines = await rlm_env._root_llm_batch(
-            context, ["prompt1", "prompt2"]
-        )
+        contents = await rlm_env._root_llm_batch(context, ["prompt1", "prompt2"])
 
         assert len(contents) == 2
         assert "budget exhausted" in contents[0].lower()
         assert "budget exhausted" in contents[1].lower()
-        assert any("skipped" in line for line in summary_lines)
-        assert any("500/500" in line for line in summary_lines)
-
-    @pytest.mark.asyncio
-    async def test_batch_summary_includes_budget_when_set(self, rlm_env):
-        rlm_env.sub_max_completion_tokens = 10000
-
-        mock_response = MagicMock()
-        mock_response.message.content = "ok"
-        mock_response.message.tool_calls = None
-        mock_response.message.is_truncated = False
-        mock_response.usage = MagicMock(prompt_tokens=10, completion_tokens=20)
-
-        state = {
-            "trajectory": [],
-            "sampling_args": {},
-            "sub_llm_completion_tokens": 200,
-        }
-        context = {
-            "client": MagicMock(),
-            "sub_model": "gpt-4",
-            "state": state,
-        }
-
-        with patch.object(
-            rlm_env,
-            "_run_sub_llm_request",
-            new=AsyncMock(
-                return_value={
-                    "choices": [{"message": {"content": "ok"}}],
-                    "_rlm_metadata": {
-                        "prompt_tokens": 10,
-                        "completion_tokens": 20,
-                        "tool_call_count": 0,
-                        "num_turns": 1,
-                        "max_turns_reached": False,
-                    },
-                }
-            ),
-        ):
-            _, summary_lines = await rlm_env._root_llm_batch(context, ["prompt1"])
-
-        # Summary should include budget info
-        budget_line = [s for s in summary_lines if "llm_batch completion tokens" in s]
-        assert len(budget_line) == 1
-        assert "/10000" in budget_line[0]
-
-    @pytest.mark.asyncio
-    async def test_batch_summary_excludes_budget_when_none(self, rlm_env):
-        assert rlm_env.sub_max_completion_tokens is None
-
-        state = {
-            "trajectory": [],
-            "sampling_args": {},
-            "sub_llm_completion_tokens": 200,
-        }
-        context = {
-            "client": MagicMock(),
-            "sub_model": "gpt-4",
-            "state": state,
-        }
-
-        with patch.object(
-            rlm_env,
-            "_run_sub_llm_request",
-            new=AsyncMock(
-                return_value={
-                    "choices": [{"message": {"content": "ok"}}],
-                    "_rlm_metadata": {
-                        "prompt_tokens": 10,
-                        "completion_tokens": 20,
-                        "tool_call_count": 0,
-                        "num_turns": 1,
-                        "max_turns_reached": False,
-                    },
-                }
-            ),
-        ):
-            _, summary_lines = await rlm_env._root_llm_batch(context, ["prompt1"])
-
-        budget_lines = [s for s in summary_lines if "llm_batch completion tokens" in s]
-        assert len(budget_lines) == 0
 
     @pytest.mark.asyncio
     async def test_system_prompt_includes_budget_when_set(self):
@@ -2458,52 +2365,6 @@ class TestRootLLMMaxCompletionTokens:
         rlm_env.root_max_completion_tokens = 1000
         state = {"root_llm_completion_tokens": 1500}
         assert rlm_env._is_root_budget_exhausted(state) is True
-
-    @pytest.mark.asyncio
-    async def test_repl_output_includes_budget_when_set(self, rlm_env):
-        rlm_env.root_max_completion_tokens = 5000
-        rlm_env._execute_code = AsyncMock(
-            return_value={
-                "status": "ok",
-                "stdout": "output",
-                "stderr": "",
-                "result": None,
-                "execution_count": 1,
-                "answer": {"ready": False, "content": ""},
-            }
-        )
-
-        state = {
-            "trajectory": [],
-            "context_warning_sent": False,
-            "root_llm_completion_tokens": 1200,
-        }
-        output = await rlm_env.call_python_repl("print('test')", state)
-
-        assert "1200/5000 root completion tokens used" in output
-
-    @pytest.mark.asyncio
-    async def test_repl_output_excludes_budget_when_none(self, rlm_env):
-        assert rlm_env.root_max_completion_tokens is None
-        rlm_env._execute_code = AsyncMock(
-            return_value={
-                "status": "ok",
-                "stdout": "output",
-                "stderr": "",
-                "result": None,
-                "execution_count": 1,
-                "answer": {"ready": False, "content": ""},
-            }
-        )
-
-        state = {
-            "trajectory": [],
-            "context_warning_sent": False,
-            "root_llm_completion_tokens": 1200,
-        }
-        output = await rlm_env.call_python_repl("print('test')", state)
-
-        assert "root completion tokens" not in output
 
     @pytest.mark.asyncio
     async def test_system_prompt_includes_root_budget_when_set(self):

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -279,6 +279,8 @@ def _ensure_rlm_metric_state(state: State) -> None:
     state.setdefault("_llm_batch_time_count", 0)
     state.setdefault("_root_tool_non_llm_total_time", 0.0)
     state.setdefault("_root_tool_non_llm_time_count", 0)
+    state.setdefault("sub_llm_max_turns_reached_frac", 0.0)
+    state.setdefault("_sub_llm_max_turns_reached_count", 0)
 
     state.setdefault("_rlm_sub_llm_call_ids", {})
     state.setdefault("_rlm_sub_llm_batch_counts", {})
@@ -406,6 +408,7 @@ class RLMMonitorRubric(vf.Rubric):
         "root_tool_call_count",
         "llm_batch_mean_time_seconds",
         "root_tool_non_llm_mean_time_seconds",
+        "sub_llm_max_turns_reached_frac",
         "summarize_count",
         "summarize_total_turns_dropped",
         "summarize_total_chars_dropped",
@@ -778,38 +781,6 @@ _RLM_BASH_TOOL_HELPER_SCRIPT = textwrap.dedent(
                 sys.stdout.write("\\n")
 
 
-    def _split_batch_lines(lines):
-        summary = []
-        per_item = {}
-        for line in lines:
-            text = str(line).strip()
-            if text.startswith("[") and "]:" in text:
-                idx_text = text[1 : text.index("]")]
-                if idx_text.isdigit():
-                    per_item[int(idx_text)] = text[text.index("]:") + 2 :].strip()
-                    continue
-            summary.append(text)
-        return summary, per_item
-
-
-    def _print_llm_batch_result(result_list, per_item_meta=None):
-        for index, item in enumerate(result_list):
-            if index > 0:
-                sys.stdout.write("\\n")
-            header = f"----- llm_batch[{index}]"
-            if per_item_meta and index in per_item_meta:
-                header = f"{header} ({per_item_meta[index]})"
-            sys.stdout.write(f"{header} -----\\n")
-            if not isinstance(item, str):
-                try:
-                    item = json.dumps(item)
-                except Exception:
-                    item = repr(item)
-            sys.stdout.write(item)
-            if not item.endswith("\\n"):
-                sys.stdout.write("\\n")
-
-
     def _load_json_payload(json_payload):
         raw = json_payload
         if raw is None and not sys.stdin.isatty():
@@ -928,16 +899,9 @@ _RLM_BASH_TOOL_HELPER_SCRIPT = textwrap.dedent(
                         prompts = [raw]
                     else:
                         prompts = _coerce_prompts(data)
-            result, print_lines = _call_root_tool(tool_name, (prompts,), {})
-            summary_lines, per_item = _split_batch_lines(print_lines)
-            if summary_lines:
-                _print_lines(summary_lines)
-            if isinstance(result, list):
-                _print_llm_batch_result(result, per_item_meta=per_item)
-            else:
-                if print_lines:
-                    _print_lines(print_lines)
-                _print_result(result)
+            result, _ = _call_root_tool(tool_name, (prompts,), {})
+            sys.stdout.write(json.dumps(result))
+            sys.stdout.write("\\n")
             return
 
         if use_json:
@@ -2625,8 +2589,7 @@ class RLMEnv(vf.StatefulToolEnv):
                     raise RuntimeError(
                         "llm_batch called outside of a tool request context."
                     )
-                results, _ = await self._root_llm_batch(context, prompts)
-                return results
+                return await self._root_llm_batch(context, prompts)
 
             llm_batch.__name__ = "llm_batch"
             tools.append(llm_batch)
@@ -2951,7 +2914,7 @@ class RLMEnv(vf.StatefulToolEnv):
         self,
         context: dict[str, Any],
         prompts: list[Any],
-    ) -> tuple[list[str], list[str]]:
+    ) -> list[str]:
         """Run a batch of sub-LLM calls for root REPL usage."""
         if not isinstance(prompts, list):
             raise ValueError("llm_batch expects a list of prompts.")
@@ -2968,14 +2931,7 @@ class RLMEnv(vf.StatefulToolEnv):
             used = state_ref.get("sub_llm_completion_tokens", 0)
             if used >= self.sub_max_completion_tokens:
                 msg = self._sub_llm_budget_exhausted_message(state_ref)
-                contents = [msg] * len(prompts)
-                summary_lines = [
-                    f"llm_batch: {len(prompts)} call(s) skipped — "
-                    f"llm_batch token budget exhausted "
-                    f"({used}/{self.sub_max_completion_tokens} "
-                    f"completion tokens used)"
-                ]
-                return contents, summary_lines
+                return [msg] * len(prompts)
 
         rid = state_ref.get("rollout_id", "?")
 
@@ -3044,38 +3000,15 @@ class RLMEnv(vf.StatefulToolEnv):
             len(prompts),
             batch_id,
         )
-        summary_lines = [f"llm_batch: {len(prompts)} call(s)"]
         contents: list[str] = []
-        for index, result in enumerate(results):
+        for result in results:
             if not result:
                 contents.append("")
-                summary_lines.append(f"  [{index}]: error")
                 continue
             message = result.get("choices", [{}])[0].get("message", {})
             contents.append(message.get("content", ""))
-            meta = result.get("_rlm_metadata", {})
-            if meta.get("error"):
-                summary_lines.append(f"  [{index}]: error")
-                continue
-            prompt_tokens = meta.get("prompt_tokens", 0)
-            completion_tokens = meta.get("completion_tokens", 0)
-            tool_calls = meta.get("tool_call_count", 0)
-            max_turns = meta.get("max_turns_reached", False)
-            status = "⚠ max turns" if max_turns else "✓"
-            summary_lines.append(
-                f"  [{index}]: {prompt_tokens} prompt tokens, "
-                f"{completion_tokens} completion tokens, "
-                f"{tool_calls} tool calls {status}"
-            )
 
-        if self.sub_max_completion_tokens is not None:
-            used = state_ref.get("sub_llm_completion_tokens", 0)
-            budget = self.sub_max_completion_tokens
-            summary_lines.append(
-                f"  [{used}/{budget} llm_batch completion tokens used]"
-            )
-
-        return contents, summary_lines
+        return contents
 
     # =========================================================================
     # Interception Server (for sub-LLM calls from worker code)
@@ -3259,17 +3192,17 @@ class RLMEnv(vf.StatefulToolEnv):
                 )
                 update_rlm_metrics_from_step(state_ref, trajectory_step)
 
-        metadata: dict[str, int | float | bool] = {
-            "prompt_tokens": prompt_tokens,
-            "completion_tokens": completion_tokens,
-            "tool_call_count": tool_call_count,
-            "num_turns": num_turns,
-            "max_turns_reached": max_turns_reached,
-        }
+        _ensure_rlm_metric_state(state_ref)
+        if max_turns_reached:
+            state_ref["_sub_llm_max_turns_reached_count"] += 1
+        call_count = state_ref.get("sub_llm_call_count", 0)
+        if call_count > 0:
+            state_ref["sub_llm_max_turns_reached_frac"] = (
+                state_ref["_sub_llm_max_turns_reached_count"] / call_count
+            )
 
         return {
             "choices": [{"message": {"content": boxed_content}}],
-            "_rlm_metadata": metadata,
         }
 
     async def _handle_root_tool_request(self, request: Any) -> Any:
@@ -3334,12 +3267,9 @@ class RLMEnv(vf.StatefulToolEnv):
                         "llm_batch does not accept extra keyword arguments: "
                         + ", ".join(sorted(kwargs))
                     )
-                result_value, print_lines = await self._root_llm_batch(
-                    root_tool_context, prompts
-                )
+                result_value = await self._root_llm_batch(root_tool_context, prompts)
             else:
                 result_value = await maybe_await(tool_func, *args, **kwargs)
-                print_lines = None
         except Exception as e:
             if self._should_stop_for_error(e):
                 state_ref["_rlm_stop_error"] = e
@@ -3351,11 +3281,7 @@ class RLMEnv(vf.StatefulToolEnv):
             self._root_tool_context_var.reset(token)
 
         result_payload = base64.b64encode(pickle.dumps(result_value)).decode("ascii")
-
-        response_body: dict[str, Any] = {"result": result_payload}
-        if print_lines:
-            response_body["print_lines"] = print_lines
-        return web.json_response(response_body)
+        return web.json_response({"result": result_payload})
 
     async def _handle_sub_llm_request(self, request: Any) -> Any:
         """Handle sub-LLM requests from worker code."""
@@ -3871,11 +3797,6 @@ class RLMEnv(vf.StatefulToolEnv):
         output = self._maybe_add_context_warning(
             output, state, ready_instruction=ready_instruction
         )
-
-        if self.root_max_completion_tokens is not None:
-            used = state.get("root_llm_completion_tokens", 0)
-            budget = self.root_max_completion_tokens
-            output += f"\n[{used}/{budget} root completion tokens used]"
 
         return output
 

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -281,6 +281,7 @@ def _ensure_rlm_metric_state(state: State) -> None:
     state.setdefault("_root_tool_non_llm_time_count", 0)
     state.setdefault("sub_llm_max_turns_reached_frac", 0.0)
     state.setdefault("_sub_llm_max_turns_reached_count", 0)
+    state.setdefault("_sub_llm_request_count", 0)
 
     state.setdefault("_rlm_sub_llm_call_ids", {})
     state.setdefault("_rlm_sub_llm_batch_counts", {})
@@ -3193,13 +3194,13 @@ class RLMEnv(vf.StatefulToolEnv):
                 update_rlm_metrics_from_step(state_ref, trajectory_step)
 
         _ensure_rlm_metric_state(state_ref)
+        state_ref["_sub_llm_request_count"] += 1
         if max_turns_reached:
             state_ref["_sub_llm_max_turns_reached_count"] += 1
-        call_count = state_ref.get("sub_llm_call_count", 0)
-        if call_count > 0:
-            state_ref["sub_llm_max_turns_reached_frac"] = (
-                state_ref["_sub_llm_max_turns_reached_count"] / call_count
-            )
+        state_ref["sub_llm_max_turns_reached_frac"] = (
+            state_ref["_sub_llm_max_turns_reached_count"]
+            / state_ref["_sub_llm_request_count"]
+        )
 
         return {
             "choices": [{"message": {"content": boxed_content}}],


### PR DESCRIPTION
## Description

- Remove all print_lines from llm_batch (summary_lines, per-sub-llm metadata, budget lines). _root_llm_batch now returns list[str] directly.
- Remove root completion token budget line from REPL output.
- Bash helper outputs llm_batch results as JSON instead of formatted headers. Remove dead _split_batch_lines and _print_llm_batch_result.
- Remove _rlm_metadata from _run_sub_llm_request success path.
- Remove print_lines from _handle_root_tool_request response.
- Add sub_llm_max_turns_reached_frac metric.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `llm_batch` root-tool contract and CLI output format (now JSON-only, no `print_lines`/metadata), which could break downstream parsers or tooling despite being localized to RLM tooling paths.
> 
> **Overview**
> Simplifies `llm_batch` end-to-end by **removing all human-formatted output/metadata**: `_root_llm_batch` now returns just `list[str]`, the root-tool HTTP response no longer includes `print_lines`, and the bash helper prints the batch result as a single JSON array.
> 
> Drops previously emitted budget/timing/token summary lines (including the root REPL completion-token budget footer) and updates tests accordingly.
> 
> Adds a new rollout metric, `sub_llm_max_turns_reached_frac`, tracked across sub-LLM requests to quantify how often sub-calls hit the max-turns limit.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b0d832e6cac1aad5fd4fba4b1da098978554e804. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->