### PR TITLE
Map Anthropic reasoning effort by provider

### DIFF
--- a/tests/test_client_multimodal_types.py
+++ b/tests/test_client_multimodal_types.py
@@ -1,6 +1,5 @@
 import pytest
 from types import SimpleNamespace
-from typing import Any
 
 from verifiers.clients.openai_chat_completions_client import OpenAIChatCompletionsClient
 from verifiers.types import (
@@ -17,26 +16,6 @@ from verifiers.types import (
     UserMessage,
 )
 from verifiers.utils.response_utils import parse_response_message
-
-
-class _RecordingCreate:
-    def __init__(self, response: Any) -> None:
-        self.response = response
-        self.calls: list[dict[str, Any]] = []
-
-    async def create(self, **kwargs: Any) -> Any:
-        self.calls.append(kwargs)
-        return self.response
-
-
-def _recording_openai(response: Any) -> tuple[Any, _RecordingCreate]:
-    recorder = _RecordingCreate(response)
-    return SimpleNamespace(chat=SimpleNamespace(completions=recorder)), recorder
-
-
-def _recording_anthropic(response: Any) -> tuple[Any, _RecordingCreate]:
-    recorder = _RecordingCreate(response)
-    return SimpleNamespace(messages=recorder), recorder
 
 
 @pytest.mark.asyncio
@@ -71,79 +50,6 @@ async def test_openai_to_native_prompt_with_typed_multimodal_content_parts():
             "input_audio": {"data": "ZHVtbXk=", "format": "wav"},
         },
     ]
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    ("model", "effort"),
-    [
-        ("anthropic/claude-opus-4.7", "xhigh"),
-        ("anthropic/claude-sonnet-4.6", "max"),
-    ],
-)
-async def test_openrouter_anthropic_reasoning_effort_maps_to_verbosity(
-    model: str, effort: str
-):
-    recording_client, recorder = _recording_openai(SimpleNamespace())
-    client = OpenAIChatCompletionsClient(recording_client)
-    client._config = SimpleNamespace(api_base_url="https://openrouter.ai/api/v1")
-
-    response = await client.get_native_response(
-        prompt=[],
-        model=model,
-        sampling_args={
-            "n": 1,
-            "reasoning_effort": effort,
-            "extra_body": {"reasoning": {"enabled": True}},
-        },
-    )
-
-    assert response is recorder.response
-    call = recorder.calls[0]
-    assert "reasoning_effort" not in call
-    assert call["extra_body"] == {
-        "reasoning": {"enabled": True},
-        "verbosity": effort,
-    }
-
-
-@pytest.mark.asyncio
-async def test_openrouter_anthropic_reasoning_effort_enables_reasoning():
-    recording_client, recorder = _recording_openai(SimpleNamespace())
-    client = OpenAIChatCompletionsClient(recording_client)
-    client._config = SimpleNamespace(api_base_url="https://api.pinference.ai/api/v1")
-
-    await client.get_native_response(
-        prompt=[],
-        model="anthropic/claude-opus-4.7",
-        sampling_args={"reasoning_effort": "high"},
-    )
-
-    call = recorder.calls[0]
-    assert call["extra_body"] == {
-        "reasoning": {"enabled": True},
-        "verbosity": "high",
-    }
-
-
-@pytest.mark.asyncio
-async def test_openrouter_anthropic_reasoning_effort_maps_opus_4_5():
-    recording_client, recorder = _recording_openai(SimpleNamespace())
-    client = OpenAIChatCompletionsClient(recording_client)
-    client._config = SimpleNamespace(api_base_url="https://openrouter.ai/api/v1")
-
-    await client.get_native_response(
-        prompt=[],
-        model="anthropic/claude-opus-4.5",
-        sampling_args={"reasoning_effort": "medium"},
-    )
-
-    call = recorder.calls[0]
-    assert "reasoning_effort" not in call
-    assert call["extra_body"] == {
-        "reasoning": {"enabled": True},
-        "verbosity": "medium",
-    }
 
 
 @pytest.mark.asyncio
