### PR TITLE
Add structured SWE rollout failure observability

### DIFF
--- a/tests/test_cli_agent_env.py
+++ b/tests/test_cli_agent_env.py
@@ -9,6 +9,8 @@ import pytest
 from datasets import Dataset
 
 import verifiers as vf
+from verifiers.envs.experimental.cli_agent_env import CliAgentMonitorRubric
+from verifiers.types import RolloutTiming
 from verifiers.utils.interception_utils import serialize_intercept_response
 
 
@@ -222,6 +224,41 @@ class TestCliAgentEnv:
         kwargs = mock_client.last_call_kwargs
         assert kwargs["tools"] is not None
         assert kwargs["tools"][0].name == "echo"
+
+
+@pytest.mark.asyncio
+async def test_cli_agent_final_log_formats_missing_first_model_call():
+    timing = RolloutTiming()
+    timing.generation.start = 100.0
+    timing.generation.end = 115.0
+    timing.setup.start = 100.0
+    timing.setup.end = 105.0
+    timing.scoring.start = 115.0
+    timing.scoring.end = 118.0
+    state = {
+        "rollout_id": "rollout_test",
+        "example_id": 2332,
+        "info": {"instance_id": "brazilian-utils__brutils-python-126"},
+        "sandbox_id": "sbx_test",
+        "trajectory": [],
+        "stop_condition": "agent_completed",
+        "agent_exit_code": 0,
+        "agent_start_time": 105.0,
+        "agent_end_time": 112.0,
+        "timing": timing,
+    }
+
+    rubric = CliAgentMonitorRubric()
+    rubric.logger = MagicMock()
+
+    await rubric.cleanup(state)
+
+    message = rubric.logger.info.call_args.args[0]
+    assert "setup_s=5.000" in message
+    assert "first_call_latency_s=n/a" in message
+    assert "agent_s=7.000" in message
+    assert "scoring_s=3.000" in message
+    assert "duration_s=18.000" in message
 
 
 @pytest.mark.asyncio

--- a/tests/test_cli_agent_env.py
+++ b/tests/test_cli_agent_env.py
@@ -3,6 +3,7 @@
 import asyncio
 import tempfile
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -11,6 +12,7 @@ from datasets import Dataset
 import verifiers as vf
 from verifiers.envs.experimental.cli_agent_env import CliAgentMonitorRubric
 from verifiers.types import RolloutTiming
+from verifiers.utils.save_utils import state_to_output
 from verifiers.utils.interception_utils import serialize_intercept_response
 
 
@@ -259,6 +261,128 @@ async def test_cli_agent_final_log_formats_missing_first_model_call():
     assert "agent_s=7.000" in message
     assert "scoring_s=3.000" in message
     assert "duration_s=18.000" in message
+
+
+@pytest.mark.asyncio
+async def test_cli_agent_failure_metrics_use_structured_failure():
+    rubric = CliAgentMonitorRubric()
+
+    assert (
+        await rubric.agent_error(
+            {
+                "failure": {
+                    "reason": "agent_poll_failed",
+                    "origin": "agent",
+                    "error_type": "AgentPollError",
+                    "root_error_type": "AgentPollError",
+                    "message": "poll failed",
+                    "logs": {},
+                }
+            }
+        )
+        == 1.0
+    )
+    assert (
+        await rubric.agent_error(
+            {
+                "failure": {
+                    "reason": "sandbox_timeout",
+                    "origin": "sandbox",
+                    "error_type": "SandboxError",
+                    "root_error_type": "SandboxError",
+                    "message": "timeout",
+                    "logs": {},
+                }
+            }
+        )
+        == 0.0
+    )
+    assert await rubric.agent_nonzero_exit({"agent_exit_code": 7}) == 1.0
+    assert await rubric.agent_nonzero_exit({"agent_exit_code": 0}) == 0.0
+    assert (
+        await rubric.agent_poll_failed(
+            {
+                "failure": {
+                    "reason": "agent_poll_failed",
+                    "origin": "agent",
+                    "error_type": "AgentPollError",
+                    "root_error_type": "AgentPollError",
+                    "message": "poll failed",
+                    "logs": {},
+                }
+            }
+        )
+        == 1.0
+    )
+
+
+def test_state_to_output_serializes_failure_and_preserves_error_fields():
+    state = vf.State(
+        input={"prompt": [], "example_id": 1, "task": "default", "info": {}}
+    )
+    state.update(
+        {
+            "example_id": 1,
+            "task": "default",
+            "prompt": [],
+            "completion": [],
+            "reward": 0.0,
+            "timing": RolloutTiming(),
+            "is_completed": True,
+            "is_truncated": False,
+            "stop_condition": "has_error",
+            "metrics": {},
+            "tool_defs": [],
+            "trajectory": [],
+            "error": vf.ModelError("model failed"),
+        }
+    )
+
+    output = state_to_output(state, state_columns=[])
+
+    assert output["error"]["error"] == "ModelError"
+    assert output["error_chain"] == "ModelError('model failed')"
+    assert output["long_error_chain"] == "ModelError"
+    assert output["failure"]["reason"] == "model_error"
+    assert output["failure"]["origin"] == "model"
+    assert output["failure"]["error_type"] == "ModelError"
+
+
+@pytest.mark.asyncio
+async def test_failure_log_collection_returns_bounded_tails(sample_dataset):
+    env = vf.CliAgentEnv(
+        run_command="python agent.py",
+        dataset=sample_dataset,
+        rubric=vf.Rubric(),
+    )
+    env.sandbox_client.get_background_job = AsyncMock(
+        return_value=SimpleNamespace(stdout="a" * 13000, stderr="err")
+    )
+    state = {"sandbox_id": "sbx", "background_job": object()}
+
+    logs = await env._collect_background_job_log_tails(state)
+
+    assert logs["agent_stdout"].endswith("a" * env.FAILURE_LOG_TAIL_CHARS)
+    assert logs["agent_stdout"].startswith("...<truncated ")
+    assert logs["agent_stderr"] == "err"
+
+
+@pytest.mark.asyncio
+async def test_failure_log_collection_suppresses_read_errors(sample_dataset):
+    env = vf.CliAgentEnv(
+        run_command="python agent.py",
+        dataset=sample_dataset,
+        rubric=vf.Rubric(),
+    )
+    env.logger = MagicMock()
+    env.get_failure_log_paths = lambda state: {"missing": "/tmp/missing.log"}
+    env.sandbox_client.execute_command = AsyncMock(side_effect=RuntimeError("boom"))
+    state = {"sandbox_id": "sbx"}
+
+    logs = await env.collect_failure_diagnostics(state)
+
+    assert logs == {}
+    env.logger.warning.assert_called()
 
 
 @pytest.mark.asyncio

--- a/tests/test_swe_rollout_observability.py
+++ b/tests/test_swe_rollout_observability.py
@@ -1,0 +1,42 @@
+from types import SimpleNamespace
+
+from verifiers.envs.experimental.composable.harnesses.opencode import (
+    build_install_script,
+)
+from verifiers.envs.experimental.composable.tasksets.swe.swe_rebench_v2 import (
+    _patch_failure_message,
+)
+
+
+def test_patch_failure_message_includes_empty_stderr_context():
+    message = _patch_failure_message(
+        "test_patch",
+        "diff --git a/test.py b/test.py\n",
+        [
+            (
+                "git_apply",
+                "git apply /tmp/test_patch.patch",
+                "/repo",
+                SimpleNamespace(exit_code=1, stdout="", stderr=""),
+            )
+        ],
+    )
+
+    assert "patch_sha256=" in message
+    assert "patch_size=" in message
+    assert "git_apply_command='git apply /tmp/test_patch.patch'" in message
+    assert "git_apply_working_dir='/repo'" in message
+    assert "git_apply_stdout='<empty>'" in message
+    assert "git_apply_stderr='<empty>'" in message
+
+
+def test_opencode_install_script_wraps_setup_steps():
+    script = build_install_script()
+
+    assert 'echo "[setup] start $name"' in script
+    assert 'echo "[setup] end $name exit=$exit_code elapsed_s=$elapsed_s"' in script
+    assert 'run_setup_step "apt_dependencies"' in script
+    assert 'run_setup_step "ripgrep_install"' in script
+    assert 'run_setup_step "download_opencode"' in script
+    assert 'run_setup_step "verify_opencode_sha256"' in script
+    assert 'run_setup_step "install_opencode"' in script

--- a/tests/test_swe_rollout_observability.py
+++ b/tests/test_swe_rollout_observability.py
@@ -1,5 +1,6 @@
 from types import SimpleNamespace
 
+from verifiers.envs.experimental.composable.composable_env import ComposableEnv
 from verifiers.envs.experimental.composable.harnesses.opencode import (
     build_install_script,
 )
@@ -33,6 +34,8 @@ def test_patch_failure_message_includes_empty_stderr_context():
 def test_opencode_install_script_wraps_setup_steps():
     script = build_install_script()
 
+    assert ": > /tmp/install_progress.log" in script
+    assert "tee -a /tmp/install_progress.log" in script
     assert 'echo "[setup] start $name"' in script
     assert 'echo "[setup] end $name exit=$exit_code elapsed_s=$elapsed_s"' in script
     assert 'run_setup_step "apt_dependencies"' in script
