### PR TITLE
CliAgentEnv: add TASK_FINISHED stop-signal hook

### DIFF
--- a/verifiers/envs/experimental/cli_agent_env.py
+++ b/verifiers/envs/experimental/cli_agent_env.py
@@ -120,6 +120,7 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
         sandbox_creations_per_minute: float | None = 128,
         timeouts: SandboxTimeouts = SandboxTimeouts(),
         keep_sandbox_for_scoring: bool = False,
+        task_finished_signal: str | None = None,
         **kwargs,
     ):
         super().__init__(max_turns=max_turns, message_type="chat", **kwargs)
@@ -137,6 +138,7 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
             timeouts=timeouts,
         )
         self.keep_sandbox_for_scoring = keep_sandbox_for_scoring
+        self.task_finished_signal = task_finished_signal
         self.run_command = run_command
         self.poll_interval = poll_interval
         self.timeout_seconds = timeout_seconds
@@ -676,6 +678,39 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
         """Check rollout timeout"""
         elapsed = time.time() - state["timing"]["start_time"]
         return elapsed > self.timeout_seconds
+
+    @vf.stop
+    async def task_finished_signal_emitted(self, state: State) -> bool:
+        """Stop when the agent emits the configured task-finished signal.
+
+        The signal is expected to arrive inside a tool-role message (e.g. the
+        model issued `echo "TASK_FINISHED"` as a bash tool call, and the tool
+        response echoes it back). Scanning only the latest intercepted prompt's
+        trailing tool messages keeps the check cheap.
+        """
+        signal = self.task_finished_signal
+        if not signal:
+            return False
+        trajectory = state.get("trajectory", [])
+        if not trajectory:
+            return False
+        last_prompt = trajectory[-1].get("prompt") or []
+        for message in reversed(last_prompt):
+            role = (
+                message.get("role")
+                if isinstance(message, dict)
+                else getattr(message, "role", None)
+            )
+            if role != "tool":
+                break
+            content = (
+                message.get("content")
+                if isinstance(message, dict)
+                else getattr(message, "content", None)
+            )
+            if content and signal in str(content):
+                return True
+        return False
 
     async def post_rollout(self, state: State):
         """


### PR DESCRIPTION
## Summary

Adds an opt-in `task_finished_signal: str | None = None` parameter to `CliAgentEnv` and a matching `@vf.stop` hook (`task_finished_signal_emitted`) that terminates the rollout when the configured signal (e.g. `"TASK_FINISHED"`) appears in the trailing tool-role messages of the agent's latest intercepted request.

The default (`None`) is a no-op, so existing envs are unaffected.

## Motivation

rlm-style agents already expose a passive-stop path when the model returns `tool_calls=[]`, but the model rarely takes that exit on its own. Analysis of v4-p1 step-27 rollouts showed a 54.5% rate of "summary-while-still-tool-calling" — the agent narrates that it's done while continuing to issue tool calls — whereas `mini_swe_agent_plus`'s analogous `MINI_SWE_AGENT_FINAL_OUTPUT` ritual is emitted in 97.4% of its rollouts.

Giving `CliAgentEnv` the same "I'm done" ritual + automatic stop hook gives the engine a reliable way to terminate when the model commits to a fix.

## Companion PR

This hook is paired with PrimeIntellect-ai/rlm#60, which instructs the rlm agent (when bash is an active tool) to emit exactly one `bash` tool call with the command `echo "TASK_FINISHED"` when confident the task is complete. Either PR alone is a no-op; both together close the loop.

## Design notes

- `task_finished_signal` defaults to `None` so the hook is opt-in; existing `CliAgentEnv` subclasses (e.g. rlm-swe harness configs) are not surprised.
- The scan only walks the **trailing run** of tool messages in the latest trajectory step's `prompt`; it does not traverse full history.
- Handles both Pydantic `ToolMessage` and dict-shaped intercepted messages.
- Substring match on content (not exact equality) so `echo` wrappers or output framing don't defeat detection.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: behavior is unchanged by default (`task_finished_signal=None`), and the new stop condition only triggers when explicitly configured based on recent tool-message content.
> 
> **Overview**
> Adds an opt-in `task_finished_signal` parameter to `CliAgentEnv` and stores it on the instance.
> 
> Introduces a new `@vf.stop` check (`task_finished_signal_emitted`) that terminates the rollout when the configured signal is detected in the *latest step’s trailing* tool-role messages, allowing agents to end runs via a deliberate tool output marker.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed421b3ad2cd42fe5b6351acbafea80d4a992136. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->