@@ -243,77 +149,6 @@ async def test_anthropic_merges_consecutive_tool_results_into_single_user_messag
         {"type": "tool_result", "tool_use_id": "call_1", "content": "result a"},
         {"type": "tool_result", "tool_use_id": "call_2", "content": "result b"},
     ]
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    ("model", "effort"),
-    [("claude-opus-4-7", "xhigh"), ("claude-sonnet-4-6", "max")],
-)
-async def test_anthropic_reasoning_effort_maps_to_output_config(
-    model: str, effort: str
-):
-    pytest.importorskip("anthropic")
-    from verifiers.clients.anthropic_messages_client import AnthropicMessagesClient
-
-    recording_client, recorder = _recording_anthropic(SimpleNamespace())
-    client = AnthropicMessagesClient(recording_client)
-
-    response = await client.get_native_response(
-        prompt=[],
-        model=model,
-        sampling_args={"max_tokens": 128, "reasoning_effort": effort},
-    )
-
-    assert response is recorder.response
-    call = recorder.calls[0]
-    assert "reasoning_effort" not in call
-    assert call["output_config"] == {"effort": effort}
-    assert call["thinking"] == {"type": "adaptive"}
-
-
-@pytest.mark.asyncio
-async def test_anthropic_opus_4_5_uses_output_config_without_adaptive_thinking():
-    pytest.importorskip("anthropic")
-    from verifiers.clients.anthropic_messages_client import AnthropicMessagesClient
-
-    recording_client, recorder = _recording_anthropic(SimpleNamespace())
-    client = AnthropicMessagesClient(recording_client)
-
-    await client.get_native_response(
-        prompt=[],
-        model="claude-opus-4-5",
-        sampling_args={"max_tokens": 4096, "reasoning_effort": "medium"},
-    )
-
-    call = recorder.calls[0]
-    assert call["output_config"] == {"effort": "medium"}
-    assert "thinking" not in call
-
-
-@pytest.mark.asyncio
-async def test_anthropic_reasoning_effort_preserves_existing_output_config():
-    pytest.importorskip("anthropic")
-    from verifiers.clients.anthropic_messages_client import AnthropicMessagesClient
-
-    recording_client, recorder = _recording_anthropic(SimpleNamespace())
-    client = AnthropicMessagesClient(recording_client)
-
-    await client.get_native_response(
-        prompt=[],
-        model="claude-opus-4-7",
-        sampling_args={
-            "max_tokens": 128,
-            "reasoning_effort": "high",
-            "output_config": {"format": {"type": "text"}},
-        },
-    )
-
-    call = recorder.calls[0]
-    assert call["output_config"] == {
-        "format": {"type": "text"},
-        "effort": "high",
-    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_client_multimodal_types.py
+++ b/tests/test_client_multimodal_types.py
@@ -1,5 +1,6 @@
 import pytest
 from types import SimpleNamespace
+from typing import Any
 
 from verifiers.clients.openai_chat_completions_client import OpenAIChatCompletionsClient
 from verifiers.types import (
@@ -16,6 +17,26 @@ from verifiers.types import (
     UserMessage,
 )
 from verifiers.utils.response_utils import parse_response_message
+
+
+class _RecordingCreate:
+    def __init__(self, response: Any) -> None:
+        self.response = response
+        self.calls: list[dict[str, Any]] = []
+
+    async def create(self, **kwargs: Any) -> Any:
+        self.calls.append(kwargs)
+        return self.response
+
+
+def _recording_openai(response: Any) -> tuple[Any, _RecordingCreate]:
+    recorder = _RecordingCreate(response)
+    return SimpleNamespace(chat=SimpleNamespace(completions=recorder)), recorder
+
+
+def _recording_anthropic(response: Any) -> tuple[Any, _RecordingCreate]:
+    recorder = _RecordingCreate(response)
+    return SimpleNamespace(messages=recorder), recorder
 
 
 @pytest.mark.asyncio
@@ -50,6 +71,59 @@ async def test_openai_to_native_prompt_with_typed_multimodal_content_parts():
             "input_audio": {"data": "ZHVtbXk=", "format": "wav"},
         },
     ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("model", "effort"),
+    [
+        ("anthropic/claude-opus-4.7", "xhigh"),
+        ("anthropic/claude-sonnet-4.6", "max"),
+    ],
+)
+async def test_openrouter_anthropic_reasoning_effort_maps_to_verbosity(
+    model: str, effort: str
+):
+    recording_client, recorder = _recording_openai(SimpleNamespace())
+    client = OpenAIChatCompletionsClient(recording_client)
+    client._config = SimpleNamespace(api_base_url="https://openrouter.ai/api/v1")
+
+    response = await client.get_native_response(
+        prompt=[],
+        model=model,
+        sampling_args={
+            "n": 1,
+            "reasoning_effort": effort,
+            "extra_body": {"reasoning": {"enabled": True}},
+        },
+    )
+
+    assert response is recorder.response
+    call = recorder.calls[0]
+    assert "reasoning_effort" not in call
+    assert call["extra_body"] == {
+        "reasoning": {"enabled": True},
+        "verbosity": effort,
+    }
+
+
+@pytest.mark.asyncio
+async def test_openrouter_anthropic_reasoning_effort_enables_reasoning():
+    recording_client, recorder = _recording_openai(SimpleNamespace())
+    client = OpenAIChatCompletionsClient(recording_client)
+    client._config = SimpleNamespace(api_base_url="https://api.pinference.ai/api/v1")
+
+    await client.get_native_response(
+        prompt=[],
+        model="anthropic/claude-opus-4.7",
+        sampling_args={"reasoning_effort": "high"},
+    )
+
+    call = recorder.calls[0]
+    assert call["extra_body"] == {
+        "reasoning": {"enabled": True},
+        "verbosity": "high",
+    }
 
 
 @pytest.mark.asyncio
