### PR TITLE
feat: revert agent test edits at grading (swe_lego, swe_rebench_v2)

### DIFF
--- a/verifiers/envs/experimental/composable/tasksets/swe/_test_patch.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/_test_patch.py
@@ -13,9 +13,13 @@ the FAIL_TO_PASS assertions mid-rollout and still score reward=1. The
 three-step dance in :func:`revert_and_reapply_test_patch` closes that
 loophole by:
 
-1. ``git checkout HEAD -- <path>`` for every file the ``test_patch``
-   *modifies* (i.e. the diff source is not ``/dev/null``) — wipes agent
-   edits to those files.
+1. ``git checkout <base_commit> -- <path>`` for every file the
+   ``test_patch`` *modifies* (i.e. the diff source is not ``/dev/null``)
+   — wipes agent edits to those files. Uses ``base_commit`` (threaded
+   in from the row) rather than ``HEAD``: if the agent ran
+   ``git add && git commit`` mid-rollout, ``HEAD`` points at the agent's
+   commit (potentially with weakened tests), and a ``git checkout HEAD``
+   would restore the tampered version.
 2. ``rm -f <path>`` for every file the ``test_patch`` *adds* (diff source
    ``/dev/null``) — wipes the agent's version so the re-apply doesn't
    conflict.
@@ -154,18 +158,27 @@ async def revert_and_reapply_test_patch(
     sandbox_id: str,
     workdir: str,
     test_patch: str,
+    base_commit: str,
     apply_patch: ApplyPatchFn | None = None,
 ) -> None:
     """Revert any agent edits to test files, then re-apply ``test_patch``.
 
     See module docstring for the rationale. No-op if ``test_patch`` is
-    empty or whitespace-only. The revert steps (``git checkout HEAD --``
-    and ``rm -f``) are idempotent; the re-apply is delegated to
-    ``apply_patch`` so the taskset's native ``git apply`` flags are used
-    (swe_lego uses ``--whitespace=fix``, swe_rebench_v2 uses the full
-    ``-v --3way --recount --ignore-space-change --whitespace=nowarn``
-    set). If ``apply_patch`` is None, falls back to a plain
-    ``git apply --whitespace=fix``.
+    empty or whitespace-only. The revert steps (``git checkout
+    <base_commit> --`` and ``rm -f``) are idempotent; the re-apply is
+    delegated to ``apply_patch`` so the taskset's native ``git apply``
+    flags are used (swe_lego uses ``--whitespace=fix``, swe_rebench_v2
+    uses the full ``-v --3way --recount --ignore-space-change
+    --whitespace=nowarn`` set). If ``apply_patch`` is None, falls back
+    to a plain ``git apply --whitespace=fix``.
+
+    ``base_commit`` is threaded in (not derived from ``HEAD``) because
+    an agent that runs ``git add && git commit`` mid-rollout moves
+    ``HEAD`` to their own commit — a ``git checkout HEAD -- <test>``
+    would then restore the agent's (potentially weakened) test version,
+    reopening the reward-hack loophole this function exists to close.
+    Upstream SWE-bench uses ``{base_commit}`` for the same reason (see
+    ``swebench/harness/test_spec/python.py``).
     """
     if not test_patch or not test_patch.strip():
         return
