### PR TITLE
feat: add disable_compaction kwarg to rlm_harness

### DIFF
--- a/verifiers/envs/experimental/composable/harnesses/rlm.py
+++ b/verifiers/envs/experimental/composable/harnesses/rlm.py
@@ -117,11 +117,9 @@ def rlm_harness(
         resolved_upload_dirs = upload_dirs
         return resolved_upload_dirs
 
-    tool_names = [
-        t
-        for t in DEFAULT_RLM_TOOL_NAMES
-        if not (disable_compaction and t == "summarize")
-    ]
+    tool_names = list(DEFAULT_RLM_TOOL_NAMES)
+    if disable_compaction:
+        tool_names = [t for t in tool_names if t != "summarize"]
 
     return Harness(
         install_script=build_install_script(),

--- a/verifiers/envs/experimental/composable/harnesses/rlm.py
+++ b/verifiers/envs/experimental/composable/harnesses/rlm.py
@@ -95,6 +95,7 @@ def rlm_harness(
     append_to_system_prompt: str | None = None,
     local_checkout: str | Path | None = None,
     gh_token: str | None = None,
+    disable_compaction: bool = False,
 ) -> Harness:
     upload_dir_mapping: dict[str, str] = {
         DEFAULT_RLM_CHECKOUT_UPLOAD_NAME: DEFAULT_RLM_CHECKOUT_PATH,
@@ -116,6 +117,8 @@ def rlm_harness(
         resolved_upload_dirs = upload_dirs
         return resolved_upload_dirs
 
+    tool_names = [t for t in DEFAULT_RLM_TOOL_NAMES if not (disable_compaction and t == "summarize")]
+
     return Harness(
         install_script=build_install_script(),
         run_command=build_run_command(instruction_path, workdir),
@@ -128,5 +131,5 @@ def rlm_harness(
         metrics_path="{workdir}/.rlm/sessions/*/meta.json",
         metrics_key="metrics",
         metrics_prefix="rlm_",
-        tool_names=list(DEFAULT_RLM_TOOL_NAMES),
+        tool_names=tool_names,
     )

--- a/verifiers/envs/experimental/composable/harnesses/rlm.py
+++ b/verifiers/envs/experimental/composable/harnesses/rlm.py
@@ -117,7 +117,11 @@ def rlm_harness(
         resolved_upload_dirs = upload_dirs
         return resolved_upload_dirs
 
-    tool_names = [t for t in DEFAULT_RLM_TOOL_NAMES if not (disable_compaction and t == "summarize")]
+    tool_names = [
+        t
+        for t in DEFAULT_RLM_TOOL_NAMES
+        if not (disable_compaction and t == "summarize")
+    ]
 
     return Harness(
         install_script=build_install_script(),


### PR DESCRIPTION
## Summary
Adds a `disable_compaction: bool = False` kwarg to `rlm_harness()`. When set, removes the `summarize` tool from the harness's tool registry — the model can no longer self-compact conversation history.

## Motivation
In RL ablations (e.g. length-shaping studies), the `summarize` tool lets the model arbitrarily collapse turns, which confounds measurements of context-length effects. We want a simple way to turn it off per-run without editing `DEFAULT_RLM_TOOL_NAMES` globally.

## Scope
RLM has two compaction mechanisms:
1. **Auto-compaction** via `RLM_MAX_TURNS_IN_CONTEXT` — already off by default (env passes `-1`)
2. **Model-callable `summarize` tool** — hardcoded into `DEFAULT_RLM_TOOL_NAMES` before this PR, not user-overridable

This PR addresses (2). (1) is already controllable via existing env arg.

## Change
- `disable_compaction=False` → unchanged behavior (tool_names = `["ipython", "summarize"]`)
- `disable_compaction=True` → `tool_names = ["ipython"]`

Default preserves back-compat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, opt-in change that only filters the harness `tool_names` list and preserves default behavior when the new flag is unset.
> 
> **Overview**
> Adds a `disable_compaction: bool = False` kwarg to `rlm_harness()` to optionally remove the `summarize` tool from the harness tool registry.
> 
> Default behavior is unchanged; when enabled, the harness passes a filtered `tool_names` list (excluding `summarize`) into `Harness(...)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4120679e36a932ce32a063b3ca45a50304266621. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->