### PR TITLE
improvement: switch verifiers PyPI publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -85,14 +85,7 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
 
-  # ---------------------------------------------------------------------------
-  # Auto-tag flow: build → publish → github-release. Build runs untrusted code
-  # (uv build, build-time deps) without `id-token: write` so a poisoned build
-  # dep cannot mint the OIDC token and impersonate the PyPI publishing identity.
-  # The OIDC job only downloads the prebuilt artifact and runs the pinned
-  # pypa publish action. The github-release job has `contents: write` but no
-  # OIDC, so its blast radius is also bounded.
-  # ---------------------------------------------------------------------------
+  # Auto-tag flow: build (no OIDC) → publish (OIDC only) → github-release.
   build-from-auto-tag:
     needs: auto-tag-on-main
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.auto-tag-on-main.outputs.created == 'true'
@@ -169,9 +162,7 @@ jobs:
           files: |
             dist/*
 
-  # ---------------------------------------------------------------------------
-  # Manual / pushed-tag flow: same three-job split as above.
-  # ---------------------------------------------------------------------------
+  # Manual / pushed-tag flow: same three-job split.
   build-tag:
     if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -85,26 +85,29 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
 
-  release-from-auto-tag:
+  # ---------------------------------------------------------------------------
+  # Auto-tag flow: build → publish → github-release. Build runs untrusted code
+  # (uv build, build-time deps) without `id-token: write` so a poisoned build
+  # dep cannot mint the OIDC token and impersonate the PyPI publishing identity.
+  # The OIDC job only downloads the prebuilt artifact and runs the pinned
+  # pypa publish action. The github-release job has `contents: write` but no
+  # OIDC, so its blast radius is also bounded.
+  # ---------------------------------------------------------------------------
+  build-from-auto-tag:
     needs: auto-tag-on-main
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.auto-tag-on-main.outputs.created == 'true'
     runs-on: ubuntu-latest
-    environment: pypi-prod
     permissions:
-      contents: write
-      id-token: write
+      contents: read
+    outputs:
+      tag: ${{ needs.auto-tag-on-main.outputs.tag }}
+      version: ${{ needs.auto-tag-on-main.outputs.version }}
     steps:
       - name: Checkout auto-created tag
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: refs/tags/${{ needs.auto-tag-on-main.outputs.tag }}
-
-      - name: Set release metadata
-        id: release
-        run: |
-          echo "tag=${{ needs.auto-tag-on-main.outputs.tag }}" >> "$GITHUB_OUTPUT"
-          echo "version=${{ needs.auto-tag-on-main.outputs.version }}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -117,24 +120,66 @@ jobs:
       - name: Build sdist and wheel
         run: uv build
 
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+          retention-days: 7
+
+  publish-from-auto-tag:
+    needs: build-from-auto-tag
+    runs-on: ubuntu-latest
+    environment: pypi-prod
+    permissions:
+      id-token: write
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+
+  github-release-from-auto-tag:
+    needs: [build-from-auto-tag, publish-from-auto-tag]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout auto-created tag
+        uses: actions/checkout@v4
+        with:
+          ref: refs/tags/${{ needs.build-from-auto-tag.outputs.tag }}
+
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.release.outputs.tag }}
-          body_path: assets/release/RELEASE_${{ steps.release.outputs.tag }}.md
+          tag_name: ${{ needs.build-from-auto-tag.outputs.tag }}
+          body_path: assets/release/RELEASE_${{ needs.build-from-auto-tag.outputs.tag }}.md
           files: |
             dist/*
 
-  tag-and-release:
+  # ---------------------------------------------------------------------------
+  # Manual / pushed-tag flow: same three-job split as above.
+  # ---------------------------------------------------------------------------
+  build-tag:
     if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
-    environment: pypi-prod
     permissions:
-      contents: write
-      id-token: write
+      contents: read
+    outputs:
+      tag: ${{ steps.release.outputs.tag }}
+      version: ${{ steps.release.outputs.version }}
     steps:
       - name: Checkout tagged release (dispatch)
         if: github.event_name == 'workflow_dispatch'
@@ -208,13 +253,51 @@ jobs:
       - name: Build sdist and wheel
         run: uv build
 
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+          retention-days: 7
+
+  publish-tag:
+    needs: build-tag
+    runs-on: ubuntu-latest
+    environment: pypi-prod
+    permissions:
+      id-token: write
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+
+  github-release-tag:
+    needs: [build-tag, publish-tag]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout tag
+        uses: actions/checkout@v4
+        with:
+          ref: refs/tags/${{ needs.build-tag.outputs.tag }}
+
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.release.outputs.tag }}
-          body_path: assets/release/RELEASE_${{ steps.release.outputs.tag }}.md
+          tag_name: ${{ needs.build-tag.outputs.tag }}
+          body_path: assets/release/RELEASE_${{ needs.build-tag.outputs.tag }}.md
           files: |
             dist/*

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -89,8 +89,10 @@ jobs:
     needs: auto-tag-on-main
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.auto-tag-on-main.outputs.created == 'true'
     runs-on: ubuntu-latest
+    environment: pypi-prod
     permissions:
       contents: write
+      id-token: write
     steps:
       - name: Checkout auto-created tag
         uses: actions/checkout@v4
@@ -116,9 +118,7 @@ jobs:
         run: uv build
 
       - name: Publish to PyPI
-        env:
-          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-        run: uv publish --token "$PYPI_TOKEN"
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
@@ -131,8 +131,10 @@ jobs:
   tag-and-release:
     if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
+    environment: pypi-prod
     permissions:
       contents: write
+      id-token: write
     steps:
       - name: Checkout tagged release (dispatch)
         if: github.event_name == 'workflow_dispatch'
@@ -207,9 +209,7 @@ jobs:
         run: uv build
 
       - name: Publish to PyPI
-        env:
-          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-        run: uv publish --token "$PYPI_TOKEN"
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/assets/release/release_workflow.md
+++ b/assets/release/release_workflow.md
@@ -11,14 +11,14 @@ version and finishes cleanly.
   - Updated release notes in `assets/release/RELEASE_vX.Y.Z.md`.
   - Any ancillary artifacts or documentation updates that belong with the release.
 - Verify CI is green on the commit you intend to tag.
-- Confirm the organization secret `PYPI_TOKEN` is configured with publish permissions for the project.
+- Confirm the `verifiers` project on PyPI has a Trusted Publisher configured for repository `PrimeIntellect-ai/verifiers`, workflow `tag-and-release.yml`, environment `pypi-prod`. The publish job authenticates via OIDC — no PyPI token is required for `verifiers`.
 
 ## Triggering the workflow
 
 1. From `main`, create an annotated tag that matches the version string (for example `git tag -a v0.1.4 -m "Release v0.1.4"`).
 2. Push the tag to GitHub with `git push origin v0.1.4`. The push is the only automatic trigger for the workflow, so each
    version runs exactly once.
-3. Watch the **Actions → Tag and Release** run to confirm `uv build`, `uv publish`, and the GitHub Release creation succeed.
+3. Watch the **Actions → Tag and Release** run to confirm `uv build`, the PyPI publish (via `pypa/gh-action-pypi-publish` using OIDC), and the GitHub Release creation succeed. The job runs in the `pypi-prod` environment.
 
 > Optional: To republish an older tag without pushing again, start **Actions → Tag and Release** manually and provide the
 > existing tag (for example `v0.1.4`). The job checks out that tag and performs the same build and publish steps.


### PR DESCRIPTION
- Both publish jobs in `tag-and-release.yml` now run in the `pypi-prod` environment with `id-token: write`
- Replaced `uv publish --token "$PYPI_TOKEN"` with `pypa/gh-action-pypi-publish` pinned to a commit SHA (v1.14.0)
- Updated `assets/release/release_workflow.md` to describe the OIDC flow

`verifiers-rl` continues to use `PYPI_TOKEN` for now; the secret stays until that workflow is migrated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release pipeline and PyPI publishing authentication; misconfiguration or artifact handoff issues could break releases, but the scope is limited to GitHub Actions workflow logic.
> 
> **Overview**
> Refactors `.github/workflows/tag-and-release.yml` to split both the auto-tag and pushed/manual tag release paths into **three jobs**: `build` (no OIDC), `publish` (OIDC-only in `pypi-prod`), and `github-release`, passing `dist/` via `upload-artifact`/`download-artifact`.
> 
> Switches PyPI publishing from `uv publish` with `PYPI_TOKEN` to pinned `pypa/gh-action-pypi-publish@v1.14.0`, and updates `assets/release/release_workflow.md` to document the Trusted Publisher/OIDC setup and new release checklist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41f8c429905430b325cb2ad48fdfecd06b01c54b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Switch verifiers PyPI publishing to OIDC trusted publishing via `pypa/gh-action-pypi-publish`
> - Splits the release workflow in [tag-and-release.yml](.github/workflows/tag-and-release.yml) into three jobs for both auto-tag and manual flows: a build job, a dedicated PyPI publish job, and a GitHub Release job.
> - The publish job uses `pypa/gh-action-pypi-publish` with OIDC (`id-token` permission, `pypi-prod` environment) instead of `uv publish` with a secret token.
> - Built distributions are passed between jobs via GitHub Actions artifact upload/download.
> - Updates [release_workflow.md](https://github.com/PrimeIntellect-ai/verifiers/pull/1386/files#diff-afa8f8577824b9ffe14535fd46f59b0deffe1cb29a0778053f61b813da9dfa94) to document the new PyPI Trusted Publisher prerequisite.
> - Behavioral Change: PyPI publishing no longer requires a stored API token; a Trusted Publisher configuration must be set up in PyPI for the repository, workflow, and environment before releases will succeed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 41f8c42.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->