### PR TITLE
chore: bump renderers to 0.1.8.dev1 and migrate to ParsedToolCall API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ dev = [
     "aiohttp>=3.9.0",
     "python-dotenv>=1.0.0",
     "nltk",
-    "renderers>=0.1.8.dev0",
+    "renderers>=0.1.8.dev1",
 ]
 
 [project.optional-dependencies]
@@ -93,7 +93,7 @@ browser = [
     "python-dotenv>=1.0.0",
 ]
 renderers = [
-    "renderers>=0.1.8.dev0",
+    "renderers>=0.1.8.dev1",
 ]
 rl = [
     "torch>=2.8.0,<2.9.0",

--- a/tests/test_renderer_client.py
+++ b/tests/test_renderer_client.py
@@ -1,11 +1,10 @@
-import json
 from functools import lru_cache
 from unittest.mock import patch
 
 import pytest
 
 import verifiers as vf
-from renderers import ParsedToolCall, RendererPool, ToolCallParseStatus
+from renderers import RendererPool
 from renderers.base import ParsedResponse, RenderedTokens, create_renderer
 from verifiers.clients.renderer_client import (
     RendererClient,
@@ -232,80 +231,6 @@ async def test_from_native_response_uses_request_id_and_token_lengths():
     assert response.usage.prompt_tokens == 3
     assert response.usage.completion_tokens == 2
     assert response.usage.total_tokens == 5
-
-
-@pytest.mark.asyncio
-async def test_from_native_response_converts_parsed_tool_calls():
-    """``renderers.client.generate`` now returns ``parsed.tool_calls`` as a
-    list of :class:`ParsedToolCall` dataclasses (renderers >=0.1.8.dev1).
-    Old code indexed the previous ``[{"function": {"name": ...}}]`` dict
-    shape; this regression test pins the new attribute-based read path."""
-    client = object.__new__(RendererClient)
-    response_dict = {
-        "request_id": "resp-tc",
-        "content": "",
-        "reasoning_content": None,
-        "tool_calls": [
-            ParsedToolCall(
-                raw='{"name":"get_weather","arguments":{"city":"sf"}}',
-                name="get_weather",
-                arguments={"city": "sf"},
-                status=ToolCallParseStatus.OK,
-                id="native_id_1",
-            ),
-        ],
-        "finish_reason": "tool_calls",
-        "prompt_ids": [1, 2, 3],
-        "completion_ids": [4, 5, 6],
-        "completion_logprobs": [-0.1, -0.2, -0.3],
-        "routed_experts": None,
-    }
-
-    response = await client.from_native_response(response_dict)
-    assert response.message.tool_calls is not None
-    assert len(response.message.tool_calls) == 1
-    tc = response.message.tool_calls[0]
-    # Prefer the renderer's native id when one was extracted (Kimi K2 etc).
-    assert tc.id == "native_id_1"
-    assert tc.name == "get_weather"
-    # ToolCall.arguments is the canonical JSON string form.
-    assert json.loads(tc.arguments) == {"city": "sf"}
-
-
-@pytest.mark.asyncio
-async def test_from_native_response_drops_malformed_tool_calls():
-    """Non-OK parse attempts (INVALID_JSON, UNCLOSED_BLOCK, …) are surfaced
-    on ``parsed.tool_calls`` for inspection but shouldn't reach the tool
-    loop. Only ``status == OK`` calls produce ``ToolCall`` records."""
-    client = object.__new__(RendererClient)
-    response_dict = {
-        "request_id": "resp-mixed",
-        "content": "",
-        "reasoning_content": None,
-        "tool_calls": [
-            ParsedToolCall(
-                raw="not json",
-                status=ToolCallParseStatus.INVALID_JSON,
-            ),
-            ParsedToolCall(
-                raw='{"name":"ok_tool","arguments":{}}',
-                name="ok_tool",
-                arguments={},
-                status=ToolCallParseStatus.OK,
-            ),
-        ],
-        "finish_reason": "tool_calls",
-        "prompt_ids": [1],
-        "completion_ids": [2],
-        "completion_logprobs": [-0.1],
-        "routed_experts": None,
-    }
-
-    response = await client.from_native_response(response_dict)
-    assert response.message.tool_calls is not None
-    assert [tc.name for tc in response.message.tool_calls] == ["ok_tool"]
-    # No native id on this call — falls back to call_<index> over OK calls.
-    assert response.message.tool_calls[0].id == "call_0"
 
 
 class _BridgeRenderer:

--- a/tests/test_renderer_client.py
+++ b/tests/test_renderer_client.py
@@ -1,10 +1,11 @@
+import json
 from functools import lru_cache
 from unittest.mock import patch
 
 import pytest
 
 import verifiers as vf
-from renderers import RendererPool
+from renderers import ParsedToolCall, RendererPool, ToolCallParseStatus
 from renderers.base import ParsedResponse, RenderedTokens, create_renderer
 from verifiers.clients.renderer_client import (
     RendererClient,
@@ -233,6 +234,80 @@ async def test_from_native_response_uses_request_id_and_token_lengths():
     assert response.usage.total_tokens == 5
 
 
+@pytest.mark.asyncio
+async def test_from_native_response_converts_parsed_tool_calls():
+    """``renderers.client.generate`` now returns ``parsed.tool_calls`` as a
+    list of :class:`ParsedToolCall` dataclasses (renderers >=0.1.8.dev1).
+    Old code indexed the previous ``[{"function": {"name": ...}}]`` dict
+    shape; this regression test pins the new attribute-based read path."""
+    client = object.__new__(RendererClient)
+    response_dict = {
+        "request_id": "resp-tc",
+        "content": "",
+        "reasoning_content": None,
+        "tool_calls": [
+            ParsedToolCall(
+                raw='{"name":"get_weather","arguments":{"city":"sf"}}',
+                name="get_weather",
+                arguments={"city": "sf"},
+                status=ToolCallParseStatus.OK,
+                id="native_id_1",
+            ),
+        ],
+        "finish_reason": "tool_calls",
+        "prompt_ids": [1, 2, 3],
+        "completion_ids": [4, 5, 6],
+        "completion_logprobs": [-0.1, -0.2, -0.3],
+        "routed_experts": None,
+    }
+
+    response = await client.from_native_response(response_dict)
+    assert response.message.tool_calls is not None
+    assert len(response.message.tool_calls) == 1
+    tc = response.message.tool_calls[0]
+    # Prefer the renderer's native id when one was extracted (Kimi K2 etc).
+    assert tc.id == "native_id_1"
+    assert tc.name == "get_weather"
+    # ToolCall.arguments is the canonical JSON string form.
+    assert json.loads(tc.arguments) == {"city": "sf"}
+
+
+@pytest.mark.asyncio
+async def test_from_native_response_drops_malformed_tool_calls():
+    """Non-OK parse attempts (INVALID_JSON, UNCLOSED_BLOCK, …) are surfaced
+    on ``parsed.tool_calls`` for inspection but shouldn't reach the tool
+    loop. Only ``status == OK`` calls produce ``ToolCall`` records."""
+    client = object.__new__(RendererClient)
+    response_dict = {
+        "request_id": "resp-mixed",
+        "content": "",
+        "reasoning_content": None,
+        "tool_calls": [
+            ParsedToolCall(
+                raw="not json",
+                status=ToolCallParseStatus.INVALID_JSON,
+            ),
+            ParsedToolCall(
+                raw='{"name":"ok_tool","arguments":{}}',
+                name="ok_tool",
+                arguments={},
+                status=ToolCallParseStatus.OK,
+            ),
+        ],
+        "finish_reason": "tool_calls",
+        "prompt_ids": [1],
+        "completion_ids": [2],
+        "completion_logprobs": [-0.1],
+        "routed_experts": None,
+    }
+
+    response = await client.from_native_response(response_dict)
+    assert response.message.tool_calls is not None
+    assert [tc.name for tc in response.message.tool_calls] == ["ok_tool"]
+    # No native id on this call — falls back to call_<index> over OK calls.
+    assert response.message.tool_calls[0].id == "call_0"
+
+
 class _BridgeRenderer:
     supports_tools = True
 
@@ -289,7 +364,7 @@ class _BridgeRenderer:
             )
         )
 
-    def parse_response(self, token_ids):
+    def parse_response(self, token_ids, *, tools=None):
         return ParsedResponse(content="")
 
     def get_stop_token_ids(self):

--- a/uv.lock
+++ b/uv.lock
@@ -4845,7 +4845,7 @@ wheels = [
 
 [[package]]
 name = "renderers"
-version = "0.1.8.dev0"
+version = "0.1.8.dev1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jinja2" },
@@ -4855,9 +4855,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "transformers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/50/de/a445036157af3367c6a962c13333427c83c08926934c541886eb87f9dcdf/renderers-0.1.8.dev0.tar.gz", hash = "sha256:71eef7bfa3d3f5849ba070d38cd89a1f6387ca7710824f2e50d8c05c9b1048b9", size = 210667, upload-time = "2026-05-12T17:48:45.352Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/05/502abe1539138ed8cdc56ed545ac55bed7951c210ac2dd9e63b76be8b3a1/renderers-0.1.8.dev1.tar.gz", hash = "sha256:188e72ca222af7aaffbc5d66892bc411c7dffaf83656a28c39269759cf6f5122", size = 228647, upload-time = "2026-05-13T17:15:29.281Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/33/936a38c7f20fbe096b751842ffc6ef254c9eb2223153aa860a122ce9a834/renderers-0.1.8.dev0-py3-none-any.whl", hash = "sha256:09bb35233f67599519c0ff6edfad469f0836a55a6b78e039cd8e7b5e527bdcb3", size = 98617, upload-time = "2026-05-12T17:48:44.222Z" },
+    { url = "https://files.pythonhosted.org/packages/05/fd/5b48793311c92c2d1d9ac1b9939599707371c3f560dd461dc5c3ef276163/renderers-0.1.8.dev1-py3-none-any.whl", hash = "sha256:4adbac299b40be19c72d369f71edabfa3d0884764b131344cf988ba3af04eada", size = 113609, upload-time = "2026-05-13T17:15:30.247Z" },
 ]
 
 [[package]]
