### PR TITLE
Add Kimi-K2 tool simulation environment

### DIFF
--- a/environments/README.md
+++ b/environments/README.md
@@ -11,6 +11,7 @@ This folder contains installable example environments that showcase common usage
 
 ### SingleTurnEnv (prompt → single response)
 - **gsm8k**: Classic QA with exact-match reward and optional response-format reward.
+- **kimi_k2_tool_sim**: Deterministic tool-use simulation with exact sequence, argument, and answer rewards.
 - **reverse_text**: XML formatting with non-binary LCS reward + format reward.
 - **continuation_quality**: Completion-style generation (`message_type="completion"`) judged for prose quality with `JudgeRubric`.
 - **mmmu**: Multimodal inputs (image + text) packed in chat content; single-turn boxed-answer check.

--- a/environments/kimi_k2_tool_sim/README.md
+++ b/environments/kimi_k2_tool_sim/README.md
@@ -1,0 +1,36 @@
+# Kimi-K2 Tool Sim
+
+Deterministic single-turn tool-use simulation tasks inspired by Kimi-K2 style
+agentic function-calling evaluations. The model does not execute tools. It must
+infer the exact tool call sequence and arguments from a compact task description
+and return the result as JSON.
+
+## Usage
+
+```python
+import verifiers as vf
+
+env = vf.load_environment("kimi-k2-tool-sim")
+```
+
+Expected completion format:
+
+```json
+{
+  "tool_calls": [
+    {"name": "orders.find", "arguments": {"email": "sam@example.com"}}
+  ],
+  "answer": "Created a refund for order ORD-8842."
+}
+```
+
+## Scoring
+
+The reward is provider-free and deterministic:
+
+- 40% exact tool-name sequence match
+- 40% argument-value matching across expected tool calls
+- 20% final answer match
+
+Malformed JSON, missing tool calls, or an incorrect number of calls receives
+zero reward.

