### PR TITLE
fix: prepend vllm/ to slashless OPENAI_MODEL in composable opencode harness

### DIFF
--- a/verifiers/envs/experimental/composable/harnesses/opencode.py
+++ b/verifiers/envs/experimental/composable/harnesses/opencode.py
@@ -182,6 +182,12 @@ export ALLOW_GIT={"1" if allow_git else "0"}
 
 mkdir -p ~/.config/opencode /logs/agent {agent_workdir}
 
+# Ensure OPENAI_MODEL has provider/model format for opencode AI SDK config.
+# LoRA adapter names (e.g. "rft-abc123") lack a slash, causing empty modelID.
+if [[ "$OPENAI_MODEL" != *"/"* ]]; then
+    export OPENAI_MODEL="vllm/$OPENAI_MODEL"
+fi
+
 SCHEMA_DOLLAR='$'
 
 cat > ~/.config/opencode/opencode.json << EOFCONFIG


### PR DESCRIPTION
## Summary

Ports the slashless-`OPENAI_MODEL` shim from PR #1114 (commit `f3e2c7e2`, which only touched `verifiers/envs/experimental/opencode_env.py`) into the composable harness path `verifiers/envs/experimental/composable/harnesses/opencode.py`. When the opencode harness was moved into the composable layout in PR #1131 (commit `7c85432e`, by `rasdani`), this shim didn't come along.

## Problem

LoRA adapter names like `rft-{run_id}` have no slash. Without the shim:

- opencode's AI SDK config parses `providerID="rft-..."`, `modelID=""`
- opencode raises `ProviderModelNotFoundError`
- opencode's non-retryable error path exits with code `0`
- verifiers' `poll_job_completion` therefore never sets `state["error"]`
- the orchestrator records an empty trajectory for the rollout

The fix is six lines of bash inside `build_opencode_run_command` that prepend `vllm/` to `OPENAI_MODEL` if it has no slash, mirroring what already shipped for the legacy `opencode_env.py` path.

## Verification

This is currently running on two RL training jobs (verifiers commit `a24509c2`):

- `sn6uxmyie9e229cjiwc9bw4v`
- `ouxh9z6sz1yru5bti2iauibf`

Both are producing healthy non-empty rollouts.

## Test plan

- [x] Verified by live RL training runs (`sn6uxmyie9e229cjiwc9bw4v`, `ouxh9z6sz1yru5bti2iauibf`) producing non-empty trajectories
- [ ] Confirm cherry-pick is clean and only touches `verifiers/envs/experimental/composable/harnesses/opencode.py`
- [ ] Pre-commit hooks (ruff check, ruff format, ty) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a small bash guard that only rewrites `OPENAI_MODEL` when it lacks `/`, aligning behavior with the legacy harness and reducing runtime config errors.
> 
> **Overview**
> Ensures the composable OpenCode harness doesn’t pass a slashless `OPENAI_MODEL` into opencode’s provider/model parsing by prepending `vllm/` when needed.
> 
> This ports the existing compatibility shim (for LoRA adapter-style model names) into `verifiers/envs/experimental/composable/harnesses/opencode.py`, preventing misconfigured `providerID`/`modelID` during `opencode run`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86e464ea7891b85ebd75862ad1df1325976d94d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->