### PR TITLE
feat: auto-register ToolMonitorRubric from harness.tool_names

### DIFF
--- a/verifiers/envs/experimental/composable/composable_env.py
+++ b/verifiers/envs/experimental/composable/composable_env.py
@@ -50,6 +50,7 @@ import verifiers as vf
 from verifiers.envs.experimental.cli_agent_env import CliAgentEnv
 from verifiers.envs.experimental.composable.harness import Harness
 from verifiers.envs.experimental.composable.task import TaskSet
+from verifiers.envs.tool_env import ToolMonitorRubric
 from verifiers.types import State
 
 logger = logging.getLogger(__name__)
@@ -85,6 +86,9 @@ class ComposableEnv(CliAgentEnv):
         self.taskset = taskset
         self.harness = harness
         self.install_env = dict(install_env) if install_env else None
+
+        if harness.tool_names:
+            self.add_rubric(ToolMonitorRubric(tool_names=list(harness.tool_names)))
 
     # -- CliAgentEnv hooks --------------------------------------------------
 

--- a/verifiers/envs/experimental/composable/harness.py
+++ b/verifiers/envs/experimental/composable/harness.py
@@ -83,6 +83,12 @@ class Harness:
     metrics_keys:
         Optional whitelist of metric keys to surface.  ``None`` means
         surface all keys found.
