### PR TITLE
RLM: inform model about max_turns_in_context limit in scaffolding

### DIFF
--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -1240,6 +1240,7 @@ In the end, the `ANSWER_CONTENT` environment variable must contain your answer. 
         enable_sub_llms: bool = True,
         enable_summarization: bool = False,
         min_turns_in_context: int = 3,
+        max_turns_in_context: int | None = None,
     ) -> None:
         self.repl_language = repl_language
         self.root_prompt_verbosity = root_prompt_verbosity
@@ -1255,6 +1256,7 @@ In the end, the `ANSWER_CONTENT` environment variable must contain your answer. 
         self.enable_sub_llms = enable_sub_llms
         self.enable_summarization = enable_summarization
         self.min_turns_in_context = min_turns_in_context
+        self.max_turns_in_context = max_turns_in_context
 
     def build_base_system_prompt(self) -> str:
         """Select the base system prompt or custom override."""
@@ -1362,13 +1364,20 @@ In the end, the `ANSWER_CONTENT` environment variable must contain your answer. 
             return self.MESSAGE_HISTORY_NOTE_BASH
         return self.MESSAGE_HISTORY_NOTE_PYTHON
 
-    def build_context_dropping_note(self) -> str:
-        """Return context-dropping documentation note, or empty string.
-
-        Currently returns empty — the ``summarize_turns`` tool docstring and
-        rejection messages provide all necessary information to the model.
-        """
-        return ""
+    def build_turn_limit_note(self) -> str:
+        """Return context-dropping documentation note, or empty string."""
+        if self.max_turns_in_context is None:
+            return ""
+        note = (
+            f"\nYour session will end after {self.max_turns_in_context}"
+            f" turns in context (each tool call counts as one turn)."
+        )
+        if self.enable_summarization:
+            note += (
+                " Use `summarize_turns` to drop old turns and stay"
+                f" within this limit beyond {self.max_turns_in_context} turns."
+            )
+        return note + "\n"
 
     def build_root_budget_note(self) -> str:
         """Return root-model token budget note, or empty string."""
@@ -1401,7 +1410,7 @@ In the end, the `ANSWER_CONTENT` environment variable must contain your answer. 
             + self.build_root_budget_note()
             + self.build_sub_budget_note()
             + self.build_message_history_note()
-            + self.build_context_dropping_note()
+            + self.build_turn_limit_note()
         )
         return "<SCAFFOLDING>\n" + body + "\n</SCAFFOLDING>\n\n"
 
@@ -2548,6 +2557,7 @@ class RLMEnv(vf.StatefulToolEnv):
             enable_sub_llms=self.enable_sub_llms,
             enable_summarization=self.enable_summarization,
             min_turns_in_context=self.min_turns_in_context,
+            max_turns_in_context=self.max_turns_in_context,
         )
 
         # Add the REPL tool (state is injected via update_tool_args)


### PR DESCRIPTION
## Description

The model had no way to know about the `max_turns_in_context` hard stop, causing it to get killed without understanding why. Add a turn limit note to the scaffolding prompt (`build_turn_limit_note`) that fires when `max_turns_in_context` is set, with an extra hint about `summarize_turns` when summarization is enabled.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk prompt-only change; it adds an optional note to the system scaffolding and threads a new config value through the prompt builder without affecting execution logic.
> 
> **Overview**
> When `max_turns_in_context` is set, the RLM scaffolding prompt now explicitly tells the model the session will hard-stop after that many visible turns (counting tool calls as turns).
> 
> If summarization is enabled, the note additionally hints to use `summarize_turns` to stay within the turn limit; this is wired by passing `max_turns_in_context` into `RLMPromptBuilder` and appending `build_turn_limit_note()` when building the system prompt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9580d5bdf405af76fde854d127987e2183a3f9c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->