### PR TITLE
fix: narrow math_verify BaseException catch to specific TimeoutException

### DIFF
--- a/tests/test_math_rubric.py
+++ b/tests/test_math_rubric.py
@@ -1,8 +1,11 @@
 """Tests for the MathRubric class."""
 
+import asyncio
+
 import pytest
 
 import verifiers as vf
+from verifiers.rubrics import math_rubric
 
 
 class TestMathRubric:
@@ -127,3 +130,85 @@ class TestMathRubric:
             assert state["metrics"]["correct_answer"] == 1.0
         else:
             assert state["metrics"]["correct_answer"] == 0.0
+
+
+class TestVerifyResponseExceptionHandling:
+    """Regression tests for the exception handling in verify_response.
+
+    See commit narrowing ``except BaseException`` to
+    ``except (Exception, MathVerifyTimeout)`` so that ``CancelledError``,
+    ``KeyboardInterrupt``, and ``SystemExit`` propagate instead of being
+    silently reported as a 0.0 score.
+    """
+
+    def test_cancellederror_propagates(self, monkeypatch):
+        """CancelledError raised during math_verify must propagate, not
+        get swallowed and reported as a score of 0.0."""
+
+        def raise_cancelled(*args, **kwargs):
+            raise asyncio.CancelledError
+
+        monkeypatch.setattr(math_rubric, "parse", raise_cancelled)
+
+        with pytest.raises(asyncio.CancelledError):
+            math_rubric.verify_response(
+                response="\\boxed{1}",
+                answer="1",
+                max_verify_chars=50_000,
+                timeout_seconds=5,
+            )
+
+    def test_keyboardinterrupt_propagates(self, monkeypatch):
+        """KeyboardInterrupt must propagate so Ctrl-C still works during
+        scoring."""
+
+        def raise_kbd(*args, **kwargs):
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr(math_rubric, "parse", raise_kbd)
+
+        with pytest.raises(KeyboardInterrupt):
+            math_rubric.verify_response(
+                response="\\boxed{1}",
+                answer="1",
+                max_verify_chars=50_000,
+                timeout_seconds=5,
+            )
+
+    def test_math_verify_timeout_returns_zero(self, monkeypatch):
+        """A real math_verify.errors.TimeoutException (which inherits from
+        BaseException, not Exception) must still be caught and reported as
+        a 0.0 score — that's why the catch is wider than just Exception."""
+        from math_verify.errors import TimeoutException
+
+        def raise_timeout(*args, **kwargs):
+            raise TimeoutException("simulated math_verify timeout")
+
+        monkeypatch.setattr(math_rubric, "parse", raise_timeout)
+
+        score, elapsed = math_rubric.verify_response(
+            response="\\boxed{1}",
+            answer="1",
+            max_verify_chars=50_000,
+            timeout_seconds=5,
+        )
+        assert score == 0.0
+        assert elapsed >= 0.0
+
+    def test_regular_exception_returns_zero(self, monkeypatch):
+        """A regular Exception from math_verify should continue to be
+        swallowed and reported as 0.0 (library-raised something weird)."""
+
+        def raise_exc(*args, **kwargs):
+            raise ValueError("simulated parse failure")
+
+        monkeypatch.setattr(math_rubric, "parse", raise_exc)
+
+        score, elapsed = math_rubric.verify_response(
+            response="\\boxed{1}",
+            answer="1",
+            max_verify_chars=50_000,
+            timeout_seconds=5,
+        )
+        assert score == 0.0
+        assert elapsed >= 0.0

--- a/verifiers/rubrics/math_rubric.py
+++ b/verifiers/rubrics/math_rubric.py
@@ -5,6 +5,7 @@ import time
 from concurrent.futures import ProcessPoolExecutor
 
 from math_verify import parse, verify
+from math_verify.errors import TimeoutException as MathVerifyTimeout
 
 from verifiers.parsers.maybe_think_parser import MaybeThinkParser
 from verifiers.parsers.parser import Parser
@@ -45,7 +46,7 @@ def verify_response(
         )
         elapsed = time.perf_counter() - start
         return float(is_correct), elapsed
-    except BaseException:
+    except (Exception, MathVerifyTimeout):
         elapsed = time.perf_counter() - start
         return 0.0, elapsed
 


### PR DESCRIPTION
## Summary

- `math_verify.errors.TimeoutException` inherits directly from `BaseException` (not `Exception`), so the existing `except BaseException` in `verify_response` was intentionally wide -- a plain `except Exception` wouldn't catch it.
- But `BaseException` also catches `asyncio.CancelledError`, `KeyboardInterrupt`, and `SystemExit`. In the rubric's async context, catching `CancelledError` and silently returning `(0.0, elapsed)` means a rollout cancelled during scoring is misreported as answering incorrectly -- polluting the reward distribution.
- Narrow to `except (Exception, MathVerifyTimeout)` by importing the specific class. Preserves the "library raised something weird, score 0" intent while letting cancellation and interrupt signals propagate.

An audit confirmed `math_verify.errors.TimeoutException` is the only non-`Exception` `BaseException` subclass in our math-scoring dep graph; sympy, latex2sympy2_extended, antlr4, stopit all use regular `Exception`.

The `except BaseException` on `verifiers/rubrics/experimental/hybrid_math_rubric.py:211` is intentionally left alone -- it's inside a Python source string executed as a sandbox subprocess, not host-side asyncio code.

## Test plan

Added regression tests in `tests/test_math_rubric.py::TestVerifyResponseExceptionHandling`:

- [x] `test_cancellederror_propagates` -- `asyncio.CancelledError` raised during `math_verify` propagates out of `verify_response` (previously silenced as 0.0).
- [x] `test_keyboardinterrupt_propagates` -- `KeyboardInterrupt` propagates so Ctrl-C still works during scoring.
- [x] `test_math_verify_timeout_returns_zero` -- a real `math_verify.errors.TimeoutException` still returns `(0.0, elapsed)` (regression for the widening the catch originally addressed).
- [x] `test_regular_exception_returns_zero` -- regular `Exception`s from `math_verify` are still swallowed and scored 0.0.

Local run: `uv run pytest tests/test_math_rubric.py -v` -- 13 passed.
Also ran `uv run ruff check` / `uv run ruff format --check` on the touched files -- clean.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes exception handling in `math_rubric.verify_response`, which can alter runtime behavior by letting cancellation/interrupt signals propagate instead of being converted into a 0.0 score. Risk is limited to math-scoring paths but could affect job cancellation/termination semantics.
> 
> **Overview**
> Narrows `verifiers/rubrics/math_rubric.py:verify_response` from catching `BaseException` to catching only `Exception` plus `math_verify.errors.TimeoutException`, so `asyncio.CancelledError`, `KeyboardInterrupt`, and `SystemExit` propagate instead of being silently scored as `0.0`.
> 
> Adds regression tests in `tests/test_math_rubric.py` to assert propagation for cancellation/interrupts while still returning `0.0` for `TimeoutException` and regular exceptions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43008de91f12444e8eaf5a7ec370399811922522. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->