### PR TITLE
TITO: treat content='' / None as equal in prefix-match + warn on MITO fallback past turn 1

### DIFF
--- a/verifiers/clients/openai_chat_completions_token_client.py
+++ b/verifiers/clients/openai_chat_completions_token_client.py
@@ -120,8 +120,7 @@ class OpenAIChatCompletionsTokenClient(OpenAIChatCompletionsClient):
             # Reaching this branch means we have a non-empty trajectory but
             # could not stitch — surface it loudly so ops catches regressions.
             self.logger.warning(
-                "TITO fell back to MITO on turn %d; see prior TITO log line for sub-reason.",
-                len(state["trajectory"]) + 1,
+                f"TITO fell back to MITO on turn {len(state['trajectory']) + 1}"
             )
             return await super().get_native_response(
                 prompt, model, sampling_args, tools, extra_headers=extra_headers

--- a/verifiers/clients/openai_chat_completions_token_client.py
+++ b/verifiers/clients/openai_chat_completions_token_client.py
@@ -118,11 +118,9 @@ class OpenAIChatCompletionsTokenClient(OpenAIChatCompletionsClient):
         prompt_ids = await self.get_prompt_ids(state, prompt, tools)
         if prompt_ids is None:
             # Reaching this branch means we have a non-empty trajectory but
-            # could not stitch — every fallback past turn 1 throws away KV
-            # cache reuse, so surface it loudly for ops to catch regressions.
+            # could not stitch — surface it loudly so ops catches regressions.
             self.logger.warning(
-                "TITO fell back to MITO on turn %d (KV cache reuse skipped); "
-                "see prior TITO log line for sub-reason.",
+                "TITO fell back to MITO on turn %d; see prior TITO log line for sub-reason.",
                 len(state["trajectory"]) + 1,
             )
             return await super().get_native_response(

--- a/verifiers/clients/openai_chat_completions_token_client.py
+++ b/verifiers/clients/openai_chat_completions_token_client.py
@@ -117,6 +117,14 @@ class OpenAIChatCompletionsTokenClient(OpenAIChatCompletionsClient):
             )
         prompt_ids = await self.get_prompt_ids(state, prompt, tools)
         if prompt_ids is None:
+            # Reaching this branch means we have a non-empty trajectory but
+            # could not stitch — every fallback past turn 1 throws away KV
+            # cache reuse, so surface it loudly for ops to catch regressions.
+            self.logger.warning(
+                "TITO fell back to MITO on turn %d (KV cache reuse skipped); "
+                "see prior TITO log line for sub-reason.",
+                len(state["trajectory"]) + 1,
+            )
             return await super().get_native_response(
                 prompt, model, sampling_args, tools, extra_headers=extra_headers
             )
@@ -159,10 +167,18 @@ class OpenAIChatCompletionsTokenClient(OpenAIChatCompletionsClient):
             if hasattr(value, "model_dump"):
                 return normalize_for_comparison(value.model_dump())
             if isinstance(value, Mapping):
-                return {
+                normalized = {
                     str(key): normalize_for_comparison(val)
                     for key, val in value.items()
                 }
+                # Treat content=None and content="" as equivalent: tool-call-only
+                # assistant messages can be serialized either way depending on the
+                # upstream pipeline (e.g., reasoning parsers strip text content
+                # to "" while other paths leave it as None). Coerce to None so
+                # prefix-match equality is unaffected.
+                if normalized.get("content") == "":
+                    normalized["content"] = None
+                return normalized
             if isinstance(value, list):
                 return [normalize_for_comparison(item) for item in value]
             return value


### PR DESCRIPTION
## Summary
Two fixes to `OpenAIChatCompletionsTokenClient`:

1. **Prefix-match leniency for empty assistant content.** `find_largest_prefix_match` did a strict equality check between the trajectory step's assistant message and the incoming prompt's assistant message. When a vLLM reasoning parser is configured, tool-call-only assistant content can be serialized as `""` on one path and `None` on the other — both semantically empty, but `"" != None`, so every post-turn-1 stitch failed and silently fell back to MITO. Coerce empty-string content to `None` inside `normalize_for_comparison`.

2. **WARN instead of silently falling back past turn 1.** Reaching the `prompt_ids is None` branch in `get_native_response` means we have a non-empty trajectory but couldn't stitch — KV-cache reuse is dropped, which is a regression we want to surface fast. Promote that branch from a silent fallback to a single `WARNING` line with the turn number, so any future regression shows up in ops logs instead of being debug-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the prefix-match normalization used to reuse cached tokens and adds new warning logging that could affect ops noise; failures could alter when the system falls back to MITO vs stitching.
> 
> **Overview**
> Improves TITO prefix matching by treating assistant `content=""` and `content=None` as equivalent during trajectory comparisons, preventing unnecessary stitch failures for tool-call-only messages.
> 
> When stitching cannot be performed despite having prior turns (`prompt_ids is None`), it now logs a `WARNING` with the turn number before falling back to MITO to make KV-cache regressions visible in production logs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c8459d9000d2bb2fdafa9aaf52337c5e6cc84e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->