### PR TITLE
ci: auto-publish .dev pre-releases to PyPI on every main push

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -16,7 +16,20 @@ This directory contains automated workflows for the verifiers project.
 - Runs ty type checks with `uv run ty check verifiers`
 - Uses configuration from `pyproject.toml`
 
-### 2. Test (`test.yml`)
+### 2. DevX Tag (`devx_tag.yml`)
+**Purpose**: Auto-create rolling `vX.Y.Z.devN` pre-release tags from the latest stable release.
+
+**Triggers**:
+- Pushes to `main`
+- Manual `workflow_dispatch`
+
+**What it does**:
+- Reads the latest published GitHub Release tag (e.g. `v0.1.13`).
+- Bumps the patch number to form a base (e.g. `v0.1.14`).
+- Picks the next free `.devN` suffix and creates `vX.Y.Z.devN` at the current SHA.
+- The created tag fires `tag-and-release.yml`, which publishes the dev build to PyPI (no GitHub Release is cut for dev tags).
+
+### 3. Test (`test.yml`)
 **Purpose**: Comprehensive testing with coverage reports.
 
 **Triggers**:

--- a/.github/workflows/devx_tag.yml
+++ b/.github/workflows/devx_tag.yml
@@ -1,0 +1,94 @@
+name: DevX Tag
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  create-dev-tag:
+    name: Create .dev tag
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create next .dev tag from latest release
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const sha = context.sha;
+
+            let latestTag;
+            try {
+              const latestRelease = await github.rest.repos.getLatestRelease({ owner, repo });
+              latestTag = latestRelease.data.tag_name;
+            } catch (error) {
+              if (error.status === 404) {
+                core.notice("No releases found. Skipping .dev tag creation.");
+                return;
+              }
+              throw error;
+            }
+
+            const semverMatch = /^(v?)(\d+)\.(\d+)(?:\.(\d+))?$/.exec(latestTag);
+            if (!semverMatch) {
+              core.setFailed(`Latest release tag '${latestTag}' is not semver-like.`);
+              return;
+            }
+
+            const [, versionPrefix, majorRaw, minorRaw, patchRaw] = semverMatch;
+            const major = Number.parseInt(majorRaw, 10);
+            const minor = Number.parseInt(minorRaw, 10);
+            const patch = Number.parseInt(patchRaw ?? "0", 10) + 1;
+            const baseTag = `${versionPrefix}${major}.${minor}.${patch}`;
+
+            const prefix = `${baseTag}.dev`;
+            const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+            const pattern = new RegExp(`^refs/tags/${escapeRegex(baseTag)}\\.dev(\\d+)$`);
+
+            for (let attempt = 0; attempt < 5; attempt += 1) {
+              const refs = await github.paginate(github.rest.git.listMatchingRefs, {
+                owner,
+                repo,
+                ref: `tags/${prefix}`,
+              });
+
+              let maxVersion = 0;
+              for (const ref of refs) {
+                const match = pattern.exec(ref.ref);
+                if (match) {
+                  const version = Number.parseInt(match[1], 10);
+                  if (version > maxVersion) {
+                    maxVersion = version;
+                  }
+                }
+              }
+
+              const tag = `${prefix}${maxVersion + 1}`;
+
+              try {
+                await github.rest.git.createRef({
+                  owner,
+                  repo,
+                  ref: `refs/tags/${tag}`,
+                  sha,
+                });
+                core.notice(`Created tag ${tag} at ${sha}`);
+                return;
+              } catch (error) {
+                if (error.status === 422) {
+                  core.warning(`Tag ${tag} already exists, retrying...`);
+                  continue;
+                }
+                throw error;
+              }
+            }
+
+            core.setFailed("Could not create a unique .dev tag after retries.");

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -175,6 +175,18 @@ jobs:
           esac
 
           VERSION="${TAG#v}"
+
+          IS_DEV=false
+          case "$VERSION" in
+            *.dev*)
+              IS_DEV=true
+              if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.dev[0-9]+$ ]]; then
+                echo "Dev tags must match 'vX.Y.Z.devN' (received '$TAG')" >&2
+                exit 1
+              fi
+              ;;
+          esac
+
           FILE_VERSION=$(python - <<'PY'
           from pathlib import Path
           import re
@@ -187,13 +199,16 @@ jobs:
           PY
           )
 
