### PR TITLE
fix(renderer-client): normalize empty content like token client

### DIFF
--- a/verifiers/clients/renderer_client.py
+++ b/verifiers/clients/renderer_client.py
@@ -125,10 +125,14 @@ def _normalize_for_comparison(value: Any, _key: str | None = None) -> Any:
     if hasattr(value, "model_dump"):
         return _normalize_for_comparison(value.model_dump(exclude_none=True))
     if isinstance(value, Mapping):
+        # Treat content="" as equivalent to content=None (absent): tool-call-only
+        # assistant messages get serialized either way depending on the upstream
+        # pipeline (e.g., reasoning parsers strip text content to "" while other
+        # paths leave it as None), and the prefix-match must be unaffected.
         return {
             str(k): _normalize_for_comparison(v, _key=str(k))
             for k, v in value.items()
-            if v is not None
+            if v is not None and not (str(k) == "content" and v == "")
         }
     if isinstance(value, list):
         return [_normalize_for_comparison(v) for v in value]


### PR DESCRIPTION
## Summary
- Stacked on top of #<feat/renderer-inference-v1-generate PR>. Mirrors a coercion already present in `OpenAIChatCompletionsTokenClient.normalize_for_comparison`: tool-call-only assistant messages can be serialized with `content=None` or `content=""` depending on the upstream pipeline (reasoning parsers strip text to `""`, other paths leave `None`), and incremental-prompt prefix matching must treat them as equivalent or it spuriously falls back to MITO.
- `renderer_client._normalize_for_comparison` already drops `None` values from mappings, so a `content=None` message normalizes to "no `content` key" while `content=""` would stay as `"content": ""`. We extend the same filter to also drop `content == ""`, unifying the two shapes.

## Test plan
- [ ] Existing renderer-client tests still pass.
- [ ] Manually verify a multi-turn rollout where one trajectory step has assistant `content=None` and the next prompt presents the same step with `content=""` (e.g. via a reasoning parser): bridge succeeds instead of falling back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small normalization tweak that only affects incremental prompt prefix-matching by treating `content:""` like missing/`None`, reducing spurious bridge failures without changing generation behavior.
> 
> **Overview**
> Improves incremental prompt prefix-matching in `renderer_client._normalize_for_comparison` by **dropping mapping keys where `content == ""`**, making tool-call-only assistant messages serialized as `content=None` vs `content=""` compare equal.
> 
> This prevents format-only drift in upstream pipelines from forcing a full re-render/fallback when stitching multi-turn prompts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2aaac1a7908cadd78a6b0eb32df6a4ea260a60e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->