### PR TITLE
rlm harness: remove dead RLM_KERNEL_PYTHON detection block

### DIFF
--- a/verifiers/envs/experimental/composable/harnesses/rlm.py
+++ b/verifiers/envs/experimental/composable/harnesses/rlm.py
@@ -75,20 +75,6 @@ export OPENAI_API_KEY="${{OPENAI_API_KEY:-intercepted}}"
 export RLM_APPEND_TO_SYSTEM_PROMPT="$(cat {shlex.quote(DEFAULT_APPEND_TO_SYSTEM_PROMPT_PATH)} 2>/dev/null || true)"
 cd "${{AGENT_WORKDIR:-{workdir}}}"
 
-# If the sandbox has a .venv, run the ipython kernel inside it so the
-# agent can inline-import project packages (numpy, pandas, etc.).
-if [ -x .venv/bin/python3 ]; then
-    PYVER=$(.venv/bin/python3 -c "import sys; print(sys.version_info[:2] >= (3,10))" 2>/dev/null || true)
-    if [ "$PYVER" = "True" ]; then
-        IPYKERNEL="ipykernel"
-    else
-        IPYKERNEL="ipykernel<7"
-    fi
-    if .venv/bin/python3 -m pip install -q "$IPYKERNEL" nest_asyncio 2>/dev/null; then
-        export RLM_KERNEL_PYTHON="$(pwd)/.venv/bin/python3"
-    fi
-fi
-
 rlm "$(cat {instruction_path})"
 """
     return f"bash -lc {shlex.quote(script)}"


### PR DESCRIPTION
## Summary

Delete the `[ -x .venv/bin/python3 ]` probe + `python3 -m pip install
ipykernel nest_asyncio` + `export RLM_KERNEL_PYTHON=…` block from
`build_run_command` in
`verifiers/envs/experimental/composable/harnesses/rlm.py`.

## Why it's dead

That block was load-bearing while rlm had `kernel_shim.py` — it pointed
the IPython kernel at the sandbox's `/testbed/.venv` so the agent could
inline-import project packages.

That changed in [rlm PR #52](https://github.com/PrimeIntellect-ai/rlm/pull/52)
(`13a760f` — "drop kernel shim; always run IPython kernel in rlm's
Python"), which:
- deleted `src/rlm/kernel_shim.py`
- stripped `RLM_KERNEL_PYTHON` reader support from `src/rlm/tools/ipython.py`

The currently-pinned rlm commit (research-prod's `rlm5/prod.toml` stamps
`rlm_ref = "7e7c28d3"` via this harness's `rlm_ref` kwarg) is well
post-#52, so `RLM_KERNEL_PYTHON` has no consumer in the rlm runtime.

Every rollout still pays for the venv probe + attempted `pip install`,
with failures silenced by `2>/dev/null`. It's dead code that muddies the
design story for anyone reading this harness.

The surrounding `cd "${AGENT_WORKDIR:-…}"` and `rlm "$(cat …)"` lines
are unchanged.

## If we ever want this back

External-kernel mode is small and self-contained to re-add — a better
version would also handle `/root/.venv` fallback and use `uv pip install
--python` instead of bare `pip`. Cheap to reintroduce; not worth keeping
as cruft now.

## Test plan

- [x] `uv run ruff check verifiers/envs/experimental/composable/harnesses/rlm.py`
- [x] `uv run ruff format verifiers/envs/experimental/composable/harnesses/rlm.py`
- [ ] Spot-check: an rlm rollout with this harness still runs `rlm "$(cat …)"` against `${AGENT_WORKDIR:-/testbed}` (no behavioral change expected — the deleted block only set an env var nobody reads)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: deletes a venv probe and `pip install` side effects that no longer feed any consumed env var, leaving the actual `rlm` invocation unchanged.
> 
> **Overview**
> Simplifies the RLM harness `build_run_command` by removing the `.venv` detection and the attempted `pip install` of `ipykernel`/`nest_asyncio`, along with the unused `RLM_KERNEL_PYTHON` export.
> 
> The run script now just sets the existing env vars, `cd`s into `${AGENT_WORKDIR:-/testbed}`, and executes `rlm "$(cat instruction)"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 750c9db270a334ba730889366ae23bdd3e97efa1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->