### PR TITLE
retry Read file timed out

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "openai>=1.108.1",
     "openai-agents>=0.0.7",
     "prime-tunnel>=0.1.6",
-    "prime-sandboxes>=0.2.21",
+    "prime-sandboxes>=0.2.25",
     "pydantic>=2.11.9",
     "requests",
     "rich",

--- a/uv.lock
+++ b/uv.lock
@@ -3765,7 +3765,7 @@ wheels = [
 
 [[package]]
 name = "prime-sandboxes"
-version = "0.2.22"
+version = "0.2.25"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -3775,9 +3775,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "tenacity" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dc/a7/eb9cb01ce7fa812022ec7c2ffaeb379e1103e07f093a4b85e879b2d0143d/prime_sandboxes-0.2.22.tar.gz", hash = "sha256:7901adca4ff7fff1e7f08c06c4b76765cd90791965216655eb3a87d459588f5e", size = 64970, upload-time = "2026-04-22T18:32:12.973Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/6d/a800c22973f99e4b9a57caa25aa1b54e54f022641b0576bfcfb064137153/prime_sandboxes-0.2.25.tar.gz", hash = "sha256:df4bf7965ccff953208b881fb743c8cde5280064a8c5a13eabeedded53dd366b", size = 66132, upload-time = "2026-05-11T23:45:19.993Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/b8/46bf98c06826fc26d982c53e10d9d4f086a4c322993a6c51188e5bd6fd30/prime_sandboxes-0.2.22-py3-none-any.whl", hash = "sha256:0a75bb02049c16b55aae7475cc4082e8559ffa6d65181b238077771a95b57855", size = 33182, upload-time = "2026-04-22T18:32:11.739Z" },
+    { url = "https://files.pythonhosted.org/packages/34/e8/2ddba24d992ef10b69eb311647443b11992fb2e9514e3a625b98b6a5da65/prime_sandboxes-0.2.25-py3-none-any.whl", hash = "sha256:c335eba6c817722365495ab3d3dfbe77f0a726d9a9f2fd3452ad44666811fbfc", size = 33621, upload-time = "2026-05-11T23:45:18.759Z" },
 ]
 
 [[package]]
@@ -6201,7 +6201,7 @@ requires-dist = [
     { name = "openai-agents", specifier = ">=0.0.7" },
     { name = "openenv-core", extras = ["core"], marker = "extra == 'openenv'", specifier = "==0.2.1" },
     { name = "peft", marker = "extra == 'rl'" },
-    { name = "prime-sandboxes", specifier = ">=0.2.21" },
+    { name = "prime-sandboxes", specifier = ">=0.2.25" },
     { name = "prime-tunnel", specifier = ">=0.1.6" },
     { name = "pydantic", specifier = ">=2.11.9" },
     { name = "python-dotenv", marker = "extra == 'browser'", specifier = ">=1.0.0" },

--- a/verifiers/envs/experimental/cli_agent_env.py
+++ b/verifiers/envs/experimental/cli_agent_env.py
@@ -158,6 +158,7 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
         self.add_rubric(CliAgentMonitorRubric())
 
     TUNNEL_CHECK_INTERVAL = 60.0  # seconds between server-side liveness checks
+    BACKGROUND_JOB_POLL_READ_ERROR_MAX_ATTEMPTS = 3
 
     def init_interception(
         self,
@@ -387,6 +388,7 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
         self, state: State, sandbox_id: str, background_job: BackgroundJob
     ) -> None:
         """Poll until background job completes, capturing output."""
+        consecutive_read_errors = 0
         while True:
             try:
                 status: BackgroundJobStatus = (
@@ -397,13 +399,22 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
             except Exception as e:
                 if not is_retryable_sandbox_read_error(e):
                     raise
+                consecutive_read_errors += 1
+                if (
+                    consecutive_read_errors
+                    > self.BACKGROUND_JOB_POLL_READ_ERROR_MAX_ATTEMPTS
+                ):
+                    raise
                 self.logger.warning(
                     "Background job poll failed with a transient sandbox read error; "
-                    "retrying: %s",
+                    "retrying (%s/%s): %s",
+                    consecutive_read_errors,
+                    self.BACKGROUND_JOB_POLL_READ_ERROR_MAX_ATTEMPTS,
                     e,
                 )
                 await asyncio.sleep(self.poll_interval)
                 continue
+            consecutive_read_errors = 0
             if status.completed:
                 state["agent_exit_code"] = status.exit_code
                 state["agent_stdout"] = status.stdout

--- a/verifiers/envs/experimental/cli_agent_env.py
+++ b/verifiers/envs/experimental/cli_agent_env.py
@@ -20,6 +20,7 @@ from verifiers.envs.experimental.sandbox_mixin import (
     SandboxMixin,
     SandboxMonitorRubric,
     SandboxTimeouts,
+    is_retryable_sandbox_read_error,
 )
 from verifiers.types import (
     AssistantMessage,
@@ -387,9 +388,22 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
     ) -> None:
         """Poll until background job completes, capturing output."""
         while True:
-            status: BackgroundJobStatus = await self.sandbox_client.get_background_job(
-                sandbox_id, background_job, timeout=self.timeouts.poll
-            )
+            try:
+                status: BackgroundJobStatus = (
+                    await self.sandbox_client.get_background_job(
+                        sandbox_id, background_job, timeout=self.timeouts.poll
+                    )
+                )
+            except Exception as e:
+                if not is_retryable_sandbox_read_error(e):
+                    raise
+                self.logger.warning(
+                    "Background job poll failed with a transient sandbox read error; "
+                    "retrying: %s",
+                    e,
+                )
+                await asyncio.sleep(self.poll_interval)
+                continue
             if status.completed:
                 state["agent_exit_code"] = status.exit_code
                 state["agent_stdout"] = status.stdout

--- a/verifiers/envs/experimental/cli_agent_env.py
+++ b/verifiers/envs/experimental/cli_agent_env.py
@@ -402,7 +402,7 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
                 consecutive_read_errors += 1
                 if (
                     consecutive_read_errors
-                    > self.BACKGROUND_JOB_POLL_READ_ERROR_MAX_ATTEMPTS
+                    >= self.BACKGROUND_JOB_POLL_READ_ERROR_MAX_ATTEMPTS
                 ):
                     raise
                 self.logger.warning(

--- a/verifiers/envs/experimental/sandbox_mixin.py
+++ b/verifiers/envs/experimental/sandbox_mixin.py
@@ -100,6 +100,7 @@ def is_retryable_sandbox_api_error(exception: BaseException) -> bool:
         "502",
         "503",
         "ConnectError",
+        "Read file timed out",
         "Temporary failure in name resolution",
     )
     return any(token in error_str for token in retry_tokens)


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds bounded retries for transient sandbox read/timeout failures during background job polling and updates the sandbox SDK dependency; main risk is slightly longer waits before surfacing real failures if errors are misclassified as retryable.
> 
> **Overview**
> Improves resilience of `CliAgentEnv` background job polling by **retrying transient sandbox read/transfer errors** (including "Read file timed out") up to a small fixed limit before failing the rollout.
> 
> Updates the `prime-sandboxes` dependency/lockfile to `>=0.2.25`, aligning runtime behavior with the new retry classification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6f435d29e4cae27ae7d53d24c42d9418f25355a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->