### PR TITLE
Add repo development best practices to AGENTS, docs, and skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,3 +21,10 @@ Use this guidance when contributing to the `verifiers` repository itself.
 - Keep changes aligned with documented architecture (`verifiers/`, `environments/`, `configs/`, `tests/`, `docs/`) and update docs when behavior changes. (See `docs/development.md`.)
 - Prefer a single clear path over maintaining parallel approaches by default; if two options exist, preserve both only when there is an explicit long-term reason.
 - Aggressively deprecate/remove inferior paths when they are not part of an intended multi-option contract, especially in repo-internal development workflows.
+- Treat public configuration and docs as part of the API. Keep TOML shapes consistent across eval, GEPA, RL, and Hosted Training; normalize legacy inputs at the ingestion boundary instead of spreading compatibility branches through examples.
+- For v1 Taskset/Harness work, make the taskset own task data, task tools, user behavior, metrics, rewards, and task-specific configuration. Use the base `vf.Harness` unless the harness really owns a reusable execution mechanism.
+- When renaming or deleting an environment/module path, update package metadata, README/docs references, tests, build includes, and generated AGENTS output in the same change.
+- For environment changes, validate the install/load/eval path, not just imports. Prefer `prime eval run` for user-visible behavior and `tests/test_envs.py` for package-install coverage when the change affects packaged examples.
+- When fixing a PR review, Bugbot issue, CI failure, or release blocker, inspect the live thread/check/log first and address the exact failure. Do not infer the root cause from stale local context.
+- Before changing dependencies, optional extras, lockfiles, or config fields consumed by `prime-cli`, `prime-rl`, Hosted Training, or public docs, trace the downstream consumer and update the matching docs/skills in the same patch.
+- Keep generated artifacts out of commits. Remove bytecode, coverage files, local eval outputs, and temporary build products unless they are explicitly part of the release artifact.

--- a/assets/agents/repo_development_best_practices.md
+++ b/assets/agents/repo_development_best_practices.md
@@ -7,3 +7,10 @@ Use this guidance when contributing to the `verifiers` repository itself.
 - Keep changes aligned with documented architecture (`verifiers/`, `environments/`, `configs/`, `tests/`, `docs/`) and update docs when behavior changes. (See `docs/development.md`.)
 - Prefer a single clear path over maintaining parallel approaches by default; if two options exist, preserve both only when there is an explicit long-term reason.
 - Aggressively deprecate/remove inferior paths when they are not part of an intended multi-option contract, especially in repo-internal development workflows.
+- Treat public configuration and docs as part of the API. Keep TOML shapes consistent across eval, GEPA, RL, and Hosted Training; normalize legacy inputs at the ingestion boundary instead of spreading compatibility branches through examples.
+- For v1 Taskset/Harness work, make the taskset own task data, task tools, user behavior, metrics, rewards, and task-specific configuration. Use the base `vf.Harness` unless the harness really owns a reusable execution mechanism.
+- When renaming or deleting an environment/module path, update package metadata, README/docs references, tests, build includes, and generated AGENTS output in the same change.
+- For environment changes, validate the install/load/eval path, not just imports. Prefer `prime eval run` for user-visible behavior and `tests/test_envs.py` for package-install coverage when the change affects packaged examples.
+- When fixing a PR review, Bugbot issue, CI failure, or release blocker, inspect the live thread/check/log first and address the exact failure. Do not infer the root cause from stale local context.
+- Before changing dependencies, optional extras, lockfiles, or config fields consumed by `prime-cli`, `prime-rl`, Hosted Training, or public docs, trace the downstream consumer and update the matching docs/skills in the same patch.
+- Keep generated artifacts out of commits. Remove bytecode, coverage files, local eval outputs, and temporary build products unless they are explicitly part of the release artifact.

