### PR TITLE
fix: use context managers for file reads in sandbox_program_utils.py

### DIFF
--- a/verifiers/v1/utils/sandbox_program_utils.py
+++ b/verifiers/v1/utils/sandbox_program_utils.py
@@ -489,7 +489,8 @@ def model_name(state):
 
 
 def load_tool_defs(protocol):
-    defs = json.loads(open(TOOL_DEFS_BY_PROTOCOL_PATH).read())
+    with open(TOOL_DEFS_BY_PROTOCOL_PATH) as f:
+        defs = json.load(f)
     return defs.get(protocol) or []
 
 
@@ -687,7 +688,8 @@ async def create_model_message(state, messages, client):
 async def run_base(task, state, client):
     prompt_messages = [*(state.get("system_prompt") or []), *(state.get("prompt") or [])]
     messages = list(prompt_messages)
-    config = json.loads(open(RUNNER_CONFIG_PATH).read())
+    with open(RUNNER_CONFIG_PATH) as f:
+        config = json.load(f)
     max_turns = int(config["max_turns"])
     turn = 0
     while max_turns <= 0 or turn < max_turns:
@@ -733,8 +735,10 @@ async def run_base(task, state, client):
 
 async def main():
     mode = sys.argv[1]
-    task = json.loads(open(TASK_PATH).read())
-    state = json.loads(open(STATE_INPUT_PATH).read())
+    with open(TASK_PATH) as f:
+        task = json.load(f)
+    with open(STATE_INPUT_PATH) as f:
+        state = json.load(f)
     original_state = json.loads(json.dumps(state))
     client = Client(state)
     try:


### PR DESCRIPTION
## Problem

Four instances of `open().read()` without a context manager in `verifiers/v1/utils/sandbox_program_utils.py`. Each call opens a file, reads its contents, but never explicitly closes the file descriptor. While Python's GC will eventually close them, this is a resource leak — especially if the code is called repeatedly or under memory pressure.

```python
# Before — file descriptor leaked
defs = json.loads(open(TOOL_DEFS_BY_PROTOCOL_PATH).read())
config = json.loads(open(RUNNER_CONFIG_PATH).read())
task = json.loads(open(TASK_PATH).read())
state = json.loads(open(STATE_INPUT_PATH).read())
```

## Fix

Replace with `with open() as f: json.load(f)` context managers, which guarantee the file is closed even if `json.load()` raises:

```python
# After — file descriptor properly managed
with open(TOOL_DEFS_BY_PROTOCOL_PATH) as f:
    defs = json.load(f)
```

## Tests

- Verified syntax with `ast.parse()`
- No behavioral change — same JSON parsing, just with proper resource cleanup

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: behavior is unchanged aside from ensuring file descriptors are always closed during JSON reads. Impact is limited to sandbox runner initialization/config loading paths.
> 
> **Overview**
> Ensures the sandbox runner code in `verifiers/v1/utils/sandbox_program_utils.py` reads JSON inputs (`tool defs`, `runner config`, `task`, and `state`) using `with open(...)` context managers and `json.load()` instead of `open().read()` + `json.loads()`.
> 
> This eliminates potential file-descriptor leaks during repeated sandbox executions without changing the parsed data or control flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4be52133fa7e9c6f0d1f925ed3e457beae96daff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->