### PR TITLE
TaskSet: accept DatasetBuilder for lazy dataset construction

### DIFF
--- a/verifiers/envs/experimental/composable/composable_env.py
+++ b/verifiers/envs/experimental/composable/composable_env.py
@@ -96,7 +96,11 @@ class ComposableEnv(CliAgentEnv):
         install_env: dict[str, str] | None = None,
         **kwargs: Any,
     ):
-        kwargs["dataset"] = taskset.get_dataset()
+        # Forward the bound method as a DatasetBuilder so the underlying
+        # Environment defers the (often expensive) build until first
+        # access. Env worker processes that only run rollouts on inputs
+        # received over ZMQ never touch the dataset.
+        kwargs["dataset"] = taskset.get_dataset
         if "rubric" not in kwargs:
             kwargs["rubric"] = taskset.get_rubric()
         super().__init__(run_command=harness.run_command, **kwargs)

--- a/verifiers/envs/experimental/composable/task.py
+++ b/verifiers/envs/experimental/composable/task.py
@@ -149,10 +149,7 @@ class TaskSet:
         """
         Args:
             dataset: The dataset backing this taskset, or a ``DatasetBuilder``
-                (zero-arg callable returning the dataset). Passing a builder
-                defers the (often expensive) build until first access — so
-                an env worker that never reads the dataset doesn't pay the
-                cost. Mirrors the ``Environment`` ``dataset`` contract.
+                (zero-arg callable returning the dataset).
             name: Human-readable taskset name.
             filter_fn: Optional Python expression string (e.g. a lambda) that
                 evaluates to a ``Callable[[dict], bool]`` and is applied to
@@ -168,23 +165,18 @@ class TaskSet:
         # debugging; the resolved predicate isn't pickle-safe and the
         # realized dataset already carries the filtered state.
         self._filter_fn_src = filter_fn
-        if callable(dataset):
-            self.dataset_source: DatasetBuilder | None = dataset
-            self._built_dataset: Any = None
-        else:
-            self.dataset_source = None
-            self._built_dataset = self._apply_filter(dataset)
-
-    def _apply_filter(self, dataset: Any) -> Any:
-        if self._filter_fn_src is None:
-            return dataset
-        predicate = _resolve_filter_fn(self._filter_fn_src)
-        return dataset.filter(predicate)
+        self.dataset_source: DatasetBuilder = (
+            dataset if callable(dataset) else (lambda ds=dataset: ds)
+        )
+        self._built_dataset: Any = None
 
     @property
     def dataset(self) -> Any:
-        if self._built_dataset is None and self.dataset_source is not None:
-            self._built_dataset = self._apply_filter(self.dataset_source())
+        if self._built_dataset is None:
+            ds = self.dataset_source()
+            if self._filter_fn_src is not None:
+                ds = ds.filter(_resolve_filter_fn(self._filter_fn_src))
+            self._built_dataset = ds
         return self._built_dataset
 
     @dataset.setter

--- a/verifiers/envs/experimental/composable/task.py
+++ b/verifiers/envs/experimental/composable/task.py
@@ -35,7 +35,7 @@ from types import ModuleType
 from typing import Any, Callable
 
 from verifiers.envs.experimental.composable._filter import _resolve_filter_fn
-from verifiers.types import Messages, State
+from verifiers.types import DatasetBuilder, Messages, State
 
 
 def _module_package_name(module: ModuleType) -> str | None:
@@ -142,13 +142,17 @@ class TaskSet:
 
     def __init__(
         self,
-        dataset: Any,
+        dataset: Any | DatasetBuilder,
         name: str = "",
         filter_fn: str | None = None,
     ):
         """
         Args:
-            dataset: The (already processed) dataset backing this taskset.
+            dataset: The dataset backing this taskset, or a ``DatasetBuilder``
+                (zero-arg callable returning the dataset). Passing a builder
+                defers the (often expensive) build until first access — so
+                an env worker that never reads the dataset doesn't pay the
+                cost. Mirrors the ``Environment`` ``dataset`` contract.
             name: Human-readable taskset name.
             filter_fn: Optional Python expression string (e.g. a lambda) that
                 evaluates to a ``Callable[[dict], bool]`` and is applied to
