### PR TITLE
fix(install): exempt hub package from uv exclude-newer cooldown

### DIFF
--- a/verifiers/utils/install_utils.py
+++ b/verifiers/utils/install_utils.py
@@ -158,6 +158,12 @@ def install_from_hub(env_id: str) -> bool:
 
     pkg_name = normalize_package_name(name)
 
+    # Exempt the hub package itself from any project-level `exclude-newer`
+    # cooldown: the user explicitly requested this version, and hub releases
+    # are typically newer than the cooldown window. Transitive deps still
+    # honor the cooldown.
+    exempt_cooldown = f"--exclude-newer-package={pkg_name}=false"
+
     cmd: list[str]
     if simple_index_url:
         if version and version != "latest":
@@ -167,13 +173,14 @@ def install_from_hub(env_id: str) -> bool:
         cmd = [
             *_uv_pip_cmd("install"),
             "--upgrade",
+            exempt_cooldown,
             pkg_spec,
             "--extra-index-url",
             simple_index_url,
         ]
     else:
         assert wheel_url is not None
-        cmd = [*_uv_pip_cmd("install"), "--upgrade", wheel_url]
+        cmd = [*_uv_pip_cmd("install"), "--upgrade", exempt_cooldown, wheel_url]
 
     logger.info(f"Installing {env_id}...")
     logger.debug(f"Command: {' '.join(cmd)}")


### PR DESCRIPTION
## Summary

- The 7-day `exclude-newer` cooldown introduced in #1274 filters Hub packages out of `vf-install owner/name`, since Hub releases are typically published within the cooldown window. Reproducible with `vf-install will/reverse-text` → `Because there are no versions of reverse-text ... was filtered by exclude-newer ...`.
- Fix: pass `--exclude-newer-package=<pkg>=false` to the `uv pip install` invocation in `install_from_hub`. The user explicitly requested this package, so it's exempted; transitive deps still honor the cooldown.
- Local (`-e`) and git installs are unaffected — `exclude-newer` only applies to registry resolution.

## Test plan

- [x] Reproduced the failure: `uv pip install reverse-text --extra-index-url https://hub.primeintellect.ai/will/simple/` from inside the repo failed with the cooldown error.
- [x] Verified the same command + `--exclude-newer-package=reverse-text=false` installs cleanly.
- [x] End-to-end: ran patched `install_from_hub("will/reverse-text")` against a fresh venv → success.
- [x] `uv run ruff check` / `ruff format --check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a single extra `uv pip install` flag to Hub installs without changing resolution for transitive dependencies or other install paths.
> 
> **Overview**
> Fixes Hub installs that were being blocked by `uv`'s project-level `exclude-newer` cooldown by passing `--exclude-newer-package=<hub_pkg>=false` in `install_from_hub`.
> 
> The exemption applies only to the explicitly requested Hub package (both index-based and wheel URL installs), while transitive dependencies still honor the cooldown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8c19167891ec8b7d502024c1d1191176250aa3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->