### PR TITLE
Prefer prime env inspect in environment skills

### DIFF
--- a/skills/browse-environments/SKILL.md
+++ b/skills/browse-environments/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: browse-environments
-description: Discover and inspect verifiers environments through the Prime ecosystem. Use when asked to find environments on the Hub, compare options, inspect metadata, check action status, pull local copies for inspection, or choose environment starting points before evaluation, training, or migration work.
+description: Discover and inspect verifiers environments through the Prime ecosystem. Use when asked to find environments on the Hub, compare options, inspect metadata, browse source files with `prime env inspect`, check action status, pull local copies when necessary, or choose environment starting points before evaluation, training, or migration work.
 ---
 
 # Browse Environments
@@ -24,12 +24,14 @@ prime env list --starred
    - Keep only candidates with passing latest action/CI status from `--show-actions` or `prime env status`.
    - Prefer candidates updated in roughly the last 2 months.
    - Prefer candidates on version `v0.1.8` or newer.
-4. Inspect details for shortlisted candidates:
+4. Inspect details and source for shortlisted candidates:
 ```bash
 prime env info owner/name
 prime env status owner/name
+prime env inspect owner/name
+prime env inspect owner/name README.md
 ```
-5. Pull source for deep inspection when needed:
+5. Pull source only when you need to edit locally, diff larger changes offline, or the inspect endpoint is unavailable:
 ```bash
 prime env pull owner/name -t ./tmp-env
 ```
@@ -51,12 +53,13 @@ For each candidate, collect:
 
 ## Prefer Official Ecosystem Paths
 1. Prefer Hub and Prime CLI workflows before manual third-party setup.
-2. Use install + smoke eval to validate real usability. Treat `prime eval run` as the canonical eval path and do not add `--skip-upload` unless the user explicitly requests that deviation:
+2. Prefer `prime env inspect` for quick code review before reaching for `prime env pull`.
+3. Use install + smoke eval to validate real usability. Treat `prime eval run` as the canonical eval path and do not add `--skip-upload` unless the user explicitly requests that deviation:
 ```bash
 prime env install owner/name
 prime eval run name -m gpt-4.1-mini -n 5
 ```
-3. For examples in the verifiers repository, use repo install path when available:
+4. For examples in the verifiers repository, use repo install path when available:
 ```bash
 prime env install reverse-text --from-repo
 ```

--- a/skills/create-environments/SKILL.md
+++ b/skills/create-environments/SKILL.md
@@ -21,6 +21,7 @@ prime eval run my-env -m gpt-4.1-mini -n 5
 ```bash
 prime env list --search "keyword"
 prime env info owner/name
+prime env inspect owner/name
 prime env install owner/name
 ```
 5. For repository examples, use repo install when available:
@@ -58,13 +59,19 @@ prime env install math-python --from-repo
 4. Benchmark runtime and remove avoidable bottlenecks before handoff.
 
 ### 3. Start From Hub Environment
-1. Install or pull the closest baseline:
+1. Inspect the closest baseline before changing anything:
+```bash
+prime env info owner/name
+prime env inspect owner/name
+prime env inspect owner/name README.md
+```
+2. Install or pull only when you need the package locally:
 ```bash
 prime env install owner/name
 prime env pull owner/name -t ./tmp-env
 ```
-2. Keep proven interfaces stable unless a migration is deliberate and explicit.
-3. Re-run smoke evals after each major change.
+3. Keep proven interfaces stable unless a migration is deliberate and explicit.
+4. Re-run smoke evals after each major change.
 
 ## Non-Negotiable Quality Rules
 1. Use deterministic, well-defined reward checks or LLM judges.

--- a/skills/review-environments/SKILL.md
+++ b/skills/review-environments/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-environments
-description: Review verifiers environments for correctness, robustness, and ecosystem compatibility. Use when asked for environment code review, quality audit, migration validation, or release readiness checks for local environments or environments pulled from the Hub.
+description: Review verifiers environments for correctness, robustness, and ecosystem compatibility. Use when asked for environment code review, quality audit, migration validation, or release readiness checks for local environments, environments browsed with `prime env inspect`, or environments pulled from the Hub.
 ---
 
 # Review Environments
@@ -10,21 +10,28 @@ Find correctness risks and regressions first, then assess maintainability and ec
 
 ## Review Input Modes
 1. Local environment module in `./environments/<env_name>`.
-2. Pulled Hub environment via `prime env pull owner/name`.
-3. Installed package under active workspace.
+2. Hub environment browsed remotely via `prime env inspect owner/name`.
+3. Pulled Hub environment via `prime env pull owner/name`.
+4. Installed package under active workspace.
 
 ## Review Workflow
 1. Identify environment contract:
 - `load_environment(...)`
 - base class and rollout behavior
 - rubric and metrics
-2. Verify installability and runtime entrypoint with the canonical eval path. Do not add `--skip-upload` unless the user explicitly requests that deviation; standard runs save automatically for the private Evaluations tab and `prime eval tui`:
+2. If the environment lives on the Hub, inspect its README and source before pulling:
+```bash
+prime env info owner/name
+prime env inspect owner/name
+prime env inspect owner/name README.md
+```
+3. Verify installability and runtime entrypoint with the canonical eval path. Do not add `--skip-upload` unless the user explicitly requests that deviation; standard runs save automatically for the private Evaluations tab and `prime eval tui`:
 ```bash
 prime env install <env>
 prime eval run <env> -m gpt-4.1-mini -n 5
 ```
-3. Trace reward pipeline and validate scoring semantics.
-4. Run targeted checks for tool/stateful behavior where applicable.
+4. Trace reward pipeline and validate scoring semantics.
+5. Run targeted checks for tool/stateful behavior where applicable.
 
 ## Endpoint And Model Selection Nudge
 1. Encourage endpoint alias setup in `configs/endpoints.toml` for reproducible review runs.


### PR DESCRIPTION
## Summary
- update browse/create/review skills to use `prime env inspect` for quick source inspection
- keep `prime env pull` as the fallback when local files are actually needed
- align Hub-environment review and migration workflows around inspect-first discovery

## Notes
- docs-only change
- depends on the new `prime env inspect` CLI command and Environments Hub inspect API landing alongside it

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only updates that change recommended CLI workflows to be inspect-first; risk is limited to potential user confusion if `prime env inspect`/API isn’t available in some environments.
> 
> **Overview**
> Updates the environment-related skills to make `prime env inspect` the default way to review Hub environment source/README and metadata, before installing or pulling locally.
> 
> Clarifies that `prime env pull` is a fallback for cases where local edits/offline diffing are needed or remote inspection is unavailable, and adjusts the browse/create/review workflows and descriptions accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38de3eee0308657a6fac1bd163f84dfb3baf242f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->