### PR TITLE
chore: v0.1.13.dev5 dev release

### DIFF
--- a/assets/release/RELEASE_v0.1.13.dev5.md
+++ b/assets/release/RELEASE_v0.1.13.dev5.md
@@ -10,6 +10,10 @@
 
 ## Changes included in v0.1.13.dev5 (since v0.1.13.dev4)
 
+### Latest changes from main
+
+- Includes the latest `main` changes through the interception proxy streaming resilience fix (#1194), along with the `mini_swe_agent` harness (#1219) and `SandboxMixin` VM sandbox support/docs (#1222).
+
 ### Features and enhancements
 
 - Add mini-swe-agent harness (#1219)

--- a/assets/release/RELEASE_v0.1.13.dev5.md
+++ b/assets/release/RELEASE_v0.1.13.dev5.md
@@ -1,0 +1,22 @@
+# Verifiers v0.1.13.dev5 Release Notes
+
+*Date:* 04/22/2026
+
+## Highlights since v0.1.13.dev4
+
+- Made the interception proxy's streaming response resilient to upstream cuts: 10s SSE keepalive comments keep idle streams warm, per-chunk `asyncio.sleep(0)` forces an event-loop yield so content and close can't race the transport flush under warmup-burst contention, and transport exceptions at prepare/write/write_eof are surfaced as `StreamInterrupted` into `state["error"]` so rollouts reschedule instead of looking like clean zero-turn completions.
+- Added a new experimental `mini_swe_agent` composable harness (pip/uv install with SHA256-verified wheel download), exported alongside existing `rlm` and `opencode` harnesses.
+- Extended `SandboxMixin` to cover VM sandboxes in addition to containers (including GPU VMs via `CreateSandboxRequest`), with documentation clarifying feature parity (file I/O, background jobs, cleanup) and container-only features (port exposure, SSH).
+
+## Changes included in v0.1.13.dev5 (since v0.1.13.dev4)
+
+### Features and enhancements
+
+- Add mini-swe-agent harness (#1219)
+- Update `SandboxMixin` (#1222)
+
+### Fixes and maintenance
+
+- fix: make interception proxy streaming resilient to upstream cuts (#1194)
+
+**Full Changelog**: https://github.com/PrimeIntellect-ai/verifiers/compare/v0.1.13.dev4...v0.1.13.dev5

--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.13.dev4"
+__version__ = "0.1.13.dev5"
 
 import importlib
 import os


### PR DESCRIPTION
## Summary
- Bump version from `0.1.13.dev4` to `0.1.13.dev5`
- Add release notes covering changes since `v0.1.13.dev4`

## Highlights since v0.1.13.dev4
- Made the interception proxy's streaming response resilient to upstream cuts: 10s SSE keepalive comments keep idle streams warm, per-chunk `asyncio.sleep(0)` forces an event-loop yield so content and close can't race the transport flush under warmup-burst contention, and transport exceptions at prepare/write/write_eof are surfaced as `StreamInterrupted` into `state["error"]` so rollouts reschedule instead of looking like clean zero-turn completions. (#1194)
- Added a new experimental `mini_swe_agent` composable harness (pip/uv install with SHA256-verified wheel download), exported alongside existing `rlm` and `opencode` harnesses. (#1219)
- Extended `SandboxMixin` to cover VM sandboxes in addition to containers (including GPU VMs via `CreateSandboxRequest`), with documentation clarifying feature parity (file I/O, background jobs, cleanup) and container-only features (port exposure, SSH). (#1222)

## Changes since v0.1.13.dev4
- fix: make interception proxy streaming resilient to upstream cuts (#1194)
- Add mini-swe-agent harness (#1219)
- Update `SandboxMixin` (#1222)

### Linked PRs
- #1194
- #1219
- #1222

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only bumps the package version and adds release notes; no runtime logic changes are included in this PR diff.
> 
> **Overview**
> Bumps `verifiers` version from `0.1.13.dev4` to `0.1.13.dev5`.
> 
> Adds `RELEASE_v0.1.13.dev5.md` with release notes summarizing upstream changes included in this dev release (proxy streaming resilience, experimental `mini_swe_agent` harness, and `SandboxMixin` VM sandbox support/docs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71534d8090bdc5659c370a6f47c509d7bbd4fde6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->