### PR TITLE
Support setup_state return-state compatibility

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -425,9 +425,10 @@ class ExampleStatefulToolEnv(StatefulToolEnv):
         super().__init__(tools=[offset_tool], **kwargs)
 
     async def setup_state(self, state, **kwargs):
-        await super().setup_state(state, **kwargs)
+        state = await super().setup_state(state, **kwargs)
         state["offset"] = 3
         state["update_calls"] = 0
+        return state
 
     def update_tool_args(self, tool_name, tool_args, messages, state, **kwargs):
         state["update_calls"] += 1

--- a/tests/test_multiturn_env.py
+++ b/tests/test_multiturn_env.py
@@ -32,6 +32,76 @@ class TestMultiTurnEnv:
         assert env.timeout_seconds is None
 
     @pytest.mark.asyncio
+    async def test_setup_state_supports_in_place_and_returned_state(
+        self, mock_client, sample_chat_dataset, make_input
+    ):
+        """setup_state may mutate state in place or return the prepared state."""
+
+        class InPlaceSetupEnv(MultiTurnEnv):
+            async def setup_state(self, state):  # type: ignore[override]
+                state["setup_marker"] = "in-place"
+
+            async def env_response(self, messages, state, **kwargs):  # type: ignore[override]
+                return [{"role": "user", "content": "Continue"}]
+
+        class ChainedSuperSetupEnv(MultiTurnEnv):
+            async def setup_state(self, state):  # type: ignore[override]
+                prepared_state = await super().setup_state(state)
+                prepared_state["setup_marker"] = "super"
+                return prepared_state
+
+            async def env_response(self, messages, state, **kwargs):  # type: ignore[override]
+                return [{"role": "user", "content": "Continue"}]
+
+        class ReplacingSetupEnv(MultiTurnEnv):
+            async def setup_state(self, state):  # type: ignore[override]
+                replacement_state = State(state)
+                replacement_state["setup_marker"] = "replaced"
+                return replacement_state
+
+            async def env_response(self, messages, state, **kwargs):  # type: ignore[override]
+                return [{"role": "user", "content": "Continue"}]
+
+        mock_client.set_default_response("Done")
+        env_kwargs = {
+            "client": mock_client,
+            "model": "test-model",
+            "dataset": sample_chat_dataset,
+            "parser": Parser(),
+            "rubric": Rubric(),
+            "max_turns": 1,
+        }
+
+        in_place_state = await InPlaceSetupEnv(**env_kwargs).rollout(
+            input=make_input(
+                prompt=[{"role": "user", "content": "Start conversation"}],
+                answer="target_answer",
+            ),
+            client=mock_client,
+            model="test-model",
+        )
+        super_state = await ChainedSuperSetupEnv(**env_kwargs).rollout(
+            input=make_input(
+                prompt=[{"role": "user", "content": "Start conversation"}],
+                answer="target_answer",
+            ),
+            client=mock_client,
+            model="test-model",
+        )
+        replaced_state = await ReplacingSetupEnv(**env_kwargs).rollout(
+            input=make_input(
+                prompt=[{"role": "user", "content": "Start conversation"}],
+                answer="target_answer",
+            ),
+            client=mock_client,
+            model="test-model",
+        )
+
+        assert in_place_state["setup_marker"] == "in-place"
+        assert super_state["setup_marker"] == "super"
+        assert replaced_state["setup_marker"] == "replaced"
+
+    @pytest.mark.asyncio
     async def test_basic_multiturn_rollout(self, mock_multiturn_env, make_input):
         """Test basic multi-turn conversation that completes normally."""
         # Configure mock to return responses that lead to completion

--- a/tests/test_opencode_rlm_env.py
+++ b/tests/test_opencode_rlm_env.py
@@ -289,7 +289,8 @@ class TestSetupState:
             OpenCodeRLMEnv.__bases__[0],
             "setup_state",
             new_callable=AsyncMock,
-        ):
+        ) as setup_state:
+            setup_state.return_value = None
             await env.setup_state(state)
         assert state["sub_llm_turns"] == 0
         assert state["sub_llm_prompt_tokens"] == 0
@@ -304,7 +305,8 @@ class TestSetupState:
             OpenCodeRLMEnv.__bases__[0],
             "setup_state",
             new_callable=AsyncMock,
