### PR TITLE
Sebastian/summarization new 2026 04 23

### DIFF
--- a/verifiers/envs/experimental/composable/harness.py
+++ b/verifiers/envs/experimental/composable/harness.py
@@ -88,7 +88,7 @@ class Harness:
         ``ComposableEnv`` auto-registers a ``ToolMonitorRubric`` that
         counts calls to each named tool (plus a total) from the
         assistant messages the harness emits into the trajectory.
-        Example: ``["ipython", "summarize"]`` for the RLM harness.
+        Example: ``["ipython"]`` for the RLM harness.
     environment_vars:
         Harness-owned environment variables for the sandbox. Merged by
         ``ComposableEnv`` between the caller-supplied ``environment_vars=``

--- a/verifiers/envs/experimental/composable/harnesses/__init__.py
+++ b/verifiers/envs/experimental/composable/harnesses/__init__.py
@@ -1,7 +1,6 @@
 from verifiers.envs.experimental.composable.harnesses.rlm import (
     DEFAULT_RLM_EXEC_TIMEOUT,
     DEFAULT_RLM_MAX_TURNS,
-    DEFAULT_RLM_MAX_TURNS_IN_CONTEXT,
     DEFAULT_RLM_REF,
     DEFAULT_RLM_REPO_URL,
     build_install_script as build_rlm_install_script,
@@ -33,7 +32,6 @@ __all__ = [
     "DEFAULT_RLM_REF",
     "DEFAULT_RLM_REPO_URL",
     "DEFAULT_RLM_MAX_TURNS",
-    "DEFAULT_RLM_MAX_TURNS_IN_CONTEXT",
     "DEFAULT_RLM_EXEC_TIMEOUT",
     "opencode_harness",
     "build_opencode_install_script",

--- a/verifiers/envs/experimental/composable/harnesses/rlm.py
+++ b/verifiers/envs/experimental/composable/harnesses/rlm.py
@@ -101,7 +101,7 @@ def rlm_harness(
     rlm_ref: str = DEFAULT_RLM_REF,
     rlm_max_turns: int = DEFAULT_RLM_MAX_TURNS,
     rlm_exec_timeout: int = DEFAULT_RLM_EXEC_TIMEOUT,
-    summarize_at_tokens: int | tuple[int, int] | list[int] | None = None,
+    summarize_at_tokens: int | None = None,
     append_to_system_prompt: str | None = None,
     local_checkout: str | Path | None = None,
     gh_token: str | None = None,
@@ -119,11 +119,10 @@ def rlm_harness(
       ``ToolMonitorRubric`` tracks exactly the active tools)
     - ``rlm_max_turns`` → ``RLM_MAX_TURNS``
     - ``rlm_exec_timeout`` → ``RLM_EXEC_TIMEOUT``
-    - ``summarize_at_tokens`` → ``RLM_SUMMARIZE_AT_TOKENS``: when set,
-      rlm auto-compacts the current branch once the prompt_tokens of a
-      turn reach the threshold. Pass an int for a fixed threshold, or a
-      ``(lo, hi)`` tuple/list to draw a uniform threshold per rollout
-      and after each compaction. ``None`` disables auto-compaction.
+    - ``summarize_at_tokens`` → ``RLM_SUMMARIZE_AT_TOKENS``: when set to
+      a positive int, rlm auto-compacts the current branch once the
+      prompt_tokens of a turn reach the threshold. ``None`` disables
+      auto-compaction.
 
     Callers do not need to — and should not — add these keys to
     ``ComposableEnv(environment_vars=...)`` themselves; pass the kwargs
@@ -193,41 +192,20 @@ def rlm_harness(
     )
 
 
-def _format_summarize_at_tokens(
-    value: int | tuple[int, int] | list[int] | None,
-) -> str | None:
+def _format_summarize_at_tokens(value: int | None) -> str | None:
     """Format ``summarize_at_tokens`` as the ``RLM_SUMMARIZE_AT_TOKENS`` string.
 
     Returns ``None`` when auto-compaction should be disabled (matches what
-    the engine expects when the env var is absent). An int becomes
-    ``"N"``; a 2-element sequence becomes ``"lo,hi"``. Any other shape is
-    rejected here so configuration errors surface at harness-build time
-    rather than deep inside the sandbox.
+    the engine expects when the env var is absent). Rejects bad shapes
+    here so configuration errors surface at harness-build time rather
+    than deep inside the sandbox.
     """
     if value is None:
         return None
-    if isinstance(value, bool):
-        raise ValueError("summarize_at_tokens must be an int or (lo, hi) pair")
-    if isinstance(value, int):
-        if value <= 0:
-            raise ValueError(f"summarize_at_tokens must be positive (got {value})")
-        return str(value)
-    if isinstance(value, (tuple, list)):
-        if len(value) != 2:
-            raise ValueError(
-                f"summarize_at_tokens pair must have 2 elements (got {value!r})"
-            )
-        lo, hi = int(value[0]), int(value[1])
-        if lo <= 0 or hi <= 0:
-            raise ValueError(
-                f"summarize_at_tokens values must be positive (got lo={lo}, hi={hi})"
-            )
-        if lo > hi:
-            raise ValueError(
-                f"summarize_at_tokens lo must be <= hi (got lo={lo}, hi={hi})"
-            )
-        return f"{lo},{hi}"
-    raise ValueError(
-        f"summarize_at_tokens must be int, (lo, hi), or None "
-        f"(got {type(value).__name__})"
-    )
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(
+            f"summarize_at_tokens must be an int or None (got {type(value).__name__})"
+        )
+    if value <= 0:
+        raise ValueError(f"summarize_at_tokens must be positive (got {value})")
+    return str(value)

--- a/verifiers/envs/experimental/composable/harnesses/rlm.py
+++ b/verifiers/envs/experimental/composable/harnesses/rlm.py
@@ -15,7 +15,6 @@ from verifiers.envs.experimental.utils.git_checkout_cache import (
 DEFAULT_RLM_REPO_URL = "github.com/PrimeIntellect-ai/rlm.git"
 DEFAULT_RLM_REF = "main"
 DEFAULT_RLM_MAX_TURNS = 100
-DEFAULT_RLM_MAX_TURNS_IN_CONTEXT = -1
 DEFAULT_RLM_EXEC_TIMEOUT = 300
 DEFAULT_APPEND_TO_SYSTEM_PROMPT_PATH = "/task/append_to_system_prompt.txt"
 DEFAULT_RLM_CHECKOUT_PATH = "/tmp/rlm-checkout"
@@ -101,8 +100,8 @@ def rlm_harness(
     rlm_repo_url: str = DEFAULT_RLM_REPO_URL,
     rlm_ref: str = DEFAULT_RLM_REF,
     rlm_max_turns: int = DEFAULT_RLM_MAX_TURNS,
-    rlm_max_turns_in_context: int = DEFAULT_RLM_MAX_TURNS_IN_CONTEXT,
     rlm_exec_timeout: int = DEFAULT_RLM_EXEC_TIMEOUT,
+    summarize_at_tokens: int | tuple[int, int] | list[int] | None = None,
     append_to_system_prompt: str | None = None,
     local_checkout: str | Path | None = None,
     gh_token: str | None = None,
@@ -119,8 +118,12 @@ def rlm_harness(
     - ``rlm_tools`` → ``RLM_TOOLS`` (also drives ``Harness.tool_names`` so
       ``ToolMonitorRubric`` tracks exactly the active tools)
     - ``rlm_max_turns`` → ``RLM_MAX_TURNS``
-    - ``rlm_max_turns_in_context`` → ``RLM_MAX_TURNS_IN_CONTEXT``
     - ``rlm_exec_timeout`` → ``RLM_EXEC_TIMEOUT``
+    - ``summarize_at_tokens`` → ``RLM_SUMMARIZE_AT_TOKENS``: when set,
+      rlm auto-compacts the current branch once the prompt_tokens of a
+      turn reach the threshold. Pass an int for a fixed threshold, or a
+      ``(lo, hi)`` tuple/list to draw a uniform threshold per rollout
+      and after each compaction. ``None`` disables auto-compaction.
 
     Callers do not need to — and should not — add these keys to
     ``ComposableEnv(environment_vars=...)`` themselves; pass the kwargs
@@ -154,13 +157,22 @@ def rlm_harness(
         resolved_upload_dirs = upload_dirs
         return resolved_upload_dirs
 
-    tool_names = list(rlm_tools) if rlm_tools is not None else ["ipython", "summarize"]
+    tool_names = list(rlm_tools) if rlm_tools is not None else ["ipython"]
 
     post_install_uploads: dict[str, str] | None = None
     post_install_script: str | None = None
     if not allow_git:
         post_install_uploads = {"/usr/local/bin/git": _GIT_SHIM_BODY}
         post_install_script = "chmod +x /usr/local/bin/git"
+
+    environment_vars: dict[str, str] = {
+        "RLM_TOOLS": ",".join(tool_names),
+        "RLM_MAX_TURNS": str(rlm_max_turns),
+        "RLM_EXEC_TIMEOUT": str(rlm_exec_timeout),
+    }
+    summarize_env = _format_summarize_at_tokens(summarize_at_tokens)
+    if summarize_env is not None:
+        environment_vars["RLM_SUMMARIZE_AT_TOKENS"] = summarize_env
 
     return Harness(
         install_script=build_install_script(),
@@ -175,12 +187,49 @@ def rlm_harness(
         metrics_key="metrics",
         metrics_prefix="rlm_",
         tool_names=tool_names,
-        environment_vars={
-            "RLM_TOOLS": ",".join(tool_names),
-            "RLM_MAX_TURNS": str(rlm_max_turns),
-            "RLM_MAX_TURNS_IN_CONTEXT": str(rlm_max_turns_in_context),
-            "RLM_EXEC_TIMEOUT": str(rlm_exec_timeout),
-        },
+        environment_vars=environment_vars,
         post_install_uploads=post_install_uploads,
         post_install_script=post_install_script,
+    )
+
+
+def _format_summarize_at_tokens(
+    value: int | tuple[int, int] | list[int] | None,
+) -> str | None:
+    """Format ``summarize_at_tokens`` as the ``RLM_SUMMARIZE_AT_TOKENS`` string.
+
+    Returns ``None`` when auto-compaction should be disabled (matches what
+    the engine expects when the env var is absent). An int becomes
+    ``"N"``; a 2-element sequence becomes ``"lo,hi"``. Any other shape is
+    rejected here so configuration errors surface at harness-build time
+    rather than deep inside the sandbox.
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise ValueError("summarize_at_tokens must be an int or (lo, hi) pair")
+    if isinstance(value, int):
+        if value <= 0:
+            raise ValueError(
+                f"summarize_at_tokens must be positive (got {value})"
+            )
+        return str(value)
+    if isinstance(value, (tuple, list)):
+        if len(value) != 2:
+            raise ValueError(
+                f"summarize_at_tokens pair must have 2 elements (got {value!r})"
+            )
+        lo, hi = int(value[0]), int(value[1])
+        if lo <= 0 or hi <= 0:
+            raise ValueError(
+                f"summarize_at_tokens values must be positive (got lo={lo}, hi={hi})"
+            )
+        if lo > hi:
+            raise ValueError(
+                f"summarize_at_tokens lo must be <= hi (got lo={lo}, hi={hi})"
+            )
+        return f"{lo},{hi}"
+    raise ValueError(
+        f"summarize_at_tokens must be int, (lo, hi), or None "
+        f"(got {type(value).__name__})"
     )

--- a/verifiers/envs/experimental/composable/harnesses/rlm.py
+++ b/verifiers/envs/experimental/composable/harnesses/rlm.py
@@ -210,9 +210,7 @@ def _format_summarize_at_tokens(
         raise ValueError("summarize_at_tokens must be an int or (lo, hi) pair")
     if isinstance(value, int):
         if value <= 0:
-            raise ValueError(
-                f"summarize_at_tokens must be positive (got {value})"
-            )
+            raise ValueError(f"summarize_at_tokens must be positive (got {value})")
         return str(value)
     if isinstance(value, (tuple, list)):
         if len(value) != 2:


### PR DESCRIPTION
## Description

Match `rlm_harness` to upstream rlm's new auto-compaction knob and drop
the turn-based context cap that rlm no longer supports.

- **New kwarg `summarize_at_tokens`**: `int | tuple[int, int] | list[int] | None`.
  Formatted into `RLM_SUMMARIZE_AT_TOKENS` (emitted only when set, so
  `None` cleanly disables auto-compaction in the sandbox). Shape and
  positivity are validated at harness-build time via a new
  `_format_summarize_at_tokens` helper, so misconfigurations surface
  locally instead of deep in the sandbox.
- **Removed `rlm_max_turns_in_context`**: kwarg, `DEFAULT_RLM_MAX_TURNS_IN_CONTEXT`,
  and the `RLM_MAX_TURNS_IN_CONTEXT` entry in `Harness.environment_vars`.
  The turn-based cap is gone upstream; there's nothing to plumb.
- **Default `rlm_tools` is now `["ipython"]`** (was `["ipython", "summarize"]`).
  The model-callable `summarize` tool was removed upstream — keeping it
  in the default would desync the sandbox's `RLM_TOOLS` list with what
  rlm actually ships.
- **Exports**: `DEFAULT_RLM_MAX_TURNS_IN_CONTEXT` removed from
  `verifiers.envs.experimental.composable.harnesses.__init__`.
- **Docstring fix** in `harness.py`: the `tool_names` example for RLM
  updated to `["ipython"]`.

Breaking changes:

Any caller passing `rlm_max_turns_in_context=...` to `rlm_harness` will
get a `TypeError`. Callers that want a context budget should migrate
to `summarize_at_tokens` — that's the supported replacement.

`DEFAULT_RLM_MAX_TURNS_IN_CONTEXT` imports will break.

Dependencies:

Requires a version of rlm that:
- Reads `RLM_SUMMARIZE_AT_TOKENS`.
- No longer registers the `summarize` tool.


## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces a new runtime behavior switch (`RLM_SUMMARIZE_AT_TOKENS`), changes default tool registration, and removes the `rlm_max_turns_in_context` API/env var, which can break existing callers.
> 
> **Overview**
> Updates the RLM composable harness to match upstream by **removing the turn-based context cap** (`DEFAULT_RLM_MAX_TURNS_IN_CONTEXT`, `rlm_max_turns_in_context`, and `RLM_MAX_TURNS_IN_CONTEXT`) and **adding token-based auto-compaction control** via a new `summarize_at_tokens` kwarg that conditionally emits `RLM_SUMMARIZE_AT_TOKENS` with upfront validation.
> 
> Also changes the **default tool list** for RLM to `['ipython']` (dropping `summarize`) and updates public exports and docs accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aea2bac826104d02f59ddddebce6f5b75985cba7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->