### PR TITLE
Simplify RLM message transcript handling

### DIFF
--- a/tests/test_rlm_env.py
+++ b/tests/test_rlm_env.py
@@ -84,7 +84,6 @@ def rlm_env() -> RLMEnv:
         max_turns=10,
         max_output_length=1000,
         repl_language="python",
-        expose_message_history=False,
         interception_url="http://test.invalid",
     )
 
@@ -105,7 +104,6 @@ def rlm_env_with_sub_tools() -> RLMEnv:
         sub_tools=[sample_tool, another_tool],
         sub_llm_max_turns=3,
         repl_language="python",
-        expose_message_history=False,
         interception_url="http://test.invalid",
     )
 
@@ -118,7 +116,6 @@ def rlm_env_bash() -> RLMEnv:
         max_turns=10,
         max_output_length=1000,
         repl_language="bash",
-        expose_message_history=False,
         interception_url="http://test.invalid",
     )
 
@@ -1646,7 +1643,7 @@ class TestSubLLMEmptyModelResponseErrorRaised:
 
 
 class TestMessageHistory:
-    """Tests for expose_message_history feature."""
+    """Tests for the always-on observable `.messages` transcript."""
 
     @pytest.fixture
     def env_with_history(self) -> RLMEnv:
@@ -1654,66 +1651,31 @@ class TestMessageHistory:
         return build_env(
             dataset,
             repl_language="python",
-            expose_message_history=True,
-            interception_url="http://test.invalid",
-        )
-
-    @pytest.fixture
-    def env_without_history(self) -> RLMEnv:
-        dataset = make_dataset({})
-        return build_env(
-            dataset,
-            repl_language="python",
-            expose_message_history=False,
             interception_url="http://test.invalid",
         )
 
     def _make_state_with_trajectory(
-        self, env: RLMEnv, messages_per_step: int = 2, num_steps: int = 1
+        self, messages_per_step: int = 2, num_steps: int = 1
     ) -> dict:
-        """Build a state dict with a realistic trajectory."""
-        trajectory_id = "main_traj"
-        trajectory = []
+        """Build a state dict with a realistic observable transcript."""
+        messages: list[vf.Message] = []
         for step_idx in range(num_steps):
