### PR TITLE
Skip OpenCode install when binary is pre-baked

### DIFF
--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.12"
+__version__ = "0.1.13.dev2"
 
 import importlib
 import os

--- a/verifiers/envs/experimental/composable/harnesses/opencode.py
+++ b/verifiers/envs/experimental/composable/harnesses/opencode.py
@@ -85,11 +85,16 @@ OPENCODE_RELEASE_TAG="${{OPENCODE_RELEASE_VERSION#v}}"
 OPENCODE_RELEASE_URL="https://github.com/$OPENCODE_RELEASE_REPO/releases/download/v$OPENCODE_RELEASE_TAG/$OPENCODE_ASSET"
 
 mkdir -p "$HOME/.opencode/bin"
-curl -fsSL "$OPENCODE_RELEASE_URL" -o /tmp/opencode.tar.gz
-{sha256_check}
-tar -xzf /tmp/opencode.tar.gz -C /tmp
-install -m 755 /tmp/opencode "$HOME/.opencode/bin/opencode"
-echo "OpenCode installed successfully"
+if [ -x "$HOME/.opencode/bin/opencode" ]; then
+  echo "OpenCode already installed, skipping download"
+else
+  curl -fsSL "$OPENCODE_RELEASE_URL" -o /tmp/opencode.tar.gz
+  {sha256_check}
+  tar -xzf /tmp/opencode.tar.gz -C /tmp
+  install -m 755 /tmp/opencode "$HOME/.opencode/bin/opencode"
+  rm -f /tmp/opencode.tar.gz /tmp/opencode
+  echo "OpenCode installed successfully"
+fi
 """
 
 

--- a/verifiers/envs/experimental/composable/harnesses/opencode.py
+++ b/verifiers/envs/experimental/composable/harnesses/opencode.py
@@ -82,11 +82,16 @@ OPENCODE_RELEASE_TAG="${{OPENCODE_RELEASE_VERSION#v}}"
 OPENCODE_RELEASE_URL="https://github.com/$OPENCODE_RELEASE_REPO/releases/download/v$OPENCODE_RELEASE_TAG/$OPENCODE_ASSET"
 
 mkdir -p "$HOME/.opencode/bin"
-curl -fsSL "$OPENCODE_RELEASE_URL" -o /tmp/opencode.tar.gz
-{sha256_check}
-tar -xzf /tmp/opencode.tar.gz -C /tmp
-install -m 755 /tmp/opencode "$HOME/.opencode/bin/opencode"
-echo "OpenCode installed successfully"
+if [ -f "$HOME/.opencode/bin/opencode" ]; then
+    echo "OpenCode already installed, skipping download"
+else
+    curl -fsSL "$OPENCODE_RELEASE_URL" -o /tmp/opencode.tar.gz
+    {sha256_check}
+    tar -xzf /tmp/opencode.tar.gz -C /tmp
+    install -m 755 /tmp/opencode "$HOME/.opencode/bin/opencode"
+    rm -f /tmp/opencode.tar.gz /tmp/opencode
+    echo "OpenCode installed successfully"
+fi
 """
 
 

--- a/verifiers/envs/experimental/opencode_env.py
+++ b/verifiers/envs/experimental/opencode_env.py
@@ -58,18 +58,27 @@ set -eo pipefail
 # that fail fresh-sandbox apt-get update mid-rollout (launchpad bug #1876035).
 apt-get -o Acquire::Retries=3 update && apt-get -o Acquire::Retries=3 install -y curl
 
-for install_attempt in 1 2 3; do
-    if {install_command}; then
-        break
-    fi
-    if [ "$install_attempt" -eq 3 ]; then
-        echo "OpenCode installation failed after 3 attempts" >&2
-        exit 1
-    fi
-    echo "OpenCode install attempt $install_attempt/3 failed, retrying in 5s..." >&2
-    sleep 5
-done
+if [ -x "$HOME/.opencode/bin/opencode" ]; then
+    echo "OpenCode already installed, skipping download"
+else
+    for install_attempt in 1 2 3; do
+        if {install_command}; then
+            break
+        fi
+        if [ "$install_attempt" -eq 3 ]; then
+            echo "OpenCode installation failed after 3 attempts" >&2
+            exit 1
+        fi
+        echo "OpenCode install attempt $install_attempt/3 failed, retrying in 5s..." >&2
+        sleep 5
+    done
+fi
 export PATH="$HOME/.opencode/bin:$PATH"
+
+if [ ! -x "$HOME/.opencode/bin/opencode" ]; then
+    echo "OpenCode binary not found after installation" >&2
+    exit 1
+fi
 
 mkdir -p ~/.config/opencode
 

--- a/verifiers/envs/experimental/opencode_rlm_env.py
+++ b/verifiers/envs/experimental/opencode_rlm_env.py
@@ -105,18 +105,27 @@ curl -fsSL https://bun.sh/install | bash
 export PATH="$HOME/.bun/bin:$PATH"
 
 # Install opencode