@@ -159,15 +163,33 @@ class TaskSet:
                 but it is still ``eval`` of user input — intended for local
                 ``vf-eval`` runs, not untrusted inputs.
         """
-        self._dataset = dataset
         self.name = name
         # Cache the raw expression (not the callable) for reproducibility /
-        # debugging; the resolved predicate isn't pickle-safe and
-        # ``self._dataset`` already carries the filtered state.
+        # debugging; the resolved predicate isn't pickle-safe and the
+        # realized dataset already carries the filtered state.
         self._filter_fn_src = filter_fn
-        if filter_fn is not None:
-            predicate = _resolve_filter_fn(filter_fn)
-            self._dataset = self._dataset.filter(predicate)
+        if callable(dataset):
+            self.dataset_source: DatasetBuilder | None = dataset
+            self._built_dataset: Any = None
+        else:
+            self.dataset_source = None
+            self._built_dataset = self._apply_filter(dataset)
+
+    def _apply_filter(self, dataset: Any) -> Any:
+        if self._filter_fn_src is None:
+            return dataset
+        predicate = _resolve_filter_fn(self._filter_fn_src)
+        return dataset.filter(predicate)
+
+    @property
+    def _dataset(self) -> Any:
+        if self._built_dataset is None and self.dataset_source is not None:
+            self._built_dataset = self._apply_filter(self.dataset_source())
+        return self._built_dataset
+
+    @_dataset.setter
+    def _dataset(self, value: Any) -> None:
+        self._built_dataset = value
 
     # -- Override these ------------------------------------------------------
 

--- a/verifiers/envs/experimental/composable/task.py
+++ b/verifiers/envs/experimental/composable/task.py
@@ -182,13 +182,13 @@ class TaskSet:
         return dataset.filter(predicate)
 
     @property
-    def _dataset(self) -> Any:
+    def dataset(self) -> Any:
         if self._built_dataset is None and self.dataset_source is not None:
             self._built_dataset = self._apply_filter(self.dataset_source())
         return self._built_dataset
 
-    @_dataset.setter
-    def _dataset(self, value: Any) -> None:
+    @dataset.setter
+    def dataset(self, value: Any) -> None:
         self._built_dataset = value
 
     # -- Override these ------------------------------------------------------
@@ -268,7 +268,7 @@ class TaskSet:
         This pre-builds the prompt so the base Environment doesn't need a
         ``question`` column.
         """
-        ds = self._dataset
+        ds = self.dataset
         if "prompt" not in ds.column_names:
 
             def add_prompt(row: dict) -> dict:
@@ -280,14 +280,14 @@ class TaskSet:
         return ds
 
     def __len__(self) -> int:
-        return len(self._dataset)
+        return len(self.dataset)
 
     def __iter__(self):
         for i in range(len(self)):
             yield self[i]
 
     def __getitem__(self, i: int) -> Task:
-        row = self._dataset[i]
+        row = self.dataset[i]
         info = row.get("info") or {}
         from verifiers.types import UserMessage
 
@@ -304,13 +304,13 @@ class TaskSet:
     def filter(self, predicate: Callable[[dict], bool]) -> TaskSet:
         clone = object.__new__(type(self))
         clone.__dict__.update(self.__dict__)
-        clone._dataset = self._dataset.filter(predicate)
+        clone.dataset = self.dataset.filter(predicate)
         return clone
 
     def take(self, n: int) -> TaskSet:
         clone = object.__new__(type(self))
         clone.__dict__.update(self.__dict__)
-        clone._dataset = self._dataset.select(range(min(n, len(self._dataset))))
+        clone.dataset = self.dataset.select(range(min(n, len(self.dataset))))
         return clone
 
     # -- Validation ----------------------------------------------------------

--- a/verifiers/envs/experimental/composable/tasksets/swe/multi_swe.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/multi_swe.py
@@ -200,7 +200,7 @@ class MultiSWETaskSet(SandboxTaskSet):
         self.ds_keep_in_memory = ds_keep_in_memory
         self.timeout_minutes = timeout_minutes
         super().__init__(
-            dataset=self._build_dataset(),
+            dataset=self._build_dataset,
             name="swe/multiswe",
             filter_fn=filter_fn,
         )

--- a/verifiers/envs/experimental/composable/tasksets/swe/openswe.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/openswe.py
@@ -101,7 +101,7 @@ class OpenSWETaskSet(SandboxTaskSet):
         self.ds_keep_in_memory = ds_keep_in_memory
         self.timeout_minutes = timeout_minutes
         super().__init__(
-            dataset=self._build_dataset(),
+            dataset=self._build_dataset,
             name="swe/openswe",
             filter_fn=filter_fn,
         )

--- a/verifiers/envs/experimental/composable/tasksets/swe/r2e_gym.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/r2e_gym.py
@@ -212,7 +212,7 @@ class R2EGymTaskSet(SandboxTaskSet):
         self.timeout_minutes = timeout_minutes
         self.hide_tests_from_agent = hide_tests_from_agent
         super().__init__(
-            dataset=self._build_dataset(),
+            dataset=self._build_dataset,
             name="swe/r2e",
             filter_fn=filter_fn,
         )

--- a/verifiers/envs/experimental/composable/tasksets/swe/swe_bench.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/swe_bench.py
@@ -372,7 +372,7 @@ class SWEBenchTaskSet(SandboxTaskSet):
         self.ds_keep_in_memory = ds_keep_in_memory
         self.timeout_minutes = timeout_minutes
         super().__init__(
-            dataset=self._build_dataset(),
+            dataset=self._build_dataset,
             name="swe/swebench",
             filter_fn=filter_fn,
         )

