### PR TITLE
swe tasksets: add 5min sandbox scoring buffer

### DIFF
--- a/verifiers/envs/experimental/composable/tasksets/swe/multi_swe.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/multi_swe.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import verifiers as vf
 from verifiers.envs.experimental.composable import SandboxSpec, SandboxTaskSet
+from verifiers.envs.experimental.composable.tasksets.swe.swe_tasksets import SCORING_BUFFER_MINUTES
 
 logger = logging.getLogger(__name__)
 
@@ -246,7 +247,7 @@ class MultiSWETaskSet(SandboxTaskSet):
         return SandboxSpec(
             image=info.get("_task_docker_image")
             or _build_docker_image(restore_row(info)),
-            timeout_minutes=self.timeout_minutes,
+            timeout_minutes=self.timeout_minutes + SCORING_BUFFER_MINUTES,
         )
 
     def get_workdir(self, info: dict) -> str:

--- a/verifiers/envs/experimental/composable/tasksets/swe/openswe.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/openswe.py
@@ -9,6 +9,7 @@ from typing import Any
 import verifiers as vf
 from datasets import load_dataset
 from verifiers.envs.experimental.composable import SandboxSpec, SandboxTaskSet
+from verifiers.envs.experimental.composable.tasksets.swe.swe_tasksets import SCORING_BUFFER_MINUTES
 
 logger = logging.getLogger(__name__)
 
@@ -130,7 +131,7 @@ class OpenSWETaskSet(SandboxTaskSet):
     def get_sandbox_spec(self, info: dict) -> SandboxSpec | None:
         return SandboxSpec(
             image=info["image_name"],
-            timeout_minutes=self.timeout_minutes,
+            timeout_minutes=self.timeout_minutes + SCORING_BUFFER_MINUTES,
         )
 
     def get_workdir(self, info: dict) -> str:

--- a/verifiers/envs/experimental/composable/tasksets/swe/r2e_gym.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/r2e_gym.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import verifiers as vf
 from verifiers.envs.experimental.composable import SandboxSpec, SandboxTaskSet
+from verifiers.envs.experimental.composable.tasksets.swe.swe_tasksets import SCORING_BUFFER_MINUTES
 
 from .log_parser import decolor_dict_keys, parse_log_fn
 
@@ -244,7 +245,7 @@ class R2EGymTaskSet(SandboxTaskSet):
     def get_sandbox_spec(self, info: dict) -> SandboxSpec | None:
         return SandboxSpec(
             image=f"{REGISTRY_PREFIX}/{info['docker_image']}",
-            timeout_minutes=self.timeout_minutes,
+            timeout_minutes=self.timeout_minutes + SCORING_BUFFER_MINUTES,
         )
 
     def get_workdir(self, info: dict) -> str:

--- a/verifiers/envs/experimental/composable/tasksets/swe/swe_bench.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/swe_bench.py
@@ -11,6 +11,7 @@ from typing import Any
 
 import verifiers as vf
 from verifiers.envs.experimental.composable import SandboxSpec, SandboxTaskSet
+from verifiers.envs.experimental.composable.tasksets.swe.swe_tasksets import SCORING_BUFFER_MINUTES
 
 # swebench's __init__.py calls logging.basicConfig() at import time (via
 # build_dataset), which hijacks the root logger with an INFO-level
@@ -407,7 +408,7 @@ class SWEBenchTaskSet(SandboxTaskSet):
         test_spec = _make_test_spec_with_retry(info, namespace="swebench")
         return SandboxSpec(
             image=f"{REGISTRY_PREFIX}/{test_spec.instance_image_key}",
-            timeout_minutes=self.timeout_minutes,
+            timeout_minutes=self.timeout_minutes + SCORING_BUFFER_MINUTES,
         )
 
     def get_workdir(self, info: dict) -> str:

--- a/verifiers/envs/experimental/composable/tasksets/swe/swe_lego.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/swe_lego.py
@@ -11,6 +11,7 @@ from typing import Any
 import verifiers as vf
 from datasets import load_dataset
 from verifiers.envs.experimental.composable import SandboxSpec, SandboxTaskSet
