### PR TITLE
opencode: write config under XDG_CONFIG_HOME

### DIFF
--- a/verifiers/envs/experimental/composable/harnesses/opencode.py
+++ b/verifiers/envs/experimental/composable/harnesses/opencode.py
@@ -190,7 +190,15 @@ if [[ -z "$OPENCODE_WORKDIR" ]]; then
     OPENCODE_WORKDIR={shlex.quote(agent_workdir)}
 fi
 
-mkdir -p ~/.config/opencode {shlex.quote(log_dir)} "$OPENCODE_WORKDIR"
+# OpenCode follows XDG spec — config is read from
+# $XDG_CONFIG_HOME/opencode/opencode.json (default $HOME/.config). Some
+# sandbox images (e.g. SWE-rebench-V2's swerebenchv2/* images) override
+# XDG_CONFIG_HOME to a non-default path like /workspace/.config; writing
+# only to ~/.config/opencode would silently miss it and the binary would
+# fall back to its bundled "opencode" provider (free hosted Cloudflare
+# tier), which rate-limits under load and silently blocks the agent.
+OPENCODE_CONFIG_DIR="${{XDG_CONFIG_HOME:-$HOME/.config}}/opencode"
+mkdir -p "$OPENCODE_CONFIG_DIR" {shlex.quote(log_dir)} "$OPENCODE_WORKDIR"
 
 # Ensure OPENAI_MODEL has provider/model format for opencode AI SDK config.
 # LoRA adapter names (e.g. "rft-abc123") lack a slash, causing empty modelID.
@@ -200,7 +208,7 @@ fi
 
 SCHEMA_DOLLAR='$'
 
-cat > ~/.config/opencode/opencode.json << EOFCONFIG
+cat > "$OPENCODE_CONFIG_DIR/opencode.json" << EOFCONFIG
 {config_json}
 EOFCONFIG
 


### PR DESCRIPTION
## Summary

- Update the composable OpenCode harness to write `opencode.json` under `${XDG_CONFIG_HOME:-$HOME/.config}/opencode`.
- Preserve the default `$HOME/.config` behavior when `XDG_CONFIG_HOME` is unset.
- Add a regression test for the generated harness command.

## Why

Some SWE-rebench-V2 sandbox images set `XDG_CONFIG_HOME=/workspace/.config`. OpenCode reads config through the XDG path, so writing only to `~/.config/opencode/opencode.json` can leave the harness config unused and cause OpenCode to fall back to its bundled provider.

## Validation

- `uv run pytest tests/test_opencode_harness.py tests/test_opencode_rlm_env.py -q`
- `uv run ruff check verifiers/envs/experimental/composable/harnesses/opencode.py tests/test_opencode_harness.py`
- pre-push hooks: ruff check, ruff format, AGENTS sync, ty ci parity

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized change to the harness shell script that only affects where config is written; main risk is mis-resolving paths in unusual sandbox env var setups.
> 
> **Overview**
> Ensures the OpenCode composable harness writes its config to `${XDG_CONFIG_HOME:-$HOME/.config}/opencode/opencode.json` and creates that directory, instead of always using `~/.config/opencode`.
> 
> This prevents sandboxes that override `XDG_CONFIG_HOME` from ignoring the generated config and falling back to the bundled default provider.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd0f22f7d706e23e82114b92b20873341f4a7c29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->