### PR TITLE
docs: add Supported Patterns section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,29 @@ prime eval run primeintellect/math-python
 
 **[FAQs](docs/faqs.md)** - Other frequently asked questions.
 
+## Supported Patterns
+
+Verifiers supports a wide range of RL environment design patterns. Here's a quick reference:
+
+| Pattern | Support | Documentation |
+|---------|---------|---------------|
+| **Single-turn Q&A** | `SingleTurnEnv` | [Environments](docs/environments.md) |
+| **Multi-turn interactions** | `MultiTurnEnv` | [Environments: Multi-Turn](docs/environments.md#custom-multi-turn-environments) |
+| **Native tool parsing** | `ToolEnv`, `StatefulToolEnv` | [Environments: Tools](docs/environments.md#tool-environments) |
+| **MCP tool integration** | `MCPEnv` | [Environments: MCP](docs/environments.md#mcp-tool-environments) |
+| **Harness-in-sandbox** | `SandboxEnv`, `PythonEnv` | [Environments](docs/environments.md) |
+| **Harness outside sandbox** | Any env with remote sandboxes | [Environments](docs/environments.md) |
+| **No sandbox** | `SingleTurnEnv`, `MultiTurnEnv` | [Environments](docs/environments.md) |
+| **Groupwise rewards** | Native support via `prime-rl` | [Training](docs/training.md) |
+| **Weighted reward functions** | `Rubric` with `weight` param | [Environments: Rubrics](docs/environments.md#multiple-reward-functions) |
+| **Intermediate reward tracking** | `Rubric.add_metric()` | [Environments: Metrics](docs/environments.md#metrics-and-monitor-rubrics) |
+| **Multiple environments** | `RubricGroup`, multi-env evals | [Environments: RubricGroup](docs/environments.md#rubric-groups) |
+| **Custom metrics/error handling** | Monitor rubrics, `add_metric()` | [Environments: Metrics](docs/environments.md#metrics-and-monitor-rubrics) |
+| **Offline evals** | `prime eval run`, `prime eval tui` | [Evaluation](docs/evaluation.md) |
+| **Resource management** | Sandbox lifecycle, `DatasetBuilder` | [Environments](docs/environments.md) |
+| **Stateful interactions** | `StatefulToolEnv`, `setup_state` | [Environments: Stateful](docs/environments.md#stateful-tool-environments) |
+| **Prompt optimization (GEPA)** | `prime gepa run` | [Training](docs/training.md) |
+
 
 ## Citation
 

--- a/verifiers/envs/integrations/textarena_env.py
+++ b/verifiers/envs/integrations/textarena_env.py
@@ -136,6 +136,10 @@ class TextArenaEnv(vf.MultiTurnEnv):
         eval_dataset_rows = []
         _, user_prompt = self.ta_env.get_observation()
         words = self.ta_env.word_list
+        # Handle dict-based word lists (e.g. TwentyQuestions-v0 uses
+        # categorized words like {"animals": [...], "fruits": [...]})
+        if isinstance(words, dict):
+            words = [w for category in words.values() for w in category]
         # set seed
         random.seed(self.seed)
         for i in range(self.num_train_examples + self.num_eval_examples):


### PR DESCRIPTION
Closes #1078

Adds a "Supported Patterns" reference table to the README listing all RL environment design patterns that verifiers supports, with links to relevant documentation.

Covers:
- Single-turn / Multi-turn interactions
- Native tool parsing / MCP tools
- Harness-in-sandbox / outside sandbox / no sandbox
- Groupwise rewards / weighted rewards / intermediate metrics
- Multiple environments (RubricGroup)
- Custom metrics / error handling
- Offline evals
- Resource management
- Stateful interactions
- Prompt optimization (GEPA)

Based on the pattern list from @willccbb tweet (https://x.com/i/status/2037734454459089027).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly documentation, plus a small defensive change to dataset generation in `TextArenaEnv` that should only broaden compatibility.
> 
> **Overview**
> Adds a new **Supported Patterns** section to `README.md`, providing a quick-reference table of common RL environment design patterns and linking each to the relevant docs/classes.
> 
> Fixes `TextArenaEnv.ta_to_hf()` to handle TextArena games whose `word_list` is a dict of categorized word lists by flattening it before sampling answers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5b402741439a30da0b1739c32726af7b87a513b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->