### PR TITLE
harness.get_upload_dirs; reduce rlm github requests

### DIFF
--- a/tests/test_composable_env.py
+++ b/tests/test_composable_env.py
@@ -441,7 +441,7 @@ async def test_composable_env_uploads_harness_dirs(tmp_path):
         harness=Harness(
             run_command="true",
             install_script="install-agent",
-            upload_dirs={"agent_src": harness_dir},
+            get_upload_dirs=lambda: {"agent_src": harness_dir},
             upload_dir_mapping={"agent_src": "/tmp/agent-src"},
         ),
     )
@@ -485,7 +485,7 @@ async def test_composable_env_rejects_duplicate_task_and_harness_upload_names(
         harness=Harness(
             run_command="true",
             install_script="install-agent",
-            upload_dirs={"skills": harness_dir},
+            get_upload_dirs=lambda: {"skills": harness_dir},
             skills_path="/task/skills",
         ),
     )

--- a/tests/test_composable_env.py
+++ b/tests/test_composable_env.py
@@ -429,6 +429,83 @@ async def test_composable_env_no_upload_when_no_dirs(tmp_path, monkeypatch):
     assert env.upload_file.await_count == 0
 
 
+@pytest.mark.asyncio
+async def test_composable_env_uploads_harness_dirs(tmp_path):
+    taskset = MockSandboxTaskSet(dataset=_make_dataset(), name="test")
+    harness_dir = tmp_path / "agent-src"
+    harness_dir.mkdir()
+    (harness_dir / "marker.txt").write_text("agent\n")
+
+    env = ComposableEnv(
+        taskset=taskset,
+        harness=Harness(
+            run_command="true",
+            install_script="install-agent",
+            upload_dirs={"agent_src": harness_dir},
+            upload_dir_mapping={"agent_src": "/tmp/agent-src"},
+        ),
+    )
+    env.sandbox_client = SimpleNamespace(
+        execute_command=AsyncMock(
+            return_value=SimpleNamespace(stdout="", stderr="", exit_code=0)
+        ),
+        teardown=lambda: None,
+    )
+    env.taskset.setup = AsyncMock()
+    env.upload_content = AsyncMock()
+    env.upload_file = AsyncMock()
+
+    await env.post_sandbox_setup({"sandbox_id": "sbx", "info": {"id": 0}})
+
+    env.upload_file.assert_awaited_once()
+    upload_call = env.upload_file.await_args
+    assert upload_call.args[0] == "sbx"
+    assert upload_call.args[1] == "/tmp/_upload_tmp_agent-src.tar.gz"
+
+    extract_call = env.sandbox_client.execute_command.await_args_list[1]
+    assert extract_call == call(
+        "sbx",
+        "mkdir -p /tmp && tar -xzf /tmp/_upload_tmp_agent-src.tar.gz -C / && rm -f /tmp/_upload_tmp_agent-src.tar.gz",
+        timeout=60,
+    )
+
+
+@pytest.mark.asyncio
+async def test_composable_env_rejects_duplicate_task_and_harness_upload_names(
+    tmp_path, monkeypatch
+):
+    mod, _ = _make_temp_taskset_package(tmp_path, monkeypatch, with_skills=True)
+    monkeypatch.setattr(MockSandboxTaskSetWithSkills, "__module__", mod.__name__)
+    taskset = MockSandboxTaskSetWithSkills(dataset=_make_dataset(), name="test")
+    harness_dir = tmp_path / "skills"
+    harness_dir.mkdir()
+
+    env = ComposableEnv(
+        taskset=taskset,
+        harness=Harness(
+            run_command="true",
+            install_script="install-agent",
+            upload_dirs={"skills": harness_dir},
+            skills_path="/task/skills",
+        ),
+    )
+    env.sandbox_client = SimpleNamespace(
+        execute_command=AsyncMock(
+            return_value=SimpleNamespace(stdout="", stderr="", exit_code=0)
+        ),
+        teardown=lambda: None,
+    )
+    env.taskset.setup = AsyncMock()
+    env.upload_content = AsyncMock()
+    env.upload_file = AsyncMock()
+
+    with pytest.raises(
+        ValueError,
+        match="Upload directory names must be unique across task and harness",
+    ):
+        await env.post_sandbox_setup({"sandbox_id": "sbx", "info": {"id": 0}})
+
+
 # ── discover_sibling_dir ─────────────────────────────────────────────────
 
 

--- a/tests/test_rlm_composable_env.py
+++ b/tests/test_rlm_composable_env.py
@@ -212,7 +212,9 @@ def test_rlm_harness_always_uploads_checkout(tmp_path, monkeypatch):
     assert harness.upload_dir_mapping is not None
 
 
-def test_resolve_local_checkout_redacts_gh_token_on_clone_failure(tmp_path, monkeypatch):
+def test_resolve_local_checkout_redacts_gh_token_on_clone_failure(
+    tmp_path, monkeypatch
+):
     failing_checkout = tmp_path / "checkout-root" / "rlm"
     token = "super/secret token"
     quoted_token = "super%2Fsecret%20token"

--- a/tests/test_rlm_composable_env.py
+++ b/tests/test_rlm_composable_env.py
@@ -21,6 +21,7 @@ from verifiers.envs.experimental.composable import (
 from verifiers.envs.experimental.composable.harnesses.rlm import (
     build_install_script,
     rlm_harness,
+    resolve_local_checkout,
 )
 
 
@@ -106,6 +107,44 @@ def test_rlm_harness_sets_metrics_fields():
 def test_rlm_harness_sets_skills_path():
     harness = rlm_harness()
     assert harness.skills_path == "/task/rlm-skills"
+
+
+def test_resolve_local_checkout_validates_explicit_path(tmp_path):
+    checkout = tmp_path / "rlm"
+    checkout.mkdir()
+    (checkout / "install.sh").write_text("#!/usr/bin/env bash\n")
+    (checkout / "pyproject.toml").write_text("[project]\nname='rlm'\nversion='0.0.0'\n")
+
+    resolved = resolve_local_checkout(checkout)
+
+    assert resolved == checkout.resolve()
+
+
+def test_resolve_local_checkout_discovers_search_dir(tmp_path):
+    search_root = tmp_path / "rlm_swe"
+    checkout = search_root / "rlm"
+    checkout.mkdir(parents=True)
+    (checkout / "install.sh").write_text("#!/usr/bin/env bash\n")
+    (checkout / "pyproject.toml").write_text("[project]\nname='rlm'\nversion='0.0.0'\n")
+
+    resolved = resolve_local_checkout(
+        prefer_local_checkout=True,
+        local_checkout_search_dirs=[search_root],
+    )
+
+    assert resolved == checkout.resolve()
+
+
+def test_rlm_harness_uploads_explicit_local_checkout(tmp_path):
+    checkout = tmp_path / "rlm"
+    checkout.mkdir()
+    (checkout / "install.sh").write_text("#!/usr/bin/env bash\n")
+    (checkout / "pyproject.toml").write_text("[project]\nname='rlm'\nversion='0.0.0'\n")
+
+    harness = rlm_harness(local_checkout=checkout, prefer_local_checkout=False)
+
+    assert harness.upload_dirs == {"rlm_checkout": checkout.resolve()}
+    assert harness.upload_dir_mapping == {"rlm_checkout": "/tmp/rlm-checkout"}
 
 
 # ── install_env ──────────────────────────────────────────────────────────

--- a/tests/test_rlm_composable_env.py
+++ b/tests/test_rlm_composable_env.py
@@ -6,6 +6,8 @@ fields and that the install script is generated correctly.
 
 import importlib
 import json
+from pathlib import Path
+import subprocess
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, call
 
@@ -87,33 +89,55 @@ def _make_temp_taskset_package(tmp_path, monkeypatch, *, with_skills: bool):
     return mod
 
 
+def _make_git_checkout(target: Path) -> Path:
+    checkout = target
+    checkout.mkdir()
+    (checkout / "install.sh").write_text("#!/usr/bin/env bash\n")
+    (checkout / "pyproject.toml").write_text("[project]\nname='rlm'\nversion='0.0.0'\n")
+    subprocess.run(["git", "init", "-b", "main"], cwd=checkout, check=True)
+    subprocess.run(["git", "add", "install.sh", "pyproject.toml"], cwd=checkout, check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=Codex",
+            "-c",
+            "user.email=codex@example.com",
+            "commit",
+            "-m",
+            "init",
+        ],
+        cwd=checkout,
+        check=True,
+    )
+    return checkout
+
+
 # ── RLM harness ──────────────────────────────────────────────────────────
 
 
