### PR TITLE
Feat/tito dynamo transport

### DIFF
--- a/packages/renderers/renderers/client.py
+++ b/packages/renderers/renderers/client.py
@@ -127,6 +127,7 @@ async def completions_request(
             "messages": [{"role": "user", "content": "(token-in mode)"}],
             "stream": False,
             "logprobs": True,
+            "stop_token_ids": stop_token_ids,
             "nvext": nvext,
         }
         if max_tokens is not None:

--- a/packages/renderers/renderers/client.py
+++ b/packages/renderers/renderers/client.py
@@ -1,7 +1,7 @@
 """Renderer-based verifiers client.
 
 All tokenization happens client-side via a Renderer:
-    messages → Renderer.render_ids() → token IDs → vLLM /v1/generate → completion tokens
+    messages → Renderer.render_ids() → token IDs → backend transport → completion tokens
     completion tokens → Renderer.parse_response() → structured message back to verifiers
 
 When a RendererPool is passed instead of a single Renderer, the sync tokenization
@@ -15,12 +15,14 @@ from __future__ import annotations
 import asyncio
 import base64
 import logging
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 import numpy as np
 from openai import AsyncOpenAI, BadRequestError
 
 from renderers.base import Message, Renderer, RendererPool, ToolSpec
+
+RendererTransport = Literal["prime_vllm_generate", "dynamo_chat_nvext"]
 
 # Logs the (per-message length, total prompt length) on every vLLM /generate
 # call at DEBUG, and the same plus the response text on a 4xx at WARNING.
@@ -45,9 +47,10 @@ async def completions_request(
     model: str,
     tools: list[ToolSpec] | None = None,
     prompt_ids: list[int] | None = None,
+    transport: RendererTransport = "prime_vllm_generate",
     **sampling_args: Any,
 ) -> dict[str, Any]:
-    """Render messages to tokens, call vLLM /v1/generate, return parsed result.
+    """Render messages to tokens, call a token-in/token-out transport.
 
     Returns a dict with: prompt_ids, completion_ids, completion_logprobs,
     content, reasoning_content, tool_calls, finish_reason, usage, routed_experts.
@@ -76,20 +79,7 @@ async def completions_request(
         prompt_ids, stop_token_ids = _prepare(renderer)
 
     # -- Build request body --
-    body: dict[str, Any] = {
-        "model": model,
-        "prompt_token_ids": prompt_ids,
-        "stop_token_ids": stop_token_ids,
-    }
-
-    # Top-level keys accepted by vLLM /generate's GenerateRequest schema. We
-    # forward anything the caller set, mirroring the OpenAI chat-completions
-    # client (which splats ``sampling_args`` into the SDK call). ``cache_salt``
-    # is set by prime-rl's orchestrator per ckpt_step to invalidate stale
-    # prefix-cache KV after each policy update — without forwarding it, vLLM
-    # silently reuses KV computed with older weights → mismatch_kl drifts up
-    # over training.
-    _GENERATE_KEYS = (
+    generate_keys = (
         "temperature",
         "top_p",
         "top_k",
@@ -102,7 +92,12 @@ async def completions_request(
         "priority",
         "cache_salt",
     )
-    for key in _GENERATE_KEYS:
+    body: dict[str, Any] = {
+        "model": model,
+        "prompt_token_ids": prompt_ids,
+        "stop_token_ids": stop_token_ids,
+    }
+    for key in generate_keys:
         if key in sampling_args and sampling_args[key] is not None:
             body[key] = sampling_args[key]
 
@@ -112,22 +107,56 @@ async def completions_request(
     if max_tokens is not None:
         body["max_tokens"] = max_tokens
 
-    # Fallback for callers using the OpenAI-SDK convention of stuffing
-    # vLLM-specific args under ``extra_body``.
     extra_body = sampling_args.get("extra_body") or {}
-    for key in _GENERATE_KEYS:
+    for key in generate_keys:
         if key not in body and key in extra_body and extra_body[key] is not None:
             body[key] = extra_body[key]
 
-    # Pass through caller-supplied HTTP headers (auth, tracing, etc.) to vLLM.
+    path = "/generate"
+    if transport == "dynamo_chat_nvext":
+        nvext: dict[str, Any] = {
+            "token_data": prompt_ids,
+            "extra_fields": ["completion_token_ids"],
+        }
+        priority = sampling_args.get("priority", extra_body.get("priority"))
+        if priority is not None:
+            nvext["agent_hints"] = {"priority": priority}
+
+        body = {
+            "model": model,
+            "messages": [{"role": "user", "content": "(token-in mode)"}],
+            "stream": False,
+            "logprobs": True,
+            "nvext": nvext,
+        }
+        if max_tokens is not None:
+            body["max_completion_tokens"] = max_tokens
+        for key in (
+            "temperature",
+            "top_p",
+            "top_k",
+            "min_p",
+            "seed",
+            "n",
+            "repetition_penalty",
+            "min_tokens",
+        ):
+            value = sampling_args.get(key, extra_body.get(key))
+            if value is not None:
+                body[key] = value
+        path = "/chat/completions"
+    elif transport != "prime_vllm_generate":
+        raise ValueError(f"Unsupported renderer transport: {transport}")
+
     extra_headers = sampling_args.get("extra_headers") or {}
 
-    # -- Send to vLLM --
     _request_logger.debug(
-        "vllm /generate: prompt_len=%d messages=%d max_tokens=%s",
+        "renderer transport=%s prompt_len=%d messages=%d max_tokens=%s stop_ids=%d",
+        transport,
         len(prompt_ids),
         len(messages),
         max_tokens,
+        len(stop_token_ids),
     )
     post_kwargs: dict[str, Any] = {
         "cast_to": cast(Any, dict[str, Any]),
@@ -136,7 +165,7 @@ async def completions_request(
     if extra_headers:
         post_kwargs["options"] = cast(Any, {"headers": extra_headers})
     try:
-        data = await client.post("/generate", **post_kwargs)
+        data = await client.post(path, **post_kwargs)
     except BadRequestError as exc:
         _log_overlong_prompt_diagnostic(
             prompt_ids=prompt_ids,
@@ -145,24 +174,48 @@ async def completions_request(
             exc=exc,
         )
         raise
+
     choices = data.get("choices") or [{}]
     choice = choices[0]
-
-    # -- Parse completion tokens --
-    completion_ids = choice.get("token_ids") or []
+    if transport == "dynamo_chat_nvext":
+        completion_ids = (
+            choice.get("token_ids")
+            or choice.get("nvext", {}).get("completion_token_ids")
+            or data.get("nvext", {}).get("completion_token_ids")
+            or []
+        )
+        completion_logprobs = [
+            float(item.get("logprob") or 0.0)
+            for item in (choice.get("logprobs") or {}).get("content") or []
+            if isinstance(item, dict)
+        ]
+        raw_re = (
+            choice.get("routed_experts")
+            or choice.get("nvext", {}).get("routed_experts")
+            or data.get("nvext", {}).get("routed_experts")
+        )
+        response_id = data.get("id") or data.get("request_id") or ""
+    else:
+        completion_ids = choice.get("token_ids") or []
+        completion_logprobs = [
+            float(lp) if lp is not None else 0.0 for lp in choice.get("logprobs") or []
+        ]
+        raw_re = choice.get("routed_experts")
+        response_id = data.get("id") or ""
 
     if pool is not None:
         parsed = await _run_pooled(pool, lambda r: r.parse_response(completion_ids))
     else:
         parsed = renderer.parse_response(completion_ids)
 
-    completion_logprobs = [
-        float(lp) if lp is not None else 0.0 for lp in choice.get("logprobs") or []
-    ]
+    # Renderer parsing is responsible for client-side tool detection. If a
+    # transport reports a plain stop but parsed tokens contain tool calls, expose
+    # the chat-style finish reason so OpenAI-compatible agent loops continue.
+    finish_reason = choice.get("finish_reason")
+    if parsed.tool_calls and finish_reason == "stop":
+        finish_reason = "tool_calls"
 
-    # Extract routed experts
     routed_experts = None
-    raw_re = choice.get("routed_experts")
     if isinstance(raw_re, dict) and "data" in raw_re and "shape" in raw_re:
         routed_experts = (
             np.frombuffer(base64.b85decode(raw_re["data"]), dtype=np.int32)
@@ -170,18 +223,8 @@ async def completions_request(
             .tolist()
         )
 
-    # vLLM's /v1/generate only knows about the raw generate loop, so it
-    # returns finish_reason in {"stop","length",…} — never "tool_calls",
-    # which is a chat-completions concept. When we extract tool calls
-    # client-side from the tokens, promote "stop" → "tool_calls" so
-    # OpenAI-compatible agent loops (AI SDK, opencode) continue past the
-    # tool turn instead of treating the response as final output.
-    finish_reason = choice.get("finish_reason")
-    if parsed.tool_calls and finish_reason == "stop":
-        finish_reason = "tool_calls"
-
     return {
-        "id": data.get("id") or "",
+        "id": response_id,
         "created": data.get("created") or 0,
         "model": data.get("model") or "",
         "prompt_ids": list(prompt_ids),
@@ -199,7 +242,7 @@ async def completions_request(
 def _log_overlong_prompt_diagnostic(
     *,
     prompt_ids: list[int],
-    messages: list[Message],
+    messages: list[Any],
     max_tokens: int | None,
     exc: BadRequestError,
 ) -> None:

--- a/packages/renderers/tests/test_client.py
+++ b/packages/renderers/tests/test_client.py
@@ -36,11 +36,14 @@ class _FakeRenderer:
 
 
 class _FakeClient:
-    def __init__(self):
+    def __init__(self, response=None):
         self.calls = []
+        self.response = response
 
     async def post(self, path, *, cast_to=dict, body=None):
         self.calls.append({"path": path, "cast_to": cast_to, "body": body})
+        if self.response is not None:
+            return self.response
         routed_experts = np.array([[[1]], [[2]]], dtype=np.int32)
         return {
             "usage": {"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5},
@@ -127,3 +130,51 @@ async def test_completions_request_uses_prebuilt_prompt_ids_without_rendering():
 
     assert client.calls[0]["body"]["prompt_token_ids"] == [11, 12, 13]
     assert result["prompt_ids"] == [11, 12, 13]
+
+
+@pytest.mark.asyncio
+async def test_completions_request_can_use_dynamo_chat_nvext_transport():
+    client = _FakeClient(
+        {
+            "id": "chatcmpl-test",
+            "model": "test-model",
+            "nvext": {"completion_token_ids": [7, 8]},
+            "choices": [
+                {
+                    "logprobs": {"content": [{"logprob": -0.1}, {"logprob": -0.2}]},
+                    "finish_reason": "stop",
+                }
+            ],
+        }
+    )
+
+    result = await completions_request(
+        client=client,
+        renderer=_FakeRenderer(),
+        messages=[{"role": "user", "content": "hi"}],
+        model="test-model",
+        tools=[{"type": "function", "function": {"name": "echo"}}],
+        transport="dynamo_chat_nvext",
+        temperature=0.3,
+        max_completion_tokens=7,
+        priority=4,
+        extra_body={"min_tokens": 2},
+    )
+
+    assert client.calls[0]["path"] == "/chat/completions"
+    body = client.calls[0]["body"]
+    assert body["nvext"] == {
+        "token_data": [1, 2, 3],
+        "extra_fields": ["completion_token_ids"],
+        "agent_hints": {"priority": 4},
+    }
+    assert body["messages"] == [{"role": "user", "content": "(token-in mode)"}]
+    assert body["logprobs"] is True
+    assert body["max_completion_tokens"] == 7
+    assert body["temperature"] == 0.3
+    assert body["min_tokens"] == 2
+    assert result["id"] == "chatcmpl-test"
+    assert result["model"] == "test-model"
+    assert result["completion_ids"] == [7, 8]
+    assert result["completion_logprobs"] == [-0.1, -0.2]
+    assert result["finish_reason"] == "tool_calls"

--- a/packages/renderers/tests/test_client.py
+++ b/packages/renderers/tests/test_client.py
@@ -170,6 +170,7 @@ async def test_completions_request_can_use_dynamo_chat_nvext_transport():
     }
     assert body["messages"] == [{"role": "user", "content": "(token-in mode)"}]
     assert body["logprobs"] is True
+    assert body["stop_token_ids"] == [99]
     assert body["max_completion_tokens"] == 7
     assert body["temperature"] == 0.3
     assert body["min_tokens"] == 2

--- a/tests/test_openai_chat_completions_token_client.py
+++ b/tests/test_openai_chat_completions_token_client.py
@@ -270,3 +270,162 @@ async def test_get_native_response_uses_token_route_when_prompt_ids_available(
     assert len(recording_client.calls) == 1
     assert recording_client.calls[0]["path"] == "/chat/completions/tokens"
     assert recording_client.calls[0]["body"]["tokens"] == [10, 20]
+
+
+# ---------------------------------------------------------------------------
+# dynamo_chat_nvext transport (Dynamo bis/dynamo-rl)
+# ---------------------------------------------------------------------------
+
+class _StubRenderer:
+    """Renderer stand-in for the dynamo_chat_nvext transport tests.
+
+    Returns deterministic ids so we can assert on body shape without pulling
+    in a real HuggingFace tokenizer download. ``render_ids`` returns a
+    fixed sequence; ``get_stop_token_ids`` returns a marker pair.
+    """
+
+    def __init__(self) -> None:
+        self.render_calls: list[dict[str, Any]] = []
+
+    def render_ids(
+        self,
+        messages,
+        *,
+        tools=None,
+        add_generation_prompt: bool = False,
+    ) -> list[int]:
+        self.render_calls.append(
+            {
+                "messages": messages,
+                "tools": tools,
+                "add_generation_prompt": add_generation_prompt,
+            }
+        )
+        # Encode the call shape into ids so tests can disambiguate the two
+        # bridge tokenize calls without a real tokenizer.
+        return [42, len(messages), int(add_generation_prompt)]
+
+    def get_stop_token_ids(self) -> list[int]:
+        return [99, 100]
+
+
+class _DynamoTestClient(OpenAIChatCompletionsTokenClient):
+    """Dynamo-transport TITO client with a stubbed renderer.
+
+    Subclass override is the cleanest way to inject the stub without going
+    through ``ClientConfig`` (which would require a real ``api_base_url``
+    and ``setup_client`` to construct the AsyncOpenAI). The recording
+    client captures the eventual ``self.client.post(...)`` call.
+    """
+
+    _stub_renderer: _StubRenderer
+
+    def __init__(self, recording_client) -> None:
+        super().__init__(recording_client)
+        self._stub_renderer = _StubRenderer()
+
+    @property
+    def renderer_transport(self) -> str:  # type: ignore[override]
+        return "dynamo_chat_nvext"
+
+    def _get_renderer(self, model: str):  # type: ignore[override]
+        return self._stub_renderer
+
+
+@pytest.mark.asyncio
+async def test_local_tokenize_uses_renderer_under_dynamo_transport():
+    """Bridge tokenize must NOT hit any HTTP route under dynamo_chat_nvext.
+
+    Goes straight through ``_local_tokenize`` -> ``renderer.render_ids``.
+    The recording client would record any errant POST; we assert it sees
+    none.
+    """
+    recording_client = _RecordingClient()
+    client = _DynamoTestClient(recording_client)
+
+    ids_full = await client.tokenize(
+        messages=[{"role": "user", "content": "u"}],
+        tools=None,
+        model="test-model",
+    )
+    ids_base = await client.tokenize(
+        messages=[{"role": "user", "content": "u"}],
+        tools=None,
+        model="test-model",
+        extra_kwargs={"add_generation_prompt": False},
+    )
+
+    # Both calls hit the renderer, neither hit the wire.
+    assert recording_client.calls == []
+    assert client._stub_renderer.render_calls[0]["add_generation_prompt"] is True
+    assert client._stub_renderer.render_calls[1]["add_generation_prompt"] is False
+    # And the stub encodes that into the returned ids' last element.
+    assert ids_full[-1] == 1
+    assert ids_base[-1] == 0
+
+
+@pytest.mark.asyncio
+async def test_get_native_response_uses_dynamo_chat_nvext_under_transport(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Dynamo transport must POST to /chat/completions with nvext.token_data.
+
+    Mirrors test_get_native_response_uses_token_route_when_prompt_ids_available
+    but for the new transport.
+    """
+    recording_client = _RecordingClient()
+    client = _DynamoTestClient(recording_client)
+
+    async def fake_get_prompt_ids(self, state, prompt_messages, oai_tools):  # noqa: ANN001
+        return [10, 20, 30]
+
+    monkeypatch.setattr(
+        OpenAIChatCompletionsTokenClient, "get_prompt_ids", fake_get_prompt_ids
+    )
+
+    state = cast(
+        State,
+        {
+            "model": "test-model",
+            "trajectory": [
+                _make_step(
+                    prompt=[{"role": "user", "content": "u1"}],
+                    completion=[{"role": "assistant", "content": "a1"}],
+                    prompt_ids=[1],
+                    completion_ids=[2],
+                )
+            ],
+        },
+    )
+    prompt = cast(Any, [{"role": "user", "content": "u2"}])
+
+    response = await client.get_native_response(
+        prompt=prompt,
+        model="test-model",
+        sampling_args={"max_completion_tokens": 16, "temperature": 0.5},
+        tools=None,
+        state=state,
+    )
+
+    assert response["ok"] is True
+    assert len(recording_client.calls) == 1
+    call = recording_client.calls[0]
+
+    # Wire-shape assertions: route, nvext.token_data, stop_token_ids,
+    # placeholder messages, sampling fields promoted.
+    assert call["path"] == "/chat/completions"
+    body = call["body"]
+    assert body["nvext"]["token_data"] == [10, 20, 30]
+    assert body["nvext"]["extra_fields"] == ["completion_token_ids"]
+    assert body["stop_token_ids"] == [99, 100]
+    assert body["messages"] == [{"role": "user", "content": "(token-in mode)"}]
+    assert body["max_completion_tokens"] == 16
+    assert body["temperature"] == 0.5
+    assert body["logprobs"] is True
+    assert body["stream"] is False
+
+    # No /chat/completions/tokens, no /tokenize for the dynamo transport.
+    assert all(
+        c["path"] != "/chat/completions/tokens" and not c["path"].endswith("/tokenize")
+        for c in recording_client.calls
+    )

