### PR TITLE
Require auth for interception endpoints

### DIFF
--- a/tests/test_cli_agent_env.py
+++ b/tests/test_cli_agent_env.py
@@ -102,6 +102,11 @@ class TestCliAgentEnv:
         env_vars = await env.build_env_vars(state)
 
         assert env_vars["OPENAI_BASE_URL"] == "https://test.trycloudflare.com/v1"
+        assert env_vars["OPENAI_API_KEY"] == env._require_interception_server().secret
+        assert env_vars["ANTHROPIC_BASE_URL"] == "https://test.trycloudflare.com"
+        assert (
+            env_vars["ANTHROPIC_API_KEY"] == env._require_interception_server().secret
+        )
         assert env_vars["OPENAI_MODEL"] == "gpt-4"
         assert env_vars["CUSTOM_VAR"] == "value"
 

--- a/tests/test_interception_utils.py
+++ b/tests/test_interception_utils.py
@@ -70,6 +70,18 @@ def test_serialize_intercept_response_passthrough_native_chat_completion():
     assert len(payload["choices"]) == 1
 
 
+def test_interception_server_authorizes_bearer_and_x_api_key():
+    server = InterceptionServer(port=0, secret="test-secret")
+    request = MagicMock()
+
+    request.headers = {"Authorization": "Bearer test-secret"}
+    assert server._authorized(request)
+    request.headers = {"x-api-key": "test-secret"}
+    assert server._authorized(request)
+    request.headers = {}
+    assert not server._authorized(request)
+
+
 def test_set_rollout_error_attaches_stream_interrupted_to_state():
     server = InterceptionServer(port=0)
     state: dict = {}

--- a/tests/test_rlm_env.py
+++ b/tests/test_rlm_env.py
@@ -1282,6 +1282,9 @@ class TestRootToolSerialization:
         payload = {"value": 123}
         mock_request = MagicMock()
         mock_request.match_info = {"rollout_id": rollout_id}
