### PR TITLE
chore: v0.1.13.dev3 dev release

### DIFF
--- a/assets/release/RELEASE_v0.1.13.dev3.md
+++ b/assets/release/RELEASE_v0.1.13.dev3.md
@@ -1,0 +1,20 @@
+# Verifiers v0.1.13.dev3 Release Notes
+
+*Date:* 04/19/2026
+
+## Highlights since v0.1.13.dev2
+
+- Propagated interception-stream write failures into rollout state as `StreamInterrupted` so truncated agent streams no longer surface as silent clean exits.
+- Made RLM checkout resolution lazy in the composable harness, so loading RLM-based environments no longer clones the private checkout up front.
+
+## Changes included in v0.1.13.dev3 (since v0.1.13.dev2)
+
+### Features and enhancements
+
+- make download of rlm lazy (#1192)
+
+### Fixes and maintenance
+
+- fix: propagate interception-stream cuts into rollout state (#1191)
+
+**Full Changelog**: https://github.com/PrimeIntellect-ai/verifiers/compare/v0.1.13.dev2...v0.1.13.dev3

--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.13.dev2"
+__version__ = "0.1.13.dev3"
 
 import importlib
 import os


### PR DESCRIPTION
## Summary
- Bump version from `0.1.13.dev2` to `0.1.13.dev3`
- Add release notes covering changes since `v0.1.13.dev2`

## Changes since v0.1.13.dev2
- fix: propagate interception-stream cuts into rollout state (#1191)
- make download of rlm lazy (#1192)

### Linked PRs
- #1191
- #1192

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a version bump plus new markdown release notes, with no functional/runtime code changes beyond `__version__`.
> 
> **Overview**
> Bumps the package version from `0.1.13.dev2` to `0.1.13.dev3`.
> 
> Adds `RELEASE_v0.1.13.dev3.md` documenting the v0.1.13.dev3 highlights (stream interruption surfacing and lazy RLM checkout resolution) and linking to the full changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23db1679832089facc199291012399751396c48c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->