### PR TITLE
Add wall-clock timeout support to MultiTurnEnv

### DIFF
--- a/assets/lab/environments/AGENTS.md
+++ b/assets/lab/environments/AGENTS.md
@@ -576,7 +576,7 @@ class MyGameEnv(vf.MultiTurnEnv):
         return state.get("lives", 1) <= 0
 ```
 
-`MultiTurnEnv` includes built-in stop conditions for errors, prompt length limits, `max_turns`, and `max_total_completion_tokens` by default.
+`MultiTurnEnv` includes built-in stop conditions for errors, prompt length limits, `max_turns`, `timeout_seconds`, and `max_total_completion_tokens` by default.
 
 Execution order can be controlled with `priority` (higher runs first). This is useful for checking cheap conditions before expensive ones:
 

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -570,7 +570,7 @@ class MyGameEnv(vf.MultiTurnEnv):
         return state.get("lives", 1) <= 0
 ```
 
-`MultiTurnEnv` includes built-in stop conditions for errors, prompt length limits, `max_turns`, and `max_total_completion_tokens` by default.
+`MultiTurnEnv` includes built-in stop conditions for errors, prompt length limits, `max_turns`, `timeout_seconds`, and `max_total_completion_tokens` by default.
 
 Execution order can be controlled with `priority` (higher runs first). This is useful for checking cheap conditions before expensive ones:
 

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -73,10 +73,10 @@ The `--env-args` flag passes arguments to your `load_environment()` function:
 prime eval run my-env -a '{"difficulty": "hard", "num_examples": 100}'
 ```
 
-The `--extra-env-kwargs` flag passes arguments directly to the environment constructor, useful for overriding defaults like `max_turns` which may not be exposed via `load_environment()`:
+The `--extra-env-kwargs` flag passes arguments directly to the environment constructor, useful for overriding defaults like `max_turns` or setting rollout limits like `timeout_seconds` which may not be exposed via `load_environment()`:
 
 ```bash
-prime eval run my-env -x '{"max_turns": 20}'
+prime eval run my-env -x '{"max_turns": 20, "timeout_seconds": 600}'
 ```
 
 #### Executor autoscaling

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -327,7 +327,12 @@ Single-response Q&A tasks. Inherits from `Environment`.
 
 ```python
 class MultiTurnEnv(Environment):
-    def __init__(self, max_turns: int = -1, **kwargs): ...
+    def __init__(
+        self,
+        max_turns: int = -1,
+        timeout_seconds: float | None = None,
+        **kwargs,
+    ): ...
 ```
 
 Multi-turn interactions. Subclasses must implement `env_response`.
@@ -339,7 +344,7 @@ async def env_response(self, messages: Messages, state: State, **kwargs) -> Mess
     """Generate environment feedback after model turn."""
 ```
 
-**Built-in stop conditions:** `has_error`, `prompt_too_long`, `max_turns_reached`, `max_total_completion_tokens_reached`, `has_final_env_response`
+**Built-in stop conditions:** `has_error`, `prompt_too_long`, `max_turns_reached`, `timeout_reached`, `max_total_completion_tokens_reached`, `has_final_env_response`
 
 **Hooks:**
 