+        mock_request.headers = {
+            "Authorization": f"Bearer {env._interception_secret}",
+        }
         mock_request.json = AsyncMock(
             return_value={
                 "tool_name": "echo_tool",

--- a/tests/test_v1_runtime_lifecycle.py
+++ b/tests/test_v1_runtime_lifecycle.py
@@ -789,6 +789,36 @@ async def test_command_env_exposes_model_endpoint_without_tool_payloads() -> Non
     }
 
 
+@pytest.mark.asyncio
+async def test_command_env_endpoint_auth_overrides_inherited_keys(monkeypatch) -> None:
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://api.openai.invalid/v1")
+    monkeypatch.setenv("OPENAI_API_KEY", "host-openai-key")
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://api.anthropic.invalid")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "host-anthropic-key")
+
+    harness = vf.Harness(toolsets=[vf.Toolset(tools=[echo_tool])])
+    task = vf.Task({"prompt": [{"role": "user", "content": "hi"}]}).freeze()
+    state = vf.State.for_task(task)
+    state["endpoint_root_url"] = "http://127.0.0.1:1/rollout/test"
+    state["endpoint_base_url"] = "http://127.0.0.1:1/rollout/test/v1"
+    harness.runtime.prepare_state(task, state)
+
+    env = await command_env({}, task, state, harness.runtime, include_base=True)
+    explicit_env = await command_env(
+        {"env": {"OPENAI_API_KEY": "program-key"}},
+        task,
+        state,
+        harness.runtime,
+        include_base=True,
+    )
+
+    assert env["OPENAI_BASE_URL"] == "http://127.0.0.1:1/rollout/test/v1"
+    assert env["OPENAI_API_KEY"] == harness.endpoint.secret
+    assert env["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:1/rollout/test"
+    assert env["ANTHROPIC_API_KEY"] == harness.endpoint.secret
+    assert explicit_env["OPENAI_API_KEY"] == "program-key"
+
+
 def test_sandbox_base_program_uses_openai_tool_payloads() -> None:
     task = vf.Task({"prompt": [{"role": "user", "content": "hi"}]}).freeze()
     state = vf.State.for_task(task)

--- a/tests/test_v1_runtime_lifecycle.py
+++ b/tests/test_v1_runtime_lifecycle.py
@@ -18,6 +18,7 @@ from verifiers.types import ClientConfig
 from verifiers.types import Response, ResponseMessage, ToolCall
 from verifiers.types import Tool
 from verifiers.v1.runtime import Runtime
+from verifiers.v1.utils.endpoint_utils import endpoint_api_key
 from verifiers.v1.utils import mcp_utils
 from verifiers.v1.utils.mcp_proxy_utils import MCP_PROXY_CONFIG_PATH, MCP_PROXY_PATH
 from verifiers.v1.utils.mcp_proxy_utils import proxy_command, proxy_source
@@ -284,16 +285,18 @@ async def endpoint_program(task, state):
     root = state["endpoint_root_url"].rstrip("/")
     client = state.get_client(api="chat")
     config = state.get_endpoint_config(api="responses")
+    auth_headers = {"Authorization": f"Bearer {config['api_key']}"}
 
     def get_json(url: str) -> dict[str, object]:
-        with urllib.request.urlopen(url) as response:
+        request = urllib.request.Request(url, headers=auth_headers)
+        with urllib.request.urlopen(request) as response:
             return json.loads(response.read().decode())
 
     def post_json(url: str, payload: dict[str, object]) -> dict[str, object]:
         request = urllib.request.Request(
             url,
             data=json.dumps(payload).encode(),
-            headers={"content-type": "application/json"},
+            headers={"content-type": "application/json", **auth_headers},
         )
         with urllib.request.urlopen(request) as response:
             return json.loads(response.read().decode())
@@ -342,7 +345,7 @@ async def mcp_proxy_program(task, state):
         json.dumps(
             {
                 "tool_base_url": f"{state['endpoint_root_url'].rstrip('/')}/vf/tools",
-                "tool_api_key": "intercepted",
+                "tool_api_key": endpoint_api_key(state),
             }
         )
     )
@@ -777,7 +780,7 @@ async def test_command_env_exposes_model_endpoint_without_tool_payloads() -> Non
     env = await command_env({}, task, state, harness.runtime, include_base=False)
 
     assert env["OPENAI_BASE_URL"] == "http://127.0.0.1:1/rollout/test/v1"
-    assert env["OPENAI_API_KEY"] == "intercepted"
+    assert env["OPENAI_API_KEY"] == harness.endpoint.secret
     assert set(env) == {
         "ANTHROPIC_API_KEY",
         "ANTHROPIC_BASE_URL",
@@ -924,7 +927,7 @@ def test_program_tools_mcp_injects_proxy_into_sandbox_program() -> None:
     config = json.loads(files[MCP_PROXY_CONFIG_PATH])
     assert config == {
         "tool_base_url": "http://127.0.0.1:1/rollout/test/vf/tools",
-        "tool_api_key": "intercepted",
+        "tool_api_key": harness.endpoint.secret,
     }
     assert proxy_command() == ["python3", MCP_PROXY_PATH, MCP_PROXY_CONFIG_PATH]
     packages = sandbox["packages"]

--- a/verifiers/envs/experimental/cli_agent_env.py
+++ b/verifiers/envs/experimental/cli_agent_env.py
@@ -311,17 +311,23 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
             "HTTPX_TIMEOUT",
             "OPENAI_MODEL",
             "OPENAI_API_KEY",
+            "ANTHROPIC_BASE_URL",
+            "ANTHROPIC_API_KEY",
         }
     )
 
     async def build_env_vars(self, state: State) -> dict[str, str]:
         """Build environment variables for the sandbox. Override to add custom vars."""
         env_vars = dict(self.environment_vars) if self.environment_vars else {}
-        env_vars["OPENAI_BASE_URL"] = state["interception_base_url"]
+        interception_base_url = str(state["interception_base_url"]).rstrip("/")
+        env_vars["OPENAI_BASE_URL"] = interception_base_url
+        env_vars["ANTHROPIC_BASE_URL"] = interception_base_url.removesuffix("/v1")
         env_vars.setdefault("OPENAI_TIMEOUT", "3600")
         env_vars.setdefault("OPENAI_REQUEST_TIMEOUT", "3600")
         env_vars.setdefault("HTTPX_TIMEOUT", "3600")
-        env_vars["OPENAI_API_KEY"] = self._require_interception_server().secret
+        secret = self._require_interception_server().secret
+        env_vars["OPENAI_API_KEY"] = secret
+        env_vars["ANTHROPIC_API_KEY"] = secret
         model = state.get("model")
         if model:
             env_vars["OPENAI_MODEL"] = model

