### PR TITLE
feat: expose training context to rubrics via request protocol

### DIFF
--- a/tests/test_environment_extra.py
+++ b/tests/test_environment_extra.py
@@ -331,6 +331,7 @@ async def test_generate_grouped_scoring_distributes_per_group(
             sampling_args,
             max_retries,
             state_columns,
+            **kwargs,
         ):
             assert isinstance(client_config, ClientConfig)
             self.client_urls_per_group.append(str(client_config.api_base_url))
@@ -426,6 +427,7 @@ async def test_run_group_server_mode_resolves_endpoint_config(
             sampling_args,
             max_retries,
             state_columns,
+            **kwargs,
         ):
             assert isinstance(client_config, ClientConfig)
             self.client_url = str(client_config.api_base_url)
@@ -485,6 +487,7 @@ async def test_run_rollout_server_mode_resolves_endpoint_config(
             sampling_args,
             max_retries,
             state_columns,
+            **kwargs,
         ):
             assert isinstance(client_config, ClientConfig)
             self.client_url = str(client_config.api_base_url)

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -673,6 +673,7 @@ class Environment(ABC):
         max_retries: int = 0,
         state_columns: list[str] | None = None,
         env_client: EnvClient | None = None,
+        training_context: dict | None = None,
     ) -> RolloutOutput:
         """Generate and, optionally, score a rollout."""
 
@@ -693,9 +694,12 @@ class Environment(ABC):
                 sampling_args,
                 max_retries,
                 state_columns,
+                training_context=training_context,
             )
 
         resolved_client = resolve_client(client)
+
+        self.rubric.training_context = training_context
 
         async def run_rollout_attempt() -> State:
             state = await self.rollout(
@@ -730,6 +734,7 @@ class Environment(ABC):
         max_retries: int = 0,
         state_columns: list[str] | None = None,
         env_client: EnvClient | None = None,
+        training_context: dict | None = None,
         **kwargs,
     ) -> list[RolloutOutput]:
         """Generate and, optionally, score one group."""
@@ -751,9 +756,12 @@ class Environment(ABC):
                 sampling_args,
                 max_retries,
                 state_columns,
+                training_context=training_context,
             )
 
         resolved_client = resolve_client(client)
+
+        self.rubric.training_context = training_context
 
         async def run_group_attempt() -> list[State]:
             rollout_tasks = [

--- a/verifiers/rubrics/rubric.py
+++ b/verifiers/rubrics/rubric.py
@@ -48,6 +48,10 @@ class Rubric:
 
         self.parser = parser or vf.Parser()
 
+        # Training context set by the orchestrator before scoring.
+        # Contains metadata like {"step": int, "ckpt_step": int}.
+        self.training_context: dict | None = None
+
         # class objects for reward functions
         self.class_objects = {}
         if self.parser:

--- a/verifiers/rubrics/rubric_group.py
+++ b/verifiers/rubrics/rubric_group.py
@@ -19,6 +19,16 @@ class RubricGroup(Rubric):
         self.rubrics = rubrics
         self.logger.debug(f"Initialized RubricGroup with {len(rubrics)} rubrics")
 
+    @property  # type: ignore[override]
+    def training_context(self) -> dict | None:
+        return self._training_context
+
+    @training_context.setter
+    def training_context(self, value: dict | None) -> None:
+        self._training_context = value
+        for rubric in getattr(self, "rubrics", []):
+            rubric.training_context = value
+
     def _get_reward_func_names(self) -> list[str]:
         names = []
         for rubric in self.rubrics:

--- a/verifiers/serve/client/env_client.py
+++ b/verifiers/serve/client/env_client.py
@@ -50,6 +50,7 @@ class EnvClient(ABC):
         sampling_args: SamplingArgs,
         max_retries: int = 0,
         state_columns: list[str] | None = None,
+        training_context: dict | None = None,
     ) -> RolloutOutput:
         resolved_client_config = resolve_client_config(client_config)
         request = RunRolloutRequest(
@@ -59,6 +60,7 @@ class EnvClient(ABC):
             sampling_args=sampling_args,
             max_retries=max_retries,
             state_columns=state_columns,
+            training_context=training_context,
         )
         response = await self.handle_run_rollout_request(request, timeout=None)
         assert response.output is not None
@@ -72,6 +74,7 @@ class EnvClient(ABC):
         sampling_args: SamplingArgs,
         max_retries: int = 0,
         state_columns: list[str] | None = None,
+        training_context: dict | None = None,
     ) -> list[RolloutOutput]:
         resolved_client_config = resolve_client_config(client_config)
         request = RunGroupRequest(
@@ -81,6 +84,7 @@ class EnvClient(ABC):
             sampling_args=sampling_args,
             max_retries=max_retries,
             state_columns=state_columns,
+            training_context=training_context,
         )
         response = await self.handle_run_group_request(request, timeout=None)
         assert response.outputs is not None

