### PR TITLE
bump interception client size to handle trajectories with images

### DIFF
--- a/verifiers/utils/interception_utils.py
+++ b/verifiers/utils/interception_utils.py
@@ -34,6 +34,7 @@ logger = logging.getLogger(__name__)
 
 
 KEEPALIVE_INTERVAL_SECONDS = 10.0
+DEFAULT_CLIENT_MAX_SIZE_BYTES = 16 * 1024 * 1024
 
 
 class StreamInterrupted(InfraError):
@@ -82,7 +83,7 @@ class InterceptionServer:
             if self._app is not None:
                 return
 
-            app = web.Application()
+            app = web.Application(client_max_size=DEFAULT_CLIENT_MAX_SIZE_BYTES)
             app.router.add_post(
                 "/rollout/{rollout_id}/v1/chat/completions",
                 self._handle_request,


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change that only increases the aiohttp `client_max_size` limit for the local interception server; main concern is slightly higher memory/abuse surface for oversized requests, but behavior is otherwise unchanged.
> 
> **Overview**
> Increases the HTTP interception server’s maximum accepted request body size by configuring aiohttp’s `client_max_size` to **16MB** (via `DEFAULT_CLIENT_MAX_SIZE_BYTES`).
> 
> This prevents large agent trajectories (e.g., requests containing image payloads) from being rejected due to request size limits, without changing request handling logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ceccd221852a0ac517f386697e3301ecec129699. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->