### PR TITLE
docs: prefix prime eval models

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ prime env install primeintellect/math-python
 
 To run a local evaluation with any OpenAI-compatible model, do:
 ```bash
-prime eval run my-env -m gpt-5-nano # run and save eval results locally
+prime eval run my-env -m openai/gpt-5-nano # run and save eval results locally
 ```
 Evaluations use [Prime Inference](https://docs.primeintellect.ai/inference/overview) by default; configure your own API endpoints in `./configs/endpoints.toml`.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -226,7 +226,7 @@ prime env init my-environment
 prime env install my-environment
 
 # Test your environment
-prime eval run my-environment -m gpt-4.1-mini -n 5
+prime eval run my-environment -m openai/gpt-4.1-mini -n 5
 ```
 
 ### Environment Module Structure
@@ -284,7 +284,7 @@ uv run ty check verifiers             # Type check (matches CI Ty target)
 # Environment tools
 prime env init new-env                       # Create environment
 prime env install new-env                    # Install environment
-prime eval run new-env -m gpt-4.1-mini -n 5  # Test environment
+prime eval run new-env -m openai/gpt-4.1-mini -n 5  # Test environment
 prime eval tui                               # Browse evals in the tree browser
 ```
 

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -310,7 +310,7 @@ async def judge_correctness(prompt, completion, answer, judge) -> float:
 judge_rubric.add_reward_func(judge_correctness)
 ```
 
-The `judge` callable formats a prompt comparing the model's response to the ground truth and returns the judge model's verdict. By default, `JudgeRubric` constructs its own `AsyncOpenAI()` client, so bare model ids like `gpt-4.1-mini` assume direct OpenAI credentials. If you want to judge through Prime Inference or another OpenAI-compatible endpoint, pass a configured `judge_client` and use the model id format that endpoint expects (for Prime Inference, for example, `openai/gpt-4.1-mini`).
+The `judge` callable formats a prompt comparing the model's response to the ground truth and returns the judge model's verdict.
 
 For more control, JudgeRubric accepts a custom `judge_prompt` template and exposes its internals (`judge_client`, `judge_model`, `judge_prompt`, `judge_sampling_args`) as class objects:
 

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -310,7 +310,7 @@ async def judge_correctness(prompt, completion, answer, judge) -> float:
 judge_rubric.add_reward_func(judge_correctness)
 ```
 
-The `judge` callable formats a prompt comparing the model's response to the ground truth and returns the judge model's verdict.
+The `judge` callable formats a prompt comparing the model's response to the ground truth and returns the judge model's verdict. By default, `JudgeRubric` constructs its own `AsyncOpenAI()` client, so bare model ids like `gpt-4.1-mini` assume direct OpenAI credentials. If you want to judge through Prime Inference or another OpenAI-compatible endpoint, pass a configured `judge_client` and use the model id format that endpoint expects (for Prime Inference, for example, `openai/gpt-4.1-mini`).
 
 For more control, JudgeRubric accepts a custom `judge_prompt` template and exposes its internals (`judge_client`, `judge_model`, `judge_prompt`, `judge_sampling_args`) as class objects:
 

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -27,7 +27,7 @@ Environments must be installed as Python packages before evaluation. From a loca
 
 ```bash
 prime env install my-env           # installs ./environments/my_env as a package
-prime eval run my-env -m gpt-4.1-mini -n 10
+prime eval run my-env -m openai/gpt-4.1-mini -n 10
 ```
 
 `prime eval` imports the environment module using Python's import system, calls its `load_environment()` function, runs 5 examples with 3 rollouts each (the default), scores them using the environment's rubric, and prints aggregate metrics.

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -7,7 +7,7 @@
 Use `prime eval run` with a small sample:
 
 ```bash
-prime eval run my-environment -m gpt-4.1-mini -n 5
+prime eval run my-environment -m openai/gpt-4.1-mini -n 5
 ```
 
 The `-s` flag prints sample outputs so you can see what's happening.
@@ -32,7 +32,7 @@ vf.print_prompt_completions_sample(outputs, n=3)
 Set the `VF_LOG_LEVEL` environment variable:
 
 ```bash
-VF_LOG_LEVEL=DEBUG prime eval run my-environment -m gpt-4.1-mini -n 5
+VF_LOG_LEVEL=DEBUG prime eval run my-environment -m openai/gpt-4.1-mini -n 5
 ```
 
 ## Environments

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -88,7 +88,7 @@ prime env install primeintellect/math-python
 
 To run a local evaluation with any OpenAI-compatible model, do:
 ```bash
-prime eval run my-env -m gpt-5-nano # run and save eval results locally
+prime eval run my-env -m openai/gpt-5-nano # run and save eval results locally
 ```
 Evaluations use [Prime Inference](https://docs.primeintellect.ai/inference/overview) by default; configure your own API endpoints in `./configs/endpoints.toml`.
 

--- a/environments/README.md
+++ b/environments/README.md
@@ -5,7 +5,7 @@ This folder contains installable example environments that showcase common usage
 ## Quick start
 
 - **Install an environment from this GitHub repo**: `prime env install math-python --from-repo`
-- **Evaluate**: `prime eval run math-python` (defaults to gpt-4.1-mini, small sample)
+- **Evaluate**: `prime eval run math-python` (defaults to openai/gpt-4.1-mini, small sample)
 
 ## Common usage patterns and examples
 

--- a/environments/alphabet_sort/README.md
+++ b/environments/alphabet_sort/README.md
@@ -29,7 +29,7 @@ Configure model and sampling:
 
 ```bash
 prime eval run alphabet-sort \
-  -m gpt-4.1-mini \
+  -m openai/gpt-4.1-mini \
   -n 20 -r 3 -t 1024 -T 0.7 \
   -a '{"max_turns": 3, "min_turns": 1, "min_names_per_turn": 1, "max_names_per_turn": 5, "similarity_power": 4}'
 ```

--- a/environments/browser_cua_example/README.md
+++ b/environments/browser_cua_example/README.md
@@ -61,7 +61,7 @@ prime eval run browser-cua-example -m openai/gpt-4o-mini -a '{"use_sandbox": fal
 By default, CUA mode uses a pre-built Docker image (`deepdream19/cua-server:latest`) for fastest startup. The image includes the CUA server binary and all dependencies pre-installed:
 
 ```bash
-prime eval run browser-cua-example -m openai/gpt-4.1-mini -b https://api.openai.com/v1 -k OPENAI_API_KEY
+prime eval run browser-cua-example -m gpt-4.1-mini -b https://api.openai.com/v1 -k OPENAI_API_KEY
 ```
 
 This is the recommended approach for production use. Startup is ~5-10 seconds compared to ~30-60 seconds with binary upload.
@@ -71,7 +71,7 @@ This is the recommended approach for production use. Startup is ~5-10 seconds co
 If you need to use a custom version of the CUA server, disable the prebuilt image to build and upload the binary at runtime:
 
 ```bash
-prime eval run browser-cua-example -m openai/gpt-4.1-mini -b https://api.openai.com/v1 -k OPENAI_API_KEY -a '{"use_prebuilt_image": false}'
+prime eval run browser-cua-example -m gpt-4.1-mini -b https://api.openai.com/v1 -k OPENAI_API_KEY -a '{"use_prebuilt_image": false}'
 ```
 
 This mode:
@@ -95,14 +95,14 @@ For local development, you can run the CUA server manually:
 
 2. **Run the evaluation with sandbox disabled**:
    ```bash
-   prime eval run browser-cua-example -m openai/gpt-4.1-mini -b https://api.openai.com/v1 -k OPENAI_API_KEY -a '{"use_sandbox": false}'
+   prime eval run browser-cua-example -m gpt-4.1-mini -b https://api.openai.com/v1 -k OPENAI_API_KEY -a '{"use_sandbox": false}'
    ```
 
 ### Custom Server URL
 
 If running the CUA server on a different port:
 ```bash
-prime eval run browser-cua-example -m openai/gpt-4.1-mini -b https://api.openai.com/v1 -k OPENAI_API_KEY -a '{"use_sandbox": false, "server_url": "http://localhost:8080"}'
+prime eval run browser-cua-example -m gpt-4.1-mini -b https://api.openai.com/v1 -k OPENAI_API_KEY -a '{"use_sandbox": false, "server_url": "http://localhost:8080"}'
 ```
 
 ## Environment Arguments

--- a/environments/browser_cua_example/browser_cua_example.py
+++ b/environments/browser_cua_example/browser_cua_example.py
@@ -12,7 +12,7 @@ for fastest startup (~5-10s). No manual server setup is required.
 
 Usage:
     # Default (pre-built image - fastest, recommended)
-    prime eval run browser-cua-example -m openai/gpt-4.1-mini -b https://api.openai.com/v1 -k OPENAI_API_KEY
+    prime eval run browser-cua-example -m gpt-4.1-mini -b https://api.openai.com/v1 -k OPENAI_API_KEY
 
     # Binary upload mode (for custom server versions)
     prime eval run browser-cua-example -m openai/gpt-4.1-mini -a '{"use_prebuilt_image": false}'

--- a/environments/continuation_quality/README.md
+++ b/environments/continuation_quality/README.md
@@ -28,7 +28,7 @@ prime eval run continuation-quality
 Configure model and sampling:
 
 ```bash
-prime eval run continuation-quality   -m gpt-4.1-mini   -n 20 -r 3 -t 1024 -T 0.7   -a '{"key": "value"}'  # env-specific args as JSON
+prime eval run continuation-quality   -m openai/gpt-4.1-mini   -n 20 -r 3 -t 1024 -T 0.7   -a '{"key": "value"}'  # env-specific args as JSON
 ```
 
 Notes:

--- a/environments/doublecheck/README.md
+++ b/environments/doublecheck/README.md
@@ -29,7 +29,7 @@ Configure model and sampling:
 
 ```bash
 prime eval run doublecheck \
-  -m gpt-4.1-mini \
+  -m openai/gpt-4.1-mini \
   -n 20 -r 3 -t 1024 -T 0.7 \
   -a '{"dataset_name": "math", "dataset_split": "train", "num_train_examples": -1}'
 ```

--- a/environments/gsm8k/README.md
+++ b/environments/gsm8k/README.md
@@ -29,7 +29,7 @@ Configure model and sampling:
 
 ```bash
 prime eval run gsm8k \
-  -m gpt-4.1-mini \
+  -m openai/gpt-4.1-mini \
   -n 20 -r 3 -t 1024 -T 0.7 \
   -a '{"num_train_examples": -1, "num_eval_examples": -1}'
 ```

--- a/environments/math_group/README.md
+++ b/environments/math_group/README.md
@@ -29,7 +29,7 @@ Configure model and sampling:
 
 ```bash
 prime eval run math-group \
-  -m gpt-4.1-mini \
+  -m openai/gpt-4.1-mini \
   -n 20 -r 3 -t 1024 -T 0.7
 ```
 

--- a/environments/math_python/README.md
+++ b/environments/math_python/README.md
@@ -29,7 +29,7 @@ Configure model and sampling:
 
 ```bash
 prime eval run math-python \
-  -m gpt-4.1-mini \
+  -m openai/gpt-4.1-mini \
   -n 20 -r 3 -t 1024 -T 0.7 \
   -a '{"dataset_name": "math", "dataset_split": "train", "num_train_examples": -1}'
 ```

--- a/environments/mcp_search_env/README.md
+++ b/environments/mcp_search_env/README.md
@@ -34,7 +34,7 @@ prime eval run mcp-search-env
 Configure model and sampling:
 
 ```bash
-prime eval run mcp-search-env   -m gpt-4.1-mini   -n 1 -r 1
+prime eval run mcp-search-env   -m openai/gpt-4.1-mini   -n 1 -r 1
 ```
 
 Notes:

--- a/environments/mmmu/README.md
+++ b/environments/mmmu/README.md
@@ -28,7 +28,7 @@ prime eval run mmmu
 Configure model and sampling:
 
 ```bash
-prime eval run mmmu   -m gpt-4.1-mini   -n 20 -r 3 -t 1024 -T 0.7   -a '{"key": "value"}'  # env-specific args as JSON
+prime eval run mmmu   -m openai/gpt-4.1-mini   -n 20 -r 3 -t 1024 -T 0.7   -a '{"key": "value"}'  # env-specific args as JSON
 ```
 
 Notes:

--- a/environments/opencode_harbor/README.md
+++ b/environments/opencode_harbor/README.md
@@ -24,7 +24,7 @@ prime eval run opencode-harbor
 Configure model and sampling:
 
 ```bash
-prime eval run opencode-harbor   -m gpt-4.1-mini   -n 20 -r 3 -t 1024 -T 0.7   -a '{"key": "value"}'  # env-specific args as JSON
+prime eval run opencode-harbor   -m openai/gpt-4.1-mini   -n 20 -r 3 -t 1024 -T 0.7   -a '{"key": "value"}'  # env-specific args as JSON
 ```
 
 Notes:

--- a/environments/openenv_echo/README.md
+++ b/environments/openenv_echo/README.md
@@ -48,7 +48,7 @@ Configure model and sampling:
 
 ```bash
 prime eval run openenv-echo \
-  -m gpt-4.1-mini \
+  -m openai/gpt-4.1-mini \
   -n 20 -r 3 -t 1024 -T 0.7
 ```
 

--- a/environments/reasoning_gym_env/README.md
+++ b/environments/reasoning_gym_env/README.md
@@ -29,7 +29,7 @@ Configure model and sampling:
 
 ```bash
 prime eval run reasoning-gym-env \
-  -m gpt-4.1-mini \
+  -m openai/gpt-4.1-mini \
   -n 20 -r 3 -t 1024 -T 0.7 \
   -a '{"gym": "arc_1d", "num_train_examples": 2000, "num_eval_examples": 2000}'
 ```

--- a/environments/reverse_text/README.md
+++ b/environments/reverse_text/README.md
@@ -29,7 +29,7 @@ Configure model and sampling:
 
 ```bash
 prime eval run reverse-text \
-  -m gpt-4.1-mini \
+  -m openai/gpt-4.1-mini \
   -n 20 -r 3 -t 1024 -T 0.7
 ```
 

--- a/environments/self_reward/README.md
+++ b/environments/self_reward/README.md
@@ -29,7 +29,7 @@ Configure model and sampling:
 
 ```bash
 prime eval run self-reward \
-  -m gpt-4.1-mini \
+  -m openai/gpt-4.1-mini \
   -n 20 -r 3 -t 1024 -T 0.7 \
   -a '{"dataset_name": "your/dataset", "judge_model": "Qwen/Qwen3-0.6B", "base_url": "http://0.0.0.0:8000/v1", "api_key_var": "JUDGE_API_KEY"}'
 ```

--- a/environments/sentence_repeater/README.md
+++ b/environments/sentence_repeater/README.md
@@ -29,7 +29,7 @@ Configure model and sampling:
 
 ```bash
 prime eval run sentence-repeater \
-  -m gpt-4.1-mini \
+  -m openai/gpt-4.1-mini \
   -n 20 -r 3 -t 1024 -T 0.7
 ```
 

--- a/environments/terminus_harbor/README.md
+++ b/environments/terminus_harbor/README.md
@@ -24,7 +24,7 @@ prime eval run terminus-harbor
 Configure model and sampling:
 
 ```bash
-prime eval run terminus-harbor   -m gpt-4.1-mini   -n 20 -r 3 -t 1024 -T 0.7   -a '{"key": "value"}'  # env-specific args as JSON
+prime eval run terminus-harbor   -m openai/gpt-4.1-mini   -n 20 -r 3 -t 1024 -T 0.7   -a '{"key": "value"}'  # env-specific args as JSON
 ```
 
 Notes:

--- a/environments/tool_test/README.md
+++ b/environments/tool_test/README.md
@@ -29,7 +29,7 @@ Configure model and sampling:
 
 ```bash
 prime eval run tool-test \
-  -m gpt-4.1-mini \
+  -m openai/gpt-4.1-mini \
   -n 20 -r 3 -t 1024 -T 0.7 \
   -a '{"num_train_examples": 1000, "num_eval_examples": 100}'
 ```

--- a/environments/toxicity_explanation/README.md
+++ b/environments/toxicity_explanation/README.md
@@ -29,7 +29,7 @@ Configure model and sampling:
 
 ```bash
 prime eval run toxicity-explanation \
-  -m gpt-4.1-mini \
+  -m openai/gpt-4.1-mini \
   -n 20 -r 3 -t 1024 -T 0.7 \
   -a '{"judge_model": "gpt-4.1-mini", "judge_base_url": "https://api.openai.com/v1", "judge_api_key_var": "OPENAI_API_KEY", "max_examples": -1}'
 ```

--- a/environments/wiki_search/README.md
+++ b/environments/wiki_search/README.md
@@ -38,7 +38,7 @@ Configure model and sampling:
 
 ```bash
 prime eval run wiki-search \
-  -m gpt-4.1-mini \
+  -m openai/gpt-4.1-mini \
   -n 20 -r 3 -t 1024 -T 0.7 \
   -a '{"judge_model": "gpt-4.1-mini", "judge_base_url": "https://api.openai.com/v1", "judge_api_key_var": "OPENAI_API_KEY", "embed_model": "text-embedding-3-small", "embed_base_url": "https://api.openai.com/v1", "embed_api_key_var": "OPENAI_API_KEY"}'
 ```

--- a/environments/wordle/README.md
+++ b/environments/wordle/README.md
@@ -29,7 +29,7 @@ Configure model and sampling:
 
 ```bash
 prime eval run wordle \
-  -m gpt-4.1-mini \
+  -m openai/gpt-4.1-mini \
   -n 20 -r 3 -t 1024 -T 0.7 \
   -a '{"num_train_examples": 2000, "num_eval_examples": 20}'
 ```

--- a/skills/browse-environments/SKILL.md
+++ b/skills/browse-environments/SKILL.md
@@ -54,7 +54,7 @@ For each candidate, collect:
 2. Use install + smoke eval to validate real usability. Treat `prime eval run` as the canonical eval path and do not add `--skip-upload` unless the user explicitly requests that deviation:
 ```bash
 prime env install owner/name
-prime eval run name -m gpt-4.1-mini -n 5
+prime eval run name -m openai/gpt-4.1-mini -n 5
 ```
 3. For examples in the verifiers repository, use repo install path when available:
 ```bash

--- a/skills/create-environments/SKILL.md
+++ b/skills/create-environments/SKILL.md
@@ -14,7 +14,7 @@ Build production-quality verifiers environments that work immediately in the Pri
 ```bash
 prime env init my-env
 prime env install my-env
-prime eval run my-env -m gpt-4.1-mini -n 5
+prime eval run my-env -m openai/gpt-4.1-mini -n 5
 ```
 3. Treat `prime eval run` as the canonical eval path. It saves results automatically, so do not add `--skip-upload` unless the user explicitly requests that deviation.
 4. Prefer an existing environment as a starting point when possible:
@@ -78,12 +78,12 @@ prime env pull owner/name -t ./tmp-env
 Run these before claiming completion:
 ```bash
 prime env install my-env
-prime eval run my-env -m gpt-4.1-mini -n 5
-prime eval run my-env -m gpt-4.1-mini -n 50 -r 1 -s
+prime eval run my-env -m openai/gpt-4.1-mini -n 5
+prime eval run my-env -m openai/gpt-4.1-mini -n 50 -r 1 -s
 ```
 If multi-turn or tool-heavy, also run with higher rollouts:
 ```bash
-prime eval run my-env -m gpt-4.1-mini -n 30 -r 3 -s
+prime eval run my-env -m openai/gpt-4.1-mini -n 30 -r 3 -s
 ```
 
 ## Publish Gate Before Large Evals Or Training
@@ -99,7 +99,7 @@ prime env push my-env --visibility PRIVATE
 ```
 4. For hosted or large-scale workflows, prefer running with the Hub slug after push:
 ```bash
-prime eval run owner/my-env -m gpt-4.1-mini -n 200 -r 3 -s
+prime eval run owner/my-env -m openai/gpt-4.1-mini -n 200 -r 3 -s
 ```
 
 ## Synthetic Data

--- a/skills/evaluate-environments/SKILL.md
+++ b/skills/evaluate-environments/SKILL.md
@@ -16,15 +16,15 @@ Run reliable environment evaluations and produce actionable summaries, not raw l
 ## Core Loop
 1. Run a smoke evaluation first (do not require pre-install):
 ```bash
-prime eval run my-env -m gpt-4.1-mini -n 5
+prime eval run my-env -m openai/gpt-4.1-mini -n 5
 ```
 2. Use owner/env slug directly when evaluating Hub environments:
 ```bash
-prime eval run owner/my-env -m gpt-4.1-mini -n 5
+prime eval run owner/my-env -m openai/gpt-4.1-mini -n 5
 ```
 3. Scale only after smoke pass:
 ```bash
-prime eval run owner/my-env -m gpt-4.1-mini -n 200 -r 3 -s
+prime eval run owner/my-env -m openai/gpt-4.1-mini -n 200 -r 3 -s
 ```
 4. Treat ownerless env ids as local-first. If not found locally, rely on Prime resolution for your remote env where applicable.
 
@@ -71,7 +71,7 @@ prime env push my-env --visibility PRIVATE
 ```
 4. For hosted environment workflows, prefer running large jobs against the Hub slug:
 ```bash
-prime eval run owner/my-env -m gpt-4.1-mini -n 200 -r 3 -s
+prime eval run owner/my-env -m openai/gpt-4.1-mini -n 200 -r 3 -s
 ```
 
 ## Prefer Config-Driven Evals Beyond Smoke Tests

--- a/skills/optimize-environments/SKILL.md
+++ b/skills/optimize-environments/SKILL.md
@@ -89,6 +89,6 @@ Report findings sorted by severity:
 ## Verification
 After applying fixes, verify with a concurrency stress test:
 ```bash
-prime eval run <env> -m gpt-4.1-mini -n 64 -r 32 -c -1 -s
+prime eval run <env> -m openai/gpt-4.1-mini -n 64 -r 32 -c -1 -s
 ```
 Compare wall-clock time and the event loop lag which is periodically logged from the env server.

--- a/skills/optimize-with-environments/SKILL.md
+++ b/skills/optimize-with-environments/SKILL.md
@@ -30,11 +30,11 @@ headers = { "X-Custom-Header" = "value" }
 ## Core Workflow
 1. Verify baseline first with `prime eval run`. Keep the default save behavior and do not add `--skip-upload` unless the user explicitly requests that deviation:
 ```bash
-prime eval run my-env -m gpt-4.1-mini -n 50 -r 3 -s
+prime eval run my-env -m openai/gpt-4.1-mini -n 50 -r 3 -s
 ```
 2. Run GEPA:
 ```bash
-prime gepa run my-env -m gpt-4.1-mini -M gpt-4.1-mini -B 500 -n 100 -N 50
+prime gepa run my-env -m openai/gpt-4.1-mini -M openai/gpt-4.1-mini -B 500 -n 100 -N 50
 ```
 3. Or run from config:
 ```bash

--- a/skills/review-environments/SKILL.md
+++ b/skills/review-environments/SKILL.md
@@ -21,7 +21,7 @@ Find correctness risks and regressions first, then assess maintainability and ec
 2. Verify installability and runtime entrypoint with the canonical eval path. Do not add `--skip-upload` unless the user explicitly requests that deviation; standard runs save automatically for the private Evaluations tab and `prime eval tui`:
 ```bash
 prime env install <env>
-prime eval run <env> -m gpt-4.1-mini -n 5
+prime eval run <env> -m openai/gpt-4.1-mini -n 5
 ```
 3. Trace reward pipeline and validate scoring semantics.
 4. Run targeted checks for tool/stateful behavior where applicable.

--- a/skills/train-with-environments/SKILL.md
+++ b/skills/train-with-environments/SKILL.md
@@ -34,7 +34,7 @@ uv run prime-rl configs/prime-rl/wiki-search.toml
 1. Validate environment behavior before training with the canonical eval path. Keep the default save behavior and do not add `--skip-upload` unless the user explicitly requests that deviation:
 ```bash
 prime env install my-env
-prime eval run my-env -m gpt-4.1-mini -n 20 -r 3 -s
+prime eval run my-env -m openai/gpt-4.1-mini -n 20 -r 3 -s
 ```
 2. Confirm reward diversity exists at baseline.
 3. Start with conservative run length and inspect samples early.

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -161,7 +161,19 @@ def help_test_can_load_env(tmp_venv_dir: Path, env_dir: Path):
 
 def help_test_can_eval_env(tmp_venv_dir: Path, env_dir: Path):
     """Test that the environment can be run via vf-eval."""
-    eval_cmd = f"cd {tmp_venv_dir} && source .venv/bin/activate && uv run vf-eval {env_dir.name} -n 1 -r 1 -t 512"
+    if os.getenv("OPENAI_API_KEY"):
+        model_flags = "-m gpt-4.1-mini -b https://api.openai.com/v1 -k OPENAI_API_KEY"
+    elif os.getenv("PRIME_API_KEY"):
+        model_flags = (
+            "-m openai/gpt-4.1-mini -b https://api.pinference.ai/api/v1 -k PRIME_API_KEY"
+        )
+    else:
+        pytest.skip("Skipping vf-eval smoke test because no API key is configured")
+
+    eval_cmd = (
+        f"cd {tmp_venv_dir} && source .venv/bin/activate && "
+        f"uv run vf-eval {env_dir.name} {model_flags} -n 1 -r 1 -t 512"
+    )
     try:
         process = subprocess.run(
             eval_cmd,

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -164,9 +164,7 @@ def help_test_can_eval_env(tmp_venv_dir: Path, env_dir: Path):
     if os.getenv("OPENAI_API_KEY"):
         model_flags = "-m gpt-4.1-mini -b https://api.openai.com/v1 -k OPENAI_API_KEY"
     elif os.getenv("PRIME_API_KEY"):
-        model_flags = (
-            "-m openai/gpt-4.1-mini -b https://api.pinference.ai/api/v1 -k PRIME_API_KEY"
-        )
+        model_flags = "-m openai/gpt-4.1-mini -b https://api.pinference.ai/api/v1 -k PRIME_API_KEY"
     else:
         pytest.skip("Skipping vf-eval smoke test because no API key is configured")
 

--- a/tests/test_setup_script.py
+++ b/tests/test_setup_script.py
@@ -212,10 +212,10 @@ def test_run_setup_prints_post_setup_call_to_action(
     assert "idea -> environment -> eval -> training" in output
     assert "prime env init my-env" in output
     assert "prime env install my-env" not in output
-    assert "prime eval run my-env -m gpt-5-nano -n 5" in output
+    assert "prime eval run my-env -m openai/gpt-5-nano -n 5" in output
     assert "prime eval tui" in output
     assert "prime rl run configs/rl/wiki-search.toml" in output
-    assert "prime gepa run my-env -m gpt-5-nano" in output
+    assert "prime gepa run my-env -m openai/gpt-5-nano" in output
 
 
 def test_run_setup_prints_prime_rl_post_setup_call_to_action(

--- a/verifiers/scripts/init.py
+++ b/verifiers/scripts/init.py
@@ -34,7 +34,7 @@ Configure model and sampling:
 
 ```bash
 prime eval run {env_id_dash} \
-  -m gpt-4.1-mini \
+  -m openai/gpt-4.1-mini \
   -n 20 -r 3 -t 1024 -T 0.7 \
   -a '{{"key": "value"}}'  # env-specific args as JSON
 ```

--- a/verifiers/scripts/setup.py
+++ b/verifiers/scripts/setup.py
@@ -369,7 +369,7 @@ def print_post_setup_call_to_action(prime_rl: bool, primary_agent: str) -> None:
     command_table = Table.grid(padding=(0, 1))
     command_table.add_row("[bold green]$[/bold green]", "prime env init my-env")
     command_table.add_row(
-        "[bold green]$[/bold green]", "prime eval run my-env -m gpt-5-nano -n 5"
+        "[bold green]$[/bold green]", "prime eval run my-env -m openai/gpt-5-nano -n 5"
     )
     command_table.add_row("[bold green]$[/bold green]", "prime eval tui")
     if prime_rl:
@@ -382,7 +382,7 @@ def print_post_setup_call_to_action(prime_rl: bool, primary_agent: str) -> None:
             "[bold green]$[/bold green]", "prime rl run configs/rl/wiki-search.toml"
         )
     command_table.add_row(
-        "[bold green]$[/bold green]", "prime gepa run my-env -m gpt-5-nano"
+        "[bold green]$[/bold green]", "prime gepa run my-env -m openai/gpt-5-nano"
     )
 
     header_text = Text.assemble(


### PR DESCRIPTION
## Summary
- prefix `prime eval run` examples with `openai/` in evaluation, development, and FAQ docs
- clarify in `docs/environments.md` that `JudgeRubric` builds its own `AsyncOpenAI()` client by default
- keep bare `judge_model` examples in `JudgeRubric` snippets, and explain that Prime Inference requires a configured `judge_client` plus provider-prefixed model ids

## Why
`prime eval run` defaults to Prime Inference-style OpenAI-compatible routing, so provider-prefixed model ids like `openai/gpt-4.1-mini` are correct there. `JudgeRubric` is different: by default it uses a direct `AsyncOpenAI()` client, so bare model ids like `gpt-4.1-mini` remain the right default unless the caller explicitly passes a custom `judge_client`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are primarily documentation/example updates plus a small adjustment to env smoke tests to select model flags based on available API keys (or skip when none are configured).
> 
> **Overview**
> Updates documentation, environment READMEs, and scaffold templates to consistently use provider-prefixed model ids (e.g. `openai/gpt-4.1-mini`) in `prime eval run`/`prime gepa run` examples and setup output.
> 
> Adjusts the `tests/test_envs.py` vf-eval smoke test to pick OpenAI vs Prime Inference flags based on `OPENAI_API_KEY`/`PRIME_API_KEY`, and to `skip` when no key is configured.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12d7d6ca7014e9077a93851f2b6ba4e435c6a769. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->