### PR TITLE
fix: NeMo RL client token id preservation

### DIFF
--- a/tests/test_nemorl_client.py
+++ b/tests/test_nemorl_client.py
@@ -110,41 +110,6 @@ async def test_token_ids_relocated_from_message_to_response():
 
 
 @pytest.mark.asyncio
-async def test_string_token_ids_normalized_to_ints():
-    """String token IDs (from vllm_model removeprefix) are converted to ints."""
-    response_dict = _make_nemo_gym_response_dict(
-        prompt_token_ids=[1, 2],
-        generation_token_ids=["100", "200"],  # strings, not ints
-        generation_log_probs=[-0.5, -0.6],
-    )
-
-    client = _make_client()
-
-    from openai.types.chat import ChatCompletion
-
-    chat_completion = ChatCompletion.model_validate(response_dict)
-    setattr(chat_completion.choices[0].message, "prompt_token_ids", [1, 2])
-    setattr(chat_completion.choices[0].message, "generation_token_ids", ["100", "200"])
-    setattr(chat_completion.choices[0].message, "generation_log_probs", [-0.5, -0.6])
-
-    with patch.object(
-        NeMoRLChatCompletionsClient.__bases__[0],
-        "get_native_response",
-        new_callable=AsyncMock,
-        return_value=chat_completion,
-    ):
-        result = await client.get_native_response(
-            prompt=[{"role": "user", "content": "Hi"}],
-            model="test-model",
-            sampling_args={"max_tokens": 100},
-        )
-
-    # Token IDs should be ints, not strings
-    assert all(isinstance(tid, int) for tid in result.choices[0].token_ids)
-    assert result.choices[0].token_ids == [100, 200]
-
-
-@pytest.mark.asyncio
 async def test_no_token_data_passes_through_unchanged():
     """When model server doesn't return token IDs, response is unchanged."""
     response_dict = _make_nemo_gym_response_dict()  # no token fields
@@ -217,3 +182,149 @@ async def test_from_native_response_produces_response_tokens():
     assert tokens.completion_logprobs == gen_logprobs
     assert tokens.prompt_mask == [0] * len(prompt_ids)
     assert tokens.completion_mask == [1] * len(gen_ids)