@@ -40,3 +43,14 @@ def test_opencode_install_script_wraps_setup_steps():
     assert 'run_setup_step "download_opencode"' in script
     assert 'run_setup_step "verify_opencode_sha256"' in script
     assert 'run_setup_step "install_opencode"' in script
+
+
+def test_observed_setup_wrapper_writes_trace_and_preserves_exit():
+    wrapped = ComposableEnv._wrap_observed_setup_command(
+        "echo hi && false", "agent_install"
+    )
+
+    assert "/tmp/vf_observed_command.log" in wrapped
+    assert "event=observed_command_started" in wrapped
+    assert "event=setup_failed" in wrapped
+    assert 'exit "${PIPESTATUS[0]}"' in wrapped

--- a/tests/test_swe_rollout_observability.py
+++ b/tests/test_swe_rollout_observability.py
@@ -4,7 +4,7 @@ from verifiers.envs.experimental.composable.composable_env import ComposableEnv
 from verifiers.envs.experimental.composable.harnesses.opencode import (
     build_install_script,
 )
-from verifiers.envs.experimental.composable.tasksets.swe.swe_rebench_v2 import (
+from verifiers.envs.experimental.composable.tasksets.swe.swe_rebench_v2.taskset import (
     _patch_failure_message,
 )
 
@@ -41,7 +41,6 @@ def test_opencode_install_script_wraps_setup_steps():
     assert 'run_setup_step "apt_dependencies"' in script
     assert 'run_setup_step "ripgrep_install"' in script
     assert 'run_setup_step "download_opencode"' in script
-    assert 'run_setup_step "verify_opencode_sha256"' in script
     assert 'run_setup_step "install_opencode"' in script
 
 

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -592,6 +592,7 @@ class Environment(ABC):
         state["reward"] = None
         state["metrics"] = None
         state["error"] = None
+        state["failure"] = None
         state["final_env_response"] = None
         state["timing"] = RolloutTiming()
         return state

--- a/verifiers/envs/experimental/cli_agent_env.py
+++ b/verifiers/envs/experimental/cli_agent_env.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import os
+import shlex
 import time
 import uuid
 from collections import Counter
@@ -39,6 +40,14 @@ from verifiers.utils.interception_utils import (
     deliver_response,
     synthesize_stream,
 )
+from verifiers.utils.failure_utils import (
+    FAILURE_ORIGIN_AGENT,
+    FAILURE_REASON_AGENT_NONZERO_EXIT,
+    FAILURE_REASON_AGENT_POLL_FAILED,
+    add_failure_logs,
+    ensure_rollout_failure,
+    tail_text,
+)
 from verifiers.utils.logging_utils import truncate
 from verifiers.utils.message_utils import normalize_messages
 
@@ -49,7 +58,13 @@ class AgentError(vf.InfraError):
     """Raised when the agent process fails or exits unexpectedly."""
 
 
-def make_agent_error(state: State, message: str) -> AgentError:
+class AgentPollError(AgentError):
+    """Raised when polling the sandbox background job fails."""
+
+
+def make_agent_error(
+    state: State, message: str, error_cls: type[AgentError] = AgentError
+) -> AgentError:
     """Create an AgentError with rollout-specific sandbox context when available."""
     context_parts = [
         f"sandbox_id={state['sandbox_id']}",
@@ -60,7 +75,7 @@ def make_agent_error(state: State, message: str) -> AgentError:
     instance_id = state_info.get("instance_id")
     if instance_id:
         context_parts.append(f"instance_id={instance_id}")
-    return AgentError(f"{message} ({', '.join(context_parts)})")
+    return error_cls(f"{message} ({', '.join(context_parts)})")
 
 
 def _collect_tool_counts(state: State) -> Counter[str]:
@@ -170,17 +185,33 @@ class CliAgentMonitorRubric(vf.Rubric):
         super().__init__(**kwargs)
         self.add_metric(self.agent_timeout)
         self.add_metric(self.agent_error)
+        self.add_metric(self.agent_nonzero_exit)
+        self.add_metric(self.agent_poll_failed)
 
     async def agent_timeout(self, state: vf.State) -> float:
         """Whether the agent timed out."""
         return float(bool(state.get("timed_out")))
 
     async def agent_error(self, state: vf.State) -> float:
-        """Whether the agent errored (non-zero exit_code)."""
+        """Whether the rollout failure originated in the CLI agent."""
+        failure = ensure_rollout_failure(state)
+        if failure is None:
+            return 0.0
+        return float(failure.get("origin") == FAILURE_ORIGIN_AGENT)
+
+    async def agent_nonzero_exit(self, state: vf.State) -> float:
+        """Whether the agent process completed with a non-zero exit code."""
         agent_exit_code = state.get("agent_exit_code")
         if agent_exit_code is None:
             return 0.0
         return float(agent_exit_code != 0)
+
+    async def agent_poll_failed(self, state: vf.State) -> float:
+        """Whether polling/reading the background agent job failed."""
+        failure = ensure_rollout_failure(state)
+        if failure is None:
+            return 0.0
+        return float(failure.get("reason") == FAILURE_REASON_AGENT_POLL_FAILED)
 
     @vf.cleanup
     async def log_rollout_finished(self, state: vf.State) -> None:
@@ -200,15 +231,19 @@ class CliAgentMonitorRubric(vf.Rubric):
         timed_out = state.get("timed_out", False)
         stop_condition = state.get("stop_condition", "unknown")
         exit_code = state.get("agent_exit_code")
+        turns = len(state.get("trajectory", []))
+        failure = ensure_rollout_failure(state)
 
         if error_info or timed_out:
-            self.logger.info(
+            self.logger.error(
                 format_rollout_log_event(
                     "rollout_aborted",
                     state,
                     stop=stop_condition,
                     exit_code=exit_code,
                     timed_out=timed_out if timed_out else None,
+                    reason=failure.get("reason") if failure else None,
+                    origin=failure.get("origin") if failure else None,
                     error=error_info,
                 )
             )
@@ -229,6 +264,20 @@ class CliAgentMonitorRubric(vf.Rubric):
                 duration_s=_rollout_total_s(state),
             )
         )
+
+        if turns == 0 and not error_info and not timed_out:
+            self.logger.error(
+                format_rollout_log_event(
+                    "rollout_empty_trajectory",
+                    state,
+                    stop=stop_condition,
+                    exit_code=exit_code,
+                    reason=failure.get("reason") if failure else None,
+                    origin=failure.get("origin") if failure else None,
+                    agent_s=_agent_duration_s(state),
+                    duration_s=_rollout_total_s(state),
+                )
+            )
 
 
 class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
@@ -399,6 +448,7 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
                 status="ok" if setup_succeeded else "error",
                 elapsed_s=time.perf_counter() - setup_start,
             )
+        return state
 
     async def _setup_sandbox_and_agent(self, state: State, rollout_id: str) -> None:
         """Create sandbox resources and launch the CLI agent."""
@@ -456,7 +506,6 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
             f"example_id={state['example_id']}",
         ]
         self.logger.info(" | ".join(parts))
-        return state
 
     async def get_docker_image(self, state: State) -> str:
         """Get the Docker image for the sandbox. Override for per-task images."""
@@ -553,9 +602,24 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
             self.logger.debug("Completion wait task cancelled")
             raise
         except Exception as e:
-            error = make_agent_error(state, f"Agent polling failed: {e}")
+            state["agent_poll_failed"] = True
+            error = make_agent_error(
+                state, f"Agent polling failed: {e}", error_cls=AgentPollError
+            )
             state["error"] = error
-            self.logger.error(str(error))
+            ensure_rollout_failure(
+                state,
+                reason=FAILURE_REASON_AGENT_POLL_FAILED,
+                origin=FAILURE_ORIGIN_AGENT,
+                error=error,
+            )
+            self.logger.error(
+                format_rollout_log_event(
+                    "agent_poll_failed",
+                    state,
+                    error=truncate(str(error), 500),
+                )
+            )
         finally:
             state["agent_completed"] = True
 
@@ -615,7 +679,21 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
                             f"(exit_code={status.exit_code}): {stderr_full}",
                         )
                     state["error"] = error
-                    self.logger.error(str(error))
+                    ensure_rollout_failure(
+                        state,
+                        reason=FAILURE_REASON_AGENT_NONZERO_EXIT,
+                        origin=FAILURE_ORIGIN_AGENT,
+                        error=error,
+                    )
+                    self.logger.error(
+                        format_rollout_log_event(
+                            "rollout_aborted",
+                            state,
+                            stop="agent_nonzero_exit",
+                            exit_code=status.exit_code,
+                            error=truncate(str(error), 500),
+                        )
+                    )
                 return
             await asyncio.sleep(self.poll_interval)
 
@@ -836,6 +914,91 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
             state, prompt_messages, await self.normalize_response(response)
         )
 