-        ):
+        ) as setup_state:
+            setup_state.return_value = None
             await env.setup_state(state)
         assert state["sub_llm_turns"] == 3
 

--- a/verifiers/envs/experimental/cli_agent_env.py
+++ b/verifiers/envs/experimental/cli_agent_env.py
@@ -225,9 +225,11 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
                 assert self._tunnel.url is not None, "Tunnel started but URL is None"
                 return self._tunnel.url
 
-    async def setup_state(self, state: State) -> None:
+    async def setup_state(self, state: State) -> State:
         """Setup sandbox + interception for this rollout"""
-        await super().setup_state(state)
+        setup_state = await super().setup_state(state)
+        if setup_state is not None:
+            state = setup_state
 
         rollout_id = f"rollout_{uuid.uuid4().hex[:8]}"
         state["rollout_id"] = rollout_id
@@ -285,6 +287,7 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
             f"example_id={state['example_id']}",
         ]
         self.logger.info(" | ".join(parts))
+        return state
 
     async def get_docker_image(self, state: State) -> str:
         """Get the Docker image for the sandbox. Override for per-task images."""

--- a/verifiers/envs/experimental/opencode_rlm_env.py
+++ b/verifiers/envs/experimental/opencode_rlm_env.py
@@ -246,12 +246,15 @@ class OpenCodeRLMEnv(OpenCodeEnv):
         env["RLM_SUB_TIMEOUT"] = str(self.sub_timeout_ms)
         return env
 
-    async def setup_state(self, state: State) -> None:
-        await super().setup_state(state)
+    async def setup_state(self, state: State) -> State:
+        setup_state = await super().setup_state(state)
+        if setup_state is not None:
+            state = setup_state
         state.setdefault("sub_llm_turns", 0)
         state.setdefault("sub_llm_prompt_tokens", 0)
         state.setdefault("sub_llm_completion_tokens", 0)
         state.setdefault("_sub_llm_tasks", set())
+        return state
 
     @staticmethod
     def _is_sub_llm_request(intercept: dict[str, Any]) -> bool:

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -3460,9 +3460,11 @@ class RLMEnv(vf.StatefulToolEnv):
         }
         return state
 
-    async def setup_state(self, state: State, **kwargs) -> None:
+    async def setup_state(self, state: State, **kwargs) -> State:
         """Setup worker, filesystem context, and interception for sub-LLM calls."""
-        await vf.StatefulToolEnv.setup_state(self, state, **kwargs)
+        setup_state = await vf.StatefulToolEnv.setup_state(self, state, **kwargs)
+        if setup_state is not None:
+            state = setup_state
 
         rollout_id = f"rlm_{uuid.uuid4().hex[:8]}"
         state["rollout_id"] = rollout_id
@@ -3528,6 +3530,7 @@ class RLMEnv(vf.StatefulToolEnv):
             state["_observable_messages"] = []
 
             _ensure_rlm_metric_state(state)
+            return state
         except Exception:
             # Best-effort cleanup to avoid leaking tunnels/sandboxes on setup failure.
             if rollout_id in self.active_rollouts:

--- a/verifiers/envs/integrations/browser_env/browser_env.py
+++ b/verifiers/envs/integrations/browser_env/browser_env.py
@@ -172,10 +172,13 @@ class BrowserEnv(vf.StatefulToolEnv):
         else:
             logger.info("BrowserEnv initialized in CUA mode")
 
-    async def setup_state(self, state: vf.State, **kwargs: Any) -> None:
+    async def setup_state(self, state: vf.State, **kwargs: Any) -> vf.State:
         """Delegate session creation to the mode strategy."""
