### PR TITLE
SWEBenchTaskSet.setup: symlink venv at /testbed/.venv matching WORKDIR

### DIFF
--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.13.dev7"
+__version__ = "0.1.13.dev8"
 
 import importlib
 import os

--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.13.dev8"
+__version__ = "0.1.13.dev7"
 
 import importlib
 import os

--- a/verifiers/envs/experimental/composable/tasksets/swe/swe_bench.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/swe_bench.py
@@ -411,7 +411,7 @@ class SWEBenchTaskSet(SandboxTaskSet):
         )
 
     def get_workdir(self, info: dict) -> str:
-        return "/root"
+        return "/testbed"
 
     def get_env_vars(self) -> dict[str, str]:
         return dict(ENV_VARS_SWEBENCH)
@@ -419,11 +419,14 @@ class SWEBenchTaskSet(SandboxTaskSet):
     async def setup(self, state) -> None:
         sandbox_client = state["sandbox_client"]
         sandbox_id = state["sandbox_id"]
-        results = await sandbox_client.execute_command(
-            sandbox_id, "ln -s /opt/miniconda3/envs/testbed /root/.venv"
-        )
-        if results.exit_code != 0:
-            raise RuntimeError(f"Setup failed: exit_code={results.exit_code}")
+        for target in ("/testbed/.venv", "/root/.venv"):
+            results = await sandbox_client.execute_command(
+                sandbox_id, f"ln -s /opt/miniconda3/envs/testbed {target}"
+            )
+            if results.exit_code != 0:
+                raise RuntimeError(
+                    f"Setup failed: exit_code={results.exit_code} target={target}"
+                )
 
     async def _run_tests(
         self,

--- a/verifiers/envs/experimental/composable/tasksets/swe/swe_bench.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/swe_bench.py
@@ -419,11 +419,14 @@ class SWEBenchTaskSet(SandboxTaskSet):
     async def setup(self, state) -> None:
         sandbox_client = state["sandbox_client"]
         sandbox_id = state["sandbox_id"]
-        results = await sandbox_client.execute_command(
-            sandbox_id, "ln -s /opt/miniconda3/envs/testbed /root/.venv"
-        )
-        if results.exit_code != 0:
-            raise RuntimeError(f"Setup failed: exit_code={results.exit_code}")
+        for target in ("/testbed/.venv", "/root/.venv"):
+            results = await sandbox_client.execute_command(
+                sandbox_id, f"ln -s /opt/miniconda3/envs/testbed {target}"
+            )
+            if results.exit_code != 0:
+                raise RuntimeError(
+                    f"Setup failed: exit_code={results.exit_code} target={target}"
+                )
 
     async def _run_tests(
         self,

--- a/verifiers/envs/experimental/composable/tasksets/swe/swe_bench.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/swe_bench.py
@@ -411,7 +411,7 @@ class SWEBenchTaskSet(SandboxTaskSet):
         )
 
     def get_workdir(self, info: dict) -> str:
-        return "/testbed"
+        return "/root"
 
     def get_env_vars(self) -> dict[str, str]:
         return dict(ENV_VARS_SWEBENCH)
@@ -419,14 +419,11 @@ class SWEBenchTaskSet(SandboxTaskSet):
     async def setup(self, state) -> None:
         sandbox_client = state["sandbox_client"]
         sandbox_id = state["sandbox_id"]
-        for target in ("/testbed/.venv", "/root/.venv"):
-            results = await sandbox_client.execute_command(
-                sandbox_id, f"ln -s /opt/miniconda3/envs/testbed {target}"
-            )
-            if results.exit_code != 0:
-                raise RuntimeError(
-                    f"Setup failed: exit_code={results.exit_code} target={target}"
-                )
+        results = await sandbox_client.execute_command(
+            sandbox_id, "ln -s /opt/miniconda3/envs/testbed /root/.venv"
+        )
+        if results.exit_code != 0:
+            raise RuntimeError(f"Setup failed: exit_code={results.exit_code}")
 
     async def _run_tests(
         self,


### PR DESCRIPTION
## Summary

The rlm harness probes `cd \$AGENT_WORKDIR && [ -x .venv/bin/python3 ]` to detect a Python venv. For SWE-bench tasks, `AGENT_WORKDIR=/testbed` (the repo root) but the existing setup only symlinked `/root/.venv -> /opt/miniconda3/envs/testbed`, so the probe missed.

This PR restores the symlink approach (and reverts the previous `get_workdir=/root` change):

- `SWEBenchTaskSet.get_workdir` stays at `/testbed` so the agent starts in the repo, where it can read/edit source.
- `SWEBenchTaskSet.setup` now creates **two** symlinks pointing at the conda env:
  - `/testbed/.venv` (new — matches `AGENT_WORKDIR` so the harness probe lands)
  - `/root/.venv` (existing — kept for backward compat)

This parallels `R2EGymTaskSet.setup` (`r2e_gym.py:293-298`), which uses the same pattern.

## Safety check (empirical)

Before symlinking over `/testbed/.venv`, verified it doesn't pre-exist on a real SWE-bench sandbox image:

```
$ prime sandbox run ... \"ls -la /testbed/.venv; ls -la /root/.venv; ls -la /opt/miniconda3/envs/testbed | head -3\"
ls: cannot access '/testbed/.venv': No such file or directory
---
ls: cannot access '/root/.venv': No such file or directory
---
total 44
drwxr-xr-x 1 root root 4096 Sep 10  2025 .
drwxr-xr-x 1 root root 4096 Sep 10  2025 ..
```

Image probed: `us-central1-docker.pkg.dev/prime-intellect-platform/prod-sandbox/swebench/sweb.eval.x86_64.astropy_1776_astropy-12907:latest` (a SWE-bench-Verified-Quick instance — `astropy__astropy-12907`).

Conclusion: neither `.venv` path is occupied, so `setup` can safely create both symlinks; the conda env at `/opt/miniconda3/envs/testbed` is the symlink target.

## Why this approach over `get_workdir=/root`

Pointing `AGENT_WORKDIR` at `/root` works for the probe but starts the agent outside the repo, which is surprising and breaks any tool that assumes cwd == repo root. Adding the extra symlink keeps existing behavior and only patches the probe path.

## Test plan

- [ ] `vf-eval` a SWE-bench task end-to-end and verify the rlm harness's venv probe succeeds with `AGENT_WORKDIR=/testbed`.
- [ ] Confirm gold-patch validation still passes (uses `/testbed` as cwd).

🤖 Generated with [Claude Code](https://claude.com/claude-code)