### PR TITLE
Fix sandbox cleanup leak paths

### DIFF
--- a/tests/test_decorator_ranks.py
+++ b/tests/test_decorator_ranks.py
@@ -336,6 +336,47 @@ class TestCleanupPriorityOrdering:
         assert env.seen_env is True
         assert env.seen_state is True
 
+    @pytest.mark.asyncio
+    async def test_cleanup_failure_does_not_skip_later_handler(self, mock_client):
+        class FailingCleanupEnv(vf.MultiTurnEnv):
+            def __init__(self, **kwargs):
+                super().__init__(max_turns=1, **kwargs)
+                self.destroyed = False
+
+            @vf.cleanup(priority=1)
+            async def failing_cleanup(self, state: State):
+                raise RuntimeError("early cleanup failed")
+
+            @vf.cleanup(priority=0)
+            async def destroy_sandbox(self, state: State):
+                self.destroyed = True
+
+            async def env_response(self, messages, state, **kwargs):
+                return []
+
+        dataset = Dataset.from_dict({"question": ["test"], "answer": ["test"]})
+        env = FailingCleanupEnv(
+            client=mock_client,
+            model="test-model",
+            dataset=dataset,
+            parser=vf.Parser(),
+            rubric=vf.Rubric(),
+        )
+        state = await env.init_state(
+            RolloutInput(
+                prompt=[{"role": "user", "content": "test"}],
+                answer="test",
+                example_id=0,
+            ),
+            client=mock_client,
+            model="test-model",
+        )
+
+        with pytest.raises(RuntimeError, match="early cleanup failed"):
+            await env.cleanup(state)
+
+        assert env.destroyed is True
+
 
 class TestTeardownPriorityOrdering:
     """Test teardown handler priority ordering."""
@@ -423,6 +464,25 @@ class TestRubricCleanupTeardown:
         rubric = MyRubric()
         asyncio.run(rubric.cleanup({"id": "a"}))
         assert rubric.cleaned == ["a"]
+
+    @pytest.mark.asyncio
+    async def test_rubric_cleanup_failure_does_not_skip_later_handler(self):
+        rubric = vf.Rubric()
+        state = {}
+
+        async def a_failing_cleanup(state: State):
+            raise RuntimeError("early rubric cleanup failed")
+
+        async def z_destroy_sandbox(state: State):
+            state["destroyed"] = True
+
+        rubric.add_cleanup_handler(a_failing_cleanup)
+        rubric.add_cleanup_handler(z_destroy_sandbox)
+
+        with pytest.raises(RuntimeError, match="early rubric cleanup failed"):
+            await rubric.cleanup(state)
+
+        assert state["destroyed"] is True
 
     def test_rubric_teardown_handlers(self):
         """Test that @vf.teardown decorated methods on a Rubric subclass are invoked."""

--- a/tests/test_sandbox_mixin.py
+++ b/tests/test_sandbox_mixin.py
@@ -1,4 +1,5 @@
 import asyncio
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -112,6 +113,55 @@ def test_create_sandbox_max_retries_is_true_retry_count():
 
     assert result == "sb-retry"
     assert obj.sandbox_client.create.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_create_sandbox_cancellation_deletes_sandbox_created_after_cancel():
+    create_started = asyncio.Event()
+    create_future = asyncio.get_running_loop().create_future()
+    delete_started = asyncio.Event()
+    allow_delete = asyncio.Event()
+
+    class FakeSandboxClient:
+        async def create(self, _request):
+            create_started.set()
+            return await create_future
+
+    class ReproMixin(SandboxMixin):
+        def __init__(self):
+            def no_retry(fn):
+                return fn
+
+            self.sandbox_client = FakeSandboxClient()
+            self.with_retry = no_retry
+            self.sandbox_creation_rate_limiter = None
+            self.active_sandboxes = set()
+            self.logger = MagicMock()
+            self.deleted = []
+
+        async def delete_sandbox(self, sandbox_id):
+            delete_started.set()
+            await allow_delete.wait()
+            self.deleted.append(sandbox_id)
+            self.deregister_sandbox(sandbox_id)
+
+    mixin = ReproMixin()
+    create = asyncio.create_task(mixin.create_sandbox({}, request=object()))
+    await create_started.wait()
+
+    create.cancel()
+    await asyncio.sleep(0)
+    create_future.set_result(SimpleNamespace(id="sb-created"))
+    await asyncio.wait_for(delete_started.wait(), timeout=1)
+
+    assert not create.done()
+
+    allow_delete.set()
+    with pytest.raises(asyncio.CancelledError):
+        await create
+
+    assert mixin.deleted == ["sb-created"]
+    assert "sb-created" not in mixin.active_sandboxes
 
 
 def test_create_sandbox_not_ready(mixin):
