### PR TITLE
Fix interception keepalive env override

### DIFF
--- a/verifiers/utils/interception_utils.py
+++ b/verifiers/utils/interception_utils.py
@@ -5,6 +5,7 @@ import hmac
 import inspect
 import json
 import logging
+import os
 import secrets
 import time
 import uuid
@@ -33,7 +34,9 @@ from verifiers.utils.logging_utils import print_time, truncate
 logger = logging.getLogger(__name__)
 
 
-KEEPALIVE_INTERVAL_SECONDS = 10.0
+KEEPALIVE_INTERVAL_SECONDS = float(
+    os.environ.get("INTERCEPTION_SERVER_KEEPALIVE_INTERVAL_SECONDS", "3.0")
+)
 DEFAULT_CLIENT_MAX_SIZE_BYTES = 16 * 1024 * 1024
 
 


### PR DESCRIPTION
## Summary
- replace the hardcoded interception keepalive interval with `INTERCEPTION_SERVER_KEEPALIVE_INTERVAL_SECONDS`
- lower the default interval from 10s to 3s so hosted streams receive keepalives before common proxy idle cutoffs

## Notes
- This is the standalone PR for original local commit `4e3bd7d2` replayed onto current `main` as `b18ef186`.

## Validation
- `uv run pytest tests/test_interception_utils.py -q`
- `uv run ruff check verifiers/utils/interception_utils.py tests/test_interception_utils.py`
- push hook: `ruff check`, `ruff format`, `ty (ci parity)`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small configuration change affecting only streaming keepalive timing, with minimal surface area beyond potential behavior changes under different env values.
> 
> **Overview**
> Updates `verifiers/utils/interception_utils.py` so the SSE keepalive interval is no longer hardcoded: `KEEPALIVE_INTERVAL_SECONDS` is now read from `INTERCEPTION_SERVER_KEEPALIVE_INTERVAL_SECONDS` (defaulting to **3.0s**, down from 10s).
> 
> This should keep hosted streaming connections alive through common proxy idle timeouts while still allowing deployments to tune the interval via environment configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b18ef186beff6390e6f10ce45bdc10f7922306dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->