### PR TITLE
add renderes  clear thinking

### DIFF
--- a/packages/renderers/renderers/base.py
+++ b/packages/renderers/renderers/base.py
@@ -299,6 +299,11 @@ def _populate_registry():
     from renderers.kimi_k25 import KimiK25Renderer
     from renderers.minimax_m2 import MiniMaxM2Renderer
     from renderers.nemotron3 import Nemotron3Renderer
+
+    class Nemotron3RendererKeepThinking(Nemotron3Renderer):
+        def __init__(self, tokenizer, **kwargs):
+            super().__init__(tokenizer, clear_thinking=False, **kwargs)
+
     from renderers.qwen3 import Qwen3Renderer
     from renderers.qwen3_vl import Qwen3VLRenderer
     from renderers.qwen35 import Qwen35Renderer
@@ -319,6 +324,7 @@ def _populate_registry():
             "kimi_k2": KimiK2Renderer,
             "kimi_k25": KimiK25Renderer,
             "nemotron3": Nemotron3Renderer,
+            "nemotron3_keep_thinking": Nemotron3RendererKeepThinking,
             "gpt_oss": GptOssRenderer,
         }
     )

--- a/packages/renderers/renderers/nemotron3.py
+++ b/packages/renderers/renderers/nemotron3.py
@@ -6,6 +6,7 @@ Nemotron 3 uses the same <|im_start|>/<|im_end|> format as Qwen3.5 but differs i
 2. System message ordering: system prompt goes BEFORE tools block.
 3. Thinking block scope: <think></think> is prepended to ALL assistant messages
    that lack thinking content (not just those after the last user query).
+   Pass ``clear_thinking=False`` to preserve thinking on historical turns too.
 4. Think separator: single \\n after </think> (not \\n\\n like Qwen3.5).
 5. Empty system message: always prepends an empty system message if none exists.
 6. Disable-thinking generation suffix: <think></think> with no trailing newlines.
@@ -79,9 +80,11 @@ class Nemotron3Renderer:
         tokenizer: PreTrainedTokenizer,
         *,
         enable_thinking: bool = True,
+        clear_thinking: bool = True,
     ):
         self._tokenizer = tokenizer
         self._enable_thinking = enable_thinking
+        self._clear_thinking = clear_thinking
 
         # Look up special token IDs from the tokenizer (not hardcoded).
         # <|endoftext|> is optional: Nemotron-3 Nano / Super tokenizers ship
@@ -290,7 +293,7 @@ class Nemotron3Renderer:
 
         # Track the most-recent plain (non-tool-call) assistant so we can
         # preserve its reasoning while stripping reasoning from earlier
-        # assistants — the Nemotron-3 template matches this pattern.
+        # assistants when clear_thinking=True.
         last_plain_assistant_idx = -1
         for j in range(len(messages) - 1, -1, -1):
             if messages[j].get("role") == "assistant" and not messages[j].get(
@@ -507,16 +510,14 @@ class Nemotron3Renderer:
         # <tool_call>, whether the content is empty or not.
         content_suffix = "\n" if tool_calls else ""
 
-        if reasoning_content and is_last_turn:
+        if reasoning_content and (is_last_turn or not self._clear_thinking):
             emit_special(self._think, msg_idx)
             emit_text("\n" + reasoning_content + "\n", msg_idx)
             emit_special(self._think_end, msg_idx)
             # Single \n separator (not \n\n like Qwen3.5)
             emit_text("\n" + content + content_suffix, msg_idx)
         elif reasoning_content:
-            # Historical assistant whose reasoning got stripped — template
-            # keeps a single \n between the collapsed <think></think> and
-            # the content as a marker that reasoning existed.
+            # Historical assistant with clear_thinking=True — collapse to empty block.
             emit_special(self._think, msg_idx)
             emit_special(self._think_end, msg_idx)
             emit_text("\n" + content + content_suffix, msg_idx)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes Nemotron3 prompt rendering semantics for `reasoning_content` by introducing a `clear_thinking` flag and a new registry entry to keep historical thinking, which can alter tokenization/training masks and downstream model behavior for Nemotron3 runs.
> 
> **Overview**
> Adds a `clear_thinking` option to `Nemotron3Renderer` that controls whether `reasoning_content` in earlier assistant turns is collapsed to an empty `<think></think>` block or preserved, updating the assistant rendering path accordingly.
> 
> Registers a new `nemotron3_keep_thinking` renderer variant (subclassing `Nemotron3Renderer` with `clear_thinking=False`) in `renderers/base.py` so callers can opt into keeping thinking content across the full conversation history.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12a9fd34c179871c7e51b98f387271f610b5f006. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->