### PR TITLE
Document eval name labels in skill

### DIFF
--- a/skills/evaluate-environments/SKILL.md
+++ b/skills/evaluate-environments/SKILL.md
@@ -97,6 +97,7 @@ prime eval run owner/my-env -m openai/gpt-4.1-mini -n 200 -r 3 -s
 prime eval run configs/eval/my-benchmark.toml
 ```
 3. Make config files the default for benchmark sweeps, multi-model comparisons, and recurring reports.
+4. Use `name` on individual `[[eval]]` entries when the same environment appears multiple times. `id` selects the environment to load; `name` labels the run in displays, summaries, metadata, and saved result paths.
 
 ## Common Evaluation Patterns
 1. Override v1 taskset and harness config through explicit child sections:
@@ -127,18 +128,34 @@ prime eval run my-env -s -o /path/to/output
 ```bash
 prime eval run configs/eval/my-benchmark.toml
 ```
-8. Pass extra HTTP headers via CLI (repeatable):
+8. Run the same environment more than once with different args by giving each entry a `name`:
+```toml
+[[eval]]
+id = "reverse-text"
+name = "reverse-text-short"
+
+[eval.args]
+max_length = 32
+
+[[eval]]
+id = "reverse-text"
+name = "reverse-text-long"
+
+[eval.args]
+max_length = 256
+```
+9. Pass extra HTTP headers via CLI (repeatable):
 ```bash
 prime eval run my-env -m my-proxy --header "X-Custom-Header: value"
 ```
-9. Set headers in `[[eval]]` TOML configs as a table or list (merge order: registry row < `headers` table < `header` list / `--header`):
+10. Set headers in `[[eval]]` TOML configs as a table or list (merge order: registry row < `headers` table < `header` list / `--header`):
 ```toml
 [[eval]]
 env_id = "my-env"
 headers = { "X-Custom-Header" = "value" }
 header = ["X-Another: val"]
 ```
-10. Run ablation sweeps using `[[ablation]]` blocks in TOML configs:
+11. Run ablation sweeps using `[[ablation]]` blocks in TOML configs:
 ```toml
 [[ablation]]
 env_id = "my-env"


### PR DESCRIPTION
## Summary
- document the new [[eval]].name field in the evaluate-environments skill
- add the duplicate-environment naming pattern for alternate args

## Validation
- uv run pre-commit run --files skills/evaluate-environments/SKILL.md
- git diff --check HEAD~1..HEAD

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes that clarify TOML config usage without affecting runtime behavior.
> 
> **Overview**
> Updates `skills/evaluate-environments/SKILL.md` to document the new `[[eval]].name` field and its distinction from `id`, including how `name` affects displayed labels, metadata, and saved result paths.
> 
> Adds a concrete TOML example showing how to run the same environment multiple times with different `[eval.args]` by assigning unique `name`s, and renumbers subsequent “Common Evaluation Patterns” items accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 359117458d895a189614a336ceecaa8abe798016. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document `name` label usage for repeated `[[eval]]` entries in skill guide
> Updates [SKILL.md](https://github.com/PrimeIntellect-ai/verifiers/pull/1388/files#diff-36d08ee11d380ecaa5beacd5b98cd8bfa0791dfa784b93956b128cafc58dbe0d) to explain how to use `name` on individual `[[eval]]` entries when the same environment appears multiple times in a config. Adds a concrete TOML example showing two `[[eval]]` blocks with `id = "reverse-text"` and different `name` values and args, and clarifies that `id` selects the environment while `name` labels the run in displays, summaries, and saved result paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3591174.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->