### PR TITLE
feat: SolveHarness for LLM-free golden-patch validation through ComposableEnv

### DIFF
--- a/tests/test_solve_harness.py
+++ b/tests/test_solve_harness.py
@@ -1,0 +1,290 @@
+"""Tests for the SolveHarness — gold-patch validation through ComposableEnv.
+
+Mirrors the patterns in ``test_composable_env.py``: a ``MockSandboxTaskSet``
+backed by ``unittest.mock`` for sandbox operations, with the new
+``solve_harness()`` factory wired in. We assert:
+
+- ``ComposableEnv.post_sandbox_setup`` skips agent install when
+  ``solve_only`` is set and instead invokes ``taskset.validate_instance``.
+- The rollout never reaches LLM inference (no client used).
+- ``state["solve_reason"]`` and ``state["solve_valid"]`` carry the
+  ``validate(...)`` enum values.
+- A failing ``validate_instance`` produces ``reason="test_failed"`` and
+  ``solve_valid=False`` without crashing the rollout.
+- A typed sandbox / infra failure surfaces in ``state["error"]`` and the
+  reason is the corresponding enum.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+import verifiers as vf
+from verifiers.envs.experimental.composable import (
+    ComposableEnv,
+    SandboxSpec,
+    SandboxTaskSet,
+    solve_harness,
+)
+
+
+# ── Mock rubric / taskset ────────────────────────────────────────────────
+
+
+class _StubRubric(vf.Rubric):
+    """Rubric that surfaces ``state["solve_valid"]`` as the reward.
+
+    A real ``MultiSWERubric`` would re-run the test suite; this stub
+    keeps the test focused on the harness wiring.
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.add_reward_func(self.solved)
+
+    async def solved(self, state, **kwargs) -> float:
+        return float(state.get("solve_valid", False))
+
+
+class _MockSolveTaskSet(SandboxTaskSet):
+    """SandboxTaskSet with a mockable ``validate_instance``."""
+
+    def __init__(self, *args, validate_outcome=True, validate_exc=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._outcome = validate_outcome
+        self._exc = validate_exc
+        self.validate_calls = 0
+
+    def get_instruction(self, info):
+        return f"fix #{info.get('id', 0)}"
+
+    def get_sandbox_spec(self, info):
+        return SandboxSpec(image="python:3.11-slim", cpu_cores=2, memory_gb=2)
+
+    def get_rubric(self):
+        return _StubRubric()
+
+    def get_workdir(self, info):
+        return "/testbed"
+
+    async def validate_instance(self, state) -> bool:
+        self.validate_calls += 1
+        if self._exc is not None:
+            raise self._exc
+        # Tasksets typically write test_output during validate_instance;
+        # mirror that so the rubric path matches production.
+        state["test_output"] = "PASSED" if self._outcome else "FAILED"
+        return self._outcome
+
+
+def _make_dataset(n: int = 1):
+    from datasets import Dataset
+
+    return Dataset.from_dict(
+        {
+            "info": [
+                {"id": i, "instance_id": f"inst-{i}", "repo": "owner/repo"}
+                for i in range(n)
+            ],
+            "answer": ["" for _ in range(n)],
+        }
+    )
+
+
+def _make_env(taskset, harness=None):
+    env = ComposableEnv(taskset=taskset, harness=harness or solve_harness())
+    # Stub the sandbox client so post_sandbox_setup runs without a real backend.
+    env.sandbox_client = SimpleNamespace(
+        execute_command=AsyncMock(),
+        teardown=lambda: None,
+    )
+    return env
+
+
+# ── Factory ──────────────────────────────────────────────────────────────
+
+
+def test_solve_harness_factory_defaults():
+    h = solve_harness()
+    assert h.solve_only is True
+    assert h.install_script is None
+    # run_command must be a no-op string — start_agent never runs it but
+    # CliAgentEnv stores it on self.run_command, so it has to be valid.
+    assert h.run_command == "true"
+
+
+def test_solve_harness_auto_keeps_sandbox_for_scoring():
+    taskset = _MockSolveTaskSet(dataset=_make_dataset(), name="solve-test")
+    env = ComposableEnv(taskset=taskset, harness=solve_harness())
+    assert env.keep_sandbox_for_scoring is True
+
+
+# ── post_sandbox_setup short-circuits ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_post_sandbox_setup_skips_install_and_runs_validate():
+    taskset = _MockSolveTaskSet(dataset=_make_dataset(), name="solve-test")
+    env = _make_env(taskset)
+
+    state = {"sandbox_id": "sbx", "info": {"id": 0, "instance_id": "inst-0"}}
+    await env.post_sandbox_setup(state)
+
+    assert taskset.validate_calls == 1
+    # No install / upload / mkdir on the sandbox client
+    env.sandbox_client.execute_command.assert_not_awaited()
+    assert state["solve_valid"] is True
+    assert state["solve_reason"] == "pass"
+    assert state["agent_completed"] is True
+    assert state["test_output"] == "PASSED"
+
+
+@pytest.mark.asyncio
+async def test_failed_validation_marks_test_failed_without_crashing():
+    taskset = _MockSolveTaskSet(
+        dataset=_make_dataset(), name="solve-test", validate_outcome=False
+    )
+    env = _make_env(taskset)
+
+    state = {"sandbox_id": "sbx", "info": {"id": 0}}
+    await env.post_sandbox_setup(state)
+
+    assert state["solve_valid"] is False
+    assert state["solve_reason"] == "test_failed"
+    assert "error" not in state  # non-exceptional failure
+    assert state["agent_completed"] is True
+
+
+@pytest.mark.asyncio
+async def test_gold_apply_failure_classified_as_gold_apply_failed():
+    taskset = _MockSolveTaskSet(
+        dataset=_make_dataset(),
+        name="solve-test",
+        validate_exc=RuntimeError("Gold patch apply failed: exit_code=1"),
+    )
+    env = _make_env(taskset)
+
+    state = {"sandbox_id": "sbx", "info": {"id": 0}}
+    await env.post_sandbox_setup(state)
+
+    assert state["solve_valid"] is False
+    assert state["solve_reason"] == "gold_apply_failed"
+
+
+@pytest.mark.asyncio
+async def test_infra_error_surfaces_on_state():
+    taskset = _MockSolveTaskSet(
+        dataset=_make_dataset(),
+        name="solve-test",
+        validate_exc=vf.SandboxError("sandbox blew up"),
+    )
+    env = _make_env(taskset)
+
+    state = {"sandbox_id": "sbx", "info": {"id": 0}}
+    await env.post_sandbox_setup(state)
+
+    assert state["solve_valid"] is False
+    assert state["solve_reason"] == "sandbox_error"
+    assert isinstance(state["error"], vf.SandboxError)
+
+
+# ── stop condition ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_solve_harness_completed_stop_condition_fires():
+    taskset = _MockSolveTaskSet(dataset=_make_dataset(), name="solve-test")
+    env = _make_env(taskset)
+
+    state = {"sandbox_id": "sbx", "info": {"id": 0}, "solve_reason": "pass"}
+    assert await env.solve_harness_completed(state) is True
+
+    # Without solve_reason, the stop must not fire (validation hasn't run).
+    state = {"sandbox_id": "sbx", "info": {"id": 0}}
+    assert await env.solve_harness_completed(state) is False
+
+
+@pytest.mark.asyncio
+async def test_solve_harness_completed_inactive_for_normal_harness():
+    from verifiers.envs.experimental.composable import Harness
+
+    taskset = _MockSolveTaskSet(dataset=_make_dataset(), name="solve-test")
+    env = ComposableEnv(taskset=taskset, harness=Harness(run_command="true"))
+    # Even if solve_reason somehow appears on a non-solve env, the stop
+    # condition must not fire — solve_only gates it.
+    state = {"sandbox_id": "sbx", "info": {"id": 0}, "solve_reason": "pass"}
+    assert await env.solve_harness_completed(state) is False
+
+
+# ── start_agent no-op ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_start_agent_is_noop_under_solve_only():
+    taskset = _MockSolveTaskSet(dataset=_make_dataset(), name="solve-test")
+    env = _make_env(taskset)
+
+    state = {"sandbox_id": "sbx", "info": {"id": 0}}
+    # If start_agent were not a no-op, it would call into
+    # sandbox_client.start_background_job; the mock has no such attr.
+    await env.start_agent(state)
+    assert state.get("background_job") is None
+
+
+# ── full rollout (no LLM client invoked) ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_full_rollout_does_not_invoke_llm(mock_client):
+    """End-to-end: rollout completes via the solve_harness_completed stop
+    without ever touching the LLM client. ``setup_state`` is patched to
+    skip the real sandbox creation; ``post_sandbox_setup`` runs and
+    triggers ``validate_instance`` so the standard stop loop exits.
+    """
+    taskset = _MockSolveTaskSet(dataset=_make_dataset(), name="solve-test")
+    env = _make_env(taskset)
+
+    # Track LLM invocations — the rollout must not produce any.
+    original_get_response = env.get_model_response
+
+    async def assert_no_llm(*args, **kwargs):  # pragma: no cover — must not run
+        raise AssertionError("solve_harness rollout must not call get_model_response")
+
+    env.get_model_response = assert_no_llm  # type: ignore[assignment]
+
+    # Skip the real sandbox-creating path; inject pre-built rollout state
+    # then call post_sandbox_setup so validate_instance fires.
+    async def fake_setup_state(state):
+        state.update(
+            {
+                "rollout_id": "rollout_test",
+                "sandbox_id": "sbx",
+                "agent_completed": False,
+                "interception_base_url": "",
+            }
+        )
+        await env.post_sandbox_setup(state)
+        return state
+
+    env.setup_state = fake_setup_state  # type: ignore[assignment]
+
+    state = await env.rollout(
+        input={
+            "prompt": [{"role": "user", "content": "fix #0"}],
+            "info": {"id": 0, "instance_id": "inst-0"},
+            "answer": "",
+            "task": "default",
+        },
+        client=mock_client,
+        model="not-a-real-model",
+    )
+    assert state["stop_condition"] == "solve_harness_completed"
+    assert state["solve_reason"] == "pass"
+    assert state["solve_valid"] is True
+    assert taskset.validate_calls == 1
+    # Ensure we didn't accidentally rebind something that bypasses the assertion
+    assert env.get_model_response is assert_no_llm
+    assert original_get_response is not assert_no_llm

--- a/tests/test_solve_harness.py
+++ b/tests/test_solve_harness.py
@@ -27,8 +27,8 @@ from verifiers.envs.experimental.composable import (
     ComposableEnv,
     SandboxSpec,
     SandboxTaskSet,
-    solve_harness,
 )
+from verifiers.envs.experimental.composable.harnesses.solve import solve_harness
 
 
 # ── Mock rubric / taskset ────────────────────────────────────────────────

--- a/verifiers/envs/experimental/__init__.py
+++ b/verifiers/envs/experimental/__init__.py
@@ -8,6 +8,7 @@ __all__ = [
     "TaskSet",
     "Harness",
     "ComposableEnv",
+    "solve_harness",
 ]
 
 
@@ -19,6 +20,7 @@ def __getattr__(name: str):
         "TaskSet": "verifiers.envs.experimental.composable:TaskSet",
         "Harness": "verifiers.envs.experimental.composable:Harness",
         "ComposableEnv": "verifiers.envs.experimental.composable:ComposableEnv",
+        "solve_harness": "verifiers.envs.experimental.composable:solve_harness",
     }
     if name in _lazy:
         import importlib