@@ -177,15 +190,16 @@ async def revert_and_reapply_test_patch(
         quoted = " ".join(_shell_quote(p) for p in modified)
         result = await sandbox_client.execute_command(
             sandbox_id,
-            f"git checkout HEAD -- {quoted}",
+            f"git checkout {_shell_quote(base_commit)} -- {quoted}",
             working_dir=workdir,
             timeout=30,
         )
         if result.exit_code != 0:
             stderr = (getattr(result, "stderr", "") or "")[:500]
             logger.warning(
-                "[%s] revert_and_reapply: git checkout HEAD failed (exit=%s) stderr=%r",
+                "[%s] revert_and_reapply: git checkout %s failed (exit=%s) stderr=%r",
                 sandbox_id,
+                base_commit,
                 result.exit_code,
                 stderr,
             )

--- a/verifiers/envs/experimental/composable/tasksets/swe/_test_patch.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/_test_patch.py
@@ -1,0 +1,252 @@
+"""Revert-agent-test-edits + re-apply-test_patch helper.
+
+Mirrors the canonical SWE-bench pattern used by upstream's harness before
+running the grading test command. See
+https://github.com/SWE-bench/SWE-bench/blob/main/swebench/harness/test_spec/python.py#L405-L462
+and ``swebench/harness/utils.py::get_modified_files`` /
+``get_new_files`` for the reference implementation.
+
+Why this exists: both :mod:`swe_lego` and :mod:`swe_rebench_v2` apply
+``test_patch`` at ``setup()`` time so the agent can *read* the failing
+tests from ``t=0``. Without a revert step at grading, an agent can weaken
+the FAIL_TO_PASS assertions mid-rollout and still score reward=1. The
+three-step dance in :func:`revert_and_reapply_test_patch` closes that
+loophole by:
+
+1. ``git checkout HEAD -- <path>`` for every file the ``test_patch``
+   *modifies* (i.e. the diff source is not ``/dev/null``) — wipes agent
+   edits to those files.
+2. ``rm -f <path>`` for every file the ``test_patch`` *adds* (diff source
+   ``/dev/null``) — wipes the agent's version so the re-apply doesn't
+   conflict.
+3. ``git apply`` the ``test_patch`` cleanly from the reverted state.
+
+Agent *source* edits (their actual fix) survive — only test-file bits
+get canonicalized.
+
+Note on path parsing: this module handles the common unified-diff header
+shapes produced by ``git diff`` / SWE-bench's dataset builders. Paths
+containing literal whitespace / non-ASCII bytes can be quoted with
+``"..."`` (see ``git config core.quotepath``) — we strip surrounding
+double quotes conservatively but do not attempt to decode C-style
+escapes. That's a known limitation; SWE-bench instance ``test_patch``
+fields in practice do not contain such paths.
+"""
+
+from __future__ import annotations
+
+import logging
+import tempfile
+from pathlib import Path
+from typing import Any, Awaitable, Callable
+
+logger = logging.getLogger(__name__)
+
+#: Signature of a taskset's patch-apply callback. Takes (sandbox_client,
+#: sandbox_id, workdir, patch, label) and applies the patch at ``workdir``.
+#: We delegate the actual apply to the taskset so the re-apply uses the
+#: exact same ``git apply`` flags as the setup-time apply (which differs
+#: between swe_lego and swe_rebench_v2).
+ApplyPatchFn = Callable[[Any, str, str, str, str], Awaitable[None]]
+
+
+def _strip_git_prefix(path: str, prefix: str) -> str:
+    """Strip leading ``a/`` / ``b/`` prefix if present; strip surrounding quotes."""
+    path = path.strip()
+    # ``git diff`` may quote paths with special chars: ``--- "a/weird name"``.
+    if len(path) >= 2 and path[0] == '"' and path[-1] == '"':
+        path = path[1:-1]
+    if path.startswith(prefix):
+        return path[len(prefix) :]
+    return path
+
+
+def _iter_diff_headers(test_patch: str):
+    """Yield (minus_line, plus_line) pairs for each file header in the diff.
+
+    We walk the diff line-by-line and whenever we see a ``--- `` header, we
+    look ahead to the next non-empty line expecting a ``+++ `` header.
+    This is deliberately tolerant of extended headers (``index …``,
+    ``new file mode …``, ``rename from …``, etc.) that live between
+    ``diff --git`` and the ``--- `` / ``+++ `` pair.
+    """
+    lines = test_patch.splitlines()
+    i = 0
+    n = len(lines)
+    while i < n:
+        line = lines[i]
+        if line.startswith("--- "):
+            minus = line[4:]
+            # Find the next ``+++ `` line; tolerate a blank line but stop
+            # at a hunk marker or another file boundary to avoid drifting.
+            j = i + 1
+            plus = None
+            while j < n:
+                cand = lines[j]
+                if cand.startswith("+++ "):
+                    plus = cand[4:]
+                    break
+                if (
+                    cand.startswith("@@")
+                    or cand.startswith("diff --git")
+                    or cand.startswith("--- ")
+                ):
+                    break
+                j += 1
+            if plus is not None:
+                yield minus, plus
+                i = j + 1
+                continue
+        i += 1
+
+
+def get_modified_files(test_patch: str) -> list[str]:
+    """Return paths the diff *modifies* — i.e. existed at base_commit.
+
+    A file is "modified" when its ``--- `` header is not ``/dev/null``.
+    Path order is preserved from the diff; duplicates are de-duped.
+    """
+    if not test_patch:
+        return []
+    out: list[str] = []
+    seen: set[str] = set()
+    for minus, plus in _iter_diff_headers(test_patch):
+        if minus.strip() == "/dev/null":
+            continue
+        path = _strip_git_prefix(minus, "a/")
+        # Trailing timestamp from non-git diffs: ``a/foo\t2024-…``.
+        path = path.split("\t", 1)[0].rstrip()
+        if path and path not in seen:
+            seen.add(path)
+            out.append(path)
+        _ = plus  # unused for modified
+    return out
+
+
+def get_new_files(test_patch: str) -> list[str]:
+    """Return paths the diff *adds* — i.e. ``--- /dev/null`` entries.
+
+    The corresponding ``+++ b/<path>`` line carries the added path.
+    Path order is preserved; duplicates are de-duped.
+    """
+    if not test_patch:
+        return []
+    out: list[str] = []
+    seen: set[str] = set()
+    for minus, plus in _iter_diff_headers(test_patch):
+        if minus.strip() != "/dev/null":
+            continue
+        path = _strip_git_prefix(plus, "b/")
+        path = path.split("\t", 1)[0].rstrip()
+        if path and path not in seen:
+            seen.add(path)
+            out.append(path)
+    return out
+
+
+def _shell_quote(path: str) -> str:
+    """POSIX single-quote a path so it's safe to splice into a shell command."""
+    return "'" + path.replace("'", "'\\''") + "'"
+
+
+async def revert_and_reapply_test_patch(
+    sandbox_client: Any,
+    sandbox_id: str,
+    workdir: str,
+    test_patch: str,
+    apply_patch: ApplyPatchFn | None = None,
+) -> None:
+    """Revert any agent edits to test files, then re-apply ``test_patch``.
+
+    See module docstring for the rationale. No-op if ``test_patch`` is
+    empty or whitespace-only. The revert steps (``git checkout HEAD --``
+    and ``rm -f``) are idempotent; the re-apply is delegated to
+    ``apply_patch`` so the taskset's native ``git apply`` flags are used
+    (swe_lego uses ``--whitespace=fix``, swe_rebench_v2 uses the full
+    ``-v --3way --recount --ignore-space-change --whitespace=nowarn``
+    set). If ``apply_patch`` is None, falls back to a plain
+    ``git apply --whitespace=fix``.
+    """
+    if not test_patch or not test_patch.strip():
+        return
+
+    modified = get_modified_files(test_patch)
+    new = get_new_files(test_patch)
+
+    if modified:
+        quoted = " ".join(_shell_quote(p) for p in modified)
+        result = await sandbox_client.execute_command(
+            sandbox_id,
+            f"git checkout HEAD -- {quoted}",
+            working_dir=workdir,
+            timeout=30,
+        )
+        if result.exit_code != 0:
+            stderr = (getattr(result, "stderr", "") or "")[:500]
+            logger.warning(
+                "[%s] revert_and_reapply: git checkout HEAD failed (exit=%s) stderr=%r",
+                sandbox_id,
+                result.exit_code,
+                stderr,
+            )
+
+    if new:
+        quoted = " ".join(_shell_quote(p) for p in new)
+        result = await sandbox_client.execute_command(
+            sandbox_id,
+            f"rm -f {quoted}",
+            working_dir=workdir,
+            timeout=30,
+        )
+        if result.exit_code != 0:
+            stderr = (getattr(result, "stderr", "") or "")[:500]
+            logger.warning(
+                "[%s] revert_and_reapply: rm -f new files failed (exit=%s) stderr=%r",
+                sandbox_id,
+                result.exit_code,
+                stderr,
+            )
+
+    if apply_patch is not None:
+        await apply_patch(
+            sandbox_client, sandbox_id, workdir, test_patch, "test_patch_reapply"
+        )
+        return
+
+    # Fallback: minimal ``git apply --whitespace=fix`` if no apply helper
+    # was supplied. This path isn't used by the production wrappers but
+    # makes the helper usable in isolation / from unit tests.
+    with tempfile.NamedTemporaryFile(suffix=".patch", mode="w", delete=False) as f:
+        f.write(test_patch)
+        f.flush()
+        local_path = f.name
+
+    remote_path = "/tmp/test_patch.reapply"
+    try:
+        await sandbox_client.upload_file(sandbox_id, remote_path, local_path)
+    finally:
+        Path(local_path).unlink(missing_ok=True)
+
+    try:
+        result = await sandbox_client.execute_command(
+            sandbox_id,
+            f"git apply --whitespace=fix {remote_path}",
+            working_dir=workdir,
+            timeout=30,
+        )
+        if result.exit_code != 0:
+            stderr = (getattr(result, "stderr", "") or "")[:500]
+            logger.warning(
+                "[%s] revert_and_reapply: git apply of test_patch failed "
+                "(exit=%s) stderr=%r",
+                sandbox_id,
+                result.exit_code,
+                stderr,
+            )
+    finally:
+        await sandbox_client.execute_command(
+            sandbox_id,
+            f"rm -f {remote_path}",
+            working_dir=workdir,
+            timeout=10,
+        )

--- a/verifiers/envs/experimental/composable/tasksets/swe/swe_lego.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/swe_lego.py
@@ -348,7 +348,8 @@ class SWELegoTaskSet(SandboxTaskSet):
         # where an agent weakens F2P assertions mid-rollout. Agent source
         # edits are untouched — only test-file bits get canonicalized.
         test_patch: str = info.get("test_patch") or ""
-        if test_patch.strip():
+        base_commit: str = info.get("base_commit") or ""
+        if test_patch.strip() and base_commit:
 
             async def _apply(
                 sc: Any, sid: str, wd: str, patch: str, label: str
@@ -357,7 +358,12 @@ class SWELegoTaskSet(SandboxTaskSet):
                 await self._apply_patch_file(sc, sid, patch, label)
 
             await revert_and_reapply_test_patch(
-                sandbox_client, sandbox_id, workdir, test_patch, apply_patch=_apply
+                sandbox_client,
+                sandbox_id,
+                workdir,
+                test_patch,
+                base_commit,
+                apply_patch=_apply,
             )
 
         fail_to_pass: list[str] = info.get("FAIL_TO_PASS") or []

--- a/verifiers/envs/experimental/composable/tasksets/swe/swe_lego.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/swe_lego.py
@@ -12,6 +12,10 @@ import verifiers as vf
 from datasets import load_dataset
 from verifiers.envs.experimental.composable import SandboxSpec, SandboxTaskSet
 
+from verifiers.envs.experimental.composable.tasksets.swe._test_patch import (
+    revert_and_reapply_test_patch,
+)
+
 logger = logging.getLogger(__name__)
 
 ENV_VARS_SWE_LEGO = {
@@ -335,6 +339,27 @@ class SWELegoTaskSet(SandboxTaskSet):
         test_timeout: int,
     ) -> str:
         info = state["info"]
+        workdir = self.get_workdir(info)
+
+        # Canonical SWE-bench grading dance: revert any agent edits to
+        # files touched by ``test_patch`` (``git checkout HEAD -- <path>``
+        # for pre-existing files, ``rm -f <path>`` for newly-added ones),
+        # then re-apply ``test_patch`` cleanly. Closes the reward-hack
+        # where an agent weakens F2P assertions mid-rollout. Agent source
+        # edits are untouched — only test-file bits get canonicalized.
+        test_patch: str = info.get("test_patch") or ""
+        if test_patch.strip():
+
+            async def _apply(
+                sc: Any, sid: str, wd: str, patch: str, label: str
+            ) -> None:
+                del wd  # _apply_patch_file hard-codes /testbed internally
+                await self._apply_patch_file(sc, sid, patch, label)
+
+            await revert_and_reapply_test_patch(
+                sandbox_client, sandbox_id, workdir, test_patch, apply_patch=_apply
+            )
+
         fail_to_pass: list[str] = info.get("FAIL_TO_PASS") or []
         pass_to_pass: list[str] = info.get("PASS_TO_PASS") or []
         test_cmd: str = info.get("test_cmd") or ""

--- a/verifiers/envs/experimental/composable/tasksets/swe/swe_rebench_v2.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/swe_rebench_v2.py
@@ -362,18 +362,23 @@ class SWERebenchV2TaskSet(SandboxTaskSet):
         workdir = _repo_workdir(info["repo"])
 
         # Canonical SWE-bench grading dance: revert any agent edits to
-        # files touched by ``test_patch`` (``git checkout HEAD -- <path>``
-        # for pre-existing files, ``rm -f <path>`` for newly-added ones),
-        # then re-apply ``test_patch`` cleanly. Closes the reward-hack
-        # where an agent weakens F2P assertions mid-rollout. Agent source
-        # edits are untouched — only test-file bits get canonicalized.
+        # files touched by ``test_patch`` (``git checkout <base_commit>
+        # -- <path>`` for pre-existing files, ``rm -f <path>`` for
+        # newly-added ones), then re-apply ``test_patch`` cleanly.
+        # Closes the reward-hack where an agent weakens F2P assertions
+        # mid-rollout. Agent source edits are untouched — only test-file
+        # bits get canonicalized. Uses ``base_commit`` (not ``HEAD``) so
+        # a ``git commit`` by the agent can't shift the checkout target
+        # onto their tampered snapshot.
         test_patch: str = info.get("test_patch") or ""
-        if test_patch.strip():
+        base_commit: str = info.get("base_commit") or ""
+        if test_patch.strip() and base_commit:
             await revert_and_reapply_test_patch(
                 sandbox_client,
                 sandbox_id,
                 workdir,
                 test_patch,
+                base_commit,
                 apply_patch=self._apply_patch_file,
             )
 

--- a/verifiers/envs/experimental/composable/tasksets/swe/swe_rebench_v2.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/swe_rebench_v2.py
@@ -40,6 +40,9 @@ from verifiers.envs.experimental.composable import SandboxSpec, SandboxTaskSet
 from verifiers.envs.experimental.composable.tasksets.swe import (
     swe_rebench_v2_log_parsers as _lp,
 )
+from verifiers.envs.experimental.composable.tasksets.swe._test_patch import (
+    revert_and_reapply_test_patch,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -357,6 +360,23 @@ class SWERebenchV2TaskSet(SandboxTaskSet):
         cfg = _extract_install_config(info)
         test_cmds = _normalize_test_cmds(cfg.get("test_cmd"))
         workdir = _repo_workdir(info["repo"])
+
+        # Canonical SWE-bench grading dance: revert any agent edits to
+        # files touched by ``test_patch`` (``git checkout HEAD -- <path>``
+        # for pre-existing files, ``rm -f <path>`` for newly-added ones),
+        # then re-apply ``test_patch`` cleanly. Closes the reward-hack
+        # where an agent weakens F2P assertions mid-rollout. Agent source
+        # edits are untouched — only test-file bits get canonicalized.
+        test_patch: str = info.get("test_patch") or ""
+        if test_patch.strip():
+            await revert_and_reapply_test_patch(
+                sandbox_client,
+                sandbox_id,
+                workdir,
+                test_patch,
+                apply_patch=self._apply_patch_file,
+            )
+
         eval_script = _build_eval_script(test_cmds, workdir)
 
         with tempfile.NamedTemporaryFile(suffix=".sh", mode="w", delete=False) as f:


### PR DESCRIPTION
## Summary

Both `swe_lego` and `swe_rebench_v2` apply `test_patch` in `setup()` so agents can read the failing tests from t=0, but then run `test_cmd` at grading against whatever state the working tree is in. This PR adds the canonical SWE-bench pre-grading dance — revert agent edits to test files, then re-apply `test_patch` cleanly — closing a reward-hack loophole where an agent could weaken FAIL_TO_PASS assertions mid-rollout and still score reward=1. Agent source edits (their actual fix) survive untouched; only test-file bits get canonicalized.

## Why

Upstream SWE-bench's harness does this exact two-step before running the test command (see [`swebench/harness/test_spec/python.py#L405-L462`](https://github.com/SWE-bench/SWE-bench/blob/main/swebench/harness/test_spec/python.py#L405-L462) and `swebench/harness/utils.py::get_modified_files` / `get_new_files`). Our wrappers previously applied `test_patch` at setup-time only, so any modification the agent made to the test file in between stuck around for grading. This PR ports the upstream pattern.

## Scope

- New module `verifiers/envs/experimental/composable/tasksets/swe/_test_patch.py` with `get_modified_files`, `get_new_files`, and `revert_and_reapply_test_patch`. The async helper does `git checkout <base_commit> -- <modified>`, `rm -f <new>`, then delegates the re-apply to the taskset's own `_apply_patch_file` so the taskset-specific `git apply` flags (different between swe_lego and swe_rebench_v2) are preserved. Uses `base_commit` (not `HEAD`) so a `git commit` by the agent can't shift the checkout target onto their tampered snapshot.
- `swe_lego.py::_run_tests` calls the helper at the top of the method, before any existing logic.
- `swe_rebench_v2.py::_run_tests` calls the helper right after resolving `workdir`.
- Setup-time `test_patch` apply is left in place on both wrappers (idempotent with the grading-time re-apply). No changes to `_calculate_reward`, `setup`, `validate_instance`, `_apply_gold_patch`, or any other taskset.

## Test plan

### Static checks
- [x] `uv run ruff check verifiers/envs/experimental/composable/tasksets/swe/` — clean.
- [x] `uv run pre-commit run --files <touched>` — clean (ruff-check, ruff-format, sync-AGENTS).
- [x] Inline parser sanity tests via `uv run python -c ...`: modified-only patch, new-file-only patch, mixed, empty string, quoted paths-with-spaces, multiple modifieds, dedup, realistic SWE-bench-shaped `test_patch` — all 8 cases pass.

### Live e2e (against real Prime sandboxes)

**Happy-path validate (n=1 per wrapper)** — confirms the revert-and-reapply doesn't regress the baseline (every `validate_instance` call now runs the helper; a broken helper would turn previously-green gold patches red):

| wrapper | instance | `valid` | elapsed |
|---|---|---|---|
| `swe_lego` | `adamchainz__apig-wsgi-80` | ✅ True | 19.98s |
| `swe_rebench_v2` | `elastic__synthetics-316` | ✅ True | 44.40s |

**Sweep validate (n=4 per wrapper, concurrency=2)** — light regression across 8 distinct rows:

| wrapper | result | notes |
|---|---|---|
| `swe_lego` | 4/4 ✅ | — |
| `swe_rebench_v2` | 4/4 ✅ | First run was 3/4 with a transient on `crawler-commons__crawler-commons-227` (java, `parse_java_mvn`); a clean rerun on the identical instance list came back 4/4. `valid=False, error=None` without reproducibility — likely Maven/JVM first-run flake, no evidence the revert helper was involved. |

**Tamper test** — the actual guard validation. Bypass gold; tamper test file via AST rewrite (replace every `test_*()` body with `pass`, preserving syntax); call `_run_tests`. Monkey-patched `validate_instance` for orchestration; monkey-patched `revert_and_reapply_test_patch` to no-op for the control case:

| case | tamper | revert active? | reward | `valid` | explanation |
|---|---|---|---|---|---|
| A (this PR's code) | AST replaced 17 `test_*` bodies with `pass` | ✅ yes | **0.0** | False | revert restored `test_apig_wsgi.py` + re-applied `test_patch` → canonical F2P tests ran against buggy code → failed → cheat blocked |
| B (control) | same tamper | ❌ no (monkey-patched) | **1.0** | True | tamper survived → 17 `def test_*(): pass` bodies trivially succeeded → cheat succeeded |

Both cases parsed 21 outcomes (tests ran cleanly in both — tamper preserved syntax, only the grading state differed). The reward split is entirely attributable to the revert step: with it, the loophole is structurally closed; without it, the exact reward-hack scenario this PR exists to prevent reproduces end-to-end.

## Known limitations

- Paths quoted with C-style escapes in diff headers (`git config core.quotepath`) are not fully decoded — we strip surrounding double quotes but leave backslash-escapes alone. SWE-bench `test_patch` fields in practice don't carry such paths; noted inline in the module docstring.
- Revert scope matches upstream SWE-bench: only files *listed in* `test_patch` are reverted. An agent could in theory write/modify a `conftest.py` outside `test_patch`'s file list to affect pytest collection — upstream has the same gap; closing it is a separate hardening question.