### PR TITLE
chore: v0.1.15.dev2 dev release

### DIFF
--- a/assets/release/RELEASE_v0.1.15.dev2.md
+++ b/assets/release/RELEASE_v0.1.15.dev2.md
@@ -1,0 +1,15 @@
+# Verifiers v0.1.15.dev2 Release Notes
+
+*Date:* 05/13/2026
+
+## Highlights since v0.1.15.dev1
+
+- **OpenCode title-generation bypass.** Disables the hidden OpenCode title agent in the legacy, composable, and v1 OpenCode harness configs while keeping the `small_model` pin to avoid falling back to the default small model and hitting rate limits.
+
+## Changes included in v0.1.15.dev2 (since v0.1.15.dev1)
+
+### Fixes and maintenance
+
+- Disable OpenCode title generation in harness configs (#1359)
+
+**Full Changelog**: https://github.com/PrimeIntellect-ai/verifiers/compare/v0.1.15.dev1...v0.1.15.dev2

--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.15.dev1"
+__version__ = "0.1.15.dev2"
 
 import importlib
 import os


### PR DESCRIPTION
## Summary
- Bump `verifiers.__version__` to `0.1.15.dev2`.
- Add `assets/release/RELEASE_v0.1.15.dev2.md` with notes covering changes since `v0.1.15.dev1`.
- Summarize the OpenCode title-generation bypass and retained `small_model` pin in this dev cut.

## Testing
- `uv run ruff format verifiers/__init__.py`
- `uv run ruff check --fix verifiers/__init__.py`
- `uv run pre-commit run --files verifiers/__init__.py assets/release/RELEASE_v0.1.15.dev2.md`
- `uv run python -c 'import verifiers; print(verifiers.__version__)'`
- `uv build`
- `git push -u origin chore/v0.1.15.dev2-dev-release` (pre-push hooks: ruff check, ruff format, ty)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dev-release housekeeping: version bump and release notes only, with no functional code changes in this diff.
> 
> **Overview**
> Bumps `verifiers.__version__` from `0.1.15.dev1` to `0.1.15.dev2`.
> 
> Adds `assets/release/RELEASE_v0.1.15.dev2.md` documenting highlights and changelog for this dev release, including the OpenCode title-generation bypass (and retained `small_model` pin) referenced as #1359.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 711f378e75146c6e1ab1356c54c3a1450d6160f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->