### PR TITLE
fix(renderer-client): wrap tools in OpenAI envelope to match training distribution

### DIFF
--- a/tests/test_renderer_client.py
+++ b/tests/test_renderer_client.py
@@ -141,6 +141,57 @@ def test_attach_tool_call_names_unknown_tool_call_id_left_unset():
 
 
 @pytest.mark.asyncio
+async def test_to_native_tool_returns_openai_envelope():
+    """``RendererClient.to_native_tool`` must wrap each ``Tool`` in the
+    OpenAI envelope (``{"type": "function", "function": {...}}``) — the
+    same shape ``OpenAIChatCompletionsClient`` sends server-side under
+    TITO/MITO. Modern function-calling models (Qwen3 family, GLM, Kimi)
+    saw the envelope at training time, so the renderer client's prompt
+    must match. Regression for the bare-form bug where rollout-mode
+    tool envs produced uniformly zero rewards because the model never
+    emitted ``<tool_call>`` blocks under an out-of-distribution prompt.
+    """
+    from verifiers.types import Tool
+
+    client = object.__new__(RendererClient)
+    tool = Tool(
+        name="get_weather",
+        description="Get the weather for a city",
+        parameters={
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"],
+        },
+    )
+
+    native = await client.to_native_tool(tool)
+    assert native["type"] == "function"
+    assert native["function"]["name"] == "get_weather"
+    assert native["function"]["description"] == "Get the weather for a city"
+    assert native["function"]["parameters"]["required"] == ["city"]
+    assert "strict" not in native["function"]
+
+
+@pytest.mark.asyncio
+async def test_to_native_tool_propagates_strict_flag():
+    """When ``Tool.strict`` is set the envelope must carry it through —
+    OpenAI's strict-schema enforcement only kicks in on the inner function
+    object, never the envelope itself."""
+    from verifiers.types import Tool
+
+    client = object.__new__(RendererClient)
+    tool = Tool(
+        name="get_weather",
+        description="Get the weather for a city",
+        parameters={"type": "object", "properties": {}},
+        strict=True,
+    )
+
+    native = await client.to_native_tool(tool)
+    assert native["function"]["strict"] is True
+
+
+@pytest.mark.asyncio
 async def test_renderer_client_accepts_dict_native_response_with_content():
     client = object.__new__(RendererClient)
 

--- a/verifiers/clients/renderer_client.py
+++ b/verifiers/clients/renderer_client.py
@@ -472,11 +472,25 @@ class RendererClient(
         )
 
     async def to_native_tool(self, tool: Tool) -> ToolSpec:
-        return ToolSpec(
-            name=tool.name,
-            description=tool.description or "",
-            parameters=tool.parameters or {},
-        )
+        # Wrap in the OpenAI envelope (``{"type": "function", "function":
+        # {...}}``) — the same shape ``OpenAIChatCompletionsClient`` sends
+        # to ``apply_chat_template`` server-side under TITO/MITO. Modern
+        # function-calling models (Qwen3 family, GLM, Kimi, ...) saw the
+        # envelope at training time, so the renderer's prompt has to match.
+        # Earlier versions emitted bare ``{name, description, parameters}``
+        # which is out-of-distribution and silently breaks tool calling
+        # (model never emits ``<tool_call>`` blocks → reward 0). The
+        # rendered ``ToolSpec`` TypedDict is a plain dict at runtime;
+        # ``cast`` here keeps type-check parity until the renderers package
+        # publishes an envelope-shaped ``ToolSpec``.
+        function: dict[str, Any] = {
+            "name": tool.name,
+            "description": tool.description or "",
+            "parameters": tool.parameters or {},
+        }
+        if tool.strict is not None:
+            function["strict"] = tool.strict
+        return cast(ToolSpec, {"type": "function", "function": function})
 
     # ── Core request cycle ──────────────────────────────────────────
 

