### PR TITLE
Fix rlm harness to use per-example AGENT_WORKDIR

### DIFF
--- a/verifiers/envs/experimental/composable/harnesses/rlm.py
+++ b/verifiers/envs/experimental/composable/harnesses/rlm.py
@@ -58,7 +58,7 @@ export PATH="$HOME/.local/bin:$PATH"
 export RLM_MODEL=$OPENAI_MODEL
 export OPENAI_API_KEY=intercepted
 export RLM_APPEND_TO_SYSTEM_PROMPT="$(cat {shlex.quote(DEFAULT_APPEND_TO_SYSTEM_PROMPT_PATH)} 2>/dev/null || true)"
-cd {workdir}
+cd "${{AGENT_WORKDIR:-{workdir}}}"
 uv run --project {shlex.quote(checkout_path)} --all-packages rlm "$(cat {instruction_path})"
 """
     return f"bash -lc {shlex.quote(script)}"


### PR DESCRIPTION
## Summary
- The rlm harness run command hardcoded `cd /testbed` at construction time
- Multi-SWE-RL workdirs are per-example (`/home/{repo}`), not `/testbed`
- Use `$AGENT_WORKDIR` env var (already set per-example by ComposableEnv) with the static workdir as fallback

## Context
All Multi-SWE-RL rollouts in the `rlm-swe` training run fail with:
```
Agent crashed before any LLM call (exit_code=1): bash: line 6: cd: /app: No such file or directory
```
Confirmed by spinning up a `mswebench/iamkun_m_dayjs:pr-769` sandbox — it has `/home/dayjs`, not `/testbed`.

## Test plan
- [x] Verified Multi-SWE-RL images use `/home/{repo}` workdirs
- [x] `AGENT_WORKDIR` is set per-example by `ComposableEnv.build_env_vars()`
- [x] R2E-Gym (which uses `/testbed`) is unaffected since `AGENT_WORKDIR` will also be `/testbed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line change to the harness working-directory selection; behavior is backwards-compatible via fallback and does not touch auth/data paths.
> 
> **Overview**
> Updates the RLM harness run script to `cd` into the per-example working directory via `AGENT_WORKDIR`, falling back to the previous static `workdir` value.
> 
> This prevents RLM rollouts from failing in sandboxes where the repo is checked out outside `/testbed` while keeping existing `/testbed`-based setups working unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52a280f3dd019329110b2d38434b935f5033debe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->