### PR TITLE
chore: v0.1.15.dev3 dev release

### DIFF
--- a/assets/release/RELEASE_v0.1.15.dev3.md
+++ b/assets/release/RELEASE_v0.1.15.dev3.md
@@ -1,0 +1,17 @@
+# Verifiers v0.1.15.dev3 Release Notes
+
+*Date:* 05/13/2026
+
+## Highlights since v0.1.15.dev2
+
+- **OverlongPromptError no longer surfaces as a spurious interception error.** `CliAgentEnv` / `ComposableEnv` rollouts that overflow the model context now report a clean `stop=prompt_too_long` without an accompanying `InterceptionError` in the eval `errors` summary. The interception server's first-error-wins guard now also short-circuits once the rollout loop has finalized via `state["prompt_too_long"]`, so tail-end failures (e.g. `write_eof` to an agent that already closed its transport) can no longer re-attach a spurious `StreamInterrupted` on top of the real stop signal.
+- **v1 sandbox commands run as background jobs.** v1 sandbox program commands and Harbor verifier tests now run through `run_background_job` instead of foreground `execute_command`, preserving configured command/test timeouts as the background-job budget.
+
+## Changes included in v0.1.15.dev3 (since v0.1.15.dev2)
+
+### Fixes and maintenance
+
+- fix: treat OverlongPromptError as stop condition in interception proxy (#1365)
+- Use background jobs for v1 sandbox commands (#1364)
+
+**Full Changelog**: https://github.com/PrimeIntellect-ai/verifiers/compare/v0.1.15.dev2...v0.1.15.dev3

--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.15.dev2"
+__version__ = "0.1.15.dev3"
 
 import importlib
 import os


### PR DESCRIPTION
## Summary

Dev release v0.1.15.dev3.

## Highlights since v0.1.15.dev2

- **OverlongPromptError no longer surfaces as a spurious interception error** — `CliAgentEnv` / `ComposableEnv` rollouts that overflow the model context now report a clean `stop=prompt_too_long` without an accompanying `InterceptionError` in the eval `errors` summary. (#1365)
- **v1 sandbox commands run as background jobs** — v1 sandbox program commands and Harbor verifier tests now run through `run_background_job` instead of foreground `execute_command`. (#1364)

Full notes: `assets/release/RELEASE_v0.1.15.dev3.md`.

## Test plan

- [x] Bump `__version__` to `0.1.15.dev3` in `verifiers/__init__.py`
- [x] Add `assets/release/RELEASE_v0.1.15.dev3.md`
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only bumps the package version and adds release notes; no runtime behavior changes are included in this diff.
> 
> **Overview**
> Bumps `verifiers` to version `0.1.15.dev3`.
> 
> Adds `RELEASE_v0.1.15.dev3.md` documenting the dev release highlights and included fixes (OverlongPromptError handling in interception proxy, and running v1 sandbox commands/tests as background jobs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6526f64dbc47d20a9ffa619eb35c6e0fc9d4a9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->