### PR TITLE
fix: replace mutable default arguments with None in StatefulToolEnv and MCPEnv

### DIFF
--- a/verifiers/envs/experimental/mcp_env.py
+++ b/verifiers/envs/experimental/mcp_env.py
@@ -148,13 +148,13 @@ class MCPEnv(vf.ToolEnv):
         self,
         # MCPEnv is designed for global server processes, not per-rollout,
         # stateful server instances with mutable task-specific data.
-        mcp_servers: List[MCPServerConfig | dict] = [],
+        mcp_servers: List[MCPServerConfig | dict] | None = None,
         max_turns: int = 10,
         error_formatter: Callable[[Exception], str] = lambda e: f"Error: {str(e)}",
         **kwargs,
     ):
         self.mcp_servers: List[MCPServerConfig] = []
-        if mcp_servers:
+        if mcp_servers is not None:
             for server in mcp_servers:
                 if isinstance(server, MCPServerConfig):
                     self.mcp_servers.append(server)

--- a/verifiers/envs/stateful_tool_env.py
+++ b/verifiers/envs/stateful_tool_env.py
@@ -66,7 +66,7 @@ class StatefulToolEnv(vf.ToolEnv):
         self.skipped_args: dict[str, list[str]] = {}
         self.max_turns: int = max_turns
 
-    def add_tool(self, tool: Callable, args_to_skip: list[str] = []):
+    def add_tool(self, tool: Callable, args_to_skip: list[str] | None = None):
         """Add a tool, optionally hiding arguments from the agent's view.
 
         Skipped args are removed from the schema shown to the agent but can be
@@ -75,6 +75,8 @@ class StatefulToolEnv(vf.ToolEnv):
 
         Assumes all non-skipped args use standard JSON types (no remaining $ref/$defs).
         """
+        if args_to_skip is None:
+            args_to_skip = []
         self.tools.append(tool)
         tool_def = convert_func_to_tool_def(filter_signature(tool, args_to_skip))
         params = tool_def.parameters


### PR DESCRIPTION
## Problem

Two instances of the classic Python mutable default argument bug:

### 1. `StatefulToolEnv.add_tool(args_to_skip=[])` — `stateful_tool_env.py:69`

The default `[]` is created **once** at function definition time and shared across all calls. If any caller mutates it (e.g., `args_to_skip.append(x)`), subsequent calls without an explicit argument see the mutated list. This is a well-known Python footgun.

### 2. `MCPEnv.__init__(mcp_servers=[])` — `mcp_env.py:151`

Same issue — the default list is shared across all `MCPEnv` instances that don't pass `mcp_servers` explicitly.

## Fix

Replace `=[]` with `=None` and initialize inside the function body:

```python
# Before
def add_tool(self, tool: Callable, args_to_skip: list[str] = []):

# After
def add_tool(self, tool: Callable, args_to_skip: list[str] | None = None):
    if args_to_skip is None:
        args_to_skip = []
```

Also changed `if mcp_servers:` to `if mcp_servers is not None:` to correctly handle an explicitly passed empty list (which is truthy with `if mcp_servers:` but should still be iterated).

## Tests

- Both files pass `ast.parse()` syntax check
- No behavioral change for callers passing explicit arguments
- Callers passing no argument now get a fresh `[]` each time instead of a shared one

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only adjust default parameter initialization to prevent shared mutable state; runtime behavior should be unchanged except eliminating cross-call/instance leakage.
> 
> **Overview**
> Prevents Python mutable-default-argument bugs in `MCPEnv.__init__` and `StatefulToolEnv.add_tool` by switching list defaults to `None` and instantiating fresh lists inside the method.
> 
> Also updates the MCP server initialization guard to `if mcp_servers is not None` so an explicitly provided empty list is handled consistently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04ad13c9e473d9acb2db5152a06a5c889a0b581f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->