### PR TITLE
fix: catch InternalServerError for overlong prompts (vLLM 0.19 compat)

### DIFF
--- a/verifiers/clients/openai_chat_completions_client.py
+++ b/verifiers/clients/openai_chat_completions_client.py
@@ -9,6 +9,7 @@ from openai import (
     AsyncOpenAI,
     AuthenticationError,
     BadRequestError,
+    InternalServerError,
     PermissionDeniedError,
 )
 from openai.types.chat import (
@@ -71,7 +72,7 @@ def handle_openai_overlong_prompt(func):
             return await func(*args, **kwargs)
         except (AuthenticationError, PermissionDeniedError):
             raise
-        except BadRequestError as e:
+        except (BadRequestError, InternalServerError) as e:
             error_text = e.response.text.lower()
             context_length_phrases = [
                 "this model's maximum context length is",


### PR DESCRIPTION
vLLM 0.18+ changed error handling for prompts that exceed max_model_len during generation. Instead of returning HTTP 400 `BadRequestError`, the engine now returns `finish_reason="error"` which becomes HTTP 500 `InternalServerError` via `GenerationError`.

`handle_openai_overlong_prompt` only caught `BadRequestError`, so overlong prompts in multi-turn were treated as real errors (`state["error"]`) instead of being classified as `prompt_too_long`.

Fix: also catch `InternalServerError` and check for context length phrases in the error text.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change to exception handling that broadens overlong-prompt detection to include `InternalServerError`, with minimal impact outside error classification.
> 
> **Overview**
> Updates `handle_openai_overlong_prompt` to also catch OpenAI `InternalServerError` (in addition to `BadRequestError`) and reclassify it as `OverlongPromptError` when the response text indicates a context-length/"prompt too long" condition.
> 
> This improves compatibility with backends (e.g., newer vLLM) that surface max-context violations as HTTP 500s, ensuring these cases are handled as expected instead of being treated as generic failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit afae65bc9555b605bd94ae47548813d996d9406c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->