+
+
+@pytest.mark.asyncio
+async def test_to_native_prompt_emits_token_extras():
+    """Assistant message extras flow onto the outgoing native dict."""
+    from verifiers.types import AssistantMessage, UserMessage
+
+    client = _make_client()
+    assistant = AssistantMessage(content="hello")
+    assistant.prompt_token_ids = [1, 2, 3]
+    assistant.generation_token_ids = [4, 5]
+    assistant.generation_log_probs = [-0.1, -0.2]
+    messages = [UserMessage(content="hi"), assistant, UserMessage(content="more")]
+
+    native_messages, _ = await client.to_native_prompt(messages)
+    assert native_messages[1]["prompt_token_ids"] == [1, 2, 3]
+    assert native_messages[1]["generation_token_ids"] == [4, 5]
+    assert native_messages[1]["generation_log_probs"] == [-0.1, -0.2]
+    assert "prompt_token_ids" not in native_messages[0]
+    assert "prompt_token_ids" not in native_messages[2]
+
+
+@pytest.mark.asyncio
+async def test_to_native_prompt_without_extras_is_clean():
+    """AssistantMessages with no token extras serialize without token fields."""
+    from verifiers.types import AssistantMessage
+
+    client = _make_client()
+    native_messages, _ = await client.to_native_prompt(
+        [AssistantMessage(content="plain")]
+    )
+    for key in ("prompt_token_ids", "generation_token_ids", "generation_log_probs"):
+        assert key not in native_messages[0]
+
+
+@pytest.mark.asyncio
+async def test_get_response_annotates_from_trajectory():
+    """get_response walks state['trajectory'] and annotates matching assistants."""
+    from verifiers.clients.nemorl_chat_completions_client import (
+        _attach_trajectory_tokens_to_prompt,
+    )
+    from verifiers.types import AssistantMessage, UserMessage
+
+    a0 = AssistantMessage(content="turn0")
+    a1 = AssistantMessage(content="turn1")
+    prompt = [
+        UserMessage(content="u0"),
+        a0,
+        UserMessage(content="u1"),
+        a1,
+        UserMessage(content="u2"),
+    ]
+    state = {
+        "trajectory": [
+            {
+                "tokens": {
+                    "prompt_ids": [1],
+                    "completion_ids": [10],
+                    "completion_logprobs": [-0.5],
+                }
+            },
+            {
+                "tokens": {
+                    "prompt_ids": [1, 10, 2],
+                    "completion_ids": [20, 21],
+                    "completion_logprobs": [-0.1, -0.2],
+                }
+            },
+        ]
+    }
+    _attach_trajectory_tokens_to_prompt(prompt, state)
+    assert a0.prompt_token_ids == [1]
+    assert a0.generation_token_ids == [10]
+    assert a1.prompt_token_ids == [1, 10, 2]
+    assert a1.generation_token_ids == [20, 21]
+    assert a1.generation_log_probs == [-0.1, -0.2]
+
+
+@pytest.mark.asyncio
+async def test_get_response_empty_trajectory_is_noop():
+    from verifiers.clients.nemorl_chat_completions_client import (
+        _attach_trajectory_tokens_to_prompt,
+    )
+    from verifiers.types import AssistantMessage, UserMessage
+
+    a = AssistantMessage(content="x")
+    prompt = [UserMessage(content="u"), a]
+    _attach_trajectory_tokens_to_prompt(prompt, {"trajectory": []})
+    assert not hasattr(a, "prompt_token_ids") or a.prompt_token_ids is None
+
+
+@pytest.mark.asyncio
+async def test_get_response_none_tokens_step_is_skipped():
+    from verifiers.clients.nemorl_chat_completions_client import (
+        _attach_trajectory_tokens_to_prompt,
+    )
+    from verifiers.types import AssistantMessage, UserMessage
+
+    a0 = AssistantMessage(content="x")
+    a1 = AssistantMessage(content="y")
+    prompt = [UserMessage(content="u"), a0, UserMessage(content="u"), a1]
+    state = {
+        "trajectory": [
+            {"tokens": None},
+            {
+                "tokens": {
+                    "prompt_ids": [1],
+                    "completion_ids": [2],
+                    "completion_logprobs": [-0.1],
+                }
+            },
+        ]
+    }
+    _attach_trajectory_tokens_to_prompt(prompt, state)
+    assert not hasattr(a0, "prompt_token_ids") or a0.prompt_token_ids is None
+    assert a1.prompt_token_ids == [1]
+
+
+@pytest.mark.asyncio
+async def test_get_response_positional_pairing_with_extra_leading_assistant():
+    """Extra leading assistant messages (e.g. few-shot) are ignored; last N paired."""
+    from verifiers.clients.nemorl_chat_completions_client import (
+        _attach_trajectory_tokens_to_prompt,
+    )
+    from verifiers.types import AssistantMessage, UserMessage
+
+    few_shot = AssistantMessage(content="few-shot example")
+    a0 = AssistantMessage(content="turn0")
+    prompt = [UserMessage(content="demo"), few_shot, UserMessage(content="u0"), a0]
+    state = {
+        "trajectory": [
+            {
+                "tokens": {
+                    "prompt_ids": [7],
+                    "completion_ids": [8],
+                    "completion_logprobs": [-0.3],
+                }
+            },
+        ]
+    }
+    _attach_trajectory_tokens_to_prompt(prompt, state)
+    assert (
+        not hasattr(few_shot, "prompt_token_ids") or few_shot.prompt_token_ids is None
+    )
+    assert a0.prompt_token_ids == [7]
+    assert a0.generation_token_ids == [8]

