### PR TITLE
Export eval parser for prime CLI reuse

### DIFF
--- a/tests/test_eval_cli.py
+++ b/tests/test_eval_cli.py
@@ -1061,6 +1061,38 @@ def test_ablation_global_defaults_apply():
     assert all(c["num_examples"] == 100 for c in configs)
 
 
+def test_ablation_endpoint_id_override_removes_global_model():
+    with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
+        f.write(
+            'model = "gpt-4.1-mini"\n\n'
+            '[[ablation]]\nenv_id = "my-env"\nendpoint_id = "proxy"\n\n'
+            "[ablation.sweep]\n"
+            "temperature = [0.0]\n"
+        )
+        f.flush()
+        configs = load_toml_config(Path(f.name))
+
+    assert len(configs) == 1
+    assert configs[0]["endpoint_id"] == "proxy"
+    assert "model" not in configs[0]
+
+
+def test_ablation_swept_model_override_removes_global_endpoint_id():
+    with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
+        f.write(
+            'endpoint_id = "proxy"\n\n'
+            '[[ablation]]\nenv_id = "my-env"\n\n'
+            "[ablation.sweep]\n"
+            'model = ["gpt-4.1-mini"]\n'
+        )
+        f.flush()
+        configs = load_toml_config(Path(f.name))
+
+    assert len(configs) == 1
+    assert configs[0]["model"] == "gpt-4.1-mini"
+    assert "endpoint_id" not in configs[0]
+
+
 def test_ablation_with_eval_blocks():
     """Ablation and eval blocks can coexist."""
     with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:

--- a/verifiers/cli/commands/eval.py
+++ b/verifiers/cli/commands/eval.py
@@ -1,6 +1,8 @@
 """Evaluation command module for external hosts."""
 
-from verifiers.scripts.eval import main
+from verifiers.scripts.eval import build_parser, main, parse_args
+
+__all__ = ["build_parser", "parse_args", "main"]
 
 
 if __name__ == "__main__":

--- a/verifiers/cli/commands/eval.py
+++ b/verifiers/cli/commands/eval.py
@@ -1,8 +1,20 @@
 """Evaluation command module for external hosts."""
 
-from verifiers.scripts.eval import build_parser, main, parse_args
+from verifiers.scripts.eval import (
+    build_extra_headers,
+    build_parser,
+    main,
+    merge_sampling_args,
+    parse_args,
+)
 
-__all__ = ["build_parser", "parse_args", "main"]
+__all__ = [
+    "build_extra_headers",
+    "build_parser",
+    "merge_sampling_args",
+    "parse_args",
+    "main",
+]
 
 
 if __name__ == "__main__":

--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -147,7 +147,7 @@ def get_env_eval_defaults(env_id: str) -> dict[str, Any]:
     return defaults
 
 
-def main():
+def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "env_id_or_config",
@@ -384,7 +384,15 @@ def main():
         default=None,
         help="Heartbeat URL for uptime monitoring",
     )
-    args = parser.parse_args()
+    return parser
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    return build_parser().parse_args(argv)
+
+
+def main(argv: list[str] | None = None):
+    args = parse_args(argv)
 
     if args.debug:  # only set up console logging in debug mode
         setup_logging(get_log_level(args.verbose))

