### PR TITLE
fix: propagate json_logging to env workers

### DIFF
--- a/verifiers/serve/server/env_router.py
+++ b/verifiers/serve/server/env_router.py
@@ -101,6 +101,7 @@ class EnvRouter:
         log_level: str | None = None,
         log_dir: str | None = None,
         console_logging: bool = True,
+        json_logging: bool = False,
         *,
         num_workers: int = 1,
         worker_heartbeat_timeout: float = 30.0,
@@ -116,6 +117,7 @@ class EnvRouter:
         self.log_level = log_level
         self.log_dir = log_dir
         self.console_logging = console_logging
+        self.json_logging = json_logging
 
         self.num_workers = num_workers
         self.worker_heartbeat_timeout = worker_heartbeat_timeout
@@ -185,6 +187,7 @@ class EnvRouter:
                 self.log_level,
                 self.log_dir,
                 self.console_logging,
+                self.json_logging,
             ),
             kwargs=dict(
                 worker_id=worker_id,

--- a/verifiers/serve/server/env_server.py
+++ b/verifiers/serve/server/env_server.py
@@ -70,6 +70,7 @@ class EnvServer(ABC):
             log_level=log_level,
             log_dir=log_dir,
             console_logging=console_logging,
+            json_logging=json_logging,
             num_workers=num_workers,
             worker_heartbeat_timeout=worker_heartbeat_timeout,
             stats_log_interval=stats_log_interval,

--- a/verifiers/serve/server/env_worker.py
+++ b/verifiers/serve/server/env_worker.py
@@ -60,6 +60,7 @@ class EnvWorker:
         log_level: str | None = None,
         log_dir: str | None = None,
         console_logging: bool = True,
+        json_logging: bool = False,
         *,
         worker_id: int,
         worker_name: str,
@@ -78,6 +79,7 @@ class EnvWorker:
         logger_kwargs: dict[str, Any] = {
             "console_logging": console_logging,
             "file_logging": log_dir is not None,
+            "json_logging": json_logging,
         }
         if log_level is not None:
             logger_kwargs["level"] = log_level


### PR DESCRIPTION
EnvServer accepted json_logging but never forwarded it to EnvRouter or EnvWorker. Worker processes called vf.setup_logging() without json_logging, so environment logs (timeouts, aborted rollouts, errors) were plain text while server/router logs were structured JSON.

- Thread json_logging through EnvServer -> EnvRouter -> EnvWorker
- Workers now emit JSON logs when the server is configured for JSON

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: threads an existing logging flag through `EnvServer` → `EnvRouter` → `EnvWorker` without changing request/response or worker lifecycle behavior.
> 
> **Overview**
> Ensures worker processes follow the server’s JSON logging configuration by propagating `json_logging` from `EnvServer` into `EnvRouter` and into each spawned `EnvWorker`.
> 
> Workers now pass `json_logging` into `vf.setup_logging()`, making worker logs consistent (structured JSON when enabled) with server/router logging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71d03ea17bed6dc62ae20121b88c1843c7f4baed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->