### PR TITLE
fix: bump opencode harness default release to v1.1.63-rl2

### DIFF
--- a/verifiers/envs/experimental/composable/harnesses/opencode.py
+++ b/verifiers/envs/experimental/composable/harnesses/opencode.py
@@ -18,9 +18,9 @@ from pathlib import Path
 # ── Defaults ─────────────────────────────────────────────────────────────
 
 DEFAULT_RELEASE_REPO = "PrimeIntellect-ai/opencode"
-DEFAULT_RELEASE_VERSION = "1.1.63-rl1"
+DEFAULT_RELEASE_VERSION = "1.1.63-rl2"
 DEFAULT_RELEASE_SHA256 = (
-    "17104d601b8bf6fd03dd46a6de055b422414b9ada524fe085b09683f455ccac1"
+    "47f4102796da50769e27d2c9ea6a9cf7941f76898390cb497278cab39c4b6ed4"
 )
 DEFAULT_SYSTEM_PROMPT = (Path(__file__).parent / "prompt.txt").read_text()
 


### PR DESCRIPTION
## Summary

Bump the opencode harness default release from `v1.1.63-rl1` to `v1.1.63-rl2`.

## Context

The new fork release (`PrimeIntellect-ai/opencode@v1.1.63-rl2`) adds `TerminalRetryExhaustedError` that surfaces session-level retry exhaustion as a non-zero exit with a structured stderr dump, so the harness can distinguish retry exhaustion from other failure modes.

See:
- `PrimeIntellect-ai/opencode#3`
- Companion research-environments bump PR: `PrimeIntellect-ai/research-environments#303`

`DEFAULT_RELEASE_REPO` is left untouched — it is already pointed at the fork, which is intentional.

## Downstream behavior

- Envs that delegate to harness defaults (e.g. `opencode_lean` before its explicit pin) will now download and run the rl2 binary.
- Envs that pass their own `release_repo` / `release_version` / `release_sha256` args are unaffected.

## Files changed

- `verifiers/envs/experimental/composable/harnesses/opencode.py` — `DEFAULT_RELEASE_VERSION` and `DEFAULT_RELEASE_SHA256` updated.

## Test plan

- [x] `git grep "1.1.63-rl1"` — no remaining hits.
- [x] `git grep "17104d601b8bf6fd03dd46a6de055b422414b9ada524fe085b09683f455ccac1"` — no remaining hits.
- [x] `uv run ruff check verifiers/envs/experimental/composable/harnesses/opencode.py` — clean.
- [x] `uv run ruff format --check verifiers/envs/experimental/composable/harnesses/opencode.py` — clean.
- [ ] Smoke run of an env that uses harness defaults against the rl2 binary.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates the default OpenCode release version and its SHA256 used for download verification, without changing harness logic or interfaces.
> 
> **Overview**
> Updates the OpenCode harness defaults to pull `PrimeIntellect-ai/opencode` release `1.1.63-rl2` instead of `1.1.63-rl1`, including the corresponding `DEFAULT_RELEASE_SHA256` used to verify the downloaded tarball.
> 
> Environments relying on harness defaults will now install/run the `rl2` binary; explicitly pinned environments are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6aedaf186130cb5336bd7bb07ccb1e14449e414b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->