### PR TITLE
Fix opencode config for model names without slash

### DIFF
--- a/verifiers/envs/experimental/opencode_env.py
+++ b/verifiers/envs/experimental/opencode_env.py
@@ -71,6 +71,12 @@ export PATH="$HOME/.opencode/bin:$PATH"
 
 mkdir -p ~/.config/opencode
 
+# Ensure OPENAI_MODEL has provider/model format for opencode AI SDK config.
+# LoRA adapter names (e.g. "rft-abc123") lack a slash, causing empty modelID.
+if [[ "$OPENAI_MODEL" != *"/"* ]]; then
+    export OPENAI_MODEL="vllm/$OPENAI_MODEL"
+fi
+
 SCHEMA_DOLLAR='$'
 
 cat > ~/.config/opencode/opencode.json << EOFCONFIG


### PR DESCRIPTION
## Summary
- LoRA adapter names (e.g. `rft-abc123`) don't contain a `/`, so the bash parameter expansion `${OPENAI_MODEL%%/*}` / `${OPENAI_MODEL##*/}` in the opencode config produces an empty `modelID`
- Prepend `vllm/` when `OPENAI_MODEL` has no slash, so the AI SDK provider/model split works correctly
- The actual model name sent in API calls is still correct (the part after `/`)

## Test plan
- [ ] Run opencode-math with a LoRA adapter name (no `/` in model name) and verify opencode starts without `ProviderModelNotFoundError`
- [ ] Run opencode-math with a HuggingFace model name (e.g. `Qwen/Qwen3-4B-Thinking-2507`) and verify no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a small guard to rewrite `OPENAI_MODEL` only when it lacks a `/`, which should only affect model naming/config generation in the OpenCode runner.
> 
> **Overview**
> Fixes OpenCode runs where `OPENAI_MODEL` is a slash-less name (e.g., LoRA adapters like `rft-abc123`) by **rewriting it to `vllm/<model>`** before generating `~/.config/opencode/opencode.json`, ensuring the provider/model split (`${OPENAI_MODEL%%/*}` / `${OPENAI_MODEL##*/}`) produces valid IDs.
> 
> Models that already use `provider/model` are left unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7085bb25639c84488ddfc14b96ff883144e5d455. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->