### PR TITLE
feat(lean): lean-guard markers + tamper-aware LeanRubric

### DIFF
--- a/tests/test_lean_task.py
+++ b/tests/test_lean_task.py
@@ -1,0 +1,344 @@
+"""Tests for ``LeanTaskSet`` lean-guard wrapping and reward enforcement."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from verifiers.envs.experimental.composable.tasksets.lean.lean_task import (
+    LEAN_GUARD_BEGIN_MARKER,
+    LEAN_GUARD_END_MARKER,
+    LeanRubric,
+    _build_starter_file,
+    _expected_protected_region,
+    _extract_protected_region,
+    _normalize_signature,
+    _wrap_with_lean_guard,
+)
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeSignature:
+    """``_normalize_signature`` must converge every starter shape on ``:= by``."""
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            (
+                "theorem foo (x : ℝ) : x = x := sorry",
+                "theorem foo (x : ℝ) : x = x := by",
+            ),
+            (
+                "theorem foo (x : ℝ) : x = x := by sorry",
+                "theorem foo (x : ℝ) : x = x := by",
+            ),
+            (
+                "theorem foo (x : ℝ) : x = x := by\n  sorry",
+                "theorem foo (x : ℝ) : x = x := by",
+            ),
+            (
+                "theorem foo (x : ℝ) : x = x",
+                "theorem foo (x : ℝ) : x = x := by",
+            ),
+            (
+                "theorem foo (x : ℝ) : x = x := by",
+                "theorem foo (x : ℝ) : x = x := by",
+            ),
+            (
+                "theorem foo (x : ℝ) : x = x :=",
+                "theorem foo (x : ℝ) : x = x := by",
+            ),
+            (
+                "theorem foo (x : ℝ) : x = x := admit",
+                "theorem foo (x : ℝ) : x = x := by",
+            ),
+        ],
+    )
+    def test_canonicalizes_to_by(self, raw: str, expected: str) -> None:
+        assert _normalize_signature(raw) == expected
+
+    def test_preserves_multiline_signatures(self) -> None:
+        raw = (
+            "theorem mathd_algebra_478\n"
+            "  (b h v : ℝ)\n"
+            "  (h : 0 < b) :\n"
+            "  v = 65 := sorry"
+        )
+        expected = (
+            "theorem mathd_algebra_478\n  (b h v : ℝ)\n  (h : 0 < b) :\n  v = 65 := by"
+        )
+        assert _normalize_signature(raw) == expected
+
+    def test_does_not_strip_internal_by(self) -> None:
+        # `by` inside a type ascription should stay; only trailing tokens are stripped.
+        raw = "theorem foo : ((by trivial : True) ∧ True) := sorry"
+        assert _normalize_signature(raw) == (
+            "theorem foo : ((by trivial : True) ∧ True) := by"
+        )
+
+
+class TestWrapWithLeanGuard:
+    def test_marker_layout(self) -> None:
+        signature = "theorem foo (x : ℝ) : x = x := by"
+        wrapped = _wrap_with_lean_guard(signature)
+        assert wrapped == (
+            "-- lean-guard: begin protected\n"
+            "theorem foo (x : ℝ) : x = x := by\n"
+            "-- lean-guard: end protected\n"
+            "  sorry\n"
+        )
+
+    def test_round_trip_via_extract(self) -> None:
+        signature = "theorem foo : True := by"
+        wrapped = _wrap_with_lean_guard(signature)
+        region = _extract_protected_region(wrapped)
+        assert region is not None
+        assert LEAN_GUARD_BEGIN_MARKER in region
+        assert LEAN_GUARD_END_MARKER in region
+        assert "  sorry" not in region
+
+
+class TestExtractProtectedRegion:
+    def test_returns_none_when_markers_missing(self) -> None:
+        assert _extract_protected_region("theorem foo := sorry") is None
+
+    def test_returns_none_when_only_begin(self) -> None:
+        content = LEAN_GUARD_BEGIN_MARKER + "\nfoo\n  sorry\n"
+        assert _extract_protected_region(content) is None
+
+    def test_returns_none_when_only_end(self) -> None:
+        content = "foo\n" + LEAN_GUARD_END_MARKER + "\n  sorry\n"
+        assert _extract_protected_region(content) is None
+
+    def test_extracts_inclusive_of_both_markers(self) -> None:
+        content = (
+            "import Mathlib\n\n"
+            "-- lean-guard: begin protected\n"
+            "theorem foo : True := by\n"
+            "-- lean-guard: end protected\n"
+            "  trivial\n"
+        )
+        region = _extract_protected_region(content)
+        assert region == (
+            "-- lean-guard: begin protected\n"
+            "theorem foo : True := by\n"
+            "-- lean-guard: end protected\n"
+        )
+
+    def test_handles_extra_text_after_end_marker_on_line(self) -> None:
+        # End marker followed by trailing text on the same line still
+        # delimits at the next newline.
+        content = (
+            "-- lean-guard: begin protected\n"
+            "theorem foo : True := by\n"
+            "-- lean-guard: end protected (do not edit)\n"
+            "  trivial\n"
+        )
+        region = _extract_protected_region(content)
+        assert region is not None
+        assert region.endswith("(do not edit)\n")
+
+
+# ---------------------------------------------------------------------------
+# _build_starter_file shape coverage
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def starter_for():
+    """Helper that runs ``_build_starter_file`` on a minimal info dict."""
+
+    def _build(stmt: str, header: str = "import Mathlib", **extra) -> str:
+        info = {"formal_statement": stmt, "header": header, **extra}
+        return _build_starter_file(info)
+
+    return _build
+
+
+class TestBuildStarterFile:
+    """Every supported starter shape must produce a wrapped file."""
+
+    @pytest.mark.parametrize(
+        "stmt",
+        [
+            "theorem foo (x : ℝ) : x = x := sorry",
+            "theorem foo (x : ℝ) : x = x := by sorry",
+            "theorem foo (x : ℝ) : x = x := by\n  sorry",
+            "theorem foo (x : ℝ) : x = x",
+            "theorem foo (x : ℝ) : x = x := by",
+            "theorem foo (x : ℝ) : x = x :=",
+        ],
+    )
+    def test_all_shapes_get_wrapped(self, starter_for, stmt: str) -> None:
+        out = starter_for(stmt)
+        assert LEAN_GUARD_BEGIN_MARKER in out
+        assert LEAN_GUARD_END_MARKER in out
+        # Body always defaults to `  sorry` after the end marker.
+        assert out.endswith("  sorry\n")
+        # The protected region must contain the canonical signature.
+        region = _extract_protected_region(out)
+        assert region is not None
+        assert "theorem foo (x : ℝ) : x = x := by" in region
+
+    def test_self_contained_imports_are_separated(self, starter_for) -> None:
+        stmt = "import Mathlib.Tactic\n\nopen Real\n\ntheorem foo : 1 + 1 = 2 := sorry"
+        out = starter_for(stmt, header="")
+        # Imports + open stay outside the protected region.
+        assert out.startswith("import Mathlib.Tactic\n\nopen Real")
+        # The theorem signature is wrapped.
+        region = _extract_protected_region(out)
+        assert region is not None
+        assert "theorem foo : 1 + 1 = 2 := by" in region
+
+    def test_multiline_signature_preserved(self, starter_for) -> None:
+        stmt = (
+            "theorem mathd_algebra_478\n"
+            "  (b h v : ℝ)\n"
+            "  (h₀ : 0 < b) :\n"
+            "  v = 65 := sorry"
+        )
+        out = starter_for(stmt, header="import Mathlib")
+        region = _extract_protected_region(out) or ""
+        assert "theorem mathd_algebra_478" in region
+        assert "(h₀ : 0 < b)" in region
+        assert "v = 65 := by" in region
+
+    def test_expected_protected_region_round_trips(self, starter_for) -> None:
+        info = {
+            "formal_statement": "theorem foo : True := sorry",
+            "header": "import Mathlib",
+        }
+        starter = _build_starter_file(info)
+        expected = _expected_protected_region(info)
+        actual = _extract_protected_region(starter)
+        assert expected == actual
+        assert expected != ""
+
+
+# ---------------------------------------------------------------------------
+# LeanRubric tamper enforcement
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _CmdResult:
+    stdout: str = ""
+    stderr: str = ""
+
+
+class _FakeSandboxClient:
+    """Minimal async sandbox stub that scripts cat / lake responses."""
+
+    def __init__(self, file_contents: str, compile_output: str = "EXIT_CODE:0\n"):
+        self._file_contents = file_contents
+        self._compile_output = compile_output
+        self.calls: list[str] = []
+
+    async def execute_command(self, sandbox_id, cmd, timeout=None):
+        self.calls.append(cmd)
+        if cmd.startswith("cat "):
+            return _CmdResult(stdout=self._file_contents)
+        if "lake env lean" in cmd:
+            return _CmdResult(stdout=self._compile_output)
+        raise AssertionError(f"unexpected command: {cmd!r}")
+
+    async def delete(self, _sandbox_id):
+        return None
+
+
+class _StubTaskSet:
+    """Just enough of ``LeanTaskSet`` for ``LeanRubric.solved``."""
+
+    proof_file_path = "/tmp/proof.lean"
+    lean_project_path = "/workspace/mathlib4"
+    compile_timeout = 120
+
+
+def _make_rubric() -> LeanRubric:
+    return LeanRubric(_StubTaskSet())  # type: ignore[arg-type]
+
+
+def _make_state(info: dict, file_contents: str, compile_output: str = "EXIT_CODE:0\n"):
+    client = _FakeSandboxClient(file_contents, compile_output)
+    state = {
+        "sandbox_client": client,
+        "sandbox_id": "sb-test",
+        "info": info,
+    }
+    return state, client
+
+
+@pytest.mark.asyncio
+class TestLeanRubricTamper:
+    """The rubric must zero out reward when the protected region is altered."""
+
+    INFO = {
+        "formal_statement": "theorem foo (x : ℝ) : x = x := sorry",
+        "header": "import Mathlib",
+    }
+
+    def _legitimate_proof(self) -> str:
+        starter = _build_starter_file(self.INFO)
+        return starter.replace("  sorry\n", "  rfl\n")
+
+    async def test_clean_proof_compiles_to_one(self) -> None:
+        rubric = _make_rubric()
+        state, _ = _make_state(self.INFO, self._legitimate_proof())
+        reward = await rubric.solved(state)
+        assert reward == 1.0
+        assert state["lean_compiled"] is True
+        assert state.get("lean_tampered") is False
+
+    async def test_signature_replaced_zeroes_reward(self) -> None:
+        rubric = _make_rubric()
+        # Cheat: replace the entire theorem with a trivially-true one.
+        cheat = "import Mathlib\n\ntheorem foo : True := trivial\n"
+        state, client = _make_state(self.INFO, cheat)
+        reward = await rubric.solved(state)
+        assert reward == 0.0
+        assert state["lean_tampered"] is True
+        assert state["lean_compiled"] is False
+        # Compile should not have been attempted once tampering is detected.
+        assert all("lake env lean" not in c for c in client.calls)
+
+    async def test_markers_removed_zeroes_reward(self) -> None:
+        rubric = _make_rubric()
+        # Markers stripped, but the signature itself was left intact.
+        starter = _build_starter_file(self.INFO)
+        no_markers = starter.replace(LEAN_GUARD_BEGIN_MARKER + "\n", "").replace(
+            LEAN_GUARD_END_MARKER + "\n", ""
+        )
+        state, _ = _make_state(self.INFO, no_markers)
+        reward = await rubric.solved(state)
+        assert reward == 0.0
+        assert state["lean_tampered"] is True
+
+    async def test_signature_subtly_altered_zeroes_reward(self) -> None:
+        rubric = _make_rubric()
+        # Swap the goal `x = x` for the trivially-true `True`.
+        starter = _build_starter_file(self.INFO)
+        tampered = starter.replace("x = x", "True")
+        state, _ = _make_state(self.INFO, tampered)
+        reward = await rubric.solved(state)
+        assert reward == 0.0
+        assert state["lean_tampered"] is True
+
+    async def test_compile_failure_after_clean_signature_returns_zero(self) -> None:
+        rubric = _make_rubric()
+        starter = _build_starter_file(self.INFO)
+        proof = starter.replace("  sorry\n", "  exact rfl\n")
+        state, _ = _make_state(
+            self.INFO,
+            proof,
+            compile_output="error: unsolved goals\nEXIT_CODE:1\n",
+        )
+        reward = await rubric.solved(state)
+        assert reward == 0.0
+        assert state["lean_compiled"] is False
+        # Tampering check passed first: the flag is cleared.
+        assert state["lean_tampered"] is False

--- a/verifiers/envs/experimental/composable/tasksets/lean/__init__.py
+++ b/verifiers/envs/experimental/composable/tasksets/lean/__init__.py
@@ -1,3 +1,13 @@
-from .lean_task import LEAN_SYSTEM_PROMPT, LeanTaskSet
+from .lean_task import (
+    LEAN_GUARD_BEGIN_MARKER,
+    LEAN_GUARD_END_MARKER,
+    LEAN_SYSTEM_PROMPT,
+    LeanTaskSet,
+)
 
-__all__ = ["LeanTaskSet", "LEAN_SYSTEM_PROMPT"]
+__all__ = [
+    "LeanTaskSet",
+    "LEAN_SYSTEM_PROMPT",
+    "LEAN_GUARD_BEGIN_MARKER",
+    "LEAN_GUARD_END_MARKER",
+]

--- a/verifiers/envs/experimental/composable/tasksets/lean/lean_task.py
+++ b/verifiers/envs/experimental/composable/tasksets/lean/lean_task.py
@@ -15,6 +15,22 @@ Usage::
 
     # Use with any agent
     env = ComposableEnv(task=prover_v1, agent=react_agent)
+
+Reward-hacking guard
+--------------------
+
+The starter proof file wraps the theorem signature in marker comments::
+
+    -- lean-guard: begin protected
+    theorem foo (x : ℝ) : x = x := by
+    -- lean-guard: end protected
+      sorry
+
+``LeanRubric`` re-reads the file post-rollout and refuses to award reward if
+the protected region was modified, defeating the trivial "rewrite the
+statement to ``True := trivial``" cheat.  The marker convention matches
+``hallerite/lean-guard`` (the OpenCode plugin) so both layers agree on what
+"protected" means.
 """
 
 from __future__ import annotations
