### PR TITLE
[codex] Align tau2 taskset config with v1 loaders

### DIFF
--- a/environments/tau2_bench_v1/tau2_bench_v1.py
+++ b/environments/tau2_bench_v1/tau2_bench_v1.py
@@ -677,47 +677,73 @@ async def tau2_num_user_tool_calls(task, state) -> float:
     return float(state.get("num_user_tool_calls", 0.0))
 
 
+class Tau2TasksetConfig(vf.TasksetConfig):
+    domain: str = "telecom"
+    user_model: str = DEFAULT_USER_MODEL
+    user_args: dict[str, object] | None = None
+    user_base_url: str = DEFAULT_USER_BASE_URL
+    user_api_key_var: str = DEFAULT_USER_API_KEY_VAR
+    max_steps: int = DEFAULT_MAX_STEPS
+    max_errors: int = DEFAULT_MAX_ERRORS
+    max_turns: int = DEFAULT_MAX_STEPS
+
+
 class Tau2Taskset(vf.Taskset):
+    config_type = Tau2TasksetConfig
+
     def __init__(
         self,
-        domain: str = "telecom",
+        domain: str | None = None,
         *,
-        user_model: str = DEFAULT_USER_MODEL,
+        user_model: str | None = None,
         user_args: Mapping[str, object] | None = None,
-        user_base_url: str = DEFAULT_USER_BASE_URL,
-        user_api_key_var: str = DEFAULT_USER_API_KEY_VAR,
-        max_steps: int = DEFAULT_MAX_STEPS,
-        max_errors: int = DEFAULT_MAX_ERRORS,
-        max_turns: int = DEFAULT_MAX_STEPS,
-        config=None,
+        user_base_url: str | None = None,
+        user_api_key_var: str | None = None,
+        max_steps: int | None = None,
+        max_errors: int | None = None,
+        max_turns: int | None = None,
+        config: vf.TasksetConfig | Mapping[str, object] | None = None,
     ):