--- a/verifiers/clients/openai_chat_completions_token_client.py
+++ b/verifiers/clients/openai_chat_completions_token_client.py
@@ -329,6 +329,13 @@ class OpenAIChatCompletionsTokenClient(OpenAIChatCompletionsClient):
                 # prefix-match equality is unaffected.
                 if normalized.get("content") == "":
                     normalized["content"] = None
+                # Drop None-valued keys so model_dump's exhaustive view (which
+                # carries e.g. thinking_blocks=None on AssistantMessage) is
+                # equivalent to to_native_prompt's slimmer view (which omits
+                # the field entirely). Without this, vf.Message-shaped input
+                # never matches the to_native_prompt-normalized step messages,
+                # which breaks the prefix match for MultiTurnEnv rollouts.
+                normalized = {k: v for k, v in normalized.items() if v is not None}
                 return normalized
             if isinstance(value, list):
                 return [normalize_for_comparison(item) for item in value]

--- a/verifiers/clients/openai_chat_completions_token_client.py
+++ b/verifiers/clients/openai_chat_completions_token_client.py
@@ -1,3 +1,4 @@
+import asyncio
 from collections.abc import Mapping
 from typing import Any, Optional, cast
 
@@ -19,7 +20,11 @@ from verifiers.clients.openai_chat_completions_client import (
     OpenAITool,
     handle_openai_overlong_prompt,
 )
