### PR TITLE
Authenticate interception server via INTERCEPTION_SECRET

### DIFF
--- a/verifiers/envs/experimental/cli_agent_env.py
+++ b/verifiers/envs/experimental/cli_agent_env.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import math
+import os
 import time
 import uuid
 from collections import Counter
@@ -156,7 +157,9 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
         self._tunnel: Tunnel | None = None
         self._tunnel_lock = asyncio.Lock()
         self._tunnel_last_checked: float = 0.0
-        self._interception_server = InterceptionServer(port=interception_port)
+        self._interception_server = InterceptionServer(
+            port=interception_port, secret=os.environ.get("INTERCEPTION_SECRET")
+        )
 
     def _require_interception_server(self) -> InterceptionServer:
         if self._interception_server is None:
@@ -296,6 +299,7 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
             "OPENAI_REQUEST_TIMEOUT",
             "HTTPX_TIMEOUT",
             "OPENAI_MODEL",
+            "OPENAI_API_KEY",
         }
     )
 
@@ -306,6 +310,9 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
         env_vars.setdefault("OPENAI_TIMEOUT", "3600")
         env_vars.setdefault("OPENAI_REQUEST_TIMEOUT", "3600")
         env_vars.setdefault("HTTPX_TIMEOUT", "3600")
+        secret = os.environ.get("INTERCEPTION_SECRET")
+        if secret:
+            env_vars["OPENAI_API_KEY"] = secret
         model = state.get("model")
         if model:
             env_vars["OPENAI_MODEL"] = model

--- a/verifiers/utils/interception_utils.py
+++ b/verifiers/utils/interception_utils.py
@@ -51,7 +51,7 @@ class InterceptionServer:
 
     def __init__(self, port: int, secret: str | None = None):
         self.port = port
-        self.secret = secret
+        self.secret = secret or None  # treat empty string as no secret
         self._app: Any = None
         self._runner: Any = None
         self._site: Any = None
@@ -157,15 +157,15 @@ class InterceptionServer:
             del self.active_rollouts[rollout_id]
 
     async def _handle_request(self, request: Any) -> Any:
+        if self.secret:
+            auth = request.headers.get("Authorization", "")
+            if not hmac.compare_digest(auth, f"Bearer {self.secret}"):
+                return web.json_response({"error": "Unauthorized"}, status=401)
+
         rollout_id = request.match_info["rollout_id"]
         context = self.active_rollouts.get(rollout_id)
         if not context:
             return web.json_response({"error": "Rollout not found"}, status=404)
-
-        if self.secret is not None:
-            auth = request.headers.get("Authorization", "")
-            if not hmac.compare_digest(auth, f"Bearer {self.secret}"):
-                return web.json_response({"error": "Unauthorized"}, status=401)
 
         try:
             request_body = await request.json()

--- a/verifiers/utils/interception_utils.py
+++ b/verifiers/utils/interception_utils.py
@@ -1,6 +1,7 @@
 """Utilities for intercepting API calls from agents running in sandboxes."""
 
 import asyncio
+import hmac
 import json
 import logging
 import time
@@ -48,8 +49,9 @@ class InterceptionServer:
     to the agent once the actual model response is obtained.
     """
 
-    def __init__(self, port: int):
+    def __init__(self, port: int, secret: str | None = None):
         self.port = port
+        self.secret = secret
         self._app: Any = None
         self._runner: Any = None
         self._site: Any = None
@@ -159,6 +161,11 @@ class InterceptionServer:
         context = self.active_rollouts.get(rollout_id)
         if not context:
             return web.json_response({"error": "Rollout not found"}, status=404)
+
+        if self.secret is not None:
+            auth = request.headers.get("Authorization", "")
+            if not hmac.compare_digest(auth, f"Bearer {self.secret}"):
+                return web.json_response({"error": "Unauthorized"}, status=401)
 
         try:
             request_body = await request.json()


### PR DESCRIPTION
## Summary

- `InterceptionServer` accepts an optional `secret` parameter; when set, validates the `Authorization: Bearer <secret>` header on every request using `hmac.compare_digest` — auth check runs **before** rollout lookup to prevent ID enumeration
- `CliAgentEnv` reads `INTERCEPTION_SECRET` from the host environment and injects it as `OPENAI_API_KEY` into sandbox env vars, overriding any dummy value (e.g. `"intercepted"`)
- `OPENAI_API_KEY` added to `PROTECTED_ENV_VARS`
- Empty string `INTERCEPTION_SECRET` treated as unset in both server and env (consistent behaviour)
- `CliAgentEnv` is backward compatible: if `INTERCEPTION_SECRET` is unset the server accepts all requests as before

## Test plan

- [x] Unit-tested: no-secret (backward compat), no-auth → 401, wrong-secret → 401, correct-secret → accepted
- [ ] Set `INTERCEPTION_SECRET=<secret>` and run a rollout end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds authentication gating to the interception HTTP server and propagates the shared secret into sandbox env vars; misconfiguration could cause rollouts to fail with 401s or inadvertently run unauthenticated if the secret is unset/empty.
> 
> **Overview**
> Adds optional request authentication to `InterceptionServer`: when `INTERCEPTION_SECRET` is set, every intercepted request must include `Authorization: Bearer <secret>` (constant-time compared) and unauthorized requests return `401` before rollout lookup.
> 
> Updates `CliAgentEnv` to read `INTERCEPTION_SECRET`, pass it into `InterceptionServer`, and (when non-empty) inject it as `OPENAI_API_KEY` into sandbox env vars while protecting `OPENAI_API_KEY` from being overridden by subclasses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f96ff0effb89b2326a4598d4381a5faf762dcd85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->