### PR TITLE
rlm harness: move git-refusal shim off the system PATH so SWE eval scripts can run git

### DIFF
--- a/tests/test_rlm_composable_env.py
+++ b/tests/test_rlm_composable_env.py
@@ -170,21 +170,36 @@ def test_rlm_harness_install_script_requires_uploaded_checkout():
 
 
 def test_rlm_harness_blocks_git_by_default(tmp_path):
-    """By default RLM uploads a sh shim at /usr/local/bin/git that
-    refuses on any invocation and exits 1. post_install_script just
-    chmods it executable."""
+    """By default RLM uploads a sh shim that refuses on any invocation
+    and exits 1. The shim is staged at /tmp and moved to
+    $HOME/.local/bin/git by the post-install script — that dir is on
+    the agent's PATH (via the run_command's ``export PATH=...``) but
+    NOT on the container's default PATH, so scoring's
+    ``execute_command`` calls (e.g. ``git apply`` in eval scripts) keep
+    resolving to the real ``/usr/bin/git``."""
     checkout = _make_git_checkout(tmp_path / "rlm")
     harness = rlm_harness(local_checkout=checkout)
 
     assert harness.post_install_uploads is not None
-    assert set(harness.post_install_uploads.keys()) == {"/usr/local/bin/git"}
+    assert set(harness.post_install_uploads.keys()) == {"/tmp/__rlm_git_shim"}
 
-    shim = harness.post_install_uploads["/usr/local/bin/git"]
+    shim = harness.post_install_uploads["/tmp/__rlm_git_shim"]
     assert shim.startswith("#!/bin/sh\n")
     assert "Bash command 'git' is not allowed." in shim
     assert "exit 1" in shim
 
-    assert harness.post_install_script == "chmod +x /usr/local/bin/git"
+    script = harness.post_install_script
+    assert script is not None
+    # Shim must end up at $HOME/.local/bin/git, executable, with parent
+    # dir created if missing.
+    assert 'mkdir -p "$HOME/.local/bin"' in script
+    assert 'mv /tmp/__rlm_git_shim "$HOME/.local/bin/git"' in script
+    assert 'chmod +x "$HOME/.local/bin/git"' in script
+    # The shim must NOT live anywhere on the container's default PATH —
+    # /usr/local/bin/git would shadow the real git for scoring's
+    # execute_command shells (which don't get $HOME/.local/bin
+    # prepended) and break ``git apply`` of test_patches in eval.sh.
+    assert "/usr/local/bin/git" not in script
 
 
 def test_rlm_harness_allow_git_uploads_nothing(tmp_path):

