### PR TITLE
fix: add missing default case in resolve_client and guard kwargs.pop in token client

### DIFF
--- a/verifiers/clients/__init__.py
+++ b/verifiers/clients/__init__.py
@@ -52,6 +52,8 @@ def resolve_client(client_or_config: Client | ClientConfig) -> Client:
                 return AnthropicMessagesClient(client_or_config)
             case "nemorl_chat_completions":
                 return NeMoRLChatCompletionsClient(client_or_config)
+            case _:
+                raise ValueError(f"Unsupported client_type: {client_type!r}")
     else:
         raise ValueError(f"Unsupported client type: {type(client_or_config)}")
 

--- a/verifiers/clients/openai_chat_completions_token_client.py
+++ b/verifiers/clients/openai_chat_completions_token_client.py
@@ -99,7 +99,7 @@ class OpenAIChatCompletionsTokenClient(OpenAIChatCompletionsClient):
             return {k: v for k, v in sampling_args.items() if v is not None}
 
         sampling_args = normalize_sampling_args(sampling_args)
-        state = cast(State, kwargs.pop("state"))
+        state = cast(State, kwargs.pop("state", None))
         extra_headers = kwargs.pop("extra_headers", None)
         # Use standard /chat/completions for: (1) first turn (no prior tokens
         # to stitch), or (2) conversations that contain multimodal content in


### PR DESCRIPTION
## Problem

Two bugs in the client resolution layer:

### 1. `resolve_client()` silently returns `None` for unrecognized `client_type`

In `verifiers/clients/__init__.py`, the `match` statement has no `case _:` default. If `client_type` is an unrecognized string, execution falls through the match and the `elif` block, and the function **implicitly returns `None`** despite the `-> Client` return type annotation. Any caller will get a `None` dereference (likely `AttributeError` or `TypeError`) when trying to use the client.

```python
# Before: unrecognized client_type → returns None silently
match client_type:
    case "openai_completions": ...
    case "openai_chat_completions": ...
    # ... no case _:
```

### 2. `kwargs.pop("state")` without default in token client

In `verifiers/clients/openai_chat_completions_token_client.py:102`, `kwargs.pop("state")` has no default value. Every other client uses `kwargs.pop("state", None)`. Without the default, calling this method without `"state"` in kwargs raises an unhelpful `KeyError` instead of a clear error message.

## Fix

1. Add `case _:` with a clear `ValueError` to the match statement in `resolve_client()`
2. Add `None` default to `kwargs.pop("state", None)` in the token client, consistent with all other clients

## Tests

- Verified both files pass `ast.parse()` syntax check
- `resolve_client()` now raises `ValueError("Unsupported client_type: 'unknown'")` instead of returning `None`
- Token client now raises `AttributeError` on `None.state` access (clear traceback) instead of `KeyError` on pop

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small error-handling tweaks that mainly change failure mode from silent `None`/`KeyError` to explicit `ValueError`/`None` defaulting.
> 
> **Overview**
> Prevents `resolve_client()` from silently returning `None` by adding a default `case _` that raises a clear `ValueError` for unsupported `client_type` values.
> 
> Makes `OpenAIChatCompletionsTokenClient.get_native_response()` tolerant of missing `state` in `kwargs` by switching `kwargs.pop("state")` to `kwargs.pop("state", None)`, aligning behavior with other clients and avoiding `KeyError`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0493b0bc533c48655f006de145f511b9d9c71024. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->