--- a/verifiers/envs/experimental/cli_agent_env.py
+++ b/verifiers/envs/experimental/cli_agent_env.py
@@ -321,9 +321,7 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
         env_vars.setdefault("OPENAI_TIMEOUT", "3600")
         env_vars.setdefault("OPENAI_REQUEST_TIMEOUT", "3600")
         env_vars.setdefault("HTTPX_TIMEOUT", "3600")
-        secret = os.environ.get("INTERCEPTION_SECRET")
-        if secret:
-            env_vars["OPENAI_API_KEY"] = secret
+        env_vars["OPENAI_API_KEY"] = self._require_interception_server().secret
         model = state.get("model")
         if model:
             env_vars["OPENAI_MODEL"] = model

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -23,10 +23,12 @@ Key features:
 import asyncio
 import base64
 import contextvars
+import hmac
 import json
 import logging
 import os
 import re
+import secrets
 import shlex
 import shutil
 import sys
@@ -553,6 +555,7 @@ def _build_python_worker_script_template() -> str:
             "        answer = json.load(f)",
             "",
             'ROOT_TOOL_URL = os.environ.get("RLM_ROOT_TOOL_URL", "")',
+            'ROOT_TOOL_HEADERS = {"Authorization": "Bearer " + os.environ.get("RLM_INTERCEPTION_SECRET", "")}',
             'ROOT_TOOL_NAMES_RAW = os.environ.get("RLM_ROOT_TOOL_NAMES", "[]")',
             "try:",
             "    ROOT_TOOL_NAMES = json.loads(ROOT_TOOL_NAMES_RAW)",
@@ -572,6 +575,7 @@ def _build_python_worker_script_template() -> str:
             "    resp = requests.post(",
             "        ROOT_TOOL_URL,",
             "        json=payload,",
+            "        headers=ROOT_TOOL_HEADERS,",
             "        timeout=SUB_LLM_TIMEOUT,",
             "    )",
             "    resp.raise_for_status()",
@@ -700,6 +704,7 @@ _RLM_BASH_TOOL_HELPER_SCRIPT = textwrap.dedent(
     import urllib.request
 
     ROOT_TOOL_URL = os.environ.get("RLM_ROOT_TOOL_URL", "")
+    ROOT_TOOL_SECRET = os.environ.get("RLM_INTERCEPTION_SECRET", "")
     ROOT_TOOL_USER_AGENT = os.environ.get(
         "RLM_ROOT_TOOL_USER_AGENT", "python-requests/2.32.3"
     )
@@ -731,6 +736,7 @@ _RLM_BASH_TOOL_HELPER_SCRIPT = textwrap.dedent(
                 "Content-Type": "application/json",
                 "Accept": "application/json",
                 "User-Agent": ROOT_TOOL_USER_AGENT,
+                "Authorization": f"Bearer {ROOT_TOOL_SECRET}",
             },
             method="POST",
         )
@@ -2408,6 +2414,7 @@ class RLMEnv(vf.StatefulToolEnv):
         self.custom_system_prompt = system_prompt
         self.interception_port = 0
         self._interception_url_override: str | None = None
+        self._interception_secret = secrets.token_urlsafe(32)
         self.pip_install_packages = pip_install_packages
         self.max_startup_wait_seconds = max_startup_wait_seconds
         self.include_sub_llm_in_trajectory = include_sub_llm_in_trajectory
@@ -2617,6 +2624,7 @@ class RLMEnv(vf.StatefulToolEnv):
         return {
             "RLM_INTERCEPTION_URL": state.get("interception_url", ""),
             "RLM_ROOT_TOOL_URL": state.get("root_tool_url", ""),
+            "RLM_INTERCEPTION_SECRET": self._interception_secret,
             "RLM_ROOT_TOOL_NAMES": json.dumps(self.root_tool_names),
             "RLM_SUB_LLM_TIMEOUT": str(self.sub_llm_timeout),
         }
@@ -3232,6 +3240,10 @@ class RLMEnv(vf.StatefulToolEnv):
 
     async def _handle_root_tool_request(self, request: Any) -> Any:
         """Handle root tool requests from worker."""
+        auth = request.headers.get("Authorization", "")
+        if not hmac.compare_digest(auth, f"Bearer {self._interception_secret}"):
+            return web.json_response({"error": "Unauthorized"}, status=401)
+
         rollout_id = request.match_info["rollout_id"]
         context = self.active_rollouts.get(rollout_id)
         if not context:
@@ -3316,6 +3328,10 @@ class RLMEnv(vf.StatefulToolEnv):
 
     async def _handle_sub_llm_request(self, request: Any) -> Any:
         """Handle sub-LLM requests from worker code."""
+        auth = request.headers.get("Authorization", "")
+        if not hmac.compare_digest(auth, f"Bearer {self._interception_secret}"):
+            return web.json_response({"error": "Unauthorized"}, status=401)
+
         rollout_id = request.match_info["rollout_id"]
         context = self.active_rollouts.get(rollout_id)
         if not context:

--- a/verifiers/utils/interception_utils.py
+++ b/verifiers/utils/interception_utils.py
@@ -5,6 +5,7 @@ import hmac
 import inspect
 import json
 import logging
+import secrets
 import time
 import uuid
 from typing import Any, cast
@@ -65,7 +66,7 @@ class InterceptionServer:
 
     def __init__(self, port: int, secret: str | None = None):
         self.port = port
-        self.secret = secret or None  # treat empty string as no secret
+        self.secret = secret or secrets.token_urlsafe(32)
         self._app: Any = None
         self._runner: Any = None
         self._site: Any = None
@@ -208,11 +209,16 @@ class InterceptionServer:
         if rollout_id in self.active_rollouts:
             del self.active_rollouts[rollout_id]
 
+    def _authorized(self, request: Any) -> bool:
+        auth = request.headers.get("Authorization", "")
+        api_key = request.headers.get("x-api-key", "")
+        return hmac.compare_digest(
+            auth, f"Bearer {self.secret}"
+        ) or hmac.compare_digest(api_key, self.secret)
+
     async def _handle_request(self, request: Any) -> Any:
-        if self.secret:
-            auth = request.headers.get("Authorization", "")
-            if not hmac.compare_digest(auth, f"Bearer {self.secret}"):
-                return web.json_response({"error": "Unauthorized"}, status=401)
+        if not self._authorized(request):
+            return web.json_response({"error": "Unauthorized"}, status=401)
 
         rollout_id = request.match_info["rollout_id"]
         context = self.active_rollouts.get(rollout_id)
@@ -247,7 +253,11 @@ class InterceptionServer:
             "stream": is_streaming,
             "chunk_queue": chunk_queue,
             "response_future": asyncio.Future(),
-            "headers": {k.lower(): v for k, v in request.headers.items()},
+            "headers": {
+                k.lower(): v
+                for k, v in request.headers.items()
+                if k.lower() not in {"authorization", "x-api-key"}
+            },
         }
 
         self.intercepts[request_id] = intercept
@@ -278,10 +288,8 @@ class InterceptionServer:
             return web.json_response(response_dict)
 
     async def _handle_tool_request(self, request: Any) -> Any:
-        if self.secret:
-            auth = request.headers.get("Authorization", "")
-            if not hmac.compare_digest(auth, f"Bearer {self.secret}"):
-                return web.json_response({"error": "Unauthorized"}, status=401)
+        if not self._authorized(request):
+            return web.json_response({"error": "Unauthorized"}, status=401)
 
         rollout_id = request.match_info["rollout_id"]
         context = self.active_rollouts.get(rollout_id)
@@ -311,10 +319,8 @@ class InterceptionServer:
         return web.json_response({"result": result})
 
     async def _handle_tools_list_request(self, request: Any) -> Any:
-        if self.secret:
-            auth = request.headers.get("Authorization", "")
-            if not hmac.compare_digest(auth, f"Bearer {self.secret}"):
-                return web.json_response({"error": "Unauthorized"}, status=401)
+        if not self._authorized(request):
+            return web.json_response({"error": "Unauthorized"}, status=401)
 
         rollout_id = request.match_info["rollout_id"]
         context = self.active_rollouts.get(rollout_id)
@@ -329,10 +335,8 @@ class InterceptionServer:
         return web.json_response({"tools": tools})
 
     async def _handle_user_request(self, request: Any) -> Any:
-        if self.secret:
-            auth = request.headers.get("Authorization", "")
-            if not hmac.compare_digest(auth, f"Bearer {self.secret}"):
-                return web.json_response({"error": "Unauthorized"}, status=401)
+        if not self._authorized(request):
+            return web.json_response({"error": "Unauthorized"}, status=401)
 
         rollout_id = request.match_info["rollout_id"]
         context = self.active_rollouts.get(rollout_id)
