### PR TITLE
Add NeMoRLChatCompletionsClient for NeMo Gym model servers

### DIFF
--- a/tests/test_nemorl_client.py
+++ b/tests/test_nemorl_client.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from verifiers.clients.nemorl_chat_completions_client import (
+    NeMoRLChatCompletionsClient,
+)
+from verifiers.types import ClientConfig
+
+
+def _make_nemo_gym_response_dict(
+    *,
+    content: str = "Hello",
+    prompt_token_ids: list[int] | None = None,
+    generation_token_ids: list[int | str] | None = None,
+    generation_log_probs: list[float] | None = None,
+) -> dict:
+    """Build a JSON dict mimicking the NeMo Gym vllm_model server response.
+
+    The vllm_model server embeds token data as extra fields in the message dict
+    and strips logprobs from the choice (they're redundant once extracted).
+    """
+    message: dict = {"role": "assistant", "content": content}
+    if prompt_token_ids is not None:
+        message["prompt_token_ids"] = prompt_token_ids
+    if generation_token_ids is not None:
+        message["generation_token_ids"] = generation_token_ids
+    if generation_log_probs is not None:
+        message["generation_log_probs"] = generation_log_probs
+
+    return {
+        "id": "chatcmpl-test",
+        "object": "chat.completion",
+        "created": 1700000000,
+        "model": "test-model",
+        "choices": [
+            {
+                "index": 0,
+                "message": message,
+                "finish_reason": "stop",
+                "logprobs": None,  # vllm_model pops raw logprobs after extraction
+            }
+        ],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    }
+
+
+def _make_client() -> NeMoRLChatCompletionsClient:
+    """Create a client with a mocked AsyncOpenAI underneath."""
+    config = ClientConfig(
+        client_type="nemorl_chat_completions",
+        api_base_url="http://localhost:8080/v1",
+        api_key_var="EMPTY",
+    )
+    client = NeMoRLChatCompletionsClient(config)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_token_ids_relocated_from_message_to_response():
+    """Token IDs in the message dict are relocated to response/choice level."""
+    prompt_ids = [1, 2, 3, 4, 5]
+    gen_ids = [10, 11, 12]
+    gen_logprobs = [-0.1, -0.2, -0.3]
+
+    response_dict = _make_nemo_gym_response_dict(
+        prompt_token_ids=prompt_ids,
+        generation_token_ids=gen_ids,
+        generation_log_probs=gen_logprobs,
+    )
+
+    client = _make_client()
+
+    # Mock the parent's get_native_response to return a ChatCompletion
+    # parsed from our dict (simulating what the OpenAI SDK does).
+    from openai.types.chat import ChatCompletion
+
+    chat_completion = ChatCompletion.model_validate(response_dict)
+    # Simulate the message having extra fields (OpenAI SDK extra="allow")
+    setattr(chat_completion.choices[0].message, "prompt_token_ids", prompt_ids)
+    setattr(chat_completion.choices[0].message, "generation_token_ids", gen_ids)
+    setattr(chat_completion.choices[0].message, "generation_log_probs", gen_logprobs)
+
+    with patch.object(
+        NeMoRLChatCompletionsClient.__bases__[0],
+        "get_native_response",
+        new_callable=AsyncMock,
+        return_value=chat_completion,
+    ):
+        result = await client.get_native_response(
+            prompt=[{"role": "user", "content": "Hi"}],
+            model="test-model",
+            sampling_args={"max_tokens": 100},
+        )
+
+    # Verify relocation
+    assert hasattr(result, "prompt_token_ids")
+    assert result.prompt_token_ids == prompt_ids
+    assert hasattr(result.choices[0], "token_ids")
+    assert result.choices[0].token_ids == gen_ids
+
+    # Verify logprobs reconstruction
+    assert result.choices[0].logprobs is not None
+    logprobs_content = result.choices[0].logprobs["content"]
+    assert len(logprobs_content) == 3
+    assert logprobs_content[0]["token"] == "token_id:10"
+    assert logprobs_content[0]["logprob"] == -0.1
+
+
+@pytest.mark.asyncio
+async def test_string_token_ids_normalized_to_ints():
+    """String token IDs (from vllm_model removeprefix) are converted to ints."""
+    response_dict = _make_nemo_gym_response_dict(
+        prompt_token_ids=[1, 2],
+        generation_token_ids=["100", "200"],  # strings, not ints
+        generation_log_probs=[-0.5, -0.6],
+    )
+
+    client = _make_client()
+
+    from openai.types.chat import ChatCompletion
+
+    chat_completion = ChatCompletion.model_validate(response_dict)
+    setattr(chat_completion.choices[0].message, "prompt_token_ids", [1, 2])
+    setattr(chat_completion.choices[0].message, "generation_token_ids", ["100", "200"])
+    setattr(chat_completion.choices[0].message, "generation_log_probs", [-0.5, -0.6])
+
+    with patch.object(
+        NeMoRLChatCompletionsClient.__bases__[0],
+        "get_native_response",
+        new_callable=AsyncMock,
+        return_value=chat_completion,
+    ):
+        result = await client.get_native_response(
+            prompt=[{"role": "user", "content": "Hi"}],
+            model="test-model",
+            sampling_args={"max_tokens": 100},
+        )
+
+    # Token IDs should be ints, not strings
+    assert all(isinstance(tid, int) for tid in result.choices[0].token_ids)
+    assert result.choices[0].token_ids == [100, 200]
+
+
+@pytest.mark.asyncio
+async def test_no_token_data_passes_through_unchanged():
+    """When model server doesn't return token IDs, response is unchanged."""
+    response_dict = _make_nemo_gym_response_dict()  # no token fields
+
+    client = _make_client()
+
+    from openai.types.chat import ChatCompletion
+
+    chat_completion = ChatCompletion.model_validate(response_dict)
+
+    with patch.object(
+        NeMoRLChatCompletionsClient.__bases__[0],
+        "get_native_response",
+        new_callable=AsyncMock,
+        return_value=chat_completion,
+    ):
+        result = await client.get_native_response(
+            prompt=[{"role": "user", "content": "Hi"}],
+            model="test-model",
+            sampling_args={"max_tokens": 100},
+        )
+
+    # No token attributes should be set
+    assert not hasattr(result, "prompt_token_ids")
+    assert not hasattr(result.choices[0], "token_ids")
+    assert result.choices[0].logprobs is None
+
+
+@pytest.mark.asyncio
+async def test_from_native_response_produces_response_tokens():
+    """End-to-end: token IDs flow through to ResponseTokens via parse_tokens."""
+    prompt_ids = [1, 2, 3]
+    gen_ids = [10, 11]
+    gen_logprobs = [-0.1, -0.2]
+
+    response_dict = _make_nemo_gym_response_dict(
+        prompt_token_ids=prompt_ids,
+        generation_token_ids=gen_ids,
+        generation_log_probs=gen_logprobs,
+    )
+
+    client = _make_client()
+
+    from openai.types.chat import ChatCompletion
+
+    chat_completion = ChatCompletion.model_validate(response_dict)
+    setattr(chat_completion.choices[0].message, "prompt_token_ids", prompt_ids)
+    setattr(chat_completion.choices[0].message, "generation_token_ids", gen_ids)
+    setattr(chat_completion.choices[0].message, "generation_log_probs", gen_logprobs)
+
+    with patch.object(
+        NeMoRLChatCompletionsClient.__bases__[0],
+        "get_native_response",
+        new_callable=AsyncMock,
+        return_value=chat_completion,
+    ):
+        native_response = await client.get_native_response(
+            prompt=[{"role": "user", "content": "Hi"}],
+            model="test-model",
+            sampling_args={"max_tokens": 100},
+        )
+
+    # Now test from_native_response which calls parse_tokens
+    vf_response = await client.from_native_response(native_response)
+
+    assert vf_response.message.tokens is not None
+    tokens = vf_response.message.tokens
+    assert tokens.prompt_ids == prompt_ids
+    assert tokens.completion_ids == gen_ids
+    assert tokens.completion_logprobs == gen_logprobs
+    assert tokens.prompt_mask == [0] * len(prompt_ids)
+    assert tokens.completion_mask == [1] * len(gen_ids)

