### PR TITLE
fix: propagate interception-stream cuts into rollout state

### DIFF
--- a/tests/test_interception_utils.py
+++ b/tests/test_interception_utils.py
@@ -1,3 +1,4 @@
+from verifiers.errors import InfraError
 from verifiers.types import (
     Response,
     ResponseMessage,
@@ -6,6 +7,8 @@ from verifiers.types import (
     Usage,
 )
 from verifiers.utils.interception_utils import (
+    InterceptionServer,
+    StreamInterrupted,
     create_empty_completion,
     serialize_intercept_response,
 )
@@ -61,3 +64,41 @@ def test_serialize_intercept_response_passthrough_native_chat_completion():
     assert payload["object"] == "chat.completion"
     assert payload["model"] == "native-model"
     assert len(payload["choices"]) == 1
+
+
+def test_set_rollout_error_attaches_stream_interrupted_to_state():
+    server = InterceptionServer(port=0)
+    state: dict = {}
+    server.register_rollout("r1", state=state)
+
+    err = StreamInterrupted("tunnel died")
+    server._set_rollout_error("r1", err)
+
+    assert state["error"] is err
+    assert isinstance(state["error"], InfraError)
+
+
+def test_set_rollout_error_is_noop_without_state():
+    # Covers the "state=None" path — upstream callers may not always wire it.
+    server = InterceptionServer(port=0)
+    server.register_rollout("r1")
+    server._set_rollout_error("r1", StreamInterrupted("nope"))
+    # No raise, and no state to read back.
+
+
+def test_set_rollout_error_does_not_clobber_existing_error():
+    # First error wins — later write failures must not hide the original cause.
+    server = InterceptionServer(port=0)
+    original = InfraError("original")
+    state: dict = {"error": original}
+    server.register_rollout("r1", state=state)
+
+    server._set_rollout_error("r1", StreamInterrupted("later"))
+
+    assert state["error"] is original
+
+
+def test_set_rollout_error_is_noop_for_unknown_rollout():
+    server = InterceptionServer(port=0)
+    # No registration — must not raise.
+    server._set_rollout_error("missing", StreamInterrupted("x"))

--- a/tests/test_interception_utils.py
+++ b/tests/test_interception_utils.py
@@ -1,3 +1,6 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
 from verifiers.errors import InfraError
 from verifiers.types import (
     Response,
@@ -6,6 +9,7 @@ from verifiers.types import (
     ToolCall,
     Usage,
 )
+from verifiers.utils import interception_utils
 from verifiers.utils.interception_utils import (
     InterceptionServer,
     StreamInterrupted,
@@ -78,14 +82,6 @@ def test_set_rollout_error_attaches_stream_interrupted_to_state():
     assert isinstance(state["error"], InfraError)
 
 
-def test_set_rollout_error_is_noop_without_state():
-    # Covers the "state=None" path — upstream callers may not always wire it.
-    server = InterceptionServer(port=0)
-    server.register_rollout("r1")
-    server._set_rollout_error("r1", StreamInterrupted("nope"))
-    # No raise, and no state to read back.
-
-
 def test_set_rollout_error_does_not_clobber_existing_error():
     # First error wins — later write failures must not hide the original cause.
     server = InterceptionServer(port=0)
@@ -98,7 +94,40 @@ def test_set_rollout_error_does_not_clobber_existing_error():
     assert state["error"] is original
 
 
-def test_set_rollout_error_is_noop_for_unknown_rollout():
+async def test_streaming_write_failure_surfaces_to_state(monkeypatch):
+    """The real failure path: a mid-SSE transport close on the client side
+    raises out of ``response.write(...)``. The except branch must funnel
+    that into ``state["error"]`` so the rollout halts via ``has_error``."""
     server = InterceptionServer(port=0)
-    # No registration — must not raise.
-    server._set_rollout_error("missing", StreamInterrupted("x"))
+    state: dict = {}
+    server.register_rollout("r1", state=state)
+
+    # Mock StreamResponse whose second write raises (first write succeeds
+    # to prove we're in the streaming loop, not failing at prepare()).
+    writes: list[bytes] = []
+
+    async def fake_write(data: bytes) -> None:
+        writes.append(data)
+        if len(writes) >= 2:
+            raise ConnectionResetError("client closed transport")
+
+    fake_response = MagicMock()
+    fake_response.prepare = AsyncMock()
+    fake_response.write = AsyncMock(side_effect=fake_write)
+    fake_response.write_eof = AsyncMock()
+    monkeypatch.setattr(
+        interception_utils.web, "StreamResponse", lambda **_: fake_response
+    )
+
+    chunk_queue: asyncio.Queue = asyncio.Queue()
+    await chunk_queue.put({"choices": [{"delta": {"content": "hi"}}]})
+    await chunk_queue.put({"choices": [{"delta": {"content": " there"}}]})
+    intercept = {
+        "chunk_queue": chunk_queue,
+        "response_future": asyncio.Future(),
+    }
+
+    await server._handle_streaming_response(MagicMock(), "r1", intercept)
+
+    assert isinstance(state["error"], StreamInterrupted)
+    assert "ConnectionResetError" in str(state["error"])

--- a/verifiers/envs/experimental/cli_agent_env.py
+++ b/verifiers/envs/experimental/cli_agent_env.py
@@ -248,8 +248,11 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
         )
         await self.create_sandbox(state, sandbox_request)
 
-        # Register rollout for interception
-        request_id_queue = interception_server.register_rollout(rollout_id)
+        # Register rollout for interception. Pass state so the server can
+        # surface stream-interruption errors (e.g. tunnel dies mid-SSE) back
+        # onto the rollout; without this the agent sees a truncated stream
+        # and often exits with code 0 and an empty trajectory.
+        request_id_queue = interception_server.register_rollout(rollout_id, state=state)
         state["request_id_queue"] = request_id_queue
         state["agent_completed"] = False
 

--- a/verifiers/utils/interception_utils.py
+++ b/verifiers/utils/interception_utils.py
@@ -23,10 +23,21 @@ from openai.types.chat.chat_completion_chunk import (
     Choice as ChunkChoice,
 )
 
+from verifiers.errors import InfraError
 from verifiers.types import Response
 from verifiers.utils.logging_utils import truncate
 
 logger = logging.getLogger(__name__)
+
+
+class StreamInterrupted(InfraError):
+    """Raised when the intercepted streaming response to the agent is cut short.
+
+    Without this, a mid-stream transport failure would be swallowed here and
+    the agent would observe a truncated (but syntactically valid) SSE stream,
+    often exiting with code 0 and an empty trajectory — bypassing the
+    non-zero-exit error capture in `CliAgentEnv.poll_job_completion`.
+    """
 
 
 class InterceptionServer:
@@ -99,10 +110,26 @@ class InterceptionServer:
                     self._site = None
                     self._app = None
 
-    def register_rollout(self, rollout_id: str) -> asyncio.Queue:
+    def _set_rollout_error(self, rollout_id: str, error: BaseException) -> None:
+        """Attach `error` to the rollout's state if one is registered and
+        unset. First error wins — later failures (e.g. the downstream
+        `response_future` raising too) should not clobber the original cause.
+        """
+        context = self.active_rollouts.get(rollout_id)
+        if context is None:
+            return
+        state = context.get("state")
+        if state is None or state.get("error"):
+            return
+        state["error"] = error
+
+    def register_rollout(
+        self, rollout_id: str, state: dict[str, Any] | None = None
+    ) -> asyncio.Queue:
         request_queue: asyncio.Queue = asyncio.Queue()
         self.active_rollouts[rollout_id] = {
             "request_id_queue": request_queue,
+            "state": state,
         }
         return request_queue
 
@@ -214,6 +241,12 @@ class InterceptionServer:
             logger.debug(f"[{rollout_id}] Streaming cancelled")
         except Exception as e:
             logger.error(f"[{rollout_id}] Streaming error: {e}")
+            self._set_rollout_error(
+                rollout_id,
+                StreamInterrupted(
+                    f"Interception stream to agent interrupted: {type(e).__name__}: {e}"
+                ),
+            )
             return response
 
         try:


### PR DESCRIPTION
## Summary

When the interception proxy's downstream transport to the agent closes mid-SSE (e.g. the Prime Tunnel drops, observed today in `xmy54wau3fh2omx66exmvscu`), `_handle_streaming_response` catches the `Cannot write to closing transport` error and returns the partial response. The agent observes a truncated-but-syntactically-valid stream, often parses it as "assistant turn, no tool_call, finish_reason=stop", and exits cleanly.

\`CliAgentEnv.poll_job_completion\` only sets \`state[\"error\"]\` when \`exit_code != 0\`, so this entire class of failure flowed through as \`stop=agent_completed | exit_code=0 | turns=0\` and surfaced to the scheduler as silent \"Empty trajectory\" warnings — bypassing every retry-exhaust and non-zero-exit mitigation (opencode rl2, #1127, etc.).

## Fix

- Thread the rollout's state through \`InterceptionServer.register_rollout(rollout_id, state=...)\`.
- On streaming write failure, set \`state[\"error\"] = StreamInterrupted(...)\`.
- First error wins (later \`response_future\` exceptions don't clobber the original cause).

## Observed pattern

```
2026-04-19 13:54:21 - verifiers.utils.interception_utils - ERROR - [rollout_2b45defe] Streaming error: Cannot write to closing transport
2026-04-19 13:54:21 - verifiers.envs.environment.ComposableEnv - INFO - Finished rollout_id=rollout_2b45defe | ... | turns=0 | tools=[] | stop=agent_completed | exit_code=0 | duration=27s
```

Pre-fix: scheduler logs \"Empty trajectory\" and re-schedules silently.
Post-fix: scheduler logs \"Rollout error: StreamInterrupted(...)\" with a concrete cause.

## Tests

Added 4 unit tests for \`_set_rollout_error\` in \`tests/test_interception_utils.py\` covering the attach / no-state / no-clobber / unknown-rollout paths.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the interception SSE streaming path and rollout state mutation; incorrect handling could mark healthy runs as failed or miss failures. Scope is contained and covered by new unit tests simulating mid-stream write errors.
> 
> **Overview**
> Ensures mid-SSE transport/write failures in `InterceptionServer._handle_streaming_response` are no longer swallowed: the server now records a rollout-scoped `StreamInterrupted` error onto the rollout `state` (first error wins).
> 
> Threads the rollout `state` into `InterceptionServer.register_rollout(..., state=state)` from `CliAgentEnv` so these streaming interruptions can halt the rollout and surface to higher-level retry/error handling, and adds unit tests covering `_set_rollout_error` behavior and the streaming write-failure path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca98c4fe1d383de07ffcd878805a6f0dee21c1da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->