### PR TITLE
Add GEPA system prompt export and path-based prompt loading

### DIFF
--- a/configs/eval/wordle.toml
+++ b/configs/eval/wordle.toml
@@ -1,0 +1,8 @@
+model = "openai/gpt-5.4"
+save_results = true
+
+[[eval]]
+env_id = "primeintellect/wordle"
+num_examples = 20
+rollouts_per_example = 1
+# env_args = { path_to_system_prompt = "/path/to/system_prompt.txt" }

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -34,6 +34,19 @@ ChatMessage = ChatCompletionMessageParam  # from openai.types.chat
 
 OpenAI's chat message type with `role`, `content`, and optional `tool_calls` / `tool_call_id` fields.
 
+### SystemMessage
+
+```python
+class SystemMessage:
+    role: Literal["system"] = "system"
+    content: MessageContent
+
+    @classmethod
+    def from_path(cls, path: str | Path) -> "SystemMessage": ...
+```
+
+Provider-agnostic system message type. Use `vf.SystemMessage.from_path(...)` to load a system prompt from a UTF-8 text file while preserving the file contents verbatim.
+
 ### Info
 
 ```python

--- a/docs/training.md
+++ b/docs/training.md
@@ -40,7 +40,8 @@ configs/
 ├── endpoints.toml
 ├── eval/
 │   ├── minimal.toml
-│   └── multi-env.toml
+│   ├── multi-env.toml
+│   └── wordle.toml
 ├── rl/
 │   ├── alphabet-sort.toml
 │   ├── gsm8k.toml
@@ -130,8 +131,9 @@ Key options:
 ### Output
 
 After optimization, you'll find:
-- `best_prompt.txt` - The optimized system prompt
-- `pareto_frontier.jsonl` - Best prompts per validation example
+- `system_prompt.txt` - The optimized system prompt. Load it with `vf.SystemMessage.from_path("/path/to/system_prompt.txt")`.
+- `results.jsonl` - Candidate prompt rows for evaluation upload; GEPA-specific fields live under `info`.
+- `pareto_frontier.jsonl` - Best candidate references per validation example
 - `metadata.json` - Run configuration and summary
 
 Use `prime eval run` to verify performance before and after optimization.

--- a/environments/wordle/README.md
+++ b/environments/wordle/README.md
@@ -39,6 +39,7 @@ prime eval run wordle \
 | --- | ---- | ------- | ----------- |
 | `num_train_examples` | int | `2000` | Number of training episodes |
 | `num_eval_examples` | int | `20` | Number of evaluation episodes |
+| `path_to_system_prompt` | str \| Path \| None | `None` | Path to a text file used as the system prompt |
 
 ### Metrics
 | Metric | Meaning |

--- a/environments/wordle/wordle.py
+++ b/environments/wordle/wordle.py
@@ -1,4 +1,5 @@
 import re
+from pathlib import Path
 
 import verifiers as vf
 from verifiers.envs.integrations.textarena_env import TextArenaEnv
@@ -57,9 +58,15 @@ def load_environment(
     num_train_examples: int = 2000,
     num_eval_examples: int = 20,
     system_prompt: str = DEFAULT_SYSTEM_PROMPT,
+    path_to_system_prompt: str | Path | None = None,
     seed: int = 0,
     **kwargs,
 ):
+    if path_to_system_prompt is not None:
+        system_prompt = (
+            Path(path_to_system_prompt).expanduser().read_text(encoding="utf-8")
+        )
+
     parser = vf.XMLParser(fields=["guess"], answer_field="guess")
 
     rubric = vf.Rubric(parser=parser)

--- a/environments/wordle/wordle.py
+++ b/environments/wordle/wordle.py
@@ -63,9 +63,9 @@ def load_environment(
     **kwargs,
 ):
     if path_to_system_prompt is not None:
-        system_prompt = (
-            Path(path_to_system_prompt).expanduser().read_text(encoding="utf-8")
-        )
+        system_prompt = vf.SystemMessage.from_path(
+            Path(path_to_system_prompt).expanduser()
+        ).content
 
     parser = vf.XMLParser(fields=["guess"], answer_field="guess")
 

--- a/tests/test_gepa_utils.py
+++ b/tests/test_gepa_utils.py
@@ -1,0 +1,138 @@
+import json
+from types import SimpleNamespace
+
+from verifiers.gepa.gepa_utils import save_gepa_results
+
+
+def _read_jsonl(path):
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line
+    ]
+
+
+def test_save_gepa_results_writes_best_system_prompt_verbatim(tmp_path):
+    prompt = "System line one.\n\nKeep this exact spacing.\n"
+    result = SimpleNamespace(
+        best_idx=0,
+        best_candidate={"system_prompt": prompt},
+        val_aggregate_scores=[1.0],
+    )
+
+    save_gepa_results(tmp_path, result)
+
+    assert (tmp_path / "system_prompt.txt").read_text(encoding="utf-8") == prompt
+    assert not (tmp_path / "best_prompt.txt").exists()
+
+
+def test_save_gepa_results_writes_upload_schema_without_task_fields(tmp_path):
+    prompt = "Answer with one word.\n"
+    result = SimpleNamespace(
+        best_idx=0,
+        best_candidate={"system_prompt": prompt},
+        val_aggregate_scores=[0.75],
+    )
+
+    save_gepa_results(
+        tmp_path,
+        result,
+        config={
+            "env_id": "wordle",
+            "model": "openai/gpt-5.4-mini",
+            "reflection_model": "openai/gpt-5.4-mini",
+        },
+    )
+
+    metadata = json.loads((tmp_path / "metadata.json").read_text(encoding="utf-8"))
+    assert metadata["schema_version"] == "verifiers.gepa.v1"
+    assert metadata["eval_kind"] == "gepa"
+    assert metadata["optimization_target"] == "system_prompt"
+    assert metadata["env_id"] == "wordle"
+    assert metadata["best_score"] == 0.75
+    assert "task" not in metadata
+    assert "task_type" not in metadata
+
+    rows = _read_jsonl(tmp_path / "results.jsonl")
+    assert rows == [
+        {
+            "example_id": 0,
+            "reward": 0.75,
+            "score": 0.75,
+            "info": {
+                "schema_version": "verifiers.gepa.v1",
+                "eval_kind": "gepa",
+                "sample_type": "gepa_candidate",
+                "optimization_target": "system_prompt",
+                "candidate_idx": 0,
+                "is_best": True,
+                "system_prompt": prompt,
+                "system_prompt_sha256": metadata["best_prompt_sha256"],
+                "diff_from_initial": "",
+                "parent_candidate_idxs": [],
+                "val_subscores": {},
+                "num_val_examples": 0,
+            },
+        }
+    ]
+    assert "task" not in rows[0]
+    assert "task_type" not in rows[0]
+    assert "task" not in rows[0]["info"]
+    assert "task_type" not in rows[0]["info"]
+
+
+def test_save_gepa_results_writes_candidate_diffs_and_frontier(tmp_path):
+    result = SimpleNamespace(
+        best_idx=1,
+        best_candidate={"system_prompt": "Base prompt.\nBetter final answer.\n"},
+        candidates=[
+            {"system_prompt": "Base prompt.\nInitial final answer.\n"},
+            {"system_prompt": "Base prompt.\nBetter final answer.\n"},
+        ],
+        val_aggregate_scores=[0.3, 0.7],
+        val_subscores=[{0: 0.2, 1: 0.4}, {0: 0.8, 1: 0.6}],
+        parents=[None, 0],
+        discovery_eval_counts=[2, 5],
+    )
+
+    save_gepa_results(tmp_path, result)
+
+    rows = _read_jsonl(tmp_path / "results.jsonl")
+    assert len(rows) == 2
+    assert rows[1]["reward"] == 0.7
+    assert rows[1]["info"]["parent_candidate_idxs"] == [0]
+    assert rows[1]["info"]["val_subscores"] == {"0": 0.8, "1": 0.6}
+    assert rows[1]["info"]["discovery_metric_calls"] == 5
+    assert "--- initial/system_prompt.txt" in rows[1]["info"]["diff_from_initial"]
+    assert "+++ candidate/system_prompt.txt" in rows[1]["info"]["diff_from_initial"]
+
+    frontier_rows = _read_jsonl(tmp_path / "pareto_frontier.jsonl")
+    assert frontier_rows == [
+        {
+            "schema_version": "verifiers.gepa.v1",
+            "valset_row": 0,
+            "best_score": 0.8,
+            "num_best_candidates": 1,
+            "best_candidates": [
+                {
+                    "candidate_idx": 1,
+                    "system_prompt_sha256": rows[1]["info"]["system_prompt_sha256"],
+                    "score": 0.8,
+                }
+            ],
+        },
+        {
+            "schema_version": "verifiers.gepa.v1",
+            "valset_row": 1,
+            "best_score": 0.6,
+            "num_best_candidates": 1,
+            "best_candidates": [
+                {
+                    "candidate_idx": 1,
+                    "system_prompt_sha256": rows[1]["info"]["system_prompt_sha256"],
+                    "score": 0.6,
+                }
+            ],
+        },
+    ]
+    assert "system_prompt" not in frontier_rows[0]["best_candidates"][0]

--- a/tests/test_gepa_utils.py
+++ b/tests/test_gepa_utils.py
@@ -26,6 +26,23 @@ def test_save_gepa_results_writes_best_system_prompt_verbatim(tmp_path):
     assert not (tmp_path / "best_prompt.txt").exists()
 
 
+def test_save_gepa_results_handles_none_best_score(tmp_path):
+    prompt = "System prompt.\n"
+    result = SimpleNamespace(
+        best_idx=0,
+        best_candidate={"system_prompt": prompt},
+        val_aggregate_scores=[None],
+    )
+
+    save_gepa_results(tmp_path, result)
+
+    metadata = json.loads((tmp_path / "metadata.json").read_text(encoding="utf-8"))
+    rows = _read_jsonl(tmp_path / "results.jsonl")
+    assert metadata["best_score"] is None
+    assert rows[0]["score"] is None
+    assert rows[0]["reward"] == 0.0
+
+
 def test_save_gepa_results_writes_upload_schema_without_task_fields(tmp_path):
     prompt = "Answer with one word.\n"
     result = SimpleNamespace(

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,0 +1,11 @@
+import verifiers as vf
+
+
+def test_system_message_from_path_reads_file_verbatim(tmp_path):
+    prompt = "You are precise.\n\nPreserve trailing newline.\n"
+    path = tmp_path / "system_prompt.txt"
+    path.write_text(prompt, encoding="utf-8")
+
+    message = vf.SystemMessage.from_path(path)
+
+    assert message == {"role": "system", "content": prompt}

--- a/tests/test_wordle_env.py
+++ b/tests/test_wordle_env.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+import pytest
+
+
+def test_wordle_load_environment_reads_system_prompt_path(tmp_path, monkeypatch):
+    pytest.importorskip("nltk")
+    pytest.importorskip("textarena")
+    from environments.wordle import wordle
+
+    class CapturingTextArenaEnv:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    prompt = "Optimized Wordle prompt.\n\nPreserve exact text.\n"
+    prompt_path = tmp_path / "system_prompt.txt"
+    prompt_path.write_text(prompt, encoding="utf-8")
+    monkeypatch.setattr(wordle, "TextArenaEnv", CapturingTextArenaEnv)
+
+    env = wordle.load_environment(path_to_system_prompt=Path(prompt_path))
+
+    assert env.kwargs["system_prompt"] == prompt

--- a/verifiers/gepa/gepa_utils.py
+++ b/verifiers/gepa/gepa_utils.py
@@ -289,6 +289,11 @@ def save_gepa_results(
     (run_dir / "system_prompt.txt").write_text(system_prompt, encoding="utf-8")
 
     # Build and save metadata
+    best_score = (
+        _to_float(val_scores[best_idx])
+        if val_scores and best_idx < len(val_scores)
+        else None
+    )
     metadata = {
         "schema_version": GEPA_SCHEMA_VERSION,
         "eval_kind": GEPA_EVAL_KIND,
@@ -300,9 +305,7 @@ def save_gepa_results(
         "reflection_model": config.get("reflection_model") if config else None,
         "num_candidates": len(candidates),
         "best_idx": best_idx,
-        "best_score": float(val_scores[best_idx])
-        if val_scores and best_idx < len(val_scores)
-        else None,
+        "best_score": best_score,
         "total_metric_calls": getattr(result, "total_metric_calls", None),
         "initial_prompt_sha256": _sha256_text(_prompt_from_candidate(candidates[0]))
         if candidates

--- a/verifiers/gepa/gepa_utils.py
+++ b/verifiers/gepa/gepa_utils.py
@@ -203,8 +203,7 @@ def save_gepa_results(
         parents = _get_field(state, "parent_program_for_candidate", [])
         discovery_eval_counts = _get_field(state, "num_metric_calls_by_discovery", [])
 
-    # Fallback to result object if state file doesn't have data
-    # Clear val_subscores too since they reference state file candidate indices
+    # Fallback to result object if state file doesn't have data.
     if not candidates:
         candidates = getattr(result, "candidates", [])
         val_subscores = getattr(result, "val_subscores", [])

--- a/verifiers/gepa/gepa_utils.py
+++ b/verifiers/gepa/gepa_utils.py
@@ -2,18 +2,173 @@
 Simple artifact saving for GEPA optimization.
 
 Saves:
+- results.jsonl: Candidate-centric rows suitable for Prime Evals upload
 - pareto_frontier.jsonl: Per valset row, the best prompt(s) and their scores
-- best_prompt.txt: The single best overall system prompt
+- system_prompt.txt: The single best overall system prompt
 - metadata.json: Run configuration and summary
 """
 
+import difflib
+import hashlib
 import json
 import pickle
 from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from datasets import Dataset
+GEPA_SCHEMA_VERSION = "verifiers.gepa.v1"
+GEPA_EVAL_KIND = "gepa"
+GEPA_OPTIMIZATION_TARGET = "system_prompt"
+
+
+def _get_field(obj: Any, key: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def _prompt_from_candidate(candidate: Any) -> str:
+    if isinstance(candidate, dict):
+        value = candidate.get("system_prompt", "")
+        return value if isinstance(value, str) else str(value)
+    if isinstance(candidate, str):
+        return candidate
+    return ""
+
+
+def _sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _to_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _candidate_score(
+    candidate_idx: int,
+    val_scores: list[Any],
+    val_subscores: list[dict[Any, Any]],
+) -> float | None:
+    if candidate_idx < len(val_scores):
+        return _to_float(val_scores[candidate_idx])
+    if candidate_idx >= len(val_subscores):
+        return None
+    scores = [_to_float(score) for score in val_subscores[candidate_idx].values()]
+    valid_scores = [score for score in scores if score is not None]
+    if not valid_scores:
+        return None
+    return sum(valid_scores) / len(valid_scores)
+
+
+def _prompt_diff(initial_prompt: str, candidate_prompt: str) -> str:
+    if initial_prompt == candidate_prompt:
+        return ""
+    diff = difflib.unified_diff(
+        initial_prompt.splitlines(),
+        candidate_prompt.splitlines(),
+        fromfile="initial/system_prompt.txt",
+        tofile="candidate/system_prompt.txt",
+        lineterm="",
+    )
+    return "\n".join(diff) + "\n"
+
+
+def _normalize_parents(parents: Any, candidate_idx: int) -> list[int]:
+    if not isinstance(parents, list) or candidate_idx >= len(parents):
+        return []
+    raw_parent_idxs = parents[candidate_idx]
+    if raw_parent_idxs is None:
+        return []
+    if not isinstance(raw_parent_idxs, list):
+        raw_parent_idxs = [raw_parent_idxs]
+    normalized = []
+    for raw_parent_idx in raw_parent_idxs:
+        if raw_parent_idx is None:
+            continue
+        try:
+            normalized.append(int(raw_parent_idx))
+        except (TypeError, ValueError):
+            continue
+    return normalized
+
+
+def _jsonable_scores(scores: dict[Any, Any]) -> dict[str, float]:
+    jsonable = {}
+    for key, value in scores.items():
+        score = _to_float(value)
+        if score is not None:
+            jsonable[str(key)] = score
+    return jsonable
+
+
+def _as_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    try:
+        return list(value)
+    except TypeError:
+        return [value]
+
+
+def _write_jsonl(path: Path, records: list[dict[str, Any]]) -> None:
+    with open(path, "w", encoding="utf-8") as f:
+        for record in records:
+            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+
+def _build_candidate_records(
+    candidates: list[Any],
+    val_scores: list[Any],
+    val_subscores: list[dict[Any, Any]],
+    parents: Any,
+    discovery_eval_counts: Any,
+    best_idx: int,
+) -> list[dict[str, Any]]:
+    initial_prompt = _prompt_from_candidate(candidates[0]) if candidates else ""
+    records = []
+    for candidate_idx, candidate in enumerate(candidates):
+        system_prompt = _prompt_from_candidate(candidate)
+        score = _candidate_score(candidate_idx, val_scores, val_subscores)
+        subscores = (
+            _jsonable_scores(val_subscores[candidate_idx])
+            if candidate_idx < len(val_subscores)
+            else {}
+        )
+        info: dict[str, Any] = {
+            "schema_version": GEPA_SCHEMA_VERSION,
+            "eval_kind": GEPA_EVAL_KIND,
+            "sample_type": "gepa_candidate",
+            "optimization_target": GEPA_OPTIMIZATION_TARGET,
+            "candidate_idx": candidate_idx,
+            "is_best": candidate_idx == best_idx,
+            "system_prompt": system_prompt,
+            "system_prompt_sha256": _sha256_text(system_prompt),
+            "diff_from_initial": _prompt_diff(initial_prompt, system_prompt),
+            "parent_candidate_idxs": _normalize_parents(parents, candidate_idx),
+            "val_subscores": subscores,
+            "num_val_examples": len(subscores),
+        }
+        if isinstance(discovery_eval_counts, list) and candidate_idx < len(
+            discovery_eval_counts
+        ):
+            info["discovery_metric_calls"] = discovery_eval_counts[candidate_idx]
+
+        records.append(
+            {
+                "example_id": candidate_idx,
+                "reward": score if score is not None else 0.0,
+                "score": score,
+                "info": info,
+            }
+        )
+    return records
 
 
 def save_gepa_results(
@@ -34,23 +189,41 @@ def save_gepa_results(
 
     # Load detailed state from gepa_state.bin (saved by GEPA library)
     state_file = run_dir / "gepa_state.bin"
+    state = {}
     candidates = []
     val_subscores = []
+    parents = []
+    discovery_eval_counts = []
 
     if state_file.exists():
         with open(state_file, "rb") as f:
             state = pickle.load(f)
-        candidates = state.get("program_candidates", [])
-        val_subscores = state.get("prog_candidate_val_subscores", [])
+        candidates = _get_field(state, "program_candidates", [])
+        val_subscores = _get_field(state, "prog_candidate_val_subscores", [])
+        parents = _get_field(state, "parent_program_for_candidate", [])
+        discovery_eval_counts = _get_field(state, "num_metric_calls_by_discovery", [])
 
     # Fallback to result object if state file doesn't have data
     # Clear val_subscores too since they reference state file candidate indices
     if not candidates:
         candidates = getattr(result, "candidates", [])
-        val_subscores = []
+        val_subscores = getattr(result, "val_subscores", [])
+        parents = getattr(result, "parents", [])
+        discovery_eval_counts = getattr(result, "discovery_eval_counts", [])
 
-    best_idx = getattr(result, "best_idx", 0)
+    try:
+        best_idx = int(getattr(result, "best_idx", 0))
+    except (TypeError, ValueError):
+        best_idx = 0
     best_candidate = getattr(result, "best_candidate", {})
+    candidates = _as_list(candidates)
+    val_subscores = _as_list(val_subscores)
+    if not candidates and best_candidate:
+        candidates = [best_candidate]
+    if not best_candidate and candidates and best_idx < len(candidates):
+        best_candidate = candidates[best_idx]
+
+    val_scores = _as_list(getattr(result, "val_aggregate_scores", None))
 
     # Build per-row frontier: for each valset row, which prompts did best
     records = []
@@ -58,23 +231,28 @@ def save_gepa_results(
         # Get all valset row indices
         all_rows: set[int] = set()
         for subscores in val_subscores:
-            all_rows.update(subscores.keys())
+            if isinstance(subscores, dict):
+                all_rows.update(subscores.keys())
 
         for row_idx in sorted(all_rows):
             # Collect scores for this row from all candidates
             row_scores = []
             for cand_idx, subscores in enumerate(val_subscores):
-                if row_idx in subscores:
-                    row_scores.append((cand_idx, subscores[row_idx]))
+                if isinstance(subscores, dict) and row_idx in subscores:
+                    score = _to_float(subscores[row_idx])
+                    if score is not None:
+                        row_scores.append((cand_idx, score))
 
             if not row_scores:
                 continue
 
             best_score = max(score for _, score in row_scores)
-            best_prompts = [
+            best_candidates = [
                 {
                     "candidate_idx": cand_idx,
-                    "system_prompt": candidates[cand_idx].get("system_prompt", ""),
+                    "system_prompt_sha256": _sha256_text(
+                        _prompt_from_candidate(candidates[cand_idx])
+                    ),
                     "score": score,
                 }
                 for cand_idx, score in row_scores
@@ -83,34 +261,60 @@ def save_gepa_results(
 
             records.append(
                 {
-                    "valset_row": row_idx,
+                    "schema_version": GEPA_SCHEMA_VERSION,
+                    "valset_row": int(row_idx),
                     "best_score": best_score,
-                    "num_best_prompts": len(best_prompts),
-                    "best_prompts": best_prompts,
+                    "num_best_candidates": len(best_candidates),
+                    "best_candidates": best_candidates,
                 }
             )
 
-    # Save frontier as JSONL
-    if records:
-        frontier_ds = Dataset.from_list(records)
-        frontier_ds.to_json(run_dir / "pareto_frontier.jsonl")
+    # Save upload-friendly candidate rows as JSONL.
+    candidate_records = _build_candidate_records(
+        candidates=candidates,
+        val_scores=val_scores,
+        val_subscores=val_subscores,
+        parents=parents,
+        discovery_eval_counts=discovery_eval_counts,
+        best_idx=best_idx,
+    )
+    _write_jsonl(run_dir / "results.jsonl", candidate_records)
 
-    # Save best prompt as plain text
-    best_prompt = best_candidate.get("system_prompt", "")
-    (run_dir / "best_prompt.txt").write_text(best_prompt)
+    # Save frontier as auxiliary JSONL.
+    if records:
+        _write_jsonl(run_dir / "pareto_frontier.jsonl", records)
+
+    # Save best system prompt as plain text.
+    system_prompt = _prompt_from_candidate(best_candidate)
+    (run_dir / "system_prompt.txt").write_text(system_prompt, encoding="utf-8")
 
     # Build and save metadata
-    val_scores = getattr(result, "val_aggregate_scores", [])
     metadata = {
+        "schema_version": GEPA_SCHEMA_VERSION,
+        "eval_kind": GEPA_EVAL_KIND,
+        "framework": "verifiers",
+        "optimizer": "gepa",
+        "optimization_target": GEPA_OPTIMIZATION_TARGET,
+        "env_id": config.get("env_id") if config else None,
+        "model": config.get("model") if config else None,
+        "reflection_model": config.get("reflection_model") if config else None,
         "num_candidates": len(candidates),
         "best_idx": best_idx,
         "best_score": float(val_scores[best_idx])
         if val_scores and best_idx < len(val_scores)
         else None,
         "total_metric_calls": getattr(result, "total_metric_calls", None),
+        "initial_prompt_sha256": _sha256_text(_prompt_from_candidate(candidates[0]))
+        if candidates
+        else None,
+        "best_prompt_sha256": _sha256_text(system_prompt),
+        "system_prompt_path": "system_prompt.txt",
+        "results_path": "results.jsonl",
         "completed_at": datetime.now().isoformat(),
     }
     if config:
         metadata["config"] = config
 
-    (run_dir / "metadata.json").write_text(json.dumps(metadata, indent=2))
+    (run_dir / "metadata.json").write_text(
+        json.dumps(metadata, indent=2), encoding="utf-8"
+    )

--- a/verifiers/scripts/setup.py
+++ b/verifiers/scripts/setup.py
@@ -96,6 +96,7 @@ EVAL_CONFIGS = _mirror_repo_configs(
     [
         "configs/eval/minimal.toml",
         "configs/eval/multi-env.toml",
+        "configs/eval/wordle.toml",
     ],
 )
 

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -109,6 +109,10 @@ class SystemMessage(CustomBaseModel):
     role: Literal["system"] = "system"
     content: MessageContent
 
+    @classmethod
+    def from_path(cls, path: str | Path) -> "SystemMessage":
+        return cls(content=Path(path).read_text(encoding="utf-8"))
+
 
 class UserMessage(CustomBaseModel):
     role: Literal["user"] = "user"


### PR DESCRIPTION
## Summary
- Export GEPA prompts verbatim to `system_prompt.txt` and add `vf.SystemMessage.from_path(...)` for loading them
- Add Wordle support for `path_to_system_prompt` and wire in a commented eval config toggle
- Rework GEPA artifacts to use upload-friendly candidate rows and remove any `task`/`task_type` usage from the new schema
- Update docs and setup mirroring to include the new Wordle eval config

## Testing
- Added unit tests for `SystemMessage.from_path`, GEPA artifact output, and Wordle prompt loading
- Ran formatting and lint checks successfully
- Ran the focused pytest subset for GEPA, types, Wordle, eval config validation, and setup mirroring

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 632aaf54991b1a55c69e95883c9aca8e6a6f8629. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->