### PR TITLE
fix: correct timing accumulation in RubricGroup

### DIFF
--- a/tests/test_rubric_group.py
+++ b/tests/test_rubric_group.py
@@ -380,6 +380,90 @@ class TestRubricGroup:
         assert hasattr(group, "parser")
 
     @pytest.mark.asyncio
+    async def test_rubric_group_score_rollout_timing(self):
+        """Test that score_rollout sets timing correctly across multiple rubrics."""
+
+        def func1(completion, **kwargs):
+            return 1.0
+
+        def func2(completion, **kwargs):
+            return 0.5
+
+        rubric1 = Rubric(funcs=[func1], weights=[1.0])
+        rubric2 = Rubric(funcs=[func2], weights=[1.0])
+        group = RubricGroup(rubrics=[rubric1, rubric2])
+
+        state = State(
+            input=RolloutInput(
+                prompt=[{"role": "user", "content": "Test"}],
+                answer="2",
+                task="default",
+                example_id=0,
+            )
+        )
+        state["completion"] = [{"role": "assistant", "content": "2"}]
+        state["trajectory"] = []
+        state["timing"] = RolloutTiming(
+            generation_ms=100.0,
+            scoring_ms=0.0,
+            total_ms=100.0,
+            start_time=0.0,
+        )
+
+        await group.score_rollout(state)
+
+        assert state["timing"]["scoring_ms"] >= 0.0
+        # total_ms should equal generation_ms plus the group's scoring_ms
+        assert state["timing"]["total_ms"] == pytest.approx(
+            100.0 + state["timing"]["scoring_ms"], abs=1.0
+        )
+        # scoring_ms should not accumulate across rubrics (not N * per-rubric time)
+        assert state["timing"]["scoring_ms"] < 1000.0
+
+    @pytest.mark.asyncio
+    async def test_rubric_group_score_group_timing(self):
+        """Test that score_group sets timing correctly across multiple rubrics."""
+
+        def func1(completion, **kwargs):
+            return 1.0
+
+        def func2(completion, **kwargs):
+            return 0.5
+
+        rubric1 = Rubric(funcs=[func1], weights=[1.0])
+        rubric2 = Rubric(funcs=[func2], weights=[1.0])
+        group = RubricGroup(rubrics=[rubric1, rubric2])
+
+        states = []
+        for i in range(2):
+            state = State(
+                input=RolloutInput(
+                    prompt=[{"role": "user", "content": "Test"}],
+                    answer="2",
+                    task="default",
+                    example_id=i,
+                )
+            )
+            state["completion"] = [{"role": "assistant", "content": "2"}]
+            state["trajectory"] = []
+            state["timing"] = RolloutTiming(
+                generation_ms=50.0,
+                scoring_ms=0.0,
+                total_ms=50.0,
+                start_time=0.0,
+            )
+            states.append(state)
+
+        await group.score_group(states)
+
+        for state in states:
+            assert state["timing"]["scoring_ms"] >= 0.0
+            # total_ms should equal generation_ms plus the group's scoring_ms
+            assert state["timing"]["total_ms"] == pytest.approx(
+                50.0 + state["timing"]["scoring_ms"], abs=1.0
+            )
+
+    @pytest.mark.asyncio
     async def test_rubric_group_score_rollout_uses_rubric_parser(self):
         """Ensure individual rubric parsers are respected during score_rollout."""
 

--- a/verifiers/rubrics/rubric_group.py
+++ b/verifiers/rubrics/rubric_group.py
@@ -1,3 +1,4 @@
+import time
 from typing import Any
 
 from verifiers.rubrics.rubric import Rubric
@@ -62,6 +63,8 @@ class RubricGroup(Rubric):
         original_metrics = (
             state.get("metrics", {}).copy() if state.get("metrics") else {}
         )
+        original_timing = state["timing"].copy()
+        start_time = time.time()
         for rubric in self.rubrics:
             await rubric.score_rollout(state)
             rubric_reward = state.get("reward", 0.0)
@@ -74,8 +77,12 @@ class RubricGroup(Rubric):
             # restore original values for next rubric
             state["reward"] = original_reward
             state["metrics"] = original_metrics.copy()
+            state["timing"] = original_timing.copy()
+        scoring_ms = (time.time() - start_time) * 1000
         state["reward"] = total_reward
         state["metrics"] = aggregated_metrics
+        state["timing"]["scoring_ms"] = scoring_ms
+        state["timing"]["total_ms"] = original_timing["total_ms"] + scoring_ms
 
     async def cleanup(self, state: State):
         """Run cleanup for all rubrics in the group."""
@@ -100,6 +107,8 @@ class RubricGroup(Rubric):
             state.get("metrics", {}).copy() if state.get("metrics") else {}
             for state in states
         ]
+        original_timings = [state["timing"].copy() for state in states]
+        start_time = time.time()
         for rubric in self.rubrics:
             await rubric.score_group(states)
             for i, state in enumerate(states):
@@ -114,6 +123,8 @@ class RubricGroup(Rubric):
                     aggregated_metrics[key][i] += value
                 state["reward"] = original_rewards[i]
                 state["metrics"] = original_metrics[i].copy()
+                state["timing"] = original_timings[i].copy()
+        scoring_ms = (time.time() - start_time) * 1000
         for i, state in enumerate(states):
             state["reward"] = aggregated_rewards[i]
             if aggregated_metrics:
@@ -121,3 +132,5 @@ class RubricGroup(Rubric):
                     state["metrics"] = {}
                 for key, values in aggregated_metrics.items():
                     state["metrics"][key] = values[i]
+            state["timing"]["scoring_ms"] = scoring_ms
+            state["timing"]["total_ms"] = original_timings[i]["total_ms"] + scoring_ms


### PR DESCRIPTION
## Summary

- `RubricGroup.score_rollout` and `score_group` called each sub-rubric's scoring method, which wrote its own `scoring_ms` and accumulated into `total_ms`. After N rubrics, `scoring_ms` held only the last rubric's time while `total_ms` was inflated N times over.
- Fix: save and restore timing state across sub-rubric calls, then compute one `scoring_ms` for the whole group and write it once at the end so `generation_ms + scoring_ms == total_ms`.
- Adds two timing-correctness tests.

## Test plan

- [ ] `test_rubric_group_score_rollout_timing` passes: `total_ms == generation_ms + scoring_ms`
- [ ] `test_rubric_group_score_group_timing` passes: same invariant holds for each state in a group
- [ ] Existing rubric group tests still pass

Closes #952


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are localized to `RubricGroup` timing bookkeeping and add tests; main behavioral impact is corrected `scoring_ms`/`total_ms` reporting for grouped scoring.
> 
> **Overview**
> Fixes `RubricGroup.score_rollout` and `score_group` so per-rubric scoring no longer inflates rollout timing: timing is saved/restored across sub-rubric calls, then a single group-level `scoring_ms` is computed and written once, keeping `total_ms` consistent.
> 
> Adds async tests asserting `total_ms == generation_ms + scoring_ms` for both single-rollout and multi-state group scoring, and that scoring time does not scale linearly with the number of rubrics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b96d263c2757731b0523004442e6cbde8aa41f08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->