+from verifiers.envs.experimental.composable.tasksets.swe.swe_tasksets import SCORING_BUFFER_MINUTES
 
 from verifiers.envs.experimental.composable.tasksets.swe._test_patch import (
     revert_and_reapply_test_patch,
@@ -268,7 +269,7 @@ class SWELegoTaskSet(SandboxTaskSet):
     def get_sandbox_spec(self, info: dict) -> SandboxSpec:
         return SandboxSpec(
             image=info["image_name"],
-            timeout_minutes=self.timeout_minutes,
+            timeout_minutes=self.timeout_minutes + SCORING_BUFFER_MINUTES,
         )
 
     def get_workdir(self, info: dict) -> str:

--- a/verifiers/envs/experimental/composable/tasksets/swe/swe_rebench_v2.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/swe_rebench_v2.py
@@ -36,6 +36,7 @@ from typing import Any
 import verifiers as vf
 from datasets import load_dataset
 from verifiers.envs.experimental.composable import SandboxSpec, SandboxTaskSet
+from verifiers.envs.experimental.composable.tasksets.swe.swe_tasksets import SCORING_BUFFER_MINUTES
 
 from verifiers.envs.experimental.composable.tasksets.swe import (
     swe_rebench_v2_log_parsers as _lp,
@@ -301,7 +302,7 @@ class SWERebenchV2TaskSet(SandboxTaskSet):
     def get_sandbox_spec(self, info: dict) -> SandboxSpec:
         return SandboxSpec(
             image=info["image_name"],
-            timeout_minutes=self.timeout_minutes,
+            timeout_minutes=self.timeout_minutes + SCORING_BUFFER_MINUTES,
         )
 
     def get_workdir(self, info: dict) -> str:

--- a/verifiers/envs/experimental/composable/tasksets/swe/swe_smith.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/swe_smith.py
@@ -32,6 +32,7 @@ from typing import Any
 import verifiers as vf
 from datasets import load_dataset
 from verifiers.envs.experimental.composable import SandboxSpec, SandboxTaskSet
+from verifiers.envs.experimental.composable.tasksets.swe.swe_tasksets import SCORING_BUFFER_MINUTES
 
 logger = logging.getLogger(__name__)
 
@@ -248,7 +249,7 @@ class SWESmithTaskSet(SandboxTaskSet):
     def get_sandbox_spec(self, info: dict) -> SandboxSpec:
         return SandboxSpec(
             image=info["image_name"],
-            timeout_minutes=self.timeout_minutes,
+            timeout_minutes=self.timeout_minutes + SCORING_BUFFER_MINUTES,
         )
 
     def get_workdir(self, info: dict) -> str:

--- a/verifiers/envs/experimental/composable/tasksets/swe/swe_tasksets.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/swe_tasksets.py
@@ -12,6 +12,14 @@ from typing import Any
 
 from verifiers.envs.experimental.composable import TaskSet
 
+# Extra minutes added to the sandbox container's TTL on top of the
+# rollout-level ``timeout_minutes``. The scoring rubric runs *after* the
+# rollout deadline fires (e.g. ``test_patch`` execution / log parsing),
+# and needs a live sandbox to do so. Without a buffer the rollout cap
+# and sandbox TTL fire simultaneously, which leaves the rubric polling
+# a dead container indefinitely.
+SCORING_BUFFER_MINUTES = 5
+
 
 def make_swe_taskset(
     backend: str = "r2e",


### PR DESCRIPTION
## Summary

- Sandbox TTL was set to `ceil(timeout_seconds / 60)` in `rlm_swe.py` and other env wrappers, tying it exactly to the rollout-level deadline.
- When both fire simultaneously the scoring rubric runs against a dead container and its sandbox-poll loop hangs indefinitely.
- Adds `SCORING_BUFFER_MINUTES = 5` in `swe_tasksets.py` and applies it at every `SandboxSpec` construction across the 7 SWE backends (`swe_bench`, `r2e_gym`, `multi_swe`, `openswe`, `swe_lego`, `swe_rebench_v2`, `swe_smith`).

## Motivation

Hit a wedge on the GLM-5.1 RLM run (5968): step-75 eval reached 96-98% then stalled for 1h+. Per-worker post-mortem showed the env workers all stuck after a `swe_bench` rubric WARNING:

```
Test execution failed: Sandbox <id> failed (TIMEOUT): Sandbox exceeded maximum runtime
Test execution failed: Read file timed out after 30s: /tmp/job_<id>.exit
```

The sandbox TTL fires at the same instant as the rollout deadline (`2700s` rollout = `ceil(2700/60) = 45min` sandbox), so when the rollout hits its cap and the rubric immediately calls into the sandbox to run `test_patch`, the sandbox is already dying. The rubric's poll then never returns and the worker holds up the eval queue.

A 5-minute headroom guarantees the rubric has a live container to score against. A separate fix (bounded retry in the rubric polling loop) would be a defense-in-depth follow-up.