### PR TITLE
fix: handle dict word_list in TextArenaEnv.ta_to_hf()

### DIFF
--- a/verifiers/envs/integrations/textarena_env.py
+++ b/verifiers/envs/integrations/textarena_env.py
@@ -136,6 +136,12 @@ class TextArenaEnv(vf.MultiTurnEnv):
         eval_dataset_rows = []
         _, user_prompt = self.ta_env.get_observation()
         words = self.ta_env.word_list
+        if isinstance(words, dict):
+            words = [
+                w
+                for values in words.values()
+                for w in (values if isinstance(values, (list, tuple)) else [values])
+            ]
         # set seed
         random.seed(self.seed)
         for i in range(self.num_train_examples + self.num_eval_examples):


### PR DESCRIPTION
## Summary

- `TextArenaEnv.ta_to_hf()` called `random.choice(words)` assuming `word_list` is a sequence, but games like `TwentyQuestions-v0` expose a categorized dict instead, causing a `KeyError` on integer indices.
- Fix flattens dict values into a list before sampling, matching how the official Wordle environment on the Hub works.

## Test plan

- [ ] Instantiate `TextArenaEnv(game="TwentyQuestions-v0")` and confirm no `KeyError` on init
- [ ] Confirm existing `Wordle-v0` behavior is unchanged (list word_list path unchanged)

Closes #1074



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small defensive change isolated to dataset generation logic, only altering how `word_list` is normalized before `random.choice`.
> 
> **Overview**
> Fixes `TextArenaEnv.ta_to_hf()` to handle TextArena games where `word_list` is a dict (e.g., categorized words) by flattening dict values into a list before sampling.
> 
> This prevents sampling/index errors while keeping existing behavior unchanged when `word_list` is already a sequence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5e7075995dac51b765ed4f3a94f997e2df6a745. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->