### PR TITLE
Avoid holding sandbox workers with `run_background_job()`

### DIFF
--- a/verifiers/utils/threaded_sandbox_client.py
+++ b/verifiers/utils/threaded_sandbox_client.py
@@ -1,10 +1,11 @@
 import asyncio
 import functools
 import logging
+import time
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Callable
 
-from prime_sandboxes import AsyncSandboxClient
+from prime_sandboxes import AsyncSandboxClient, CommandTimeoutError
 
 from verifiers.utils.thread_utils import (
     get_or_create_thread_attr,
@@ -73,6 +74,30 @@ class ThreadedAsyncSandboxClient:
             return await loop.run_in_executor(self.executor, run_in_thread)
 
         return wrapper
+
+    async def run_background_job(
+        self,
+        sandbox_id: str,
+        command: str,
+        timeout: int = 900,
+        working_dir: str | None = None,
+        env: dict[str, str] | None = None,
+        poll_interval: int = 3,
+    ) -> Any:
+        """Run a background job without occupying a worker while polling."""
+        job = await self.start_background_job(
+            sandbox_id,
+            command,
+            working_dir=working_dir,
+            env=env,
+        )
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            status = await self.get_background_job(sandbox_id, job)
+            if status.completed:
+                return status
+            await asyncio.sleep(poll_interval)
+        raise CommandTimeoutError(sandbox_id, command, timeout)
 
     def teardown(self, wait: bool = True) -> None:
         """Teardown the thread pool executor."""


### PR DESCRIPTION
## Summary
- Override `ThreadedAsyncSandboxClient.run_background_job` in place so long-running job polling does not occupy a sandbox client worker between polls.
- Keep the public method signature and timeout behavior aligned with `prime_sandboxes.AsyncSandboxClient.run_background_job`.
- No test files are changed in this PR.

## Why this lives in verifiers
`prime-sandboxes` already exposes the right lower-level primitives: `start_background_job(...)` and `get_background_job(...)`. Direct users of `AsyncSandboxClient.run_background_job(...)` are not blocked by a thread-pool worker while `asyncio.sleep(...)` polls.

The limitation appears when `verifiers` calls `prime_sandboxes.AsyncSandboxClient.run_background_job(...)` through `ThreadedAsyncSandboxClient.__getattr__`. The wrapper submits the whole SDK coroutine to one executor worker and waits for it to return. For long SWE test suites, that means a sandbox-client worker is occupied for the full test duration, including all polling sleeps. At high rollout concurrency, `test_run_s` can then include local executor queueing before the sandbox command has actually started.

This PR keeps the SDK behavior unchanged and fixes the wrapper boundary: only the short `start_background_job(...)` and `get_background_job(...)` calls use threaded client workers; the wait between polls happens in the outer async loop.

## Validation
- `uv run ruff check verifiers/utils/threaded_sandbox_client.py` - passed
- `uv run python -m py_compile verifiers/utils/threaded_sandbox_client.py` - passed
- `git diff --check` - passed
- Pre-push hooks: ruff check, ruff format, ty (ci parity) - passed
- GitHub CI on draft PR: Ruff, Ty, Environments, Verifiers 3.10/3.11/3.12/3.13 - passed

## Multi-SWE Trial
Ran a 32-example high-concurrency `swe_task_debugger` validation slice on `PrimeIntellect/Multi-SWE-RL-Clean` with `-c 128`, using rows whose prior high-concurrency `test_run_s` clustered around ~780-818s.

Output:
`/home/daniel/git/research-prod/artifacts/multi_swe_bgjob_polling_trial_20260510/evals/swe_task_debugger--none/3ab6eb0e/results.jsonl`

Summary:
- Previous selected-row `test_run_s`: median 803.8s, mean 798.6s.
- New selected-row `test_run_s`: median 145.3s, mean 147.0s, max 313.4s.
- Aggregate improvement by ratio of means: 5.43x lower measured `test_run_s`.
- Per-row speedup: mean 10.96x, median 5.61x, range 2.58x-32.80x.
- `fatedier__frp-2383`: 778.3s -> 28.0s.
- `zeromicro__go-zero-2361`: 786.9s -> 56.0s; single-sandbox repro was 52.0s.
- `alibaba__fastjson2-201`: 806.5s -> 160.3s; single-sandbox repro was 117.7s.

The env worker still logged `threaded-sandbox-client-...=16`, so this trial isolates the polling change rather than increasing the sandbox client worker cap.