-for install_attempt in 1 2 3; do
-    if {install_command}; then
-        break
-    fi
-    if [ "$install_attempt" -eq 3 ]; then
-        echo "OpenCode installation failed after 3 attempts" >&2
-        exit 1
-    fi
-    echo "OpenCode install attempt $install_attempt/3 failed, retrying in 5s..." >&2
-    sleep 5
-done
+if [ -x "$HOME/.opencode/bin/opencode" ]; then
+    echo "OpenCode already installed, skipping download"
+else
+    for install_attempt in 1 2 3; do
+        if {install_command}; then
+            break
+        fi
+        if [ "$install_attempt" -eq 3 ]; then
+            echo "OpenCode installation failed after 3 attempts" >&2
+            exit 1
+        fi
+        echo "OpenCode install attempt $install_attempt/3 failed, retrying in 5s..." >&2
+        sleep 5
+    done
+fi
 export PATH="$HOME/.opencode/bin:$PATH"
+
+if [ ! -x "$HOME/.opencode/bin/opencode" ]; then
+    echo "OpenCode binary not found after installation" >&2
+    exit 1
+fi
 
 # Install RLM plugin
 git clone --branch {plugin_branch} https://github.com/{plugin_repo}.git {plugin_install_path}

--- a/verifiers/v1/packages/harnesses/opencode.py
+++ b/verifiers/v1/packages/harnesses/opencode.py
@@ -179,10 +179,15 @@ OPENCODE_RELEASE_TAG="${{OPENCODE_RELEASE_VERSION#v}}"
 OPENCODE_RELEASE_URL="https://github.com/$OPENCODE_RELEASE_REPO/releases/download/v$OPENCODE_RELEASE_TAG/$OPENCODE_ASSET"
 
 mkdir -p "$HOME/.opencode/bin"
-curl -fsSL "$OPENCODE_RELEASE_URL" -o /tmp/opencode.tar.gz
-{sha256_check}
-tar -xzf /tmp/opencode.tar.gz -C /tmp
-install -m 755 /tmp/opencode "$HOME/.opencode/bin/opencode"
+if [ -x "$HOME/.opencode/bin/opencode" ]; then
+  echo "OpenCode already installed, skipping download"
+else
+  curl -fsSL "$OPENCODE_RELEASE_URL" -o /tmp/opencode.tar.gz
+  {sha256_check}
+  tar -xzf /tmp/opencode.tar.gz -C /tmp
+  install -m 755 /tmp/opencode "$HOME/.opencode/bin/opencode"
+  rm -f /tmp/opencode.tar.gz /tmp/opencode
+fi
 """
 
 


### PR DESCRIPTION
## Summary
- Skip OpenCode download/install when `$HOME/.opencode/bin/opencode` already exists and is executable.
- Apply the guard to every generated OpenCode install path:
  - composable OpenCode harness
  - legacy experimental `OpenCodeEnv`
  - experimental `OpenCodeRLMEnv`
  - v1 `vf.OpenCode` used by `opencode_harbor`
- Keep retry behavior for non-prebaked sandboxes and clean temporary tarball/extracted binary after release-tarball installs.

## Why
This keeps Docker image pre-baking effective: when OpenCode is already baked into the sandbox image, rollout setup no longer re-downloads and overwrites it. That saves rollout startup time and avoids transient GitHub/opencode installer failures for pre-baked images.

## Notes
- Dropped the stale `verifiers.__version__` bump from the original draft.
- Refreshed on current `main`.
- Removed the standalone test file from the refreshed diff.

## Validation
- `uv run pytest tests/test_opencode_rlm_env.py tests/test_opencode_harbor.py tests/test_v1_harbor_cli.py -q`
- `uv run ruff check verifiers/envs/experimental/composable/harnesses/opencode.py verifiers/envs/experimental/opencode_env.py verifiers/envs/experimental/opencode_rlm_env.py verifiers/v1/packages/harnesses/opencode.py`
- push hook: `ruff check`, `ruff format`, `ty (ci parity)`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk shell-script changes limited to OpenCode sandbox setup; main risk is potential false-positive/negative executable detection affecting installs in fresh sandboxes.
> 
> **Overview**
> Prevents OpenCode from being re-downloaded/overwritten in sandboxes where `$HOME/.opencode/bin/opencode` is already present and executable, across the composable harness, `OpenCodeEnv`, `OpenCodeRLMEnv`, and the v1 `OpenCode` harness.
> 
> For non-prebaked environments, keeps the existing install behavior (including retries where applicable), adds a post-install check that the binary exists in the experimental env templates, and cleans up temporary tarball/extracted files after release-tarball installs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74f8779b9f5079b432df766ce8486331a6838c13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->