### PR TITLE
Fix AgentError double-wrapping in poll_job_completion

### DIFF
--- a/verifiers/envs/experimental/cli_agent_env.py
+++ b/verifiers/envs/experimental/cli_agent_env.py
@@ -376,10 +376,12 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
                     )
                     if len(state.get("trajectory", [])) == 0:
                         stderr_snippet = (status.stderr or "")[:500]
-                        raise AgentError(
+                        error = AgentError(
                             f"Agent crashed before any LLM call "
                             f"(exit_code={status.exit_code}): {stderr_snippet}"
                         )
+                        state["error"] = error
+                        self.logger.error(str(error))
                 return
             await asyncio.sleep(1)
 


### PR DESCRIPTION
## Summary

`poll_job_completion()` was raising `AgentError`, which the generic `except Exception` handler in `wait_for_completion()` caught and re-wrapped as `AgentError("Agent polling failed: ...")`, obscuring the original crash context (exit code, stderr snippet).

Fix: set `state["error"]` directly in `poll_job_completion()` instead of raising. This is simpler and consistent with how errors propagate in this system — through state, not exceptions. The `except Exception` handler now only catches unexpected failures (network errors, API issues) where wrapping as `AgentError` is correct.

## Background: "Empty trajectory" warnings

Before #1127, when an agent crashed before any LLM call (e.g. dead tunnel), `poll_job_completion()` recorded the non-zero exit code but returned normally — no exception, no `state["error"]`. The rollout ended with an empty trajectory and no error.

The scheduler (`scheduler.py`) treats any rollout with `len(trajectory) == 0` as a failure and reschedules it. This path is **general** (not env-specific), but the **silent failure mode** — empty trajectory with no error to explain it — was specific to `CliAgentEnv`'s background-task architecture. In a normal `MultiTurnEnv`, the rollout loop catches `vf.Error` and sets `state["error"]`, so empty trajectories always have a corresponding error.

With a dead tunnel this created an infinite retry loop: scheduler reschedules → agent hits dead tunnel → crashes instantly → empty trajectory → reschedule → repeat. The only symptom was a flood of `"Empty trajectory ... re-scheduling"` warnings with no root cause.

PR #1127 fixed this by surfacing the crash as `AgentError`, but did so by raising — which hit the double-wrapping bug. This PR completes the fix by setting state directly.

Closes: related to #1127

🤖 Generated with [Claude Code](https://claude.com/claude-code)