### PR TITLE
fix: pin RLM_HOME outside agent workdir to survive destructive ops

### DIFF
--- a/tests/test_rlm_composable_env.py
+++ b/tests/test_rlm_composable_env.py
@@ -202,7 +202,7 @@ def test_rlm_harness_uses_explicit_local_checkout(tmp_path):
 
     assert harness.get_upload_dirs() == {"rlm_checkout": checkout.resolve()}
     assert harness.upload_dir_mapping == {"rlm_checkout": "/tmp/rlm-checkout"}
-    assert harness.metrics_path == "{workdir}/.rlm/sessions/*/meta.json"
+    assert harness.metrics_path == "/tmp/.rlm/sessions/*/meta.json"
     assert harness.metrics_key == "metrics"
     assert harness.metrics_prefix == "rlm_"
     assert harness.skills_path == "/task/rlm-skills"
@@ -703,7 +703,7 @@ async def test_rlm_collects_logs_and_metrics(tmp_path):
         ),
         call(
             "sbx",
-            'f=$(ls /testbed/.rlm/sessions/*/meta.json 2>/dev/null | head -1) && cat "$f" || echo "{}"',
+            'f=$(ls /tmp/.rlm/sessions/*/meta.json 2>/dev/null | head -1) && cat "$f" || echo "{}"',
             working_dir=None,
         ),
     ]

--- a/verifiers/envs/experimental/composable/harnesses/rlm.py
+++ b/verifiers/envs/experimental/composable/harnesses/rlm.py
@@ -26,6 +26,11 @@ DEFAULT_RLM_MAX_DEPTH = 0
 DEFAULT_APPEND_TO_SYSTEM_PROMPT_PATH = "/task/append_to_system_prompt.txt"
 DEFAULT_RLM_CHECKOUT_PATH = "/tmp/rlm-checkout"
 DEFAULT_RLM_CHECKOUT_UPLOAD_NAME = "rlm_checkout"
+# Pinned outside the agent workdir because the agent has full destructive
+# control over its workdir (git clean -fdx, rm -rf, git stash, etc.) and any
+# of those wipe rlm's session dir mid-rollout, breaking the next meta.json
+# write with FileNotFoundError.
+DEFAULT_RLM_HOME = "/tmp/.rlm"
 DEFAULT_RLM_LOCAL_CHECKOUT_CACHE_ROOT = (
     Path.home() / ".cache" / "verifiers" / "rlm-checkouts"
 )
@@ -130,6 +135,12 @@ def rlm_harness(
     ``ComposableEnv(environment_vars=...)`` themselves; pass the kwargs
     here and the harness owns the env var plumbing.
 
+    The harness also pins ``RLM_HOME`` to ``DEFAULT_RLM_HOME`` (an
+    absolute path outside any task workdir) so rlm session state cannot
+    be wiped by the agent's own destructive ops on its workdir.
+    ``metrics_path`` follows the same path so post-rollout metrics
+    collection keeps matching where rlm actually writes.
+
     Git access from inside the agent is refused at the rlm tool layer
     (bash + ipython): rlm detects shell escapes and AST-walks
     ``subprocess.run`` / ``os.system`` / ``os.popen`` for a literal
@@ -175,6 +186,7 @@ def rlm_harness(
         "RLM_MAX_TURNS": str(rlm_max_turns),
         "RLM_EXEC_TIMEOUT": str(rlm_exec_timeout),
         "RLM_MAX_DEPTH": str(rlm_max_depth),
+        "RLM_HOME": DEFAULT_RLM_HOME,
     }
 
     def env_vars_for_rollout(state: State) -> dict[str, str]:
@@ -197,7 +209,7 @@ def rlm_harness(
         skills_path="/task/rlm-skills",
         get_upload_dirs=get_upload_dirs,
         upload_dir_mapping=upload_dir_mapping,
-        metrics_path="{workdir}/.rlm/sessions/*/meta.json",
+        metrics_path=f"{DEFAULT_RLM_HOME}/sessions/*/meta.json",
         metrics_key="metrics",
         metrics_prefix="rlm_",
         tool_names=tool_names,


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR --

The harness defaulted RLM_HOME to .rlm (relative), so with CWD=/testbed session state landed in /testbed/.rlm/. Agent ops that wipe the workdir (git clean -fdx, rm -rf, git stash) then deleted the session dir mid-rollout, breaking the next meta.json write — observed on ~3% of SWE-bench rollouts. Pin to /tmp/.rlm and align metrics_path.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes where rlm writes/reads session state by forcing `RLM_HOME` (and the metrics glob) to `/tmp/.rlm`, which could affect environments relying on the previous workdir-relative location.
> 
> **Overview**
> Pins rlm session state outside the agent workdir by setting `RLM_HOME` to `/tmp/.rlm` in `rlm_harness`, preventing agent cleanup commands from deleting rlm’s session directory mid-rollout.
> 
> Aligns post-rollout metrics collection with this new location by updating the harness `metrics_path` (and related tests) to read `meta.json` from `/tmp/.rlm/sessions/*` instead of `{workdir}/.rlm/...`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6372ed6a76c658439028ad9fc69294c093a423d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->