### PR TITLE
Harness owns env_vars; rlm harness keeps only sandbox-plumbing defaults

### DIFF
--- a/verifiers/envs/experimental/composable/composable_env.py
+++ b/verifiers/envs/experimental/composable/composable_env.py
@@ -123,6 +123,10 @@ class ComposableEnv(CliAgentEnv):
 
     async def build_env_vars(self, state: State) -> dict[str, str]:
         env_vars = await super().build_env_vars(state)
+        # Harness env vars act as defaults — only fill keys the user
+        # (via ``CLIAgentEnv(environment_vars=...)``) did not set.
+        for k, v in self.harness.env_vars.items():
+            env_vars.setdefault(k, v)
         info = state.get("info") or {}
         task_env_vars = self.taskset.get_env_vars()
         if task_env_vars:

--- a/verifiers/envs/experimental/composable/harness.py
+++ b/verifiers/envs/experimental/composable/harness.py
@@ -16,7 +16,7 @@ connects them.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -75,6 +75,13 @@ class Harness:
     metrics_keys:
         Optional whitelist of metric keys to surface.  ``None`` means
         surface all keys found.
+    env_vars:
+        Harness-owned sandbox env vars forwarded to the agent at
+        runtime. Merged into the sandbox env by ``ComposableEnv`` with
+        the lowest precedence — values set via
+        ``CLIAgentEnv(environment_vars=...)`` or by the task win.
+        Lets a harness declare agent defaults (e.g. the rlm harness
+        setting ``OPENAI_API_KEY=intercepted``) in one place.
     """
 
     install_script: str | None = None
@@ -90,6 +97,7 @@ class Harness:
     metrics_prefix: str = ""
     metrics_key: str | None = None
     metrics_keys: list[str] | None = None
+    env_vars: dict[str, str] = field(default_factory=dict)
 
     def get_effective_upload_dir_mapping(self) -> dict[str, str] | None:
         """Return the merged upload mapping (skills_path + upload_dir_mapping)."""

--- a/verifiers/envs/experimental/composable/harnesses/rlm.py
+++ b/verifiers/envs/experimental/composable/harnesses/rlm.py
@@ -12,6 +12,19 @@ DEFAULT_RLM_TOOLS = "bash,edit"
 DEFAULT_RLM_MAX_TURNS = 100
 DEFAULT_APPEND_TO_SYSTEM_PROMPT_PATH = "/task/append_to_system_prompt.txt"
 
+# Harness-owned sandbox env vars for the rlm agent. Kept intentionally
+# minimal: OPENAI_API_KEY=intercepted routes inference through the
+# verifiers interception tunnel (sandbox plumbing, not an rlm knob);
+# RLM_MAX_TURNS raises rlm's dev default (30) to a value appropriate
+# for longer sandbox-based rollouts. Every other rlm-side knob
+# (RLM_MAX_TURNS_IN_CONTEXT, RLM_EXEC_TIMEOUT, RLM_ENABLED_TOOLS, ...)
+# is left to rlm's own defaults; callers pass overrides via
+# ``rlm_harness(env_vars={...})``.
+DEFAULT_RLM_ENV_VARS: dict[str, str] = {
+    "OPENAI_API_KEY": "intercepted",
+    "RLM_MAX_TURNS": str(DEFAULT_RLM_MAX_TURNS),
+}
+
 
 def build_install_script(
     rlm_repo_url: str = DEFAULT_RLM_REPO_URL,
@@ -68,7 +81,10 @@ def rlm_harness(
     rlm_repo_url: str = DEFAULT_RLM_REPO_URL,
     rlm_branch: str = DEFAULT_RLM_BRANCH,
     append_to_system_prompt: str | None = None,
+    env_vars: dict[str, str] | None = None,
 ) -> Harness:
+    """Build the rlm harness. ``env_vars`` layers on top of
+    ``DEFAULT_RLM_ENV_VARS``; user keys win."""
     return Harness(
         install_script=build_install_script(rlm_repo_url, rlm_branch),
         run_command=build_run_command(instruction_path, workdir),
@@ -79,4 +95,5 @@ def rlm_harness(
         metrics_path="{workdir}/.rlm/sessions/*/meta.json",
         metrics_key="metrics",
         metrics_prefix="rlm_",
+        env_vars={**DEFAULT_RLM_ENV_VARS, **(env_vars or {})},
     )


### PR DESCRIPTION
## Summary

Restructures how harness-level env vars reach the sandbox so there's one source of truth per concern:

1. **\`Harness\` dataclass gains \`env_vars: dict[str, str]\`** — harnesses declare their own defaults instead of downstream envs re-declaring them.
2. **\`ComposableEnv.build_env_vars\`** merges \`harness.env_vars\` with lowest precedence (via \`setdefault\`), so values passed via \`CLIAgentEnv(environment_vars=...)\` or by the task still win.
3. **\`rlm_harness(env_vars=...)\`** accepts overrides and bakes the resulting dict into the returned \`Harness\`.
4. **\`DEFAULT_RLM_ENV_VARS\` shrinks** to only what the harness genuinely needs to set:
   - \`OPENAI_API_KEY=intercepted\` — sandbox plumbing (routes through interception tunnel).
   - \`RLM_MAX_TURNS=100\` — rlm's internal default is 30 (dev placeholder); 100 is the SWE-appropriate default we were already shipping.
   - Dropped \`RLM_SYSTEM_PROMPT_VERBOSITY=heavy\` (rlm never read it — dead).
   - Dropped \`RLM_MAX_TURNS_IN_CONTEXT=-1\` (matches rlm's own default — redundant).
   
   Other rlm-side knobs (\`RLM_EXEC_TIMEOUT\`, \`RLM_ENABLED_TOOLS\`, ...) are now left to rlm's own defaults. Callers override via \`rlm_harness(env_vars={...})\`.

## Motivation

Before this PR, \`rlm-swe\` re-declared its own \`DEFAULT_RLM_ENV_VARS\` and passed the merged dict via \`environment_vars=\` — a second plumbing path parallel to the harness. With the \`Harness.env_vars\` field, there's one source per concern: rlm's defaults inside rlm, sandbox-plumbing inside the harness, user overrides in a single pass-through.

See matching [research-environments#282](https://github.com/PrimeIntellect-ai/research-environments/pull/282) which becomes a thin pass-through once this lands.

## Test plan

- \`ruff check\` / \`ruff format --check\` — clean
- \`pytest tests/test_rlm_composable_env.py\` — 6/6 pass (existing tests still green with \`env_vars\` field added)
- \`pytest tests/test_composable_env.py\` — 30/30 pass (harness field additive)