### PR TITLE
fix: port rlm harness dedup install script

### DIFF
--- a/verifiers/envs/experimental/composable/harnesses/rlm.py
+++ b/verifiers/envs/experimental/composable/harnesses/rlm.py
@@ -13,11 +13,11 @@ DEFAULT_APPEND_TO_SYSTEM_PROMPT_PATH = "/task/append_to_system_prompt.txt"
 
 
 def build_install_script(rlm_repo_url: str = DEFAULT_RLM_REPO_URL) -> str:
-    return (
-        "set -e; "
-        'command -v uv >/dev/null 2>&1 || { curl -LsSf https://astral.sh/uv/install.sh | sh; source "$HOME/.local/bin/env"; }; '
-        f'uv tool install --python 3.11 "rlm @ git+https://${{GH_TOKEN}}@{rlm_repo_url}"'
+    raw_base = rlm_repo_url.removesuffix(".git").replace(
+        "github.com", "raw.githubusercontent.com"
     )
+    url = f"https://${{GH_TOKEN}}@{raw_base}/main/install.sh"
+    return f"(curl -fsSL {url} || wget -qO- {url}) > /tmp/rlm-install.sh && bash /tmp/rlm-install.sh"
 
 
 def build_run_command(


### PR DESCRIPTION
## Summary
Ports research-environments#266 to the verifiers copy of the rlm harness. The install script was updated to use raw GitHub `install.sh` instead of `uv tool install` to avoid duplicate installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the RLM harness installs dependencies by executing a remote `install.sh`, which can affect reproducibility and runtime setup if the script or URL assumptions change.
> 
> **Overview**
> Updates the RLM composable harness install flow to **stop using `uv tool install`** and instead download and run the repo’s `install.sh` from `raw.githubusercontent.com` (authenticated via `GH_TOKEN`), with a `curl`/`wget` fallback.
> 
> This is intended to avoid duplicate installs and centralize installation logic in the upstream RLM script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8090941dec6b83576c89a85a590101cdb105e642. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->