### PR TITLE
cli_agent_env: honor self.poll_interval in poll loop

### DIFF
--- a/verifiers/envs/experimental/cli_agent_env.py
+++ b/verifiers/envs/experimental/cli_agent_env.py
@@ -383,7 +383,7 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
                         state["error"] = error
                         self.logger.error(str(error))
                 return
-            await asyncio.sleep(1)
+            await asyncio.sleep(self.poll_interval)
 
     async def check_agent_completed(self, state: State) -> bool:
         """Check if agent process has completed."""


### PR DESCRIPTION
## Description

The poll loop slept for a hardcoded 1s between iterations, ignoring `self.poll_interval` (which was stored but unused). Wire it through.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line bug fix that only changes the sleep duration between background-job status polls, affecting timing but not core control flow or data handling.
> 
> **Overview**
> Updates `CliAgentEnv.poll_job_completion` to sleep using the configured `self.poll_interval` instead of a hardcoded 1s, so agent completion polling respects caller configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e15938c9d158fc704e1d17263536c732833c4d11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->