### PR TITLE
fix: guard against None content in JudgeRubric judge response

### DIFF
--- a/verifiers/rubrics/judge_rubric.py
+++ b/verifiers/rubrics/judge_rubric.py
@@ -95,7 +95,14 @@ class JudgeRubric(Rubric):
                 messages=[{"role": "user", "content": judge_prompt}],
                 **judge_args,
             )
-            judge_response = str(judge_response.choices[0].message.content)
+            content = judge_response.choices[0].message.content
+            if content is None:
+                raise RuntimeError(
+                    f"Judge model returned None content. "
+                    f"This usually means the model returned tool_calls or a refusal. "
+                    f"Model: {self.judge_model}"
+                )
+            judge_response = str(content)
         except RateLimitError as e:
             self.logger.warning(
                 f"Rate limit exceeded when calling judge model '{self.judge_model}'. "


### PR DESCRIPTION
## Problem

In `verifiers/rubrics/judge_rubric.py:98`, the judge response is extracted with:

```python
judge_response = str(judge_response.choices[0].message.content)
```

When the judge model returns **tool_calls** or a **refusal** (e.g., content filter), `message.content` is `None`. In Python, `str(None)` produces the literal string `"None"`, which is then parsed as the judge's scoring response. This causes:

1. **Silent incorrect scoring** — the judge "evaluates" the string "None" instead of the actual response
2. **No error signal** — the caller has no idea the judge failed; it just gets a wrong score
3. **Hard-to-debug training issues** — if using this for RL training, the wrong rewards silently corrupt the training signal

## Fix

Check for `None` content and raise a clear `RuntimeError` with diagnostic info:

```python
content = judge_response.choices[0].message.content
if content is None:
    raise RuntimeError(
        f"Judge model returned None content. "
        f"This usually means the model returned tool_calls or a refusal. "
        f"Model: {self.judge_model}"
    )
judge_response = str(content)
```

The error is raised **inside** the existing `try/except Exception` block (line 126), so it will be caught and logged properly with the model name.

## Before vs After

| Scenario | Before | After |
|----------|--------|-------|
| Normal response | Works correctly | Works correctly |
| `content = None` | `str(None)` = `"None"` → silent wrong score | `RuntimeError` → logged + propagated |
| Tool calls only | `str(None)` = `"None"` → silent wrong score | `RuntimeError` → logged + propagated |

## Tests

This change only affects the error path when `content is None`. The happy path (non-None content) is completely unchanged. Existing tests that mock the judge client with valid responses will continue to pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes judge scoring behavior to raise an exception when the model returns `None` content (e.g., tool calls/refusals), which may surface new runtime failures for callers that previously received a silent "None" string.
> 
> **Overview**
> Prevents silent mis-scoring in `JudgeRubric` by validating the judge model response before parsing.
> 
> When `choices[0].message.content` is `None` (commonly due to tool calls or refusals), the code now raises a descriptive `RuntimeError` instead of converting `None` to the literal string `"None"` and caching/returning it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e8644b41190e00e205495827fc5e68705411ffa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->