--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -90,6 +90,58 @@ PROVIDER_CONFIGS: dict[str, dict[str, str]] = {
 DEFAULT_PROVIDER = "prime"
 
 
+def merge_sampling_args(
+    sampling_args: dict[str, Any] | None,
+    *,
+    max_tokens: int | None = None,
+    temperature: float | None = None,
+    prefer_existing_keys: bool = True,
+    include_none_max_tokens: bool = False,
+) -> dict[str, Any]:
+    merged_sampling_args = dict(sampling_args or {})
+
+    if (not prefer_existing_keys or "max_tokens" not in merged_sampling_args) and (
+        include_none_max_tokens or max_tokens is not None
+    ):
+        merged_sampling_args["max_tokens"] = max_tokens
+
+    if temperature is not None and (
+        not prefer_existing_keys or "temperature" not in merged_sampling_args
+    ):
+        merged_sampling_args["temperature"] = temperature
+
+    return merged_sampling_args
+
+
+def build_extra_headers(raw: dict[str, Any]) -> dict[str, str]:
+    eval_headers_table: dict[str, str] = {}
+    raw_headers = raw.get("headers")
+    if raw_headers is not None:
+        eval_headers_table = _validate_extra_headers_value(raw_headers)
+
+    raw_header_values = raw.get("header")
+    if raw_header_values is None:
+        raw_header_values = []
+    if not isinstance(raw_header_values, list):
+        raise ValueError("'header' must be a list of 'Name: Value' strings")
+
+    eval_headers_from_list: dict[str, str] = {}
+    for header_value in raw_header_values:
+        if not isinstance(header_value, str):
+            raise ValueError(
+                f"Each 'header' entry must be a string 'Name: Value', got: {header_value!r}"
+            )
+        if ":" not in header_value:
+            raise ValueError(f"--header must be 'Name: Value', got: {header_value!r}")
+        key, value = header_value.split(":", 1)
+        key, value = key.strip(), value.strip()
+        if not key:
+            raise ValueError("--header name cannot be empty")
+        eval_headers_from_list[key] = value
+
+    return {**eval_headers_table, **eval_headers_from_list}
+
+
 def get_env_eval_defaults(env_id: str) -> dict[str, Any]:
     """Get eval config defaults from the environment module's pyproject.toml.
 
@@ -572,35 +624,14 @@ def main(argv: list[str] | None = None):
             )
 
         # Merge sampling args
-        merged_sampling_args: dict = {}
-        if raw.get("sampling_args") is not None:
-            merged_sampling_args.update(raw["sampling_args"])
-        if "max_tokens" not in merged_sampling_args:
-            merged_sampling_args["max_tokens"] = raw.get("max_tokens")
-        raw_temp = raw.get("temperature")
-        if raw_temp is not None and "temperature" not in merged_sampling_args:
-            merged_sampling_args["temperature"] = raw_temp
+        merged_sampling_args = merge_sampling_args(
+            raw.get("sampling_args"),
+            max_tokens=raw.get("max_tokens"),
+            temperature=raw.get("temperature"),
+            include_none_max_tokens=True,
+        )
         # Build headers: registry < [[eval]] headers table < header list / --header
-        eval_headers_table: dict[str, str] = {}
-        raw_headers = raw.get("headers")
-        if raw_headers is not None:
-            eval_headers_table = _validate_extra_headers_value(raw_headers)
-
-        eval_headers_from_list: dict[str, str] = {}
-        for h in raw.get("header") or []:
-            if not isinstance(h, str):
-                raise ValueError(
-                    f"Each 'header' entry must be a string 'Name: Value', got: {h!r}"
-                )
-            if ":" not in h:
-                raise ValueError(f"--header must be 'Name: Value', got: {h!r}")
-            k, v = h.split(":", 1)
-            k, v = k.strip(), v.strip()
-            if not k:
-                raise ValueError("--header name cannot be empty")
-            eval_headers_from_list[k] = v
-
-        eval_headers_merged = {**eval_headers_table, **eval_headers_from_list}
+        eval_headers_merged = build_extra_headers(raw)
 
         registry_headers_base: dict[str, str] = {}
         if endpoint_group is not None:

--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -388,7 +388,10 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
-    return build_parser().parse_args(argv)
+    parser = build_parser()
+    if argv is None:
+        return parser.parse_args()
+    return parser.parse_args(argv)
 
 
 def main(argv: list[str] | None = None):

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -330,8 +330,14 @@ def _expand_ablation(ablation: dict, global_defaults: dict) -> list[dict]:
                 f"sweep.env_args — use one or the other"
             )
 
+    explicit_keys = (set(ablation.keys()) - {"sweep"}) | set(sweep.keys())
+
     # Fixed fields: global defaults overridden by ablation-level fields
     fixed = {**global_defaults, **ablation}
+    if "endpoint_id" in explicit_keys and "model" not in explicit_keys:
+        fixed.pop("model", None)
+    if "model" in explicit_keys and "endpoint_id" not in explicit_keys:
+        fixed.pop("endpoint_id", None)
 
     # Expand cartesian product
     keys = [k for k, _ in dimensions]

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -351,7 +351,9 @@ def _expand_ablation(ablation: dict, global_defaults: dict) -> list[dict]:
     return expanded
 
 
-def load_toml_config(path: Path) -> list[dict]:
+def load_toml_config(
+    path: Path, extra_valid_fields: set[str] | None = None
+) -> list[dict]:
     """Loads and validates a TOML config file.
 
     Config format supports global defaults at the top level, with per-eval overrides
@@ -454,6 +456,7 @@ def load_toml_config(path: Path) -> list[dict]:
         "save_to_hf_hub",
         "hf_hub_dataset_name",
     }
+    valid_fields |= extra_valid_fields or set()
 
     # validate global fields
     if global_defaults:
@@ -475,6 +478,10 @@ def load_toml_config(path: Path) -> list[dict]:
             )
         # global defaults, then per-eval overrides
         merged = {**global_defaults, **eval_config}
+        if "endpoint_id" in eval_config and "model" not in eval_config:
+            merged.pop("model", None)
+        if "model" in eval_config and "endpoint_id" not in eval_config:
+            merged.pop("endpoint_id", None)
         merged_eval_list.append(merged)
 
     # expand [[ablation]] blocks into eval configs


### PR DESCRIPTION
## Summary
- export the eval parser and parse helper from the CLI entrypoint
- let the TOML config loader accept extra valid fields for downstream CLIs
- preserve per-eval model vs endpoint override behavior inside the shared TOML loader

## Testing
- uv run ruff format
- uv run ruff check --fix
- uv run python3 -c 'from verifiers.cli.commands.eval import build_parser, parse_args; parser = build_parser(); ns = parse_args(["gsm8k"]); print(type(parser).__name__, ns.env_id_or_config)'

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors CLI argument parsing and TOML config merging logic that directly affects how evaluations are configured (model/endpoint selection, headers, sampling args). Mis-merges could change which endpoint/model is used or what headers/sampling parameters are sent.
> 
> **Overview**
> **Makes the eval CLI parser reusable and factors out config-merging helpers.** `verifiers/scripts/eval.py` is refactored to expose `build_parser`, `parse_args(argv)`, `merge_sampling_args`, and `build_extra_headers`, with `main()` now accepting optional `argv`; `verifiers/cli/commands/eval.py` re-exports these symbols for downstream CLIs.
> 
> **Adjusts TOML config loading/ablation expansion behavior.** `load_toml_config` now accepts `extra_valid_fields` for schema extension, and both `[[eval]]` merges and `[[ablation]]` expansion now drop the global `model` when `endpoint_id` is explicitly set (and vice versa) to preserve per-block override semantics; new tests cover the ablation override cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 125b7ec5c17882c7d50d3b358ec5a918c5e57e48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->