--- a/environments/AGENTS.md
+++ b/environments/AGENTS.md
@@ -576,7 +576,7 @@ class MyGameEnv(vf.MultiTurnEnv):
         return state.get("lives", 1) <= 0
 ```
 
-`MultiTurnEnv` includes built-in stop conditions for errors, prompt length limits, `max_turns`, and `max_total_completion_tokens` by default.
+`MultiTurnEnv` includes built-in stop conditions for errors, prompt length limits, `max_turns`, `timeout_seconds`, and `max_total_completion_tokens` by default.
 
 Execution order can be controlled with `priority` (higher runs first). This is useful for checking cheap conditions before expensive ones:
 

--- a/skills/evaluate-environments/SKILL.md
+++ b/skills/evaluate-environments/SKILL.md
@@ -89,7 +89,7 @@ prime eval run my-env -a '{"difficulty":"hard"}'
 ```
 2. Override constructor kwargs:
 ```bash
-prime eval run my-env -x '{"max_turns":20}'
+prime eval run my-env -x '{"max_turns":20,"timeout_seconds":600}'
 ```
 3. Save extra state columns:
 ```bash

--- a/tests/test_cli_agent_env.py
+++ b/tests/test_cli_agent_env.py
@@ -1,6 +1,8 @@
 """Tests for CliAgentEnv and HarborEnv."""
 
+import asyncio
 import tempfile
+import time
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -63,6 +65,7 @@ class TestCliAgentEnv:
         assert env.docker_image == "python:3.11-slim"
         assert env.interception_port == 8765
         assert env.timeout_seconds == 3600.0
+        assert env.timeout_reached.__func__ is vf.MultiTurnEnv.timeout_reached
 
     def test_init_custom_config(self, sample_dataset):
         """Test initialization with custom configuration."""
@@ -130,6 +133,9 @@ class TestCliAgentEnv:
         state = {"agent_completed": True}
         assert await env.agent_completed(state) is True
 
+        state = {"agent_completed": True, "timed_out": True}
+        assert await env.agent_completed(state) is False
+
     @pytest.mark.asyncio
     async def test_timeout_reached_stop_condition(self, sample_dataset):
         """Test the timeout_reached stop condition."""
@@ -139,13 +145,56 @@ class TestCliAgentEnv:
             rubric=vf.Rubric(),
             timeout_seconds=10.0,
         )
-        import time
 
-        state = {"timing": {"start_time": time.time()}}
+        state = {
+            "timing": {"start_time": time.time()},
+            "_start_perf_counter": time.perf_counter(),
+        }
         assert await env.timeout_reached(state) is False
 
-        state = {"timing": {"start_time": time.time() - 20}}
+        state = {
+            "timing": {"start_time": time.time() - 20},
+            "_start_perf_counter": time.perf_counter() - 20,
+        }
         assert await env.timeout_reached(state) is True
+        assert state["timed_out"] is True
+        assert state["is_truncated"] is True
+
+    def test_disabled_timeout_omits_sandbox_timeout(self, sample_dataset):
+        """Disabling rollout timeout should not send a zero-minute sandbox timeout."""
+        env = vf.CliAgentEnv(
+            run_command="python agent.py",
+            dataset=sample_dataset,
+            rubric=vf.Rubric(),
+            timeout_seconds=None,
+        )
+
+        resources = env.get_sandbox_resources({})
+
+        assert "timeout_minutes" not in resources
+
+    @pytest.mark.asyncio
+    async def test_poll_next_request_exits_on_rollout_timeout(self, sample_dataset):
+        """Polling should unblock when the inherited rollout timeout is reached."""
+        env = vf.CliAgentEnv(
+            run_command="python agent.py",
+            dataset=sample_dataset,
+            rubric=vf.Rubric(),
+            timeout_seconds=0.01,
+            poll_interval=0.001,
+        )
+        state = {
+            "request_id_queue": asyncio.Queue(),
+            "agent_completed": False,
+            "timing": {"start_time": time.time() - 1.0},
+            "_start_perf_counter": time.perf_counter() - 1.0,
+        }
+
+        request_id = await env._poll_next_request(state)
+
+        assert request_id is None
+        assert state["timed_out"] is True
+        assert state["is_truncated"] is True
 
     @pytest.mark.asyncio
     async def test_env_response_returns_empty(self, sample_dataset):

--- a/tests/test_eval_cli.py
+++ b/tests/test_eval_cli.py
@@ -230,6 +230,20 @@ def test_cli_temperature_not_added_when_none(monkeypatch, run_cli):
     assert "temperature" not in sa
 
 
+def test_cli_extra_env_kwargs_support_timeout_seconds(monkeypatch, run_cli):
+    captured = run_cli(
+        monkeypatch,
+        {
+            "extra_env_kwargs": {"timeout_seconds": 30, "foo": "bar"},
+        },
+    )
+
+    assert captured["configs"][0].extra_env_kwargs == {
+        "timeout_seconds": 30,
+        "foo": "bar",
+    }
+
+
 def test_cli_headers_table_and_list_merge(monkeypatch, run_cli):
     captured = run_cli(
         monkeypatch,
@@ -870,6 +884,17 @@ def test_load_toml_config_global_values_with_per_eval_override():
     assert result[1]["env_id"] == "env2"
     assert result[1]["model"] == "gpt-5"  # still inherits global
     assert result[1]["num_examples"] == 50  # per-eval override
+
+
+def test_load_toml_config_with_extra_env_kwargs():
+    with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
+        f.write(
+            '[[eval]]\nenv_id = "env1"\n[eval.extra_env_kwargs]\ntimeout_seconds = 600\n'
+        )
+        f.flush()
+        result = load_toml_config(Path(f.name))
+
+    assert result[0]["extra_env_kwargs"] == {"timeout_seconds": 600}
 
 
 def test_load_toml_config_invalid_global_field():

--- a/tests/test_multiturn_env.py
+++ b/tests/test_multiturn_env.py
@@ -1,5 +1,8 @@
 """Tests for the MultiTurnEnv class."""
 
+import asyncio
+import time
+
 import pytest
 from datasets import Dataset
 
@@ -12,6 +15,7 @@ class TestMultiTurnEnv:
     def test_multiturn_env_initialization(self, mock_multiturn_env):
         """Test MultiTurnEnv initialization."""
         assert mock_multiturn_env.max_turns == 3
+        assert mock_multiturn_env.timeout_seconds is None
         assert mock_multiturn_env.message_type == "chat"  # Default from parent
 
     def test_multiturn_env_default_max_turns(self, mock_client, sample_chat_dataset):
@@ -26,6 +30,31 @@ class TestMultiTurnEnv:
             rubric=Rubric(),
         )
         assert env.max_turns == -1  # Default value
+        assert env.timeout_seconds is None
+
+    @pytest.mark.asyncio
+    async def test_timeout_reached_stop_condition(
+        self, mock_client, sample_chat_dataset
+    ):
+        """Test the timeout_reached stop condition."""
+        from tests.conftest import SimpleMultiTurnEnv
+
+        env = SimpleMultiTurnEnv(
+            client=mock_client,
+            model="test-model",
+            dataset=sample_chat_dataset,
+            parser=Parser(),
+            rubric=Rubric(),
+            timeout_seconds=10.0,
+        )
+
+        state: State = {"timing": {"start_time": time.time()}}
+        assert await env.timeout_reached(state) is False
+        assert state.get("timed_out") is None
+
+        state = {"timing": {"start_time": time.time() - 20}}
+        assert await env.timeout_reached(state) is True
+        assert state["timed_out"] is True
 
     @pytest.mark.asyncio
     async def test_basic_multiturn_rollout(self, mock_multiturn_env, make_input):
@@ -102,6 +131,44 @@ class TestMultiTurnEnv:
         assert completion[0]["role"] == "assistant"
         assert completion[1]["role"] == "user"
         assert completion[2]["role"] == "assistant"
+
+    @pytest.mark.asyncio
+    async def test_timeout_seconds_limits_rollout(
+        self, mock_client, sample_chat_dataset, make_input
+    ):
+        """Test that rollout stops when the wall-clock timeout is reached."""
+
+        class SlowMultiTurnEnv(MultiTurnEnv):
+            async def env_response(self, messages, state, **kwargs):  # type: ignore[override]
+                await asyncio.sleep(0.05)
+                return [{"role": "user", "content": "Continue"}]
+
+        env = SlowMultiTurnEnv(
+            client=mock_client,
+            model="test-model",
+            dataset=sample_chat_dataset,
+            parser=Parser(),
+            rubric=Rubric(),
+            timeout_seconds=0.01,
+        )
+        mock_client.set_default_response("Still going")
+
+        prompt = [{"role": "user", "content": "Start conversation"}]
+        state = await env.rollout(
+            input=make_input(prompt=prompt, answer="target_answer"),
+            client=mock_client,
+            model="test-model",
+        )
+
+        assert len(state["trajectory"]) == 1
+        assert state["timed_out"] is True
+        assert state["is_completed"] is True
+        assert state["is_truncated"] is True
+        assert state["stop_condition"] == "timeout_reached"
+        completion = state["completion"]
+        assert len(completion) == 1
+        assert completion[0]["role"] == "assistant"
+        assert completion[0]["content"] == "Still going"
 
     @pytest.mark.asyncio
     async def test_override_is_completed_respects_max_turns(

--- a/tests/test_multiturn_env.py
+++ b/tests/test_multiturn_env.py
@@ -48,13 +48,20 @@ class TestMultiTurnEnv:
             timeout_seconds=10.0,
         )
 
-        state: State = {"timing": {"start_time": time.time()}}
+        state: State = {
+            "timing": {"start_time": time.time()},
+            "_start_perf_counter": time.perf_counter(),
+        }
         assert await env.timeout_reached(state) is False
         assert state.get("timed_out") is None
 
-        state = {"timing": {"start_time": time.time() - 20}}
+        state = {
+            "timing": {"start_time": time.time() - 20},
+            "_start_perf_counter": time.perf_counter() - 20,
+        }
         assert await env.timeout_reached(state) is True
         assert state["timed_out"] is True
+        assert state["is_truncated"] is True
 
     @pytest.mark.asyncio
     async def test_basic_multiturn_rollout(self, mock_multiturn_env, make_input):
@@ -140,8 +147,11 @@ class TestMultiTurnEnv:
 
         class SlowMultiTurnEnv(MultiTurnEnv):
             async def env_response(self, messages, state, **kwargs):  # type: ignore[override]
-                await asyncio.sleep(0.05)
                 return [{"role": "user", "content": "Continue"}]
+
+            async def add_model_response(self, state, prompt_messages, response):  # type: ignore[override]
+                await super().add_model_response(state, prompt_messages, response)
+                await asyncio.sleep(0.05)
 
         env = SlowMultiTurnEnv(
             client=mock_client,
@@ -169,6 +179,45 @@ class TestMultiTurnEnv:
         assert len(completion) == 1
         assert completion[0]["role"] == "assistant"
         assert completion[0]["content"] == "Still going"
+
+    @pytest.mark.asyncio
+    async def test_timeout_seconds_limits_setup(
+        self, mock_client, sample_chat_dataset, make_input
+    ):
+        """Test that the rollout timeout applies while setup is in flight."""
+
+        class SlowSetupEnv(MultiTurnEnv):
+            async def setup_state(self, state):  # type: ignore[override]
+                await asyncio.sleep(1)
+                return state
+
+            async def env_response(self, messages, state, **kwargs):  # type: ignore[override]
+                return [{"role": "user", "content": "Continue"}]
+
+        env = SlowSetupEnv(
+            client=mock_client,
+            model="test-model",
+            dataset=sample_chat_dataset,
+            parser=Parser(),
+            rubric=Rubric(),
+            timeout_seconds=0.01,
+        )
+
+        state = await env.rollout(
+            input=make_input(
+                prompt=[{"role": "user", "content": "Start conversation"}],
+                answer="target_answer",
+            ),
+            client=mock_client,
+            model="test-model",
+        )
+
+        assert state["timed_out"] is True
+        assert state["is_completed"] is True
+        assert state["is_truncated"] is True
+        assert state["stop_condition"] == "timeout_reached"
+        assert state["trajectory"] == []
+        assert state["completion"] == []
 
     @pytest.mark.asyncio
     async def test_override_is_completed_respects_max_turns(

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -618,6 +618,7 @@ class Environment(ABC):
             total_ms=0.0,
             start_time=time.time(),
         )
+        state["_start_perf_counter"] = time.perf_counter()
         return state
 
     @abstractmethod
@@ -663,8 +664,8 @@ class Environment(ABC):
         return False
 
     async def _render_timing(self, state: State):
-        start_time = state["timing"]["start_time"]
-        end_time = time.time()
+        start_time = state.get("_start_perf_counter", state["timing"]["start_time"])
+        end_time = time.perf_counter()
         state["timing"]["generation_ms"] = (end_time - start_time) * 1000
         state["timing"]["total_ms"] = (end_time - start_time) * 1000
 

--- a/verifiers/envs/experimental/cli_agent_env.py
+++ b/verifiers/envs/experimental/cli_agent_env.py
@@ -53,7 +53,7 @@ class CliAgentMonitorRubric(vf.Rubric):
 
     async def agent_timeout(self, state: vf.State) -> float:
         """Whether the agent timed out."""
-        return float(bool(state.get("agent_timed_out")))
+        return float(bool(state.get("agent_timed_out") or state.get("timed_out")))
 
     async def agent_error(self, state: vf.State) -> float:
         """Whether the agent errored (non-zero exit_code)."""
@@ -77,7 +77,7 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
         interception_port: int | None = None,
         interception_url: str | None = None,
         max_turns: int = -1,
-        timeout_seconds: float = 3600.0,
+        timeout_seconds: float | None = 3600.0,
         poll_interval: float = 1.0,
         docker_image: str = "python:3.11-slim",
         start_command: str = "tail -f /dev/null",
@@ -102,7 +102,12 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
         keep_sandbox_for_scoring: bool = False,
         **kwargs,
     ):
-        super().__init__(max_turns=max_turns, message_type="chat", **kwargs)
+        super().__init__(
+            max_turns=max_turns,
+            timeout_seconds=timeout_seconds,
+            message_type="chat",
+            **kwargs,
+        )
         self.init_sandbox_client(
             max_retries=max_retries,
             base_delay=base_delay,
@@ -118,7 +123,6 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
         self.keep_sandbox_for_scoring = keep_sandbox_for_scoring
         self.run_command = run_command
         self.poll_interval = poll_interval
-        self.timeout_seconds = timeout_seconds
         self.docker_image = docker_image
         self.start_command = start_command
         self.cpu_cores = cpu_cores
@@ -226,22 +230,24 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
         docker_image = await self.get_docker_image(state)
         resources = self.get_sandbox_resources(state)
 
-        sandbox_request = CreateSandboxRequest(
-            name=rollout_id,
-            docker_image=docker_image,
-            start_command=self.start_command,
-            cpu_cores=resources["cpu_cores"],
-            memory_gb=resources["memory_gb"],
-            disk_size_gb=resources["disk_size_gb"],
-            gpu_count=resources["gpu_count"],
-            gpu_type=resources.get("gpu_type"),
-            vm=resources.get("vm", resources["gpu_count"] > 0),
-            timeout_minutes=resources["timeout_minutes"],
-            environment_vars=env_vars,
-            team_id=self.team_id,
-            advanced_configs=self.advanced_configs,
-            labels=self.labels if self.labels else [],
-        )
+        sandbox_request_kwargs = {
+            "name": rollout_id,
+            "docker_image": docker_image,
+            "start_command": self.start_command,
+            "cpu_cores": resources["cpu_cores"],
+            "memory_gb": resources["memory_gb"],
+            "disk_size_gb": resources["disk_size_gb"],
+            "gpu_count": resources["gpu_count"],
+            "gpu_type": resources.get("gpu_type"),
+            "vm": resources.get("vm", resources["gpu_count"] > 0),
+            "environment_vars": env_vars,
+            "team_id": self.team_id,
+            "advanced_configs": self.advanced_configs,
+            "labels": self.labels if self.labels else [],
+        }
+        if "timeout_minutes" in resources:
+            sandbox_request_kwargs["timeout_minutes"] = resources["timeout_minutes"]
+        sandbox_request = CreateSandboxRequest(**cast(Any, sandbox_request_kwargs))
         self.logger.debug(
             f"Creating sandbox with OPENAI_BASE_URL={env_vars.get('OPENAI_BASE_URL')} "
             f"docker_image={docker_image}"
@@ -269,18 +275,17 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
 
     def get_sandbox_resources(self, state: State) -> dict[str, Any]:
         """Get sandbox resource allocation. Override for per-instance resources."""
-        timeout_seconds = self.timeout_seconds
-        if timeout_seconds is None:
-            timeout_seconds = 0.0
-        return {
+        resources = {
             "cpu_cores": self.cpu_cores,
             "memory_gb": self.memory_gb,
             "disk_size_gb": self.disk_size_gb,
             "gpu_count": self.gpu_count,
             "gpu_type": None,
             "vm": self.gpu_count > 0,
-            "timeout_minutes": math.ceil(timeout_seconds / 60),
         }
+        if self.timeout_seconds is not None:
+            resources["timeout_minutes"] = math.ceil(self.timeout_seconds / 60)
+        return resources
 
     # Keys set by build_env_vars that subclasses must not override.
     PROTECTED_ENV_VARS = frozenset(
@@ -347,6 +352,7 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
         except asyncio.TimeoutError:
             self.logger.warning(f"Agent timed out after {self.timeout_seconds}s")
             state["agent_timed_out"] = True
+            self.mark_timed_out(state)
         except asyncio.CancelledError:
             self.logger.debug("Completion wait task cancelled")
             raise
@@ -474,7 +480,14 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
                 if await self.check_agent_completed(state):
                     state["agent_completed"] = True
                     return None
-                if time.time() - state["timing"]["start_time"] > self.timeout_seconds:
+                start_time = state.get(
+                    "_start_perf_counter", state["timing"]["start_time"]
+                )
+                if (
+                    self.timeout_seconds is not None
+                    and time.perf_counter() - start_time > self.timeout_seconds
+                ):
+                    self.mark_timed_out(state)
                     return None
 
     async def get_prompt_messages(self, state: State) -> Messages:
@@ -634,13 +647,11 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
     @vf.stop
     async def agent_completed(self, state: State) -> bool:
         """Check if agent has completed."""
-        return state.get("agent_completed", False)
-
-    @vf.stop
-    async def timeout_reached(self, state: State) -> bool:
-        """Check rollout timeout"""
-        elapsed = time.time() - state["timing"]["start_time"]
-        return elapsed > self.timeout_seconds
+        return (
+            state.get("agent_completed", False)
+            and not state.get("agent_timed_out", False)
+            and not state.get("timed_out", False)
+        )
 
     async def post_rollout(self, state: State):
         """
@@ -665,7 +676,7 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
             f"{type(error).__name__}: {truncate(str(error), 80)}" if error else None
         )
         exit_code = state.get("agent_exit_code")
-        timed_out = state.get("agent_timed_out", False)
+        timed_out = state.get("agent_timed_out", False) or state.get("timed_out", False)
         duration_s = state["timing"].get("total_ms", 0) / 1000
         tools_str = ",".join(f"{k}:{v}" for k, v in tool_counts.most_common())
         parts = [

--- a/verifiers/envs/experimental/cli_agent_env.py
+++ b/verifiers/envs/experimental/cli_agent_env.py
@@ -269,6 +269,9 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
 
     def get_sandbox_resources(self, state: State) -> dict[str, Any]:
         """Get sandbox resource allocation. Override for per-instance resources."""
+        timeout_seconds = self.timeout_seconds
+        if timeout_seconds is None:
+            timeout_seconds = 0.0
         return {
             "cpu_cores": self.cpu_cores,
             "memory_gb": self.memory_gb,
@@ -276,7 +279,7 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
             "gpu_count": self.gpu_count,
             "gpu_type": None,
             "vm": self.gpu_count > 0,
-            "timeout_minutes": math.ceil(self.timeout_seconds / 60),
+            "timeout_minutes": math.ceil(timeout_seconds / 60),
         }
 
     # Keys set by build_env_vars that subclasses must not override.

--- a/verifiers/envs/experimental/sandbox_mixin.py
+++ b/verifiers/envs/experimental/sandbox_mixin.py
@@ -169,8 +169,24 @@ class SandboxMixin:
         if self.sandbox_creation_rate_limiter is not None:
             await self.sandbox_creation_rate_limiter.acquire()
 
+        create_task = asyncio.create_task(
+            self.with_retry(self.sandbox_client.create)(request)
+        )
         try:
-            sandbox = await self.with_retry(self.sandbox_client.create)(request)
+            sandbox = await asyncio.shield(create_task)
+        except asyncio.CancelledError:
+
+            def cleanup_created_sandbox(task: asyncio.Task):
+                try:
+                    sandbox = task.result()
+                except BaseException:
+                    return
+                self.register_sandbox(sandbox.id)
+                state["sandbox_id"] = sandbox.id
+                asyncio.create_task(self.delete_sandbox(sandbox.id))
+
+            create_task.add_done_callback(cleanup_created_sandbox)
+            raise
         except Exception as e:
             raise SandboxCreationError(f"Failed to create sandbox: {e}") from e
 

--- a/verifiers/envs/multiturn_env.py
+++ b/verifiers/envs/multiturn_env.py
@@ -79,10 +79,15 @@ class MultiTurnEnv(vf.Environment):
     async def timeout_reached(self, state: State) -> bool:
         if self.timeout_seconds is None:
             return False
-        if time.time() - state["timing"]["start_time"] <= self.timeout_seconds:
+        start_time = state.get("_start_perf_counter", state["timing"]["start_time"])
+        if time.perf_counter() - start_time <= self.timeout_seconds:
             return False
-        state["timed_out"] = True
+        self.mark_timed_out(state)
         return True
+
+    def mark_timed_out(self, state: State) -> None:
+        state["timed_out"] = True
+        state["is_truncated"] = True
 
     @vf.stop
     async def max_total_completion_tokens_reached(self, state: State) -> bool:
@@ -203,16 +208,16 @@ class MultiTurnEnv(vf.Environment):
 
             rollout_task = asyncio.create_task(run_rollout_loop())
             done, _ = await asyncio.wait({rollout_task}, timeout=self.timeout_seconds)
-            if rollout_task in done:
+            if rollout_task in done or rollout_task.done():
                 return await rollout_task
 
-            rollout_task.cancel()
+            if not rollout_task.cancel():
+                return await rollout_task
             with suppress(asyncio.CancelledError):
                 await rollout_task
 
-            state["timed_out"] = True
+            self.mark_timed_out(state)
             state["is_completed"] = True
-            state["is_truncated"] = True
             state["stop_condition"] = "timeout_reached"
             await self._render_timing(state)
             await self._cleanup(state)

--- a/verifiers/envs/multiturn_env.py
+++ b/verifiers/envs/multiturn_env.py
@@ -1,6 +1,8 @@
 import asyncio
 import logging
+import time
 from abc import abstractmethod
+from contextlib import suppress
 from typing import final
 
 import verifiers as vf
@@ -35,9 +37,15 @@ class MultiTurnMonitorRubric(vf.Rubric):
 
 
 class MultiTurnEnv(vf.Environment):
-    def __init__(self, max_turns: int = -1, **kwargs):
+    def __init__(
+        self,
+        max_turns: int = -1,
+        timeout_seconds: float | None = None,
+        **kwargs,
+    ):
         super().__init__(**kwargs)
         self.max_turns = max_turns
+        self.timeout_seconds = timeout_seconds
         self.max_total_completion_tokens: int = -1
 
         self.add_rubric(MultiTurnMonitorRubric())
@@ -66,6 +74,15 @@ class MultiTurnEnv(vf.Environment):
     @vf.stop
     async def max_turns_reached(self, state: State) -> bool:
         return len(state["trajectory"]) >= self.max_turns and self.max_turns > 0
+
+    @vf.stop
+    async def timeout_reached(self, state: State) -> bool:
+        if self.timeout_seconds is None:
+            return False
+        if time.time() - state["timing"]["start_time"] <= self.timeout_seconds:
+            return False
+        state["timed_out"] = True
+        return True
 
     @vf.stop
     async def max_total_completion_tokens_reached(self, state: State) -> bool:
@@ -151,7 +168,11 @@ class MultiTurnEnv(vf.Environment):
         sampling_args: SamplingArgs | None = None,
     ) -> State:
         state = await self.init_state(input, client, model, sampling_args)
-        try:
+        rollout_task: asyncio.Task[State] | None = None
+
+        async def run_rollout_loop() -> State:
+            nonlocal state
+
             try:
                 state = await self.setup_state(state)
             except vf.Error as e:
@@ -175,6 +196,32 @@ class MultiTurnEnv(vf.Environment):
                         state["error"] = e
             await self.render_completion(state)
             return state
+
+        try:
+            if self.timeout_seconds is None:
+                return await run_rollout_loop()
+
+            rollout_task = asyncio.create_task(run_rollout_loop())
+            done, _ = await asyncio.wait({rollout_task}, timeout=self.timeout_seconds)
+            if rollout_task in done:
+                return await rollout_task
+
+            rollout_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await rollout_task
+
+            state["timed_out"] = True
+            state["is_completed"] = True
+            state["is_truncated"] = True
+            state["stop_condition"] = "timeout_reached"
+            await self._render_timing(state)
+            await self._cleanup(state)
+            await self.render_completion(state)
+            return state
         except asyncio.CancelledError:
+            if rollout_task is not None and not rollout_task.done():
+                rollout_task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await rollout_task
             await self._cleanup(state)
             raise


### PR DESCRIPTION
## Summary
- add a nullable `timeout_seconds` kwarg to `MultiTurnEnv` and stop timed out rollouts with `timeout_reached`
- keep timeout configuration on the existing kwargs path (`extra_env_kwargs`) instead of adding a first-party eval flag
- add focused tests and docs updates, plus a tiny `CliAgentEnv` typing fix needed for the repo's `ty` pre-push check

## Testing
- `uv run pytest tests/test_multiturn_env.py tests/test_eval_cli.py`
- `uv run pre-commit run --all-files`
- ad hoc smoke test: `ToolEnv` with a 10s sleeping tool and `timeout_seconds=5` stopped in ~5s with `stop_condition=timeout_reached`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds cancellation-based wall-clock timeouts to the core multi-turn rollout loop and timing measurements, which can affect rollout termination, cleanup, and state flags across all derived environments.
> 
> **Overview**
> Adds a nullable `timeout_seconds` to `MultiTurnEnv` and a built-in `timeout_reached` stop condition that marks rollouts as timed out/truncated and can hard-stop the rollout loop via task cancellation when the wall-clock limit is exceeded (including during `setup_state`).
> 
> Updates rollout timing to use `time.perf_counter()` (tracked via `_start_perf_counter`) and propagates the new timeout behavior through `CliAgentEnv` (inherits the stop condition, allows disabling sandbox timeouts, and treats timeouts as non-completions) plus makes sandbox creation resilient to cancellation by scheduling cleanup of a sandbox created after the caller is cancelled.
> 
> Extends CLI/TOML config parsing tests to ensure `extra_env_kwargs.timeout_seconds` is preserved, adds focused timeout-related unit tests, and updates docs/examples to mention `timeout_seconds` as a default stop/rollout limit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4ea7c95c45f49a4990c72a4f184256f8ccbc557. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->