### PR TITLE
add timeout_minutes kwarg to R2E / SWEBench / Multi-SWE / OpenSWE tasksets

### DIFF
--- a/verifiers/envs/experimental/composable/tasksets/swe/multi_swe.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/multi_swe.py
@@ -181,6 +181,7 @@ class MultiSWETaskSet(SandboxTaskSet):
         filter_repos: list[str] | None = None,
         ds_num_proc: int | None = 8,
         ds_keep_in_memory: bool = True,
+        timeout_minutes: int = 60,
     ):
         self.dataset_name = dataset_name
         self.split = split
@@ -188,6 +189,7 @@ class MultiSWETaskSet(SandboxTaskSet):
         self.filter_repos = filter_repos
         self.ds_num_proc = ds_num_proc
         self.ds_keep_in_memory = ds_keep_in_memory
+        self.timeout_minutes = timeout_minutes
         super().__init__(dataset=self._build_dataset(), name="swe/multiswe")
 
     def _build_dataset(self) -> Any:
@@ -230,7 +232,8 @@ class MultiSWETaskSet(SandboxTaskSet):
     def get_sandbox_spec(self, info: dict) -> SandboxSpec | None:
         return SandboxSpec(
             image=info.get("_task_docker_image")
-            or _build_docker_image(restore_row(info))
+            or _build_docker_image(restore_row(info)),
+            timeout_minutes=self.timeout_minutes,
         )
 
     def get_workdir(self, info: dict) -> str:

--- a/verifiers/envs/experimental/composable/tasksets/swe/openswe.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/openswe.py
@@ -83,12 +83,14 @@ class OpenSWETaskSet(SandboxTaskSet):
         filter_repos: list[str] | None = None,
         ds_num_proc: int | None = 8,
         ds_keep_in_memory: bool = True,
+        timeout_minutes: int = 60,
     ):
         self.dataset_name = dataset_name
         self.config = config
         self.filter_repos = filter_repos
         self.ds_num_proc = ds_num_proc
         self.ds_keep_in_memory = ds_keep_in_memory
+        self.timeout_minutes = timeout_minutes
         super().__init__(dataset=self._build_dataset(), name="swe/openswe")
 
     def _build_dataset(self) -> Any:
@@ -113,7 +115,10 @@ class OpenSWETaskSet(SandboxTaskSet):
         return info["problem_statement"]
 
     def get_sandbox_spec(self, info: dict) -> SandboxSpec | None:
-        return SandboxSpec(image=info["image_name"])
+        return SandboxSpec(
+            image=info["image_name"],
+            timeout_minutes=self.timeout_minutes,
+        )
 
     def get_workdir(self, info: dict) -> str:
         return "/testbed"

--- a/verifiers/envs/experimental/composable/tasksets/swe/r2e_gym.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/r2e_gym.py
@@ -176,6 +176,7 @@ class R2EGymTaskSet(SandboxTaskSet):
         filter_repos: list[str] | None = None,
         ds_num_proc: int | None = 8,
         ds_keep_in_memory: bool = True,
+        timeout_minutes: int = 60,
     ):
         self.dataset_name = dataset_name
         self.repo_path = repo_path
@@ -183,6 +184,7 @@ class R2EGymTaskSet(SandboxTaskSet):
         self.filter_repos = filter_repos
         self.ds_num_proc = ds_num_proc
         self.ds_keep_in_memory = ds_keep_in_memory
+        self.timeout_minutes = timeout_minutes
         super().__init__(dataset=self._build_dataset(), name="swe/r2e")
 
     def _build_dataset(self) -> Any:
@@ -210,7 +212,10 @@ class R2EGymTaskSet(SandboxTaskSet):
         return info["problem_statement"]
 
     def get_sandbox_spec(self, info: dict) -> SandboxSpec | None:
-        return SandboxSpec(image=f"{REGISTRY_PREFIX}/{info['docker_image']}")
+        return SandboxSpec(
+            image=f"{REGISTRY_PREFIX}/{info['docker_image']}",
+            timeout_minutes=self.timeout_minutes,
+        )
 
     def get_workdir(self, info: dict) -> str:
         return self.repo_path

--- a/verifiers/envs/experimental/composable/tasksets/swe/swe_bench.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/swe_bench.py
@@ -354,12 +354,14 @@ class SWEBenchTaskSet(SandboxTaskSet):
         filter_repos: list[str] | None = None,
         ds_num_proc: int | None = 8,
         ds_keep_in_memory: bool = True,
+        timeout_minutes: int = 60,
     ):
         self.dataset_name = dataset_name
         self.skip_install = skip_install
         self.filter_repos = filter_repos
         self.ds_num_proc = ds_num_proc
         self.ds_keep_in_memory = ds_keep_in_memory
+        self.timeout_minutes = timeout_minutes
         super().__init__(dataset=self._build_dataset(), name="swe/swebench")
 
     def _build_dataset(self) -> Any:
@@ -390,7 +392,10 @@ class SWEBenchTaskSet(SandboxTaskSet):
 
     def get_sandbox_spec(self, info: dict) -> SandboxSpec | None:
         test_spec = _make_test_spec_with_retry(info, namespace="swebench")
-        return SandboxSpec(image=f"{REGISTRY_PREFIX}/{test_spec.instance_image_key}")
+        return SandboxSpec(
+            image=f"{REGISTRY_PREFIX}/{test_spec.instance_image_key}",
+            timeout_minutes=self.timeout_minutes,
+        )
 
     def get_workdir(self, info: dict) -> str:
         return "/testbed"


### PR DESCRIPTION
## Summary

`SWELegoTaskSet` accepts a `timeout_minutes: int = 60` constructor kwarg and threads it into `SandboxSpec`. The other four SWE tasksets (R2E, SWE-bench, Multi-SWE, OpenSWE) hardcoded the 60-minute `SandboxSpec` default with no way for callers to extend the sandbox container lifetime.

This PR mirrors the `SWELegoTaskSet` pattern on all four: adds a `timeout_minutes` constructor kwarg, stores it on the instance, and passes it to `SandboxSpec(...)` in `get_sandbox_spec()`.

## Motivation

Downstream composable envs (e.g. `rlm-swe` in research-environments) pass `timeout_seconds` to `ComposableEnv` for the agent rollout deadline, but `ComposableEnv.get_sandbox_resources()` reads the sandbox lifetime from `spec.timeout_minutes`. Before this PR, if a caller wanted `timeout_seconds > 3600`, the sandbox was still torn down at 60 minutes, cutting off the agent mid-rollout and breaking `keep_sandbox_for_scoring`.

After this PR, downstream envs can pass `timeout_minutes=math.ceil(timeout_seconds/60)` to the taskset factory and keep the two deadlines aligned — see the companion [research-environments PR](https://github.com/PrimeIntellect-ai/research-environments/pull/292).

## Test plan

- [x] Each taskset's constructor signature now includes `timeout_minutes: int = 60`
- [x] `get_sandbox_spec(info)` threads it through to `SandboxSpec(image=..., timeout_minutes=self.timeout_minutes)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: the change only adds an optional `timeout_minutes` constructor parameter and threads it into `SandboxSpec`, affecting sandbox lifetime but not task logic or scoring.
> 
> **Overview**
> Adds a `timeout_minutes: int = 60` constructor kwarg to the `MultiSWETaskSet`, `OpenSWETaskSet`, `R2EGymTaskSet`, and `SWEBenchTaskSet` tasksets.
> 
> Each taskset now stores `self.timeout_minutes` and passes it into `SandboxSpec(..., timeout_minutes=self.timeout_minutes)` in `get_sandbox_spec()`, allowing callers to extend/shorten sandbox container lifetime per taskset instead of relying on the hardcoded 60-minute default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fa7f4dba472a7487f7bed86e446855b79e36b75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->