### PR TITLE
fix: clear root logger hijacked by swebench import

### DIFF
--- a/verifiers/envs/experimental/composable/tasksets/swe/swe_bench.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/swe_bench.py
@@ -12,6 +12,14 @@ from typing import Any
 import verifiers as vf
 from verifiers.envs.experimental.composable import SandboxSpec, SandboxTaskSet
 
+# swebench's __init__.py calls logging.basicConfig() at import time (via
+# build_dataset), which hijacks the root logger with an INFO-level
+# StreamHandler.  Eagerly import it and clear the damage so downstream
+# loggers aren't flooded.
+import swebench  # noqa: F401
+
+logging.root.handlers.clear()
+
 logger = logging.getLogger(__name__)
 
 REGISTRY_PREFIX = "us-central1-docker.pkg.dev/prime-intellect-platform/prod-sandbox"


### PR DESCRIPTION
## Summary
- `swebench`'s `__init__.py` imports `build_dataset` which calls `logging.basicConfig()` at module level, adding an INFO-level `StreamHandler` to the root logger
- This floods all downstream loggers (e.g. in `rlm_swe`, `mini_swe_agent_plus`) with unwanted output
- Fix: eagerly import `swebench` at the top of `swe_bench.py` and immediately clear `logging.root.handlers`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized logging change with minimal behavioral impact beyond log configuration; main risk is unexpectedly removing handlers if other code relied on root logger setup at import time.
> 
> **Overview**
> Prevents `swebench` from flooding downstream logs by *eagerly importing* it in `swe_bench.py` and then clearing `logging.root.handlers` to undo its import-time `logging.basicConfig()` side effects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29db3ed0f1ade99bf1298192808da14c66a68481. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->