### PR TITLE
Fix v1 env config projection and typed child loader boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ env = vf.Env(
 
 The same environment package is the unit used by evals and `prime-rl`. The
 trainer owns model, endpoint, sampling, and rollout count; v1-specific taskset
-and harness options stay under `env.args.config`:
+and harness options stay under `env.taskset` and `env.harness`:
 
 ```toml
 # configs/rl/my-v1-env.toml
@@ -184,10 +184,13 @@ max_tokens = 4096
 [[env]]
 id = "my-env"
 
-[env.args.config.harness]
+[env.args]
+arg1 = "non-th-arg"
+
+[env.harness]
 max_turns = 1
 
-[env.args.config.taskset.scoring.contains_answer]
+[env.taskset.scoring.contains_answer]
 weight = 1.0
 ```
 

--- a/README.md
+++ b/README.md
@@ -146,12 +146,12 @@ def source():
 async def contains_answer(task, state) -> float:
     return float(task["answer"] in str(state.get("completion") or ""))
 
-def load_taskset(config=None):
+def load_taskset(config: vf.TasksetConfig | None = None):
     return vf.Taskset(source=source, rewards=[contains_answer], config=config)
 
-def load_environment(config=None) -> vf.Env:
-    config = config or {}
-    return vf.Env(taskset=load_taskset(config.get("taskset")))
+def load_environment(config: vf.EnvConfig | None = None) -> vf.Env:
+    config = config or vf.EnvConfig()
+    return vf.Env(taskset=load_taskset(config=config.taskset))
 ```
 If no harness is passed, `vf.Env` uses the base endpoint-backed harness. See
 **[BYO Harness](docs/byo-harness.md)** for the advanced v1 taskset/harness API.

--- a/configs/eval/alphabet-sort.toml
+++ b/configs/eval/alphabet-sort.toml
@@ -6,9 +6,9 @@ rollouts_per_example = 3
 save_results = true
 
 [[eval]]
-env_id = "alphabet-sort"
+id = "alphabet-sort"
 
-[eval.env_args]
+[eval.args]
 min_turns = 3
 max_turns = 5
 power_per_turn = false

--- a/configs/eval/debug.toml
+++ b/configs/eval/debug.toml
@@ -2,14 +2,14 @@ model = "openai/gpt-4.1-mini"
 save_results = true
 
 [[eval]]
-env_id = "primeintellect/wiki-search"
+id = "primeintellect/wiki-search"
 
 [[eval]]
-env_id = "gsm8k"
+id = "gsm8k"
 num_examples = 20
 rollouts_per_example = 1
 sampling_args = { max_tokens = 1024 }
 independent_scoring = true
 
 [[eval]]
-env_id = "alphabet-sort"
+id = "alphabet-sort"

--- a/configs/eval/duplicate-env.toml
+++ b/configs/eval/duplicate-env.toml
@@ -1,6 +1,6 @@
 [[eval]]
-env_id = "alphabet-sort"
+id = "alphabet-sort"
 
 [[eval]]
-env_id = "alphabet-sort"
+id = "alphabet-sort"
 max_concurrent = 1

--- a/configs/eval/minimal.toml
+++ b/configs/eval/minimal.toml
@@ -1,3 +1,3 @@
 [[eval]]
-env_id = "gsm8k"
+id = "gsm8k"
 

--- a/configs/eval/multi-env.toml
+++ b/configs/eval/multi-env.toml
@@ -5,17 +5,17 @@ save_results = true
 rollouts_per_example = 3
 
 [[eval]]
-env_id = "bfcl-v3"
+id = "bfcl-v3"
 num_examples = 100
 
 [[eval]]
-env_id = "tau2-bench"
+id = "tau2-bench"
 num_examples = 100
 
 [[eval]]
-env_id = "wiki-search"
+id = "wiki-search"
 num_examples = 100
 
 [[eval]]
-env_id = "tool-test"
+id = "tool-test"
 num_examples = 100

--- a/configs/eval/single-turn.toml
+++ b/configs/eval/single-turn.toml
@@ -1,20 +1,20 @@
 [[eval]]
-env_id = "math500"
+id = "math500"
 num_examples = -1
 rollouts_per_example = 1
 
 [[eval]]
-env_id = "aime2024"
+id = "aime2024"
 num_examples = -1
 rollouts_per_example = 8
 
 [[eval]]
-env_id = "gpqa"
+id = "gpqa"
 num_examples = -1
 rollouts_per_example = 1
 
 [[eval]]
-env_id = "livecodebench"
+id = "livecodebench"
 num_examples = -1
 rollouts_per_example = 1
 max_concurrent = 16 # to limit sandbox usage

--- a/configs/eval/tools.toml
+++ b/configs/eval/tools.toml
@@ -2,21 +2,21 @@ model = "openai/gpt-5-mini"
 save_results = true
 
 [[eval]]
-env_id = "bfcl-v3"
+id = "bfcl-v3"
 num_examples = 100
 rollouts_per_example = 3
 
 [[eval]]
-env_id = "tau2-bench"
+id = "tau2-bench"
 num_examples = 100
 rollouts_per_example = 3
 
 [[eval]]
-env_id = "wiki-search"
+id = "wiki-search"
 num_examples = 100
 rollouts_per_example = 3
 
 [[eval]]
-env_id = "tool-test"
+id = "tool-test"
 num_examples = 100
 rollouts_per_example = 3

--- a/configs/eval/wordle.toml
+++ b/configs/eval/wordle.toml
@@ -2,7 +2,7 @@ model = "openai/gpt-5.4"
 save_results = true
 
 [[eval]]
-env_id = "primeintellect/wordle"
+id = "primeintellect/wordle"
 num_examples = 20
 rollouts_per_example = 1
-# env_args = { path_to_system_prompt = "/path/to/system_prompt.txt" }
+# args = { path_to_system_prompt = "/path/to/system_prompt.txt" }

--- a/docs/byo-harness.md
+++ b/docs/byo-harness.md
@@ -309,7 +309,8 @@ def load_environment(config: vf.EnvConfig | None = None):
     )
 ```
 
-Eval config passes that object through `env_args.config`:
+Eval config passes named environment args through `args` and v1 config through
+the `taskset`/`harness` sections:
 
 ```toml
 model = "openai/gpt-5.4-mini"
@@ -320,10 +321,10 @@ rollouts_per_example = 3
 env_id = "my-v1-env"
 sampling_args = { max_tokens = 4096 }
 
-[eval.env_args.config.harness]
+[eval.harness]
 max_turns = 4
 
-[eval.env_args.config.taskset.scoring.exact_answer]
+[eval.taskset.scoring.exact_answer]
 weight = 0.5
 ```
 
@@ -368,7 +369,7 @@ def load_environment(
     )
 ```
 
-RL and Hosted Training config uses the same inner shape under `args.config`:
+RL and Hosted Training config uses the same shape under `env`:
 
 ```toml
 model = "Qwen/Qwen3-30B-A3B-Instruct-2507"
@@ -382,10 +383,13 @@ max_tokens = 4096
 [[env]]
 id = "primeintellect/my-v1-env"
 
-[env.args.config.harness]
+[env.args]
+arg1 = "non-th-arg"
+
+[env.harness]
 max_turns = 8
 
-[env.args.config.taskset.toolsets.search]
+[env.taskset.toolsets.search]
 tools = ["my_env.tools:search"]
 bindings = { "search.index" = "objects.index" }
 ```
@@ -393,7 +397,7 @@ bindings = { "search.index" = "objects.index" }
 Callable config uses `fn = "module:callable"` when metadata is needed:
 
 ```toml
-[[env.args.config.taskset.rewards]]
+[[env.taskset.rewards]]
 fn = "my_env.signals:exact_answer"
 weight = 1.0
 priority = 0
@@ -407,14 +411,14 @@ For command harnesses, keep endpoint and tool registration under the requested
 `program.tools` interface:
 
 ```toml
-[env.args.config.harness.program]
+[env.harness.program]
 command = ["my-cli", "run", "--config", "/tmp/my-cli.json"]
 sandbox = true
 
-[env.args.config.harness.program.tools]
+[env.harness.program.tools]
 mcp = { fn = "my_env.cli:write_cli_config" }
 
-[env.args.config.harness.program.bindings]
+[env.harness.program.bindings]
 "write_cli_config.endpoint_config" = { fn = "my_env.cli:endpoint_config" }
 ```
 

--- a/docs/byo-harness.md
+++ b/docs/byo-harness.md
@@ -43,13 +43,13 @@ async def contains_answer(task, state) -> float:
     return float(task["answer"] in str(state.get("completion") or ""))
 
 
-def load_taskset(config=None):
+def load_taskset(config: vf.TasksetConfig | None = None):
     return vf.Taskset(source=source, rewards=[contains_answer], config=config)
 
 
-def load_environment(config=None):
-    config = config or {}
-    return vf.Env(taskset=load_taskset(config.get("taskset")))
+def load_environment(config: vf.EnvConfig | None = None):
+    config = config or vf.EnvConfig()
+    return vf.Env(taskset=load_taskset(config=config.taskset))
 ```
 
 ## Tasksets
@@ -60,12 +60,18 @@ zero-argument loader so imports and constructors stay cheap.
 
 ```python
 from datasets import load_dataset
+import verifiers.v1 as vf
 
 
-def load_taskset(config=None):
-    config = config or {}
-    dataset_name = config.get("dataset_name", "gsm8k")
-    split = config.get("split", "train")
+class GSM8KTasksetConfig(vf.TasksetConfig):
+    dataset_name: str = "gsm8k"
+    split: str = "train"
+
+
+def load_taskset(config: vf.TasksetConfig | None = None):
+    config = GSM8KTasksetConfig(config)
+    dataset_name = config.dataset_name
+    split = config.split
 
     def source():
         dataset = load_dataset(dataset_name, "main", split=split)
@@ -76,7 +82,7 @@ def load_taskset(config=None):
                 "answer": row["answer"],
             }
 
-    return vf.Taskset(source=source)
+    return vf.Taskset(source=source, config=config)
 ```
 
 Source rows are JSON-serializable mappings. Config is resolved before source
@@ -171,18 +177,18 @@ Create a harness when rollout behavior is no longer just "call the model with
 the resolved taskset tools."
 
 ```python
-def load_harness(config=None):
+def load_harness(config: vf.HarnessConfig | None = None):
     return vf.Harness(
         program={"fn": "my_env.program:run"},
         config=config,
     )
 
 
-def load_environment(config=None):
-    config = config or {}
+def load_environment(config: vf.EnvConfig | None = None):
+    config = config or vf.EnvConfig()
     return vf.Env(
-        taskset=load_taskset(config.get("taskset")),
-        harness=load_harness(config.get("harness")),
+        taskset=load_taskset(config=config.taskset),
+        harness=load_harness(config=config.harness),
     )
 ```
 
@@ -295,11 +301,11 @@ The recommended loader takes one `config` object and routes its `taskset` and
 `harness` sections:
 
 ```python
-def load_environment(config=None):
-    config = config or {}
+def load_environment(config: vf.EnvConfig | None = None):
+    config = config or vf.EnvConfig()
     return vf.Env(
-        taskset=load_taskset(config.get("taskset")),
-        harness=load_harness(config.get("harness")),
+        taskset=load_taskset(config=config.taskset),
+        harness=load_harness(config=config.harness),
     )
 ```
 
@@ -319,6 +325,47 @@ max_turns = 4
 
 [eval.env_args.config.taskset.scoring.exact_answer]
 weight = 0.5
+```
+
+For concise v0-style named args, pass typed child config objects as defaults.
+Explicit `taskset`/`harness` sections stay the most specific source and override
+those defaults.
+
+```python
+class MyTasksetConfig(vf.TasksetConfig):
+    split: str = "train"
+
+
+def load_taskset(
+    split: str | None = None,
+    config: vf.TasksetConfig | None = None,
+):
+    config = MyTasksetConfig(config, split=split)
+    ...
+
+
+def load_harness(
+    max_turns: int | None = None,
+    config: vf.HarnessConfig | None = None,
+):
+    config = vf.HarnessConfig(config, max_turns=max_turns)
+    ...
+
+
+def load_environment(
+    config: vf.EnvConfig | None = None,
+    split: str = "train",
+    max_turns: int = 10,
+):
+    config = vf.EnvConfig(
+        config,
+        taskset=MyTasksetConfig(split=split),
+        harness=vf.HarnessConfig(max_turns=max_turns),
+    )
+    return vf.Env(
+        taskset=load_taskset(config=config.taskset),
+        harness=load_harness(config=config.harness),
+    )
 ```
 
 RL and Hosted Training config uses the same inner shape under `args.config`:

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -92,7 +92,7 @@ The same key works in TOML configs as a top-level entry of an `[[eval]]` table:
 
 ```toml
 [[eval]]
-env_id = "my-env"
+id = "my-env"
 timeout = 600
 ```
 
