### PR TITLE
RLMEnv: max_turns_in_context random sampling

### DIFF
--- a/tests/test_rlm_env.py
+++ b/tests/test_rlm_env.py
@@ -881,6 +881,118 @@ class TestRLMEnvInitialization:
     def test_bash_tool_removed(self, rlm_env):
         assert "bash" not in rlm_env.tool_map
 
+    # -- max_turns_in_context range validation --------------------------------
+
+    def test_max_turns_in_context_single_int(self):
+        dataset = make_dataset({})
+        env = build_env(dataset, max_turns_in_context=10, min_turns_in_context=3)
+        assert env._max_turns_in_context_range == (10, 10)
+
+    def test_max_turns_in_context_one_element_sequence(self):
+        dataset = make_dataset({})
+        env = build_env(dataset, max_turns_in_context=[10], min_turns_in_context=3)
+        assert env._max_turns_in_context_range == (10, 10)
+
+    def test_max_turns_in_context_two_element_sequence(self):
+        dataset = make_dataset({})
+        env = build_env(dataset, max_turns_in_context=[10, 20], min_turns_in_context=3)
+        assert env._max_turns_in_context_range == (10, 20)
+
+    def test_max_turns_in_context_tuple_input(self):
+        dataset = make_dataset({})
+        env = build_env(dataset, max_turns_in_context=(8, 15), min_turns_in_context=3)
+        assert env._max_turns_in_context_range == (8, 15)
+
+    def test_max_turns_in_context_none(self):
+        dataset = make_dataset({})
+        env = build_env(dataset, max_turns_in_context=None)
+        assert env._max_turns_in_context_range is None
+
+    def test_max_turns_in_context_equal_lo_hi(self):
+        dataset = make_dataset({})
+        env = build_env(dataset, max_turns_in_context=[10, 10], min_turns_in_context=3)
+        assert env._max_turns_in_context_range == (10, 10)
+
+    def test_max_turns_in_context_inverted_range_raises(self):
+        dataset = make_dataset({})
+        with pytest.raises(ValueError, match="max_turns_in_context"):
+            build_env(dataset, max_turns_in_context=[20, 10], min_turns_in_context=3)
+
+    def test_max_turns_in_context_three_elements_raises(self):
+        dataset = make_dataset({})
+        with pytest.raises(ValueError, match="max_turns_in_context"):
+            build_env(dataset, max_turns_in_context=[5, 10, 15], min_turns_in_context=3)
+
+    def test_max_turns_in_context_empty_sequence_raises(self):
+        dataset = make_dataset({})
+        with pytest.raises(ValueError, match="max_turns_in_context"):
+            build_env(dataset, max_turns_in_context=[], min_turns_in_context=3)
+
+    def test_max_turns_in_context_non_int_elements_raises(self):
+        dataset = make_dataset({})
+        with pytest.raises(ValueError, match="max_turns_in_context"):
+            build_env(dataset, max_turns_in_context=[5.0, 10.0], min_turns_in_context=3)
+
+    def test_max_turns_in_context_below_min_turns_raises(self):
+        dataset = make_dataset({})
+        with pytest.raises(ValueError, match="min_turns_in_context"):
+            build_env(dataset, max_turns_in_context=3, min_turns_in_context=3)
+
+    def test_max_turns_in_context_range_lo_below_min_turns_raises(self):
+        dataset = make_dataset({})
+        with pytest.raises(ValueError, match="min_turns_in_context"):
+            build_env(dataset, max_turns_in_context=[2, 10], min_turns_in_context=3)
+
+    def test_max_turns_in_context_range_sampling_in_setup_state(self):
+        """Sampled value should fall within the configured range."""
+        dataset = make_dataset({})
+        env = build_env(
+            dataset,
+            max_turns_in_context=[10, 20],
+            min_turns_in_context=3,
+            repl_language="python",
+            interception_url="http://test.invalid",
+        )
+        state = vf.State()
+        state["prompt"] = [UserMessage(content="test")]
+        state["trajectory"] = []
+        state["info"] = {}
+        state["_sampled_max_turns_in_context"] = None
+        # Manually sample the way setup_state does (without full sandbox setup)
+        lo, hi = env._max_turns_in_context_range
+        import random
+
+        random.seed(42)
+        samples = {random.randint(lo, hi) for _ in range(200)}
+        assert all(lo <= s <= hi for s in samples)
+        assert len(samples) > 1  # not degenerate
+
+    def test_max_turns_in_context_prompt_builder_receives_value(self):
+        """build_system_prompt should embed the sampled value in the prompt."""
+        dataset = make_dataset({})
+        env = build_env(
+            dataset,
+            max_turns_in_context=15,
+            min_turns_in_context=3,
+            repl_language="python",
+            interception_url="http://test.invalid",
+        )
+        prompt = env.prompt_builder.build_system_prompt(max_turns_in_context=15)
+        assert "15" in prompt
+        assert "turns in context" in prompt
+
+    def test_max_turns_in_context_prompt_builder_none_omits_note(self):
+        """build_system_prompt with None should not include the turn limit note."""
+        dataset = make_dataset({})
+        env = build_env(
+            dataset,
+            max_turns_in_context=None,
+            repl_language="python",
+            interception_url="http://test.invalid",
+        )
+        prompt = env.prompt_builder.build_system_prompt(max_turns_in_context=None)
+        assert "turns in context" not in prompt
+
 
 class TestToolSplitConfiguration:
     def test_repl_tool_name_collision_raises(self):