@@ -6212,7 +6212,7 @@ requires-dist = [
     { name = "pyzmq", specifier = ">=27.1.0" },
     { name = "reasoning-gym", marker = "extra == 'rg'" },
     { name = "regex", specifier = "<2026.4.4" },
-    { name = "renderers", marker = "extra == 'renderers'", specifier = ">=0.1.8.dev0" },
+    { name = "renderers", marker = "extra == 'renderers'", specifier = ">=0.1.8.dev1" },
     { name = "requests" },
     { name = "requests", marker = "extra == 'rl'" },
     { name = "rich" },
@@ -6244,7 +6244,7 @@ dev = [
     { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "reasoning-gym" },
-    { name = "renderers", specifier = ">=0.1.8.dev0" },
+    { name = "renderers", specifier = ">=0.1.8.dev1" },
     { name = "ruff" },
     { name = "stagehand", specifier = ">=3.0.0" },
     { name = "textarena" },

--- a/verifiers/clients/renderer_client.py
+++ b/verifiers/clients/renderer_client.py
@@ -21,9 +21,11 @@ from openai import AsyncOpenAI
 from renderers import Message as RendererMessage
 from renderers import (
     MultimodalRenderer,
+    ParsedToolCall,
     RenderedTokens,
     Renderer,
     RendererPool,
+    ToolCallParseStatus,
     ToolSpec,
     create_renderer_pool,
     is_multimodal,
@@ -598,6 +600,9 @@ class RendererClient(
             raise EmptyModelResponseError("Model returned no response")
 
         has_content = bool(response.get("content"))
+        # ``tool_calls`` is now ``list[ParsedToolCall]`` (renderers >=0.1.8.dev1)
+        # — a non-empty list with only malformed attempts still counts as the
+        # model having tried to call a tool, so we don't filter by status here.
         has_tool_calls = bool(response.get("tool_calls"))
         has_reasoning = bool(response.get("reasoning_content"))
         if not (has_content or has_tool_calls or has_reasoning):
@@ -611,20 +616,31 @@ class RendererClient(
         reasoning_content = response.get("reasoning_content")
         finish_reason = _parse_finish_reason(response.get("finish_reason"))
 
+        # renderers >=0.1.8.dev1 emits ParsedToolCall dataclasses (with .name,
+        # .arguments, .status, .id). Skip non-OK attempts — they're surfaced
+        # on the parsed response so trainers can inspect, but verifiers'
+        # tool-loop only acts on well-formed calls.
         tool_calls = None
-        raw_tcs = response.get("tool_calls")
-        if raw_tcs:
+        raw_tcs = response.get("tool_calls") or []
+        ok_tcs = [
+            tc
+            for tc in raw_tcs
+            if isinstance(tc, ParsedToolCall)
+            and tc.status == ToolCallParseStatus.OK
+            and tc.name
+        ]
+        if ok_tcs:
             tool_calls = [
                 ToolCall(
-                    id=f"call_{i}",
-                    name=tc["function"]["name"],
+                    id=tc.id or f"call_{i}",
+                    name=tc.name or "",
                     arguments=(
-                        tc["function"]["arguments"]
-                        if isinstance(tc["function"]["arguments"], str)
-                        else json.dumps(tc["function"]["arguments"])
+                        tc.arguments
+                        if isinstance(tc.arguments, str)
+                        else json.dumps(tc.arguments or {})
                     ),
                 )
-                for i, tc in enumerate(raw_tcs)
+                for i, tc in enumerate(ok_tcs)
             ]
 
         prompt_ids = response.get("prompt_ids", [])


### PR DESCRIPTION
## Summary

- Bumps `renderers` from `0.1.8.dev0` → `0.1.8.dev1`.
- Migrates `RendererClient.from_native_response` to the new `ParsedToolCall` dataclass shape — `parsed.tool_calls` is now `list[ParsedToolCall]` (with `.name` / `.arguments` / `.status` / `.id`) instead of `list[dict]`.
- Filters out non-OK parse attempts (`INVALID_JSON`, `UNCLOSED_BLOCK`, `MISSING_NAME`, `MALFORMED_STRUCTURE`) so malformed tool blocks never reach the tool loop; prefers each call's native id when the format carries one (Kimi K2), falling back to `call_<i>` over the OK subset.

What changed upstream in [`renderers`](https://github.com/PrimeIntellect-ai/renderers) between `0.1.8.dev0` and `0.1.8.dev1`:

- PrimeIntellect-ai/renderers#22 `feat(parsing): per-attempt ParsedToolCall with status + token spans` — the breaking change driving this PR.
- PrimeIntellect-ai/renderers#28 `fix(parsing): schema-aware tool-arg coercion for XML-style parsers` — `parse_response(token_ids, *, tools=...)`; `renderers.client.generate` already forwards the tools list, so verifiers picks this up transparently.
- PrimeIntellect-ai/renderers#18 `feat: renderer emits numpy, not torch` — `multi_modal_data` payloads now ship numpy arrays. The vLLM-side mm encoder converts at its `torch.cat` boundary; verifiers treats `multi_modal_data` as an opaque sidecar.
- PrimeIntellect-ai/renderers#21 new `LagunaXS2Renderer`; PrimeIntellect-ai/renderers#25 Qwen3.5 inline-image fix for tool responses; PrimeIntellect-ai/renderers#23 SGLang HTTP recipe; PrimeIntellect-ai/renderers#27 Apache 2.0 license; PrimeIntellect-ai/renderers#20 hatch-vcs versioning.

Compare on the renderers repo: [`renderers-v0.1.8.dev0...renderers-v0.1.8.dev1`](https://github.com/PrimeIntellect-ai/renderers/compare/renderers-v0.1.8.dev0...renderers-v0.1.8.dev1).

## Test plan

- [x] `uv run pytest tests/test_renderer_client.py` — 34 passed against renderers 0.1.8.dev1
- [x] Full suite (`tests/` minus `tests/test_envs.py` which needs `OPENAI_API_KEY`) — green