@@ -338,17 +338,17 @@ model = "openai/gpt-4.1-mini"
 num_examples = 50
 
 [[eval]]
-env_id = "gsm8k"
+id = "gsm8k"
 num_examples = 100  # overrides global default
 rollouts_per_example = 5
 
 [[eval]]
-env_id = "alphabet-sort"
+id = "alphabet-sort"
 # Uses global num_examples (50)
 rollouts_per_example = 3
 
 [[eval]]
-env_id = "math-python"
+id = "math-python"
 # Uses global defaults and built-in defaults for unspecified values
 ```
 
@@ -356,45 +356,49 @@ A minimal config requires only a single `[[eval]]` section:
 
 ```toml
 [[eval]]
-env_id = "gsm8k"
+id = "gsm8k"
 ```
 
-Each `[[eval]]` section must contain an `env_id` field. All other fields are optional:
+Each `[[eval]]` section must contain an `id` field. `env_id` is accepted as a
+legacy alias and normalizes to the same internal field. All other fields are
+optional:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `env_id` | string | **Required.** Environment module name |
-| `env_args` | table | Arguments passed to `load_environment()` |
+| `id` | string | **Required.** Environment module name |
+| `args` | table | Arguments passed to `load_environment()` |
+| `taskset` | table | v1 taskset config passed through `config.taskset` |
+| `harness` | table | v1 harness config passed through `config.harness` |
 | `num_examples` | integer | Number of dataset examples to evaluate |
 | `rollouts_per_example` | integer | Rollouts per example |
 | `extra_env_kwargs` | table | Arguments passed to environment constructor |
 | `model` | string | Model to evaluate |
 | `endpoint_id` | string | Endpoint registry id (requires TOML `endpoints_path`) |
 
-Example with `env_args`:
+Example with environment args:
 
 ```toml
 [[eval]]
-env_id = "math-python"
+id = "math-python"
 num_examples = 50
 
-[eval.env_args]
+[eval.args]
 difficulty = "hard"
 split = "test"
 ```
 
-For v1 BYO Harness environments, pass taskset/harness config under
-`env_args.config`:
+For v1 BYO Harness environments, pass taskset/harness config through sibling
+`taskset` and `harness` sections:
 
 ```toml
 [[eval]]
-env_id = "my-v1-env"
+id = "my-v1-env"
 sampling_args = { max_tokens = 4096 }
 
-[eval.env_args.config.harness]
+[eval.harness]
 max_turns = 4
 
-[eval.env_args.config.taskset.scoring.exact_answer]
+[eval.taskset.scoring.exact_answer]
 weight = 0.5
 ```
 
@@ -413,23 +417,23 @@ num_examples = 50
 # Sweep temperature × difficulty → 6 eval configs
 # split is fixed across all combinations
 [[ablation]]
-env_id = "my-env"
-env_args = {split = "test"}
+id = "my-env"
+args = {split = "test"}
 
 [ablation.sweep]
 temperature = [0.0, 0.5, 1.0]
 
-[ablation.sweep.env_args]
+[ablation.sweep.args]
 difficulty = ["easy", "hard"]
 ```
 
-- **Fixed fields** in the `[[ablation]]` block (like `env_id`) apply to all expanded configs
+- **Fixed fields** in the `[[ablation]]` block (like `id`) apply to all expanded configs
 - **`[ablation.sweep]`** keys are lists of values crossed as a cartesian product
-- **`[ablation.sweep.env_args]`** keys are swept and merged into the `env_args` dict
-- **Fixed `env_args`** can be set alongside swept ones (e.g. `env_args = {split = "test"}` keeps `split` fixed while sweeping other env args). The same key cannot appear in both fixed and swept env_args.
+- **`[ablation.sweep.args]`** keys are swept and merged into environment args
+- **Fixed `args`** can be set alongside swept ones (e.g. `args = {split = "test"}` keeps `split` fixed while sweeping other env args). The same key cannot appear in both fixed and swept args.
 - Multiple `[[ablation]]` blocks are independent (no cross-product between blocks)
 - `[[ablation]]` and `[[eval]]` blocks can coexist in the same config file
-- `env_id` can be a fixed field or a sweep key (e.g. `env_id = ["env-a", "env-b"]`), but note that all swept envs must accept the same `env_args` — use separate `[[ablation]]` blocks for envs with different argument schemas
+- `id` can be a fixed field or a sweep key (e.g. `id = ["env-a", "env-b"]`), but note that all swept envs must accept the same `args` — use separate `[[ablation]]` blocks for envs with different argument schemas
 
 Use `--abbreviated-summary` (`-A`) to get a compact summary focused on settings and stats, which is useful when comparing many ablation runs.
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -93,12 +93,12 @@ def source():
 async def contains_answer(task, state) -> float:
     return float(task["answer"] in str(state.get("completion") or ""))
 
-def load_taskset(config=None):
+def load_taskset(config: vf.TasksetConfig | None = None):
     return vf.Taskset(source=source, rewards=[contains_answer], config=config)
 
-def load_environment(config=None) -> vf.Env:
-    config = config or {}
-    return vf.Env(taskset=load_taskset(config.get("taskset")))
+def load_environment(config: vf.EnvConfig | None = None) -> vf.Env:
+    config = config or vf.EnvConfig()
+    return vf.Env(taskset=load_taskset(config=config.taskset))
 ```
 If no harness is passed, `vf.Env` uses the base endpoint-backed harness. See
 [BYO Harness](byo-harness.md) for the advanced v1 taskset/harness API.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -958,6 +958,48 @@ Provider-agnostic tool definition. Environments define tools using this type; ea
 
 ## Configuration Types
 
+### v1 Config
+
+```python
+class Config(BaseModel):
+    def __init__(self, config: object | None = None, /, **data: object): ...
+
+    @classmethod
+    def from_config(cls, config: object | None = None, /, **data: object) -> Self: ...
+
+    @classmethod
+    def from_toml(
+        cls, path: str | Path, section: str | Iterable[str] | None = None
+    ) -> Self: ...
+
+class EnvConfig(Config):
+    taskset: object | None = None
+    harness: object | None = None
+
+class TasksetConfig(Config):
+    taskset_id: str | None = None
+    system_prompt: object | None = None
+    source: object | None = None
+    eval_source: object | None = None
+    user: object | None = None
+
+class HarnessConfig(Config):
+    program: object | None = None
+    system_prompt: object | None = None
+    sandbox: SandboxConfig | None = None
+    model: str | None = None
+    sampling_args: dict[str, object] = {}
+    max_turns: int = 10
+```
+
+`EnvConfig` is the typed v1 loader envelope. TOML `[env.taskset]` and
+`[env.harness]` sections flow to `config.taskset` and `config.harness`;
+environment-specific named args flow through `[env.args]`.
+
+`Config` subclasses accept a positional source config plus direct keyword
+overrides. The source object is positional-only so subclasses can define a real
+field named `config`.
+
 ### ClientConfig
 
 ```python

--- a/docs/training.md
+++ b/docs/training.md
@@ -75,7 +75,7 @@ name = "qwen3-30b-i-alphabet-sort"
 ```
 
 For v1 BYO Harness environments, put taskset/harness config under
-`args.config`:
+`taskset` and `harness`:
 
 ```toml
 model = "Qwen/Qwen3-30B-A3B-Instruct-2507"
@@ -89,14 +89,17 @@ max_tokens = 4096
 [[env]]
 id = "primeintellect/my-v1-env"
 
-[env.args.config.harness]
+[env.args]
+arg1 = "non-th-arg"
+
+[env.harness]
 max_turns = 8
 
-[env.args.config.taskset.toolsets.search]
+[env.taskset.toolsets.search]
 tools = ["my_env.tools:search"]
 bindings = { "search.index" = "objects.index" }
 
