### PR TITLE
Expose RLM metrics to verifiers

### DIFF
--- a/tests/test_rlm_composable_env.py
+++ b/tests/test_rlm_composable_env.py
@@ -407,3 +407,56 @@ async def test_rlm_collects_logs_and_metrics(tmp_path):
         "rlm_prompt_tokens": 100.0,
         "rlm_completion_tokens": 25.0,
     }
+
+
+@pytest.mark.asyncio
+async def test_rlm_harness_metrics_rubric_does_not_crash_scoring(tmp_path):
+    taskset = MockSandboxTaskSet(dataset=_make_dataset(), name="test")
+    metrics = {
+        "turns": 3,
+        "stop_reason": "done",
+        "prompt_tokens": 100,
+        "completion_tokens": 25,
+    }
+    harness = rlm_harness(local_checkout=_make_git_checkout(tmp_path / "rlm"))
+    env = ComposableEnv(
+        taskset=taskset,
+        harness=Harness(
+            run_command=harness.run_command,
+            metrics_path=harness.metrics_path,
+            metrics_key=harness.metrics_key,
+            metrics_prefix=harness.metrics_prefix,
+        ),
+    )
+    env.sandbox_client = SimpleNamespace(
+        execute_command=AsyncMock(
+            return_value=SimpleNamespace(
+                stdout=json.dumps({"metrics": metrics}),
+                stderr="",
+                exit_code=0,
+            )
+        ),
+        teardown=lambda: None,
+    )
+
+    state = {
+        "sandbox_id": "sbx",
+        "info": {"id": 0},
+        "prompt": [{"role": "user", "content": "Fix bug #0"}],
+        "completion": [{"role": "assistant", "content": "done"}],
+        "task": "test",
+        "answer": "",
+        "timing": {"total_ms": 0},
+        "trajectory": [],
+        "test_output": "PASS",
+    }
+
+    await env.post_rollout(state)
+    await env.rubric.score_rollout(state)
+    await env.rubric.cleanup(state)
+
+    assert state["reward"] == 1.0
+    assert state["metrics"]["solved"] == 1.0
+    assert state["metrics"]["rlm_turns"] == 3.0
+    assert state["metrics"]["rlm_prompt_tokens"] == 100.0
+    assert state["metrics"]["rlm_completion_tokens"] == 25.0

--- a/tests/test_rlm_composable_env.py
+++ b/tests/test_rlm_composable_env.py
@@ -396,6 +396,12 @@ async def test_rlm_collects_logs_and_metrics(tmp_path):
     assert state["rlm_stop_reason"] == "done"
     assert state["rlm_prompt_tokens"] == 100
     assert state["rlm_completion_tokens"] == 25
