### PR TITLE
chore: point DEFAULT_RLM_REPO_URL to rlm-harness

### DIFF
--- a/verifiers/envs/experimental/composable/harnesses/rlm.py
+++ b/verifiers/envs/experimental/composable/harnesses/rlm.py
@@ -18,7 +18,7 @@ from verifiers.envs.experimental.utils.git_checkout_cache import (
 if TYPE_CHECKING:
     from verifiers.types import State
 
-DEFAULT_RLM_REPO_URL = "github.com/PrimeIntellect-ai/rlm.git"
+DEFAULT_RLM_REPO_URL = "github.com/PrimeIntellect-ai/rlm-harness.git"
 DEFAULT_RLM_REF = "main"
 DEFAULT_RLM_MAX_TURNS = 100
 DEFAULT_RLM_EXEC_TIMEOUT = 300


### PR DESCRIPTION
## Summary
- Update `DEFAULT_RLM_REPO_URL` in `verifiers/envs/experimental/composable/harnesses/rlm.py` to `github.com/PrimeIntellect-ai/rlm-harness.git`.
- The RLM agent harness now lives at `PrimeIntellect-ai/rlm-harness` rather than `PrimeIntellect-ai/rlm`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 87494e27df54d1e6c0d5d3bc8a8c57a3ab1792dd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->