-[[env.args.config.taskset.rewards]]
+[[env.taskset.rewards]]
 fn = "my_env.signals:exact_answer"
 weight = 1.0
 ```

--- a/environments/bfcl_v3/bfcl_v3.py
+++ b/environments/bfcl_v3/bfcl_v3.py
@@ -18,6 +18,15 @@ BFCL_TOOLSET_REF = "bfcl_v3:load_bfcl_toolset"
 _BFCL_PATCHED = False
 
 
+class BFCLTasksetConfig(vf.TasksetConfig):
+    test_category: str = "simple_python"
+    examples_per_category: int = -1
+
+
+class BFCLHarnessConfig(vf.HarnessConfig):
+    test_category: str = "simple_python"
+
+
 def modded_convert_func_name(function_name: str, model_name: str) -> str:
     _ = model_name
     return re.sub(r"\.", "_", function_name)
@@ -558,7 +567,7 @@ async def bfcl_multi_turn_program(
 
 
 class BFCLMultiTurnHarness(vf.Harness):
-    def __init__(self, config=None):
+    def __init__(self, config: vf.HarnessConfig | None = None):
         super().__init__(program=self.run_bfcl_multi_turn, config=config)
 
     async def run_bfcl_multi_turn(self, task: vf.Task, state: vf.State) -> vf.State:
@@ -566,22 +575,31 @@ class BFCLMultiTurnHarness(vf.Harness):
 
 
 def load_taskset(
-    test_category: str = "simple_python",
-    examples_per_category: int = -1,
-    config=None,
+    test_category: str | None = None,
+    examples_per_category: int | None = None,
+    config: vf.TasksetConfig | None = None,
 ) -> vf.Taskset:
+    config = BFCLTasksetConfig(
+        config,
+        test_category=test_category,
+        examples_per_category=examples_per_category,
+    )
     return vf.Taskset(
-        source=build_source(test_category, examples_per_category),
+        source=build_source(config.test_category, config.examples_per_category),
         rewards=[bfcl_reward],
         config=config,
     )
 
 
-def load_harness(test_category: str = "simple_python", config=None) -> vf.Harness:
+def load_harness(
+    test_category: str | None = None,
+    config: vf.HarnessConfig | None = None,
+) -> vf.Harness:
+    config = BFCLHarnessConfig(config, test_category=test_category)
     patch_bfcl_eval()
     from bfcl_eval.utils import is_multi_turn
 
-    if is_multi_turn(test_category):
+    if is_multi_turn(config.test_category):
         return BFCLMultiTurnHarness(config=config)
     return vf.Harness(config=config)
 
@@ -589,18 +607,19 @@ def load_harness(test_category: str = "simple_python", config=None) -> vf.Harnes
 def load_v1_environment(
     test_category: str = "simple_python",
     examples_per_category: int = -1,
-    config=None,
+    config: vf.EnvConfig | None = None,
 ) -> vf.Env:
-    return vf.Env(
-        taskset=load_taskset(
+    config = vf.EnvConfig(
+        config,
+        taskset=BFCLTasksetConfig(
             test_category=test_category,
             examples_per_category=examples_per_category,
-            config=getattr(config, "taskset", None) if config is not None else None,
         ),
-        harness=load_harness(
-            test_category=test_category,
-            config=getattr(config, "harness", None) if config is not None else None,
-        ),
+        harness=BFCLHarnessConfig(test_category=test_category),
+    )
+    return vf.Env(
+        taskset=load_taskset(config=config.taskset),
+        harness=load_harness(config=config.harness),
     )
 
 

--- a/environments/dspy_flights/dspy_flights.py
+++ b/environments/dspy_flights/dspy_flights.py
@@ -363,7 +363,7 @@ def stringify_nested(value: object) -> object:
     return str(value)
 
 
-def load_taskset(config=None):
+def load_taskset(config: vf.TasksetConfig | None = None):
     return vf.Taskset(
         source=source,
         rewards=[expected_database_change],
@@ -372,15 +372,16 @@ def load_taskset(config=None):
     )
 
 
-def load_harness(config=None):
+def load_harness(config: vf.HarnessConfig | None = None):
     return vf.Harness(
         program={"fn": "dspy_flights:run_dspy_flight_program"},
         config=config,
     )
 
 
-def load_environment(config=None):
+def load_environment(config: vf.EnvConfig | None = None):
+    config = config or vf.EnvConfig()
     return vf.Env(
-        taskset=load_taskset(getattr(config, "taskset", None)),
-        harness=load_harness(getattr(config, "harness", None)),
+        taskset=load_taskset(config=config.taskset),
+        harness=load_harness(config=config.harness),
     )

--- a/environments/hello_group_reward_v1/hello_group_reward_v1.py
+++ b/environments/hello_group_reward_v1/hello_group_reward_v1.py
@@ -13,6 +13,14 @@ Return the assigned candidate exactly.
 """
 
 
+class GroupRewardTasksetConfig(vf.TasksetConfig):
+    num_examples: int = -1
+
+
+class GroupRewardHarnessConfig(vf.HarnessConfig):
+    max_turns: int = 1
+
+
 TASKS: list[dict[str, object]] = [
     {
         "task_id": "distributed-systems",
@@ -242,9 +250,14 @@ def source(num_examples: int = -1):
         }
 
 
-def load_taskset(num_examples: int = -1, config=None) -> GroupRewardTaskset:
+def load_taskset(
+    num_examples: int | None = None,
+    config: vf.TasksetConfig | None = None,
+) -> GroupRewardTaskset:
+    config = GroupRewardTasksetConfig(config, num_examples=num_examples)
+
     def load_rows():
-        return source(num_examples=num_examples)
+        return source(num_examples=config.num_examples)
 
     return GroupRewardTaskset(
         source=load_rows,
@@ -258,19 +271,34 @@ def load_taskset(num_examples: int = -1, config=None) -> GroupRewardTaskset:
     )
 
 
-def load_harness(config=None) -> vf.Harness:
-    return vf.Harness(program=candidate_program, max_turns=1, config=config)
-
-
-def load_environment(num_examples: int = -1, config=None) -> vf.Env:
-    return vf.Env(
-        taskset=load_taskset(
-            num_examples=num_examples,
-            config=getattr(config, "taskset", None),
-        ),
-        harness=load_harness(getattr(config, "harness", None)),
+def load_harness(
+    max_turns: int | None = None,
+    config: vf.HarnessConfig | None = None,
+) -> vf.Harness:
+    config = GroupRewardHarnessConfig(config, max_turns=max_turns)
+    return vf.Harness(
+        program=candidate_program,
+        max_turns=config.max_turns,
+        config=config,
     )
 
 
-def load_v1_environment(num_examples: int = -1, config=None) -> vf.Env:
+def load_environment(
+    num_examples: int = -1,
+    config: vf.EnvConfig | None = None,
+) -> vf.Env:
+    config = vf.EnvConfig(
+        config,
+        taskset=GroupRewardTasksetConfig(num_examples=num_examples),
+    )
+    return vf.Env(
+        taskset=load_taskset(config=config.taskset),
+        harness=load_harness(config=config.harness),
+    )
+
+
+def load_v1_environment(
+    num_examples: int = -1,
+    config: vf.EnvConfig | None = None,
+) -> vf.Env:
     return load_environment(num_examples=num_examples, config=config)

--- a/environments/hello_parallel_sandbox_v1/hello_parallel_sandbox_v1.py
+++ b/environments/hello_parallel_sandbox_v1/hello_parallel_sandbox_v1.py
@@ -88,6 +88,14 @@ PROGRAM_SANDBOX = {
 }
 
 
+class ParallelSandboxTasksetConfig(vf.TasksetConfig):
+    num_examples: int = -1
+
+
+class ParallelSandboxHarnessConfig(vf.HarnessConfig):
+    max_turns: int = 4
+
+
 async def bash(command: str, sandbox, state) -> str:
     """Run a bash command in the active program sandbox."""
     result = await sandbox.execute(command, timeout=120, working_dir="/tmp")
@@ -279,9 +287,14 @@ def source(num_examples: int = -1):
         }
 
 
-def load_taskset(num_examples: int = -1, config=None) -> vf.Taskset:
+def load_taskset(
+    num_examples: int | None = None,
+    config: vf.TasksetConfig | None = None,
+) -> vf.Taskset:
+    config = ParallelSandboxTasksetConfig(config, num_examples=num_examples)
+
     def load_rows():
-        return source(num_examples=num_examples)
+        return source(num_examples=config.num_examples)
 
     return vf.Taskset(
         source=load_rows,
@@ -295,11 +308,15 @@ def load_taskset(num_examples: int = -1, config=None) -> vf.Taskset:
     )
 
 
-def load_harness(max_turns: int = 4, config=None) -> vf.Harness:
+def load_harness(
+    max_turns: int | None = None,
+    config: vf.HarnessConfig | None = None,
+) -> vf.Harness:
+    config = ParallelSandboxHarnessConfig(config, max_turns=max_turns)
     return vf.Harness(
         program={"sandbox": True, "tools": "callable"},
         sandbox=PROGRAM_SANDBOX,
-        max_turns=max_turns,
+        max_turns=config.max_turns,
         config=config,
     )
 
@@ -307,24 +324,23 @@ def load_harness(max_turns: int = 4, config=None) -> vf.Harness:
 def load_environment(
     num_examples: int = -1,
     max_turns: int = 4,
-    config=None,
+    config: vf.EnvConfig | None = None,
 ) -> vf.Env:
+    config = vf.EnvConfig(
+        config,
+        taskset=ParallelSandboxTasksetConfig(num_examples=num_examples),
+        harness=ParallelSandboxHarnessConfig(max_turns=max_turns),
+    )
     return vf.Env(
-        taskset=load_taskset(
-            num_examples=num_examples,
-            config=getattr(config, "taskset", None),
-        ),
-        harness=load_harness(
-            max_turns=max_turns,
-            config=getattr(config, "harness", None),
-        ),
+        taskset=load_taskset(config=config.taskset),
+        harness=load_harness(config=config.harness),
     )
 
 
 def load_v1_environment(
     num_examples: int = -1,
     max_turns: int = 4,
-    config=None,
+    config: vf.EnvConfig | None = None,
 ) -> vf.Env:
     return load_environment(
         num_examples=num_examples,

--- a/environments/hello_rlm_v1/hello_rlm_v1.py
+++ b/environments/hello_rlm_v1/hello_rlm_v1.py
@@ -57,7 +57,7 @@ def source():
     ]
 
 
-def load_taskset(config=None):
+def load_taskset(config: vf.TasksetConfig | None = None):
     return vf.Taskset(
         source=source,
         rewards=[exact_answer],
@@ -66,7 +66,7 @@ def load_taskset(config=None):
 
 
 def load_harness(
-    config=None,
+    config: vf.HarnessConfig | None = None,
     workdir: str = "/workspace",
     instruction_path: str = "/task/instruction.md",
     rlm_repo_url: str = DEFAULT_RLM_REPO_URL,
@@ -82,7 +82,7 @@ def load_harness(
     rlm_tools: list[str] | None = None,
     rlm_env: Mapping[str, str] | None = None,
 ):
-    harness_config = vf.HarnessConfig.model_validate(config or {})
+    harness_config = vf.HarnessConfig(config)
     if not include_sub_rlm_trajectories:
         harness_config.keep_trajectory_step = keep_only_parent_rlm_steps
     tool_names = list(rlm_tools) if rlm_tools is not None else ["ipython"]
@@ -149,10 +149,11 @@ def load_harness(
     )
 
 
-def load_environment(config=None):
+def load_environment(config: vf.EnvConfig | None = None):
+    config = config or vf.EnvConfig()
     return vf.Env(
-        taskset=load_taskset(getattr(config, "taskset", None)),
-        harness=load_harness(getattr(config, "harness", None)),
+        taskset=load_taskset(config=config.taskset),
+        harness=load_harness(config=config.harness),
     )
 
 

--- a/environments/hello_self_judge_v1/hello_self_judge_v1.py
+++ b/environments/hello_self_judge_v1/hello_self_judge_v1.py
@@ -154,6 +154,14 @@ TASKS: list[dict[str, object]] = [
 ]
 
 
+class SelfJudgeTasksetConfig(vf.TasksetConfig):
+    num_examples: int = -1
+
+
+class SelfJudgeHarnessConfig(vf.HarnessConfig):
+    max_turns: int = 8
+
+
 async def bash(command: str, sandbox, state) -> str:
     """Run a bash command in the rollout sandbox and return stdout/stderr."""
     result = await sandbox.execute(command, timeout=120, working_dir="/tmp")
@@ -330,9 +338,14 @@ def load_bash_toolset(config=None) -> vf.Toolset:
     )
 
 
-def load_taskset(num_examples: int = -1, config=None) -> vf.Taskset:
+def load_taskset(
+    num_examples: int | None = None,
+    config: vf.TasksetConfig | None = None,
+) -> vf.Taskset:
+    config = SelfJudgeTasksetConfig(config, num_examples=num_examples)
+
     def load_rows():
-        return source(num_examples=num_examples)
+        return source(num_examples=config.num_examples)
 
     return vf.Taskset(
         source=load_rows,
@@ -345,34 +358,34 @@ def load_taskset(num_examples: int = -1, config=None) -> vf.Taskset:
     )
 
 
-def load_harness(max_turns: int = 8, config=None) -> vf.Harness:
-    return vf.Harness(
-        max_turns=max_turns,
-        config=config,
-    )
+def load_harness(
+    max_turns: int | None = None,
+    config: vf.HarnessConfig | None = None,
+) -> vf.Harness:
+    config = SelfJudgeHarnessConfig(config, max_turns=max_turns)
+    return vf.Harness(max_turns=config.max_turns, config=config)
 
 
 def load_environment(
     num_examples: int = -1,
     max_turns: int = 8,
-    config=None,
+    config: vf.EnvConfig | None = None,
 ) -> vf.Env:
+    config = vf.EnvConfig(
+        config,
+        taskset=SelfJudgeTasksetConfig(num_examples=num_examples),
+        harness=SelfJudgeHarnessConfig(max_turns=max_turns),
+    )
     return vf.Env(
-        taskset=load_taskset(
-            num_examples=num_examples,
-            config=getattr(config, "taskset", None),
-        ),
-        harness=load_harness(
-            max_turns=max_turns,
-            config=getattr(config, "harness", None),
-        ),
+        taskset=load_taskset(config=config.taskset),
+        harness=load_harness(config=config.harness),
     )
 
 
 def load_v1_environment(
     num_examples: int = -1,
     max_turns: int = 8,
-    config=None,
+    config: vf.EnvConfig | None = None,
 ) -> vf.Env:
     return load_environment(
         num_examples=num_examples,

--- a/environments/hello_subagent_v1/hello_subagent_v1.py
+++ b/environments/hello_subagent_v1/hello_subagent_v1.py
@@ -50,24 +50,19 @@ def source():
     ]
 
 
-def load_child_harness(config=None):
-    return vf.Harness(config=config)
+def load_child_harness():
+    return vf.Harness()
 
 
-def load_toolset(config=None):
+def load_toolset():
     return vf.Toolset(
         tools=[ask_subagent],
-        bindings={
-            "ask_subagent.harness": load_child_harness(
-                getattr(config, "child_harness", None)
-            )
-        },
+        bindings={"ask_subagent.harness": load_child_harness()},
         scope="rollout",
-        config=config,
     )
 
 
-def load_taskset(config=None):
+def load_taskset(config: vf.TasksetConfig | None = None):
     return vf.Taskset(
         source=source,
         system_prompt=(
@@ -80,16 +75,17 @@ def load_taskset(config=None):
     )
 
 
-def load_harness(config=None):
+def load_harness(config: vf.HarnessConfig | None = None):
     return vf.Harness(
-        toolsets=[load_toolset(getattr(config, "toolset", None))],
+        toolsets=[load_toolset()],
         metrics=[subagent_calls],
         config=config,
     )
 
 
-def load_environment(config=None):
+def load_environment(config: vf.EnvConfig | None = None):
+    config = config or vf.EnvConfig()
     return vf.Env(
-        taskset=load_taskset(getattr(config, "taskset", None)),
-        harness=load_harness(getattr(config, "harness", None)),
+        taskset=load_taskset(config=config.taskset),
+        harness=load_harness(config=config.harness),
     )

--- a/environments/nested_harness_v1/nested_harness_v1.py
+++ b/environments/nested_harness_v1/nested_harness_v1.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 import verifiers.v1 as vf
 
 
+class NestedHarnessConfig(vf.HarnessConfig):
+    toolset: vf.ToolsetConfig | None = None
+
+
 async def child_program(task, state):
     state["answer"] = str(task["prompt"]).upper()
     state["completion"] = [{"role": "assistant", "content": state["answer"]}]
@@ -45,7 +49,7 @@ def load_child_harness():
     return vf.Harness(program=child_program)
 
 
-def load_toolset(config=None):
+def load_toolset(config: vf.ToolsetConfig | None = None):
     return vf.Toolset(
         tools=[call_harness],
         objects={"child_harness": load_child_harness},
@@ -68,7 +72,7 @@ async def parent_program(task, state):
     return state
 
 
-def load_taskset(config=None):
+def load_taskset(config: vf.TasksetConfig | None = None):
     return vf.Taskset(
         source=source,
         rewards=[exact_answer],
@@ -76,17 +80,19 @@ def load_taskset(config=None):
     )
 
 
-def load_harness(config=None):
+def load_harness(config: NestedHarnessConfig | None = None):
+    config = NestedHarnessConfig(config)
     return vf.Harness(
         program=parent_program,
-        toolsets=[load_toolset(getattr(config, "toolset", None))],
+        toolsets=[load_toolset(config.toolset)],
         metrics=[child_calls],
         config=config,
     )
 
 
-def load_environment(config=None):
+def load_environment(config: vf.EnvConfig | None = None):
+    config = config or vf.EnvConfig()
     return vf.Env(
-        taskset=load_taskset(getattr(config, "taskset", None)),
-        harness=load_harness(getattr(config, "harness", None)),
+        taskset=load_taskset(config=config.taskset),
+        harness=load_harness(config=config.harness),
     )

--- a/environments/rlm_swe_v1/rlm_swe_v1.py
+++ b/environments/rlm_swe_v1/rlm_swe_v1.py
@@ -11,7 +11,7 @@ _TASKS_DIR = Path(__file__).parent / "tasks"
 
 
 def load_taskset(
-    config=None,
+    config: vf.TasksetConfig | None = None,
     tasks: str | Path | None = None,
     task_names: list[str] | None = None,
     cache_dir: str | Path | None = None,
@@ -28,7 +28,8 @@ def load_taskset(
     scope: str | None = None,
     env: dict[str, object] | None = None,
 ) -> vf.HarborTaskset:
-    if tasks is None and _TASKS_DIR.is_dir():
+    config = vf.HarborTasksetConfig(config)
+    if tasks is None and config.tasks is None and _TASKS_DIR.is_dir():
         tasks = _TASKS_DIR
     return vf.HarborTaskset(
         tasks=tasks,
@@ -51,7 +52,7 @@ def load_taskset(
 
 
 def load_harness(
-    config=None,
+    config: vf.HarnessConfig | None = None,
     workdir: str = "/app",
     gh_token: str | None = None,
     rlm_tools: list[str] | None = None,
@@ -70,57 +71,82 @@ def load_harness(
     )
 
 
-def load_environment(config=None, **kwargs: Any) -> vf.Env:
-    config_obj = config or {}
-    taskset_config = getattr(config_obj, "taskset", None) or (
-        config_obj.get("taskset") if isinstance(config_obj, dict) else None
+def load_environment(
+    config: vf.EnvConfig | None = None,
+    tasks: str | Path | None = None,
+    task_names: list[str] | None = None,
+    cache_dir: str | Path | None = None,
+    refresh: bool | None = None,
+    docker_image: str | None = None,
+    cpu_cores: float | None = None,
+    memory_gb: float | None = None,
+    disk_size_gb: float | None = None,
+    timeout_minutes: int | None = None,
+    agent_timeout_seconds: float | None = None,
+    verifier_timeout_seconds: float | None = None,
+    workdir: str | None = None,
+    task_dir: str | None = None,
+    scope: str | None = None,
+    env: dict[str, object] | None = None,
+    instruction_path: str | None = None,
+    rlm_repo_url: str | None = None,
+    rlm_ref: str | None = None,
+    rlm_max_turns: int | None = None,
+    rlm_exec_timeout: int | None = None,
+    rlm_max_depth: int | None = None,
+    summarize_at_tokens: int | tuple[int, int] | list[int] | None = None,
+    include_sub_rlm_trajectories: bool | None = None,
+    append_to_system_prompt: str | None = None,
+    local_checkout: str | Path | None = None,
+    gh_token: str | None = None,
+    rlm_tools: list[str] | None = None,
+    rlm_env: dict[str, object] | None = None,
+    skills: str | Path | None = _SKILLS_DIR if _SKILLS_DIR.is_dir() else None,
+) -> vf.Env:
+    config = vf.EnvConfig(
+        config,
+        taskset=vf.HarborTasksetConfig(
+            tasks=tasks,
+            task_names=task_names,
+            cache_dir=str(cache_dir) if cache_dir is not None else None,
+            refresh=refresh,
+            docker_image=docker_image,
+            cpu_cores=cpu_cores,
+            memory_gb=memory_gb,
+            disk_size_gb=disk_size_gb,
+            timeout_minutes=timeout_minutes,
+            agent_timeout_seconds=agent_timeout_seconds,
+            verifier_timeout_seconds=verifier_timeout_seconds,
+            workdir=workdir,
+            task_dir=task_dir,
+            scope=scope,
+            env=env,
+        ),
     )
-    harness_config = getattr(config_obj, "harness", None) or (
-        config_obj.get("harness") if isinstance(config_obj, dict) else None
+    taskset = load_taskset(config=config.taskset)
+    rlm_kwargs = {
+        key: value
+        for key, value in {
+            "instruction_path": instruction_path,
+            "rlm_repo_url": rlm_repo_url,
+            "rlm_ref": rlm_ref,
+            "rlm_max_turns": rlm_max_turns,
+            "rlm_exec_timeout": rlm_exec_timeout,
+            "rlm_max_depth": rlm_max_depth,
+            "summarize_at_tokens": summarize_at_tokens,
+            "include_sub_rlm_trajectories": include_sub_rlm_trajectories,
+            "append_to_system_prompt": append_to_system_prompt,
+            "local_checkout": local_checkout,
+            "rlm_env": rlm_env,
+        }.items()
+        if value is not None
+    }
+    harness = load_harness(
+        config=config.harness,
+        workdir=taskset.workdir,
+        gh_token=gh_token,
+        rlm_tools=rlm_tools,
+        skills=skills,
+        **rlm_kwargs,
     )
-    taskset = load_taskset(taskset_config, **taskset_kwargs(kwargs))
-    harness = load_harness(harness_config, **harness_kwargs(kwargs, taskset))
     return vf.Env(taskset=taskset, harness=harness)
-
-
-def taskset_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
-    keys = {
-        "tasks",
-        "task_names",
-        "cache_dir",
-        "refresh",
-        "docker_image",
-        "cpu_cores",
-        "memory_gb",
-        "disk_size_gb",
-        "timeout_minutes",
-        "agent_timeout_seconds",
-        "verifier_timeout_seconds",
-        "workdir",
-        "task_dir",
-        "scope",
-        "env",
-    }
-    return {key: kwargs[key] for key in keys if key in kwargs}
-
-
-def harness_kwargs(kwargs: dict[str, Any], taskset: vf.HarborTaskset) -> dict[str, Any]:
-    harness_keys = {
-        "instruction_path",
-        "rlm_repo_url",
-        "rlm_ref",
-        "rlm_max_turns",
-        "rlm_exec_timeout",
-        "rlm_max_depth",
-        "summarize_at_tokens",
-        "include_sub_rlm_trajectories",
-        "append_to_system_prompt",
-        "local_checkout",
-        "gh_token",
-        "rlm_tools",
-        "rlm_env",
-        "skills",
-    }
-    values = {key: kwargs[key] for key in harness_keys if key in kwargs}
-    values.setdefault("workdir", taskset.workdir)
-    return values

--- a/packages/verifiers-rl/verifiers_rl/rl/README.md
+++ b/packages/verifiers-rl/verifiers_rl/rl/README.md
@@ -32,6 +32,8 @@ uv sync --extra rl
   - `[inference].gpus` (int; number of GPUs for vLLM)
   - `[trainer].gpus` (int; number of GPUs for training)
 - Optional `*.args` tables forward keyword arguments to their respective CLIs:
+  - `[env.args]` → passed as named args to `load_environment(...)`
+  - `[env.taskset]` / `[env.harness]` → passed through `config.taskset` / `config.harness`
   - `[inference.args]` → forwarded to `vf-vllm` (keys converted to `--kebab-case` flags)
   - `[trainer.args]` → mapped to `RLConfig` (see Configuration below)
 

--- a/packages/verifiers-rl/verifiers_rl/scripts/train.py
+++ b/packages/verifiers-rl/verifiers_rl/scripts/train.py
@@ -7,6 +7,7 @@ except ImportError:
     import tomli as tomllib
 
 import verifiers as vf
+from verifiers.utils.env_config_utils import config_table, normalize_env_config_sections
 from verifiers_rl.rl.trainer import RLConfig, RLTrainer
 
 
@@ -27,8 +28,11 @@ def main() -> None:
         config = tomllib.load(f)
 
     model = config["model"]
-    env_id = config["env"]["id"]
-    env_args = config["env"].get("args", {})
+    env_config = normalize_env_config_sections(config["env"])
+    env_id = env_config.get("id")
+    if not isinstance(env_id, str) or not env_id:
+        raise SystemExit("Missing required 'env.id' in TOML.")
+    env_args = config_table(env_config.get("env_args", {}), "env.env_args")
     env = vf.load_environment(env_id=env_id, **env_args)
     rl_config = RLConfig(**config["trainer"].get("args", {}))
     trainer = RLTrainer(model=model, env=env, args=rl_config)

--- a/skills/evaluate-environments/SKILL.md
+++ b/skills/evaluate-environments/SKILL.md
@@ -139,7 +139,7 @@ env_id = "my-env"
 [ablation.sweep]
 temperature = [0.0, 0.5, 1.0]
 
-[ablation.sweep.env_args]
+[ablation.sweep.args]
 difficulty = ["easy", "hard"]
 ```
 This generates the cartesian product (6 configs in this example). Use `--abbreviated-summary` (`-A`) for compact ablation results.

