### PR TITLE
Pin ipykernel<7 for older sandbox Pythons

### DIFF
--- a/verifiers/envs/experimental/composable/harnesses/rlm.py
+++ b/verifiers/envs/experimental/composable/harnesses/rlm.py
@@ -34,8 +34,16 @@ cd "${{AGENT_WORKDIR:-{workdir}}}"
 
 # If the sandbox has a .venv, run the ipython kernel inside it so the
 # agent can inline-import project packages (numpy, pandas, etc.).
-if [ -x .venv/bin/python3 ] && .venv/bin/python3 -m pip install -q ipykernel nest_asyncio 2>/dev/null; then
-    export RLM_KERNEL_PYTHON="$(pwd)/.venv/bin/python3"
+if [ -x .venv/bin/python3 ]; then
+    PYVER=$(.venv/bin/python3 -c "import sys; print(sys.version_info[:2] >= (3,10))" 2>/dev/null || true)
+    if [ "$PYVER" = "True" ]; then
+        IPYKERNEL="ipykernel"
+    else
+        IPYKERNEL="ipykernel<7"
+    fi
+    if .venv/bin/python3 -m pip install -q "$IPYKERNEL" nest_asyncio 2>/dev/null; then
+        export RLM_KERNEL_PYTHON="$(pwd)/.venv/bin/python3"
+    fi
 fi
 
 rlm "$(cat {instruction_path})"


### PR DESCRIPTION
ipykernel 7+ requires Python 3.10+. Many R2E-Gym `.venv`s use 3.7-3.9, causing `pip install ipykernel` to fail (38k crashes in previous run).

Detects the `.venv` Python version and pins `ipykernel<7` for <3.10, latest for 3.10+. Falls back to rlm's own Python if install still fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to a sandbox startup script that only affects dependency installation and kernel selection logic.
> 
> **Overview**
> Updates the RLM harness run script to **detect the sandbox `.venv` Python version** and install a compatible Jupyter kernel dependency: `ipykernel` for Python ≥3.10 and `ipykernel<7` for older versions.
> 
> The harness now only sets `RLM_KERNEL_PYTHON` when the version-appropriate `pip install` succeeds, allowing fallback to the default RLM Python when it doesn’t.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dcb4ce9a0456b8a7363a5a4587e3e3ab0467709. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->