### PR TITLE
fix: SandboxTimeouts fields must be int (sidecar deserializes as u64)

### DIFF
--- a/tests/test_sandbox_mixin.py
+++ b/tests/test_sandbox_mixin.py
@@ -361,26 +361,29 @@ def test_mixin_teardown_handlers_are_decorated():
 
 def test_sandbox_timeouts_defaults(mixin):
     assert isinstance(mixin.timeouts, SandboxTimeouts)
-    assert mixin.timeouts.read_file == 10.0
-    assert mixin.timeouts.extract == 60.0
-    assert mixin.timeouts.poll == 60.0
-    assert mixin.timeouts.mkdir == 10.0
+    assert mixin.timeouts.read_file == 10
+    assert mixin.timeouts.extract == 60
+    assert mixin.timeouts.poll == 60
+    assert mixin.timeouts.mkdir == 10
+    # Sandbox sidecar deserializes `timeout` as u64, so fields must be int.
+    for field_name in ("read_file", "extract", "poll", "mkdir"):
+        assert isinstance(getattr(mixin.timeouts, field_name), int), field_name
 
 
 def test_sandbox_timeouts_override():
-    custom = SandboxTimeouts(read_file=5.0, extract=120.0)
+    custom = SandboxTimeouts(read_file=5, extract=120)
     obj = ConcreteMixin(max_retries=1, base_delay=0.01, timeouts=custom)
-    assert obj.timeouts.read_file == 5.0
-    assert obj.timeouts.extract == 120.0
+    assert obj.timeouts.read_file == 5
+    assert obj.timeouts.extract == 120
     # Untouched fields remain at defaults.
-    assert obj.timeouts.poll == 60.0
-    assert obj.timeouts.mkdir == 10.0
+    assert obj.timeouts.poll == 60
+    assert obj.timeouts.mkdir == 10
 
 
 def test_sandbox_timeouts_is_frozen():
     t = SandboxTimeouts()
     with pytest.raises(Exception):
-        t.read_file = 99.0  # type: ignore[misc]
+        t.read_file = 99  # type: ignore[misc]
 
 
 def test_read_file_uses_timeouts_default(mixin):
@@ -399,7 +402,7 @@ def test_read_file_uses_timeouts_default_when_configured():
     obj = ConcreteMixin(
         max_retries=1,
         base_delay=0.01,
-        timeouts=SandboxTimeouts(read_file=7.5),
+        timeouts=SandboxTimeouts(read_file=7),
     )
     obj.logger = MagicMock()
     fake_result = MagicMock(content="hi")
@@ -407,17 +410,17 @@ def test_read_file_uses_timeouts_default_when_configured():
 
     asyncio.run(obj.read_file("sb-1", "/tmp/y"))
 
-    obj.sandbox_client.read_file.assert_awaited_once_with("sb-1", "/tmp/y", timeout=7.5)
+    obj.sandbox_client.read_file.assert_awaited_once_with("sb-1", "/tmp/y", timeout=7)
 
 
 def test_read_file_explicit_override_beats_default(mixin):
     fake_result = MagicMock(content="hello")
     mixin.sandbox_client.read_file = AsyncMock(return_value=fake_result)
 
-    asyncio.run(mixin.read_file("sb-1", "/tmp/x", timeout=123.0))
+    asyncio.run(mixin.read_file("sb-1", "/tmp/x", timeout=123))
 
     mixin.sandbox_client.read_file.assert_awaited_once_with(
-        "sb-1", "/tmp/x", timeout=123.0
+        "sb-1", "/tmp/x", timeout=123
     )
 
 
@@ -441,7 +444,7 @@ def test_upload_bundle_respects_custom_extract_timeout():
     obj = ConcreteMixin(
         max_retries=1,
         base_delay=0.01,
-        timeouts=SandboxTimeouts(extract=180.0),
+        timeouts=SandboxTimeouts(extract=180),
     )
     obj.logger = MagicMock()
 
@@ -456,7 +459,7 @@ def test_upload_bundle_respects_custom_extract_timeout():
     asyncio.run(obj.upload_bundle("sb-1", {"a.txt": "x"}, "/tmp/dest"))
 
     _, kwargs = obj.sandbox_client.execute_command.call_args
