### PR TITLE
Tighten BugBot releasability and dependency rules

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -1,5 +1,31 @@
 # BugBot Instructions
 
+## Releasable State
+
+Every PR should leave Verifiers in a releasable state. Treat the merge commit as something that could be built, packaged, and published immediately after CI passes.
+
+Request changes when a PR:
+
+- Leaves known failing tests, lint, type checks, packaging checks, or release workflows unresolved
+- Adds or weakens skips, xfails, broad exception handling, or CI conditionals to hide broken behavior
+- Requires manual cleanup, local-only files, unpublished artifacts, or untracked generated files before release
+- Leaves version metadata, release notes, package configuration, docs, or lockfiles inconsistent with the changed behavior
+
+If validation is limited by missing credentials or external services, the PR should state the exact limitation while still preserving the normal releasable checks for code, packaging, and docs.
+
+## Dependency Sources
+
+Do not accept new or modified dependency declarations that pin packages to GitHub sources. Verifiers dependency surfaces should resolve from package indexes or other stable release channels, not repository snapshots.
+
+Request changes for dependency specs such as:
+
+- `git+https://github.com/...`
+- `git@github.com:...`
+- `package @ https://github.com/...`
+- `[tool.uv.sources]` entries that point at GitHub repositories
+
+When a GitHub-only upstream is unavoidable for an environment or integration, ask the author to make an explicit release-path decision instead of pinning the GitHub source directly in Verifiers.
+
 ## Documentation Updates
 
 Any PR that adds or modifies core user-facing functionality as described in `docs/` must update the relevant documentation. This includes changes classes and APIs described in:

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 William Brown
+Copyright (c) 2026 Prime Intellect
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to reviewer instructions and license text, with no runtime or behavioral code modifications.
> 
> **Overview**
> Strengthens `.cursor/BUGBOT.md` review criteria by explicitly requiring PRs to leave the repo in a *releasable state* (no hidden failures, skipped checks, or post-merge cleanup) and by rejecting dependency specs that pin to GitHub sources.
> 
> Updates `LICENSE` to change the copyright notice to `2026 Prime Intellect` and fixes the missing trailing newline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab5f86e25895ed285578f36a59528c759eaef13b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->