### PR TITLE
fix: close leaked file handles in sandbox_program_utils.py

### DIFF
--- a/verifiers/v1/utils/sandbox_program_utils.py
+++ b/verifiers/v1/utils/sandbox_program_utils.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from __future__ import annotations
 
 import json
@@ -369,7 +370,7 @@ def model_name(state):
 
 
 def load_tool_defs(protocol):
-    defs = json.loads(open(TOOL_DEFS_BY_PROTOCOL_PATH).read())
+    defs = json.loads(Path(TOOL_DEFS_BY_PROTOCOL_PATH).read_text())
     return defs.get(protocol) or []
 
 
@@ -567,7 +568,7 @@ async def create_model_message(state, messages, client):
 async def run_base(task, state, client):
     prompt_messages = [*(state.get("system_prompt") or []), *(state.get("prompt") or [])]
     messages = list(prompt_messages)
-    config = json.loads(open(RUNNER_CONFIG_PATH).read())
+    config = json.loads(Path(RUNNER_CONFIG_PATH).read_text())
     max_turns = int(config["max_turns"])
     turn = 0
     while max_turns <= 0 or turn < max_turns:
@@ -613,8 +614,8 @@ async def run_base(task, state, client):
 
 async def main():
     mode = sys.argv[1]
-    task = json.loads(open(TASK_PATH).read())
-    state = json.loads(open(STATE_INPUT_PATH).read())
+    task = json.loads(Path(TASK_PATH).read_text())
+    state = json.loads(Path(STATE_INPUT_PATH).read_text())
     original_state = json.loads(json.dumps(state))
     client = Client(state)
     try:


### PR DESCRIPTION
## Problem

In `verifiers/v1/utils/sandbox_program_utils.py`, there are 4 instances of `json.loads(open(PATH).read())` which create file handles that are never explicitly closed:

- Line 372: `json.loads(open(TOOL_DEFS_BY_PROTOCOL_PATH).read())`
- Line 570: `json.loads(open(RUNNER_CONFIG_PATH).read())`
- Line 616: `json.loads(open(TASK_PATH).read())`
- Line 617: `json.loads(open(STATE_INPUT_PATH).read())`

These rely on garbage collection to close the file descriptors, which is unreliable — especially on alternative Python implementations (PyPy, GraalPy) where GC behavior differs from CPython.

## Fix

Replace all 4 instances with `json.loads(Path(PATH).read_text())`, which:
1. Uses `pathlib.Path.read_text()` — the idiomatic Python 3 way to read files
2. Properly closes the file handle after reading (context manager internally)
3. Also adds `from pathlib import Path` import

## Before vs After

```python
# Before (file handle leaked)
defs = json.loads(open(TOOL_DEFS_BY_PROTOCOL_PATH).read())

# After (properly closed)
defs = json.loads(Path(TOOL_DEFS_BY_PROTOCOL_PATH).read_text())
```

## Tests

This is a pure refactor with no behavioral change. All existing tests should continue to pass since `Path.read_text()` returns the same `str` that `open().read()` does.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the sandbox runner’s startup/config loading path; while intended as a no-op refactor, it changes how multiple JSON files are read and could break execution if imports/paths are incorrect.
> 
> **Overview**
> Replaces several `json.loads(open(PATH).read())` reads in `sandbox_program_utils.py` with `Path(PATH).read_text()` to ensure file handles are not leaked when loading tool defs, runner config, task, and state.
> 
> Adds a `pathlib.Path` import to support the new file-reading approach.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc76283cf87f37e3cc505d44645fe55adfa15fa2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->