### PR TITLE
fix: add tool_calls to TITO bridge dummy assistant

### DIFF
--- a/verifiers/clients/openai_chat_completions_token_client.py
+++ b/verifiers/clients/openai_chat_completions_token_client.py
@@ -2,7 +2,11 @@ from collections.abc import Mapping
 from typing import Any, Optional, cast
 
 from openai import AsyncOpenAI, BaseModel
-from openai.types.chat import ChatCompletion, ChatCompletionAssistantMessageParam
+from openai.types.chat import (
+    ChatCompletion,
+    ChatCompletionAssistantMessageParam,
+    ChatCompletionMessageToolCallParam,
+)
 
 from verifiers.clients.openai_chat_completions_client import (
     OpenAIChatCompletionsClient,
@@ -250,11 +254,11 @@ class OpenAIChatCompletionsTokenClient(OpenAIChatCompletionsClient):
             dummy_assistant: OpenAIChatMessage = ChatCompletionAssistantMessageParam(
                 role="assistant",
                 tool_calls=[
-                    {
-                        "id": tc_id,
-                        "type": "function",
-                        "function": {"name": "f", "arguments": "{}"},
-                    }
+                    ChatCompletionMessageToolCallParam(
+                        id=tc_id,
+                        type="function",
+                        function={"name": "f", "arguments": "{}"},
+                    )
                     for tc_id in tool_call_ids
                 ],
             )

--- a/verifiers/clients/openai_chat_completions_token_client.py
+++ b/verifiers/clients/openai_chat_completions_token_client.py
@@ -5,7 +5,10 @@ from openai import AsyncOpenAI, BaseModel
 from openai.types.chat import (
     ChatCompletion,
     ChatCompletionAssistantMessageParam,
-    ChatCompletionMessageToolCallParam,
+)
+from openai.types.chat.chat_completion_message_function_tool_call_param import (
+    ChatCompletionMessageFunctionToolCallParam,
+    Function,
 )
 
 from verifiers.clients.openai_chat_completions_client import (
@@ -254,10 +257,10 @@ class OpenAIChatCompletionsTokenClient(OpenAIChatCompletionsClient):
             dummy_assistant: OpenAIChatMessage = ChatCompletionAssistantMessageParam(
                 role="assistant",
                 tool_calls=[
-                    ChatCompletionMessageToolCallParam(
+                    ChatCompletionMessageFunctionToolCallParam(
                         id=tc_id,
                         type="function",
-                        function={"name": "f", "arguments": "{}"},
+                        function=Function(name="f", arguments="{}"),
                     )
                     for tc_id in tool_call_ids
                 ],

--- a/verifiers/clients/openai_chat_completions_token_client.py
+++ b/verifiers/clients/openai_chat_completions_token_client.py
@@ -231,9 +231,37 @@ class OpenAIChatCompletionsTokenClient(OpenAIChatCompletionsClient):
         # assistant and env response is correct, while avoiding template behaviors
         # that depend on the assistant being the last message (e.g., Qwen3's
         # context-dependent think block injection with add_generation_prompt=False).
-        dummy_assistant: OpenAIChatMessage = ChatCompletionAssistantMessageParam(
-            role="assistant", content="x"
-        )
+        # Collect tool_call_ids from leading tool messages so the dummy
+        # assistant satisfies chat-template validation ("tool message must
+        # follow an assistant message with a tool call").
+        tool_call_ids: list[str] = []
+        for msg in env_messages:
+            if _get_role(msg) != "tool":
+                break
+            tc_id = (
+                msg.get("tool_call_id")
+                if hasattr(msg, "get")
+                else getattr(msg, "tool_call_id", None)
+            )
+            if tc_id:
+                tool_call_ids.append(tc_id)
+
+        if tool_call_ids:
+            dummy_assistant: OpenAIChatMessage = ChatCompletionAssistantMessageParam(
+                role="assistant",
+                tool_calls=[
+                    {
+                        "id": tc_id,
+                        "type": "function",
+                        "function": {"name": "f", "arguments": "{}"},
+                    }
+                    for tc_id in tool_call_ids
+                ],
+            )
+        else:
+            dummy_assistant: OpenAIChatMessage = ChatCompletionAssistantMessageParam(
+                role="assistant", content="x"
+            )
 
         try:
             bridge_full_ids = await self.tokenize(


### PR DESCRIPTION
## Summary

- When the TITO bridge builds its dummy assistant message for dual-tokenization, it now includes `tool_calls` matching the `tool_call_id`s from any leading tool messages in the env response. This fixes chat templates (e.g. MiniMax-M2.5) that validate tool messages must follow an assistant with tool_calls: `"Message has tool role, but there was no previous assistant message with a tool call!"`
- The plain-user-message path (no tool calls) is unchanged — the dummy assistant still uses `content="x"`.

## What was tested

**Offline tokenizer tests** — bridge prefix property (base is prefix of full, bridge adds tokens):

| Model | single_tool | multi_tool | tool+user | plain_user |
|-------|:-----------:|:----------:|:---------:|:----------:|
| Qwen/Qwen3-0.6B | ✓ | ✓ | ✓ | ✓ |
| Qwen/Qwen3-4B | ✓ | ✓ | ✓ | ✓ |
| THUDM/GLM-4-9B-0414 | ✓ | ✓ | ✓ | ✓ |
| MiniMaxAI/MiniMax-M2.5 | ✓ | ✓ | ✓ | ✓ |

**Live vLLM integration tests** — bridge prefix property via real `/tokenize` endpoint:

| Model | single_tool | multi_tool | tool+user | plain_user |
|-------|:-----------:|:----------:|:---------:|:----------:|
| Qwen/Qwen3-0.6B | ✓ | ✓ | ✓ | ✓ |
| THUDM/GLM-4-9B-0414 | ✓ | ✓ | ✓ | ✓ |

**E2E test** — called `get_prompt_ids()` directly on a live Qwen3 vLLM server with a crafted multi-turn State (turn 1 = assistant with tool_calls, turn 2 = tool results as env_messages). All 4 message patterns return valid stitched token IDs (TITO succeeds, no MITO fallback).

**Regression** — full test suite: 888 passed, 4 failed (all pre-existing on main), 0 regressions.

## Test plan

- [x] Offline bridge prefix property: Qwen3-0.6B, Qwen3-4B, GLM-4-9B-0414, MiniMax-M2.5
- [x] Live vLLM bridge prefix: Qwen3-0.6B, GLM-4-9B-0414
- [x] E2E `get_prompt_ids()` through `OpenAIChatCompletionsTokenClient` on live vLLM
- [x] Existing unit tests pass (4/4 in `test_openai_chat_completions_token_client.py`)
- [x] Full test suite — no regressions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes prompt token stitching logic for tool-message turns by synthesizing `tool_calls` on the dummy assistant, which could affect token alignment/prefix caching if the constructed tool-call structure differs from model expectations.
> 
> **Overview**
> Fixes TITO (token-stitching) bridging when the env tail begins with `tool` messages by building the dummy assistant message with matching `tool_calls` derived from leading `tool_call_id`s, satisfying chat templates that require tool messages to follow an assistant tool call.
> 
> The no-tool path is unchanged (dummy assistant still uses `content="x"`), and new OpenAI type imports are added to construct the synthetic tool-call objects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09e1443aba8d52262d3616589f19381922c8cfe8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->