### PR TITLE
fix: surface mid-rollout agent crashes as infra errors

### DIFF
--- a/verifiers/envs/experimental/cli_agent_env.py
+++ b/verifiers/envs/experimental/cli_agent_env.py
@@ -374,17 +374,20 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
                         f"Agent completed successfully (exit_code={status.exit_code})"
                     )
                 else:
-                    self.logger.warning(
-                        f"Agent failed (exit_code={status.exit_code}) stdout={status.stdout}, stderr={status.stderr}"
-                    )
-                    if len(state.get("trajectory", [])) == 0:
-                        stderr_snippet = (status.stderr or "")[:500]
+                    stderr_snippet = (status.stderr or "")[:500]
+                    num_turns = len(state.get("trajectory", []))
+                    if num_turns == 0:
                         error = AgentError(
                             f"Agent crashed before any LLM call "
                             f"(exit_code={status.exit_code}): {stderr_snippet}"
                         )
-                        state["error"] = error
-                        self.logger.error(str(error))
+                    else:
+                        error = AgentError(
+                            f"Agent crashed after {num_turns} turn(s) "
+                            f"(exit_code={status.exit_code}): {stderr_snippet}"
+                        )
+                    state["error"] = error
+                    self.logger.error(str(error))
                 return
             await asyncio.sleep(self.poll_interval)
 


### PR DESCRIPTION
## Summary

`CliAgentEnv.poll_job_completion` only set `state["error"] = AgentError(...)` when the agent crashed *before* its first LLM call. If the agent made one or more turns and then exited non-zero we logged a warning but left `state["error"]` unset — so downstream would not be aware of the crash.

This always builds an `AgentError` on non-zero exit. The message distinguishes `crashed before any LLM call` vs `crashed after N turn(s)` for debuggability.

## Test plan

- [x] `uv run ruff check verifiers/envs/experimental/cli_agent_env.py` — clean
- [x] `uv run pytest tests/test_cli_agent_env.py tests/test_composable_env.py tests/test_rlm_composable_env.py` — 53/53 pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rollout error propagation for CLI agent runs by setting `state["error"]` on any non-zero exit, which may alter downstream control flow and failure classification. Logic is small but affects infra-level monitoring and scoring behavior.
> 
> **Overview**
> Ensures CLI agent rollouts consistently surface agent crashes as infra errors by **always** creating and storing an `AgentError` in `state["error"]` when the agent exits non-zero.
> 
> The error message now distinguishes crashes **before the first LLM call** vs **after N turns**, and logs the resulting error (with a short stderr snippet) instead of only warning in the post-turn crash case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68bc01bff8bdb0ba0c73342970738ff5bb8a7e17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->