### PR TITLE
fix: avoid TOCTOU port race in CliAgentEnv interception server

### DIFF
--- a/verifiers/envs/experimental/cli_agent_env.py
+++ b/verifiers/envs/experimental/cli_agent_env.py
@@ -150,11 +150,6 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
         self.advanced_configs = advanced_configs
         self.labels = labels
 
-        # Pass 0 to let the OS assign a free port at bind time; resolved
-        # post-start via InterceptionServer.port. Picking the port up front
-        # via get_free_port() opens a TOCTOU race where the port can be
-        # taken between selection and aiohttp's bind, causing every rollout
-        # to fail with OSError(98, "address already in use").
         interception_port = 0 if interception_port is None else interception_port
         self.init_interception(interception_port, interception_url)
         self.add_rubric(SandboxMonitorRubric())

--- a/verifiers/envs/experimental/cli_agent_env.py
+++ b/verifiers/envs/experimental/cli_agent_env.py
@@ -39,7 +39,6 @@ from verifiers.utils.interception_utils import (
 )
 from verifiers.utils.logging_utils import print_time, truncate
 from verifiers.utils.message_utils import normalize_messages
-from verifiers.utils.serve_utils import get_free_port
 
 logger = logging.getLogger(__name__)
 
@@ -151,9 +150,12 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
         self.advanced_configs = advanced_configs
         self.labels = labels
 
-        interception_port = (
-            get_free_port() if interception_port is None else interception_port
-        )
+        # Pass 0 to let the OS assign a free port at bind time; resolved
+        # post-start via InterceptionServer.port. Picking the port up front
+        # via get_free_port() opens a TOCTOU race where the port can be
+        # taken between selection and aiohttp's bind, causing every rollout
+        # to fail with OSError(98, "address already in use").
+        interception_port = 0 if interception_port is None else interception_port
         self.init_interception(interception_port, interception_url)
         self.add_rubric(SandboxMonitorRubric())
         self.add_rubric(CliAgentMonitorRubric())
@@ -236,6 +238,7 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
 
         interception_server = self._require_interception_server()
         await interception_server.start()
+        self.interception_port = interception_server.port
 
         if self.interception_url is None:
             tunnel_url = await self.get_tunnel_url()


### PR DESCRIPTION
## Summary

`CliAgentEnv.__init__` was picking the `interception_port` via `get_free_port()` and then handing that number to `InterceptionServer`, which binds an aiohttp `TCPSite` later inside `setup_state`. `get_free_port()` only holds the port until the probing socket closes, so anything between that close and aiohttp's `bind()` can steal it. On a busy host (e.g. several env-server subprocesses spawning concurrently in prime-rl) this is reproducible.

When the bind loses, `InterceptionServer.start()` raises `OSError(98, "address already in use")` on the first rollout. Because `_app` is only set after a successful bind, every subsequent rollout retries `start()`, attempts the same dead port, and fails with the same error — every rollout for that env warns `Rollout failed: OSError(98 ...)` indefinitely.

The fix: pass `0` so the OS assigns a free port at bind time. `InterceptionServer.start()` already resolves the OS-assigned port after `site.start()` (the same pattern `rlm_env.py` uses). `self.interception_port` is updated post-start so external readers (e.g. tests, tunnel setup) see the real port.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 7455fc4336b2c1b1e34526574b8891d68d34253a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->