### PR TITLE
rlm harness: rename real git aside, install shim at its real path, restore before scoring

### DIFF
--- a/tests/test_rlm_composable_env.py
+++ b/tests/test_rlm_composable_env.py
@@ -169,39 +169,6 @@ def test_rlm_harness_install_script_requires_uploaded_checkout():
     assert "/usr/local/bin/" not in script
 
 
-def test_rlm_harness_blocks_git_by_default(tmp_path):
-    """By default RLM uploads a sh shim that refuses on any invocation
-    and exits 1. The shim is staged at /tmp and moved to
-    $HOME/.local/bin/git by the post-install script — that dir is on
-    the agent's PATH (via the run_command's ``export PATH=...``) but
-    NOT on the container's default PATH, so scoring's
-    ``execute_command`` calls (e.g. ``git apply`` in eval scripts) keep
-    resolving to the real ``/usr/bin/git``."""
-    checkout = _make_git_checkout(tmp_path / "rlm")
-    harness = rlm_harness(local_checkout=checkout)
-
-    assert harness.post_install_uploads is not None
-    assert set(harness.post_install_uploads.keys()) == {"/tmp/__rlm_git_shim"}
-
-    shim = harness.post_install_uploads["/tmp/__rlm_git_shim"]
-    assert shim.startswith("#!/bin/sh\n")
-    assert "Bash command 'git' is not allowed." in shim
-    assert "exit 1" in shim
-
-    script = harness.post_install_script
-    assert script is not None
-    # Shim must end up at $HOME/.local/bin/git, executable, with parent
-    # dir created if missing.
-    assert 'mkdir -p "$HOME/.local/bin"' in script
-    assert 'mv /tmp/__rlm_git_shim "$HOME/.local/bin/git"' in script
-    assert 'chmod +x "$HOME/.local/bin/git"' in script
-    # The shim must NOT live anywhere on the container's default PATH —
-    # /usr/local/bin/git would shadow the real git for scoring's
-    # execute_command shells (which don't get $HOME/.local/bin
-    # prepended) and break ``git apply`` of test_patches in eval.sh.
-    assert "/usr/local/bin/git" not in script
-
-
 def test_rlm_harness_allow_git_uploads_nothing(tmp_path):
     """``allow_git=True`` skips the shim entirely — no uploads, no
     post-install script. Matches opencode's ``allow_git=True`` default:

--- a/verifiers/envs/experimental/composable/composable_env.py
+++ b/verifiers/envs/experimental/composable/composable_env.py
@@ -196,12 +196,8 @@ class ComposableEnv(CliAgentEnv):
         await self._run_post_install(sandbox_id)
 
     async def post_rollout(self, state: State) -> None:
-        """Collect agent logs and harness metrics after the agent finishes.
-
-        Scoring is handled entirely by the rubric (via ``score_rollout``),
-        not here.  Use ``keep_sandbox_for_scoring=True`` so the sandbox
-        stays alive for the rubric to run tests / read files.
-        """
+        """Collect agent logs / metrics, run ``Harness.pre_score_script``,
+        then defer to ``super().post_rollout``."""
         sandbox_id = state.get("sandbox_id")
         if sandbox_id and self.harness.log_path and "agent_logs" not in state:
             try:
@@ -217,6 +213,9 @@ class ComposableEnv(CliAgentEnv):
 
         if sandbox_id and self.harness.metrics_path:
             await self._collect_harness_metrics(sandbox_id, state)
+
+        if sandbox_id and self.harness.pre_score_script:
+            await self._run_pre_score(sandbox_id)
 
         await super().post_rollout(state)
 
@@ -338,6 +337,22 @@ class ComposableEnv(CliAgentEnv):
                 raise vf.SandboxError(
                     f"Post-install failed (exit={result.exit_code}): {output[:500]}"
                 )
+
+    async def _run_pre_score(self, sandbox_id: str) -> None:
+        script = self.harness.pre_score_script
+        if not script:
+            return
+        try:
+            result = await self.sandbox_client.execute_command(
+                sandbox_id, script, timeout=self.harness.install_timeout
+            )
+            if result.exit_code != 0:
+                output = (result.stdout or "") + (result.stderr or "")
+                self.logger.warning(
+                    f"Pre-score script failed (exit={result.exit_code}): {output[:500]}"
+                )
+        except Exception as e:
+            self.logger.warning(f"Pre-score script raised: {e}")
 
     # -- Directory upload ------------------------------------------------------
 

--- a/verifiers/envs/experimental/composable/harness.py
+++ b/verifiers/envs/experimental/composable/harness.py
@@ -100,14 +100,17 @@ class Harness:
         Optional mapping from sandbox path → file content. Uploaded via
         the single-file upload path (same as instruction / system
         prompt) AFTER ``install_script`` finishes. Use for small
-        harness-computed assets — e.g. RLM's git refusal shim staged
-        into ``$HOME/.local/bin/git``. For large directories use
-        ``upload_dir_mapping`` instead.
+        harness-computed assets — e.g. RLM's git refusal shim. For large
+        directories use ``upload_dir_mapping`` instead.
     post_install_script:
         Optional shell snippet run AFTER ``post_install_uploads`` land in
         the sandbox. Typical use: ``chmod +x`` on the uploaded files, or
         any other wiring that needs them in place first. Failure is
         fatal, same as ``install_script``.
+    pre_score_script:
+        Optional shell snippet run between rollout and scoring to undo
+        sandbox modifications made for the agent's sake. Failure is
+        logged but non-fatal.
     """
 
     install_script: str | None = None
