### PR TITLE
Refactor experimental RLM checkout caching

### DIFF
--- a/tests/test_rlm_composable_env.py
+++ b/tests/test_rlm_composable_env.py
@@ -15,12 +15,22 @@ import pytest
 
 import verifiers as vf
 from verifiers.envs.experimental.composable import (
+    composable_env as composable_env_module,
+)
+from verifiers.envs.experimental.composable import (
     ComposableEnv,
     Harness,
     SandboxSpec,
     SandboxTaskSet,
 )
 from verifiers.envs.experimental.composable.harnesses import rlm as rlm_module
+from verifiers.envs.experimental.utils import (
+    git_checkout_cache as git_checkout_cache_module,
+)
+from verifiers.envs.experimental.utils.file_locks import (
+    exclusive_path_lock,
+    shared_path_lock,
+)
 from verifiers.envs.experimental.composable.harnesses.rlm import (
     build_install_script,
     rlm_harness,
@@ -116,6 +126,37 @@ def _make_git_checkout(target: Path) -> Path:
     return checkout
 
 
+def _git_head_commit(checkout: Path) -> str:
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=checkout,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip().lower()
+
+
+def _commit_file(checkout: Path, name: str, content: str) -> str:
+    (checkout / name).write_text(content)
+    subprocess.run(["git", "add", name], cwd=checkout, check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=Codex",
+            "-c",
+            "user.email=codex@example.com",
+            "commit",
+            "-m",
+            f"update {name}",
+        ],
+        cwd=checkout,
+        check=True,
+    )
+    return _git_head_commit(checkout)
+
+
 # ── RLM harness ──────────────────────────────────────────────────────────
 
 
@@ -126,56 +167,53 @@ def test_rlm_harness_install_script_requires_uploaded_checkout():
     assert 'bash "$RLM_CHECKOUT_PATH/install.sh"' in script
 
 
-def test_rlm_harness_sets_metrics_fields(tmp_path):
-    harness = rlm_harness(local_checkout=_make_git_checkout(tmp_path / "rlm"))
+def test_rlm_harness_uses_explicit_local_checkout(tmp_path):
+    checkout = _make_git_checkout(tmp_path / "rlm")
+    harness = rlm_harness(local_checkout=checkout)
+
+    assert harness.get_upload_dirs() == {"rlm_checkout": checkout.resolve()}
+    assert harness.upload_dir_mapping == {"rlm_checkout": "/tmp/rlm-checkout"}
     assert harness.metrics_path == "{workdir}/.rlm/sessions/*/meta.json"
     assert harness.metrics_key == "metrics"
     assert harness.metrics_prefix == "rlm_"
-
-
-def test_rlm_harness_sets_skills_path(tmp_path):
-    harness = rlm_harness(local_checkout=_make_git_checkout(tmp_path / "rlm"))
     assert harness.skills_path == "/task/rlm-skills"
 
 
-def test_resolve_local_checkout_validates_explicit_path(tmp_path):
-    checkout = _make_git_checkout(tmp_path / "rlm")
+def test_resolve_local_checkout_rejects_missing_explicit_path(tmp_path):
+    missing_checkout = tmp_path / "missing-rlm"
 
-    resolved = resolve_local_checkout(checkout)
-
-    assert resolved == checkout.resolve()
-
-
-def test_rlm_harness_uploads_explicit_local_checkout(tmp_path):
-    checkout = _make_git_checkout(tmp_path / "rlm")
-
-    harness = rlm_harness(local_checkout=checkout)
-
-    assert harness.get_upload_dirs is not None
-    assert harness.get_upload_dirs() == {"rlm_checkout": checkout.resolve()}
-    assert harness.upload_dir_mapping == {"rlm_checkout": "/tmp/rlm-checkout"}
+    with pytest.raises(ValueError, match="not a directory"):
+        resolve_local_checkout(missing_checkout)
 
 
-def test_resolve_local_checkout_materializes_host_cache(tmp_path):
+def test_resolve_local_checkout_materializes_host_cache_for_named_ref(
+    tmp_path, monkeypatch
+):
     source_checkout = _make_git_checkout(tmp_path / "rlm-source")
