### PR TITLE
rlm_harness: plumb max_context_tokens + max_seq_len fallback

### DIFF
--- a/verifiers/envs/experimental/composable/harnesses/rlm.py
+++ b/verifiers/envs/experimental/composable/harnesses/rlm.py
@@ -184,10 +184,16 @@ def rlm_harness(
     if summarize_env is not None:
         environment_vars["RLM_SUMMARIZE_AT_TOKENS"] = summarize_env
     # max_context_tokens (explicit) wins over max_seq_len (prime-rl default).
-    effective_max_context = (
-        max_context_tokens if max_context_tokens is not None else max_seq_len
-    )
-    max_context_env = _format_max_context_tokens(effective_max_context)
+    # Validate via whichever kwarg actually carried the value so a bad
+    # fallback gets reported against its real source name.
+    if max_context_tokens is not None:
+        max_context_env = _format_positive_int(
+            "max_context_tokens", max_context_tokens
+        )
+    elif max_seq_len is not None:
+        max_context_env = _format_positive_int("max_seq_len", max_seq_len)
+    else:
+        max_context_env = None
     if max_context_env is not None:
         environment_vars["RLM_MAX_CONTEXT_TOKENS"] = max_context_env
 
@@ -231,8 +237,3 @@ def _format_positive_int(name: str, value: int | None) -> str | None:
 def _format_summarize_at_tokens(value: int | None) -> str | None:
     """Format ``summarize_at_tokens`` as the ``RLM_SUMMARIZE_AT_TOKENS`` string."""
     return _format_positive_int("summarize_at_tokens", value)
-
-
-def _format_max_context_tokens(value: int | None) -> str | None:
-    """Format ``max_context_tokens`` as the ``RLM_MAX_CONTEXT_TOKENS`` string."""
-    return _format_positive_int("max_context_tokens", value)

--- a/verifiers/envs/experimental/composable/harnesses/rlm.py
+++ b/verifiers/envs/experimental/composable/harnesses/rlm.py
@@ -102,6 +102,8 @@ def rlm_harness(
     rlm_max_turns: int = DEFAULT_RLM_MAX_TURNS,
     rlm_exec_timeout: int = DEFAULT_RLM_EXEC_TIMEOUT,
     summarize_at_tokens: int | None = None,
+    max_context_tokens: int | None = None,
+    max_seq_len: int | None = None,
     append_to_system_prompt: str | None = None,
     local_checkout: str | Path | None = None,
     gh_token: str | None = None,
@@ -123,6 +125,15 @@ def rlm_harness(
       a positive int, rlm auto-compacts the current branch once the
       prompt_tokens of a turn reach the threshold. ``None`` disables
       auto-compaction.
+    - ``max_context_tokens`` / ``max_seq_len`` → ``RLM_MAX_CONTEXT_TOKENS``:
+      hard context ceiling. When a turn's prompt_tokens exceeds this,
+      rlm rolls back the most recent tool result to a short stub and
+      fires compaction; per-call ``max_completion_tokens`` is also
+      derived from the remaining budget. ``max_context_tokens`` wins
+      when both are provided; otherwise ``max_seq_len`` is the fallback
+      and matches what prime-rl injects via
+      ``extra_env_kwargs["max_seq_len"]``. ``None`` on both disables
+      the ceiling.
 
     Callers do not need to — and should not — add these keys to
     ``ComposableEnv(environment_vars=...)`` themselves; pass the kwargs
@@ -172,6 +183,13 @@ def rlm_harness(
     summarize_env = _format_summarize_at_tokens(summarize_at_tokens)
     if summarize_env is not None:
         environment_vars["RLM_SUMMARIZE_AT_TOKENS"] = summarize_env
+    # max_context_tokens (explicit) wins over max_seq_len (prime-rl default).
+    effective_max_context = (
+        max_context_tokens if max_context_tokens is not None else max_seq_len
+    )
+    max_context_env = _format_max_context_tokens(effective_max_context)
+    if max_context_env is not None:
+        environment_vars["RLM_MAX_CONTEXT_TOKENS"] = max_context_env
 
     return Harness(
         install_script=build_install_script(),
@@ -192,20 +210,29 @@ def rlm_harness(
     )
 
 
-def _format_summarize_at_tokens(value: int | None) -> str | None:
-    """Format ``summarize_at_tokens`` as the ``RLM_SUMMARIZE_AT_TOKENS`` string.
+def _format_positive_int(name: str, value: int | None) -> str | None:
+    """Format a positive-int harness kwarg as the env-var string.
 
-    Returns ``None`` when auto-compaction should be disabled (matches what
-    the engine expects when the env var is absent). Rejects bad shapes
-    here so configuration errors surface at harness-build time rather
+    Returns ``None`` when the feature should be disabled. Rejects bad
+    shapes so configuration errors surface at harness-build time rather
     than deep inside the sandbox.
     """
     if value is None:
         return None
     if isinstance(value, bool) or not isinstance(value, int):
         raise ValueError(
-            f"summarize_at_tokens must be an int or None (got {type(value).__name__})"
+            f"{name} must be an int or None (got {type(value).__name__})"
         )
     if value <= 0:
-        raise ValueError(f"summarize_at_tokens must be positive (got {value})")
+        raise ValueError(f"{name} must be positive (got {value})")
     return str(value)
+
+
+def _format_summarize_at_tokens(value: int | None) -> str | None:
+    """Format ``summarize_at_tokens`` as the ``RLM_SUMMARIZE_AT_TOKENS`` string."""
+    return _format_positive_int("summarize_at_tokens", value)
+
+
+def _format_max_context_tokens(value: int | None) -> str | None:
+    """Format ``max_context_tokens`` as the ``RLM_MAX_CONTEXT_TOKENS`` string."""
+    return _format_positive_int("max_context_tokens", value)

--- a/verifiers/envs/experimental/composable/harnesses/rlm.py
+++ b/verifiers/envs/experimental/composable/harnesses/rlm.py
@@ -187,9 +187,7 @@ def rlm_harness(
     # Validate via whichever kwarg actually carried the value so a bad
     # fallback gets reported against its real source name.
     if max_context_tokens is not None:
-        max_context_env = _format_positive_int(
-            "max_context_tokens", max_context_tokens
-        )
+        max_context_env = _format_positive_int("max_context_tokens", max_context_tokens)
     elif max_seq_len is not None:
         max_context_env = _format_positive_int("max_seq_len", max_seq_len)
     else:
@@ -226,9 +224,7 @@ def _format_positive_int(name: str, value: int | None) -> str | None:
     if value is None:
         return None
     if isinstance(value, bool) or not isinstance(value, int):
-        raise ValueError(
-            f"{name} must be an int or None (got {type(value).__name__})"
-        )
+        raise ValueError(f"{name} must be an int or None (got {type(value).__name__})")
     if value <= 0:
         raise ValueError(f"{name} must be positive (got {value})")
     return str(value)


### PR DESCRIPTION
Paired with the rlm-side max_context_tokens kwarg. The harness now accepts either an explicit max_context_tokens (user-set budget) or a max_seq_len fallback (matches what prime-rl injects into the env worker via extra_env_kwargs["max_seq_len"]). Explicit wins when both are given. Either one, when positive, is emitted as RLM_MAX_CONTEXT_TOKENS.

Extracted the positive-int env-var formatter as
_format_positive_int since summarize_at_tokens and max_context_tokens validate identically; _format_summarize_at_tokens and the new _format_max_context_tokens are one-line wrappers. Misconfig raises at harness-build time, not inside the sandbox.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: limited to harness env-var plumbing and input validation, but may change runtime behavior if callers begin setting the new context ceiling.
> 
> **Overview**
> Adds support for a hard context ceiling in `rlm_harness` via new `max_context_tokens` (preferred) and `max_seq_len` (fallback) parameters, emitting `RLM_MAX_CONTEXT_TOKENS` when either is set to a positive int.
> 
> Refactors token-threshold validation into a shared `_format_positive_int` helper and updates `summarize_at_tokens` formatting to use it, ensuring misconfigurations fail fast at harness-build time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18d9b1bd03a8fac8a9ec7f5954ea41ed3db823ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->