-            prompt_msgs = [
-                vf.UserMessage(content=f"Step {step_idx} user message {i}")
-                for i in range(messages_per_step)
-            ]
-            completion_msgs = [
+            for i in range(messages_per_step):
+                messages.append(
+                    vf.UserMessage(content=f"Step {step_idx} user message {i}")
+                )
+            messages.append(
                 vf.AssistantMessage(content=f"Step {step_idx} assistant response")
-            ]
-            trajectory.append(
-                {
-                    "prompt": prompt_msgs,
-                    "completion": completion_msgs,
-                    "response": None,
-                    "tokens": None,
-                    "reward": None,
-                    "advantage": None,
-                    "is_truncated": False,
-                    "trajectory_id": trajectory_id,
-                    "extras": {},
-                }
             )
-        return {
-            "trajectory": trajectory,
-            "trajectory_id": trajectory_id,
-            "_messages_uploaded_count": 0,
-        }
+        return {"_observable_messages": messages}
 
     def test_build_message_history_empty_trajectory(self, env_with_history):
-        state = {
-            "trajectory": [],
-            "trajectory_id": "main",
-            "_messages_uploaded_count": 0,
-        }
+        state = {"_observable_messages": []}
         result = env_with_history._build_message_history(state)
         assert result == []
 
     def test_build_message_history_one_step(self, env_with_history):
-        state = self._make_state_with_trajectory(
-            env_with_history, messages_per_step=1, num_steps=1
-        )
+        state = self._make_state_with_trajectory(messages_per_step=1, num_steps=1)
         result = env_with_history._build_message_history(state)
         # 1 prompt message + 1 completion message = 2 messages
         assert len(result) == 2
@@ -1723,121 +1685,34 @@ class TestMessageHistory:
         assert result[1]["content"] == "Step 0 assistant response"
 
     def test_build_message_history_multi_step(self, env_with_history):
-        state = self._make_state_with_trajectory(
-            env_with_history, messages_per_step=2, num_steps=3
-        )
+        state = self._make_state_with_trajectory(messages_per_step=2, num_steps=3)
         result = env_with_history._build_message_history(state)
-        # Last step: 2 prompt messages + 1 completion = 3
-        assert len(result) == 3
-        # Should be from the last step
-        assert result[0]["content"] == "Step 2 user message 0"
-        assert result[1]["content"] == "Step 2 user message 1"
-        assert result[2]["content"] == "Step 2 assistant response"
+        # Full transcript: 3 steps * (2 user + 1 assistant) = 9
+        assert len(result) == 9
+        assert result[0]["content"] == "Step 0 user message 0"
+        assert result[-1]["content"] == "Step 2 assistant response"
 
-    def test_build_message_history_skips_sub_llm_steps(self, env_with_history):
-        main_id = "main_traj"
-        sub_id = "sub_batch_1"
-        trajectory = [
-            {
-                "prompt": [vf.UserMessage(content="main prompt")],
-                "completion": [vf.AssistantMessage(content="main response")],
-                "response": None,
-                "tokens": None,
-                "reward": None,
-                "advantage": None,
-                "is_truncated": False,
-                "trajectory_id": main_id,
-                "extras": {},
-            },
-            {
-                "prompt": [vf.UserMessage(content="sub prompt")],
-                "completion": [vf.AssistantMessage(content="sub response")],
-                "response": None,
-                "tokens": None,
-                "reward": None,
-                "advantage": None,
-                "is_truncated": False,
-                "trajectory_id": sub_id,
-                "extras": {"is_sub_llm_call": True},
-            },
-        ]
+    def test_build_message_history_preserves_summaries(self, env_with_history):
         state = {
-            "trajectory": trajectory,
-            "trajectory_id": main_id,
-            "_messages_uploaded_count": 0,
+            "_observable_messages": [
+                UserMessage(content="scaffolded prompt"),
+                vf.AssistantMessage(
+                    content="<SUMMARY>\n[Turns 1-1] summary\n</SUMMARY>\n\nresponse 1"
+                ),
+            ]
         }
         result = env_with_history._build_message_history(state)
-        # Should only include the main step's messages
         assert len(result) == 2
-        assert result[0]["content"] == "main prompt"
-        assert result[1]["content"] == "main response"
-
-    def test_incremental_delta_computation(self, env_with_history):
-        """Verify that only new messages are uploaded on subsequent calls."""
-        main_id = "main_traj"
-        # Step 0: 1 user + 1 assistant = 2 messages
-        step0 = {
-            "prompt": [vf.UserMessage(content="q0")],
-            "completion": [vf.AssistantMessage(content="a0")],
-            "response": None,
-            "tokens": None,
-            "reward": None,
-            "advantage": None,
-            "is_truncated": False,
-            "trajectory_id": main_id,
-            "extras": {},
-        }
-        state = {
-            "trajectory": [step0],
-            "trajectory_id": main_id,
-            "_messages_uploaded_count": 0,
-        }
-
-        # First call: all messages are new
-        messages = env_with_history._build_message_history(state)
-        uploaded_count = state["_messages_uploaded_count"]
-        new_messages = messages[uploaded_count:]
-        assert len(new_messages) == 2
-
-        # Simulate upload completing
-        state["_messages_uploaded_count"] = len(messages)
-
-        # Step 1: prompt = [q0, a0, tool_result], completion = [a1] = 4 messages total
-        step1 = {
-            "prompt": [
-                vf.UserMessage(content="q0"),
-                vf.AssistantMessage(content="a0"),
-                vf.ToolMessage(tool_call_id="tc1", content="tool output"),
-            ],
-            "completion": [vf.AssistantMessage(content="a1")],
-            "response": None,
-            "tokens": None,
-            "reward": None,
-            "advantage": None,
-            "is_truncated": False,
-            "trajectory_id": main_id,
-            "extras": {},
-        }
-        state["trajectory"].append(step1)
-
-        # Second call: only the new messages
-        messages = env_with_history._build_message_history(state)
-        new_messages = messages[state["_messages_uploaded_count"] :]
-        # Delta = 4 total - 2 already uploaded = 2 new messages
-        assert len(new_messages) == 2
-        assert new_messages[0]["role"] == "tool"
-        assert new_messages[1]["role"] == "assistant"
-        assert new_messages[1]["content"] == "a1"
+        assert "<SUMMARY>" in result[1]["content"]
+        assert "[Turns 1-1] summary" in result[1]["content"]
 
     @pytest.mark.asyncio
     async def test_upload_creates_file_on_first_call_with_empty_trajectory(
         self, env_with_history
     ):
-        """First call with no trajectory should touch .messages to create it."""
+        """First call with no transcript should create an empty `.messages` file."""
         state = {
-            "trajectory": [],
-            "trajectory_id": "main",
-            "_messages_uploaded_count": 0,
+            "_observable_messages": [],
             "rollout_id": "test_rollout",
         }
 
@@ -1852,15 +1727,12 @@ class TestMessageHistory:
         env_with_history._executor._execute_sandbox_command.assert_called_once()
         cmd = env_with_history._executor._execute_sandbox_command.call_args[0][1]
         assert ".messages" in cmd
-        assert "touch" in cmd
-        assert state["_messages_uploaded_count"] == 0
+        assert ": >" in cmd
 
     @pytest.mark.asyncio
     async def test_upload_message_history_calls_sandbox_command(self, env_with_history):
-        """Verify _upload_message_history sends base64-encoded JSONL via sandbox command."""
-        state = self._make_state_with_trajectory(
-            env_with_history, messages_per_step=1, num_steps=1
-        )
+        """Verify `_upload_message_history` overwrites `.messages` with JSONL."""
+        state = self._make_state_with_trajectory(messages_per_step=1, num_steps=1)
         state["rollout_id"] = "test_rollout"
 
         mock_session = MagicMock()
@@ -1878,18 +1750,15 @@ class TestMessageHistory:
         cmd = call_args[0][1]
         assert ".messages" in cmd
         assert "base64" in cmd
-
-        # Counter should be updated
-        assert state["_messages_uploaded_count"] == 2
+        assert " > " in cmd
 
     @pytest.mark.asyncio
-    async def test_upload_skips_when_no_new_messages(self, env_with_history):
-        """Verify no sandbox command when all messages already uploaded."""
-        state = self._make_state_with_trajectory(
-            env_with_history, messages_per_step=1, num_steps=1
-        )
+    async def test_upload_overwrites_even_when_transcript_unchanged(
+        self, env_with_history
+    ):
+        """Overwrite semantics mean the file is rewritten on every upload."""
+        state = self._make_state_with_trajectory(messages_per_step=1, num_steps=1)
         state["rollout_id"] = "test_rollout"
-        state["_messages_uploaded_count"] = 2  # Already uploaded all 2 messages
 
         mock_session = MagicMock()
         mock_session.sandbox_id = "sandbox_123"
@@ -1898,16 +1767,14 @@ class TestMessageHistory:
         env_with_history._executor._execute_sandbox_command = AsyncMock()
 
         await env_with_history._upload_message_history(state)
+        await env_with_history._upload_message_history(state)
 
-        # Should NOT have called sandbox command
-        env_with_history._executor._execute_sandbox_command.assert_not_called()
+        assert env_with_history._executor._execute_sandbox_command.await_count == 2
 
     @pytest.mark.asyncio
     async def test_upload_failure_is_non_fatal(self, env_with_history):
         """Verify that sandbox command failure doesn't raise."""
-        state = self._make_state_with_trajectory(
-            env_with_history, messages_per_step=1, num_steps=1
-        )
+        state = self._make_state_with_trajectory(messages_per_step=1, num_steps=1)
         state["rollout_id"] = "test_rollout"
 
         mock_session = MagicMock()
@@ -1921,16 +1788,12 @@ class TestMessageHistory:
         # Should not raise
         await env_with_history._upload_message_history(state)
 
-        # Counter should NOT be updated
-        assert state["_messages_uploaded_count"] == 0
-
     @pytest.mark.asyncio
-    async def test_system_prompt_includes_history_note_when_enabled(self):
+    async def test_system_prompt_includes_history_note(self):
         dataset = make_dataset({})
         env = build_env(
             dataset,
             repl_language="python",
-            expose_message_history=True,
             interception_url="http://test.invalid",
         )
         env._ensure_interception_server = AsyncMock()
@@ -1943,27 +1806,8 @@ class TestMessageHistory:
             prompt = result["rlm_system_prompt"]
             assert ".messages" in prompt
             assert "JSONL" in prompt
-        finally:
-            await env.cleanup_rlm_state(result)
-
-    @pytest.mark.asyncio
-    async def test_system_prompt_excludes_history_note_when_disabled(self):
-        dataset = make_dataset({})
-        env = build_env(
-            dataset,
-            repl_language="python",
-            expose_message_history=False,
-            interception_url="http://test.invalid",
-        )
-        env._ensure_interception_server = AsyncMock()
-        env._executor.prepare_filesystem = AsyncMock()
-        env._executor.setup = AsyncMock()
-
-        state = {"info": {}, "model": "m", "client": MagicMock()}
-        result = await env.setup_state(state)
-        try:
-            prompt = result["rlm_system_prompt"]
-            assert ".messages" not in prompt
+            assert "observable conversation transcript" in prompt
+            assert "<SUMMARY>" not in prompt
         finally:
             await env.cleanup_rlm_state(result)
 
@@ -1973,7 +1817,6 @@ class TestMessageHistory:
         env = build_env(
             dataset,
             repl_language="bash",
-            expose_message_history=True,
             interception_url="http://test.invalid",
         )
         env._ensure_interception_server = AsyncMock()
@@ -1986,20 +1829,15 @@ class TestMessageHistory:
             prompt = result["rlm_system_prompt"]
             assert ".messages" in prompt
             assert "cat .messages" in prompt
+            assert "<SUMMARY>" not in prompt
         finally:
             await env.cleanup_rlm_state(result)
 
-    def test_expose_message_history_defaults_to_true(self):
-        dataset = make_dataset({})
-        env = build_env(dataset, interception_url="http://test.invalid")
-        assert env.expose_message_history is True
-
     @pytest.mark.asyncio
-    async def test_setup_state_initializes_upload_counter(self):
+    async def test_setup_state_initializes_observable_transcript(self):
         dataset = make_dataset({})
         env = build_env(
             dataset,
-            expose_message_history=True,
             interception_url="http://test.invalid",
         )
         env._ensure_interception_server = AsyncMock()
@@ -2009,7 +1847,7 @@ class TestMessageHistory:
         state = {"info": {}, "model": "m", "client": MagicMock()}
         result = await env.setup_state(state)
         try:
-            assert result["_messages_uploaded_count"] == 0
+            assert result["_observable_messages"] == []
         finally:
             await env.cleanup_rlm_state(result)
 
@@ -2716,17 +2554,12 @@ class TestSummarizeTurns:
     @pytest.fixture
     def env_with_summarize(self) -> RLMEnv:
         dataset = make_dataset({})
-        import warnings
-
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", UserWarning)
-            return build_env(
-                dataset,
-                enable_summarization=True,
-                min_turns_in_context=3,
-                expose_message_history=False,
-                interception_url="http://test.invalid",
-            )
+        return build_env(
+            dataset,
+            enable_summarization=True,
+            min_turns_in_context=3,
+            interception_url="http://test.invalid",
+        )
 
     @pytest.fixture
     def env_without_summarize(self) -> RLMEnv:
@@ -2734,7 +2567,6 @@ class TestSummarizeTurns:
         return build_env(
             dataset,
             enable_summarization=False,
-            expose_message_history=False,
             interception_url="http://test.invalid",
         )
 
@@ -2811,34 +2643,6 @@ class TestSummarizeTurns:
     # =====================================================================
     # Default configuration
     # =====================================================================
-
-    def test_expose_message_history_defaults_to_true(self):
-        dataset = make_dataset({})
-        env = build_env(dataset, interception_url="http://test.invalid")
-        assert env.expose_message_history is True
-
-    def test_warning_when_dropping_without_message_history(self):
-        dataset = make_dataset({})
-        with pytest.warns(UserWarning, match="enable_summarization=True"):
-            build_env(
-                dataset,
-                enable_summarization=True,
-                expose_message_history=False,
-                interception_url="http://test.invalid",
-            )
-
-    def test_no_warning_when_dropping_with_message_history(self):
-        dataset = make_dataset({})
-        import warnings
-
-        with warnings.catch_warnings():
-            warnings.simplefilter("error")
-            build_env(
-                dataset,
-                enable_summarization=True,
-                expose_message_history=True,
-                interception_url="http://test.invalid",
-            )
 
     # =====================================================================
     # System prompt
@@ -3113,43 +2917,186 @@ class TestSummarizeTurns:
         assert "r0" in result[1].content
 
     # =====================================================================
-    # .messages file unaffected
+    # .messages / observable transcript
     # =====================================================================
 
-    def test_message_history_excludes_summaries(self, env_with_summarize):
-        """_build_message_history returns uncompacted history without <SUMMARY> tags."""
-        trajectory_id = "main_traj"
+    def test_message_history_preserves_summaries(self, env_with_summarize):
+        """Observable `.messages` preserves summary blocks."""
         state = {
-            "trajectory_id": trajectory_id,
+            "_observable_messages": [
+                UserMessage(content="scaffolded prompt"),
+                vf.AssistantMessage(
+                    content="<SUMMARY>\n[Turns 1-1] some summary\n</SUMMARY>\n\nresponse 1"
+                ),
+            ],
+        }
+
+        history = env_with_summarize._build_message_history(state)
+        assert "<SUMMARY>" in history[1]["content"]
+
+    @pytest.mark.asyncio
+    async def test_add_model_response_appends_raw_completion(self, env_with_summarize):
+        """Main-model completions should be appended without retroactive annotation."""
+        state = {
+            "trajectory_id": "main_traj",
+            "trajectory": [],
+            "prompt": [UserMessage(content="scaffolded prompt")],
+            "_observable_messages": [],
+        }
+
+        prompt_messages = [
+            UserMessage(content="scaffolded prompt"),
+            vf.AssistantMessage(
+                content="<SUMMARY>\n[Turns 1-1] summarized turn 0\n</SUMMARY>\n\nresponse 1"
+            ),
+            vf.ToolMessage(
+                tool_call_id="tsum", content="[Turns 1-1] summarized turn 0"
+            ),
+        ]
+
+        mock_response = MagicMock()
+        mock_response.message.is_truncated = False
+        mock_response.usage = MagicMock(prompt_tokens=1, completion_tokens=1)
+
+        with (
+            patch(
+                "verifiers.envs.multiturn_env.parse_response_message",
+                new=AsyncMock(return_value=[vf.AssistantMessage(content="response 2")]),
+            ),
+            patch(
+                "verifiers.envs.multiturn_env.parse_response_tokens",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            await env_with_summarize.add_model_response(
+                state, prompt_messages, mock_response
+            )
+
+        observable = state["_observable_messages"]
+        assert len(observable) == 4
+        assert observable[0].content == "scaffolded prompt"
+        assert observable[-1].content == "response 2"
+
+    @pytest.mark.asyncio
+    async def test_summarize_turns_updates_observable_insertion_point(
+        self, env_with_summarize
+    ):
+        """summarize_turns should add the summary to the assistant turn it targets."""
+        state = self._make_state(main_turns=5)
+        state["_observable_messages"] = [UserMessage(content="prompt")]
+        for i in range(5):
+            state["_observable_messages"].append(
+                vf.AssistantMessage(content=f"response {i}")
+            )
+
+        await env_with_summarize.summarize_turns(
+            n_turns=2, summary="batch 1", state=state
+        )
+
+        assistants = [
+            message
+            for message in state["_observable_messages"]
+            if message.role == "assistant"
+        ]
+        assert "<SUMMARY>" not in assistants[0].content
+        assert "<SUMMARY>" not in assistants[1].content
+        assert assistants[2].content.startswith("<SUMMARY>")
+        assert "[Turns 1-2] batch 1" in assistants[2].content
+        assert assistants[2].content.endswith("response 2")
+
+    @pytest.mark.asyncio
+    async def test_summarize_turns_moves_observable_summary_to_new_turn(
+        self, env_with_summarize
+    ):
+        """A later summarize call should move the summary to the new insertion turn."""
+        state = self._make_state(main_turns=6)
+        state["_observable_messages"] = [UserMessage(content="prompt")]
+        for i in range(6):
+            state["_observable_messages"].append(
+                vf.AssistantMessage(content=f"response {i}")
+            )
+
+        await env_with_summarize.summarize_turns(
+            n_turns=2, summary="batch 1", state=state
+        )
+        await env_with_summarize.summarize_turns(
+            n_turns=1, summary="batch 2", state=state
+        )
+
+        assistants = [
+            message
+            for message in state["_observable_messages"]
+            if message.role == "assistant"
+        ]
+        assert "<SUMMARY>" not in assistants[2].content
+        assert assistants[3].content.startswith("<SUMMARY>")
+        assert "[Turns 1-2] batch 1" in assistants[3].content
+        assert "[Turns 3-3] batch 2" in assistants[3].content
+
+    @pytest.mark.asyncio
+    async def test_env_response_appends_tool_messages_to_observable_log(
+        self, env_with_summarize
+    ):
+        """Tool/env messages should be appended when they occur, not reconstructed later."""
+
+        def echo_tool(text: str) -> str:
+            return text
+
+        env_with_summarize.add_tool(echo_tool)
+        state = {"trajectory": [], "_observable_messages": []}
+        tool_call = vf.ToolCall(
+            id="call_0",
+            name="echo_tool",
+            arguments=json.dumps({"text": "tool 0"}),
+        )
+        messages = [
+            UserMessage(content="prompt"),
+            vf.AssistantMessage(content=None, tool_calls=[tool_call]),
+        ]
+
+        result = await env_with_summarize.env_response(messages, state)
+
+        assert len(result) == 1
+        assert result[0].content == "tool 0"
+        assert len(state["_observable_messages"]) == 1
+        assert state["_observable_messages"][0].content == "tool 0"
+
+    @pytest.mark.asyncio
+    async def test_render_completion_uses_observable_log(self, env_with_summarize):
+        """render_completion should return the tracked observable rollout verbatim."""
+        state = {
+            "trajectory_id": "main_traj",
+            "prompt": [UserMessage(content="prompt")],
             "trajectory": [
                 {
-                    "prompt": [
-                        UserMessage(content="scaffolded prompt"),
-                    ],
-                    "completion": [
-                        vf.AssistantMessage(content="response 0"),
-                        vf.ToolMessage(tool_call_id="t0", content="tool 0"),
-                        vf.AssistantMessage(content="response 1"),
-                    ],
+                    "prompt": [UserMessage(content="prompt")],
+                    "completion": [vf.AssistantMessage(content="unused")],
                     "response": None,
                     "tokens": None,
                     "reward": None,
                     "advantage": None,
                     "is_truncated": False,
-                    "trajectory_id": trajectory_id,
+                    "trajectory_id": "main_traj",
                     "extras": {},
                 }
             ],
-            "_summary_text": "[Turns 1-1] some summary",
-            "_keep_from_assistant_index": 1,
+            "_observable_messages": [
+                UserMessage(content="prompt"),
+                vf.AssistantMessage(
+                    content="<SUMMARY>\n[Turns 1-1] summarized turn 0\n</SUMMARY>\n\nresponse 0"
+                ),
+                vf.ToolMessage(tool_call_id="t0", content="tool 0"),
+                vf.AssistantMessage(content="response 2"),
+            ],
         }
 
-        history = env_with_summarize._build_message_history(state)
+        await env_with_summarize.render_completion(state)
 
-        for entry in history:
-            content = entry.get("content", "")
-            if isinstance(content, str):
-                assert "<SUMMARY>" not in content
+        completion = state["completion"]
+        assert len(completion) == 3
+        assert completion[0].content.startswith("<SUMMARY>")
+        assert completion[1].content == "tool 0"
+        assert completion[2].content == "response 2"
 
     # =====================================================================
     # Metrics
@@ -3269,14 +3216,11 @@ class TestSummarizeTurns:
         )
         assert result == messages
 
-    def test_warn_when_dropping_without_message_history(self):
-        """Warning still fires when enable_summarization=True
-        but expose_message_history=False."""
+    def test_summarization_setup_emits_no_history_warning(self):
+        """Summarization setup should not warn about `.messages`."""
         dataset = make_dataset({})
-        with pytest.warns(UserWarning, match="enable_summarization=True"):
-            build_env(
-                dataset,
-                enable_summarization=True,
-                expose_message_history=False,
-                interception_url="http://test.invalid",
-            )
+        build_env(
+            dataset,
+            enable_summarization=True,
+            interception_url="http://test.invalid",
+        )

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -1183,21 +1183,6 @@ class RLMPromptBuilder:
         ),
     }
 