--- a/verifiers/envs/experimental/composable/tasksets/swe/swe_lego.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/swe_lego.py
@@ -214,7 +214,7 @@ class SWELegoTaskSet(SandboxTaskSet):
         self.ds_keep_in_memory = ds_keep_in_memory
         self.timeout_minutes = timeout_minutes
         super().__init__(
-            dataset=self._build_dataset(),
+            dataset=self._build_dataset,
             name="swe/swelego",
             filter_fn=filter_fn,
         )

--- a/verifiers/envs/experimental/composable/tasksets/swe/swe_rebench_v2.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/swe_rebench_v2.py
@@ -243,7 +243,7 @@ class SWERebenchV2TaskSet(SandboxTaskSet):
         self.timeout_minutes = timeout_minutes
         suffix = f"-{language}" if language else ""
         super().__init__(
-            dataset=self._build_dataset(),
+            dataset=self._build_dataset,
             name=f"swe/swerebench-v2{suffix}",
             filter_fn=filter_fn,
         )

--- a/verifiers/envs/experimental/composable/tasksets/swe/swe_smith.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/swe_smith.py
@@ -204,7 +204,7 @@ class SWESmithTaskSet(SandboxTaskSet):
         self.ds_keep_in_memory = ds_keep_in_memory
         self.timeout_minutes = timeout_minutes
         super().__init__(
-            dataset=self._build_dataset(),
+            dataset=self._build_dataset,
             name=f"swe/swesmith-{language}",
             filter_fn=filter_fn,
         )


### PR DESCRIPTION
## Summary

`ComposableEnv` runs in two processes when used through `vf-eval` /
`Environment.start_server`: the parent loads the env once to slice off
`_get_eval_inputs`, and a ZMQ worker subprocess loads it again to run
rollouts. The worker only consumes inputs sent over ZMQ — it never
touches `self.dataset` — but it currently re-runs every dataset
`map(...)` because both `R2EGymTaskSet.__init__` and
`ComposableEnv.__init__` materialize the dataset eagerly.

For `vf-eval rlm-swe -n1 -r1` against R2E-Gym this is ~33s of redundant
Map work in the worker; observed startup drops from **87s → 45s**.

## What changes

- `TaskSet` now accepts `Dataset | DatasetBuilder` (mirroring the
  existing `Environment.__init__` contract). The `dataset` argument is
  always wrapped as a `DatasetBuilder` — non-callables become a trivial
  `lambda ds=dataset: ds` — and the `dataset` property is the single
  place that builds and applies `filter_fn`. Materialization happens on
  first `taskset.dataset` access.
- `_dataset` is promoted to a public `dataset` property (with a setter
  used by `filter()` / `take()`).
- `ComposableEnv` forwards `taskset.get_dataset` (the bound method) as
  the dataset, so both layers stay lazy end-to-end and `Environment`
  treats it as a `DatasetBuilder` (no eager `build_dataset()` in
  `__init__`).
- SWE tasksets that called `super().__init__(dataset=self._build_dataset())`
  now pass the bound `_build_dataset` callable (r2e_gym, openswe,
  swe_bench, swe_lego, swe_smith, multi_swe, swe_rebench_v2).

## Verification

Probed `TaskSet.dataset` materialization and `EnvWorker.__init__` with
PID-tagged stderr markers, then ran `vf-eval rlm-swe -n1 -r1
--num-workers 1`. The materialize line fired exactly once in the
parent (`MainProcess`); the worker (`rlm-swe-0`) loaded the env without
triggering a build. The R2E-Gym `Map (num_proc=8): 0/4578` progress bar
appeared only adjacent to the parent's materialize line — confirming
the worker no longer pays the per-process Map cost.

## Test plan

- [x] `pytest tests/test_composable_env.py tests/test_rlm_composable_env.py` — 51 passed
- [x] `vf-eval rlm-swe -n1 -r1 --num-workers 1` — single materialize event in parent, none in worker

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dataset construction timing by making `TaskSet` and `ComposableEnv` pass/build datasets lazily, which could affect any code that assumed eager filtering/mapping or relied on dataset side effects during initialization.
> 
> **Overview**
> Makes `TaskSet` accept a `DatasetBuilder` and lazily materialize/filter the dataset on first `taskset.dataset` access, replacing the previous eager `_dataset` initialization.
> 
> Updates `ComposableEnv` to pass `taskset.get_dataset` (a builder) into the underlying `Environment` so dataset `map(...)` work is deferred and avoids redundant dataset builds in worker subprocesses.
> 
> Switches SWE tasksets to pass their `_build_dataset` callable into `super().__init__` instead of eagerly building the dataset in `__init__`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c57530bf6864929c073e6e17acb1fa239ba8ce6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->