### PR TITLE
chore: v0.1.13.dev2 dev release

### DIFF
--- a/assets/release/RELEASE_v0.1.13.dev2.md
+++ b/assets/release/RELEASE_v0.1.13.dev2.md
@@ -1,0 +1,29 @@
+# Verifiers v0.1.13.dev2 Release Notes
+
+*Date:* 04/19/2026
+
+## Highlights since v0.1.13.dev1
+
+- Added richer token usage reporting, including final-context token metrics, updated displays, and API docs.
+- Expanded `vf-tui` compare mode so you can inspect any numeric metric with inline selection and adaptive bucketing.
+- Improved composable/RLM harness integration with harness-owned upload dirs, cached local RLM checkouts, and auto-registered tool monitoring from `harness.tool_names`.
+- Surfaced CLI agent crashes as infra errors even after prior turns, and now include full traces in agent error logs for debugging.
+- Removed dead RLM tool config constants from the composable harness exports.
+
+## Changes included in v0.1.13.dev2 (since v0.1.13.dev1)
+
+### Features and enhancements
+
+- Better token count metrics (#1108)
+- vf-tui: compare for all metrics (#1117)
+- harness.get_upload_dirs; reduce rlm github requests (#1178)
+- tool-env: ToolMonitorRubric takes tool_names instead of tools (#1179)
+- feat: auto-register ToolMonitorRubric from harness.tool_names (#1181)
+- feat: include full trace in agent error logs (#1185)
+
+### Fixes and maintenance
+
+- cli-agent: surface agent crashes as infra errors after any turn (#1177)
+- Remove dead RLM tool config constants (#1189)
+
+**Full Changelog**: https://github.com/PrimeIntellect-ai/verifiers/compare/v0.1.13.dev1...v0.1.13.dev2

--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.13.dev1"
+__version__ = "0.1.13.dev2"
 
 import importlib
 import os


### PR DESCRIPTION
## Summary

- Bump version from `0.1.13.dev1` to `0.1.13.dev2`
- Add release notes covering changes since `v0.1.13.dev1`

## Changes since v0.1.13.dev1
- Better token count metrics (#1108)
- vf-tui: compare for all metrics (#1117)
- cli-agent: surface agent crashes as infra errors after any turn (#1177)
- harness.get_upload_dirs; reduce rlm github requests (#1178)
- tool-env: ToolMonitorRubric takes tool_names instead of tools (#1179)
- feat: auto-register ToolMonitorRubric from harness.tool_names (#1181)
- feat: include full trace in agent error logs (#1185)
- Remove dead RLM tool config constants (#1189)

### Linked PRs
- #1108
- #1117
- #1177
- #1178
- #1179
- #1181
- #1185
- #1189

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only bumps the package version and adds release notes; there are no functional code changes beyond the version string.
> 
> **Overview**
> Bumps `verifiers` from `0.1.13.dev1` to `0.1.13.dev2`.
> 
> Adds `RELEASE_v0.1.13.dev2.md` documenting highlights and the included changes since `v0.1.13.dev1` (token metrics, `vf-tui` compare enhancements, harness/RLM integration tweaks, and improved CLI-agent crash/error logging).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 514f540e5cb79de04c53d6ae5d2da32c01bb7130. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->