--- a/environments/kimi_k2_tool_sim/kimi_k2_tool_sim.py
+++ b/environments/kimi_k2_tool_sim/kimi_k2_tool_sim.py
@@ -1,0 +1,295 @@
+import json
+import re
+from collections.abc import Sequence
+from typing import Any
+
+from datasets import Dataset
+import verifiers as vf
+
+SYSTEM_PROMPT = """You are solving a deterministic tool-use simulation task.
+
+Return only JSON with this schema:
+{
+  "tool_calls": [
+    {"name": "tool_name", "arguments": {"key": "value"}}
+  ],
+  "answer": "final short answer"
+}
+
+Do not execute tools. Infer the exact call sequence from the available tools,
+conversation, and target objective."""
+
+TASKS: list[dict[str, Any]] = [
+    {
+        "id": "weather_then_calendar",
+        "available_tools": [
+            {
+                "name": "weather.lookup",
+                "description": "Look up the forecast for a city and date.",
+                "required_arguments": ["city", "date"],
+            },
+            {
+                "name": "calendar.create_event",
+                "description": "Create a calendar event.",
+                "required_arguments": ["title", "date", "time"],
+            },
+        ],
+        "conversation": (
+            "User: If the forecast in Austin tomorrow is sunny, schedule "
+            "tennis practice for 7 AM tomorrow.\n"
+            "Context: Tomorrow is 2026-05-12. The embedded forecast table says "
+            "Austin on 2026-05-12 is sunny."
+        ),
+        "target": "Check the forecast before creating the event.",
+        "expected_tool_calls": [
+            {
+                "name": "weather.lookup",
+                "arguments": {"city": "Austin", "date": "2026-05-12"},
+            },
+            {
+                "name": "calendar.create_event",
+                "arguments": {
+                    "title": "tennis practice",
+                    "date": "2026-05-12",
+                    "time": "07:00",
+                },
+            },
+        ],
+        "answer": "Scheduled tennis practice for 7 AM tomorrow.",
+    },
+    {
+        "id": "refund_lookup",
+        "available_tools": [
+            {
+                "name": "orders.find",
+                "description": "Find an order by email and item.",
+                "required_arguments": ["email", "item"],
+            },
+            {
+                "name": "refunds.create",
+                "description": "Create a refund for an order.",
+                "required_arguments": ["order_id", "reason"],
+            },
+        ],
+        "conversation": (
+            "User: Refund the blue backpack order for sam@example.com because "
+            "the zipper broke.\nContext: Matching order id is ORD-8842."
+        ),
+        "target": "Look up the order before creating the refund.",
+        "expected_tool_calls": [
+            {
+                "name": "orders.find",
+                "arguments": {"email": "sam@example.com", "item": "blue backpack"},
+            },
+            {
+                "name": "refunds.create",
+                "arguments": {
+                    "order_id": "ORD-8842",
+                    "reason": "zipper broke",
+                },
+            },
+        ],
+        "answer": "Created a refund for order ORD-8842.",
+    },
+    {
+        "id": "repo_issue_summary",
+        "available_tools": [
+            {
+                "name": "github.search_issues",
+                "description": "Search repository issues.",
+                "required_arguments": ["repo", "query"],
+            },
+            {
+                "name": "notion.create_page",
+                "description": "Create a Notion page.",
+                "required_arguments": ["database", "title", "summary"],
+            },
+        ],
+        "conversation": (
+            "User: Summarize open crash issues in acme/mobile into the "
+            "Engineering Triage database.\nContext: The issue search should use "
+            "query 'is:issue is:open crash'."
+        ),
+        "target": "Search GitHub, then create a triage page.",
+        "expected_tool_calls": [
+            {
+                "name": "github.search_issues",
+                "arguments": {
+                    "repo": "acme/mobile",
+                    "query": "is:issue is:open crash",
+                },
+            },
+            {
+                "name": "notion.create_page",
+                "arguments": {
+                    "database": "Engineering Triage",
+                    "title": "Open crash issues in acme/mobile",
+                    "summary": "Summarize open crash issues from acme/mobile.",
+                },
+            },
+        ],
+        "answer": "Created an Engineering Triage page for open crash issues.",
+    },
+    {
+        "id": "currency_invoice",
+        "available_tools": [
+            {
+                "name": "fx.convert",
+                "description": "Convert money between currencies.",
+                "required_arguments": ["amount", "from_currency", "to_currency"],
+            },
+            {
+                "name": "invoice.draft",
+                "description": "Draft an invoice.",
+                "required_arguments": ["customer", "amount", "currency"],
+            },
+        ],
+        "conversation": (
+            "User: Draft an invoice for Contoso for 1200 EUR converted to USD.\n"
+            "Context: The conversion result is 1296 USD."
+        ),
+        "target": "Convert the amount before drafting the invoice.",
+        "expected_tool_calls": [
+            {
+                "name": "fx.convert",
+                "arguments": {
+                    "amount": "1200",
+                    "from_currency": "EUR",
+                    "to_currency": "USD",
+                },
+            },
+            {
+                "name": "invoice.draft",
+                "arguments": {
+                    "customer": "Contoso",
+                    "amount": "1296",
+                    "currency": "USD",
+                },
+            },
+        ],
+        "answer": "Drafted a USD invoice for Contoso for 1296.",
+    },
+]
+
+
+def _normalize_value(value: Any) -> str:
+    return str(value).strip().lower()
+
+
+def _extract_completion_text(completion: Any) -> str:
+    if isinstance(completion, str):
+        return completion
+    if isinstance(completion, Sequence) and completion:
+        last_message = completion[-1]
+        if isinstance(last_message, dict):
+            return str(last_message.get("content", ""))
+    return str(completion)
+
+
+def extract_json_object(text: str) -> dict[str, Any]:
+    """Extract a JSON object from a raw or fenced completion."""
+    stripped = text.strip()
+    fenced = re.search(r"```(?:json)?\s*(.*?)\s*```", stripped, re.DOTALL)
+    if fenced:
+        stripped = fenced.group(1)
+    parsed = json.loads(stripped)
+    if not isinstance(parsed, dict):
+        raise TypeError("completion must be a JSON object")
+    return parsed
+
+
+def format_question(task: dict[str, Any]) -> str:
+    tools_json = json.dumps(task["available_tools"], indent=2, sort_keys=True)
+    return (
+        f"Available tools:\n{tools_json}\n\n"
+        f"Conversation:\n{task['conversation']}\n\n"
+        f"Target objective:\n{task['target']}"
+    )
+
+
+def build_dataset(num_examples: int = -1) -> Dataset:
+    tasks = TASKS if num_examples < 0 else TASKS[:num_examples]
+    rows = []
+    for task in tasks:
+        rows.append(
+            {
+                "question": format_question(task),
+                "answer": json.dumps(
+                    {
+                        "tool_calls": task["expected_tool_calls"],
+                        "answer": task["answer"],
+                    },
+                    sort_keys=True,
+                ),
+                "info": {
+                    "task_id": task["id"],
+                    "available_tools": task["available_tools"],
+                    "target": task["target"],
+                },
+            }
+        )
+    return Dataset.from_list(rows)
+
+
+def _coerce_tool_calls(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    return [call for call in value if isinstance(call, dict)]
+
+
+def tool_sequence_reward(completion: Any, answer: str, **kwargs: Any) -> float:
+    del kwargs
+    try:
+        actual = extract_json_object(_extract_completion_text(completion))
+        expected = json.loads(answer)
+    except (json.JSONDecodeError, TypeError):
+        return 0.0
+
+    actual_calls = _coerce_tool_calls(actual.get("tool_calls"))
+    expected_calls = _coerce_tool_calls(expected.get("tool_calls"))
+    if not actual_calls or len(actual_calls) != len(expected_calls):
+        return 0.0
+
+    sequence_score = float(
+        [call.get("name") for call in actual_calls]
+        == [call.get("name") for call in expected_calls]
+    )
+
+    argument_matches = 0
+    argument_total = 0
+    for actual_call, expected_call in zip(actual_calls, expected_calls, strict=True):
+        actual_arguments = actual_call.get("arguments", {})
+        expected_arguments = expected_call.get("arguments", {})
+        if not isinstance(actual_arguments, dict) or not isinstance(
+            expected_arguments, dict
+        ):
+            continue
+        for key, expected_value in expected_arguments.items():
+            argument_total += 1
+            if _normalize_value(actual_arguments.get(key, "")) == _normalize_value(
+                expected_value
+            ):
+                argument_matches += 1
+
+    argument_score = argument_matches / argument_total if argument_total else 0.0
+    answer_score = float(
+        _normalize_value(actual.get("answer", ""))
+        == _normalize_value(expected["answer"])
+    )
+    return 0.4 * sequence_score + 0.4 * argument_score + 0.2 * answer_score
+
+
+def load_environment(
+    num_train_examples: int = -1,
+    num_eval_examples: int = -1,
+    system_prompt: str = SYSTEM_PROMPT,
+) -> vf.Environment:
+    train_dataset = build_dataset(num_train_examples)
+    eval_dataset = build_dataset(num_eval_examples)
+    rubric = vf.Rubric(funcs=[tool_sequence_reward], weights=[1.0])
+    return vf.SingleTurnEnv(
+        dataset=train_dataset,
+        eval_dataset=eval_dataset,
+        system_prompt=system_prompt,
+        rubric=rubric,
+    )

--- a/environments/kimi_k2_tool_sim/kimi_k2_tool_sim.py
+++ b/environments/kimi_k2_tool_sim/kimi_k2_tool_sim.py
@@ -260,12 +260,12 @@ def tool_sequence_reward(completion: Any, answer: str, **kwargs: Any) -> float:
     for actual_call, expected_call in zip(actual_calls, expected_calls, strict=True):
         actual_arguments = actual_call.get("arguments", {})
         expected_arguments = expected_call.get("arguments", {})
-        if not isinstance(actual_arguments, dict) or not isinstance(
-            expected_arguments, dict
-        ):
+        if not isinstance(expected_arguments, dict):
+            continue
+        argument_total += len(expected_arguments)
+        if not isinstance(actual_arguments, dict):
             continue
         for key, expected_value in expected_arguments.items():
-            argument_total += 1
             if _normalize_value(actual_arguments.get(key, "")) == _normalize_value(
                 expected_value
             ):

--- a/environments/kimi_k2_tool_sim/pyproject.toml
+++ b/environments/kimi_k2_tool_sim/pyproject.toml
@@ -7,5 +7,12 @@ dependencies = [
     "verifiers>=0.1.14",
 ]
 
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build]
+include = ["kimi_k2_tool_sim.py", "README.md", "pyproject.toml"]
+
 [project.entry-points."verifiers.environments"]
 kimi-k2-tool-sim = "kimi_k2_tool_sim:load_environment"

