### PR TITLE
fixes rlm compaction prompt so we still get tito hit

### DIFF
--- a/tests/test_openai_chat_completions_token_client.py
+++ b/tests/test_openai_chat_completions_token_client.py
@@ -169,7 +169,9 @@ async def test_get_native_response_falls_back_to_super_when_no_prefix_match(
     sentinel = {"source": "super"}
     calls: list[dict[str, Any]] = []
 
-    async def fake_get_prompt_ids(self, state, prompt_messages, oai_tools):  # noqa: ANN001
+    async def fake_get_prompt_ids(  # noqa: ANN001
+        self, state, prompt_messages, oai_tools, chat_template_kwargs=None
+    ):
         return None
 
     async def fake_super_get_native_response(  # noqa: ANN001
@@ -235,7 +237,9 @@ async def test_get_native_response_uses_token_route_when_prompt_ids_available(
     recording_client = _RecordingClient()
     client = OpenAIChatCompletionsTokenClient(recording_client)
 
-    async def fake_get_prompt_ids(self, state, prompt_messages, oai_tools):  # noqa: ANN001
+    async def fake_get_prompt_ids(  # noqa: ANN001
+        self, state, prompt_messages, oai_tools, chat_template_kwargs=None
+    ):
         return [10, 20]
 
     monkeypatch.setattr(

--- a/verifiers/clients/openai_chat_completions_token_client.py
+++ b/verifiers/clients/openai_chat_completions_token_client.py
@@ -115,7 +115,18 @@ class OpenAIChatCompletionsTokenClient(OpenAIChatCompletionsClient):
             return await super().get_native_response(
                 prompt, model, sampling_args, tools, extra_headers=extra_headers
             )
-        prompt_ids = await self.get_prompt_ids(state, prompt, tools)
+        # The bridge tokenize calls inside get_prompt_ids must run under the
+        # same chat-template config as the engine's actual generation,
+        # otherwise the bridge tokens won't line up with what vLLM streamed
+        # (e.g. GLM-5.1's `clear_thinking` flag changes the rendering of past
+        # assistants — and of the dummy assistant we use for the bridge —
+        # which can break the bridge prefix property).
+        chat_template_kwargs = (sampling_args.get("extra_body", {}) or {}).get(
+            "chat_template_kwargs"
+        ) or {}
+        prompt_ids = await self.get_prompt_ids(
+            state, prompt, tools, chat_template_kwargs=chat_template_kwargs
+        )
         if prompt_ids is None:
             # Reaching this branch means we have a non-empty trajectory but
             # could not stitch — surface it loudly so ops catches regressions.
@@ -148,6 +159,7 @@ class OpenAIChatCompletionsTokenClient(OpenAIChatCompletionsClient):
         state: State,
         prompt_messages: OpenAIChatMessages,
         oai_tools: list[OpenAITool] | None,
+        chat_template_kwargs: dict | None = None,
     ) -> list[int] | None:
         """
         Build prompt_ids for the next turn by stitching engine tokens with
@@ -266,9 +278,16 @@ class OpenAIChatCompletionsTokenClient(OpenAIChatCompletionsClient):
             if tc_id:
                 tool_call_ids.append(tc_id)
 
+        # GLM-5.1's chat template only renders `<think>{rc}</think>` for an
+        # assistant when `reasoning_content` ends up *defined*. The cascade
+        # that defines it from position (`idx > last_user_index`) flips when
+        # env_messages ends in a user message, breaking the bridge prefix
+        # property. Setting reasoning_content="" forces branch 1 of the
+        # cascade so the dummy renders identically across env-tail shapes.
         if tool_call_ids:
             dummy_assistant: OpenAIChatMessage = ChatCompletionAssistantMessageParam(
                 role="assistant",
+                reasoning_content="",  # type: ignore[typeddict-unknown-key]
                 tool_calls=[
                     ChatCompletionMessageFunctionToolCallParam(
                         id=tc_id,
@@ -280,20 +299,31 @@ class OpenAIChatCompletionsTokenClient(OpenAIChatCompletionsClient):
             )
         else:
             dummy_assistant: OpenAIChatMessage = ChatCompletionAssistantMessageParam(
-                role="assistant", content="x"
+                role="assistant",
+                reasoning_content="",  # type: ignore[typeddict-unknown-key]
+                content="x",
             )
+
+        # Forward the rollout's chat_template_kwargs so the bridge is
+        # rendered under the same template config as the engine's stream.
+        forwarded_ctk = (
+            {"chat_template_kwargs": dict(chat_template_kwargs)}
+            if chat_template_kwargs
+            else {}
+        )
 
         try:
             bridge_full_ids = await self.tokenize(
                 messages=[dummy_assistant] + env_messages,
                 tools=oai_tools,
                 model=state["model"],
+                extra_kwargs=dict(forwarded_ctk),
             )
             bridge_base_ids = await self.tokenize(
                 messages=[dummy_assistant],
                 tools=oai_tools,
                 model=state["model"],
-                extra_kwargs=dict(add_generation_prompt=False),
+                extra_kwargs=dict(add_generation_prompt=False, **forwarded_ctk),
             )
         except Exception:
             self.logger.debug("TITO: bridge tokenization failed, falling back to MITO")

--- a/verifiers/clients/openai_chat_completions_token_client.py
+++ b/verifiers/clients/openai_chat_completions_token_client.py
@@ -121,9 +121,11 @@ class OpenAIChatCompletionsTokenClient(OpenAIChatCompletionsClient):
         # (e.g. GLM-5.1's `clear_thinking` flag changes the rendering of past
         # assistants — and of the dummy assistant we use for the bridge —
         # which can break the bridge prefix property).
-        chat_template_kwargs = (sampling_args.get("extra_body", {}) or {}).get(
-            "chat_template_kwargs"
-        ) or {}
+        # `extra_body` is guaranteed by normalize_sampling_args above;
+        # `chat_template_kwargs` is rollout-configured and may be absent.
+        chat_template_kwargs = sampling_args["extra_body"].get(
+            "chat_template_kwargs", {}
+        )
         prompt_ids = await self.get_prompt_ids(
             state, prompt, tools, chat_template_kwargs=chat_template_kwargs
         )


### PR DESCRIPTION
## Description
fixes glm rlm compaction request when we have a trailing user message. without this we fallback to mito and get a break when we should have extension

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches token-stitching (TITO) prompt-id construction and tokenization parameters, where small template mismatches can cause incorrect prompts or unexpected MITO fallbacks. Scope is localized but model/template-specific behavior makes regressions possible.
> 
> **Overview**
> Improves token-stitching (TITO) reliability by **passing `chat_template_kwargs` from generation sampling args into `get_prompt_ids()` and the underlying `/tokenize` bridge calls**, ensuring bridge tokens are generated under the same chat-template configuration as the main stream.
> 
> Adjusts the dummy assistant used for bridge tokenization to always define `reasoning_content` (notably for GLM-5.1), preventing prefix-property breakage when the environment message tail ends with a user message. Tests were updated to match the new `get_prompt_ids(..., chat_template_kwargs=...)` signature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51de36d6d145f186ec30b3f76deafc117157694c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->