### PR TITLE
Fix unsafe eval in agent calculator tools

### DIFF
--- a/environments/langchain_deep_agents_env/langchain_deep_agents_env.py
+++ b/environments/langchain_deep_agents_env/langchain_deep_agents_env.py
@@ -1,13 +1,35 @@
 from __future__ import annotations
 
+import ast
+import math
+import operator
 import re
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from typing import Any
 
 import verifiers as vf
 from verifiers.utils.data_utils import load_example_dataset
 
 ANSWER_RE = re.compile(r"^\s*ANSWER\s*:?\s*(.+?)\s*$", re.IGNORECASE)
+
+MAX_EXPRESSION_LENGTH = 256
+MAX_AST_NODES = 64
+MAX_ABSOLUTE_VALUE = 1e100
+MAX_POWER_EXPONENT = 100
+
+BINARY_OPERATORS: dict[type[ast.operator], Callable[[float, float], float]] = {
+    ast.Add: operator.add,
+    ast.Sub: operator.sub,
+    ast.Mult: operator.mul,
+    ast.Div: operator.truediv,
+    ast.FloorDiv: operator.floordiv,
+    ast.Mod: operator.mod,
+    ast.Pow: operator.pow,
+}
+UNARY_OPERATORS: dict[type[ast.unaryop], Callable[[float], float]] = {
+    ast.UAdd: operator.pos,
+    ast.USub: operator.neg,
+}
 
 SYSTEM_PROMPT = (
     "You are a math problem solver. Use the calculate tool to evaluate "
@@ -17,19 +39,55 @@ SYSTEM_PROMPT = (
 )
 
 
+def _check_numeric_limit(value: float) -> float:
+    if not math.isfinite(value) or abs(value) > MAX_ABSOLUTE_VALUE:
+        raise ValueError("result is too large")
+    return value
+
+
+def _evaluate_math_node(node: ast.AST) -> float:
+    if isinstance(node, ast.Expression):
+        return _evaluate_math_node(node.body)
+    if isinstance(node, ast.Constant):
+        if isinstance(node.value, bool) or not isinstance(node.value, int | float):
+            raise ValueError("only numeric literals are allowed")
+        return _check_numeric_limit(node.value)
+    if isinstance(node, ast.UnaryOp) and type(node.op) in UNARY_OPERATORS:
+        return _check_numeric_limit(
+            UNARY_OPERATORS[type(node.op)](_evaluate_math_node(node.operand))
+        )
+    if isinstance(node, ast.BinOp) and type(node.op) in BINARY_OPERATORS:
+        left = _evaluate_math_node(node.left)
+        right = _evaluate_math_node(node.right)
+        if isinstance(node.op, ast.Pow) and abs(right) > MAX_POWER_EXPONENT:
+            raise ValueError("exponent is too large")
+        return _check_numeric_limit(BINARY_OPERATORS[type(node.op)](left, right))
+    raise ValueError("only arithmetic expressions are allowed")
+
+
+def evaluate_math_expression(expression: str) -> float:
+    expression = expression.strip()
+    if len(expression) > MAX_EXPRESSION_LENGTH:
+        raise ValueError("expression is too long")
+    tree = ast.parse(expression, mode="eval")
+    if sum(1 for _ in ast.walk(tree)) > MAX_AST_NODES:
+        raise ValueError("expression is too complex")
+    return _evaluate_math_node(tree)
+
+
+def calculate(expression: str) -> str:
+    """Evaluate a mathematical expression and return the result."""
+    try:
+        result = evaluate_math_expression(expression)
+    except Exception as exc:
+        return f"Error: {exc}"
+    return str(result)
+
+
 async def run_langchain_deep_agents_program(task: Mapping[str, Any], state: Any):
     from deepagents import create_deep_agent
     from langchain_core.tools import tool
     from langchain_openai import ChatOpenAI
-
-    @tool
-    def calculate(expression: str) -> str:
-        """Evaluate a mathematical expression and return the result."""
-        try:
-            result = eval(expression, {"__builtins__": {}}, {})
-        except Exception as exc:
-            return f"Error: {exc}"
-        return str(result)
 
     endpoint_config = state.get_endpoint_config(api="chat")
     model = ChatOpenAI(
@@ -39,7 +97,7 @@ async def run_langchain_deep_agents_program(task: Mapping[str, Any], state: Any)
     )
     agent = create_deep_agent(
         model=model,
-        tools=[calculate],
+        tools=[tool(calculate)],
         system_prompt=SYSTEM_PROMPT,
     )
 

--- a/environments/openai_agents_env/openai_agents_env.py
+++ b/environments/openai_agents_env/openai_agents_env.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import ast
+import math
+import operator
 import re
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from typing import Any
 
 import verifiers as vf
@@ -9,11 +12,66 @@ from verifiers.utils.data_utils import load_example_dataset
 
 ANSWER_RE = re.compile(r"^\s*ANSWER\s*:?\s*(.+?)\s*$", re.IGNORECASE)
 
+MAX_EXPRESSION_LENGTH = 256
+MAX_AST_NODES = 64
+MAX_ABSOLUTE_VALUE = 1e100
+MAX_POWER_EXPONENT = 100
+
+BINARY_OPERATORS: dict[type[ast.operator], Callable[[float, float], float]] = {
+    ast.Add: operator.add,
+    ast.Sub: operator.sub,
+    ast.Mult: operator.mul,
+    ast.Div: operator.truediv,
+    ast.FloorDiv: operator.floordiv,
+    ast.Mod: operator.mod,
+    ast.Pow: operator.pow,
+}
+UNARY_OPERATORS: dict[type[ast.unaryop], Callable[[float], float]] = {
+    ast.UAdd: operator.pos,
+    ast.USub: operator.neg,
+}
+
+
+def _check_numeric_limit(value: float) -> float:
+    if not math.isfinite(value) or abs(value) > MAX_ABSOLUTE_VALUE:
+        raise ValueError("result is too large")
+    return value
+
+
+def _evaluate_math_node(node: ast.AST) -> float:
+    if isinstance(node, ast.Expression):
+        return _evaluate_math_node(node.body)
+    if isinstance(node, ast.Constant):
+        if isinstance(node.value, bool) or not isinstance(node.value, int | float):
+            raise ValueError("only numeric literals are allowed")
+        return _check_numeric_limit(node.value)
+    if isinstance(node, ast.UnaryOp) and type(node.op) in UNARY_OPERATORS:
+        return _check_numeric_limit(
+            UNARY_OPERATORS[type(node.op)](_evaluate_math_node(node.operand))
+        )
+    if isinstance(node, ast.BinOp) and type(node.op) in BINARY_OPERATORS:
+        left = _evaluate_math_node(node.left)
+        right = _evaluate_math_node(node.right)
+        if isinstance(node.op, ast.Pow) and abs(right) > MAX_POWER_EXPONENT:
+            raise ValueError("exponent is too large")
+        return _check_numeric_limit(BINARY_OPERATORS[type(node.op)](left, right))
+    raise ValueError("only arithmetic expressions are allowed")
+
+
+def evaluate_math_expression(expression: str) -> float:
+    expression = expression.strip()
+    if len(expression) > MAX_EXPRESSION_LENGTH:
+        raise ValueError("expression is too long")
+    tree = ast.parse(expression, mode="eval")
+    if sum(1 for _ in ast.walk(tree)) > MAX_AST_NODES:
+        raise ValueError("expression is too complex")
+    return _evaluate_math_node(tree)
+
 
 def calculate(expression: str) -> str:
     """Evaluate a math expression and return the result."""
     try:
-        result = eval(expression, {"__builtins__": {}}, {})
+        result = evaluate_math_expression(expression)
     except Exception as exc:
         return f"Error: {exc}"
     return str(result)

--- a/tests/test_agent_calculate_safety.py
+++ b/tests/test_agent_calculate_safety.py
@@ -1,0 +1,18 @@
+from environments.langchain_deep_agents_env.langchain_deep_agents_env import (
+    calculate as langchain_calculate,
+)
+from environments.openai_agents_env.openai_agents_env import (
+    calculate as openai_calculate,
+)
+
+
+def test_agent_calculate_allows_arithmetic() -> None:
+    assert openai_calculate("2 + 3 * 4") == "14"
+    assert langchain_calculate("2 ** 8") == "256"
+
+
+def test_agent_calculate_rejects_python_introspection() -> None:
+    payload = "().__class__.__base__.__subclasses__()"
+
+    assert openai_calculate(payload).startswith("Error:")
+    assert langchain_calculate(payload).startswith("Error:")


### PR DESCRIPTION
### Motivation
- Example environments exposed a `calculate(expression)` tool that used `eval(..., {"__builtins__": {}}, {})`, which is bypassable and allows arbitrary host execution via Python introspection. 
- This posed a high-severity RCE risk because the expression input is fully controlled by model/tool calls. 
- The change replaces the unsafe eval with a strict arithmetic evaluator to eliminate the RCE surface while preserving the tool's intended math functionality.

### Description
- Replace `eval(...)` with an AST-based arithmetic evaluator in `environments/openai_agents_env/openai_agents_env.py` that only permits numeric literals, unary/binary arithmetic operators, and enforces limits on expression length, AST node count, numeric magnitude, and exponent size. 
- Apply the same safe evaluator to `environments/langchain_deep_agents_env/langchain_deep_agents_env.py` and register the LangChain tool as `tool(calculate)` so the tool schema remains available to agents. 
- Add helper functions `evaluate_math_expression`, `_evaluate_math_node`, and related operator/limit tables to centralize parsing, evaluation, and safety checks. 
- Add regression tests in `tests/test_agent_calculate_safety.py` to assert that ordinary arithmetic still computes and that Python introspection payloads are rejected.

### Testing
- Ran `uv run pre-commit install` and `uv run pre-commit run --all-files`, both completed successfully. 
- Ran `uv run ruff check --fix environments/openai_agents_env/... environments/langchain_deep_agents_env/... tests/test_agent_calculate_safety.py` and formatting/linting checks passed. 
- Ran `uv run pytest tests/test_agent_calculate_safety.py` and the two new tests passed (`2 passed`). 
- Attempted full test run with `uv run pytest tests/` which reported unrelated failures and errors (41 failed, 10 errors) caused by external environment issues: Hugging Face downloads failed with `403 Forbidden` through the proxy and sandbox teardown attempted Prime Sandboxes API calls without `PRIME_API_KEY`, so the failures are environmental, not regressions introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbcf3cb7f08332a518a474cd20dc88)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent tool execution by replacing `eval` with a restricted AST evaluator; low code surface but may change behavior for previously-accepted (non-arithmetic) expressions and introduces new limits/errors.
> 
> **Overview**
> Replaces the `calculate(expression)` tool implementation in both example agent environments to remove `eval` and instead evaluate a strictly-whitelisted arithmetic AST (numeric literals plus unary/binary ops), with guardrails on expression length/complexity, exponent size, and numeric magnitude.
> 
> Updates the LangChain Deep Agents environment to register the tool via `tool(calculate)` (rather than an inner `@tool` function) and adds regression tests ensuring normal arithmetic still works while Python introspection payloads are rejected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f6f34150c5fe2606523600a4d30cf4b1a770f34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->