### PR TITLE
r2e_gym: add hide_tests_from_agent flag + surface instance_id/repo in validate() output

### DIFF
--- a/verifiers/envs/experimental/composable/tasksets/swe/r2e_gym.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/r2e_gym.py
@@ -116,9 +116,15 @@ def _extract_gold_patch(
 
 
 def _process_example(x):
+    info = {**x}
+    # Expose generic instance_id / repo aliases so TaskSet.validate() can
+    # surface them in JSONL output (R2E-Gym rows natively use commit_hash
+    # and repo_name).
+    info.setdefault("instance_id", x.get("commit_hash"))
+    info.setdefault("repo", x.get("repo_name"))
     return {
         "question": x["problem_statement"],
-        "info": {**x},
+        "info": info,
         "answer": "",
     }
 
@@ -178,6 +184,7 @@ class R2EGymTaskSet(SandboxTaskSet):
         ds_num_proc: int | None = 8,
         ds_keep_in_memory: bool = True,
         timeout_minutes: int = 60,
+        hide_tests_from_agent: bool = True,
     ):
         """
         Args:
@@ -186,6 +193,15 @@ class R2EGymTaskSet(SandboxTaskSet):
                 post-``_process_example`` rows, so predicates see the
                 ``{"question", "info", "answer", ...}`` shape (e.g.
                 ``"lambda x: x['info']['repo_name'] == 'pandas-dev/pandas'"``).
+            hide_tests_from_agent: When True (default), ``setup()`` tars
+                ``/r2e_tests`` off to the host and removes it from the
+                sandbox so the running agent can't read the ground-truth
+                tests; ``_run_tests()`` uploads the archive back at scoring
+                time. Required for fair agent rollouts. Set False when no
+                agent is running (e.g., ``TaskSet.validate()``) to swap in
+                an in-sandbox ``mv /r2e_tests /testbed/r2e_tests`` instead —
+                eliminates the per-row tar/download/upload roundtrip and
+                cuts setup cost by an order of magnitude.
         """
         self.dataset_name = dataset_name
         self.repo_path = repo_path
@@ -194,6 +210,7 @@ class R2EGymTaskSet(SandboxTaskSet):
         self.ds_num_proc = ds_num_proc
         self.ds_keep_in_memory = ds_keep_in_memory
         self.timeout_minutes = timeout_minutes
+        self.hide_tests_from_agent = hide_tests_from_agent
         super().__init__(
             dataset=self._build_dataset(),
             name="swe/r2e",
@@ -248,7 +265,15 @@ class R2EGymTaskSet(SandboxTaskSet):
         }
 
     async def setup(self, state) -> None:
-        """Symlink venv, clean pycache, download r2e_tests to host and remove from sandbox."""
+        """Symlink venv, clean pycache, stage r2e_tests for scoring.
+
+        If ``hide_tests_from_agent`` (default), tars ``/r2e_tests`` off to
+        the host and removes it from the sandbox so the agent can't read
+        the tests while working; ``_run_tests()`` uploads the archive back
+        for scoring. If False (no-agent flows like validate), just
+        ``mv /r2e_tests /testbed/r2e_tests`` in-sandbox — no host I/O,
+        much faster setup.
+        """
         sandbox_client = state["sandbox_client"]
         sandbox_id = state["sandbox_id"]
 
@@ -299,7 +324,13 @@ class R2EGymTaskSet(SandboxTaskSet):
         except Exception as e:
             logger.warning(f"Continuing without deleting pycache: {e!r}")
 
-        # Download r2e_tests to host, remove from sandbox
+        if not self.hide_tests_from_agent:
+            # Fast-path: no agent is running, so tests can live in
+            # /testbed/r2e_tests from the start. No host roundtrip.
+            await _exec(f"mv /r2e_tests {self.repo_path}/r2e_tests", timeout=60)
+            return
+
+        # Agent-safe path: stash tests on host, remove from sandbox.
         remote_archive = "/tmp/r2e_tests.tar.gz"
         local_archive_path = str(Path("/tmp") / f"r2e_tests_{sandbox_id}.tar.gz")
         await _exec(f"tar -C / -czf {remote_archive} r2e_tests", timeout=300)
@@ -320,29 +351,38 @@ class R2EGymTaskSet(SandboxTaskSet):
         state: dict,
         test_timeout: int,
     ) -> str:
-        """Upload cached r2e_tests, run run_tests.sh, return test output."""
-        # Upload cached r2e_tests archive back to sandbox
+        """Restore r2e_tests into /testbed if needed, run run_tests.sh, return output.
+
+        With ``hide_tests_from_agent=True`` (default), setup() parked the
+        tests on the host — upload + extract now. With False, setup()
+        already moved them into ``/testbed/r2e_tests`` in-sandbox, so
+        there's nothing to restore.
+        """
         local_archive_path = state.get("r2e_tests_archive_local_path")
-        if not local_archive_path or not Path(local_archive_path).exists():
+        if local_archive_path and Path(local_archive_path).exists():
+            remote_archive = "/tmp/r2e_tests_roundtrip.tar.gz"
+            await sandbox_client.upload_file(
+                sandbox_id=sandbox_id,
+                file_path=remote_archive,
+                local_file_path=local_archive_path,
+                timeout=300,
+            )
+            results = await sandbox_client.execute_command(
+                sandbox_id,
+                f"tar -C {self.repo_path} -xzf {remote_archive}",
+                timeout=300,
+            )
+            if results.exit_code != 0:
+                raise RuntimeError(
+                    f"Failed to extract r2e_tests: exit_code={results.exit_code}"
+                )
+            Path(local_archive_path).unlink(missing_ok=True)
+            del state["r2e_tests_archive_local_path"]
+        elif self.hide_tests_from_agent:
             raise RuntimeError(
                 f"Missing cached r2e_tests archive: {local_archive_path}"
             )
