### PR TITLE
fix: preserve inner task names and raise on unknown task in EnvGroup

### DIFF
--- a/assets/lab/environments/AGENTS.md
+++ b/assets/lab/environments/AGENTS.md
@@ -786,7 +786,25 @@ combined = vf.EnvGroup(
 )
 ```
 
-The group concatenates all sub-environment datasets, tagging each row with a `task` column that routes rollouts to the appropriate environment for generation and scoring. Metrics from all environments are tracked together. 
+The group concatenates all sub-environment datasets, tagging each row with a `task` column that routes rollouts to the appropriate environment for generation and scoring. Metrics from all environments are tracked together.
+
+Passing an unknown task name to `get_env_for_task` raises a `ValueError` listing the available task names, making misconfiguration immediately visible rather than silently misrouting to the first sub-environment.
+
+An `EnvGroup` can itself be used as a sub-environment inside another `EnvGroup`. The outer group automatically inherits the inner group's task names and routes through both levels, so each inner task name maps correctly to its environment:
+
+```python
+inner = vf.EnvGroup(
+    envs=[math_env, code_env],
+    env_names=["math", "code"],
+)
+
+# prime-rl wraps user envs this way; task names are preserved through both levels
+outer = vf.EnvGroup(envs=[inner], env_names=["my_env"])
+# outer.get_env_for_task("math") -> inner -> math_env
+# outer.get_env_for_task("code") -> inner -> code_env
+```
+
+Task names must be unique across all levels of nesting; a collision raises `ValueError` at construction time.
 
 ## Performance
 

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -780,7 +780,25 @@ combined = vf.EnvGroup(
 )
 ```
 
-The group concatenates all sub-environment datasets, tagging each row with a `task` column that routes rollouts to the appropriate environment for generation and scoring. Metrics from all environments are tracked together. 
+The group concatenates all sub-environment datasets, tagging each row with a `task` column that routes rollouts to the appropriate environment for generation and scoring. Metrics from all environments are tracked together.
+
+Passing an unknown task name to `get_env_for_task` raises a `ValueError` listing the available task names, making misconfiguration immediately visible rather than silently misrouting to the first sub-environment.
+
+An `EnvGroup` can itself be used as a sub-environment inside another `EnvGroup`. The outer group automatically inherits the inner group's task names and routes through both levels, so each inner task name maps correctly to its environment:
+
+```python
+inner = vf.EnvGroup(
+    envs=[math_env, code_env],
+    env_names=["math", "code"],
+)
+
+# prime-rl wraps user envs this way; task names are preserved through both levels
+outer = vf.EnvGroup(envs=[inner], env_names=["my_env"])
+# outer.get_env_for_task("math") -> inner -> math_env
+# outer.get_env_for_task("code") -> inner -> code_env
+```
+
+Task names must be unique across all levels of nesting; a collision raises `ValueError` at construction time.
 
 ## Performance
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -471,11 +471,15 @@ OpenEnv integration that runs OpenEnv projects in Prime Sandboxes using a prebui
 ```python
 env_group = vf.EnvGroup(
     envs=[env1, env2, env3],
-    names=["math", "code", "qa"]  # optional
+    env_names=["math", "code", "qa"]  # optional
 )
 ```
 
-Combines multiple environments for mixed-task training.
+Combines multiple environments for mixed-task training. Each row in the concatenated dataset is tagged with a `task` column that routes rollouts and scoring to the correct sub-environment.
+
+`get_env_for_task(task)` raises `ValueError` for unknown task names (listing available tasks) rather than silently falling back to `envs[0]`.
+
+An `EnvGroup` can be nested inside another `EnvGroup`. The outer group automatically inherits the inner group's task names so routing works through both levels. Task names must be unique across all nesting levels; a collision raises `ValueError` at construction time.
 
 ---
 

