### PR TITLE
Add per-rollout auth to interception servers

### DIFF
--- a/assets/lab/environments/AGENTS.md
+++ b/assets/lab/environments/AGENTS.md
@@ -576,7 +576,7 @@ class MyGameEnv(vf.MultiTurnEnv):
         return state.get("lives", 1) <= 0
 ```
 
-`MultiTurnEnv` includes built-in stop conditions for errors, prompt length limits, and `max_turns` by default.
+`MultiTurnEnv` includes built-in stop conditions for errors, prompt length limits, `max_turns`, and `max_total_completion_tokens` by default.
 
 Execution order can be controlled with `priority` (higher runs first). This is useful for checking cheap conditions before expensive ones:
 
@@ -891,7 +891,11 @@ These require additional dependencies installed via extras (e.g., `uv add 'verif
 Newer and more experimental environment classes include:
 
 - **`GymEnv`** — universal runner for Gym-compatible environments (OpenAI Gym / Gymnasium API)
-- **`CliAgentEnv`** — runs custom agent code inside sandboxes, intercepting API requests. Accepts sandbox configuration parameters including `docker_image`, `cpu_cores`, `memory_gb`, `disk_size_gb`, `gpu_count`, `timeout_minutes`, `environment_vars`, and `labels` for sandbox categorization. Also accepts retry tuning (like `max_retries`) and connection pooling ( like `sandbox_client_max_workers`) parameters via `SandboxMixin`
+- **`CliAgentEnv`** — runs custom agent code inside sandboxes, intercepting API requests. Accepts sandbox configuration parameters including `docker_image`, `cpu_cores`, `memory_gb`, `disk_size_gb`, `gpu_count`, `gpu_type`, `timeout_minutes`, `environment_vars`, and `labels` for sandbox categorization. Also accepts retry tuning (like `max_retries`) and connection pooling (like `sandbox_client_max_workers`) parameters via `SandboxMixin`. Subclasses can override `get_sandbox_resources(state)` for per-instance resource allocation and `build_env_vars(state)` for custom environment variables (`PROTECTED_ENV_VARS` cannot be overridden). VMs are auto-enabled when `gpu_count > 0`
+- **`ComposableEnv`** — `CliAgentEnv` subclass that separates *what to solve* (`TaskSet`) from *how to solve it* (`Harness`). Wire a task collection and an agent config together with zero subclassing. Delegates sandbox spec, instruction, setup, and env vars to the `TaskSet`; install script, run command, and system prompt to the `Harness`. Scoring is owned by per-taskset rubrics
+  - **`TaskSet`** / **`SandboxTaskSet`** — define task collections. `SandboxTaskSet` adds `SandboxSpec` (image, CPU, memory, GPU, timeout) per instance, a `setup(state)` hook, and `validate_instance(state)` for gold-patch validation. Key methods: `get_instruction(info)`, `get_rubric()`, `get_sandbox_spec(info)`, `get_env_vars()`. Includes `validate(n, concurrency)` for bulk validation and `filter()`/`take()` combinators
+  - **`Harness`** — agent-side config dataclass: `install_script`, `run_command`, `system_prompt`, `system_prompt_path`, `instruction_path`, `log_path`
+  - **`SandboxSpec`** — per-instance sandbox requirements: `image`, `cpu_cores`, `memory_gb`, `disk_size_gb`, `gpu_count`, `gpu_type`, `timeout_minutes`
 - **`HarborEnv`** — loads Harbor-format agent benchmark tasks
 - **`RLMEnv`** — implements [Recursive Language Models](https://alexzhang13.github.io/blog/2025/rlm/) for unbounded context processing via REPL-based decomposition and recursive sub-LLM calls
 - **`OpenCodeEnv`** — runs [OpenCode](https://opencode.ai) CLI agents inside sandboxes with API call interception

--- a/environments/AGENTS.md
+++ b/environments/AGENTS.md
@@ -576,7 +576,7 @@ class MyGameEnv(vf.MultiTurnEnv):
         return state.get("lives", 1) <= 0
 ```
 
-`MultiTurnEnv` includes built-in stop conditions for errors, prompt length limits, and `max_turns` by default.
+`MultiTurnEnv` includes built-in stop conditions for errors, prompt length limits, `max_turns`, and `max_total_completion_tokens` by default.
 
 Execution order can be controlled with `priority` (higher runs first). This is useful for checking cheap conditions before expensive ones:
 
@@ -891,7 +891,11 @@ These require additional dependencies installed via extras (e.g., `uv add 'verif
 Newer and more experimental environment classes include:
 
 - **`GymEnv`** — universal runner for Gym-compatible environments (OpenAI Gym / Gymnasium API)
-- **`CliAgentEnv`** — runs custom agent code inside sandboxes, intercepting API requests. Accepts sandbox configuration parameters including `docker_image`, `cpu_cores`, `memory_gb`, `disk_size_gb`, `gpu_count`, `timeout_minutes`, `environment_vars`, and `labels` for sandbox categorization. Also accepts retry tuning (like `max_retries`) and connection pooling ( like `sandbox_client_max_workers`) parameters via `SandboxMixin`
+- **`CliAgentEnv`** — runs custom agent code inside sandboxes, intercepting API requests. Accepts sandbox configuration parameters including `docker_image`, `cpu_cores`, `memory_gb`, `disk_size_gb`, `gpu_count`, `gpu_type`, `timeout_minutes`, `environment_vars`, and `labels` for sandbox categorization. Also accepts retry tuning (like `max_retries`) and connection pooling (like `sandbox_client_max_workers`) parameters via `SandboxMixin`. Subclasses can override `get_sandbox_resources(state)` for per-instance resource allocation and `build_env_vars(state)` for custom environment variables (`PROTECTED_ENV_VARS` cannot be overridden). VMs are auto-enabled when `gpu_count > 0`
+- **`ComposableEnv`** — `CliAgentEnv` subclass that separates *what to solve* (`TaskSet`) from *how to solve it* (`Harness`). Wire a task collection and an agent config together with zero subclassing. Delegates sandbox spec, instruction, setup, and env vars to the `TaskSet`; install script, run command, and system prompt to the `Harness`. Scoring is owned by per-taskset rubrics
+  - **`TaskSet`** / **`SandboxTaskSet`** — define task collections. `SandboxTaskSet` adds `SandboxSpec` (image, CPU, memory, GPU, timeout) per instance, a `setup(state)` hook, and `validate_instance(state)` for gold-patch validation. Key methods: `get_instruction(info)`, `get_rubric()`, `get_sandbox_spec(info)`, `get_env_vars()`. Includes `validate(n, concurrency)` for bulk validation and `filter()`/`take()` combinators
+  - **`Harness`** — agent-side config dataclass: `install_script`, `run_command`, `system_prompt`, `system_prompt_path`, `instruction_path`, `log_path`
+  - **`SandboxSpec`** — per-instance sandbox requirements: `image`, `cpu_cores`, `memory_gb`, `disk_size_gb`, `gpu_count`, `gpu_type`, `timeout_minutes`
 - **`HarborEnv`** — loads Harbor-format agent benchmark tasks
 - **`RLMEnv`** — implements [Recursive Language Models](https://alexzhang13.github.io/blog/2025/rlm/) for unbounded context processing via REPL-based decomposition and recursive sub-LLM calls
 - **`OpenCodeEnv`** — runs [OpenCode](https://opencode.ai) CLI agents inside sandboxes with API call interception

--- a/tests/test_interception_auth.py
+++ b/tests/test_interception_auth.py
@@ -8,6 +8,7 @@ Verifies that:
 """
 
 import asyncio
+from typing import Any
 
 import pytest
 from aiohttp import ClientSession
@@ -34,7 +35,11 @@ def _chat_payload(content: str = "hello") -> dict:
 
 
 async def _post(
-    base: str, rollout_id: str, token: str | None = None, timeout: float = 0.5
+    base: str,
+    rollout_id: str,
+    token: str | None = None,
+    timeout: float = 0.5,
+    payload: Any | None = None,
 ):
     """POST to a rollout endpoint, return (status, body) or 'timeout'."""
     headers = {}
@@ -44,7 +49,7 @@ async def _post(
         async with ClientSession() as session:
             async with session.post(
                 f"{base}/rollout/{rollout_id}/v1/chat/completions",
-                json=_chat_payload(),
+                json=_chat_payload() if payload is None else payload,
                 headers=headers,
                 timeout=__import__("aiohttp").ClientTimeout(total=timeout),
             ) as resp:
@@ -133,3 +138,41 @@ async def test_cross_rollout_blocked(server: InterceptionServer):
 
     server.unregister_rollout("rollout_a")
     server.unregister_rollout("rollout_b")
+
+
+@pytest.mark.asyncio
+async def test_missing_messages_rejected(server: InterceptionServer):
+    """Authenticated requests without messages return a 400 instead of crashing."""
+    token = generate_interception_token()
+    server.register_rollout("rollout_missing_messages", auth_token=token)
+    base = f"http://127.0.0.1:{server.port}"
+
+    status, body = await _post(
+        base,
+        "rollout_missing_messages",
+        token=token,
+        payload={"model": "test-model"},
+    )
+    assert status == 400
+    assert body["error"] == "Request body must include 'messages'"
+
+    server.unregister_rollout("rollout_missing_messages")
+
+
+@pytest.mark.asyncio
+async def test_non_object_body_rejected(server: InterceptionServer):
+    """Authenticated requests must send a JSON object."""
+    token = generate_interception_token()
+    server.register_rollout("rollout_non_object", auth_token=token)
+    base = f"http://127.0.0.1:{server.port}"
+
+    status, body = await _post(
+        base,
+        "rollout_non_object",
+        token=token,
+        payload=["not", "an", "object"],
+    )
+    assert status == 400
+    assert body["error"] == "Request body must be a JSON object"
+
+    server.unregister_rollout("rollout_non_object")

--- a/tests/test_interception_auth.py
+++ b/tests/test_interception_auth.py
@@ -1,0 +1,135 @@
+"""Tests for per-rollout authentication on the interception server.
+
+Verifies that:
+- Requests with valid tokens are accepted
+- Requests with invalid/missing tokens are rejected (401)
+- Unregistered rollout IDs are rejected (404)
+- Graceful fallback: rollouts registered without a token skip auth
+"""
+
+import asyncio
+
+import pytest
+from aiohttp import ClientSession
+
+from verifiers.utils.interception_utils import (
+    InterceptionServer,
+    generate_interception_token,
+)
+
+
+@pytest.fixture
+async def server():
+    srv = InterceptionServer(port=0)
+    await srv.start()
+    yield srv
+    await srv.stop()
+
+
+def _chat_payload(content: str = "hello") -> dict:
+    return {
+        "model": "test-model",
+        "messages": [{"role": "user", "content": content}],
+    }
+
+
+async def _post(
+    base: str, rollout_id: str, token: str | None = None, timeout: float = 0.5
+):
+    """POST to a rollout endpoint, return (status, body) or 'timeout'."""
+    headers = {}
+    if token is not None:
+        headers["Authorization"] = f"Bearer {token}"
+    try:
+        async with ClientSession() as session:
+            async with session.post(
+                f"{base}/rollout/{rollout_id}/v1/chat/completions",
+                json=_chat_payload(),
+                headers=headers,
+                timeout=__import__("aiohttp").ClientTimeout(total=timeout),
+            ) as resp:
+                body = await resp.json()
+                return resp.status, body
+    except asyncio.TimeoutError:
+        return "accepted", None
+
+
+@pytest.mark.asyncio
+async def test_valid_token_accepted(server: InterceptionServer):
+    """Request with the correct bearer token is accepted."""
+    token = generate_interception_token()
+    server.register_rollout("rollout_auth_ok", auth_token=token)
+    base = f"http://127.0.0.1:{server.port}"
+
+    result = await _post(base, "rollout_auth_ok", token=token)
+    # "accepted" means the server didn't reject — it's waiting for a model response
+    assert result[0] == "accepted" or result[0] == 200
+
+    server.unregister_rollout("rollout_auth_ok")
+
+
+@pytest.mark.asyncio
+async def test_missing_token_rejected(server: InterceptionServer):
+    """Request with no Authorization header is rejected when auth is configured."""
+    token = generate_interception_token()
+    server.register_rollout("rollout_no_token", auth_token=token)
+    base = f"http://127.0.0.1:{server.port}"
+
+    status, body = await _post(base, "rollout_no_token", token=None)
+    assert status == 401
+    assert body["error"] == "Unauthorized"
+
+    server.unregister_rollout("rollout_no_token")
+
+
+@pytest.mark.asyncio
+async def test_wrong_token_rejected(server: InterceptionServer):
+    """Request with an incorrect bearer token is rejected."""
+    token = generate_interception_token()
+    server.register_rollout("rollout_bad_token", auth_token=token)
+    base = f"http://127.0.0.1:{server.port}"
+
+    status, body = await _post(base, "rollout_bad_token", token="wrong-token")
+    assert status == 401
+    assert body["error"] == "Unauthorized"
+
+    server.unregister_rollout("rollout_bad_token")
+
+
+@pytest.mark.asyncio
+async def test_unknown_rollout_404(server: InterceptionServer):
+    """Request to a non-existent rollout ID returns 404."""
+    base = f"http://127.0.0.1:{server.port}"
+
+    status, body = await _post(base, "rollout_nonexistent", token=None)
+    assert status == 404
+
+
+@pytest.mark.asyncio
+async def test_no_token_graceful_fallback(server: InterceptionServer):
+    """Rollout registered without a token accepts any request (backwards compat)."""
+    server.register_rollout("rollout_no_auth")
+    base = f"http://127.0.0.1:{server.port}"
+
+    result = await _post(base, "rollout_no_auth", token=None)
+    # Should be accepted (not 401), waiting for model response
+    assert result[0] == "accepted" or result[0] == 200
+
+    server.unregister_rollout("rollout_no_auth")
+
+
+@pytest.mark.asyncio
+async def test_cross_rollout_blocked(server: InterceptionServer):
+    """Token for rollout A cannot be used to access rollout B."""
+    token_a = generate_interception_token()
+    token_b = generate_interception_token()
+    server.register_rollout("rollout_a", auth_token=token_a)
+    server.register_rollout("rollout_b", auth_token=token_b)
+    base = f"http://127.0.0.1:{server.port}"
+
+    # Use A's token to access B's endpoint
+    status, body = await _post(base, "rollout_b", token=token_a)
+    assert status == 401, "Cross-rollout access should be rejected"
+
+    server.unregister_rollout("rollout_a")
+    server.unregister_rollout("rollout_b")

--- a/tests/test_interception_utils.py
+++ b/tests/test_interception_utils.py
@@ -1,3 +1,5 @@
+import pytest
+
 from verifiers.types import (
     Response,
     ResponseMessage,
@@ -61,3 +63,8 @@ def test_serialize_intercept_response_passthrough_native_chat_completion():
     assert payload["object"] == "chat.completion"
     assert payload["model"] == "native-model"
     assert len(payload["choices"]) == 1
+
+
+def test_serialize_intercept_response_rejects_invalid_input_type():
+    with pytest.raises(TypeError, match="Unsupported intercepted response type: str"):
+        serialize_intercept_response("0")

--- a/tests/test_interception_utils.py
+++ b/tests/test_interception_utils.py
@@ -9,6 +9,7 @@ from verifiers.types import (
 )
 from verifiers.utils.interception_utils import (
     create_empty_completion,
+    has_valid_bearer_auth,
     serialize_intercept_response,
 )
 
@@ -68,3 +69,18 @@ def test_serialize_intercept_response_passthrough_native_chat_completion():
 def test_serialize_intercept_response_rejects_invalid_input_type():
     with pytest.raises(TypeError, match="Unsupported intercepted response type: str"):
         serialize_intercept_response("0")
+
+
+@pytest.mark.parametrize(
+    ("auth_header", "expected_token", "expected_valid"),
+    [
+        ("Bearer secret-token", "secret-token", True),
+        ("Bearer wrong-token", "secret-token", False),
+        ("", "secret-token", False),
+        ("", None, True),
+    ],
+)
+def test_has_valid_bearer_auth(
+    auth_header: str, expected_token: str | None, expected_valid: bool
+):
+    assert has_valid_bearer_auth(auth_header, expected_token) is expected_valid

--- a/tests/test_rlm_env.py
+++ b/tests/test_rlm_env.py
@@ -835,6 +835,24 @@ class TestBashToolHelper:
         assert captured["headers"]["Authorization"] == "Bearer secret-token"
 
 
+class TestRLMAuthCheck:
+    def test_check_rollout_auth_accepts_matching_bearer_token(self):
+        env = build_env(make_dataset({}))
+        request = MagicMock(headers={"Authorization": "Bearer secret-token"})
+
+        assert env._check_rollout_auth(request, {"auth_token": "secret-token"}) is None
+
+    def test_check_rollout_auth_rejects_wrong_bearer_token(self):
+        env = build_env(make_dataset({}))
+        request = MagicMock(headers={"Authorization": "Bearer wrong-token"})
+
+        response = env._check_rollout_auth(request, {"auth_token": "secret-token"})
+
+        assert response is not None
+        assert response.status == 401
+        assert json.loads(response.text)["error"] == "Unauthorized"
+
+
 # =============================================================================
 # 3. Initialization and Configuration
 # =============================================================================

--- a/tests/test_rlm_env.py
+++ b/tests/test_rlm_env.py
@@ -645,6 +645,7 @@ class TestBashToolHelper:
         argv: list[str],
         stdin_data: str = "",
         response_data: dict | None = None,
+        env_overrides: dict[str, str] | None = None,
     ) -> tuple[str, str, int, dict | None]:
         helper_source = extract_bash_helper_source()
         stdout_buffer = io.StringIO()
@@ -652,6 +653,8 @@ class TestBashToolHelper:
         env = {
             "RLM_ROOT_TOOL_URL": "http://example.invalid/",
         }
+        if env_overrides:
+            env.update(env_overrides)
         captured_payload: dict | None = None
         with patch("urllib.request.urlopen") as mock_urlopen:
 
@@ -664,6 +667,7 @@ class TestBashToolHelper:
                     "tool_name": data.get("tool_name"),
                     "args": args,
                     "kwargs": kwargs,
+                    "headers": dict(req.header_items()),
                 }
                 return response
 
@@ -818,6 +822,17 @@ class TestBashToolHelper:
         assert stderr == ""
         parsed = json.loads(stdout.strip())
         assert parsed == ["first", "second"]
+
+    def test_root_tool_auth_header_added_when_token_present(self):
+        stdout, stderr, code, captured = self._run_helper(
+            ["--tool", "other_tool", "--json", json.dumps({"args": [1]})],
+            env_overrides={"RLM_AUTH_TOKEN": "secret-token"},
+        )
+        assert code == 0
+        assert stderr == ""
+        assert "ok" in stdout
+        assert captured is not None
+        assert captured["headers"]["Authorization"] == "Bearer secret-token"
 
 
 # =============================================================================

--- a/verifiers/envs/experimental/cli_agent_env.py
+++ b/verifiers/envs/experimental/cli_agent_env.py
@@ -30,6 +30,7 @@ from verifiers.types import (
 from verifiers.utils.interception_utils import (
     InterceptionServer,
     deliver_response,
+    generate_interception_token,
     synthesize_stream,
 )
 from verifiers.utils.logging_utils import print_time, truncate
@@ -188,6 +189,8 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
 
         rollout_id = f"rollout_{uuid.uuid4().hex[:8]}"
         state["rollout_id"] = rollout_id
+        auth_token = generate_interception_token()
+        state["interception_auth_token"] = auth_token
 
         interception_server = self._require_interception_server()
         await interception_server.start()
@@ -227,7 +230,9 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
         await self.create_sandbox(state, sandbox_request)
 
         # Register rollout for interception
-        request_id_queue = interception_server.register_rollout(rollout_id)
+        request_id_queue = interception_server.register_rollout(
+            rollout_id, auth_token=auth_token
+        )
         state["request_id_queue"] = request_id_queue
         state["agent_completed"] = False
 
@@ -261,6 +266,7 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
     PROTECTED_ENV_VARS = frozenset(
         {
             "OPENAI_BASE_URL",
+            "OPENAI_API_KEY",
             "OPENAI_TIMEOUT",
             "OPENAI_REQUEST_TIMEOUT",
             "HTTPX_TIMEOUT",
@@ -272,6 +278,9 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
         """Build environment variables for the sandbox. Override to add custom vars."""
         env_vars = dict(self.environment_vars) if self.environment_vars else {}
         env_vars["OPENAI_BASE_URL"] = state["interception_base_url"]
+        auth_token = state.get("interception_auth_token")
+        if auth_token:
+            env_vars["OPENAI_API_KEY"] = auth_token
         env_vars.setdefault("OPENAI_TIMEOUT", "3600")
         env_vars.setdefault("OPENAI_REQUEST_TIMEOUT", "3600")
         env_vars.setdefault("HTTPX_TIMEOUT", "3600")

--- a/verifiers/envs/experimental/opencode_env.py
+++ b/verifiers/envs/experimental/opencode_env.py
@@ -358,7 +358,7 @@ class OpenCodeEnv(CliAgentEnv):
                     "name": "${OPENAI_MODEL%%/*}",
                     "options": {
                         "baseURL": "$OPENAI_BASE_URL",
-                        "apiKey": "intercepted",
+                        "apiKey": "${OPENAI_API_KEY:-intercepted}",
                         "timeout": self.provider_timeout_ms,
                     },
                     "models": {

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -79,6 +79,7 @@ from verifiers.types import (
 )
 from verifiers.utils.async_utils import maybe_await
 from verifiers.utils.data_utils import extract_boxed_answer
+from verifiers.utils.interception_utils import generate_interception_token
 from verifiers.utils.message_utils import concat_messages, from_raw_message
 from verifiers.utils.response_utils import (
     parse_response_message,
@@ -708,6 +709,7 @@ _RLM_BASH_TOOL_HELPER_SCRIPT = textwrap.dedent(
         "RLM_ROOT_TOOL_USER_AGENT", "python-requests/2.32.3"
     )
     SUB_LLM_TIMEOUT = int(os.environ.get("RLM_SUB_LLM_TIMEOUT", "300"))
+    _RLM_AUTH_TOKEN = os.environ.get("RLM_AUTH_TOKEN", "")
 
 
     def _decode_arg(raw: str):
@@ -727,15 +729,19 @@ _RLM_BASH_TOOL_HELPER_SCRIPT = textwrap.dedent(
             "kwargs": kwargs,
         }
 
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "User-Agent": ROOT_TOOL_USER_AGENT,
+        }
+        if _RLM_AUTH_TOKEN:
+            headers["Authorization"] = f"Bearer {_RLM_AUTH_TOKEN}"
+
         data = json.dumps(payload).encode("utf-8")
         req = urllib.request.Request(
             ROOT_TOOL_URL,
             data=data,
-            headers={
-                "Content-Type": "application/json",
-                "Accept": "application/json",
-                "User-Agent": ROOT_TOOL_USER_AGENT,
-            },
+            headers=headers,
             method="POST",
         )
         try:
@@ -3479,7 +3485,7 @@ class RLMEnv(vf.StatefulToolEnv):
         state["interception_url"] = interception_url
         state["root_tool_url"] = root_tool_url
 
-        auth_token = secrets.token_hex(32)
+        auth_token = generate_interception_token()
         state["interception_auth_token"] = auth_token
 
         self.active_rollouts[rollout_id] = {

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -27,6 +27,7 @@ import json
 import logging
 import os
 import re
+import secrets
 import shlex
 import shutil
 import sys
@@ -554,6 +555,8 @@ def _build_python_worker_script_template() -> str:
             "",
             'ROOT_TOOL_URL = os.environ.get("RLM_ROOT_TOOL_URL", "")',
             'ROOT_TOOL_NAMES_RAW = os.environ.get("RLM_ROOT_TOOL_NAMES", "[]")',
+            '_RLM_AUTH_TOKEN = os.environ.get("RLM_AUTH_TOKEN", "")',
+            '_RLM_AUTH_HEADERS = {"Authorization": f"Bearer {_RLM_AUTH_TOKEN}"} if _RLM_AUTH_TOKEN else {}',
             "try:",
             "    ROOT_TOOL_NAMES = json.loads(ROOT_TOOL_NAMES_RAW)",
             "except Exception:",
@@ -572,6 +575,7 @@ def _build_python_worker_script_template() -> str:
             "    resp = requests.post(",
             "        ROOT_TOOL_URL,",
             "        json=payload,",
+            "        headers=_RLM_AUTH_HEADERS,",
             "        timeout=SUB_LLM_TIMEOUT,",
             "    )",
             "    resp.raise_for_status()",
@@ -2619,6 +2623,7 @@ class RLMEnv(vf.StatefulToolEnv):
             "RLM_ROOT_TOOL_URL": state.get("root_tool_url", ""),
             "RLM_ROOT_TOOL_NAMES": json.dumps(self.root_tool_names),
             "RLM_SUB_LLM_TIMEOUT": str(self.sub_llm_timeout),
+            "RLM_AUTH_TOKEN": state.get("interception_auth_token", ""),
         }
 
     def _compute_fs_metadata(
@@ -3237,6 +3242,10 @@ class RLMEnv(vf.StatefulToolEnv):
         if not context:
             return web.json_response({"error": "Rollout not found"}, status=404)
 
+        auth_error = self._check_rollout_auth(request, context)
+        if auth_error is not None:
+            return auth_error
+
         try:
             request_body = await request.json()
         except Exception as e:
@@ -3314,12 +3323,30 @@ class RLMEnv(vf.StatefulToolEnv):
             response_body["result_repr"] = repr(result_value)
         return web.json_response(response_body)
 
+    def _check_rollout_auth(self, request: Any, context: dict) -> web.Response | None:
+        """Check bearer token for a rollout request. Returns error response or None."""
+        expected_token = context.get("auth_token")
+        if expected_token is not None:
+            auth_header = request.headers.get("Authorization", "")
+            bearer_token = (
+                auth_header.removeprefix("Bearer ")
+                if auth_header.startswith("Bearer ")
+                else ""
+            )
+            if not secrets.compare_digest(bearer_token, expected_token):
+                return web.json_response({"error": "Unauthorized"}, status=401)
+        return None
+
     async def _handle_sub_llm_request(self, request: Any) -> Any:
         """Handle sub-LLM requests from worker code."""
         rollout_id = request.match_info["rollout_id"]
         context = self.active_rollouts.get(rollout_id)
         if not context:
             return web.json_response({"error": "Rollout not found"}, status=404)
+
+        auth_error = self._check_rollout_auth(request, context)
+        if auth_error is not None:
+            return auth_error
 
         try:
             request_body = await request.json()
@@ -3452,11 +3479,15 @@ class RLMEnv(vf.StatefulToolEnv):
         state["interception_url"] = interception_url
         state["root_tool_url"] = root_tool_url
 
+        auth_token = secrets.token_hex(32)
+        state["interception_auth_token"] = auth_token
+
         self.active_rollouts[rollout_id] = {
             "client": state.get("client"),
             "model": state.get("model"),
             "sub_model": self.sub_model or state.get("model"),
             "state": state,
+            "auth_token": auth_token,
         }
         return state
 

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -27,7 +27,6 @@ import json
 import logging
 import os
 import re
-import secrets
 import shlex
 import shutil
 import sys
@@ -79,7 +78,10 @@ from verifiers.types import (
 )
 from verifiers.utils.async_utils import maybe_await
 from verifiers.utils.data_utils import extract_boxed_answer
-from verifiers.utils.interception_utils import generate_interception_token
+from verifiers.utils.interception_utils import (
+    generate_interception_token,
+    has_valid_bearer_auth,
+)
 from verifiers.utils.message_utils import concat_messages, from_raw_message
 from verifiers.utils.response_utils import (
     parse_response_message,
@@ -3331,16 +3333,11 @@ class RLMEnv(vf.StatefulToolEnv):
 
     def _check_rollout_auth(self, request: Any, context: dict) -> web.Response | None:
         """Check bearer token for a rollout request. Returns error response or None."""
-        expected_token = context.get("auth_token")
-        if expected_token is not None:
-            auth_header = request.headers.get("Authorization", "")
-            bearer_token = (
-                auth_header.removeprefix("Bearer ")
-                if auth_header.startswith("Bearer ")
-                else ""
-            )
-            if not secrets.compare_digest(bearer_token, expected_token):
-                return web.json_response({"error": "Unauthorized"}, status=401)
+        if not has_valid_bearer_auth(
+            request.headers.get("Authorization", ""),
+            context.get("auth_token"),
+        ):
+            return web.json_response({"error": "Unauthorized"}, status=401)
         return None
 
     async def _handle_sub_llm_request(self, request: Any) -> Any:

--- a/verifiers/utils/interception_utils.py
+++ b/verifiers/utils/interception_utils.py
@@ -1,12 +1,13 @@
 """Utilities for intercepting API calls from agents running in sandboxes."""
 
 import asyncio
+from collections.abc import Mapping
 import json
 import logging
 import secrets
 import time
 import uuid
-from typing import Any, cast
+from typing import Any, Protocol, cast, runtime_checkable
 
 from aiohttp import web
 from openai.types.chat import (
@@ -28,6 +29,11 @@ from verifiers.types import Response
 from verifiers.utils.logging_utils import truncate
 
 logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class SupportsModelDump(Protocol):
+    def model_dump(self) -> dict[str, Any]: ...
 
 
 class InterceptionServer:
@@ -425,7 +431,9 @@ def _response_content_to_text(content: Any) -> str:
     return ""
 
 
-def serialize_intercept_response(response: Any) -> dict[str, Any]:
+def serialize_intercept_response(
+    response: Response | SupportsModelDump | Mapping[str, object],
+) -> dict[str, Any]:
     """Serialize intercepted responses to OpenAI ChatCompletion JSON shape."""
     if isinstance(response, Response):
         message = response.message
@@ -470,9 +478,20 @@ def serialize_intercept_response(response: Any) -> dict[str, Any]:
 
         return output
 
-    if hasattr(response, "model_dump"):
-        return response.model_dump()
-    return dict(response)
+    if isinstance(response, SupportsModelDump):
+        model_dump = response.model_dump()
+        if isinstance(model_dump, Mapping):
+            return dict(model_dump)
+        raise TypeError("model_dump() must return a mapping")
+
+    if isinstance(response, Mapping):
+        return dict(response)
+
+    raise TypeError(
+        "Unsupported intercepted response type: "
+        f"{type(response).__name__}. Expected Response, model_dump()-compatible "
+        "object, or mapping."
+    )
 
 
 def _log_request(rollout_id: str, body: dict) -> None:

--- a/verifiers/utils/interception_utils.py
+++ b/verifiers/utils/interception_utils.py
@@ -153,6 +153,17 @@ class InterceptionServer:
         except Exception as e:
             return web.json_response({"error": f"Invalid JSON: {e}"}, status=400)
 
+        if not isinstance(request_body, dict):
+            return web.json_response(
+                {"error": "Request body must be a JSON object"}, status=400
+            )
+        if "messages" not in request_body:
+            return web.json_response(
+                {"error": "Request body must include 'messages'"}, status=400
+            )
+        if not isinstance(request_body["messages"], list):
+            return web.json_response({"error": "'messages' must be a list"}, status=400)
+
         _log_request(rollout_id, request_body)
 
         is_streaming = request_body.get("stream", False)

--- a/verifiers/utils/interception_utils.py
+++ b/verifiers/utils/interception_utils.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import logging
+import secrets
 import time
 import uuid
 from typing import Any, cast
@@ -99,10 +100,13 @@ class InterceptionServer:
                     self._site = None
                     self._app = None
 
-    def register_rollout(self, rollout_id: str) -> asyncio.Queue:
+    def register_rollout(
+        self, rollout_id: str, auth_token: str | None = None
+    ) -> asyncio.Queue:
         request_queue: asyncio.Queue = asyncio.Queue()
         self.active_rollouts[rollout_id] = {
             "request_id_queue": request_queue,
+            "auth_token": auth_token,
         }
         return request_queue
 
@@ -132,6 +136,17 @@ class InterceptionServer:
         context = self.active_rollouts.get(rollout_id)
         if not context:
             return web.json_response({"error": "Rollout not found"}, status=404)
+
+        expected_token = context.get("auth_token")
+        if expected_token is not None:
+            auth_header = request.headers.get("Authorization", "")
+            bearer_token = (
+                auth_header.removeprefix("Bearer ")
+                if auth_header.startswith("Bearer ")
+                else ""
+            )
+            if not secrets.compare_digest(bearer_token, expected_token):
+                return web.json_response({"error": "Unauthorized"}, status=401)
 
         try:
             request_body = await request.json()
@@ -228,6 +243,11 @@ class InterceptionServer:
         except ConnectionResetError:
             logger.debug(f"[{rollout_id}] Client disconnected before write_eof")
         return response
+
+
+def generate_interception_token() -> str:
+    """Generate a cryptographically random token for rollout authentication."""
+    return secrets.token_hex(32)
 
 
 def deliver_response(

--- a/verifiers/utils/interception_utils.py
+++ b/verifiers/utils/interception_utils.py
@@ -38,7 +38,7 @@ class SupportsModelDump(Protocol):
 
 def has_valid_bearer_auth(auth_header: str, expected_token: str | None) -> bool:
     """Return whether the bearer auth header matches the expected token."""
-    if expected_token is None:
+    if not expected_token:
         return True
     bearer_token = (
         auth_header.removeprefix("Bearer ") if auth_header.startswith("Bearer ") else ""

--- a/verifiers/utils/interception_utils.py
+++ b/verifiers/utils/interception_utils.py
@@ -36,6 +36,16 @@ class SupportsModelDump(Protocol):
     def model_dump(self) -> dict[str, Any]: ...
 
 
+def has_valid_bearer_auth(auth_header: str, expected_token: str | None) -> bool:
+    """Return whether the bearer auth header matches the expected token."""
+    if expected_token is None:
+        return True
+    bearer_token = (
+        auth_header.removeprefix("Bearer ") if auth_header.startswith("Bearer ") else ""
+    )
+    return secrets.compare_digest(bearer_token, expected_token)
+
+
 class InterceptionServer:
     """
     HTTP server that intercepts API requests from agents.
@@ -143,16 +153,11 @@ class InterceptionServer:
         if not context:
             return web.json_response({"error": "Rollout not found"}, status=404)
 
-        expected_token = context.get("auth_token")
-        if expected_token is not None:
-            auth_header = request.headers.get("Authorization", "")
-            bearer_token = (
-                auth_header.removeprefix("Bearer ")
-                if auth_header.startswith("Bearer ")
-                else ""
-            )
-            if not secrets.compare_digest(bearer_token, expected_token):
-                return web.json_response({"error": "Unauthorized"}, status=401)
+        if not has_valid_bearer_auth(
+            request.headers.get("Authorization", ""),
+            context.get("auth_token"),
+        ):
+            return web.json_response({"error": "Unauthorized"}, status=401)
 
         try:
             request_body = await request.json()


### PR DESCRIPTION
## Summary

- The interception server (used by `CliAgentEnv`, `OpenCodeEnv`, `OpenCodeRLMEnv`) and the RLM inline server accept unauthenticated HTTP requests routed only by rollout ID. Model-generated code running inside a sandbox can read its `OPENAI_BASE_URL` env var, extract the tunnel base URL, and POST to a sibling rollout's endpoint — injecting a request into another rollout's training loop with no auth barrier.
- This PR adds per-rollout bearer token authentication: a random 256-bit token is generated at rollout setup, stored server-side, passed to the sandbox (as `OPENAI_API_KEY` for CliAgentEnv / `RLM_AUTH_TOKEN` for RLMEnv), and verified via `Authorization: Bearer <token>` on every request using constant-time comparison.
- Rollouts registered without a token skip the check, preserving backwards compatibility.

## Changes

- **`interception_utils.py`**: `register_rollout()` accepts optional `auth_token`; handler checks bearer token with `secrets.compare_digest`; new `generate_interception_token()` helper
- **`cli_agent_env.py`**: generates token, passes to `register_rollout()`, sets `OPENAI_API_KEY` in sandbox env vars (OpenAI SDK sends it as `Authorization: Bearer` automatically), adds `OPENAI_API_KEY` to `PROTECTED_ENV_VARS`
- **`rlm_env.py`**: generates token, stores in `active_rollouts`, checks in both `_handle_sub_llm_request` and `_handle_root_tool_request`, passes to worker via `RLM_AUTH_TOKEN` env var, worker includes it in `requests.post()` headers

## Test plan

- [x] `tests/test_interception_auth.py` — 6 new tests: valid token accepted, missing token rejected (401), wrong token rejected (401), unknown rollout (404), graceful fallback (no token = no check), cross-rollout token rejected
- [x] All 243 existing related tests pass (`interception`, `composable`, `rlm`, `opencode_rlm`, `xml_parser`)
- [x] `ruff check`, `ruff format`, `pre-commit run --all-files` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds authentication to internal interception and RLM HTTP endpoints and changes how sandboxes/agents pass credentials, which is security-sensitive and could break agent traffic if tokens are mishandled.
> 
> **Overview**
> Introduces **per-rollout bearer-token authentication** for interception endpoints to prevent cross-rollout request injection. Rollouts can now be registered with an `auth_token`, requests are validated via constant-time comparison, and missing/invalid tokens return `401` while unknown rollouts return `404`.
> 
> Updates `CliAgentEnv` and `RLMEnv` to generate a fresh token per rollout, store it in state/server context, and pass it into sandbox/worker processes (`OPENAI_API_KEY` / `RLM_AUTH_TOKEN`) so outbound calls include `Authorization: Bearer ...`; `OpenCodeEnv` is updated to read `OPENAI_API_KEY` when present. Adds stricter request-body validation on the interception server plus new unit tests covering auth success/failure, cross-rollout blocking, and bad payload handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71a758550c74fc8874e9dcb3d2ce22d463235e72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->