### PR TITLE
Revert "types: TaskSet.filter / .take return Self, not TaskSet (#1232)"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.12", "3.13"]
+        python-version: ["3.10", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/verifiers/envs/experimental/composable/task.py
+++ b/verifiers/envs/experimental/composable/task.py
@@ -32,7 +32,7 @@ from dataclasses import dataclass
 from importlib.abc import Traversable
 from pathlib import Path
 from types import ModuleType
-from typing import Any, Callable, Self
+from typing import Any, Callable
 
 from verifiers.envs.experimental.composable._filter import _resolve_filter_fn
 from verifiers.types import Messages, State
@@ -279,13 +279,13 @@ class TaskSet:
 
     # -- Combinators ---------------------------------------------------------
 
-    def filter(self, predicate: Callable[[dict], bool]) -> Self:
+    def filter(self, predicate: Callable[[dict], bool]) -> TaskSet:
         clone = object.__new__(type(self))
         clone.__dict__.update(self.__dict__)
         clone._dataset = self._dataset.filter(predicate)
         return clone
 
-    def take(self, n: int) -> Self:
+    def take(self, n: int) -> TaskSet:
         clone = object.__new__(type(self))
         clone.__dict__.update(self.__dict__)
         clone._dataset = self._dataset.select(range(min(n, len(self._dataset))))


### PR DESCRIPTION
## Summary
- Reverts #1232 (commit b5fe8aa2).
- Adds Python 3.10 and 3.11 to the pytest matrix so we can confirm compatibility before restoring #1232.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
