### PR TITLE
Update RLM harness test to match git-clone install script

### DIFF
--- a/tests/test_rlm_composable_env.py
+++ b/tests/test_rlm_composable_env.py
@@ -91,9 +91,9 @@ def _make_temp_taskset_package(tmp_path, monkeypatch, *, with_skills: bool):
 
 def test_rlm_harness_install_script_downloads_repo_install_sh():
     script = build_install_script()
-    assert "raw.githubusercontent.com" in script
-    assert "install.sh" in script
-    assert "bash /tmp/rlm-install.sh" in script
+    assert "git clone --depth 1 --branch main" in script
+    assert "github.com/PrimeIntellect-ai/rlm.git" in script
+    assert "bash /tmp/rlm-checkout/install.sh" in script
 
 
 def test_rlm_harness_sets_metrics_fields():


### PR DESCRIPTION
## Description

#1159 switched the install script from fetching install.sh via raw.githubusercontent.com to cloning the repo, but this test still asserted the old URL, failing CI.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change aligning assertions with an already-changed install script; minimal risk beyond potential brittleness if the script format changes again.
> 
> **Overview**
> Updates the RLM harness install-script test to match the new install behavior: cloning the `rlm` repo (branch `main`) into `/tmp/rlm-checkout` and running `install.sh` from that checkout, instead of asserting a `raw.githubusercontent.com` download.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b397cb396efd3a52173a53defe4b80c5724a96c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->