-def test_rlm_harness_install_script_downloads_repo_install_sh():
+def test_rlm_harness_install_script_clones_only_when_checkout_missing():
     script = build_install_script()
-    assert "git clone --depth 1 --branch main" in script
+    assert 'if [ ! -f "$RLM_CHECKOUT_PATH/install.sh" ]; then' in script
+    assert 'git clone --depth 1 --branch "$RLM_REPO_BRANCH"' in script
     assert "github.com/PrimeIntellect-ai/rlm.git" in script
-    assert "bash /tmp/rlm-checkout/install.sh" in script
+    assert 'bash "$RLM_CHECKOUT_PATH/install.sh"' in script
 
 
 def test_rlm_harness_sets_metrics_fields():
-    harness = rlm_harness()
+    harness = rlm_harness(prefer_local_checkout=False)
     assert harness.metrics_path == "{workdir}/.rlm/sessions/*/meta.json"
     assert harness.metrics_key == "metrics"
     assert harness.metrics_prefix == "rlm_"
 
 
 def test_rlm_harness_sets_skills_path():
-    harness = rlm_harness()
+    harness = rlm_harness(prefer_local_checkout=False)
     assert harness.skills_path == "/task/rlm-skills"
 
 
 def test_resolve_local_checkout_validates_explicit_path(tmp_path):
-    checkout = tmp_path / "rlm"
-    checkout.mkdir()
-    (checkout / "install.sh").write_text("#!/usr/bin/env bash\n")
-    (checkout / "pyproject.toml").write_text("[project]\nname='rlm'\nversion='0.0.0'\n")
+    checkout = _make_git_checkout(tmp_path / "rlm")
 
     resolved = resolve_local_checkout(checkout)
 
@@ -122,10 +146,8 @@ def test_resolve_local_checkout_validates_explicit_path(tmp_path):
 
 def test_resolve_local_checkout_discovers_search_dir(tmp_path):
     search_root = tmp_path / "rlm_swe"
-    checkout = search_root / "rlm"
-    checkout.mkdir(parents=True)
-    (checkout / "install.sh").write_text("#!/usr/bin/env bash\n")
-    (checkout / "pyproject.toml").write_text("[project]\nname='rlm'\nversion='0.0.0'\n")
+    search_root.mkdir()
+    checkout = _make_git_checkout(search_root / "rlm")
 
     resolved = resolve_local_checkout(
         prefer_local_checkout=True,
@@ -136,14 +158,42 @@ def test_resolve_local_checkout_discovers_search_dir(tmp_path):
 
 
 def test_rlm_harness_uploads_explicit_local_checkout(tmp_path):
-    checkout = tmp_path / "rlm"
-    checkout.mkdir()
-    (checkout / "install.sh").write_text("#!/usr/bin/env bash\n")
-    (checkout / "pyproject.toml").write_text("[project]\nname='rlm'\nversion='0.0.0'\n")
+    checkout = _make_git_checkout(tmp_path / "rlm")
 
     harness = rlm_harness(local_checkout=checkout, prefer_local_checkout=False)
 
     assert harness.upload_dirs == {"rlm_checkout": checkout.resolve()}
+    assert harness.upload_dir_mapping == {"rlm_checkout": "/tmp/rlm-checkout"}
+
+
+def test_resolve_local_checkout_materializes_host_cache(tmp_path):
+    source_checkout = _make_git_checkout(tmp_path / "rlm-source")
+    cache_dir = tmp_path / "cache" / "rlm"
+
+    resolved = resolve_local_checkout(
+        prefer_local_checkout=True,
+        rlm_repo_url=str(source_checkout),
+        rlm_branch="main",
+        local_checkout_cache_dir=cache_dir,
+    )
+
+    assert resolved == cache_dir.resolve()
+    assert (cache_dir / ".git").is_dir()
+    assert (cache_dir / "install.sh").is_file()
+    assert (cache_dir / "pyproject.toml").is_file()
+
+
+def test_rlm_harness_uses_host_cache_when_no_local_checkout(tmp_path):
+    source_checkout = _make_git_checkout(tmp_path / "rlm-source")
+    cache_dir = tmp_path / "cache" / "rlm"
+
+    harness = rlm_harness(
+        rlm_repo_url=str(source_checkout),
+        rlm_branch="main",
+        local_checkout_cache_dir=cache_dir,
+    )
+
+    assert harness.upload_dirs == {"rlm_checkout": cache_dir.resolve()}
     assert harness.upload_dir_mapping == {"rlm_checkout": "/tmp/rlm-checkout"}
 
 
@@ -248,7 +298,7 @@ async def test_rlm_collects_logs_and_metrics():
         "prompt_tokens": 100,
         "completion_tokens": 25,
     }