--- a/verifiers/clients/nemorl_chat_completions_client.py
+++ b/verifiers/clients/nemorl_chat_completions_client.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any, cast
+
 from verifiers.clients.openai_chat_completions_client import (
     OpenAIChatCompletionsClient,
     OpenAIChatMessages,
@@ -7,25 +9,20 @@ from verifiers.clients.openai_chat_completions_client import (
     OpenAITool,
     handle_openai_overlong_prompt,
 )
-from verifiers.types import SamplingArgs
+from verifiers.types import (
+    AssistantMessage,
+    Messages,
+    Response,
+    SamplingArgs,
+    Tool,
+)
 
 
 class NeMoRLChatCompletionsClient(OpenAIChatCompletionsClient):
-    """Client for NeMo Gym model servers that embed token IDs in the message dict.
-
-    NeMo Gym's model servers (e.g., vllm_model) return token information as
-    extra fields on the chat completion message:
-        - message.prompt_token_ids: list[int]
-        - message.generation_token_ids: list[int | str]
-        - message.generation_log_probs: list[float]
-
-    Verifiers' parse_tokens() (called by from_native_response) expects:
-        - response.prompt_token_ids (top-level attribute)
-        - choice.token_ids (choice-level attribute)
-        - choice.logprobs.content (list of {token, logprob, top_logprobs} dicts)
-
-    This client relocates the fields after calling the standard OpenAI chat
-    completions endpoint, so the rest of the verifiers pipeline works unchanged.
+    """
+    Client for NeMo Gym vllm_model server.
+    Formats requests properly for NeMo RL's retokenization fix.
+    Implements token ids request for retokenization fix in NeMo RL and formats properly for verifiers.
     """
 
     @handle_openai_overlong_prompt
@@ -37,45 +34,24 @@ class NeMoRLChatCompletionsClient(OpenAIChatCompletionsClient):
         tools: list[OpenAITool] | None = None,
         **kwargs,
     ) -> OpenAIChatResponse:
-        # Standard OpenAI chat completions call to the NeMo Gym model server.
-        # The model server handles logprobs, tokenization, and token ID extraction
-        # internally. Extra fields survive because the OpenAI SDK's ChatCompletion
-        # and ChatCompletionMessage models use extra="allow".
+        """Move NeMo Gym's message-level token id fields to where verifiers' `parse_tokens()` expects them."""
         response = await super().get_native_response(
             prompt, model, sampling_args, tools, **kwargs
         )
-
         choice = response.choices[0]
         message = choice.message
 
-        # Extract token data from the message's extra fields.
-        # These are set by the NeMo Gym model server when
-        # return_token_id_information is enabled.
         prompt_token_ids = getattr(message, "prompt_token_ids", None)
         generation_token_ids = getattr(message, "generation_token_ids", None)
         generation_log_probs = getattr(message, "generation_log_probs", None)
 
         if prompt_token_ids is None and generation_token_ids is None:
-            # No token data from the model server; pass through unchanged.
-            # parse_tokens() will return None, which is correct for inference-only.
             return response
 
-        # Normalize string token IDs to ints.
-        # The vllm_model server may return strings after removeprefix("token_id:").
-        if prompt_token_ids and isinstance(prompt_token_ids[0], str):
-            prompt_token_ids = [int(tid) for tid in prompt_token_ids]
-        if generation_token_ids and isinstance(generation_token_ids[0], str):
-            generation_token_ids = [int(tid) for tid in generation_token_ids]
-
-        # Relocate to where parse_tokens() expects them.
         if prompt_token_ids is not None:
-            setattr(response, "prompt_token_ids", prompt_token_ids)
+            response.prompt_token_ids = prompt_token_ids
         if generation_token_ids is not None:
-            setattr(choice, "token_ids", generation_token_ids)
-
-        # Reconstruct logprobs structure from token IDs + log probs.
-        # parse_tokens() handles both Pydantic ChoiceLogprobs objects and plain
-        # dicts, so a dict is sufficient and avoids an import.
+            choice.token_ids = generation_token_ids
         if generation_token_ids and generation_log_probs:
             choice.logprobs = {
                 "content": [
@@ -85,3 +61,58 @@ class NeMoRLChatCompletionsClient(OpenAIChatCompletionsClient):
             }
 
         return response
+
+    async def get_response(
+        self,
+        prompt: Messages,
+        model: str,
+        sampling_args: SamplingArgs,
+        tools: list[Tool] | None = None,
+        **kwargs,
+    ) -> Response:
+        """Annotate prior assistant messages with their trajectory tokens before delegating to the parent client."""
+        state = kwargs.get("state")
+        if state is not None:
+            _attach_trajectory_tokens_to_prompt(prompt, state)
+        return await super().get_response(prompt, model, sampling_args, tools, **kwargs)
+
+    async def to_native_prompt(
+        self, messages: Messages
+    ) -> tuple[OpenAIChatMessages, dict[str, Any]]:
+        """Serialize per-assistant token extras onto the outgoing native chat dicts so the server receives them."""
+        native_messages, extras = await super().to_native_prompt(messages)
+        for msg, native_msg in zip(messages, native_messages):
+            if not isinstance(msg, AssistantMessage):
+                continue
+            native_dict = cast("dict[str, Any]", native_msg)
+            for key in (
+                "prompt_token_ids",
+                "generation_token_ids",
+                "generation_log_probs",
+            ):
+                val = getattr(msg, key, None)
+                if val is not None:
+                    native_dict[key] = list(val)
+        return native_messages, extras
+
+
+def _attach_trajectory_tokens_to_prompt(
+    prompt: Messages, state: dict[str, Any]
+) -> None:
+    """Attach each past assistant message's token ids from the trajectory."""
+    trajectory = state.get("trajectory") or []
+    if not trajectory:
+        return
+    indices = [i for i, m in enumerate(prompt) if isinstance(m, AssistantMessage)]
+    step_tokens = [step.get("tokens") for step in trajectory]
+    n = min(len(indices), len(step_tokens))
+    for i, tokens in zip(indices[-n:], step_tokens[-n:]):
+        if tokens is None:
+            continue
+        msg = prompt[i]
+        if (prompt_ids := tokens.get("prompt_ids")) is not None:
+            msg.prompt_token_ids = list(prompt_ids)
+        if (completion_ids := tokens.get("completion_ids")) is not None:
+            msg.generation_token_ids = list(completion_ids)
+        if (completion_logprobs := tokens.get("completion_logprobs")) is not None:
+            msg.generation_log_probs = list(completion_logprobs)

--- a/verifiers/clients/nemorl_chat_completions_client.py
+++ b/verifiers/clients/nemorl_chat_completions_client.py
@@ -21,8 +21,7 @@ from verifiers.types import (
 class NeMoRLChatCompletionsClient(OpenAIChatCompletionsClient):
     """
     Client for NeMo Gym vllm_model server.
-    Formats requests properly for NeMo RL's retokenization fix.
-    Implements token ids request for retokenization fix in NeMo RL and formats properly for verifiers.
+    Formats requests for NeMo RL's server-side vLLM retokenization fix, and translates to verifiers format.
     """
 
     @handle_openai_overlong_prompt


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches NeMo RL client request/response shaping for token IDs and logprobs, which can affect downstream training/scoring if mismatched. Logic is straightforward but depends on correct trajectory-to-message alignment and server expectations.
> 
> **Overview**
> **Preserves token metadata across NeMo RL chat turns.** The NeMo RL client now serializes `prompt_token_ids`, `generation_token_ids`, and `generation_log_probs` onto outgoing assistant message dicts (`to_native_prompt`) and, when `state['trajectory']` is provided, annotates prior `AssistantMessage`s with the corresponding token data before calling the parent `get_response`.
> 
> `get_native_response` still relocates NeMo Gym’s message-level token fields onto the response/choice in the shape expected by `parse_tokens`, and tests were updated/expanded to cover prompt serialization, trajectory attachment behavior (including empty/None steps and extra leading assistants), while removing the string-token-id normalization case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 545b5395db96b4c28f2b1a9ee66d180d85811e59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->