@@ -129,6 +132,7 @@ class Harness:
     environment_vars: dict[str, str] | None = None
     post_install_uploads: dict[str, str] | None = None
     post_install_script: str | None = None
+    pre_score_script: str | None = None
 
     def get_effective_upload_dir_mapping(self) -> dict[str, str] | None:
         """Return the merged upload mapping (skills_path + upload_dir_mapping)."""

--- a/verifiers/envs/experimental/composable/harnesses/rlm.py
+++ b/verifiers/envs/experimental/composable/harnesses/rlm.py
@@ -24,12 +24,28 @@ DEFAULT_RLM_LOCAL_CHECKOUT_CACHE_ROOT = (
 )
 _REQUIRED_CHECKOUT_FILES = ("install.sh", "pyproject.toml")
 
-_GIT_SHIM_BODY = (
-    "#!/bin/sh\n"
-    "echo \"Bash command 'git' is not allowed. "
-    'Please use a different command or tool." >&2\n'
-    "exit 1\n"
-)
+_GIT_SHIM_INSTALL_SCRIPT = """set -eu
+git_path="$(command -v git 2>/dev/null || true)"
+[ -z "$git_path" ] && exit 0
+real_path="$(readlink -f "$git_path")"
+[ -z "$real_path" ] || [ ! -e "$real_path" ] && exit 0
+mv "$real_path" "$(dirname "$real_path")/twit"
+cat > "$real_path" <<'EOF'
+#!/bin/sh
+echo "Bash command 'git' is not allowed. Please use a different command or tool." >&2
+exit 1
+EOF
+chmod 0755 "$real_path"
+"""
+
+_GIT_SHIM_UNINSTALL_SCRIPT = """set -eu
+git_path="$(command -v git 2>/dev/null || true)"
+[ -z "$git_path" ] && exit 0
+real_path="$(readlink -f "$git_path")"
+twit_path="$(dirname "$real_path")/twit"
+[ -e "$twit_path" ] && mv -f "$twit_path" "$real_path"
+exit 0
+"""
 
 
 def resolve_local_checkout(
@@ -114,19 +130,10 @@ def rlm_harness(
     ``ComposableEnv(environment_vars=...)`` themselves; pass the kwargs
     here and the harness owns the env var plumbing.
 
-    ``allow_git`` defaults to False, mirroring opencode's bash tool. When
-    False, a refusal shim is dropped at ``$HOME/.local/bin/git`` (the
-    same dir ``uv tool install rlm`` writes to, which RLM's ``run_command``
-    prepends to ``PATH``). This blocks git for the RLM bash tool, the
-    ipython tool's ``!cmd`` / ``%%bash`` cells, and any
-    ``subprocess.run(["git", ...])`` from inside ipython — all three
-    inherit the agent process's PATH and resolve through the shim first.
-    Crucially, the shim is NOT installed on a system PATH dir, so a
-    rubric / scoring step running ``git apply`` or ``git checkout`` via
-    ``sandbox_client.execute_command`` (which uses the container's
-    default PATH, *not* ``$HOME/.local/bin``) still resolves to the real
-    git in ``/usr/bin``. Set ``allow_git=True`` for environments that
-    genuinely need git inside the agent's tools.
+    With ``allow_git=False`` (default), the post-install step renames
+    the real ``git`` to ``twit`` in the same directory and drops a
+    refusal shim at git's resolved path. The pre-score hook reverses
+    the rename before scoring.
     """
     upload_dir_mapping: dict[str, str] = {
         DEFAULT_RLM_CHECKOUT_UPLOAD_NAME: DEFAULT_RLM_CHECKOUT_PATH,
@@ -150,27 +157,11 @@ def rlm_harness(
 
     tool_names = list(rlm_tools) if rlm_tools is not None else ["ipython"]
 
-    post_install_uploads: dict[str, str] | None = None
     post_install_script: str | None = None
+    pre_score_script: str | None = None
     if not allow_git:
-        # Drop the shim into the same dir ``uv tool install rlm`` uses
-        # ($HOME/.local/bin), which the RLM run_command prepends to PATH
-        # for the agent. This dir is *not* on the container's default
-        # PATH, so the rubric's ``sandbox_client.execute_command`` calls
-        # (skip-install diff, eval.sh's ``git checkout`` / ``git apply``,
-        # gold-patch apply) keep resolving to the real ``/usr/bin/git``.
-        # Uploading directly into ``$HOME/.local/bin`` requires shell
-        # expansion, so stage the body in /tmp and let the post-install
-        # script move it; that script is just dispatched as a string to
-        # ``execute_command``, which runs under a shell that expands
-        # ``$HOME``.
-        post_install_uploads = {"/tmp/__rlm_git_shim": _GIT_SHIM_BODY}
-        post_install_script = (
-            "set -e; "
-            'mkdir -p "$HOME/.local/bin"; '
-            'mv /tmp/__rlm_git_shim "$HOME/.local/bin/git"; '
-            'chmod +x "$HOME/.local/bin/git"'
-        )
+        post_install_script = _GIT_SHIM_INSTALL_SCRIPT
+        pre_score_script = _GIT_SHIM_UNINSTALL_SCRIPT
 
     environment_vars: dict[str, str] = {
         "RLM_TOOLS": ",".join(tool_names),
@@ -195,8 +186,8 @@ def rlm_harness(
         metrics_prefix="rlm_",
         tool_names=tool_names,
         environment_vars=environment_vars,
-        post_install_uploads=post_install_uploads,
         post_install_script=post_install_script,
+        pre_score_script=pre_score_script,
     )
 
 


### PR DESCRIPTION
## Summary

Replaces the PATH-precedence approaches of #1225 (shim at `/usr/local/bin/git` — blocked scoring too) and #1244 (shim at `$HOME/.local/bin/git` — broke on multi-swe images whose default scoring PATH happens to include `$HOME/.local/bin`, e.g. 86 `Bash command 'git' is not allowed.` events in scoring on Apr 26 with #1244 active).

**post-install** renames the resolved real `git` binary to `<dirname>/twit` and drops the shim at git's original resolved path.

**pre_score_script** (new `Harness` field, run between rollout and scoring in `ComposableEnv.post_rollout`) reverses the rename.

PATH ordering and container-specific shell init are irrelevant — the shim sits where the real binary was; restoration is symmetric.

## Files

- `verifiers/envs/experimental/composable/harness.py` — adds `Harness.pre_score_script`.
- `verifiers/envs/experimental/composable/composable_env.py` — invokes `pre_score_script` from `post_rollout` after metrics collection. Failure is logged, not raised.
- `verifiers/envs/experimental/composable/harnesses/rlm.py` — new `_GIT_SHIM_INSTALL_SCRIPT` / `_GIT_SHIM_UNINSTALL_SCRIPT`. Drops the `$HOME/.local/bin/git` placement.

## Test plan

Verified locally on `debian:bookworm-slim`, `ubuntu:24.04`, `python:3.11-slim`: install blocks `git status` with the refusal message; uninstall restores `git --version` to the original release; second uninstall is a no-op.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sandbox lifecycle hooks and changes how the RLM harness disables `git` by renaming the real binary and swapping in a shim, which could impact installs/scoring if restoration fails or images differ. Mitigated by making the restore step best-effort and limiting the change to the RLM harness plus a new optional hook.
> 
> **Overview**
> Updates the RLM harness’s default `allow_git=False` behavior to **disable `git` by renaming the resolved real `git` binary to `twit` and writing a refusal shim at the original path**, rather than relying on PATH precedence.
> 
> Adds a new optional `Harness.pre_score_script`, executed by `ComposableEnv.post_rollout` after log/metrics collection, to **undo agent-specific sandbox modifications before scoring** (non-fatal on failure).
> 
> Adjusts tests by removing the old git-shim upload assertions (no more `$HOME/.local/bin` staged upload) and keeping `allow_git=True` as a no-op for post-install hooks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7650724e58e7818bc549c3af57f70652f4bec73f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->