-    assert kwargs["timeout"] == 180.0
+    assert kwargs["timeout"] == 180
 
 
 def test_cli_agent_env_poll_uses_timeouts_poll():
@@ -469,11 +472,11 @@ def test_cli_agent_env_poll_uses_timeouts_poll():
         env,
         max_retries=1,
         base_delay=0.01,
-        timeouts=SandboxTimeouts(poll=90.0),
+        timeouts=SandboxTimeouts(poll=90),
     )
 
-    assert env.timeouts.poll == 90.0
-    assert env.timeouts.read_file == 10.0  # untouched
+    assert env.timeouts.poll == 90
+    assert env.timeouts.read_file == 10  # untouched
 
 
 def test_cli_agent_env_defaults_match_hardcodes():

--- a/verifiers/envs/experimental/sandbox_mixin.py
+++ b/verifiers/envs/experimental/sandbox_mixin.py
@@ -54,12 +54,17 @@ class SandboxTimeouts:
     and from ``MultiTurnEnv.timeout_seconds`` (wall-clock rollout cap).
     These control individual httpx request-level timeouts against the
     sandbox gateway; override when your sandbox is slow or far away.
+
+    Types are ``int``: the sandbox sidecar deserializes the ``exec``
+    request body's ``timeout`` field as ``u64``, so passing a Python
+    ``float`` (e.g. ``10.0``) JSON-serializes as ``10.0`` and is
+    rejected on the wire.
     """
 
-    read_file: float = 10.0
-    extract: float = 60.0
-    poll: float = 60.0
-    mkdir: float = 10.0
+    read_file: int = 10
+    extract: int = 60
+    poll: int = 60
+    mkdir: int = 10
 
 
 class SandboxMonitorRubric(vf.Rubric):
@@ -319,7 +324,7 @@ class SandboxMixin:
         self,
         sandbox_id: str,
         remote_path: str,
-        timeout: float | None = None,
+        timeout: int | None = None,
     ) -> str | None:
         """Read a file from the sandbox, returning its contents or None on failure."""
         timeout = self.timeouts.read_file if timeout is None else timeout


### PR DESCRIPTION
## Summary

Hotfix for regression introduced by #1207. The sandbox sidecar rejects float timeout values.

## Root cause

- `platform/sandbox/sidecar/src/main.rs:53` — `timeout: Option<u64>` on the exec request body
- `prime-sandboxes/src/prime_sandboxes/sandbox.py:637` — `execute_command(..., timeout: Optional[int] = None)`
- #1207 introduced ```python
  @dataclass(frozen=True)
  class SandboxTimeouts:
      read_file: float = 10.0
      extract:   float = 60.0
      poll:      float = 60.0
      mkdir:     float = 10.0
  ```
  Python JSON-serializes `10.0` as \`10.0\`, which serde rejects when deserializing into \`u64\`.

## Observable regression

\`ComposableEnv.post_sandbox_setup()\` fails on its initial \`mkdir -p …\` exec with the sidecar rejecting the float \`timeout\`. Happens before any rollout turns, before any rubric code — purely in the sandbox bootstrap.

## Fix

- Change \`SandboxTimeouts\` field types + defaults from \`float\` to \`int\`.
- Narrow \`SandboxMixin.read_file\`'s optional \`timeout\` kwarg to \`int | None\`.
- Update tests to use int literals.
- Add a docstring note explaining the u64 contract so nobody accidentally reintroduces floats.

## Verification

- \`tests/test_sandbox_mixin.py\` + \`tests/test_cli_agent_env.py\` + \`tests/test_composable_env.py\`: all pass
- ruff clean, ty clean
- Defaults are byte-identical to the pre-#1207 hardcoded values (10, 60), preserving intent

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes public type hints/defaults for `SandboxTimeouts` and the `SandboxMixin.read_file` timeout parameter, which could affect downstream callers passing floats.
> 
> **Overview**
> Fixes a regression where sandbox request `timeout` values were being JSON-encoded as floats and rejected by the sandbox sidecar.
> 
> `SandboxTimeouts` fields/defaults are switched from `float` to `int`, `SandboxMixin.read_file(timeout=...)` is narrowed to `int | None`, and tests are updated to assert integer timeouts (including a new check that all timeout fields are `int`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8884f20bd198006c1d1a9a4cbac7672f4c28112d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->