-    MESSAGE_HISTORY_NOTE_PYTHON: str = """
-The file `.messages` in your working directory contains your conversation history (JSONL, one message object per line). It is updated before each code execution. You can read it, e.g.:
-```python
-import json
-history = [json.loads(line) for line in open(".messages")]
-```
-"""
-
-    MESSAGE_HISTORY_NOTE_BASH: str = """
-The file `.messages` in your working directory contains your conversation history (JSONL, one message object per line). It is updated before each code execution. You can read it, e.g.:
-```bash
-cat .messages  # one JSON object per line
-```
-"""
-
     PYTHON_BASE_PROMPT: str = """You have the `call_python_repl` tool and a filesystem available to you.
 
 There exists an `answer` variable, which is a dict. `answer["content"]` must contain your answer. When the final answer is set, set `answer["ready"] = True`.
@@ -1231,7 +1216,6 @@ In the end, the `ANSWER_CONTENT` environment variable must contain your answer. 
         sub_prompt_verbosity: Literal["light", "medium", "heavy"],
         custom_system_prompt: str | None,
         pip_install_packages: str,
-        expose_message_history: bool,
         root_max_completion_tokens: int | None,
         sub_max_completion_tokens: int | None,
         sub_llm_max_turns: int,
@@ -1247,7 +1231,6 @@ In the end, the `ANSWER_CONTENT` environment variable must contain your answer. 
         self.sub_prompt_verbosity = sub_prompt_verbosity
         self.custom_system_prompt = custom_system_prompt
         self.pip_install_packages = pip_install_packages
-        self.expose_message_history = expose_message_history
         self.root_max_completion_tokens = root_max_completion_tokens
         self.sub_max_completion_tokens = sub_max_completion_tokens
         self.sub_llm_max_turns = sub_llm_max_turns
@@ -1356,14 +1339,6 @@ In the end, the `ANSWER_CONTENT` environment variable must contain your answer. 
 
         return "\n".join(lines)
 
-    def build_message_history_note(self) -> str:
-        """Return the message-history documentation note, or empty string."""
-        if not self.expose_message_history:
-            return ""
-        if self.repl_language == "bash":
-            return self.MESSAGE_HISTORY_NOTE_BASH
-        return self.MESSAGE_HISTORY_NOTE_PYTHON
-
     def build_turn_limit_note(self) -> str:
         """Return context-dropping documentation note, or empty string."""
         if self.max_turns_in_context is None:
@@ -1401,6 +1376,21 @@ In the end, the `ANSWER_CONTENT` environment variable must contain your answer. 
 
     def build_system_prompt(self) -> str:
         """Assemble the full RLM system prompt, wrapped in scaffolding tags."""
+        if self.repl_language == "bash":
+            message_history_note = """
+The file `.messages` in your working directory contains the full observable conversation transcript (JSONL, one message object per line). It is overwritten before each code execution. You can read it, e.g.:
+```bash
+cat .messages  # one JSON object per line
+```
+"""
+        else:
+            message_history_note = """
+The file `.messages` in your working directory contains the full observable conversation transcript (JSONL, one message object per line). It is overwritten before each code execution. You can read it, e.g.:
+```python
+import json
+history = [json.loads(line) for line in open(".messages")]
+```
+"""
         body = (
             self.build_base_system_prompt()
             + self.build_packages_documentation()
@@ -1409,7 +1399,7 @@ In the end, the `ANSWER_CONTENT` environment variable must contain your answer. 
             + self.build_sub_tools_documentation()
             + self.build_root_budget_note()
             + self.build_sub_budget_note()
-            + self.build_message_history_note()
+            + message_history_note
             + self.build_turn_limit_note()
         )
         return "<SCAFFOLDING>\n" + body + "\n</SCAFFOLDING>\n\n"
@@ -2284,10 +2274,6 @@ class RLMEnv(vf.StatefulToolEnv):
         abort_on_code_timeout: If True, abort the rollout when code execution times out.
                    If False (default), return an error message to the model so it can
                    try a more efficient approach.
-        expose_message_history: If True, the model's conversation history is
-                   written to `.messages` (JSONL) in the sandbox working directory
-                   and updated incrementally before each code execution. This lets
-                   the model read or forward its own conversation to sub-LLMs.
         retain_filesystem_after_rollout: If True, keep filesystem after rollout.
         sandbox_docker_image: Docker image for sandbox backend (default: python:3.11-slim)
         sandbox_cpu_cores: Sandbox CPU cores (default: 1)
@@ -2377,7 +2363,6 @@ class RLMEnv(vf.StatefulToolEnv):
         max_startup_wait_seconds: int = 120,
         code_execution_timeout: int = 120,
         abort_on_code_timeout: bool = False,
-        expose_message_history: bool = True,
         retain_filesystem_after_rollout: bool = False,
         sandbox_docker_image: str = "python:3.11-slim",
         sandbox_cpu_cores: int = 1,
@@ -2429,7 +2414,6 @@ class RLMEnv(vf.StatefulToolEnv):
         self.context_warning_threshold = context_warning_threshold
         self.code_execution_timeout = code_execution_timeout
         self.abort_on_code_timeout = abort_on_code_timeout
-        self.expose_message_history = expose_message_history
         self.enable_summarization = enable_summarization
         self.min_turns_in_context = min_turns_in_context
         self.max_turns_in_context = max_turns_in_context
@@ -2440,16 +2424,6 @@ class RLMEnv(vf.StatefulToolEnv):
                 "max_turns_in_context ineffective.",
                 max_turns_in_context,
                 max_turns,
-            )
-        if self.enable_summarization and not self.expose_message_history:
-            import warnings
-
-            warnings.warn(
-                "enable_summarization=True but expose_message_history=False. "
-                "The model won't be able to read dropped context from .messages. "
-                "Consider setting expose_message_history=True.",
-                UserWarning,
-                stacklevel=2,
             )
         if not self.enable_sub_llms:
             if sub_max_completion_tokens is not None:
@@ -2548,7 +2522,6 @@ class RLMEnv(vf.StatefulToolEnv):
             sub_prompt_verbosity=self.sub_prompt_verbosity,
             custom_system_prompt=self.custom_system_prompt,
             pip_install_packages=self.pip_install_packages,
-            expose_message_history=self.expose_message_history,
             root_max_completion_tokens=self.root_max_completion_tokens,
             sub_max_completion_tokens=self.sub_max_completion_tokens,
             sub_llm_max_turns=self.sub_llm_max_turns,
@@ -3549,12 +3522,10 @@ class RLMEnv(vf.StatefulToolEnv):
             # Initialize FIFO sequence counter for detecting stale responses
             state["_exec_seq"] = 0
 
-            # Initialize message history upload counter
-            state["_messages_uploaded_count"] = 0
-
             # Initialize context dropping state
             state["_keep_from_assistant_index"] = 0
             state["_summary_text"] = ""
+            state["_observable_messages"] = []
 
             _ensure_rlm_metric_state(state)
 
@@ -3738,20 +3709,9 @@ class RLMEnv(vf.StatefulToolEnv):
     # Message History Upload
     # =========================================================================
 
-    _SUMMARY_BLOCK_RE = re.compile(r"<SUMMARY>\n.*?\n</SUMMARY>\n\n", re.DOTALL)
-
     def _build_message_history(self, state: State) -> list[dict[str, Any]]:
-        """Build the serialized message history from the trajectory.
-
-        Reads from the last main trajectory step (which has the full
-        cumulative conversation in its prompt) and strips any injected
-        ``<SUMMARY>`` blocks so that ``.messages`` reflects the raw
-        conversation without summarization artifacts.
-        """
-        last_main = self._last_main_trajectory_step(state)
-        if last_main is None:
-            return []
-        messages = concat_messages([last_main["prompt"], last_main["completion"]])
+        """Build the serialized observable message history for `.messages`."""
+        messages = cast(Messages, state.get("_observable_messages", []))
         serialized: list[dict[str, Any]] = []
         for msg in messages:
             if hasattr(msg, "model_dump"):
@@ -3760,32 +3720,31 @@ class RLMEnv(vf.StatefulToolEnv):
                 entry = dict(msg)
             else:
                 continue
-            content = entry.get("content")
-            if isinstance(content, str) and "<SUMMARY>" in content:
-                entry["content"] = self._SUMMARY_BLOCK_RE.sub("", content)
             serialized.append(entry)
         return serialized
 
     async def _upload_message_history(self, state: State) -> None:
-        """Incrementally upload new messages to .messages (JSONL) in the sandbox."""
+        """Overwrite `.messages` in the sandbox with the observable transcript."""
         messages = self._build_message_history(state)
-        uploaded_count: int = state.get("_messages_uploaded_count", 0)
-        new_messages = messages[uploaded_count:]
-        if not new_messages and uploaded_count > 0:
-            return
 
-        session = self._executor._get_session(state)
+        try:
+            session = self._executor._get_session(state)
+        except RLMSessionError:
+            return
         assert session.sandbox_id is not None, "sandbox must be initialized"
         fs_root = session.sandbox_fs_root or state.get("rlm_fs_root_remote", "")
         remote_path = f"{fs_root}/.messages"
 
-        if new_messages:
-            lines = [json.dumps(msg, ensure_ascii=False) for msg in new_messages]
+        if messages:
+            lines = [json.dumps(msg, ensure_ascii=False) for msg in messages]
             delta = "\n".join(lines) + "\n"
             delta_b64 = base64.b64encode(delta.encode("utf-8")).decode("ascii")
-            cmd = f"echo '{delta_b64}' | base64 -d >> {remote_path}"
+            cmd = (
+                f"mkdir -p {shlex.quote(fs_root)} && "
+                f"echo '{delta_b64}' | base64 -d > {shlex.quote(remote_path)}"
+            )
         else:
-            cmd = f"touch {remote_path}"
+            cmd = f"mkdir -p {shlex.quote(fs_root)} && : > {shlex.quote(remote_path)}"
 
         try:
             await self._executor._execute_sandbox_command(
@@ -3793,7 +3752,6 @@ class RLMEnv(vf.StatefulToolEnv):
                 f"bash -lc {shlex.quote(cmd)}",
                 timeout=30,
             )
-            state["_messages_uploaded_count"] = len(messages)
         except Exception as e:
             logger.warning("Failed to upload message history: %s", e)
 
@@ -3824,8 +3782,7 @@ class RLMEnv(vf.StatefulToolEnv):
             len(code),
         )
 
-        if self.expose_message_history:
-            await self._upload_message_history(state)
+        await self._upload_message_history(state)
 
         execution_start = perf_counter()
         result = await self._execute_code(code, state)
@@ -3946,6 +3903,7 @@ class RLMEnv(vf.StatefulToolEnv):
         state["_summary_text"] = (
             f"{prev_summary}\n{section}" if prev_summary else section
         )
+        self._refresh_observable_summary_insertion(state)
 
         logger.debug(
             "[%s] main turn %d: summarize_turns: %d turn(s) dropped "
@@ -4062,6 +4020,11 @@ class RLMEnv(vf.StatefulToolEnv):
                 state["raw_prompt"] = state["prompt"]
             state["prompt"] = prompt_messages
         await super().add_model_response(state, prompt_messages, response)
+        if not state.get("_observable_messages"):
+            self._append_observable_messages(state, cast(Messages, state["prompt"]))
+        self._append_observable_messages(
+            state, cast(Messages, state["trajectory"][-1]["completion"])
+        )
 
     def _main_turn_count(self, state: State) -> int:
         """Count the number of main-model trajectory steps."""
@@ -4163,52 +4126,85 @@ class RLMEnv(vf.StatefulToolEnv):
         # Inject or replace summary in the first remaining assistant message
         if summary_text and remaining:
             first_asst = remaining[0]
-            summary_block = f"<SUMMARY>\n{summary_text}\n</SUMMARY>\n\n"
-            content = getattr(first_asst, "content", None)
-            if isinstance(content, str):
-                # Strip any existing summary block before prepending the new one
-                content = re.sub(
-                    r"<SUMMARY>\n.*?\n</SUMMARY>\n\n",
-                    "",
-                    content,
-                    count=1,
-                    flags=re.DOTALL,
-                )
-                remaining[0] = AssistantMessage(
-                    content=summary_block + content,
-                    tool_calls=getattr(first_asst, "tool_calls", None),
-                    reasoning_content=getattr(first_asst, "reasoning_content", None),
-                    thinking_blocks=getattr(first_asst, "thinking_blocks", None),
-                )
-            elif isinstance(content, list):
-                # Remove any existing summary text block, then prepend new one
-                filtered = [
-                    part
-                    for part in content
-                    if not (
-                        isinstance(part, dict)
-                        and part.get("type") == "text"
-                        and "<SUMMARY>" in str(part.get("text", ""))
-                    )
-                ]
-                new_content = [
-                    {"type": "text", "text": summary_block},
-                    *filtered,
-                ]
-                remaining[0] = AssistantMessage(
-                    content=new_content,
-                    tool_calls=getattr(first_asst, "tool_calls", None),
-                    reasoning_content=getattr(first_asst, "reasoning_content", None),
-                    thinking_blocks=getattr(first_asst, "thinking_blocks", None),
-                )
+            remaining[0] = self._with_summary_on_assistant_message(
+                first_asst, summary_text
+            )
 
         return preamble + remaining
+
+    def _with_summary_on_assistant_message(
+        self, message: Message, summary_text: str
+    ) -> AssistantMessage:
+        """Return an assistant message with the provided summary block applied."""
+        summary_block = f"<SUMMARY>\n{summary_text}\n</SUMMARY>\n\n"
+        content = getattr(message, "content", None)
+        if isinstance(content, str):
+            content = re.sub(
+                r"^<SUMMARY>\n.*?\n</SUMMARY>\n\n",
+                "",
+                content,
+                count=1,
+                flags=re.DOTALL,
+            )
+            content = summary_block + content if summary_text else content
+        elif isinstance(content, list):
+            filtered = [
+                part
+                for part in content
+                if not (
+                    isinstance(part, dict)
+                    and part.get("type") == "text"
+                    and "<SUMMARY>" in str(part.get("text", ""))
+                )
+            ]
+            content = (
+                [{"type": "text", "text": summary_block}, *filtered]
+                if summary_text
+                else filtered
+            )
+        else:
+            content = summary_block if summary_text else content
+
+        return AssistantMessage(
+            content=content,
+            tool_calls=getattr(message, "tool_calls", None),
+            reasoning_content=getattr(message, "reasoning_content", None),
+            thinking_blocks=getattr(message, "thinking_blocks", None),
+        )
+
+    def _refresh_observable_summary_insertion(self, state: State) -> None:
+        """Move the cumulative summary block onto the current visible assistant turn."""
+        observable = cast(Messages, state.get("_observable_messages", []))
+        if not observable:
+            return
+
+        target_assistant_index = state.get("_keep_from_assistant_index", 0)
+        summary_text = state.get("_summary_text", "")
+        assistant_index = 0
+
+        for i, message in enumerate(observable):
+            if getattr(message, "role", None) != "assistant":
+                continue
+            if summary_text and assistant_index == target_assistant_index:
+                observable[i] = self._with_summary_on_assistant_message(
+                    message, summary_text
+                )
+            else:
+                observable[i] = self._with_summary_on_assistant_message(message, "")
+            assistant_index += 1
+
+    def _append_observable_messages(self, state: State, messages: Messages) -> None:
+        """Append messages to the observable transcript."""
+        observable = cast(list[Message], state.setdefault("_observable_messages", []))
+        observable.extend(_clone_messages(messages))
 
     async def env_response(
         self, messages: Messages, state: State, **kwargs
     ) -> Messages:
         """Override to set final_env_response when answer is ready, root budget or context turn limit is exhausted."""
         tool_messages = await super().env_response(messages, state, **kwargs)
+        if tool_messages:
+            self._append_observable_messages(state, tool_messages)
         if "final_answer" in state:
             state["final_env_response"] = tool_messages
         elif self._is_root_budget_exhausted(state):
@@ -4296,7 +4292,7 @@ class RLMEnv(vf.StatefulToolEnv):
                 await self._teardown_tunnel()
 
     async def render_completion(self, state: State):
-        """Render completion from main model steps only, ignoring sub-LLM steps."""
+        """Render the tracked observable main-model rollout."""
         rid = state.get("rollout_id", "?")
         _ensure_rlm_metric_state(state)
         logger.debug(
@@ -4312,26 +4308,9 @@ class RLMEnv(vf.StatefulToolEnv):
             state["completion"] = []
             return
 
-        # Find the last trajectory step from the main model (matching trajectory_id)
-        main_trajectory_id = state["trajectory_id"]
-        last_main_step = None
-        for step in reversed(state["trajectory"]):
-            if step.get("trajectory_id") == main_trajectory_id:
-                last_main_step = step
-                break
-
-        if last_main_step is None:
-            state["completion"] = []
-            return
-
-        last_prompt = last_main_step["prompt"]
-        last_completion = last_main_step["completion"]
-        full_conversation = concat_messages([last_prompt, last_completion])
-        if state.get("final_env_response"):
-            full_conversation = concat_messages(
-                [full_conversation, state["final_env_response"]]
-            )
-        state["completion"] = full_conversation[len(state["prompt"]) :]
+        observable = cast(Messages, state.get("_observable_messages", []))
+        prompt = cast(Messages, state.get("prompt", []))
+        state["completion"] = _clone_messages(observable[len(prompt) :])
 
     async def post_rollout(self, state: State):
         """Read final answer from worker if not already set."""


### PR DESCRIPTION
## Description

This PR simplifies `RLMEnv` transcript handling by making `.messages` always-on and using a single canonical transcript for both sandbox visibility and `render_completion()`.

Main changes:
- removed the deprecated `expose_message_history` path entirely
- made `.messages` an overwrite-on-update full transcript instead of incremental append
- tracked a canonical transcript in state and used it for both `.messages` and rendered completion
- stopped reconstructing completion history from the final compacted prompt state
- moved summary placement to `summarize_turns()` itself, so the cumulative `<SUMMARY>` block is attached to the assistant turn that currently carries it in the transcript
- simplified the prompt note for `.messages` and removed summary-specific wording from that prompt text

Why:
- reduces branching and state reconstruction logic
- makes observability more faithful and easier to reason about
- keeps full rollout history while still reflecting where summarization is currently attached

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `RLMEnv` records and exposes the conversation transcript and how `render_completion()` is derived, which can affect observability and rollout outputs. Risk is moderate due to state-shape changes and altered `.messages` write semantics, but scope is largely internal and covered by updated tests.
> 
> **Overview**
> **Transcript handling is simplified and made always-on.** The `expose_message_history` flag and incremental `.messages` append/upload counter are removed; the env now maintains a canonical `state["_observable_messages"]` transcript that is **always** uploaded before REPL execution.
> 
> **`.messages` semantics change to full overwrite and becomes the source of truth.** `_upload_message_history()` now rewrites the entire JSONL file each time (or truncates it empty), and `_build_message_history()` serializes directly from `_observable_messages` (including `<SUMMARY>` blocks).
> 
> **Completion rendering and summarization are aligned to the observable transcript.** `render_completion()` now slices from `_observable_messages` instead of reconstructing from the last trajectory step, tool responses are appended to the observable log as they occur, and `summarize_turns()` refreshes/moves the cumulative `<SUMMARY>` block onto the current target assistant turn in the observable transcript. Tests are updated accordingly and the prior summarization warning about missing `.messages` is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 474801d298ea75671bfd459a58708d3087c7701f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->