### PR TITLE
vf-eval: replace -d/--debug with --disable-tui, rename --tui to --fullscreen

### DIFF
--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -208,8 +208,8 @@ When evaluating multiple environments, the display shows an overview panel at th
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
 | `--verbose` | `-v` | false | Enable debug logging |
-| `--fullscreen` | — | false | Use alternate screen buffer (fullscreen) for the Rich display |
-| `--disable-tui` | — | false | Disable Rich display; use normal logging and tqdm progress |
+| `--fullscreen` | `-f` | false | Use alternate screen buffer (fullscreen) for the Rich display |
+| `--disable-tui` | `-d` | false | Disable Rich display; use normal logging and tqdm progress |
 | `--abbreviated-summary` | `-A` | false | Abbreviated summary: show settings and stats, skip example prompts |
 | `--output-dir` | `-o` | — | Custom output directory for evaluation results and logs |
 | `--save-results` | `-s` | false | Save results to disk |

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -209,9 +209,7 @@ When evaluating multiple environments, the display shows an overview panel at th
 |------|-------|---------|-------------|
 | `--verbose` | `-v` | false | Enable debug logging |
 | `--fullscreen` | — | false | Use alternate screen buffer (fullscreen) for the Rich display |
-| `--tui` | `-u` | false | [Deprecated] Alias for `--fullscreen` |
 | `--disable-tui` | — | false | Disable Rich display; use normal logging and tqdm progress |
-| `--debug` | `-d` | false | [Deprecated] Alias for `--disable-tui` |
 | `--abbreviated-summary` | `-A` | false | Abbreviated summary: show settings and stats, skip example prompts |
 | `--output-dir` | `-o` | — | Custom output directory for evaluation results and logs |
 | `--save-results` | `-s` | false | Save results to disk |

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -208,7 +208,8 @@ When evaluating multiple environments, the display shows an overview panel at th
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
 | `--verbose` | `-v` | false | Enable debug logging |
-| `--tui` | `-u` | false | Use alternate screen mode (TUI) for display |
+| `--fullscreen` | — | false | Use alternate screen buffer (fullscreen) for the Rich display |
+| `--tui` | `-u` | false | [Deprecated] Alias for `--fullscreen` |
 | `--disable-tui` | — | false | Disable Rich display; use normal logging and tqdm progress |
 | `--debug` | `-d` | false | [Deprecated] Alias for `--disable-tui` |
 | `--abbreviated-summary` | `-A` | false | Abbreviated summary: show settings and stats, skip example prompts |

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -209,7 +209,8 @@ When evaluating multiple environments, the display shows an overview panel at th
 |------|-------|---------|-------------|
 | `--verbose` | `-v` | false | Enable debug logging |
 | `--tui` | `-u` | false | Use alternate screen mode (TUI) for display |
-| `--debug` | `-d` | false | Disable Rich display; use normal logging and tqdm progress |
+| `--disable-tui` | — | false | Disable Rich display; use normal logging and tqdm progress |
+| `--debug` | `-d` | false | [Deprecated] Alias for `--disable-tui` |
 | `--abbreviated-summary` | `-A` | false | Abbreviated summary: show settings and stats, skip example prompts |
 | `--output-dir` | `-o` | — | Custom output directory for evaluation results and logs |
 | `--save-results` | `-s` | false | Save results to disk |

--- a/tests/test_eval_cli.py
+++ b/tests/test_eval_cli.py
@@ -59,6 +59,7 @@ def run_cli(make_metadata, make_state, make_input):
             "extra_env_kwargs": {},
             "max_retries": 0,
             "tui": False,
+            "disable_tui": False,
             "debug": False,
             "abbreviated_summary": False,
             "heartbeat_url": None,

--- a/tests/test_eval_cli.py
+++ b/tests/test_eval_cli.py
@@ -58,6 +58,7 @@ def run_cli(make_metadata, make_state, make_input):
             "hf_hub_dataset_name": "",
             "extra_env_kwargs": {},
             "max_retries": 0,
+            "fullscreen": False,
             "tui": False,
             "disable_tui": False,
             "debug": False,

--- a/tests/test_eval_cli.py
+++ b/tests/test_eval_cli.py
@@ -59,9 +59,7 @@ def run_cli(make_metadata, make_state, make_input):
             "extra_env_kwargs": {},
             "max_retries": 0,
             "fullscreen": False,
-            "tui": False,
             "disable_tui": False,
-            "debug": False,
             "abbreviated_summary": False,
             "heartbeat_url": None,
         }

--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -392,11 +392,17 @@ def build_parser() -> argparse.ArgumentParser:
         help='Extra environment as JSON object (e.g., \'{"key": "value", "num": 42}\'). Passed to environment constructor.',
     )
     parser.add_argument(
+        "--fullscreen",
+        default=False,
+        action="store_true",
+        help="Use fullscreen (alternate-screen) mode for the Rich live evaluation display",
+    )
+    parser.add_argument(
         "--tui",
         "-u",
         default=False,
         action="store_true",
-        help="Use TUI mode for live evaluation display",
+        help="[DEPRECATED] Alias for --fullscreen. Will be removed in a future release.",
     )
     parser.add_argument(
         "--disable-tui",
@@ -465,6 +471,24 @@ def main(argv: list[str] | None = None):
             stacklevel=2,
         )
         args.disable_tui = True
