### PR TITLE
Pin OpenCode small model to intercepted provider

### DIFF
--- a/verifiers/envs/experimental/composable/harnesses/opencode.py
+++ b/verifiers/envs/experimental/composable/harnesses/opencode.py
@@ -129,6 +129,12 @@ def build_opencode_config(
             }
         },
         "model": model_id,
+        # Without small_model, title/summary sub-agents fall through to
+        # opencode/gpt-5-nano (free hosted Cloudflare tier) and rate-limit
+        # under concurrent rollouts, which silently blocks the main agent
+        # before it issues any LLM call. See OpenCode provider.ts
+        # getSmallModel() priority chain. Pin to the same intercepted model.
+        "small_model": model_id,
     }
 
     if disable_compaction:


### PR DESCRIPTION
## Summary
- Pin OpenCode `small_model` to the same intercepted model in every generated OpenCode config.
- Cover composable OpenCode harnesses, legacy `OpenCodeEnv`/`OpenCodeRLMEnv`/`OpenCodeQAEnv`, and v1 `vf.OpenCode` used by `opencode_harbor`.

## Affected code locations
- `verifiers/envs/experimental/composable/harnesses/opencode.py`
- `verifiers/envs/experimental/opencode_env.py`
- `verifiers/v1/packages/harnesses/opencode.py`

## Why
Without `small_model`, OpenCode title/summary sub-agents can fall through to the built-in free hosted `opencode/gpt-5-nano` path instead of the intercepted provider. Under concurrent rollouts that path rate-limits before the main agent issues an intercepted LLM request, which can produce empty trajectories that verifiers cannot observe.

## Notes
- This is the standalone PR for original local commit `a75ad33c`, expanded to all affected OpenCode config builders.
- The standalone test file from the first draft was removed.

## Validation
- `uv run ruff check verifiers/envs/experimental/composable/harnesses/opencode.py verifiers/envs/experimental/opencode_env.py verifiers/envs/experimental/opencode_rlm_env.py verifiers/v1/packages/harnesses/opencode.py`
- `uv run pytest tests/test_opencode_rlm_env.py tests/test_opencode_harbor.py tests/test_v1_harbor_cli.py -q`
- push hook: `ruff check`, `ruff format`, `ty (ci parity)`