### PR TITLE
Add example disregard terminal handling

### DIFF
--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -697,6 +697,37 @@ class TestMaybeRetry:
         error_info = rollout_outputs[0]["error"]
         assert "InfraError" == error_info["error"]
 
+    @pytest.mark.asyncio
+    async def test_example_disregard_drops_group_without_retry(
+        self, mock_client, make_input
+    ):
+        """ExampleDisregardError drops the whole group instead of retrying it."""
+        dataset = Dataset.from_dict({"question": ["test"], "answer": ["test"]})
+        env = RetryCounterEnv(
+            fail_count=0, dataset=dataset, parser=Parser(), rubric=Rubric()
+        )
+        score_calls = 0
+
+        async def score_group(states):
+            nonlocal score_calls
+            score_calls += 1
+            states[0]["error"] = vf.ExampleDisregardError("example drifted")
+
+        env.rubric.score_group = score_group  # type: ignore[method-assign]
+
+        inputs = [make_input(example_id=0), make_input(example_id=0)]
+        with patch("verifiers.utils.async_utils.logger.warning") as mock_warning:
+            outputs = await env.generate(
+                inputs, client=mock_client, model="test-model", max_retries=3
+            )
+
+        assert outputs["outputs"] == []
+        assert env.call_counts[0] == 2
+        assert score_calls == 1
+        warning = mock_warning.call_args[0][0]
+        assert "ExampleDisregardError" in warning
+        assert "Returning result without retry" in warning
+
 
 class TestEmptyModelResponseErrors:
     """Test cases for empty and invalid model response error handling."""

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -68,6 +68,7 @@ from verifiers.types import (
     flatten_task_input,
 )
 from verifiers.utils.async_utils import (
+    find_error_in_state,
     maybe_call_with_named_args,
     maybe_retry,
     maybe_semaphore,
@@ -825,7 +826,13 @@ class Environment(ABC):
                 sampling_args,
             )
 
-        group_states = await maybe_retry(run_group_attempt, max_retries=max_retries)()
+        group_states = await maybe_retry(
+            run_group_attempt,
+            max_retries=max_retries,
+            terminal_error_types=(vf.ExampleDisregardError,),
+        )()
+        if find_error_in_state(group_states, (vf.ExampleDisregardError,)) is not None:
+            return []
         outputs = [
             state_to_output(state, state_columns or []) for state in group_states
         ]

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -828,7 +828,6 @@ class Environment(ABC):
         group_states = await maybe_retry(
             run_group_attempt,
             max_retries=max_retries,
-            terminal_error_types=(vf.ExampleDisregardError,),
             on_terminal=lambda _states, _error: [],
         )()
         outputs = [

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -68,7 +68,6 @@ from verifiers.types import (
     flatten_task_input,
 )
 from verifiers.utils.async_utils import (
-    find_error_in_state,
     maybe_call_with_named_args,
     maybe_retry,
     maybe_semaphore,
@@ -830,9 +829,8 @@ class Environment(ABC):
             run_group_attempt,
             max_retries=max_retries,
             terminal_error_types=(vf.ExampleDisregardError,),
+            on_terminal=lambda _states, _error: [],
         )()
-        if find_error_in_state(group_states, (vf.ExampleDisregardError,)) is not None:
-            return []
         outputs = [
             state_to_output(state, state_columns or []) for state in group_states
         ]

--- a/verifiers/errors.py
+++ b/verifiers/errors.py
@@ -50,6 +50,12 @@ class InfraError(Error):
     pass
 
 
+class ExampleDisregardError(Error):
+    """Used to drop an ungradeable example group without retrying."""
+
+    pass
+
+
 class TunnelError(InfraError):
     """Raised when a tunnel process dies or becomes unreachable."""
 

--- a/verifiers/utils/async_utils.py
+++ b/verifiers/utils/async_utils.py
@@ -157,7 +157,7 @@ def maybe_retry(
         vf.InfraError,
         vf.InvalidModelResponseError,
     ),
-    terminal_error_types: tuple[type[Exception], ...] = (),
+    terminal_error_types: tuple[type[Exception], ...] = (vf.ExampleDisregardError,),
     on_terminal: Callable[[T, Exception], T] | None = None,
 ) -> Callable[..., Coroutine[Any, Any, T]]:
     """

--- a/verifiers/utils/async_utils.py
+++ b/verifiers/utils/async_utils.py
@@ -158,6 +158,7 @@ def maybe_retry(
         vf.InvalidModelResponseError,
     ),
     terminal_error_types: tuple[type[Exception], ...] = (),
+    on_terminal: Callable[[T, Exception], T] | None = None,
 ) -> Callable[..., Coroutine[Any, Any, T]]:
     """
     Return retry-wrapped function if max_retries > 0, else return func unchanged.
