### PR TITLE
[codex] bump uv to >=0.11.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ rl = [
 
 [tool.uv]
 preview = true
-required-version = "<0.11.0"
+required-version = ">=0.11.1"
 
 [tool.uv.extra-build-dependencies]
 flash-attn = [{ requirement = "torch", match-runtime = true }]


### PR DESCRIPTION
## Summary
- bump the repo's required `uv` version from `<0.11.0` to `>=0.11.1`
- keep the existing `flash-attn` `match-runtime = true` configuration unchanged
- stop rejecting all `0.11.x` releases now that the `0.11.0` regression has been fixed upstream

## Why
`uv 0.11.0` regressed `flash-attn` resolution for our setup because of the `Dynamic: requires-dist` handling discussed in the upstream issue:
- https://github.com/astral-sh/uv/issues/18690

That regression was fixed upstream by the merged revert PR:
- https://github.com/astral-sh/uv/pull/18692

This change updates our version gate so we reject the known-bad `0.11.0`, while allowing `0.11.1+`.

## Impact
- `uv 0.11.0` is still blocked
- `uv 0.11.1+` is allowed again
- no local metadata workaround is introduced
- `flash-attn` continues to use `match-runtime = true`

## Validation
- `uvx uv@0.11.0 sync --frozen` fails with the required-version gate
- `uvx uv@0.11.1 sync --frozen` succeeds
- `uvx uv@0.11.2 sync --frozen` succeeds

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk tooling-only change, but it can affect dependency resolution/lockstep installs for contributors and CI by allowing newer `uv` versions.
> 
> **Overview**
> Raises the `uv` `required-version` in `pyproject.toml` from `<0.11.0` to `>=0.11.1`, re-allowing `0.11.x` now that upstream regressions are fixed.
> 
> No other dependency or build configuration changes are made (including the existing `flash-attn` `match-runtime` setup).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2f029cd6f30bb2e8b0b3ba286c5125b6218e0b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->