### PR TITLE
fix #1074: handle dict-based word_list in TextArenaEnv.ta_to_hf()

### DIFF
--- a/verifiers/envs/integrations/textarena_env.py
+++ b/verifiers/envs/integrations/textarena_env.py
@@ -136,6 +136,10 @@ class TextArenaEnv(vf.MultiTurnEnv):
         eval_dataset_rows = []
         _, user_prompt = self.ta_env.get_observation()
         words = self.ta_env.word_list
+        # Handle dict-based word lists (e.g. TwentyQuestions-v0 uses
+        # categorized words like {"animals": [...], "fruits": [...]})
+        if isinstance(words, dict):
+            words = [w for category in words.values() for w in category]
         # set seed
         random.seed(self.seed)
         for i in range(self.num_train_examples + self.num_eval_examples):


### PR DESCRIPTION
Fixes #1074

Games like TwentyQuestions-v0 use categorized word lists (dict with category keys mapping to word lists). `ta_to_hf()` called `random.choice()` directly on the `word_list`, causing `KeyError` when it is a dict.

Fix: flatten dict word lists into a single list before sampling.

This likely affects any TextArena game that uses categorized word lists, not just TwentyQuestions-v0.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized data-prep change that only affects how answers are sampled when `word_list` is dict-shaped.
> 
> **Overview**
> Fixes `TextArenaEnv.ta_to_hf()` to support TextArena games where `word_list` is a dict of categorized word lists by flattening it to a single list before calling `random.choice()`.
> 
> This prevents runtime errors when generating train/eval datasets for games like `TwentyQuestions-v0` that don’t expose `word_list` as a plain list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48cc7844dc3eb414637d259bbdb5c7f829886229. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->