--- a/skills/train-with-environments/SKILL.md
+++ b/skills/train-with-environments/SKILL.md
@@ -53,6 +53,25 @@ prime env push my-env --visibility PRIVATE
 ```
 4. For hosted RL and shared workflows, prefer Hub IDs after push (for example `owner/my-env` in config `[[env]].id`).
 
+## RL TOML Environment Sections
+1. Use the same environment config shape for Hosted Training and `prime-rl`.
+2. Put normal `load_environment(...)` named args in `[env.args]`.
+3. Put v1 taskset config in `[env.taskset]` and v1 harness config in `[env.harness]`.
+4. Keep model, endpoint, sampling, rollout count, and trainer controls outside the environment sections unless configuring a nested or auxiliary harness model.
+```toml
+[[env]]
+id = "owner/my-env"
+
+[env.args]
+split = "train"
+
+[env.taskset]
+num_examples = 1000
+
+[env.harness]
+max_turns = 8
+```
+
 ## Hyperparameter Rules Of Thumb
 1. Use `rollouts_per_example` and `batch_size` together.
 2. Treat `batch_size` as total rollout samples per step, not number of groups.

--- a/tests/test_eval_cli.py
+++ b/tests/test_eval_cli.py
@@ -666,6 +666,26 @@ def test_load_toml_config_single_eval():
         assert result[0]["env_id"] == "env1"
 
 
+def test_load_toml_config_single_eval_id_alias():
+    """Single eval accepts id and normalizes to env_id."""
+    with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
+        f.write('[[eval]]\nid = "env1"\n')
+        f.flush()
+        result = load_toml_config(Path(f.name))
+        assert len(result) == 1
+        assert result[0]["env_id"] == "env1"
+        assert "id" not in result[0]
+
+
+def test_load_toml_config_rejects_id_and_env_id():
+    """A single eval cannot use both id spellings."""
+    with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
+        f.write('[[eval]]\nid = "env1"\nenv_id = "env2"\n')
+        f.flush()
+        with pytest.raises(ValueError, match="both id and env_id"):
+            load_toml_config(Path(f.name))
+
+
 def test_repo_eval_example_configs_are_valid():
     """Bundled example configs should parse with the current eval config schema."""
     config_paths = sorted(Path("configs/eval").glob("*.toml"))
@@ -700,6 +720,35 @@ def test_load_toml_config_with_env_args():
         assert result[0]["env_args"]["max_examples"] == 100
 
 
+def test_load_toml_config_with_args_taskset_harness():
+    """args/taskset/harness sections normalize into load_environment kwargs."""
+    with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
+        f.write(
+            '[[eval]]\nenv_id = "env1"\n'
+            "[eval.args]\n"
+            'split = "train"\n\n'
+            "[eval.taskset]\n"
+            "num_examples = 10\n\n"
+            "[eval.harness]\n"
+            "max_turns = 5\n"
+        )
+        f.flush()
+        result = load_toml_config(Path(f.name))
+
+    assert len(result) == 1
+    assert result[0]["env_id"] == "env1"
+    assert result[0]["env_args"] == {
+        "split": "train",
+        "config": {
+            "taskset": {"num_examples": 10},
+            "harness": {"max_turns": 5},
+        },
+    }
+    assert "args" not in result[0]
+    assert "taskset" not in result[0]
+    assert "harness" not in result[0]
+
+
 def test_load_toml_config_missing_env_section():
     """TOML without [[eval]] section raises ValueError."""
     with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
@@ -718,8 +767,8 @@ def test_load_toml_config_empty_eval_list():
             load_toml_config(Path(f.name))
 
 
-def test_load_toml_config_missing_env_id():
-    """[[eval]] without env_id field raises ValueError."""
+def test_load_toml_config_missing_id():
+    """[[eval]] without id field raises ValueError."""
     with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
         f.write('[[eval]]\nname = "env1"\n')
         f.flush()
@@ -1116,15 +1165,15 @@ def test_ablation_cartesian_product():
     assert "gpt-4.1-mini" in models and "gpt-4.1" in models
 
 
-def test_ablation_env_args_sweep():
-    """sweep.env_args keys are merged into env_args dict."""
+def test_ablation_args_sweep():
+    """sweep.args keys are merged into env_args dict."""
     with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
         f.write(
             '[[ablation]]\nenv_id = "my-env"\n'
-            'env_args = {fixed_key = "fixed"}\n\n'
+            'args = {fixed_key = "fixed"}\n\n'
             "[ablation.sweep]\n"
             "temperature = [0.0, 1.0]\n\n"
-            "[ablation.sweep.env_args]\n"
+            "[ablation.sweep.args]\n"
             'difficulty = ["easy", "hard"]\n'
         )
         f.flush()
@@ -1134,6 +1183,17 @@ def test_ablation_env_args_sweep():
     for c in configs:
         assert c["env_args"]["fixed_key"] == "fixed"
         assert c["env_args"]["difficulty"] in ("easy", "hard")
+
+
+def test_ablation_args_sweep_key_is_explicitly_freeform():
+    """sweep.args and sweep.env_args do not rely on valid_fields membership."""
+    sweep = {"args": {"difficulty": []}, "env_args": {"split": []}}
+
+    invalid = verifiers.utils.eval_utils.invalid_ablation_sweep_fields(
+        sweep, valid_fields=set()
+    )
+
+    assert invalid == set()
 
 
 def test_ablation_global_defaults_apply():
@@ -1237,6 +1297,32 @@ def test_ablation_env_id_in_sweep():
     assert "env-a" in env_ids and "env-b" in env_ids
 
 
+def test_ablation_id_aliases_normalize_to_env_id():
+    """Ablation fixed and swept id aliases normalize to env_id."""
+    with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
+        f.write(
+            '[[ablation]]\nid = "fixed-env"\n\n'
+            "[ablation.sweep]\n"
+            "temperature = [0.0, 1.0]\n"
+        )
+        f.flush()
+        fixed_configs = load_toml_config(Path(f.name))
+
+    assert all(c["env_id"] == "fixed-env" for c in fixed_configs)
+
+    with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
+        f.write(
+            "[[ablation]]\n\n"
+            "[ablation.sweep]\n"
+            'id = ["env-a", "env-b"]\n'
+            "temperature = [0.0]\n"
+        )
+        f.flush()
+        swept_configs = load_toml_config(Path(f.name))
+
+    assert [c["env_id"] for c in swept_configs] == ["env-a", "env-b"]
+
+
 def test_ablation_empty_sweep_raises():
     """Ablation without sweep section raises ValueError."""
     with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
@@ -1272,24 +1358,24 @@ def test_ablation_invalid_sweep_field_raises():
             load_toml_config(Path(f.name))
 
 
-def test_ablation_missing_env_id_raises():
-    """Ablation without env_id (fixed or swept) raises ValueError."""
+def test_ablation_missing_id_raises():
+    """Ablation without id (fixed or swept) raises ValueError."""
     with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
         f.write("[[ablation]]\n\n[ablation.sweep]\ntemperature = [0.0, 1.0]\n")
         f.flush()
-        with pytest.raises(ValueError, match="env_id"):
+        with pytest.raises(ValueError, match="id"):
             load_toml_config(Path(f.name))
 
 
-def test_ablation_overlapping_env_args_raises():
-    """Same key in fixed env_args and sweep.env_args raises ValueError."""
+def test_ablation_overlapping_args_raises():
+    """Same key in fixed args and sweep.args raises ValueError."""
     with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
         f.write(
             '[[ablation]]\nenv_id = "my-env"\n'
-            'env_args = {difficulty = "easy"}\n\n'
+            'args = {difficulty = "easy"}\n\n'
             "[ablation.sweep]\n"
             "temperature = [0.0, 1.0]\n\n"
-            "[ablation.sweep.env_args]\n"
+            "[ablation.sweep.args]\n"
             'difficulty = ["easy", "hard"]\n'
         )
         f.flush()

--- a/tests/test_v1_config_extension.py
+++ b/tests/test_v1_config_extension.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib
 import sys
 import types
 from collections.abc import Mapping
@@ -10,6 +11,7 @@ import pytest
 import verifiers as vf
 from verifiers.v1 import (
     Env,
+    EnvConfig,
     Harness,
     HarnessConfig,
     State,
@@ -1023,6 +1025,281 @@ def test_config_schema_is_visible_from_primary_types() -> None:
     assert "program" in HarnessConfig.schema_text()
     assert "image" in vf.SandboxConfig.schema_text()
     assert "bindings" in vf.ToolsetConfig.schema_text()
+
+
+def test_env_config_normalizes_mapping_config_to_attributes() -> None:
+    config = EnvConfig(
+        {
+            "taskset": {"taskset_id": "dict"},
+            "harness": {"model": "configured-model"},
+        }
+    )
+
+    assert config.taskset == {"taskset_id": "dict"}
+    assert config.harness == {"model": "configured-model"}
+
+
+def test_env_config_rejects_unknown_top_level_sections() -> None:
+    with pytest.raises(ValueError):
+        EnvConfig({"taskset": {}, "math": {"taskset": {}}})
+
+
+def test_env_config_requires_child_sections_to_be_configs() -> None:
+    with pytest.raises(ValueError):
+        EnvConfig({"taskset": 1})
+
+
+def test_env_config_merges_child_config_defaults_with_nested_sections() -> None:
+    class LocalTasksetConfig(TasksetConfig):
+        split: str = "train"
+
+    child_config = LocalTasksetConfig({"split": "nested"}, split=None)
+    config = EnvConfig(
+        {
+            "taskset": {"split": "nested"},
+            "harness": {"max_turns": 3},
+        },
+        taskset=LocalTasksetConfig(split="default"),
+        harness=HarnessConfig(max_turns=10),
+    )
+    default_config = EnvConfig(
+        {"taskset": {}},
+        taskset=LocalTasksetConfig(split="kwarg"),
+    )
+
+    assert child_config.split == "nested"
+    assert isinstance(config.taskset, LocalTasksetConfig)
+    assert config.taskset.split == "nested"
+    assert isinstance(config.harness, HarnessConfig)
+    assert config.harness.max_turns == 3
+    assert isinstance(default_config.taskset, LocalTasksetConfig)
+    assert default_config.taskset.split == "kwarg"
+
+
+def test_load_environment_coerces_typed_env_config_arg(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module_name = "typed_env_config"
+    module = types.ModuleType(module_name)
+    seen: dict[str, object] = {}
+
+    def load_environment(split: str = "train", config: EnvConfig | None = None) -> Env:
+        seen["split"] = split
+        seen["config"] = config
+        config = config or EnvConfig()
+        return Env(
+            taskset=Taskset(source=source_loader, config=config.taskset),
+            harness=Harness(config=config.harness),
+        )
+
+    module.load_environment = load_environment
+    monkeypatch.setitem(sys.modules, module_name, module)
+
+    env = vf.load_environment(
+        "typed-env-config",
+        split="test",
+        config={
+            "taskset": {"taskset_id": "typed"},
+            "harness": {"model": "typed-model"},
+        },
+    )
+
+    assert seen["split"] == "test"
+    assert isinstance(seen["config"], EnvConfig)
+    assert env.taskset.config.taskset_id == "typed"
+    assert env.harness.config.model == "typed-model"
+    assert env.env_args == {
+        "split": "test",
+        "config": {
+            "taskset": {"taskset_id": "typed"},
+            "harness": {"model": "typed-model"},
+        },
+    }
+
+
+def test_load_environment_leaves_untyped_config_arg_as_kwargs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module_name = "untyped_env_config"
+    module = types.ModuleType(module_name)
+    seen: dict[str, object] = {}
+
+    def load_environment(split: str = "train", config=None) -> Env:
+        seen["split"] = split
+        seen["config"] = config
+        return Env(taskset=Taskset(source=source_loader))
+
+    module.load_environment = load_environment
+    monkeypatch.setitem(sys.modules, module_name, module)
+
+    vf.load_environment(
+        "untyped-env-config",
+        split="test",
+        config={"taskset": {"taskset_id": "raw"}},
+    )
+
+    assert seen["split"] == "test"
+    assert seen["config"] == {"taskset": {"taskset_id": "raw"}}
+
+
+def test_config_objects_project_to_base_config_fields() -> None:
+    class LocalHarnessConfig(HarnessConfig):
+        toolset: object | None = None
+
+    config = LocalHarnessConfig({"model": "parent", "toolset": {"show": ["search"]}})
+    harness_config = HarnessConfig(config)
+
+    assert config.toolset == {"show": ["search"]}
+    assert harness_config.model == "parent"
+    assert not hasattr(harness_config, "toolset")
+
+
+def test_unset_base_config_defaults_do_not_override_child_defaults() -> None:
+    class LocalHarnessConfig(HarnessConfig):
+        max_turns: int = 4
+
+    default_config = LocalHarnessConfig(HarnessConfig())
+    explicit_config = LocalHarnessConfig(HarnessConfig(max_turns=10))
+
+    assert default_config.max_turns == 4
+    assert explicit_config.max_turns == 10
+
+
+def test_config_field_name_is_allowed_in_typed_configs() -> None:
+    class LocalTasksetConfig(TasksetConfig):
+        config: dict[str, object] | None = None
+
+    loaded_config = LocalTasksetConfig.from_config({"config": {"mode": "loaded"}})
+    direct_config = LocalTasksetConfig(config={"mode": "direct"})
+    merged_config = LocalTasksetConfig(
+        {"taskset_id": "local"},
+        config={"mode": "merged"},
+    )
+
+    assert loaded_config.config == {"mode": "loaded"}
+    assert direct_config.config == {"mode": "direct"}
+    assert merged_config.taskset_id == "local"
+    assert merged_config.config == {"mode": "merged"}
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    [
+        "environments.dspy_flights.dspy_flights",
+        "environments.hello_group_reward_v1.hello_group_reward_v1",
+        "environments.hello_parallel_sandbox_v1.hello_parallel_sandbox_v1",
+        "environments.hello_rlm_v1.hello_rlm_v1",
+        "environments.hello_self_judge_v1.hello_self_judge_v1",
+        "environments.hello_subagent_v1.hello_subagent_v1",
+        "environments.nested_harness_v1.nested_harness_v1",
+    ],
+)
+def test_reference_v1_loaders_preserve_mapping_config_sections(
+    module_name: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = importlib.import_module(module_name)
+    env_id = module_name.rsplit(".", 1)[-1]
+    monkeypatch.setitem(sys.modules, env_id, module)
+
+    env = vf.load_environment(
+        env_id,
+        config={
+            "taskset": {"taskset_id": "from-env-args"},
+            "harness": {"model": "configured-model"},
+        },
+    )
+
+    assert env.taskset.config.taskset_id == "from-env-args"
+    assert env.harness.config.model == "configured-model"
+
+
+def test_reference_v1_harness_loaders_preserve_child_defaults() -> None:
+    group_reward = importlib.import_module(
+        "environments.hello_group_reward_v1.hello_group_reward_v1"
+    )
+    parallel_sandbox = importlib.import_module(
+        "environments.hello_parallel_sandbox_v1.hello_parallel_sandbox_v1"
+    )
+    self_judge = importlib.import_module(
+        "environments.hello_self_judge_v1.hello_self_judge_v1"
+    )
+
+    assert group_reward.load_harness().config.max_turns == 1
+    assert parallel_sandbox.load_harness().config.max_turns == 4
+    assert self_judge.load_harness().config.max_turns == 8
+
+
+def test_bfcl_v1_loader_preserves_mapping_config_sections(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = importlib.import_module("environments.bfcl_v3.bfcl_v3")
+    seen: dict[str, object] = {}
+
+    def fake_taskset(config: object = None, **kwargs: object) -> Taskset:
+        _ = kwargs
+        seen["taskset_config"] = config
+        return Taskset(source=source_loader, config=config)
+
+    def fake_harness(config: object = None, **kwargs: object) -> Harness:
+        _ = kwargs
+        seen["harness_config"] = config
+        return Harness(config=config)
+
+    monkeypatch.setattr(module, "load_taskset", fake_taskset)
+    monkeypatch.setattr(module, "load_harness", fake_harness)
+
+    env = module.load_v1_environment(
+        config=EnvConfig(
+            taskset={"taskset_id": "bfcl-env-args"},
+            harness={"model": "bfcl-model"},
+        )
+    )
+
+    assert env.taskset.config.taskset_id == "bfcl-env-args"
+    assert env.harness.config.model == "bfcl-model"
+    assert isinstance(seen["taskset_config"], module.BFCLTasksetConfig)
+    assert isinstance(seen["harness_config"], module.BFCLHarnessConfig)
+
+
+def test_self_judge_loader_projects_shortcuts_to_child_configs() -> None:
+    module = importlib.import_module(
+        "environments.hello_self_judge_v1.hello_self_judge_v1"
+    )
+
+    taskset = module.load_taskset(num_examples=2)
+    harness = module.load_harness(max_turns=3)
+    shortcut_env = module.load_environment(num_examples=2, max_turns=3)
+    override_env = module.load_environment(
+        num_examples=2,
+        max_turns=3,
+        config=EnvConfig(
+            taskset={"num_examples": 1},
+            harness={"max_turns": 5},
+        ),
+    )
+
+    assert len(taskset.rows()) == 2
+    assert harness.config.max_turns == 3
+    assert len(shortcut_env.taskset.rows()) == 2
+    assert shortcut_env.harness.config.max_turns == 3
+    assert len(override_env.taskset.rows()) == 1
+    assert override_env.harness.config.max_turns == 5
+
+
+def test_subagent_loader_keeps_child_harness_internal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = importlib.import_module("environments.hello_subagent_v1.hello_subagent_v1")
+    monkeypatch.setitem(sys.modules, "hello_subagent_v1", module)
+
+    env = vf.load_environment(
+        "hello-subagent-v1", config={"harness": {"model": "parent"}}
+    )
+
+    assert env.harness.config.model == "parent"
+    child_harness = env.harness.toolsets[0].bindings["ask_subagent.harness"]
+    assert child_harness.config.model is None
 
 
 def test_nested_configs_validate_and_feed_runtime_objects() -> None:

--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -61,6 +61,7 @@ __all__ = [
     "BrowserEnv",
     "OpenEnvEnv",
     "Env",
+    "EnvConfig",
     "Task",
     "Taskset",
     "TasksetConfig",
@@ -165,6 +166,7 @@ _LAZY_IMPORTS = {
     "BrowserEnv": "verifiers.envs.integrations.browser_env:BrowserEnv",
     "OpenEnvEnv": "verifiers.envs.integrations.openenv_env:OpenEnvEnv",
     "Env": "verifiers.v1:Env",
+    "EnvConfig": "verifiers.v1:EnvConfig",
     "Task": "verifiers.v1:Task",
     "Taskset": "verifiers.v1:Taskset",
     "TasksetConfig": "verifiers.v1:TasksetConfig",
@@ -249,6 +251,7 @@ if TYPE_CHECKING:
     from .utils.env_utils import load_environment  # noqa: F401
     from .v1 import (  # noqa: F401
         Env,
+        EnvConfig,
         Harness,
         HarnessConfig,
         MCPTool,

--- a/verifiers/utils/env_config_utils.py
+++ b/verifiers/utils/env_config_utils.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import cast
+
+
+def config_table(value: object, field: str) -> dict[str, object]:
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{field} must be a table.")
+    return dict(cast(Mapping[str, object], value))
+
+
+def normalize_env_config_sections(raw: Mapping[str, object]) -> dict[str, object]:
+    config = dict(raw)
+    env_args = config_table(config.pop("env_args", {}), "env_args")
+    args = config_table(config.pop("args", {}), "args")
+    overlap = set(env_args) & set(args)
+    if overlap:
+        raise ValueError(
+            f"Environment arg key(s) {overlap} appear in both args and env_args."
+        )
+    env_args = {**env_args, **args}
+
+    taskset = config.pop("taskset", None)
+    harness = config.pop("harness", None)
+    child_config: dict[str, object] = {}
+    if taskset is not None:
+        child_config["taskset"] = config_table(taskset, "taskset")
+    if harness is not None:
+        child_config["harness"] = config_table(harness, "harness")
+
+    if child_config:
+        existing_config = config_table(env_args.get("config", {}), "env_args.config")
+        overlap = set(existing_config) & set(child_config)
+        if overlap:
+            raise ValueError(
+                f"Environment config section(s) {overlap} appear in both config and top-level sections."
+            )
+        env_args["config"] = {**existing_config, **child_config}
+
+    if env_args:
+        config["env_args"] = env_args
+    return config

--- a/verifiers/utils/env_utils.py
+++ b/verifiers/utils/env_utils.py
@@ -1,10 +1,12 @@
 import importlib
 import inspect
 import logging
-from typing import Callable
+from types import UnionType
+from typing import Callable, Union, get_args, get_origin, get_type_hints
 
 from verifiers.envs.environment import Environment
 from verifiers.utils.config_utils import MissingKeyError
+from verifiers.v1.config import EnvConfig
 
 
 def load_environment(env_id: str, **env_args) -> Environment:
@@ -67,7 +69,8 @@ def load_environment(env_id: str, **env_args) -> Environment:
             if default_values:
                 logger.info(f"Using default args: {', '.join(default_values)}")
 
-        env_instance: Environment = env_load_func(**env_args)
+        call_env_args = coerce_typed_env_config(env_load_func, sig, env_args)
+        env_instance: Environment = env_load_func(**call_env_args)
         env_instance.env_id = env_instance.env_id or env_id
         env_instance.env_args = env_instance.env_args or env_args
 
@@ -89,3 +92,51 @@ def load_environment(env_id: str, **env_args) -> Environment:
             f"Failed to load environment {env_id} with args {env_args}: {str(e)}"
         )
         raise RuntimeError(f"Failed to load environment '{env_id}': {str(e)}") from e
+
+
+def coerce_typed_env_config(
+    env_load_func: Callable[..., Environment],
+    sig: inspect.Signature,
+    env_args: dict,
+) -> dict:
+    if "config" not in env_args:
+        return env_args
+    config_type = env_config_annotation(env_load_func, sig)
+    if config_type is None:
+        return env_args
+
+    config = env_args["config"]
+    if config is None or isinstance(config, config_type):
+        return env_args
+
+    call_env_args = dict(env_args)
+    call_env_args["config"] = config_type.from_config(config)
+    return call_env_args
+
+
+def env_config_annotation(
+    env_load_func: Callable[..., Environment],
+    sig: inspect.Signature,
+) -> type[EnvConfig] | None:
+    if "config" not in sig.parameters:
+        return None
+    try:
+        annotation = get_type_hints(env_load_func).get("config")
+    except Exception:
+        annotation = sig.parameters["config"].annotation
+    return env_config_type(annotation)
+
+
+def env_config_type(annotation: object) -> type[EnvConfig] | None:
+    if annotation is inspect.Parameter.empty:
+        return None
+    origin = get_origin(annotation)
+    if origin in (Union, UnionType):
+        for arg in get_args(annotation):
+            config_type = env_config_type(arg)
+            if config_type is not None:
+                return config_type
+        return None
+    if isinstance(annotation, type) and issubclass(annotation, EnvConfig):
+        return annotation
+    return None

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -36,6 +36,7 @@ from verifiers.types import (
     _validate_extra_headers_value,
 )
 from verifiers.utils.async_utils import EventLoopLagMonitor
+from verifiers.utils.env_config_utils import config_table, normalize_env_config_sections
 from verifiers.utils.import_utils import load_toml
 from verifiers.utils.logging_utils import (
     log_level,
@@ -45,6 +46,7 @@ from verifiers.utils.logging_utils import (
 from verifiers.utils.path_utils import get_eval_results_path
 
 logger = logging.getLogger(__name__)
+FREEFORM_ABLATION_SWEEP_FIELDS = {"args", "env_args"}
 
 
 def _coerce_endpoint(raw_endpoint: object, source: str) -> Endpoint:
@@ -247,17 +249,17 @@ def _expand_ablation(ablation: dict, global_defaults: dict) -> list[dict]:
     """Expand an [[ablation]] block into eval configs via cartesian product.
 
     Sweep keys are lists of values under [ablation.sweep]. Environment args
-    can be swept via [ablation.sweep.env_args]. All sweep dimensions are
+    can be swept via [ablation.sweep.args]. All sweep dimensions are
     crossed to produce one eval config per combination.
 
     Example TOML:
         [[ablation]]
-        env_id = "my-env"
+        id = "my-env"
 
         [ablation.sweep]
         temperature = [0.0, 0.5]
 
-        [ablation.sweep.env_args]
+        [ablation.sweep.args]
         difficulty = ["easy", "hard"]
 
     This produces 4 eval configs (2 temperatures × 2 difficulties).
@@ -265,6 +267,7 @@ def _expand_ablation(ablation: dict, global_defaults: dict) -> list[dict]:
     ablation = dict(ablation)  # don't mutate caller's dict
     sweep = ablation.pop("sweep", {})
     sweep = dict(sweep)  # copy before mutating
+    args_sweep = sweep.pop("args", {})
     env_args_sweep = sweep.pop("env_args", {})
 
     # Collect all sweep dimensions: [(key, [values]), ...]
@@ -283,20 +286,31 @@ def _expand_ablation(ablation: dict, global_defaults: dict) -> list[dict]:
                 f"{type(values).__name__} for '{key}'"
             )
         dimensions.append((f"env_args.{key}", values))
+    for key, values in args_sweep.items():
+        if not isinstance(values, list):
+            raise ValueError(
+                f"Ablation sweep.args values must be lists, got "
+                f"{type(values).__name__} for '{key}'"
+            )
+        dimensions.append((f"args.{key}", values))
 
     if not dimensions:
         raise ValueError(
             "[[ablation]] block must have a non-empty [ablation.sweep] section"
         )
 
-    # Guard against same key in both fixed env_args and sweep.env_args
-    fixed_env_args = ablation.get("env_args", {})
-    if fixed_env_args and env_args_sweep:
-        overlap = set(fixed_env_args.keys()) & set(env_args_sweep.keys())
+    # Guard against same key in both fixed env args and swept env args.
+    fixed_env_args = {
+        **config_table(ablation.get("env_args", {}), "ablation.env_args"),
+        **config_table(ablation.get("args", {}), "ablation.args"),
+    }
+    swept_env_arg_keys = set(env_args_sweep) | set(args_sweep)
+    if fixed_env_args and swept_env_arg_keys:
+        overlap = set(fixed_env_args) & swept_env_arg_keys
         if overlap:
             raise ValueError(
-                f"env_args key(s) {overlap} appear in both fixed env_args and "
-                f"sweep.env_args — use one or the other"
+                f"environment arg key(s) {overlap} appear in both fixed args and "
+                f"sweep args — use one or the other"
             )
 
     explicit_keys = (set(ablation.keys()) - {"sweep"}) | set(sweep.keys())
@@ -319,11 +333,29 @@ def _expand_ablation(ablation: dict, global_defaults: dict) -> list[dict]:
             if key.startswith("env_args."):
                 env_key = key[len("env_args.") :]
                 config["env_args"] = {**config.get("env_args", {}), env_key: value}
+            elif key.startswith("args."):
+                env_key = key[len("args.") :]
+                config["args"] = {**config.get("args", {}), env_key: value}
             else:
                 config[key] = value
         expanded.append(config)
 
     return expanded
+
+
+def normalize_env_id_alias(config: Mapping[str, Any], section: str) -> dict[str, Any]:
+    normalized = dict(config)
+    if "id" in normalized and "env_id" in normalized:
+        raise ValueError(f"{section} cannot contain both id and env_id.")
+    if "id" in normalized:
+        normalized["env_id"] = normalized.pop("id")
+    return normalized
+
+
+def invalid_ablation_sweep_fields(
+    sweep: Mapping[str, Any], valid_fields: set[str]
+) -> set[str]:
+    return set(sweep) - valid_fields - FREEFORM_ABLATION_SWEEP_FIELDS
 
 
 def load_toml_config(
@@ -339,20 +371,20 @@ def load_toml_config(
         num_examples = 10
 
         [[eval]]
-        env_id = "gsm8k"
+        id = "gsm8k"
 
         [[eval]]
-        env_id = "math-python"
+        id = "math-python"
         num_examples = 5  # overrides global default
 
         # Ablation: cartesian product of sweep values
         [[ablation]]
-        env_id = "my-env"
+        id = "my-env"
 
         [ablation.sweep]
         temperature = [0.0, 0.5, 1.0]
 
-        [ablation.sweep.env_args]
+        [ablation.sweep.args]
         difficulty = ["easy", "hard"]
         # → 6 eval configs
     """
@@ -381,8 +413,15 @@ def load_toml_config(
             f"Config file must contain at least one [[eval]] or [[ablation]] section: {path}"
         )
 
+    eval_list = [
+        normalize_env_id_alias(eval_config, "[[eval]]") for eval_config in eval_list
+    ]
+    ablation_list = [
+        normalize_env_id_alias(ablation, "[[ablation]]") for ablation in ablation_list
+    ]
+
     if not all("env_id" in e for e in eval_list):
-        raise ValueError(f"All [[eval]] sections must contain an env_id field: {path}")
+        raise ValueError(f"All [[eval]] sections must contain an id field: {path}")
 
     # extract global defaults (everything except 'eval' and 'ablation' keys)
     global_defaults = {
@@ -394,7 +433,10 @@ def load_toml_config(
     valid_fields = {
         # environment
         "env_id",
+        "args",
         "env_args",
+        "taskset",
+        "harness",
         "env_dir_path",
         "endpoints_path",
         "extra_env_kwargs",
@@ -460,10 +502,18 @@ def load_toml_config(
             merged.pop("model", None)
         if "model" in eval_config and "endpoint_id" not in eval_config:
             merged.pop("endpoint_id", None)
-        merged_eval_list.append(merged)
+        merged_eval_list.append(normalize_env_config_sections(merged))
 
     # expand [[ablation]] blocks into eval configs
     for ablation in ablation_list:
+        if isinstance(ablation.get("sweep"), Mapping):
+            ablation = {
+                **ablation,
+                "sweep": normalize_env_id_alias(
+                    cast(Mapping[str, Any], ablation["sweep"]),
+                    "[ablation.sweep]",
+                ),
+            }
         # Validate fixed fields (everything except 'sweep')
         ablation_fixed_keys = set(ablation.keys()) - {"sweep"}
         invalid_fields = ablation_fixed_keys - valid_fields
@@ -472,22 +522,25 @@ def load_toml_config(
                 f"Invalid field(s) {invalid_fields} in [[ablation]] block. "
                 f"Valid fields are: {sorted(valid_fields)}"
             )
-        # Validate sweep keys (except env_args which has freeform sub-keys)
+        # Validate sweep keys (except arg tables, which have freeform sub-keys)
         sweep = ablation.get("sweep", {})
-        invalid_sweep = set(sweep.keys()) - valid_fields - {"env_args"}
+        invalid_sweep = invalid_ablation_sweep_fields(sweep, valid_fields)
         if invalid_sweep:
             raise ValueError(
                 f"Invalid sweep field(s) {invalid_sweep} in [[ablation]] block. "
                 f"Valid fields are: {sorted(valid_fields)}"
             )
-        expanded = _expand_ablation(ablation, global_defaults)
+        expanded = [
+            normalize_env_config_sections(config)
+            for config in _expand_ablation(ablation, global_defaults)
+        ]
         merged_eval_list.extend(expanded)
 
     # Validate all expanded configs have env_id
     for config in merged_eval_list:
         if "env_id" not in config:
             raise ValueError(
-                "All eval configs (including expanded ablations) must have an env_id"
+                "All eval configs (including expanded ablations) must have an id"
             )
 
     # Resolve endpoints_path relative to the config file location

--- a/verifiers/v1/README.md
+++ b/verifiers/v1/README.md
@@ -145,13 +145,13 @@ async def contains_answer(task, state) -> float:
     return float(task["answer"] in str(state.get("completion") or ""))
 
 
-def load_taskset(config=None):
+def load_taskset(config: vf.TasksetConfig | None = None):
     return vf.Taskset(source=source, rewards=[contains_answer], config=config)
 
 
-def load_environment(config=None):
-    config = config or {}
-    return vf.Env(taskset=load_taskset(config.get("taskset")))
+def load_environment(config: vf.EnvConfig | None = None):
+    config = config or vf.EnvConfig()
+    return vf.Env(taskset=load_taskset(config=config.taskset))
 ```
 
 Standalone harness use is the same runner without the `Env` adapter:
@@ -195,12 +195,18 @@ loader.
 
 ```python
 from datasets import load_dataset
+import verifiers.v1 as vf
 
 
-def load_taskset(config=None):
-    config = config or {}
-    dataset_name = config.get("dataset_name", "gsm8k")
-    split = config.get("split", "train")
+class GSM8KTasksetConfig(vf.TasksetConfig):
+    dataset_name: str = "gsm8k"
+    split: str = "train"
+
+
+def load_taskset(config: vf.TasksetConfig | None = None):
+    config = GSM8KTasksetConfig(config)
+    dataset_name = config.dataset_name
+    split = config.split
 
     def source():
         dataset = load_dataset(dataset_name, "main", split=split)
@@ -211,7 +217,7 @@ def load_taskset(config=None):
                 "answer": row["answer"],
             }
 
-    return vf.Taskset(source=source)
+    return vf.Taskset(source=source, config=config)
 ```
 
 `eval_source` is optional. If it is omitted, `get_eval_dataset()` uses the same
@@ -1101,28 +1107,28 @@ recommended loader shape is:
 import verifiers.v1 as vf
 
 
-def load_taskset(config=None):
+def load_taskset(config: vf.TasksetConfig | None = None):
     return vf.Taskset(source=source, rewards=[exact], config=config)
 
 
