### PR TITLE
Make harness install timeout configurable

### DIFF
--- a/verifiers/envs/experimental/composable/composable_env.py
+++ b/verifiers/envs/experimental/composable/composable_env.py
@@ -174,7 +174,7 @@ class ComposableEnv(CliAgentEnv):
             result = await self.sandbox_client.execute_command(
                 sandbox_id,
                 self.harness.install_script,
-                timeout=300,
+                timeout=self.harness.install_timeout,
             )
             if result.exit_code != 0:
                 output = (result.stdout or "") + (result.stderr or "")

--- a/verifiers/envs/experimental/composable/harness.py
+++ b/verifiers/envs/experimental/composable/harness.py
@@ -31,6 +31,8 @@ class Harness:
     ----------
     install_script:
         Shell command to install the agent binary in the sandbox.
+    install_timeout:
+        Timeout in seconds for the install script. Defaults to 300.
     run_command:
         Shell command to start the agent.
     system_prompt:
@@ -50,6 +52,7 @@ class Harness:
     """
 
     install_script: str | None = None
+    install_timeout: int = 300
     run_command: str = ""
     system_prompt: str | None = None
     system_prompt_path: str = "/task/system_prompt.txt"

--- a/verifiers/envs/experimental/composable/harnesses/rlm.py
+++ b/verifiers/envs/experimental/composable/harnesses/rlm.py
@@ -69,9 +69,11 @@ def rlm_harness(
     rlm_repo_url: str = DEFAULT_RLM_REPO_URL,
     rlm_branch: str = DEFAULT_RLM_BRANCH,
     append_to_system_prompt: str | None = None,
+    install_timeout: int = 600,
 ) -> Harness:
     return Harness(
         install_script=build_install_script(rlm_repo_url, rlm_branch),
+        install_timeout=install_timeout,
         run_command=build_run_command(instruction_path, workdir),
         system_prompt=append_to_system_prompt,
         system_prompt_path=DEFAULT_APPEND_TO_SYSTEM_PROMPT_PATH,


### PR DESCRIPTION
## Description

The install_script timeout was hardcoded to 300s, causing RLM installs to fail in slower sandboxes. Add install_timeout to the Harness dataclass (default 300s) and default it to 600s in rlm_harness().

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to sandbox command timeout behavior; main risk is longer waits/hanging installs if misconfigured.
> 
> **Overview**
> Makes the agent `install_script` timeout configurable via a new `Harness.install_timeout` field (default `300s`) and updates `ComposableEnv` to use it instead of a hardcoded `300s`.
> 
> Updates `rlm_harness()` to accept an `install_timeout` parameter and defaults it to `600s` to better handle slower sandbox installs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39f818dcd98290011dbaea6fbf226c845cadb426. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->