-        await self._mode_impl.setup_state(state, **kwargs)
-        await super().setup_state(state, **kwargs)
+        state = await self._mode_impl.setup_state(state, **kwargs)
+        setup_state = await super().setup_state(state, **kwargs)
+        if setup_state is not None:
+            state = setup_state
+        return state
 
     def update_tool_args(
         self,

--- a/verifiers/envs/integrations/browser_env/modes/base.py
+++ b/verifiers/envs/integrations/browser_env/modes/base.py
@@ -14,7 +14,7 @@ class BrowserMode(Protocol):
         """Register mode-specific tools with the environment."""
         ...
 
-    async def setup_state(self, state: vf.State, **kwargs: Any) -> None:
+    async def setup_state(self, state: vf.State, **kwargs: Any) -> vf.State:
         """Create session and initialize state for this mode. Mutate state in place."""
         ...
 

--- a/verifiers/envs/integrations/browser_env/modes/cua_mode.py
+++ b/verifiers/envs/integrations/browser_env/modes/cua_mode.py
@@ -815,7 +815,7 @@ class CUAMode:
 
     # ==================== Lifecycle Methods ====================
 
-    async def setup_state(self, state: vf.State, **kwargs: Any) -> None:
+    async def setup_state(self, state: vf.State, **kwargs: Any) -> vf.State:
         """Create a browser session (and sandbox if in sandbox mode)."""
         if self._execution_mode == "local":
             # Local mode: create session via HTTP
@@ -883,6 +883,7 @@ class CUAMode:
                 # Wrap all other exceptions in BrowserSandboxError
                 # This ensures cleanup_session is called via stop_errors mechanism
                 raise vf.BrowserSandboxError(e)
+        return state
 
     def update_tool_args(
         self,

--- a/verifiers/envs/integrations/browser_env/modes/dom_mode.py
+++ b/verifiers/envs/integrations/browser_env/modes/dom_mode.py
@@ -99,11 +99,12 @@ class DOMMode:
         )
         return session
 
-    async def setup_state(self, state: vf.State, **kwargs: Any) -> None:
+    async def setup_state(self, state: vf.State, **kwargs: Any) -> vf.State:
         """Create per-rollout Stagehand session."""
         session = await self._create_session(state)
         state["stagehand_session"] = session
         state["stagehand_session_id"] = session.id
+        return state
 
     def _get_llm_config(self, state: vf.State) -> dict[str, Any] | None:
         """Extract model configuration from verifiers state to route LLM calls."""

--- a/verifiers/envs/integrations/openenv_env.py
+++ b/verifiers/envs/integrations/openenv_env.py
@@ -337,7 +337,7 @@ class OpenEnvEnv(vf.MultiTurnEnv):
                         f"message {msg_idx}: `content` cannot be null."
                     )
 
-    async def setup_state(self, state: vf.State) -> None:
+    async def setup_state(self, state: vf.State) -> vf.State:
         try:
             server = await self._create_server()
             state["openenv_server"] = server
@@ -365,7 +365,7 @@ class OpenEnvEnv(vf.MultiTurnEnv):
                 result = await self._invoke(cast(Any, mcp_client).reset, seed=seed)
                 state["openenv_done"] = bool(result.done)
                 state["prompt"] = self._require_prompt_messages(state)
-                return
+                return state
 
             client = GenericEnvClient(base_url=server.base_url)
             await self._invoke(cast(Any, client).connect)
@@ -373,6 +373,7 @@ class OpenEnvEnv(vf.MultiTurnEnv):
             result = await self._invoke(cast(Any, client).reset, seed=seed)
             state["openenv_done"] = bool(result.done)
             state["prompt"] = self._require_prompt_messages(state)
+            return state
         except Exception:
             await self._cleanup_openenv_state(state)
             raise

--- a/verifiers/envs/integrations/textarena_env.py
+++ b/verifiers/envs/integrations/textarena_env.py
@@ -100,10 +100,11 @@ class TextArenaEnv(vf.MultiTurnEnv):
             memo[id(word_list)] = word_list
         return memo
 
-    async def setup_state(self, state: vf.State, **kwargs) -> None:
+    async def setup_state(self, state: vf.State, **kwargs) -> vf.State:
         ta_env = await asyncio.to_thread(deepcopy, self.ta_env, self.shared_memo.copy())
         ta_env.state.game_state["secret_word"] = state["answer"]  # type: ignore[unresolved-attribute]
         state["ta_env"] = ta_env
+        return state
 
     @vf.cleanup
     async def cleanup_ta_env(self, state: vf.State):

