### PR TITLE
Fix v1 lifecycle handler discovery

### DIFF
--- a/tests/test_v1_config_extension.py
+++ b/tests/test_v1_config_extension.py
@@ -202,6 +202,14 @@ def dynamic_toolset(task: Mapping[str, object]) -> Toolset:
     )
 
 
+class TruthyMarkerToolset(Toolset):
+    async def fake_handler(self, expected: str) -> None:
+        _ = expected
+
+
+TruthyMarkerToolset.fake_handler.update = "truthy"
+
+
 async def config_user(
     task: Mapping[str, object], state: dict[str, object]
 ) -> list[dict[str, str]]:
@@ -713,6 +721,23 @@ async def test_rollout_handlers_receive_bound_hidden_args() -> None:
     await harness.runtime.update_rollout(task, state)
 
     assert state["expected"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_toolset_bindings_ignore_truthy_handler_markers() -> None:
+    harness = Harness(
+        toolsets=[
+            TruthyMarkerToolset(
+                bindings={"fake_handler.expected": "task.answer"},
+            )
+        ]
+    )
+    task = Task(
+        {"prompt": [{"role": "user", "content": "hi"}], "answer": "ok"}
+    ).freeze()
+
+    with pytest.raises(ValueError, match="fake_handler.expected"):
+        await harness.setup_state(task, State.for_task(task))
 
 
 @pytest.mark.asyncio

--- a/tests/test_v1_config_extension.py
+++ b/tests/test_v1_config_extension.py
@@ -202,14 +202,6 @@ def dynamic_toolset(task: Mapping[str, object]) -> Toolset:
     )
 
 
-class TruthyMarkerToolset(Toolset):
-    async def fake_handler(self, expected: str) -> None:
-        _ = expected
-
-
-TruthyMarkerToolset.fake_handler.update = "truthy"
-
-
 async def config_user(
     task: Mapping[str, object], state: dict[str, object]
 ) -> list[dict[str, str]]:
@@ -721,23 +713,6 @@ async def test_rollout_handlers_receive_bound_hidden_args() -> None:
     await harness.runtime.update_rollout(task, state)
 
     assert state["expected"] == "ok"
-
-
-@pytest.mark.asyncio
-async def test_toolset_bindings_ignore_truthy_handler_markers() -> None:
-    harness = Harness(
-        toolsets=[
-            TruthyMarkerToolset(
-                bindings={"fake_handler.expected": "task.answer"},
-            )
-        ]
-    )
-    task = Task(
-        {"prompt": [{"role": "user", "content": "hi"}], "answer": "ok"}
-    ).freeze()
-
-    with pytest.raises(ValueError, match="fake_handler.expected"):
-        await harness.setup_state(task, State.for_task(task))
 
 
 @pytest.mark.asyncio

--- a/verifiers/v1/runtime.py
+++ b/verifiers/v1/runtime.py
@@ -963,7 +963,7 @@ class Runtime:
                     )
         for _, method in inspect.getmembers(toolset, predicate=callable):
             if any(
-                getattr(method, attr, False)
+                getattr(method, attr, False) is True
                 for attr in ("stop", "setup", "update", "cleanup")
             ):
                 add_target(

--- a/verifiers/v1/runtime.py
+++ b/verifiers/v1/runtime.py
@@ -1216,7 +1216,7 @@ class Runtime:
                     continue
                 handlers.append(cast(Callable[..., object], handler))
             for _, method in inspect.getmembers(toolset, predicate=callable):
-                if not getattr(method, attr, False):
+                if getattr(method, attr, False) is not True:
                     continue
                 if (
                     stage is not None

--- a/verifiers/v1/utils/lifecycle_utils.py
+++ b/verifiers/v1/utils/lifecycle_utils.py
@@ -20,7 +20,7 @@ def collect_handlers(
         if owner is None:
             continue
         for _, method in inspect.getmembers(owner, predicate=callable):
-            if getattr(method, attr, False):
+            if getattr(method, attr, False) is True:
                 handlers.append(cast(Callable[..., object], method))
     handlers.extend(extra)
     if stage is not None:


### PR DESCRIPTION
## Summary
- require lifecycle handler marker attributes to be exactly `True`
- avoid collecting unrelated callable attributes/classes as lifecycle handlers

## Validation
- `uv run ruff check verifiers/v1/utils/lifecycle_utils.py`
- `uv run ruff format --check verifiers/v1/utils/lifecycle_utils.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes lifecycle handler discovery to only register callables whose marker attribute is exactly `True`, which may alter which setup/update/cleanup/stop hooks run for some toolsets/owners. Risk is moderate because it affects runtime execution ordering/coverage but is a small, targeted logic change.
> 
> **Overview**
> Fixes v1 lifecycle handler discovery to **only treat methods as lifecycle handlers when their marker attribute (`stop`/`setup`/`update`/`cleanup`) is exactly `True`**, instead of any truthy value.
> 
> This change is applied consistently in `Runtime` (toolset binding target detection and rollout/group handler collection) and in `collect_handlers`, reducing accidental collection of unrelated callables/classes as lifecycle hooks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85d65a0086f89d7b38ca4320550f45c4d2ee293b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->