### PR TITLE
Fix host-side eval in composable CP wrapper input parsing

### DIFF
--- a/verifiers/envs/experimental/composable/tasksets/cp/test_utils.py
+++ b/verifiers/envs/experimental/composable/tasksets/cp/test_utils.py
@@ -1,6 +1,7 @@
 # modifed from https://github.com/hendrycks/apps/blob/main/eval/testing_util.py
 # https://github.com/NovaSky-AI/SkyThought/blob/main/skythought/skythought_evals/tasks/taco/taco_util.py
 import asyncio
+import ast
 import io
 import json
 import logging
@@ -196,7 +197,9 @@ def compare_stdout_results(
 
 
 def generate_cb_wrapper_script(synthesized_code, method_name, inputs):
-    inputs_repr = list(map(eval, inputs.split("\n")))
+    inputs_repr = [
+        ast.literal_eval(line) for line in inputs.splitlines() if line.strip()
+    ]
     return f"""
 {synthesized_code}
 


### PR DESCRIPTION
### Motivation
- Prevent arbitrary host-side code execution from dataset-controlled CP test inputs by removing unsafe `eval` usage when generating wrapper scripts.

### Description
- Replace `eval` with `ast.literal_eval` when parsing per-line `inputs` in `generate_cb_wrapper_script` in `verifiers/envs/experimental/composable/tasksets/cp/test_utils.py` and add the `import ast` statement to support safe literal parsing.

### Testing
- Ran `uv run pre-commit install` and `uv run ruff check --fix verifiers/envs/experimental/composable/tasksets/cp/test_utils.py` with no remaining lint errors.
- Ran `uv run pytest tests/test_composable_env.py` and all tests passed (`17 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de69e4cdfc8332abd97902c19044a3)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized change that only affects how per-line CP test inputs are parsed and reduces host-side code execution risk; may cause failures if inputs relied on non-literal Python expressions.
> 
> **Overview**
> **Improves safety of composable CP wrapper generation** by removing `eval` when parsing per-line `inputs` for `generate_cb_wrapper_script` and switching to `ast.literal_eval` with blank-line filtering.
> 
> Adds the required `import ast`, ensuring dataset-controlled inputs can only be Python literals (not arbitrary code) when building the sandbox execution scripts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04e06c270f8dfd90649342e1f324f77b550b35ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->