@@ -222,6 +223,8 @@ def maybe_retry(
         terminal_error = find_error_in_state(result, terminal_error_types)
         if terminal_error is not None:
             log_terminal(terminal_error)
+            if on_terminal is not None:
+                return on_terminal(result, terminal_error)
             return result
         if max_retries > 0:
             retry_error = find_error_in_state(result, retry_error_types)

--- a/verifiers/utils/async_utils.py
+++ b/verifiers/utils/async_utils.py
@@ -5,7 +5,7 @@ from collections import deque
 from collections.abc import Mapping
 from collections.abc import Coroutine
 from time import perf_counter
-from typing import Any, AsyncContextManager, Callable, Optional, TypeVar
+from typing import Any, AsyncContextManager, Callable, Optional, TypeVar, cast
 
 import numpy as np
 import tenacity as tc
@@ -153,10 +153,11 @@ def maybe_retry(
     max_retries: int = 0,
     initial: float = 1.0,
     max_wait: float = 60.0,
-    error_types: tuple[type[Exception], ...] = (
+    retry_error_types: tuple[type[Exception], ...] = (
         vf.InfraError,
         vf.InvalidModelResponseError,
     ),
+    terminal_error_types: tuple[type[Exception], ...] = (),
 ) -> Callable[..., Coroutine[Any, Any, T]]:
     """
     Return retry-wrapped function if max_retries > 0, else return func unchanged.
@@ -166,28 +167,8 @@ def maybe_retry(
     Usage:
         state = await maybe_retry(self.run_rollout, max_retries=3)(input, client, ...)
     """
-    if max_retries <= 0:
+    if max_retries <= 0 and not terminal_error_types:
         return func
-
-    def reraise_error_from_state(result, error_types: tuple[type[Exception], ...]):
-        """Re-raise specified errors from state(s) to trigger tenacity retry."""
-        if isinstance(result, dict):
-            err = result.get("error")
-            if err and any(isinstance(err, err_type) for err_type in error_types):
-                raise err
-            if isinstance(err, Mapping):
-                retry_error = error_info_to_exception(err, error_types)
-                if retry_error is not None:
-                    raise retry_error
-        elif isinstance(result, list):
-            for state in result:
-                err = state.get("error")
-                if err and any(isinstance(err, err_type) for err_type in error_types):
-                    raise err
-                if isinstance(err, Mapping):
-                    retry_error = error_info_to_exception(err, error_types)
-                    if retry_error is not None:
-                        raise retry_error
 
     def log_retry(retry_state: tc.RetryCallState) -> None:
         """Log a warning with the exception and the number of attempts."""
@@ -204,6 +185,14 @@ def maybe_retry(
         next_action = retry_state.next_action.sleep if retry_state.next_action else 0
         logger.warning(
             f"Caught {error_chain} in {caller}. Retrying in {print_time(next_action)} (retry {retry_state.attempt_number}/{max_retries})"
+        )
+
+    def log_terminal(error: Exception) -> None:
+        """Log a warning when a terminal error stops retries."""
+        caller = getattr(func, "__name__", "unknown function")
+        error_chain = repr(ErrorChain(error))
+        logger.warning(
+            f"Caught {error_chain} in {caller}. Returning result without retry."
         )
 
     last_result = None
@@ -230,17 +219,53 @@ def maybe_retry(
         nonlocal last_result
         result = await func(*args, **kwargs)
         last_result = result  # store result
-        reraise_error_from_state(result, error_types)
+        terminal_error = find_error_in_state(result, terminal_error_types)
+        if terminal_error is not None:
+            log_terminal(terminal_error)
+            return result
+        if max_retries > 0:
+            retry_error = find_error_in_state(result, retry_error_types)
+            if retry_error is not None:
+                raise retry_error
         return result
 
     wrapper.__name__ = getattr(func, "__name__", "unknown")
     wrapper.__qualname__ = getattr(func, "__qualname__", "unknown")
 
+    if max_retries <= 0:
+        return wrapper
+
     return tc.AsyncRetrying(
-        retry=tc.retry_if_exception_type(error_types),
+        retry=tc.retry_if_exception_type(retry_error_types),
         stop=tc.stop_after_attempt(max_retries + 1),
         wait=tc.wait_exponential_jitter(initial=initial, max=max_wait),
         before_sleep=log_retry,
         retry_error_callback=return_last_result,
         reraise=True,
     ).wraps(wrapper)
+
+
+def find_error_in_state(
+    result: Any,
+    error_types: tuple[type[Exception], ...],
+) -> Exception | None:
+    """Return the first matching error from a state or list of states."""
+
+    def match_error(err: object) -> Exception | None:
+        if isinstance(err, Exception) and any(
+            isinstance(err, err_type) for err_type in error_types
+        ):
+            return err
+        if isinstance(err, Mapping):
+            return error_info_to_exception(cast(Mapping[str, object], err), error_types)
+        return None
+
+    if isinstance(result, dict):
+        return match_error(result.get("error"))
+    elif isinstance(result, list):
+        for state in result:
+            if isinstance(state, dict):
+                matched = match_error(state.get("error"))
+                if matched is not None:
+                    return matched
+    return None


### PR DESCRIPTION
## Summary

- Add `vf.ExampleDisregard` as a non-infra signal for ungradeable examples.
- Extend `maybe_retry` with `retry_error_types` and `terminal_error_types`
- Treat `ExampleDisregard` as terminal in grouped generation and return an empty group so the example is not retried or emitted to the trainer.
- Add focused coverage showing a disregarded group is dropped without retry.

## Validation

- `.venv/bin/python -m pytest tests/test_environment.py::TestMaybeRetry -q`
- `.venv/bin/python -m pytest tests/test_environment.py -q`
- `.venv/bin/python -m ruff check verifiers/errors.py verifiers/utils/async_utils.py verifiers/envs/environment.py tests/test_environment.py`
- `uv run pre-commit run --files verifiers/errors.py verifiers/utils/async_utils.py verifiers/envs/environment.py tests/test_environment.py`
- pre-push hooks: ruff, format, AGENTS sync, ty ci parity

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `ExampleDisregardError` terminal error handling to drop ungradeable example groups without retry
> - Adds a new `ExampleDisregardError` class in [`verifiers/errors.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1382/files#diff-1a63e3834df0345e5df7fae38d22291a0a93ef0aa144b1c66c0fe2ffcc4500c0) to signal that an example group is ungradeable and should be dropped.
> - Refactors `maybe_retry` in [`verifiers/utils/async_utils.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1382/files#diff-5e5c0a475b1277fb889a3c5958da1b55d5dc86df6eed010149e9ec0208d57fea): renames `error_types` to `retry_error_types`, adds `terminal_error_types` (defaulting to `ExampleDisregardError`), and introduces an optional `on_terminal` callback.
> - Updates the group attempt runner in [`verifiers/envs/environment.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1382/files#diff-066aa9922fcaf4d3d3fc471b078fbfa64512119dbb81392b7feba435fc92c0aa) to pass `on_terminal=lambda _states, _error: []`, so terminal errors drop the group by returning an empty state list instead of retrying.
> - Behavioral Change: `maybe_retry` now wraps calls even when `max_retries<=0` to handle terminal errors; terminal errors log a warning and short-circuit rather than triggering retries.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eaede12.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes grouped generation retry semantics by dropping entire groups on `ExampleDisregardError`, which can affect output counts and downstream training/eval behavior. Retry logic is generalized, so misclassification of terminal vs retryable errors could lead to unexpected non-retries.
> 
> **Overview**
> Introduces `ExampleDisregardError` to signal an *ungradeable* example group that should be **dropped** rather than retried.
> 
> Extends `maybe_retry` to support separate `retry_error_types` vs `terminal_error_types`, adding `find_error_in_state` and a terminal-path warning; `Environment.run_group` now treats `ExampleDisregardError` as terminal and returns an empty group output.
> 
> Adds a focused async test ensuring a group marked with `ExampleDisregardError` emits no outputs and does not retry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1761108f07e4f42b8278f9bea73b693bee6ee79f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->