### PR TITLE
tomllib/tomli guard for python 3.10

### DIFF
--- a/verifiers/envs/experimental/composable/tasksets/harbor/harbor.py
+++ b/verifiers/envs/experimental/composable/tasksets/harbor/harbor.py
@@ -4,9 +4,13 @@ import json
 import logging
 import tarfile
 import tempfile
-import tomllib
 from pathlib import Path
 from typing import Any
+
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib
 
 import verifiers as vf
 from verifiers.envs.experimental.composable import SandboxSpec, SandboxTaskSet


### PR DESCRIPTION
## Description

Harbor was missing the tomli fallback import when Python <=3.10, in which case tomllib cannot be used.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Very small change limited to module imports to support older Python versions; no runtime behavior changes beyond enabling TOML parsing on Python <=3.10.
> 
> **Overview**
> Fixes Harbor task loading on Python <=3.10 by wrapping the `tomllib` import in a `try/except` and falling back to `tomli`.
> 
> This keeps TOML parsing behavior the same while restoring compatibility when the stdlib `tomllib` module is not available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4440be329e6eac038b16d64342df57ba45168d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->