### PR TITLE
chore: v0.1.13.dev1 dev release

### DIFF
--- a/assets/release/RELEASE_v0.1.13.dev1.md
+++ b/assets/release/RELEASE_v0.1.13.dev1.md
@@ -1,0 +1,26 @@
+# Verifiers v0.1.13.dev1 Release Notes
+
+*Date:* 04/18/2026
+
+## Highlights since v0.1.12
+
+- Added the SWELego-Real TaskSet (PrimeIntellect fork, filtered upstream) for broader SWE benchmark coverage.
+- Added `timeout_minutes` kwarg to R2E, SWEBench, Multi-SWE, and OpenSWE tasksets for finer-grained per-task timeout control.
+- Surfaced agent timeout as `state['error']` in `CliAgentEnv` so timeouts are visible in eval results.
+- Fixed `CliAgentEnv` poll loop to honor `self.poll_interval` consistently.
+- Bumped `prime-sandboxes` to 0.2.20.
+
+## Changes included in v0.1.13.dev1 (since v0.1.12)
+
+### Features and enhancements
+
+- feat: add SWELego-Real TaskSet (PrimeIntellect fork, filtered upstream) (#1149)
+- feat: add `timeout_minutes` kwarg to R2E / SWEBench / Multi-SWE / OpenSWE tasksets (#1171)
+
+### Fixes and maintenance
+
+- fix: surface agent timeout as `state['error']` in `CliAgentEnv` (#1170)
+- fix: honor `self.poll_interval` in `CliAgentEnv` poll loop (#1173)
+- chore: bump prime-sandboxes to 0.2.20 (#1174)
+
+**Full Changelog**: https://github.com/PrimeIntellect-ai/verifiers/compare/v0.1.12...v0.1.13.dev1

--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.12"
+__version__ = "0.1.13.dev1"
 
 import importlib
 import os


### PR DESCRIPTION
## Summary
- Bump version from `0.1.12` to `0.1.13.dev1`
- Add release notes covering changes since `v0.1.12`

## Changes since v0.1.12
- feat: add SWELego-Real TaskSet (PrimeIntellect fork, filtered upstream) (#1149)
- feat: add `timeout_minutes` kwarg to R2E / SWEBench / Multi-SWE / OpenSWE tasksets (#1171)
- fix: surface agent timeout as `state['error']` in `CliAgentEnv` (#1170)
- fix: honor `self.poll_interval` in `CliAgentEnv` poll loop (#1173)
- chore: bump prime-sandboxes to 0.2.20 (#1174)

### Linked PRs
- #1149
- #1171
- #1170
- #1173
- #1174

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only bumps the package version and adds a release-notes markdown file, with no runtime logic changes.
> 
> **Overview**
> Bumps `verifiers` version from `0.1.12` to `0.1.13.dev1`.
> 
> Adds `assets/release/RELEASE_v0.1.13.dev1.md` documenting highlights and linked PRs included in the `v0.1.13.dev1` dev release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9941f6addb559bc61e9ae951a27f5a99475ac2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->