### PR TITLE
Silence per-turn HTTP log spam from interception servers

### DIFF
--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -3047,7 +3047,7 @@ class RLMEnv(vf.StatefulToolEnv):
                 self._handle_root_tool_request,
             )
 
-            runner = web.AppRunner(app)
+            runner = web.AppRunner(app, access_log=None)
             await runner.setup()
             site = web.TCPSite(
                 runner, self._interception_bind_host, self.interception_port

--- a/verifiers/utils/interception_utils.py
+++ b/verifiers/utils/interception_utils.py
@@ -54,6 +54,15 @@ class InterceptionServer:
             if self._app is not None:
                 return
 
+            # Silence per-turn HTTP log spam that would otherwise escape
+            # framework-level stdout/stderr capture (e.g. training-framework
+            # redirection into a log file): the OpenAI client that forwards
+            # intercepted requests uses httpx at INFO level, producing one line
+            # per forwarded call. aiohttp's own access log is suppressed via
+            # ``access_log=None`` on the AppRunner below.
+            for name in ("httpx", "httpcore"):
+                logging.getLogger(name).setLevel(logging.WARNING)
+
             app = web.Application()
             app.router.add_post(
                 "/rollout/{rollout_id}/v1/chat/completions",
@@ -64,7 +73,7 @@ class InterceptionServer:
                 lambda _: web.json_response({"status": "ok"}),
             )
 
-            runner = web.AppRunner(app)
+            runner = web.AppRunner(app, access_log=None)
             await runner.setup()
             site = web.TCPSite(runner, "0.0.0.0", self.port)
             await site.start()


### PR DESCRIPTION
## Summary

- Pass `access_log=None` to `web.AppRunner` in both `InterceptionServer.start` (`verifiers/utils/interception_utils.py`) and `RLMEnv._ensure_interception_server` (`verifiers/envs/experimental/rlm_env.py`) to drop aiohttp's default per-request access-log line.
- Raise `httpx` / `httpcore` logger levels to `WARNING` when the interception server starts, so the OpenAI client that forwards intercepted calls stops emitting one INFO line per forwarded request.

## Motivation

When running a CLI-agent environment (e.g. `rlm-swe`) that routes the sandboxed agent's OpenAI calls through the interception server + Prime Tunnel, every turn produces two INFO log lines on the verifiers **host** process:

```
2026-04-17 00:35:04,637 - httpx - INFO - HTTP Request: POST http://.../v1/chat/completions "HTTP/1.1 200 OK"
2026-04-17 00:35:04,638 - aiohttp.access - INFO - 127.0.0.1 ... "POST /rollout/rollout_1e344269/v1/chat/completions HTTP/1.1" 200 918 "-" "AsyncOpenAI/Python 2.32.0"
```

For an RLM rollout with `max_turns=100` (the default), that's ~200 lines per rollout — and because these come from the verifiers host process rather than the sandbox, they escape framework-level stdout/stderr capture (e.g. `prime-rl` redirecting a training run's output into a log file) and spam the terminal.

The two fixes together kill both sources: `access_log=None` stops aiohttp from even creating the inbound access-log record, and the httpx/httpcore level bump stops the outbound forwarded-request chatter.

## Test plan

- [x] `uv run ruff check --fix .`
- [x] `uv run pre-commit run --files <changed files>`
- [x] `uv run pytest tests/ --ignore=tests/test_envs.py` passes (the `test_envs.py` env-install tests failed only because of local disk-quota / missing `PRIME_API_KEY`; unrelated to this change).
- [ ] Verify on a live `rlm-swe` rollout that the two log lines no longer appear per turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only changes (suppression of access logs and lowering verbosity for `httpx`/`httpcore`) with minimal functional impact beyond reduced observability if those INFO logs were relied on for debugging.
> 
> **Overview**
> Reduces per-turn log spam from the sandbox interception HTTP servers by disabling aiohttp access logging (passing `access_log=None` to `web.AppRunner`) in both `InterceptionServer.start` and `RLMEnv._ensure_interception_server`.
> 
> Also raises the `httpx`/`httpcore` logger levels to `WARNING` when the interception server starts, suppressing INFO-level outbound request logs from forwarded OpenAI calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50e5fa1ba79ac46624fef8d49b5e47fb4ac743a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->