--- a/verifiers/clients/__init__.py
+++ b/verifiers/clients/__init__.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from verifiers.clients.anthropic_messages_client import AnthropicMessagesClient
 from verifiers.clients.client import Client
+from verifiers.clients.nemorl_chat_completions_client import (
+    NeMoRLChatCompletionsClient,
+)
 from verifiers.clients.openai_chat_completions_client import OpenAIChatCompletionsClient
 from verifiers.clients.openai_chat_completions_token_client import (
     OpenAIChatCompletionsTokenClient,
@@ -26,12 +29,15 @@ def resolve_client(client_or_config: Client | ClientConfig) -> Client:
                 return OpenAIChatCompletionsTokenClient(client_or_config)
             case "anthropic_messages":
                 return AnthropicMessagesClient(client_or_config)
+            case "nemorl_chat_completions":
+                return NeMoRLChatCompletionsClient(client_or_config)
     else:
         raise ValueError(f"Unsupported client type: {type(client_or_config)}")
 
 
 __all__ = [
     "AnthropicMessagesClient",
+    "NeMoRLChatCompletionsClient",
     "OpenAICompletionsClient",
     "OpenAIChatCompletionsClient",
     "OpenAIChatCompletionsTokenClient",

--- a/verifiers/clients/nemorl_chat_completions_client.py
+++ b/verifiers/clients/nemorl_chat_completions_client.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from verifiers.clients.openai_chat_completions_client import (
+    OpenAIChatCompletionsClient,
+    OpenAIChatMessages,
+    OpenAIChatResponse,
+    OpenAITool,
+    handle_openai_overlong_prompt,
+)
+from verifiers.types import SamplingArgs
+
+
+class NeMoRLChatCompletionsClient(OpenAIChatCompletionsClient):
+    """Client for NeMo Gym model servers that embed token IDs in the message dict.
+
+    NeMo Gym's model servers (e.g., vllm_model) return token information as
+    extra fields on the chat completion message:
+        - message.prompt_token_ids: list[int]
+        - message.generation_token_ids: list[int | str]
+        - message.generation_log_probs: list[float]
+
+    Verifiers' parse_tokens() (called by from_native_response) expects:
+        - response.prompt_token_ids (top-level attribute)
+        - choice.token_ids (choice-level attribute)
+        - choice.logprobs.content (list of {token, logprob, top_logprobs} dicts)
+
+    This client relocates the fields after calling the standard OpenAI chat
+    completions endpoint, so the rest of the verifiers pipeline works unchanged.
+    """
+
+    @handle_openai_overlong_prompt
+    async def get_native_response(
+        self,
+        prompt: OpenAIChatMessages,
+        model: str,
+        sampling_args: SamplingArgs,
+        tools: list[OpenAITool] | None = None,
+        **kwargs,
+    ) -> OpenAIChatResponse:
+        # Standard OpenAI chat completions call to the NeMo Gym model server.
+        # The model server handles logprobs, tokenization, and token ID extraction
+        # internally. Extra fields survive because the OpenAI SDK's ChatCompletion
+        # and ChatCompletionMessage models use extra="allow".
+        response = await super().get_native_response(
+            prompt, model, sampling_args, tools, **kwargs
+        )
+
+        choice = response.choices[0]
+        message = choice.message
+
+        # Extract token data from the message's extra fields.
+        # These are set by the NeMo Gym model server when
+        # return_token_id_information is enabled.
+        prompt_token_ids = getattr(message, "prompt_token_ids", None)
+        generation_token_ids = getattr(message, "generation_token_ids", None)
+        generation_log_probs = getattr(message, "generation_log_probs", None)
+
+        if prompt_token_ids is None and generation_token_ids is None:
+            # No token data from the model server; pass through unchanged.
+            # parse_tokens() will return None, which is correct for inference-only.
+            return response
+
+        # Normalize string token IDs to ints.
+        # The vllm_model server may return strings after removeprefix("token_id:").
+        if prompt_token_ids and isinstance(prompt_token_ids[0], str):
+            prompt_token_ids = [int(tid) for tid in prompt_token_ids]
+        if generation_token_ids and isinstance(generation_token_ids[0], str):
+            generation_token_ids = [int(tid) for tid in generation_token_ids]
+
+        # Relocate to where parse_tokens() expects them.
+        if prompt_token_ids is not None:
+            setattr(response, "prompt_token_ids", prompt_token_ids)
+        if generation_token_ids is not None:
+            setattr(choice, "token_ids", generation_token_ids)
+
+        # Reconstruct logprobs structure from token IDs + log probs.
+        # parse_tokens() handles both Pydantic ChoiceLogprobs objects and plain
+        # dicts, so a dict is sufficient and avoids an import.
+        if generation_token_ids and generation_log_probs:
+            choice.logprobs = {
+                "content": [
+                    {"token": f"token_id:{tid}", "logprob": lp, "top_logprobs": []}
+                    for tid, lp in zip(generation_token_ids, generation_log_probs)
+                ]
+            }
+
+        return response

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -36,6 +36,7 @@ ClientType = Literal[
     "openai_chat_completions",
     "openai_chat_completions_token",
     "anthropic_messages",
+    "nemorl_chat_completions",
 ]
 MessageType = Literal["chat", "completion"]  # deprecated
 


### PR DESCRIPTION
## Summary

- Adds `NeMoRLChatCompletionsClient`, a new client type extending
  `OpenAIChatCompletionsClient` for NeMo Gym model servers
- Registers `"nemorl_chat_completions"` as a new `ClientType`
- Includes unit tests

## Motivation

NeMo Gym's verifiers_agent currently requires a pinned verifiers version
(`==0.1.9.post3`), a custom 70-line HTTP client, and a runtime patch of
`parse_response_messages` to shuttle token IDs through the pipeline.

The root cause: NeMo Gym model servers (vllm_model, openai_model) return
token information as extra fields in the chat completion message dict
(`message.prompt_token_ids`, `message.generation_token_ids`,
`message.generation_log_probs`), but `parse_tokens()` expects them as
attributes on the response/choice objects. This client bridges that gap
with a single `get_native_response` override that relocates the fields
after the standard OpenAI SDK call.

With this client, the NeMo Gym verifiers_agent can drop the version pin,
the custom HTTP client, and the runtime patch — reducing ~340 lines to ~250.

## Test plan

- [x] Unit: token IDs relocated from message to response/choice
- [x] Unit: string token IDs normalized to ints
- [x] Unit: graceful passthrough when no token data present
- [x] Unit: end-to-end flow through `from_native_response` produces `ResponseTokens`
- [x] Integration: validated on A10 GPU with Qwen3-4B + NeMo Gym + acereason-math

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are additive (new client type + tests) and only affect behavior when explicitly selecting `client_type="nemorl_chat_completions"`.
> 
> **Overview**
> Adds `NeMoRLChatCompletionsClient`, a new chat-completions client variant that post-processes NeMo Gym model-server responses by moving token ID fields from `message.*` extras onto the response/choice attributes expected by `parse_tokens()`, normalizing string token IDs, and reconstructing a minimal `logprobs` structure.
> 
> Registers the new `"nemorl_chat_completions"` `ClientType` in `types.py` and wires it into `resolve_client`, and includes unit tests covering relocation, normalization, passthrough when no token data exists, and end-to-end token parsing via `from_native_response`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7d138fbec8dc9e14bf21f04b933ea6c7f0cb06a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->