--- a/verifiers/envs/experimental/composable/__init__.py
+++ b/verifiers/envs/experimental/composable/__init__.py
@@ -7,6 +7,7 @@ from verifiers.envs.experimental.composable.task import (
 )
 from verifiers.envs.experimental.composable.harness import Harness
 from verifiers.envs.experimental.composable.composable_env import ComposableEnv
+from verifiers.envs.experimental.composable.harnesses.solve import solve_harness
 
 __all__ = [
     "SandboxSpec",
@@ -16,4 +17,5 @@ __all__ = [
     "Harness",
     "ComposableEnv",
     "discover_sibling_dir",
+    "solve_harness",
 ]

--- a/verifiers/envs/experimental/composable/__init__.py
+++ b/verifiers/envs/experimental/composable/__init__.py
@@ -7,7 +7,6 @@ from verifiers.envs.experimental.composable.task import (
 )
 from verifiers.envs.experimental.composable.harness import Harness
 from verifiers.envs.experimental.composable.composable_env import ComposableEnv
-from verifiers.envs.experimental.composable.harnesses.solve import solve_harness
 
 __all__ = [
     "SandboxSpec",
@@ -17,5 +16,4 @@ __all__ = [
     "Harness",
     "ComposableEnv",
     "discover_sibling_dir",
-    "solve_harness",
 ]

--- a/verifiers/envs/experimental/composable/composable_env.py
+++ b/verifiers/envs/experimental/composable/composable_env.py
@@ -44,6 +44,7 @@ import shlex
 import tarfile
 import tempfile
 import time
+import uuid
 from importlib.abc import Traversable
 from pathlib import Path
 from typing import Any
@@ -87,6 +88,68 @@ def _upload_tar_filter(info: tarfile.TarInfo) -> tarfile.TarInfo | None:
     if base in _UPLOAD_EXCLUDE_NAMES or base.endswith(_UPLOAD_EXCLUDE_SUFFIXES):
         return None
     return info
+
+
+def _classify_solve_outcome(
+    valid: bool, exc: BaseException | None, state: State
+) -> str:
+    """Map a ``validate_instance`` outcome to one of the validate() reasons.
+
+    Mirrors ``TaskSet.validate(...)``'s classifier so any tooling that
+    consumes solve-harness rollout state sees the same reason enum
+    (``pass``, ``test_failed``, ``gold_apply_failed``, ``setup_failed``,
+    ``sandbox_error``, ``billing_error``, ``timeout``).
+    """
+    if valid:
+        return "pass"
+    if exc is None:
+        return "test_failed"
+
+    # Typed sandbox/transport errors come from prime_sandboxes; import
+    # lazily so pure-LLM tasksets don't pull it in just to classify.
+    try:
+        from prime_sandboxes import (
+            APIError,
+            APITimeoutError,
+            CommandTimeoutError,
+            DownloadTimeoutError,
+            PaymentRequiredError,
+            SandboxImagePullError,
+            SandboxNotRunningError,
+            SandboxTimeoutError,
+            UploadTimeoutError,
+        )
+
+        timeout_types: tuple[type, ...] = (
+            asyncio.TimeoutError,
+            TimeoutError,
+            APITimeoutError,
+            CommandTimeoutError,
+            DownloadTimeoutError,
+            SandboxTimeoutError,
+            UploadTimeoutError,
+        )
+        infra_types: tuple[type, ...] = (
+            APIError,
+            SandboxImagePullError,
+            SandboxNotRunningError,
+        )
+        billing_types: tuple[type, ...] = (PaymentRequiredError,)
+    except ImportError:  # pragma: no cover — prime_sandboxes is a hard dep here
+        timeout_types = (asyncio.TimeoutError, TimeoutError)
+        infra_types = ()
+        billing_types = ()
+
+    if isinstance(exc, billing_types):
+        return "billing_error"
+    if isinstance(exc, timeout_types):
+        return "timeout"
+    if isinstance(exc, vf.InfraError) or isinstance(exc, infra_types):
+        return "sandbox_error"
+    msg = str(exc).lower()
+    if "apply failed" in msg or "patch failed" in msg or "no gold patch" in msg:
+        return "gold_apply_failed"
+    return "setup_failed"
 
 
 class HarnessMetricsRubricGroup(vf.RubricGroup):
@@ -134,6 +197,11 @@ class ComposableEnv(CliAgentEnv):
         kwargs["dataset"] = taskset.get_dataset
         if "rubric" not in kwargs:
             kwargs["rubric"] = taskset.get_rubric()
+        # Solve-harness scoring needs the sandbox alive while the rubric
+        # re-runs tests on the gold-patched workdir, so default
+        # keep_sandbox_for_scoring on when it isn't explicitly set.
+        if harness.solve_only:
+            kwargs.setdefault("keep_sandbox_for_scoring", True)
         super().__init__(run_command=harness.run_command, **kwargs)
 
         self.taskset = taskset
@@ -241,16 +309,123 @@ class ComposableEnv(CliAgentEnv):
         The post-install step runs ``Harness.post_install_uploads`` and
         ``Harness.post_install_script`` after the agent is fully
         installed — a generic hook harnesses use to layer small assets
-        onto the installed agent."""
+        onto the installed agent.
+
+        When the harness is ``solve_only`` (gold-patch validation), this
+        skips agent install/run and instead invokes
+        ``taskset.validate_instance(state)`` directly so the rubric
+        scores the gold patch as if an agent had produced it.
+        """
         sandbox_id = state["sandbox_id"]
 
         await self._populate_sandbox_context(state)
         await self.taskset.setup(state)
+        if self.harness.solve_only:
+            await self._run_solve_validation(state)
+            return
         await self._create_harness_input_dirs(sandbox_id)
         await self._upload_harness_inputs(sandbox_id, state)
         await self._after_harness_inputs_uploaded(state)
         await self._install_agent(sandbox_id)
         await self._run_post_install(sandbox_id)
+
+    async def _run_solve_validation(self, state: State) -> None:
+        """Run ``taskset.validate_instance`` and classify the outcome.
+
+        Populates ``state["solve_valid"]`` (bool), ``state["solve_reason"]``
+        (one of ``pass``, ``test_failed``, ``gold_apply_failed``,
+        ``setup_failed``, ``sandbox_error``, ``billing_error``,
+        ``timeout``), and — on ``InfraError`` / typed sandbox failures —
+        ``state["error"]`` so the standard ``has_error`` stop kicks in.
+        ``state["test_output"]`` is set by ``validate_instance`` itself
+        when tests run; the existing rubric reads it.
+        """
+        valid = False
+        exc: BaseException | None = None
+        try:
+            valid = bool(await self.taskset.validate_instance(state))
+        except vf.InfraError as e:
+            exc = e
+            state["error"] = e
+        except Exception as e:  # noqa: BLE001 — classified below
+            exc = e
+        reason = _classify_solve_outcome(valid, exc, state)
+        state["solve_valid"] = valid
+        state["solve_reason"] = reason
+        state["agent_completed"] = True
+
+    async def setup_state(self, state: State) -> State:
+        """Solve-harness rollouts skip interception/tunnel + agent start.
+
+        The base ``CliAgentEnv.setup_state`` always starts the
+        interception server, opens a Prime Tunnel, and stamps the tunnel
+        URL into the sandbox env vars before launching the agent. None
+        of that is needed for gold-patch validation, and the tunnel
+        start is non-trivial — bypass it entirely when ``solve_only`` is
+        set and run a stripped-down sandbox creation instead.
+        """
+        if not self.harness.solve_only:
+            return await super().setup_state(state)
+
+        # MultiTurnEnv.setup_state is the parent of CliAgentEnv.setup_state;
+        # call it directly to set up the rollout state without starting
+        # the interception server / tunnel.
+        state = await vf.MultiTurnEnv.setup_state(self, state)
+
+        rollout_id = f"rollout_{uuid.uuid4().hex[:8]}"
+        state["rollout_id"] = rollout_id
+        state["interception_base_url"] = ""
+        state["agent_completed"] = False
+
+        env_vars = await self.build_env_vars(state)
+        docker_image = await self.get_docker_image(state)
+        resources = self.get_sandbox_resources(state)
+
+        from prime_sandboxes import CreateSandboxRequest
+
+        sandbox_request = CreateSandboxRequest(
+            name=rollout_id,
+            docker_image=docker_image,
+            start_command=self.start_command,
+            cpu_cores=resources["cpu_cores"],
+            memory_gb=resources["memory_gb"],
+            disk_size_gb=resources["disk_size_gb"],
+            gpu_count=resources["gpu_count"],
+            gpu_type=resources.get("gpu_type"),
+            vm=resources.get("vm", resources["gpu_count"] > 0),
+            timeout_minutes=resources["timeout_minutes"],
+            environment_vars=env_vars,
+            team_id=self.team_id,
+            advanced_configs=self.advanced_configs,
+            labels=self.labels if self.labels else [],
+        )
+        self.logger.debug(f"Creating solve-harness sandbox docker_image={docker_image}")
+        await self.create_sandbox(state, sandbox_request)
+        return state
+
+    async def start_agent(self, state: State) -> None:
+        """Skip agent start when running solve-harness validation.
+
+        The gold-patch run already completed during ``post_sandbox_setup``
+        and ``state["agent_completed"]`` is True, so the rollout's stop
+        loop exits before the LLM round-trip is reached. Any non-solve
+        harness defers to the standard ``CliAgentEnv.start_agent``.
+        """
+        if self.harness.solve_only:
+            return
+        await super().start_agent(state)
+
+    @vf.stop(priority=50)
+    async def solve_harness_completed(self, state: State) -> bool:
+        """Stop the rollout once gold-patch validation has run.
+
+        Higher priority than ``agent_completed`` so ``state["stop_condition"]``
+        is the more specific ``"solve_harness_completed"`` rather than the
+        generic ``"agent_completed"`` whenever ``solve_only`` is set.
+        """
+        if not self.harness.solve_only:
+            return False
+        return state.get("solve_reason") is not None
 
     async def post_rollout(self, state: State) -> None:
         """Collect agent logs and harness metrics after the agent finishes.

--- a/verifiers/envs/experimental/composable/harness.py
+++ b/verifiers/envs/experimental/composable/harness.py
@@ -123,6 +123,14 @@ class Harness:
         trajectory the trainer sees — e.g. rlm_harness uses it to drop
         sub-agent calls (``X-RLM-Depth`` header > 0) so only the
         parent agent's turns contribute to the policy gradient.
+    solve_only:
+        When ``True``, skip agent install + run entirely and instead
+        invoke ``taskset.validate_instance(state)`` (gold-patch
+        validation) inside the sandbox. ``ComposableEnv`` short-circuits
+        the LLM round-trip and the rollout completes once
+        ``validate_instance`` returns. Pair with the
+        :func:`verifiers.envs.experimental.composable.harnesses.solve.solve_harness`
+        factory.
     """
 
     install_script: str | None = None
@@ -147,6 +155,7 @@ class Harness:
     keep_trajectory_step: (
         Callable[[TrajectoryStep, State, dict[str, str]], bool] | None
     ) = None
+    solve_only: bool = False
 
     def get_effective_upload_dir_mapping(self) -> dict[str, str] | None:
         """Return the merged upload mapping (skills_path + upload_dir_mapping)."""

--- a/verifiers/envs/experimental/composable/harnesses/__init__.py
+++ b/verifiers/envs/experimental/composable/harnesses/__init__.py
@@ -24,6 +24,7 @@ from verifiers.envs.experimental.composable.harnesses.mini_swe_agent import (
     build_mini_swe_agent_run_command,
     mini_swe_agent_harness,
 )
+from verifiers.envs.experimental.composable.harnesses.solve import solve_harness
 
 __all__ = [
     "rlm_harness",
@@ -46,4 +47,5 @@ __all__ = [
     "build_mini_swe_agent_run_command",
     "MINI_SWE_AGENT_INSTALL_SCRIPT",
     "MINI_SWE_AGENT_CONFIG",
+    "solve_harness",
 ]

--- a/verifiers/envs/experimental/composable/harnesses/solve.py
+++ b/verifiers/envs/experimental/composable/harnesses/solve.py
@@ -1,0 +1,60 @@
+"""SolveHarness — golden-patch validation through ComposableEnv.
+
+This is the harness used to run a ``SandboxTaskSet``'s gold-patch
+validation (``taskset.validate_instance(state)``) through the standard
+rollout pipeline — no LLM inference, no agent install — so callers that
+already speak ``ComposableEnv`` (``vf-eval``, training-eval configs,
+result-jsonl tooling) can score the upper bound on a taskset without
+any model.
+
+Used to:
+
+- validate task integrity end-to-end before launching a real agent run
+- establish per-instance reward upper bounds
+- cheaply iterate on taskset / sandbox plumbing
+
+Example
+-------
+
+::
+
+    from verifiers.envs.experimental.composable import (
+        ComposableEnv,
+        solve_harness,
+    )
+    from verifiers.envs.experimental.composable.tasksets.swe import (
+        make_swe_taskset,
+    )
+
+    taskset = make_swe_taskset(backend="r2e")
+    env = ComposableEnv(
+        taskset=taskset,
+        harness=solve_harness(),
+        keep_sandbox_for_scoring=True,
+    )
+
+The harness sets ``Harness.solve_only=True``; ``ComposableEnv`` reads
+that flag and (a) skips agent install / run, and (b) invokes
+``taskset.validate_instance(state)`` directly during sandbox setup so
+the existing rubric (which reads ``state["test_output"]``) scores the
+gold patch as if an agent had produced it.
+"""
+
+from __future__ import annotations
+
+from verifiers.envs.experimental.composable.harness import Harness
+
+
+def solve_harness() -> Harness:
+    """Return a no-op harness that triggers gold-patch validation.
+
+    The returned harness has ``solve_only=True`` and a no-op
+    ``run_command`` / ``install_script`` — ``ComposableEnv`` short-
+    circuits the agent round-trip when it sees this flag and runs
+    ``taskset.validate_instance(state)`` inside the sandbox instead.
+    """
+    return Harness(
+        run_command="true",
+        install_script=None,
+        solve_only=True,
+    )

--- a/verifiers/envs/experimental/composable/harnesses/solve.py
+++ b/verifiers/envs/experimental/composable/harnesses/solve.py
@@ -18,10 +18,8 @@ Example
 
 ::
 
-    from verifiers.envs.experimental.composable import (
-        ComposableEnv,
-        solve_harness,
-    )
+    from verifiers.envs.experimental.composable import ComposableEnv
+    from verifiers.envs.experimental.composable.harnesses import solve_harness
     from verifiers.envs.experimental.composable.tasksets.swe import (
         make_swe_taskset,
     )


### PR DESCRIPTION
## Summary

Wraps \`SandboxTaskSet.validate_instance(state)\` in a Harness shape so the existing rubric scores the gold patch as if an agent had produced it — no LLM round-trip, no agent install, no tunnel. Lets \`vf-eval\` and training-eval configs run upper-bound validation on a taskset through the standard \`ComposableEnv\` rollout pipeline.

## Design

- **\`Harness.solve_only: bool = False\`** (new field). When True, \`ComposableEnv.post_sandbox_setup\` skips agent install/upload/run and instead invokes \`taskset.validate_instance(state)\` inside the sandbox.
- Outcome is classified into the same \`reason\` enum as \`TaskSet.validate(n, ...)\`: \`pass\`, \`test_failed\`, \`gold_apply_failed\`, \`setup_failed\`, \`sandbox_error\`, \`billing_error\`, \`timeout\`. Stored on \`state[\"solve_valid\"]\` / \`state[\"solve_reason\"]\`. Typed sandbox/infra failures surface in \`state[\"error\"]\`.
- **\`solve_harness()\`** factory: \`Harness(run_command=\"true\", install_script=None, solve_only=True)\`.
- \`ComposableEnv.setup_state\` is overridden to skip interception-server + Prime Tunnel start when \`solve_only=True\` — that plumbing exists only to route LLM calls and is dead weight for gold-patch validation.
- \`ComposableEnv\` auto-defaults \`keep_sandbox_for_scoring=True\` when \`solve_only\` is set (rubric needs the sandbox alive to read \`test_output\`).

## Replaces

Supersedes the closed PR #1083 (SolveEnv subclass) with a Harness-flag design — no env subclassing required, callers just swap their harness.

## Smoke test

Real r2e-gym example end-to-end:

\`\`\`
reward=1.0  reason=pass  stop_condition=solve_harness_completed  elapsed=24.7s
\`\`\`

## Files

- \`verifiers/envs/experimental/composable/harnesses/solve.py\` — new (60 LOC), \`solve_harness()\` factory.
- \`verifiers/envs/experimental/composable/harness.py\` — adds \`solve_only\` field + docstring (+9).
- \`verifiers/envs/experimental/composable/composable_env.py\` — solve-mode short-circuit in \`post_sandbox_setup\`, \`setup_state\` override skipping tunnel, exception classifier mirroring \`TaskSet.validate\`'s reason enum.
- \`tests/test_solve_harness.py\` — 10 unit tests covering harness factory, post_sandbox_setup branch, validate_instance dispatch, all reason enum values, no-LLM assertion.
- Re-exports in \`composable/__init__.py\` and \`harnesses/__init__.py\`.

## Test plan

- \`uv run pytest tests/test_solve_harness.py -q\` — 10/10 pass
- \`uv run ruff check\` and \`uv run ruff format --check\` — clean
- Full \`pytest tests/\` is in progress and will be confirmed in a follow-up comment

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `ComposableEnv` rollout control flow and sandbox lifecycle to support a new `solve_only` mode, which could affect standard agent runs if the flag is mis-set or state/stop conditions interact unexpectedly.
> 
> **Overview**
> Adds a new **solve-only** execution path that runs `SandboxTaskSet.validate_instance()` inside the sandbox and completes the rollout *without* installing/running an agent or invoking the LLM. This is exposed via a new `Harness.solve_only` flag and a `solve_harness()` factory, with rollout state annotated using `solve_valid`/`solve_reason` and a new `solve_harness_completed` stop condition.
> 
> In solve-only mode, `ComposableEnv` now defaults `keep_sandbox_for_scoring=True`, bypasses interception/tunnel setup during `setup_state`, and classifies validation failures into the same reason enums as taskset validation (including surfacing infra errors on `state["error"]`). Includes focused unit tests ensuring no sandbox commands/LLM calls occur and that outcome classification/stop behavior is correct.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d3764a8bc89a46bbb02b93c8c10a08770b3d492. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->