### PR TITLE
feat: send X-Session-ID header during eval for DP-aware routing

### DIFF
--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -228,6 +228,12 @@ def main():
         help="Extra HTTP header to pass to inference API. 'Name: Value'. Repeatable.",
     )
     parser.add_argument(
+        "--session-id-routing",
+        default=False,
+        action="store_true",
+        help="Send X-Session-ID header (from example_id) for DP-aware sticky routing via vllm-router.",
+    )
+    parser.add_argument(
         "--num-examples",
         "-n",
         type=int,
@@ -628,13 +634,16 @@ def main():
             ]
 
         assert primary_api_base_url is not None
+        extra_headers_from_state: dict[str, str] = {}
+        if raw.get("session_id_routing"):
+            extra_headers_from_state["X-Session-ID"] = "example_id"
         client_config = ClientConfig(
             client_type=cast(ClientType, client_type),
             api_key_var=resolved_api_key_var,
             api_base_url=primary_api_base_url,
             endpoint_configs=endpoint_configs,
             extra_headers=merged_headers,
-            extra_headers_from_state={"X-Session-ID": "example_id"},
+            extra_headers_from_state=extra_headers_from_state,
         )
 
         # Backward-compatible TOML field: resume_path

--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -634,6 +634,7 @@ def main():
             api_base_url=primary_api_base_url,
             endpoint_configs=endpoint_configs,
             extra_headers=merged_headers,
+            extra_headers_from_state={"X-Session-ID": "example_id"},
         )
 
         # Backward-compatible TOML field: resume_path

--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -228,12 +228,6 @@ def main():
         help="Extra HTTP header to pass to inference API. 'Name: Value'. Repeatable.",
     )
     parser.add_argument(
-        "--session-id-routing",
-        default=False,
-        action="store_true",
-        help="Send X-Session-ID header (from example_id) for DP-aware sticky routing via vllm-router.",
-    )
-    parser.add_argument(
         "--num-examples",
         "-n",
         type=int,
@@ -634,16 +628,13 @@ def main():
             ]
 
         assert primary_api_base_url is not None
-        extra_headers_from_state: dict[str, str] = {}
-        if raw.get("session_id_routing"):
-            extra_headers_from_state["X-Session-ID"] = "example_id"
         client_config = ClientConfig(
             client_type=cast(ClientType, client_type),
             api_key_var=resolved_api_key_var,
             api_base_url=primary_api_base_url,
             endpoint_configs=endpoint_configs,
             extra_headers=merged_headers,
-            extra_headers_from_state=extra_headers_from_state,
+            extra_headers_from_state={"X-Session-ID": "example_id"},
         )
 
         # Backward-compatible TOML field: resume_path


### PR DESCRIPTION

tested with

```
  uv run vf-eval gsm8k --model gpt-4o-mini -n 3 -r 1 --api-base-url https://api.openai.com/v1 --api-key-var OPENAI_API_KEY --debug                                               
uv run vf-eval gsm8k --model openai/gpt-4o-mini -n 3 -r 1  --debug
```

## Summary
- Sets `extra_headers_from_state={"X-Session-ID": "example_id"}` when building the `ClientConfig` in `vf eval`
- Every inference request now includes `X-Session-ID: <example_id>`, enabling the vllm-router to do consistent-hash sticky routing to the same DP rank
- No need to know `dp_rank_count` — the router handles it automatically
- Matches the approach used in prime-rl (`rl.py` auto-configures the same header)
- The header is silently ignored when no vllm-router is present, so this is safe to always enable

## Test plan
- [x] `ruff check` passes
- [x] `pytest tests/test_eval_cli.py tests/test_client_config.py` passes
- [ ] Run `vf eval` against a vllm-router endpoint and verify `X-Session-ID` header is sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change that only adds an extra request header during eval runs; risk is limited to potential compatibility issues with strict HTTP gateways or unexpected routing behavior.
> 
> **Overview**
> `vf eval` now configures `ClientConfig.extra_headers_from_state` to map `X-Session-ID` from the per-request `state` (using `example_id`), causing all inference calls during eval runs to automatically include an `X-Session-ID` header.
> 
> This enables DP-aware/sticky routing when a router is present while remaining a no-op for backends that ignore the header.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 775891076a7d2f46f105850a913cd8f05becaa36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->