### PR TITLE
Fix Harbor Hub task root handling

### DIFF
--- a/verifiers/v1/packages/tasksets/harbor.py
+++ b/verifiers/v1/packages/tasksets/harbor.py
@@ -172,6 +172,7 @@ class HarborTaskset(Taskset):
                 "cpu_cores": parse_number(environment.get("cpus"), self.cpu_cores),
                 "memory_gb": parse_gb(environment.get("memory"), self.memory_gb),
                 "disk_size_gb": parse_gb(environment.get("storage"), self.disk_size_gb),
+                "network_access": bool(environment.get("allow_internet", True)),
                 "timeout_minutes": self.timeout_minutes,
                 "command_timeout": int(
                     parse_number(
@@ -282,8 +283,9 @@ def download_harbor_dataset(
         )
     root = cache_dir or Path.home() / ".cache" / "verifiers" / "harbor"
     dataset_dir = root / safe_dataset_dir_name(dataset_id)
+    task_root = dataset_dir / dataset_id.rsplit("/", 1)[-1]
     if dataset_dir.exists() and not refresh:
-        return dataset_dir
+        return task_root
     dataset_dir.parent.mkdir(parents=True, exist_ok=True)
     if harbor_bin is not None:
         command = [
@@ -308,7 +310,7 @@ def download_harbor_dataset(
     if refresh:
         command.append("--overwrite")
     subprocess.run(command, check=True)
-    return dataset_dir
+    return task_root
 
 
 def safe_dataset_dir_name(dataset_id: str) -> str:


### PR DESCRIPTION
## Summary
- unwrap Harbor Hub downloads that place task directories under a single nested dataset directory
- map Harbor `allow_internet` task metadata to sandbox `network_access`

## Validation
- `uv run ruff check verifiers/v1/packages/tasksets/harbor.py`
- manually verified cached `scale-ai/swe-atlas-tw` and `terminal-bench/terminal-bench-2-1` resolve to task roots

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Harbor datasets resolve their cached root directory and how sandbox internet access is configured, which can affect task discovery and runtime behavior. Risk is moderate due to potential path/permission mismatches and network access changes for existing tasks.
> 
> **Overview**
> Fixes Harbor Hub dataset downloads to resolve to the actual task root directory (handling the extra nested directory created by some downloads) instead of returning the top-level cache directory.
> 
> Also maps Harbor task `environment.allow_internet` metadata onto sandbox `network_access`, allowing tasks to explicitly disable/enable internet access during execution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd2c3657c139e819fe74e88de6f8cee307ceca25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->