-def load_harness(config=None):
+def load_harness(config: vf.HarnessConfig | None = None):
     return vf.Harness(config=config)
 
 
-def load_environment(config=None):
-    config = config or {}
+def load_environment(config: vf.EnvConfig | None = None):
+    config = config or vf.EnvConfig()
     return vf.Env(
-        taskset=load_taskset(config.get("taskset")),
-        harness=load_harness(config.get("harness")),
+        taskset=load_taskset(config=config.taskset),
+        harness=load_harness(config=config.harness),
     )
 ```
 
 If the base harness is enough, omit `load_harness`:
 
 ```python
-def load_environment(config=None):
-    config = config or {}
-    return vf.Env(taskset=load_taskset(config.get("taskset")))
+def load_environment(config: vf.EnvConfig | None = None):
+    config = config or vf.EnvConfig()
+    return vf.Env(taskset=load_taskset(config=config.taskset))
 ```
 
 With that loader, eval TOML routes v1 config through `env_args.config`:
@@ -1142,6 +1148,46 @@ max_turns = 4
 
 [eval.env_args.config.taskset.scoring.exact_answer]
 weight = 0.5
+```
+
+For concise named args, pass typed child config objects as defaults. Explicit
+nested sections win over those defaults.
+
+```python
+class MyTasksetConfig(vf.TasksetConfig):
+    split: str = "train"
+
+
+def load_taskset(
+    split: str | None = None,
+    config: vf.TasksetConfig | None = None,
+):
+    config = MyTasksetConfig(config, split=split)
+    ...
+
+
+def load_harness(
+    max_turns: int | None = None,
+    config: vf.HarnessConfig | None = None,
+):
+    config = vf.HarnessConfig(config, max_turns=max_turns)
+    ...
+
+
+def load_environment(
+    config: vf.EnvConfig | None = None,
+    split: str = "train",
+    max_turns: int = 10,
+):
+    config = vf.EnvConfig(
+        config,
+        taskset=MyTasksetConfig(split=split),
+        harness=vf.HarnessConfig(max_turns=max_turns),
+    )
+    return vf.Env(
+        taskset=load_taskset(config=config.taskset),
+        harness=load_harness(config=config.harness),
+    )
 ```
 
 RL and Hosted Training TOML routes the same v1 config through `args.config`:
@@ -1398,8 +1444,8 @@ taskset_config = vf.TasksetConfig.from_toml("local.toml", "taskset")
 harness_config = vf.HarnessConfig.from_toml("local.toml", "harness")
 
 env = vf.Env(
-    taskset=load_taskset(taskset_config),
-    harness=load_harness(harness_config),
+    taskset=load_taskset(config=taskset_config),
+    harness=load_harness(config=harness_config),
 )
 ```
 
@@ -1421,7 +1467,7 @@ class WikiTaskset(vf.Taskset):
     config_type = WikiTasksetConfig
 
     def __init__(self, config):
-        config = self.config_type.model_validate(config)
+        config = self.config_type(config)
 
         def load_db():
             return open_db(config.db_path)

--- a/verifiers/v1/README.md
+++ b/verifiers/v1/README.md
@@ -1131,7 +1131,8 @@ def load_environment(config: vf.EnvConfig | None = None):
     return vf.Env(taskset=load_taskset(config=config.taskset))
 ```
 
-With that loader, eval TOML routes v1 config through `env_args.config`:
+With that loader, eval TOML routes named environment args through `args` and v1
+config through the `taskset`/`harness` sections:
 
 ```toml
 # configs/eval/my-v1-env.toml
@@ -1143,10 +1144,13 @@ rollouts_per_example = 3
 env_id = "my-v1-env"
 sampling_args = { max_tokens = 4096, reasoning_effort = "medium" }
 
-[eval.env_args.config.harness]
+[eval.args]
+split = "test"
+
+[eval.harness]
 max_turns = 4
 
-[eval.env_args.config.taskset.scoring.exact_answer]
+[eval.taskset.scoring.exact_answer]
 weight = 0.5
 ```
 
@@ -1190,7 +1194,7 @@ def load_environment(
     )
 ```
 
-RL and Hosted Training TOML routes the same v1 config through `args.config`:
+RL and Hosted Training TOML uses the same split under `env`:
 
 ```toml
 # configs/rl/my-v1-env.toml
@@ -1205,10 +1209,13 @@ max_tokens = 4096
 [[env]]
 id = "primeintellect/my-v1-env"
 
-[env.args.config.harness]
+[env.args]
+split = "train"
+
+[env.harness]
 max_turns = 8
 
-[env.args.config.taskset.scoring.exact_answer]
+[env.taskset.scoring.exact_answer]
 weight = 1.0
 ```
 
@@ -1246,20 +1253,20 @@ Callable config fields use one grammar. Function identity is always the Python
 function name; TOML does not define custom metric/reward/update names.
 
 ```toml
-[[env.args.config.taskset.setups]]
+[[env.taskset.setups]]
 fn = "my_env.setup:prepare_state"
 priority = 20
 
-[[env.args.config.taskset.updates]]
+[[env.taskset.updates]]
 fn = "my_env.signals:parse_answer"
 priority = 10
 
-[[env.args.config.taskset.rewards]]
+[[env.taskset.rewards]]
 fn = "my_env.signals:exact_answer"
 weight = 1.0
 priority = 0
 
-[[env.args.config.harness.cleanups]]
+[[env.harness.cleanups]]
 fn = "my_env.signals:close_trace"
 stage = "group"
 ```
@@ -1267,7 +1274,7 @@ stage = "group"
 A bare string is shorthand when no metadata is needed:
 
 ```toml
-[env.args.config.taskset]
+[env.taskset]
 rewards = ["my_env.signals:exact_answer"]
 ```
 
@@ -1278,10 +1285,10 @@ plural args (`tasks, states`). Rollout-stage callables are the default and use
 `scoring` tunes existing signal names:
 
 ```toml
-[env.args.config.taskset.scoring.exact_answer]
+[env.taskset.scoring.exact_answer]
 weight = 0.5
 
-[env.args.config.harness.scoring.turns]
+[env.harness.scoring.turns]
 skip = true
 ```
 
@@ -1295,7 +1302,7 @@ Use zero-argument source loaders in config so environment construction stays
 cheap and import-safe:
 
 ```toml
-[env.args.config.taskset]
+[env.taskset]
 source = "my_env.data:train_rows"
 eval_source = "my_env.data:eval_rows"
 ```
@@ -1317,14 +1324,14 @@ def train_rows():
 Toolsets are addressable resource packages, so TOML keys are toolset ids:
 
 ```toml
-[env.args.config.taskset.toolsets]
+[env.taskset.toolsets]
 wiki = "my_env.tools:load_wiki_toolset"
 
-[env.args.config.taskset.toolsets.python]
+[env.taskset.toolsets.python]
 fn = "my_env.tools:load_python_toolset"
 packages = ["numpy", "pandas"]
 
-[env.args.config.taskset.toolsets.search]
+[env.taskset.toolsets.search]
 tools = ["my_env.tools:search"]
 bindings = { "search.index" = "objects.index" }
 ```
@@ -1349,7 +1356,7 @@ remove a subset. Do not set both.
 Python programs can be configured directly:
 
 ```toml
-[env.args.config.harness.program]
+[env.harness.program]
 fn = "my_env.programs:run_agent"
 sandbox = true
 tools = "callable"
@@ -1359,14 +1366,14 @@ Command programs use `command` and can receive the resolved tools as an MCP
 server when they run in a sandbox:
 
 ```toml
-[env.args.config.harness.program]
+[env.harness.program]
 command = ["bash", "-lc", "my-cli run /task/instruction.md"]
 sandbox = true
 
-[env.args.config.harness.program.tools]
+[env.harness.program.tools]
 mcp = true
 
-[env.args.config.harness.program.files]
+[env.harness.program.files]
 "/task/instruction.md" = "task.instruction"
 ```
 
@@ -1375,14 +1382,14 @@ tool or endpoint config after the interception endpoint is live and before the
 command runs:
 
 ```toml
-[env.args.config.harness.program]
+[env.harness.program]
 command = ["my-cli", "run", "--config", "/tmp/my-cli.json"]
 sandbox = true
 
-[env.args.config.harness.program.tools]
+[env.harness.program.tools]
 mcp = { fn = "my_env.cli:write_cli_config" }
 
-[env.args.config.harness.program.bindings]
+[env.harness.program.bindings]
 "write_cli_config.endpoint_config" = { fn = "my_env.cli:endpoint_config" }
 ```
 

--- a/verifiers/v1/RE_MIGRATION.md
+++ b/verifiers/v1/RE_MIGRATION.md
@@ -52,7 +52,7 @@ Every migrated package should expose:
 import verifiers.v1 as vf
 
 
-def load_taskset(config=None) -> vf.Taskset:
+def load_taskset(config: vf.TasksetConfig | None = None) -> vf.Taskset:
     return vf.Taskset(
         source=load_rows,
         system_prompt=SYSTEM_PROMPT,
@@ -63,22 +63,24 @@ def load_taskset(config=None) -> vf.Taskset:
     )
 
 