+    assert state["_harness_metrics"] == {
+        "rlm_turns": 3.0,
+        "rlm_prompt_tokens": 100.0,
+        "rlm_completion_tokens": 25.0,
+    }
+    await env.rubric.cleanup(state)
     assert state["metrics"] == {
         "rlm_turns": 3.0,
         "rlm_prompt_tokens": 100.0,

--- a/tests/test_rlm_composable_env.py
+++ b/tests/test_rlm_composable_env.py
@@ -396,3 +396,8 @@ async def test_rlm_collects_logs_and_metrics(tmp_path):
     assert state["rlm_stop_reason"] == "done"
     assert state["rlm_prompt_tokens"] == 100
     assert state["rlm_completion_tokens"] == 25
+    assert state["metrics"] == {
+        "rlm_turns": 3.0,
+        "rlm_prompt_tokens": 100.0,
+        "rlm_completion_tokens": 25.0,
+    }

--- a/verifiers/envs/experimental/composable/composable_env.py
+++ b/verifiers/envs/experimental/composable/composable_env.py
@@ -334,8 +334,16 @@ class ComposableEnv(CliAgentEnv):
                 data = data.get(self.harness.metrics_key, {})
             prefix = self.harness.metrics_prefix
             allowed = self.harness.metrics_keys
+            state_metrics = state.setdefault("metrics", {})
+            if not isinstance(state_metrics, dict):
+                raise TypeError(
+                    "state['metrics'] must be a dict when collecting harness metrics"
+                )
             for key, value in data.items():
                 if allowed is None or key in allowed:
-                    state[f"{prefix}{key}"] = value
+                    prefixed_key = f"{prefix}{key}"
+                    state[prefixed_key] = value
+                    if isinstance(value, (int, float)):
+                        state_metrics[prefixed_key] = float(value)
         except Exception as e:
             self.logger.warning(f"Failed to collect harness metrics: {e}")

--- a/verifiers/envs/experimental/composable/composable_env.py
+++ b/verifiers/envs/experimental/composable/composable_env.py
@@ -58,6 +58,12 @@ logger = logging.getLogger(__name__)
 
 
 class _HarnessMetricsRubric(vf.Rubric):
+    async def score_rollout(self, state: State) -> None:
+        return
+
+    async def score_group(self, states: list[State]) -> None:
+        return
+
     @cleanup
     async def merge_harness_metrics(self, state: State) -> None:
         harness_metrics = state.get("_harness_metrics")

--- a/verifiers/envs/experimental/composable/composable_env.py
+++ b/verifiers/envs/experimental/composable/composable_env.py
@@ -47,6 +47,7 @@ from pathlib import Path
 from typing import Any
 
 import verifiers as vf
+from verifiers.decorators import cleanup
 from verifiers.envs.experimental.cli_agent_env import CliAgentEnv
 from verifiers.envs.experimental.composable.harness import Harness
 from verifiers.envs.experimental.composable.task import TaskSet
@@ -54,6 +55,21 @@ from verifiers.envs.tool_env import ToolMonitorRubric
 from verifiers.types import State
 
 logger = logging.getLogger(__name__)
+
+
+class _HarnessMetricsRubric(vf.Rubric):
+    @cleanup
+    async def merge_harness_metrics(self, state: State) -> None:
+        harness_metrics = state.get("_harness_metrics")
+        if not isinstance(harness_metrics, dict):
+            return
+        state_metrics = state.get("metrics")
+        if not isinstance(state_metrics, dict):
+            state_metrics = {}
+            state["metrics"] = state_metrics
+        for key, value in harness_metrics.items():
+            if isinstance(key, str) and isinstance(value, (int, float)):
+                state_metrics[key] = float(value)
 
 
 class ComposableEnv(CliAgentEnv):
@@ -89,6 +105,8 @@ class ComposableEnv(CliAgentEnv):
 
         if harness.tool_names:
             self.add_rubric(ToolMonitorRubric(tool_names=list(harness.tool_names)))
+        if harness.metrics_path:
+            self.add_rubric(_HarnessMetricsRubric())
 
     # -- CliAgentEnv hooks --------------------------------------------------
 
@@ -334,16 +352,15 @@ class ComposableEnv(CliAgentEnv):
                 data = data.get(self.harness.metrics_key, {})
             prefix = self.harness.metrics_prefix
             allowed = self.harness.metrics_keys
-            state_metrics = state.setdefault("metrics", {})
-            if not isinstance(state_metrics, dict):
-                raise TypeError(
-                    "state['metrics'] must be a dict when collecting harness metrics"
-                )
+            harness_metrics = state.get("_harness_metrics")
+            if not isinstance(harness_metrics, dict):
+                harness_metrics = {}
+                state["_harness_metrics"] = harness_metrics
             for key, value in data.items():
                 if allowed is None or key in allowed:
                     prefixed_key = f"{prefix}{key}"
                     state[prefixed_key] = value
                     if isinstance(value, (int, float)):
-                        state_metrics[prefixed_key] = float(value)
+                        harness_metrics[prefixed_key] = float(value)
         except Exception as e:
             self.logger.warning(f"Failed to collect harness metrics: {e}")

--- a/verifiers/envs/experimental/composable/composable_env.py
+++ b/verifiers/envs/experimental/composable/composable_env.py
@@ -57,7 +57,7 @@ from verifiers.types import State
 logger = logging.getLogger(__name__)
 
 
-class _HarnessMetricsRubric(vf.Rubric):
+class HarnessMetricsRubric(vf.Rubric):
     async def score_rollout(self, state: State) -> None:
         return
 
@@ -112,7 +112,7 @@ class ComposableEnv(CliAgentEnv):
         if harness.tool_names:
             self.add_rubric(ToolMonitorRubric(tool_names=list(harness.tool_names)))
         if harness.metrics_path:
-            self.add_rubric(_HarnessMetricsRubric())
+            self.add_rubric(HarnessMetricsRubric())
 
     # -- CliAgentEnv hooks --------------------------------------------------
 

--- a/verifiers/rubrics/rubric_group.py
+++ b/verifiers/rubrics/rubric_group.py
@@ -65,6 +65,8 @@ class RubricGroup(Rubric):
         for rubric in self.rubrics:
             await rubric.score_rollout(state)
             rubric_reward = state.get("reward", 0.0)
+            if rubric_reward is None:
+                rubric_reward = 0.0
             rubric_metrics = (
                 state.get("metrics", {}).copy() if state.get("metrics") else {}
             )
@@ -104,6 +106,8 @@ class RubricGroup(Rubric):
             await rubric.score_group(states)
             for i, state in enumerate(states):
                 rubric_reward = state.get("reward", 0.0)
+                if rubric_reward is None:
+                    rubric_reward = 0.0
                 rubric_metrics = (
                     state.get("metrics", {}).copy() if state.get("metrics") else {}
                 )


### PR DESCRIPTION
## Description

Previously, `ComposableEnv` metrics were namespaces but never added to `state["metrics"]` and thus never made visible. This PR fixes that, especially with an eye on the RLM harness.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches scoring/aggregation paths by adding a new cleanup rubric and changing `RubricGroup` to treat `None` rewards as 0, which could affect how rewards/metrics are combined across rubrics.
> 
> **Overview**
> **ComposableEnv now exposes harness-collected numeric metrics via `state["metrics"]`.** It collects prefixed numeric values into `state["_harness_metrics"]` during `post_rollout`, then a new `HarnessMetricsRubric` merges them into `state["metrics"]` during rubric cleanup when `metrics_path` is configured.
> 
> **Rubric aggregation is made more robust** by treating `None` `reward` values as `0.0` in `RubricGroup` for both `score_rollout` and `score_group`, avoiding crashes when a rubric only contributes metrics.
> 
> Tests are updated/added to assert RLM harness metrics end up in `state["metrics"]` after cleanup and that scoring still succeeds with the new metrics rubric.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3a4f7143e50686fd4612864d31f0bd4799e6ffb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->