### PR TITLE
validate(): extract resume-file parsing into a named helper

### DIFF
--- a/verifiers/envs/experimental/composable/task.py
+++ b/verifiers/envs/experimental/composable/task.py
@@ -375,7 +375,8 @@ class TaskSet:
             with a smaller ``n`` than a prior run shouldn't surface
             out-of-range rows in the returned results or summary stats.
             Malformed / non-JSON lines and rows without an integer ``index``
-            are silently skipped.
+            are silently skipped. Logs a one-line resume summary when any
+            prior rows are found.
             """
             rows: list[dict] = []
             indices: set[int] = set()
@@ -391,6 +392,12 @@ class TaskSet:
                     if isinstance(row.get("index"), int) and row["index"] < total:
                         rows.append(row)
                         indices.add(row["index"])
+            if rows:
+                logger.info(
+                    "Resuming: %d rows already in %s, will skip",
+                    len(rows),
+                    path,
+                )
             return rows, indices
 
         out_path_p = Path(out_path) if out_path is not None else None
@@ -400,12 +407,6 @@ class TaskSet:
             out_path_p.parent.mkdir(parents=True, exist_ok=True)
             if resume and out_path_p.exists():
                 prior_rows, completed_indices = _read_prior_rows(out_path_p)
-                if prior_rows:
-                    logger.info(
-                        "Resuming: %d rows already in %s, will skip",
-                        len(prior_rows),
-                        out_path_p,
-                    )
             else:
                 # truncate so repeated runs don't mix with old output
                 out_path_p.write_text("")

--- a/verifiers/envs/experimental/composable/task.py
+++ b/verifiers/envs/experimental/composable/task.py
@@ -367,29 +367,39 @@ class TaskSet:
             raise ValueError(
                 "resume=True requires out_path; nothing to resume from without a JSONL sink."
             )
+
+        def _read_prior_rows(path: Path) -> tuple[list[dict], set[int]]:
+            """Parse a prior JSONL and return ``(prior_rows, completed_indices)``.
+
+            Only rows whose ``index`` is in ``[0, total)`` are kept — resuming
+            with a smaller ``n`` than a prior run shouldn't surface
+            out-of-range rows in the returned results or summary stats.
+            Malformed / non-JSON lines and rows without an integer ``index``
+            are silently skipped.
+            """
+            rows: list[dict] = []
+            indices: set[int] = set()
+            with path.open() as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        row = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if isinstance(row.get("index"), int) and row["index"] < total:
+                        rows.append(row)
+                        indices.add(row["index"])
+            return rows, indices
+
         out_path_p = Path(out_path) if out_path is not None else None
         prior_rows: list[dict] = []
         completed_indices: set[int] = set()
         if out_path_p is not None:
             out_path_p.parent.mkdir(parents=True, exist_ok=True)
             if resume and out_path_p.exists():
-                with out_path_p.open() as f:
-                    for line in f:
-                        line = line.strip()
-                        if not line:
-                            continue
-                        try:
-                            row = json.loads(line)
-                        except json.JSONDecodeError:
-                            continue
-                        if isinstance(row.get("index"), int):
-                            # only keep rows within the current validation
-                            # range — resuming with a smaller ``n`` than a
-                            # prior run shouldn't surface out-of-range rows
-                            # in the returned results or the summary stats.
-                            if row["index"] < total:
-                                prior_rows.append(row)
-                                completed_indices.add(row["index"])
+                prior_rows, completed_indices = _read_prior_rows(out_path_p)
                 if prior_rows:
                     logger.info(
                         "Resuming: %d rows already in %s, will skip",


### PR DESCRIPTION
## Summary

Addresses [@snimu's readability feedback](https://github.com/PrimeIntellect-ai/verifiers/pull/1169) on the resume block in `TaskSet.validate()` — the previous code was a three-level nested `for`/`try`/`if` chain inline, which obscured the simple intent ("parse prior JSONL, filter to in-range indices").

## Changes

`verifiers/envs/experimental/composable/task.py`:
- Pulls the resume-file reader into a local helper `_read_prior_rows(path) -> (rows, indices)` with a brief docstring explaining the in-range filter rationale.
- Top-level resume flow is now flat and reads top-to-bottom:

  ```python
  if resume and out_path_p.exists():
      prior_rows, completed_indices = _read_prior_rows(out_path_p)
      if prior_rows:
          logger.info("Resuming: %d rows already in %s, will skip", ...)
  else:
      out_path_p.write_text("")
  ```

## No behavior change

Helper preserves existing semantics:
- Only rows whose `index` is in `[0, total)` are kept — resuming with a smaller `n` than a prior run still doesn't leak out-of-range rows into the result list or summary stats.
- Blank / non-JSON lines and rows without an integer `index` are silently skipped (same as before).
- Returns `(rows, indices)` so the main loop's `todo` filter keeps working unchanged.

## Test plan

- [x] `ruff check` / `ruff format --check` clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor confined to `TaskSet.validate()` resume handling; intended behavior is preserved but could affect edge cases around malformed JSONL or index filtering if incorrect.
> 
> **Overview**
> Refactors `TaskSet.validate()` resume logic by extracting prior JSONL parsing into a local `_read_prior_rows()` helper with a docstring, reducing nested control flow.
> 
> Resume behavior remains the same: it reads existing `out_path` JSONL, filters to in-range integer `index` values (`< total`), skips malformed/blank lines, and returns both `prior_rows` and `completed_indices` for subsequent validation and logging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c14c2e3ef4a10af6339411a02c7f7497fcc2c3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->