### PR TITLE
Add max_total_tokens parameter to MultiTurnEnv

### DIFF
--- a/docs/environments.md
+++ b/docs/environments.md
@@ -570,7 +570,7 @@ class MyGameEnv(vf.MultiTurnEnv):
         return state.get("lives", 1) <= 0
 ```
 
-`MultiTurnEnv` includes built-in stop conditions for errors, prompt length limits, and `max_turns` by default.
+`MultiTurnEnv` includes built-in stop conditions for errors, prompt length limits, `max_turns`, and `max_total_completion_tokens` by default.
 
 Execution order can be controlled with `priority` (higher runs first). This is useful for checking cheap conditions before expensive ones:
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -339,7 +339,7 @@ async def env_response(self, messages: Messages, state: State, **kwargs) -> Mess
     """Generate environment feedback after model turn."""
 ```
 
-**Built-in stop conditions:** `has_error`, `prompt_too_long`, `max_turns_reached`, `has_final_env_response`
+**Built-in stop conditions:** `has_error`, `prompt_too_long`, `max_turns_reached`, `max_total_completion_tokens_reached`, `has_final_env_response`
 
 **Hooks:**
 
@@ -349,6 +349,7 @@ async def env_response(self, messages: Messages, state: State, **kwargs) -> Mess
 | `get_prompt_messages(state)` | Customize prompt construction |
 | `render_completion(state)` | Customize completion rendering |
 | `add_trajectory_step(state, step)` | Customize trajectory handling |
+| `set_max_total_completion_tokens(int)` | Set maximum total completion tokens |
 
 #### ToolEnv
 

--- a/verifiers/envs/multiturn_env.py
+++ b/verifiers/envs/multiturn_env.py
@@ -35,12 +35,16 @@ class MultiTurnMonitorRubric(vf.Rubric):
 
 
 class MultiTurnEnv(vf.Environment):
-    def __init__(self, max_turns: int = -1, max_total_tokens: int = -1, **kwargs):
+    def __init__(self, max_turns: int = -1, **kwargs):
         super().__init__(**kwargs)
         self.max_turns = max_turns
-        self.max_total_tokens = max_total_tokens
+        self.max_total_completion_tokens: int = -1
 
         self.add_rubric(MultiTurnMonitorRubric())
+
+    def set_max_total_completion_tokens(self, max_total_completion_tokens: int) -> None:
+        """Set the maximum total completion tokens for this environment."""
+        self.max_total_completion_tokens = max_total_completion_tokens
 
     @abstractmethod
     async def env_response(
@@ -64,13 +68,13 @@ class MultiTurnEnv(vf.Environment):
         return len(state["trajectory"]) >= self.max_turns and self.max_turns > 0
 
     @vf.stop
-    async def max_total_tokens_reached(self, state: State) -> bool:
-        if self.max_total_tokens <= 0:
+    async def max_total_completion_tokens_reached(self, state: State) -> bool:
+        if self.max_total_completion_tokens <= 0:
             return False
         usage = self.get_state_usage(state)
         if usage is None:
             return False
-        return usage["output_tokens"] >= self.max_total_tokens
+        return usage["output_tokens"] >= self.max_total_completion_tokens
 
     @vf.stop
     async def has_final_env_response(self, state: State) -> bool:

--- a/verifiers/envs/multiturn_env.py
+++ b/verifiers/envs/multiturn_env.py
@@ -35,9 +35,10 @@ class MultiTurnMonitorRubric(vf.Rubric):
 
 
 class MultiTurnEnv(vf.Environment):
-    def __init__(self, max_turns: int = -1, **kwargs):
+    def __init__(self, max_turns: int = -1, max_total_tokens: int = -1, **kwargs):
         super().__init__(**kwargs)
         self.max_turns = max_turns
+        self.max_total_tokens = max_total_tokens
 
         self.add_rubric(MultiTurnMonitorRubric())
 
@@ -61,6 +62,15 @@ class MultiTurnEnv(vf.Environment):
     @vf.stop
     async def max_turns_reached(self, state: State) -> bool:
         return len(state["trajectory"]) >= self.max_turns and self.max_turns > 0
+
+    @vf.stop
+    async def max_total_tokens_reached(self, state: State) -> bool:
+        if self.max_total_tokens <= 0:
+            return False
+        usage = self.get_state_usage(state)
+        if usage is None:
+            return False
+        return usage["output_tokens"] >= self.max_total_tokens
 
     @vf.stop
     async def has_final_env_response(self, state: State) -> bool:


### PR DESCRIPTION
## Summary
- Adds `max_total_tokens` parameter to `MultiTurnEnv` to limit total output tokens across all turns in a multi-turn rollout
- Uses the existing `StateUsageTracker` to accumulate token usage
- Disabled by default (`max_total_tokens=-1`)

## Usage
```python
env = MyMultiTurnEnv(max_total_tokens=1000)  # Stop after 1000 output tokens
```

Works for all environments that inherit from `MultiTurnEnv` (ToolEnv, StatefulToolEnv, SandboxEnv, etc.).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new built-in termination condition to multi-turn rollouts based on accumulated output token usage, which can change when/why rollouts stop across all `MultiTurnEnv` subclasses. Behavior is disabled by default but misconfiguration or missing usage tracking could lead to unexpected early/late termination.
> 
> **Overview**
> Adds an optional `max_total_completion_tokens` limit to `MultiTurnEnv`, including a new built-in stop condition `max_total_completion_tokens_reached` that ends a rollout once cumulative output tokens (via `get_state_usage`) meet the configured threshold.
> 
> Updates the API/docs to document the new stop condition and exposes `set_max_total_completion_tokens()` as a configuration hook.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d66162a18da1dbd9f394aeb6fb7f169279d7bbe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->