### PR TITLE
fix: offload composable _upload_dir tar build to thread

### DIFF
--- a/verifiers/envs/experimental/composable/composable_env.py
+++ b/verifiers/envs/experimental/composable/composable_env.py
@@ -36,6 +36,7 @@ harnesses that need a per-instance workdir while still using a static
 
 from __future__ import annotations
 
+import asyncio
 import importlib.resources as resources
 import json
 import logging
@@ -300,9 +301,16 @@ class ComposableEnv(CliAgentEnv):
         local_source: Traversable | Path,
         remote_dest: str,
     ) -> None:
-        """Tar, upload, and extract a directory into the sandbox."""
+        """Tar, upload, and extract a directory into the sandbox.
+
+        Building the gzipped tar is sync, CPU-bound, and for large sources can
+        take hundreds of milliseconds; offload it to a worker thread so the
+        event loop stays responsive when many rollouts upload in parallel.
+        """
         remote_tar = f"/tmp/_upload_{remote_dest.strip('/').replace('/', '_')}.tar.gz"
-        tmp_path = self._build_dir_archive(local_source, remote_dest)
+        tmp_path = await asyncio.to_thread(
+            self._build_dir_archive, local_source, remote_dest
+        )
         try:
             await self.upload_file(sandbox_id, remote_tar, str(tmp_path))
             dest_parent = shlex.quote(str(Path(remote_dest).parent))


### PR DESCRIPTION
## Summary

- `ComposableEnv._upload_dir` builds a gzipped tar of the local upload source per rollout via the sync `_build_dir_archive`.
- For sources of even a few MB the tar + gzip runs in the hundreds of milliseconds. When a worker services many rollouts concurrently (e.g. 128/worker), every rollout's setup path hits this call at the same time and the event loop stalls for tens of seconds.
- Observed in practice as `verifiers.serve.server.env_router.EnvRouter - WARNING - Worker N heartbeat timeout (33.5s), restarting` with no rollout progress while the loop was pinned on tar work.

Fix: wrap the `_build_dir_archive` call in `asyncio.to_thread` so it runs on a worker thread and the event loop is free to drive sandbox I/O, heartbeats, and everything else concurrently.

The existing `shared_path_lock` inside `_build_dir_archive` still serializes writers against a shared source, so this change doesn't weaken any invariants — it just stops starving the loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces `asyncio.to_thread` into the directory upload path, changing concurrency/threading behavior; while low surface area, any thread-safety or exception-handling issues could impact sandbox setup across many parallel rollouts.
> 
> **Overview**
> **Prevents event-loop stalls during sandbox directory uploads.** `ComposableEnv._upload_dir` now builds the tar.gz archive via `asyncio.to_thread(...)` instead of running the CPU-bound `_build_dir_archive` synchronously.
> 
> This keeps the async worker responsive (heartbeats and sandbox I/O) when many rollouts upload large directories in parallel, and updates the docstring/imports accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 783a3c6b61cbe68df4c76f19068ca80fb1b4df88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->