### PR TITLE
cli_agent_env: bump default poll_interval from 1s to 5s

### DIFF
--- a/verifiers/envs/experimental/cli_agent_env.py
+++ b/verifiers/envs/experimental/cli_agent_env.py
@@ -97,7 +97,7 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
         interception_url: str | None = None,
         max_turns: int = -1,
         timeout_seconds: float = 3600.0,
-        poll_interval: float = 3.0,
+        poll_interval: float = 5.0,
         docker_image: str = "python:3.11-slim",
         start_command: str = "tail -f /dev/null",
         cpu_cores: int = 1,

--- a/verifiers/envs/experimental/cli_agent_env.py
+++ b/verifiers/envs/experimental/cli_agent_env.py
@@ -97,7 +97,7 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
         interception_url: str | None = None,
         max_turns: int = -1,
         timeout_seconds: float = 3600.0,
-        poll_interval: float = 1.0,
+        poll_interval: float = 3.0,
         docker_image: str = "python:3.11-slim",
         start_command: str = "tail -f /dev/null",
         cpu_cores: int = 1,


### PR DESCRIPTION
## Summary

Bumps the default `poll_interval` for `CliAgentEnv.__init__` from `1.0` to `5.0` seconds (one-line change at `verifiers/envs/experimental/cli_agent_env.py:100`).

## Why

`CliAgentEnv.poll_job_completion` (`verifiers/envs/experimental/cli_agent_env.py:391`) loops doing `await sandbox_client.get_background_job(...)` then `await asyncio.sleep(self.poll_interval)`. Each `get_background_job` call (impl at `prime_sandboxes/sandbox.py:1727-1767`) issues a single read-file HTTP request to the sandbox gateway for `/tmp/job_<job_id>.exit` — i.e. one network round trip per tick, just to check whether the agent's marker file exists yet.

Under multi-env hosted RL with the orchestrator's `max_inflight_rollouts=384`, a 1.0s default fans out to up to ~384 read-file requests per second hitting the same sandbox API gateway. In live training this manifested as a steady stream of:

- `AgentError('Agent polling failed: Read file failed: HTTP 408 GET ...')` (gateway-side timeouts)
- `AgentError('Agent polling failed: Read file timed out after 60s: ...')` (client-side timeouts)

…which drove constant rollout re-scheduling and pushed step time ~3x over the working math-only baseline.

## Why 5.0

The 1s default is the outlier in the codebase. Other call sites already use slower intervals:

- `verifiers/envs/experimental/harbor_env/env.py:242` — passes `poll_interval=5` (explicit slowest precedent)
- `verifiers/envs/experimental/sandbox_mixin.py:267` — defaults to `poll_interval=3`
- `prime_sandboxes/sandbox.py:1776` (`run_background_job` SDK helper) — defaults to `poll_interval=3`

Matching `harbor_env`'s `5` cuts steady-state poll load 5× and gives the most headroom against the 60s sandbox-client read timeout under burst.

## Trade-off

Up to ~4 extra seconds of perceived completion-detection latency per rollout in the worst case. Invisible vs multi-minute generation time, and far cheaper than the 60s client timeouts the poll storm currently produces.

## Scope

One-line default change. Callers that explicitly pass `poll_interval=` are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)