+    tool_names:
+        Names of the tools the agent uses internally.  When non-empty,
+        ``ComposableEnv`` auto-registers a ``ToolMonitorRubric`` that
+        counts calls to each named tool (plus a total) from the
+        assistant messages the harness emits into the trajectory.
+        Example: ``["ipython", "summarize"]`` for the RLM harness.
     """
 
     install_script: str | None = None
@@ -100,6 +106,7 @@ class Harness:
     metrics_prefix: str = ""
     metrics_key: str | None = None
     metrics_keys: list[str] | None = None
+    tool_names: list[str] | None = None
 
     def get_effective_upload_dir_mapping(self) -> dict[str, str] | None:
         """Return the merged upload mapping (skills_path + upload_dir_mapping)."""

--- a/verifiers/envs/experimental/composable/harnesses/rlm.py
+++ b/verifiers/envs/experimental/composable/harnesses/rlm.py
@@ -20,6 +20,7 @@ from verifiers.envs.experimental.composable import Harness
 DEFAULT_RLM_REPO_URL = "github.com/PrimeIntellect-ai/rlm.git"
 DEFAULT_RLM_BRANCH = "main"
 DEFAULT_RLM_TOOLS = "bash,edit"
+DEFAULT_RLM_TOOL_NAMES = ["ipython", "summarize"]
 DEFAULT_RLM_MAX_TURNS = 100
 DEFAULT_APPEND_TO_SYSTEM_PROMPT_PATH = "/task/append_to_system_prompt.txt"
 DEFAULT_RLM_CHECKOUT_PATH = "/tmp/rlm-checkout"
@@ -283,4 +284,5 @@ def rlm_harness(
         metrics_path="{workdir}/.rlm/sessions/*/meta.json",
         metrics_key="metrics",
         metrics_prefix="rlm_",
+        tool_names=list(DEFAULT_RLM_TOOL_NAMES),
     )

--- a/verifiers/envs/stateful_tool_env.py
+++ b/verifiers/envs/stateful_tool_env.py
@@ -104,7 +104,7 @@ class StatefulToolEnv(vf.ToolEnv):
         tool_name = getattr(tool, "__name__", tool.__class__.__name__)
         self.tool_map[tool_name] = tool
         self.skipped_args[tool_name] = args_to_skip
-        self.tool_monitor_rubric.add_tool_metric(tool)
+        self.tool_monitor_rubric.add_tool_metric(tool_name)
 
     def remove_tool(self, tool: Callable):
         self.tools.remove(tool)
@@ -114,7 +114,7 @@ class StatefulToolEnv(vf.ToolEnv):
         ]
         self.tool_map.pop(tool_name)
         self.skipped_args.pop(tool_name)
-        self.tool_monitor_rubric.remove_tool_metric(tool)
+        self.tool_monitor_rubric.remove_tool_metric(tool_name)
 
     @abstractmethod
     def update_tool_args(

--- a/verifiers/envs/tool_env.py
+++ b/verifiers/envs/tool_env.py
@@ -11,25 +11,22 @@ from verifiers.utils.tool_utils import (
 
 
 class ToolMonitorRubric(vf.Rubric):
-    def __init__(self, tools: list[Callable] | None = None, **kwargs):
+    def __init__(self, tool_names: list[str] | None = None, **kwargs):
         super().__init__(**kwargs)
 
-        self.tools = tools or []
-        self.tool_names = [tool.__name__ for tool in self.tools]  # type: ignore[union-attr]
+        self.tool_names = list(tool_names) if tool_names else []
 
         # add tool metrics
         self.add_metric(self.total_tool_calls)
         for tool_name in self.tool_names:
             self.add_metric(self.get_tool_call_count_func(tool_name))
 
-    def add_tool_metric(self, tool: Callable):
-        tool_name = tool.__name__  # type: ignore[union-attr]
+    def add_tool_metric(self, tool_name: str):
         if tool_name not in self.tool_names:
             self.tool_names.append(tool_name)
             self.add_metric(self.get_tool_call_count_func(tool_name))
 
-    def remove_tool_metric(self, tool: Callable):
-        tool_name = tool.__name__  # type: ignore[union-attr]
+    def remove_tool_metric(self, tool_name: str):
         if tool_name in self.tool_names:
             self.tool_names.remove(tool_name)
             metric_name = f"{tool_name}_calls"
@@ -94,7 +91,9 @@ class ToolEnv(vf.MultiTurnEnv):
         }
         super().__init__(tool_defs=self.tool_defs, max_turns=max_turns, **kwargs)
 
-        self.tool_monitor_rubric = ToolMonitorRubric(tools=self.tools)
+        self.tool_monitor_rubric = ToolMonitorRubric(
+            tool_names=list(self.tool_map.keys())
+        )
         self.add_rubric(self.tool_monitor_rubric)
 
     def _should_stop_for_error(self, err: Exception) -> bool:
@@ -106,8 +105,9 @@ class ToolEnv(vf.MultiTurnEnv):
         if self.tool_defs is None:
             self.tool_defs = []
         self.tool_defs.append(convert_func_to_tool_def(tool))
-        self.tool_map[getattr(tool, "__name__", tool.__class__.__name__)] = tool
-        self.tool_monitor_rubric.add_tool_metric(tool)
+        tool_name = getattr(tool, "__name__", tool.__class__.__name__)
+        self.tool_map[tool_name] = tool
+        self.tool_monitor_rubric.add_tool_metric(tool_name)
 
     def remove_tool(self, tool: Callable):
         self.tools.remove(tool)
@@ -116,7 +116,7 @@ class ToolEnv(vf.MultiTurnEnv):
         self.tool_defs.remove(convert_func_to_tool_def(tool))
         tool_name = getattr(tool, "__name__", tool.__class__.__name__)
         self.tool_map.pop(tool_name)
-        self.tool_monitor_rubric.remove_tool_metric(tool)
+        self.tool_monitor_rubric.remove_tool_metric(tool_name)
 
     @vf.stop
     async def no_tools_called(self, state: vf.State) -> bool:


### PR DESCRIPTION
## Summary
- Adds `tool_names: list[str] | None = None` to the `Harness` dataclass.
- `ComposableEnv.__init__` auto-registers a `ToolMonitorRubric` over `harness.tool_names` when non-empty, so the built-in agent tools are tracked automatically.
- RLM harness declares `tool_names=["ipython", "summarize"]` (new `DEFAULT_RLM_TOOL_NAMES` constant — distinct from the existing `DEFAULT_RLM_TOOLS` CLI-flag string).

Stacked on #1179 (ToolMonitorRubric's `tool_names` API).

## Test plan
- [x] `uv run pytest tests/test_composable_env.py tests/test_tool_env.py tests/test_stateful_tool_env.py tests/test_rlm_composable_env.py` — 73 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an optional `Harness.tool_names` field and conditionally attaches a metrics-only `ToolMonitorRubric`; behavior changes only when `tool_names` is set and may slightly alter reported metrics.
> 
> **Overview**
> **Composable harnesses can now declare internal tool usage for automatic monitoring.** The `Harness` dataclass adds optional `tool_names`, and `ComposableEnv` now auto-registers `ToolMonitorRubric` when this list is non-empty to record per-tool and total tool-call counts.
> 
> The RLM harness is updated to populate `tool_names` (via new `DEFAULT_RLM_TOOL_NAMES`), enabling tool-call metrics for its internal tools without manual rubric wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b868747ca97fd403a18cba505826ed317f1f61f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->