+    FAILURE_LOG_TAIL_CHARS = 12000
+    SETUP_DIAGNOSTIC_LOG_PATHS = {
+        "observed_command_log": "/tmp/vf_observed_command.log",
+        "install_progress_log": "/tmp/install_progress.log",
+    }
+
+    def get_failure_log_paths(self, state: State) -> dict[str, str]:
+        """Return sandbox paths whose bounded tails should be attached to failures."""
+        return dict(self.SETUP_DIAGNOSTIC_LOG_PATHS)
+
+    async def _read_sandbox_log_tail(
+        self, sandbox_id: str, path: str, *, max_chars: int | None = None
+    ) -> str:
+        max_chars = max_chars or self.FAILURE_LOG_TAIL_CHARS
+        quoted_path = shlex.quote(path)
+        result = await self.sandbox_client.execute_command(
+            sandbox_id,
+            f"tail -c {int(max_chars)} {quoted_path} 2>/dev/null || true",
+            working_dir=None,
+            timeout=self.timeouts.read_file,
+        )
+        return (result.stdout or "").strip()
+
+    async def _collect_background_job_log_tails(self, state: State) -> dict[str, str]:
+        logs: dict[str, str] = {}
+        for key in ("agent_stdout", "agent_stderr"):
+            if state.get(key):
+                logs[key] = tail_text(state.get(key), self.FAILURE_LOG_TAIL_CHARS)
+
+        sandbox_id = state.get("sandbox_id")
+        background_job = state.get("background_job")
+        if (
+            sandbox_id
+            and background_job
+            and not {"agent_stdout", "agent_stderr"} <= logs.keys()
+        ):
+            try:
+                status = await self.sandbox_client.get_background_job(
+                    sandbox_id, background_job, timeout=self.timeouts.poll
+                )
+                if status.stdout and "agent_stdout" not in logs:
+                    logs["agent_stdout"] = tail_text(
+                        status.stdout, self.FAILURE_LOG_TAIL_CHARS
+                    )
+                if status.stderr and "agent_stderr" not in logs:
+                    logs["agent_stderr"] = tail_text(
+                        status.stderr, self.FAILURE_LOG_TAIL_CHARS
+                    )
+            except Exception as e:
+                self.logger.warning(
+                    format_rollout_log_event(
+                        "diagnostic_collection_failed",
+                        state,
+                        source="background_job",
+                        error=f"{type(e).__name__}: {truncate(str(e), 200)}",
+                    )
+                )
+        return logs
+
+    async def collect_failure_diagnostics(self, state: State) -> dict[str, str]:
+        """Collect bounded diagnostic log tails without masking rollout failures."""
+        logs = await self._collect_background_job_log_tails(state)
+        sandbox_id = state.get("sandbox_id")
+        if sandbox_id:
+            for name, path in self.get_failure_log_paths(state).items():
+                try:
+                    value = await self._read_sandbox_log_tail(sandbox_id, path)
+                except Exception as e:
+                    self.logger.warning(
+                        format_rollout_log_event(
+                            "diagnostic_collection_failed",
+                            state,
+                            source=name,
+                            error=f"{type(e).__name__}: {truncate(str(e), 200)}",
+                        )
+                    )
+                    continue
+                if value:
+                    logs[name] = tail_text(value, self.FAILURE_LOG_TAIL_CHARS)
+        for name, value in logs.items():
+            self.logger.debug(
+                f"{format_rollout_log_event('failure_log_collected', state, source=name, chars=len(value))}\n{value}"
+            )
+        return logs
+
     @vf.teardown
     async def teardown_resources(self):
         """Stop Prime Tunnel and HTTP interception server."""
@@ -863,8 +1026,6 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
             except asyncio.CancelledError:
                 pass
 
-        state.pop("background_job", None)
-
         rollout_id = state.get("rollout_id")
         if rollout_id and self._interception_server is not None:
             self._interception_server.unregister_rollout(rollout_id)
@@ -880,6 +1041,10 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
         run computation here and cache the result in state before sandbox is destroyed.
         """
         state["_cli_agent_tool_counts"] = dict(_collect_tool_counts(state))
+        failure = ensure_rollout_failure(state)
+        if failure is not None:
+            logs = await self.collect_failure_diagnostics(state)
+            add_failure_logs(state, logs)
 
     @vf.cleanup
     async def destroy_sandbox(self, state: State):
@@ -902,6 +1067,7 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
                 self.deregister_sandbox(sandbox_id)
             else:
                 await self.delete_sandbox(sandbox_id)
+        state.pop("background_job", None)
 
     async def env_response(
         self, messages: Messages, state: State, **kwargs

--- a/verifiers/envs/experimental/cli_agent_env.py
+++ b/verifiers/envs/experimental/cli_agent_env.py
@@ -20,7 +20,9 @@ from verifiers.envs.experimental.sandbox_mixin import (
     SandboxMixin,
     SandboxMonitorRubric,
     SandboxTimeouts,
+    format_rollout_log_event,
     is_retryable_sandbox_read_error,
+    log_rollout_event,
 )
 from verifiers.types import (
     AssistantMessage,
@@ -37,7 +39,7 @@ from verifiers.utils.interception_utils import (
     deliver_response,
     synthesize_stream,
 )
-from verifiers.utils.logging_utils import print_time, truncate
+from verifiers.utils.logging_utils import truncate
 from verifiers.utils.message_utils import normalize_messages
 
 logger = logging.getLogger(__name__)
@@ -61,6 +63,106 @@ def make_agent_error(state: State, message: str) -> AgentError:
     return AgentError(f"{message} ({', '.join(context_parts)})")
 
 
+def _collect_tool_counts(state: State) -> Counter[str]:
+    tool_counts: Counter[str] = Counter()
+    for step in state.get("trajectory", []):
+        for msg in step.get("completion", []):
+            if isinstance(msg, AssistantMessage) and isinstance(msg.tool_calls, list):
+                for tc in msg.tool_calls:
+                    if isinstance(tc, ToolCall):
+                        tool_counts[tc.name] += 1
+    return tool_counts
+
+
+def _phase(timing: Any, name: str) -> Any:
+    if timing is None:
+        return None
+    if isinstance(timing, dict):
+        return timing.get(name)
+    return getattr(timing, name, None)
+
+
+def _span_start(span: Any) -> float:
+    if span is None:
+        return 0.0
+    if isinstance(span, dict):
+        return float(span.get("start", 0.0) or 0.0)
+    return float(getattr(span, "start", 0.0) or 0.0)
+
+
+def _span_end(span: Any) -> float:
+    if span is None:
+        return 0.0
+    if isinstance(span, dict):
+        return float(span.get("end", 0.0) or 0.0)
+    return float(getattr(span, "end", 0.0) or 0.0)
+
+
+def _span_duration(span: Any) -> float:
+    if span is None:
+        return 0.0
+    duration = (
+        span.get("duration")
+        if isinstance(span, dict)
+        else getattr(span, "duration", None)
+    )
+    if duration is not None:
+        return float(duration or 0.0)
+    end = _span_end(span)
+    start = _span_start(span)
+    return end - start if end > 0 and start > 0 else 0.0
+
+
+def _time_spans(timing: Any, name: str) -> list[Any]:
+    phase = _phase(timing, name)
+    if phase is None:
+        return []
+    if isinstance(phase, dict):
+        spans = phase.get("spans", [])
+    else:
+        spans = getattr(phase, "spans", [])
+    return list(spans or [])
+
+
+def _first_call_latency_s(state: State) -> float | None:
+    timing = state.get("timing")
+    spans = _time_spans(timing, "model")
+    if not spans:
+        return None
+    first_model_start = _span_start(spans[0])
+    agent_start = float(state.get("agent_start_time") or 0.0)
+    if agent_start <= 0:
+        agent_start = _span_end(_phase(timing, "setup"))
+    if first_model_start <= 0 or agent_start <= 0:
+        return None
+    return max(0.0, first_model_start - agent_start)
+
+
+def _agent_duration_s(state: State) -> float:
+    agent_start = float(state.get("agent_start_time") or 0.0)
+    if agent_start <= 0:
+        return 0.0
+    agent_end = float(state.get("agent_end_time") or 0.0)
+    if agent_end <= 0:
+        agent_end = _span_end(_phase(state.get("timing"), "generation"))
+    return max(0.0, agent_end - agent_start) if agent_end > 0 else 0.0
+
+
+def _rollout_total_s(state: State) -> float:
+    timing = state.get("timing")
+    scoring = _phase(timing, "scoring")
+    generation = _phase(timing, "generation")
+    scoring_end = _span_end(scoring)
+    generation_start = _span_start(generation)
+    if scoring_end > 0 and generation_start > 0:
+        return max(0.0, scoring_end - generation_start)
+    return _span_duration(generation)
+
+
+def _format_optional_s(value: float | None) -> str:
+    return "n/a" if value is None else f"{value:.3f}"
+
+
 class CliAgentMonitorRubric(vf.Rubric):
     """Monitor rubric that tracks CLI agent execution state."""
 
@@ -79,6 +181,54 @@ class CliAgentMonitorRubric(vf.Rubric):
         if agent_exit_code is None:
             return 0.0
         return float(agent_exit_code != 0)
+
+    @vf.cleanup
+    async def log_rollout_finished(self, state: vf.State) -> None:
+        """Log final rollout lifecycle details after scoring has completed."""
+        if state.get("_cli_agent_rollout_finished_logged"):
+            return
+        state["_cli_agent_rollout_finished_logged"] = True
+
+        tool_counts = Counter(state.get("_cli_agent_tool_counts") or {})
+        if not tool_counts:
+            tool_counts = _collect_tool_counts(state)
+        tools_str = ",".join(f"{k}:{v}" for k, v in tool_counts.most_common())
+        error = state.get("error")
+        error_info = (
+            f"{type(error).__name__}: {truncate(str(error), 80)}" if error else None
+        )
+        timed_out = state.get("timed_out", False)
+        stop_condition = state.get("stop_condition", "unknown")
+        exit_code = state.get("agent_exit_code")
+
+        if error_info or timed_out:
+            self.logger.info(
+                format_rollout_log_event(
+                    "rollout_aborted",
+                    state,
+                    stop=stop_condition,
+                    exit_code=exit_code,
+                    timed_out=timed_out if timed_out else None,
+                    error=error_info,
+                )
+            )
+
+        timing = state.get("timing")
+        self.logger.info(
+            format_rollout_log_event(
+                "rollout_finished",
+                state,
+                turns=len(state.get("trajectory", [])),
+                tools=f"[{tools_str}]",
+                stop=stop_condition,
+                exit_code=exit_code,
+                setup_s=_span_duration(_phase(timing, "setup")),
+                first_call_latency_s=_format_optional_s(_first_call_latency_s(state)),
+                agent_s=_agent_duration_s(state),
+                scoring_s=_span_duration(_phase(timing, "scoring")),
+                duration_s=_rollout_total_s(state),
+            )
+        )
 
 
 class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
@@ -235,6 +385,23 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
 
         rollout_id = f"rollout_{uuid.uuid4().hex[:8]}"
         state["rollout_id"] = rollout_id
+        setup_start = time.perf_counter()
+        setup_succeeded = False
+        log_rollout_event(self.logger, "setup_started", state)
+        try:
+            await self._setup_sandbox_and_agent(state, rollout_id)
+            setup_succeeded = True
+        finally:
+            log_rollout_event(
+                self.logger,
+                "setup_finished",
+                state,
+                status="ok" if setup_succeeded else "error",
+                elapsed_s=time.perf_counter() - setup_start,
+            )
+
+    async def _setup_sandbox_and_agent(self, state: State, rollout_id: str) -> None:
+        """Create sandbox resources and launch the CLI agent."""
 
         interception_server = self._require_interception_server()
         await interception_server.start()
@@ -347,6 +514,8 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
         sandbox_id = state["sandbox_id"]
 
         self.logger.debug(f"Starting agent in sandbox {sandbox_id}")
+        launch_start = time.perf_counter()
+        log_rollout_event(self.logger, "agent_launch_started", state)
         try:
             background_job: BackgroundJob = (
                 await self.sandbox_client.start_background_job(
@@ -361,6 +530,12 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
 
         state["completion_wait_task"] = asyncio.create_task(
             self.wait_for_completion(state)
+        )
+        log_rollout_event(
+            self.logger,
+            "agent_launched",
+            state,
+            elapsed_s=time.perf_counter() - launch_start,
         )
 
     async def wait_for_completion(self, state: State) -> None:
@@ -416,6 +591,7 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
                 continue
             consecutive_read_errors = 0
             if status.completed:
+                state["agent_end_time"] = time.time()
                 state["agent_exit_code"] = status.exit_code
                 state["agent_stdout"] = status.stdout
                 state["agent_stderr"] = status.stderr
@@ -703,47 +879,7 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
         Override for custom post-rollout logic. For example, if sandbox state is needed for reward functions,
         run computation here and cache the result in state before sandbox is destroyed.
         """
