### PR TITLE
chore: v0.1.12.dev6 dev release

### DIFF
--- a/assets/release/RELEASE_v0.1.12.dev6.md
+++ b/assets/release/RELEASE_v0.1.12.dev6.md
@@ -1,0 +1,25 @@
+# Verifiers v0.1.12.dev6 Release Notes
+
+*Date:* 04/15/2026
+
+## Highlights since v0.1.12.dev5
+
+- Exported the eval parser and normalization helpers so Prime CLI can reuse Verifiers eval parsing and config loading.
+- Fixed eval ablation config overrides so explicit `model` and `endpoint_id` settings behave correctly.
+- Propagated `json_logging` from EnvServer to env workers so worker logs stay structured when JSON logging is enabled.
+- Fixed the RLM harness install flow to avoid duplicate installs and restored Harbor TOML loading on Python 3.10.
+
+## Changes included in v0.1.12.dev6 (since v0.1.12.dev5)
+
+### Features and enhancements
+
+- feat: export eval parser and normalization helpers for Prime CLI reuse (#1135)
+- fix: handle ablation `model` and `endpoint_id` overrides in eval configs (#1135)
+
+### Fixes and maintenance
+
+- fix: propagate `json_logging` to env workers (#1138)
+- fix: port RLM harness dedup install script update (#1133)
+- fix: add `tomli` fallback for Harbor on Python 3.10 (#1136)
+
+**Full Changelog**: https://github.com/PrimeIntellect-ai/verifiers/compare/v0.1.12.dev5...v0.1.12.dev6

--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.12.dev5"
+__version__ = "0.1.12.dev6"
 
 import importlib
 import os


### PR DESCRIPTION
## Summary
- Bump version from `0.1.12.dev5` to `0.1.12.dev6`
- Add release notes covering changes since `v0.1.12.dev5`

### Key changes in this release
- Export eval parser and normalization helpers for Prime CLI reuse, including correct ablation `model` / `endpoint_id` override handling (#1135)
- Propagate `json_logging` from `EnvServer` to env workers so worker logs stay structured when JSON logging is enabled (#1138)
- Fix the RLM harness install flow to avoid duplicate installs (#1133)
- Restore Harbor TOML loading on Python 3.10 via `tomli` fallback (#1136)

## Changes since v0.1.12.dev5
- fix: port RLM harness dedup install script update (#1133)
- feat: export eval parser and normalization helpers for Prime CLI reuse (#1135)
- fix: handle ablation `model` / `endpoint_id` overrides in eval configs (#1135)
- fix: add `tomli` fallback for Harbor on Python 3.10 (#1136)
- fix: propagate `json_logging` to env workers (#1138)

### Linked PRs
- #1133
- #1135
- #1136
- #1138

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates the package version string and adds a release-notes markdown file; no runtime logic changes.
> 
> **Overview**
> Updates `__version__` to `0.1.12.dev6`.
> 
> Adds `assets/release/RELEASE_v0.1.12.dev6.md` documenting the `v0.1.12.dev6` release highlights and changelog entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 783ff4e1688b3203f6fc75fb72a7209273344201. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->