-        resolved_user_args = DEFAULT_LLM_ARGS_USER if user_args is None else user_args
-        session_factory = load_session_factory(
+        config = Tau2TasksetConfig(
+            config,
             domain=domain,
             user_model=user_model,
-            user_args=tau2_user_args(
-                resolved_user_args, user_base_url, user_api_key_var
-            ),
-            max_steps=max_steps,
-            max_errors=max_errors,
-        )
-        toolset = load_toolset(
-            domain=domain,
-            user_model=user_model,
-            user_args=resolved_user_args,
+            user_args=dict(user_args) if user_args is not None else None,
             user_base_url=user_base_url,
             user_api_key_var=user_api_key_var,
             max_steps=max_steps,
             max_errors=max_errors,
+            max_turns=max_turns,
+        )
+        resolved_user_args = (
+            DEFAULT_LLM_ARGS_USER if config.user_args is None else config.user_args
+        )
+        session_factory = load_session_factory(
+            domain=config.domain,
+            user_model=config.user_model,
+            user_args=tau2_user_args(
+                resolved_user_args, config.user_base_url, config.user_api_key_var
+            ),
+            max_steps=config.max_steps,
+            max_errors=config.max_errors,
+        )
+        toolset = load_toolset(
+            domain=config.domain,
+            user_model=config.user_model,
+            user_args=resolved_user_args,
+            user_base_url=config.user_base_url,
+            user_api_key_var=config.user_api_key_var,
+            max_steps=config.max_steps,
+            max_errors=config.max_errors,
             session_factory=session_factory,
         )
 
         def load_rows():
-            return source(domain, max_turns=max_turns)
+            return source(config.domain, max_turns=config.max_turns)
 
         super().__init__(
             source=load_rows,
-            taskset_id=f"tau2_{domain}",
+            taskset_id=f"tau2_{config.domain}",
             setups=[make_tau2_setup(session_factory)],
             rewards=[tau2_reward],
             metrics=[
@@ -733,16 +759,16 @@ class Tau2Taskset(vf.Taskset):
 
 
 def load_taskset(
-    domain: str = "telecom",
+    domain: str | None = None,
     *,
-    user_model: str = DEFAULT_USER_MODEL,
+    user_model: str | None = None,
     user_args: Mapping[str, object] | None = None,
-    user_base_url: str = DEFAULT_USER_BASE_URL,
-    user_api_key_var: str = DEFAULT_USER_API_KEY_VAR,
-    max_steps: int = DEFAULT_MAX_STEPS,
-    max_errors: int = DEFAULT_MAX_ERRORS,
-    max_turns: int = DEFAULT_MAX_STEPS,
-    config=None,
+    user_base_url: str | None = None,
+    user_api_key_var: str | None = None,
+    max_steps: int | None = None,
+    max_errors: int | None = None,
+    max_turns: int | None = None,
+    config: vf.TasksetConfig | Mapping[str, object] | None = None,
 ) -> Tau2Taskset:
     return Tau2Taskset(
         domain=domain,
@@ -767,16 +793,23 @@ def load_v1_environment(
     max_steps: int = DEFAULT_MAX_STEPS,
     max_errors: int = DEFAULT_MAX_ERRORS,
     max_turns: int = DEFAULT_MAX_STEPS,
+    config: vf.EnvConfig | None = None,
 ) -> vf.Env:
+    config = vf.EnvConfig(
+        config,
+        taskset=Tau2TasksetConfig(
+            domain=domain,
+            user_model=user_model,
+            user_args=dict(user_args) if user_args is not None else None,
+            user_base_url=user_base_url,
+            user_api_key_var=user_api_key_var,
+            max_steps=max_steps,
+            max_errors=max_errors,
+            max_turns=max_turns,
+        ),
+    )
     taskset = load_taskset(
-        domain=domain,
-        user_model=user_model,
-        user_args=user_args,
-        user_base_url=user_base_url,
-        user_api_key_var=user_api_key_var,
-        max_steps=max_steps,
-        max_errors=max_errors,
-        max_turns=max_turns,
+        config=config.taskset,
     )
     return vf.Env(taskset=taskset)
 
@@ -791,6 +824,7 @@ def load_environment(
     max_steps: int = DEFAULT_MAX_STEPS,
     max_errors: int = DEFAULT_MAX_ERRORS,
     max_turns: int = DEFAULT_MAX_STEPS,
+    config: vf.EnvConfig | None = None,
 ) -> vf.Env:
     return load_v1_environment(
         domain=domain,
@@ -801,4 +835,5 @@ def load_environment(
         max_steps=max_steps,
         max_errors=max_errors,
         max_turns=max_turns,
+        config=config,
     )

--- a/environments/tau2_bench_v1/tau2_bench_v1.py
+++ b/environments/tau2_bench_v1/tau2_bench_v1.py
@@ -811,7 +811,7 @@ def load_v1_environment(
     taskset = load_taskset(
         config=config.taskset,
     )
-    return vf.Env(taskset=taskset)
+    return vf.Env(taskset=taskset, harness=vf.Harness(config=config.harness))
 
 
 def load_environment(

--- a/tests/test_v1_config_extension.py
+++ b/tests/test_v1_config_extension.py
@@ -1262,6 +1262,130 @@ def test_bfcl_v1_loader_preserves_mapping_config_sections(
     assert isinstance(seen["harness_config"], module.BFCLHarnessConfig)
 
 
+def test_tau2_loader_forwards_mapping_harness_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_tau2_import_stubs(monkeypatch)
+    module = importlib.import_module("environments.tau2_bench_v1.tau2_bench_v1")
+    seen: dict[str, object] = {}
+
+    def fake_taskset(config: object = None) -> Taskset:
+        seen["taskset_config"] = config
+        return Taskset(source=source_loader)
+
+    monkeypatch.setattr(module, "load_taskset", fake_taskset)
+
+    env = module.load_v1_environment(
+        config=EnvConfig(
+            taskset={"max_turns": 7},
+            harness={"model": "configured-model", "max_turns": 3},
+        )
+    )
+
+    assert type(env.harness) is Harness
+    assert env.harness.config.model == "configured-model"
+    assert env.harness.config.max_turns == 3
+    assert isinstance(seen["taskset_config"], module.Tau2TasksetConfig)
+    assert seen["taskset_config"].max_turns == 7
+
+
+def install_tau2_import_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
+    modules = [
+        "tau2",
+        "tau2.agent",
+        "tau2.agent.llm_agent",
+        "tau2.config",
+        "tau2.data_model",
+        "tau2.data_model.message",
+        "tau2.data_model.simulation",
+        "tau2.data_model.tasks",
+        "tau2.environment",
+        "tau2.environment.environment",
+        "tau2.evaluator",
+        "tau2.evaluator.evaluator",
+        "tau2.orchestrator",
+        "tau2.orchestrator.orchestrator",
+        "tau2.registry",
+        "tau2.run",
+        "tau2.user",
+        "tau2.user.user_simulator",
+        "tau2.utils",
+        "tau2.utils.utils",
+    ]
+    for module_name in modules:
+        monkeypatch.setitem(sys.modules, module_name, types.ModuleType(module_name))
+
+    llm_agent = sys.modules["tau2.agent.llm_agent"]
+    llm_agent.AGENT_INSTRUCTION = "agent"
+    llm_agent.SYSTEM_PROMPT = "{agent_instruction} {domain_policy}"
+    llm_agent.LLMAgent = type("LLMAgent", (), {})
+    llm_agent.is_valid_agent_history_message = lambda message: True
+
+    config = sys.modules["tau2.config"]
+    config.DEFAULT_LLM_ARGS_AGENT = {}
+    config.DEFAULT_LLM_ARGS_USER = {}
+    config.DEFAULT_MAX_ERRORS = 10
+    config.DEFAULT_MAX_STEPS = 20
+
+    message = sys.modules["tau2.data_model.message"]
+    for name in (
+        "AssistantMessage",
+        "Message",
+        "MultiToolMessage",
+        "ToolCall",
+        "ToolMessage",
+        "UserMessage",
+    ):
+        setattr(message, name, type(name, (), {}))
+
+    simulation = sys.modules["tau2.data_model.simulation"]
+    simulation.SimulationRun = type("SimulationRun", (), {})
+    simulation.TerminationReason = type(
+        "TerminationReason",
+        (),
+        {
+            "AGENT_ERROR": "agent_error",
+            "AGENT_STOP": "agent_stop",
+            "MAX_STEPS": "max_steps",
+            "TOO_MANY_ERRORS": "too_many_errors",
+            "USER_STOP": "user_stop",
+        },
+    )
+
+    tasks = sys.modules["tau2.data_model.tasks"]
+    tasks.Task = type("Task", (), {})
+
+    environment = sys.modules["tau2.environment.environment"]
+    environment.Environment = type("Environment", (), {})
+
+    evaluator = sys.modules["tau2.evaluator.evaluator"]
+    evaluator.EvaluationType = type("EvaluationType", (), {"ALL": "all"})
+    evaluator.evaluate_simulation = lambda **kwargs: None
+
+    orchestrator = sys.modules["tau2.orchestrator.orchestrator"]
+    orchestrator.DEFAULT_FIRST_AGENT_MESSAGE = object()
+    orchestrator.Role = type(
+        "Role", (), {"AGENT": "agent", "ENV": "env", "USER": "user"}
+    )
+
+    registry_module = sys.modules["tau2.registry"]
+    registry_module.registry = type(
+        "Registry", (), {"get_env_constructor": lambda *args: None}
+    )()
+
+    run = sys.modules["tau2.run"]
+    run.load_tasks = lambda *args, **kwargs: []
+
+    user_simulator = sys.modules["tau2.user.user_simulator"]
+    user_simulator.UserSimulator = type("UserSimulator", (), {})
+    user_simulator.is_valid_user_history_message = lambda message: True
+
+    utils = sys.modules["tau2.utils.utils"]
+    utils.DATA_DIR = "unused"
+    utils.format_time = lambda value: str(value)
+    utils.get_now = lambda: "now"
+
+
 def test_self_judge_loader_projects_shortcuts_to_child_configs() -> None:
     module = importlib.import_module(
         "environments.hello_self_judge_v1.hello_self_judge_v1"


### PR DESCRIPTION
## Summary
- Add `Tau2TasksetConfig` so tau2-specific options live behind the taskset config surface.
- Route `load_environment(..., config=...)` through `vf.EnvConfig` and `config.taskset` while continuing to use the vanilla base `vf.Harness`.
- Preserve explicit user simulator endpoint overrides via `user_base_url` and `user_api_key_var` without adding `Tau2Harness`, `load_harness`, or catch-all kwargs.

## Validation
- `uv run pre-commit install`
- `uv run ruff check environments/tau2_bench_v1/tau2_bench_v1.py tests/test_v1_runtime_lifecycle.py tests/test_v1_config_extension.py`
- `uv run ruff format --check environments/tau2_bench_v1/tau2_bench_v1.py tests/test_v1_runtime_lifecycle.py tests/test_v1_config_extension.py`
- `uv run pytest tests/test_v1_runtime_lifecycle.py::test_taskset_setup_initializes_base_harness_prompt_and_sampling -q`
- `uv run pytest tests/test_v1_config_extension.py -q`
- tau2 editable config probe for custom `user_base_url` / `user_api_key_var`
- `uv build environments/tau2_bench_v1 --out-dir /private/tmp/tau2-build-pr`
- pre-push hooks: ruff, ruff format, ty CI parity

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how `tau2_bench_v1` resolves constructor kwargs vs `config` mappings and how the harness is instantiated, which could subtly alter defaulting/override behavior for existing callers.
> 
> **Overview**
> Adds a typed `Tau2TasksetConfig` and refactors `Tau2Taskset`/`load_taskset` to resolve all tau2-specific options (domain, user simulator endpoint overrides, limits, `max_turns`) through that config object rather than ad-hoc kwargs.
> 
> Updates `load_v1_environment`/`load_environment` to normalize the optional `config` via `vf.EnvConfig`, forward `config.taskset` into `load_taskset`, and instantiate the base `vf.Harness` from `config.harness` (instead of relying on implicit harness defaults).
> 
> Extends `test_v1_config_extension.py` with tau2 import stubs and a regression test ensuring mapping-style `EnvConfig` correctly sets harness fields while producing a `Tau2TasksetConfig` for the taskset section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1ad1f5b88bbe0c5fd25efe2442fdadd2ef4ca8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->