### PR TITLE
Fix misleading completion_text fallback in DSPy/OpenAI/LangChain agent envs

### DIFF
--- a/environments/dspy_rlm/dspy_rlm.py
+++ b/environments/dspy_rlm/dspy_rlm.py
@@ -64,7 +64,7 @@ def completion_text(state: Mapping[str, Any]) -> str:
         if isinstance(last_message, Mapping):
             return str(last_message.get("content") or "")
         return str(getattr(last_message, "content", last_message) or "")
-    return str(state.get("agent_result") or "")
+    return ""
 
 
 def extract_dspy_answer(text: str) -> str:

--- a/environments/langchain_deep_agents_env/langchain_deep_agents_env.py
+++ b/environments/langchain_deep_agents_env/langchain_deep_agents_env.py
@@ -88,7 +88,7 @@ def completion_text(state: Mapping[str, Any]) -> str:
         if isinstance(last_message, Mapping):
             return str(last_message.get("content") or "")
         return str(getattr(last_message, "content", last_message) or "")
-    return str(state.get("agent_result") or "")
+    return ""
 
 
 def extract_answer(text: str) -> str:

--- a/environments/openai_agents_env/openai_agents_env.py
+++ b/environments/openai_agents_env/openai_agents_env.py
@@ -92,7 +92,7 @@ def completion_text(state: Mapping[str, Any]) -> str:
         if isinstance(last_message, Mapping):
             return str(last_message.get("content") or "")
         return str(getattr(last_message, "content", last_message) or "")
-    return str(state.get("agent_result") or "")
+    return ""
 
 
 def extract_answer(text: str) -> str:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

In `completion_text` helpers used by the DSPy RLM, OpenAI Agents, and LangChain Deep Agents example environments, the final return used `str(state.get("agent_result") or "")`. That line is only reached after:

1. `agent_result is None` (otherwise we return earlier), and  
2. No usable `completion` messages were found.

With `agent_result` already known to be `None`, that expression always evaluates to an empty string. Replacing it with `return ""` matches behavior and documents that there is no further fallback.

## Files

- `environments/dspy_rlm/dspy_rlm.py`
- `environments/openai_agents_env/openai_agents_env.py`
- `environments/langchain_deep_agents_env/langchain_deep_agents_env.py`

## Base branch

These environments live on `cooper/apienv` (not yet on `main`), so this PR targets `cooper/apienv`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-744390e6-a6a0-41be-ad70-39914f693603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-744390e6-a6a0-41be-ad70-39914f693603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

