### PR TITLE
chore: v0.1.13.dev6 dev release

### DIFF
--- a/assets/release/RELEASE_v0.1.13.dev6.md
+++ b/assets/release/RELEASE_v0.1.13.dev6.md
@@ -1,0 +1,20 @@
+# Verifiers v0.1.13.dev6 Release Notes
+
+*Date:* 04/23/2026
+
+## Highlights since v0.1.13.dev5
+
+- `rlm_harness` is now the single source of truth for RLM_* sandbox env vars. New kwargs `rlm_max_turns`, `rlm_max_turns_in_context`, `rlm_exec_timeout` map 1:1 onto the matching env vars on `Harness.environment_vars` and merge into the sandbox via `ComposableEnv.build_env_vars` (harness-wins). Research envs can stop setting these via `ComposableEnv(environment_vars=…)` — pass them through as harness kwargs instead.
+- `TaskSet.filter` / `.take` now return `Self`, not `TaskSet`, so subclass types survive taskset chaining for downstream typed consumers.
+
+## Changes included in v0.1.13.dev6 (since v0.1.13.dev5)
+
+### Features and enhancements
+
+- rlm_harness: own RLM_MAX_TURNS / _IN_CONTEXT / _EXEC_TIMEOUT env vars (#1229)
+
+### Fixes and maintenance
+
+- types: TaskSet.filter / .take return Self, not TaskSet (#1232)
+
+**Full Changelog**: https://github.com/PrimeIntellect-ai/verifiers/compare/v0.1.13.dev5...v0.1.13.dev6

--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.13.dev5"
+__version__ = "0.1.13.dev6"
 
 import importlib
 import os


### PR DESCRIPTION
## Summary

- Bump version from `0.1.13.dev5` to `0.1.13.dev6`
- Add release notes covering changes since `v0.1.13.dev5`

## Changes since v0.1.13.dev5
- types: TaskSet.filter / .take return Self, not TaskSet (#1232)
- rlm_harness: own RLM_MAX_TURNS / _IN_CONTEXT / _EXEC_TIMEOUT env vars (#1229)

### Linked PRs
- #1232
- #1229

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only bumps the package version and adds release notes; no runtime behavior changes are introduced in this PR.
> 
> **Overview**
> Bumps `verifiers` version from `0.1.13.dev5` to `0.1.13.dev6` and adds `RELEASE_v0.1.13.dev6.md` with the release notes referencing the prior changes (RLM harness env var ownership and `TaskSet.filter`/`.take` typing update).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a45271e79a0fa4e2cf5e93ebd9514abdae9b229. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->