### PR TITLE
Plumb keep_thinking through renderer factory

### DIFF
--- a/packages/renderers/renderers/base.py
+++ b/packages/renderers/renderers/base.py
@@ -341,8 +341,9 @@ def create_renderer_pool(
     HuggingFace fast tokenizers release the GIL during Rust encoding, so
     threads achieve real parallelism.
 
-    ``keep_thinking``, ``tool_parser``, and ``reasoning_parser`` are forwarded
-    to ``create_renderer`` for each renderer slot.
+    ``keep_thinking=True`` forces compatible renderers to preserve historical
+    thinking blocks. ``tool_parser`` and ``reasoning_parser`` are forwarded to
+    ``create_renderer`` for each renderer slot.
     """
 
     def factory() -> Renderer:
@@ -377,8 +378,9 @@ def create_renderer(
         renderer: Renderer name ('qwen3', 'qwen3_vl', 'qwen3.5', 'glm5', 'glm4.5',
                   'minimax-m2', 'deepseek_v3', 'kimi_k2', 'kimi_k25', 'nemotron3',
                   'gpt_oss', 'default') or 'auto' to detect from model name.
-        keep_thinking: Preserve historical assistant reasoning blocks for
-                  renderers that support that behavior.
+        keep_thinking: When True, preserve historical assistant reasoning
+                  blocks for renderers that support that behavior. When False,
+                  use the selected renderer's default.
         tool_parser: Name of a tool parser registered in ``renderers.parsers``.
                   Only consumed by DefaultRenderer. Model-specific renderers
                   have their own parsing wired in.
@@ -406,7 +408,7 @@ def create_renderer(
             )
 
         supports_keep_thinking = "keep_thinking" in inspect.signature(cls).parameters
-        if supports_keep_thinking:
+        if keep_thinking and supports_keep_thinking:
             kwargs["keep_thinking"] = keep_thinking
         elif keep_thinking:
             raise ValueError(f"Renderer {name!r} does not support keep_thinking=True")

--- a/packages/renderers/renderers/base.py
+++ b/packages/renderers/renderers/base.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import queue
+import inspect
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import Any, Callable, Literal, Protocol, TypedDict, runtime_checkable
@@ -330,6 +331,7 @@ def create_renderer_pool(
     renderer: str = "auto",
     size: int = 16,
     *,
+    keep_thinking: bool = False,
     tool_parser: str | None = None,
     reasoning_parser: str | None = None,
 ) -> RendererPool:
@@ -339,8 +341,8 @@ def create_renderer_pool(
     HuggingFace fast tokenizers release the GIL during Rust encoding, so
     threads achieve real parallelism.
 
-    ``tool_parser`` and ``reasoning_parser`` are forwarded to
-    ``create_renderer`` when the pool falls back to ``DefaultRenderer``.
+    ``keep_thinking``, ``tool_parser``, and ``reasoning_parser`` are forwarded
+    to ``create_renderer`` for each renderer slot.
     """
 
     def factory() -> Renderer:
@@ -352,6 +354,7 @@ def create_renderer_pool(
         return create_renderer(
             tokenizer,
             renderer=renderer,
+            keep_thinking=keep_thinking,
             tool_parser=tool_parser,
             reasoning_parser=reasoning_parser,
         )
@@ -363,6 +366,7 @@ def create_renderer(
     tokenizer,
     renderer: str = "auto",
     *,
+    keep_thinking: bool = False,
     tool_parser: str | None = None,
     reasoning_parser: str | None = None,
 ) -> Renderer:
@@ -373,6 +377,8 @@ def create_renderer(
         renderer: Renderer name ('qwen3', 'qwen3_vl', 'qwen3.5', 'glm5', 'glm4.5',
                   'minimax-m2', 'deepseek_v3', 'kimi_k2', 'kimi_k25', 'nemotron3',
                   'gpt_oss', 'default') or 'auto' to detect from model name.
+        keep_thinking: Preserve historical assistant reasoning blocks for
+                  renderers that support that behavior.
         tool_parser: Name of a tool parser registered in ``renderers.parsers``.
                   Only consumed by DefaultRenderer. Model-specific renderers
                   have their own parsing wired in.
@@ -387,22 +393,33 @@ def create_renderer(
     if reasoning_parser is not None:
         default_kwargs["reasoning_parser"] = reasoning_parser
 
+    def instantiate_renderer(name: str, cls) -> Renderer:
+        kwargs: dict[str, Any] = {}
+        if name == "default":
+            kwargs.update(default_kwargs)
+        elif default_kwargs:
+            logger.info(
+                "tool_parser / reasoning_parser are only consumed by "
+                "DefaultRenderer; ignoring for renderer=%r which has "
+                "built-in behavior.",
+                name,
+            )
+
+        supports_keep_thinking = "keep_thinking" in inspect.signature(cls).parameters
+        if supports_keep_thinking:
+            kwargs["keep_thinking"] = keep_thinking
+        elif keep_thinking:
+            raise ValueError(f"Renderer {name!r} does not support keep_thinking=True")
+
+        return cls(tokenizer, **kwargs)
+
     if renderer != "auto":
         cls = RENDERER_REGISTRY.get(renderer)
         if cls is None:
             raise ValueError(
                 f"Unknown renderer {renderer!r}. Available: {', '.join(sorted(RENDERER_REGISTRY))}"
             )
-        if renderer == "default":
-            return cls(tokenizer, **default_kwargs)
-        if default_kwargs:
-            logger.info(
-                "tool_parser / reasoning_parser are only consumed by "
-                "DefaultRenderer; ignoring for renderer=%r which has "
-                "built-in behavior.",
-                renderer,
-            )
-        return cls(tokenizer)
+        return instantiate_renderer(renderer, cls)
 
     # Auto-detect from model name via exact match on the canonical HF id.
     # Fine-tunes and renamed checkpoints miss on purpose — their chat
@@ -412,7 +429,7 @@ def create_renderer(
     model_name = getattr(tokenizer, "name_or_path", "")
     renderer_name = MODEL_RENDERER_MAP.get(model_name)
     if renderer_name is not None:
-        return RENDERER_REGISTRY[renderer_name](tokenizer)
+        return instantiate_renderer(renderer_name, RENDERER_REGISTRY[renderer_name])
 
     # No match — fall back to default (apply_chat_template). For fine-tunes
     # with customized chat templates this is the *correct* choice, so we don't
@@ -423,7 +440,7 @@ def create_renderer(
         "reasoning_parser=<name> to enable structured output parsing.",
         model_name or "<unnamed tokenizer>",
     )
-    return RENDERER_REGISTRY["default"](tokenizer, **default_kwargs)
+    return instantiate_renderer("default", RENDERER_REGISTRY["default"])
 
 
 # ---------------------------------------------------------------------------

--- a/packages/renderers/renderers/base.py
+++ b/packages/renderers/renderers/base.py
@@ -331,7 +331,7 @@ def create_renderer_pool(
     renderer: str = "auto",
     size: int = 16,
     *,
-    keep_thinking: bool = False,
+    keep_thinking: bool | None = None,
     tool_parser: str | None = None,
     reasoning_parser: str | None = None,
 ) -> RendererPool:
@@ -341,8 +341,9 @@ def create_renderer_pool(
     HuggingFace fast tokenizers release the GIL during Rust encoding, so
     threads achieve real parallelism.
 
-    ``keep_thinking=True`` forces compatible renderers to preserve historical
-    thinking blocks. ``tool_parser`` and ``reasoning_parser`` are forwarded to
+    ``keep_thinking`` overrides compatible renderer defaults when set to
+    ``True`` or ``False``. ``None`` preserves the selected renderer's default.
+    ``tool_parser`` and ``reasoning_parser`` are forwarded to
     ``create_renderer`` for each renderer slot.
     """
 
@@ -367,7 +368,7 @@ def create_renderer(
     tokenizer,
     renderer: str = "auto",
     *,
-    keep_thinking: bool = False,
+    keep_thinking: bool | None = None,
     tool_parser: str | None = None,
     reasoning_parser: str | None = None,
 ) -> Renderer:
@@ -380,7 +381,8 @@ def create_renderer(
                   'gpt_oss', 'default') or 'auto' to detect from model name.
         keep_thinking: When True, preserve historical assistant reasoning
                   blocks for renderers that support that behavior. When False,
-                  use the selected renderer's default.
+                  disable it for compatible renderers. When None, use the
+                  selected renderer's default.
         tool_parser: Name of a tool parser registered in ``renderers.parsers``.
                   Only consumed by DefaultRenderer. Model-specific renderers
                   have their own parsing wired in.
@@ -408,9 +410,9 @@ def create_renderer(
             )
 
         supports_keep_thinking = "keep_thinking" in inspect.signature(cls).parameters
-        if keep_thinking and supports_keep_thinking:
+        if keep_thinking is not None and supports_keep_thinking:
             kwargs["keep_thinking"] = keep_thinking
-        elif keep_thinking:
+        elif keep_thinking is True:
             raise ValueError(f"Renderer {name!r} does not support keep_thinking=True")
 
         return cls(tokenizer, **kwargs)

--- a/packages/renderers/tests/test_keep_thinking.py
+++ b/packages/renderers/tests/test_keep_thinking.py
@@ -90,6 +90,15 @@ def test_create_renderer_forwards_keep_thinking_to_model_renderer():
     assert "PRIORTHINK_MARKER" in keep_text
 
 
+def test_create_renderer_preserves_keep_thinking_renderer_default():
+    tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-8B", trust_remote_code=True)
+
+    renderer = create_renderer(tokenizer, renderer="qwen3-keep-thinking")
+
+    text = tokenizer.decode(renderer.render_ids(_multi_turn_messages()))
+    assert "PRIORTHINK_MARKER" in text
+
+
 def test_create_renderer_rejects_keep_thinking_for_unsupported_renderer():
     tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-8B", trust_remote_code=True)
 

--- a/packages/renderers/tests/test_keep_thinking.py
+++ b/packages/renderers/tests/test_keep_thinking.py
@@ -99,6 +99,19 @@ def test_create_renderer_preserves_keep_thinking_renderer_default():
     assert "PRIORTHINK_MARKER" in text
 
 
+def test_create_renderer_can_disable_keep_thinking_renderer_default():
+    tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-8B", trust_remote_code=True)
+
+    renderer = create_renderer(
+        tokenizer,
+        renderer="qwen3-keep-thinking",
+        keep_thinking=False,
+    )
+
+    text = tokenizer.decode(renderer.render_ids(_multi_turn_messages()))
+    assert "PRIORTHINK_MARKER" not in text
+
+
 def test_create_renderer_rejects_keep_thinking_for_unsupported_renderer():
     tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-8B", trust_remote_code=True)
 

--- a/packages/renderers/tests/test_keep_thinking.py
+++ b/packages/renderers/tests/test_keep_thinking.py
@@ -20,6 +20,7 @@ from renderers import (
     Qwen3Renderer,
     Qwen35Renderer,
     Qwen36Renderer,
+    create_renderer,
 )
 
 # Renderer class + canonical HF model id.
@@ -72,3 +73,25 @@ def test_keep_thinking_retains_prior_turn_reasoning(renderer_cls, hf_model):
     # keep_thinking=True must additionally retain the prior turn's marker.
     assert "PRIORTHINK_MARKER" not in default_text
     assert "PRIORTHINK_MARKER" in keep_text
+
+
+def test_create_renderer_forwards_keep_thinking_to_model_renderer():
+    tokenizer = AutoTokenizer.from_pretrained(
+        "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16", trust_remote_code=True
+    )
+
+    default_renderer = create_renderer(tokenizer, renderer="nemotron3")
+    keep_renderer = create_renderer(tokenizer, renderer="nemotron3", keep_thinking=True)
+
+    default_text = tokenizer.decode(default_renderer.render_ids(_multi_turn_messages()))
+    keep_text = tokenizer.decode(keep_renderer.render_ids(_multi_turn_messages()))
+
+    assert "PRIORTHINK_MARKER" not in default_text
+    assert "PRIORTHINK_MARKER" in keep_text
+
+
+def test_create_renderer_rejects_keep_thinking_for_unsupported_renderer():
+    tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-8B", trust_remote_code=True)
+
+    with pytest.raises(ValueError, match="does not support keep_thinking"):
+        create_renderer(tokenizer, renderer="default", keep_thinking=True)

--- a/tests/test_renderer_client.py
+++ b/tests/test_renderer_client.py
@@ -44,7 +44,7 @@ def test_renderer_client_honors_configured_renderer_name():
         "Qwen/Qwen3-VL-4B-Instruct",
         renderer="qwen3_vl",
         size=1,
-        keep_thinking=False,
+        keep_thinking=None,
         tool_parser=None,
         reasoning_parser=None,
     )
@@ -74,7 +74,7 @@ def test_renderer_client_uses_renderer_model_name_override():
         "Qwen/Qwen3-VL-4B-Instruct",
         renderer="qwen3_vl",
         size=1,
-        keep_thinking=False,
+        keep_thinking=None,
         tool_parser=None,
         reasoning_parser=None,
     )

--- a/tests/test_renderer_client.py
+++ b/tests/test_renderer_client.py
@@ -44,6 +44,7 @@ def test_renderer_client_honors_configured_renderer_name():
         "Qwen/Qwen3-VL-4B-Instruct",
         renderer="qwen3_vl",
         size=1,
+        keep_thinking=False,
         tool_parser=None,
         reasoning_parser=None,
     )
@@ -73,6 +74,39 @@ def test_renderer_client_uses_renderer_model_name_override():
         "Qwen/Qwen3-VL-4B-Instruct",
         renderer="qwen3_vl",
         size=1,
+        keep_thinking=False,
+        tool_parser=None,
+        reasoning_parser=None,
+    )
+
+
+def test_renderer_client_forwards_keep_thinking_to_renderer_pool():
+    RendererClient._shared_pools.clear()
+
+    client = object.__new__(RendererClient)
+    client._renderer = None
+    client._pool_size = 1
+    client._config = vf.ClientConfig(
+        client_type="renderer",
+        renderer="nemotron3",
+        renderer_keep_thinking=True,
+    )
+
+    sentinel_pool = RendererPool.__new__(RendererPool)
+    with patch(
+        "verifiers.clients.renderer_client.create_renderer_pool",
+        return_value=sentinel_pool,
+    ) as create_pool_mock:
+        pool = client._get_renderer_or_pool(
+            "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16"
+        )
+
+    assert pool is sentinel_pool
+    create_pool_mock.assert_called_once_with(
+        "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
+        renderer="nemotron3",
+        size=1,
+        keep_thinking=True,
         tool_parser=None,
         reasoning_parser=None,
     )

--- a/verifiers/clients/renderer_client.py
+++ b/verifiers/clients/renderer_client.py
@@ -377,11 +377,11 @@ class RendererClient(
     so that concurrent rollouts tokenize in parallel threads.
     """
 
-    # Cache key is (renderer_model_name, renderer_name, keep_thinking,
+    # Cache key is (renderer_model_name, renderer_name, keep_thinking override,
     # tool_parser, reasoning_parser, pool_size) so that different renderer
     # behavior, parser configs, or pool sizes for the same model don't collide.
     _shared_pools: ClassVar[
-        dict[tuple[str, str, bool, str | None, str | None, int], RendererPool]
+        dict[tuple[str, str, bool | None, str | None, str | None, int], RendererPool]
     ] = {}
     _shared_pools_lock: ClassVar[threading.Lock] = threading.Lock()
 
@@ -418,7 +418,7 @@ class RendererClient(
         )
         tool_parser = self._config.tool_parser if self._config is not None else None
         keep_thinking = (
-            self._config.renderer_keep_thinking if self._config is not None else False
+            self._config.renderer_keep_thinking if self._config is not None else None
         )
         reasoning_parser = (
             self._config.reasoning_parser if self._config is not None else None

--- a/verifiers/clients/renderer_client.py
+++ b/verifiers/clients/renderer_client.py
@@ -377,11 +377,11 @@ class RendererClient(
     so that concurrent rollouts tokenize in parallel threads.
     """
 
-    # Cache key is (renderer_model_name, renderer_name, tool_parser,
-    # reasoning_parser, pool_size) so that different parser configs or pool
-    # sizes for the same model don't collide.
+    # Cache key is (renderer_model_name, renderer_name, keep_thinking,
+    # tool_parser, reasoning_parser, pool_size) so that different renderer
+    # behavior, parser configs, or pool sizes for the same model don't collide.
     _shared_pools: ClassVar[
-        dict[tuple[str, str, str | None, str | None, int], RendererPool]
+        dict[tuple[str, str, bool, str | None, str | None, int], RendererPool]
     ] = {}
     _shared_pools_lock: ClassVar[threading.Lock] = threading.Lock()
 
@@ -417,12 +417,16 @@ class RendererClient(
             else model
         )
         tool_parser = self._config.tool_parser if self._config is not None else None
+        keep_thinking = (
+            self._config.renderer_keep_thinking if self._config is not None else False
+        )
         reasoning_parser = (
             self._config.reasoning_parser if self._config is not None else None
         )
         cache_key = (
             renderer_model,
             renderer_name,
+            keep_thinking,
             tool_parser,
             reasoning_parser,
             self._pool_size,
@@ -434,6 +438,7 @@ class RendererClient(
                     renderer_model,
                     renderer=renderer_name,
                     size=self._pool_size,
+                    keep_thinking=keep_thinking,
                     tool_parser=tool_parser,
                     reasoning_parser=reasoning_parser,
                 )

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -496,7 +496,7 @@ class ClientConfig(BaseModel):
     client_type: ClientType = "openai_chat_completions"
     renderer: str = "auto"
     renderer_model_name: str | None = None
-    renderer_keep_thinking: bool = False
+    renderer_keep_thinking: bool | None = None
     renderer_pool_size: int | None = None
     tool_parser: str | None = None
     reasoning_parser: str | None = None

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -496,6 +496,7 @@ class ClientConfig(BaseModel):
     client_type: ClientType = "openai_chat_completions"
     renderer: str = "auto"
     renderer_model_name: str | None = None
+    renderer_keep_thinking: bool = False
     renderer_pool_size: int | None = None
     tool_parser: str | None = None
     reasoning_parser: str | None = None


### PR DESCRIPTION
## Summary
- adds a generic tri-state `keep_thinking` argument to `create_renderer` and `create_renderer_pool`
- preserves renderer constructor defaults when `keep_thinking=None`, forces enabled with `True`, and forces disabled with `False`
- adds `ClientConfig.renderer_keep_thinking` and carries it through `RendererClient` into the shared renderer pool
- raises a clear error when `keep_thinking=True` is requested for an unsupported renderer instead of adding per-model registry aliases

## Test plan
- `uv run pytest packages/renderers/tests/test_keep_thinking.py -k 'create_renderer'`
- `uv run pytest tests/test_renderer_client.py -k 'renderer_client_forwards_keep_thinking or renderer_client_honors_configured_renderer_name or renderer_client_uses_renderer_model_name_override'`
- `uv run ruff check packages/renderers/renderers/base.py packages/renderers/tests/test_keep_thinking.py verifiers/types.py verifiers/clients/renderer_client.py tests/test_renderer_client.py`
- `uv run ruff format --check packages/renderers/renderers/base.py packages/renderers/tests/test_keep_thinking.py verifiers/types.py verifiers/clients/renderer_client.py tests/test_renderer_client.py`
- `git diff --check`

Note: `uv run pytest packages/renderers/tests/test_keep_thinking.py` reaches the new regression and passes 10/11 tests locally, but the existing `moonshotai/Kimi-K2.5` tokenizer case fails in this environment because `tiktoken` is not installed.

Stacked on #1278.