@@ -244,8 +294,9 @@ def test_run_background_job_command_timeout(mixin):
     )
 
     state = {"sandbox_id": "sb-1"}
-    with pytest.raises(CommandTimeoutError):
+    with pytest.raises(vf.SandboxError):
         asyncio.run(mixin.run_background_job(state, command="cmd", timeout=10))
+    assert state["sandbox_timeout"] is True
 
 
 def test_run_background_job_oom(mixin):

--- a/tests/test_threaded_sandbox_client.py
+++ b/tests/test_threaded_sandbox_client.py
@@ -1,0 +1,43 @@
+import asyncio
+import threading
+
+from verifiers.utils import threaded_sandbox_client as threaded_module
+
+
+def test_teardown_closes_per_thread_async_clients(monkeypatch):
+    ping_barrier = threading.Barrier(2)
+
+    class FakeAsyncSandboxClient:
+        instances = []
+
+        def __init__(self, **_kwargs):
+            self.closed = False
+            FakeAsyncSandboxClient.instances.append(self)
+
+        async def ping(self):
+            ping_barrier.wait(timeout=2)
+            return "pong"
+
+        async def aclose(self):
+            self.closed = True
+
+    monkeypatch.setattr(
+        threaded_module,
+        "AsyncSandboxClient",
+        FakeAsyncSandboxClient,
+    )
+
+    async def scenario():
+        client = threaded_module.ThreadedAsyncSandboxClient(max_workers=2)
+        try:
+            assert await asyncio.gather(client.ping(), client.ping()) == [
+                "pong",
+                "pong",
+            ]
+        finally:
+            client.teardown(wait=True)
+
+    asyncio.run(scenario())
+
+    assert len(FakeAsyncSandboxClient.instances) == 2
+    assert all(client.closed for client in FakeAsyncSandboxClient.instances)

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -633,14 +633,25 @@ class Environment(ABC):
         """
         Finalize rollout state and clean up rollout-local resources.
         """
+        cleanup_error: Exception | None = None
         for handler in self._cleanup_handlers:
