### PR TITLE
Pin regex<2026.4.4 (missing cp312/cp313 wheels)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dependencies = [
     "msgpack>=1.1.2",
     "aiolimiter>=1.2.1",
     "setproctitle>=1.3.0",
+    "regex<2026.4.4",  # 2026.4.4 missing cp312/cp313 wheels
 ]
 
 [dependency-groups]


### PR DESCRIPTION
## Description

we need to pin `regex<2026.4.4` or the CI will always fail, with:

```markdown
hint: You're using CPython 3.12 (`cp312`), but `regex` (v2026.4.4) only has wheels with the following Python ABI tags: `cp310`, `cp311`
```

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency change that only constrains the `regex` version to avoid CI/install failures on Python 3.12/3.13 due to missing wheels.
> 
> **Overview**
> Pins the `regex` dependency to `<2026.4.4` in `pyproject.toml` to avoid install/CI failures on Python 3.12/3.13 where `regex==2026.4.4` lacks compatible wheels.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 906f69fe3c5c898caab7cd8dff9da1642324c6ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->