### PR TITLE
fix: scope env DEBUG to env module logger, not root

### DIFF
--- a/verifiers/utils/env_utils.py
+++ b/verifiers/utils/env_utils.py
@@ -15,6 +15,15 @@ def load_environment(env_id: str, **env_args) -> Environment:
     try:
         module = importlib.import_module(module_name)
 
+        # Mirror verifiers' configured level onto the env's module logger so
+        # env code using logging.getLogger(__name__) emits at that level via
+        # the root JSON handler. Children (e.g. f"{module_name}.scoring")
+        # inherit. Root stays at default WARNING so third-party libs (httpx,
+        # httpcore, …) don't spam at DEBUG.
+        vf_level = logging.getLogger("verifiers").level
+        if vf_level:
+            logging.getLogger(module_name).setLevel(vf_level)
+
         if not hasattr(module, "load_environment"):
             raise AttributeError(
                 f"Module '{module_name}' does not have a 'load_environment' function. "

--- a/verifiers/utils/logging_utils.py
+++ b/verifiers/utils/logging_utils.py
@@ -109,11 +109,6 @@ def setup_logging(
     # prevent the logger from propagating messages to the root logger
     logger.propagate = False
 
-    # when json_logging, attach a JSON handler at root so env code using
-    # logging.getLogger(__name__) gets JSON-formatted. Do NOT raise root level:
-    # third-party libs (httpx, httpcore, …) inherit their effective level from
-    # root, and lowering it floods logs with their DEBUG output. Per-env level
-    # is set in load_environment() instead.
     if json_logging:
         root = logging.getLogger()
         root.handlers = [

--- a/verifiers/utils/logging_utils.py
+++ b/verifiers/utils/logging_utils.py
@@ -109,14 +109,16 @@ def setup_logging(
     # prevent the logger from propagating messages to the root logger
     logger.propagate = False
 
-    # when json_logging, also configure the root logger so environment code
-    # using logging.getLogger(__name__) emits JSON too
+    # when json_logging, attach a JSON handler at root so env code using
+    # logging.getLogger(__name__) gets JSON-formatted. Do NOT raise root level:
+    # third-party libs (httpx, httpcore, …) inherit their effective level from
+    # root, and lowering it floods logs with their DEBUG output. Per-env level
+    # is set in load_environment() instead.
     if json_logging:
         root = logging.getLogger()
         root.handlers = [
             h for h in root.handlers if not isinstance(h.formatter, JsonFormatter)
         ]
-        root.setLevel(log_level)
         root_handler = logging.StreamHandler(sys.stderr)
         root_handler.setFormatter(formatter)
         root_handler.setLevel(log_level)


### PR DESCRIPTION
- `setup_logging(json_logging=True)` lowered root level, so httpx/httpcore (NOTSET inherit root) flooded logs with DEBUG.
- Drop `root.setLevel`. Promote only the loaded env's module logger in `load_environment()`.
- Env code using `logging.getLogger(__name__)` still emits at the configured level via the root JSON handler; third-party libs stay at default WARNING.
- Makes the mute-list in #1234 unnecessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global logging behavior by no longer lowering the root logger level during JSON logging, which could affect what log records appear from environment modules vs. other libraries. Risk is limited to observability/log output rather than functional runtime behavior.
> 
> **Overview**
> Adjusts JSON logging setup to **stop setting the root logger level**, preventing third-party libraries (e.g. `httpx`/`httpcore`) from inheriting DEBUG and flooding output.
> 
> When an environment is loaded, `load_environment()` now **mirrors the configured `verifiers` log level onto the loaded environment’s module logger**, so env code using `logging.getLogger(__name__)` still emits at the intended level via the root JSON handler without globally increasing verbosity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 161bbd7f5bb0e01ab5e3a66b4cd142fefe419a6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->