--- a/environments/kimi_k2_tool_sim/pyproject.toml
+++ b/environments/kimi_k2_tool_sim/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "kimi-k2-tool-sim"
+version = "0.1.0"
+description = "Deterministic Kimi-K2 style tool-use simulation environment"
+dependencies = [
+    "datasets",
+    "verifiers>=0.1.14",
+]
+
+[project.entry-points."verifiers.environments"]
+kimi-k2-tool-sim = "kimi_k2_tool_sim:load_environment"

--- a/tests/test_kimi_k2_tool_sim_environment.py
+++ b/tests/test_kimi_k2_tool_sim_environment.py
@@ -59,6 +59,17 @@ def test_tool_sequence_reward_gives_partial_argument_credit():
     assert 0.0 < score < 1.0
 
 
+def test_tool_sequence_reward_counts_non_dict_arguments_as_misses():
+    dataset = kimi_k2_tool_sim.build_dataset(1)
+    expected = json.loads(dataset[0]["answer"])
+    expected["tool_calls"][1]["arguments"] = None
+    completion = json.dumps(expected)
+
+    score = kimi_k2_tool_sim.tool_sequence_reward(completion, dataset[0]["answer"])
+
+    assert score < 1.0
+
+
 def test_tool_sequence_reward_rejects_bad_json():
     dataset = kimi_k2_tool_sim.build_dataset(1)
 

