### PR TITLE
Use background jobs for v1 sandbox commands

### DIFF
--- a/tests/test_v1_harbor_cli.py
+++ b/tests/test_v1_harbor_cli.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import sys
+import types
 from pathlib import Path
 from typing import cast
 
@@ -8,6 +10,7 @@ import pytest
 
 import verifiers.v1 as vf
 from verifiers.v1.packages.harnesses.pi import pi_mcp_json, pi_models_json
+from verifiers.v1.packages.tasksets.harbor import harbor_reward
 from verifiers.v1.utils.program_utils import merge_task_program
 
 
@@ -80,6 +83,76 @@ def test_harbor_taskset_constructs_env_with_opencode(tmp_path: Path) -> None:
     assert task["task_name"] == "task-a"
     assert isinstance(env.harness, vf.OpenCode)
     assert "task_dir" not in cast(dict[str, object], env.harness.program)
+
+
+class FakeHarborCommandResult:
+    def __init__(
+        self,
+        *,
+        exit_code: int = 0,
+        stdout: str = "",
+        stderr: str = "",
+    ):
+        self.exit_code = exit_code
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+class FakeHarborSandboxClient:
+    instances: list["FakeHarborSandboxClient"] = []
+
+    def __init__(self):
+        self.execute_commands: list[tuple[str, int | None, str | None]] = []
+        self.background_jobs: list[tuple[str, str, int | None, str | None]] = []
+        type(self).instances.append(self)
+
+    async def upload_file(self, *args: object, **kwargs: object) -> None:
+        _ = args, kwargs
+
+    async def execute_command(
+        self, *args: object, **kwargs: object
+    ) -> FakeHarborCommandResult:
+        command = str(kwargs.get("command") or args[1])
+        timeout = cast(int | None, kwargs.get("timeout"))
+        working_dir = cast(str | None, kwargs.get("working_dir"))
+        self.execute_commands.append((command, timeout, working_dir))
+        if "reward.txt" in command:
+            return FakeHarborCommandResult(stdout="1\n")
+        return FakeHarborCommandResult()
+
+    async def run_background_job(
+        self, *args: object, **kwargs: object
+    ) -> FakeHarborCommandResult:
+        sandbox_id = str(kwargs.get("sandbox_id") or args[0])
+        command = str(kwargs.get("command") or args[1])
+        timeout = cast(int | None, kwargs.get("timeout"))
+        working_dir = cast(str | None, kwargs.get("working_dir"))
+        self.background_jobs.append((sandbox_id, command, timeout, working_dir))
+        return FakeHarborCommandResult(stdout="tests passed")
+
+    async def aclose(self) -> None:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_harbor_reward_uses_background_job_for_tests(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    task_dir = write_harbor_task(tmp_path)
+    fake_module = types.ModuleType("prime_sandboxes")
+    fake_module.AsyncSandboxClient = FakeHarborSandboxClient
+    monkeypatch.setitem(sys.modules, "prime_sandboxes", fake_module)
+    FakeHarborSandboxClient.instances = []
+
+    reward = await harbor_reward(
+        {"harbor": {"task_dir": str(task_dir), "test_timeout": 120}},
+        {"sandbox_id": "sbx-1"},
+    )
+
+    client = FakeHarborSandboxClient.instances[0]
+    assert reward == 1.0
+    assert client.background_jobs == [("sbx-1", "bash test.sh", 120, "/tests")]
+    assert ("bash test.sh", 120, "/tests") not in client.execute_commands
 
 
 def test_packaged_harbor_and_opencode_imports_are_reexported() -> None:

--- a/tests/test_v1_runtime_lifecycle.py
+++ b/tests/test_v1_runtime_lifecycle.py
@@ -109,6 +109,7 @@ class FakeSandboxClient:
     created: list[str] = []
     deleted: list[str] = []
     commands: list[tuple[str, str]] = []
+    background_jobs: list[tuple[str, str, int | None, str | None]] = []
     uploads: list[tuple[str, str, bytes]] = []
 
     @classmethod
@@ -116,6 +117,7 @@ class FakeSandboxClient:
         cls.created = []
         cls.deleted = []
         cls.commands = []
+        cls.background_jobs = []
         cls.uploads = []
 
     async def create(self, request: FakeCreateSandboxRequest) -> FakeSandboxResult:
@@ -133,6 +135,17 @@ class FakeSandboxClient:
         sandbox_id = str(kwargs.get("sandbox_id") or args[0])
         command = str(kwargs.get("command") or args[1])
         type(self).commands.append((sandbox_id, command))
+        return FakeCommandResult()
+
+    async def run_background_job(
+        self, *args: object, **kwargs: object
+    ) -> FakeCommandResult:
+        sandbox_id = str(kwargs.get("sandbox_id") or args[0])
+        command = str(kwargs.get("command") or args[1])
+        timeout = cast(int | None, kwargs.get("timeout"))
+        working_dir = cast(str | None, kwargs.get("working_dir"))
+        type(self).commands.append((sandbox_id, command))
+        type(self).background_jobs.append((sandbox_id, command, timeout, working_dir))
         return FakeCommandResult()
 
     async def upload_bytes(self, *args: object, **kwargs: object) -> None:
@@ -1191,6 +1204,26 @@ async def test_sandbox_state_input_upload_runs_after_rollout_setup(
         if path == "/tmp/vf_state_in.json"
     }
     assert uploads["/tmp/vf_state_in.json"]["state_input_setup"] is True
+
+
+@pytest.mark.asyncio
+async def test_task_command_uses_background_job(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_fake_sandboxes(monkeypatch)
+    install_fake_endpoint_tunnel(monkeypatch)
+
+    harness = vf.CLIHarness(command=["sleep", "120"], sandbox=True)
+    task = vf.Task(
+        {
+            "prompt": [{"role": "user", "content": "hi"}],
+            "sandbox": {"command_timeout": 120},
+        }
+    ).freeze()
+
+    await harness.run(task)
+
+    assert ("sbx-1", "sleep 120", 120, "/app") in FakeSandboxClient.background_jobs
 
 
 @pytest.mark.asyncio

--- a/verifiers/v1/packages/tasksets/harbor.py
+++ b/verifiers/v1/packages/tasksets/harbor.py
@@ -333,11 +333,12 @@ async def harbor_reward(task, state) -> float:
     client = AsyncSandboxClient()
     try:
         await upload_harbor_tests(client, sandbox_id, task_dir)
-        result = await client.execute_command(
+        test_timeout = int(parse_number(harbor.get("test_timeout"), 900))
+        result = await client.run_background_job(
             sandbox_id=sandbox_id,
             command="bash test.sh",
             working_dir="/tests",
-            timeout=int(parse_number(harbor.get("test_timeout"), 900)),
+            timeout=test_timeout,
         )
         state["harbor_tests"] = {
             "returncode": result.exit_code,

--- a/verifiers/v1/utils/sandbox_utils.py
+++ b/verifiers/v1/utils/sandbox_utils.py
@@ -262,12 +262,13 @@ async def run_sandbox_command(
             )
         argv = await command_argv(program, task, state, runtime)
         env = await command_env(program, task, state, runtime, include_base=False)
-        result = await lease.client.execute_command(
-            lease.id,
-            shlex.join(argv),
+        command = shlex.join(argv)
+        command_timeout = cast(int | None, sandbox_config.get("command_timeout"))
+        result = await lease.run_background_job(
+            command,
+            timeout=command_timeout,
             working_dir=workdir,
             env=env,
-            timeout=cast(int | None, sandbox_config.get("command_timeout")),
         )
         state["command"] = {
             "argv": argv,


### PR DESCRIPTION
## Summary
- run v1 sandbox program commands through sandbox background jobs instead of foreground exec
- run v1 Harbor verifier tests through background jobs as well
- preserve configured command/test timeouts as the background-job timeout budget

## Testing
- `uv run ruff format`
- `uv run ruff check --fix`
- `uv run pytest tests/test_v1_harbor_cli.py`
- `uv run pytest tests/test_v1_runtime_lifecycle.py`
- `uv run pre-commit run --files verifiers/v1/utils/sandbox_utils.py verifiers/v1/packages/tasksets/harbor.py tests/test_v1_harbor_cli.py tests/test_v1_runtime_lifecycle.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Switches v1 sandbox command execution and Harbor verifier test runs from foreground `execute_command` to `run_background_job`, which may change timing/streaming semantics and error handling in sandboxed runs. Behavior is covered by new tests but touches core runtime execution paths.
> 
> **Overview**
> Updates v1 sandbox command execution to run the main program command via `run_background_job` (instead of `execute_command`), passing through `command_timeout` as the background job timeout budget.
> 
> Similarly updates `harbor_reward` to execute `bash test.sh` using a sandbox background job, with `harbor.test_timeout` preserved as the job timeout, and adds/updates tests to assert background-job usage and recorded parameters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce8866814763a0732b1e6aa5769e5c63c38be9b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->