### PR TITLE
chore: self types

### DIFF
--- a/verifiers/envs/experimental/composable/task.py
+++ b/verifiers/envs/experimental/composable/task.py
@@ -32,7 +32,7 @@ from dataclasses import dataclass
 from importlib.abc import Traversable
 from pathlib import Path
 from types import ModuleType
-from typing import Any, Callable
+from typing import Any, Callable, Self
 
 from verifiers.envs.experimental.composable._filter import _resolve_filter_fn
 from verifiers.types import Messages, State
@@ -279,13 +279,13 @@ class TaskSet:
 
     # -- Combinators ---------------------------------------------------------
 
-    def filter(self, predicate: Callable[[dict], bool]) -> TaskSet:
+    def filter(self, predicate: Callable[[dict], bool]) -> Self:
         clone = object.__new__(type(self))
         clone.__dict__.update(self.__dict__)
         clone._dataset = self._dataset.filter(predicate)
         return clone
 
-    def take(self, n: int) -> TaskSet:
+    def take(self, n: int) -> Self:
         clone = object.__new__(type(self))
         clone.__dict__.update(self.__dict__)
         clone._dataset = self._dataset.select(range(min(n, len(self._dataset))))


### PR DESCRIPTION
## Summary

Tiny annotation change: `TaskSet.filter(...)` and `TaskSet.take(...)` now return `Self` (PEP 673) instead of `TaskSet`.

## Why

Runtime already preserves the caller's subclass — each combinator does `object.__new__(type(self))`. But the return annotation is `TaskSet`, which collapses the type info statically. Subclass users then have to `cast` every chained filter, or their downstream code complains:

```python
class GeneralAgentTaskSet(ToolTaskSet): ...

taskset = GeneralAgentTaskSet(...)
taskset = taskset.filter(...)   # was: TaskSet, not GeneralAgentTaskSet
ToolEnv(taskset=taskset, ...)   # type error: TaskSet not assignable to ToolTaskSet
```

With `Self` the narrowing is preserved and subclasses chain cleanly.

## Changes

- `verifiers/envs/experimental/composable/task.py`: add `Self` import, change return annotations on `filter` and `take`.

Zero runtime change — pure annotation widening.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a type-annotation-only change that doesn’t affect runtime behavior, but it may require Python versions/type checkers that support `typing.Self`.
> 
> **Overview**
> Updates `TaskSet.filter()` and `TaskSet.take()` return types to `Self` (PEP 673) and adds the `Self` import, so chaining these combinators preserves subclass types in static typing without casts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a3afa281edf79e8172db5676bc748c64beb13ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->