### PR TITLE
fix(renderer_client): access ParsedToolCall via dataclass attrs

### DIFF
--- a/verifiers/clients/renderer_client.py
+++ b/verifiers/clients/renderer_client.py
@@ -22,6 +22,7 @@ from renderers import (
     RenderedTokens,
     Renderer,
     RendererPool,
+    ToolCallParseStatus,
     ToolSpec,
     create_renderer_pool,
     is_multimodal,
@@ -612,18 +613,23 @@ class RendererClient(
         tool_calls = None
         raw_tcs = response.get("tool_calls")
         if raw_tcs:
+            # Drop malformed parses (INVALID_JSON / UNCLOSED_BLOCK / ...) —
+            # `ToolCall` requires non-null `name`/`arguments`, and the renderer
+            # client itself only promotes finish_reason to "tool_calls" when at
+            # least one OK call is present (renderers/client.py).
             tool_calls = [
                 ToolCall(
-                    id=f"call_{i}",
-                    name=tc["function"]["name"],
+                    id=tc.id or f"call_{i}",
+                    name=tc.name,
                     arguments=(
-                        tc["function"]["arguments"]
-                        if isinstance(tc["function"]["arguments"], str)
-                        else json.dumps(tc["function"]["arguments"])
+                        tc.arguments
+                        if isinstance(tc.arguments, str)
+                        else json.dumps(tc.arguments)
                     ),
                 )
                 for i, tc in enumerate(raw_tcs)
-            ]
+                if tc.status == ToolCallParseStatus.OK
+            ] or None
 
         prompt_ids = response.get("prompt_ids", [])
         completion_ids = response.get("completion_ids", [])


### PR DESCRIPTION
## Summary

The renderer client's `from_native_response` was still treating each entry in `response["tool_calls"]` as an OpenAI-shaped dict (`tc["function"]["name"]`). But `renderers>=0.1.8.dev0` — which this package pins, and which `renderer_client.py` requires for `MultimodalRenderer` / `is_multimodal` — returns `parsed.tool_calls` as a list of `ParsedToolCall` dataclass instances. Every renderer-mode rollout that produced a tool call therefore raised:

```
TypeError: 'ParsedToolCall' object is not subscriptable
```

which the env wrapped into `ModelError(...) -> TypeError(...)` and aborted.

After switching to attribute access, a second issue surfaced: `ParsedToolCall.name` is `Optional[str]` (it's `None` for malformed parses like `INVALID_JSON` / `UNCLOSED_BLOCK`), but verifiers' `ToolCall` model requires non-null strings:

```
1 validation error for ToolCall
arguments
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
```

This change:

- Accesses `tc.name` / `tc.arguments` directly, and uses the parser's native `tc.id` when present (e.g. Kimi K2's native tool-call ids), falling back to the synthesized `call_{i}` otherwise.
- Filters to `status == ToolCallParseStatus.OK` before constructing `ToolCall`. This mirrors `renderers/client.py` itself, which only promotes `finish_reason` to `"tool_calls"` when there is at least one OK call. Malformed attempts are intentionally surfaced on `parsed.tool_calls` (per the dataclass docstring, for trainer-side selective loss masking), but they shouldn't be forwarded to verifiers' tool-execution layer.

Reproduced on a Nemotron-3-Nano-30B-A3B RL run with the `nemotron-3` renderer; rollouts started succeeding once both shapes were handled.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `RendererClient.from_native_response` to access `ParsedToolCall` fields via dataclass attributes
> Updates tool call parsing in [renderer_client.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1385/files#diff-4309037b1656944b1991edc5baa1d16760d74155d7adc9fef41a2080ce8605e1) to read `id`, `name`, `arguments`, and `status` directly from `ParsedToolCall` dataclass attributes instead of treating them as dicts with a nested `function` field.
>
> - Filters tool calls to only include those with `ToolCallParseStatus.OK`, dropping malformed parses, and sets `tool_calls` to `None` when none pass.
> - Preserves provided tool call IDs when present, falling back to a generated `call_i` ID.
> - Behavioral Change: `Response.message.tool_calls` now excludes any tool calls that did not parse successfully.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 209711f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->