+
+    if args.tui:
+        import warnings
+
+        warnings.warn(
+            "The `-u`/`--tui` flag is deprecated and will be removed in a future release. "
+            "Use `--fullscreen` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        args.fullscreen = True
+
+    if args.disable_tui and args.fullscreen:
+        raise SystemExit(
+            "error: --disable-tui and --fullscreen are mutually exclusive "
+            "(--disable-tui turns off the Rich display entirely; --fullscreen only "
+            "controls whether the Rich display uses the alternate screen buffer)."
+        )
 
     if args.disable_tui:  # only set up console logging when TUI is disabled
         setup_logging(get_log_level(args.verbose))
@@ -783,7 +807,7 @@ def main(argv: list[str] | None = None):
         asyncio.run(
             run_evaluations_tui(
                 eval_run_config,
-                tui_mode=args.tui,
+                fullscreen=args.fullscreen,
                 compact=args.abbreviated_summary,
             )
         )

--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -393,12 +393,14 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--fullscreen",
+        "-f",
         default=False,
         action="store_true",
         help="Use fullscreen (alternate-screen) mode for the Rich live evaluation display",
     )
     parser.add_argument(
         "--disable-tui",
+        "-d",
         default=False,
         action="store_true",
         help="Disable Rich display; use normal logging and tqdm progress instead",

--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -399,11 +399,17 @@ def build_parser() -> argparse.ArgumentParser:
         help="Use TUI mode for live evaluation display",
     )
     parser.add_argument(
+        "--disable-tui",
+        default=False,
+        action="store_true",
+        help="Disable Rich display; use normal logging and tqdm progress instead",
+    )
+    parser.add_argument(
         "--debug",
         "-d",
         default=False,
         action="store_true",
-        help="Disable Rich display; use normal logging and tqdm progress instead",
+        help="[DEPRECATED] Alias for --disable-tui. Will be removed in a future release.",
     )
     parser.add_argument(
         "--max-retries",
@@ -449,7 +455,18 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 def main(argv: list[str] | None = None):
     args = parse_args(argv)
 
-    if args.debug:  # only set up console logging in debug mode
+    if args.debug:
+        import warnings
+
+        warnings.warn(
+            "The `-d`/`--debug` flag is deprecated and will be removed in a future release. "
+            "Use `--disable-tui` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        args.disable_tui = True
+
+    if args.disable_tui:  # only set up console logging when TUI is disabled
         setup_logging(get_log_level(args.verbose))
 
     # Build raw configs: both paths produce list[dict]
@@ -731,7 +748,7 @@ def main(argv: list[str] | None = None):
             num_workers=raw.get("num_workers", "auto"),
             disable_env_server=raw.get("disable_env_server", False),
             verbose=raw.get("verbose", False),
-            debug=raw.get("debug", False),
+            disable_tui=raw.get("disable_tui", raw.get("debug", False)),
             state_columns=raw.get("state_columns", []),
             save_results=raw.get("save_results", False),
             resume_path=resume_path,
@@ -760,7 +777,7 @@ def main(argv: list[str] | None = None):
     eval_run_config = EvalRunConfig(
         evals=eval_configs, heartbeat_url=args.heartbeat_url
     )
-    if args.debug:
+    if args.disable_tui:
         asyncio.run(run_evaluations(eval_run_config))
     else:
         asyncio.run(

--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -398,24 +398,10 @@ def build_parser() -> argparse.ArgumentParser:
         help="Use fullscreen (alternate-screen) mode for the Rich live evaluation display",
     )
     parser.add_argument(
-        "--tui",
-        "-u",
-        default=False,
-        action="store_true",
-        help="[DEPRECATED] Alias for --fullscreen. Will be removed in a future release.",
-    )
-    parser.add_argument(
         "--disable-tui",
         default=False,
         action="store_true",
         help="Disable Rich display; use normal logging and tqdm progress instead",
-    )
-    parser.add_argument(
-        "--debug",
-        "-d",
-        default=False,
-        action="store_true",
-        help="[DEPRECATED] Alias for --disable-tui. Will be removed in a future release.",
     )
     parser.add_argument(
         "--max-retries",
@@ -460,28 +446,6 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 def main(argv: list[str] | None = None):
     args = parse_args(argv)
-
-    if args.debug:
-        import warnings
-
-        warnings.warn(
-            "The `-d`/`--debug` flag is deprecated and will be removed in a future release. "
-            "Use `--disable-tui` instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        args.disable_tui = True
-
-    if args.tui:
-        import warnings
-
-        warnings.warn(
-            "The `-u`/`--tui` flag is deprecated and will be removed in a future release. "
-            "Use `--fullscreen` instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        args.fullscreen = True
 
     if args.disable_tui and args.fullscreen:
         raise SystemExit(
@@ -772,7 +736,7 @@ def main(argv: list[str] | None = None):
             num_workers=raw.get("num_workers", "auto"),
             disable_env_server=raw.get("disable_env_server", False),
             verbose=raw.get("verbose", False),
-            disable_tui=raw.get("disable_tui", raw.get("debug", False)),
+            disable_tui=raw.get("disable_tui", False),
             state_columns=raw.get("state_columns", []),
             save_results=raw.get("save_results", False),
             resume_path=resume_path,

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -534,7 +534,7 @@ class EvalConfig(BaseModel):
     disable_env_server: bool = False
     # logging
     verbose: bool = False
-    debug: bool = False
+    disable_tui: bool = False
     # saving
     output_dir: str | None = None
     state_columns: list[str] | None = None

--- a/verifiers/utils/display_utils.py
+++ b/verifiers/utils/display_utils.py
@@ -188,7 +188,7 @@ class BaseDisplay:
 
     def get_log_hint(self) -> Text | None:
         """Return an optional hint for viewing full logs."""
-        return Text("full logs: --debug", style="dim")
+        return Text("full logs: --disable-tui", style="dim")
 
     def _make_log_panel(self) -> Panel:
         """Create a panel showing recent log messages with placeholder lines."""

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -818,7 +818,7 @@ async def run_evaluation(
                 num_workers=num_workers,
                 log_level=get_log_level(config.verbose),
                 log_dir=log_dir,
-                console_logging=config.debug,
+                console_logging=config.disable_tui,
             )
             if on_log_file is not None:
                 from verifiers.serve import EnvServer

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -453,7 +453,7 @@ def load_toml_config(
         "disable_env_server",
         # logging
         "verbose",
-        "debug",
+        "disable_tui",
         # saving
         "output_dir",
         "state_columns",

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -916,13 +916,14 @@ async def run_evaluations(config: EvalRunConfig) -> None:
 
 
 async def run_evaluations_tui(
-    config: EvalRunConfig, tui_mode: bool = True, compact: bool = False
+    config: EvalRunConfig, fullscreen: bool = False, compact: bool = False
 ) -> None:
     """Run multi-environment evaluation with a Rich display.
 
     Args:
         config: Evaluation run configuration.
-        tui_mode: If True, use alternate screen (--tui flag). If False, refresh in-place.
+        fullscreen: If True, use alternate screen buffer (--fullscreen flag).
+            If False, refresh in-place.
         compact: If True, show compact summary (settings + stats, skip example prompts).
     """
     from verifiers.utils.eval_display import EvalDisplay, is_tty
@@ -939,7 +940,7 @@ async def run_evaluations_tui(
 
         heart = Heartbeat(config.heartbeat_url)
 
-    display = EvalDisplay(config.evals, screen=tui_mode, compact=compact)
+    display = EvalDisplay(config.evals, screen=fullscreen, compact=compact)
 
     async def run_with_progress(
         env_config: EvalConfig, env_idx: int
@@ -1043,7 +1044,7 @@ async def run_evaluations_tui(
                 )
 
                 display.refresh()
-                if tui_mode:
+                if fullscreen:
                     await display.wait_for_exit()
             finally:
                 refresh_stop.set()


### PR DESCRIPTION
## Summary

Clean up the `vf-eval` display flags. Two separate concerns were conflated under names that made them hard to reason about:

1. **Whether to use the Rich display at all** — previously `-d`/`--debug`, now `-d`/`--disable-tui`.
2. **Whether the Rich display uses the alternate screen buffer** — previously `-u`/`--tui`, now `-f`/`--fullscreen`.

### Changes

- Add `--disable-tui` (`-d`) and `--fullscreen` (`-f`) as the canonical flag names.
- Update the log-panel hint (`full logs: --disable-tui`) and docs table.
- Raise `SystemExit` if both `--disable-tui` and `--fullscreen` are passed.

## ⚠️ Breaking changes

| Old | New |
|---|---|
| `-d` / `--debug` | `-d` / `--disable-tui` |
| `-u` / `--tui` | `-f` / `--fullscreen` |

The `-d` short flag is preserved but now maps to `--disable-tui`. `-u` is no longer accepted — use `-f`/`--fullscreen` instead. Running `vf-eval env-id --debug` or `vf-eval env-id --tui` after this change will fail with an argparse `unrecognized arguments` error. Any downstream tooling or TOML configs that set `debug=true` on `EvalConfig` will also need updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to breaking CLI/TOML config surface changes (`--debug`/`--tui` removed) and updated config schema (`debug`→`disable_tui`), which can break downstream scripts and saved configs if not migrated.
> 
> **Overview**
> Clarifies `vf-eval` display controls by renaming `--tui` to `--fullscreen` (alternate screen buffer) and `--debug` to `--disable-tui` (turn off Rich display and use normal logging/tqdm), and updates docs/tests accordingly.
> 
> Adds a guard in `verifiers/scripts/eval.py` that exits when `--disable-tui` and `--fullscreen` are both provided, and propagates the renamed setting through `EvalConfig`, TOML validation (`eval_utils.valid_fields`), env server `console_logging`, and the on-screen log hint text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4faaf5d0f318b18a6e373c3504e208b97e32c021. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->