--- a/verifiers/clients/renderer_client.py
+++ b/verifiers/clients/renderer_client.py
@@ -474,8 +474,8 @@ class RendererClient(
     async def to_native_tool(self, tool: Tool) -> ToolSpec:
         function: dict[str, Any] = {
             "name": tool.name,
-            "description": tool.description or "",
-            "parameters": tool.parameters or {},
+            "description": tool.description,
+            "parameters": tool.parameters,
         }
         if tool.strict is not None:
             function["strict"] = tool.strict

--- a/verifiers/clients/renderer_client.py
+++ b/verifiers/clients/renderer_client.py
@@ -394,19 +394,6 @@ class RendererClient(
     ] = {}
     _shared_pools_lock: ClassVar[threading.Lock] = threading.Lock()
 
-    # Cache of ``max_model_len`` per (api_base_url, model). Fixed at server
-    # startup, so cache forever per process. See
-    # ``_get_max_model_len`` for why this is needed.
-    # TODO(vllm-upstream): Drop once vLLM patches
-    # ``vllm/entrypoints/serve/disagg/serving.py::ServingTokens.serve_tokens``
-    # to apply ``get_max_tokens()`` like
-    # ``vllm/entrypoints/openai/chat_completion/serving.py`` does at L284.
-    # Once that lands, ``/inference/v1/generate`` will default ``max_tokens``
-    # to ``max_model_len - prompt_len`` server-side and this cache + the
-    # fallback in ``get_native_response`` become dead code.
-    _max_model_len_cache: ClassVar[dict[tuple[str, str], int]] = {}
-    _max_model_len_lock: ClassVar[asyncio.Lock | None] = None
-
     def __init__(
         self,
         config: ClientConfig,
@@ -474,63 +461,6 @@ class RendererClient(
 
         return self._shared_pools[cache_key]
 
-    async def _get_max_model_len(self, model: str) -> int | None:
-        """Fetch ``max_model_len`` for ``model`` from vLLM's ``/v1/models``.
-
-        ``vllm.SamplingParams.max_tokens`` defaults to ``16``.
-        ``/v1/chat/completions`` masks this server-side via
-        ``get_max_tokens(max_model_len, request.max_tokens, prompt_len, ...)``
-        so callers that omit ``max_tokens`` get the full remaining context.
-        ``/inference/v1/generate`` (the endpoint this client talks to) is a
-        thin pass-through that hands ``SamplingParams`` to the engine
-        verbatim, so the 16-token default leaks through and silently caps
-        every generation at 16 tokens — long enough to start a tool-call
-        envelope but not long enough to close one, producing reward 0 on
-        any tool-using rollout.
-
-        Until vLLM applies the same defaulting in ``serve_tokens``, query
-        ``max_model_len`` once per (server, model) and cache forever.
-        Returns ``None`` if the server doesn't surface ``max_model_len``
-        in ``/v1/models``; the caller falls back to the original behaviour
-        (no client-side default) in that case.
-        """
-        base = str(self.client.base_url).rstrip("/")
-        key = (base, model)
-        cached = self._max_model_len_cache.get(key)
-        if cached is not None:
-            return cached
-
-        if RendererClient._max_model_len_lock is None:
-            RendererClient._max_model_len_lock = asyncio.Lock()
-        async with RendererClient._max_model_len_lock:
-            cached = self._max_model_len_cache.get(key)
-            if cached is not None:
-                return cached
-            try:
-                resp = await self.client.get(
-                    "/models",
-                    cast_to=cast(Any, dict[str, Any]),
-                )
-            except Exception as exc:
-                self.logger.warning(
-                    "RendererClient: failed to fetch max_model_len from /v1/models "
-                    "(%s); generations will use vLLM's SamplingParams default of 16 "
-                    "tokens unless caller sets max_tokens. Set "
-                    "max_completion_tokens explicitly to avoid silent truncation.",
-                    exc,
-                )
-                return None
-
-            for entry in (resp or {}).get("data", []) or []:
-                if not isinstance(entry, dict) or entry.get("id") != model:
-                    continue
-                mml = entry.get("max_model_len")
-                if isinstance(mml, int) and mml > 0:
-                    self._max_model_len_cache[key] = mml
-                    return mml
-                break
-            return None
-
     # ── Type conversions ────────────────────────────────────────────
 
     async def to_native_prompt(
@@ -590,19 +520,6 @@ class RendererClient(
             state=kwargs.get("state"),
             tools=tools,
         )
-
-        # /inference/v1/generate hands SamplingParams to the engine verbatim
-        # and skips the get_max_tokens() defaulting that /v1/chat/completions
-        # applies. Replicate that defaulting here so caller-omitted max_tokens
-        # doesn't silently fall to vLLM's 16-token SamplingParams default.
-        # TODO(vllm-upstream): Drop once vLLM patches serve_tokens
-        # (vllm/entrypoints/serve/disagg/serving.py) to call get_max_tokens().
-        if "max_tokens" not in sampling_params:
-            max_model_len = await self._get_max_model_len(model)
-            if max_model_len is not None:
-                sampling_params["max_tokens"] = max(
-                    1, max_model_len - len(prompt_ids)
-                )
 
         return await generate(
             client=self.client,

--- a/verifiers/clients/renderer_client.py
+++ b/verifiers/clients/renderer_client.py
@@ -394,6 +394,19 @@ class RendererClient(
     ] = {}
     _shared_pools_lock: ClassVar[threading.Lock] = threading.Lock()
 
+    # Cache of ``max_model_len`` per (api_base_url, model). Fixed at server
+    # startup, so cache forever per process. See
+    # ``_get_max_model_len`` for why this is needed.
+    # TODO(vllm-upstream): Drop once vLLM patches
+    # ``vllm/entrypoints/serve/disagg/serving.py::ServingTokens.serve_tokens``
+    # to apply ``get_max_tokens()`` like
+    # ``vllm/entrypoints/openai/chat_completion/serving.py`` does at L284.
+    # Once that lands, ``/inference/v1/generate`` will default ``max_tokens``
+    # to ``max_model_len - prompt_len`` server-side and this cache + the
+    # fallback in ``get_native_response`` become dead code.
+    _max_model_len_cache: ClassVar[dict[tuple[str, str], int]] = {}
+    _max_model_len_lock: ClassVar[asyncio.Lock | None] = None
+
     def __init__(
         self,
         config: ClientConfig,
@@ -461,6 +474,63 @@ class RendererClient(
 
         return self._shared_pools[cache_key]
 
+    async def _get_max_model_len(self, model: str) -> int | None:
+        """Fetch ``max_model_len`` for ``model`` from vLLM's ``/v1/models``.
+
+        ``vllm.SamplingParams.max_tokens`` defaults to ``16``.
+        ``/v1/chat/completions`` masks this server-side via
+        ``get_max_tokens(max_model_len, request.max_tokens, prompt_len, ...)``
+        so callers that omit ``max_tokens`` get the full remaining context.
+        ``/inference/v1/generate`` (the endpoint this client talks to) is a
+        thin pass-through that hands ``SamplingParams`` to the engine
+        verbatim, so the 16-token default leaks through and silently caps
+        every generation at 16 tokens — long enough to start a tool-call
+        envelope but not long enough to close one, producing reward 0 on
+        any tool-using rollout.
+
+        Until vLLM applies the same defaulting in ``serve_tokens``, query
+        ``max_model_len`` once per (server, model) and cache forever.
+        Returns ``None`` if the server doesn't surface ``max_model_len``
+        in ``/v1/models``; the caller falls back to the original behaviour
+        (no client-side default) in that case.
+        """
+        base = str(self.client.base_url).rstrip("/")
+        key = (base, model)
+        cached = self._max_model_len_cache.get(key)
+        if cached is not None:
+            return cached
+
+        if RendererClient._max_model_len_lock is None:
+            RendererClient._max_model_len_lock = asyncio.Lock()
+        async with RendererClient._max_model_len_lock:
+            cached = self._max_model_len_cache.get(key)
+            if cached is not None:
+                return cached
+            try:
+                resp = await self.client.get(
+                    "/models",
+                    cast_to=cast(Any, dict[str, Any]),
+                )
+            except Exception as exc:
+                self.logger.warning(
+                    "RendererClient: failed to fetch max_model_len from /v1/models "
+                    "(%s); generations will use vLLM's SamplingParams default of 16 "
+                    "tokens unless caller sets max_tokens. Set "
+                    "max_completion_tokens explicitly to avoid silent truncation.",
+                    exc,
+                )
+                return None
+
+            for entry in (resp or {}).get("data", []) or []:
+                if not isinstance(entry, dict) or entry.get("id") != model:
+                    continue
+                mml = entry.get("max_model_len")
+                if isinstance(mml, int) and mml > 0:
+                    self._max_model_len_cache[key] = mml
+                    return mml
+                break
+            return None
+
     # ── Type conversions ────────────────────────────────────────────
 
     async def to_native_prompt(
@@ -520,6 +590,19 @@ class RendererClient(
             state=kwargs.get("state"),
             tools=tools,
         )
+
+        # /inference/v1/generate hands SamplingParams to the engine verbatim
+        # and skips the get_max_tokens() defaulting that /v1/chat/completions
+        # applies. Replicate that defaulting here so caller-omitted max_tokens
+        # doesn't silently fall to vLLM's 16-token SamplingParams default.
+        # TODO(vllm-upstream): Drop once vLLM patches serve_tokens
+        # (vllm/entrypoints/serve/disagg/serving.py) to call get_max_tokens().
+        if "max_tokens" not in sampling_params:
+            max_model_len = await self._get_max_model_len(model)
+            if max_model_len is not None:
+                sampling_params["max_tokens"] = max(
+                    1, max_model_len - len(prompt_ids)
+                )
 
         return await generate(
             client=self.client,

--- a/verifiers/clients/renderer_client.py
+++ b/verifiers/clients/renderer_client.py
@@ -472,17 +472,6 @@ class RendererClient(
         )
 
     async def to_native_tool(self, tool: Tool) -> ToolSpec:
-        # Wrap in the OpenAI envelope (``{"type": "function", "function":
-        # {...}}``) — the same shape ``OpenAIChatCompletionsClient`` sends
-        # to ``apply_chat_template`` server-side under TITO/MITO. Modern
-        # function-calling models (Qwen3 family, GLM, Kimi, ...) saw the
-        # envelope at training time, so the renderer's prompt has to match.
-        # Earlier versions emitted bare ``{name, description, parameters}``
-        # which is out-of-distribution and silently breaks tool calling
-        # (model never emits ``<tool_call>`` blocks → reward 0). The
-        # rendered ``ToolSpec`` TypedDict is a plain dict at runtime;
-        # ``cast`` here keeps type-check parity until the renderers package
-        # publishes an envelope-shaped ``ToolSpec``.
         function: dict[str, Any] = {
             "name": tool.name,
             "description": tool.description or "",


### PR DESCRIPTION
## Summary
- `RendererClient.to_native_tool` was returning bare-form `{name, description, parameters}` while every other client (`OpenAIChatCompletionsClient`, `OpenAIResponsesClient`) wraps tools in the OpenAI envelope `{type: function, function: {...}}`.
- Modern function-calling models (Qwen3 family, GLM, Kimi, ...) saw the envelope at training time. TITO/MITO send envelope server-side via `apply_chat_template`, so the model recognises the tools list and emits `<tool_call>` blocks. Under `use_renderer=true`, the renderer was given bare-form tools and produced an out-of-distribution prompt — Qwen3's `tool | tojson` is a passthrough, so the model saw a tool list it had never been trained on and reliably failed to emit `<tool_call>`. Multi-turn ToolEnv rollouts hit zero rewards and tripped the `zero_advantage` filter at step 0.
- Bug has existed since `RendererClient` was introduced (#1068, the "feat: add renderers package" PR). Single-turn / no-tool smoke tests (reverse-text) never exercised this path, so it slipped past CI for ~7 days until a real ToolEnv rollout hit it.

## Test plan
- [x] `uv run pytest tests/test_renderer_client.py` (32 existing + 2 new envelope-contract tests pass)
- [x] `uv run pytest tests/test_renderer_client.py tests/test_renderer_e2e.py` (42 total pass)
- [ ] Re-run a multi-turn ToolEnv rollout under `use_renderer=true` against `Qwen/Qwen3-4B-Instruct-2507` and confirm non-zero rewards on first step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the wire format of tools passed to the renderer to match OpenAI’s `{type:"function", function:{...}}` contract, which can affect tool-calling behavior across models and any code expecting the previous bare `{name, description, parameters}` shape.
> 
> **Overview**
> Ensures `RendererClient.to_native_tool` emits tools in the OpenAI function-calling envelope (`{"type":"function","function":{...}}`) instead of the prior bare `{name, description, parameters}` dict, aligning renderer-mode prompts with other OpenAI clients.
> 
> Propagates `Tool.strict` into the inner `function` object when set, and adds regression tests asserting the envelope shape and strict-flag behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2eb1a38a30d07984dc9698f9e2c8d2c927ec4274. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->