### PR TITLE
make download of rlm lazy

### DIFF
--- a/verifiers/envs/experimental/composable/harnesses/rlm.py
+++ b/verifiers/envs/experimental/composable/harnesses/rlm.py
@@ -259,18 +259,21 @@ def rlm_harness(
     local_checkout: str | Path | None = None,
     gh_token: str | None = None,
 ) -> Harness:
-    resolved_local_checkout = resolve_local_checkout(
-        local_checkout,
-        rlm_repo_url=rlm_repo_url,
-        rlm_branch=rlm_branch,
-        gh_token=gh_token,
-    )
-    upload_dirs: dict[str, Traversable | Path] = {
-        DEFAULT_RLM_CHECKOUT_UPLOAD_NAME: resolved_local_checkout,
-    }
     upload_dir_mapping: dict[str, str] = {
         DEFAULT_RLM_CHECKOUT_UPLOAD_NAME: DEFAULT_RLM_CHECKOUT_PATH,
     }
+
+    def get_upload_dirs() -> dict[str, Traversable | Path]:
+        resolved_local_checkout = resolve_local_checkout(
+            local_checkout,
+            rlm_repo_url=rlm_repo_url,
+            rlm_branch=rlm_branch,
+            gh_token=gh_token,
+        )
+        return {
+            DEFAULT_RLM_CHECKOUT_UPLOAD_NAME: resolved_local_checkout,
+        }
+
     return Harness(
         install_script=build_install_script(),
         run_command=build_run_command(instruction_path, workdir),
@@ -278,7 +281,7 @@ def rlm_harness(
         system_prompt_path=DEFAULT_APPEND_TO_SYSTEM_PROMPT_PATH,
         instruction_path=instruction_path,
         skills_path="/task/rlm-skills",
-        get_upload_dirs=lambda: upload_dirs,
+        get_upload_dirs=get_upload_dirs,
         upload_dir_mapping=upload_dir_mapping,
         metrics_path="{workdir}/.rlm/sessions/*/meta.json",
         metrics_key="metrics",


### PR DESCRIPTION
## Description

Eager download of the rlm package caused research-environments tests to fail because they caused actual package downloads which failed due to a missing GH_TOKEN. This makes the download lazy.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small refactor to defer resolving/cloning the RLM checkout until `get_upload_dirs` is invoked, mainly affecting when network/Git access is triggered.
> 
> **Overview**
> Prevents `rlm_harness` from eagerly resolving/cloning the RLM repo at harness construction time by moving `resolve_local_checkout(...)` into a dedicated `get_upload_dirs()` callback.
> 
> This makes RLM checkout/download *lazy*, avoiding unintended git/GitHub token requirements in environments (e.g., tests) that create the harness but never upload the checkout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d445eb570567db2dafd561432a6ee02d002ad560. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->