--- a/tests/test_kimi_k2_tool_sim_environment.py
+++ b/tests/test_kimi_k2_tool_sim_environment.py
@@ -1,0 +1,76 @@
+import importlib.util
+import json
+from pathlib import Path
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "environments"
+    / "kimi_k2_tool_sim"
+    / "kimi_k2_tool_sim.py"
+)
+SPEC = importlib.util.spec_from_file_location("kimi_k2_tool_sim", MODULE_PATH)
+assert SPEC is not None
+kimi_k2_tool_sim = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(kimi_k2_tool_sim)
+
+
+def test_build_dataset_has_expected_columns():
+    dataset = kimi_k2_tool_sim.build_dataset()
+
+    assert len(dataset) == 4
+    assert set(dataset.column_names) == {"question", "answer", "info"}
+    assert "Available tools" in dataset[0]["question"]
+    assert "tool_calls" in json.loads(dataset[0]["answer"])
+
+
+def test_extract_json_object_accepts_fenced_json():
+    parsed = kimi_k2_tool_sim.extract_json_object(
+        """```json
+{"tool_calls": [{"name": "orders.find", "arguments": {"email": "sam@example.com"}}], "answer": "done"}
+```"""
+    )
+
+    assert parsed == {
+        "tool_calls": [
+            {"name": "orders.find", "arguments": {"email": "sam@example.com"}}
+        ],
+        "answer": "done",
+    }
+
+
+def test_tool_sequence_reward_exact_match():
+    dataset = kimi_k2_tool_sim.build_dataset(1)
+    answer = dataset[0]["answer"]
+    completion = [{"role": "assistant", "content": answer}]
+
+    assert kimi_k2_tool_sim.tool_sequence_reward(completion, answer) == 1.0
+
+
+def test_tool_sequence_reward_gives_partial_argument_credit():
+    dataset = kimi_k2_tool_sim.build_dataset(1)
+    expected = json.loads(dataset[0]["answer"])
+    expected["tool_calls"][0]["arguments"]["city"] = "Dallas"
+    completion = json.dumps(expected)
+
+    score = kimi_k2_tool_sim.tool_sequence_reward(completion, dataset[0]["answer"])
+
+    assert 0.0 < score < 1.0
+
+
+def test_tool_sequence_reward_rejects_bad_json():
+    dataset = kimi_k2_tool_sim.build_dataset(1)
+
+    assert (
+        kimi_k2_tool_sim.tool_sequence_reward("not json", dataset[0]["answer"]) == 0.0
+    )
+
+
+def test_load_environment_returns_single_turn_env():
+    env = kimi_k2_tool_sim.load_environment(num_train_examples=2, num_eval_examples=1)
+
+    assert env.dataset is not None
+    assert len(env.dataset) == 2
+    assert env.eval_dataset is not None
+    assert len(env.eval_dataset) == 1


### PR DESCRIPTION
Claims https://algora.io/PrimeIntellect-ai/bounties/de4q6RZcDpDDQPXL

## Summary
- adds a deterministic `kimi_k2_tool_sim` SingleTurnEnv for tool-call sequence simulation
- includes four provider-free scenarios covering lookup/action, refund, issue-summary, and currency/invoice workflows
- scores completions with exact tool sequence, argument matching, and final-answer rewards
- documents installation/usage and adds focused regression tests

## Validation
- `uv run pytest tests/test_kimi_k2_tool_sim_environment.py -q`
- `uv run ruff check environments/kimi_k2_tool_sim tests/test_kimi_k2_tool_sim_environment.py`
- `uv run ruff format --check environments/kimi_k2_tool_sim tests/test_kimi_k2_tool_sim_environment.py`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new, self-contained example environment plus docs/tests, with no changes to shared runtime or security-sensitive logic.
> 
> **Overview**
> Adds a new deterministic `kimi-k2-tool-sim` `SingleTurnEnv` that evaluates simulated tool-use by requiring JSON output with an exact tool-call sequence, argument matching, and final answer matching across four built-in scenarios.
> 
> Registers the environment via `pyproject.toml` entry point, documents install/usage and scoring, links it from `environments/README.md`, and adds targeted tests covering dataset construction, JSON extraction, reward partial credit, and error handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 169f468e7c725d5e3d3a8735fd24fb866b88905a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->