### PR TITLE
Fix CliAgentEnv stuck on dead tunnel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "nest-asyncio>=1.6.0", # for jupyter notebooks
     "openai>=1.108.1",
     "openai-agents>=0.0.7",
-    "prime-tunnel>=0.1.5",
+    "prime-tunnel>=0.1.6",
     "prime-sandboxes>=0.2.19",
     "pydantic>=2.11.9",
     "requests",

--- a/verifiers/envs/experimental/cli_agent_env.py
+++ b/verifiers/envs/experimental/cli_agent_env.py
@@ -174,7 +174,7 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
                 if now - self._tunnel_last_checked > self.TUNNEL_CHECK_INTERVAL:
                     self._tunnel_last_checked = now
                     try:
-                        registered = await self._tunnel.check_registered()  # type: ignore[attr-defined]
+                        registered = await self._tunnel.check_registered()
                         if not registered:
                             self.logger.warning(
                                 "Tunnel registration expired server-side, recreating."

--- a/verifiers/envs/experimental/cli_agent_env.py
+++ b/verifiers/envs/experimental/cli_agent_env.py
@@ -174,7 +174,7 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
                 if now - self._tunnel_last_checked > self.TUNNEL_CHECK_INTERVAL:
                     self._tunnel_last_checked = now
                     try:
-                        registered = await self._tunnel.check_registered()
+                        registered = await self._tunnel.check_registered()  # type: ignore[attr-defined]
                         if not registered:
                             self.logger.warning(
                                 "Tunnel registration expired server-side, recreating."

--- a/verifiers/envs/experimental/cli_agent_env.py
+++ b/verifiers/envs/experimental/cli_agent_env.py
@@ -137,6 +137,8 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
         self.add_rubric(SandboxMonitorRubric())
         self.add_rubric(CliAgentMonitorRubric())
 
+    TUNNEL_CHECK_INTERVAL = 60.0  # seconds between server-side liveness checks
+
     def init_interception(
         self,
         interception_port: int = 8765,
@@ -147,6 +149,7 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
         self.interception_url = interception_url
         self._tunnel: Tunnel | None = None
         self._tunnel_lock = asyncio.Lock()
+        self._tunnel_last_checked: float = 0.0
         self._interception_server = InterceptionServer(port=interception_port)
 
     def _require_interception_server(self) -> InterceptionServer:
@@ -165,6 +168,24 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
                 self._tunnel.sync_stop()
                 self._tunnel = None
 
+            # Periodic server-side liveness check
+            if self._tunnel is not None:
+                now = time.time()
+                if now - self._tunnel_last_checked > self.TUNNEL_CHECK_INTERVAL:
+                    try:
+                        registered = await self._tunnel.check_registered()
+                        self._tunnel_last_checked = now
+                        if not registered:
+                            self.logger.warning(
+                                "Tunnel registration expired server-side, recreating."
+                            )
+                            self._tunnel.sync_stop()
+                            self._tunnel = None
+                    except Exception as e:
+                        self.logger.warning(
+                            f"Tunnel health check failed (will retry): {e}"
+                        )
+
             if self._tunnel is None:
                 interception_server = self._require_interception_server()
                 port = interception_server.port
@@ -176,6 +197,7 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
                 else:
                     self._tunnel = Tunnel(local_port=port)
                 url = await self._tunnel.start()
+                self._tunnel_last_checked = time.time()
                 self.logger.debug(f"Prime Tunnel started: {url}")
                 return url
             else:
@@ -352,6 +374,12 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
                     self.logger.warning(
                         f"Agent failed (exit_code={status.exit_code}) stdout={status.stdout}, stderr={status.stderr}"
                     )
+                    if len(state.get("trajectory", [])) == 0:
+                        stderr_snippet = (status.stderr or "")[:500]
+                        raise AgentError(
+                            f"Agent crashed before any LLM call "
+                            f"(exit_code={status.exit_code}): {stderr_snippet}"
+                        )
                 return
             await asyncio.sleep(1)
 

--- a/verifiers/envs/experimental/cli_agent_env.py
+++ b/verifiers/envs/experimental/cli_agent_env.py
@@ -172,9 +172,9 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
             if self._tunnel is not None:
                 now = time.time()
                 if now - self._tunnel_last_checked > self.TUNNEL_CHECK_INTERVAL:
+                    self._tunnel_last_checked = now
                     try:
                         registered = await self._tunnel.check_registered()
-                        self._tunnel_last_checked = now
                         if not registered:
                             self.logger.warning(
                                 "Tunnel registration expired server-side, recreating."


### PR DESCRIPTION
## Summary
- Raise `AgentError` when agent crashes (`exit_code!=0`) with empty trajectory (turns=0), instead of silently producing an empty trajectory
- Add periodic server-side tunnel liveness check in `get_tunnel_url()` using `Tunnel.check_registered()` — detects expired registrations and recreates the tunnel
- Throttle the check to once per 60s via `_tunnel_last_checked` to avoid API spam

## Context
A training run (rlm-swe) got stuck for 30+ hours because:
1. The Prime tunnel died server-side while the frpc process stayed alive
2. Every rollout's agent got `404 Tunnel Not Found`, crashed with `exit_code=1`
3. Empty trajectories (turns=0) were silently re-scheduled by the orchestrator in an infinite loop

Three gaps allowed this:
- **Gap 1** (fixed in companion PR): No way to check server-side tunnel health — only `is_running` (process liveness) existed
- **Gap 2** (this PR): Agent crash with empty trajectory was silent — `exit_code=1` stored but no `state["error"]` set
- **Gap 3** (this PR): Dead tunnel URL never refreshed — `get_tunnel_url` reused the same dead URL

Depends on: https://github.com/PrimeIntellect-ai/prime/pull/new/daniel/tunnel-check-registered

## Test plan
- [x] Code passes `ruff check` and `ruff format`
- [x] Syntax verified via `ast.parse`
- [ ] Integration test: start tunnel, delete via API, verify `get_tunnel_url` recreates
- [ ] Verify agent crash with empty trajectory now shows `AgentError` in orchestrator logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sandbox/agent execution control-flow and tunnel lifecycle management; failures could cause rollouts to error more aggressively or recreate tunnels unnecessarily, but changes are localized and throttled.
> 
> **Overview**
> Prevents `CliAgentEnv.get_tunnel_url()` from reusing a tunnel whose **server-side registration has expired** by adding a throttled (60s) `Tunnel.check_registered()` liveness check that recreates the tunnel when needed.
> 
> When the sandboxed agent exits non-zero **before any LLM call**, `poll_job_completion()` now raises `AgentError` with a stderr snippet instead of silently producing an empty trajectory.
> 
> Bumps the `prime-tunnel` dependency to `>=0.1.6` to support the new registration check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e097378723932a3cccafa44a6d022074d6a475ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->