-    checkout_dir = tmp_path / "checkout-root" / "rlm"
-
-    resolved = resolve_local_checkout(
-        local_checkout=checkout_dir,
-        rlm_repo_url=str(source_checkout),
-        rlm_branch="main",
+    source_commit = _git_head_commit(source_checkout)
+    monkeypatch.setattr(
+        rlm_module,
+        "DEFAULT_RLM_LOCAL_CHECKOUT_CACHE_ROOT",
+        tmp_path / "cache-root",
     )
 
-    assert resolved == checkout_dir.resolve()
-    assert (checkout_dir / ".git").is_dir()
-    assert (checkout_dir / "install.sh").is_file()
-    assert (checkout_dir / "pyproject.toml").is_file()
+    resolved = resolve_local_checkout(
+        rlm_repo_url=str(source_checkout),
+        rlm_ref="main",
+    )
+
+    assert resolved.name == source_commit
+    assert resolved.is_dir()
+    assert (resolved / ".git").exists()
+    assert (resolved / "install.sh").is_file()
+    assert (resolved / "pyproject.toml").is_file()
 
 
 def test_rlm_harness_uses_default_host_cache_when_local_checkout_unspecified(
     tmp_path, monkeypatch
 ):
     source_checkout = _make_git_checkout(tmp_path / "rlm-source")
+    source_commit = _git_head_commit(source_checkout)
     monkeypatch.setattr(
         rlm_module,
         "DEFAULT_RLM_LOCAL_CHECKOUT_CACHE_ROOT",
@@ -184,19 +222,20 @@ def test_rlm_harness_uses_default_host_cache_when_local_checkout_unspecified(
 
     harness = rlm_harness(
         rlm_repo_url=str(source_checkout),
-        rlm_branch="main",
+        rlm_ref="main",
     )
 
     assert harness.get_upload_dirs is not None
     upload_checkout = harness.get_upload_dirs()["rlm_checkout"]
     assert isinstance(upload_checkout, Path)
     assert upload_checkout.is_dir()
-    assert upload_checkout.name.startswith("rlm-source-main-")
+    assert upload_checkout.name == source_commit
     assert harness.upload_dir_mapping == {"rlm_checkout": "/tmp/rlm-checkout"}
 
 
-def test_rlm_harness_always_uploads_checkout(tmp_path, monkeypatch):
+def test_rlm_harness_memoizes_resolved_checkout_per_instance(tmp_path, monkeypatch):
     source_checkout = _make_git_checkout(tmp_path / "rlm-source")
+    second_commit = _commit_file(source_checkout, "README.md", "updated\n")
     monkeypatch.setattr(
         rlm_module,
         "DEFAULT_RLM_LOCAL_CHECKOUT_CACHE_ROOT",
@@ -205,19 +244,96 @@ def test_rlm_harness_always_uploads_checkout(tmp_path, monkeypatch):
 
     harness = rlm_harness(
         rlm_repo_url=str(source_checkout),
-        rlm_branch="main",
+        rlm_ref="main",
+    )
+    first_upload_checkout = harness.get_upload_dirs()["rlm_checkout"]
+
+    _commit_file(source_checkout, "extra.txt", "third\n")
+    second_upload_checkout = harness.get_upload_dirs()["rlm_checkout"]
+
+    assert isinstance(first_upload_checkout, Path)
+    assert first_upload_checkout.name == second_commit
+    assert second_upload_checkout == first_upload_checkout
+
+
+def test_rlm_harness_resolves_new_commit_for_new_instance(tmp_path, monkeypatch):
+    source_checkout = _make_git_checkout(tmp_path / "rlm-source")
+    first_commit = _git_head_commit(source_checkout)
+    monkeypatch.setattr(
+        rlm_module,
+        "DEFAULT_RLM_LOCAL_CHECKOUT_CACHE_ROOT",
+        tmp_path / "cache-root",
     )
 
-    assert harness.get_upload_dirs is not None
-    assert harness.upload_dir_mapping is not None
+    first_harness = rlm_harness(
+        rlm_repo_url=str(source_checkout),
+        rlm_ref="main",
+    )
+    first_checkout = first_harness.get_upload_dirs()["rlm_checkout"]
+    assert isinstance(first_checkout, Path)
+    assert first_checkout.name == first_commit
+
+    second_commit = _commit_file(source_checkout, "README.md", "updated\n")
+
+    second_harness = rlm_harness(
+        rlm_repo_url=str(source_checkout),
+        rlm_ref="main",
+    )
+    second_checkout = second_harness.get_upload_dirs()["rlm_checkout"]
+    assert isinstance(second_checkout, Path)
+    assert second_checkout.name == second_commit
+    assert second_checkout != first_checkout
+    assert not first_checkout.exists()
+
+
+def test_rlm_harness_skips_pruning_locked_stale_checkout(tmp_path, monkeypatch):
+    source_checkout = _make_git_checkout(tmp_path / "rlm-source")
+    first_commit = _git_head_commit(source_checkout)
+    monkeypatch.setattr(
+        rlm_module,
+        "DEFAULT_RLM_LOCAL_CHECKOUT_CACHE_ROOT",
+        tmp_path / "cache-root",
+    )
+
+    first_harness = rlm_harness(
+        rlm_repo_url=str(source_checkout),
+        rlm_ref="main",
+    )
+    first_checkout = first_harness.get_upload_dirs()["rlm_checkout"]
+    assert isinstance(first_checkout, Path)
+    assert first_checkout.name == first_commit
+
+    second_commit = _commit_file(source_checkout, "README.md", "updated\n")
+
+    with shared_path_lock(first_checkout, suffix=".upload.lock"):
+        second_harness = rlm_harness(
+            rlm_repo_url=str(source_checkout),
+            rlm_ref="main",
+        )
+        second_checkout = second_harness.get_upload_dirs()["rlm_checkout"]
+        assert isinstance(second_checkout, Path)
+        assert second_checkout.name == second_commit
+        assert first_checkout.exists()
+
+    third_harness = rlm_harness(
+        rlm_repo_url=str(source_checkout),
+        rlm_ref="main",
+    )
+    third_checkout = third_harness.get_upload_dirs()["rlm_checkout"]
+    assert third_checkout == second_checkout
+    assert not first_checkout.exists()
 
 
 def test_resolve_local_checkout_redacts_gh_token_on_clone_failure(
     tmp_path, monkeypatch
 ):
-    failing_checkout = tmp_path / "checkout-root" / "rlm"
     token = "super/secret token"
     quoted_token = "super%2Fsecret%20token"
+    monkeypatch.setattr(
+        rlm_module,
+        "DEFAULT_RLM_LOCAL_CHECKOUT_CACHE_ROOT",
+        tmp_path / "cache-root",
+    )
 
     def _raise_clone_error(*args, **kwargs):
         raise subprocess.CalledProcessError(
@@ -229,19 +345,38 @@ def test_resolve_local_checkout_redacts_gh_token_on_clone_failure(
             ),
         )
 
-    monkeypatch.setattr(rlm_module.subprocess, "run", _raise_clone_error)
+    monkeypatch.setattr(git_checkout_cache_module.subprocess, "run", _raise_clone_error)
 
     with pytest.raises(RuntimeError) as exc_info:
         resolve_local_checkout(
-            local_checkout=failing_checkout,
             rlm_repo_url="github.com/PrimeIntellect-ai/rlm.git",
-            rlm_branch="main",
+            rlm_ref="main",
             gh_token=token,
         )
 
     message = str(exc_info.value)
     assert token not in message
     assert "<redacted>" in message
+
+
+def test_resolve_local_checkout_materializes_host_cache_for_exact_commit(
+    tmp_path, monkeypatch
+):
+    source_checkout = _make_git_checkout(tmp_path / "rlm-source")
+    second_commit = _commit_file(source_checkout, "README.md", "updated\n")
+    monkeypatch.setattr(
+        rlm_module,
+        "DEFAULT_RLM_LOCAL_CHECKOUT_CACHE_ROOT",
+        tmp_path / "cache-root",
+    )
+
+    resolved = resolve_local_checkout(
+        rlm_repo_url=str(source_checkout),
+        rlm_ref=second_commit,
+    )
+
+    assert resolved.name == second_commit
+    assert resolved.is_dir()
 
 
 # ── install_env ──────────────────────────────────────────────────────────
@@ -331,6 +466,43 @@ async def test_rlm_uploads_skills_before_install(tmp_path, monkeypatch):
         "mkdir -p /task && tar -xzf /tmp/_upload_task_rlm-skills.tar.gz -C / && rm -f /tmp/_upload_task_rlm-skills.tar.gz",
         timeout=60,
     )
+
+
+def test_build_dir_archive_holds_shared_lock_for_local_path(tmp_path):
+    taskset = MockSandboxTaskSet(dataset=_make_dataset(), name="test")
+    env = ComposableEnv(
+        taskset=taskset,
+        harness=Harness(run_command="true"),
+    )
+    local_source = tmp_path / "srcdir"
+    local_source.mkdir()
+    (local_source / "file.txt").write_text("hello\n")
+
+    class _FakeTar:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def add(self, path, arcname):
+            assert Path(path) == local_source
+            with pytest.raises(BlockingIOError):
+                with exclusive_path_lock(
+                    local_source,
+                    suffix=".upload.lock",
+                    nonblocking=True,
+                ):
+                    pass
+
+    original_open = composable_env_module.tarfile.open
+    composable_env_module.tarfile.open = lambda *args, **kwargs: _FakeTar()
+    try:
+        tar_path = env._build_dir_archive(local_source, "/task/srcdir")
+    finally:
+        composable_env_module.tarfile.open = original_open
+
+    tar_path.unlink(missing_ok=True)
 
 
 # ── RLM metrics via harness fields ──────────────────────────────────────

--- a/verifiers/envs/experimental/composable/composable_env.py
+++ b/verifiers/envs/experimental/composable/composable_env.py
@@ -50,6 +50,7 @@ import verifiers as vf
 from verifiers.envs.experimental.cli_agent_env import CliAgentEnv
 from verifiers.envs.experimental.composable.harness import Harness
 from verifiers.envs.experimental.composable.task import TaskSet
+from verifiers.envs.experimental.utils.file_locks import shared_path_lock
 from verifiers.envs.tool_env import ToolMonitorRubric
 from verifiers.types import State
 
@@ -330,7 +331,8 @@ class ComposableEnv(CliAgentEnv):
         arcname = remote_dest.lstrip("/")
         with tarfile.open(tar_path, "w:gz") as tar:
             if isinstance(local_source, Path):
-                tar.add(local_source, arcname=arcname)
+                with shared_path_lock(local_source, suffix=".upload.lock"):
+                    tar.add(local_source, arcname=arcname)
             else:
                 with resources.as_file(local_source) as local_path:
                     tar.add(local_path, arcname=arcname)

--- a/verifiers/envs/experimental/composable/harnesses/__init__.py
+++ b/verifiers/envs/experimental/composable/harnesses/__init__.py
@@ -1,6 +1,6 @@
 from verifiers.envs.experimental.composable.harnesses.rlm import (
-    DEFAULT_RLM_BRANCH,
     DEFAULT_RLM_MAX_TURNS,
+    DEFAULT_RLM_REF,
     DEFAULT_RLM_REPO_URL,
     build_install_script as build_rlm_install_script,
     build_run_command as build_rlm_run_command,
@@ -21,7 +21,7 @@ __all__ = [
     "rlm_harness",
     "build_rlm_install_script",
     "build_rlm_run_command",
-    "DEFAULT_RLM_BRANCH",
+    "DEFAULT_RLM_REF",
     "DEFAULT_RLM_REPO_URL",
     "DEFAULT_RLM_MAX_TURNS",
     "opencode_harness",

--- a/verifiers/envs/experimental/composable/harnesses/rlm.py
+++ b/verifiers/envs/experimental/composable/harnesses/rlm.py
@@ -2,23 +2,18 @@
 
 from __future__ import annotations
 
-import hashlib
-import os
-from collections.abc import Iterator
-from contextlib import contextmanager
-import fcntl
 from importlib.abc import Traversable
 from pathlib import Path
 import shlex
-import shutil
-import subprocess
-import tempfile
-from urllib.parse import quote, urlsplit, urlunsplit
 
 from verifiers.envs.experimental.composable import Harness
+from verifiers.envs.experimental.utils.git_checkout_cache import (
+    resolve_git_checkout,
+    validate_git_checkout,
+)
 
 DEFAULT_RLM_REPO_URL = "github.com/PrimeIntellect-ai/rlm.git"
-DEFAULT_RLM_BRANCH = "main"
+DEFAULT_RLM_REF = "main"
 DEFAULT_RLM_TOOL_NAMES = ["ipython", "summarize"]
 DEFAULT_RLM_MAX_TURNS = 100
 DEFAULT_APPEND_TO_SYSTEM_PROMPT_PATH = "/task/append_to_system_prompt.txt"
@@ -27,185 +22,27 @@ DEFAULT_RLM_CHECKOUT_UPLOAD_NAME = "rlm_checkout"
 DEFAULT_RLM_LOCAL_CHECKOUT_CACHE_ROOT = (
     Path.home() / ".cache" / "verifiers" / "rlm-checkouts"
 )
-
-
-def _validate_local_checkout(path: Path) -> Path:
-    path = path.expanduser().resolve()
-    if not path.is_dir():
-        raise ValueError(f"RLM local checkout is not a directory: {path}")
-    required = [path / "install.sh", path / "pyproject.toml"]
-    missing = [item.name for item in required if not item.is_file()]
-    if missing:
-        missing_list = ", ".join(missing)
-        raise ValueError(
-            f"RLM local checkout is missing required files ({missing_list}): {path}"
-        )
-    if not (path / ".git").exists():
-        raise ValueError(
-            f"RLM local checkout must be a git checkout or worktree: {path}"
-        )
-    return path
-
-
-def _slugify_cache_component(text: str) -> str:
-    slug = "".join(char.lower() if char.isalnum() else "-" for char in text)
-    slug = slug.strip("-")
-    return slug or "rlm"
-
-
-def _default_local_checkout_cache_dir(
-    rlm_repo_url: str,
-    rlm_branch: str,
-) -> Path:
-    repo_name = rlm_repo_url.rstrip("/").rsplit("/", 1)[-1].removesuffix(".git")
-    fingerprint = hashlib.sha256(f"{rlm_repo_url}\n{rlm_branch}".encode()).hexdigest()[
-        :12
-    ]
-    cache_name = (
-        f"{_slugify_cache_component(repo_name)}-"
-        f"{_slugify_cache_component(rlm_branch)}-{fingerprint}"
-    )
-    return DEFAULT_RLM_LOCAL_CHECKOUT_CACHE_ROOT / cache_name
-
-
-def _build_clone_url(
-    rlm_repo_url: str,
-    gh_token: str | None = None,
-) -> str:
-    if rlm_repo_url.startswith("github.com/"):
-        token_prefix = f"{quote(gh_token, safe='')}@" if gh_token else ""
-        return f"https://{token_prefix}{rlm_repo_url}"
-
-    if gh_token and rlm_repo_url.startswith(
-        ("https://github.com/", "http://github.com/")
-    ):
-        parsed = urlsplit(rlm_repo_url)
-        if "@" not in parsed.netloc:
-            return urlunsplit(
-                (
-                    parsed.scheme,
-                    f"{quote(gh_token, safe='')}@{parsed.netloc}",
-                    parsed.path,
-                    parsed.query,
-                    parsed.fragment,
-                )
-            )
-
-    return rlm_repo_url
-
-
-def _redact_clone_error_detail(detail: str, gh_token: str | None = None) -> str:
-    if not gh_token:
-        return detail
-    redacted = detail.replace(gh_token, "<redacted>")
-    quoted_token = quote(gh_token, safe="")
-    if quoted_token != gh_token:
-        redacted = redacted.replace(quoted_token, "<redacted>")
-    return redacted
-
-
-@contextmanager
-def _checkout_lock(lock_path: Path) -> Iterator[None]:
-    lock_path.parent.mkdir(parents=True, exist_ok=True)
-    with lock_path.open("w") as lock_file:
-        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
-        yield
-
-
-def _clone_checkout(
-    target_dir: Path,
-    *,
-    rlm_repo_url: str,
-    rlm_branch: str,
-    gh_token: str | None = None,
-) -> Path:
-    target_dir.parent.mkdir(parents=True, exist_ok=True)
-    clone_url = _build_clone_url(rlm_repo_url, gh_token)
-    temp_parent = target_dir.parent
-    temp_dir = Path(
-        tempfile.mkdtemp(prefix=f".{target_dir.name}.tmp-", dir=temp_parent)
-    )
-    checkout_dir = temp_dir / "checkout"
-    env = os.environ.copy()
-    if gh_token:
-        env.setdefault("GH_TOKEN", gh_token)
-    try:
-        subprocess.run(
-            [
-                "git",
-                "clone",
-                "--depth",
-                "1",
-                "--branch",
-                rlm_branch,
-                clone_url,
-                str(checkout_dir),
-            ],
-            check=True,
-            capture_output=True,
-            text=True,
-            env=env,
-        )
-    except FileNotFoundError as exc:
-        shutil.rmtree(temp_dir, ignore_errors=True)
-        raise RuntimeError(
-            "git is required to populate the local RLM checkout cache"
-        ) from exc
-    except subprocess.CalledProcessError as exc:
-        shutil.rmtree(temp_dir, ignore_errors=True)
-        detail = exc.stderr.strip() or exc.stdout.strip() or str(exc)
-        detail = _redact_clone_error_detail(detail, gh_token)
-        raise RuntimeError(
-            f"Failed to clone RLM checkout into host cache at {target_dir}: {detail}"
-        ) from exc
-
-    if target_dir.exists():
-        if target_dir.is_dir():
-            shutil.rmtree(target_dir)
-        else:
-            target_dir.unlink()
-    checkout_dir.rename(target_dir)
-    shutil.rmtree(temp_dir, ignore_errors=True)
-    return _validate_local_checkout(target_dir)
-
-
-def ensure_local_checkout(
-    *,
-    rlm_repo_url: str,
-    rlm_branch: str,
-    local_checkout: str | Path | None = None,
-    gh_token: str | None = None,
-) -> Path:
-    checkout_dir = (
-        Path(local_checkout).expanduser()
-        if local_checkout is not None
-        else _default_local_checkout_cache_dir(rlm_repo_url, rlm_branch)
-    ).resolve()
-    lock_path = checkout_dir.parent / f".{checkout_dir.name}.lock"
-    with _checkout_lock(lock_path):
-        try:
-            return _validate_local_checkout(checkout_dir)
-        except ValueError:
-            return _clone_checkout(
-                checkout_dir,
-                rlm_repo_url=rlm_repo_url,
-                rlm_branch=rlm_branch,
-                gh_token=gh_token,
-            )
+_REQUIRED_CHECKOUT_FILES = ("install.sh", "pyproject.toml")
 
 
 def resolve_local_checkout(
     local_checkout: str | Path | None = None,
     *,
     rlm_repo_url: str = DEFAULT_RLM_REPO_URL,
-    rlm_branch: str = DEFAULT_RLM_BRANCH,
+    rlm_ref: str = DEFAULT_RLM_REF,
     gh_token: str | None = None,
 ) -> Path:
-    return ensure_local_checkout(
-        rlm_repo_url=rlm_repo_url,
-        rlm_branch=rlm_branch,
-        local_checkout=local_checkout,
+    if local_checkout is not None:
+        return validate_git_checkout(
+            Path(local_checkout),
+            required_files=_REQUIRED_CHECKOUT_FILES,
+        )
+    return resolve_git_checkout(
+        repo_url=rlm_repo_url,
+        ref=rlm_ref,
+        cache_root=DEFAULT_RLM_LOCAL_CHECKOUT_CACHE_ROOT,
         gh_token=gh_token,
+        required_files=_REQUIRED_CHECKOUT_FILES,
     )
 
 
@@ -254,7 +91,7 @@ def rlm_harness(
     workdir: str = "/testbed",
     instruction_path: str = "/task/instruction.md",
     rlm_repo_url: str = DEFAULT_RLM_REPO_URL,
-    rlm_branch: str = DEFAULT_RLM_BRANCH,
+    rlm_ref: str = DEFAULT_RLM_REF,
     append_to_system_prompt: str | None = None,
     local_checkout: str | Path | None = None,
     gh_token: str | None = None,
@@ -262,17 +99,22 @@ def rlm_harness(
     upload_dir_mapping: dict[str, str] = {
         DEFAULT_RLM_CHECKOUT_UPLOAD_NAME: DEFAULT_RLM_CHECKOUT_PATH,
     }
+    resolved_upload_dirs: dict[str, Traversable | Path] | None = None
 
     def get_upload_dirs() -> dict[str, Traversable | Path]:
-        resolved_local_checkout = resolve_local_checkout(
-            local_checkout,
-            rlm_repo_url=rlm_repo_url,
-            rlm_branch=rlm_branch,
-            gh_token=gh_token,
-        )
-        return {
-            DEFAULT_RLM_CHECKOUT_UPLOAD_NAME: resolved_local_checkout,
+        nonlocal resolved_upload_dirs
+        if resolved_upload_dirs is not None:
+            return resolved_upload_dirs
+        upload_dirs: dict[str, Traversable | Path] = {
+            DEFAULT_RLM_CHECKOUT_UPLOAD_NAME: resolve_local_checkout(
+                local_checkout,
+                rlm_repo_url=rlm_repo_url,
+                rlm_ref=rlm_ref,
+                gh_token=gh_token,
+            )
         }
+        resolved_upload_dirs = upload_dirs
+        return resolved_upload_dirs
 
     return Harness(
         install_script=build_install_script(),

--- a/verifiers/envs/experimental/utils/__init__.py
+++ b/verifiers/envs/experimental/utils/__init__.py
@@ -1,0 +1,23 @@
+from verifiers.envs.experimental.utils.file_locks import (
+    exclusive_file_lock,
+    exclusive_path_lock,
+    shared_file_lock,
+    shared_path_lock,
+    sibling_lock_path,
+)
+from verifiers.envs.experimental.utils.git_checkout_cache import (
+    DEFAULT_GIT_CHECKOUT_CACHE_ROOT,
+    resolve_git_checkout,
+    validate_git_checkout,
+)
+
+__all__ = [
+    "DEFAULT_GIT_CHECKOUT_CACHE_ROOT",
+    "exclusive_file_lock",
+    "exclusive_path_lock",
+    "resolve_git_checkout",
+    "shared_file_lock",
+    "shared_path_lock",
+    "sibling_lock_path",
+    "validate_git_checkout",
+]

--- a/verifiers/envs/experimental/utils/file_locks.py
+++ b/verifiers/envs/experimental/utils/file_locks.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+import fcntl
+from pathlib import Path
+
+
+def sibling_lock_path(path: Path, suffix: str = ".lock") -> Path:
+    resolved = path.expanduser().resolve()
+    return resolved.parent / f".{resolved.name}{suffix}"
+
+
+@contextmanager
+def shared_file_lock(lock_path: Path) -> Iterator[None]:
+    lock_path = lock_path.expanduser().resolve()
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a+") as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_SH)
+        yield
+
+
+@contextmanager
+def exclusive_file_lock(
+    lock_path: Path,
+    *,
+    nonblocking: bool = False,
+) -> Iterator[None]:
+    lock_path = lock_path.expanduser().resolve()
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    flags = fcntl.LOCK_EX | (fcntl.LOCK_NB if nonblocking else 0)
+    with lock_path.open("a+") as lock_file:
+        fcntl.flock(lock_file.fileno(), flags)
+        yield
+
+
+@contextmanager
+def shared_path_lock(path: Path, suffix: str = ".lock") -> Iterator[None]:
+    with shared_file_lock(sibling_lock_path(path, suffix)):
+        yield
+
+
+@contextmanager
+def exclusive_path_lock(
+    path: Path,
+    *,
+    suffix: str = ".lock",
+    nonblocking: bool = False,
+) -> Iterator[None]:
+    with exclusive_file_lock(
+        sibling_lock_path(path, suffix),
+        nonblocking=nonblocking,
+    ):
+        yield

--- a/verifiers/envs/experimental/utils/git_checkout_cache.py
+++ b/verifiers/envs/experimental/utils/git_checkout_cache.py
@@ -1,0 +1,358 @@
+from __future__ import annotations
+
+import hashlib
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+from urllib.parse import quote, urlsplit, urlunsplit
+
+from verifiers.envs.experimental.utils.file_locks import (
+    exclusive_file_lock,
+    exclusive_path_lock,
+    sibling_lock_path,
+)
+
+DEFAULT_GIT_CHECKOUT_CACHE_ROOT = Path.home() / ".cache" / "verifiers" / "git-checkouts"
+_FULL_COMMIT_SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+
+
+def validate_git_checkout(
+    path: Path,
+    *,
+    required_files: tuple[str, ...] = (),
+) -> Path:
+    path = path.expanduser().resolve()
+    if not path.is_dir():
+        raise ValueError(f"Git checkout is not a directory: {path}")
+    missing = [name for name in required_files if not (path / name).exists()]
+    if missing:
+        missing_list = ", ".join(missing)
+        raise ValueError(
+            f"Git checkout is missing required files ({missing_list}): {path}"
+        )
+    if not (path / ".git").exists():
+        raise ValueError(f"Git checkout must be a git checkout or worktree: {path}")
+    return path
+
+
+def _slugify_cache_component(text: str) -> str:
+    slug = "".join(char.lower() if char.isalnum() else "-" for char in text)
+    slug = slug.strip("-")
+    return slug or "repo"
+
+
+def _repo_cache_dir(cache_root: Path, repo_url: str) -> Path:
+    repo_name = repo_url.rstrip("/").rsplit("/", 1)[-1].removesuffix(".git")
+    fingerprint = hashlib.sha256(repo_url.encode()).hexdigest()[:12]
+    return cache_root / f"{_slugify_cache_component(repo_name)}-{fingerprint}"
+
+
+def _mirror_dir(repo_cache_dir: Path) -> Path:
+    return repo_cache_dir / "mirror.git"
+
+
+def _worktrees_dir(repo_cache_dir: Path) -> Path:
+    return repo_cache_dir / "worktrees"
+
+
+def _checkout_dir_for_commit(repo_cache_dir: Path, commit_sha: str) -> Path:
+    return _worktrees_dir(repo_cache_dir) / commit_sha.lower()
+
+
+def _build_clone_url(repo_url: str, gh_token: str | None = None) -> str:
+    if repo_url.startswith("github.com/"):
+        token_prefix = f"{quote(gh_token, safe='')}@" if gh_token else ""
+        return f"https://{token_prefix}{repo_url}"
+
+    if gh_token and repo_url.startswith(("https://github.com/", "http://github.com/")):
+        parsed = urlsplit(repo_url)
+        if "@" not in parsed.netloc:
+            return urlunsplit(
+                (
+                    parsed.scheme,
+                    f"{quote(gh_token, safe='')}@{parsed.netloc}",
+                    parsed.path,
+                    parsed.query,
+                    parsed.fragment,
+                )
+            )
+
+    return repo_url
+
+
+def _redact_clone_error_detail(detail: str, gh_token: str | None = None) -> str:
+    if not gh_token:
+        return detail
+    redacted = detail.replace(gh_token, "<redacted>")
+    quoted_token = quote(gh_token, safe="")
+    if quoted_token != gh_token:
+        redacted = redacted.replace(quoted_token, "<redacted>")
+    return redacted
+
+
+def _git_env(gh_token: str | None) -> dict[str, str]:
+    env = os.environ.copy()
+    if gh_token:
+        env.setdefault("GH_TOKEN", gh_token)
+    return env
+
+
+def _git_required_error() -> RuntimeError:
+    return RuntimeError("git is required to populate the local checkout cache")
+
+
+def _run_git(
+    args: list[str],
+    *,
+    gh_token: str | None = None,
+    cwd: Path | None = None,
+    failure: str,
+) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            args,
+            cwd=cwd,
+            check=True,
+            capture_output=True,
+            text=True,
+            env=_git_env(gh_token),
+        )
+    except FileNotFoundError as exc:
+        raise _git_required_error() from exc
+    except subprocess.CalledProcessError as exc:
+        detail = exc.stderr.strip() or exc.stdout.strip() or str(exc)
+        detail = _redact_clone_error_detail(detail, gh_token)
+        raise RuntimeError(f"{failure}: {detail}") from exc
+
+
+def _ensure_mirror(
+    repo_cache_dir: Path,
+    *,
+    repo_url: str,
+    gh_token: str | None = None,
+) -> Path:
+    mirror_dir = _mirror_dir(repo_cache_dir)
+    clone_url = _build_clone_url(repo_url, gh_token)
+    if not mirror_dir.is_dir():
+        _run_git(
+            ["git", "clone", "--mirror", clone_url, str(mirror_dir)],
+            gh_token=gh_token,
+            failure=f"Failed to clone repo mirror for {repo_url}",
+        )
+        return mirror_dir
+
+    _run_git(
+        ["git", "--git-dir", str(mirror_dir), "remote", "set-url", "origin", clone_url],
+        gh_token=gh_token,
+        failure=f"Failed to update repo mirror origin for {repo_url}",
+    )
+    _run_git(
+        ["git", "--git-dir", str(mirror_dir), "fetch", "--prune", "--tags", "origin"],
+        gh_token=gh_token,
+        failure=f"Failed to fetch repo mirror for {repo_url}",
+    )
+    return mirror_dir
+
+
+def _resolve_local_named_ref(mirror_dir: Path, ref: str) -> str | None:
+    matches: set[str] = set()
+    for candidate in (
+        f"refs/heads/{ref}",
+        f"refs/remotes/origin/{ref}",
+        f"refs/tags/{ref}^{{}}",
+        f"refs/tags/{ref}",
+    ):
+        result = subprocess.run(
+            ["git", "--git-dir", str(mirror_dir), "rev-parse", "--verify", candidate],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            matches.add(result.stdout.strip().lower())
+    if not matches:
+        return None
+    if len(matches) > 1:
+        raise RuntimeError(
+            f"Ref {ref!r} is ambiguous in the local cache; matched {sorted(matches)}"
+        )
+    return next(iter(matches))
+
+
+def _ensure_commit_present(
+    mirror_dir: Path,
+    *,
+    repo_url: str,
+    commit_sha: str,
+    gh_token: str | None = None,
+) -> str:
+    existing = subprocess.run(
+        [
+            "git",
+            "--git-dir",
+            str(mirror_dir),
+            "rev-parse",
+            "--verify",
+            f"{commit_sha}^{{commit}}",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if existing.returncode == 0:
+        return existing.stdout.strip().lower()
+
+    _run_git(
+        [
+            "git",
+            "--git-dir",
+            str(mirror_dir),
+            "fetch",
+            "--depth",
+            "1",
+            "origin",
+            commit_sha,
+        ],
+        gh_token=gh_token,
+        failure=f"Failed to fetch exact commit {commit_sha!r} from {repo_url}",
+    )
+    fetched = _run_git(
+        [
+            "git",
+            "--git-dir",
+            str(mirror_dir),
+            "rev-parse",
+            "--verify",
+            f"{commit_sha}^{{commit}}",
+        ],
+        gh_token=gh_token,
+        failure=f"Failed to resolve exact commit {commit_sha!r} in local cache for {repo_url}",
+    )
+    return fetched.stdout.strip().lower()
+
+
+def _resolve_ref_to_commit(
+    mirror_dir: Path,
+    *,
+    repo_url: str,
+    ref: str,
+    gh_token: str | None = None,
+) -> str:
+    named_ref_commit = _resolve_local_named_ref(mirror_dir, ref)
+    if named_ref_commit is not None:
+        return named_ref_commit
+    if not _FULL_COMMIT_SHA_RE.fullmatch(ref):
+        raise RuntimeError(
+            f"Ref {ref!r} was not found as a branch/tag and is not a full 40-char commit SHA"
+        )
+    return _ensure_commit_present(
+        mirror_dir,
+        repo_url=repo_url,
+        commit_sha=ref.lower(),
+        gh_token=gh_token,
+    )
+
+
+def _materialize_worktree(
+    repo_cache_dir: Path,
+    *,
+    commit_sha: str,
+    required_files: tuple[str, ...] = (),
+) -> Path:
+    mirror_dir = _mirror_dir(repo_cache_dir)
+    checkout_dir = _checkout_dir_for_commit(repo_cache_dir, commit_sha)
+    try:
+        return validate_git_checkout(checkout_dir, required_files=required_files)
+    except ValueError:
+        if checkout_dir.exists():
+            shutil.rmtree(checkout_dir, ignore_errors=True)
+
+    checkout_dir.parent.mkdir(parents=True, exist_ok=True)
+    _run_git(
+        [
+            "git",
+            "--git-dir",
+            str(mirror_dir),
+            "worktree",
+            "add",
+            "--detach",
+            str(checkout_dir),
+            commit_sha,
+        ],
+        failure=f"Failed to materialize checkout for commit {commit_sha}",
+    )
+    return validate_git_checkout(checkout_dir, required_files=required_files)
+
+
+def _prune_stale_worktrees(repo_cache_dir: Path, keep_checkout: Path) -> None:
+    mirror_dir = _mirror_dir(repo_cache_dir)
+    worktrees_dir = _worktrees_dir(repo_cache_dir)
+    if not worktrees_dir.is_dir():
+        return
+    for candidate in worktrees_dir.iterdir():
+        if not candidate.is_dir() or candidate == keep_checkout:
+            continue
+        try:
+            with exclusive_path_lock(
+                candidate,
+                suffix=".upload.lock",
+                nonblocking=True,
+            ):
+                _run_git(
+                    [
+                        "git",
+                        "--git-dir",
+                        str(mirror_dir),
+                        "worktree",
+                        "remove",
+                        "--force",
+                        str(candidate),
+                    ],
+                    failure=f"Failed to remove stale checkout {candidate}",
+                )
+        except BlockingIOError:
+            continue
+        sibling_lock_path(candidate, ".upload.lock").unlink(missing_ok=True)
+    _run_git(
+        ["git", "--git-dir", str(mirror_dir), "worktree", "prune"],
+        failure=f"Failed to prune stale worktree metadata for {mirror_dir}",
+    )
+
+
+def resolve_git_checkout(
+    *,
+    repo_url: str,
+    ref: str,
+    cache_root: Path = DEFAULT_GIT_CHECKOUT_CACHE_ROOT,
+    local_checkout: str | Path | None = None,
+    gh_token: str | None = None,
+    required_files: tuple[str, ...] = (),
+) -> Path:
+    if local_checkout is not None:
+        return validate_git_checkout(
+            Path(local_checkout), required_files=required_files
+        )
+
+    repo_cache_dir = _repo_cache_dir(cache_root.expanduser().resolve(), repo_url)
+    repo_cache_dir.mkdir(parents=True, exist_ok=True)
+    with exclusive_file_lock(repo_cache_dir / ".repo.lock"):
+        mirror_dir = _ensure_mirror(
+            repo_cache_dir,
+            repo_url=repo_url,
+            gh_token=gh_token,
+        )
+        resolved_commit = _resolve_ref_to_commit(
+            mirror_dir,
+            repo_url=repo_url,
+            ref=ref,
+            gh_token=gh_token,
+        )
+        checkout = _materialize_worktree(
+            repo_cache_dir,
+            commit_sha=resolved_commit,
+            required_files=required_files,
+        )
+        _prune_stale_worktrees(repo_cache_dir, checkout)
+        return checkout

--- a/verifiers/envs/experimental/utils/git_checkout_cache.py
+++ b/verifiers/envs/experimental/utils/git_checkout_cache.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import logging
 import os
 from pathlib import Path
 import re
@@ -16,6 +17,8 @@ from verifiers.envs.experimental.utils.file_locks import (
 
 DEFAULT_GIT_CHECKOUT_CACHE_ROOT = Path.home() / ".cache" / "verifiers" / "git-checkouts"
 _FULL_COMMIT_SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+
+logger = logging.getLogger(__name__)
 
 
 def validate_git_checkout(
@@ -161,8 +164,7 @@ def _resolve_local_named_ref(mirror_dir: Path, ref: str) -> str | None:
     for candidate in (
         f"refs/heads/{ref}",
         f"refs/remotes/origin/{ref}",
-        f"refs/tags/{ref}^{{}}",
-        f"refs/tags/{ref}",
+        f"refs/tags/{ref}^{{commit}}",
     ):
         result = subprocess.run(
             ["git", "--git-dir", str(mirror_dir), "rev-parse", "--verify", candidate],
@@ -271,6 +273,10 @@ def _materialize_worktree(
 
     checkout_dir.parent.mkdir(parents=True, exist_ok=True)
     _run_git(
+        ["git", "--git-dir", str(mirror_dir), "worktree", "prune"],
+        failure=f"Failed to prune stale worktree metadata for {mirror_dir}",
+    )
+    _run_git(
         [
             "git",
             "--git-dir",
@@ -314,11 +320,17 @@ def _prune_stale_worktrees(repo_cache_dir: Path, keep_checkout: Path) -> None:
                 )
         except BlockingIOError:
             continue
+        except RuntimeError as exc:
+            logger.warning(str(exc))
+            continue
         sibling_lock_path(candidate, ".upload.lock").unlink(missing_ok=True)
-    _run_git(
-        ["git", "--git-dir", str(mirror_dir), "worktree", "prune"],
-        failure=f"Failed to prune stale worktree metadata for {mirror_dir}",
-    )
+    try:
+        _run_git(
+            ["git", "--git-dir", str(mirror_dir), "worktree", "prune"],
+            failure=f"Failed to prune stale worktree metadata for {mirror_dir}",
+        )
+    except RuntimeError as exc:
+        logger.warning(str(exc))
 
 
 def resolve_git_checkout(


### PR DESCRIPTION
## Description

- Introduce commit-keyed experimental RLM checkout caching with `rlm_ref`
- Add shared experimental utils for git checkout caching and upload locks
- Make stale cached checkouts auto-prune when they are no longer in use

Changes:

- add `verifiers.envs.experimental.utils.git_checkout_cache` for ref resolution, commit-keyed cache materialization, and stale-checkout pruning
- add `verifiers.envs.experimental.utils.file_locks` for shared/exclusive path locks during archive creation and cleanup
- switch the experimental RLM harness to use `rlm_ref` (default `main`) instead of branch-keyed cache resolution
- keep `local_checkout` as a validation-only bypass for an existing checkout
- memoize the resolved checkout per harness instance so one run stays pinned to one resolved commit
- update `ComposableEnv` archive creation to hold a shared lock while reading local upload dirs
- update the focused experimental RLM/composable tests to cover the new cache and locking behavior



## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [x] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how git checkouts are mirrored, materialized, and pruned, and adds filesystem locking around uploads; mistakes could cause flaky caching behavior or unintended deletion of cached worktrees. Scope is limited to experimental harness/utilities but touches subprocess/git and concurrency-sensitive paths.
> 
> **Overview**
> Refactors experimental RLM checkout resolution to use a new shared `verifiers.envs.experimental.utils` package, including generic `file_locks` and a `git_checkout_cache` that maintains a repo mirror plus per-commit worktrees and supports branch/tag/full-SHA refs.
> 
> Updates the RLM harness API from `rlm_branch` to `rlm_ref`, treats `local_checkout` as a validation-only bypass, memoizes the resolved checkout per harness instance, and prunes stale cached worktrees when they are not locked for upload.
> 
> Adds upload-time shared locking in `ComposableEnv._build_dir_archive` to avoid pruning/races while archiving local directories, and expands `test_rlm_composable_env.py` to cover ref-to-commit materialization, per-instance pinning vs. new instance updates, lock-protected stale checkout retention, and GH token redaction on clone errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f0d86bb4308fd40ed854c2786ead4585f73c9a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->