### PR TITLE
tunnel log callback

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "nest-asyncio>=1.6.0", # for jupyter notebooks
     "openai>=1.108.1",
     "openai-agents>=0.0.7",
-    "prime-tunnel>=0.1.6",
+    "prime-tunnel>=0.1.7",
     "prime-sandboxes>=0.2.21",
     "pydantic>=2.11.9",
     "requests",

--- a/verifiers/envs/experimental/cli_agent_env.py
+++ b/verifiers/envs/experimental/cli_agent_env.py
@@ -185,8 +185,10 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
                     try:
                         registered = await self._tunnel.check_registered()
                         if not registered:
+                            frpc_output = "\n".join(self._tunnel.recent_output)
                             self.logger.warning(
-                                "Tunnel registration expired server-side, recreating."
+                                "Tunnel registration expired server-side, recreating. "
+                                f"frpc output:\n{frpc_output}"
                             )
                             self._tunnel.sync_stop()
                             self._tunnel = None
@@ -198,13 +200,15 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
             if self._tunnel is None:
                 interception_server = self._require_interception_server()
                 port = interception_server.port
+                tunnel_log_cb = lambda line: self.logger.debug(f"tunnel: {line}")
                 if self.logger.isEnabledFor(logging.DEBUG):
                     self._tunnel = Tunnel(
                         local_port=port,
                         log_level="debug",
+                        log_callback=tunnel_log_cb,
                     )
                 else:
-                    self._tunnel = Tunnel(local_port=port)
+                    self._tunnel = Tunnel(local_port=port, log_callback=tunnel_log_cb)
                 url = await self._tunnel.start()
                 self._tunnel_last_checked = time.time()
                 self.logger.debug(f"Prime Tunnel started: {url}")


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to logging/observability around tunnel lifecycle plus a patch-level dependency bump, with no functional changes to sandbox execution flow.
> 
> **Overview**
> Improves Prime Tunnel observability in `CliAgentEnv.get_tunnel_url()` by wiring a `log_callback` (emitting tunnel output to debug logs) and including recent `frpc` output when server-side registration expires and the tunnel is recreated.
> 
> Bumps the `prime-tunnel` dependency from `0.1.6` to `0.1.7` to support the new callback behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7e907d64b9ffe0c87b2741eefc367f90b27d86b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->