### PR TITLE
Harden RLM root-tool transport to remove unsafe pickle deserialization

### DIFF
--- a/tests/test_rlm_env.py
+++ b/tests/test_rlm_env.py
@@ -1,12 +1,10 @@
 """Tests for the RLMEnv class (filesystem-based, local-only)."""
 
 import ast
-import base64
 import contextlib
 import io
 import json
 import os
-import pickle
 import shutil
 from pathlib import Path
 from typing import Any
@@ -656,7 +654,6 @@ class TestBashToolHelper:
         stderr_buffer = io.StringIO()
         env = {
             "RLM_ROOT_TOOL_URL": "http://example.invalid/",
-            "RLM_ROOT_TOOL_SERIALIZATION": "pickle",
         }
         captured_payload: dict | None = None
         with patch("urllib.request.urlopen") as mock_urlopen:
@@ -664,8 +661,8 @@ class TestBashToolHelper:
             def _capture_request(req, timeout=300):
                 nonlocal captured_payload
                 data = json.loads(req.data.decode("utf-8"))
-                args = list(pickle.loads(base64.b64decode(data["args"])))
-                kwargs = pickle.loads(base64.b64decode(data["kwargs"]))
+                args = data["args"]
+                kwargs = data["kwargs"]
                 captured_payload = {
                     "tool_name": data.get("tool_name"),
                     "args": args,
@@ -678,7 +675,7 @@ class TestBashToolHelper:
             response.__exit__.return_value = None
             if response_data is None:
                 response_data = {
-                    "result": base64.b64encode(pickle.dumps(["ok"])).decode("ascii"),
+                    "result": ["ok"],
                     "error": None,
                 }
             response.read.return_value = json.dumps(response_data).encode("utf-8")
@@ -814,9 +811,7 @@ class TestBashToolHelper:
     def test_llm_batch_output_headers_with_metadata(self):
         payload = json.dumps({"prompts": ["one", "two"]})
         response_data = {
-            "result": base64.b64encode(pickle.dumps(["first", "second"])).decode(
-                "ascii"
-            ),
+            "result": ["first", "second"],
             "error": None,
             "print_lines": [
                 "llm_batch: 2 call(s) in 0.10s",
@@ -1273,13 +1268,13 @@ class TestLLMBatchPromptValidation:
 
 
 # =============================================================================
-# 9. Root Tool Serialization (pickle)
+# 9. Root Tool Serialization
 # =============================================================================
 
 
 class TestRootToolSerialization:
     @pytest.mark.asyncio
-    async def test_root_tool_request_uses_pickle(self):
+    async def test_root_tool_request_uses_json(self):
         def echo_tool(value):
             return value
 
@@ -1296,17 +1291,13 @@ class TestRootToolSerialization:
         }
 
         payload = {"value": 123}
-        args_payload = base64.b64encode(pickle.dumps((payload,))).decode("ascii")
-        kwargs_payload = base64.b64encode(pickle.dumps({})).decode("ascii")
-
         mock_request = MagicMock()
         mock_request.match_info = {"rollout_id": rollout_id}
         mock_request.json = AsyncMock(
             return_value={
                 "tool_name": "echo_tool",
-                "serialization": "pickle",
-                "args": args_payload,
-                "kwargs": kwargs_payload,
+                "args": [payload],
+                "kwargs": {},
             }
         )
 
@@ -1314,9 +1305,7 @@ class TestRootToolSerialization:
         assert response.status == 200
 
         response_data = json.loads(response.text)
-        result_payload = response_data["result"]
-        decoded = pickle.loads(base64.b64decode(result_payload))
-        assert decoded == payload
+        assert response_data["result"] == payload
 
 
 # =============================================================================

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -3337,7 +3337,7 @@ class RLMEnv(vf.StatefulToolEnv):
         try:
             json.dumps(result_value)
             response_body["result"] = result_value
-        except TypeError:
+        except (TypeError, ValueError):
             response_body["result_repr"] = repr(result_value)
         return web.json_response(response_body)
 

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -26,7 +26,6 @@ import contextvars
 import json
 import logging
 import os
-import pickle
 import re
 import shlex
 import shutil
@@ -512,7 +511,6 @@ def _build_python_worker_script_template() -> str:
         "import io",
         "import json",
         "import os",
-        "import pickle",
         "import sys",
     ]
 
@@ -558,12 +556,10 @@ def _build_python_worker_script_template() -> str:
             "    if not ROOT_TOOL_URL:",
             '        raise RuntimeError("Root tool URL not configured")',
             "",
-            '    args_payload = base64.b64encode(pickle.dumps(args)).decode("ascii")',
-            '    kwargs_payload = base64.b64encode(pickle.dumps(kwargs)).decode("ascii")',
             f"    payload = {dict_open}",
             '        "tool_name": tool_name,',
-            '        "args": args_payload,',
-            '        "kwargs": kwargs_payload,',
+            '        "args": list(args),',
+            '        "kwargs": kwargs,',
             f"    {dict_close}",
             "",
             "    resp = requests.post(",
@@ -578,7 +574,9 @@ def _build_python_worker_script_template() -> str:
             "            print(line)",
             '    if data.get("error"):',
             '        raise RuntimeError(data["error"])',
-            '    return pickle.loads(base64.b64decode(data.get("result", "")))',
+            '    if "result" in data:',
+            '        return data["result"]',
+            '    return data.get("result_repr")',
             "",
             "def _make_root_tool(name: str):",
             "    def _tool(*args, **kwargs):",
@@ -694,7 +692,6 @@ _RLM_BASH_TOOL_HELPER_SCRIPT = textwrap.dedent(
     import base64
     import json
     import os
-    import pickle
     import sys
     import urllib.error
     import urllib.request
@@ -717,12 +714,10 @@ _RLM_BASH_TOOL_HELPER_SCRIPT = textwrap.dedent(
         if not ROOT_TOOL_URL:
             raise RuntimeError("Root tool URL not configured")
 
-        args_payload = base64.b64encode(pickle.dumps(args)).decode("ascii")
-        kwargs_payload = base64.b64encode(pickle.dumps(kwargs)).decode("ascii")
         payload = {
             "tool_name": tool_name,
-            "args": args_payload,
-            "kwargs": kwargs_payload,
+            "args": list(args),
+            "kwargs": kwargs,
         }
 
         data = json.dumps(payload).encode("utf-8")
@@ -750,8 +745,9 @@ _RLM_BASH_TOOL_HELPER_SCRIPT = textwrap.dedent(
         if response_data.get("error"):
             raise RuntimeError(response_data["error"])
 
-        result_payload = response_data.get("result", "")
-        result = pickle.loads(base64.b64decode(result_payload))
+        result = response_data.get("result")
+        if "result" not in response_data:
+            result = response_data.get("result_repr")
         print_lines = response_data.get("print_lines") or []
         return result, print_lines
 
@@ -3296,15 +3292,16 @@ class RLMEnv(vf.StatefulToolEnv):
         if state_ref is None:
             return web.json_response({"error": "State not available"}, status=500)
 
-        try:
-            args = pickle.loads(base64.b64decode(request_body.get("args", "")))
-            kwargs = pickle.loads(base64.b64decode(request_body.get("kwargs", "")))
-            if not isinstance(args, tuple):
-                raise ValueError("Pickle args payload must be a tuple.")
-            if not isinstance(kwargs, dict):
-                raise ValueError("Pickle kwargs payload must be a dict.")
-        except Exception as e:
-            return web.json_response({"error": str(e)}, status=400)
+        args_raw = request_body.get("args", [])
+        kwargs_raw = request_body.get("kwargs", {})
+        if not isinstance(args_raw, list):
+            return web.json_response({"error": "args must be a JSON array"}, status=400)
+        if not isinstance(kwargs_raw, dict):
+            return web.json_response(
+                {"error": "kwargs must be a JSON object"}, status=400
+            )
+        args = tuple(args_raw)
+        kwargs = kwargs_raw
 
         parent_turn = context.get("current_turn", 0)
         root_tool_context = {
@@ -3350,9 +3347,12 @@ class RLMEnv(vf.StatefulToolEnv):
             )
             self._root_tool_context_var.reset(token)
 
-        result_payload = base64.b64encode(pickle.dumps(result_value)).decode("ascii")
-
-        response_body: dict[str, Any] = {"result": result_payload}
+        response_body: dict[str, Any] = {}
+        try:
+            json.dumps(result_value)
+            response_body["result"] = result_value
+        except TypeError:
+            response_body["result_repr"] = repr(result_value)
         if print_lines:
             response_body["print_lines"] = print_lines
         return web.json_response(response_body)

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -3339,8 +3339,6 @@ class RLMEnv(vf.StatefulToolEnv):
             response_body["result"] = result_value
         except TypeError:
             response_body["result_repr"] = repr(result_value)
-        if print_lines:
-            response_body["print_lines"] = print_lines
         return web.json_response(response_body)
 
     async def _handle_sub_llm_request(self, request: Any) -> Any:

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -514,7 +514,6 @@ def _build_python_worker_script_template() -> str:
     lines: list[str] = [
         "",
         "import ast",
-        "import base64",
         "import contextlib",
         "import io",
         "import json",
@@ -697,7 +696,6 @@ def _build_python_worker_script_template() -> str:
 
 _RLM_BASH_TOOL_HELPER_SCRIPT = textwrap.dedent(
     """
-    import base64
     import json
     import os
     import sys


### PR DESCRIPTION
### Motivation
- Sandbox mode exposes the root-tool endpoint via a tunnel and the handler previously accepted base64-encoded `pickle` blobs and called `pickle.loads` on them, enabling sandbox-to-host RCE; this change removes that attack surface.

### Description
- Replace pickle/base64 transport in worker helpers with plain JSON `args` (array) and `kwargs` (object) in both the Python worker script template and the bash tool helper. 
- Update the root-tool HTTP handler `_handle_root_tool_request` to accept JSON `args`/`kwargs`, validate that `args` is a list and `kwargs` is a dict, and convert `args` to a tuple before invoking the tool. 
- Return JSON-native `result` values when possible and include a `result_repr` fallback for non-JSON-serializable return values instead of serializing results with `pickle`. 
- Update tests in `tests/test_rlm_env.py` to assert JSON transport behavior and remove test reliance on `pickle` payloads.

### Testing
- Ran `python -m ruff check verifiers/envs/experimental/rlm_env.py tests/test_rlm_env.py` which passed. 
- Ran `python -m pytest tests/test_rlm_env.py -k "RootToolSerialization or BashToolHelper"` which exercised the bash helper and related tests; most assertions passed but the async test collection failed due to missing `pytest-asyncio` in this environment (test harness limitation), producing one failing test. 
- Attempted `uv run pre-commit install` / `uv run pytest ...` but `uv` failed in this container due to `pyproject.toml`/network build dependency resolution issues (outside scope of the code change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce8771b4608332a47d4e79ea3e4956)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the on-the-wire protocol between sandbox workers and the host root-tool endpoint, which could break compatibility with older workers/tools and alters how tool results are returned/parsed. Security risk is reduced by removing unsafe `pickle` deserialization, but functional regressions may surface for non-JSON-serializable tool outputs.
> 
> **Overview**
> Removes `pickle`/base64 serialization from the RLM root-tool request/response path and switches worker helpers (Python template + bash helper) to send plain JSON `args` (array) and `kwargs` (object).
> 
> Updates `_handle_root_tool_request` to validate/normalize JSON `args`/`kwargs` before invocation and to return a JSON-native `result` when serializable, otherwise falling back to `result_repr`. Tests are updated to assert the new JSON transport and result handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c630a20acf7bfe7864138c11111ba839a3184cf5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->