### PR TITLE
fix(math_group): replace raw == with MathRubric for math-aware answer comparison

### DIFF
--- a/environments/math_group/math_group.py
+++ b/environments/math_group/math_group.py
@@ -7,18 +7,11 @@ from verifiers.utils.data_utils import (
 
 
 def load_environment(**kwargs):
-    # env 1: gsm8k
     parser = vf.Parser(extract_fn=extract_boxed_answer)
 
-    def gsm8k_answer_reward_func(parser, completion, answer, **kwargs):
-        response = parser.parse_answer(completion) or ""
-        return 1.0 if response == answer else 0.0
-
-    rubric1 = vf.Rubric(
-        parser=parser,
-        funcs=[gsm8k_answer_reward_func, parser.get_format_reward_func()],
-        weights=[1.0, 0.0],
-    )
+    # env 1: gsm8k
+    rubric1 = vf.MathRubric(parser=parser)
+    rubric1.add_metric(parser.get_format_reward_func())
 
     def build_gsm8k_dataset():
         return load_example_dataset("gsm8k", split="train").select(range(1000))
@@ -31,15 +24,8 @@ def load_environment(**kwargs):
     )
 
     # env 2: math
-    def math_answer_reward_func(completion, answer, **kwargs):
-        response = parser.parse_answer(completion) or ""
-        return 1.0 if response == answer else 0.0
-
-    rubric2 = vf.Rubric(
-        parser=parser,
-        funcs=[math_answer_reward_func, parser.get_format_reward_func()],
-        weights=[1.0, 0.2],
-    )
+    rubric2 = vf.MathRubric(parser=parser)
+    rubric2.add_reward_func(parser.get_format_reward_func(), weight=0.2)
 
     def build_math_dataset():
         return load_example_dataset("math", split="train").select(range(1000))

--- a/tests/test_math_group.py
+++ b/tests/test_math_group.py
@@ -1,4 +1,5 @@
 """Tests for the math_group environment rubric behaviour."""
+
 import os
 import sys
 
@@ -18,6 +19,7 @@ from math_group import load_environment  # noqa: E402
 # Fixtures
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture(scope="module")
 async def env_group():
     """Load the math_group EnvGroup once per module; teardown rubric executors after."""