-            await maybe_call_with_named_args(
-                handler,
-                task=task,
-                state=state,
-                env=self,
-                resources=resources,
-            )
+            try:
+                await maybe_call_with_named_args(
+                    handler,
+                    task=task,
+                    state=state,
+                    env=self,
+                    resources=resources,
+                )
+            except Exception as e:
+                if cleanup_error is None:
+                    cleanup_error = e
+                self.logger.exception(
+                    "Cleanup handler %s failed",
+                    getattr(handler, "__name__", repr(handler)),
+                )
+        if cleanup_error is not None:
+            raise cleanup_error
 
     async def _teardown(self):
         """

--- a/verifiers/envs/experimental/sandbox_mixin.py
+++ b/verifiers/envs/experimental/sandbox_mixin.py
@@ -238,16 +238,15 @@ class SandboxMixin:
         try:
             sandbox = await asyncio.shield(create_task)
         except asyncio.CancelledError:
-
-            def cleanup_created_sandbox(task: asyncio.Task):
-                try:
-                    sandbox = task.result()
-                except BaseException:
-                    return
-                self.register_sandbox(sandbox.id)
-                asyncio.create_task(self.delete_sandbox(sandbox.id))
-
-            create_task.add_done_callback(cleanup_created_sandbox)
+            try:
+                sandbox = await create_task
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                self.logger.debug(f"Sandbox create failed after cancellation: {e}")
+                raise asyncio.CancelledError from e
+            self.register_sandbox(sandbox.id)
+            await self.delete_sandbox(sandbox.id)
             raise
         except Exception as e:
             raise SandboxCreationError(f"Failed to create sandbox: {e}") from e
@@ -334,6 +333,12 @@ class SandboxMixin:
         except SandboxTimeoutError as e:
             state["sandbox_timeout"] = True
             self.logger.error(f"Sandbox timeout during background job: {repr(e)}")
+            raise vf.SandboxError() from e
+        except CommandTimeoutError as e:
+            state["sandbox_timeout"] = True
+            self.logger.error(
+                f"Sandbox command timeout during background job: {repr(e)}"
+            )
             raise vf.SandboxError() from e
 
     async def upload_file(

--- a/verifiers/rubrics/rubric.py
+++ b/verifiers/rubrics/rubric.py
@@ -293,8 +293,19 @@ class Rubric:
 
     async def cleanup(self, state: State):
         """Run all @vf.cleanup-decorated methods on this rubric."""
+        cleanup_error: Exception | None = None
         for handler in self._cleanup_handlers:
-            await self._call_cleanup_handler(handler, state)
+            try:
+                await self._call_cleanup_handler(handler, state)
+            except Exception as e:
+                if cleanup_error is None:
+                    cleanup_error = e
+                self.logger.exception(
+                    "Cleanup handler %s failed",
+                    getattr(handler, "__name__", repr(handler)),
+                )
+        if cleanup_error is not None:
+            raise cleanup_error
 
     async def _call_cleanup_handler(self, handler: Callable[..., Any], state: State):
         objects = self.cleanup_objects(handler, state)

--- a/verifiers/utils/threaded_sandbox_client.py
+++ b/verifiers/utils/threaded_sandbox_client.py
@@ -1,6 +1,7 @@
 import asyncio
 import functools
 import logging
+import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Callable
@@ -10,6 +11,7 @@ from prime_sandboxes import AsyncSandboxClient, CommandTimeoutError
 from verifiers.utils.thread_utils import (
     get_or_create_thread_attr,
     get_or_create_thread_loop,
+    get_thread_local_storage,
     register_executor,
     unregister_executor,
 )
@@ -40,6 +42,8 @@ class ThreadedAsyncSandboxClient:
             max_workers=worker_cap,
             thread_name_prefix="threaded-sandbox-client-executor",
         )
+        self._client_thread_ids: set[int] = set()
+        self._client_lock = threading.Lock()
         self.executor_name = f"threaded-sandbox-client-{id(self)}"
         register_executor(
             self.executor_name,
@@ -67,6 +71,8 @@ class ThreadedAsyncSandboxClient:
                     AsyncSandboxClient,
                     **self.client_kwargs,
                 )
+                with self._client_lock:
+                    self._client_thread_ids.add(threading.get_ident())
                 method = getattr(sandbox_client, name)
                 return loop.run_until_complete(method(*args, **kwargs))
 
@@ -99,7 +105,69 @@ class ThreadedAsyncSandboxClient:
             await asyncio.sleep(poll_interval)
         raise CommandTimeoutError(sandbox_id, command, timeout)
 
+    def _close_thread_client(
+        self,
+        barrier: threading.Barrier | None = None,
+    ) -> tuple[int, bool]:
+        if barrier is not None:
+            try:
+                barrier.wait(timeout=5.0)
+            except threading.BrokenBarrierError:
+                pass
+
+        thread_id = threading.get_ident()
+        thread_local = get_thread_local_storage()
+        sandbox_client = getattr(thread_local, "sandbox_client", None)
+        if sandbox_client is None:
+            return thread_id, False
+
+        loop = get_or_create_thread_loop()
+        try:
+            loop.run_until_complete(sandbox_client.aclose())
+        finally:
+            delattr(thread_local, "sandbox_client")
+            with self._client_lock:
+                self._client_thread_ids.discard(thread_id)
+        return thread_id, True
+
+    def _close_thread_clients(self, wait: bool) -> None:
+        with self._client_lock:
+            pending_thread_ids = set(self._client_thread_ids)
+        if not pending_thread_ids:
+            return
+
+        if not wait:
+            for _ in pending_thread_ids:
+                self.executor.submit(self._close_thread_client)
+            return
+
+        # Close from the owning worker thread so AsyncSandboxClient uses its
+        # original event loop while releasing keepalive sockets.
+        for _ in range(3):
+            if not pending_thread_ids:
+                break
+            barrier = threading.Barrier(len(pending_thread_ids))
+            futures = [
+                self.executor.submit(self._close_thread_client, barrier)
+                for _ in pending_thread_ids
+            ]
+            for future in futures:
+                try:
+                    thread_id, closed = future.result()
+                except Exception:
+                    self.logger.exception("Failed to close sandbox client in worker")
+                    continue
+                if closed:
+                    pending_thread_ids.discard(thread_id)
+
+        if pending_thread_ids:
+            self.logger.warning(
+                "Failed to close sandbox clients in %d worker thread(s)",
+                len(pending_thread_ids),
+            )
+
     def teardown(self, wait: bool = True) -> None:
         """Teardown the thread pool executor."""
         unregister_executor(self.executor_name)
+        self._close_thread_clients(wait=wait)
         self.executor.shutdown(wait=wait)


### PR DESCRIPTION
## Summary

Fixes four sandbox cleanup weak spots with focused fake-backed repro tests, without requiring real remote sandboxes or model inference.

1. `ThreadedAsyncSandboxClient.teardown()` now closes each worker thread's thread-local `AsyncSandboxClient` with `aclose()` before executor shutdown, so keepalive sockets/fds are not left to interpreter teardown.
2. `SandboxMixin.create_sandbox()` now handles cancellation during an in-flight `create()` by waiting for the shielded create result and deleting any sandbox that was created before re-raising cancellation, instead of scheduling an untracked orphan delete task.
3. `Environment.cleanup()` and `Rubric.cleanup()` now attempt all cleanup handlers and then re-raise the first cleanup failure, so later cleanup handlers such as sandbox destruction are not skipped.
4. `SandboxMixin.run_background_job()` now classifies `prime_sandboxes.CommandTimeoutError` as a sandbox timeout: it sets `state["sandbox_timeout"] = True` and raises `vf.SandboxError` consistently with `SandboxTimeoutError`.

## Tests / Repros Added

- `tests/test_threaded_sandbox_client.py::test_teardown_closes_per_thread_async_clients`
  - Forces two worker threads with fake async clients and asserts both clients receive `aclose()` during teardown.
- `tests/test_sandbox_mixin.py::test_create_sandbox_cancellation_deletes_sandbox_created_after_cancel`
  - Cancels while `create()` is pending, returns a fake sandbox after cancellation, blocks fake deletion, and asserts cancellation does not finish until deletion is drained.
- `tests/test_decorator_ranks.py::TestCleanupPriorityOrdering::test_cleanup_failure_does_not_skip_later_handler`
  - Proves an environment cleanup handler that raises does not skip a later destroy-style handler.
- `tests/test_decorator_ranks.py::TestRubricCleanupTeardown::test_rubric_cleanup_failure_does_not_skip_later_handler`
  - Proves a rubric cleanup handler that raises does not skip a later destroy-style handler.
- Updated `tests/test_sandbox_mixin.py::test_run_background_job_command_timeout`
  - Proves command timeouts set `sandbox_timeout` and raise `vf.SandboxError`.

## Validation

```bash
/usr/bin/env -u PRIME_API_KEY -u PRIME_TEAM_ID -u PRIME_ORG_ID -u PRIME_SANDBOX_API_KEY -u VIRTUAL_ENV \
  uv run --no-env-file pytest tests/test_threaded_sandbox_client.py tests/test_sandbox_mixin.py tests/test_decorator_ranks.py -q

/usr/bin/env -u VIRTUAL_ENV \
  uv run --no-env-file ruff check verifiers/utils/threaded_sandbox_client.py verifiers/envs/experimental/sandbox_mixin.py verifiers/envs/environment.py verifiers/rubrics/rubric.py tests/test_threaded_sandbox_client.py tests/test_sandbox_mixin.py tests/test_decorator_ranks.py

git diff --check
```

Local pre-push hooks also passed: ruff check, ruff format, Semgrep v1 policy, Sync AGENTS.md, and ty (ci parity).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix sandbox cleanup leak paths by continuing after handler failures and closing per-thread clients on teardown
> - `Environment.cleanup` and `Rubric.cleanup` now catch exceptions from individual handlers, log them, continue running remaining handlers, and re-raise only the first exception after all handlers complete.
> - `ThreadedAsyncSandboxClient` tracks which worker threads have created per-thread `AsyncSandboxClient` instances and closes them during `teardown`, preventing connection leaks on shutdown.
> - `SandboxMixin.run_background_job` now catches `CommandTimeoutError`, sets `state['sandbox_timeout'] = True`, and raises `vf.SandboxError` instead of propagating the raw timeout error.
> - Behavioral Change: cleanup methods previously stopped at the first failure; now all handlers always run, which may surface previously hidden errors in later handlers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 246bf91.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches async cancellation, cleanup ordering, and threaded client teardown, which can subtly affect error propagation and resource lifecycle under load. Changes are well-covered by new repro tests but could surface previously masked cleanup failures.
> 
> **Overview**
> Fixes several sandbox/resource leak edge cases by making cleanup and teardown more robust under failures and cancellation.
> 
> `Environment.cleanup()` and `Rubric.cleanup()` now **run all cleanup handlers even if earlier ones raise**, logging failures and re-raising the first error afterward so later handlers (e.g., sandbox destruction) still execute.
> 
> `SandboxMixin.create_sandbox()` now ensures **cancellation during sandbox creation still deletes any sandbox created after the cancel**, and `run_background_job()` now treats `CommandTimeoutError` as a sandbox timeout (`state["sandbox_timeout"]=True`) while raising `vf.SandboxError` consistently.
> 
> `ThreadedAsyncSandboxClient.teardown()` now tracks per-thread `AsyncSandboxClient` instances and **closes them via `aclose()` before executor shutdown**; new focused tests cover each repro scenario (cleanup failure ordering, cancellation cleanup, command timeout classification, and per-thread client closure).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 246bf9148eb2e90c3061b0b57728bfadbf09a10b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->