### PR TITLE
Fix host-side eval in composable CP wrapper input parsing

### DIFF
--- a/verifiers/envs/experimental/composable/tasksets/cp/test_utils.py
+++ b/verifiers/envs/experimental/composable/tasksets/cp/test_utils.py
@@ -1,6 +1,7 @@
 # modifed from https://github.com/hendrycks/apps/blob/main/eval/testing_util.py
 # https://github.com/NovaSky-AI/SkyThought/blob/main/skythought/skythought_evals/tasks/taco/taco_util.py
 import asyncio
+import ast
 import io
 import json
 import logging
@@ -196,7 +197,9 @@ def compare_stdout_results(
 
 
 def generate_cb_wrapper_script(synthesized_code, method_name, inputs):
-    inputs_repr = list(map(eval, inputs.split("\n")))
+    inputs_repr = [
+        ast.literal_eval(line) for line in inputs.splitlines() if line.strip()
+    ]
     return f"""
 {synthesized_code}
 


### PR DESCRIPTION
### Motivation
- Prevent arbitrary host-side code execution from dataset-controlled CP test inputs by removing unsafe `eval` usage when generating wrapper scripts.

### Description
- Replace `eval` with `ast.literal_eval` when parsing per-line `inputs` in `generate_cb_wrapper_script` in `verifiers/envs/experimental/composable/tasksets/cp/test_utils.py` and add the `import ast` statement to support safe literal parsing.

### Testing
- Ran `uv run pre-commit install` and `uv run ruff check --fix verifiers/envs/experimental/composable/tasksets/cp/test_utils.py` with no remaining lint errors.
- Ran `uv run pytest tests/test_composable_env.py` and all tests passed (`17 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de69e4cdfc8332abd97902c19044a3)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low-touch change but it alters how CP wrapper inputs are parsed; any dataset inputs that relied on arbitrary `eval` expressions will now fail, though this removes a host-side code execution risk.
> 
> **Overview**
> Hardens composable CP function-call evaluation by replacing `eval`-based parsing of per-line test inputs with `ast.literal_eval` in `generate_cb_wrapper_script`.
> 
> This prevents dataset-controlled inputs from executing arbitrary Python on the host while generating wrapper scripts, at the cost of only allowing Python literal values in inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b86c679e5174693b6346a6d2a0f326ef8fe1c354. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->