### PR TITLE
Install sandbox fn program packages

### DIFF
--- a/docs/byo-harness.md
+++ b/docs/byo-harness.md
@@ -211,6 +211,12 @@ receive callable tool handles by default, or can set
 `program={"sandbox": True, "tools": "callable"}` when the base loop is moved
 into a sandbox.
 
+For sandboxed `program.fn` refs, v1 resolves the owning local package from the
+resolved module root: single-file modules use `pyproject.toml` in the same
+directory as the module file, and package modules use `pyproject.toml` inside
+the package directory. v1 uploads that package and installs it in the program
+sandbox. Package dependencies are normal `[project.dependencies]`.
+
 Programs are also the right shape for LLM-free replay:
 
 ```python

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -681,6 +681,12 @@ tool loop.
 | `{"fn": "pkg.module:run", ...}` | Importable Python program. |
 | `{"command": ["cmd", "arg"], ...}` | Local or sandboxed command. |
 
+Sandboxed `program.fn` refs resolve their owning local package from the resolved
+module root: single-file modules use `pyproject.toml` in the same directory as
+the module file, and package modules use `pyproject.toml` inside the package
+directory. v1 uploads and installs that package in the program sandbox. Package
+dependencies come from normal `[project.dependencies]`.
+
 #### Env
 
 ```python

--- a/environments/README.md
+++ b/environments/README.md
@@ -58,7 +58,7 @@ This folder contains installable example environments that showcase common usage
 
 - **Taskset/Harness v1**
   - **bfcl_v3**: BFCL v3 function-calling eval using task-local dynamic tool schemas and v1 rewards.
-  - **dspy_flights**: DSPy flight-support entrypoint configured against the v1 interception endpoint.
+  - **dspy_flights**: Sandboxed DSPy flight-support `program.fn` entrypoint installed from its package `pyproject.toml` and configured against the v1 interception endpoint.
   - **hello_group_reward_v1**: Deterministic v1 reference for group updates, metrics, rewards, advantages, and cleanup.
   - **tau2_bench_v1**: `tau2-bench-v1` τ²-bench taskset/user/tool pattern on the v1 harness runtime.
 

--- a/environments/dspy_flights/README.md
+++ b/environments/dspy_flights/README.md
@@ -1,3 +1,7 @@
 # dspy-flights
 
 Minimal v1 environment for a third-party DSPy flight-support program.
+
+`load_harness()` uses a sandboxed Python `program.fn` entrypoint. v1 resolves
+this package from `pyproject.toml`, installs it in the program sandbox, and then
+runs `dspy_flights:run_dspy_flight_program` with normal package dependencies.

--- a/environments/dspy_flights/dspy_flights.py
+++ b/environments/dspy_flights/dspy_flights.py
@@ -11,6 +11,14 @@ from pydantic import BaseModel
 
 import verifiers.v1 as vf
 
+PROGRAM_SANDBOX = {
+    "image": "python:3.11-slim",
+    "network_access": True,
+    "timeout_minutes": 60,
+    "command_timeout": 900,
+    "install_timeout": 900,
+}
+
 
 class Date(BaseModel):
     # Somehow LLM is bad at specifying `datetime.datetime`, so
@@ -374,7 +382,8 @@ def load_taskset(config: vf.TasksetConfig | None = None):
 
 def load_harness(config: vf.HarnessConfig | None = None):
     return vf.Harness(
-        program={"fn": "dspy_flights:run_dspy_flight_program"},
+        program={"fn": "dspy_flights:run_dspy_flight_program", "sandbox": True},
+        sandbox=PROGRAM_SANDBOX,
         config=config,
     )
 

--- a/environments/dspy_flights/pyproject.toml
+++ b/environments/dspy_flights/pyproject.toml
@@ -3,7 +3,7 @@ name = "dspy-flights"
 version = "0.1.0"
 tags = ["dspy", "program", "v1"]
 license = "Apache-2.0"
