### PR TITLE
fix: surface agent timeout as state['error'] in CliAgentEnv

### DIFF
--- a/verifiers/envs/experimental/cli_agent_env.py
+++ b/verifiers/envs/experimental/cli_agent_env.py
@@ -344,6 +344,9 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
         except asyncio.TimeoutError:
             self.logger.warning(f"Agent timed out after {self.timeout_seconds}s")
             state["agent_timed_out"] = True
+            state["error"] = AgentError(
+                f"Agent timed out after {self.timeout_seconds}s"
+            )
         except asyncio.CancelledError:
             self.logger.debug("Completion wait task cancelled")
             raise


### PR DESCRIPTION
## Problem

`CliAgentEnv.wait_for_completion` catches `asyncio.TimeoutError` but only sets `state["agent_timed_out"] = True`, leaving `state["error"]` unset. When the agent times out without producing any trajectory, the rollout comes back with `trajectory=[], error=None`, and the orchestrator scheduler reschedules it as a generic "Empty trajectory" with no diagnostic — indistinguishable from a genuinely silent empty rollout.

## Fix

In the `asyncio.TimeoutError` branch, also set `state["error"] = AgentError(f"Agent timed out after {self.timeout_seconds}s")`, mirroring the style of the `except Exception` branch directly below. `agent_timed_out=True` is preserved for existing downstream checks elsewhere in the file.

## Context

Third in a series closing silent-failure holes in `CliAgentEnv`:

- #1127 — non-zero exit + empty trajectory
- #1130 — AgentError double-wrapping
- this PR — timeout path

A companion fix in prime-rl reorders the scheduler's `if empty / elif error` so that the error branch is checked first (otherwise this surfaced error would still be hidden behind the empty-trajectory branch). See companion PR in prime-rl.

## Tests

No regression test was added. The existing `tests/test_cli_agent_env.py` covers `timeout_reached` (the stop-condition) but does not exercise `wait_for_completion`'s `asyncio.TimeoutError` path. Adding such a test would require mocking `asyncio.wait_for` and the background-job polling loop, which felt out of scope for a 3-line fix — flagged here for a follow-up if desired.

## Checks

- `uv run ruff check verifiers/envs/experimental/cli_agent_env.py` — passed
- `uv run ruff format --check verifiers/envs/experimental/cli_agent_env.py` — already formatted

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to timeout handling that only affects how errors are surfaced in rollout state; minimal behavioral impact beyond improved diagnostics and potential downstream branching on `state["error"]`.
> 
> **Overview**
> `CliAgentEnv.wait_for_completion` now records timeouts as a real failure by setting `state["error"]` to an `AgentError` when `asyncio.wait_for` hits `TimeoutError`, in addition to the existing `state["agent_timed_out"] = True` flag.
> 
> This ensures timeout rollouts surface a diagnostic error instead of looking like a silent empty trajectory to downstream schedulers/consumers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e88fd94d4ea2b1c25a6ef25e0815984845285805. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->