### PR TITLE
fix: pass explicit 60s timeout to get_background_job in poll_job_completion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "openai>=1.108.1",
     "openai-agents>=0.0.7",
     "prime-tunnel>=0.1.6",
-    "prime-sandboxes>=0.2.21",
+    "prime-sandboxes>=0.2.20",
     "pydantic>=2.11.9",
     "requests",
     "rich",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "openai>=1.108.1",
     "openai-agents>=0.0.7",
     "prime-tunnel>=0.1.6",
-    "prime-sandboxes>=0.2.20",
+    "prime-sandboxes>=0.2.21",
     "pydantic>=2.11.9",
     "requests",
     "rich",

--- a/verifiers/envs/experimental/cli_agent_env.py
+++ b/verifiers/envs/experimental/cli_agent_env.py
@@ -366,7 +366,7 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
         """Poll until background job completes, capturing output."""
         while True:
             status: BackgroundJobStatus = await self.sandbox_client.get_background_job(
-                sandbox_id, background_job
+                sandbox_id, background_job, timeout=60.0
             )
             if status.completed:
                 state["agent_exit_code"] = status.exit_code


### PR DESCRIPTION
## Summary

`CliAgentEnv.poll_job_completion` polls background-job status via `self.sandbox_client.get_background_job(...)`. Without an explicit `timeout`, that call inherits the prime-sandboxes `APIClient` default of 30s (`httpx.Timeout(30.0, connect=10.0)`). When the sandbox gateway is briefly slow on the status read, `httpx.ReadTimeout` fires and `poll_job_completion` wraps it as `AgentError('Agent polling failed: Read file timed out after 30s: /tmp/job_XXX.exit')`.

Observed ~51 such failures on one 30B opencode-math run.

## Change

One line, one kwarg:

```python
status: BackgroundJobStatus = await self.sandbox_client.get_background_job(
    sandbox_id, background_job, timeout=60.0
)
```

### Why 60s (and not higher)?

- 60s doubles the tolerance for a transient gateway blip (which is the actual observed failure mode — short stalls, not permanently-dead reads).
- A much larger value would let a truly stuck gateway wedge the rollout for a long time before the outer retry/timeout machinery gets a chance to intervene; 60s is long enough to absorb a blip, short enough to fail fast on a real hang.
- Raising the `APIClient` default globally would also affect unrelated fast lookups — this keeps the change scoped to the known-slow path.

## Dependency

Requires prime-sandboxes PR [PrimeIntellect-ai/prime#540](https://github.com/PrimeIntellect-ai/prime/pull/540) (merged), which adds the `timeout` kwarg to `get_background_job`. Consumed via prime-sandboxes release PR [PrimeIntellect-ai/prime#541](https://github.com/PrimeIntellect-ai/prime/pull/541) (bumps to `0.2.21`).

The `pyproject.toml` constraint has been bumped to `prime-sandboxes>=0.2.21` (see commit `874faa8f`). **Lockfile update is deferred** until the 0.2.21 release lands on the index — `uv lock` currently fails to resolve because 0.2.21 is not yet published. Once PR #541 merges and the package is published, a follow-up commit will run `uv lock` to pin the resolved version.

## Test plan

- [x] `uv run ruff check verifiers/envs/experimental/cli_agent_env.py` — clean.
- [x] `uv run ruff format --check verifiers/envs/experimental/cli_agent_env.py` — clean.
- [x] `uv run pytest tests/test_cli_agent_env.py` — 17 passed. (No existing coverage of `poll_job_completion`; this change is a kwarg passthrough, so no new tests added.)
- [x] Pre-commit hooks (ruff check, ruff format, ty) passed on commit and push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to background-job polling behavior plus a minor dependency bump; main risk is compatibility/regression if the new `prime-sandboxes` timeout handling behaves unexpectedly.
> 
> **Overview**
> Reduces transient `ReadTimeout` failures when polling sandbox background-job status by passing an explicit `timeout=60.0` to `sandbox_client.get_background_job()` in `CliAgentEnv.poll_job_completion`.
> 
> Bumps `prime-sandboxes` dependency to `>=0.2.21` to pick up the new `timeout` parameter support.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f807c50df90152b31e4d06a49e21c07d3fa5078. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->