### PR TITLE
Propagate typed exceptions from SWE/Harbor validate_instance

### DIFF
--- a/verifiers/envs/experimental/composable/tasksets/harbor/harbor.py
+++ b/verifiers/envs/experimental/composable/tasksets/harbor/harbor.py
@@ -237,19 +237,24 @@ class HarborTaskSet(SandboxTaskSet):
             )
 
     async def validate_instance(self, state) -> bool:
-        """Apply gold patch, run tests, and check if reward > 0."""
+        """Apply gold patch, run tests, and check if reward > 0.
+
+        Exceptions propagate to the caller (``TaskSet.validate``) so
+        ``CommandTimeoutError`` / ``vf.InfraError`` / gold-apply failures
+        can be classified by their type instead of being flattened into
+        ``test_failed``. Agent rollouts use the rubric (not this method),
+        which keeps its own try/except so a transient failure still scores
+        0 rather than crashing the rollout.
+        """
         sandbox_client = state["sandbox_client"]
         sandbox_id = state["sandbox_id"]
-        try:
-            await self._apply_gold_patch(sandbox_client, sandbox_id, state)
-            test_output = await self._run_tests(
-                sandbox_client, sandbox_id, state, state.get("test_timeout", 900)
-            )
-            state["test_output"] = test_output
-            info = state.get("info") or {}
-            return float(self._calculate_reward(state.get("test_output", ""), info)) > 0
-        except Exception:
-            return False
+        await self._apply_gold_patch(sandbox_client, sandbox_id, state)
+        test_output = await self._run_tests(
+            sandbox_client, sandbox_id, state, state.get("test_timeout", 900)
+        )
+        state["test_output"] = test_output
+        info = state.get("info") or {}
+        return float(self._calculate_reward(state.get("test_output", ""), info)) > 0
 
 
 class HarborDatasetRubric(vf.Rubric):

--- a/verifiers/envs/experimental/composable/tasksets/swe/multi_swe.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/multi_swe.py
@@ -381,16 +381,21 @@ class MultiSWETaskSet(SandboxTaskSet):
         return MultiSWERubric(self)
 
     async def validate_instance(self, state) -> bool:
-        """Apply gold patch, run tests, and check if reward > 0."""
+        """Apply gold patch, run tests, and check if reward > 0.
+
+        Exceptions propagate to the caller (``TaskSet.validate``) so
+        ``CommandTimeoutError`` / ``vf.InfraError`` / gold-apply failures
+        can be classified by their type instead of being flattened into
+        ``test_failed``. Agent rollouts use the rubric (not this method),
+        which keeps its own try/except so a transient failure still scores
+        0 rather than crashing the rollout.
+        """
         sandbox_client = state["sandbox_client"]
         sandbox_id = state["sandbox_id"]
-        try:
-            await self._apply_gold_patch(sandbox_client, sandbox_id, state)
-            test_output = await self._run_tests(
-                sandbox_client, sandbox_id, state, state.get("test_timeout", 900)
-            )
-            state["test_output"] = test_output
-            info = state.get("info") or {}
-            return float(self._calculate_reward(state.get("test_output", ""), info)) > 0
-        except Exception:
-            return False
+        await self._apply_gold_patch(sandbox_client, sandbox_id, state)
+        test_output = await self._run_tests(
+            sandbox_client, sandbox_id, state, state.get("test_timeout", 900)
+        )
+        state["test_output"] = test_output
+        info = state.get("info") or {}
+        return float(self._calculate_reward(state.get("test_output", ""), info)) > 0

--- a/verifiers/envs/experimental/composable/tasksets/swe/openswe.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/openswe.py
@@ -215,16 +215,21 @@ class OpenSWETaskSet(SandboxTaskSet):
         return OpenSWERubric(self)
 
     async def validate_instance(self, state) -> bool:
-        """Apply gold patch, run tests, and check if reward > 0."""
+        """Apply gold patch, run tests, and check if reward > 0.
+
+        Exceptions propagate to the caller (``TaskSet.validate``) so
+        ``CommandTimeoutError`` / ``vf.InfraError`` / gold-apply failures
+        can be classified by their type instead of being flattened into
+        ``test_failed``. Agent rollouts use the rubric (not this method),
+        which keeps its own try/except so a transient failure still scores
+        0 rather than crashing the rollout.
+        """
         sandbox_client = state["sandbox_client"]
         sandbox_id = state["sandbox_id"]
-        try:
-            await self._apply_gold_patch(sandbox_client, sandbox_id, state)
-            test_output = await self._run_tests(
-                sandbox_client, sandbox_id, state, state.get("test_timeout", 900)
-            )
-            state["test_output"] = test_output
-            info = state.get("info") or {}
-            return float(self._calculate_reward(state.get("test_output", ""), info)) > 0
-        except Exception:
-            return False
+        await self._apply_gold_patch(sandbox_client, sandbox_id, state)
+        test_output = await self._run_tests(
+            sandbox_client, sandbox_id, state, state.get("test_timeout", 900)
+        )
+        state["test_output"] = test_output
+        info = state.get("info") or {}
+        return float(self._calculate_reward(state.get("test_output", ""), info)) > 0

--- a/verifiers/envs/experimental/composable/tasksets/swe/r2e_gym.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/r2e_gym.py
@@ -398,16 +398,21 @@ class R2EGymTaskSet(SandboxTaskSet):
         return R2ERubric(self)
 
     async def validate_instance(self, state) -> bool:
-        """Apply gold patch, run tests, and check if reward > 0."""
+        """Apply gold patch, run tests, and check if reward > 0.
+
+        Exceptions propagate to the caller (``TaskSet.validate``) so
+        ``CommandTimeoutError`` / ``vf.InfraError`` / gold-apply failures
+        can be classified by their type instead of being flattened into
+        ``test_failed``. Agent rollouts use the rubric (not this method),
+        which keeps its own try/except so a transient failure still scores
+        0 rather than crashing the rollout.
+        """
         sandbox_client = state["sandbox_client"]
         sandbox_id = state["sandbox_id"]
-        try:
-            await self._apply_gold_patch(sandbox_client, sandbox_id, state)
-            test_output = await self._run_tests(
-                sandbox_client, sandbox_id, state, state.get("test_timeout", 900)
-            )
-            state["test_output"] = test_output
-            info = state.get("info") or {}
-            return float(self._calculate_reward(state.get("test_output", ""), info)) > 0
-        except Exception:
-            return False
+        await self._apply_gold_patch(sandbox_client, sandbox_id, state)
+        test_output = await self._run_tests(
+            sandbox_client, sandbox_id, state, state.get("test_timeout", 900)
+        )
+        state["test_output"] = test_output
+        info = state.get("info") or {}
+        return float(self._calculate_reward(state.get("test_output", ""), info)) > 0

--- a/verifiers/envs/experimental/composable/tasksets/swe/swe_bench.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/swe_bench.py
@@ -627,16 +627,21 @@ class SWEBenchTaskSet(SandboxTaskSet):
         return SWEBenchRubric(self)
 
     async def validate_instance(self, state) -> bool:
-        """Apply gold patch, run tests, and check if reward > 0."""
+        """Apply gold patch, run tests, and check if reward > 0.
+
+        Exceptions propagate to the caller (``TaskSet.validate``) so
+        ``CommandTimeoutError`` / ``vf.InfraError`` / gold-apply failures
+        can be classified by their type instead of being flattened into
+        ``test_failed``. Agent rollouts use the rubric (not this method),
+        which keeps its own try/except so a transient failure still scores
+        0 rather than crashing the rollout.
+        """
         sandbox_client = state["sandbox_client"]
         sandbox_id = state["sandbox_id"]