-          if [ "$FILE_VERSION" != "$VERSION" ]; then
+          if [ "$IS_DEV" = "true" ]; then
+            echo "Dev tag $TAG; verifiers/__init__.py declares '$FILE_VERSION' and will be overridden for the build."
+          elif [ "$FILE_VERSION" != "$VERSION" ]; then
             echo "Version mismatch: tag requests '$VERSION' but verifiers/__init__.py defines '$FILE_VERSION'" >&2
             exit 1
           fi
 
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "is_dev=$IS_DEV" >> "$GITHUB_OUTPUT"
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -202,6 +217,29 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+
+      - name: Override __version__ for dev build
+        if: steps.release.outputs.is_dev == 'true'
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          python - <<'PY'
+          import os
+          import re
+          from pathlib import Path
+
+          version = os.environ["VERSION"]
+          path = Path("verifiers/__init__.py")
+          text = path.read_text()
+          new_text, count = re.subn(
+              r'__version__\s*=\s*"[^"]+"',
+              f'__version__ = "{version}"',
+              text,
+          )
+          if count != 1:
+              raise SystemExit(f"Expected exactly one __version__ assignment, found {count}")
+          path.write_text(new_text)
+          PY
 
       - name: Build sdist and wheel
         run: uv build
@@ -212,6 +250,7 @@ jobs:
         run: uv publish --token "$PYPI_TOKEN"
 
       - name: Create GitHub Release
+        if: steps.release.outputs.is_dev != 'true'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.release.outputs.tag }}


### PR DESCRIPTION
## Description

Ports [prime-rl's `devx_tag.yaml`](https://github.com/PrimeIntellect-ai/prime-rl/blob/main/.github/workflows/devx_tag.yaml) to verifiers so every commit on `main` automatically gets a rolling `vX.Y.(Z+1).devN` tag, and teaches `tag-and-release.yml` to publish those dev tags to PyPI.

### What changes

- **`.github/workflows/devx_tag.yml`** (new) — on every push to `main`, reads the latest published GitHub Release (e.g. `v0.1.13`), bumps patch to form a base, and creates `vX.Y.(Z+1).devN` at the current SHA. Retries on collision.
- **`.github/workflows/tag-and-release.yml`** — detects `v*.dev*` tags. For dev tags it skips the strict `__init__.py == tag` check, rewrites `__version__` in `verifiers/__init__.py` in-place before `uv build`, publishes to PyPI, and skips the GitHub Release creation step (no `RELEASE_*.md` expected). Stable `vX.Y.Z` flow is unchanged.
- **`.github/workflows/README.md`** — documents the new DevX Tag workflow.

### Note for reviewers

The workflow no-ops with a `notice` until at least one `vX.Y.Z` GitHub Release exists, since dev tags are computed off the latest stable. Today `__version__` in `verifiers/__init__.py` is `0.1.13.dev3`, so the first stable cut after this lands will start the dev cycle.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Testing

- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

Workflow-only change; will exercise on first `main` push after merge.

## Checklist

- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds automation that creates and publishes `.dev` tags and mutates `verifiers/__init__.py` during CI builds, which could mis-tag or publish unintended versions if the tag parsing/creation logic misbehaves. Stable release flow is mostly preserved, but changes touch the release/publish pipeline.
> 
> **Overview**
> Adds a new `devx_tag.yml` workflow that, on every push to `main` (or manual dispatch), derives the next `vX.Y.(Z+1).devN` tag from the latest GitHub Release and creates it at the current commit.
> 
> Updates `tag-and-release.yml` to recognize `vX.Y.Z.devN` tags, skip the strict tag-vs-`__version__` check, temporarily override `__version__` for the build, publish to PyPI, and **skip GitHub Release creation** for dev tags. Documentation in `.github/workflows/README.md` is updated to describe the new workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3894f50a1285e8b03ce22eedf277a86ed470ee1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->