### PR TITLE
Disable OpenCode title generation in harness configs

### DIFF
--- a/verifiers/envs/experimental/composable/harnesses/opencode.py
+++ b/verifiers/envs/experimental/composable/harnesses/opencode.py
@@ -113,6 +113,9 @@ def build_opencode_config(
     provider_timeout_ms: int = 3_600_000,
 ) -> str:
     """Generate opencode.json config content."""
+    agent_config: dict[str, object] = {
+        "title": {"disable": True},
+    }
     config: dict = {
         "${SCHEMA_DOLLAR}schema": "https://opencode.ai/config.json",
         "provider": {
@@ -134,12 +137,10 @@ def build_opencode_config(
             }
         },
         "model": model_id,
-        # Without small_model, title/summary sub-agents fall through to
-        # opencode/gpt-5-nano (free hosted Cloudflare tier) and rate-limit
-        # under concurrent rollouts, which silently blocks the main agent
-        # before it issues any LLM call. See OpenCode provider.ts
-        # getSmallModel() priority chain. Pin to the same intercepted model.
+        # Keep the small-model pin to avoid falling back to the default small
+        # model and hitting rate limits; disable title calls below.
         "small_model": model_id,
+        "agent": agent_config,
     }
 
     if disable_compaction:
@@ -151,7 +152,7 @@ def build_opencode_config(
     if disabled_tools:
         agent_build["tools"] = {tool: False for tool in disabled_tools}
     if agent_build:
-        config["agent"] = {"build": agent_build}
+        agent_config["build"] = agent_build
 
     return json.dumps(config, indent=2)
 

--- a/verifiers/envs/experimental/opencode_env.py
+++ b/verifiers/envs/experimental/opencode_env.py
@@ -362,6 +362,9 @@ class OpenCodeEnv(CliAgentEnv):
         enable_interleaved: bool = True,
     ) -> str:
         """Build OpenCode config."""
+        agent_config: dict[str, object] = {
+            "title": {"disable": True},
+        }
         config: dict = {
             "${SCHEMA_DOLLAR}schema": "https://opencode.ai/config.json",
             "provider": {
@@ -388,9 +391,10 @@ class OpenCodeEnv(CliAgentEnv):
                 }
             },
             "model": "$OPENAI_MODEL",
-            # Keep title/summary sub-agents on the intercepted provider instead
-            # of falling back to OpenCode's hosted free small model.
+            # Keep the small-model pin to avoid falling back to the default small
+            # model and hitting rate limits; disable title calls below.
             "small_model": "$OPENAI_MODEL",
+            "agent": agent_config,
         }
 
         if disable_compaction:
@@ -402,7 +406,7 @@ class OpenCodeEnv(CliAgentEnv):
                 build_config["prompt"] = "{file:" + system_prompt_path + "}"
             if disabled_tools:
                 build_config["tools"] = {tool: False for tool in disabled_tools}
-            config["agent"] = {"build": build_config}
+            agent_config["build"] = build_config
 
         return json.dumps(config, indent=2)
 

--- a/verifiers/v1/packages/harnesses/opencode.py
+++ b/verifiers/v1/packages/harnesses/opencode.py
@@ -198,6 +198,9 @@ def build_opencode_config(
     disable_compaction: bool,
     provider_timeout_ms: int,
 ) -> str:
+    agent_config: dict[str, object] = {
+        "title": {"disable": True},
+    }
     config: dict[str, object] = {
         "${SCHEMA_DOLLAR}schema": "https://opencode.ai/config.json",
         "provider": {
@@ -218,9 +221,10 @@ def build_opencode_config(
             }
         },
         "model": "intercepted/model",
-        # Keep title/summary sub-agents on the intercepted provider instead
-        # of falling back to OpenCode's hosted free small model.
+        # Keep the small-model pin to avoid falling back to the default small
+        # model and hitting rate limits; disable title calls below.
         "small_model": "intercepted/model",
+        "agent": agent_config,
         "mcp": {
             "verifiers-tools": {
                 "type": "local",
@@ -237,7 +241,7 @@ def build_opencode_config(
     if disabled_tools:
         build_config["tools"] = {tool: False for tool in disabled_tools}
     if build_config:
-        config["agent"] = {"build": build_config}
+        agent_config["build"] = build_config
     return json.dumps(config, indent=2)
 
 


### PR DESCRIPTION
## Summary
- disable the hidden OpenCode `title` agent in the legacy, composable, and v1 OpenCode harness configs
- keep the existing `small_model` pins for older OpenCode builds while preventing background title-generation LLM calls
- preserve existing build-agent config by merging it under the same `agent` map

## Validation
- `bun test test/agent/agent.test.ts -t "agent disable removes agent from list"` in `/home/ubuntu/git/opencode/packages/opencode`
- direct OpenCode config check: default config leaves `Agent.get("title")` present; `agent.title.disable=true` makes it absent
- `uv run pytest tests/test_opencode_rlm_env.py::TestOpenCodeConfig tests/test_v1_harbor_cli.py::test_opencode_config_owns_opencode_harness_fields`
- `uv run ruff check verifiers/envs/experimental/composable/harnesses/opencode.py verifiers/envs/experimental/opencode_env.py verifiers/v1/packages/harnesses/opencode.py`
- `uv run ty check verifiers/v1/packages/harnesses/opencode.py verifiers/envs/experimental/composable/harnesses/opencode.py verifiers/envs/experimental/opencode_env.py`
- one `OpenCodeEnv` smoke rollout against Pinference `qwen/qwen3-30b-a3b-instruct-2507`: one model request, one turn, zero title-generation requests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: config-only changes that disable a sub-agent and slightly restructure the generated `agent` map, with minimal impact beyond OpenCode runtime behavior.
> 
> **Overview**
> Disables OpenCode’s hidden title-generation sub-agent across the composable, experimental `OpenCodeEnv`, and v1 harness config generators by adding `agent.title.disable=true`, preventing background LLM calls.
> 
> Refactors config assembly so any existing `agent.build` settings (prompt/tools) are merged under the same `agent` object instead of overwriting it, while keeping the existing `small_model` pin to avoid fallback rate limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c27c998f161a9a3f821cf86bae595832c654083. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->