-        tool_counts: Counter[str] = Counter()
-        for step in state.get("trajectory", []):
-            for msg in step.get("completion", []):
-                if isinstance(msg, AssistantMessage) and isinstance(
-                    msg.tool_calls, list
-                ):
-                    for tc in msg.tool_calls:
-                        if isinstance(tc, ToolCall):
-                            tool_counts[tc.name] += 1
-
-        example_id = state.get("example_id")
-        num_turns = len(state.get("trajectory", []))
-        stop_condition = state.get("stop_condition", "unknown")
-        error = state.get("error")
-        error_summary = (
-            f"{type(error).__name__}: {truncate(str(error), 80)}" if error else None
-        )
-        exit_code = state.get("agent_exit_code")
-        timed_out = state.get("timed_out", False)
-        # post_rollout runs during finalization, before Environment.run_rollout
-        # stamps scoring.end. timing.total is therefore still 0 here, so derive
-        # the live duration from the generation-phase start.
-        timing = state.get("timing")
-        gen = getattr(timing, "generation", None) if timing is not None else None
-        gen_start = getattr(gen, "start", 0.0) if gen is not None else 0.0
-        duration_s = time.time() - gen_start if gen_start > 0 else 0.0
-        tools_str = ",".join(f"{k}:{v}" for k, v in tool_counts.most_common())
-        parts = [
-            f"Finished rollout_id={state.get('rollout_id')}",
-            f"example_id={example_id}",
-            f"turns={num_turns}",
-            f"tools=[{tools_str}]",
-            f"stop={stop_condition}",
-            f"exit_code={exit_code}",
-            f"duration={print_time(duration_s)}",
-        ]
-        if timed_out:
-            parts.append("timed_out=True")
-        if error_summary:
-            parts.append(f"error={error_summary}")
-        self.logger.info(" | ".join(parts))
+        state["_cli_agent_tool_counts"] = dict(_collect_tool_counts(state))
 
     @vf.cleanup
     async def destroy_sandbox(self, state: State):

--- a/verifiers/envs/experimental/composable/composable_env.py
+++ b/verifiers/envs/experimental/composable/composable_env.py
@@ -50,6 +50,7 @@ import verifiers as vf
 from verifiers.envs.experimental.cli_agent_env import CliAgentEnv
 from verifiers.envs.experimental.composable.harness import Harness
 from verifiers.envs.experimental.composable.task import TaskSet
+from verifiers.envs.experimental.sandbox_mixin import log_rollout_event
 from verifiers.envs.experimental.utils.file_locks import shared_path_lock
 from verifiers.envs.tool_env import ToolMonitorRubric
 from verifiers.types import State, TrajectoryStep
@@ -265,7 +266,7 @@ class ComposableEnv(CliAgentEnv):
             state["test_timeout"] = spec.timeout_minutes * 60
         else:
             state["test_timeout"] = self.compute_sandbox_timeout_minutes() * 60
-        await self.taskset.setup(state)
+        await self._run_setup_step(state, "task_setup", self.taskset.setup, state)
         dirs = {self.harness.instruction_path.rsplit("/", 1)[0]}
         if self.harness.system_prompt:
             dirs.add(self.harness.system_prompt_path.rsplit("/", 1)[0])
@@ -273,10 +274,56 @@ class ComposableEnv(CliAgentEnv):
         await self.sandbox_client.execute_command(
             sandbox_id, f"mkdir -p {mkdir_args}", timeout=self.timeouts.mkdir
         )