--- a/verifiers/envs/experimental/composable/composable_env.py
+++ b/verifiers/envs/experimental/composable/composable_env.py
@@ -315,8 +315,8 @@ class ComposableEnv(CliAgentEnv):
         """Upload harness ``post_install_uploads`` and run ``post_install_script``.
 
         Runs after ``_install_agent`` so harnesses can layer small assets
-        on top of a fully-installed agent (e.g. RLM uploads its
-        ``/usr/local/bin/git`` refusal shim and chmods it executable).
+        on top of a fully-installed agent (e.g. RLM stages its git refusal
+        shim into ``$HOME/.local/bin/git`` and chmods it executable).
         Uses the single-file upload path — not ``_upload_dir`` — because
         these are small, harness-computed blobs of content rather than
         local directories on disk.

--- a/verifiers/envs/experimental/composable/harness.py
+++ b/verifiers/envs/experimental/composable/harness.py
@@ -100,9 +100,9 @@ class Harness:
         Optional mapping from sandbox path → file content. Uploaded via
         the single-file upload path (same as instruction / system
         prompt) AFTER ``install_script`` finishes. Use for small
-        harness-computed assets — e.g. RLM's ``/usr/local/bin/git``
-        refusal shim. For large directories use ``upload_dir_mapping``
-        instead.
+        harness-computed assets — e.g. RLM's git refusal shim staged
+        into ``$HOME/.local/bin/git``. For large directories use
+        ``upload_dir_mapping`` instead.
     post_install_script:
         Optional shell snippet run AFTER ``post_install_uploads`` land in
         the sandbox. Typical use: ``chmod +x`` on the uploaded files, or

--- a/verifiers/envs/experimental/composable/harnesses/rlm.py
+++ b/verifiers/envs/experimental/composable/harnesses/rlm.py
@@ -115,12 +115,18 @@ def rlm_harness(
     here and the harness owns the env var plumbing.
 
     ``allow_git`` defaults to False, mirroring opencode's bash tool. When
-    False, a ``/usr/local/bin/git`` shim is uploaded that refuses on any
-    invocation — this covers the RLM bash tool, the ipython tool's
-    ``!cmd`` / ``%%bash`` cells, and any ``subprocess.run(["git", ...])``
-    from inside ipython, since all three resolve via PATH and hit the
-    shim first. Set ``allow_git=True`` for environments that genuinely
-    need git.
+    False, a refusal shim is dropped at ``$HOME/.local/bin/git`` (the
+    same dir ``uv tool install rlm`` writes to, which RLM's ``run_command``
+    prepends to ``PATH``). This blocks git for the RLM bash tool, the
+    ipython tool's ``!cmd`` / ``%%bash`` cells, and any
+    ``subprocess.run(["git", ...])`` from inside ipython — all three
+    inherit the agent process's PATH and resolve through the shim first.
+    Crucially, the shim is NOT installed on a system PATH dir, so a
+    rubric / scoring step running ``git apply`` or ``git checkout`` via
+    ``sandbox_client.execute_command`` (which uses the container's
+    default PATH, *not* ``$HOME/.local/bin``) still resolves to the real
+    git in ``/usr/bin``. Set ``allow_git=True`` for environments that
+    genuinely need git inside the agent's tools.
     """
     upload_dir_mapping: dict[str, str] = {
         DEFAULT_RLM_CHECKOUT_UPLOAD_NAME: DEFAULT_RLM_CHECKOUT_PATH,
@@ -147,8 +153,24 @@ def rlm_harness(
     post_install_uploads: dict[str, str] | None = None
     post_install_script: str | None = None
     if not allow_git:
-        post_install_uploads = {"/usr/local/bin/git": _GIT_SHIM_BODY}
-        post_install_script = "chmod +x /usr/local/bin/git"
+        # Drop the shim into the same dir ``uv tool install rlm`` uses
+        # ($HOME/.local/bin), which the RLM run_command prepends to PATH
+        # for the agent. This dir is *not* on the container's default
+        # PATH, so the rubric's ``sandbox_client.execute_command`` calls
+        # (skip-install diff, eval.sh's ``git checkout`` / ``git apply``,
+        # gold-patch apply) keep resolving to the real ``/usr/bin/git``.
+        # Uploading directly into ``$HOME/.local/bin`` requires shell
+        # expansion, so stage the body in /tmp and let the post-install
+        # script move it; that script is just dispatched as a string to
+        # ``execute_command``, which runs under a shell that expands
+        # ``$HOME``.
+        post_install_uploads = {"/tmp/__rlm_git_shim": _GIT_SHIM_BODY}
+        post_install_script = (
+            "set -e; "
+            'mkdir -p "$HOME/.local/bin"; '
+            'mv /tmp/__rlm_git_shim "$HOME/.local/bin/git"; '
+            'chmod +x "$HOME/.local/bin/git"'
+        )
 
     environment_vars: dict[str, str] = {
         "RLM_TOOLS": ",".join(tool_names),


### PR DESCRIPTION
## Summary

- The RLM git-refusal shim was landing at `/usr/local/bin/git`, which is on the container's default PATH ahead of `/usr/bin/git`. Every sandbox shell (including the rubric's `sandbox_client.execute_command` calls during scoring) saw the shim, so the canonical SWE-bench eval script's `git checkout <base_commit> -- <test_files>` and `git apply test_patch` both silently failed (script uses `set -uxo pipefail`, no `-e`). pytest then ran on the un-patched test file and the FAIL_TO_PASS IDs added by the test_patch were never present — so even a perfect gold-patch fix scored `reward=0` for every task whose test_patch adds new test cases (the majority of SWE-bench Verified Quick).
- This PR moves the shim to `\$HOME/.local/bin/git` — the same dir `uv tool install rlm` writes to, which the agent's `run_command` already prepends to PATH via `export PATH=\"\$HOME/.local/bin:\$PATH\"`. The agent still resolves git through the shim (blocked); the rubric's `execute_command` runs with the container's default PATH (no `\$HOME/.local/bin`) and resolves the real `/usr/bin/git` (works).

Affected tasksets: every SWE family that runs `git apply` / `git checkout` inside `_run_tests` (`swe_bench`, `r2e_gym`, `openswe`, `swe_lego`, `swe_rebench_v2`, `swe_smith`, `multi_swe`). No taskset code changes — the harness fix is enough.

The upload path must be a literal string (no env expansion at sandbox-create time), so the shim body is staged at `/tmp/__rlm_git_shim` and the post-install script (which IS a shell) moves it via `\$HOME` expansion.

### Repro / verification

End-to-end on `sweb.eval.x86_64.astropy_1776_astropy-12907` (instance 0 of SWE-Bench-Verified-Quick):

| | shim @ `/usr/local/bin/git` (before) | shim @ `\$HOME/.local/bin/git` (this PR) |
|---|---|---|
| `which -a git` (default PATH, scoring) | `/usr/local/bin/git` (shim) → exit 1 | `/usr/bin/git` (real) ✓ |
| `which -a git` (agent PATH) | shim ✓ | shim ✓ |
| eval.sh w/ gold patch — items collected | **11** (test_patch never applied) | **15** ✓ |
| eval.sh w/ gold patch — result | `compound_model[6,9]` IDs missing → reward 0 | all 15 PASSED |

The agent is still git-blocked: I verified `bash -c 'export PATH=\$HOME/.local/bin:\$PATH && git --version'` returns `Bash command 'git' is not allowed.` exit 1.

## Test plan

- [x] `uv run pytest tests/test_rlm_composable_env.py` — 19 passed (test updated to assert the new shim path & that no path on the container's default PATH is touched).
- [x] `uv run ruff check` / `uv run ruff format` clean on all touched files.
- [x] Manually verified shim placement on a fresh `astropy_1776_astropy-12907` sandbox via `prime sandbox`.
- [x] Manually verified eval.sh now collects 15 tests (vs 11 before) when the gold patch is applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes sandbox post-install behavior and PATH shadowing for `git`, which affects both agent tool execution and evaluation/scoring scripts. Failures here could either re-enable git for the agent or continue breaking `git apply/checkout` during scoring.
> 
> **Overview**
> Moves the default RLM git-blocking shim off the system PATH: instead of uploading `git` to `/usr/local/bin`, the harness now uploads the shim to `/tmp/__rlm_git_shim` and a post-install script relocates it to `"$HOME/.local/bin/git"` (creating the directory and chmod’ing it). This keeps the agent git-blocked (agent prepends `$HOME/.local/bin` to PATH) while allowing scoring/eval `execute_command` calls to continue using the real `/usr/bin/git`.
> 
> Updates the RLM harness docs and tests to assert the new upload location and post-install script behavior, and clarifies comments in `ComposableEnv`/`Harness` about post-install usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dffe056d65bd8776d46ddba6fdfa2c236167f5af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->