@@ -360,10 +364,8 @@ class InterceptionServer:
         return web.json_response({"messages": messages})
 
     async def _handle_stop_request(self, request: Any) -> Any:
-        if self.secret:
-            auth = request.headers.get("Authorization", "")
-            if not hmac.compare_digest(auth, f"Bearer {self.secret}"):
-                return web.json_response({"error": "Unauthorized"}, status=401)
+        if not self._authorized(request):
+            return web.json_response({"error": "Unauthorized"}, status=401)
 
         rollout_id = request.match_info["rollout_id"]
         context = self.active_rollouts.get(rollout_id)

--- a/verifiers/v1/utils/endpoint_utils.py
+++ b/verifiers/v1/utils/endpoint_utils.py
@@ -138,10 +138,12 @@ class Endpoint:
         logger: logging.Logger | None = None,
     ):
         self.port = get_free_port() if port is None else port
-        self.secret = secret or os.environ.get("ENDPOINT_SECRET")
         self.use_tunnel = use_tunnel
         self.logger = logger or logging.getLogger(__name__)
-        self.server = InterceptionServer(self.port, secret=self.secret)
+        self.server = InterceptionServer(
+            self.port, secret=secret or os.environ.get("ENDPOINT_SECRET")
+        )
+        self.secret = self.server.secret
         self._tunnel: object | None = None
         self._tunnel_lock = asyncio.Lock()
         self._tunnel_last_checked = 0.0

--- a/verifiers/v1/utils/program_utils.py
+++ b/verifiers/v1/utils/program_utils.py
@@ -116,11 +116,11 @@ async def command_env(
     if isinstance(endpoint_base_url, str):
         api_key = endpoint_api_key(runtime)
         endpoint_root_url = state.get("endpoint_root_url")
-        env.setdefault("OPENAI_BASE_URL", endpoint_base_url)
-        env.setdefault("OPENAI_API_KEY", api_key)
+        env["OPENAI_BASE_URL"] = endpoint_base_url
+        env["OPENAI_API_KEY"] = api_key
         if isinstance(endpoint_root_url, str):
-            env.setdefault("ANTHROPIC_BASE_URL", endpoint_root_url)
-            env.setdefault("ANTHROPIC_API_KEY", api_key)
+            env["ANTHROPIC_BASE_URL"] = endpoint_root_url
+            env["ANTHROPIC_API_KEY"] = api_key
     raw_env = program.get("env", {})
     if not isinstance(raw_env, Mapping):
         raise TypeError("program.env must be a mapping.")


### PR DESCRIPTION
## Summary
- Generate a default secret for `InterceptionServer` and require auth on model/tool/user/stop interception routes.
- Propagate generated secrets through v1 `Endpoint`, sandbox command env, legacy `CliAgentEnv`, and RLM worker helpers.
- Accept both Bearer and `x-api-key` auth for protocol compatibility, and redact auth headers from stored intercept metadata.

## Validation
- `uv run pytest tests/test_interception_utils.py tests/test_v1_endpoint_protocols.py tests/test_v1_runtime_lifecycle.py tests/test_cli_agent_env.py tests/test_rlm_env.py` -> 260 passed
- `uv run pytest tests/test_v1_harbor_cli.py tests/test_opencode_harbor.py tests/test_opencode_rlm_env.py tests/test_composable_env.py tests/test_rlm_composable_env.py` -> 107 passed
- `uv run pre-commit run --all-files` -> passed
- Independent sub-agent validation confirmed unauthenticated routes return 401 and authenticated routes still work.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds mandatory auth checks to interception HTTP routes and propagates generated secrets into multiple runtimes/sandbox envs; mis-propagation could break agent rollouts or tool proxying.
> 
> **Overview**
> This PR **requires authentication for all interception server routes** (model, tools, user, stop), generating a default per-server secret and validating requests via either `Authorization: Bearer ...` or `x-api-key`.
> 
> It **propagates the generated secret** through v1 `Endpoint`/`command_env`, the experimental `CliAgentEnv` (now sets both OpenAI/Anthropic base URLs + API keys from the interception server), and `RLMEnv` worker helpers (adds bearer auth headers and enforces them on root-tool and sub-LLM endpoints).
> 
> Intercept metadata storage is tightened by **redacting auth headers** from saved request headers, and tests are updated/added to cover the new auth behavior and env var overriding semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdfc2f8261636dc42ac3911594d467ffffe313bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->