-        await self._upload_harness_inputs(sandbox_id, state)
-        await self._after_harness_inputs_uploaded(state)
-        await self._install_agent(sandbox_id)
-        await self._run_post_install(sandbox_id)
+        await self._run_setup_step(
+            state,
+            "upload_harness_inputs",
+            self._upload_harness_inputs,
+            sandbox_id,
+            state,
+        )
+        await self._run_setup_step(
+            state,
+            "after_harness_inputs_uploaded",
+            self._after_harness_inputs_uploaded,
+            state,
+        )
+        await self._run_setup_step(
+            state, "agent_install", self._install_agent, sandbox_id
+        )
+        await self._run_setup_step(
+            state, "post_install", self._run_post_install, sandbox_id
+        )
+
+    async def _run_setup_step(
+        self,
+        state: State,
+        step: str,
+        func: Any,
+        *args: Any,
+    ) -> Any:
+        start = time.perf_counter()
+        log_rollout_event(self.logger, "setup_step_started", state, step=step)
+        try:
+            result = await func(*args)
+        except BaseException:
+            log_rollout_event(
+                self.logger,
+                "setup_step_finished",
+                state,
+                step=step,
+                status="error",
+                elapsed_s=time.perf_counter() - start,
+            )
+            raise
+        log_rollout_event(
+            self.logger,
+            "setup_step_finished",
+            state,
+            step=step,
+            status="ok",
+            elapsed_s=time.perf_counter() - start,
+        )
+        return result
 
     async def post_rollout(self, state: State) -> None:
         """Collect agent logs and harness metrics after the agent finishes.

--- a/verifiers/envs/experimental/composable/composable_env.py
+++ b/verifiers/envs/experimental/composable/composable_env.py
@@ -50,10 +50,18 @@ import verifiers as vf
 from verifiers.envs.experimental.cli_agent_env import CliAgentEnv
 from verifiers.envs.experimental.composable.harness import Harness
 from verifiers.envs.experimental.composable.task import TaskSet
-from verifiers.envs.experimental.sandbox_mixin import log_rollout_event
+from verifiers.envs.experimental.sandbox_mixin import (
+    format_rollout_log_event,
+    log_rollout_event,
+)
 from verifiers.envs.experimental.utils.file_locks import shared_path_lock
 from verifiers.envs.tool_env import ToolMonitorRubric
 from verifiers.types import State, TrajectoryStep
+from verifiers.utils.failure_utils import (
+    FAILURE_ORIGIN_SANDBOX,
+    FAILURE_REASON_SANDBOX_SETUP_FAILED,
+    ensure_rollout_failure,
+)
 from verifiers.utils.logging_utils import print_size, print_time
 
 logger = logging.getLogger(__name__)
@@ -305,7 +313,22 @@ class ComposableEnv(CliAgentEnv):
         log_rollout_event(self.logger, "setup_step_started", state, step=step)
         try:
             result = await func(*args)
-        except BaseException:
+        except BaseException as e:
+            if not isinstance(e, asyncio.CancelledError):
+                ensure_rollout_failure(
+                    state,
+                    reason=FAILURE_REASON_SANDBOX_SETUP_FAILED,
+                    origin=FAILURE_ORIGIN_SANDBOX,
+                    error=e,
+                )
+                self.logger.error(
+                    format_rollout_log_event(
+                        "setup_failed",
+                        state,
+                        step=step,
+                        error=f"{type(e).__name__}: {str(e)[:500]}",
+                    )
+                )
             log_rollout_event(
                 self.logger,
                 "setup_step_finished",
@@ -408,6 +431,34 @@ class ComposableEnv(CliAgentEnv):
             kwargs["env"] = self.install_env
         return kwargs
 
+    def get_failure_log_paths(self, state: State) -> dict[str, str]:
+        paths = super().get_failure_log_paths(state)
+        if self.harness.log_path:
+            paths["agent_log"] = self.harness.log_path
+        return paths
+
+    @staticmethod
+    def _wrap_observed_setup_command(command: str, step: str) -> str:
+        """Wrap setup commands with a grep-friendly trace log in the sandbox."""
+        one_line = " ".join(command.split())
+        if len(one_line) > 1000:
+            one_line = one_line[:1000] + "...<truncated>"
+        script = f"""\
+set +e
+{{
+  echo "event=observed_command_started step={shlex.quote(step)} command={shlex.quote(one_line)}"
+  bash -lc {shlex.quote(command)}
+  exit_code="$?"
+  if [ "$exit_code" -ne 0 ]; then
+    echo "event=setup_failed step={shlex.quote(step)} exit_code=$exit_code"
+  fi
+  echo "event=observed_command_finished step={shlex.quote(step)} exit_code=$exit_code"
+  exit "$exit_code"
+}} 2>&1 | tee -a /tmp/vf_observed_command.log
+exit "${{PIPESTATUS[0]}}"
+"""
+        return f"bash -lc {shlex.quote(script)}"
+
     async def _install_agent(self, sandbox_id: str) -> None:
         """Install the agent inside the sandbox when an install script is present."""
         if self.harness.install_script:
@@ -415,7 +466,9 @@ class ComposableEnv(CliAgentEnv):
             install_start = time.perf_counter()
             result = await self.sandbox_client.execute_command(
                 sandbox_id,
-                self.harness.install_script,
+                self._wrap_observed_setup_command(
+                    self.harness.install_script, "agent_install"
+                ),
                 **self._get_install_execute_kwargs(),
             )
             elapsed = time.perf_counter() - install_start
@@ -446,7 +499,9 @@ class ComposableEnv(CliAgentEnv):
             self.logger.debug(f"Running post-install script in sandbox {sandbox_id}")
             result = await self.sandbox_client.execute_command(
                 sandbox_id,
-                self.harness.post_install_script,
+                self._wrap_observed_setup_command(
+                    self.harness.post_install_script, "post_install"
+                ),
                 **self._get_install_execute_kwargs(),
             )
             if result.exit_code != 0:

--- a/verifiers/envs/experimental/composable/harnesses/opencode.py
+++ b/verifiers/envs/experimental/composable/harnesses/opencode.py
@@ -60,18 +60,19 @@ def build_install_script(
     # bug #1876035. apt's default retries is 0, so one bad fetch fails the rollout.
     return f"""\
 set -e
+: > /tmp/install_progress.log
 run_setup_step() {{
   name="$1"
   shift
   start="$(date +%s)"
-  echo "[setup] start $name"
+  echo "[setup] start $name" | tee -a /tmp/install_progress.log
   set +e
   eval "$*"
   exit_code="$?"
   set -e
   end="$(date +%s)"
   elapsed_s="$((end - start))"
-  echo "[setup] end $name exit=$exit_code elapsed_s=$elapsed_s"
+  echo "[setup] end $name exit=$exit_code elapsed_s=$elapsed_s" | tee -a /tmp/install_progress.log
   return "$exit_code"
 }}
 

--- a/verifiers/envs/experimental/composable/harnesses/opencode.py
+++ b/verifiers/envs/experimental/composable/harnesses/opencode.py
@@ -50,7 +50,8 @@ def build_install_script(
 ) -> str:
     """Build the shell script that installs OpenCode in a sandbox."""
     rg_install = (
-        "apt-get -o Acquire::Retries=3 install -y -qq ripgrep > /dev/null 2>&1 || true"
+        'run_setup_step "ripgrep_install" '
+        '"apt-get -o Acquire::Retries=3 install -y -qq ripgrep > /dev/null 2>&1 || true"'
         if install_ripgrep
         else ""
     )
