### PR TITLE
swe rubrics: hard wall-clock timeout on test execution

### DIFF
--- a/verifiers/envs/experimental/composable/tasksets/swe/multi_swe.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/multi_swe.py
@@ -9,7 +9,9 @@ from typing import Any
 
 import verifiers as vf
 from verifiers.envs.experimental.composable import SandboxSpec, SandboxTaskSet
-from verifiers.envs.experimental.composable.tasksets.swe.swe_tasksets import SCORING_BUFFER_MINUTES
+from verifiers.envs.experimental.composable.tasksets.swe.swe_tasksets import (
+    SCORING_BUFFER_MINUTES,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -154,16 +156,12 @@ class MultiSWERubric(vf.Rubric):
         timeout = state.get("test_timeout", 900)
         try:
             test_output = await asyncio.wait_for(
-                self.taskset._run_tests(
-                    sandbox_client, sandbox_id, state, timeout
-                ),
+                self.taskset._run_tests(sandbox_client, sandbox_id, state, timeout),
                 timeout=timeout + 60,
             )
             state["test_output"] = test_output
         except asyncio.TimeoutError:
-            logger.warning(
-                f"Test execution wall-clock timeout after {timeout + 60}s"
-            )
+            logger.warning(f"Test execution wall-clock timeout after {timeout + 60}s")
             state["test_output"] = "ERROR: wall-clock timeout"
             return 0.0
         except Exception as e:
@@ -178,7 +176,7 @@ class MultiSWERubric(vf.Rubric):
         sandbox_id = state.get("sandbox_id")
         if sandbox_client and sandbox_id:
             try:
-                await sandbox_client.delete(sandbox_id)
+                await asyncio.wait_for(sandbox_client.delete(sandbox_id), timeout=300)
             except Exception:
                 pass
 

--- a/verifiers/envs/experimental/composable/tasksets/swe/multi_swe.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/multi_swe.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 import shlex
 import tempfile
@@ -152,10 +153,19 @@ class MultiSWERubric(vf.Rubric):
             return 0.0
         timeout = state.get("test_timeout", 900)
         try:
-            test_output = await self.taskset._run_tests(
-                sandbox_client, sandbox_id, state, timeout
+            test_output = await asyncio.wait_for(
+                self.taskset._run_tests(
+                    sandbox_client, sandbox_id, state, timeout
+                ),
+                timeout=timeout + 60,
             )
             state["test_output"] = test_output
+        except asyncio.TimeoutError:
+            logger.warning(
+                f"Test execution wall-clock timeout after {timeout + 60}s"
+            )
+            state["test_output"] = "ERROR: wall-clock timeout"
+            return 0.0
         except Exception as e:
             logger.warning(f"Test execution failed: {e}")
             state["test_output"] = f"ERROR: {e}"

--- a/verifiers/envs/experimental/composable/tasksets/swe/openswe.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/openswe.py
@@ -10,7 +10,9 @@ from typing import Any
 import verifiers as vf
 from datasets import load_dataset
 from verifiers.envs.experimental.composable import SandboxSpec, SandboxTaskSet
-from verifiers.envs.experimental.composable.tasksets.swe.swe_tasksets import SCORING_BUFFER_MINUTES
+from verifiers.envs.experimental.composable.tasksets.swe.swe_tasksets import (
+    SCORING_BUFFER_MINUTES,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -55,16 +57,12 @@ class OpenSWERubric(vf.Rubric):
         timeout = state.get("test_timeout", 900)
         try:
             test_output = await asyncio.wait_for(
-                self.taskset._run_tests(
-                    sandbox_client, sandbox_id, state, timeout
-                ),
+                self.taskset._run_tests(sandbox_client, sandbox_id, state, timeout),
                 timeout=timeout + 60,
             )
             state["test_output"] = test_output
         except asyncio.TimeoutError:
-            logger.warning(
-                f"Test execution wall-clock timeout after {timeout + 60}s"
-            )
+            logger.warning(f"Test execution wall-clock timeout after {timeout + 60}s")
             state["test_output"] = "ERROR: wall-clock timeout"
             return 0.0
         except Exception as e:
@@ -79,7 +77,7 @@ class OpenSWERubric(vf.Rubric):
         sandbox_id = state.get("sandbox_id")
         if sandbox_client and sandbox_id:
             try:
-                await sandbox_client.delete(sandbox_id)
+                await asyncio.wait_for(sandbox_client.delete(sandbox_id), timeout=300)
             except Exception:
                 pass
 

--- a/verifiers/envs/experimental/composable/tasksets/swe/openswe.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/openswe.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 import re
 import tempfile
@@ -53,10 +54,19 @@ class OpenSWERubric(vf.Rubric):
             return 0.0
         timeout = state.get("test_timeout", 900)
         try:
-            test_output = await self.taskset._run_tests(
-                sandbox_client, sandbox_id, state, timeout
+            test_output = await asyncio.wait_for(
+                self.taskset._run_tests(
+                    sandbox_client, sandbox_id, state, timeout
+                ),
+                timeout=timeout + 60,
             )
             state["test_output"] = test_output
+        except asyncio.TimeoutError:
+            logger.warning(
+                f"Test execution wall-clock timeout after {timeout + 60}s"
+            )
+            state["test_output"] = "ERROR: wall-clock timeout"
+            return 0.0
         except Exception as e:
             logger.warning(f"Test execution failed: {e}")
             state["test_output"] = f"ERROR: {e}"

--- a/verifiers/envs/experimental/composable/tasksets/swe/r2e_gym.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/r2e_gym.py
@@ -9,7 +9,9 @@ from typing import Any
 
 import verifiers as vf
 from verifiers.envs.experimental.composable import SandboxSpec, SandboxTaskSet
-from verifiers.envs.experimental.composable.tasksets.swe.swe_tasksets import SCORING_BUFFER_MINUTES
+from verifiers.envs.experimental.composable.tasksets.swe.swe_tasksets import (
+    SCORING_BUFFER_MINUTES,
+)
 
 from .log_parser import decolor_dict_keys, parse_log_fn
 
@@ -153,16 +155,12 @@ class R2ERubric(vf.Rubric):
         timeout = state.get("test_timeout", 900)
         try:
             test_output = await asyncio.wait_for(
-                self.taskset._run_tests(
-                    sandbox_client, sandbox_id, state, timeout
-                ),
+                self.taskset._run_tests(sandbox_client, sandbox_id, state, timeout),
                 timeout=timeout + 60,
             )
             state["test_output"] = test_output
         except asyncio.TimeoutError:
-            logger.warning(
-                f"Test execution wall-clock timeout after {timeout + 60}s"
-            )
+            logger.warning(f"Test execution wall-clock timeout after {timeout + 60}s")
             state["test_output"] = "ERROR: wall-clock timeout"
             return 0.0
         except Exception as e:
@@ -177,7 +175,7 @@ class R2ERubric(vf.Rubric):
         sandbox_id = state.get("sandbox_id")
         if sandbox_client and sandbox_id:
             try:
-                await sandbox_client.delete(sandbox_id)
+                await asyncio.wait_for(sandbox_client.delete(sandbox_id), timeout=300)
             except Exception:
                 pass
 

--- a/verifiers/envs/experimental/composable/tasksets/swe/r2e_gym.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/r2e_gym.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import tempfile
@@ -151,10 +152,19 @@ class R2ERubric(vf.Rubric):
             return 0.0
         timeout = state.get("test_timeout", 900)
         try:
-            test_output = await self.taskset._run_tests(
-                sandbox_client, sandbox_id, state, timeout
+            test_output = await asyncio.wait_for(
+                self.taskset._run_tests(
+                    sandbox_client, sandbox_id, state, timeout
+                ),
+                timeout=timeout + 60,
             )
             state["test_output"] = test_output
+        except asyncio.TimeoutError:
+            logger.warning(
+                f"Test execution wall-clock timeout after {timeout + 60}s"
+            )
+            state["test_output"] = "ERROR: wall-clock timeout"
+            return 0.0
         except Exception as e:
             logger.warning(f"Test execution failed: {e}")
             state["test_output"] = f"ERROR: {e}"

--- a/verifiers/envs/experimental/composable/tasksets/swe/swe_bench.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/swe_bench.py
@@ -12,7 +12,9 @@ from typing import Any
 
 import verifiers as vf
 from verifiers.envs.experimental.composable import SandboxSpec, SandboxTaskSet
-from verifiers.envs.experimental.composable.tasksets.swe.swe_tasksets import SCORING_BUFFER_MINUTES
+from verifiers.envs.experimental.composable.tasksets.swe.swe_tasksets import (
+    SCORING_BUFFER_MINUTES,
+)
 
 # swebench's __init__.py calls logging.basicConfig() at import time (via
 # build_dataset), which hijacks the root logger with an INFO-level
@@ -326,16 +328,12 @@ class SWEBenchRubric(vf.Rubric):
         timeout = state.get("test_timeout", 900)
         try:
             test_output = await asyncio.wait_for(
-                self.taskset._run_tests(
-                    sandbox_client, sandbox_id, state, timeout
-                ),
+                self.taskset._run_tests(sandbox_client, sandbox_id, state, timeout),
                 timeout=timeout + 60,
             )
             state["test_output"] = test_output
         except asyncio.TimeoutError:
-            logger.warning(
-                f"Test execution wall-clock timeout after {timeout + 60}s"
-            )
+            logger.warning(f"Test execution wall-clock timeout after {timeout + 60}s")
             state["test_output"] = "ERROR: wall-clock timeout"
             return 0.0
         except Exception as e:
@@ -350,7 +348,7 @@ class SWEBenchRubric(vf.Rubric):
         sandbox_id = state.get("sandbox_id")
         if sandbox_client and sandbox_id:
             try:
-                await sandbox_client.delete(sandbox_id)
+                await asyncio.wait_for(sandbox_client.delete(sandbox_id), timeout=300)
             except Exception:
                 pass
 

--- a/verifiers/envs/experimental/composable/tasksets/swe/swe_bench.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/swe_bench.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import re
@@ -324,10 +325,19 @@ class SWEBenchRubric(vf.Rubric):
             return 0.0
         timeout = state.get("test_timeout", 900)
         try:
-            test_output = await self.taskset._run_tests(
-                sandbox_client, sandbox_id, state, timeout
+            test_output = await asyncio.wait_for(
+                self.taskset._run_tests(
+                    sandbox_client, sandbox_id, state, timeout
+                ),
+                timeout=timeout + 60,
             )
             state["test_output"] = test_output
+        except asyncio.TimeoutError:
+            logger.warning(
+                f"Test execution wall-clock timeout after {timeout + 60}s"
+            )
+            state["test_output"] = "ERROR: wall-clock timeout"
+            return 0.0
         except Exception as e:
             logger.warning(f"Test execution failed: {e}")
             state["test_output"] = f"ERROR: {e}"

--- a/verifiers/envs/experimental/composable/tasksets/swe/swe_lego.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/swe_lego.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import re
@@ -143,11 +144,21 @@ class SWELegoRubric(vf.Rubric):
         sandbox_id = state.get("sandbox_id")
         if not sandbox_client or not sandbox_id:
             return 0.0
+        timeout = state.get("test_timeout", 900)
         try:
-            test_output = await self.taskset._run_tests(
-                sandbox_client, sandbox_id, state, state.get("test_timeout", 900)
+            test_output = await asyncio.wait_for(
+                self.taskset._run_tests(
+                    sandbox_client, sandbox_id, state, timeout
+                ),
+                timeout=timeout + 60,
             )
             state["test_output"] = test_output
+        except asyncio.TimeoutError:
+            logger.warning(
+                f"Test execution wall-clock timeout after {timeout + 60}s"
+            )
+            state["test_output"] = "ERROR: wall-clock timeout"
+            return 0.0
         except Exception as e:
             logger.warning(f"Test execution failed: {e}")
             state["test_output"] = f"ERROR: {e}"

--- a/verifiers/envs/experimental/composable/tasksets/swe/swe_lego.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/swe_lego.py
@@ -12,7 +12,9 @@ from typing import Any
 import verifiers as vf
 from datasets import load_dataset
 from verifiers.envs.experimental.composable import SandboxSpec, SandboxTaskSet
-from verifiers.envs.experimental.composable.tasksets.swe.swe_tasksets import SCORING_BUFFER_MINUTES
+from verifiers.envs.experimental.composable.tasksets.swe.swe_tasksets import (
+    SCORING_BUFFER_MINUTES,
+)
 
 from verifiers.envs.experimental.composable.tasksets.swe._test_patch import (
     revert_and_reapply_test_patch,
@@ -147,16 +149,12 @@ class SWELegoRubric(vf.Rubric):
         timeout = state.get("test_timeout", 900)
         try:
             test_output = await asyncio.wait_for(
-                self.taskset._run_tests(
-                    sandbox_client, sandbox_id, state, timeout
-                ),
+                self.taskset._run_tests(sandbox_client, sandbox_id, state, timeout),
                 timeout=timeout + 60,
             )
             state["test_output"] = test_output
         except asyncio.TimeoutError:
-            logger.warning(
-                f"Test execution wall-clock timeout after {timeout + 60}s"
-            )
+            logger.warning(f"Test execution wall-clock timeout after {timeout + 60}s")
             state["test_output"] = "ERROR: wall-clock timeout"
             return 0.0
         except Exception as e:
@@ -171,7 +169,7 @@ class SWELegoRubric(vf.Rubric):
         sandbox_id = state.get("sandbox_id")
         if sandbox_client and sandbox_id:
             try:
-                await sandbox_client.delete(sandbox_id)
+                await asyncio.wait_for(sandbox_client.delete(sandbox_id), timeout=300)
             except Exception:
                 pass
 

--- a/verifiers/envs/experimental/composable/tasksets/swe/swe_rebench_v2.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/swe_rebench_v2.py
@@ -37,7 +37,9 @@ from typing import Any
 import verifiers as vf
 from datasets import load_dataset
 from verifiers.envs.experimental.composable import SandboxSpec, SandboxTaskSet
-from verifiers.envs.experimental.composable.tasksets.swe.swe_tasksets import SCORING_BUFFER_MINUTES
+from verifiers.envs.experimental.composable.tasksets.swe.swe_tasksets import (
+    SCORING_BUFFER_MINUTES,
+)
 
 from verifiers.envs.experimental.composable.tasksets.swe import (
     swe_rebench_v2_log_parsers as _lp,
@@ -203,16 +205,12 @@ class SWERebenchV2Rubric(vf.Rubric):
         timeout = state.get("test_timeout", 900)
         try:
             test_output = await asyncio.wait_for(
-                self.taskset._run_tests(
-                    sandbox_client, sandbox_id, state, timeout
-                ),
+                self.taskset._run_tests(sandbox_client, sandbox_id, state, timeout),
                 timeout=timeout + 60,
             )
             state["test_output"] = test_output
         except asyncio.TimeoutError:
-            logger.warning(
-                f"Test execution wall-clock timeout after {timeout + 60}s"
-            )
+            logger.warning(f"Test execution wall-clock timeout after {timeout + 60}s")
             state["test_output"] = "ERROR: wall-clock timeout"
             return 0.0
         except Exception as e:
@@ -227,7 +225,7 @@ class SWERebenchV2Rubric(vf.Rubric):
         sandbox_id = state.get("sandbox_id")
         if sandbox_client and sandbox_id:
             try:
-                await sandbox_client.delete(sandbox_id)
+                await asyncio.wait_for(sandbox_client.delete(sandbox_id), timeout=300)
             except Exception:
                 pass
 

--- a/verifiers/envs/experimental/composable/tasksets/swe/swe_rebench_v2.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/swe_rebench_v2.py
@@ -26,6 +26,7 @@ Workdir is ``/{repo-name}`` (second half of ``owner/repo``) — *not*
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import re
@@ -199,11 +200,21 @@ class SWERebenchV2Rubric(vf.Rubric):
         sandbox_id = state.get("sandbox_id")
         if not sandbox_client or not sandbox_id:
             return 0.0
+        timeout = state.get("test_timeout", 900)
         try:
-            test_output = await self.taskset._run_tests(
-                sandbox_client, sandbox_id, state, state.get("test_timeout", 900)
+            test_output = await asyncio.wait_for(
+                self.taskset._run_tests(
+                    sandbox_client, sandbox_id, state, timeout
+                ),
+                timeout=timeout + 60,
             )
             state["test_output"] = test_output
+        except asyncio.TimeoutError:
+            logger.warning(
+                f"Test execution wall-clock timeout after {timeout + 60}s"
+            )
+            state["test_output"] = "ERROR: wall-clock timeout"
+            return 0.0
         except Exception as e:
             logger.warning(f"Test execution failed: {e}")
             state["test_output"] = f"ERROR: {e}"

--- a/verifiers/envs/experimental/composable/tasksets/swe/swe_smith.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/swe_smith.py
@@ -22,6 +22,7 @@ priority languages (py, go, java, js, ts, rs) have 100% coverage.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import shlex
 import tempfile
@@ -154,11 +155,21 @@ class SWESmithRubric(vf.Rubric):
         sandbox_id = state.get("sandbox_id")
         if not sandbox_client or not sandbox_id:
             return 0.0
+        timeout = state.get("test_timeout", 900)
         try:
-            test_output = await self.taskset._run_tests(
-                sandbox_client, sandbox_id, state, state.get("test_timeout", 900)
+            test_output = await asyncio.wait_for(
+                self.taskset._run_tests(
+                    sandbox_client, sandbox_id, state, timeout
+                ),
+                timeout=timeout + 60,
             )
             state["test_output"] = test_output
+        except asyncio.TimeoutError:
+            logger.warning(
+                f"Test execution wall-clock timeout after {timeout + 60}s"
+            )
+            state["test_output"] = "ERROR: wall-clock timeout"
+            return 0.0
         except Exception as e:
             logger.warning(f"Test execution failed: {e}")
             state["test_output"] = f"ERROR: {e}"

--- a/verifiers/envs/experimental/composable/tasksets/swe/swe_smith.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/swe_smith.py
@@ -33,7 +33,9 @@ from typing import Any
 import verifiers as vf
 from datasets import load_dataset
 from verifiers.envs.experimental.composable import SandboxSpec, SandboxTaskSet
-from verifiers.envs.experimental.composable.tasksets.swe.swe_tasksets import SCORING_BUFFER_MINUTES
+from verifiers.envs.experimental.composable.tasksets.swe.swe_tasksets import (
+    SCORING_BUFFER_MINUTES,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -158,16 +160,12 @@ class SWESmithRubric(vf.Rubric):
         timeout = state.get("test_timeout", 900)
         try:
             test_output = await asyncio.wait_for(
-                self.taskset._run_tests(
-                    sandbox_client, sandbox_id, state, timeout
-                ),
+                self.taskset._run_tests(sandbox_client, sandbox_id, state, timeout),
                 timeout=timeout + 60,
             )
             state["test_output"] = test_output
         except asyncio.TimeoutError:
-            logger.warning(
-                f"Test execution wall-clock timeout after {timeout + 60}s"
-            )
+            logger.warning(f"Test execution wall-clock timeout after {timeout + 60}s")
             state["test_output"] = "ERROR: wall-clock timeout"
             return 0.0
         except Exception as e:
@@ -182,7 +180,7 @@ class SWESmithRubric(vf.Rubric):
         sandbox_id = state.get("sandbox_id")
         if sandbox_client and sandbox_id:
             try:
-                await sandbox_client.delete(sandbox_id)
+                await asyncio.wait_for(sandbox_client.delete(sandbox_id), timeout=300)
             except Exception:
                 pass
 


### PR DESCRIPTION
## Summary

- Wrap each rubric's `await self.taskset._run_tests(...)` in `asyncio.wait_for(..., timeout+60)` so a hung sandbox call cannot pin the worker forever.
- Catch `asyncio.TimeoutError` ahead of the existing `except Exception` and fall back to `reward = 0.0` with an explicit `"ERROR: wall-clock timeout"` test_output.
- Applied to all 7 SWE backends: `swe_bench`, `r2e_gym`, `multi_swe`, `openswe`, `swe_lego`, `swe_rebench_v2`, `swe_smith`.

**Stacked on top of #1245 (`fix/sandbox-scoring-buffer`)** — the two PRs close complementary failure modes:
- #1245: keep the sandbox alive past the rollout deadline so the rubric has a live container to score against.
- This PR: ensure the rubric gives up after its budget elapses even if the sandbox is alive but the underlying call is stuck.

## Motivation

On a live run we hit a different wedge than the sandbox-TTL race #1245 addresses:

```
Finished rollout_id=... stop=agent_completed | duration=21-30m
Skipping eval install step (pure-python changes detected).
[then nothing]
```

All 4 `rlm-swe-high-eval` workers stopped at exactly this point — sandboxes still alive, rubric never returned. The existing `timeout` arg passed into `_run_tests` is a *soft* per-read budget; if the inner sandbox-poll loop retries indefinitely on read-timeouts, the await never completes.

`asyncio.wait_for(..., timeout+60)` enforces a hard wall-clock budget regardless of the inner call's state, cancels the coroutine, and lets the rubric finalize as `reward=0.0`. 60s slack is added on top of the inner soft timeout so we don't fight the inner machinery on legitimate slow runs.

## Test plan

- ruff `All checks passed`
- (No unit tests added — the change is a 5-line wrapper around an existing await.)