--- a/verifiers/serve/server/env_worker.py
+++ b/verifiers/serve/server/env_worker.py
@@ -138,6 +138,7 @@ class EnvWorker:
     async def handle_run_rollout(
         self, request: RunRolloutRequest
     ) -> RunRolloutResponse:
+        self.env.rubric.training_context = request.training_context
         client = await self.resolve_client(request.client_config)
         output = await self.env.run_rollout(
             input=request.input,
@@ -150,6 +151,7 @@ class EnvWorker:
         return RunRolloutResponse(output=output)
 
     async def handle_run_group(self, request: RunGroupRequest) -> RunGroupResponse:
+        self.env.rubric.training_context = request.training_context
         client = await self.resolve_client(request.client_config)
         outputs = await self.env.run_group(
             group_inputs=request.group_inputs,

--- a/verifiers/serve/types.py
+++ b/verifiers/serve/types.py
@@ -51,6 +51,7 @@ class RunRolloutRequest(BaseRequest):
     sampling_args: SamplingArgs
     max_retries: int
     state_columns: list[str] | None
+    training_context: dict | None = None
 
 
 class RunRolloutResponse(BaseResponse):
@@ -68,6 +69,7 @@ class RunGroupRequest(BaseRequest):
     sampling_args: SamplingArgs
     max_retries: int
     state_columns: list[str] | None
+    training_context: dict | None = None
 
 
 class RunGroupResponse(BaseResponse):


### PR DESCRIPTION
## Summary

Adds an optional `training_context` dict that orchestrators can pass to rubrics before scoring. This enables step-aware reward functions (curriculum learning, penalty warmup, dynamic weights) without requiring environments to maintain internal step counters or process restarts via env-args-scheduler.

## Motivation

There is currently no way for a rubric to know the current training step. This forces environment authors to use fragile workarounds like self-incrementing counters that don't survive checkpoint resume and don't reflect the true orchestrator step. Use cases blocked by this gap:

- **Reward warmup**: ramping penalty weights over training (e.g. tool call penalty warmup)
- **Curriculum learning**: changing reward thresholds or component weights based on progress
- **Adaptive scoring**: adjusting difficulty based on training metrics

The existing `env_args_scheduler` (PR #2207 in prime-rl) solves this by hot-reloading entire environments, which is too heavy for continuous reward parameter changes.

## Design

The `training_context` is a simple `dict | None` that flows through both execution paths:

**Server mode (ZMQ):**
```
orchestrator → EnvClient.run_group(training_context={"step": N})
  → RunGroupRequest(training_context={"step": N})
    → env_worker sets rubric.training_context before scoring
```

**Local mode (in-process):**
```
Environment.run_group(training_context={"step": N})
  → sets self.rubric.training_context before scoring
```

**Usage in a custom rubric:**
```python
class MyRubric(vf.Rubric):
    async def score_group(self, states):
        step = (self.training_context or {}).get("step", 0)
        warmup_progress = min(1.0, step / 100)
        penalty = -0.05 * warmup_progress
        # ... use penalty in scoring
```

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing

- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Changes

| File | Change |
|------|--------|
| `verifiers/serve/types.py` | Add optional `training_context: dict \| None = None` to `RunRolloutRequest` and `RunGroupRequest` |
| `verifiers/rubrics/rubric.py` | Add `self.training_context: dict \| None = None` to `Rubric.__init__` |
| `verifiers/serve/client/env_client.py` | Accept and forward `training_context` in `run_rollout` and `run_group` |
| `verifiers/serve/server/env_worker.py` | Set `self.env.rubric.training_context` before handling requests |
| `verifiers/envs/environment.py` | Accept `training_context` in `run_rollout`/`run_group`, set on rubric in local mode, forward to env_client in server mode |

## Backward Compatibility

Fully backward-compatible:
- All new parameters default to `None`
- Existing orchestrators that don't send `training_context` see zero behavior change
- Existing rubrics that don't read `self.training_context` are unaffected
- Wire protocol: old servers receiving a request with the extra field will ignore it (Pydantic `model_config` is not strict); old clients sending requests without it work fine since the field has a default

## Companion PR

The prime-rl companion PR (to populate `training_context` from the scheduler) is independent — this PR is useful standalone for:
- Local-mode environments (set `training_context` directly in `run_group` calls)
- Custom orchestrators built on verifiers
- Any user who wants step-aware rubrics without prime-rl

## Additional Notes

See also: prime-rl companion PR that populates this field from the scheduler's step counter.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new mutable `training_context` plumbing through local and server execution paths; incorrect propagation or concurrent request handling could cause context leakage between rollouts/groups.
> 
> **Overview**
> Introduces an optional `training_context: dict | None` that can be passed into `Environment.run_rollout`/`run_group` and carried through the ZMQ request protocol.
> 
> In local mode, the context is set on `self.rubric.training_context` before scoring; in server mode it is forwarded via `RunRolloutRequest`/`RunGroupRequest` and applied in `EnvWorker` before executing the request. Test stubs were updated to accept extra kwargs for the extended call signatures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf0a711eeda91ddceb78a13d28af70524243f41d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->