-from verifiers.types import SamplingArgs, State
+from verifiers.types import RendererTransport, SamplingArgs, State
+
+# Sentinel returned by transports that don't tokenize over HTTP. Lets callers
+# route around the legacy /tokenize body shape without changing the signature.
+_DEFAULT_TRANSPORT: RendererTransport = "prime_vllm_generate"
 
 
 def _has_multimodal_content(messages) -> bool:
@@ -64,7 +69,22 @@ class TokenizeResponse(BaseModel):
 
 
 class OpenAIChatCompletionsTokenClient(OpenAIChatCompletionsClient):
-    """Wrapper for custom vLLM route /v1/chat/completions/tokens via AsyncOpenAI client."""
+    """Token-in/token-out chat client.
+
+    Two transports share this class:
+
+    * ``prime_vllm_generate`` (default): the historical TITO surface that
+      posts to vLLM's ``/v1/chat/completions/tokens`` and uses the engine's
+      ``/tokenize`` for bridge-token computation. This is what vanilla vLLM
+      ``>=0.20`` exposes.
+    * ``dynamo_chat_nvext``: posts pre-tokenized prompts to Dynamo's standard
+      ``/v1/chat/completions`` route with ``nvext.token_data`` carrying the
+      stitched ``prompt_ids``. Bridge tokenization runs locally via the
+      ``renderers`` package (no ``/tokenize`` round-trip) since Dynamo
+      doesn't expose vLLM's token routes. Selection is via
+      ``ClientConfig.renderer_transport``; same field the renderer client
+      consults so a single config option drives both clients consistently.
+    """
 
     @property
     def token_client(self) -> AsyncOpenAI:
@@ -73,6 +93,51 @@ class OpenAIChatCompletionsTokenClient(OpenAIChatCompletionsClient):
         if base_url.endswith("/v1"):
             base_url = base_url[:-3]
         return self.client.with_options(base_url=base_url)
+
+    @property
+    def renderer_transport(self) -> RendererTransport:
+        """Wire-shape selector. ``ClientConfig.renderer_transport`` if set,
+        else the default vLLM TITO shape. Mirrors the same field used by
+        ``RendererClient`` so backend selection stays in one place."""
+        return cast(
+            RendererTransport,
+            getattr(self._config, "renderer_transport", _DEFAULT_TRANSPORT)
+            if self._config is not None
+            else _DEFAULT_TRANSPORT,
+        )
+
+    def _get_renderer(self, model: str):
+        """Lazy, per-model renderer cache. Used only by the ``dynamo_chat_nvext``
+        transport for client-side tokenization and stop-token resolution.
+
+        Loaded on first use and reused across calls so we pay the
+        ``AutoTokenizer.from_pretrained`` cost once. The renderer's
+        underlying tokenizer is HuggingFace fast-tokenizer-backed, so the
+        wrapping ``asyncio.to_thread`` calls in ``tokenize()`` get real
+        parallelism (the Rust encode releases the GIL).
+        """
+        cache: dict[str, Any] = self.__dict__.setdefault("_renderer_cache", {})
+        if model in cache:
+            return cache[model]
+        try:
+            from renderers import create_renderer  # type: ignore[import-not-found]
+            from transformers import AutoTokenizer  # type: ignore[import-not-found]
+        except ImportError as exc:  # pragma: no cover - dependency surface
+            raise ImportError(
+                "OpenAIChatCompletionsTokenClient with renderer_transport="
+                "'dynamo_chat_nvext' requires the 'renderers' and 'transformers' "
+                "packages. Install via `pip install verifiers[renderers]` or add "
+                "renderers + transformers to your environment."
+            ) from exc
+        tokenizer = AutoTokenizer.from_pretrained(model)
+        renderer_name = (
+            getattr(self._config, "renderer", "auto")
+            if self._config is not None
+            else "auto"
+        )
+        renderer = create_renderer(tokenizer, renderer=renderer_name or "auto")
+        cache[model] = renderer
+        return renderer
 
     @handle_openai_overlong_prompt
     async def get_native_response(
@@ -126,6 +191,16 @@ class OpenAIChatCompletionsTokenClient(OpenAIChatCompletionsClient):
                 prompt, model, sampling_args, tools, extra_headers=extra_headers
             )
 