-    harness = rlm_harness()
+    harness = rlm_harness(prefer_local_checkout=False)
     env = ComposableEnv(
         taskset=taskset,
         harness=Harness(

--- a/tests/test_rlm_composable_env.py
+++ b/tests/test_rlm_composable_env.py
@@ -195,8 +195,13 @@ def test_rlm_harness_uses_default_host_cache_when_local_checkout_unspecified(
     assert harness.upload_dir_mapping == {"rlm_checkout": "/tmp/rlm-checkout"}
 
 
-def test_rlm_harness_always_uploads_checkout(tmp_path):
+def test_rlm_harness_always_uploads_checkout(tmp_path, monkeypatch):
     source_checkout = _make_git_checkout(tmp_path / "rlm-source")
+    monkeypatch.setattr(
+        rlm_module,
+        "DEFAULT_RLM_LOCAL_CHECKOUT_CACHE_ROOT",
+        tmp_path / "cache-root",
+    )
 
     harness = rlm_harness(
         rlm_repo_url=str(source_checkout),
@@ -205,6 +210,36 @@ def test_rlm_harness_always_uploads_checkout(tmp_path):
 
     assert harness.get_upload_dirs is not None
     assert harness.upload_dir_mapping is not None
+
+
+def test_resolve_local_checkout_redacts_gh_token_on_clone_failure(tmp_path, monkeypatch):
+    failing_checkout = tmp_path / "checkout-root" / "rlm"
+    token = "super/secret token"
+    quoted_token = "super%2Fsecret%20token"
+
+    def _raise_clone_error(*args, **kwargs):
+        raise subprocess.CalledProcessError(
+            128,
+            args[0],
+            stderr=(
+                "fatal: could not read from "
+                f"https://{quoted_token}@github.com/PrimeIntellect-ai/rlm.git"
+            ),
+        )
+
+    monkeypatch.setattr(rlm_module.subprocess, "run", _raise_clone_error)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        resolve_local_checkout(
+            local_checkout=failing_checkout,
+            rlm_repo_url="github.com/PrimeIntellect-ai/rlm.git",
+            rlm_branch="main",
+            gh_token=token,
+        )
+
+    message = str(exc_info.value)
+    assert token not in message
+    assert "<redacted>" in message
 
 
 # ── install_env ──────────────────────────────────────────────────────────

--- a/tests/test_rlm_composable_env.py
+++ b/tests/test_rlm_composable_env.py
@@ -151,7 +151,8 @@ def test_rlm_harness_uploads_explicit_local_checkout(tmp_path):
 
     harness = rlm_harness(local_checkout=checkout)
 
-    assert harness.upload_dirs == {"rlm_checkout": checkout.resolve()}
+    assert harness.get_upload_dirs is not None
+    assert harness.get_upload_dirs() == {"rlm_checkout": checkout.resolve()}
     assert harness.upload_dir_mapping == {"rlm_checkout": "/tmp/rlm-checkout"}
 
 
@@ -186,7 +187,8 @@ def test_rlm_harness_uses_default_host_cache_when_local_checkout_unspecified(
         rlm_branch="main",
     )
 
-    upload_checkout = harness.upload_dirs["rlm_checkout"]
+    assert harness.get_upload_dirs is not None
+    upload_checkout = harness.get_upload_dirs()["rlm_checkout"]
     assert isinstance(upload_checkout, Path)
     assert upload_checkout.is_dir()
     assert upload_checkout.name.startswith("rlm-source-main-")
@@ -201,7 +203,7 @@ def test_rlm_harness_always_uploads_checkout(tmp_path):
         rlm_branch="main",
     )
 
-    assert harness.upload_dirs is not None
+    assert harness.get_upload_dirs is not None
     assert harness.upload_dir_mapping is not None
 
 

--- a/tests/test_rlm_composable_env.py
+++ b/tests/test_rlm_composable_env.py
@@ -95,7 +95,9 @@ def _make_git_checkout(target: Path) -> Path:
     (checkout / "install.sh").write_text("#!/usr/bin/env bash\n")
     (checkout / "pyproject.toml").write_text("[project]\nname='rlm'\nversion='0.0.0'\n")
     subprocess.run(["git", "init", "-b", "main"], cwd=checkout, check=True)
-    subprocess.run(["git", "add", "install.sh", "pyproject.toml"], cwd=checkout, check=True)
+    subprocess.run(
+        ["git", "add", "install.sh", "pyproject.toml"], cwd=checkout, check=True
+    )
     subprocess.run(
         [
             "git",
@@ -116,23 +118,22 @@ def _make_git_checkout(target: Path) -> Path:
 # ── RLM harness ──────────────────────────────────────────────────────────
 
 
-def test_rlm_harness_install_script_clones_only_when_checkout_missing():
+def test_rlm_harness_install_script_requires_uploaded_checkout():
     script = build_install_script()
-    assert 'if [ ! -f "$RLM_CHECKOUT_PATH/install.sh" ]; then' in script
-    assert 'git clone --depth 1 --branch "$RLM_REPO_BRANCH"' in script
-    assert "github.com/PrimeIntellect-ai/rlm.git" in script
+    assert 'test -f "$RLM_CHECKOUT_PATH/install.sh"' in script
+    assert "git clone" not in script
     assert 'bash "$RLM_CHECKOUT_PATH/install.sh"' in script
 
 
-def test_rlm_harness_sets_metrics_fields():
-    harness = rlm_harness(prefer_local_checkout=False)
+def test_rlm_harness_sets_metrics_fields(tmp_path):
+    harness = rlm_harness(local_checkout=_make_git_checkout(tmp_path / "rlm"))
     assert harness.metrics_path == "{workdir}/.rlm/sessions/*/meta.json"
     assert harness.metrics_key == "metrics"
     assert harness.metrics_prefix == "rlm_"
 
 
-def test_rlm_harness_sets_skills_path():
-    harness = rlm_harness(prefer_local_checkout=False)
+def test_rlm_harness_sets_skills_path(tmp_path):
+    harness = rlm_harness(local_checkout=_make_git_checkout(tmp_path / "rlm"))
     assert harness.skills_path == "/task/rlm-skills"
 
 
@@ -150,7 +151,6 @@ def test_resolve_local_checkout_discovers_search_dir(tmp_path):
     checkout = _make_git_checkout(search_root / "rlm")
 
     resolved = resolve_local_checkout(
-        prefer_local_checkout=True,
         local_checkout_search_dirs=[search_root],
     )
 
@@ -160,7 +160,7 @@ def test_resolve_local_checkout_discovers_search_dir(tmp_path):
 def test_rlm_harness_uploads_explicit_local_checkout(tmp_path):
     checkout = _make_git_checkout(tmp_path / "rlm")
 
-    harness = rlm_harness(local_checkout=checkout, prefer_local_checkout=False)
+    harness = rlm_harness(local_checkout=checkout)
 
     assert harness.upload_dirs == {"rlm_checkout": checkout.resolve()}
     assert harness.upload_dir_mapping == {"rlm_checkout": "/tmp/rlm-checkout"}
@@ -171,7 +171,6 @@ def test_resolve_local_checkout_materializes_host_cache(tmp_path):
     cache_dir = tmp_path / "cache" / "rlm"
 
     resolved = resolve_local_checkout(
-        prefer_local_checkout=True,
         rlm_repo_url=str(source_checkout),
         rlm_branch="main",
         local_checkout_cache_dir=cache_dir,
@@ -195,6 +194,20 @@ def test_rlm_harness_uses_host_cache_when_no_local_checkout(tmp_path):
 
     assert harness.upload_dirs == {"rlm_checkout": cache_dir.resolve()}
     assert harness.upload_dir_mapping == {"rlm_checkout": "/tmp/rlm-checkout"}
+
+
+def test_rlm_harness_always_uploads_checkout(tmp_path):
+    source_checkout = _make_git_checkout(tmp_path / "rlm-source")
+    cache_dir = tmp_path / "cache" / "rlm"
+
+    harness = rlm_harness(
+        rlm_repo_url=str(source_checkout),
+        rlm_branch="main",
+        local_checkout_cache_dir=cache_dir,
+    )
+
+    assert harness.upload_dirs is not None
+    assert harness.upload_dir_mapping is not None
 
 
 # ── install_env ──────────────────────────────────────────────────────────
@@ -290,7 +303,7 @@ async def test_rlm_uploads_skills_before_install(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_rlm_collects_logs_and_metrics():
+async def test_rlm_collects_logs_and_metrics(tmp_path):
     taskset = MockSandboxTaskSet(dataset=_make_dataset(), name="test")
     metrics = {
         "turns": 3,
@@ -298,7 +311,7 @@ async def test_rlm_collects_logs_and_metrics():
         "prompt_tokens": 100,
         "completion_tokens": 25,
     }
-    harness = rlm_harness(prefer_local_checkout=False)
+    harness = rlm_harness(local_checkout=_make_git_checkout(tmp_path / "rlm"))
     env = ComposableEnv(
         taskset=taskset,
         harness=Harness(

--- a/tests/test_rlm_composable_env.py
+++ b/tests/test_rlm_composable_env.py
@@ -20,6 +20,7 @@ from verifiers.envs.experimental.composable import (
     SandboxSpec,
     SandboxTaskSet,
 )
+from verifiers.envs.experimental.composable.harnesses import rlm as rlm_module
 from verifiers.envs.experimental.composable.harnesses.rlm import (
     build_install_script,
     rlm_harness,
@@ -145,18 +146,6 @@ def test_resolve_local_checkout_validates_explicit_path(tmp_path):
     assert resolved == checkout.resolve()
 
 
-def test_resolve_local_checkout_discovers_search_dir(tmp_path):
-    search_root = tmp_path / "rlm_swe"
-    search_root.mkdir()
-    checkout = _make_git_checkout(search_root / "rlm")
-
-    resolved = resolve_local_checkout(
-        local_checkout_search_dirs=[search_root],
-    )
-
-    assert resolved == checkout.resolve()
-
-
 def test_rlm_harness_uploads_explicit_local_checkout(tmp_path):
     checkout = _make_git_checkout(tmp_path / "rlm")
 
@@ -168,42 +157,48 @@ def test_rlm_harness_uploads_explicit_local_checkout(tmp_path):
 
 def test_resolve_local_checkout_materializes_host_cache(tmp_path):
     source_checkout = _make_git_checkout(tmp_path / "rlm-source")
-    cache_dir = tmp_path / "cache" / "rlm"
+    checkout_dir = tmp_path / "checkout-root" / "rlm"
 
     resolved = resolve_local_checkout(
+        local_checkout=checkout_dir,
         rlm_repo_url=str(source_checkout),
         rlm_branch="main",
-        local_checkout_cache_dir=cache_dir,
     )
 
-    assert resolved == cache_dir.resolve()
-    assert (cache_dir / ".git").is_dir()
-    assert (cache_dir / "install.sh").is_file()
-    assert (cache_dir / "pyproject.toml").is_file()
+    assert resolved == checkout_dir.resolve()
+    assert (checkout_dir / ".git").is_dir()
+    assert (checkout_dir / "install.sh").is_file()
+    assert (checkout_dir / "pyproject.toml").is_file()
 
 
-def test_rlm_harness_uses_host_cache_when_no_local_checkout(tmp_path):
+def test_rlm_harness_uses_default_host_cache_when_local_checkout_unspecified(
+    tmp_path, monkeypatch
+):
     source_checkout = _make_git_checkout(tmp_path / "rlm-source")
-    cache_dir = tmp_path / "cache" / "rlm"
+    monkeypatch.setattr(
+        rlm_module,
+        "DEFAULT_RLM_LOCAL_CHECKOUT_CACHE_ROOT",
+        tmp_path / "cache-root",
+    )
 
     harness = rlm_harness(
         rlm_repo_url=str(source_checkout),
         rlm_branch="main",
-        local_checkout_cache_dir=cache_dir,
     )
 
-    assert harness.upload_dirs == {"rlm_checkout": cache_dir.resolve()}
+    upload_checkout = harness.upload_dirs["rlm_checkout"]
+    assert isinstance(upload_checkout, Path)
+    assert upload_checkout.is_dir()
+    assert upload_checkout.name.startswith("rlm-source-main-")
     assert harness.upload_dir_mapping == {"rlm_checkout": "/tmp/rlm-checkout"}
 
 
 def test_rlm_harness_always_uploads_checkout(tmp_path):
     source_checkout = _make_git_checkout(tmp_path / "rlm-source")
-    cache_dir = tmp_path / "cache" / "rlm"
 
     harness = rlm_harness(
         rlm_repo_url=str(source_checkout),
         rlm_branch="main",
-        local_checkout_cache_dir=cache_dir,
     )
 
     assert harness.upload_dirs is not None

--- a/verifiers/envs/experimental/composable/composable_env.py
+++ b/verifiers/envs/experimental/composable/composable_env.py
@@ -228,9 +228,10 @@ class ComposableEnv(CliAgentEnv):
     def _get_upload_dirs(self) -> dict[str, Traversable | Path]:
         """Merge task-owned and harness-owned upload directories."""
         task_upload_dirs = dict(self.taskset.get_upload_dirs() or {})
-        harness_upload_dirs = dict(
-            self.harness.get_upload_dirs() if self.harness.get_upload_dirs else {}
+        harness_upload_dirs_value = (
+            self.harness.get_upload_dirs() if self.harness.get_upload_dirs else None
         )
+        harness_upload_dirs = dict(harness_upload_dirs_value or {})
         duplicate_names = sorted(set(task_upload_dirs) & set(harness_upload_dirs))
         if duplicate_names:
             names = ", ".join(repr(name) for name in duplicate_names)

--- a/verifiers/envs/experimental/composable/composable_env.py
+++ b/verifiers/envs/experimental/composable/composable_env.py
@@ -211,11 +211,11 @@ class ComposableEnv(CliAgentEnv):
     async def _after_harness_inputs_uploaded(self, state: State) -> None:
         """Upload task-declared directories to harness-declared sandbox paths.
 
-        Joins ``TaskSet.get_upload_dirs()`` (logical name → local source)
-        with ``Harness.upload_dir_mapping`` (logical name → sandbox path).
+        Joins task-declared and harness-declared upload directories with
+        ``Harness.upload_dir_mapping`` (logical name → sandbox path).
         Only directories whose logical name appears in both are uploaded.
         """
-        upload_dirs = self.taskset.get_upload_dirs()
+        upload_dirs = self._get_upload_dirs()
         mapping = self.harness.get_effective_upload_dir_mapping()
         if not upload_dirs or not mapping:
             return
@@ -224,6 +224,20 @@ class ComposableEnv(CliAgentEnv):
             remote_dest = mapping.get(name)
             if remote_dest is not None:
                 await self._upload_dir(sandbox_id, local_source, remote_dest)
+
+    def _get_upload_dirs(self) -> dict[str, Traversable | Path]:
+        """Merge task-owned and harness-owned upload directories."""
+        task_upload_dirs = dict(self.taskset.get_upload_dirs() or {})
+        harness_upload_dirs = dict(self.harness.upload_dirs or {})
+        duplicate_names = sorted(set(task_upload_dirs) & set(harness_upload_dirs))
+        if duplicate_names:
+            names = ", ".join(repr(name) for name in duplicate_names)
+            raise ValueError(
+                "Upload directory names must be unique across task and harness; "
+                f"duplicates: {names}."
+            )
+        task_upload_dirs.update(harness_upload_dirs)
+        return task_upload_dirs
 
     def _get_install_execute_kwargs(self) -> dict[str, Any]:
         """Keyword arguments passed to sandbox install command execution."""

--- a/verifiers/envs/experimental/composable/composable_env.py
+++ b/verifiers/envs/experimental/composable/composable_env.py
@@ -228,7 +228,9 @@ class ComposableEnv(CliAgentEnv):
     def _get_upload_dirs(self) -> dict[str, Traversable | Path]:
         """Merge task-owned and harness-owned upload directories."""
         task_upload_dirs = dict(self.taskset.get_upload_dirs() or {})
-        harness_upload_dirs = dict(self.harness.upload_dirs or {})
+        harness_upload_dirs = dict(
+            self.harness.get_upload_dirs() if self.harness.get_upload_dirs else {}
+        )
         duplicate_names = sorted(set(task_upload_dirs) & set(harness_upload_dirs))
         if duplicate_names:
             names = ", ".join(repr(name) for name in duplicate_names)

--- a/verifiers/envs/experimental/composable/harness.py
+++ b/verifiers/envs/experimental/composable/harness.py
@@ -95,9 +95,7 @@ class Harness:
     sandbox_spec: SandboxSpec | None = None
     skills_path: str | None = None
     upload_dir_mapping: dict[str, str] | None = None
-    get_upload_dirs: (
-        Callable[[], dict[str, Traversable | Path] | None] | None
-    ) = None
+    get_upload_dirs: Callable[[], dict[str, Traversable | Path] | None] | None = None
     metrics_path: str | None = None
     metrics_prefix: str = ""
     metrics_key: str | None = None

--- a/verifiers/envs/experimental/composable/harness.py
+++ b/verifiers/envs/experimental/composable/harness.py
@@ -17,6 +17,8 @@ connects them.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from importlib.abc import Traversable
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -58,6 +60,12 @@ class Harness:
         ``skills_path`` is merged into this mapping automatically.
         Use for non-skills directories; for skills prefer
         ``skills_path``.
+    upload_dirs:
+        Optional harness-owned local directories to upload into the
+        sandbox before install. These are merged with task-declared
+        upload dirs by ``ComposableEnv`` and resolved via the same
+        ``upload_dir_mapping`` logical-name contract.
+        Example: ``{"agent_src": Path("/path/to/checkout")}``.
     metrics_path:
         Glob pattern for a JSON metrics file inside the sandbox,
         collected after the rollout.  May contain ``{workdir}`` which is
@@ -87,6 +95,7 @@ class Harness:
     sandbox_spec: SandboxSpec | None = None
     skills_path: str | None = None
     upload_dir_mapping: dict[str, str] | None = None
+    upload_dirs: dict[str, Traversable | Path] | None = None
     metrics_path: str | None = None
     metrics_prefix: str = ""
     metrics_key: str | None = None

--- a/verifiers/envs/experimental/composable/harness.py
+++ b/verifiers/envs/experimental/composable/harness.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from importlib.abc import Traversable
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable
 
 if TYPE_CHECKING:
     from verifiers.envs.experimental.composable.task import SandboxSpec
@@ -60,12 +60,12 @@ class Harness:
         ``skills_path`` is merged into this mapping automatically.
         Use for non-skills directories; for skills prefer
         ``skills_path``.
-    upload_dirs:
-        Optional harness-owned local directories to upload into the
-        sandbox before install. These are merged with task-declared
-        upload dirs by ``ComposableEnv`` and resolved via the same
-        ``upload_dir_mapping`` logical-name contract.
-        Example: ``{"agent_src": Path("/path/to/checkout")}``.
+    get_upload_dirs:
+        Optional callable returning harness-owned local directories to
+        upload into the sandbox before install. These are merged with
+        task-declared upload dirs by ``ComposableEnv`` and resolved via
+        the same ``upload_dir_mapping`` logical-name contract.
+        Example: ``lambda: {"agent_src": Path("/path/to/checkout")}``.
     metrics_path:
         Glob pattern for a JSON metrics file inside the sandbox,
         collected after the rollout.  May contain ``{workdir}`` which is
@@ -95,7 +95,9 @@ class Harness:
     sandbox_spec: SandboxSpec | None = None
     skills_path: str | None = None
     upload_dir_mapping: dict[str, str] | None = None
-    upload_dirs: dict[str, Traversable | Path] | None = None
+    get_upload_dirs: (
+        Callable[[], dict[str, Traversable | Path] | None] | None
+    ) = None
     metrics_path: str | None = None
     metrics_prefix: str = ""
     metrics_key: str | None = None

--- a/verifiers/envs/experimental/composable/harnesses/rlm.py
+++ b/verifiers/envs/experimental/composable/harnesses/rlm.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import hashlib
 import os
 from collections.abc import Iterator
-from collections.abc import Iterable
 from contextlib import contextmanager
 import fcntl
 from importlib.abc import Traversable
@@ -46,18 +45,6 @@ def _validate_local_checkout(path: Path) -> Path:
             f"RLM local checkout must be a git checkout or worktree: {path}"
         )
     return path
-
-
-def _discover_local_checkout(search_dirs: Iterable[str | Path]) -> Path | None:
-    for search_dir in search_dirs:
-        candidate = Path(search_dir).expanduser().resolve() / "rlm"
-        if not candidate.is_dir():
-            continue
-        try:
-            return _validate_local_checkout(candidate)
-        except ValueError:
-            continue
-    return None
 
 
 def _slugify_cache_component(text: str) -> str:
@@ -175,21 +162,21 @@ def ensure_local_checkout(
     *,
     rlm_repo_url: str,
     rlm_branch: str,
-    local_checkout_cache_dir: str | Path | None = None,
+    local_checkout: str | Path | None = None,
     gh_token: str | None = None,
 ) -> Path:
-    cache_dir = (
-        Path(local_checkout_cache_dir).expanduser()
-        if local_checkout_cache_dir is not None
+    checkout_dir = (
+        Path(local_checkout).expanduser()
+        if local_checkout is not None
         else _default_local_checkout_cache_dir(rlm_repo_url, rlm_branch)
     ).resolve()
-    lock_path = cache_dir.parent / f".{cache_dir.name}.lock"
+    lock_path = checkout_dir.parent / f".{checkout_dir.name}.lock"
     with _checkout_lock(lock_path):
         try:
-            return _validate_local_checkout(cache_dir)
+            return _validate_local_checkout(checkout_dir)
         except ValueError:
             return _clone_checkout(
-                cache_dir,
+                checkout_dir,
                 rlm_repo_url=rlm_repo_url,
                 rlm_branch=rlm_branch,
                 gh_token=gh_token,
@@ -201,19 +188,12 @@ def resolve_local_checkout(
     *,
     rlm_repo_url: str = DEFAULT_RLM_REPO_URL,
     rlm_branch: str = DEFAULT_RLM_BRANCH,
-    local_checkout_search_dirs: Iterable[str | Path] | None = None,
-    local_checkout_cache_dir: str | Path | None = None,
     gh_token: str | None = None,
 ) -> Path:
-    if local_checkout is not None:
-        return _validate_local_checkout(Path(local_checkout))
-    discovered_checkout = _discover_local_checkout(local_checkout_search_dirs or ())
-    if discovered_checkout is not None:
-        return discovered_checkout
     return ensure_local_checkout(
         rlm_repo_url=rlm_repo_url,
         rlm_branch=rlm_branch,
-        local_checkout_cache_dir=local_checkout_cache_dir,
+        local_checkout=local_checkout,
         gh_token=gh_token,
     )
 
@@ -266,16 +246,12 @@ def rlm_harness(
     rlm_branch: str = DEFAULT_RLM_BRANCH,
     append_to_system_prompt: str | None = None,
     local_checkout: str | Path | None = None,
-    local_checkout_search_dirs: Iterable[str | Path] | None = None,
-    local_checkout_cache_dir: str | Path | None = None,
     gh_token: str | None = None,
 ) -> Harness:
     resolved_local_checkout = resolve_local_checkout(
         local_checkout,
         rlm_repo_url=rlm_repo_url,
         rlm_branch=rlm_branch,
-        local_checkout_search_dirs=local_checkout_search_dirs,
-        local_checkout_cache_dir=local_checkout_cache_dir,
         gh_token=gh_token,
     )
     upload_dirs: dict[str, Traversable | Path] = {

--- a/verifiers/envs/experimental/composable/harnesses/rlm.py
+++ b/verifiers/envs/experimental/composable/harnesses/rlm.py
@@ -267,7 +267,7 @@ def rlm_harness(
         system_prompt_path=DEFAULT_APPEND_TO_SYSTEM_PROMPT_PATH,
         instruction_path=instruction_path,
         skills_path="/task/rlm-skills",
-        upload_dirs=upload_dirs,
+        get_upload_dirs=lambda: upload_dirs,
         upload_dir_mapping=upload_dir_mapping,
         metrics_path="{workdir}/.rlm/sessions/*/meta.json",
         metrics_key="metrics",

--- a/verifiers/envs/experimental/composable/harnesses/rlm.py
+++ b/verifiers/envs/experimental/composable/harnesses/rlm.py
@@ -2,10 +2,19 @@
 
 from __future__ import annotations
 
+import hashlib
+import os
+from collections.abc import Iterator
 from collections.abc import Iterable
+from contextlib import contextmanager
+import fcntl
 from importlib.abc import Traversable
 from pathlib import Path
 import shlex
+import shutil
+import subprocess
+import tempfile
+from urllib.parse import quote, urlsplit, urlunsplit
 
 from verifiers.envs.experimental.composable import Harness
 
@@ -16,6 +25,9 @@ DEFAULT_RLM_MAX_TURNS = 100
 DEFAULT_APPEND_TO_SYSTEM_PROMPT_PATH = "/task/append_to_system_prompt.txt"
 DEFAULT_RLM_CHECKOUT_PATH = "/tmp/rlm-checkout"
 DEFAULT_RLM_CHECKOUT_UPLOAD_NAME = "rlm_checkout"
+DEFAULT_RLM_LOCAL_CHECKOUT_CACHE_ROOT = (
+    Path.home() / ".cache" / "verifiers" / "rlm-checkouts"
+)
 
 
 def _validate_local_checkout(path: Path) -> Path:
@@ -29,6 +41,8 @@ def _validate_local_checkout(path: Path) -> Path:
         raise ValueError(
             f"RLM local checkout is missing required files ({missing_list}): {path}"
         )
+    if not (path / ".git").exists():
+        raise ValueError(f"RLM local checkout must be a git checkout or worktree: {path}")
     return path
 
 
@@ -44,16 +58,158 @@ def _discover_local_checkout(search_dirs: Iterable[str | Path]) -> Path | None:
     return None
 
 
+def _slugify_cache_component(text: str) -> str:
+    slug = "".join(char.lower() if char.isalnum() else "-" for char in text)
+    slug = slug.strip("-")
+    return slug or "rlm"
+
+
+def _default_local_checkout_cache_dir(
+    rlm_repo_url: str,
+    rlm_branch: str,
+) -> Path:
+    repo_name = rlm_repo_url.rstrip("/").rsplit("/", 1)[-1].removesuffix(".git")
+    fingerprint = hashlib.sha256(f"{rlm_repo_url}\n{rlm_branch}".encode()).hexdigest()[:12]
+    cache_name = (
+        f"{_slugify_cache_component(repo_name)}-"
+        f"{_slugify_cache_component(rlm_branch)}-{fingerprint}"
+    )
+    return DEFAULT_RLM_LOCAL_CHECKOUT_CACHE_ROOT / cache_name
+
+
+def _build_clone_url(
+    rlm_repo_url: str,
+    gh_token: str | None = None,
+) -> str:
+    if rlm_repo_url.startswith("github.com/"):
+        token_prefix = f"{quote(gh_token, safe='')}@" if gh_token else ""
+        return f"https://{token_prefix}{rlm_repo_url}"
+
+    if gh_token and rlm_repo_url.startswith(("https://github.com/", "http://github.com/")):
+        parsed = urlsplit(rlm_repo_url)
+        if "@" not in parsed.netloc:
+            return urlunsplit(
+                (
+                    parsed.scheme,
+                    f"{quote(gh_token, safe='')}@{parsed.netloc}",
+                    parsed.path,
+                    parsed.query,
+                    parsed.fragment,
+                )
+            )
+
+    return rlm_repo_url
+
+
+@contextmanager
+def _checkout_lock(lock_path: Path) -> Iterator[None]:
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("w") as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        yield
+
+
+def _clone_checkout(
+    target_dir: Path,
+    *,
+    rlm_repo_url: str,
+    rlm_branch: str,
+    gh_token: str | None = None,
+) -> Path:
+    target_dir.parent.mkdir(parents=True, exist_ok=True)
+    clone_url = _build_clone_url(rlm_repo_url, gh_token)
+    temp_parent = target_dir.parent
+    temp_dir = Path(
+        tempfile.mkdtemp(prefix=f".{target_dir.name}.tmp-", dir=temp_parent)
+    )
+    checkout_dir = temp_dir / "checkout"
+    env = os.environ.copy()
+    if gh_token:
+        env.setdefault("GH_TOKEN", gh_token)
+    try:
+        subprocess.run(
+            [
+                "git",
+                "clone",
+                "--depth",
+                "1",
+                "--branch",
+                rlm_branch,
+                clone_url,
+                str(checkout_dir),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+    except FileNotFoundError as exc:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+        raise RuntimeError("git is required to populate the local RLM checkout cache") from exc
+    except subprocess.CalledProcessError as exc:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+        detail = exc.stderr.strip() or exc.stdout.strip() or str(exc)
+        raise RuntimeError(
+            f"Failed to clone RLM checkout into host cache at {target_dir}: {detail}"
+        ) from exc
+
+    if target_dir.exists():
+        if target_dir.is_dir():
+            shutil.rmtree(target_dir)
+        else:
+            target_dir.unlink()
+    checkout_dir.rename(target_dir)
+    shutil.rmtree(temp_dir, ignore_errors=True)
+    return _validate_local_checkout(target_dir)
+
+
+def ensure_local_checkout(
+    *,
+    rlm_repo_url: str,
+    rlm_branch: str,
+    local_checkout_cache_dir: str | Path | None = None,
+    gh_token: str | None = None,
+) -> Path:
+    cache_dir = (
+        Path(local_checkout_cache_dir).expanduser()
+        if local_checkout_cache_dir is not None
+        else _default_local_checkout_cache_dir(rlm_repo_url, rlm_branch)
+    ).resolve()
+    lock_path = cache_dir.parent / f".{cache_dir.name}.lock"
+    with _checkout_lock(lock_path):
+        try:
+            return _validate_local_checkout(cache_dir)
+        except ValueError:
+            return _clone_checkout(
+                cache_dir,
+                rlm_repo_url=rlm_repo_url,
+                rlm_branch=rlm_branch,
+                gh_token=gh_token,
+            )
+
+
 def resolve_local_checkout(
     local_checkout: str | Path | None = None,
     *,
+    rlm_repo_url: str = DEFAULT_RLM_REPO_URL,
+    rlm_branch: str = DEFAULT_RLM_BRANCH,
     prefer_local_checkout: bool = True,
     local_checkout_search_dirs: Iterable[str | Path] | None = None,
+    local_checkout_cache_dir: str | Path | None = None,
+    gh_token: str | None = None,
 ) -> Path | None:
     if local_checkout is not None:
         return _validate_local_checkout(Path(local_checkout))
     if prefer_local_checkout:
-        return _discover_local_checkout(local_checkout_search_dirs or ())
+        discovered_checkout = _discover_local_checkout(local_checkout_search_dirs or ())
+        if discovered_checkout is not None:
+            return discovered_checkout
+        return ensure_local_checkout(
+            rlm_repo_url=rlm_repo_url,
+            rlm_branch=rlm_branch,
+            local_checkout_cache_dir=local_checkout_cache_dir,
+            gh_token=gh_token,
+        )
     return None
 
 
@@ -61,18 +217,30 @@ def build_install_script(
     rlm_repo_url: str = DEFAULT_RLM_REPO_URL,
     rlm_branch: str = DEFAULT_RLM_BRANCH,
 ) -> str:
-    # Clone via git protocol instead of fetching install.sh from
-    # raw.githubusercontent.com which has a 60 req/hr hard cap per IP.
-    # rlm_repo_url is expected to be a bare github.com/org/repo.git path;
-    # GH_TOKEN is injected at shell expansion time for private repos.
-    return (
-        "command -v git >/dev/null 2>&1 || { apt-get update -qq && apt-get install -y -qq git; }"
-        f" && git clone --depth 1 --branch {rlm_branch}"
-        f' "https://${{GH_TOKEN:+${{GH_TOKEN}}@}}{rlm_repo_url}" /tmp/rlm-checkout'
-        f" && RLM_REPO_URL={rlm_repo_url}"
-        f" RLM_REPO_BRANCH={rlm_branch}"
-        " bash /tmp/rlm-checkout/install.sh"
-    )
+    script = f"""\
+set -eo pipefail
+command -v git >/dev/null 2>&1 || {{ apt-get update -qq && apt-get install -y -qq git; }}
+export RLM_REPO_URL={shlex.quote(rlm_repo_url)}
+export RLM_REPO_BRANCH={shlex.quote(rlm_branch)}
+export RLM_CHECKOUT_PATH={shlex.quote(DEFAULT_RLM_CHECKOUT_PATH)}
+if [ ! -f "$RLM_CHECKOUT_PATH/install.sh" ]; then
+    rm -rf "$RLM_CHECKOUT_PATH"
+    case "$RLM_REPO_URL" in
+        https://*|http://*)
+            CLONE_URL="$RLM_REPO_URL"
+            ;;
+        github.com/*)
+            CLONE_URL="https://${{GH_TOKEN:+${{GH_TOKEN}}@}}$RLM_REPO_URL"
+            ;;
+        *)
+            CLONE_URL="$RLM_REPO_URL"
+            ;;
+    esac
+    git clone --depth 1 --branch "$RLM_REPO_BRANCH" "$CLONE_URL" "$RLM_CHECKOUT_PATH"
+fi
+bash "$RLM_CHECKOUT_PATH/install.sh"
+"""
+    return f"bash -lc {shlex.quote(script)}"
 
 
 def build_run_command(
@@ -115,11 +283,17 @@ def rlm_harness(
     local_checkout: str | Path | None = None,
     prefer_local_checkout: bool = True,
     local_checkout_search_dirs: Iterable[str | Path] | None = None,
+    local_checkout_cache_dir: str | Path | None = None,
+    gh_token: str | None = None,
 ) -> Harness:
     resolved_local_checkout = resolve_local_checkout(
         local_checkout,
+        rlm_repo_url=rlm_repo_url,
+        rlm_branch=rlm_branch,
         prefer_local_checkout=prefer_local_checkout,
         local_checkout_search_dirs=local_checkout_search_dirs,
+        local_checkout_cache_dir=local_checkout_cache_dir,
+        gh_token=gh_token,
     )
     upload_dirs: dict[str, Traversable | Path] | None = None
     upload_dir_mapping: dict[str, str] | None = None

--- a/verifiers/envs/experimental/composable/harnesses/rlm.py
+++ b/verifiers/envs/experimental/composable/harnesses/rlm.py
@@ -94,6 +94,16 @@ def _build_clone_url(
     return rlm_repo_url
 
 
+def _redact_clone_error_detail(detail: str, gh_token: str | None = None) -> str:
+    if not gh_token:
+        return detail
+    redacted = detail.replace(gh_token, "<redacted>")
+    quoted_token = quote(gh_token, safe="")
+    if quoted_token != gh_token:
+        redacted = redacted.replace(quoted_token, "<redacted>")
+    return redacted
+
+
 @contextmanager
 def _checkout_lock(lock_path: Path) -> Iterator[None]:
     lock_path.parent.mkdir(parents=True, exist_ok=True)
@@ -144,6 +154,7 @@ def _clone_checkout(
     except subprocess.CalledProcessError as exc:
         shutil.rmtree(temp_dir, ignore_errors=True)
         detail = exc.stderr.strip() or exc.stdout.strip() or str(exc)
+        detail = _redact_clone_error_detail(detail, gh_token)
         raise RuntimeError(
             f"Failed to clone RLM checkout into host cache at {target_dir}: {detail}"
         ) from exc

--- a/verifiers/envs/experimental/composable/harnesses/rlm.py
+++ b/verifiers/envs/experimental/composable/harnesses/rlm.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
+from importlib.abc import Traversable
+from pathlib import Path
 import shlex
 
 from verifiers.envs.experimental.composable import Harness
@@ -11,6 +14,47 @@ DEFAULT_RLM_BRANCH = "main"
 DEFAULT_RLM_TOOLS = "bash,edit"
 DEFAULT_RLM_MAX_TURNS = 100
 DEFAULT_APPEND_TO_SYSTEM_PROMPT_PATH = "/task/append_to_system_prompt.txt"
+DEFAULT_RLM_CHECKOUT_PATH = "/tmp/rlm-checkout"
+DEFAULT_RLM_CHECKOUT_UPLOAD_NAME = "rlm_checkout"
+
+
+def _validate_local_checkout(path: Path) -> Path:
+    path = path.expanduser().resolve()
+    if not path.is_dir():
+        raise ValueError(f"RLM local checkout is not a directory: {path}")
+    required = [path / "install.sh", path / "pyproject.toml"]
+    missing = [item.name for item in required if not item.is_file()]
+    if missing:
+        missing_list = ", ".join(missing)
+        raise ValueError(
+            f"RLM local checkout is missing required files ({missing_list}): {path}"
+        )
+    return path
+
+
+def _discover_local_checkout(search_dirs: Iterable[str | Path]) -> Path | None:
+    for search_dir in search_dirs:
+        candidate = Path(search_dir).expanduser().resolve() / "rlm"
+        if not candidate.is_dir():
+            continue
+        try:
+            return _validate_local_checkout(candidate)
+        except ValueError:
+            continue
+    return None
+
+
+def resolve_local_checkout(
+    local_checkout: str | Path | None = None,
+    *,
+    prefer_local_checkout: bool = True,
+    local_checkout_search_dirs: Iterable[str | Path] | None = None,
+) -> Path | None:
+    if local_checkout is not None:
+        return _validate_local_checkout(Path(local_checkout))
+    if prefer_local_checkout:
+        return _discover_local_checkout(local_checkout_search_dirs or ())
+    return None
 
 
 def build_install_script(
@@ -68,7 +112,24 @@ def rlm_harness(
     rlm_repo_url: str = DEFAULT_RLM_REPO_URL,
     rlm_branch: str = DEFAULT_RLM_BRANCH,
     append_to_system_prompt: str | None = None,
+    local_checkout: str | Path | None = None,
+    prefer_local_checkout: bool = True,
+    local_checkout_search_dirs: Iterable[str | Path] | None = None,
 ) -> Harness:
+    resolved_local_checkout = resolve_local_checkout(
+        local_checkout,
+        prefer_local_checkout=prefer_local_checkout,
+        local_checkout_search_dirs=local_checkout_search_dirs,
+    )
+    upload_dirs: dict[str, Traversable | Path] | None = None
+    upload_dir_mapping: dict[str, str] | None = None
+    if resolved_local_checkout is not None:
+        upload_dirs = {
+            DEFAULT_RLM_CHECKOUT_UPLOAD_NAME: resolved_local_checkout,
+        }
+        upload_dir_mapping = {
+            DEFAULT_RLM_CHECKOUT_UPLOAD_NAME: DEFAULT_RLM_CHECKOUT_PATH,
+        }
     return Harness(
         install_script=build_install_script(rlm_repo_url, rlm_branch),
         run_command=build_run_command(instruction_path, workdir),
@@ -76,6 +137,8 @@ def rlm_harness(
         system_prompt_path=DEFAULT_APPEND_TO_SYSTEM_PROMPT_PATH,
         instruction_path=instruction_path,
         skills_path="/task/rlm-skills",
+        upload_dirs=upload_dirs,
+        upload_dir_mapping=upload_dir_mapping,
         metrics_path="{workdir}/.rlm/sessions/*/meta.json",
         metrics_key="metrics",
         metrics_prefix="rlm_",

--- a/verifiers/envs/experimental/composable/harnesses/rlm.py
+++ b/verifiers/envs/experimental/composable/harnesses/rlm.py
@@ -42,7 +42,9 @@ def _validate_local_checkout(path: Path) -> Path:
             f"RLM local checkout is missing required files ({missing_list}): {path}"
         )
     if not (path / ".git").exists():
-        raise ValueError(f"RLM local checkout must be a git checkout or worktree: {path}")
+        raise ValueError(
+            f"RLM local checkout must be a git checkout or worktree: {path}"
+        )
     return path
 
 
@@ -69,7 +71,9 @@ def _default_local_checkout_cache_dir(
     rlm_branch: str,
 ) -> Path:
     repo_name = rlm_repo_url.rstrip("/").rsplit("/", 1)[-1].removesuffix(".git")
-    fingerprint = hashlib.sha256(f"{rlm_repo_url}\n{rlm_branch}".encode()).hexdigest()[:12]
+    fingerprint = hashlib.sha256(f"{rlm_repo_url}\n{rlm_branch}".encode()).hexdigest()[
+        :12
+    ]
     cache_name = (
         f"{_slugify_cache_component(repo_name)}-"
         f"{_slugify_cache_component(rlm_branch)}-{fingerprint}"
@@ -85,7 +89,9 @@ def _build_clone_url(
         token_prefix = f"{quote(gh_token, safe='')}@" if gh_token else ""
         return f"https://{token_prefix}{rlm_repo_url}"
 
-    if gh_token and rlm_repo_url.startswith(("https://github.com/", "http://github.com/")):
+    if gh_token and rlm_repo_url.startswith(
+        ("https://github.com/", "http://github.com/")
+    ):
         parsed = urlsplit(rlm_repo_url)
         if "@" not in parsed.netloc:
             return urlunsplit(
@@ -145,7 +151,9 @@ def _clone_checkout(
         )
     except FileNotFoundError as exc:
         shutil.rmtree(temp_dir, ignore_errors=True)
-        raise RuntimeError("git is required to populate the local RLM checkout cache") from exc
+        raise RuntimeError(
+            "git is required to populate the local RLM checkout cache"
+        ) from exc
     except subprocess.CalledProcessError as exc:
         shutil.rmtree(temp_dir, ignore_errors=True)
         detail = exc.stderr.strip() or exc.stdout.strip() or str(exc)
@@ -193,51 +201,28 @@ def resolve_local_checkout(
     *,
     rlm_repo_url: str = DEFAULT_RLM_REPO_URL,
     rlm_branch: str = DEFAULT_RLM_BRANCH,
-    prefer_local_checkout: bool = True,
     local_checkout_search_dirs: Iterable[str | Path] | None = None,
     local_checkout_cache_dir: str | Path | None = None,
     gh_token: str | None = None,
-) -> Path | None:
+) -> Path:
     if local_checkout is not None:
         return _validate_local_checkout(Path(local_checkout))
-    if prefer_local_checkout:
-        discovered_checkout = _discover_local_checkout(local_checkout_search_dirs or ())
-        if discovered_checkout is not None:
-            return discovered_checkout
-        return ensure_local_checkout(
-            rlm_repo_url=rlm_repo_url,
-            rlm_branch=rlm_branch,
-            local_checkout_cache_dir=local_checkout_cache_dir,
-            gh_token=gh_token,
-        )
-    return None
+    discovered_checkout = _discover_local_checkout(local_checkout_search_dirs or ())
+    if discovered_checkout is not None:
+        return discovered_checkout
+    return ensure_local_checkout(
+        rlm_repo_url=rlm_repo_url,
+        rlm_branch=rlm_branch,
+        local_checkout_cache_dir=local_checkout_cache_dir,
+        gh_token=gh_token,
+    )
 
 
-def build_install_script(
-    rlm_repo_url: str = DEFAULT_RLM_REPO_URL,
-    rlm_branch: str = DEFAULT_RLM_BRANCH,
-) -> str:
+def build_install_script() -> str:
     script = f"""\
 set -eo pipefail
-command -v git >/dev/null 2>&1 || {{ apt-get update -qq && apt-get install -y -qq git; }}
-export RLM_REPO_URL={shlex.quote(rlm_repo_url)}
-export RLM_REPO_BRANCH={shlex.quote(rlm_branch)}
 export RLM_CHECKOUT_PATH={shlex.quote(DEFAULT_RLM_CHECKOUT_PATH)}
-if [ ! -f "$RLM_CHECKOUT_PATH/install.sh" ]; then
-    rm -rf "$RLM_CHECKOUT_PATH"
-    case "$RLM_REPO_URL" in
-        https://*|http://*)
-            CLONE_URL="$RLM_REPO_URL"
-            ;;
-        github.com/*)
-            CLONE_URL="https://${{GH_TOKEN:+${{GH_TOKEN}}@}}$RLM_REPO_URL"
-            ;;
-        *)
-            CLONE_URL="$RLM_REPO_URL"
-            ;;
-    esac
-    git clone --depth 1 --branch "$RLM_REPO_BRANCH" "$CLONE_URL" "$RLM_CHECKOUT_PATH"
-fi
+test -f "$RLM_CHECKOUT_PATH/install.sh"
 bash "$RLM_CHECKOUT_PATH/install.sh"
 """
     return f"bash -lc {shlex.quote(script)}"
@@ -281,7 +266,6 @@ def rlm_harness(
     rlm_branch: str = DEFAULT_RLM_BRANCH,
     append_to_system_prompt: str | None = None,
     local_checkout: str | Path | None = None,
-    prefer_local_checkout: bool = True,
     local_checkout_search_dirs: Iterable[str | Path] | None = None,
     local_checkout_cache_dir: str | Path | None = None,
     gh_token: str | None = None,
@@ -290,22 +274,18 @@ def rlm_harness(
         local_checkout,
         rlm_repo_url=rlm_repo_url,
         rlm_branch=rlm_branch,
-        prefer_local_checkout=prefer_local_checkout,
         local_checkout_search_dirs=local_checkout_search_dirs,
         local_checkout_cache_dir=local_checkout_cache_dir,
         gh_token=gh_token,
     )
-    upload_dirs: dict[str, Traversable | Path] | None = None
-    upload_dir_mapping: dict[str, str] | None = None
-    if resolved_local_checkout is not None:
-        upload_dirs = {
-            DEFAULT_RLM_CHECKOUT_UPLOAD_NAME: resolved_local_checkout,
-        }
-        upload_dir_mapping = {
-            DEFAULT_RLM_CHECKOUT_UPLOAD_NAME: DEFAULT_RLM_CHECKOUT_PATH,
-        }
+    upload_dirs: dict[str, Traversable | Path] = {
+        DEFAULT_RLM_CHECKOUT_UPLOAD_NAME: resolved_local_checkout,
+    }
+    upload_dir_mapping: dict[str, str] = {
+        DEFAULT_RLM_CHECKOUT_UPLOAD_NAME: DEFAULT_RLM_CHECKOUT_PATH,
+    }
     return Harness(
-        install_script=build_install_script(rlm_repo_url, rlm_branch),
+        install_script=build_install_script(),
         run_command=build_run_command(instruction_path, workdir),
         system_prompt=append_to_system_prompt,
         system_prompt_path=DEFAULT_APPEND_TO_SYSTEM_PROMPT_PATH,


### PR DESCRIPTION
## Description

Make the RLM composable harness use a host-side checkout cache and upload-only sandbox installs.

- `rlm_local_checkout`: defaults to default cache but is user-settable
  - the rlm package is downloaded into this location, unless it's already there
  - then it's uploaded to each sandbox
  - this avoids too many requests to a private github repo
- adds `get_upload_dirs` to the harness to upload agent-specific assets (like the rlm repo)

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [x] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the sandbox install flow for the `rlm` harness to rely on host-side git checkouts that are uploaded into the sandbox, plus new merging/validation logic for upload directories; failures here can break agent installs and introduce host filesystem/cache dependencies. Token handling is improved via redaction, but git/clone behavior and locking add some operational complexity.
> 
> **Overview**
> **Composable harnesses can now upload their own local directories** into the sandbox via a new `Harness.get_upload_dirs` hook, which `ComposableEnv` merges with task-provided upload dirs and rejects duplicate logical names.
> 
> **The `rlm` harness no longer clones from GitHub inside the sandbox.** Instead it resolves (and if needed, clones) a host-side checkout into a cache directory (with file locking and GH token redaction on errors) and always uploads that checkout to `/tmp/rlm-checkout` before running the install script.
> 
> Tests are expanded to cover harness-owned uploads, duplicate-name rejection, host-cache materialization, and updated `rlm` install-script expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47efef4554eac879fef2d43aadb506f7abbc253a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->