### PR TITLE
Harden RLM root tool RPC serialization

### DIFF
--- a/tests/test_rlm_env.py
+++ b/tests/test_rlm_env.py
@@ -1,12 +1,10 @@
 """Tests for the RLMEnv class (filesystem-based, local-only)."""
 
 import ast
-import base64
 import contextlib
 import io
 import json
 import os
-import pickle
 import shutil
 from pathlib import Path
 from typing import Any
@@ -656,7 +654,6 @@ class TestBashToolHelper:
         stderr_buffer = io.StringIO()
         env = {
             "RLM_ROOT_TOOL_URL": "http://example.invalid/",
-            "RLM_ROOT_TOOL_SERIALIZATION": "pickle",
         }
         captured_payload: dict | None = None
         with patch("urllib.request.urlopen") as mock_urlopen:
@@ -664,12 +661,10 @@ class TestBashToolHelper:
             def _capture_request(req, timeout=300):
                 nonlocal captured_payload
                 data = json.loads(req.data.decode("utf-8"))
-                args = list(pickle.loads(base64.b64decode(data["args"])))
-                kwargs = pickle.loads(base64.b64decode(data["kwargs"]))
                 captured_payload = {
                     "tool_name": data.get("tool_name"),
-                    "args": args,
-                    "kwargs": kwargs,
+                    "args": data.get("args"),
+                    "kwargs": data.get("kwargs"),
                 }
                 return response
 
@@ -678,7 +673,7 @@ class TestBashToolHelper:
             response.__exit__.return_value = None
             if response_data is None:
                 response_data = {
-                    "result": base64.b64encode(pickle.dumps(["ok"])).decode("ascii"),
+                    "result": ["ok"],
                     "error": None,
                 }
             response.read.return_value = json.dumps(response_data).encode("utf-8")
