### PR TITLE
release v0.1.15.dev7

### DIFF
--- a/assets/release/RELEASE_v0.1.15.dev7.md
+++ b/assets/release/RELEASE_v0.1.15.dev7.md
@@ -1,0 +1,25 @@
+# Verifiers v0.1.15.dev7 Release Notes
+
+*Date:* 05/15/2026
+
+## Highlights since v0.1.15.dev6
+
+- **PyPI release pipeline moved to Trusted Publishing.** The `Tag and Release` workflow now publishes via PyPA OIDC, gated on the `pypi-prod` GitHub environment, with build, publish, and GitHub-release split into separate jobs so build-time code never sees the publishing identity. The long-lived `PYPI_TOKEN` is no longer used to release `verifiers`.
+- **Per-eval naming for duplicate environment runs.** `prime eval run` now accepts per-eval name labels so duplicate environments produce distinct, disambiguated runs.
+
+## Changes included in v0.1.15.dev7 (since v0.1.15.dev6)
+
+### Release infrastructure
+
+- improvement: switch verifiers PyPI publish to OIDC trusted publishing (#1386)
+
+### Evals
+
+- Add per-eval names for duplicate environment runs (#1384)
+- Document eval name labels in skill (#1388)
+
+### Docs
+
+- Add AGENTS.local guidance to Lab workspace docs (#1383)
+
+**Full Changelog**: https://github.com/PrimeIntellect-ai/verifiers/compare/v0.1.15.dev6...v0.1.15.dev7

--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.15.dev6"
+__version__ = "0.1.15.dev7"
 
 import importlib
 import os


### PR DESCRIPTION
First release after the OIDC trusted-publishing migration. Dev release to validate the new build → publish → github-release split end-to-end.

- Bump `__version__` to `0.1.15.dev7`
- Add `assets/release/RELEASE_v0.1.15.dev7.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only bumps the package version and adds release-notes documentation, with no runtime logic changes beyond the version string.
> 
> **Overview**
> Prepares the `v0.1.15.dev7` dev release by bumping `verifiers.__version__` and adding `RELEASE_v0.1.15.dev7.md` documenting the release highlights (Trusted Publishing/OIDC PyPI pipeline and per-eval naming support) and the full changelog link.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63ce166c8093581a5b8903026df1090a074c081f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Release verifiers v0.1.15.dev7
> Bumps `__version__` in [verifiers/__init__.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1389/files#diff-3667172df996e6596aa8d26557b92b4cb78ee7d2280a3cae14623ce4677e781e) from `0.1.15.dev6` to `0.1.15.dev7` and adds release notes in [RELEASE_v0.1.15.dev7.md](https://github.com/PrimeIntellect-ai/verifiers/pull/1389/files#diff-d0a26a6e19f82903a421ef9f585ea88a260aa5d445b187f8d353df16b27a23a5).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 63ce166.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->