### PR TITLE
Fix command injection in composable harness metrics collection

### DIFF
--- a/tests/test_composable_env.py
+++ b/tests/test_composable_env.py
@@ -2,6 +2,7 @@
 
 import importlib
 import json
+import shlex
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, call
 
@@ -590,3 +591,39 @@ async def test_composable_env_no_metrics_when_path_not_set():
 
     # No execute_command calls since no log_path and no metrics_path
     env.sandbox_client.execute_command.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_composable_env_metrics_command_quotes_untrusted_workdir():
+    class InjectionWorkdirTaskSet(MockSandboxTaskSet):
+        def get_workdir(self, info):
+            return '/tmp/workdir$(echo hacked); rm -rf "/tmp/nope"'
+
+    taskset = InjectionWorkdirTaskSet(dataset=_make_dataset(), name="test")
+    env = ComposableEnv(
+        taskset=taskset,
+        harness=Harness(run_command="true", metrics_path="{workdir}/metrics*.json"),
+    )
+    env.sandbox_client = SimpleNamespace(
+        execute_command=AsyncMock(
+            return_value=SimpleNamespace(
+                stdout=json.dumps({"turns": 1}),
+                stderr="",
+                exit_code=0,
+            )
+        ),
+        teardown=lambda: None,
+    )
+
+    state = {
+        "sandbox_id": "sbx",
+        "info": {"id": 0},
+        "timing": {"total_ms": 0},
+        "trajectory": [],
+    }
+
+    await env.post_rollout(state)
+
+    command = env.sandbox_client.execute_command.await_args.args[1]
+    expected_glob = '/tmp/workdir$(echo hacked); rm -rf "/tmp/nope"/metrics*.json'
+    assert shlex.quote(expected_glob) in command

--- a/verifiers/envs/experimental/composable/composable_env.py
+++ b/verifiers/envs/experimental/composable/composable_env.py
@@ -301,11 +301,15 @@ class ComposableEnv(CliAgentEnv):
         info = state.get("info") or {}
         workdir = self.taskset.get_workdir(info)
         metrics_glob = self.harness.metrics_path.format(workdir=workdir)
+        python_snippet = (
+            "import glob, pathlib, sys; "
+            "matches = glob.glob(sys.argv[1]); "
+            "print(pathlib.Path(matches[0]).read_text() if matches else '{}')"
+        )
         try:
             result = await self.sandbox_client.execute_command(
                 sandbox_id,
-                f"f=$(ls {metrics_glob} 2>/dev/null | head -1) "
-                '&& cat "$f" || echo "{}"',
+                f"python -c {shlex.quote(python_snippet)} {shlex.quote(metrics_glob)}",
                 working_dir=None,
             )
             data = json.loads((result.stdout or "{}").strip())


### PR DESCRIPTION
### Motivation
- The harness metrics collection used an unquoted shell `ls {metrics_glob}` expansion built from `workdir`, allowing shell metacharacter injection when `workdir` is derived from untrusted task metadata.

### Description
- Replace the shell `ls`/shell pipeline with a small Python `-c` snippet that uses `glob` to find the first match and prints its contents, avoiding shell glob expansion semantics.
- Shell-quote both the Python snippet and the formatted `metrics_glob` with `shlex.quote` before passing them to `execute_command` to prevent shell interpretation of untrusted characters.
- Preserve original behavior by reading the first matching metrics JSON file and defaulting to `{}` when no matches exist.
- Add a regression test that supplies a malicious `workdir` and asserts the generated command contains the shell-quoted metrics glob, and add the required `shlex` import for the test.

### Testing
- Ran `uv run ruff check verifiers/envs/experimental/composable/composable_env.py tests/test_composable_env.py` and formatting fixes; the checks passed.
- Ran `uv run pytest tests/test_composable_env.py -q` and all tests in the file passed.
- Ran `uv run pre-commit run --files verifiers/envs/experimental/composable/composable_env.py tests/test_composable_env.py` and pre-commit hooks passed after autoformatting changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1f2ee64248332b2578ba81a6d0f24)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sandbox command construction for metrics collection; incorrect quoting or Python invocation could break metrics retrieval, but scope is limited and covered by a regression test.
> 
> **Overview**
> Fixes a command-injection vector in `ComposableEnv` harness metrics collection by replacing the shell `ls|head|cat` pipeline with a `python -c` snippet that performs globbing and file reading safely.
> 
> Both the Python snippet and the formatted `metrics_glob` are now passed through `shlex.quote`, and a new test asserts that an untrusted/malicious `workdir` is properly quoted in the generated metrics command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e90e93182b66e21a3ab2ce18be41bb8cff60e42d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->