### PR TITLE
swe tasksets: default ds_num_proc to None for all SWE tasksets

### DIFF
--- a/verifiers/envs/experimental/composable/tasksets/swe/multi_swe.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/multi_swe.py
@@ -180,7 +180,7 @@ class MultiSWETaskSet(SandboxTaskSet):
         exclude_langs: tuple[str, ...] = ("c", "cpp"),
         filter_repos: list[str] | None = None,
         filter_fn: str | None = None,
-        ds_num_proc: int | None = 8,
+        ds_num_proc: int | None = None,
         ds_keep_in_memory: bool = True,
         timeout_minutes: int = 60,
     ):

--- a/verifiers/envs/experimental/composable/tasksets/swe/openswe.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/openswe.py
@@ -82,7 +82,7 @@ class OpenSWETaskSet(SandboxTaskSet):
         config: str = "openswe_oss",
         filter_repos: list[str] | None = None,
         filter_fn: str | None = None,
-        ds_num_proc: int | None = 8,
+        ds_num_proc: int | None = None,
         ds_keep_in_memory: bool = True,
         timeout_minutes: int = 60,
     ):

--- a/verifiers/envs/experimental/composable/tasksets/swe/r2e_gym.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/r2e_gym.py
@@ -181,7 +181,7 @@ class R2EGymTaskSet(SandboxTaskSet):
         alt_path: str = "/root",
         filter_repos: list[str] | None = None,
         filter_fn: str | None = None,
-        ds_num_proc: int | None = 8,
+        ds_num_proc: int | None = None,
         ds_keep_in_memory: bool = True,
         timeout_minutes: int = 60,
         hide_tests_from_agent: bool = True,

--- a/verifiers/envs/experimental/composable/tasksets/swe/swe_bench.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/swe_bench.py
@@ -353,7 +353,7 @@ class SWEBenchTaskSet(SandboxTaskSet):
         skip_install: bool = True,
         filter_repos: list[str] | None = None,
         filter_fn: str | None = None,
-        ds_num_proc: int | None = 8,
+        ds_num_proc: int | None = None,
         ds_keep_in_memory: bool = True,
         timeout_minutes: int = 60,
     ):


### PR DESCRIPTION
## Summary
- `dataset.map(num_proc=8)` is a pessimization for SWE `_process_example` — the function is a trivial dict-pack, but pickling Arrow chunks across 8 workers dwarfs the actual work. R2E-Gym in particular embeds full `parsed_commit_content` JSON in every row (~760KB/row, 3.5GB cached), so the IPC tax is enormous.
- Multi-proc also re-infers feature types per shard, which has already bitten `multi_swe.py` (List(null) vs List(string) concat error — it pinned `num_proc=None` for the map but still ran multi-proc on `load_dataset` and `filter`).
- Flips the `ds_num_proc` default from `8` → `None` in `R2EGymTaskSet`, `SWEBenchTaskSet`, `MultiSWETaskSet`, `OpenSWETaskSet`. (`SWESmithTaskSet`, `SWELegoTaskSet`, `SWERebenchV2TaskSet` already defaulted to `None`.) The kwarg stays — callers who want multi-proc can still opt in explicitly.

## Measured speedup (full TaskSet construction, cached datasets)

| taskset | rows | before | after | speedup |
|---|---:|---:|---:|---:|
| R2E-Gym | 4578 | 31.0s | 13.5s | **2.3x** |
| SWE-bench Verified | 500 | 1.6s | 0.4s | **3.7x** |
| SWE-bench Verified Quick | 468 | 1.2s | 0.4s | **3.1x** |

R2E-Gym alone: ~17s shaved off every `vf-eval` startup.

Tasksets without cached datasets locally (Multi-SWE, SWE-Lego, SWE-rebench-V2, SWE-Smith, OpenSWE) weren't measured but use the same `_process_example` pattern, so the same finding applies.

## Caller compat
The kwarg signature is unchanged — only the default flips. No caller breaks.

## Test plan
- [x] All seven SWE tasksets import cleanly
- [x] `R2EGymTaskSet()` end-to-end load completes in 13.5s on the cached dataset (down from ~31s)
- [ ] Full CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)