### PR TITLE
fix: mute httpcore/httpx DEBUG when env-worker json_logging sets root level

### DIFF
--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,5 +1,7 @@
 import logging
 
+import pytest
+
 import verifiers as vf
 
 
@@ -101,6 +103,54 @@ class TestLogLevel:
             assert logger.level == logging.DEBUG
 
         assert logger.level == original_level
+
+
+class TestJsonLoggingMutesHttpNoise:
+    """Tests that setup_logging(json_logging=True) mutes httpcore/httpx DEBUG."""
+
+    @pytest.fixture
+    def restore_logging_state(self):
+        """Snapshot + restore root, verifiers, httpcore, and httpx logger state."""
+        names = (None, "verifiers", "httpcore", "httpx")
+        saved: list[tuple[logging.Logger, int, list[logging.Handler], bool]] = []
+        for name in names:
+            lg = logging.getLogger(name) if name else logging.getLogger()
+            saved.append((lg, lg.level, list(lg.handlers), lg.propagate))
+        try:
+            yield
+        finally:
+            for lg, level, handlers, propagate in saved:
+                lg.setLevel(level)
+                lg.handlers = handlers
+                lg.propagate = propagate
+
+    def test_json_logging_debug_mutes_httpcore_and_httpx(self, restore_logging_state):
+        """setup_logging at DEBUG with json_logging=True pins httpcore/httpx to WARNING."""
+        vf.setup_logging(level="DEBUG", json_logging=True)
+
+        assert logging.getLogger("httpcore").getEffectiveLevel() == logging.WARNING
+        assert logging.getLogger("httpx").getEffectiveLevel() == logging.WARNING
+
+        # Root stays at DEBUG so user code and other namespaces still emit DEBUG.
+        assert logging.getLogger().getEffectiveLevel() == logging.DEBUG
+        # A sibling user logger (no explicit level) inherits root's DEBUG, proving
+        # we didn't over-mute.
+        assert (
+            logging.getLogger("some.random.user.logger").getEffectiveLevel()
+            == logging.DEBUG
+        )
+
+    def test_non_json_logging_does_not_mute_httpcore(self, restore_logging_state):
+        """json_logging=False must not mutate httpcore/httpx levels."""
+        # Start from a known baseline.
+        logging.getLogger("httpcore").setLevel(logging.NOTSET)
+        logging.getLogger("httpx").setLevel(logging.NOTSET)
+
+        vf.setup_logging(level="DEBUG", json_logging=False)
+
+        # Unchanged by the non-json path.
+        assert logging.getLogger("httpcore").level == logging.NOTSET
+        assert logging.getLogger("httpx").level == logging.NOTSET
 
 
 class TestQuietVerifiers:

--- a/verifiers/utils/logging_utils.py
+++ b/verifiers/utils/logging_utils.py
@@ -122,6 +122,15 @@ def setup_logging(
         root_handler.setLevel(log_level)
         root.addHandler(root_handler)
 
+        # Mute httpcore/httpx per-request DEBUG trace noise. At scale, env workers
+        # poll background jobs at ~1Hz * max_inflight_rollouts, producing thousands
+        # of DEBUG lines/sec from httpcore.http11 with no diagnostic value. Pin
+        # these two namespaces above root DEBUG; real connection errors still
+        # surface as httpx exceptions. For wire-level debugging, use the
+        # HTTPX_LOG_LEVEL opt-in (see envs/experimental/sandbox_mixin.py).
+        logging.getLogger("httpcore").setLevel(logging.WARNING)
+        logging.getLogger("httpx").setLevel(logging.WARNING)
+
 
 @contextmanager
 def log_level(level: str | int):


### PR DESCRIPTION
## Summary

Recent commit \`71d03ea1\` propagated \`json_logging=True\` into env workers, making \`setup_logging()\` call \`root.setLevel(log_level)\`. When users configure \`log.level = \"debug\"\` in hosted-RL \`run_config\` (common), \`httpcore.http11\`'s per-request trace (\`send_request_headers.started\`, \`receive_response_headers.complete\`, …) now fires for every httpx call.

On a 30B opencode-math run with \`max_inflight_rollouts=384\` and \`poll_job_completion\` polling \`get_background_job\` at 1Hz (post-#1206), this produces **~3000-4000 DEBUG lines/sec/worker** into Loki — drowning the real diagnostic signal.

## Fix

Two-line mute inside the \`if json_logging:\` block in \`verifiers/utils/logging_utils.py\`, after the root handler + level are configured:

\`\`\`python
logging.getLogger(\"httpcore\").setLevel(logging.WARNING)
logging.getLogger(\"httpx\").setLevel(logging.WARNING)
\`\`\`

Only applies when root is explicitly forced to DEBUG via \`json_logging=True\`. Does not change behavior when \`json_logging=False\`.

## Side effects

Lose per-request wire-level trace (connection pool state, header send/receive timing). In practice:
- Real connection failures still propagate via \`httpx\` exceptions at WARNING/ERROR — not lost.
- \`HTTPX_LOG_LEVEL=DEBUG\` opt-in in \`sandbox_mixin.py:31-37\` stays available for actual wire debugging.

## Tests

New \`TestJsonLoggingMutesHttpNoise\` class in \`tests/test_logging.py\` with teardown fixture that snapshots + restores root/verifiers/httpcore/httpx state:
- \`setup_logging(level=\"DEBUG\", json_logging=True)\` → httpcore/httpx \`getEffectiveLevel() == WARNING\`, root + sibling user logger still at DEBUG.
- \`setup_logging(level=\"DEBUG\", json_logging=False)\` → does NOT mutate httpcore/httpx levels.

\`tests/test_logging.py\` → 12 passed. Combined with \`test_env_server.py\` → 22 passed. ruff + ty clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change only adjusts log levels for `httpcore`/`httpx` when `json_logging=True`, plus focused tests; main behavior impact is reduced HTTP wire-level debug output.
> 
> **Overview**
> When `setup_logging(json_logging=True)` configures the root logger at `DEBUG`, it now **pins `httpcore` and `httpx` loggers to `WARNING`** to prevent high-volume per-request debug trace noise while leaving root/user loggers at the requested level.
> 
> Adds tests that snapshot/restore logging state and assert the mute applies only in the JSON-logging path (and does not affect `json_logging=False`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd005229a474e6f5c4b9205528b2517956ac4fd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->