-        try:
-            await self._apply_gold_patch(sandbox_client, sandbox_id, state)
-            test_output = await self._run_tests(
-                sandbox_client, sandbox_id, state, state.get("test_timeout", 900)
-            )
-            state["test_output"] = test_output
-            info = state.get("info") or {}
-            return float(self._calculate_reward(state.get("test_output", ""), info)) > 0
-        except Exception:
-            return False
+        await self._apply_gold_patch(sandbox_client, sandbox_id, state)
+        test_output = await self._run_tests(
+            sandbox_client, sandbox_id, state, state.get("test_timeout", 900)
+        )
+        state["test_output"] = test_output
+        info = state.get("info") or {}
+        return float(self._calculate_reward(state.get("test_output", ""), info)) > 0


### PR DESCRIPTION
## Summary

Drops the blanket `except Exception: return False` from `validate_instance` in five tasksets: **SWEBench, MultiSWE, R2E-Gym, OpenSWE, Harbor**. The blanket except was flattening `CommandTimeoutError`, `vf.InfraError`, `PaymentRequiredError`, and `RuntimeError("apply failed")` into `reason=test_failed` for anyone running `TaskSet.validate()`, which made it impossible to tell real regressions from infra flakes, timeouts, or billing outages.

`TaskSet.validate()._validate_once` already wraps the call in its own try/except and records `error_type`, so exceptions now reach the classifier with their real type. The streaming classifier in #1169 uses that typed signal to bucket rows into `timeout` / `sandbox_error` / `billing_error` / `gold_apply_failed` rather than lumping them all into `test_failed`.

Matches the equivalent fix already applied to `SWELegoTaskSet` in PR #1149 (`add-swelego-taskset`) — this PR brings the other five tasksets in line so classification is consistent across the composable SWE/Harbor family.

## Why this matters

Concrete failure mode we hit while curating SWE-Lego-Real-Data: a row that genuinely timed out on the sandbox's 60-min budget came back as `reason=test_failed` with an *empty* `test_output_tail` (state["test_output"] never got assigned because `_run_tests` raised). With the blanket except gone, the same row now comes back with `reason=timeout` and `error_type=CommandTimeoutError`, which is the signal `max_retries` / rerun-with-bigger-timeout tooling actually needs.

## Agent rollouts unaffected

Rollouts go through the per-taskset rubric's `solved()` method — which keeps its own try/except so a transient sandbox failure still scores 0 rather than crashing the rollout. The rubric is where transient-failure tolerance belongs (so a training run survives one flaky sandbox); `validate_instance` is where typed signals belong (so dataset curation can distinguish infra from gold-patch bugs).

## Test plan

- [x] `uv run ruff check` / `uv run ruff format --check` / `uv run pre-commit run --files …` all clean across the five files.
- [x] Visual: the five `validate_instance` bodies are now identical in structure to `SWELegoTaskSet.validate_instance` (already merged pattern on `add-swelego-taskset`).
- [ ] Reviewer: run `await taskset.validate(n=5, out_path=...)` on any of the five after merging #1169; confirm that a forced timeout / infra kill now shows up as `reason=timeout` / `reason=sandbox_error` with `error_type` set, not as `reason=test_failed` with an empty tail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior changes in validation/error reporting: callers that relied on `validate_instance` always returning `False` on failure may now see exceptions and need to handle them. Core execution logic is unchanged, but error propagation paths are now exercised.
> 
> **Overview**
> Removes the blanket `except Exception: return False` from `validate_instance` across Harbor and four composable SWE tasksets (SWEBench, MultiSWE, R2E-Gym, OpenSWE), and updates docstrings to clarify the new behavior.
> 
> As a result, gold-patch apply failures, timeouts, and infra/billing errors now **propagate as typed exceptions** to the caller instead of being flattened into a generic `False`/`test_failed`, improving downstream failure classification while leaving rollout scoring to the rubrics’ own error handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1af2ca0277e6a1f34f7b911e9f442f7dc31a713. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->