### PR TITLE
Keep harness metrics merge inside experimental composable env

### DIFF
--- a/verifiers/envs/experimental/composable/composable_env.py
+++ b/verifiers/envs/experimental/composable/composable_env.py
@@ -47,7 +47,6 @@ from pathlib import Path
 from typing import Any
 
 import verifiers as vf
-from verifiers.decorators import cleanup
 from verifiers.envs.experimental.cli_agent_env import CliAgentEnv
 from verifiers.envs.experimental.composable.harness import Harness
 from verifiers.envs.experimental.composable.task import TaskSet
@@ -57,15 +56,10 @@ from verifiers.types import State
 logger = logging.getLogger(__name__)
 
 
-class HarnessMetricsRubric(vf.Rubric):
-    async def score_rollout(self, state: State) -> None:
-        return
-
-    async def score_group(self, states: list[State]) -> None:
-        return
-
-    @cleanup
-    async def merge_harness_metrics(self, state: State) -> None:
+class HarnessMetricsRubricGroup(vf.RubricGroup):
+    async def cleanup(self, state: State) -> None:
+        for rubric in self.rubrics:
+            await rubric.cleanup(state)
         harness_metrics = state.get("_harness_metrics")
         if not isinstance(harness_metrics, dict):
             return
@@ -112,7 +106,12 @@ class ComposableEnv(CliAgentEnv):
         if harness.tool_names:
             self.add_rubric(ToolMonitorRubric(tool_names=list(harness.tool_names)))
         if harness.metrics_path:
-            self.add_rubric(HarnessMetricsRubric())
+            rubrics = (
+                list(self.rubric.rubrics)
+                if isinstance(self.rubric, vf.RubricGroup)
+                else [self.rubric]
+            )
+            self.rubric = HarnessMetricsRubricGroup(rubrics=rubrics)
 
     # -- CliAgentEnv hooks --------------------------------------------------
 

--- a/verifiers/rubrics/rubric_group.py
+++ b/verifiers/rubrics/rubric_group.py
@@ -65,8 +65,6 @@ class RubricGroup(Rubric):
         for rubric in self.rubrics:
             await rubric.score_rollout(state)
             rubric_reward = state.get("reward", 0.0)
-            if rubric_reward is None:
-                rubric_reward = 0.0
             rubric_metrics = (
                 state.get("metrics", {}).copy() if state.get("metrics") else {}
             )
@@ -106,8 +104,6 @@ class RubricGroup(Rubric):
             await rubric.score_group(states)
             for i, state in enumerate(states):
                 rubric_reward = state.get("reward", 0.0)
-                if rubric_reward is None:
-                    rubric_reward = 0.0
                 rubric_metrics = (
                     state.get("metrics", {}).copy() if state.get("metrics") else {}
                 )


### PR DESCRIPTION
## Description

Previous PR touched core verifiers logic (in non-harmful ways, but still); this undoes those changes and solves the problem they were meant to address fully inside experimental

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how rewards are aggregated in `RubricGroup` by no longer coercing `None` rewards to `0.0`, which could surface type errors if any rubric returns `None`. The new harness-metrics merge runs during rubric cleanup in the experimental env and should be low impact outside that path.
> 
> **Overview**
> Moves harness metrics merging fully into the experimental `ComposableEnv` by replacing the standalone `HarnessMetricsRubric` (and its `@cleanup` decorator) with a `HarnessMetricsRubricGroup` that runs child rubric cleanup then folds `_harness_metrics` into `state["metrics"]`.
> 
> When `harness.metrics_path` is set, `ComposableEnv` now wraps the existing rubric (or existing `RubricGroup`) inside this new group so metrics are merged without touching core scoring flow.
> 
> Separately, `RubricGroup` no longer normalizes `None` rewards to `0.0` during `score_rollout`/`score_group`, relying on rubrics to always set numeric rewards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ae31b42746a908b09ad0710e5c0622d0acd0115. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->