### PR TITLE
feat: include full trace in agent error logs

### DIFF
--- a/verifiers/envs/experimental/cli_agent_env.py
+++ b/verifiers/envs/experimental/cli_agent_env.py
@@ -374,17 +374,17 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
                         f"Agent completed successfully (exit_code={status.exit_code})"
                     )
                 else:
-                    stderr_snippet = (status.stderr or "")[:500]
+                    stderr_full = status.stderr or ""
                     num_turns = len(state.get("trajectory", []))
                     if num_turns == 0:
                         error = AgentError(
                             f"Agent crashed before any LLM call "
-                            f"(exit_code={status.exit_code}): {stderr_snippet}"
+                            f"(exit_code={status.exit_code}): {stderr_full}"
                         )
                     else:
                         error = AgentError(
                             f"Agent crashed after {num_turns} turn(s) "
-                            f"(exit_code={status.exit_code}): {stderr_snippet}"
+                            f"(exit_code={status.exit_code}): {stderr_full}"
                         )
                     state["error"] = error
                     self.logger.error(str(error))


### PR DESCRIPTION
## Summary
- Stop truncating `status.stderr` to 500 chars when building the `AgentError` in `CliAgentEnv.poll_job_completion` — the full stderr (including the agent's traceback) now flows into the error message, which is what we need to debug crashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk behavior change limited to error message formatting, though it may increase log/error payload size when agents crash with large stderr.
> 
> **Overview**
> **Improves crash diagnostics for CLI agents.** When the sandboxed agent exits non-zero, `CliAgentEnv.poll_job_completion` now includes the full `status.stderr` in the raised/logged `AgentError` instead of truncating it to 500 characters, preserving complete tracebacks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83e78d8991ca004a16b270dae2751a9350e80bd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->