### PR TITLE
chore: v0.1.15.dev6 dev release

### DIFF
--- a/assets/release/RELEASE_v0.1.15.dev6.md
+++ b/assets/release/RELEASE_v0.1.15.dev6.md
@@ -1,0 +1,21 @@
+# Verifiers v0.1.15.dev6 Release Notes
+
+*Date:* 05/14/2026
+
+## Highlights since v0.1.15.dev5
+
+- **Routed-experts token metadata is handled as an opaque payload.** OpenAI-compatible chat and text-completions clients now preserve routed-experts data without expanding it through user-facing message types, and token parsing truncates that sidecar alongside prompt/completion tokens when a rollout is clipped to `max_seq_len`.
+- **v1 `EnvConfig` typing is stricter.** The v1 loader envelope, config docs, generated environment templates, examples, and tests now keep environment-level configuration narrow while routing taskset- and harness-owned fields through their concrete config classes.
+
+## Changes included in v0.1.15.dev6 (since v0.1.15.dev5)
+
+### Tokens and clients
+
+- Consume split routed-experts payloads in OpenAI-compatible clients (#1363)
+- Move routed-experts helpers into response utilities (#1373)
+
+### v1 config
+
+- Tighten v1 `EnvConfig` typing (#1371)
+
+**Full Changelog**: https://github.com/PrimeIntellect-ai/verifiers/compare/v0.1.15.dev5...v0.1.15.dev6

--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.15.dev5"
+__version__ = "0.1.15.dev6"
 
 import importlib
 import os


### PR DESCRIPTION
## Summary
- Bump `verifiers` to `0.1.15.dev6`.
- Add release notes for routed-experts payload handling and v1 `EnvConfig` typing.

## Validation
- `uv run pre-commit run --files verifiers/__init__.py assets/release/RELEASE_v0.1.15.dev6.md`
- `env PYTHONDONTWRITEBYTECODE=1 uv run python -c "import verifiers; print(verifiers.__version__)"`
- `uv build --out-dir /private/tmp/verifiers-dist-0.1.15.dev6`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates the package version string and adds release-note documentation, with no runtime logic changes.
> 
> **Overview**
> Updates `verifiers.__version__` to `0.1.15.dev6`.
> 
> Adds `assets/release/RELEASE_v0.1.15.dev6.md` documenting the release highlights and changelog items (routed-experts payload preservation/truncation behavior and stricter v1 `EnvConfig` typing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9769eb4e2b2035775a83c0a17d0ce210690c810. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump version to v0.1.15.dev6
> Updates `__version__` in [verifiers/__init__.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1375/files#diff-3667172df996e6596aa8d26557b92b4cb78ee7d2280a3cae14623ce4677e781e) from `0.1.15.dev5` to `0.1.15.dev6` and adds corresponding release notes in [RELEASE_v0.1.15.dev6.md](https://github.com/PrimeIntellect-ai/verifiers/pull/1375/files#diff-e82377e48f8ab38632f468915f3ece48871e212f208dc5ba48b45cd32c2a370b).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a9769eb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->