@@ -28,6 +44,9 @@ from verifiers.envs.experimental.composable import SandboxSpec, SandboxTaskSet
 DEFAULT_DOCKER_IMAGE = "cmkkc4gtv000mapvd5jegz3yz/lean-tactic:mathlib-v4.27.0-v3"
 LEAN_PROJECT_PATH = "/workspace/mathlib4"
 PROOF_FILE_PATH = "/tmp/proof.lean"
+
+LEAN_GUARD_BEGIN_MARKER = "-- lean-guard: begin protected"
+LEAN_GUARD_END_MARKER = "-- lean-guard: end protected"
 
 LEAN_SYSTEM_PROMPT = """\
 You are a Lean 4 theorem prover.
@@ -53,7 +72,11 @@ If you have not compiled, you are not done.
 Rules:
 - No `sorry` or `admit` in the final proof
 - Use Lean 4 / Mathlib syntax
-- Each response must contain EXACTLY ONE tool call\
+- Each response must contain EXACTLY ONE tool call
+- The lines wrapped by `-- lean-guard: begin protected` and \
+`-- lean-guard: end protected` are the locked theorem signature. \
+DO NOT modify them, the markers, or anything between them. \
+Only edit the lines BELOW `-- lean-guard: end protected` (the proof body).\
 """
 
 
