### PR TITLE
git_checkout_cache: hold per-process in-use lock so concurrent resolves don't nuke active worktrees

### DIFF
--- a/tests/test_rlm_composable_env.py
+++ b/tests/test_rlm_composable_env.py
@@ -100,6 +100,20 @@ def _make_temp_taskset_package(tmp_path, monkeypatch, *, with_skills: bool):
     return mod
 
 
+@pytest.fixture(autouse=True)
+def _release_in_use_locks_between_tests():
+    """Drop process-lifetime in-use locks so tests don't leak fds/state.
+
+    ``resolve_git_checkout`` keeps a shared lock on each resolved
+    checkout open for the resolving process's lifetime. Tests that
+    create checkouts in a shared cache root would otherwise see the
+    pruner skip them, masking real regressions; release everything on
+    teardown.
+    """
+    yield
+    git_checkout_cache_module._release_all_in_use_locks()
+
+
 def _make_git_checkout(target: Path) -> Path:
     checkout = target
     checkout.mkdir()
@@ -302,7 +316,14 @@ def test_rlm_harness_memoizes_resolved_checkout_per_instance(tmp_path, monkeypat
     assert second_upload_checkout == first_upload_checkout
 
 
-def test_rlm_harness_resolves_new_commit_for_new_instance(tmp_path, monkeypatch):
+def test_rlm_harness_preserves_prior_checkout_while_leased(tmp_path, monkeypatch):
+    """A second resolve in the same process must NOT prune the first
+    checkout. ``resolve_git_checkout`` holds a process-lifetime shared
+    lock on every checkout it materializes, and the pruner takes that
+    lock exclusive non-blocking — so as long as this process is still
+    holding the first lease, a concurrent resolve for a different ref
+    cannot nuke the active worktree out from under a long-running eval.
+    """
     source_checkout = _make_git_checkout(tmp_path / "rlm-source")
     first_commit = _git_head_commit(source_checkout)
     monkeypatch.setattr(
@@ -329,10 +350,42 @@ def test_rlm_harness_resolves_new_commit_for_new_instance(tmp_path, monkeypatch)
     assert isinstance(second_checkout, Path)
     assert second_checkout.name == second_commit
     assert second_checkout != first_checkout
+    assert first_checkout.exists()
+
+
+def test_rlm_harness_prunes_stale_checkout_after_lease_released(tmp_path, monkeypatch):
+    """Once the in-use lease is dropped (e.g. the prior process exited),
+    the next resolve's prune step removes the stale worktree."""
+    source_checkout = _make_git_checkout(tmp_path / "rlm-source")
+    monkeypatch.setattr(
+        rlm_module,
+        "DEFAULT_RLM_LOCAL_CHECKOUT_CACHE_ROOT",
+        tmp_path / "cache-root",
+    )
+
+    first_checkout = rlm_harness(
+        rlm_repo_url=str(source_checkout),
+        rlm_ref="main",
+    ).get_upload_dirs()["rlm_checkout"]
+    _commit_file(source_checkout, "README.md", "updated\n")
+    git_checkout_cache_module._release_all_in_use_locks()
+
+    second_checkout = rlm_harness(
+        rlm_repo_url=str(source_checkout),
+        rlm_ref="main",
+    ).get_upload_dirs()["rlm_checkout"]
+    assert second_checkout != first_checkout
     assert not first_checkout.exists()
 
 
-def test_rlm_harness_skips_pruning_locked_stale_checkout(tmp_path, monkeypatch):
+def test_rlm_harness_skips_pruning_externally_locked_stale_checkout(
+    tmp_path, monkeypatch
+):
+    """Another process holding the in-use lock blocks the pruner. We
+    simulate a peer process by releasing our own lease first, then
+    manually taking a shared ``.in-use.lock`` while a fresh resolve
+    runs — the pruner's exclusive non-blocking attempt fails and the
+    stale checkout survives."""
     source_checkout = _make_git_checkout(tmp_path / "rlm-source")
     first_commit = _git_head_commit(source_checkout)
     monkeypatch.setattr(
@@ -346,26 +399,24 @@ def test_rlm_harness_skips_pruning_locked_stale_checkout(tmp_path, monkeypatch):
         rlm_ref="main",
     )
     first_checkout = first_harness.get_upload_dirs()["rlm_checkout"]
-    assert isinstance(first_checkout, Path)
     assert first_checkout.name == first_commit
 
     second_commit = _commit_file(source_checkout, "README.md", "updated\n")
+    git_checkout_cache_module._release_all_in_use_locks()
 
-    with shared_path_lock(first_checkout, suffix=".upload.lock"):
-        second_harness = rlm_harness(
+    with shared_path_lock(first_checkout, suffix=".in-use.lock"):
+        second_checkout = rlm_harness(
             rlm_repo_url=str(source_checkout),
             rlm_ref="main",
-        )
-        second_checkout = second_harness.get_upload_dirs()["rlm_checkout"]
-        assert isinstance(second_checkout, Path)
+        ).get_upload_dirs()["rlm_checkout"]
         assert second_checkout.name == second_commit
         assert first_checkout.exists()
 
-    third_harness = rlm_harness(
+    git_checkout_cache_module._release_all_in_use_locks()
+    third_checkout = rlm_harness(
         rlm_repo_url=str(source_checkout),
         rlm_ref="main",
-    )
-    third_checkout = third_harness.get_upload_dirs()["rlm_checkout"]
+    ).get_upload_dirs()["rlm_checkout"]
     assert third_checkout == second_checkout
     assert not first_checkout.exists()
 
@@ -614,7 +665,7 @@ def test_build_dir_archive_holds_shared_lock_for_local_path(tmp_path):
             with pytest.raises(BlockingIOError):
                 with exclusive_path_lock(
                     local_source,
-                    suffix=".upload.lock",
+                    suffix=".in-use.lock",
                     nonblocking=True,
                 ):
                     pass

--- a/verifiers/envs/experimental/composable/composable_env.py
+++ b/verifiers/envs/experimental/composable/composable_env.py
@@ -385,7 +385,7 @@ class ComposableEnv(CliAgentEnv):
         arcname = remote_dest.lstrip("/")
         with tarfile.open(tar_path, "w:gz") as tar:
             if isinstance(local_source, Path):
-                with shared_path_lock(local_source, suffix=".upload.lock"):
+                with shared_path_lock(local_source, suffix=".in-use.lock"):
                     tar.add(local_source, arcname=arcname)
             else:
                 with resources.as_file(local_source) as local_path:

--- a/verifiers/envs/experimental/utils/git_checkout_cache.py
+++ b/verifiers/envs/experimental/utils/git_checkout_cache.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import fcntl
 import hashlib
 import logging
 import os
@@ -7,6 +8,7 @@ from pathlib import Path
 import re
 import shutil
 import subprocess
+from typing import IO
 from urllib.parse import quote, urlsplit, urlunsplit
 
 from verifiers.envs.experimental.utils.file_locks import (
@@ -14,6 +16,12 @@ from verifiers.envs.experimental.utils.file_locks import (
     exclusive_path_lock,
     sibling_lock_path,
 )
+
+_IN_USE_LOCK_SUFFIX = ".in-use.lock"
+
+# Open file handles that hold a process-lifetime shared lock on each
+# resolved checkout's in-use lock file. See ``_acquire_in_use_lock``.
+_held_in_use_locks: dict[Path, IO] = {}
 
 DEFAULT_GIT_CHECKOUT_CACHE_ROOT = Path.home() / ".cache" / "verifiers" / "git-checkouts"
 _FULL_COMMIT_SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
@@ -292,6 +300,40 @@ def _materialize_worktree(
     return validate_git_checkout(checkout_dir, required_files=required_files)
 
 
+def _acquire_in_use_lock(checkout: Path) -> None:
+    """Hold a process-lifetime shared lock on the checkout's in-use lock.
+
+    The file handle is stashed in ``_held_in_use_locks`` and never closed
+    until the process exits, so the kernel keeps the shared lock alive
+    for the entire eval lifetime — including the gaps between uploads.
+    ``_prune_stale_worktrees`` takes an exclusive non-blocking lock on
+    the same file and skips the candidate when that fails, which is what
+    keeps a concurrent ``resolve_git_checkout`` for a different ref from
+    nuking this process's active worktree.
+    """
+    lock_path = sibling_lock_path(checkout, _IN_USE_LOCK_SUFFIX)
+    if lock_path in _held_in_use_locks:
+        return
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    fh = lock_path.open("a+")
+    try:
+        fcntl.flock(fh.fileno(), fcntl.LOCK_SH)
+    except Exception:
+        fh.close()
+        raise
+    _held_in_use_locks[lock_path] = fh
+
+
+def _release_all_in_use_locks() -> None:
+    """Release every process-lifetime in-use lock. For tests."""
+    for fh in _held_in_use_locks.values():
+        try:
+            fh.close()
+        except Exception:
+            pass
+    _held_in_use_locks.clear()
+
+
 def _prune_stale_worktrees(repo_cache_dir: Path, keep_checkout: Path) -> None:
     mirror_dir = _mirror_dir(repo_cache_dir)
     worktrees_dir = _worktrees_dir(repo_cache_dir)
@@ -303,7 +345,7 @@ def _prune_stale_worktrees(repo_cache_dir: Path, keep_checkout: Path) -> None:
         try:
             with exclusive_path_lock(
                 candidate,
-                suffix=".upload.lock",
+                suffix=_IN_USE_LOCK_SUFFIX,
                 nonblocking=True,
             ):
                 _run_git(
@@ -323,7 +365,7 @@ def _prune_stale_worktrees(repo_cache_dir: Path, keep_checkout: Path) -> None:
         except RuntimeError as exc:
             logger.warning(str(exc))
             continue
-        sibling_lock_path(candidate, ".upload.lock").unlink(missing_ok=True)
+        sibling_lock_path(candidate, _IN_USE_LOCK_SUFFIX).unlink(missing_ok=True)
     try:
         _run_git(
             ["git", "--git-dir", str(mirror_dir), "worktree", "prune"],
@@ -366,5 +408,6 @@ def resolve_git_checkout(
             commit_sha=resolved_commit,
             required_files=required_files,
         )
+        _acquire_in_use_lock(checkout)
         _prune_stale_worktrees(repo_cache_dir, checkout)
         return checkout


### PR DESCRIPTION
## Summary
- `_prune_stale_worktrees` gated removal on `.upload.lock`, which is only held during the brief `tar.add` window in `_build_dir_archive`. Between uploads, a concurrent `resolve_git_checkout` for a different ref could win the non-blocking exclusive and `git worktree remove --force` an active eval's checkout — a long-running RLM eval would silently lose its worktree mid-run.
- Lease lifetime is now per-process, not per-upload. `resolve_git_checkout` takes a shared lock on `<worktrees>/.<sha>.in-use.lock` and stashes the open fd in a module-level dict, so the kernel holds the lock until the resolving process exits. The pruner takes exclusive non-blocking on the same file and skips candidates whose lock is held.
- Net effect: multiple `vf-eval` invocations against different `rlm_ref`s on the same machine no longer race to delete each other's worktrees.

## Why this is safe
- `fcntl.flock` releases on process exit, so a hard crash automatically frees the lease — no stale-lock cleanup needed.
- Same-`rlm_ref` parallel resolves stack shared on the same lock and share one worktree.
- The global `.repo.lock` still serializes mirror operations; only the post-resolve eval phase runs concurrently.
- The redundant per-upload `.in-use.lock` in `_build_dir_archive` (renamed from `.upload.lock`) provides defense-in-depth for callers that bypass `resolve_git_checkout`.

## Test plan
- [x] `tests/test_rlm_composable_env.py` — 20 passing, including three new/updated tests:
  - `test_rlm_harness_preserves_prior_checkout_while_leased` — same-process second resolve does not prune the first checkout
  - `test_rlm_harness_prunes_stale_checkout_after_lease_released` — pruning resumes once the lease is dropped
  - `test_rlm_harness_skips_pruning_externally_locked_stale_checkout` — peer process holding `.in-use.lock` blocks the pruner
- [x] `tests/test_composable_env.py` — 34 passing (one unrelated pre-existing failure on `main` is not affected)
- [ ] Soak: run two `vf-eval` invocations with different `rlm_ref`s on the same machine and verify both finish without `worktree remove --force` activity in cache logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes git worktree pruning/locking behavior to use process-lifetime `fcntl` locks, which affects concurrency and cache cleanup and could cause unexpected retention or deletion if locking semantics differ across environments.
> 
> **Overview**
> Prevents concurrent `resolve_git_checkout` calls (e.g. parallel evals) from pruning an actively-used git worktree by introducing a process-lifetime shared `.in-use.lock` held via an open file descriptor in `git_checkout_cache`.
> 
> Updates stale-worktree pruning and directory-archive uploads to gate on the new `.in-use.lock` (replacing the prior short-lived `.upload.lock`), and expands RLM/composable env tests to cover lease-preservation, pruning after lease release, and skipping pruning when another process holds the lock.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 016e0f7f25204cfa041c69ddac242d1b4fda902e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->