### PR TITLE
chore: v0.1.15.dev5 dev release

### DIFF
--- a/assets/release/RELEASE_v0.1.15.dev5.md
+++ b/assets/release/RELEASE_v0.1.15.dev5.md
@@ -1,0 +1,16 @@
+# Verifiers v0.1.15.dev5 Release Notes
+
+*Date:* 05/14/2026
+
+## Highlights since v0.1.15.dev4
+
+- **Terminus2 is now a bundled v1 CLI harness.** `vf.Terminus2` runs Harbor's Terminus 2 agent behind the v1 harness boundary, is exported from `verifiers.v1` and the root `verifiers` namespace, uses OpenAI-compatible proxy defaults, and captures optional Terminus2 logs as artifacts.
+- **Harbor sandbox defaults stay explicit.** Harbor tasksets and task freezing now preserve only task-provided sandbox settings, including `network_access` only when task config explicitly sets internet access.
+
+## Changes included in v0.1.15.dev5 (since v0.1.15.dev4)
+
+### v1 harnesses and tasksets
+
+- Add Terminus2 harness (#1356)
+
+**Full Changelog**: https://github.com/PrimeIntellect-ai/verifiers/compare/v0.1.15.dev4...v0.1.15.dev5

--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.15.dev4"
+__version__ = "0.1.15.dev5"
 
 import importlib
 import os


### PR DESCRIPTION
## Summary
- Bump `verifiers.__version__` to `0.1.15.dev5`.
- Add `assets/release/RELEASE_v0.1.15.dev5.md` with notes covering changes since `v0.1.15.dev4`.
- Summarize the bundled `vf.Terminus2` harness and explicit Harbor sandbox defaults from #1356 in this dev cut.

## Testing
- `uv run ruff format verifiers/__init__.py`
- `uv run ruff check --fix verifiers/__init__.py`
- `uv run pre-commit run --files verifiers/__init__.py assets/release/RELEASE_v0.1.15.dev5.md`
- `uv run python3 -c 'import verifiers; print(verifiers.__version__)'`\n- `uv build`\n- `git push -u origin chore/v0.1.15.dev5-dev-release` (pre-push hooks: ruff check, ruff format, Semgrep v1 policy, Sync AGENTS.md from docs, ty)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only change: bumps the package version and adds release notes; no functional code paths are modified in this PR.
> 
> **Overview**
> Updates `verifiers.__version__` from `0.1.15.dev4` to `0.1.15.dev5`.
> 
> Adds `RELEASE_v0.1.15.dev5.md` documenting highlights for this dev cut (notably the bundled `vf.Terminus2` v1 harness and explicit Harbor sandbox default behavior) and linking to the full changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd4dee416b8f3e50102ee9934a0d43be24b2f015. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->