+        if self.renderer_transport == "dynamo_chat_nvext":
+            return await self._post_dynamo_chat_nvext(
+                prompt=prompt,
+                prompt_ids=prompt_ids,
+                model=model,
+                tools=tools,
+                sampling_args=sampling_args,
+                extra_headers=extra_headers,
+            )
+
         extra_body = sampling_args.pop("extra_body", {})
         body = dict(
             model=model,
@@ -138,6 +213,85 @@ class OpenAIChatCompletionsTokenClient(OpenAIChatCompletionsClient):
 
         return await self.client.post(
             "/chat/completions/tokens",
+            body=body,
+            cast_to=ChatCompletion,
+            options={"headers": extra_headers} if extra_headers else {},
+        )
+
+    async def _post_dynamo_chat_nvext(
+        self,
+        prompt: OpenAIChatMessages,
+        prompt_ids: list[int],
+        model: str,
+        tools: list[OpenAITool] | None,
+        sampling_args: dict,
+        extra_headers: Mapping[str, str] | None,
+    ) -> OpenAIChatResponse:
+        """Post stitched prompt_ids to Dynamo's chat-completions route.
+
+        Wire shape mirrors what ``RendererClient`` produces for
+        ``dynamo_chat_nvext`` (placeholder messages + ``nvext.token_data`` +
+        explicit ``stop_token_ids``) so a Dynamo deployment validated against
+        renderer-mode automatically accepts TITO-mode traffic too. The
+        engine ignores ``messages`` when ``nvext.token_data`` is present, so
+        the placeholder body stays small regardless of trajectory length.
+        """
+        renderer = self._get_renderer(model)
+        stop_token_ids = list(renderer.get_stop_token_ids())
+
+        extra_body = dict(sampling_args.pop("extra_body", {}) or {})
+
+        nvext: dict[str, Any] = {
+            "token_data": prompt_ids,
+            "extra_fields": ["completion_token_ids"],
+        }
+        priority = sampling_args.get("priority", extra_body.get("priority"))
+        if priority is not None:
+            nvext["agent_hints"] = {"priority": priority}
+
+        body: dict[str, Any] = {
+            "model": model,
+            "messages": [{"role": "user", "content": "(token-in mode)"}],
+            "stream": False,
+            "logprobs": True,
+            "stop_token_ids": stop_token_ids,
+            "nvext": nvext,
+        }
+        if tools:
+            body["tools"] = tools
+
+        # Promote sampling fields that Dynamo's chat-completions surface
+        # accepts directly. Anything else stays in extra_body and rides as
+        # an unrecognized passthrough field (validate.rs:104 allowlist).
+        promotable = (
+            "max_completion_tokens",
+            "max_tokens",
+            "temperature",
+            "top_p",
+            "top_k",
+            "min_p",
+            "seed",
+            "n",
+            "repetition_penalty",
+            "min_tokens",
+        )
+        for key in promotable:
+            value = sampling_args.get(key, extra_body.get(key))
+            if value is not None:
+                body[key] = value
+
+        # Pass any remaining unhandled extra_body keys straight through (e.g.
+        # cache_salt, return_token_ids). Dynamo's PASSTHROUGH_EXTRA_FIELDS
+        # allowlist accepts these without rejection.
+        passthrough = {
+            k: v
+            for k, v in extra_body.items()
+            if k not in promotable and v is not None and k not in body
+        }
+        body.update(passthrough)
+
+        return await self.client.post(
+            "/chat/completions",
             body=body,
             cast_to=ChatCompletion,
             options={"headers": extra_headers} if extra_headers else {},
@@ -338,9 +492,27 @@ class OpenAIChatCompletionsTokenClient(OpenAIChatCompletionsClient):
         extra_kwargs: dict | None = None,
         **kwargs,
     ) -> list[int]:
-        """Tokenize messages using the vLLM /tokenize API."""
+        """Tokenize messages.
+
+        ``dynamo_chat_nvext`` transport: tokenizes locally via the
+        ``renderers`` package, no network call. Runs on a worker thread so
+        the event loop stays free; HuggingFace fast tokenizers release the
+        GIL during the Rust encode pass.
+
+        Default transport: posts to vLLM's ``/tokenize`` route on the
+        host root.
+        """
         if extra_kwargs is None:
             extra_kwargs = {}
+
+        if self.renderer_transport == "dynamo_chat_nvext":
+            return await self._local_tokenize(
+                messages=messages,
+                tools=tools,
+                model=model,
+                extra_kwargs=extra_kwargs,
+            )
+
         if isinstance(messages, str):
             body = dict(
                 model=model,
@@ -361,3 +533,45 @@ class OpenAIChatCompletionsTokenClient(OpenAIChatCompletionsClient):
                 "/tokenize", body=body, cast_to=TokenizeResponse
             )
         return tokenize_response.tokens
+
+    async def _local_tokenize(
+        self,
+        messages: str | OpenAIChatMessages,
+        tools: list[OpenAITool] | None,
+        model: str,
+        extra_kwargs: dict,
+    ) -> list[int]:
+        """Local in-process tokenization for the dynamo transport.
+
+        Bridge tokenization under TITO calls this twice per turn (once for
+        ``add_generation_prompt=True`` and once for ``False``). Both calls
+        go through the same renderer, so the chat-template + tool-call
+        normalization is consistent with whatever Dynamo's worker would
+        produce server-side.
+        """
+        renderer = self._get_renderer(model)
+
+        def _render() -> list[int]:
+            if isinstance(messages, str):
+                tokenizer = getattr(renderer, "tokenizer", None)
+                if tokenizer is None:
+                    raise RuntimeError(
+                        "Renderer for model %r does not expose a tokenizer; "
+                        "cannot tokenize a raw string under dynamo_chat_nvext."
+                        % model
+                    )
+                # Strip BOS for parity with vLLM /tokenize (which never
+                # prepends a BOS for raw-prompt tokenize requests).
+                encoded = tokenizer(messages, add_special_tokens=False)
+                return list(encoded["input_ids"])
+
+            add_generation_prompt = bool(extra_kwargs.get("add_generation_prompt", True))
+            return list(
+                renderer.render_ids(
+                    cast(Any, list(messages)),
+                    tools=cast(Any, tools),
+                    add_generation_prompt=add_generation_prompt,
+                )
+            )
+
+        return await asyncio.to_thread(_render)

--- a/verifiers/clients/renderer_client.py
+++ b/verifiers/clients/renderer_client.py
@@ -488,6 +488,9 @@ class RendererClient(
             model=model,
             tools=tools,
             prompt_ids=prompt_ids,
+            transport=getattr(
+                self._config, "renderer_transport", "prime_vllm_generate"
+            ),
             **args,
         )
 

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -41,6 +41,7 @@ ClientType = Literal[
     "anthropic_messages",
     "nemorl_chat_completions",
 ]
+RendererTransport = Literal["prime_vllm_generate", "dynamo_chat_nvext"]
 MessageType = Literal["chat", "completion"]  # deprecated
 
 
@@ -498,6 +499,7 @@ class ClientConfig(BaseModel):
     renderer: str = "auto"
     renderer_model_name: str | None = None
     renderer_pool_size: int | None = None
+    renderer_transport: RendererTransport = "prime_vllm_generate"
     tool_parser: str | None = None
     reasoning_parser: str | None = None
     api_key_var: str = "PRIME_API_KEY"


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds an alternate request/response wire format and local tokenization path that changes how prompts/completions are sent and parsed when `renderer_transport` is enabled, which could affect inference correctness and tool-call handling. Default behavior remains unchanged but misconfiguration or backend mismatches could cause failures.
> 
> **Overview**
> Adds a new configurable `RendererTransport` (`prime_vllm_generate` vs `dynamo_chat_nvext`) and threads it through `ClientConfig`, `RendererClient`, and `OpenAIChatCompletionsTokenClient` so deployments can target Dynamo’s `/chat/completions` `nvext.token_data` token-in/token-out interface.
> 
> Updates `renderers.client.completions_request` to build/POST the Dynamo `nvext` request shape, parse completion token ids/logprobs from Dynamo-style responses, and normalize `finish_reason` to `tool_calls` when tool calls are detected client-side.
> 
> Extends TITO (`OpenAIChatCompletionsTokenClient`) to support the Dynamo transport by posting stitched `prompt_ids` to `/chat/completions`, performing bridge tokenization locally via a cached renderer/tokenizer (no `/tokenize` round-trip), and making prefix matching more robust by dropping `None`-valued keys during message normalization. Adds targeted tests covering the new transport and local tokenization behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8dc4d2dc8edf214e2440d76071e8bd08ba0f774. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->