### PR TITLE
chore: v0.1.13.dev7 dev release

### DIFF
--- a/assets/release/RELEASE_v0.1.13.dev7.md
+++ b/assets/release/RELEASE_v0.1.13.dev7.md
@@ -1,0 +1,21 @@
+# Verifiers v0.1.13.dev7 Release Notes
+
+*Date:* 04/24/2026
+
+## Highlights since v0.1.13.dev6
+
+- `rlm_harness` swaps turn-based context caps for token-based auto-compaction: new `summarize_at_tokens: int | None` kwarg maps to `RLM_SUMMARIZE_AT_TOKENS`, while `rlm_max_turns_in_context` / `RLM_MAX_TURNS_IN_CONTEXT` are removed to match upstream `rlm`. `summarize` also drops out of the default `rlm_tools` set. Invalid shapes fail at harness-build time instead of deep inside the sandbox.
+- Reverted `TaskSet.filter` / `.take` returning `Self` (originally #1232) — the change broke Python 3.10/3.11 compatibility. CI now exercises the 3.10 and 3.11 test matrices so the fix can be restored with confidence.
+
+## Changes included in v0.1.13.dev7 (since v0.1.13.dev6)
+
+### Features and enhancements
+
+- rlm_harness: add `summarize_at_tokens`, drop `rlm_max_turns_in_context` (#1236)
+
+### Fixes and maintenance
+
+- Revert "types: TaskSet.filter / .take return Self, not TaskSet (#1232)" (#1237)
+- ci: add Python 3.10 and 3.11 to the test matrix (#1237)
+
+**Full Changelog**: https://github.com/PrimeIntellect-ai/verifiers/compare/v0.1.13.dev6...v0.1.13.dev7

--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.13.dev6"
+__version__ = "0.1.13.dev7"
 
 import importlib
 import os


### PR DESCRIPTION
## Summary

- Bumps `verifiers.__version__` to `0.1.13.dev7` and adds `assets/release/RELEASE_v0.1.13.dev7.md`.
- Notes since `v0.1.13.dev6`: `rlm_harness` swap to token-based auto-compaction via `summarize_at_tokens` (#1236), and the `TaskSet.filter/.take → Self` revert plus Python 3.10/3.11 CI matrix (#1237).

## Test plan

- [x] CI is green on this branch
- [x] Release notes render correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping only: updates the package version and adds documentation; no runtime behavior changes are introduced in this PR diff.
> 
> **Overview**
> Bumps `verifiers.__version__` to `0.1.13.dev7` and adds `RELEASE_v0.1.13.dev7.md`.
> 
> The release notes document (but do not implement here) the `rlm_harness` move to token-based auto-compaction via `summarize_at_tokens`, a revert of `TaskSet.filter`/`.take` returning `Self` for Python 3.10/3.11 compatibility, and CI matrix coverage for those versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56fda02650f81554b099e2e663b869fdf38d215e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->