@@ -149,6 +223,58 @@ async def test_anthropic_merges_consecutive_tool_results_into_single_user_messag
         {"type": "tool_result", "tool_use_id": "call_1", "content": "result a"},
         {"type": "tool_result", "tool_use_id": "call_2", "content": "result b"},
     ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("model", "effort"),
+    [("claude-opus-4-7", "xhigh"), ("claude-sonnet-4-6", "max")],
+)
+async def test_anthropic_reasoning_effort_maps_to_output_config(
+    model: str, effort: str
+):
+    pytest.importorskip("anthropic")
+    from verifiers.clients.anthropic_messages_client import AnthropicMessagesClient
+
+    recording_client, recorder = _recording_anthropic(SimpleNamespace())
+    client = AnthropicMessagesClient(recording_client)
+
+    response = await client.get_native_response(
+        prompt=[],
+        model=model,
+        sampling_args={"max_tokens": 128, "reasoning_effort": effort},
+    )
+
+    assert response is recorder.response
+    call = recorder.calls[0]
+    assert "reasoning_effort" not in call
+    assert call["output_config"] == {"effort": effort}
+    assert call["thinking"] == {"type": "adaptive"}
+
+
+@pytest.mark.asyncio
+async def test_anthropic_reasoning_effort_preserves_existing_output_config():
+    pytest.importorskip("anthropic")
+    from verifiers.clients.anthropic_messages_client import AnthropicMessagesClient
+
+    recording_client, recorder = _recording_anthropic(SimpleNamespace())
+    client = AnthropicMessagesClient(recording_client)
+
+    await client.get_native_response(
+        prompt=[],
+        model="claude-opus-4-7",
+        sampling_args={
+            "max_tokens": 128,
+            "reasoning_effort": "high",
+            "output_config": {"format": {"type": "text"}},
+        },
+    )
+
+    call = recorder.calls[0]
+    assert call["output_config"] == {
+        "format": {"type": "text"},
+        "effort": "high",
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_client_multimodal_types.py
+++ b/tests/test_client_multimodal_types.py
@@ -127,6 +127,26 @@ async def test_openrouter_anthropic_reasoning_effort_enables_reasoning():
 
 
 @pytest.mark.asyncio
+async def test_openrouter_anthropic_reasoning_effort_maps_opus_4_5():
+    recording_client, recorder = _recording_openai(SimpleNamespace())
+    client = OpenAIChatCompletionsClient(recording_client)
+    client._config = SimpleNamespace(api_base_url="https://openrouter.ai/api/v1")
+
+    await client.get_native_response(
+        prompt=[],
+        model="anthropic/claude-opus-4.5",
+        sampling_args={"reasoning_effort": "medium"},
+    )
+
+    call = recorder.calls[0]
+    assert "reasoning_effort" not in call
+    assert call["extra_body"] == {
+        "reasoning": {"enabled": True},
+        "verbosity": "medium",
+    }
+
+
+@pytest.mark.asyncio
 async def test_anthropic_to_native_prompt_with_typed_multimodal_content_parts():
     pytest.importorskip("anthropic")
     from verifiers.clients.anthropic_messages_client import AnthropicMessagesClient
@@ -250,6 +270,25 @@ async def test_anthropic_reasoning_effort_maps_to_output_config(
     assert "reasoning_effort" not in call
     assert call["output_config"] == {"effort": effort}
     assert call["thinking"] == {"type": "adaptive"}
+
+
+@pytest.mark.asyncio
+async def test_anthropic_opus_4_5_uses_output_config_without_adaptive_thinking():
+    pytest.importorskip("anthropic")
+    from verifiers.clients.anthropic_messages_client import AnthropicMessagesClient
+
+    recording_client, recorder = _recording_anthropic(SimpleNamespace())
+    client = AnthropicMessagesClient(recording_client)
+
+    await client.get_native_response(
+        prompt=[],
+        model="claude-opus-4-5",
+        sampling_args={"max_tokens": 4096, "reasoning_effort": "medium"},
+    )
+
+    call = recorder.calls[0]
+    assert call["output_config"] == {"effort": "medium"}
+    assert "thinking" not in call
 
 
 @pytest.mark.asyncio

--- a/verifiers/clients/anthropic_messages_client.py
+++ b/verifiers/clients/anthropic_messages_client.py
@@ -342,6 +342,20 @@ class AnthropicMessagesClient(
     ) -> AnthropicMessage:
         def normalize_sampling_args(sampling_args: SamplingArgs) -> dict:
             sampling_args = dict(sampling_args)
+            reasoning_effort = sampling_args.pop("reasoning_effort", None)
+            model_id = model.lower().replace(".", "-").replace("_", "-")
+            if reasoning_effort is not None and (
+                model_id.startswith("anthropic/") or model_id.startswith("claude-")
+            ):
+                output_config = dict(sampling_args.get("output_config") or {})
+                output_config["effort"] = reasoning_effort
+                sampling_args["output_config"] = output_config
+                if "thinking" not in sampling_args and (
+                    "4-7" in model_id or "4-6" in model_id
+                ):
+                    sampling_args["thinking"] = {"type": "adaptive"}
+            elif reasoning_effort is not None:
+                sampling_args["reasoning_effort"] = reasoning_effort
             max_tokens = sampling_args.pop("max_tokens", None)
             sampling_args.pop("n", None)
             sampling_args.pop("stop", None)

--- a/verifiers/clients/anthropic_messages_client.py
+++ b/verifiers/clients/anthropic_messages_client.py
@@ -50,6 +50,13 @@ from verifiers.types import (
 from verifiers.utils.client_utils import setup_anthropic_client
 
 
+ANTHROPIC_ADAPTIVE_THINKING_MODELS = {
+    "claude-opus-4-7",
+    "claude-opus-4-6",
+    "claude-sonnet-4-6",
+}
+
+
 def _handle_anthropic_overlong_prompt(func):
     """Decorator to handle overlong prompt errors from the Anthropic API."""
 
@@ -343,19 +350,19 @@ class AnthropicMessagesClient(
         def normalize_sampling_args(sampling_args: SamplingArgs) -> dict:
             sampling_args = dict(sampling_args)
             reasoning_effort = sampling_args.pop("reasoning_effort", None)
-            model_id = model.lower().replace(".", "-").replace("_", "-")
-            if reasoning_effort is not None and (
-                model_id.startswith("anthropic/") or model_id.startswith("claude-")
-            ):
+            if reasoning_effort is not None:
+                model_id = (
+                    model.lower().split("/")[-1].replace(".", "-").replace("_", "-")
+                )
                 output_config = dict(sampling_args.get("output_config") or {})
                 output_config["effort"] = reasoning_effort
                 sampling_args["output_config"] = output_config
-                if "thinking" not in sampling_args and (
-                    "4-7" in model_id or "4-6" in model_id
+                if "thinking" not in sampling_args and any(
+                    model_id == adaptive_model
+                    or model_id.startswith(f"{adaptive_model}-")
+                    for adaptive_model in ANTHROPIC_ADAPTIVE_THINKING_MODELS
                 ):
                     sampling_args["thinking"] = {"type": "adaptive"}
-            elif reasoning_effort is not None:
-                sampling_args["reasoning_effort"] = reasoning_effort
             max_tokens = sampling_args.pop("max_tokens", None)
             sampling_args.pop("n", None)
             sampling_args.pop("stop", None)

--- a/verifiers/clients/openai_chat_completions_client.py
+++ b/verifiers/clients/openai_chat_completions_client.py
@@ -258,15 +258,17 @@ class OpenAIChatCompletionsClient(
             elif self._config is not None:
                 api_base_url = self._config.api_base_url
             reasoning_effort = sampling_args.pop("reasoning_effort", None)
-            model_id = model.lower().replace(".", "-").replace("_", "-")
-            api_base_url = (api_base_url or "").lower()
+            model_id = model.lower().split("/")[-1].replace(".", "-").replace("_", "-")
+            is_anthropic_route = (
+                "openrouter.ai" in (api_base_url or "").lower()
+                or "pinference.ai" in (api_base_url or "").lower()
+            )
             if (
                 reasoning_effort is not None
-                and (
-                    model_id.startswith("anthropic/") or model_id.startswith("claude-")
-                )
-                and ("openrouter.ai" in api_base_url or "pinference.ai" in api_base_url)
+                and model_id.startswith("claude-")
+                and is_anthropic_route
             ):
+                # OpenRouter/Pinference route Anthropic reasoning_effort through extra_body.
                 extra_body = dict(sampling_args.get("extra_body") or {})
                 extra_body["verbosity"] = reasoning_effort
                 reasoning = dict(extra_body.get("reasoning") or {})

--- a/verifiers/clients/openai_chat_completions_client.py
+++ b/verifiers/clients/openai_chat_completions_client.py
@@ -252,6 +252,29 @@ class OpenAIChatCompletionsClient(
     ) -> OpenAIChatResponse:
         def normalize_sampling_args(sampling_args: SamplingArgs):
             sampling_args = dict(sampling_args)
+            api_base_url = None
+            if hasattr(self.client, "base_url"):
+                api_base_url = str(self.client.base_url)
+            elif self._config is not None:
+                api_base_url = self._config.api_base_url
+            reasoning_effort = sampling_args.pop("reasoning_effort", None)
+            model_id = model.lower().replace(".", "-").replace("_", "-")
+            api_base_url = (api_base_url or "").lower()
+            if (
+                reasoning_effort is not None
+                and (
+                    model_id.startswith("anthropic/") or model_id.startswith("claude-")
+                )
+                and ("openrouter.ai" in api_base_url or "pinference.ai" in api_base_url)
+            ):
+                extra_body = dict(sampling_args.get("extra_body") or {})
+                extra_body["verbosity"] = reasoning_effort
+                reasoning = dict(extra_body.get("reasoning") or {})
+                reasoning.setdefault("enabled", True)
+                extra_body["reasoning"] = reasoning
+                sampling_args["extra_body"] = extra_body
+            elif reasoning_effort is not None:
+                sampling_args["reasoning_effort"] = reasoning_effort
             if "max_tokens" in sampling_args:
                 sampling_args["max_completion_tokens"] = sampling_args.pop("max_tokens")
             return {k: v for k, v in sampling_args.items() if v is not None}


### PR DESCRIPTION
## Summary
- Map `sampling_args.reasoning_effort` to `extra_body.verbosity` for Anthropic models on OpenRouter/Prime OpenAI-compatible routes.
- Map `reasoning_effort` to native Anthropic `output_config.effort` and enable adaptive thinking for Claude 4.6/4.7 when unset.
- Add focused client tests for Claude 4.6/4.7 OpenRouter-style and native Anthropic mappings.

## Verification
- `uv run ruff check --fix verifiers/clients/openai_chat_completions_client.py verifiers/clients/anthropic_messages_client.py tests/test_client_multimodal_types.py`
- `uv run pytest tests/test_client_multimodal_types.py`
- Pre-push hooks: ruff check, ruff format, ty (ci parity)
- Live Prime GPQA 1x1 checks on `anthropic/claude-opus-4.7`:
  - `reasoning_effort="high"`: https://app.primeintellect.ai/dashboard/evaluations/rbej739yowcedihefu7sqykk
  - `reasoning_effort="xhigh"`: https://app.primeintellect.ai/dashboard/evaluations/gl5n8e3cv0fcesfhjwgm1bcz
  - `reasoning_effort="max"`: https://app.primeintellect.ai/dashboard/evaluations/ieaij5d5dpnjtcmlycby2wjg

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches request parameter normalization for both Anthropic and OpenAI chat clients, which can change model behavior and cost/latency characteristics across providers. Risk is mitigated by being gated to `reasoning_effort` presence and specific Claude/OpenRouter-style routes.
> 
> **Overview**
> Adds provider-specific translation of `sampling_args.reasoning_effort` in both clients.
> 
> For native Anthropic `messages`, it now maps `reasoning_effort` to `output_config.effort` and auto-enables `thinking={"type":"adaptive"}` for select Claude 4.6/4.7 models when `thinking` isn’t already set.
> 
> For OpenAI-compatible chat completions routed to Anthropic via OpenRouter/Pinference, it maps `reasoning_effort` into `extra_body.verbosity` (and ensures `extra_body.reasoning.enabled`) while leaving other models/providers to use the standard `reasoning_effort` field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4c1fc71bbf365d5acb2eb79c8d2516aa7f06a89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->