### PR TITLE
harbor mcp support

### DIFF
--- a/environments/opencode_harbor/opencode_harbor.py
+++ b/environments/opencode_harbor/opencode_harbor.py
@@ -1,6 +1,8 @@
 import json
 import logging
+import shlex
 from pathlib import Path
+from typing import Any
 
 from verifiers.envs.experimental.harbor_env import HarborEnv
 
@@ -119,17 +121,19 @@ DATASETS = {
 
 
 def _build_opencode_config(
+    base_url: str,
     disabled_tools: list[str] | None = None,
     system_prompt_path: str | None = None,
+    mcp_servers: list[dict[str, Any]] | None = None,
 ) -> str:
     config: dict = {
-        "${SCHEMA_DOLLAR}schema": "https://opencode.ai/config.json",
+        "$schema": "https://opencode.ai/config.json",
         "provider": {
             "intercepted": {
                 "npm": "@ai-sdk/openai-compatible",
                 "name": "Intercepted",
                 "options": {
-                    "baseURL": "$OPENAI_BASE_URL",
+                    "baseURL": base_url,
                     "apiKey": "intercepted",
                     "timeout": 600000,
                 },
@@ -156,18 +160,25 @@ def _build_opencode_config(
 
         config["agent"] = {"build": build_config}
 
+    if mcp_servers:
+        mcp: dict[str, dict[str, Any]] = {}
+        for server in mcp_servers:
+            name = server["name"]
+            transport = server.get("transport", "sse")
+            if transport == "stdio":
+                cmd_list: list[str] = []
+                if server.get("command"):
+                    cmd_list.append(server["command"])
+                cmd_list.extend(server.get("args", []))
+                mcp[name] = {"type": "local", "command": cmd_list}
+            else:
+                mcp[name] = {"type": "remote", "url": server.get("url", "")}
+        config["mcp"] = mcp
+
     return json.dumps(config, indent=2)
 
 
-def _build_run_command(
-    agent_workdir: str,
-    disabled_tools: list[str] | None = None,
-    has_system_prompt: bool = False,
-) -> str:
-    # Path where we'll upload the system prompt in the sandbox
-    system_prompt_sandbox_path = "/opencode/prompt.txt" if has_system_prompt else None
-    config_json = _build_opencode_config(disabled_tools, system_prompt_sandbox_path)
-
+def _build_run_command(agent_workdir: str) -> str:
     return f"""
 set -e
 
@@ -175,18 +186,6 @@ apt-get update && apt-get install -y curl
 
 curl -fsSL https://opencode.ai/install | bash
 export PATH="$HOME/.opencode/bin:$PATH"
-
-# Create opencode config directory
-mkdir -p ~/.config/opencode
-
-# Preserve JSON schema key literal in unquoted heredoc while still expanding
-# OPENAI_BASE_URL.
-SCHEMA_DOLLAR='$'
-
-# Create opencode.json config
-cat > ~/.config/opencode/opencode.json << EOFCONFIG
-{config_json}
-EOFCONFIG
 
 mkdir -p /logs/agent
 
@@ -213,11 +212,7 @@ class OpenCodeHarborEnv(HarborEnv):
         self.disabled_tools = disabled_tools
 
         super().__init__(
-            run_command=_build_run_command(
-                agent_workdir,
-                disabled_tools=disabled_tools,
-                has_system_prompt=system_prompt_path is not None,
-            ),
+            run_command=_build_run_command(agent_workdir),
             dataset_path=dataset_path,
             tasks=tasks,
             agent_workdir=agent_workdir,
@@ -226,16 +221,16 @@ class OpenCodeHarborEnv(HarborEnv):
         )
 
     async def post_sandbox_setup(self, state) -> None:
-        """Upload Harbor task assets and optional system prompt after sandbox creation."""
+        """Upload Harbor task assets, system prompt, and OpenCode config after sandbox creation."""
         await super().post_sandbox_setup(state)
+
+        sandbox_id = state["sandbox_id"]
 
         if self.system_prompt_path:
             if not self.system_prompt_path.exists():
                 raise FileNotFoundError(
                     f"System prompt file not found: {self.system_prompt_path}"
                 )
-
-            sandbox_id = state["sandbox_id"]
             await self.sandbox_client.execute_command(
                 sandbox_id, "mkdir -p /opencode", working_dir=None
             )
@@ -243,6 +238,29 @@ class OpenCodeHarborEnv(HarborEnv):
                 sandbox_id, "/opencode/prompt.txt", str(self.system_prompt_path)
             )
             logger.info(f"Uploaded system prompt from {self.system_prompt_path}")
+
+        task_info: dict[str, Any] = state.get("info", {}) or {}
+        mcp_servers = task_info.get("mcp_servers") or []
+
+        system_prompt_sandbox_path = (
+            "/opencode/prompt.txt" if self.system_prompt_path else None
+        )
+        config_json = _build_opencode_config(
+            base_url=state["interception_base_url"],
+            disabled_tools=self.disabled_tools,
+            system_prompt_path=system_prompt_sandbox_path,
+            mcp_servers=mcp_servers,
+        )
+        escaped = shlex.quote(config_json)
+        await self.sandbox_client.execute_command(
+            sandbox_id,
+            f"mkdir -p ~/.config/opencode && echo {escaped} > ~/.config/opencode/opencode.json",
+            working_dir=None,
+        )
+        if mcp_servers:
+            logger.info(
+                f"Registered {len(mcp_servers)} MCP server(s) in OpenCode config"
+            )
 
 
 def load_environment(

--- a/tests/test_opencode_harbor.py
+++ b/tests/test_opencode_harbor.py
@@ -1,6 +1,5 @@
 import importlib.util
 import json
-import subprocess
 from pathlib import Path
 
 
@@ -22,36 +21,109 @@ def _load_opencode_module():
     return module
 
 
-def test_opencode_config_renders_valid_json_after_shell_expansion():
+FAKE_BASE_URL = "https://tunnel.example.invalid/rollout/abc123/v1"
+
+
+def test_opencode_config_renders_valid_json():
     module = _load_opencode_module()
-    run_command = module._build_run_command(
-        "/app",
+    config_str = module._build_opencode_config(
+        base_url=FAKE_BASE_URL,
         disabled_tools=["webfetch", "question"],
-        has_system_prompt=True,
+        system_prompt_path="/opencode/prompt.txt",
     )
 
-    prefix = "cat > ~/.config/opencode/opencode.json << EOFCONFIG\n"
-    suffix = "\nEOFCONFIG"
-    config_block = run_command.split(prefix, 1)[1].split(suffix, 1)[0]
-
-    script = f"""OPENAI_BASE_URL=https://example.invalid SCHEMA_DOLLAR='$' bash -lc 'cat <<EOFCONFIG
-{config_block}
-EOFCONFIG'"""
-    rendered = subprocess.run(
-        script,
-        shell=True,
-        executable="/bin/bash",
-        capture_output=True,
-        text=True,
-        check=True,
-    ).stdout
-
-    config = json.loads(rendered)
+    config = json.loads(config_str)
     assert config["$schema"] == "https://opencode.ai/config.json"
-    assert config["provider"]["intercepted"]["options"]["baseURL"] == (
-        "https://example.invalid"
-    )
+    assert config["provider"]["intercepted"]["options"]["baseURL"] == FAKE_BASE_URL
     assert "agent" in config
     assert config["agent"]["build"]["prompt"] == "{file:/opencode/prompt.txt}"
     assert config["agent"]["build"]["tools"]["webfetch"] is False
     assert config["agent"]["build"]["tools"]["question"] is False
+
+
+def test_opencode_config_with_mcp_servers():
+    module = _load_opencode_module()
+
+    mcp_servers = [
+        {
+            "name": "mcp-server",
+            "transport": "streamable-http",
+            "url": "http://mcp-server:8000/mcp",
+        },
+        {
+            "name": "local-tools",
+            "transport": "stdio",
+            "command": "/usr/bin/mcp-server",
+            "args": ["--verbose"],
+        },
+    ]
+    config_str = module._build_opencode_config(
+        base_url=FAKE_BASE_URL, mcp_servers=mcp_servers
+    )
+
+    config = json.loads(config_str)
+    assert "mcp" in config
+    assert config["mcp"]["mcp-server"] == {
+        "type": "remote",
+        "url": "http://mcp-server:8000/mcp",
+    }
+    assert config["mcp"]["local-tools"] == {
+        "type": "local",
+        "command": ["/usr/bin/mcp-server", "--verbose"],
+    }
+
+
+def test_opencode_config_no_mcp_when_empty():
+    module = _load_opencode_module()
+    config_str = module._build_opencode_config(base_url=FAKE_BASE_URL)
+    config = json.loads(config_str)
+    assert "mcp" not in config
+
+
+def test_opencode_config_mcp_sse_transport():
+    module = _load_opencode_module()
+
+    mcp_servers = [
+        {
+            "name": "sse-server",
+            "transport": "sse",
+            "url": "http://mcp-server:8000/sse",
+        },
+    ]
+    config_str = module._build_opencode_config(
+        base_url=FAKE_BASE_URL, mcp_servers=mcp_servers
+    )
+
+    config = json.loads(config_str)
+    assert config["mcp"]["sse-server"] == {
+        "type": "remote",
+        "url": "http://mcp-server:8000/sse",
+    }
+
+
+def test_opencode_config_mcp_stdio_no_args():
+    module = _load_opencode_module()
+
+    mcp_servers = [
+        {
+            "name": "simple-server",
+            "transport": "stdio",
+            "command": "/usr/bin/mcp-server",
+        },
+    ]
+    config_str = module._build_opencode_config(
+        base_url=FAKE_BASE_URL, mcp_servers=mcp_servers
+    )
+
+    config = json.loads(config_str)
+    assert config["mcp"]["simple-server"] == {
+        "type": "local",
+        "command": ["/usr/bin/mcp-server"],
+    }
+
+
+def test_run_command_does_not_contain_config():
+    module = _load_opencode_module()
+    run_command = module._build_run_command("/app")
+    assert "opencode.json" not in run_command
+    assert "opencode run" in run_command

--- a/verifiers/envs/experimental/harbor_env.py
+++ b/verifiers/envs/experimental/harbor_env.py
@@ -67,13 +67,16 @@ class HarborEnv(vf.CliAgentEnv):
 
             messages = [{"role": "user", "content": instruction}]
 
+            env_config = config.get("environment", {})
+
             task_entry = {
                 "example_id": len(tasks),
                 "task": task_dir.name,
                 "prompt": messages,
                 "info": {
                     "task_dir": str(task_dir),
-                    "docker_image": config.get("environment", {}).get("docker_image"),
+                    "docker_image": env_config.get("docker_image"),
+                    "mcp_servers": env_config.get("mcp_servers", []),
                     "config": config,
                 },
             }


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how OpenCode is configured by moving config creation from the startup script into async sandbox setup and injecting per-task MCP settings, which could break agent startup if quoting or state fields are wrong. Touches sandbox command execution and task metadata plumbing but stays scoped to the Harbor/OpenCode integration.
> 
> **Overview**
> Adds per-task **MCP server configuration** to the OpenCode Harbor environment: Harbor now reads `environment.mcp_servers` from each `task.toml` and surfaces it in task `info`, and `OpenCodeHarborEnv` writes an `opencode.json` that includes an `mcp` section (remote URL or local stdio command).
> 
> Refactors OpenCode config generation to take an explicit `base_url` (no shell env expansion) and moves config creation out of `_build_run_command` into `post_sandbox_setup`, where it uploads the optional system prompt and writes the config via a quoted `echo`. Tests are updated to validate the new config rendering and MCP mapping behavior, and to assert the run script no longer embeds config content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7071a706a72021f6c494384d30aace7edf9e4298. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->