-        remote_archive = "/tmp/r2e_tests_roundtrip.tar.gz"
-        await sandbox_client.upload_file(
-            sandbox_id=sandbox_id,
-            file_path=remote_archive,
-            local_file_path=local_archive_path,
-            timeout=300,
-        )
-        results = await sandbox_client.execute_command(
-            sandbox_id, f"tar -C {self.repo_path} -xzf {remote_archive}", timeout=300
-        )
-        if results.exit_code != 0:
-            raise RuntimeError(
-                f"Failed to extract r2e_tests: exit_code={results.exit_code}"
-            )
-        Path(local_archive_path).unlink(missing_ok=True)
-        del state["r2e_tests_archive_local_path"]
+        # else: fast-path — setup() already placed tests at /testbed/r2e_tests.
 
         # Build env vars string
         env_str = " ".join(f"{k}={v}" for k, v in self.get_env_vars().items())


### PR DESCRIPTION
## Summary

Two quality-of-life improvements to `R2EGymTaskSet` surfaced while running the full 4578-row gold-patch validation:

### 1. `hide_tests_from_agent: bool = True`

Controls whether `setup()` stashes `/r2e_tests` on the host (current behavior, agent-safe) or leaves it in-sandbox via an in-place `mv /r2e_tests /testbed/r2e_tests` (new fast-path).

**Why it matters.** The current roundtrip is ~2-3 min per row dominated by the tar → `download_file` → `rm` in setup plus the `upload_file` → extract in `_run_tests`. Each of those blocks a `ThreadedAsyncSandboxClient` worker thread for the entire transfer — and `TaskSet.validate()` caps worker count at `min(concurrency // 8, 50)`, so 50 concurrent validate tasks serialize through 6 workers, each pinned on I/O. Under concurrency=50 we measured ~2.4 rows/min; after enabling the fast-path + patching the worker cap we hit ~40 rows/min.

Keep the default `True` for agent rollouts (the hiding is the whole point — R2E-Gym's gold-truth tests can't be visible to the agent). Set `False` when the caller *knows* no agent is involved (e.g. `TaskSet.validate()` for gold-patch validation / dataset cleanup).

### 2. Expose `instance_id` / `repo` aliases in `info`

R2E-Gym rows natively use `commit_hash` and `repo_name`. `TaskSet.validate()` looks for generic `info["instance_id"]` and `info["repo"]` to populate each JSONL row's identity fields — with R2E-Gym those were always `None`, so the streaming log was unreadable. `_process_example` now sets both aliases via `setdefault` so downstream code that reads the original names keeps working.

## Changes

`verifiers/envs/experimental/composable/tasksets/swe/r2e_gym.py`:
- `__init__`: new `hide_tests_from_agent: bool = True` kwarg, stored on self
- `setup()`: branches on the flag — fast-path does a single `mv`, slow-path keeps the existing tar/download/delete roundtrip
- `_run_tests()`: restoration step now conditional on a cached archive; fast-path skips it (tests already in `/testbed/r2e_tests` from setup)
- `_process_example`: adds `instance_id` and `repo` aliases pointing at `commit_hash` / `repo_name`
- Docstrings updated to explain the tradeoff

## Validation

Ran the full 4578-row gold-patch validation (`R2EGymTaskSet(hide_tests_from_agent=False)`) plus a retry pass on 15 pillow sandbox_errors:

| | Count | Rate |
|---|---|---|
| Pass | **4515** | 98.62% |
| test_failed | 62 | 1.35% |
| setup_failed | 1 | 0.02% |
| sandbox_error (post-retry) | 0 | 0% |

Per-row median elapsed dropped from ~300s (slow-path) to ~60s for cached images (fast-path), and the control set of 30 random passing rows showed zero regressions.

The remaining 62 `test_failed` are a mix of real gold-patch regressions (~7-10) and dataset-drift artifacts where our env makes tests pass that `expected_output_json` had marked `FAILED` (~5-10) — visible in future follow-up work but not in scope here.

## Test plan

- [x] Gold-patch validation: 4515/4578 pass (98.62%) with `hide_tests_from_agent=False`
- [x] 30-row passing control set: 30/30 still pass (no setup regressions)
- [x] Pillow sandbox_error retry: 15/15 pass
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how test artifacts are moved between host and sandbox during setup/scoring, which could impact correctness or leak-prevention if misconfigured, though the default preserves current agent-safe behavior.
> 
> **Overview**
> Adds a `hide_tests_from_agent` flag to `R2EGymTaskSet` to choose between the existing agent-safe test staging flow (tar `/r2e_tests` to host, delete in-sandbox, restore on scoring) and a new fast-path for non-agent runs that keeps tests in-sandbox via `mv /r2e_tests /testbed/r2e_tests`.
> 
> Also updates `_run_tests()` to only restore tests when a cached archive exists, and extends `_process_example()` to include `info["instance_id"]` and `info["repo"]` aliases so `TaskSet.validate()` outputs have stable identifiers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab65f3240d053930a0e49db2911fc8253e85fc1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->