### PR TITLE
chore: v0.1.12.dev5 dev release

### DIFF
--- a/assets/release/RELEASE_v0.1.12.dev5.md
+++ b/assets/release/RELEASE_v0.1.12.dev5.md
@@ -1,0 +1,15 @@
+# Verifiers v0.1.12.dev5 Release Notes
+
+*Date:* 04/14/2026
+
+## Highlights since v0.1.12.dev4
+
+- Moved all harnesses and tasksets from research-environments into verifiers proper. Environments can now import directly from `verifiers.envs.experimental.composable` instead of relying on relative path dependencies.
+
+## Changes included in v0.1.12.dev5 (since v0.1.12.dev4)
+
+### Features and enhancements
+
+- feat: move harnesses (rlm, opencode) and tasksets (swe, lean, math, cp, harbor) into `verifiers.envs.experimental.composable` (#1131)
+
+**Full Changelog**: https://github.com/PrimeIntellect-ai/verifiers/compare/v0.1.12.dev4...v0.1.12.dev5

--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.12.dev4"
+__version__ = "0.1.12.dev5"
 
 import importlib
 import os


### PR DESCRIPTION
## Summary
- Bump version to `0.1.12.dev5`
- Release notes for harnesses/tasksets move (#1131)

## Changes since v0.1.12.dev4
- feat: move harnesses (rlm, opencode) and tasksets (swe, lean, math, cp, harbor) into `verifiers.envs.experimental.composable` (#1131)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping only: a version constant bump and new markdown release notes, with no functional code changes.
> 
> **Overview**
> Bumps the package version to `0.1.12.dev5`.
> 
> Adds `RELEASE_v0.1.12.dev5.md` documenting the v0.1.12.dev5 highlights, including the prior move of harnesses/tasksets into `verifiers.envs.experimental.composable`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63c6cc906cdb53fc500c0f6143fc4b3d471e8eac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->