-def load_harness(config=None) -> vf.Harness:
+def load_harness(config: vf.HarnessConfig | None = None) -> vf.Harness:
     return vf.Harness(config=config)
 
 
-def load_v1_environment(config=None) -> vf.Env:
+def load_v1_environment(config: vf.EnvConfig | None = None) -> vf.Env:
+    config = config or vf.EnvConfig()
     return vf.Env(
-        taskset=load_taskset(getattr(config, "taskset", None)),
-        harness=load_harness(getattr(config, "harness", None)),
+        taskset=load_taskset(config=config.taskset),
+        harness=load_harness(config=config.harness),
     )
 ```
 
 If the base harness is enough, omit `load_harness`:
 
 ```python
-def load_v1_environment(config=None) -> vf.Env:
-    return vf.Env(taskset=load_taskset(getattr(config, "taskset", None)))
+def load_v1_environment(config: vf.EnvConfig | None = None) -> vf.Env:
+    config = config or vf.EnvConfig()
+    return vf.Env(taskset=load_taskset(config=config.taskset))
 ```
 
 Rows should be plain serializable task data:
@@ -158,12 +160,13 @@ async def exact(task, state) -> float:
     return float(str(task["answer"]).strip() in completion_text(state))
 
 
-def load_taskset(config=None):
+def load_taskset(config: vf.TasksetConfig | None = None):
     return vf.Taskset(source=source, rewards=[exact], config=config)
 
 
-def load_v1_environment(config=None):
-    return vf.Env(taskset=load_taskset(getattr(config, "taskset", None)))
+def load_v1_environment(config: vf.EnvConfig | None = None):
+    config = config or vf.EnvConfig()
+    return vf.Env(taskset=load_taskset(config=config.taskset))
 ```
 
 Gotchas:
@@ -222,7 +225,7 @@ def load_toolset(config=None):
     )
 
 
-def load_taskset(config=None):
+def load_taskset(config: vf.TasksetConfig | None = None):
     return vf.Taskset(
         source=source,
         toolsets=[load_toolset()],
@@ -643,11 +646,17 @@ Migration:
 Example:
 
 ```python
+class SuiteConfig(vf.Config):
+    math: object | None = None
+    graph: object | None = None
+
+
 def load_environment(config=None):
+    config = SuiteConfig(config)
     return vf.EnvGroup(
         [
-            load_math_environment(getattr(config, "math", None)),
-            load_graph_environment(getattr(config, "graph", None)),
+            load_math_environment(config.math),
+            load_graph_environment(config.graph),
         ]
     )
 ```

--- a/verifiers/v1/__init__.py
+++ b/verifiers/v1/__init__.py
@@ -13,6 +13,7 @@ from verifiers.decorators import (
 
 from .config import (
     Config,
+    EnvConfig,
     HarnessConfig,
     MCPToolConfig,
     SandboxConfig,
@@ -45,6 +46,7 @@ from .user import User
 __all__ = [
     "Config",
     "Env",
+    "EnvConfig",
     "Harness",
     "HarnessConfig",
     "HarborTaskset",

--- a/verifiers/v1/config.py
+++ b/verifiers/v1/config.py
@@ -20,6 +20,24 @@ except ModuleNotFoundError:
 class Config(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
 
+    def __init__(self, config: object | None = None, /, **data: object):
+        super().__init__(**type(self)._merge_config_data(config, data))
+
+    @classmethod
+    def from_config(cls, config: object | None = None, /, **data: object) -> Self:
+        return cls(**cls._merge_config_data(config, data))
+
+    @classmethod
+    def _merge_config_data(
+        cls, config: object | None, data: dict[str, object]
+    ) -> dict[str, object]:
+        data = omit_none(data)
+        if config is not None:
+            base = config_data(config, cls)
+            base.update(data)
+            data = base
+        return data
+
     @classmethod
     def from_toml(
         cls, path: str | Path, section: str | Iterable[str] | None = None
@@ -32,7 +50,7 @@ class Config(BaseModel):
                 if not isinstance(data, Mapping):
                     raise TypeError(f"TOML section {section!r} does not exist.")
                 data = data[key]
-        return cls.model_validate(data)
+        return cls.from_config(data)
 
     @classmethod
     def schema_text(cls) -> str:
@@ -42,6 +60,26 @@ class Config(BaseModel):
                 f"- {name}: {annotation_text(field.annotation)} = {default_text(field)}"
             )
         return "\n".join(lines)
+
+
+def config_data(value: object, target: type[Config] | None = None) -> dict[str, object]:
+    if value is None:
+        data: dict[str, object] = {}
+    elif isinstance(value, Config):
+        data = value.model_dump(exclude_none=True, exclude_unset=True)
+        if target is not None:
+            data = {
+                key: item for key, item in data.items() if key in target.model_fields
+            }
+    elif isinstance(value, Mapping):
+        data = string_mapping(cast(Mapping[object, object], value))
+    else:
+        raise TypeError("Config must be a mapping or Config object.")
+    return data
+
+
+def omit_none(data: Mapping[str, object]) -> dict[str, object]:
+    return {key: value for key, value in data.items() if value is not None}
 
 
 class SandboxConfig(Config):
@@ -166,6 +204,48 @@ class HarnessConfig(Config):
     max_turns: int = 10
 
 
+class EnvConfig(Config):
+    taskset: object | None = None
+    harness: object | None = None
+
+    @field_validator("taskset", "harness")
+    @classmethod
+    def validate_child_config(cls, value: object) -> object:
+        if value is not None:
+            try:
+                config_data(value)
+            except TypeError as exc:
+                raise ValueError(str(exc)) from exc
+        return value
+
+    @classmethod
+    def _merge_config_data(
+        cls, config: object | None, data: dict[str, object]
+    ) -> dict[str, object]:
+        data = omit_none(data)
+        if config is None:
+            return data
+        base = config_data(config, cls)
+        for section in ("taskset", "harness"):
+            default = data.get(section)
+            override = base.pop(section, None)
+            if default is None:
+                if override is not None:
+                    data[section] = override
+                continue
+            if override is not None:
+                data[section] = merge_child_config(default, override)
+        base.update(data)
+        return base
+
+
+def merge_child_config(default: object, override: object) -> object:
+    merged = deep_merge(config_data(default), config_data(override))
+    if isinstance(default, Config):
+        return type(default)(merged)
+    return merged
+
+
 def merge_config_value(value: object, config: object) -> object:
     if config is None:
         return value
@@ -199,7 +279,7 @@ def sandbox_config_mapping(value: object | None) -> dict[str, object] | None:
         prefer = mapping.get("prefer")
         if prefer is not None and prefer != "program":
             raise ValueError("sandbox.prefer must be 'program'.")
-        return SandboxConfig.model_validate(mapping).model_dump(exclude_none=True)
+        return SandboxConfig.from_config(mapping).model_dump(exclude_none=True)
     raise TypeError("Sandbox config must be a mapping.")
 
 

--- a/verifiers/v1/harness.py
+++ b/verifiers/v1/harness.py
@@ -92,7 +92,7 @@ class Harness:
         # Config.
         config: HarnessConfig | Mapping[str, object] | None = None,
     ):
-        self.config = type(self).config_type.model_validate(config or {})
+        self.config = type(self).config_type.from_config(config)
         if max_turns is not None:
             self.config.max_turns = max_turns
         program_value = resolve_config_object(

--- a/verifiers/v1/packages/harnesses/rlm.py
+++ b/verifiers/v1/packages/harnesses/rlm.py
@@ -58,7 +58,7 @@ class RLM(CLIHarness):
         config: HarnessConfig | Mapping[str, object] | None = None,
         **kwargs: Any,
     ):
-        harness_config = HarnessConfig.model_validate(config or {})
+        harness_config = HarnessConfig.from_config(config)
         if (
             not include_sub_rlm_trajectories
             and harness_config.keep_trajectory_step is None

--- a/verifiers/v1/packages/tasksets/harbor.py
+++ b/verifiers/v1/packages/tasksets/harbor.py
@@ -64,7 +64,7 @@ class HarborTaskset(Taskset):
         config: HarborTasksetConfig | Mapping[str, object] | None = None,
         **kwargs: Any,
     ):
-        self.config = type(self).config_type.model_validate(config or {})
+        self.config = type(self).config_type.from_config(config)
         self.tasks = merge_config_value(tasks, self.config.tasks)
         self.task_names = list(
             task_names

--- a/verifiers/v1/taskset.py
+++ b/verifiers/v1/taskset.py
@@ -50,7 +50,7 @@ class Taskset:
         # Config.
         config: TasksetConfig | Mapping[str, object] | None = None,
     ):
-        self.config = type(self).config_type.model_validate(config or {})
+        self.config = type(self).config_type.from_config(config)
         source_value = resolve_config_object(
             merge_config_value(source, self.config.source)
         )

--- a/verifiers/v1/toolset.py
+++ b/verifiers/v1/toolset.py
@@ -10,7 +10,6 @@ from .config import (
     SandboxConfig,
     ToolsetConfig,
     config_callables,
-    config_mapping,
     resolve_config_object,
     sandbox_config_mapping,
     string_mapping,
@@ -295,13 +294,7 @@ def tool_item(value: object) -> object:
 def toolset_config_mapping(config: object | None) -> Mapping[str, object]:
     if config is None:
         return {}
-    if isinstance(config, ToolsetConfig):
-        return config.model_dump(exclude_none=True)
-    if not isinstance(config, Mapping):
-        return {}
-    return ToolsetConfig.model_validate(config_mapping(config)).model_dump(
-        exclude_none=True
-    )
+    return ToolsetConfig.from_config(config).model_dump(exclude_none=True)
 
 
 def string_items(value: object) -> list[str] | None:
@@ -350,7 +343,7 @@ class MCPTool:
 
     @classmethod
     def from_mapping(cls, spec: Mapping[str, object]) -> MCPTool:
-        config = MCPToolConfig.model_validate(spec)
+        config = MCPToolConfig.from_config(spec)
         return cls(
             command=config.command,
             args=config.args,

--- a/verifiers/v1/user.py
+++ b/verifiers/v1/user.py
@@ -5,7 +5,7 @@ from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Literal, cast
 
-from .config import UserConfig, config_mapping, import_config_ref, resolve_config_object
+from .config import UserConfig, import_config_ref, resolve_config_object
 from .utils.trajectory_utils import completion_from_trajectory
 
 UserScope = Literal["rollout", "group", "global"]
@@ -65,7 +65,7 @@ def normalize_user(value: object | None) -> User | None:
 
 
 def user_from_mapping(spec: Mapping[str, object]) -> User:
-    config = UserConfig.model_validate(config_mapping(spec))
+    config = UserConfig.from_config(spec)
     fn = config.fn
     if isinstance(fn, str):
         fn = import_config_ref(fn)


### PR DESCRIPTION
## Summary
- Normalize v1 environment config through a strict `EnvConfig` with only `taskset` and `harness` sections.
- Route TOML and shortcut args into typed `TasksetConfig` and `HarnessConfig` child configs before calling `load_taskset` and `load_harness`.
- Update affected example environments, docs, and tests to match the new boundary.
- Replace internal config construction patterns with `from_config(...)` helpers where needed.

## Testing
- Added regression coverage for TOML mapping config, shortcut projection, nested overrides, BFCL loader config typing, and self-judge config routing.
- Ran `ruff check`, `ruff format --check`, `ty check` on touched v1 code, `pytest tests/test_v1_config_extension.py -q`, `pytest tests/test_v1*.py -q`, and `pre-commit run --all-files`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how TOML configs and `load_environment()` arguments are normalized/coerced (including new `id`/`args` aliases and typed `EnvConfig` coercion), which could break existing configs or custom environments if assumptions differ.
> 
> **Overview**
> **v1 environment config handling is tightened and normalized.** Adds `EnvConfig` (exported via `verifiers` and `verifiers.v1`) as the only top-level v1 config envelope, with explicit `taskset` and `harness` child sections that merge defaults and validate shapes.
> 
> **TOML and loader boundaries are updated to match the new split.** Eval/ablation TOML parsing now accepts `id` as an alias for `env_id`, supports `[eval.args]` plus sibling `[eval.taskset]`/`[eval.harness]` sections (normalized back into `env_args.config` internally), and adds similar support for ablation sweeps via `args`. RL training TOML parsing is updated to normalize these sections as well.
> 
> **Example environments and docs are migrated to typed config patterns.** Multiple v1 sample envs now type their loader `config` params (`TasksetConfig`/`HarnessConfig`/`EnvConfig`), project shortcut args into typed child configs, and switch v1 `Config` construction to `from_config(...)`; test coverage is expanded for aliasing/normalization, typed-config coercion during `vf.load_environment`, and config-merge behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1c99b2967f06001f75621966588c0dec861c15f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->