### PR TITLE
Set RLM_KERNEL_PYTHON to sandbox .venv for inline imports

### DIFF
--- a/verifiers/envs/experimental/composable/harnesses/rlm.py
+++ b/verifiers/envs/experimental/composable/harnesses/rlm.py
@@ -31,6 +31,14 @@ export RLM_MODEL=$OPENAI_MODEL
 export OPENAI_API_KEY=intercepted
 export RLM_APPEND_TO_SYSTEM_PROMPT="$(cat {shlex.quote(DEFAULT_APPEND_TO_SYSTEM_PROMPT_PATH)} 2>/dev/null || true)"
 cd "${{AGENT_WORKDIR:-{workdir}}}"
+
+# If the sandbox has a .venv, run the ipython kernel inside it so the
+# agent can inline-import project packages (numpy, pandas, etc.).
+if [ -x .venv/bin/python3 ]; then
+    .venv/bin/python3 -m pip install -q ipykernel nest_asyncio 2>/dev/null || true
+    export RLM_KERNEL_PYTHON="$(pwd)/.venv/bin/python3"
+fi
+
 rlm "$(cat {instruction_path})"
 """
     return f"bash -lc {shlex.quote(script)}"


### PR DESCRIPTION
## Summary
Installs `ipykernel` + `nest_asyncio` into the sandbox's `.venv` and sets `RLM_KERNEL_PYTHON` so the ipython kernel runs in the sandbox's Python. The agent can then `import numpy` inline instead of needing `!python3`.

Depends on https://github.com/PrimeIntellect-ai/rlm/pull/25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, guarded change to the harness startup script; main risk is minor environment side effects (extra pip install/time) when a `.venv` is present.
> 
> **Overview**
> Updates the `rlm` harness run script to detect a sandbox `.venv` and, when present, install `ipykernel`/`nest_asyncio` into it and set `RLM_KERNEL_PYTHON` to the `.venv` interpreter so inline Python imports resolve against project packages.
> 
> If no `.venv` exists, behavior remains unchanged and `rlm` runs as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb3ca7c7aa6c2779c4f2727e6469ee5060d48768. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->