### PR TITLE
Pin OpenCode small model in legacy configs

### DIFF
--- a/verifiers/envs/experimental/opencode_env.py
+++ b/verifiers/envs/experimental/opencode_env.py
@@ -379,6 +379,9 @@ class OpenCodeEnv(CliAgentEnv):
                 }
             },
             "model": "$OPENAI_MODEL",
+            # Keep title/summary sub-agents on the intercepted provider instead
+            # of falling back to OpenCode's hosted free small model.
+            "small_model": "$OPENAI_MODEL",
         }
 
         if disable_compaction:

--- a/verifiers/v1/packages/harnesses/opencode.py
+++ b/verifiers/v1/packages/harnesses/opencode.py
@@ -213,6 +213,9 @@ def build_opencode_config(
             }
         },
         "model": "intercepted/model",
+        # Keep title/summary sub-agents on the intercepted provider instead
+        # of falling back to OpenCode's hosted free small model.
+        "small_model": "intercepted/model",
         "mcp": {
             "verifiers-tools": {
                 "type": "local",


### PR DESCRIPTION
## Summary
- Pin legacy experimental `OpenCodeEnv` `small_model` to `$OPENAI_MODEL`.
- Pin v1 `vf.OpenCode` `small_model` to `intercepted/model`, covering `environments/opencode_harbor`.

## Context
PR #1323 already merged the composable OpenCode harness change. This follow-up covers the remaining affected OpenCode config builders so title/summary sub-agents stay on the intercepted provider instead of falling through to OpenCode's hosted free small model path.

## Affected code locations
- `verifiers/envs/experimental/opencode_env.py`
- `verifiers/v1/packages/harnesses/opencode.py`

## Validation
- `uv run ruff check verifiers/envs/experimental/composable/harnesses/opencode.py verifiers/envs/experimental/opencode_env.py verifiers/envs/experimental/opencode_rlm_env.py verifiers/v1/packages/harnesses/opencode.py`
- `uv run pytest tests/test_opencode_rlm_env.py tests/test_opencode_harbor.py tests/test_v1_harbor_cli.py -q`
- push hook: `ruff check`, `ruff format`, `ty (ci parity)`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: config-only change that pins OpenCode sub-agent model selection; main behavior change is preventing fallback to OpenCode’s hosted small model, which could affect outputs but not security-critical logic.
> 
> **Overview**
> Pins OpenCode’s `small_model` in legacy config builders so title/summary sub-agents stay on the intercepted provider instead of falling back to OpenCode’s hosted small model.
> 
> This sets `small_model` to `$OPENAI_MODEL` in `OpenCodeEnv.build_opencode_config` and to `intercepted/model` in v1 `build_opencode_config` (used by the `vf.OpenCode` harness).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cb8639b0d8169abc81c1bc1466a7a5150f9ea15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->