-description = "v1 environment that runs a DSPy flight-support program through the interception endpoint."
+description = "v1 environment that runs a sandboxed DSPy flight-support program through the interception endpoint."
 requires-python = ">=3.11"
 dependencies = [
     "verifiers>=0.1.13.dev0",

--- a/tests/test_v1_runtime_lifecycle.py
+++ b/tests/test_v1_runtime_lifecycle.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import shlex
 import sys
 import tempfile
 import urllib.request
@@ -24,11 +25,14 @@ from verifiers.v1.utils.mcp_proxy_utils import MCP_PROXY_CONFIG_PATH, MCP_PROXY_
 from verifiers.v1.utils.mcp_proxy_utils import proxy_command, proxy_source
 from verifiers.v1.utils.program_utils import command_env
 from verifiers.v1.utils.sandbox_program_utils import (
+    PACKAGE_ROOT,
     RUNNER_CONFIG_PATH,
+    SandboxPackage,
     TOOL_DEFS_BY_PROTOCOL_PATH,
     TOOL_DEFS_PATH,
     apply_internal_state_patch,
     runner_source,
+    sandbox_program_package,
     sandbox_runner_program,
 )
 from verifiers.v1.utils.sandbox_utils import (
@@ -856,6 +860,135 @@ def test_sandbox_base_program_uses_openai_tool_payloads() -> None:
     tool_payloads_by_protocol = json.loads(files[TOOL_DEFS_BY_PROTOCOL_PATH])
     assert tool_payloads_by_protocol["openai_responses"][0]["name"] == "echo_tool"
     assert tool_payloads_by_protocol["anthropic_messages"][0]["name"] == "echo_tool"
+
+
+def test_sandbox_fn_program_installs_local_package(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module_path = tmp_path / "local_program.py"
+    module_path.write_text("async def run(task, state): return state\n")
+    (tmp_path / "pyproject.toml").write_text(
+        """
+[project]
+name = "local-program"
+version = "0.1.0"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+""".strip()
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    task = vf.Task({"prompt": [{"role": "user", "content": "hi"}]}).freeze()
+    state = vf.State.for_task(task)
+    program = sandbox_runner_program(
+        program={"env": {"PYTHONPATH": "/custom"}},
+        task=task,
+        state=state,
+        mode="fn",
+        fn_ref="local_program:run",
+        max_turns=1,
+        tool_defs=[],
+    )
+
+    dirs = cast(dict[str, object], program["dirs"])
+    env = cast(dict[str, object], program["env"])
+    command = cast(list[str], program["command"])
+    setup = cast(list[str], program["setup"])
+    assert dirs[PACKAGE_ROOT] == tmp_path.resolve()
+    assert env["PYTHONPATH"] == "/custom"
+    assert "pip install" in setup[1]
+    assert shlex.quote(PACKAGE_ROOT) in setup[1]
+    assert command[2].endswith(" /tmp/vf_program_runner.py fn local_program:run")
+
+
+def test_sandbox_fn_program_resolves_local_module_package(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module_path = tmp_path / "standalone_program.py"
+    module_path.write_text("async def run(task, state): return state\n")
+    (tmp_path / "pyproject.toml").write_text(
+        """
+[project]
+name = "standalone-program"
+version = "0.1.0"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+""".strip()
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    package = sandbox_program_package(mode="fn", fn_ref="standalone_program:run")
+
+    assert package == SandboxPackage(local_root=tmp_path.resolve())
+
+
+def test_sandbox_fn_program_resolves_package_module_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    package = tmp_path / "package_program"
+    package.mkdir()
+    (package / "__init__.py").write_text("")
+    (package / "worker.py").write_text("async def run(task, state): return state\n")
+    (package / "pyproject.toml").write_text(
+        """
+[project]
+name = "package-program"
+version = "0.1.0"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+""".strip()
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    package_root = sandbox_program_package(
+        mode="fn", fn_ref="package_program.worker:run"
+    )
+
+    assert package_root == SandboxPackage(local_root=package.resolve())
+
+
+def test_sandbox_fn_program_does_not_walk_to_parent_pyproject(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "nested_program.py").write_text("async def run(task, state): return state\n")
+    (tmp_path / "pyproject.toml").write_text(
+        """
+[project]
+name = "parent-program"
+version = "0.1.0"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+""".strip()
+    )
+    monkeypatch.syspath_prepend(str(src))
+
+    with pytest.raises(ValueError, match="beside the resolved environment module"):
+        sandbox_program_package(mode="fn", fn_ref="nested_program:run")
+
+
+def test_sandbox_fn_program_does_not_install_stdlib_packages() -> None:
+    assert sandbox_program_package(mode="fn", fn_ref="json:dumps") is None
+
+
+def test_sandbox_fn_program_requires_local_pyproject(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module_path = tmp_path / "unpackaged_program.py"
+    module_path.write_text("async def run(task, state): return state\n")
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    with pytest.raises(ValueError, match="no pyproject.toml"):
+        sandbox_program_package(mode="fn", fn_ref="unpackaged_program:run")
 
 
 def test_sandbox_python_program_installs_runtime_client_deps() -> None:

--- a/verifiers/v1/README.md
+++ b/verifiers/v1/README.md
@@ -899,6 +899,13 @@ Sandboxed base and Python entrypoint programs use the callable interface by
 default. Set `program={"sandbox": True, "tools": "callable"}` when the config
 should make that interface explicit.
 
+When a sandboxed `program.fn` ref points at local source, v1 resolves the
+package from the module root: single-file modules use `pyproject.toml` in the
+same directory as the module file, and package modules use `pyproject.toml`
+inside the package directory. v1 uploads that package root and installs it in
+the program sandbox before running the entrypoint. Dependencies are normal
+package dependencies.
+
 Command programs do not have a universal Python call surface. If
 `program.tools` requests `mcp`, v1 materializes an MCP proxy for the resolved
 toolsets. Generic CLI programs usually need a setup command to add that MCP

--- a/verifiers/v1/utils/sandbox_program_utils.py
+++ b/verifiers/v1/utils/sandbox_program_utils.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
+import importlib.machinery
+import importlib.util
 import json
 import shlex
+import sys
+import sysconfig
 from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, cast
 
 from verifiers.utils.interception_utils import serialize_tool_defs
@@ -12,6 +18,7 @@ from ..state import State
 from ..task import Task
 from .sandbox_utils import (
     VF_STATE_INPUT_PATH_KEY,
+    python_package_install_command,
     python_runtime_command,
     python_runtime_setup_command,
     run_sandbox_command,
@@ -26,6 +33,7 @@ TOOL_DEFS_BY_PROTOCOL_PATH = "/tmp/vf_tool_defs_by_protocol.json"
 RUNNER_PATH = "/tmp/vf_program_runner.py"
 STATE_ARTIFACT = "__vf_state"
 PYTHON_PROGRAM_PACKAGES = ("openai", "anthropic", "requests")
+PACKAGE_ROOT = "/tmp/vf_program_package"
 
 
 def python_program_sandbox(sandbox_config: Mapping[str, object]) -> dict[str, object]:
@@ -126,6 +134,9 @@ def sandbox_runner_program(
     max_turns: int,
     tool_defs: object,
 ) -> dict[str, object]:
+    package = sandbox_program_package(mode=mode, fn_ref=fn_ref)
+    if package is not None:
+        program = sandbox_program_with_package(program, package)
     files = dict(cast(Mapping[str, object], program.get("files") or {}))
     files[TASK_PATH] = json.dumps(task)
     files[TOOL_DEFS_PATH] = json.dumps(
@@ -147,22 +158,131 @@ def sandbox_runner_program(
     artifacts = dict(cast(Mapping[str, object], program.get("artifacts") or {}))
     artifacts[STATE_ARTIFACT] = {"path": STATE_OUTPUT_PATH, "format": "json"}
     command = python_runtime_command(
-        RUNNER_PATH, *([mode] if fn_ref is None else [mode, fn_ref])
+        RUNNER_PATH,
+        *([mode] if fn_ref is None else [mode, fn_ref]),
     )
     setup = program.get("setup") or []
     if isinstance(setup, str):
         setup = [setup]
     if not isinstance(setup, list):
         setup = [setup]
+    package_setup = [] if package is None else [package.install_command]
     return {
         **dict(program),
         "files": files,
         "command": command,
         "env": dict(cast(Mapping[str, object], program.get("env") or {})),
-        "setup": [python_runtime_setup_command(), *setup],
+        "setup": [python_runtime_setup_command(), *package_setup, *setup],
         "artifacts": artifacts,
         VF_STATE_INPUT_PATH_KEY: STATE_INPUT_PATH,
     }
+
+
+@dataclass(frozen=True)
+class SandboxPackage:
+    local_root: Path
+    remote_root: str = PACKAGE_ROOT
+
+    @property
+    def install_command(self) -> str:
+        return python_package_install_command(shlex.quote(self.remote_root))
+
+
+def sandbox_program_package(*, mode: str, fn_ref: str | None) -> SandboxPackage | None:
+    if mode != "fn" or fn_ref is None:
+        return None
+    module_name, _, _ = fn_ref.partition(":")
+    if not module_name:
+        raise ValueError("program.fn must include a module path.")
+    spec = importlib.util.find_spec(module_name)
+    if spec is None:
+        raise ImportError(f"Cannot resolve program.fn module {module_name!r}.")
+    roots = package_roots_for_module(module_name, spec)
+    if not roots:
+        return None
+    if len(roots) != 1:
+        raise ValueError(
+            f"program.fn {fn_ref!r} resolved to multiple package roots: "
+            f"{sorted(str(root) for root in roots)}."
+        )
+    return SandboxPackage(local_root=next(iter(roots)))
+
+
+def sandbox_program_with_package(
+    program: Mapping[str, object], package: SandboxPackage
+) -> Mapping[str, object]:
+    merged = dict(program)
+    dirs = dict(cast(Mapping[str, object], merged.get("dirs") or {}))
+    if package.remote_root in dirs:
+        raise ValueError(
+            f"program.dirs already defines internal package path {package.remote_root!r}."
+        )
+    dirs[package.remote_root] = package.local_root
+    merged["dirs"] = dirs
+    return merged
+
+
+def package_roots_for_module(
+    module_name: str, spec: importlib.machinery.ModuleSpec
+) -> set[Path]:
+    roots = set()
+    for path in module_source_paths(spec):
+        if is_external_import_path(path):
+            continue
+        root = module_package_root(path)
+        if root is None:
+            raise ValueError(
+                f"Sandboxed program.fn {module_name!r} resolves to local source "
+                f"{path}, but no pyproject.toml was found beside the resolved "
+                "environment module or package."
+            )
+        roots.add(root)
+    return roots
+
+
+def module_source_paths(spec: importlib.machinery.ModuleSpec) -> list[Path]:
+    origin = spec.origin
+    if spec.submodule_search_locations:
+        return [Path(path).resolve() for path in spec.submodule_search_locations]
+    if origin in {None, "built-in", "frozen"}:
+        return []
+    return [Path(origin).resolve()]
+
+
+def module_package_root(path: Path) -> Path | None:
+    root = path if path.is_dir() else path.parent
+    if (root / "pyproject.toml").is_file():
+        return root
+    return None
+
+
+def is_external_import_path(path: Path) -> bool:
+    parts = set(path.parts)
+    if "site-packages" in parts or "dist-packages" in parts:
+        return True
+    for prefix in interpreter_prefixes():
+        try:
+            path.relative_to(prefix)
+        except ValueError:
+            continue
+        return True
+    return False
+
+
+def interpreter_prefixes() -> list[Path]:
+    prefixes: list[Path] = []
+    for key in ("stdlib", "platstdlib"):
+        value = sysconfig.get_path(key)
+        if value:
+            prefixes.append(Path(value).resolve())
+    for value in (sys.base_prefix, sys.base_exec_prefix):
+        if value:
+            prefixes.append(Path(value).resolve())
+    unique: list[Path] = []
+    for prefix in prefixes:
+        if prefix not in unique:
+            unique.append(prefix)
+    return unique
 
 
 def runner_source() -> str:


### PR DESCRIPTION
## Summary
- infer sandboxed Python `program.fn` packages only when the resolved local environment module root exports `pyproject.toml` directly: same directory for a single-file module, inside the package directory for a package module
- upload and install that package in the program sandbox before the runner imports the entrypoint, using normal `[project.dependencies]`
- update `dspy_flights` as a concrete packaged env example using a sandboxed DSPy entrypoint
- document the package-native sandboxed Python program pattern

## Validation
- `UV_CACHE_DIR=/private/tmp/uv-cache uv run pre-commit run --files verifiers/v1/utils/sandbox_program_utils.py tests/test_v1_runtime_lifecycle.py docs/byo-harness.md docs/reference.md verifiers/v1/README.md environments/dspy_flights/dspy_flights.py environments/dspy_flights/README.md environments/dspy_flights/pyproject.toml environments/README.md`
- `UV_CACHE_DIR=/private/tmp/uv-cache uv run pytest tests/test_v1_runtime_lifecycle.py -q -k sandbox_fn_program`
- `uv run pytest tests/test_v1_runtime_lifecycle.py -q`
- `uv run pytest tests/test_v1_config_extension.py -q -k "reference_v1_loaders or dspy"`
- `uv run pytest tests/test_v1_mini_swe_agent.py -q`
- `UV_CACHE_DIR=/private/tmp/uv-cache uv run pre-commit run --files docs/byo-harness.md docs/reference.md verifiers/v1/README.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies v1 sandbox program startup to auto-upload and `pip install` local `program.fn` packages, which can affect how sandboxed entrypoints resolve imports and run setup commands.
> 
> **Overview**
> Sandboxed v1 `program.fn` entrypoints now detect when the referenced module resolves to *local* source, locate the owning package root via an adjacent `pyproject.toml`, upload that directory into the sandbox, and `pip install` it before running the runner.
> 
> This adds explicit package-resolution/validation behavior (e.g., no walking to parent `pyproject.toml`, ignore stdlib/site-packages, error on ambiguous roots) with new lifecycle tests covering the expected install command and failure cases.
> 
> Updates the `dspy_flights` example to run its DSPy entrypoint as a sandboxed `program.fn` installed from its package, and documents the new pattern in the v1 docs/reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ffd0814aeb9f816600a5237eae1722c1d98d8d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->