--- a/environments/AGENTS.md
+++ b/environments/AGENTS.md
@@ -786,7 +786,25 @@ combined = vf.EnvGroup(
 )
 ```
 
-The group concatenates all sub-environment datasets, tagging each row with a `task` column that routes rollouts to the appropriate environment for generation and scoring. Metrics from all environments are tracked together. 
+The group concatenates all sub-environment datasets, tagging each row with a `task` column that routes rollouts to the appropriate environment for generation and scoring. Metrics from all environments are tracked together.
+
+Passing an unknown task name to `get_env_for_task` raises a `ValueError` listing the available task names, making misconfiguration immediately visible rather than silently misrouting to the first sub-environment.
+
+An `EnvGroup` can itself be used as a sub-environment inside another `EnvGroup`. The outer group automatically inherits the inner group's task names and routes through both levels, so each inner task name maps correctly to its environment:
+
+```python
+inner = vf.EnvGroup(
+    envs=[math_env, code_env],
+    env_names=["math", "code"],
+)
+
+# prime-rl wraps user envs this way; task names are preserved through both levels
+outer = vf.EnvGroup(envs=[inner], env_names=["my_env"])
+# outer.get_env_for_task("math") -> inner -> math_env
+# outer.get_env_for_task("code") -> inner -> code_env
+```
+
+Task names must be unique across all levels of nesting; a collision raises `ValueError` at construction time.
 
 ## Performance
 

--- a/tests/test_env_group.py
+++ b/tests/test_env_group.py
@@ -353,8 +353,38 @@ class TestEnvGroup:
 
         assert env_group.get_env_for_task("math") == env1
         assert env_group.get_env_for_task("code") == env2
-        # Unknown task returns first environment as fallback
-        assert env_group.get_env_for_task("unknown") == env1
+        # Unknown task should raise rather than silently misroute
+        with pytest.raises(ValueError, match="No environment found for task"):
+            env_group.get_env_for_task("unknown")
+
+    def test_nested_env_group_preserves_inner_tasks(self, mock_client):
+        """Wrapping an EnvGroup in another EnvGroup must preserve inner task names."""
+        env1 = SingleTurnEnv(
+            client=mock_client,
+            model="test-model",
+            dataset=Dataset.from_dict({"question": ["q1"], "answer": ["a1"]}),
+            rubric=Rubric(),
+        )
+        env2 = SingleTurnEnv(
+            client=mock_client,
+            model="test-model",
+            dataset=Dataset.from_dict({"question": ["q2"], "answer": ["a2"]}),
+            rubric=Rubric(),
+        )
+
+        inner_group = EnvGroup(envs=[env1, env2], env_names=["math", "code"])
+        outer_group = EnvGroup(envs=[inner_group], env_names=["my_env"])
+
+        # Inner task names should be present in the outer env_map
+        assert outer_group.get_env_for_task("math") is inner_group
+        assert outer_group.get_env_for_task("code") is inner_group
+
+        # Dataset should retain the inner task labels
+        dataset = outer_group.get_dataset()
+        tasks = set(dataset["task"])
+        assert "math" in tasks
+        assert "code" in tasks
+        assert "my_env" not in tasks
 
     @pytest.mark.asyncio
     async def test_env_group_generate(self, mock_client, make_input):

--- a/tests/test_env_group.py
+++ b/tests/test_env_group.py
@@ -379,12 +379,36 @@ class TestEnvGroup:
         assert outer_group.get_env_for_task("math") is inner_group
         assert outer_group.get_env_for_task("code") is inner_group
 
+        # Stale outer name should be removed so it does not cause misleading lookups
+        with pytest.raises(ValueError, match="No environment found for task"):
+            outer_group.get_env_for_task("my_env")
+
         # Dataset should retain the inner task labels
         dataset = outer_group.get_dataset()
         tasks = set(dataset["task"])
         assert "math" in tasks
         assert "code" in tasks
         assert "my_env" not in tasks
+
+    def test_nested_env_group_name_collision_raises(self, mock_client):
+        """A nested EnvGroup whose inner task name collides with a sibling env raises."""
+        env1 = SingleTurnEnv(
+            client=mock_client,
+            model="test-model",
+            dataset=Dataset.from_dict({"question": ["q1"], "answer": ["a1"]}),
+            rubric=Rubric(),
+        )
+        env2 = SingleTurnEnv(
+            client=mock_client,
+            model="test-model",
+            dataset=Dataset.from_dict({"question": ["q2"], "answer": ["a2"]}),
+            rubric=Rubric(),
+        )
+
+        inner_group = EnvGroup(envs=[env1], env_names=["math"])
+        # "math" is both an inner task name and the name of a sibling env
+        with pytest.raises(ValueError, match="conflicts with an existing task name"):
+            EnvGroup(envs=[inner_group, env2], env_names=["group", "math"])
 
     @pytest.mark.asyncio
     async def test_env_group_generate(self, mock_client, make_input):

--- a/verifiers/envs/env_group.py
+++ b/verifiers/envs/env_group.py
@@ -173,6 +173,29 @@ class EnvGroup(vf.Environment):
 
             return add_task
 
+        def _register_nested_env_map(inner_env: "EnvGroup", outer_name: str) -> None:
+            """Expand a nested EnvGroup's task names into the outer env_map.
+
+            Registers each inner task name pointing to inner_env, then removes the
+            outer_name entry unless that name is also an inner task name (which would
+            mean the pop would undo the registration we just did).
+            Raises ValueError if an inner task name conflicts with a pre-existing
+            sibling env entry.
+            """
+            for inner_name in inner_env.env_map:
+                if (
+                    inner_name in self.env_map
+                    and self.env_map[inner_name] is not inner_env
+                ):
+                    raise ValueError(
+                        f"Inner task name '{inner_name}' from nested EnvGroup "
+                        f"'{outer_name}' conflicts with an existing task name in the "
+                        f"outer EnvGroup. Use unique task names across all levels."
+                    )
+                self.env_map[inner_name] = inner_env
+            if outer_name not in inner_env.env_map:
+                self.env_map.pop(outer_name, None)
+
         for env, name in zip(self.envs, self.env_names):
             add_task = make_add_task_fn(name)
 
@@ -181,20 +204,7 @@ class EnvGroup(vf.Environment):
             if env_dataset is not None:
                 if isinstance(env, EnvGroup):
                     # Preserve inner task names so routing works through both levels.
-                    # Register each inner task name pointing to the inner EnvGroup,
-                    # and remove the stale outer name to avoid misleading lookups.
-                    for inner_name in env.env_map:
-                        if (
-                            inner_name in self.env_map
-                            and self.env_map[inner_name] is not env
-                        ):
-                            raise ValueError(
-                                f"Inner task name '{inner_name}' from nested EnvGroup "
-                                f"'{name}' conflicts with an existing task name in the "
-                                f"outer EnvGroup. Use unique task names across all levels."
-                            )
-                        self.env_map[inner_name] = env
-                    self.env_map.pop(name, None)
+                    _register_nested_env_map(env, name)
                 else:
                     # override task column to use env_name for routing
                     if "task" in env_dataset.column_names:
@@ -205,18 +215,7 @@ class EnvGroup(vf.Environment):
             env_eval_dataset = env.build_eval_dataset()
             if env_eval_dataset is not None:
                 if isinstance(env, EnvGroup):
-                    for inner_name in env.env_map:
-                        if (
-                            inner_name in self.env_map
-                            and self.env_map[inner_name] is not env
-                        ):
-                            raise ValueError(
-                                f"Inner task name '{inner_name}' from nested EnvGroup "
-                                f"'{name}' conflicts with an existing task name in the "
-                                f"outer EnvGroup. Use unique task names across all levels."
-                            )
-                        self.env_map[inner_name] = env
-                    self.env_map.pop(name, None)
+                    _register_nested_env_map(env, name)
                 else:
                     # override task column to use env_name for routing
                     if "task" in env_eval_dataset.column_names:

--- a/verifiers/envs/env_group.py
+++ b/verifiers/envs/env_group.py
@@ -179,18 +179,28 @@ class EnvGroup(vf.Environment):
             # Build dataset if using DatasetBuilder, returns None if not available
             env_dataset = env.build_dataset()
             if env_dataset is not None:
-                # override task column to use env_name for routing
-                if "task" in env_dataset.column_names:
-                    env_dataset = env_dataset.remove_columns(["task"])
-                env_dataset = env_dataset.map(add_task, **map_kwargs)
+                if isinstance(env, EnvGroup):
+                    # Preserve inner task names so routing works through both levels.
+                    # Register each inner task name pointing to the inner EnvGroup.
+                    for inner_name in env.env_map:
+                        self.env_map[inner_name] = env
+                else:
+                    # override task column to use env_name for routing
+                    if "task" in env_dataset.column_names:
+                        env_dataset = env_dataset.remove_columns(["task"])
+                    env_dataset = env_dataset.map(add_task, **map_kwargs)
                 datasets.append(env_dataset)
             # Build eval_dataset if using DatasetBuilder, returns None if not available
             env_eval_dataset = env.build_eval_dataset()
             if env_eval_dataset is not None:
-                # override task column to use env_name for routing
-                if "task" in env_eval_dataset.column_names:
-                    env_eval_dataset = env_eval_dataset.remove_columns(["task"])
-                env_eval_dataset = env_eval_dataset.map(add_task, **map_kwargs)
+                if isinstance(env, EnvGroup):
+                    for inner_name in env.env_map:
+                        self.env_map[inner_name] = env
+                else:
+                    # override task column to use env_name for routing
+                    if "task" in env_eval_dataset.column_names:
+                        env_eval_dataset = env_eval_dataset.remove_columns(["task"])
+                    env_eval_dataset = env_eval_dataset.map(add_task, **map_kwargs)
                 eval_datasets.append(env_eval_dataset)
         dataset = concatenate_datasets(datasets) if datasets else None
         eval_dataset = concatenate_datasets(eval_datasets) if eval_datasets else None
@@ -320,7 +330,13 @@ class EnvGroup(vf.Environment):
         return await env.rollout(input, client, model, sampling_args)
 
     def get_env_for_task(self, task: str) -> vf.Environment:
-        return self.env_map.get(task, self.envs[0])
+        env = self.env_map.get(task)
+        if env is None:
+            available = list(self.env_map.keys())
+            raise ValueError(
+                f"No environment found for task '{task}'. Available tasks: {available}"
+            )
+        return env
 
     def set_max_seq_len(self, max_seq_len: int | None) -> None:
         """Set the max_seq_len value for this environment group and all sub-environments."""

--- a/verifiers/envs/env_group.py
+++ b/verifiers/envs/env_group.py
@@ -181,9 +181,20 @@ class EnvGroup(vf.Environment):
             if env_dataset is not None:
                 if isinstance(env, EnvGroup):
                     # Preserve inner task names so routing works through both levels.
-                    # Register each inner task name pointing to the inner EnvGroup.
+                    # Register each inner task name pointing to the inner EnvGroup,
+                    # and remove the stale outer name to avoid misleading lookups.
                     for inner_name in env.env_map:
+                        if (
+                            inner_name in self.env_map
+                            and self.env_map[inner_name] is not env
+                        ):
+                            raise ValueError(
+                                f"Inner task name '{inner_name}' from nested EnvGroup "
+                                f"'{name}' conflicts with an existing task name in the "
+                                f"outer EnvGroup. Use unique task names across all levels."
+                            )
                         self.env_map[inner_name] = env
+                    self.env_map.pop(name, None)
                 else:
                     # override task column to use env_name for routing
                     if "task" in env_dataset.column_names:
@@ -195,7 +206,17 @@ class EnvGroup(vf.Environment):
             if env_eval_dataset is not None:
                 if isinstance(env, EnvGroup):
                     for inner_name in env.env_map:
+                        if (
+                            inner_name in self.env_map
+                            and self.env_map[inner_name] is not env
+                        ):
+                            raise ValueError(
+                                f"Inner task name '{inner_name}' from nested EnvGroup "
+                                f"'{name}' conflicts with an existing task name in the "
+                                f"outer EnvGroup. Use unique task names across all levels."
+                            )
                         self.env_map[inner_name] = env
+                    self.env_map.pop(name, None)
                 else:
                     # override task column to use env_name for routing
                     if "task" in env_eval_dataset.column_names:


### PR DESCRIPTION
## Summary

Two related fixes for `EnvGroup` task routing:

**1. Nested EnvGroup silently misroutes all tasks to envs[0]**

When an `EnvGroup` is wrapped inside another `EnvGroup` (as prime-rl does when registering user envs), the outer group was unconditionally overwriting the inner task names with a single outer name. The inner `EnvGroup` then could not find those outer names in its own `env_map` and silently fell back to `envs[0]` for every rollout, and scored everything as 0.0.

Fix: when a sub-env is itself an `EnvGroup`, register each of its task names in the outer `env_map` pointing to the inner group, and leave the inner task column in the dataset unchanged. Routing then flows `outer -> inner group -> correct sub-env` as expected.

**2. Silent fallback masks misconfiguration**

`get_env_for_task` was returning `envs[0]` for any unrecognized task. This made it impossible to notice routing failures. It now raises `ValueError` with the list of available task names.

## Test plan

- [ ] `test_get_env_for_task` updated: unknown task raises `ValueError` instead of returning `envs[0]`
- [ ] `test_nested_env_group_preserves_inner_tasks`: wrapping an EnvGroup preserves inner task names in dataset and env_map
- [ ] All existing `TestEnvGroup` and `TestEnvGroupRubric` tests still pass

Closes #1008


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core rollout routing behavior in `EnvGroup` (now raises on unknown tasks and alters nested task mapping), which could surface previously-hidden misconfigurations and break callers relying on fallback behavior.
> 
> **Overview**
> **EnvGroup task routing is now strict and nesting-safe.** `EnvGroup` preserves inner `task` labels when an `EnvGroup` is wrapped inside another `EnvGroup`, expands the outer `env_map` to include the inner task names, and rejects task-name collisions at construction time.
> 
> **Misconfiguration is no longer silent.** `get_env_for_task` now raises a `ValueError` listing available tasks rather than defaulting to `envs[0]`; tests were updated/added for unknown-task errors, nested routing, and name-collision handling, and docs were updated to describe the new behavior (including `env_names` in the reference).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50dbd92e1e6314dc9dbb6bd8b32bf9f6e97d445d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->