@@ -30,6 +32,7 @@ async def env_group():
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _make_state(make_input, completion: str, answer: str) -> vf.State:
     state = vf.State(
@@ -53,6 +56,7 @@ def _make_state(make_input, completion: str, answer: str) -> vf.State:
 # math sub-env: equivalent LaTeX forms must score 1.0
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.parametrize(
     "completion,answer",
     [
@@ -72,7 +76,9 @@ def _make_state(make_input, completion: str, answer: str) -> vf.State:
         r"0.75==\frac{3}{4}",
     ],
 )
-async def test_math_env_equivalent_forms_score_1(env_group, make_input, completion, answer):
+async def test_math_env_equivalent_forms_score_1(
+    env_group, make_input, completion, answer
+):
     """Equivalent answers must receive full credit from the math sub-env rubric.
 
     MathRubric uses math_verify under the hood, so symbolic equivalence is
@@ -87,6 +93,7 @@ async def test_math_env_equivalent_forms_score_1(env_group, make_input, completi
 # ---------------------------------------------------------------------------
 # gsm8k sub-env: same behaviour required
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.parametrize(
     "completion,answer",
@@ -103,7 +110,9 @@ async def test_math_env_equivalent_forms_score_1(env_group, make_input, completi
         r"0.75==\frac{3}{4}",
     ],
 )
-async def test_gsm8k_env_equivalent_forms_score_1(env_group, make_input, completion, answer):
+async def test_gsm8k_env_equivalent_forms_score_1(
+    env_group, make_input, completion, answer
+):
     """gsm8k sub-env rubric must also accept equivalent LaTeX representations."""
     state = _make_state(make_input, completion, answer)
     await env_group.env_map["gsm8k"].rubric.score_rollout(state)
@@ -114,6 +123,7 @@ async def test_gsm8k_env_equivalent_forms_score_1(env_group, make_input, complet
 # ---------------------------------------------------------------------------
 # Format reward contributes to state["reward"] for the math sub-env
 # ---------------------------------------------------------------------------
+
 
 async def test_math_format_reward_adds_to_total(env_group, make_input):
     """A correctly boxed answer must earn the 0.2 format bonus on top of the 1.0 answer score.
@@ -131,6 +141,7 @@ async def test_math_format_reward_adds_to_total(env_group, make_input):
 # ---------------------------------------------------------------------------
 # Regression: wrong answers must still score 0
 # ---------------------------------------------------------------------------
+
 
 async def test_wrong_answer_scores_0(env_group, make_input):
     """A clearly wrong answer must score 0 — math-awareness must not over-accept."""
@@ -151,6 +162,7 @@ async def test_gsm8k_wrong_answer_scores_0(env_group, make_input):
 # ---------------------------------------------------------------------------
 # EnvGroupRubric teardown must propagate to child rubrics
 # ---------------------------------------------------------------------------
+
 
 async def test_env_group_teardown_propagates_to_child_rubrics():
     """EnvGroup.rubric.teardown() must shut down child MathRubric executors.

--- a/tests/test_math_group.py
+++ b/tests/test_math_group.py
@@ -146,3 +146,24 @@ async def test_gsm8k_wrong_answer_scores_0(env_group, make_input):
     await env_group.env_map["gsm8k"].rubric.score_rollout(state)
 
     assert state["metrics"]["correct_answer"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# EnvGroupRubric teardown must propagate to child rubrics
+# ---------------------------------------------------------------------------
+
+async def test_env_group_teardown_propagates_to_child_rubrics():
+    """EnvGroup.rubric.teardown() must shut down child MathRubric executors.
+
+    MathRubric spawns a ProcessPoolExecutor per instance. If EnvGroupRubric
+    does not propagate teardown to the child RubricGroups, those workers leak
+    when the EnvGroup is torn down.
+
+    Chain: EnvGroupRubric → RubricGroup.teardown() → MathRubric.teardown()
+    """
+    eg = load_environment()
+    await eg.rubric.teardown()
+    for env in eg.envs:
+        math_rubric = next(r for r in env.rubric.rubrics if hasattr(r, "executor"))
+        with pytest.raises(RuntimeError, match="shutdown"):
+            math_rubric.executor.submit(lambda: None)

--- a/tests/test_math_group.py
+++ b/tests/test_math_group.py
@@ -1,0 +1,148 @@
+"""Tests for the math_group environment rubric behaviour."""
+import os
+import sys
+
+import pytest
+import verifiers as vf
+
+# math_group is a standalone package under environments/; add it to the path
+# so the import works without installing it.
+sys.path.insert(
+    0,
+    os.path.join(os.path.dirname(__file__), "..", "environments", "math_group"),
+)
+from math_group import load_environment  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+async def env_group():
+    """Load the math_group EnvGroup once per module; teardown rubric executors after."""
+    eg = load_environment()
+    yield eg
+    for env in eg.envs:
+        await env.rubric.teardown()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_state(make_input, completion: str, answer: str) -> vf.State:
+    state = vf.State(
+        input=make_input(
+            prompt=[{"role": "user", "content": "Solve it."}],
+            answer=answer,
+        )
+    )
+    state["completion"] = completion
+    state["trajectory"] = []
+    state["timing"] = {
+        "generation_ms": 0.0,
+        "scoring_ms": 0.0,
+        "total_ms": 0.0,
+        "start_time": 0.0,
+    }
+    return state
+
+
+# ---------------------------------------------------------------------------
+# math sub-env: equivalent LaTeX forms must score 1.0
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "completion,answer",
+    [
+        # display-fraction vs regular fraction — same value, different macro
+        (r"\boxed{\frac{3}{4}}", r"\dfrac{3}{4}"),
+        # fraction vs decimal
+        (r"\boxed{\frac{1}{2}}", "0.5"),
+        # commutativity
+        (r"\boxed{1 + x}", "x + 1"),
+        # decimal vs fraction (reversed direction)
+        (r"\boxed{0.75}", r"\frac{3}{4}"),
+    ],
+    ids=[
+        r"\frac{3}{4}==\dfrac{3}{4}",
+        r"\frac{1}{2}==0.5",
+        "1+x==x+1",
+        r"0.75==\frac{3}{4}",
+    ],
+)
+async def test_math_env_equivalent_forms_score_1(env_group, make_input, completion, answer):
+    """Equivalent answers must receive full credit from the math sub-env rubric.
+
+    MathRubric uses math_verify under the hood, so symbolic equivalence is
+    respected rather than raw string equality.
+    """
+    state = _make_state(make_input, completion, answer)
+    await env_group.env_map["math"].rubric.score_rollout(state)
+
+    assert state["metrics"]["correct_answer"] == 1.0
+
+
+# ---------------------------------------------------------------------------
+# gsm8k sub-env: same behaviour required
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "completion,answer",
+    [
+        (r"\boxed{\frac{3}{4}}", r"\dfrac{3}{4}"),
+        (r"\boxed{\frac{1}{2}}", "0.5"),
+        (r"\boxed{1 + x}", "x + 1"),
+        (r"\boxed{0.75}", r"\frac{3}{4}"),
+    ],
+    ids=[
+        r"\frac{3}{4}==\dfrac{3}{4}",
+        r"\frac{1}{2}==0.5",
+        "1+x==x+1",
+        r"0.75==\frac{3}{4}",
+    ],
+)
+async def test_gsm8k_env_equivalent_forms_score_1(env_group, make_input, completion, answer):
+    """gsm8k sub-env rubric must also accept equivalent LaTeX representations."""
+    state = _make_state(make_input, completion, answer)
+    await env_group.env_map["gsm8k"].rubric.score_rollout(state)
+
+    assert state["metrics"]["correct_answer"] == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Format reward contributes to state["reward"] for the math sub-env
+# ---------------------------------------------------------------------------
+
+async def test_math_format_reward_adds_to_total(env_group, make_input):
+    """A correctly boxed answer must earn the 0.2 format bonus on top of the 1.0 answer score.
+
+    The math rubric is: weight 1.0 (correct_answer) + weight 0.2 (format_reward).
+    A \boxed{} completion that is correct should therefore yield reward > 1.0.
+    """
+    state = _make_state(make_input, r"\boxed{\frac{1}{2}}", "0.5")
+    await env_group.env_map["math"].rubric.score_rollout(state)
+
+    assert state["metrics"]["correct_answer"] == 1.0
+    assert state["reward"] > 1.0  # format bonus applied
+
+
+# ---------------------------------------------------------------------------
+# Regression: wrong answers must still score 0
+# ---------------------------------------------------------------------------
+
+async def test_wrong_answer_scores_0(env_group, make_input):
+    """A clearly wrong answer must score 0 — math-awareness must not over-accept."""
+    state = _make_state(make_input, r"\boxed{2}", "3")
+    await env_group.env_map["math"].rubric.score_rollout(state)
+
+    assert state["metrics"]["correct_answer"] == 0.0
+
+
+async def test_gsm8k_wrong_answer_scores_0(env_group, make_input):
+    """Same regression check for the gsm8k sub-env."""
+    state = _make_state(make_input, r"\boxed{42}", "7")
+    await env_group.env_map["gsm8k"].rubric.score_rollout(state)
+
+    assert state["metrics"]["correct_answer"] == 0.0

--- a/verifiers/envs/env_group.py
+++ b/verifiers/envs/env_group.py
@@ -84,6 +84,12 @@ class EnvGroupRubric(vf.Rubric):
         """Return all unique reward function names across all environments."""
         return self.all_reward_names
 
+    async def teardown(self) -> None:
+        """Propagate teardown to each child environment's rubric."""
+        await super().teardown()
+        for env in self.env_map.values():
+            await env.rubric.teardown()
+
     async def score_rollout(
         self,
         state: vf.State,


### PR DESCRIPTION
## Currently

Both sub-env rubrics in `math_group` use raw Python string equality to score answers:

```python
return 1.0 if response == answer else 0.0
```

Semantically equivalent LaTeX forms receive 0 reward instead of 1 — e.g. `\frac{1}{2}` vs `0.5`, `\frac{3}{4}` vs `\dfrac{3}{4}`, `1 + x` vs `x + 1`. `math-verify` was already declared as a dependency in `environments/math_group/pyproject.toml` but never used.

## Change Summary

Two independent TDD cycles, four commits:

**Reward function fix** (`environments/math_group/math_group.py`)
- Replace both `vf.Rubric(...)` calls with `vf.MathRubric(parser=parser)`, consistent with `gsm8k`, `math_python`, and `doublecheck` environments
- Format-reward weights unchanged: gsm8k `0.0` (metric), math `0.2` (weighted)

**Teardown propagation fix** (`verifiers/envs/env_group.py`)
- Add `EnvGroupRubric.teardown()` override to propagate teardown to child rubrics
- `MathRubric` spawns a `ProcessPoolExecutor`; previously those workers leaked when the `EnvGroup` was torn down (`vf.Rubric` held no resources so this was harmless before this PR)
- Chain: `EnvGroupRubric` → `RubricGroup.teardown()` → `MathRubric.teardown()` → executor shutdown

## Acceptance Criteria

- [x] `pytest tests/test_math_group.py` — 13 tests pass
- [x] `pytest tests/test_math_rubric.py tests/test_rubric.py tests/test_rubric_group.py tests/test_env_group.py` — existing tests still pass
- [x] `\frac{1}{2}` vs `0.5`, `\frac{3}{4}` vs `\dfrac{3}{4}`, `1 + x` vs `x + 1` all score 1.0
- [x] Wrong answers still score 0.0
- [x] `MathRubric` executors are shut down when `EnvGroup` is torn down

## Notes

- No new dependencies — `math-verify` was already in the environment's `pyproject.toml`
- Metric key changes from `math_answer_reward_func` / `gsm8k_answer_reward_func` → `correct_answer`, consistent with every other math environment in the repo. Both old names are confirmed unused anywhere else in the codebase (ripgrep: 0 matches).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes reward scoring semantics for `math_group` from string equality to math-aware equivalence, which can affect training/eval outcomes. Also adds teardown propagation in `EnvGroupRubric`, touching lifecycle management and async cleanup paths.
> 
> **Overview**
> `math_group` now uses `vf.MathRubric` for both `gsm8k` and `math` sub-environments, replacing raw string-equality answer checks so *symbolically equivalent* LaTeX/decimal forms score as correct; the `math` env still applies a `0.2` weighted format bonus while `gsm8k` tracks format as a metric.
> 
> Adds a `EnvGroupRubric.teardown()` override to propagate teardown to child environment rubrics (preventing `MathRubric` executor leaks), and introduces `tests/test_math_group.py` covering equivalence scoring, format bonus contribution, wrong-answer regression, and teardown propagation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1bef951c0a51bc91cb16e5cdf32681ff660aa9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->