@@ -996,6 +1108,30 @@ class TestStopConditions:
         state = {}
         result = await rlm_env.answer_ready(state)
         assert result is False
+
+    def test_max_turns_in_context_reached_reads_from_state(self):
+        dataset = make_dataset({})
+        env = build_env(dataset, max_turns_in_context=[10, 20], min_turns_in_context=3)
+        main_id = "main"
+        state = vf.State()
+        state["trajectory_id"] = main_id
+        state["trajectory"] = [{"trajectory_id": main_id}] * 15
+        state["_keep_from_assistant_index"] = 0
+        state["_sampled_max_turns_in_context"] = 12
+        assert env._is_max_turns_in_context_reached(state) is True
+
+        state["_sampled_max_turns_in_context"] = 20
+        assert env._is_max_turns_in_context_reached(state) is False
+
+    def test_max_turns_in_context_reached_none_always_false(self):
+        dataset = make_dataset({})
+        env = build_env(dataset, max_turns_in_context=None)
+        state = vf.State()
+        state["trajectory_id"] = "main"
+        state["trajectory"] = [{"trajectory_id": "main"}] * 100
+        state["_keep_from_assistant_index"] = 0
+        state["_sampled_max_turns_in_context"] = None
+        assert env._is_max_turns_in_context_reached(state) is False
 
 
 # =============================================================================

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -26,6 +26,7 @@ import contextvars
 import json
 import logging
 import os
+import random
 import re
 import shlex
 import shutil
@@ -35,6 +36,7 @@ import tempfile
 import textwrap
 import time
 import uuid
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from time import perf_counter
@@ -1224,7 +1226,6 @@ In the end, the `ANSWER_CONTENT` environment variable must contain your answer. 
         enable_sub_llms: bool = True,
         enable_summarization: bool = False,
         min_turns_in_context: int = 3,
-        max_turns_in_context: int | None = None,
     ) -> None:
         self.repl_language = repl_language
         self.root_prompt_verbosity = root_prompt_verbosity
@@ -1239,7 +1240,6 @@ In the end, the `ANSWER_CONTENT` environment variable must contain your answer. 
         self.enable_sub_llms = enable_sub_llms
         self.enable_summarization = enable_summarization
         self.min_turns_in_context = min_turns_in_context
-        self.max_turns_in_context = max_turns_in_context
 
     def build_base_system_prompt(self) -> str:
         """Select the base system prompt or custom override."""
@@ -1339,18 +1339,18 @@ In the end, the `ANSWER_CONTENT` environment variable must contain your answer. 
 
         return "\n".join(lines)
 
