### PR TITLE
fix: respect framework-injected OPENAI_API_KEY in RLM and opencode harnesses

### DIFF
--- a/verifiers/envs/experimental/composable/harnesses/opencode.py
+++ b/verifiers/envs/experimental/composable/harnesses/opencode.py
@@ -113,7 +113,7 @@ def build_opencode_config(
                 "name": provider_display_name or provider_key,
                 "options": {
                     "baseURL": "$OPENAI_BASE_URL",
-                    "apiKey": "intercepted",
+                    "apiKey": "${OPENAI_API_KEY:-intercepted}",
                     "timeout": provider_timeout_ms,
                 },
                 "models": {

--- a/verifiers/envs/experimental/composable/harnesses/rlm.py
+++ b/verifiers/envs/experimental/composable/harnesses/rlm.py
@@ -64,7 +64,7 @@ def build_run_command(
 set -eo pipefail
 export PATH="$HOME/.local/bin:$PATH"
 export RLM_MODEL=$OPENAI_MODEL
-export OPENAI_API_KEY=intercepted
+export OPENAI_API_KEY="${{OPENAI_API_KEY:-intercepted}}"
 export RLM_APPEND_TO_SYSTEM_PROMPT="$(cat {shlex.quote(DEFAULT_APPEND_TO_SYSTEM_PROMPT_PATH)} 2>/dev/null || true)"
 cd "${{AGENT_WORKDIR:-{workdir}}}"
 


### PR DESCRIPTION
## Summary

Follow-up to #1180 (INTERCEPTION_SECRET auth). The RLM and opencode harnesses both hardcoded the literal `"intercepted"` as the agent's OpenAI API key — a placeholder from when the interception proxy did no auth. After #1180, `build_env_vars` injects the real `INTERCEPTION_SECRET` as `OPENAI_API_KEY`; the hardcoded values clobbered it and every agent request hit the proxy with `Bearer intercepted` → 401.

## Fix

Use bash-style default expansion `${OPENAI_API_KEY:-intercepted}` in both sites. Preserves the pre-auth path when no secret is configured.

- `verifiers/envs/experimental/composable/harnesses/rlm.py`: `export OPENAI_API_KEY="${OPENAI_API_KEY:-intercepted}"` in the shell run command
- `verifiers/envs/experimental/composable/harnesses/opencode.py`: `"apiKey": "${OPENAI_API_KEY:-intercepted}"` in the generated `opencode.json`

Two-line diff total.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches credential propagation in harness run/config generation; a small shell-expansion change but can affect authentication behavior across agents if mis-specified.
> 
> **Overview**
> Prevents composable harnesses from clobbering a framework-injected `OPENAI_API_KEY` by switching hardcoded `intercepted` placeholders to shell default expansion (`${OPENAI_API_KEY:-intercepted}`).
> 
> This updates both the RLM run wrapper and the OpenCode `opencode.json` generation to *use the real key when present* while retaining the prior `intercepted` fallback when it is not set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b17e7acd6b16979aac71976313ced5248effc864. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->