### PR TITLE
rlm_harness: own RLM_MAX_TURNS / _IN_CONTEXT / _EXEC_TIMEOUT env vars

### DIFF
--- a/verifiers/envs/experimental/composable/harnesses/__init__.py
+++ b/verifiers/envs/experimental/composable/harnesses/__init__.py
@@ -1,5 +1,7 @@
 from verifiers.envs.experimental.composable.harnesses.rlm import (
+    DEFAULT_RLM_EXEC_TIMEOUT,
     DEFAULT_RLM_MAX_TURNS,
+    DEFAULT_RLM_MAX_TURNS_IN_CONTEXT,
     DEFAULT_RLM_REF,
     DEFAULT_RLM_REPO_URL,
     build_install_script as build_rlm_install_script,
@@ -31,6 +33,8 @@ __all__ = [
     "DEFAULT_RLM_REF",
     "DEFAULT_RLM_REPO_URL",
     "DEFAULT_RLM_MAX_TURNS",
+    "DEFAULT_RLM_MAX_TURNS_IN_CONTEXT",
+    "DEFAULT_RLM_EXEC_TIMEOUT",
     "opencode_harness",
     "build_opencode_install_script",
     "build_opencode_config",

--- a/verifiers/envs/experimental/composable/harnesses/rlm.py
+++ b/verifiers/envs/experimental/composable/harnesses/rlm.py
@@ -15,6 +15,8 @@ from verifiers.envs.experimental.utils.git_checkout_cache import (
 DEFAULT_RLM_REPO_URL = "github.com/PrimeIntellect-ai/rlm.git"
 DEFAULT_RLM_REF = "main"
 DEFAULT_RLM_MAX_TURNS = 100
+DEFAULT_RLM_MAX_TURNS_IN_CONTEXT = -1
+DEFAULT_RLM_EXEC_TIMEOUT = 300
 DEFAULT_APPEND_TO_SYSTEM_PROMPT_PATH = "/task/append_to_system_prompt.txt"
 DEFAULT_RLM_CHECKOUT_PATH = "/tmp/rlm-checkout"
 DEFAULT_RLM_CHECKOUT_UPLOAD_NAME = "rlm_checkout"
@@ -98,6 +100,9 @@ def rlm_harness(
     instruction_path: str = "/task/instruction.md",
     rlm_repo_url: str = DEFAULT_RLM_REPO_URL,
     rlm_ref: str = DEFAULT_RLM_REF,
+    rlm_max_turns: int = DEFAULT_RLM_MAX_TURNS,
+    rlm_max_turns_in_context: int = DEFAULT_RLM_MAX_TURNS_IN_CONTEXT,
+    rlm_exec_timeout: int = DEFAULT_RLM_EXEC_TIMEOUT,
     append_to_system_prompt: str | None = None,
     local_checkout: str | Path | None = None,
     gh_token: str | None = None,
@@ -106,13 +111,20 @@ def rlm_harness(
 ) -> Harness:
     """Build an RLM harness.
 
-    ``rlm_tools`` is the single source of truth for which builtin tools are
-    active. The same list drives both ``Harness.tool_names`` (so
-    ``ToolMonitorRubric`` tracks exactly the active tools) and
-    ``Harness.environment_vars["RLM_TOOLS"]`` (so the RLM sandbox advertises
-    the same set to the model). Callers do not need to — and should not —
-    add ``RLM_TOOLS`` to ``ComposableEnv(environment_vars=...)`` themselves;
-    the harness owns it.
+    The harness is the single source of truth for every ``RLM_*`` sandbox
+    env var the RLM subprocess reads. Kwargs map 1:1 onto env vars written
+    to ``Harness.environment_vars`` and merged into the sandbox by
+    ``ComposableEnv`` (harness-wins):
+
+    - ``rlm_tools`` → ``RLM_TOOLS`` (also drives ``Harness.tool_names`` so
+      ``ToolMonitorRubric`` tracks exactly the active tools)
+    - ``rlm_max_turns`` → ``RLM_MAX_TURNS``
+    - ``rlm_max_turns_in_context`` → ``RLM_MAX_TURNS_IN_CONTEXT``
+    - ``rlm_exec_timeout`` → ``RLM_EXEC_TIMEOUT``
+
+    Callers do not need to — and should not — add these keys to
+    ``ComposableEnv(environment_vars=...)`` themselves; pass the kwargs
+    here and the harness owns the env var plumbing.
 
     ``allow_git`` defaults to False, mirroring opencode's bash tool. When
     False, a ``/usr/local/bin/git`` shim is uploaded that refuses on any
@@ -163,7 +175,12 @@ def rlm_harness(
         metrics_key="metrics",
         metrics_prefix="rlm_",
         tool_names=tool_names,
-        environment_vars={"RLM_TOOLS": ",".join(tool_names)},
+        environment_vars={
+            "RLM_TOOLS": ",".join(tool_names),
+            "RLM_MAX_TURNS": str(rlm_max_turns),
+            "RLM_MAX_TURNS_IN_CONTEXT": str(rlm_max_turns_in_context),
+            "RLM_EXEC_TIMEOUT": str(rlm_exec_timeout),
+        },
         post_install_uploads=post_install_uploads,
         post_install_script=post_install_script,
     )


### PR DESCRIPTION
## Description

Extends the pattern that already makes rlm_harness the single source of truth for RLM_TOOLS: add rlm_max_turns / rlm_max_turns_in_context / rlm_exec_timeout kwargs that map 1:1 onto the matching RLM_* env vars on Harness.environment_vars. Research envs can stop setting these themselves via ComposableEnv(environment_vars=...) — the harness-wins merge inside ComposableEnv.build_env_vars already lands them in the sandbox.

Adds two module-level default constants alongside the existing DEFAULT_RLM_MAX_TURNS: DEFAULT_RLM_MAX_TURNS_IN_CONTEXT = -1 and DEFAULT_RLM_EXEC_TIMEOUT = 300. Behaviour is additive: unspecified kwargs pick up the same defaults the research envs use today, so existing callers are unaffected.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how RLM runtime limits are injected into the sandbox (turn limits and exec timeout), which could alter agent behavior if callers relied on setting these env vars elsewhere.
> 
> **Overview**
> `rlm_harness` now owns additional RLM sandbox configuration by adding `rlm_max_turns`, `rlm_max_turns_in_context`, and `rlm_exec_timeout` kwargs and exporting them as `RLM_MAX_TURNS`, `RLM_MAX_TURNS_IN_CONTEXT`, and `RLM_EXEC_TIMEOUT` in `Harness.environment_vars` (alongside `RLM_TOOLS`).
> 
> It introduces new defaults (`DEFAULT_RLM_MAX_TURNS_IN_CONTEXT = -1`, `DEFAULT_RLM_EXEC_TIMEOUT = 300`) and re-exports these constants from `harnesses/__init__.py`, clarifying in-docstring that callers should pass kwargs rather than setting `RLM_*` via `ComposableEnv(environment_vars=...)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 793a1f6b50a2341250fed83b68e576834fef88bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->