@@ -814,9 +809,7 @@ class TestBashToolHelper:
     def test_llm_batch_output_headers_with_metadata(self):
         payload = json.dumps({"prompts": ["one", "two"]})
         response_data = {
-            "result": base64.b64encode(pickle.dumps(["first", "second"])).decode(
-                "ascii"
-            ),
+            "result": ["first", "second"],
             "error": None,
             "print_lines": [
                 "llm_batch: 2 call(s) in 0.10s",
@@ -1273,13 +1266,13 @@ class TestLLMBatchPromptValidation:
 
 
 # =============================================================================
-# 9. Root Tool Serialization (pickle)
+# 9. Root Tool Serialization (json)
 # =============================================================================
 
 
 class TestRootToolSerialization:
     @pytest.mark.asyncio
-    async def test_root_tool_request_uses_pickle(self):
+    async def test_root_tool_request_uses_json(self):
         def echo_tool(value):
             return value
 
@@ -1296,17 +1289,14 @@ class TestRootToolSerialization:
         }
 
         payload = {"value": 123}
-        args_payload = base64.b64encode(pickle.dumps((payload,))).decode("ascii")
-        kwargs_payload = base64.b64encode(pickle.dumps({})).decode("ascii")
-
         mock_request = MagicMock()
         mock_request.match_info = {"rollout_id": rollout_id}
         mock_request.json = AsyncMock(
             return_value={
                 "tool_name": "echo_tool",
-                "serialization": "pickle",
-                "args": args_payload,
-                "kwargs": kwargs_payload,
+                "serialization": "json",
+                "args": [payload],
+                "kwargs": {},
             }
         )
 
@@ -1314,9 +1304,7 @@ class TestRootToolSerialization:
         assert response.status == 200
 
         response_data = json.loads(response.text)
-        result_payload = response_data["result"]
-        decoded = pickle.loads(base64.b64decode(result_payload))
-        assert decoded == payload
+        assert response_data["result"] == payload
 
 
 # =============================================================================

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -506,7 +506,6 @@ def _build_python_worker_script_template() -> str:
     lines: list[str] = [
         "",
         "import ast",
-        "import base64",
         "import contextlib",
         "import io",
         "import json",

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -26,7 +26,6 @@ import contextvars
 import json
 import logging
 import os
-import pickle
 import re
 import shlex
 import shutil
@@ -512,7 +511,6 @@ def _build_python_worker_script_template() -> str:
         "import io",
         "import json",
         "import os",
-        "import pickle",
         "import sys",
     ]
 
@@ -558,12 +556,10 @@ def _build_python_worker_script_template() -> str:
             "    if not ROOT_TOOL_URL:",
             '        raise RuntimeError("Root tool URL not configured")',
             "",
-            '    args_payload = base64.b64encode(pickle.dumps(args)).decode("ascii")',
-            '    kwargs_payload = base64.b64encode(pickle.dumps(kwargs)).decode("ascii")',
             f"    payload = {dict_open}",
             '        "tool_name": tool_name,',
-            '        "args": args_payload,',
-            '        "kwargs": kwargs_payload,',
+            '        "args": list(args),',
+            '        "kwargs": kwargs,',
             f"    {dict_close}",
             "",
             "    resp = requests.post(",
@@ -578,7 +574,7 @@ def _build_python_worker_script_template() -> str:
             "            print(line)",
             '    if data.get("error"):',
             '        raise RuntimeError(data["error"])',
-            '    return pickle.loads(base64.b64decode(data.get("result", "")))',
+            '    return data.get("result")',
             "",
             "def _make_root_tool(name: str):",
             "    def _tool(*args, **kwargs):",
@@ -691,10 +687,8 @@ def _build_python_worker_script_template() -> str:
 
 _RLM_BASH_TOOL_HELPER_SCRIPT = textwrap.dedent(
     """
-    import base64
     import json
     import os
-    import pickle
     import sys
     import urllib.error
     import urllib.request
@@ -717,12 +711,10 @@ _RLM_BASH_TOOL_HELPER_SCRIPT = textwrap.dedent(
         if not ROOT_TOOL_URL:
             raise RuntimeError("Root tool URL not configured")
 
-        args_payload = base64.b64encode(pickle.dumps(args)).decode("ascii")
-        kwargs_payload = base64.b64encode(pickle.dumps(kwargs)).decode("ascii")
         payload = {
             "tool_name": tool_name,
-            "args": args_payload,
-            "kwargs": kwargs_payload,
+            "args": list(args),
+            "kwargs": kwargs,
         }
 
         data = json.dumps(payload).encode("utf-8")
@@ -750,8 +742,7 @@ _RLM_BASH_TOOL_HELPER_SCRIPT = textwrap.dedent(
         if response_data.get("error"):
             raise RuntimeError(response_data["error"])
 
-        result_payload = response_data.get("result", "")
-        result = pickle.loads(base64.b64decode(result_payload))
+        result = response_data.get("result")
         print_lines = response_data.get("print_lines") or []
         return result, print_lines
 
@@ -3291,18 +3282,24 @@ class RLMEnv(vf.StatefulToolEnv):
             return web.json_response(
                 {"error": f"Tool '{tool_name}' not found"}, status=404
             )
+        serialization = request_body.get("serialization")
+        if serialization not in (None, "", "json"):
+            return web.json_response(
+                {"error": "Unsupported root tool serialization mode."}, status=400
+            )
 
         state_ref = context.get("state")
         if state_ref is None:
             return web.json_response({"error": "State not available"}, status=500)
 
         try:
-            args = pickle.loads(base64.b64decode(request_body.get("args", "")))
-            kwargs = pickle.loads(base64.b64decode(request_body.get("kwargs", "")))
-            if not isinstance(args, tuple):
-                raise ValueError("Pickle args payload must be a tuple.")
+            args = request_body.get("args", [])
+            kwargs = request_body.get("kwargs", {})
+            if not isinstance(args, (list, tuple)):
+                raise ValueError("Tool args payload must be a list.")
             if not isinstance(kwargs, dict):
-                raise ValueError("Pickle kwargs payload must be a dict.")
+                raise ValueError("Tool kwargs payload must be an object.")
+            args = tuple(args)
         except Exception as e:
             return web.json_response({"error": str(e)}, status=400)
 
@@ -3350,9 +3347,14 @@ class RLMEnv(vf.StatefulToolEnv):
             )
             self._root_tool_context_var.reset(token)
 
-        result_payload = base64.b64encode(pickle.dumps(result_value)).decode("ascii")
+        try:
+            json.dumps(result_value, ensure_ascii=True, allow_nan=False)
+        except (TypeError, ValueError):
+            return web.json_response(
+                {"error": "Root tool result must be JSON-serializable."}, status=500
+            )
 
-        response_body: dict[str, Any] = {"result": result_payload}
+        response_body: dict[str, Any] = {"result": result_value}
         if print_lines:
             response_body["print_lines"] = print_lines
         return web.json_response(response_body)


### PR DESCRIPTION
### Motivation
- Prevent remote code execution via the new root-tool RPC by eliminating untrusted `pickle` deserialization and exec-driven deserializers in the RLM worker/helper paths. 
- The interception-exposed endpoint previously accepted attacker-controlled `serialization` and `deserializer_code`, allowing arbitrary code execution during argument decoding. 
- Constrain the root-tool path to structured JSON to remove arbitrary-deserialization attack surface while preserving the tool RPC functionality.

### Description
- Remove pickle-based encoding/decoding from the Python worker template and the Bash helper so `args`/`kwargs` are sent as JSON lists/objects and the helper reads `result` directly from JSON. 
- Update `_handle_root_tool_request` to reject unsupported `serialization` modes (only `json` accepted), validate that `args` is a list and `kwargs` is an object, convert `args` to a tuple for calling, and forbid unsafe `pickle.loads`. 
- Require that root tool return values are JSON-serializable and return the JSON value in the RPC response instead of a base64/pickle payload. 
- Update related tests to exercise the JSON-only serialization flow and to capture JSON `args`/`kwargs` and results.

### Testing
- Ran `ruff check verifiers/envs/experimental/rlm_env.py tests/test_rlm_env.py` which passed. 
- Ran `pytest -q tests/test_rlm_env.py -k 'BashToolHelper'` and the Bash helper tests passed. 
- Attempted `pytest -q tests/test_rlm_env.py -k 'RootToolSerialization or BashToolHelper'`, which failed in this environment because the async test requires the `pytest-asyncio` plugin that is not available here (test failure is due to environment limitation, not the code changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce887edb6c8332bfd1d116d18afe3c)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the root-tool RPC wire format and server-side request/response handling; while it reduces deserialization RCE risk, it can break any callers still using the previous pickle/base64 protocol and adds stricter validation of tool results.
> 
> **Overview**
> **Hardens the RLM root-tool RPC by removing `pickle` serialization entirely and switching to structured JSON payloads/results.** The worker template and bash helper now send `args` as JSON arrays and `kwargs` as JSON objects, and consume `result` directly from JSON (no base64 encoding/decoding).
> 
> On the server side, `_handle_root_tool_request` now rejects non-JSON `serialization` modes, validates `args`/`kwargs` types, converts `args` to a tuple for invocation, and enforces that tool return values are JSON-serializable before returning them.
> 
> Tests are updated to assert the new JSON request/response shapes for both the bash helper flow and root tool request handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b6c82693b14d1004e11d59feecee6f41313f44e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->