-    def build_turn_limit_note(self) -> str:
+    def build_turn_limit_note(self, max_turns_in_context: int | None) -> str:
         """Return context-dropping documentation note, or empty string."""
-        if self.max_turns_in_context is None:
+        if max_turns_in_context is None:
             return ""
         note = (
-            f"\nYour session will end after {self.max_turns_in_context}"
+            f"\nYour session will end after {max_turns_in_context}"
             f" turns in context (each tool call counts as one turn)."
         )
         if self.enable_summarization:
             note += (
                 " Use `summarize_turns` to drop old turns and stay"
-                f" within this limit beyond {self.max_turns_in_context} turns."
+                f" within this limit beyond {max_turns_in_context} turns."
             )
         return note + "\n"
 
@@ -1374,7 +1374,7 @@ In the end, the `ANSWER_CONTENT` environment variable must contain your answer. 
             f"across all llm_batch() calls.\n"
         )
 
-    def build_system_prompt(self) -> str:
+    def build_system_prompt(self, max_turns_in_context: int | None = None) -> str:
         """Assemble the full RLM system prompt, wrapped in scaffolding tags."""
         if self.repl_language == "bash":
             message_history_note = """
@@ -1400,7 +1400,7 @@ history = [json.loads(line) for line in open(".messages")]
             + self.build_root_budget_note()
             + self.build_sub_budget_note()
             + message_history_note
-            + self.build_turn_limit_note()
+            + self.build_turn_limit_note(max_turns_in_context)
         )
         return "<SCAFFOLDING>\n" + body + "\n</SCAFFOLDING>\n\n"
 
@@ -2248,10 +2248,14 @@ class RLMEnv(vf.StatefulToolEnv):
         min_turns_in_context: Minimum turns that must remain after summarization
                    (default: 3). Only has effect when enable_summarization=True.
         max_turns_in_context: Maximum number of visible turns in context before
-                   the rollout is stopped. Without summarization this behaves
+                   the rollout is stopped. Accepts a single int or a sequence
+                   of one or two ints. When two values ``[lo, hi]`` are given,
+                   a limit is sampled uniformly at random from ``[lo, hi]``
+                   (inclusive) per rollout. Without summarization this behaves
                    identically to max_turns. With summarization it limits how
-                   many turns remain after compaction. None (default) means no
-                   limit beyond max_turns.
+                   many turns remain after compaction. The lower bound must be
+                   greater than ``min_turns_in_context``. None (default) means
+                   no limit beyond max_turns.
         max_output_length: Maximum length of code execution output
         max_sub_llm_parallelism: Maximum number of concurrent sub-LLM calls
         system_prompt: Custom system prompt (default: RLM standard prompt)
@@ -2352,7 +2356,7 @@ class RLMEnv(vf.StatefulToolEnv):
         enable_sub_llms: bool = True,
         enable_summarization: bool = False,
         min_turns_in_context: int = 3,
-        max_turns_in_context: int | None = None,
+        max_turns_in_context: int | Sequence[int] | None = None,
         max_output_length: int = 8192,
         max_sub_llm_parallelism: int = 5,
         system_prompt: str | None = None,
@@ -2416,15 +2420,38 @@ class RLMEnv(vf.StatefulToolEnv):
         self.abort_on_code_timeout = abort_on_code_timeout
         self.enable_summarization = enable_summarization
         self.min_turns_in_context = min_turns_in_context
-        self.max_turns_in_context = max_turns_in_context
-        if max_turns_in_context is not None and max_turns_in_context > max_turns:
-            logger.warning(
-                "max_turns_in_context=%d > max_turns=%d. "
-                "max_turns will always trigger first, making "
-                "max_turns_in_context ineffective.",
-                max_turns_in_context,
-                max_turns,
-            )
+        self._max_turns_in_context_range: tuple[int, int] | None = None
+        if max_turns_in_context is not None:
+            if isinstance(max_turns_in_context, int):
+                pair = (max_turns_in_context, max_turns_in_context)
+            else:
+                pair = tuple(max_turns_in_context)
+                if len(pair) == 1:
+                    pair = (pair[0], pair[0])
+            if (
+                len(pair) != 2
+                or not all(isinstance(v, int) for v in pair)
+                or pair[0] > pair[1]
+            ):
+                raise ValueError(
+                    f"max_turns_in_context must be an int or a 1-2 element "
+                    f"[lo, hi] sequence of ints; got {max_turns_in_context!r}"
+                )
+            if pair[0] <= min_turns_in_context:
+                raise ValueError(
+                    f"max_turns_in_context lower bound ({pair[0]}) must be "
+                    f"greater than min_turns_in_context ({min_turns_in_context})"
+                )
+            self._max_turns_in_context_range = cast(tuple[int, int], pair)
+            if pair[0] > max_turns:
+                logger.warning(
+                    "max_turns_in_context range [%d, %d] > max_turns=%d. "
+                    "max_turns will always trigger first, making "
+                    "max_turns_in_context ineffective.",
+                    pair[0],
+                    pair[1],
+                    max_turns,
+                )
         if not self.enable_sub_llms:
             if sub_max_completion_tokens is not None:
                 logger.warning(
@@ -2530,7 +2557,6 @@ class RLMEnv(vf.StatefulToolEnv):
             enable_sub_llms=self.enable_sub_llms,
             enable_summarization=self.enable_summarization,
             min_turns_in_context=self.min_turns_in_context,
-            max_turns_in_context=self.max_turns_in_context,
         )
 
         # Add the REPL tool (state is injected via update_tool_args)
@@ -3503,7 +3529,14 @@ class RLMEnv(vf.StatefulToolEnv):
             state["retain_filesystem_after_rollout"] = (
                 self.retain_filesystem_after_rollout
             )
-            state["rlm_system_prompt"] = self.prompt_builder.build_system_prompt()
+            if self._max_turns_in_context_range is not None:
+                lo, hi = self._max_turns_in_context_range
+                state["_sampled_max_turns_in_context"] = random.randint(lo, hi)
+            else:
+                state["_sampled_max_turns_in_context"] = None
+            state["rlm_system_prompt"] = self.prompt_builder.build_system_prompt(
+                max_turns_in_context=state["_sampled_max_turns_in_context"],
+            )
             state["rlm_root_tools"] = [
                 _tool_display_name(tool) for tool in self.root_tools
             ]
@@ -4225,12 +4258,13 @@ class RLMEnv(vf.StatefulToolEnv):
 
     def _is_max_turns_in_context_reached(self, state: State) -> bool:
         """Check if visible turns in context exceed max_turns_in_context."""
-        if self.max_turns_in_context is None:
+        limit = state.get("_sampled_max_turns_in_context")
+        if limit is None:
             return False
         visible = self._main_turn_count(state) - state.get(
             "_keep_from_assistant_index", 0
         )
-        return visible >= self.max_turns_in_context
+        return visible >= limit
 
     # =========================================================================
     # Stop Conditions


### PR DESCRIPTION
## Description

Allow max_turns_in_context to accept a [lo, hi] range for per-rollout random sampling.

max_turns_in_context now accepts int | Sequence[int] | None. When a two-element sequence is given, a limit is sampled uniformly from [lo, hi] per rollout. The lower bound must exceed min_turns_in_context. The sampled value is stored in state and passed to the prompt builder so each rollout sees its own limit.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [x] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rollout stop-condition behavior by sampling and persisting a per-rollout `max_turns_in_context` limit, which could alter termination timing and prompt content across runs. Added validation reduces misconfiguration risk but the new randomness can affect reproducibility if not controlled.
> 
> **Overview**
> Adds support for configuring `max_turns_in_context` as either a single int or a 1–2 element range, with **per-rollout uniform random sampling** when a range is provided.
> 
> The sampled limit is stored in state (`_sampled_max_turns_in_context`), used by `_is_max_turns_in_context_reached`, and threaded into `RLMPromptBuilder.build_system_prompt` so the system prompt reflects the rollout-specific turn limit. Extensive new tests cover input validation, sampling behavior, prompt inclusion/omission, and stop-condition evaluation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 482f8d18b8b7e94eb30de4ee1827d96697e4a6d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->