### PR TITLE
fix: narrow send_cancel BaseException catch to Exception

### DIFF
--- a/tests/test_env_server.py
+++ b/tests/test_env_server.py
@@ -326,6 +326,72 @@ class TestRetryOnServerError:
             await client.close()
 
 
+class TestSendCancelErrorHandling:
+    """Tests that ``send_cancel`` swallows transport errors but not
+    cancellation or interrupt signals."""
+
+    @pytest.mark.asyncio
+    async def test_send_cancel_swallows_connection_error(self):
+        """Transport-layer failures are silently swallowed (best-effort cleanup)."""
+        client = make_client()
+        try:
+            client.socket.send_multipart = AsyncMock(
+                side_effect=ConnectionError("closed")
+            )
+            # Should not raise
+            await client.send_cancel("req_1")
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_send_cancel_swallows_oserror(self):
+        """OSError from the socket layer is silently swallowed."""
+        client = make_client()
+        try:
+            client.socket.send_multipart = AsyncMock(side_effect=OSError("nope"))
+            await client.send_cancel("req_1")
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_send_cancel_propagates_cancelled_error(self):
+        """``asyncio.CancelledError`` must propagate, not be silenced.
+
+        Especially important in a method literally named ``send_cancel``: the
+        prior ``except BaseException`` was denying the caller's own
+        cancellation.
+        """
+        client = make_client()
+        try:
+            client.socket.send_multipart = AsyncMock(side_effect=asyncio.CancelledError)
+            with pytest.raises(asyncio.CancelledError):
+                await client.send_cancel("req_1")
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_send_cancel_propagates_keyboard_interrupt(self):
+        """``KeyboardInterrupt`` must propagate through best-effort cleanup."""
+        client = make_client()
+        try:
+            client.socket.send_multipart = AsyncMock(side_effect=KeyboardInterrupt)
+            with pytest.raises(KeyboardInterrupt):
+                await client.send_cancel("req_1")
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_send_cancel_propagates_system_exit(self):
+        """``SystemExit`` must propagate through best-effort cleanup."""
+        client = make_client()
+        try:
+            client.socket.send_multipart = AsyncMock(side_effect=SystemExit)
+            with pytest.raises(SystemExit):
+                await client.send_cancel("req_1")
+        finally:
+            await client.close()
+
+
 class TestCancelForwarding:
     """Tests that client-side cancellation is forwarded through the router.
 

--- a/verifiers/serve/client/zmq_env_client.py
+++ b/verifiers/serve/client/zmq_env_client.py
@@ -146,7 +146,10 @@ class ZMQEnvClient(EnvClient):
         """Send a cancel signal (empty payload) to the server for a request."""
         try:
             await self.socket.send_multipart([request_id.encode(), b""])
-        except BaseException:
+        except Exception:
+            # Best-effort cancel notification; transport/socket errors here are
+            # deliberately swallowed. Cancellation and interrupt signals still
+            # propagate (they are not `Exception` subclasses).
             pass
 
     async def cancel_all_pending(


### PR DESCRIPTION
## Summary

`ZMQEnvClient.send_cancel` caught `BaseException` and silently passed. Intent was best-effort cleanup — transport/socket errors shouldn't break shutdown. But `BaseException` also swallows:

- `asyncio.CancelledError` — denying the caller's cancellation. Particularly ironic in a method literally named `send_cancel`.
- `KeyboardInterrupt` — eating user Ctrl-C during cleanup.
- `SystemExit` — ignoring explicit `sys.exit()`.

Narrowed to `except Exception: pass`. Transport / socket / ZMQ errors still swallowed as before; cancellation and interrupt signals now propagate correctly.

## Changes

- \`verifiers/serve/client/zmq_env_client.py\` — single-line catch narrowing with comment
- \`tests/test_env_server.py\` — added \`TestSendCancelErrorHandling\` with 5 tests:
  - \`test_send_cancel_swallows_connection_error\` — regression: transport errors silently swallowed
  - \`test_send_cancel_swallows_oserror\` — regression: OSError silently swallowed
  - \`test_send_cancel_propagates_cancelled_error\` — the headline bug
  - \`test_send_cancel_propagates_keyboard_interrupt\`
  - \`test_send_cancel_propagates_system_exit\`

## Verification

- \`uv run pytest tests/test_env_server.py -x -q\` — 15 passed (10 existing + 5 new)
- \`uv run ruff check\` + \`ruff format --check\` — clean

## Context

Part of a small audit of \`BaseException\` catches in verifiers following bugbot's review on #1196. See the plan file for the full inventory; companion PR is #1197 (same narrowing applied to \`math_verify\` calls in \`math_rubric.py\`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a narrowly-scoped exception-handling tweak in `send_cancel` plus targeted tests; behavior only changes for cancellation/interrupt signals while keeping transport errors best-effort.
> 
> **Overview**
> `ZMQEnvClient.send_cancel` now catches `Exception` instead of `BaseException`, so best-effort cancel notifications still ignore socket/transport failures but **no longer suppress** `asyncio.CancelledError`, `KeyboardInterrupt`, or `SystemExit`.
> 
> Adds a new `TestSendCancelErrorHandling` suite verifying transport errors are swallowed and cancellation/interrupt signals propagate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6598c35436574cf78cb1876164ca869e83ee86a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->