--- a/docs/development.md
+++ b/docs/development.md
@@ -10,6 +10,7 @@ This guide covers setup, testing, and contributing to the verifiers package.
 - [Running Tests](#running-tests)
 - [Writing Tests](#writing-tests)
 - [Contributing](#contributing)
+- [Contributor Practices](#contributor-practices)
 - [Common Issues](#common-issues)
 - [Environment Development](#environment-development)
 - [Quick Reference](#quick-reference)
@@ -192,6 +193,40 @@ def test_with_mock(mock_client):
 - [ ] Pre-commit and pre-push hooks pass on latest commit/push
 - [ ] Added tests for new functionality
 - [ ] Updated documentation if needed
+
+## Contributor Practices
+
+### Public Surface
+
+Treat public config, docs, starter examples, skills, and generated agent
+guidance as one surface. If a behavior changes for users, update all matching
+surfaces in the same patch.
+
+For TOML config, keep one shape across eval, GEPA, RL, and Hosted Training.
+Normalize old or alternate inputs at the loader boundary, then keep examples on
+the current golden path.
+
+For v1 Taskset/Harness environments, put task data, task-owned tools, user
+behavior, metrics, rewards, and task-specific configuration on the `Taskset`.
+Use the base `vf.Harness` unless the harness owns a reusable execution adapter
+such as a CLI, framework program, sandboxed program, or nested harness flow.
+
+### Validation By Change Type
+
+- Core runtime or shared config parsing: run the focused unit tests plus `uv run pre-commit run --all-files`.
+- Example environment behavior: run the focused tests and a real `prime eval run` smoke when credentials and endpoint access are available.
+- Environment packaging: exercise `tests/test_envs.py` for the changed environment so a fresh venv installs the environment package and its dependencies.
+- Docs or generated agent guidance: run `uv run python scripts/sync.py` and include the regenerated files.
+- Release prep: verify the version source, release notes commit range, `uv build`, and final worktree status.
+- PR/CI follow-up: inspect the live review thread, check run, or log before patching, then rerun the smallest check that proves the fix.
+
+### Downstream Checks
+
+Before changing dependencies, optional extras, lockfiles, exported config fields,
+or upload/eval metadata, trace the consumers in `prime-cli`, `prime-rl`, Hosted
+Training, and public docs when they are in scope. Update the consumer or document
+the compatibility boundary rather than assuming transitive behavior remains
+safe.
 
 ## Common Issues
 

--- a/skills/create-environments/SKILL.md
+++ b/skills/create-environments/SKILL.md
@@ -46,6 +46,36 @@ prime env install math-python --from-repo
 3. Implement `load_environment(...) -> vf.Environment` with explicit arguments.
 4. Add `pyproject.toml` defaults in `[tool.verifiers.eval]` only when stable.
 
+### V1 Taskset/Harness Shape
+1. Put task data, task-owned tools, user behavior, metrics, rewards, and task-specific configuration on the `Taskset`.
+2. Use the base `vf.Harness` unless the harness owns a reusable execution adapter such as a CLI, framework program, sandboxed program, or nested harness flow.
+3. Avoid one-off harness classes whose only purpose is to hold task behavior. That behavior belongs behind the taskset.
+4. Keep small example environments direct. Do not add private helper layers, duplicate loader paths, or optional knobs unless they clarify a real reusable boundary.
+5. Use the current config shape consistently:
+```toml
+[[env]]
+id = "owner/my-env"
+
+[env.args]
+split = "train"
+
+[env.taskset]
+num_examples = 100
+
+[env.harness]
+max_turns = 8
+```
+6. In code, normalize config at the loader boundary and pass child configs directly:
+```python
+def load_environment(config: vf.EnvConfig | None = None) -> vf.Env:
+    config = config or vf.EnvConfig()
+    return vf.Env(
+        taskset=load_taskset(config.taskset),
+        harness=load_harness(config.harness),
+    )
+```
+7. If concise env-level named args are useful, map them explicitly into `vf.EnvConfig(...)` once in `load_environment`; do not thread loose kwargs through taskset and harness internals.
+
 ### 2. Port From Another Library, Project, or Paper
 1. Create a strict source-to-target mapping before coding:
 - dataset rows and splits
@@ -84,6 +114,10 @@ prime eval run my-env -m openai/gpt-4.1-mini -n 50 -r 1 -s
 If multi-turn or tool-heavy, also run with higher rollouts:
 ```bash
 prime eval run my-env -m openai/gpt-4.1-mini -n 30 -r 3 -s
+```
+For repo example environments, also use the package-install path when packaging or dependencies changed:
+```bash
+uv run pytest tests/test_envs.py -k my_env -vv
 ```
 
 ## Publish Gate Before Large Evals Or Training

--- a/skills/evaluate-environments/SKILL.md
+++ b/skills/evaluate-environments/SKILL.md
@@ -27,6 +27,12 @@ prime eval run owner/my-env -m openai/gpt-4.1-mini -n 5
 prime eval run owner/my-env -m openai/gpt-4.1-mini -n 200 -r 3 -s
 ```
 4. Treat ownerless env ids as local-first. If not found locally, rely on Prime resolution for your remote env where applicable.
+5. When the user asks for a "real" or "base" eval, do not substitute a tiny smoke run. Use the requested model/env and make the run size explicit before interpreting results.
+6. If the user says the defaults are fine or asks for no flags, use the shortest canonical command and rely on global config:
+```bash
+prime eval run my-env
+prime eval run my-env -m openai/gpt-4.1-mini
+```
 
 ## Endpoint Shortcuts And Model Family Choice
 1. Encourage users to define endpoint aliases in `configs/endpoints.toml` so model, base URL, and key wiring stay reusable.
@@ -167,6 +173,9 @@ prime eval samples <eval-id>
 2. Record exact command lines and key flags in the report.
 3. Call out missing credentials, endpoint mismatches, and dependency errors directly.
 4. Do not overinterpret tiny sample runs.
+5. Distinguish a completed rollout with poor reward from an environment/runtime failure.
+6. For timeout debugging, check the environment's own timeout behavior and the outer sandbox/eval timeout before changing reward logic.
+7. For repo example changes, use `tests/test_envs.py -k <env>` when package installability is part of the risk, not just `prime eval run` from the current checkout.
 
 ## Output Format
 Return:

--- a/skills/optimize-with-environments/SKILL.md
+++ b/skills/optimize-with-environments/SKILL.md
@@ -52,9 +52,10 @@ prime gepa run configs/gepa/qwen-3-5.toml
 
 ## Output Artifacts
 Expect and inspect:
-1. `best_prompt.txt`
+1. `system_prompt.txt`
 2. `pareto_frontier.jsonl`
 3. `metadata.json`
+Load optimized prompts with `vf.SystemMessage.from_path("/path/to/system_prompt.txt")` so the saved prompt is used verbatim.
 
 ## Quality Rules
 1. Do not optimize on top of broken reward logic.

--- a/skills/review-environments/SKILL.md
+++ b/skills/review-environments/SKILL.md
@@ -37,11 +37,13 @@ prime eval run <env> -m openai/gpt-4.1-mini -n 5
 1. Reward correctness:
 - Prefer deterministic, explicit checks or LLM judges.
 - Flag best-effort keyword or style heuristics unless explicitly approved.
+- Verify the scoring semantics from code before treating a low reward as an implementation failure. Some environments intentionally complete with `0.0` reward when the model fails the task.
 2. Environment self-containment:
 - Flag any requirement for user-managed background services before `load_environment()`.
 - Require environment-managed lifecycle for sandboxes/sessions.
 3. v1 taskset/harness contracts:
 - Expect new taskset/harness environments to use the v1 `vf.Env` / `vf.Taskset` / `vf.Harness` format.
+- Expect tasksets to own task data, task-owned tools, user behavior, metrics, rewards, and task-specific config. Flag one-off harness classes that only wrap task behavior.
 - Verify `Task` data is serializable, `state` remains serializable at rollout boundaries, and model/client controls flow through runtime state rather than top-level dataset columns.
 - For V1 harness programs, verify framework clients consume `state.get_endpoint_config(api="chat")` rather than hardcoding an upstream LLM endpoint. For `CliAgentEnv` agents, verify sandboxed agent code consumes the injected interception endpoint; the proxy is what makes rollouts visible to the rubric.
 4. Migration fidelity:
@@ -51,6 +53,14 @@ prime eval run <env> -m openai/gpt-4.1-mini -n 5
 - Ensure required keys are validated in `load_environment()` with `vf.ensure_keys(...)`.
 6. Performance and scaling:
 - Identify obvious bottlenecks in dataset loading, rubric calls, or tool execution.
+7. Packaging and repo hygiene:
+- If an environment was renamed or moved, verify `pyproject.toml`, README/docs references, package include paths, tests, and generated AGENTS output were updated together.
+- Flag bytecode, coverage files, local eval outputs, and temporary build artifacts unless they are intentional release assets.
+
+## Config And Docs Surface
+1. Check that eval, GEPA, RL, and Hosted Training examples use the same public TOML shape where applicable.
+2. For v1 configs, prefer `[env.args]`, `[env.taskset]`, and `[env.harness]`; loader code should normalize at the boundary instead of spreading compatibility branches through examples.
+3. If docs changed public behavior, verify the relevant bundled skill was updated too.
 
 ## Findings Format
 Return findings first, sorted by severity:


### PR DESCRIPTION
## Summary
- Added recurring `verifiers` repo guidance to the root AGENTS source and regenerated the derived AGENTS files.
- Documented the current public config shape, v1 Taskset/Harness ownership, downstream-consumer checks, and validation expectations in `docs/development.md`.
- Aligned the environment-focused skills with the patterns that kept recurring in recent `verifiers` work: taskset-owned behavior, canonical eval validation, review/CI follow-through, and GEPA prompt loading.

## Testing
- `uv run pre-commit install`
- `uv run python scripts/sync.py`
- `uv run pre-commit run --files AGENTS.md assets/agents/repo_development_best_practices.md docs/development.md skills/create-environments/SKILL.md skills/evaluate-environments/SKILL.md skills/optimize-with-environments/SKILL.md skills/review-environments/SKILL.md`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates that standardize contributor guidance and workflow expectations; no runtime code paths or APIs are modified.
> 
> **Overview**
> Adds explicit *repo contributor practices* around treating public config/docs as API, standardizing TOML shapes across workflows, and clarifying v1 `Taskset`/`Harness` ownership (plus downstream-consumer checks and validation expectations).
> 
> Regenerates and updates `AGENTS.md`/`assets/agents/repo_development_best_practices.md` and aligns environment skills to emphasize canonical `prime eval run` usage, package-install validation via `tests/test_envs.py`, more precise eval guidance, and loading GEPA outputs from `system_prompt.txt`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16f6b87d63341bf8f8974089defca1c08c8b1338. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->