@@ -59,27 +60,42 @@ def build_install_script(
     # bug #1876035. apt's default retries is 0, so one bad fetch fails the rollout.
     return f"""\
 set -e
-apt-get -o Acquire::Retries=3 update -qq && apt-get -o Acquire::Retries=3 install -y -qq curl tar > /dev/null 2>&1
+run_setup_step() {{
+  name="$1"
+  shift
+  start="$(date +%s)"
+  echo "[setup] start $name"
+  set +e
+  eval "$*"
+  exit_code="$?"
+  set -e
+  end="$(date +%s)"
+  elapsed_s="$((end - start))"
+  echo "[setup] end $name exit=$exit_code elapsed_s=$elapsed_s"
+  return "$exit_code"
+}}
+
+run_setup_step "apt_dependencies" "apt-get -o Acquire::Retries=3 update -qq && apt-get -o Acquire::Retries=3 install -y -qq curl tar > /dev/null 2>&1"
 {rg_install}
 
-case "$(uname -m)" in
+run_setup_step "detect_arch" 'case "$(uname -m)" in
   x86_64) OPENCODE_ARCH=x64 ;;
   aarch64|arm64) OPENCODE_ARCH=arm64 ;;
   *) echo "Unsupported architecture: $(uname -m)"; exit 1 ;;
-esac
+esac'
 
 OPENCODE_ASSET="opencode-linux-$OPENCODE_ARCH.tar.gz"
 OPENCODE_RELEASE_URL="https://github.com/{DEFAULT_RELEASE_REPO}/releases/download/v{DEFAULT_RELEASE_VERSION}/$OPENCODE_ASSET"
 
 mkdir -p "$HOME/.opencode/bin"
 if [ -x "$HOME/.opencode/bin/opencode" ]; then
-  echo "OpenCode already installed, skipping download"
+  echo "OpenCode already installed, skipping download" | tee -a /tmp/install_progress.log
 else
-  curl -fsSL "$OPENCODE_RELEASE_URL" -o /tmp/opencode.tar.gz
-  tar -xzf /tmp/opencode.tar.gz -C /tmp
-  install -m 755 /tmp/opencode "$HOME/.opencode/bin/opencode"
+  run_setup_step "download_opencode" 'curl -fsSL "$OPENCODE_RELEASE_URL" -o /tmp/opencode.tar.gz'
+  run_setup_step "extract_opencode" "tar -xzf /tmp/opencode.tar.gz -C /tmp"
+  run_setup_step "install_opencode" 'install -m 755 /tmp/opencode "$HOME/.opencode/bin/opencode"'
   rm -f /tmp/opencode.tar.gz /tmp/opencode
-  echo "OpenCode installed successfully"
+  echo "OpenCode installed successfully" | tee -a /tmp/install_progress.log
 fi
 """
 

--- a/verifiers/envs/experimental/composable/tasksets/swe/swe_rebench_v2/taskset.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/swe_rebench_v2/taskset.py
@@ -24,16 +24,21 @@ Workdir is ``/{repo-name}`` (second half of ``owner/repo``) — *not*
 ``/testbed`` — because upstream eval scripts cd to that path.
 """
 
+from __future__ import annotations
+
+import hashlib
 import json
 import logging
 import re
 import tempfile
+import time
 from pathlib import Path
 from typing import Any
 
 import verifiers as vf
 from datasets import load_dataset
 from verifiers.envs.experimental.composable import SandboxSpec, SandboxTaskSet
+from verifiers.envs.experimental.sandbox_mixin import log_rollout_event
 
 from verifiers.envs.experimental.composable.tasksets.swe.shared.test_patch import (
     revert_and_reapply_test_patch,
@@ -45,6 +50,8 @@ logger = logging.getLogger(__name__)
 
 
 DATASET_NAME = "nebius/SWE-rebench-V2"
+PATCH_OUTPUT_LIMIT = 800
+PATCH_PREVIEW_LIMIT = 500
 
 
 # Broad PATH covering all known SWE-rebench-V2 language toolchains.
@@ -106,6 +113,55 @@ def _extract_install_config(info: dict) -> dict:
     if isinstance(cfg, dict):
         return cfg
     raise ValueError("install_config missing or wrong type")
+
+
+def _normalize_test_cmds(test_cmd: Any) -> list[str]:
+    if isinstance(test_cmd, str):
+        cmds = [test_cmd]
+    elif isinstance(test_cmd, list):
+        cmds = [c for c in test_cmd if isinstance(c, str) and c.strip()]
+    else:
+        raise ValueError(f"install_config.test_cmd unsupported type: {type(test_cmd)}")
+    if not cmds:
+        raise ValueError("install_config.test_cmd is empty")
+    return cmds
+
+
+def _truncate_context(value: str | None, limit: int = PATCH_OUTPUT_LIMIT) -> str:
+    if not value:
+        return "<empty>"
+    if len(value) <= limit:
+        return value
+    return value[:limit] + f"... <truncated {len(value) - limit} chars>"
+
+
+def _patch_preview(patch: str) -> str:
+    return _truncate_context(patch, PATCH_PREVIEW_LIMIT)
+
+
+def _patch_failure_message(
+    label: str,
+    patch: str,
+    attempts: list[tuple[str, str, str, Any]],
+) -> str:
+    patch_bytes = patch.encode("utf-8")
+    lines = [
+        f"{label} apply failed",
+        f"patch_sha256={hashlib.sha256(patch_bytes).hexdigest()}",
+        f"patch_size={len(patch_bytes)}",
+        f"patch_preview={_patch_preview(patch)!r}",
+    ]
+    for name, command, workdir, result in attempts:
+        lines.extend(
+            [
+                f"{name}_command={command!r}",
+                f"{name}_working_dir={workdir!r}",
+                f"{name}_exit_code={getattr(result, 'exit_code', None)}",
+                f"{name}_stdout={_truncate_context(getattr(result, 'stdout', None))!r}",
+                f"{name}_stderr={_truncate_context(getattr(result, 'stderr', None))!r}",
+            ]
+        )
+    return "\n".join(lines)
 
 
 def _build_eval_script(test_cmds: list[str], workdir: str) -> str:
@@ -289,8 +345,19 @@ class SWERebenchV2TaskSet(SandboxTaskSet):
             "&& install -m 755 /tmp/ripgrep-${V}-x86_64-unknown-linux-musl/rg /usr/local/bin/rg; "
             "}"
         )
+        rg_start = time.perf_counter()
+        log_rollout_event(logger, "setup_step_started", state, step="ripgrep_install")
         result = await sandbox_client.execute_command(
             sandbox_id, rg_install, timeout=120
+        )
+        log_rollout_event(
+            logger,
+            "setup_step_finished",
+            state,
+            step="ripgrep_install",
+            status="ok" if result.exit_code == 0 else "error",
+            exit_code=result.exit_code,
+            elapsed_s=time.perf_counter() - rg_start,
         )
         if result.exit_code != 0:
             logger.warning(
@@ -301,7 +368,12 @@ class SWERebenchV2TaskSet(SandboxTaskSet):
         test_patch = (info or {}).get("test_patch") or ""
         if test_patch.strip():
             await self._apply_patch_file(
-                sandbox_client, sandbox_id, workdir, test_patch, "test_patch"
+                sandbox_client,
+                sandbox_id,
+                workdir,
+                test_patch,
+                "test_patch",
+                state=state,
             )
 
     async def _run_tests(
@@ -411,7 +483,12 @@ class SWERebenchV2TaskSet(SandboxTaskSet):
         workdir: str,
         patch: str,
         label: str,
+        state: dict | None = None,
     ) -> None:
+        context_state = state or {"sandbox_id": sandbox_id}
+        patch_start = time.perf_counter()
+        patch_succeeded = False
+        log_rollout_event(logger, "setup_step_started", context_state, step=label)
         with tempfile.NamedTemporaryFile(suffix=".patch", mode="w", delete=False) as f:
             f.write(patch)
             f.flush()
@@ -419,32 +496,89 @@ class SWERebenchV2TaskSet(SandboxTaskSet):
 
         remote_path = f"/tmp/{label}.patch"
         try:
-            await sandbox_client.upload_file(sandbox_id, remote_path, local_path)
-        finally:
-            Path(local_path).unlink(missing_ok=True)
+            try:
+                await sandbox_client.upload_file(sandbox_id, remote_path, local_path)
+            finally:
+                Path(local_path).unlink(missing_ok=True)
 
-        # Upstream eval.py uses ``git apply -v --3way --recount
-        # --ignore-space-change --whitespace=nowarn``. We follow the same
-        # flags; fall back to ``patch --fuzz=5`` if git apply rejects.
-        git_cmd = (
-            "git apply -v --3way --recount --ignore-space-change "
-            f"--whitespace=nowarn {remote_path}"
-        )
-        result = await sandbox_client.execute_command(
-            sandbox_id, git_cmd, working_dir=workdir, timeout=60
-        )
-        if result.exit_code != 0:
-            result = await sandbox_client.execute_command(
+            # Upstream eval.py uses ``git apply -v --3way --recount
+            # --ignore-space-change --whitespace=nowarn``. We follow the same
+            # flags; fall back to ``patch --fuzz=5`` if git apply rejects.
+            git_cmd = (
+                "git apply -v --3way --recount --ignore-space-change "
+                f"--whitespace=nowarn {remote_path}"
+            )
+            git_start = time.perf_counter()
+            log_rollout_event(
+                logger,
+                "setup_step_started",
+                context_state,
+                step=f"{label}_git_apply",
+                command=git_cmd,
+            )
+            git_result = await sandbox_client.execute_command(
+                sandbox_id, git_cmd, working_dir=workdir, timeout=60
+            )
+            log_rollout_event(
+                logger,
+                "setup_step_finished",
+                context_state,
+                step=f"{label}_git_apply",
+                status="ok" if git_result.exit_code == 0 else "error",
+                exit_code=git_result.exit_code,
+                elapsed_s=time.perf_counter() - git_start,
+            )
+            if git_result.exit_code == 0:
+                patch_succeeded = True
+                return
+
+            fallback_cmd = f"patch --fuzz=5 -p1 -i {remote_path}"
+            fallback_start = time.perf_counter()
+            log_rollout_event(
+                logger,
+                "setup_step_started",
+                context_state,
+                step=f"{label}_fallback_patch",
+                command=fallback_cmd,
+            )
+            fallback_result = await sandbox_client.execute_command(
                 sandbox_id,
-                f"patch --fuzz=5 -p1 -i {remote_path}",
+                fallback_cmd,
                 working_dir=workdir,
                 timeout=60,
             )
-            if result.exit_code != 0:
-                stderr = (result.stderr or "")[:500]
-                raise RuntimeError(
-                    f"{label} apply failed: exit_code={result.exit_code} stderr={stderr}"
+            log_rollout_event(
+                logger,
+                "setup_step_finished",
+                context_state,
+                step=f"{label}_fallback_patch",
+                status="ok" if fallback_result.exit_code == 0 else "error",
+                exit_code=fallback_result.exit_code,
+                elapsed_s=time.perf_counter() - fallback_start,
+            )
+            if fallback_result.exit_code == 0:
+                patch_succeeded = True
+                return
+
+            raise RuntimeError(
+                _patch_failure_message(
+                    label,
+                    patch,
+                    [
+                        ("git_apply", git_cmd, workdir, git_result),
+                        ("fallback_patch", fallback_cmd, workdir, fallback_result),
+                    ],
                 )
+            )
+        finally:
+            log_rollout_event(
+                logger,
+                "setup_step_finished",
+                context_state,
+                step=label,
+                status="ok" if patch_succeeded else "error",
+                elapsed_s=time.perf_counter() - patch_start,
+            )
 
     async def _apply_gold_patch(
         self, sandbox_client: Any, sandbox_id: str, state: dict
@@ -454,7 +588,9 @@ class SWERebenchV2TaskSet(SandboxTaskSet):
         if not patch or not patch.strip():
             raise RuntimeError("No gold patch in info['patch']")
         workdir = _repo_workdir(info["repo"])
-        await self._apply_patch_file(sandbox_client, sandbox_id, workdir, patch, "gold")
+        await self._apply_patch_file(
+            sandbox_client, sandbox_id, workdir, patch, "gold", state=state
+        )
 
     def get_rubric(self):
         return SWERebenchV2Rubric(self)

--- a/verifiers/envs/experimental/composable/tasksets/swe/swe_rebench_v2/taskset.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/swe_rebench_v2/taskset.py
@@ -24,8 +24,6 @@ Workdir is ``/{repo-name}`` (second half of ``owner/repo``) — *not*
 ``/testbed`` — because upstream eval scripts cd to that path.
 """
 
-from __future__ import annotations
-
 import hashlib
 import json
 import logging

--- a/verifiers/envs/experimental/opencode_env.py
+++ b/verifiers/envs/experimental/opencode_env.py
@@ -222,6 +222,11 @@ class OpenCodeEnv(CliAgentEnv):
     def remote_logs_path(self) -> str:
         return f"{self.asset_dir}/logs.txt"
 
+    def get_failure_log_paths(self, state: vf.State) -> dict[str, str]:
+        paths = super().get_failure_log_paths(state)
+        paths["agent_log"] = self.remote_logs_path
+        return paths
+
     async def post_sandbox_setup(self, state: vf.State) -> None:
         """Upload prompt and optional system prompt after sandbox creation."""
         sandbox_id = state.get("sandbox_id")
@@ -341,7 +346,7 @@ class OpenCodeEnv(CliAgentEnv):
                 num_turns = len(state.get("trajectory", []))
                 agent_error = state.get("agent_exit_code", 0) != 0
                 if (agent_error or num_turns == 0) and agent_logs:
-                    logger.warning(
+                    logger.debug(
                         f"Agent logs (example_id={state.get('example_id')}, "
                         f"exit_code={state.get('agent_exit_code')}, turns={num_turns}):\n{agent_logs}"
                     )

--- a/verifiers/envs/experimental/sandbox_mixin.py
+++ b/verifiers/envs/experimental/sandbox_mixin.py
@@ -49,6 +49,40 @@ class SandboxNotReadyError(vf.SandboxError): ...
 class SandboxSetupError(vf.SandboxError): ...
 
 
+def format_rollout_log_event(
+    event: str,
+    state: dict[str, Any] | None = None,
+    **fields: Any,
+) -> str:
+    """Format rollout lifecycle logs with stable context fields."""
+    state = state or {}
+    info = state.get("info") or {}
+    instance_id = info.get("instance_id") if isinstance(info, dict) else None
+    parts: list[str] = [f"event={event}"]
+    context = {
+        "rollout_id": state.get("rollout_id"),
+        "example_id": state.get("example_id"),
+        "instance_id": instance_id,
+        "sandbox_id": state.get("sandbox_id"),
+    }
+    for key, value in {**context, **fields}.items():
+        if value is None:
+            continue
+        if isinstance(value, float):
+            value = f"{value:.3f}"
+        parts.append(f"{key}={value}")
+    return " | ".join(parts)
+
+
+def log_rollout_event(
+    logger: logging.Logger,
+    event: str,
+    state: dict[str, Any] | None = None,
+    **fields: Any,
+) -> None:
+    logger.info(format_rollout_log_event(event, state, **fields))
+
+
 @dataclass(frozen=True)
 class SandboxTimeouts:
     """Per-operation HTTP timeouts (seconds) for sandbox client calls.
@@ -229,6 +263,8 @@ class SandboxMixin:
             SandboxNotReadyError: If sandbox fails to become ready.
             SandboxSetupError: If post_sandbox_setup hook fails.
         """
+        create_start = time.perf_counter()
+        log_rollout_event(self.logger, "sandbox_create_started", state)
         if self.sandbox_creation_rate_limiter is not None:
             await self.sandbox_creation_rate_limiter.acquire()
 
@@ -271,6 +307,12 @@ class SandboxMixin:
             raise SandboxNotReadyError(
                 f"Sandbox {sandbox.id} failed to become ready: {e}"
             ) from e
+        log_rollout_event(
+            self.logger,
+            "sandbox_created",
+            state,
+            elapsed_s=time.perf_counter() - create_start,
+        )
 
         try:
             self.logger.debug(f"Running post-sandbox setup in sandbox {sandbox.id}")

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -399,6 +399,15 @@ class ErrorData(TypedDict):
     error_chain_str: str
 
 
+class FailureInfo(TypedDict):
+    reason: str
+    origin: str
+    error_type: str | None
+    root_error_type: str | None
+    message: str
+    logs: dict[str, str]
+
+
 class RolloutOutput(dict):
     """Serialized output from a rollout (mirrors RolloutInput).
 
@@ -408,8 +417,8 @@ class RolloutOutput(dict):
 
     Required fields: example_id, prompt, completion, reward, timing,
                      is_completed, is_truncated, metrics
-    Optional fields: answer, info, error, stop_condition, trajectory, tool_defs,
-                     token_usage
+    Optional fields: answer, info, error, failure, stop_condition, trajectory,
+                     tool_defs, token_usage
     Additional fields: arbitrary serializable state_columns
     """
 
@@ -426,6 +435,7 @@ class RolloutOutput(dict):
     answer: str
     info: Info
     error: ErrorData | None
+    failure: FailureInfo | None
     stop_condition: str | None
     trajectory: list["TrajectoryStep"]
     tool_defs: list[Tool]

--- a/verifiers/utils/failure_utils.py
+++ b/verifiers/utils/failure_utils.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+from typing import Any, TypedDict
+
+from verifiers.errors import ModelError, SandboxError, TunnelError
+
+
+class RolloutFailure(TypedDict):
+    reason: str
+    origin: str
+    error_type: str | None
+    root_error_type: str | None
+    message: str
+    logs: dict[str, str]
+
+
+FAILURE_REASON_AGENT_NONZERO_EXIT = "agent_nonzero_exit"
+FAILURE_REASON_AGENT_POLL_FAILED = "agent_poll_failed"
+FAILURE_REASON_AGENT_EMPTY_TRAJECTORY = "agent_empty_trajectory"
+FAILURE_REASON_ROLLOUT_TIMEOUT = "rollout_timeout"
+FAILURE_REASON_SANDBOX_OOM = "sandbox_oom"
+FAILURE_REASON_SANDBOX_TIMEOUT = "sandbox_timeout"
+FAILURE_REASON_SANDBOX_COMMAND_FAILED = "sandbox_command_failed"
+FAILURE_REASON_SANDBOX_SETUP_FAILED = "sandbox_setup_failed"
+FAILURE_REASON_TUNNEL_ERROR = "tunnel_error"
+FAILURE_REASON_STREAM_INTERRUPTED = "stream_interrupted"
+FAILURE_REASON_MODEL_ERROR = "model_error"
+FAILURE_REASON_ENV_SERVER_ERROR = "env_server_error"
+FAILURE_REASON_UNKNOWN = "unknown"
+
+FAILURE_ORIGIN_AGENT = "agent"
+FAILURE_ORIGIN_SANDBOX = "sandbox"
+FAILURE_ORIGIN_TUNNEL = "tunnel"
+FAILURE_ORIGIN_MODEL = "model"
+FAILURE_ORIGIN_ENV_SERVER = "env_server"
+FAILURE_ORIGIN_ROLLOUT = "rollout"
+FAILURE_ORIGIN_UNKNOWN = "unknown"
+
+DEFAULT_FAILURE_MESSAGE_CHARS = 2000
+DEFAULT_FAILURE_LOG_CHARS = 12000
+
+
+def tail_text(value: Any, max_chars: int = DEFAULT_FAILURE_LOG_CHARS) -> str:
+    """Return a bounded string tail for logs and diagnostic messages."""
+    text = "" if value is None else str(value)
+    if len(text) <= max_chars:
+        return text
+    return f"...<truncated {len(text) - max_chars} chars>\n{text[-max_chars:]}"
+
+
+def _error_chain(error: BaseException | None) -> list[BaseException]:
+    chain: list[BaseException] = []
+    seen: set[int] = set()
+    while error is not None and id(error) not in seen:
+        seen.add(id(error))
+        chain.append(error)
+        error = error.__cause__
+    return chain
+
+
+def _chain_type_names(error: BaseException | None) -> list[str]:
+    return [type(item).__name__ for item in _error_chain(error)]
+
+
+def _has_chain_type(error: BaseException | None, type_name: str) -> bool:
+    return type_name in _chain_type_names(error)
+
+
+def classify_rollout_failure(
+    state: dict[str, Any],
+    error: BaseException | None = None,
+    *,
+    detect_empty_trajectory: bool = True,
+) -> tuple[str, str]:
+    """Classify a rollout failure into a dashboard-oriented reason/origin pair."""
+    error = state.get("error") if error is None else error
+
+    if state.get("timed_out"):
+        return FAILURE_REASON_ROLLOUT_TIMEOUT, FAILURE_ORIGIN_ROLLOUT
+    if state.get("sandbox_oom"):
+        return FAILURE_REASON_SANDBOX_OOM, FAILURE_ORIGIN_SANDBOX
+    if state.get("sandbox_timeout"):
+        return FAILURE_REASON_SANDBOX_TIMEOUT, FAILURE_ORIGIN_SANDBOX
+
+    if error is not None:
+        if _has_chain_type(error, "StreamInterrupted"):
+            return FAILURE_REASON_STREAM_INTERRUPTED, FAILURE_ORIGIN_TUNNEL
+        if isinstance(error, TunnelError) or _has_chain_type(error, "TunnelError"):
+            return FAILURE_REASON_TUNNEL_ERROR, FAILURE_ORIGIN_TUNNEL
+        if isinstance(error, ModelError) or _has_chain_type(error, "ModelError"):
+            return FAILURE_REASON_MODEL_ERROR, FAILURE_ORIGIN_MODEL
+        if state.get("agent_poll_failed") or _has_chain_type(error, "AgentPollError"):
+            return FAILURE_REASON_AGENT_POLL_FAILED, FAILURE_ORIGIN_AGENT
+        if _has_chain_type(error, "AgentError"):
+            agent_exit_code = state.get("agent_exit_code")
+            if agent_exit_code is not None and agent_exit_code != 0:
+                return FAILURE_REASON_AGENT_NONZERO_EXIT, FAILURE_ORIGIN_AGENT
+            return FAILURE_REASON_AGENT_POLL_FAILED, FAILURE_ORIGIN_AGENT
+        if _has_chain_type(error, "SandboxSetupError"):
+            return FAILURE_REASON_SANDBOX_SETUP_FAILED, FAILURE_ORIGIN_SANDBOX
+        if isinstance(error, SandboxError) or _has_chain_type(error, "SandboxError"):
+            return FAILURE_REASON_SANDBOX_COMMAND_FAILED, FAILURE_ORIGIN_SANDBOX
+
+    agent_exit_code = state.get("agent_exit_code")
+    if agent_exit_code is not None and agent_exit_code != 0:
+        return FAILURE_REASON_AGENT_NONZERO_EXIT, FAILURE_ORIGIN_AGENT
+
+    trajectory = state.get("trajectory")
+    if (
+        detect_empty_trajectory
+        and isinstance(trajectory, list)
+        and len(trajectory) == 0
+    ):
+        return FAILURE_REASON_AGENT_EMPTY_TRAJECTORY, FAILURE_ORIGIN_AGENT
+
+    return FAILURE_REASON_UNKNOWN, FAILURE_ORIGIN_UNKNOWN
+
+
+def make_rollout_failure(
+    state: dict[str, Any],
+    *,
+    reason: str | None = None,
+    origin: str | None = None,
+    error: BaseException | None = None,
+    message: str | None = None,
+    logs: dict[str, str] | None = None,
+    detect_empty_trajectory: bool = True,
+) -> RolloutFailure:
+    """Build a JSON-serializable rollout failure payload."""
+    error = state.get("error") if error is None else error
+    classified_reason, classified_origin = classify_rollout_failure(
+        state, error, detect_empty_trajectory=detect_empty_trajectory
+    )
+    reason = reason or classified_reason
+    origin = origin or classified_origin
+    chain = _error_chain(error)
+    error_type = type(error).__name__ if error is not None else None
+    root_error_type = type(chain[-1]).__name__ if chain else None
+    if message is None:
+        message = str(error) if error is not None else reason
+    return {
+        "reason": reason,
+        "origin": origin,
+        "error_type": error_type,
+        "root_error_type": root_error_type,
+        "message": tail_text(message, DEFAULT_FAILURE_MESSAGE_CHARS),
+        "logs": {str(k): tail_text(v) for k, v in (logs or {}).items()},
+    }
+
+
+def normalize_rollout_failure(value: Any) -> RolloutFailure | None:
+    """Normalize an existing failure-like mapping into the public payload shape."""
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        return None
+    logs = value.get("logs")
+    return {
+        "reason": str(value.get("reason") or FAILURE_REASON_UNKNOWN),
+        "origin": str(value.get("origin") or FAILURE_ORIGIN_UNKNOWN),
+        "error_type": value.get("error_type"),
+        "root_error_type": value.get("root_error_type"),
+        "message": str(value.get("message") or ""),
+        "logs": {
+            str(k): tail_text(v)
+            for k, v in (logs if isinstance(logs, dict) else {}).items()
+        },
+    }
+
+
+def ensure_rollout_failure(
+    state: dict[str, Any],
+    *,
+    reason: str | None = None,
+    origin: str | None = None,
+    error: BaseException | None = None,
+    message: str | None = None,
+    logs: dict[str, str] | None = None,
+    detect_empty_trajectory: bool = True,
+    overwrite: bool = False,
+) -> RolloutFailure | None:
+    """Set and return state['failure'] when the state has a classified failure."""
+    existing = normalize_rollout_failure(state.get("failure"))
+    if existing is not None and not overwrite:
+        if logs:
+            existing["logs"].update({str(k): tail_text(v) for k, v in logs.items()})
+            state["failure"] = existing
+        return existing
+
+    error = state.get("error") if error is None else error
+    should_create = (
+        error is not None
+        or state.get("timed_out")
+        or state.get("sandbox_oom")
+        or state.get("sandbox_timeout")
+    )
+    trajectory = state.get("trajectory")
+    should_create = should_create or (
+        detect_empty_trajectory
+        and isinstance(trajectory, list)
+        and len(trajectory) == 0
+    )
+    should_create = should_create or reason is not None or origin is not None
+    if not should_create:
+        return None
+
+    failure = make_rollout_failure(
+        state,
+        reason=reason,
+        origin=origin,
+        error=error,
+        message=message,
+        logs=logs,
+        detect_empty_trajectory=detect_empty_trajectory,
+    )
+    state["failure"] = failure
+    return failure
+
+
+def add_failure_logs(
+    state: dict[str, Any],
+    logs: dict[str, str],
+    *,
+    detect_empty_trajectory: bool = True,
+) -> RolloutFailure | None:
+    """Merge bounded diagnostic logs into state['failure'] if a failure exists."""
+    if not logs:
+        return normalize_rollout_failure(state.get("failure"))
+    failure = ensure_rollout_failure(
+        state, logs=logs, detect_empty_trajectory=detect_empty_trajectory
+    )
+    if failure is None:
+        return None
+    failure["logs"].update({str(k): tail_text(v) for k, v in logs.items()})
+    state["failure"] = failure
+    return failure

--- a/verifiers/utils/failure_utils.py
+++ b/verifiers/utils/failure_utils.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any, TypedDict
 
 from verifiers.errors import ModelError, SandboxError, TunnelError

--- a/verifiers/utils/save_utils.py
+++ b/verifiers/utils/save_utils.py
@@ -25,6 +25,7 @@ from verifiers.types import (
     Tool,
 )
 from verifiers.utils.error_utils import error_data, validate_error_data
+from verifiers.utils.failure_utils import ensure_rollout_failure
 from verifiers.utils.message_utils import (
     sanitize_tool_calls,
     serialize_messages_for_output,
@@ -289,6 +290,9 @@ def state_to_output(
             output["error"] = validate_error_data(error)
         output["error_chain"] = output["error"]["error_chain_repr"]
         output["long_error_chain"] = output["error"]["error_chain_str"]
+    failure = ensure_rollout_failure(state, detect_empty_trajectory=False)
+    if failure is not None:
+        output["failure"] = failure
     # only include optional fields if non-empty
     if "answer" in output and not output["answer"]:
         output.pop("answer")


### PR DESCRIPTION
## Summary
- Add a serialized `failure` rollout payload with stable `reason`, `origin`, error type metadata, message, and bounded diagnostic logs.
- Serialize `failure` from `state_to_output()` while preserving the existing `error`, `error_chain`, and `long_error_chain` fields.
- Redefine CLI-agent monitor metrics so `agent_error` means `failure.origin == "agent"`, while `agent_nonzero_exit` preserves the old narrow non-zero-exit meaning and `agent_poll_failed` tracks background polling/read failures.
- Classify sandbox, tunnel, model, and rollout-timeout failures away from `agent_error`; keep `sandbox_oom`, `sandbox_timeout`, and `agent_timeout` metrics.
- Collect best-effort failure diagnostics before sandbox deletion: agent stdout/stderr tails, harness/agent log file tails, `/tmp/vf_observed_command.log`, and `/tmp/install_progress.log`.
- Wrap composable agent install/post-install shell commands with grep-friendly observed-command traces and failure lines without masking the original setup failure.
- Keep rollout logs grep-friendly with `event=... key=value` messages for aborts, finishes, empty trajectories, setup failures, and agent polling failures.

Companion scheduler metrics PR: PrimeIntellect-ai/prime-rl#2411.

## Compatibility Note
- `agent_error` is intentionally broadened to all agent-origin failures.
- `agent_nonzero_exit` preserves the previous narrow non-zero process exit signal.

## Validation
- `uv run ruff check verifiers/utils/failure_utils.py verifiers/envs/experimental/cli_agent_env.py verifiers/envs/experimental/composable/composable_env.py verifiers/envs/experimental/composable/harnesses/opencode.py verifiers/envs/experimental/opencode_env.py verifiers/utils/save_utils.py verifiers/types.py verifiers/envs/environment.py tests/test_cli_agent_env.py tests/test_swe_rollout_observability.py`
- `python -m py_compile verifiers/utils/failure_utils.py verifiers/envs/experimental/cli_agent_env.py verifiers/envs/experimental/composable/composable_env.py verifiers/envs/experimental/opencode_env.py verifiers/utils/save_utils.py verifiers/types.py verifiers/envs/environment.py`
- `uv run pytest tests/test_cli_agent_env.py tests/test_swe_rollout_observability.py tests/test_environment_extra.py::test_state_to_output_uses_state_usage_not_trajectory tests/test_save_utils.py`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add structured failure observability and lifecycle logging to SWE rollout pipeline
> - Introduces `FailureInfo` and `RolloutFailure` typed structs with a central `failure_utils` module to classify, build, and attach structured failure data to rollout state, covering reasons like `agent_nonzero_exit` and `agent_poll_failed`.
> - Adds new `CliAgentMonitorRubric` cleanup hook (`log_rollout_finished`) that emits structured lifecycle events (`rollout_finished`, `rollout_aborted`, `rollout_empty_trajectory`) with timing breakdowns and tool usage counts.
> - Wraps sandbox setup steps, agent install, and post-install scripts with structured start/finish log events and elapsed timing; shell commands are traced via `_wrap_observed_setup_command` which writes to `/tmp/vf_observed_command.log`.
> - Adds `collect_failure_diagnostics` and `get_failure_log_paths` to `CliAgentEnv` for best-effort, non-fatal collection of bounded log tails from sandbox paths and background job stdout/stderr on failure.
> - Extends `state_to_output` in `save_utils` to attach a structured `failure` object to `RolloutOutput` when a failure is detectable from state.
> - `SWERebenchV2TaskSet._apply_patch_file` now emits structured per-attempt logs and raises a detailed `RuntimeError` with bounded stdout/stderr on failure.
> - Behavioral Change: `CliAgentMonitorRubric.agent_error` metric now derives from structured failure origin rather than exit codes; `post_rollout` no longer emits the ad-hoc 'Finished rollout' log (moved to rubric cleanup).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a782d34.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->