### PR TITLE
Guard RLM_KERNEL_PYTHON on successful ipykernel install

### DIFF
--- a/verifiers/envs/experimental/composable/harnesses/rlm.py
+++ b/verifiers/envs/experimental/composable/harnesses/rlm.py
@@ -34,8 +34,7 @@ cd "${{AGENT_WORKDIR:-{workdir}}}"
 
 # If the sandbox has a .venv, run the ipython kernel inside it so the
 # agent can inline-import project packages (numpy, pandas, etc.).
-if [ -x .venv/bin/python3 ]; then
-    .venv/bin/python3 -m pip install -q ipykernel nest_asyncio 2>/dev/null || true
+if [ -x .venv/bin/python3 ] && .venv/bin/python3 -m pip install -q ipykernel nest_asyncio 2>/dev/null; then
     export RLM_KERNEL_PYTHON="$(pwd)/.venv/bin/python3"
 fi
 


### PR DESCRIPTION
One-line fix: only set `RLM_KERNEL_PYTHON` if `pip install ipykernel` succeeds. Many R2E-Gym sandbox `.venv`s lack pip or can't install packages, causing 38k "No module named ipykernel_launcher" crashes.

When pip fails, the kernel falls back to rlm's own Python (no inline imports of sandbox packages, but no crash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to a harness startup script that mainly affects error handling and fallback behavior.
> 
> **Overview**
> Prevents the RLM harness from forcing the kernel to run from a sandbox `.venv` when `ipykernel` (and `nest_asyncio`) cannot be installed.
> 
> `build_run_command` now sets `RLM_KERNEL_PYTHON` only if `.venv/bin/python3 -m pip install ...` succeeds, allowing a safe fallback to RLM’s default Python instead of failing at kernel launch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22d31cec804207d6d09b58b5727eba2cd2543914. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->