@@ -137,35 +160,95 @@ def _build_preamble(
     return preamble
 
 
+def _normalize_signature(stmt: str) -> str:
+    """Canonicalize a Lean theorem statement to end with `:= by`.
+
+    Strips trailing ``sorry``/``admit`` placeholders and any trailing
+    ``by`` / ``:=`` tokens, then re-appends `` := by`` so the result
+    is uniformly shaped regardless of the input dataset's convention
+    (``:= sorry``, ``:= by sorry``, ``:= by\\n  sorry``, etc.).
+    """
+    s = stmt.rstrip()
+    s = re.sub(r"\s*\b(?:sorry|admit)\b\s*$", "", s)
+    s = re.sub(r"\s*\bby\b\s*$", "", s)
+    s = re.sub(r"\s*:=\s*$", "", s)
+    return s.rstrip() + " := by"
+
+
+def _split_imports_and_signature(stmt: str) -> tuple[str, str]:
+    """Split a self-contained statement into ``(imports_block, signature)``.
+
+    ``formal_statement`` fields occasionally contain their own ``import``
+    preamble.  We split at the first ``theorem``/``lemma``/``example``
+    keyword so the signature can be wrapped independently of imports.
+    """
+    decl_match = re.search(
+        r"^(?:theorem|lemma|example)\s",
+        stmt,
+        flags=re.MULTILINE,
+    )
+    if not decl_match:
+        return "", stmt
+    return stmt[: decl_match.start()].rstrip(), stmt[decl_match.start() :]
+
+
+def _wrap_with_lean_guard(signature: str) -> str:
+    """Wrap a normalized ``... := by`` signature with lean-guard markers."""
+    return f"{LEAN_GUARD_BEGIN_MARKER}\n{signature}\n{LEAN_GUARD_END_MARKER}\n  sorry\n"
+
+
+def _extract_protected_region(content: str) -> str | None:
+    """Return the text from the begin marker through the end-of-end-line.
+
+    Returns ``None`` if either marker is missing or out of order.
+    Mirrors the substring extracted by ``hallerite/lean-guard``'s plugin
+    so the two implementations agree on what "protected" means.
+    """
+    begin = content.find(LEAN_GUARD_BEGIN_MARKER)
+    if begin == -1:
+        return None
+    end = content.find(LEAN_GUARD_END_MARKER, begin)
+    if end == -1:
+        return None
+    end_of_end_line = content.find("\n", end)
+    if end_of_end_line == -1:
+        protected_end = len(content)
+    else:
+        protected_end = end_of_end_line + 1
+    return content[begin:protected_end]
+
+
 def _build_starter_file(info: dict) -> str:
-    """Build the proof file: imports + header + formal_statement + sorry."""
+    """Build the proof file: imports + header + protected signature + sorry."""
     stmt = info.get("formal_statement", "")
+
     if stmt.strip().startswith("import "):
-        # Self-contained statement, use as-is
-        if not re.search(r"\bsorry\b", stmt):
-            if stmt.rstrip().endswith(":= by"):
-                stmt += "\n  sorry"
-            elif stmt.rstrip().endswith(":="):
-                stmt += " sorry"
-            else:
-                stmt += " := by\n  sorry"
-        return stmt + "\n"
+        imports_block, signature_raw = _split_imports_and_signature(stmt)
+        preamble = imports_block
+    else:
+        imports_str = info.get("imports", "import Mathlib")
+        header = info.get("header", "")
+        normalize = info.get("_normalize_mathlib_imports", False)
+        preamble = _build_preamble(imports_str, header, normalize)
+        signature_raw = stmt
 
-    imports_str = info.get("imports", "import Mathlib")
-    header = info.get("header", "")
-    normalize = info.get("_normalize_mathlib_imports", False)
-    preamble = _build_preamble(imports_str, header, normalize)
+    signature = _normalize_signature(signature_raw)
+    wrapped = _wrap_with_lean_guard(signature)
 
-    # Ensure statement ends with sorry
-    if not re.search(r"\bsorry\b", stmt):
-        if stmt.rstrip().endswith(":= by"):
-            stmt += "\n  sorry"
-        elif stmt.rstrip().endswith(":="):
-            stmt += " sorry"
-        else:
-            stmt += " := by\n  sorry"
+    if preamble:
+        return preamble.rstrip() + "\n\n" + wrapped
+    return wrapped
 
-    return preamble + "\n\n" + stmt + "\n"
+
+def _expected_protected_region(info: dict) -> str:
+    """Compute the protected region for a task instance from its ``info`` dict.
+
+    Re-runs ``_build_starter_file`` so the rubric and the setup step share
+    the exact same wrapping logic — no separate state plumbing needed.
+    """
+    starter = _build_starter_file(info)
+    region = _extract_protected_region(starter)
+    return region or ""
 
 
 # ---------------------------------------------------------------------------
@@ -174,7 +257,12 @@ def _build_starter_file(info: dict) -> str:
 
 
 class LeanRubric(vf.Rubric):
-    """Scores Lean tasks by compiling the proof in the sandbox."""
+    """Scores Lean tasks by compiling the proof in the sandbox.
+
+    Before compiling, verifies the lean-guard protected region in
+    ``/tmp/proof.lean`` matches the original starter; tampering yields
+    ``reward=0`` and sets ``state["lean_tampered"]=True``.
+    """
 
     def __init__(self, taskset: "LeanTaskSet", **kwargs):
         super().__init__(**kwargs)
@@ -187,6 +275,29 @@ class LeanRubric(vf.Rubric):
         if not sandbox_client or not sandbox_id:
             return 0.0
         timeout = state.get("test_timeout", 900)
+
+        info = state.get("info") or {}
+        expected_region = _expected_protected_region(info)
+        if expected_region:
+            try:
+                cat_result = await sandbox_client.execute_command(
+                    sandbox_id,
+                    f"cat {self.taskset.proof_file_path}",
+                    timeout=10,
+                )
+                current_content = cat_result.stdout or ""
+            except Exception:
+                state["lean_tampered"] = True
+                state["lean_compiled"] = False
+                return 0.0
+
+            actual_region = _extract_protected_region(current_content)
+            if actual_region != expected_region:
+                state["lean_tampered"] = True
+                state["lean_compiled"] = False
+                return 0.0
+            state["lean_tampered"] = False
+
         try:
             cmd = f"cd {self.taskset.lean_project_path} && lake env lean {self.taskset.proof_file_path} 2>&1; echo EXIT_CODE:$?"
             result = await sandbox_client.execute_command(


### PR DESCRIPTION
## Summary

Closes a trivial reward-hack in `LeanTaskSet`: previously, an agent could rewrite `/tmp/proof.lean` to `theorem foo : True := trivial` (or axiomatize the goal). The compile would succeed with no `sorry` warning, and `LeanRubric.solved` returned `reward=1.0`. There was no statement-preservation check.

This PR wraps the theorem signature in marker comments at starter-file generation time and validates them in the rubric:

```lean
import Mathlib

-- lean-guard: begin protected
theorem foo (x : ℝ) : x = x := by
-- lean-guard: end protected
  sorry
```

`LeanRubric.solved` re-reads the file post-rollout, extracts the region between the markers, and refuses to award reward if it differs from the original. The model is free to edit anything BELOW the end marker (the proof body); anything above is locked.

The marker convention matches [hallerite/lean-guard](https://github.com/hallerite/lean-guard) (an OpenCode plugin that gives in-rollout feedback for the same gap), so both layers agree on what "protected" means. The plugin and the rubric are complementary: the plugin tells the agent "your edit was reverted" mid-rollout; the rubric is the hard gate at scoring time.

Benefits both `opencode-lean` and `rlm-lean` (and any future `LeanTaskSet` consumer) without per-env changes.

## Implementation

- `_normalize_signature` canonicalizes every input shape (`:= sorry`, `:= by sorry`, `:= by\n  sorry`, no-`:=`, ends-with-`:= by`, ends-with-`:=`, `:= admit`) to end with `:= by`. Multi-line signatures preserved verbatim.
- `_split_imports_and_signature` separates self-contained statements (`formal_statement` fields that include their own `import` preamble) so imports stay outside the protected region.
- `_wrap_with_lean_guard` produces the canonical wrapped form with `  sorry` as the body.
- `_build_starter_file` rewritten to use the helpers.
- `_extract_protected_region` mirrors the substring extraction from the OpenCode plugin (begin marker through end-of-end-marker-line).
- `_expected_protected_region` recomputes the protected region from `info` so the rubric and setup share one source of truth — no separate state plumbing.
- `LeanRubric.solved` runs the tamper check before `lake env lean`; on mismatch it short-circuits to `0.0` without compiling and sets `state["lean_tampered"] = True`.
- `LEAN_SYSTEM_PROMPT` documents the marker rule for the agent.
- Marker constants exported from the package init.

## Tests

`tests/test_lean_task.py` — 30 tests, all passing:

- 7 parametrized normalization cases covering every starter shape
- Multi-line signature preservation
- `by` inside a type ascription is not stripped
- Marker layout + extract round-trip
- `_extract_protected_region` returns `None` when markers missing / only-begin / only-end
- Marker extraction is inclusive of both markers
- Trailing text after end marker on the same line is tolerated
- All 6 starter shapes get wrapped (parametrized)
- Self-contained imports stay outside the protected region
- Multi-line signature contents preserved through wrap
- `_expected_protected_region` round-trips with `_build_starter_file`
- Clean proof passes (`reward=1.0`, `lean_compiled=True`, `lean_tampered=False`)
- Signature replaced (`theorem foo : True := trivial`) → `reward=0.0`, `lean_tampered=True`, **compile not even attempted**
- Markers removed → `reward=0.0`, `lean_tampered=True`
- Signature subtly altered (e.g. swap `x = x` for `True`) → `reward=0.0`, `lean_tampered=True`
- Compile failure after clean signature returns `0.0` with `lean_tampered=False` (verifies tamper check ran first)

```
tests/test_lean_task.py ..............................                   [100%]
============================== 30 passed in 0.32s ==============================
```

## Smoke test

End-to-end against `rlm-lean` (PrimeIntellect-ai/research-environments#346) using `openai/gpt-5.4` via Prime Inference on minif2f `mathd_algebra_478`:

- `reward=1.0`, `solved=1.0`, `num_turns=3`, 2 ipython tool calls
- Agent used `text.replace('  sorry\n', '  calc\n    v = ...')` — surgical edit of the body below the end marker, protected region untouched
- Lean parsed through the marker comments without issue (they are `--` line comments, syntactically whitespace-equivalent)

## Future work (out of scope)

- `#print axioms <theorem_name>` post-compile check to reject newly-introduced non-builtin axioms (signature preservation alone closes this for `axiom foo : ...` because the `theorem` keyword can't be replaced, but a model could still introduce an `axiom unsafe_assume : ...` separately and use it; closing that needs the axioms check).
- Reject `native_decide` (sometimes unsound) at the rubric level.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes starter proof-file generation and the rubric’s scoring path to enforce signature immutability; mistakes could cause false tamper detections or incorrectly zero rewards across Lean tasks.
> 
> **Overview**
> Adds a **reward-hacking guard** for `LeanTaskSet` by wrapping the theorem signature in `-- lean-guard: begin/end protected` markers and standardizing all dataset statement shapes to a canonical `... := by` signature before inserting `sorry`.
> 
> Updates `LeanRubric.solved` to `cat` the proof file and compare the extracted protected region against the expected starter region, short-circuiting to `reward=0` (and setting `state["lean_tampered"]`) when markers/signature are missing or changed, and only compiling when the signature region matches.
> 
> Exports the marker constants from `tasksets.lean`, updates `LEAN_SYSTEM_PROMPT` to instruct agents not to edit the protected region, and adds comprehensive tests covering normalization/wrapping/extraction plus rubric tamper vs compile behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38ddf49824c4de777e93219f65dfc97008234bcf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->