--- a/verifiers/envs/multiturn_env.py
+++ b/verifiers/envs/multiturn_env.py
@@ -94,8 +94,9 @@ class MultiTurnEnv(vf.Environment):
         """Check if env_response signaled termination via final_env_response."""
         return state.get("final_env_response") is not None
 
-    async def setup_state(self, state: State) -> None:
+    async def setup_state(self, state: State) -> State | None:
         """Override to add environment-specific state fields. Mutate state in place."""
+        return state
 
     async def get_prompt_messages(self, state: State) -> Messages:
         """Override for rollouts with non-linear message sequences."""
@@ -175,10 +176,13 @@ class MultiTurnEnv(vf.Environment):
         state = await self.init_state(input, client, model, sampling_args)
 
         async def rollout_loop() -> None:
+            nonlocal state
             state["timing"].generation.start = time.time()
             state["timing"].setup.start = time.time()
             try:
-                await self.setup_state(state)
+                setup_state = await self.setup_state(state)
+                if setup_state is not None:
+                    state = setup_state
             except vf.Error as e:
                 state["error"] = e
             finally:

--- a/verifiers/envs/python_env.py
+++ b/verifiers/envs/python_env.py
@@ -205,13 +205,16 @@ PY
         )
         self.remove_tool(self.bash)  # omit from agent tool list
 
-    async def setup_state(self, state: vf.State, **kwargs: Any) -> None:
-        await super().setup_state(state, **kwargs)
+    async def setup_state(self, state: vf.State, **kwargs: Any) -> vf.State:
+        setup_state = await super().setup_state(state, **kwargs)
+        if setup_state is not None:
+            state = setup_state
         state["python_state"] = {
             "ready": False,
             "execution_count": 0,
             "ready_wait_time": 0.0,
         }
+        return state
 
     def update_tool_args(
         self,

--- a/verifiers/envs/sandbox_env.py
+++ b/verifiers/envs/sandbox_env.py
@@ -224,7 +224,7 @@ class SandboxEnv(vf.StatefulToolEnv):
         """Return sandbox request for this rollout. Override to customize per-state."""
         return self.sandbox_request.model_copy()
 
-    async def setup_state(self, state: vf.State, **kwargs) -> None:
+    async def setup_state(self, state: vf.State, **kwargs) -> vf.State:
         """Create per-rollout sandbox"""
         request = self.get_sandbox_request(state)
         try:
@@ -239,7 +239,10 @@ class SandboxEnv(vf.StatefulToolEnv):
             "ready_wait_time": 0.0,
             "command_execution_times": [],
         }
-        await super().setup_state(state, **kwargs)
+        setup_state = await super().setup_state(state, **kwargs)
+        if setup_state is not None:
+            state = setup_state
+        return state
 
     def update_tool_args(
         self,


### PR DESCRIPTION
## Summary
- Keep `MultiTurnEnv.setup_state` compatible with both in-place mutation and `return state`
- Preserve returned state from `setup_state` in legacy env subclasses that chain through `super()`
- Add regression coverage for in-place setup, returned setup state, and chained `super()` overrides

## Testing
- `uv run ruff check --fix ...`
- `uv run ruff format ...`
- `uv run pytest tests/test_multiturn_env.py tests/test_stateful_tool_env.py tests/test_sandbox_env.py -q`
- `uv run pytest tests/test_v1_runtime_lifecycle.py::test_taskset_setup_initializes_base_harness_prompt_and_sampling -q`
- `uv run --python 3.13 ty check verifiers`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core rollout lifecycle by allowing `setup_state` to optionally return a replacement state and propagating that through multiple environment subclasses; mistakes could lead to missing/incorrect per-rollout initialization.
> 
> **Overview**
> Updates `MultiTurnEnv.setup_state` and the rollout loop to support *both* legacy in-place mutation and a new/optional `return state` pattern, including handling subclasses that replace the state object.
> 
> Propagates this compatibility through multiple env implementations (e.g. sandbox, browser modes, OpenEnv, TextArena, Python, CLI/RLM envs) by capturing `super().setup_state(...)` return values and returning the final state.
> 
> Adds regression tests ensuring in-place setup, chained `super()` overrides, and full state replacement all work, and adjusts mocks to account for `setup_state` possibly returning `None`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd2b8a2f3588243d8ae78b9fdcdf124456ee2591. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->