### PR TITLE
perf(save): skip backward-byte scan on hot path

### DIFF
--- a/tests/test_save_utils.py
+++ b/tests/test_save_utils.py
@@ -28,12 +28,12 @@ from verifiers.utils.metric_utils import (
 from verifiers.utils.save_utils import (
     GenerateOutputsBuilder,
     _delta_intermediate_mm_data,
-    _truncate_malformed_trailing_line,
     extract_usage_tokens,
     load_outputs,
     make_serializable,
     save_new_outputs,
     states_to_outputs,
+    truncate_malformed_trailing_line,
     validate_resume_metadata,
 )
 from verifiers.utils.usage_utils import StateUsageTracker
@@ -475,10 +475,9 @@ class TestSaveNewOutputs:
             "\n".join(lines + [malformed_trailing_line]), encoding="utf-8"
         )
 
-        # New contract: callers (the resume path) explicitly invoke the
-        # truncate once before appending; `save_new_outputs` no longer
-        # self-heals on every call.
-        _truncate_malformed_trailing_line(outputs_path)
+        # Caller drops the partial trailing row before appending so the new
+        # row lands on a valid JSONL boundary.
+        truncate_malformed_trailing_line(outputs_path)
         save_new_outputs(
             [{"example_id": 3, "label": "row-3"}],
             results_path,

--- a/tests/test_save_utils.py
+++ b/tests/test_save_utils.py
@@ -28,6 +28,7 @@ from verifiers.utils.metric_utils import (
 from verifiers.utils.save_utils import (
     GenerateOutputsBuilder,
     _delta_intermediate_mm_data,
+    _truncate_malformed_trailing_line,
     extract_usage_tokens,
     load_outputs,
     make_serializable,
@@ -474,6 +475,10 @@ class TestSaveNewOutputs:
             "\n".join(lines + [malformed_trailing_line]), encoding="utf-8"
         )
 
+        # New contract: callers (the resume path) explicitly invoke the
+        # truncate once before appending; `save_new_outputs` no longer
+        # self-heals on every call.
+        _truncate_malformed_trailing_line(outputs_path)
         save_new_outputs(
             [{"example_id": 3, "label": "row-3"}],
             results_path,

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -84,9 +84,9 @@ from verifiers.utils.save_utils import (
     save_new_outputs,
     save_outputs,
     state_to_output,
+    truncate_malformed_trailing_line,
     validate_resume_metadata,
 )
-from verifiers.utils.save_utils import _truncate_malformed_trailing_line
 from verifiers.utils.usage_utils import StateUsageTracker
 
 _MESSAGE_TYPE_UNSET = object()
@@ -1007,10 +1007,9 @@ class Environment(ABC):
                 )
                 on_log(f"Resuming evaluation from {results_path}")
                 outputs = load_outputs(results_path)
-                # A crashed prior write may have left a partial trailing row.
-                # Drop it once now so subsequent appends in save_new_outputs
-                # don't have to scan the file on every save.
-                _truncate_malformed_trailing_line(results_path / "results.jsonl")
+                # Drop any partial trailing row left by a crashed prior write
+                # so subsequent appends start from a valid JSONL boundary.
+                truncate_malformed_trailing_line(results_path / "results.jsonl")
                 builder.add_outputs(outputs)
                 filtered_inputs = filter_inputs(
                     raw_inputs, outputs, rollouts_per_example

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -86,6 +86,7 @@ from verifiers.utils.save_utils import (
     state_to_output,
     validate_resume_metadata,
 )
+from verifiers.utils.save_utils import _truncate_malformed_trailing_line
 from verifiers.utils.usage_utils import StateUsageTracker
 
 _MESSAGE_TYPE_UNSET = object()
@@ -1006,6 +1007,10 @@ class Environment(ABC):
                 )
                 on_log(f"Resuming evaluation from {results_path}")
                 outputs = load_outputs(results_path)
+                # A crashed prior write may have left a partial trailing row.
+                # Drop it once now so subsequent appends in save_new_outputs
+                # don't have to scan the file on every save.
+                _truncate_malformed_trailing_line(results_path / "results.jsonl")
                 builder.add_outputs(outputs)
                 filtered_inputs = filter_inputs(
                     raw_inputs, outputs, rollouts_per_example

--- a/verifiers/utils/save_utils.py
+++ b/verifiers/utils/save_utils.py
@@ -792,33 +792,16 @@ def _truncate_malformed_trailing_line(outputs_path: Path) -> None:
 
 
 def save_new_outputs(new_outputs: list[RolloutOutput], results_path: Path):
-    """Saves new rollout outputs to disk (in append mode)."""
-    outputs_path = results_path / "results.jsonl"
-    # Fast path: the file ends with a newline => previous append finished
-    # cleanly, no malformed trailing row to fix. We only fall back to the
-    # expensive backward-byte scan when the last byte isn't '\n', which only
-    # happens after a crashed write. The fast path is critical on networked
-    # filesystems (BeeGFS / NFS), where the byte-by-byte backward scan in
-    # `_truncate_malformed_trailing_line` is dominated by per-syscall latency
-    # and can take tens of seconds for a single large rollout payload.
-    needs_truncate = True
-    if outputs_path.exists() and outputs_path.is_file():
-        try:
-            with open(outputs_path, "rb") as f:
-                f.seek(0, 2)
-                if f.tell() == 0:
-                    needs_truncate = False
-                else:
-                    f.seek(-1, 2)
-                    if f.read(1) == b"\n":
-                        needs_truncate = False
-        except OSError:
-            # Fall back to the safe path if the cheap probe fails for any reason.
-            needs_truncate = True
-    else:
-        needs_truncate = False
-    if needs_truncate:
-        _truncate_malformed_trailing_line(outputs_path)
+    """Saves new rollout outputs to disk (in append mode).
+
+    Callers that resume from a results.jsonl that may have a partial trailing
+    row left behind by a crashed prior write must first call
+    `_truncate_malformed_trailing_line(results_path / "results.jsonl")` once
+    before the first append. We do not repeat that check on every append: the
+    backward-byte scan in `_truncate_malformed_trailing_line` does
+    O(last_line_length) syscalls and is catastrophic on networked filesystems
+    (BeeGFS / NFS).
+    """
     save_outputs(new_outputs, results_path, mode="a")
 
 

--- a/verifiers/utils/save_utils.py
+++ b/verifiers/utils/save_utils.py
@@ -794,7 +794,31 @@ def _truncate_malformed_trailing_line(outputs_path: Path) -> None:
 def save_new_outputs(new_outputs: list[RolloutOutput], results_path: Path):
     """Saves new rollout outputs to disk (in append mode)."""
     outputs_path = results_path / "results.jsonl"
-    _truncate_malformed_trailing_line(outputs_path)
+    # Fast path: the file ends with a newline => previous append finished
+    # cleanly, no malformed trailing row to fix. We only fall back to the
+    # expensive backward-byte scan when the last byte isn't '\n', which only
+    # happens after a crashed write. The fast path is critical on networked
+    # filesystems (BeeGFS / NFS), where the byte-by-byte backward scan in
+    # `_truncate_malformed_trailing_line` is dominated by per-syscall latency
+    # and can take tens of seconds for a single large rollout payload.
+    needs_truncate = True
+    if outputs_path.exists() and outputs_path.is_file():
+        try:
+            with open(outputs_path, "rb") as f:
+                f.seek(0, 2)
+                if f.tell() == 0:
+                    needs_truncate = False
+                else:
+                    f.seek(-1, 2)
+                    if f.read(1) == b"\n":
+                        needs_truncate = False
+        except OSError:
+            # Fall back to the safe path if the cheap probe fails for any reason.
+            needs_truncate = True
+    else:
+        needs_truncate = False
+    if needs_truncate:
+        _truncate_malformed_trailing_line(outputs_path)
     save_outputs(new_outputs, results_path, mode="a")
 
 

--- a/verifiers/utils/save_utils.py
+++ b/verifiers/utils/save_utils.py
@@ -769,7 +769,7 @@ def _get_last_nonempty_line_bounds(file_obj: Any) -> tuple[int, bytes] | None:
     return line_start, file_obj.read(line_end - line_start)
 
 
-def _truncate_malformed_trailing_line(outputs_path: Path) -> None:
+def truncate_malformed_trailing_line(outputs_path: Path) -> None:
     """Drop a malformed trailing JSONL row so future appends stay valid."""
     if not outputs_path.exists() or not outputs_path.is_file():
         return
@@ -792,16 +792,7 @@ def _truncate_malformed_trailing_line(outputs_path: Path) -> None:
 
 
 def save_new_outputs(new_outputs: list[RolloutOutput], results_path: Path):
-    """Saves new rollout outputs to disk (in append mode).
-
-    Callers that resume from a results.jsonl that may have a partial trailing
-    row left behind by a crashed prior write must first call
-    `_truncate_malformed_trailing_line(results_path / "results.jsonl")` once
-    before the first append. We do not repeat that check on every append: the
-    backward-byte scan in `_truncate_malformed_trailing_line` does
-    O(last_line_length) syscalls and is catastrophic on networked filesystems
-    (BeeGFS / NFS).
-    """
+    """Saves new rollout outputs to disk (in append mode)."""
     save_outputs(new_outputs, results_path, mode="a")
 
 


### PR DESCRIPTION
## Summary

`save_new_outputs` calls `truncate_malformed_trailing_line` on every append. The helper walks the file backwards one byte at a time (`seek(); read(1)` per byte) to find the previous `\n` and validate the trailing row.

That walk only matters once per run — to clean up a partial row a crashed prior write may have left behind. After the first successful append the file ends in `\n` and the walk does nothing.

On a networked filesystem (BeeGFS / NFS) each `read(1)` is a network round trip. For an ~80 KB multi-turn bfcl-v3 rollout the scan does ~80,000 syscalls per save → tens of seconds of wall-time. Because `save_new_outputs` is awaited inline via `asyncio.to_thread` inside the `as_completed` loop, the client's main coroutine parks while the scan runs and no new dispatches happen.

## Change

Hoist the truncate call out of `save_new_outputs` and run it exactly once, at the resume site in `Environment.generate`, right after `load_outputs`. Steady-state appends no longer pay the scan cost; crash recovery still works because the resume path runs it before any append.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when malformed trailing JSONL cleanup occurs (now only on resume), which could affect correctness if callers append to an existing partially-written `results.jsonl` without going through the resume path. Otherwise the change is localized and primarily performance-motivated.
> 
> **Overview**
> Speeds up incremental result saving by removing the backward byte-scan/truncation step from the hot append path in `save_new_outputs`, so steady-state `results.jsonl` appends no longer pay an O(file-size) tail check.
> 
> The malformed-trailing-line cleanup helper is promoted to public (`truncate_malformed_trailing_line`) and is now invoked once during `Environment.generate` resume (after `load_outputs`) to repair any partial final row before future appends; tests are updated to reflect that the caller performs the truncation explicitly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7f4df03f52c2963ef838e112dca0f15ff2a643c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move malformed trailing-line truncation out of `save_new_outputs` onto the call site
> - `truncate_malformed_trailing_line` is renamed from a private helper to a public function in [save_utils.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1376/files#diff-e4491159a12a733bc8861a33ba9d2d09b27942f04c4baa1629f0806efa07547d), and `save_new_outputs` no longer calls it internally.
> - [environment.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1376/files#diff-066aa9922fcaf4d3d3fc471b078fbfa64512119dbb81392b7feba435fc92c0aa) now calls `truncate_malformed_trailing_line` explicitly on `results.jsonl` during the resume-evaluation path, before appending new outputs.
> - Behavioral Change: callers of `save_new_outputs` are now responsible for ensuring a valid JSONL boundary before appending; the function itself no longer truncates.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b7f4df0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->