### PR TITLE
Skip secret-backed environment tests for fork PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,7 @@ jobs:
           uv run pytest tests/ -v --ignore=tests/test_envs.py --cov=verifiers --cov-report=xml --cov-report=term
   test-envs:
     name: Environments
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:


### PR DESCRIPTION
## Summary
- Skip the `Environments` job on forked pull requests where repository secrets are unavailable
- Keep the secret-backed environment coverage running for pushes and same-repo PRs
- Preserve the main test matrix for external contributors without making CI fail on missing secrets

## Testing
- `git diff --check`
- `uv run pre-commit run --files .github/workflows/test.yml`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI change that only gates the `test-envs` job to avoid running secret-dependent tests on forked pull requests. Main test job behavior is unchanged.
> 
> **Overview**
> Prevents CI failures on forked pull requests by adding a job-level condition to skip the secret-backed `Environments` (`test-envs`) job unless the PR originates from the same repository (or the workflow is triggered by a non-PR event).
> 
> The main `Verifiers` test matrix still runs for all PRs and pushes; only the env tests are now gated based on secret availability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 252690d45584caaffded09a2425ab6badf9e4991. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->