### PR TITLE
Add emulator training eval environments

### DIFF
--- a/configs/eval/emulator-gpt-5-4-mini-chip8-suite.toml
+++ b/configs/eval/emulator-gpt-5-4-mini-chip8-suite.toml
@@ -1,0 +1,17 @@
+# Suite-backed gpt-5.4-mini canary for the easiest emulator environment.
+# This is the cheapest real verifier path before launching the all-env suite.
+model = "openai/gpt-5.4-mini"
+provider = "prime"
+num_examples = 1
+rollouts_per_example = 1
+max_concurrent = 1
+max_tokens = 4096
+temperature = 0.2
+save_results = true
+disable_tui = true
+output_dir = "/tmp/emulator-gpt54-chip8-suite"
+
+[[eval]]
+id = "emulator-chip8"
+name = "emulator-chip8-suite-canary"
+args = { max_tasks = 1, sandbox_timeout_minutes = 30, environment_timeout = 60, agent_step_limit = 1, max_turns = 1 }

--- a/configs/eval/emulator-gpt-5-4-mini-prime-smoke.toml
+++ b/configs/eval/emulator-gpt-5-4-mini-prime-smoke.toml
@@ -1,0 +1,62 @@
+# Fast all-env infrastructure smoke for the emulator benchmark curriculum.
+# This verifies that each environment loads, provisions a Prime sandbox, and can
+# complete a one-action MiniSWEAgent rollout with openai/gpt-5.4-mini.
+model = "openai/gpt-5.4-mini"
+provider = "prime"
+num_examples = 1
+rollouts_per_example = 1
+max_concurrent = 2
+max_tokens = 128
+save_results = true
+disable_tui = true
+output_dir = "/tmp/emulator-gpt54-prime-smoke"
+
+[[eval]]
+id = "emulator-chip8"
+name = "emulator-chip8-prime-smoke"
+args = { prime_smoke = true, max_tasks = 1, sandbox_timeout_minutes = 30, environment_timeout = 60, agent_step_limit = 1, max_turns = 1 }
+
+[[eval]]
+id = "emulator-i8080-space-invaders"
+name = "emulator-i8080-space-invaders-prime-smoke"
+args = { prime_smoke = true, max_tasks = 1, sandbox_timeout_minutes = 30, environment_timeout = 60, agent_step_limit = 1, max_turns = 1 }
+
+[[eval]]
+id = "emulator-gameboy-dmg"
+name = "emulator-gameboy-dmg-prime-smoke"
+args = { prime_smoke = true, max_tasks = 1, sandbox_timeout_minutes = 30, environment_timeout = 60, agent_step_limit = 1, max_turns = 1 }
+
+[[eval]]
+id = "emulator-nes"
+name = "emulator-nes-prime-smoke"
+args = { prime_smoke = true, max_tasks = 1, sandbox_timeout_minutes = 30, environment_timeout = 60, agent_step_limit = 1, max_turns = 1 }
+
+[[eval]]
+id = "emulator-sms"
+name = "emulator-sms-prime-smoke"
+args = { prime_smoke = true, max_tasks = 1, sandbox_timeout_minutes = 30, environment_timeout = 60, agent_step_limit = 1, max_turns = 1 }
+
+[[eval]]
+id = "emulator-gameboy-cgb"
+name = "emulator-gameboy-cgb-prime-smoke"
+args = { prime_smoke = true, max_tasks = 1, sandbox_timeout_minutes = 30, environment_timeout = 60, agent_step_limit = 1, max_turns = 1 }
+
+[[eval]]
+id = "emulator-gba"
+name = "emulator-gba-prime-smoke"
+args = { prime_smoke = true, max_tasks = 1, sandbox_timeout_minutes = 30, environment_timeout = 60, agent_step_limit = 1, max_turns = 1 }
+
+[[eval]]
+id = "emulator-genesis"
+name = "emulator-genesis-prime-smoke"
+args = { prime_smoke = true, max_tasks = 1, sandbox_timeout_minutes = 30, environment_timeout = 60, agent_step_limit = 1, max_turns = 1 }
+
+[[eval]]
+id = "emulator-snes"
+name = "emulator-snes-prime-smoke"
+args = { prime_smoke = true, max_tasks = 1, sandbox_timeout_minutes = 30, environment_timeout = 60, agent_step_limit = 1, max_turns = 1 }
+
+[[eval]]
+id = "emulator-ps1"
+name = "emulator-ps1-prime-smoke"
+args = { prime_smoke = true, max_tasks = 1, sandbox_timeout_minutes = 30, environment_timeout = 60, agent_step_limit = 1, max_turns = 1 }

--- a/configs/eval/emulator-gpt-5-4-mini-suite.toml
+++ b/configs/eval/emulator-gpt-5-4-mini-suite.toml
@@ -1,0 +1,64 @@
+# Full all-env gpt-5.4-mini private eval entrypoint.
+# Unlike the prime-smoke config, this runs the real implementation prompts and
+# the suite-backed verifier for every emulator environment. Expect long runtime
+# and private artifact mounts for copyrighted ROM/BIOS cases.
+model = "openai/gpt-5.4-mini"
+provider = "prime"
+num_examples = 1
+rollouts_per_example = 1
+max_concurrent = 1
+max_tokens = 4096
+temperature = 0.2
+save_results = true
+disable_tui = true
+output_dir = "/tmp/emulator-gpt54-suite"
+
+[[eval]]
+id = "emulator-chip8"
+name = "emulator-chip8-suite"
+args = { max_tasks = 1, sandbox_timeout_minutes = 120, environment_timeout = 21600, agent_step_limit = 1000, max_turns = 80 }
+
+[[eval]]
+id = "emulator-i8080-space-invaders"
+name = "emulator-i8080-space-invaders-suite"
+args = { max_tasks = 1, sandbox_timeout_minutes = 120, environment_timeout = 21600, agent_step_limit = 1000, max_turns = 80 }
+
+[[eval]]
+id = "emulator-gameboy-dmg"
+name = "emulator-gameboy-dmg-suite"
+args = { max_tasks = 1, sandbox_timeout_minutes = 120, environment_timeout = 21600, agent_step_limit = 1000, max_turns = 80 }
+
+[[eval]]
+id = "emulator-nes"
+name = "emulator-nes-suite"
+args = { max_tasks = 1, sandbox_timeout_minutes = 120, environment_timeout = 21600, agent_step_limit = 1000, max_turns = 80 }
+
+[[eval]]
+id = "emulator-sms"
+name = "emulator-sms-suite"
+args = { max_tasks = 1, sandbox_timeout_minutes = 120, environment_timeout = 21600, agent_step_limit = 1000, max_turns = 80 }
+
+[[eval]]
+id = "emulator-gameboy-cgb"
+name = "emulator-gameboy-cgb-suite"
+args = { max_tasks = 1, sandbox_timeout_minutes = 120, environment_timeout = 21600, agent_step_limit = 1000, max_turns = 80 }
+
+[[eval]]
+id = "emulator-gba"
+name = "emulator-gba-suite"
+args = { max_tasks = 1, sandbox_timeout_minutes = 120, environment_timeout = 21600, agent_step_limit = 1000, max_turns = 80 }
+
+[[eval]]
+id = "emulator-genesis"
+name = "emulator-genesis-suite"
+args = { max_tasks = 1, sandbox_timeout_minutes = 120, environment_timeout = 21600, agent_step_limit = 1000, max_turns = 80 }
+
+[[eval]]
+id = "emulator-snes"
+name = "emulator-snes-suite"
+args = { max_tasks = 1, sandbox_timeout_minutes = 120, environment_timeout = 21600, agent_step_limit = 1000, max_turns = 80 }
+
+[[eval]]
+id = "emulator-ps1"
+name = "emulator-ps1-suite"
+args = { max_tasks = 1, sandbox_timeout_minutes = 120, environment_timeout = 21600, agent_step_limit = 1000, max_turns = 80 }

--- a/configs/rl/emulator-chip8-minimal.toml
+++ b/configs/rl/emulator-chip8-minimal.toml
@@ -1,0 +1,41 @@
+# Minimal Prime Labs / Hosted Training LoRA example for the emulator benchmark.
+# This intentionally uses a trainable open-weight Hosted Training model; use
+# openai/gpt-5.4-mini for eval, not finetuning.
+model = "openai/gpt-oss-20b"
+
+max_steps = 10
+batch_size = 8
+rollouts_per_example = 2
+
+[sampling]
+max_tokens = 4096
+temperature = 0.7
+reasoning_effort = "low"
+
+[[env]]
+id = "emulator-chip8"
+
+[env.args]
+max_tasks = 1
+sandbox_timeout_minutes = 60
+environment_timeout = 7200
+agent_step_limit = 250
+max_turns = 40
+
+# Keep online eval cheap during bring-up. Remove or expand this block after the
+# first reward-diversity check.
+[eval]
+interval = 5
+num_examples = 1
+rollouts_per_example = 1
+eval_base_model = true
+
+[[eval.env]]
+id = "emulator-chip8"
+
+[eval.env.args]
+max_tasks = 1
+sandbox_timeout_minutes = 30
+environment_timeout = 1800
+agent_step_limit = 100
+max_turns = 20

--- a/configs/rl/emulator-chip8-prime-rl-smoke.toml
+++ b/configs/rl/emulator-chip8-prime-rl-smoke.toml
@@ -1,0 +1,59 @@
+# Self-managed prime-rl smoke for a 2-GPU node.
+# This is the config used to validate that emulator environments can enter a
+# real trainer/orchestrator/inference loop outside Hosted Training.
+
+max_steps = 1
+seq_len = 4096
+max_async_level = 0
+
+[deployment]
+gpus_per_node = 2
+num_train_gpus = 1
+num_infer_gpus = 1
+
+[model]
+name = "Qwen/Qwen3-0.6B"
+
+[orchestrator]
+batch_size = 1
+rollouts_per_example = 1
+# Renderer mode preserves tokenized trajectory data for prime-rl without using
+# the token-client chat endpoint, which rejects MiniSWEAgent's system message.
+use_token_client = false
+use_renderer = true
+
+[[orchestrator.filters]]
+type = "gibberish"
+enforce = false
+
+[[orchestrator.filters]]
+type = "repetition"
+enforce = false
+
+[[orchestrator.filters]]
+type = "zero_advantage"
+# A one-rollout smoke batch has zero advantage by construction; keep this as a
+# monitored signal instead of filtering out the only training sample.
+enforce = false
+
+[orchestrator.train.sampling]
+max_completion_tokens = 512
+temperature = 0.7
+
+[[orchestrator.train.env]]
+id = "emulator-chip8"
+name = "emulator-chip8"
+args = { max_tasks = 1, sandbox_timeout_minutes = 30, environment_timeout = 1800, agent_step_limit = 20, max_turns = 4, inline_system_prompt = true }
+timeout = 2400
+max_total_completion_tokens = 2048
+
+[trainer]
+max_steps = 1
+max_async_level = 0
+
+[trainer.optim]
+lr = 1e-6
+
+[ckpt]
+
+[inference]

--- a/environments/emulator_chip8/README.md
+++ b/environments/emulator_chip8/README.md
@@ -1,0 +1,5 @@
+# emulator-chip8
+
+Level 1 emulator implementation benchmark for CHIP-8. The task asks the agent
+to implement a deterministic Rust emulator with the common benchmark API and is
+graded with public contract tests plus hidden deterministic verifier checks.

--- a/environments/emulator_chip8/emulator_chip8.py
+++ b/environments/emulator_chip8/emulator_chip8.py
@@ -1,0 +1,14 @@
+import sys
+from pathlib import Path
+
+ENVIRONMENTS_DIR = Path(__file__).resolve().parents[1]
+if str(ENVIRONMENTS_DIR) not in sys.path:
+    sys.path.insert(0, str(ENVIRONMENTS_DIR))
+
+from emulator_common import load_emulator_environment  # noqa: E402
+
+MANIFEST_PATH = Path(__file__).resolve().parent / "tasks" / "manifest.json"
+
+
+def load_environment(config=None, **kwargs):
+    return load_emulator_environment(MANIFEST_PATH, config=config, **kwargs)

--- a/environments/emulator_chip8/pyproject.toml
+++ b/environments/emulator_chip8/pyproject.toml
@@ -1,0 +1,24 @@
+[project]
+name = "emulator-chip8"
+description = "Prime emulator benchmark env for CHIP-8"
+tags = ["emulator", "chip8", "systems", "sandbox", "rust", "eval"]
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = ["verifiers"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build]
+include = ["emulator_chip8.py", "pyproject.toml", "README.md", "tasks/manifest.json", "tasks/public_tests.json"]
+
+[project.entry-points."verifiers.environments"]
+emulator-chip8 = "emulator_chip8:load_environment"
+
+[tool.verifiers.eval]
+num_examples = 1
+rollouts_per_example = 1
+
+[tool.uv.sources]
+verifiers = { path = "../..", editable = true }

--- a/environments/emulator_chip8/tasks/manifest.json
+++ b/environments/emulator_chip8/tasks/manifest.json
@@ -1,0 +1,27 @@
+{
+  "environment_id": "emulator-chip8",
+  "module_name": "emulator_chip8",
+  "level": 1,
+  "slug": "chip8",
+  "display_name": "CHIP-8",
+  "difficulty": "Very Easy",
+  "goal": "Implement a CHIP-8 interpreter capable of loading and executing standard ROMs.",
+  "base_prompt": "Implement a CHIP-8 emulator in Rust.",
+  "core_concepts": ["Virtual machines", "Opcode decoding", "Memory management", "Display rendering", "Input handling", "Timers"],
+  "requirements": ["64x32 monochrome display", "Full CHIP-8 instruction set", "Keypad input", "Delay and sound timers", "ROM loading", "Deterministic execution"],
+  "exposed_api": ["step()", "reset()", "framebuffer()", "keypad input API"],
+  "public_verification": ["IBM Logo ROM", "Corax opcode test", "Timendus CHIP-8 suite"],
+  "hidden_verification": ["Timing edge cases", "Invalid opcode handling", "Quirk ROMs"],
+  "success_criteria": ["All public tests pass", "Deterministic framebuffer hashes", "Stable execution for 10000 cycles"],
+  "framebuffer": {"width": 64, "height": 32},
+  "runtime": {"smoke_cycles": 10000, "verify_timeout_seconds": 900},
+  "scoring_weights": {"correctness": 0.65, "determinism": 0.2, "performance": 0.1, "quality": 0.05},
+  "verification_cases": [
+    {"id": "chip8_ibm_logo", "stage": "public", "kind": "rom", "name": "IBM Logo ROM", "expected_signal": "framebuffer_hash", "source": "public"},
+    {"id": "chip8_corax_opcode", "stage": "public", "kind": "rom", "name": "Corax opcode test", "expected_signal": "pass_marker", "source": "public"},
+    {"id": "chip8_timendus_suite", "stage": "public", "kind": "rom_suite", "name": "Timendus CHIP-8 suite", "expected_signal": "suite_pass_rate", "source": "public"},
+    {"id": "chip8_timer_edges", "stage": "hidden", "kind": "generated_rom", "name": "Timing edge cases", "expected_signal": "trace_crc", "source": "generated"},
+    {"id": "chip8_invalid_opcode", "stage": "hidden", "kind": "generated_rom", "name": "Invalid opcode handling", "expected_signal": "error_contract", "source": "generated"},
+    {"id": "chip8_quirks", "stage": "hidden", "kind": "rom_suite", "name": "Quirk ROMs", "expected_signal": "frame_sequence_hash", "source": "withheld"}
+  ]
+}

--- a/environments/emulator_chip8/tasks/public_tests.json
+++ b/environments/emulator_chip8/tasks/public_tests.json
@@ -1,0 +1,14 @@
+{
+  "environment_id": "emulator-chip8",
+  "sources": [
+    {
+      "name": "Timendus CHIP-8 test suite",
+      "kind": "git",
+      "url": "https://github.com/Timendus/chip8-test-suite",
+      "ref": "main",
+      "license": "GPL-3.0",
+      "covers": ["IBM Logo ROM", "Corax opcode test", "Timendus CHIP-8 suite"],
+      "notes": "Includes IBM logo, Corax+ opcode, flags, quirks, keypad, and sound ROMs."
+    }
+  ]
+}

--- a/environments/emulator_common/GPT_5_4_MINI_EVAL_REPORT.md
+++ b/environments/emulator_common/GPT_5_4_MINI_EVAL_REPORT.md
@@ -1,0 +1,152 @@
+# Emulator GPT-5.4 Mini Eval Report
+
+Generated on 2026-05-15 for branch `feat/emulator-benchmark`.
+
+## Scope
+
+This report covers three paths:
+
+1. `configs/eval/emulator-gpt-5-4-mini-prime-smoke.toml` runs all ten emulator envs in `prime_smoke` mode. This validates environment loading, Prime sandbox provisioning, MiniSWEAgent command execution, and reward plumbing only.
+2. `configs/eval/emulator-gpt-5-4-mini-suite.toml` runs the real implementation prompts and suite-backed verifier contracts for all ten emulator envs under `openai/gpt-5.4-mini`.
+3. `configs/rl/emulator-chip8-prime-rl-smoke.toml` is the self-managed `prime-rl` bring-up config used on the provided 2 x RTX PRO 6000 node.
+
+## Commands
+
+Install local env packages before running these configs:
+
+```bash
+for env in \
+  emulator_chip8 emulator_i8080_space_invaders emulator_gameboy_dmg emulator_nes \
+  emulator_sms emulator_gameboy_cgb emulator_gba emulator_genesis emulator_snes \
+  emulator_ps1
+do
+  uv pip install -e "environments/$env"
+done
+```
+
+If the default public toolchain image is not pullable from the current Prime
+account, set `PRIME_TOOLCHAIN_IMAGE` to a completed `programbench-toolchain`
+image display ref from your image list before running `vf-eval`:
+
+```bash
+uv run prime images list --plain --output table
+export PRIME_TOOLCHAIN_IMAGE="<displayRef for programbench-toolchain:latest>"
+```
+
+Run the fast all-env smoke:
+
+```bash
+uv run vf-eval configs/eval/emulator-gpt-5-4-mini-prime-smoke.toml --disable-tui
+```
+
+Run the real all-env suite:
+
+```bash
+uv run vf-eval configs/eval/emulator-gpt-5-4-mini-suite.toml --disable-tui
+```
+
+Run the self-managed training smoke after `prime-rl` is set up:
+
+```bash
+rl @ configs/rl/emulator-chip8-prime-rl-smoke.toml --output-dir outputs/emulator-chip8-smoke --clean-output-dir
+```
+
+## Prime Smoke Results
+
+Source artifacts: `/tmp/emulator-gpt54-prime-smoke/evals/*/metadata.json` and `results.jsonl`.
+
+The all-env smoke returned reward `1.00` for all ten environments. Treat this only as a sandbox and harness plumbing check. It does not run emulator ROM suites and must not be interpreted as GPT-5.4 Mini passing emulator correctness tests.
+
+## Full Suite Results
+
+Source artifacts: `/tmp/emulator-gpt54-suite/evals/*/*/metadata.json`.
+
+| Env | Reward | Error | Public ROM pass | Build | Runner contract | Determinism | Turns | Runtime |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| `emulator-chip8` | 0.54 | 0.00 | 0.00 | 1.00 | 1.00 | 0.00 | 7 | 135s |
+| `emulator-gameboy-cgb` | 0.54 | 0.00 | 0.00 | 1.00 | 1.00 | 0.00 | 8 | 151s |
+| `emulator-gameboy-dmg` | 0.54 | 0.00 | 0.00 | 1.00 | 1.00 | 0.00 | 13 | 166s |
+| `emulator-gba` | 0.54 | 0.00 | 0.00 | 1.00 | 1.00 | 0.00 | 7 | 122s |
+| `emulator-genesis` | 1.00 | 0.00 | 1.00 | 1.00 | 1.00 | 1.00 | 12 | 157s |
+| `emulator-i8080-space-invaders` | 0.54 | 0.00 | 0.00 | 1.00 | 1.00 | 0.00 | 7 | 140s |
+| `emulator-nes` | 0.50 | 0.00 | 0.00 | 1.00 | 1.00 | 0.00 | 10 | 159s |
+| `emulator-ps1` | 0.54 | 0.00 | 0.00 | 1.00 | 1.00 | 0.00 | 9 | 167s |
+| `emulator-sms` | 0.54 | 1.00 | 0.00 | 1.00 | 1.00 | 0.00 | 6 | 87s |
+| `emulator-snes` | 0.52 | 0.00 | 0.00 | 1.00 | 1.00 | 0.00 | 9 | 146s |
+
+Aggregate suite status:
+
+```text
+envs evaluated       : 10
+mean reward          : 0.58
+mean error           : 0.10
+full public pass envs: 1 / 10
+public pass sum      : 1.00
+error envs           : emulator-sms
+```
+
+Interpretation:
+
+- `openai/gpt-5.4-mini` did not pass all emulator tests. Nine of ten envs had `public_rom_pass_rate = 0.00`.
+- The suite shows that the build path, runner contract, and verifier scoring path execute across the full curriculum.
+- The Genesis result reached `public_rom_pass_rate = 1.00` against the currently configured public source manifest. Keep private artifacts mounted before treating that as comprehensive Genesis coverage.
+- The SMS rollout recorded `avg_error = 1.00` and `emulator_agent_exit_status = -1.00`; this is a rollout failure signal, not a solved emulator.
+
+## Training Configs
+
+Hosted Training config: `configs/rl/emulator-chip8-minimal.toml`.
+
+The hosted example uses `openai/gpt-oss-20b`, a Hosted Training model, because `openai/gpt-5.4-mini` is used here as an evaluator rather than a fine-tuning target.
+
+```bash
+uv run prime train configs/rl/emulator-chip8-minimal.toml
+```
+
+Self-managed node config: `configs/rl/emulator-chip8-prime-rl-smoke.toml`.
+
+This config targets a 2-GPU machine with one inference GPU and one trainer GPU. It uses `Qwen/Qwen3-0.6B` for a one-step smoke run, enables renderer mode for `prime-rl` trajectory metadata, and passes `inline_system_prompt = true` so the emulator guidance is a user message instead of a separate system message.
+
+## Node Validation
+
+Node: `root@31.22.104.54`, hostname `chess-dagger-2xpro6000b`, 2 x NVIDIA RTX PRO 6000 Blackwell Server Edition 96GB.
+
+Validated setup:
+
+- Branch cloned on the node at `/root/verifiers-emulator`.
+- `uv sync` completed.
+- All ten emulator env packages installed editable into the repo venv.
+- `uv run pytest tests/test_emulator_benchmark_envs.py -q` passed with `53 passed`.
+- `prime lab setup --prime-rl --skip-agents-md --skip-install --no-interactive` completed.
+- The current repo and all ten emulator env packages were installed editable into `prime-rl/.venv`.
+- `renderers==0.1.8.dev0` was installed into `prime-rl/.venv` so the self-managed run uses the renderer API expected by this branch.
+- `rl @ prime-rl/configs/emulator_chip8_smoke.toml --dry-run` completed successfully with renderer mode.
+
+Completed training smoke:
+
+```text
+output dir   : /root/verifiers-emulator/outputs/emulator-chip8-smoke
+model        : Qwen/Qwen3-0.6B
+orchestrator : Step 0, reward 0.5400, 3868 tokens/sample, 105.12s
+trainer      : Step 0, loss 0.0000, entropy 0.5280, mismatch KL 0.0019
+trainer      : grad norm 0.0019, LR 1.00e-06, throughput 9202 tokens/s
+checkpoint   : outputs/emulator-chip8-smoke/checkpoints/step_1/trainer/
+weights      : outputs/emulator-chip8-smoke/weights/step_1/
+```
+
+The training smoke required `verifiers.v1.Env.apply_controls()` to mirror `sampling_args` onto the top-level rollout state. `prime-rl` reads `sampling_args` from saved rollout outputs while v1 runtime controls already store the same value under `state["runtime"]["sampling_args"]`.
+
+CPU build node validation:
+
+```text
+node       : root@86.38.238.176
+hostname   : pb-coordinator
+branch     : feat/emulator-benchmark
+command    : uv run pytest tests/test_emulator_benchmark_envs.py tests/test_v1_runtime_lifecycle.py::test_v1_env_apply_controls_mirrors_sampling_args_for_rollout_outputs -q
+result     : 56 passed
+```
+
+## Private Eval Notes
+
+- Some public upstream repositories are source-only and do not ship ready ROMs. The verifier supports mounted/generated private artifacts through `EMULATOR_PRIVATE_ARTIFACT_DIR`.
+- Do not commit copyrighted ROM or BIOS bytes. Mount them privately and require SHA-256 manifests before scoring.
+- Start training with CHIP-8 until reward diversity is visible, then expand to `emulator-nes` and `emulator-gameboy-dmg`. Keep the harder systems eval-only until the lower-level tasks show nonzero public ROM pass rates.

--- a/environments/emulator_common/README.md
+++ b/environments/emulator_common/README.md
@@ -1,0 +1,12 @@
+# emulator_common
+
+Shared harness code for the emulator implementation benchmark environments.
+
+The platform-specific environments keep only their manifest, README, package
+metadata, and `load_environment()` entry point. This shared layer owns task
+loading, sandbox defaults, starter Rust crate files, deterministic verifier
+upload, and reward parsing.
+
+Prime sandbox settings follow `~/Planning/prime_infra_guide.md`: toolchain image
+selection is read from `PRIME_TOOLCHAIN_IMAGE`, team IDs are not hardcoded, and
+long-running grading uses `run_background_job`.

--- a/environments/emulator_common/TRAINING_READY_AUDIT.md
+++ b/environments/emulator_common/TRAINING_READY_AUDIT.md
@@ -1,0 +1,41 @@
+# Emulator Prime Env Training-Readiness Audit
+
+Generated on 2026-05-14 for branch `feat/emulator-benchmark`.
+
+## Objective Checklist
+
+| Requirement | Evidence |
+| --- | --- |
+| Ten emulator Prime envs exist | `environments/emulator_{chip8,i8080_space_invaders,gameboy_dmg,nes,sms,gameboy_cgb,gba,genesis,snes,ps1}` |
+| Shared suite verifier replaces scaffold-only scoring | `environments/emulator_common/suite_adapters.py` fetches sources, discovers public/private artifacts, invokes runner cases, scores build/contract/source/pass-rate/signals/determinism/runtime |
+| Standard runner contract documented | `environments/emulator_common/runner_contract.py`; generated `README.md` and `verification/runner_contract.json` include the contract |
+| Private artifact support | `EMULATOR_PRIVATE_ARTIFACT_DIR` or `/private/emulator`; mounted files/directories are included in executed artifacts |
+| RL score breakdowns | `build_score`, `public_rom_pass_rate`, `framebuffer_hash_score`, `trace_cpu_score`, `audio_perf_score`, `deterministic_replay_score`, `runtime_stability_score`, `runner_contract_score` |
+| No committed private ROM/BIOS bytes | Manifest-only private artifact declarations; secret scan over emulator envs/tests found no team ID, API key, private key, GitHub token, or HF token |
+| Local tests | `uv run pytest tests/test_emulator_benchmark_envs.py` -> `47 passed`; `uv run ruff check ...` -> `All checks passed`; source verification all OK |
+| CPU-node tests | On `root@86.38.238.176`: pytest `47 passed`, ruff OK, source verification all OK |
+| Generated starter crate build gate | On CPU node: all ten generated Rust starters passed `cargo test`, `cargo build --release`, `--contract-version`, `--self-test`, and deterministic no-arg JSON smoke |
+| Real verifier invocation | On CPU node: CHIP-8 starter fetched Timendus and executed 8 `.ch8` artifacts; reward `0.54`, public pass rate `0.0`, build/contract/source/stability all `1.0` |
+| Real gpt-5.4-mini eval | `/tmp/emulator-real-suite-gpt54-priority/.../results.jsonl`: reward `0.54`; verifier metrics populated from the actual suite path |
+| Prime smoke all ten | `/tmp/emulator-prime-smoke-after/evals/*/results.jsonl`: all ten reward `1.0`, stop `command_completed` |
+
+## Env Mapping
+
+| Env | Public suites wired | Executable public artifacts found | Private/generated artifacts expected | Local | CPU | Prime/gpt-5.4-mini |
+| --- | --- | ---: | --- | --- | --- | --- |
+| `emulator-chip8` | Timendus suite covering IBM/Corax/quirks | 8 | None | Pass | Pass | real eval reward `0.54`; prime smoke `1.0` |
+| `emulator-i8080-space-invaders` | PCjs 8080 exerciser source/page | 9 exerciser source fixtures | `space_invaders_rom_set` | Pass | Pass | prime smoke `1.0` |
+| `emulator-gameboy-dmg` | c-sp index, mooneye, dmg-acid2, SameSuite | 0 prebuilt in fetched repos | `gameboy_dmg_public_test_roms`, `pokemon_red_rom` | Pass | Pass | prime smoke `1.0` |
+| `emulator-nes` | christopherpow NES test ROM archive, NESdev wiki | 128 cap | None | Pass | Pass | prime smoke `1.0` |
+| `emulator-sms` | SMSTestSuite, redcode Z80, SMS Power page | 0 prebuilt `.sms` ROMs | `sms_test_suite_roms`, `zexdoc_zexall_roms` | Pass | Pass | prime smoke `1.0` |
+| `emulator-gameboy-cgb` | cgb-acid2, mooneye, SameSuite, c-sp index | 0 prebuilt in fetched repos | `gameboy_cgb_public_test_roms` | Pass | Pass | prime smoke `1.0` |
+| `emulator-gba` | mGBA suite, jsmolka gba-tests, TONC, NBA hw-test | 38 | `gba_bios` | Pass | Pass | prime smoke `1.0` |
+| `emulator-genesis` | Tom Harte 68000 sparse fixtures, redcode Z80, 240p, Sega Retro page | 128 cap, mainly Tom Harte `.json.gz` | `genesis_240p_suite_rom`, `genesis_z80_fixture_roms`, `sonic_rom` | Pass | Pass | prime smoke `1.0` |
+| `emulator-snes` | Peter Lemon, undisbeliever, SNESdev, Snes Central/blargg | 128 cap | None | Pass | Pass | prime smoke `1.0` |
+| `emulator-ps1` | Peter Lemon PSX, psxsdk, psx-spx GPU spec | 128 cap | `ps1_bios` | Pass | Pass | prime smoke `1.0` |
+
+## Remaining Limitations
+
+- Several public upstream repos are source-only and do not ship ready emulator ROMs. Those suites are intentionally represented as mounted/generated artifacts through the documented private artifact paths above.
+- The verifier executes discovered or mounted artifacts through the standard runner contract; it does not commit or vendor copyrighted ROM/BIOS bytes.
+- The gpt-5.4-mini real rollout still had an agent command error, but the reward path now runs the verifier anyway and records the agent error separately, producing suite-based reward components.

--- a/environments/emulator_common/__init__.py
+++ b/environments/emulator_common/__init__.py
@@ -1,0 +1,12 @@
+"""Shared harness utilities for emulator implementation benchmark envs."""
+
+from .env_factory import load_emulator_environment
+from .loader import load_manifest
+from .task_schema import EmulatorManifest, VerificationCase
+
+__all__ = [
+    "EmulatorManifest",
+    "VerificationCase",
+    "load_emulator_environment",
+    "load_manifest",
+]

--- a/environments/emulator_common/env_factory.py
+++ b/environments/emulator_common/env_factory.py
@@ -1,0 +1,494 @@
+import json
+import logging
+from pathlib import Path
+
+import verifiers.v1 as vf
+
+from .loader import load_manifest, manifest_to_rows
+from .runners import VERIFIER_SCRIPT, build_program_config, hidden_manifest_json
+from .sandbox import WORKSPACE, build_sandbox_config
+from .task_schema import EmulatorManifest
+from .test_sources import PublicTestManifest, load_public_test_manifest
+
+logger = logging.getLogger(__name__)
+
+SYSTEM_PROMPT = """\
+You are implementing a hardware emulator for a deterministic coding benchmark.
+Prioritize correct CPU semantics, memory maps, rendering determinism, timing,
+clear module boundaries, and tests that make debugging tractable.
+"""
+
+AGENT_EXIT_STATUS_PATH = "/tmp/emulator_agent_exit_status"
+
+
+def _allow_verifier_after_agent_exit(harness: vf.MiniSWEAgent) -> vf.MiniSWEAgent:
+    """Keep verifier scoring reachable after a nonzero agent command exit."""
+    program = getattr(harness, "program", None)
+    if not isinstance(program, dict):
+        return harness
+    command = program.get("command")
+    if not isinstance(command, list) or len(command) < 3:
+        return harness
+    run_script = command[2]
+    if not isinstance(run_script, str):
+        return harness
+
+    wrapped_command = list(command)
+    wrapped_command[2] = (
+        f"{run_script}\n"
+        "status=$?\n"
+        f"printf '%s\\n' \"$status\" > {AGENT_EXIT_STATUS_PATH}\n"
+        'if [ "$status" -ne 0 ]; then\n'
+        '  echo "[emulator-benchmark] mini-swe-agent exited with status '
+        '$status; running verifier anyway." >&2\n'
+        "fi\n"
+        "exit 0\n"
+    )
+    program["command"] = wrapped_command
+
+    artifacts = dict(program.get("artifacts") or {})
+    artifacts["emulator_agent_exit_status"] = {
+        "path": AGENT_EXIT_STATUS_PATH,
+        "format": "text",
+        "optional": True,
+    }
+    program["artifacts"] = artifacts
+    return harness
+
+
+def _helper_source(filename: str) -> str:
+    return (Path(__file__).resolve().parent / filename).read_text(encoding="utf-8")
+
+
+def _score_component(state: vf.ConfigData, name: str) -> float:
+    score = state.get("emulator_score", {})
+    if not isinstance(score, dict):
+        return 0.0
+    components = score.get("components", {})
+    if not isinstance(components, dict):
+        return 0.0
+    return float(components.get(name, 0.0))
+
+
+class EmulatorTaskset(vf.Taskset):
+    def __init__(
+        self,
+        manifest: EmulatorManifest,
+        *,
+        public_test_manifest: PublicTestManifest,
+        max_tasks: int | None = None,
+        cpu_cores: int | None = None,
+        memory_gb: int | None = None,
+        network_access: bool = True,
+        sandbox_timeout_minutes: int | None = None,
+        inline_system_prompt: bool = False,
+        config: vf.TasksetConfig | None = None,
+    ):
+        self.manifest = manifest
+        self.public_test_manifest = public_test_manifest
+        self.max_tasks = max_tasks
+        self.cpu_cores = cpu_cores
+        self.memory_gb = memory_gb
+        self.network_access = network_access
+        self.sandbox_timeout_minutes = sandbox_timeout_minutes
+        self.inline_system_prompt = inline_system_prompt
+        super().__init__(
+            source=self.load_rows,
+            taskset_id=manifest.environment_id,
+            config=config,
+        )
+
+    def load_rows(self) -> list[vf.ConfigData]:
+        rows = manifest_to_rows(
+            self.manifest,
+            max_tasks=self.max_tasks,
+            cpu_cores=self.cpu_cores,
+            memory_gb=self.memory_gb,
+            network_access=self.network_access,
+            sandbox_timeout_minutes=self.sandbox_timeout_minutes,
+        )
+        for row in rows:
+            if self.inline_system_prompt:
+                instruction = f"{SYSTEM_PROMPT.strip()}\n\n{row['instruction']}"
+                row["question"] = instruction
+                row["instruction"] = instruction
+                row["prompt"] = [{"role": "user", "content": instruction}]
+            row["info"]["public_test_sources"] = self.public_test_manifest.to_dict()
+        return rows
+
+    @vf.setup(priority=250)
+    async def setup_emulator_sandbox(self, task, state, sandbox=None) -> None:
+        if sandbox is None:
+            raise RuntimeError("Emulator benchmark setup requires an active sandbox.")
+        state["_emulator_sandbox"] = sandbox
+        state["sandbox_id"] = getattr(sandbox, "id", state.get("sandbox_id"))
+        result = await sandbox.execute(
+            "mkdir -p /workspace/src /workspace/tests /workspace/verification",
+            timeout=30,
+        )
+        if result.exit_code != 0:
+            raise RuntimeError(f"workspace setup failed: {result.stderr}")
+
+    @vf.reward(weight=1.0, priority=100)
+    async def solved(self, task, state) -> float:
+        agent_error = state.get("error")
+        sandbox = state.get("_emulator_sandbox")
+        if sandbox is None:
+            state["emulator_score"] = {"score": 0.0, "error": "missing sandbox"}
+            return 0.0
+
+        manifest_json = hidden_manifest_json(task)
+        await sandbox.upload_bytes(
+            "/tmp/emulator_hidden_manifest.json",
+            manifest_json.encode("utf-8"),
+            "emulator_hidden_manifest.json",
+        )
+        await sandbox.upload_bytes(
+            "/tmp/emulator_verify.py",
+            VERIFIER_SCRIPT.encode("utf-8"),
+            "emulator_verify.py",
+        )
+        await sandbox.upload_bytes(
+            "/tmp/emulator_suite_adapters.py",
+            _helper_source("suite_adapters.py").encode("utf-8"),
+            "emulator_suite_adapters.py",
+        )
+        source_json = json.dumps(task["info"].get("public_test_sources", {}))
+        await sandbox.upload_bytes(
+            "/tmp/emulator_public_tests.json",
+            source_json.encode("utf-8"),
+            "emulator_public_tests.json",
+        )
+        verify_timeout = int(
+            task["info"].get("runtime", {}).get("verify_timeout_seconds", 900)
+        )
+        command = (
+            "python3 /tmp/emulator_verify.py "
+            "--workspace /workspace "
+            "--manifest /tmp/emulator_hidden_manifest.json "
+            "--sources /tmp/emulator_public_tests.json "
+            "--output /tmp/emulator_score.json"
+        )
+        result = await sandbox.run_background_job(
+            command,
+            timeout=verify_timeout,
+            working_dir=WORKSPACE,
+        )
+        state["emulator_verify_stdout"] = result.stdout or ""
+        state["emulator_verify_stderr"] = result.stderr or ""
+
+        output = await sandbox.execute("cat /tmp/emulator_score.json", timeout=30)
+        if output.exit_code != 0:
+            state["emulator_score"] = {
+                "score": 0.0,
+                "error": "missing verifier output",
+                "stdout": result.stdout or "",
+                "stderr": result.stderr or "",
+            }
+            return 0.0
+        try:
+            parsed = json.loads(output.stdout or "{}")
+        except json.JSONDecodeError as exc:
+            state["emulator_score"] = {"score": 0.0, "error": str(exc)}
+            return 0.0
+        agent_exit_status = state.get("artifacts", {}).get("emulator_agent_exit_status")
+        if agent_exit_status is not None and isinstance(parsed, dict):
+            parsed["agent_exit_status"] = str(agent_exit_status).strip()
+        if agent_error is not None and isinstance(parsed, dict):
+            parsed["agent_error"] = str(agent_error)
+        state["emulator_score"] = parsed
+        return float(parsed.get("score", 0.0))
+
+    @vf.metric
+    async def public_test_score(self, task, state) -> float:
+        _ = task
+        return _score_component(state, "public_rom_pass_rate")
+
+    @vf.metric
+    async def deterministic_runner_score(self, task, state) -> float:
+        _ = task
+        return _score_component(state, "deterministic_replay_score")
+
+    @vf.metric
+    async def public_rom_pass_rate(self, task, state) -> float:
+        _ = task
+        return _score_component(state, "public_rom_pass_rate")
+
+    @vf.metric
+    async def runner_contract_score(self, task, state) -> float:
+        _ = task
+        return _score_component(state, "runner_contract_score")
+
+    @vf.metric
+    async def build_score(self, task, state) -> float:
+        _ = task
+        return _score_component(state, "build_score")
+
+    @vf.metric
+    async def framebuffer_hash_score(self, task, state) -> float:
+        _ = task
+        return _score_component(state, "framebuffer_hash_score")
+
+    @vf.metric
+    async def trace_cpu_score(self, task, state) -> float:
+        _ = task
+        return _score_component(state, "trace_cpu_score")
+
+    @vf.metric
+    async def audio_perf_score(self, task, state) -> float:
+        _ = task
+        return _score_component(state, "audio_perf_score")
+
+    @vf.metric
+    async def runtime_stability_score(self, task, state) -> float:
+        _ = task
+        return _score_component(state, "runtime_stability_score")
+
+    @vf.metric
+    async def emulator_agent_exit_status(self, task, state) -> float:
+        _ = task
+        score = state.get("emulator_score", {})
+        if not isinstance(score, dict):
+            return -1.0
+        try:
+            return float(score.get("agent_exit_status", -1.0))
+        except (TypeError, ValueError):
+            return -1.0
+
+    @vf.cleanup
+    async def cleanup_emulator_sandbox_state(self, task, state) -> None:
+        _ = task
+        state.pop("_emulator_sandbox", None)
+
+
+@vf.reward(weight=1.0)
+async def eval_smoke_passed(task, state) -> float:
+    return float(state.get("answer") == task.get("answer"))
+
+
+@vf.metric
+async def eval_smoke_public_case_count(task, state) -> float:
+    _ = state
+    public_cases = task["info"].get("public_cases", [])
+    return float(len(public_cases) if isinstance(public_cases, list) else 0)
+
+
+async def eval_smoke_program(task, state) -> vf.ConfigData:
+    answer = str(task.get("answer", "pass"))
+    state["answer"] = answer
+    state["completion"] = [{"role": "assistant", "content": answer}]
+    state["emulator_score"] = {
+        "mode": "eval_smoke",
+        "score": 1.0,
+        "environment_id": task["info"].get("environment_id"),
+    }
+    return state
+
+
+def load_eval_smoke_taskset(
+    manifest: EmulatorManifest,
+    *,
+    public_test_manifest: PublicTestManifest,
+    max_tasks: int | None = None,
+    config: vf.TasksetConfig | None = None,
+) -> vf.Taskset:
+    rows = manifest_to_rows(manifest, max_tasks=max_tasks)
+    for row in rows:
+        row.pop("sandbox", None)
+        row.pop("program", None)
+        row["info"]["public_test_sources"] = public_test_manifest.to_dict()
+    return vf.Taskset(
+        source=rows,
+        taskset_id=f"{manifest.environment_id}-eval-smoke",
+        rewards=[eval_smoke_passed],
+        metrics=[eval_smoke_public_case_count],
+        config=config,
+    )
+
+
+def load_eval_smoke_harness(
+    *,
+    config: vf.HarnessConfig | None = None,
+) -> vf.Harness:
+    return vf.Harness(program=eval_smoke_program, config=config)
+
+
+@vf.reward(weight=1.0)
+async def prime_smoke_passed(task, state) -> float:
+    _ = task
+    return float(state.get("error") is None)
+
+
+@vf.metric
+async def prime_smoke_environment_level(task, state) -> float:
+    _ = state
+    return float(task["info"].get("level", 0))
+
+
+def prime_smoke_instruction(manifest: EmulatorManifest) -> str:
+    return f"""\
+This is an infrastructure smoke test for the {manifest.display_name} emulator
+benchmark environment, not the emulator implementation task.
+
+Do not inspect files, edit files, or run tests. Finish immediately with exactly
+one action:
+
+```mswea_bash_command
+echo COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT
+```
+"""
+
+
+def load_prime_smoke_taskset(
+    manifest: EmulatorManifest,
+    *,
+    public_test_manifest: PublicTestManifest,
+    max_tasks: int | None = None,
+    cpu_cores: int | None = None,
+    memory_gb: int | None = None,
+    network_access: bool = True,
+    sandbox_timeout_minutes: int | None = None,
+    config: vf.TasksetConfig | None = None,
+) -> vf.Taskset:
+    rows = manifest_to_rows(
+        manifest,
+        max_tasks=max_tasks,
+        cpu_cores=cpu_cores,
+        memory_gb=memory_gb,
+        network_access=network_access,
+        sandbox_timeout_minutes=sandbox_timeout_minutes,
+    )
+    instruction = prime_smoke_instruction(manifest)
+    for row in rows:
+        row["task_id"] = f"{manifest.environment_id}__prime_smoke"
+        row["question"] = instruction
+        row["instruction"] = instruction
+        row["prompt"] = [{"role": "user", "content": instruction}]
+        row["info"]["public_test_sources"] = public_test_manifest.to_dict()
+    return vf.Taskset(
+        source=rows,
+        taskset_id=f"{manifest.environment_id}-prime-smoke",
+        rewards=[prime_smoke_passed],
+        metrics=[prime_smoke_environment_level],
+        config=config,
+    )
+
+
+def _load_harness(
+    manifest: EmulatorManifest,
+    *,
+    config: vf.HarnessConfig | None = None,
+    cpu_cores: int | None = None,
+    memory_gb: int | None = None,
+    network_access: bool = True,
+    sandbox_timeout_minutes: int | None = None,
+    environment_timeout: int = 21600,
+    agent_step_limit: int = 1000,
+    max_turns: int | None = None,
+    allow_agent_failure_for_scoring: bool = False,
+    inline_system_prompt: bool = False,
+) -> vf.MiniSWEAgent:
+    sandbox = build_sandbox_config(
+        cpu_cores=cpu_cores,
+        memory_gb=memory_gb,
+        network_access=network_access,
+        timeout_minutes=sandbox_timeout_minutes,
+    )
+    harness = vf.MiniSWEAgent(
+        agent_workdir=WORKSPACE,
+        environment_timeout=environment_timeout,
+        extra_config_specs=[f"agent.step_limit={agent_step_limit}"],
+        system_prompt=None if inline_system_prompt else SYSTEM_PROMPT,
+        sandbox=sandbox,
+        program=build_program_config(manifest),
+        max_turns=max_turns,
+        config=config,
+    )
+    if allow_agent_failure_for_scoring:
+        return _allow_verifier_after_agent_exit(harness)
+    return harness
+
+
+def load_emulator_environment(
+    manifest_path: str | Path,
+    *,
+    config: vf.EnvConfig | None = None,
+    max_tasks: int | None = None,
+    cpu_cores: int | None = None,
+    memory_gb: int | None = None,
+    network_access: bool = True,
+    sandbox_timeout_minutes: int | None = None,
+    environment_timeout: int = 21600,
+    agent_step_limit: int = 1000,
+    max_turns: int | None = None,
+    eval_smoke: bool = False,
+    prime_smoke: bool = False,
+    inline_system_prompt: bool = False,
+) -> vf.Env:
+    config = config or vf.EnvConfig()
+    manifest_path = Path(manifest_path)
+    manifest = load_manifest(manifest_path)
+    public_test_manifest = load_public_test_manifest(
+        manifest_path.parent / "public_tests.json"
+    )
+    if eval_smoke:
+        return vf.Env(
+            taskset=load_eval_smoke_taskset(
+                manifest,
+                public_test_manifest=public_test_manifest,
+                max_tasks=max_tasks,
+                config=config.taskset,
+            ),
+            harness=load_eval_smoke_harness(config=config.harness),
+        )
+
+    if prime_smoke:
+        return vf.Env(
+            taskset=load_prime_smoke_taskset(
+                manifest,
+                public_test_manifest=public_test_manifest,
+                max_tasks=max_tasks,
+                cpu_cores=cpu_cores,
+                memory_gb=memory_gb,
+                network_access=network_access,
+                sandbox_timeout_minutes=sandbox_timeout_minutes,
+                config=config.taskset,
+            ),
+            harness=_load_harness(
+                manifest,
+                config=config.harness,
+                cpu_cores=cpu_cores,
+                memory_gb=memory_gb,
+                network_access=network_access,
+                sandbox_timeout_minutes=sandbox_timeout_minutes,
+                environment_timeout=environment_timeout,
+                agent_step_limit=agent_step_limit,
+                max_turns=max_turns,
+            ),
+        )
+
+    taskset = EmulatorTaskset(
+        manifest,
+        public_test_manifest=public_test_manifest,
+        max_tasks=max_tasks,
+        cpu_cores=cpu_cores,
+        memory_gb=memory_gb,
+        network_access=network_access,
+        sandbox_timeout_minutes=sandbox_timeout_minutes,
+        inline_system_prompt=inline_system_prompt,
+        config=config.taskset,
+    )
+    harness = _load_harness(
+        manifest,
+        config=config.harness,
+        cpu_cores=cpu_cores,
+        memory_gb=memory_gb,
+        network_access=network_access,
+        sandbox_timeout_minutes=sandbox_timeout_minutes,
+        environment_timeout=environment_timeout,
+        agent_step_limit=agent_step_limit,
+        max_turns=max_turns,
+        allow_agent_failure_for_scoring=True,
+        inline_system_prompt=inline_system_prompt,
+    )
+    return vf.Env(taskset=taskset, harness=harness)

--- a/environments/emulator_common/graders/__init__.py
+++ b/environments/emulator_common/graders/__init__.py
@@ -1,0 +1,15 @@
+"""Deterministic grading helpers for emulator benchmark outputs."""
+
+from .audio import audio_crc
+from .framebuffer import framebuffer_sha256, frame_sequence_sha256
+from .perf import fps, stable_within
+from .trace import trace_crc
+
+__all__ = [
+    "audio_crc",
+    "fps",
+    "frame_sequence_sha256",
+    "framebuffer_sha256",
+    "stable_within",
+    "trace_crc",
+]

--- a/environments/emulator_common/graders/audio.py
+++ b/environments/emulator_common/graders/audio.py
@@ -1,0 +1,10 @@
+import zlib
+from collections.abc import Iterable
+
+
+def audio_crc(samples: bytes | bytearray | Iterable[int]) -> str:
+    if isinstance(samples, (bytes, bytearray)):
+        payload = bytes(samples)
+    else:
+        payload = bytes(int(sample) & 0xFF for sample in samples)
+    return f"{zlib.crc32(payload) & 0xFFFFFFFF:08x}"

--- a/environments/emulator_common/graders/framebuffer.py
+++ b/environments/emulator_common/graders/framebuffer.py
@@ -1,0 +1,22 @@
+import hashlib
+from collections.abc import Iterable
+
+
+def framebuffer_sha256(pixels: bytes | bytearray | Iterable[int]) -> str:
+    if isinstance(pixels, (bytes, bytearray)):
+        payload = bytes(pixels)
+    else:
+        payload = bytes(int(pixel) & 0xFF for pixel in pixels)
+    return hashlib.sha256(payload).hexdigest()
+
+
+def frame_sequence_sha256(frames: Iterable[bytes | bytearray | Iterable[int]]) -> str:
+    digest = hashlib.sha256()
+    for frame in frames:
+        if isinstance(frame, (bytes, bytearray)):
+            payload = bytes(frame)
+        else:
+            payload = bytes(int(pixel) & 0xFF for pixel in frame)
+        digest.update(len(payload).to_bytes(8, "little"))
+        digest.update(payload)
+    return digest.hexdigest()

--- a/environments/emulator_common/graders/perf.py
+++ b/environments/emulator_common/graders/perf.py
@@ -1,0 +1,10 @@
+def fps(frames: int, elapsed_seconds: float) -> float:
+    if elapsed_seconds <= 0:
+        return 0.0
+    return float(frames) / float(elapsed_seconds)
+
+
+def stable_within(values: list[float], tolerance: float) -> bool:
+    if not values:
+        return False
+    return max(values) - min(values) <= tolerance + 1e-9

--- a/environments/emulator_common/graders/trace.py
+++ b/environments/emulator_common/graders/trace.py
@@ -1,0 +1,15 @@
+import json
+import zlib
+from collections.abc import Iterable
+from typing import TypeAlias
+
+TraceValue: TypeAlias = str | int | float | bool | None
+TraceEvent: TypeAlias = dict[str, TraceValue]
+
+
+def trace_crc(events: Iterable[TraceEvent]) -> str:
+    crc = 0
+    for event in events:
+        payload = json.dumps(dict(event), sort_keys=True, separators=(",", ":"))
+        crc = zlib.crc32(payload.encode("utf-8"), crc)
+    return f"{crc & 0xFFFFFFFF:08x}"

--- a/environments/emulator_common/loader.py
+++ b/environments/emulator_common/loader.py
@@ -1,0 +1,94 @@
+import json
+from pathlib import Path
+
+from verifiers.v1.types import ConfigData
+
+from .sandbox import build_sandbox_config
+from .task_schema import EmulatorManifest
+
+
+def load_manifest(path: str | Path) -> EmulatorManifest:
+    manifest_path = Path(path)
+    with manifest_path.open(encoding="utf-8") as f:
+        data = json.load(f)
+    manifest = EmulatorManifest.from_mapping(data)
+    if manifest.module_name != manifest_path.parent.parent.name:
+        raise ValueError(
+            "manifest module_name must match its environment directory: "
+            f"{manifest.module_name!r} != {manifest_path.parent.parent.name!r}"
+        )
+    return manifest
+
+
+def build_instruction(manifest: EmulatorManifest) -> str:
+    public = "\n".join(f"- {name}" for name in manifest.public_verification)
+    hidden = "\n".join(f"- {name}" for name in manifest.hidden_verification)
+    requirements = "\n".join(f"- {item}" for item in manifest.requirements)
+    concepts = ", ".join(manifest.core_concepts)
+    exposed = "\n".join(f"- {item}" for item in manifest.exposed_api)
+    success = "\n".join(f"- {item}" for item in manifest.success_criteria)
+    framebuffer = manifest.framebuffer or {"width": 0, "height": 0}
+    return f"""\
+{manifest.base_prompt}
+
+You are working in /workspace. Implement this as a Rust crate.
+
+Benchmark level: {manifest.level}
+System: {manifest.display_name}
+Difficulty: {manifest.difficulty}
+Core concepts: {concepts}
+
+Functional requirements:
+{requirements}
+
+Required public API:
+{exposed or "- Use the common Emulator API from src/lib.rs."}
+
+Framebuffer contract:
+- Width: {framebuffer.get("width", 0)}
+- Height: {framebuffer.get("height", 0)}
+- framebuffer() must return deterministic, row-major pixels.
+
+Public verification targets:
+{public}
+
+Hidden verification categories:
+{hidden}
+
+Success criteria:
+{success}
+
+You may add dependencies, modules, tests, and build scripts as needed. Keep the
+emulator deterministic: identical ROM bytes, input events, and cycle budgets
+must produce identical framebuffer hashes, traces, and observable outputs.
+"""
+
+
+def manifest_to_rows(
+    manifest: EmulatorManifest,
+    *,
+    max_tasks: int | None = None,
+    cpu_cores: int | None = None,
+    memory_gb: int | None = None,
+    network_access: bool = True,
+    sandbox_timeout_minutes: int | None = None,
+) -> list[ConfigData]:
+    info = manifest.to_info()
+    instruction = build_instruction(manifest)
+    row = {
+        "example_id": 0,
+        "task_id": f"{manifest.environment_id}__implementation",
+        "question": instruction,
+        "instruction": instruction,
+        "prompt": [{"role": "user", "content": instruction}],
+        "answer": "pass",
+        "info": info,
+        "sandbox": build_sandbox_config(
+            cpu_cores=cpu_cores,
+            memory_gb=memory_gb,
+            network_access=network_access,
+            timeout_minutes=sandbox_timeout_minutes,
+        ),
+    }
+    rows = [row]
+    return rows[:max_tasks] if max_tasks else rows

--- a/environments/emulator_common/runner_contract.py
+++ b/environments/emulator_common/runner_contract.py
@@ -1,0 +1,98 @@
+from typing import TypeAlias
+
+JsonValue: TypeAlias = (
+    str | int | float | bool | None | list["JsonValue"] | dict[str, "JsonValue"]
+)
+JsonData: TypeAlias = dict[str, JsonValue]
+
+CONTRACT_VERSION = "emulator-runner-v1"
+DEFAULT_EXECUTABLE = "/workspace/target/release/emulator-runner"
+DEFAULT_JSON_OUTPUT = "/tmp/emulator_case_output.json"
+
+
+def runner_contract() -> JsonData:
+    return {
+        "version": CONTRACT_VERSION,
+        "build_command": "cargo build --release",
+        "executable_path": DEFAULT_EXECUTABLE,
+        "self_test": [DEFAULT_EXECUTABLE, "--self-test"],
+        "contract_version": [DEFAULT_EXECUTABLE, "--contract-version"],
+        "case_command": [
+            DEFAULT_EXECUTABLE,
+            "--platform",
+            "<platform>",
+            "--case",
+            "<case_id>",
+            "--rom",
+            "<rom_or_suite_artifact_path>",
+            "--cycles",
+            "<cycle_budget>",
+            "--frames",
+            "<frame_budget>",
+            "--output",
+            "<json_output_path>",
+        ],
+        "case_output_schema": {
+            "required": ["platform", "case_id", "passed"],
+            "optional": [
+                "cycles",
+                "frames",
+                "serial",
+                "framebuffer_sha256",
+                "frame_sequence_sha256",
+                "trace_crc32",
+                "audio_crc32",
+                "perf",
+                "log",
+            ],
+        },
+    }
+
+
+def runner_contract_markdown() -> str:
+    return """\
+## Emulator runner contract
+
+The grader builds the Rust crate with:
+
+```sh
+cargo build --release
+```
+
+It then expects an executable at `target/release/emulator-runner`. The runner
+must support these commands:
+
+```sh
+emulator-runner --contract-version
+emulator-runner --self-test
+emulator-runner --platform <slug> --case <case_id> --rom <path> \\
+  --cycles <cycle_budget> --frames <frame_budget> --output <json_path>
+```
+
+`--rom` is the input artifact path. Most cases pass a ROM image; processor-test
+suites can pass a machine-readable fixture such as a JSON or compressed JSON
+file when the case kind documents that contract.
+
+The per-case JSON output must include:
+
+```json
+{
+  "platform": "chip8",
+  "case_id": "chip8_timendus_suite",
+  "passed": true,
+  "cycles": 10000,
+  "frames": 1,
+  "framebuffer_sha256": "...",
+  "frame_sequence_sha256": "...",
+  "trace_crc32": "...",
+  "audio_crc32": "...",
+  "serial": "optional pass/fail text",
+  "perf": {"fps": 60.0}
+}
+```
+
+For CPU/trace tests, emit `trace_crc32` or pass/fail serial text. For visual
+tests, emit `framebuffer_sha256` or `frame_sequence_sha256`. For audio-capable
+platforms, emit `audio_crc32` when the test exercises audio. Re-running the same
+ROM/case/cycle budget must produce identical JSON signals.
+"""

--- a/environments/emulator_common/runners.py
+++ b/environments/emulator_common/runners.py
@@ -1,0 +1,366 @@
+import json
+import textwrap
+
+from verifiers.v1.types import ConfigData, ProgramData
+
+from .runner_contract import runner_contract, runner_contract_markdown
+from .task_schema import EmulatorManifest
+
+
+def cargo_toml_file(task: ConfigData, state: ConfigData | None = None) -> str:
+    _ = state
+    package = str(task["info"]["slug"]).replace("_", "-")
+    return f"""\
+[package]
+name = "{package}"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "emulator_benchmark"
+path = "src/lib.rs"
+
+[[bin]]
+name = "emulator-runner"
+path = "src/main.rs"
+
+[dependencies]
+"""
+
+
+def starter_lib_file(task: ConfigData, state: ConfigData | None = None) -> str:
+    _ = state
+    info = task["info"]
+    width = int(info.get("framebuffer", {}).get("width", 160))
+    height = int(info.get("framebuffer", {}).get("height", 144))
+    cycles = int(info.get("runtime", {}).get("smoke_cycles", 1024))
+    return f"""\
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EmulatorError(pub String);
+
+impl std::fmt::Display for EmulatorError {{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {{
+        f.write_str(&self.0)
+    }}
+}}
+
+impl std::error::Error for EmulatorError {{}}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Snapshot {{
+    pub cycles: u64,
+    pub framebuffer: Vec<u8>,
+}}
+
+#[derive(Debug, Clone)]
+pub struct Emulator {{
+    cycles: u64,
+    rom: Vec<u8>,
+    framebuffer: Vec<u8>,
+    keys: [bool; 16],
+}}
+
+impl Default for Emulator {{
+    fn default() -> Self {{
+        Self::new()
+    }}
+}}
+
+impl Emulator {{
+    pub const WIDTH: usize = {width};
+    pub const HEIGHT: usize = {height};
+    pub const SMOKE_CYCLES: u64 = {cycles};
+
+    pub fn new() -> Self {{
+        Self {{
+            cycles: 0,
+            rom: Vec::new(),
+            framebuffer: vec![0; Self::WIDTH * Self::HEIGHT],
+            keys: [false; 16],
+        }}
+    }}
+
+    pub fn reset(&mut self) {{
+        self.cycles = 0;
+        self.framebuffer.fill(0);
+        self.keys = [false; 16];
+    }}
+
+    pub fn load_rom(&mut self, rom: &[u8]) -> Result<(), EmulatorError> {{
+        self.rom.clear();
+        self.rom.extend_from_slice(rom);
+        self.reset();
+        Ok(())
+    }}
+
+    pub fn step(&mut self) -> Result<(), EmulatorError> {{
+        self.cycles = self.cycles.wrapping_add(1);
+        Ok(())
+    }}
+
+    pub fn run_cycles(&mut self, cycles: u64) -> Result<(), EmulatorError> {{
+        for _ in 0..cycles {{
+            self.step()?;
+        }}
+        Ok(())
+    }}
+
+    pub fn framebuffer(&self) -> &[u8] {{
+        &self.framebuffer
+    }}
+
+    pub fn set_key(&mut self, key: usize, pressed: bool) {{
+        if key < self.keys.len() {{
+            self.keys[key] = pressed;
+        }}
+    }}
+
+    pub fn save_state(&self) -> Snapshot {{
+        Snapshot {{
+            cycles: self.cycles,
+            framebuffer: self.framebuffer.clone(),
+        }}
+    }}
+
+    pub fn load_state(&mut self, snapshot: &Snapshot) -> Result<(), EmulatorError> {{
+        self.cycles = snapshot.cycles;
+        self.framebuffer = snapshot.framebuffer.clone();
+        Ok(())
+    }}
+
+    pub fn cycles(&self) -> u64 {{
+        self.cycles
+    }}
+}}
+"""
+
+
+def starter_main_file(task: ConfigData, state: ConfigData | None = None) -> str:
+    _ = state
+    info = task["info"]
+    platform = str(info["slug"])
+    smoke_cycles = int(info.get("runtime", {}).get("smoke_cycles", 1024))
+    return f"""\
+use emulator_benchmark::Emulator;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{{Hash, Hasher}};
+
+fn hash_bytes(bytes: &[u8]) -> String {{
+    let mut hasher = DefaultHasher::new();
+    bytes.hash(&mut hasher);
+    format!("{{:016x}}", hasher.finish())
+}}
+
+fn json_arg(args: &[String], name: &str) -> Option<String> {{
+    args.windows(2)
+        .find(|window| window[0] == name)
+        .map(|window| window[1].clone())
+}}
+
+fn main() {{
+    let args: Vec<String> = std::env::args().collect();
+    if args.iter().any(|arg| arg == "--contract-version") {{
+        println!("emulator-runner-v1");
+        return;
+    }}
+    if args.iter().any(|arg| arg == "--self-test") {{
+        println!("{{{{\\\"ok\\\":true,\\\"contract\\\":\\\"emulator-runner-v1\\\"}}}}");
+        return;
+    }}
+    if let Some(output_path) = json_arg(&args, "--output") {{
+        let case_id = json_arg(&args, "--case").unwrap_or_else(|| "unknown".to_string());
+        let cycles: u64 = json_arg(&args, "--cycles")
+            .and_then(|value| value.parse().ok())
+            .unwrap_or({smoke_cycles});
+        let mut emulator = Emulator::new();
+        if let Some(rom_path) = json_arg(&args, "--rom") {{
+            let rom = std::fs::read(rom_path).unwrap_or_default();
+            emulator.load_rom(&rom).expect("load_rom");
+        }}
+        emulator.run_cycles(cycles).expect("run_cycles");
+        let frame_hash = hash_bytes(emulator.framebuffer());
+        let payload = format!(
+            "{{{{\\\"platform\\\":\\\"{platform}\\\",\\\"case_id\\\":\\\"{{}}\\\",\\\"passed\\\":false,\\\"cycles\\\":{{}},\\\"frames\\\":1,\\\"framebuffer_sha256\\\":\\\"{{}}\\\",\\\"serial\\\":\\\"starter scaffold does not implement public ROM suite\\\"}}}}",
+            case_id,
+            emulator.cycles(),
+            frame_hash
+        );
+        std::fs::write(output_path, payload).expect("write output");
+        return;
+    }}
+
+    let mut emulator = Emulator::new();
+    let rom: Vec<u8> = (0u8..=31).collect();
+    emulator.load_rom(&rom).expect("load_rom");
+    emulator.run_cycles({smoke_cycles}).expect("run_cycles");
+    let frame_hash = hash_bytes(emulator.framebuffer());
+    println!(
+        "{{{{\\\"platform\\\":\\\"{platform}\\\",\\\"cycles\\\":{{}},\\\"framebuffer_hash\\\":\\\"{{}}\\\",\\\"deterministic\\\":true}}}}",
+        emulator.cycles(),
+        frame_hash
+    );
+}}
+"""
+
+
+def public_contract_file(task: ConfigData, state: ConfigData | None = None) -> str:
+    _ = state
+    info = task["info"]
+    width = int(info.get("framebuffer", {}).get("width", 160))
+    height = int(info.get("framebuffer", {}).get("height", 144))
+    return f"""\
+use emulator_benchmark::Emulator;
+
+#[test]
+fn exposes_required_core_api() {{
+    let mut emulator = Emulator::new();
+    emulator.reset();
+    emulator.load_rom(&[0x00, 0x01, 0x02, 0x03]).unwrap();
+    emulator.step().unwrap();
+    emulator.run_cycles(8).unwrap();
+    emulator.set_key(0, true);
+    let snapshot = emulator.save_state();
+    emulator.load_state(&snapshot).unwrap();
+    assert_eq!(emulator.framebuffer().len(), {width * height});
+}}
+
+#[test]
+fn deterministic_replay_from_same_rom() {{
+    let rom = [0x42, 0x99, 0x10, 0x77, 0x00, 0xFE];
+    let mut first = Emulator::new();
+    let mut second = Emulator::new();
+    first.load_rom(&rom).unwrap();
+    second.load_rom(&rom).unwrap();
+    first.run_cycles(32).unwrap();
+    second.run_cycles(32).unwrap();
+    assert_eq!(first.framebuffer(), second.framebuffer());
+    assert_eq!(first.cycles(), second.cycles());
+}}
+"""
+
+
+def workspace_readme_file(task: ConfigData, state: ConfigData | None = None) -> str:
+    _ = state
+    info = task["info"]
+    public = "\n".join(f"- {item}" for item in info["public_verification"])
+    hidden = "\n".join(f"- {item}" for item in info["hidden_verification"])
+    return f"""\
+# {info["display_name"]} Emulator Task
+
+Implement the emulator in this Rust crate. The public contract tests in
+`tests/public_contract.rs` check the required harness API. The benchmark grader
+also checks deterministic command output, required platform terminology, and
+the verification targets below.
+
+{runner_contract_markdown()}
+
+## Public verification targets
+
+{public}
+
+## Hidden verification categories
+
+{hidden}
+"""
+
+
+def public_manifest_file(task: ConfigData, state: ConfigData | None = None) -> str:
+    _ = state
+    payload = {
+        "platform": task["info"]["slug"],
+        "public_cases": task["info"]["public_cases"],
+        "framebuffer": task["info"].get("framebuffer", {}),
+        "runtime": task["info"].get("runtime", {}),
+        "runner_contract": runner_contract(),
+    }
+    return json.dumps(payload, indent=2, sort_keys=True)
+
+
+def hidden_manifest_json(task: ConfigData) -> str:
+    payload = {
+        "platform": task["info"]["slug"],
+        "display_name": task["info"]["display_name"],
+        "requirements": task["info"]["requirements"],
+        "public_cases": task["info"]["public_cases"],
+        "hidden_cases": task["info"]["hidden_cases"],
+        "framebuffer": task["info"].get("framebuffer", {}),
+        "runtime": task["info"].get("runtime", {}),
+        "scoring_weights": task["info"].get("scoring_weights", {}),
+        "runner_contract": runner_contract(),
+    }
+    return json.dumps(payload, indent=2, sort_keys=True)
+
+
+def build_program_config(manifest: EmulatorManifest) -> ProgramData:
+    _ = manifest
+    return {
+        "files": {
+            "/workspace/Cargo.toml": cargo_toml_file,
+            "/workspace/src/lib.rs": starter_lib_file,
+            "/workspace/src/main.rs": starter_main_file,
+            "/workspace/tests/public_contract.rs": public_contract_file,
+            "/workspace/verification/public_manifest.json": public_manifest_file,
+            "/workspace/verification/runner_contract.json": lambda task, state=None: (
+                json.dumps(runner_contract(), indent=2, sort_keys=True)
+            ),
+            "/workspace/README.md": workspace_readme_file,
+        },
+        "setup": [
+            "mkdir -p /workspace/src /workspace/tests /workspace/verification",
+            (
+                "printf '%s\\n' "
+                "'export PATH=/usr/local/cargo/bin:/root/.cargo/bin:/usr/local/bin:$PATH' "
+                "'export CARGO_HOME=/usr/local/cargo' "
+                "'export PAGER=cat' "
+                "'export MANPAGER=cat' "
+                "> /etc/profile.d/emulator_toolchain.sh || true"
+            ),
+        ],
+        "env": {
+            "AGENT_WORKDIR": "/workspace",
+            "PATH": (
+                "/usr/local/cargo/bin:/root/.cargo/bin:/usr/local/sbin:"
+                "/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+            ),
+            "CARGO_HOME": "/usr/local/cargo",
+            "PAGER": "cat",
+            "MANPAGER": "cat",
+        },
+    }
+
+
+VERIFIER_SCRIPT = textwrap.dedent(
+    r"""
+    import argparse
+    import json
+    import subprocess
+    import sys
+    from pathlib import Path
+
+
+    def main() -> int:
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--workspace", required=True)
+        parser.add_argument("--manifest", required=True)
+        parser.add_argument("--sources", required=True)
+        parser.add_argument("--output", required=True)
+        args = parser.parse_args()
+
+        sys.path.insert(0, "/tmp")
+        from emulator_suite_adapters import verify_workspace
+
+        workspace = Path(args.workspace)
+        with open(args.manifest, encoding="utf-8") as f:
+            manifest = json.load(f)
+        with open(args.sources, encoding="utf-8") as f:
+            sources = json.load(f)
+        result = verify_workspace(workspace, manifest, sources)
+        Path(args.output).write_text(json.dumps(result, indent=2, sort_keys=True), encoding="utf-8")
+        print(json.dumps({"score": result["score"], "passed": result["passed"]}, sort_keys=True))
+        return 0 if result["score"] > 0 else 1
+
+
+    if __name__ == "__main__":
+        sys.exit(main())
+    """
+).strip()

--- a/environments/emulator_common/sandbox.py
+++ b/environments/emulator_common/sandbox.py
@@ -1,0 +1,38 @@
+import os
+
+from verifiers.v1.types import ConfigData
+
+WORKSPACE = "/workspace"
+DEFAULT_TOOLCHAIN_IMAGE = "primeintellect/programbench-toolchain:latest"
+DEFAULT_CPU_CORES = 4
+DEFAULT_MEMORY_GB = 8
+DEFAULT_DISK_GB = 12
+DEFAULT_TIMEOUT_MINUTES = 360
+
+
+def toolchain_image() -> str:
+    return os.environ.get("PRIME_TOOLCHAIN_IMAGE", DEFAULT_TOOLCHAIN_IMAGE)
+
+
+def build_sandbox_config(
+    *,
+    cpu_cores: int | None = None,
+    memory_gb: int | None = None,
+    network_access: bool = True,
+    timeout_minutes: int | None = None,
+) -> ConfigData:
+    resolved_timeout = timeout_minutes or DEFAULT_TIMEOUT_MINUTES
+    return {
+        "image": toolchain_image(),
+        "cpu_cores": cpu_cores or DEFAULT_CPU_CORES,
+        "memory_gb": memory_gb or DEFAULT_MEMORY_GB,
+        "disk_size_gb": DEFAULT_DISK_GB,
+        "gpu_count": 0,
+        "workdir": WORKSPACE,
+        "scope": "rollout",
+        "timeout_minutes": resolved_timeout,
+        "command_timeout": resolved_timeout * 60,
+        # Required for the vf-eval model tunnel. The benchmark itself does not
+        # require source lookup network access.
+        "network_access": network_access,
+    }

--- a/environments/emulator_common/scripts/verify_test_sources.py
+++ b/environments/emulator_common/scripts/verify_test_sources.py
@@ -1,0 +1,56 @@
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ENVIRONMENTS_ROOT = Path(__file__).resolve().parents[2]
+if str(ENVIRONMENTS_ROOT) not in sys.path:
+    sys.path.insert(0, str(ENVIRONMENTS_ROOT))
+
+from emulator_common.test_sources import (  # noqa: E402
+    load_public_test_manifest,
+    verify_source_reachable,
+)
+
+
+def iter_manifests(root: Path):
+    yield from sorted(root.glob("emulator_*/tasks/public_tests.json"))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=ENVIRONMENTS_ROOT)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    results = []
+    ok = True
+    for path in iter_manifests(args.root):
+        manifest = load_public_test_manifest(path)
+        for source in manifest.sources:
+            reachable, detail = verify_source_reachable(source)
+            results.append(
+                {
+                    "environment_id": manifest.environment_id,
+                    "source": source.name,
+                    "url": source.url,
+                    "kind": source.kind,
+                    "ok": reachable,
+                    "detail": detail,
+                }
+            )
+            ok = ok and reachable
+
+    if args.json:
+        print(json.dumps(results, indent=2, sort_keys=True))
+    else:
+        for row in results:
+            status = "OK" if row["ok"] else "FAIL"
+            print(
+                f"{status} {row['environment_id']} {row['source']} {row['url']} {row['detail']}"
+            )
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/environments/emulator_common/suite_adapters.py
+++ b/environments/emulator_common/suite_adapters.py
@@ -1,0 +1,637 @@
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import time
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TypeAlias
+
+JsonValue: TypeAlias = (
+    str | int | float | bool | None | list["JsonValue"] | dict[str, "JsonValue"]
+)
+JsonData: TypeAlias = dict[str, JsonValue]
+
+CONTRACT_VERSION = "emulator-runner-v1"
+DEFAULT_EXECUTABLE = "target/release/emulator-runner"
+
+ROM_EXTENSIONS_BY_PLATFORM = {
+    "chip8": (".ch8", ".c8", ".rom"),
+    "i8080_space_invaders": (".bin", ".rom", ".com"),
+    "gameboy_dmg": (".gb", ".gbc"),
+    "gameboy_cgb": (".gbc", ".gb"),
+    "nes": (".nes",),
+    "sms": (".sms", ".gg", ".sg"),
+    "gba": (".gba", ".mb", ".bin"),
+    "genesis": (".md", ".gen", ".bin", ".smd", ".json", ".json.gz"),
+    "snes": (".sfc", ".smc", ".bs"),
+    "ps1": (".exe", ".ps-exe", ".cue", ".iso", ".bin"),
+}
+
+VISUAL_SIGNALS = {
+    "framebuffer_hash",
+    "frame_sequence_hash",
+    "palette_hash",
+    "stability_hash",
+}
+TRACE_SIGNALS = {
+    "trace_crc",
+    "cpu_trace_crc",
+    "event_log_crc",
+    "memory_snapshot_hash",
+    "mapper_event_hash",
+    "swi_trace_crc",
+    "gte_trace_crc",
+    "serial_pass",
+    "pass_marker",
+    "suite_pass_rate",
+    "timeout_free_run",
+}
+AUDIO_SIGNALS = {"audio_crc"}
+
+
+@dataclass(frozen=True)
+class CaseRun:
+    case_id: str
+    case_name: str
+    artifact: str
+    passed: bool
+    output: JsonData
+    stdout: str
+    stderr: str
+    returncode: int
+    elapsed_seconds: float
+
+
+def stable_hash(value: JsonValue) -> str:
+    payload = json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _text_tail(value: str | bytes | None, limit: int = 12000) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        value = value.decode("utf-8", errors="replace")
+    return value[-limit:]
+
+
+def run_command(
+    command: list[str],
+    cwd: Path,
+    timeout: int,
+    *,
+    env: dict[str, str] | None = None,
+) -> JsonData:
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=str(cwd),
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=timeout,
+            env=env,
+        )
+        return {
+            "ok": completed.returncode == 0,
+            "returncode": completed.returncode,
+            "stdout": _text_tail(completed.stdout),
+            "stderr": _text_tail(completed.stderr),
+        }
+    except subprocess.TimeoutExpired as exc:
+        return {
+            "ok": False,
+            "returncode": 124,
+            "stdout": _text_tail(exc.stdout),
+            "stderr": _text_tail(f"{_text_tail(exc.stderr)}\nTIMEOUT"),
+        }
+
+
+def build_workspace(workspace: Path, timeout: int) -> JsonData:
+    cargo_test = run_command(
+        ["cargo", "test", "--all", "--", "--nocapture"],
+        workspace,
+        timeout,
+    )
+    cargo_build = run_command(["cargo", "build", "--release"], workspace, timeout)
+    return {"cargo_test": cargo_test, "cargo_build": cargo_build}
+
+
+def locate_runner(workspace: Path) -> Path | None:
+    env_runner = os.environ.get("EMULATOR_RUNNER")
+    candidates = []
+    if env_runner:
+        candidates.append(Path(env_runner))
+    candidates.extend(
+        [
+            workspace / "emulator-runner",
+            workspace / DEFAULT_EXECUTABLE,
+            workspace / "target/release/emulator_benchmark",
+        ]
+    )
+    for candidate in candidates:
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return candidate
+    return None
+
+
+def check_runner_contract(
+    workspace: Path, runner: Path | None, timeout: int
+) -> JsonData:
+    if runner is None:
+        return {"ok": False, "error": "missing runner executable"}
+    version = run_command([str(runner), "--contract-version"], workspace, timeout)
+    self_test = run_command([str(runner), "--self-test"], workspace, timeout)
+    version_text = str(version.get("stdout") or "").strip()
+    version_ok = version["ok"] and CONTRACT_VERSION in version_text
+    return {
+        "ok": bool(version_ok and self_test["ok"]),
+        "version": version,
+        "self_test": self_test,
+        "runner": str(runner),
+    }
+
+
+def fetch_source(source: JsonData, destination: Path, timeout: int) -> JsonData:
+    name = str(source["name"])
+    kind = str(source["kind"])
+    target = destination / safe_name(name)
+    if target.exists():
+        shutil.rmtree(target)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if kind == "git":
+        sparse_paths = [str(path) for path in source.get("sparse_paths", [])]
+        command = ["git", "clone", "--depth", "1"]
+        if sparse_paths:
+            command.extend(["--filter", "blob:none", "--sparse"])
+        ref = source.get("ref")
+        if ref:
+            command.extend(["--branch", str(ref)])
+        command.extend([str(source["url"]), str(target)])
+        started = time.monotonic()
+        result = run_command(command, destination, timeout)
+        if result["ok"] and sparse_paths:
+            sparse = run_command(
+                ["git", "-C", str(target), "sparse-checkout", "set", *sparse_paths],
+                destination,
+                timeout,
+            )
+            result["ok"] = bool(sparse["ok"])
+            result["returncode"] = sparse["returncode"]
+            result["stdout"] = f"{result.get('stdout', '')}\n{sparse.get('stdout', '')}"
+            result["stderr"] = f"{result.get('stderr', '')}\n{sparse.get('stderr', '')}"
+        if result["ok"]:
+            write_source_metadata(target, source)
+        result["elapsed_seconds"] = round(time.monotonic() - started, 3)
+        result["path"] = str(target)
+        result["source"] = name
+        result["sparse_paths"] = sparse_paths
+        return result
+    if kind == "http":
+        target.mkdir(parents=True, exist_ok=True)
+        headers = {"User-Agent": "verifiers-emulator-suite-fetch/0.1"}
+        try:
+            request = urllib.request.Request(str(source["url"]), headers=headers)
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                body = response.read()
+            (target / "index.html").write_bytes(body)
+            write_source_metadata(target, source)
+            return {
+                "ok": True,
+                "returncode": 0,
+                "stdout": f"HTTP bytes={len(body)}",
+                "stderr": "",
+                "path": str(target),
+                "source": name,
+            }
+        except Exception as exc:
+            return {
+                "ok": False,
+                "returncode": 1,
+                "stdout": "",
+                "stderr": str(exc),
+                "path": str(target),
+                "source": name,
+            }
+    if kind == "local":
+        local_path = Path(str(source["url"])).expanduser()
+        if not local_path.exists():
+            return {
+                "ok": False,
+                "returncode": 1,
+                "stdout": "",
+                "stderr": f"local source missing: {local_path}",
+                "path": str(target),
+                "source": name,
+            }
+        if local_path.is_dir():
+            shutil.copytree(local_path, target)
+        else:
+            target.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(local_path, target / local_path.name)
+        write_source_metadata(target, source)
+        return {
+            "ok": True,
+            "returncode": 0,
+            "stdout": "local source copied",
+            "stderr": "",
+            "path": str(target),
+            "source": name,
+        }
+    if kind == "private-artifact":
+        return {
+            "ok": True,
+            "returncode": 0,
+            "stdout": "private artifact source documented; mounted separately",
+            "stderr": "",
+            "path": str(target),
+            "source": name,
+            "private_artifact": True,
+        }
+    return {
+        "ok": False,
+        "returncode": 1,
+        "stdout": "",
+        "stderr": f"unsupported source kind: {kind}",
+        "path": str(target),
+        "source": name,
+    }
+
+
+def safe_name(value: str) -> str:
+    out = "".join(ch.lower() if ch.isalnum() else "-" for ch in value)
+    return "-".join(part for part in out.split("-") if part)[:96] or "source"
+
+
+def write_source_metadata(target: Path, source: JsonData) -> None:
+    metadata = {
+        key: source[key]
+        for key in ("artifact_globs", "artifact_extensions")
+        if key in source
+    }
+    if metadata:
+        (target / ".emulator_source.json").write_text(
+            json.dumps(metadata, sort_keys=True),
+            encoding="utf-8",
+        )
+
+
+def source_artifact_candidates(root: Path) -> list[Path]:
+    metadata_path = root / ".emulator_source.json"
+    if metadata_path.exists():
+        try:
+            metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            metadata = {}
+        globs = [str(pattern) for pattern in metadata.get("artifact_globs", [])]
+        if globs:
+            paths: list[Path] = []
+            for pattern in globs:
+                paths.extend(root.glob(pattern))
+            return paths
+    return list(root.rglob("*"))
+
+
+def source_artifact_extensions(root: Path, default: tuple[str, ...]) -> tuple[str, ...]:
+    metadata_path = root / ".emulator_source.json"
+    if not metadata_path.exists():
+        return default
+    try:
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return default
+    extensions = tuple(
+        str(value).lower() for value in metadata.get("artifact_extensions", [])
+    )
+    return extensions or default
+
+
+def discover_artifacts(platform: str, source_roots: list[Path]) -> list[Path]:
+    found: list[Path] = []
+    for root in source_roots:
+        if not root.exists():
+            continue
+        extensions = source_artifact_extensions(
+            root, ROM_EXTENSIONS_BY_PLATFORM.get(platform, (".rom", ".bin"))
+        )
+        for path in source_artifact_candidates(root):
+            if path.is_file() and path.name.lower().endswith(extensions):
+                if path.stat().st_size > 0:
+                    found.append(path)
+    return sorted(set(found), key=lambda p: str(p))[:128]
+
+
+def private_artifact_paths(public_sources: JsonData) -> list[JsonData]:
+    artifact_root = Path(
+        os.environ.get("EMULATOR_PRIVATE_ARTIFACT_DIR", "/private/emulator")
+    )
+    rows: list[JsonData] = []
+    for artifact in public_sources.get("private_artifacts", []):
+        name = str(artifact.get("name", "artifact"))
+        candidates = [
+            artifact_root / name,
+            artifact_root / f"{name}.bin",
+            artifact_root / f"{name}.rom",
+        ]
+        mounted = [str(path) for path in candidates if path.exists()]
+        row = dict(artifact)
+        row["mounted_paths"] = mounted
+        row["available"] = bool(mounted)
+        rows.append(row)
+    return rows
+
+
+def case_for_artifact(
+    artifact: Path, public_cases: list[JsonData], index: int
+) -> JsonData:
+    if not public_cases:
+        return {
+            "id": f"public_artifact_{index}",
+            "name": artifact.name,
+            "expected_signal": "suite_pass_rate",
+        }
+    lowered = str(artifact).lower()
+    for case in public_cases:
+        tokens = [
+            token
+            for token in str(case.get("name", "")).lower().replace("-", " ").split()
+            if len(token) >= 3
+        ]
+        if tokens and any(token in lowered for token in tokens):
+            return case
+    return public_cases[index % len(public_cases)]
+
+
+def invoke_case(
+    workspace: Path,
+    runner: Path,
+    platform: str,
+    case: JsonData,
+    artifact: Path,
+    runtime: JsonData,
+    timeout: int,
+) -> CaseRun:
+    output_path = (
+        workspace
+        / "verification"
+        / f"{case['id']}-{stable_hash(str(artifact))[:10]}.json"
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    cycles = int(runtime.get("smoke_cycles", 10000))
+    frames = max(1, int(runtime.get("smoke_frames", 1)))
+    command = [
+        str(runner),
+        "--platform",
+        platform,
+        "--case",
+        str(case["id"]),
+        "--rom",
+        str(artifact),
+        "--cycles",
+        str(cycles),
+        "--frames",
+        str(frames),
+        "--output",
+        str(output_path),
+    ]
+    started = time.monotonic()
+    result = run_command(command, workspace, timeout)
+    elapsed = time.monotonic() - started
+    output: JsonData = {}
+    if output_path.exists():
+        try:
+            output = json.loads(output_path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            output = {"parse_error": str(exc)}
+    passed = bool(result["ok"] and output.get("passed") is True)
+    return CaseRun(
+        case_id=str(case["id"]),
+        case_name=str(case.get("name", case["id"])),
+        artifact=str(artifact),
+        passed=passed,
+        output=output,
+        stdout=str(result.get("stdout") or ""),
+        stderr=str(result.get("stderr") or ""),
+        returncode=int(result.get("returncode", 1)),
+        elapsed_seconds=round(elapsed, 3),
+    )
+
+
+def replay_determinism(
+    workspace: Path,
+    runner: Path,
+    platform: str,
+    case: JsonData,
+    artifact: Path,
+    runtime: JsonData,
+    timeout: int,
+) -> JsonData:
+    first = invoke_case(workspace, runner, platform, case, artifact, runtime, timeout)
+    second = invoke_case(workspace, runner, platform, case, artifact, runtime, timeout)
+    keys = [
+        "passed",
+        "cycles",
+        "frames",
+        "serial",
+        "framebuffer_sha256",
+        "frame_sequence_sha256",
+        "trace_crc32",
+        "audio_crc32",
+        "perf",
+    ]
+    lhs = {key: first.output.get(key) for key in keys if key in first.output}
+    rhs = {key: second.output.get(key) for key in keys if key in second.output}
+    return {
+        "ok": bool(first.passed and second.passed and lhs == rhs),
+        "first": first.output,
+        "second": second.output,
+        "artifact": str(artifact),
+        "case_id": str(case["id"]),
+    }
+
+
+def signal_scores(cases: list[JsonData], runs: list[CaseRun]) -> dict[str, float]:
+    expected_by_id = {
+        str(case["id"]): str(case.get("expected_signal", "")) for case in cases
+    }
+    visual_total = trace_total = audio_total = 0
+    visual_hits = trace_hits = audio_hits = 0
+    for run in runs:
+        expected = expected_by_id.get(run.case_id, "")
+        output = run.output
+        if expected in VISUAL_SIGNALS or "frame" in expected or "palette" in expected:
+            visual_total += 1
+            if output.get("framebuffer_sha256") or output.get("frame_sequence_sha256"):
+                visual_hits += 1
+        if expected in TRACE_SIGNALS or "trace" in expected or "serial" in expected:
+            trace_total += 1
+            if output.get("trace_crc32") or output.get("serial") or run.passed:
+                trace_hits += 1
+        if expected in AUDIO_SIGNALS or "audio" in expected:
+            audio_total += 1
+            if output.get("audio_crc32"):
+                audio_hits += 1
+    return {
+        "framebuffer_hash_score": visual_hits / visual_total if visual_total else 1.0,
+        "trace_cpu_score": trace_hits / trace_total if trace_total else 1.0,
+        "audio_perf_score": audio_hits / audio_total if audio_total else 1.0,
+    }
+
+
+def verify_workspace(
+    workspace: Path | str,
+    manifest: JsonData,
+    public_sources: JsonData,
+    *,
+    source_root: Path | str | None = None,
+    timeout: int | None = None,
+    skip_build: bool = False,
+) -> JsonData:
+    workspace = Path(workspace)
+    timeout = int(
+        timeout or manifest.get("runtime", {}).get("verify_timeout_seconds", 900)
+    )
+    platform = str(manifest["platform"])
+    public_cases = list(manifest.get("public_cases", []))
+    runtime = dict(manifest.get("runtime", {}))
+
+    if skip_build:
+        build = {
+            "cargo_test": {
+                "ok": True,
+                "returncode": 0,
+                "stdout": "build skipped by fixture",
+                "stderr": "",
+            },
+            "cargo_build": {
+                "ok": True,
+                "returncode": 0,
+                "stdout": "build skipped by fixture",
+                "stderr": "",
+            },
+        }
+    else:
+        build = build_workspace(workspace, timeout)
+    runner = locate_runner(workspace)
+    contract = check_runner_contract(workspace, runner, min(timeout, 120))
+
+    source_cache = Path(source_root or workspace / "verification" / "public_suites")
+    source_cache.mkdir(parents=True, exist_ok=True)
+    fetches = [
+        fetch_source(source, source_cache, min(timeout, 240))
+        for source in public_sources.get("sources", [])
+    ]
+    fetched_roots = [
+        Path(str(row["path"]))
+        for row in fetches
+        if row.get("ok") and not row.get("private_artifact")
+    ]
+    public_artifacts = discover_artifacts(platform, fetched_roots)
+    private_artifacts = private_artifact_paths(public_sources)
+    private_artifact_roots: list[Path] = []
+    private_artifact_files: list[Path] = []
+    for row in private_artifacts:
+        for mounted_path in row.get("mounted_paths", []):
+            path = Path(str(mounted_path))
+            if path.is_dir():
+                private_artifact_roots.append(path)
+            elif path.is_file():
+                private_artifact_files.append(path)
+    private_discovered = discover_artifacts(platform, private_artifact_roots)
+    artifacts = sorted(
+        set([*public_artifacts, *private_discovered, *private_artifact_files]),
+        key=lambda path: str(path),
+    )[:128]
+
+    runs: list[CaseRun] = []
+    if runner is not None and contract.get("ok"):
+        for index, artifact in enumerate(artifacts):
+            case = case_for_artifact(artifact, public_cases, index)
+            runs.append(
+                invoke_case(
+                    workspace,
+                    runner,
+                    platform,
+                    case,
+                    artifact,
+                    runtime,
+                    timeout,
+                )
+            )
+
+    deterministic = {"ok": False, "reason": "no executed artifact"}
+    if runner is not None and contract.get("ok") and artifacts:
+        case = case_for_artifact(artifacts[0], public_cases, 0)
+        deterministic = replay_determinism(
+            workspace, runner, platform, case, artifacts[0], runtime, timeout
+        )
+
+    source_success = (
+        sum(1 for row in fetches if row.get("ok")) / len(fetches) if fetches else 0.0
+    )
+    build_score = float(build["cargo_test"]["ok"] and build["cargo_build"]["ok"])
+    contract_score = 1.0 if contract.get("ok") else 0.0
+    public_pass_rate = sum(1 for run in runs if run.passed) / len(runs) if runs else 0.0
+    runtime_stability = (
+        1.0 if contract.get("ok") and build["cargo_build"]["ok"] else 0.0
+    )
+    signal = signal_scores(public_cases, runs)
+    components = {
+        "build_score": build_score,
+        "runner_contract_score": contract_score,
+        "public_source_score": source_success,
+        "public_rom_pass_rate": public_pass_rate,
+        "framebuffer_hash_score": signal["framebuffer_hash_score"],
+        "trace_cpu_score": signal["trace_cpu_score"],
+        "audio_perf_score": signal["audio_perf_score"],
+        "deterministic_replay_score": 1.0 if deterministic.get("ok") else 0.0,
+        "runtime_stability_score": runtime_stability,
+        "private_artifact_availability": (
+            sum(1 for row in private_artifacts if row.get("available"))
+            / len(private_artifacts)
+            if private_artifacts
+            else 1.0
+        ),
+    }
+    score = (
+        0.12 * components["build_score"]
+        + 0.10 * components["runner_contract_score"]
+        + 0.08 * components["public_source_score"]
+        + 0.40 * components["public_rom_pass_rate"]
+        + 0.10 * components["framebuffer_hash_score"]
+        + 0.08 * components["trace_cpu_score"]
+        + 0.04 * components["audio_perf_score"]
+        + 0.06 * components["deterministic_replay_score"]
+        + 0.02 * components["runtime_stability_score"]
+    )
+    return {
+        "score": round(float(score), 6),
+        "passed": score >= 0.90,
+        "components": components,
+        "build": build,
+        "runner_contract": contract,
+        "public_sources": fetches,
+        "artifact_count": len(artifacts),
+        "public_artifact_count": len(public_artifacts),
+        "private_artifact_count": len(private_discovered) + len(private_artifact_files),
+        "artifacts": [str(path) for path in artifacts[:128]],
+        "case_runs": [
+            {
+                "case_id": run.case_id,
+                "case_name": run.case_name,
+                "artifact": run.artifact,
+                "passed": run.passed,
+                "returncode": run.returncode,
+                "elapsed_seconds": run.elapsed_seconds,
+                "output": run.output,
+                "stdout": run.stdout,
+                "stderr": run.stderr,
+            }
+            for run in runs
+        ],
+        "deterministic_replay": deterministic,
+        "private_artifacts": private_artifacts,
+    }

--- a/environments/emulator_common/task_schema.py
+++ b/environments/emulator_common/task_schema.py
@@ -1,0 +1,156 @@
+from dataclasses import dataclass, field
+from typing import TypeAlias
+
+JsonValue: TypeAlias = (
+    str | int | float | bool | None | list["JsonValue"] | dict[str, "JsonValue"]
+)
+JsonData: TypeAlias = dict[str, JsonValue]
+
+
+REQUIRED_MANIFEST_FIELDS = {
+    "environment_id",
+    "module_name",
+    "level",
+    "slug",
+    "display_name",
+    "difficulty",
+    "goal",
+    "base_prompt",
+    "requirements",
+    "core_concepts",
+    "public_verification",
+    "hidden_verification",
+    "success_criteria",
+    "verification_cases",
+}
+
+
+@dataclass(frozen=True)
+class VerificationCase:
+    id: str
+    stage: str
+    kind: str
+    name: str
+    expected_signal: str
+    source: str = "external"
+    notes: str = ""
+
+    @classmethod
+    def from_mapping(cls, value: JsonData) -> "VerificationCase":
+        missing = {
+            key
+            for key in ("id", "stage", "kind", "name", "expected_signal")
+            if key not in value
+        }
+        if missing:
+            raise ValueError(f"verification case is missing fields: {sorted(missing)}")
+        return cls(
+            id=str(value["id"]),
+            stage=str(value["stage"]),
+            kind=str(value["kind"]),
+            name=str(value["name"]),
+            expected_signal=str(value["expected_signal"]),
+            source=str(value.get("source", "external")),
+            notes=str(value.get("notes", "")),
+        )
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "id": self.id,
+            "stage": self.stage,
+            "kind": self.kind,
+            "name": self.name,
+            "expected_signal": self.expected_signal,
+            "source": self.source,
+            "notes": self.notes,
+        }
+
+
+@dataclass(frozen=True)
+class EmulatorManifest:
+    environment_id: str
+    module_name: str
+    level: int
+    slug: str
+    display_name: str
+    difficulty: str
+    goal: str
+    base_prompt: str
+    requirements: tuple[str, ...]
+    core_concepts: tuple[str, ...]
+    public_verification: tuple[str, ...]
+    hidden_verification: tuple[str, ...]
+    success_criteria: tuple[str, ...]
+    verification_cases: tuple[VerificationCase, ...]
+    exposed_api: tuple[str, ...] = ()
+    framebuffer: dict[str, int] = field(default_factory=dict)
+    runtime: dict[str, int] = field(default_factory=dict)
+    scoring_weights: dict[str, float] = field(default_factory=dict)
+
+    @classmethod
+    def from_mapping(cls, value: JsonData) -> "EmulatorManifest":
+        missing = REQUIRED_MANIFEST_FIELDS - set(value)
+        if missing:
+            raise ValueError(f"manifest is missing fields: {sorted(missing)}")
+        cases = tuple(
+            VerificationCase.from_mapping(case)
+            for case in value.get("verification_cases", [])
+        )
+        if not cases:
+            raise ValueError("manifest must define at least one verification case")
+        return cls(
+            environment_id=str(value["environment_id"]),
+            module_name=str(value["module_name"]),
+            level=int(value["level"]),
+            slug=str(value["slug"]),
+            display_name=str(value["display_name"]),
+            difficulty=str(value["difficulty"]),
+            goal=str(value["goal"]),
+            base_prompt=str(value["base_prompt"]).strip(),
+            requirements=tuple(map(str, value["requirements"])),
+            core_concepts=tuple(map(str, value["core_concepts"])),
+            public_verification=tuple(map(str, value["public_verification"])),
+            hidden_verification=tuple(map(str, value["hidden_verification"])),
+            success_criteria=tuple(map(str, value["success_criteria"])),
+            verification_cases=cases,
+            exposed_api=tuple(map(str, value.get("exposed_api", ()))),
+            framebuffer={
+                str(k): int(v) for k, v in value.get("framebuffer", {}).items()
+            },
+            runtime={str(k): int(v) for k, v in value.get("runtime", {}).items()},
+            scoring_weights={
+                str(k): float(v) for k, v in value.get("scoring_weights", {}).items()
+            },
+        )
+
+    def public_cases(self) -> list[dict[str, str]]:
+        return [
+            case.to_dict() for case in self.verification_cases if case.stage == "public"
+        ]
+
+    def hidden_cases(self) -> list[dict[str, str]]:
+        return [
+            case.to_dict() for case in self.verification_cases if case.stage == "hidden"
+        ]
+
+    def to_info(self) -> JsonData:
+        return {
+            "environment_id": self.environment_id,
+            "module_name": self.module_name,
+            "level": self.level,
+            "slug": self.slug,
+            "display_name": self.display_name,
+            "difficulty": self.difficulty,
+            "goal": self.goal,
+            "requirements": list(self.requirements),
+            "core_concepts": list(self.core_concepts),
+            "exposed_api": list(self.exposed_api),
+            "public_verification": list(self.public_verification),
+            "hidden_verification": list(self.hidden_verification),
+            "success_criteria": list(self.success_criteria),
+            "public_cases": self.public_cases(),
+            "hidden_cases": self.hidden_cases(),
+            "framebuffer": dict(self.framebuffer),
+            "runtime": dict(self.runtime),
+            "scoring_weights": dict(self.scoring_weights),
+        }

--- a/environments/emulator_common/test_sources.py
+++ b/environments/emulator_common/test_sources.py
@@ -1,0 +1,139 @@
+import json
+import subprocess
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TypeAlias
+
+JsonValue: TypeAlias = (
+    str | int | float | bool | None | list["JsonValue"] | dict[str, "JsonValue"]
+)
+JsonData: TypeAlias = dict[str, JsonValue]
+
+
+@dataclass(frozen=True)
+class TestSource:
+    name: str
+    kind: str
+    url: str
+    covers: tuple[str, ...]
+    license: str = "unknown"
+    ref: str | None = None
+    sparse_paths: tuple[str, ...] = ()
+    artifact_globs: tuple[str, ...] = ()
+    artifact_extensions: tuple[str, ...] = ()
+    notes: str = ""
+
+    @classmethod
+    def from_mapping(cls, value: JsonData) -> "TestSource":
+        missing = {"name", "kind", "url", "covers"} - set(value)
+        if missing:
+            raise ValueError(f"test source is missing fields: {sorted(missing)}")
+        return cls(
+            name=str(value["name"]),
+            kind=str(value["kind"]),
+            url=str(value["url"]),
+            covers=tuple(map(str, value["covers"])),
+            license=str(value.get("license", "unknown")),
+            ref=str(value["ref"]) if value.get("ref") is not None else None,
+            sparse_paths=tuple(map(str, value.get("sparse_paths", ()))),
+            artifact_globs=tuple(map(str, value.get("artifact_globs", ()))),
+            artifact_extensions=tuple(map(str, value.get("artifact_extensions", ()))),
+            notes=str(value.get("notes", "")),
+        )
+
+    def to_dict(self) -> JsonData:
+        payload: JsonData = {
+            "name": self.name,
+            "kind": self.kind,
+            "url": self.url,
+            "covers": list(self.covers),
+            "license": self.license,
+            "notes": self.notes,
+        }
+        if self.ref is not None:
+            payload["ref"] = self.ref
+        if self.sparse_paths:
+            payload["sparse_paths"] = list(self.sparse_paths)
+        if self.artifact_globs:
+            payload["artifact_globs"] = list(self.artifact_globs)
+        if self.artifact_extensions:
+            payload["artifact_extensions"] = list(self.artifact_extensions)
+        return payload
+
+
+@dataclass(frozen=True)
+class PublicTestManifest:
+    environment_id: str
+    sources: tuple[TestSource, ...]
+    private_artifacts: tuple[JsonData, ...] = ()
+
+    @classmethod
+    def from_mapping(cls, value: JsonData) -> "PublicTestManifest":
+        missing = {"environment_id", "sources"} - set(value)
+        if missing:
+            raise ValueError(
+                f"public test manifest is missing fields: {sorted(missing)}"
+            )
+        sources = tuple(TestSource.from_mapping(item) for item in value["sources"])
+        if not sources:
+            raise ValueError("public test manifest must define at least one source")
+        return cls(
+            environment_id=str(value["environment_id"]),
+            sources=sources,
+            private_artifacts=tuple(
+                dict(item) for item in value.get("private_artifacts", ())
+            ),
+        )
+
+    def covered_names(self) -> set[str]:
+        return {name for source in self.sources for name in source.covers}
+
+    def to_dict(self) -> JsonData:
+        return {
+            "environment_id": self.environment_id,
+            "sources": [source.to_dict() for source in self.sources],
+            "private_artifacts": [dict(item) for item in self.private_artifacts],
+        }
+
+
+def load_public_test_manifest(path: str | Path) -> PublicTestManifest:
+    with Path(path).open(encoding="utf-8") as f:
+        return PublicTestManifest.from_mapping(json.load(f))
+
+
+def verify_source_reachable(source: TestSource, timeout: int = 20) -> tuple[bool, str]:
+    if source.kind == "git":
+        command = ["git", "ls-remote", "--heads", source.url]
+        if source.ref:
+            command.append(source.ref)
+        result = subprocess.run(
+            command,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=timeout,
+        )
+        if result.returncode == 0:
+            if source.ref and not result.stdout.strip():
+                return False, f"missing git branch/ref: {source.ref}"
+            return True, result.stdout.strip().splitlines()[
+                0
+            ] if result.stdout.strip() else "ok"
+        return False, (result.stderr or result.stdout).strip()
+
+    if source.kind in {"http", "private-artifact"}:
+        headers = {"User-Agent": "verifiers-emulator-source-check/0.1"}
+        request = urllib.request.Request(source.url, method="HEAD", headers=headers)
+        try:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                return 200 <= response.status < 400, f"HTTP {response.status}"
+        except Exception:
+            try:
+                fallback = urllib.request.Request(source.url, headers=headers)
+                with urllib.request.urlopen(fallback, timeout=timeout) as response:
+                    return 200 <= response.status < 400, f"HTTP {response.status}"
+            except Exception as exc:
+                return False, str(exc)
+
+    return False, f"unsupported source kind: {source.kind}"

--- a/environments/emulator_gameboy_cgb/README.md
+++ b/environments/emulator_gameboy_cgb/README.md
@@ -1,0 +1,5 @@
+# emulator-gameboy-cgb
+
+Level 6 emulator implementation benchmark extending DMG compatibility to Game
+Boy Color functionality: CGB mode, VRAM banks, HDMA, double-speed mode, color
+palettes, and dual-mode compatibility.

--- a/environments/emulator_gameboy_cgb/emulator_gameboy_cgb.py
+++ b/environments/emulator_gameboy_cgb/emulator_gameboy_cgb.py
@@ -1,0 +1,14 @@
+import sys
+from pathlib import Path
+
+ENVIRONMENTS_DIR = Path(__file__).resolve().parents[1]
+if str(ENVIRONMENTS_DIR) not in sys.path:
+    sys.path.insert(0, str(ENVIRONMENTS_DIR))
+
+from emulator_common import load_emulator_environment  # noqa: E402
+
+MANIFEST_PATH = Path(__file__).resolve().parent / "tasks" / "manifest.json"
+
+
+def load_environment(config=None, **kwargs):
+    return load_emulator_environment(MANIFEST_PATH, config=config, **kwargs)

--- a/environments/emulator_gameboy_cgb/pyproject.toml
+++ b/environments/emulator_gameboy_cgb/pyproject.toml
@@ -1,0 +1,24 @@
+[project]
+name = "emulator-gameboy-cgb"
+description = "Prime emulator benchmark env for Game Boy Color"
+tags = ["emulator", "gameboy-color", "cgb", "systems", "sandbox", "rust", "eval"]
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = ["verifiers"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build]
+include = ["emulator_gameboy_cgb.py", "pyproject.toml", "README.md", "tasks/manifest.json", "tasks/public_tests.json"]
+
+[project.entry-points."verifiers.environments"]
+emulator-gameboy-cgb = "emulator_gameboy_cgb:load_environment"
+
+[tool.verifiers.eval]
+num_examples = 1
+rollouts_per_example = 1
+
+[tool.uv.sources]
+verifiers = { path = "../..", editable = true }

--- a/environments/emulator_gameboy_cgb/tasks/manifest.json
+++ b/environments/emulator_gameboy_cgb/tasks/manifest.json
@@ -1,0 +1,27 @@
+{
+  "environment_id": "emulator-gameboy-cgb",
+  "module_name": "emulator_gameboy_cgb",
+  "level": 6,
+  "slug": "gameboy_cgb",
+  "display_name": "Game Boy Color",
+  "difficulty": "Hard",
+  "goal": "Extend the Game Boy emulator to support Game Boy Color hardware.",
+  "base_prompt": "Extend the existing DMG emulator to support Game Boy Color functionality.",
+  "core_concepts": ["Backward compatibility", "DMA", "VRAM banking", "Palette systems", "Double-speed mode"],
+  "requirements": ["CGB mode", "VRAM banks", "HDMA", "Double-speed mode", "Color palettes", "Backward compatibility"],
+  "exposed_api": ["frame stepping", "framebuffer access", "save/load state", "CGB mode controls", "palette access"],
+  "public_verification": ["cgb-acid2", "mooneye CGB tests", "SameSuite CGB"],
+  "hidden_verification": ["HDMA timing", "Palette edge cases", "Dual-mode compatibility"],
+  "success_criteria": ["CGB public tests pass", "DMG compatibility remains stable", "Color framebuffer hashes match"],
+  "framebuffer": {"width": 160, "height": 144},
+  "runtime": {"smoke_cycles": 70224, "verify_timeout_seconds": 1800},
+  "scoring_weights": {"correctness": 0.7, "determinism": 0.15, "performance": 0.1, "quality": 0.05},
+  "verification_cases": [
+    {"id": "cgb_acid2", "stage": "public", "kind": "rom", "name": "cgb-acid2", "expected_signal": "framebuffer_hash", "source": "public"},
+    {"id": "cgb_mooneye", "stage": "public", "kind": "rom_suite", "name": "mooneye CGB tests", "expected_signal": "suite_pass_rate", "source": "public"},
+    {"id": "cgb_samesuite", "stage": "public", "kind": "rom_suite", "name": "SameSuite CGB", "expected_signal": "suite_pass_rate", "source": "public"},
+    {"id": "cgb_hdma_timing", "stage": "hidden", "kind": "generated_rom", "name": "HDMA timing", "expected_signal": "event_log_crc", "source": "generated"},
+    {"id": "cgb_palette_edges", "stage": "hidden", "kind": "generated_rom", "name": "Palette edge cases", "expected_signal": "palette_hash", "source": "generated"},
+    {"id": "cgb_dual_mode", "stage": "hidden", "kind": "generated_rom", "name": "Dual-mode compatibility", "expected_signal": "frame_sequence_hash", "source": "generated"}
+  ]
+}

--- a/environments/emulator_gameboy_cgb/tasks/public_tests.json
+++ b/environments/emulator_gameboy_cgb/tasks/public_tests.json
@@ -1,0 +1,46 @@
+{
+  "environment_id": "emulator-gameboy-cgb",
+  "sources": [
+    {
+      "name": "CGB Acid2",
+      "kind": "git",
+      "url": "https://github.com/mattcurrie/cgb-acid2",
+      "ref": "master",
+      "license": "MIT",
+      "covers": ["cgb-acid2"]
+    },
+    {
+      "name": "Mooneye test suite",
+      "kind": "git",
+      "url": "https://github.com/Gekkio/mooneye-test-suite",
+      "ref": "main",
+      "license": "MIT",
+      "covers": ["mooneye CGB tests"]
+    },
+    {
+      "name": "SameSuite",
+      "kind": "git",
+      "url": "https://github.com/LIJI32/SameSuite",
+      "ref": "master",
+      "license": "MIT",
+      "covers": ["SameSuite CGB"]
+    },
+    {
+      "name": "c-sp Game Boy test ROM index",
+      "kind": "git",
+      "url": "https://github.com/c-sp/game-boy-test-roms",
+      "ref": "master",
+      "license": "mixed-see-upstream",
+      "covers": ["cgb-acid2", "mooneye CGB tests", "SameSuite CGB"],
+      "notes": "Cross-indexes CGB public suites and expected outputs."
+    }
+  ],
+  "private_artifacts": [
+    {
+      "name": "gameboy_cgb_public_test_roms",
+      "required_for": ["cgb-acid2", "mooneye CGB tests", "SameSuite CGB"],
+      "storage": "private/generated artifact bucket or mounted secret volume",
+      "hash_policy": "sha256 manifest required before scoring"
+    }
+  ]
+}

--- a/environments/emulator_gameboy_dmg/README.md
+++ b/environments/emulator_gameboy_dmg/README.md
@@ -1,0 +1,5 @@
+# emulator-gameboy-dmg
+
+Level 3 emulator implementation benchmark for the monochrome Nintendo Game Boy
+DMG. The task covers LR35902 CPU behavior, timers, interrupts, PPU rendering,
+MBC1, deterministic stepping, and save-state support.

--- a/environments/emulator_gameboy_dmg/emulator_gameboy_dmg.py
+++ b/environments/emulator_gameboy_dmg/emulator_gameboy_dmg.py
@@ -1,0 +1,14 @@
+import sys
+from pathlib import Path
+
+ENVIRONMENTS_DIR = Path(__file__).resolve().parents[1]
+if str(ENVIRONMENTS_DIR) not in sys.path:
+    sys.path.insert(0, str(ENVIRONMENTS_DIR))
+
+from emulator_common import load_emulator_environment  # noqa: E402
+
+MANIFEST_PATH = Path(__file__).resolve().parent / "tasks" / "manifest.json"
+
+
+def load_environment(config=None, **kwargs):
+    return load_emulator_environment(MANIFEST_PATH, config=config, **kwargs)

--- a/environments/emulator_gameboy_dmg/pyproject.toml
+++ b/environments/emulator_gameboy_dmg/pyproject.toml
@@ -1,0 +1,24 @@
+[project]
+name = "emulator-gameboy-dmg"
+description = "Prime emulator benchmark env for Nintendo Game Boy DMG"
+tags = ["emulator", "gameboy", "dmg", "systems", "sandbox", "rust", "eval"]
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = ["verifiers"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build]
+include = ["emulator_gameboy_dmg.py", "pyproject.toml", "README.md", "tasks/manifest.json", "tasks/public_tests.json"]
+
+[project.entry-points."verifiers.environments"]
+emulator-gameboy-dmg = "emulator_gameboy_dmg:load_environment"
+
+[tool.verifiers.eval]
+num_examples = 1
+rollouts_per_example = 1
+
+[tool.uv.sources]
+verifiers = { path = "../..", editable = true }

--- a/environments/emulator_gameboy_dmg/tasks/manifest.json
+++ b/environments/emulator_gameboy_dmg/tasks/manifest.json
@@ -1,0 +1,30 @@
+{
+  "environment_id": "emulator-gameboy-dmg",
+  "module_name": "emulator_gameboy_dmg",
+  "level": 3,
+  "slug": "gameboy_dmg",
+  "display_name": "Nintendo Game Boy (DMG)",
+  "difficulty": "Medium",
+  "goal": "Implement a monochrome Game Boy emulator.",
+  "base_prompt": "Implement a Nintendo Game Boy (DMG) emulator in Rust.",
+  "core_concepts": ["CPU emulation", "Interrupt systems", "PPU rendering", "Memory banking", "Hardware timing"],
+  "requirements": ["Sharp LR35902 CPU", "Memory map", "Interrupt controller", "Timer subsystem", "PPU rendering", "Joypad input", "Cartridge loading", "MBC1 support"],
+  "exposed_api": ["frame stepping", "framebuffer access", "save/load state", "deterministic stepping"],
+  "public_verification": ["blargg test ROMs", "mooneye-gb", "dmg-acid2", "Mealybug Tearoom tests", "SameSuite"],
+  "hidden_verification": ["Scanline timing", "OAM corruption edge cases", "Interrupt race conditions", "Pokemon Red gameplay stability"],
+  "success_criteria": ["Pass at least 90 percent of public ROMs", "Correct framebuffer hashes", "Stable 30-minute gameplay session"],
+  "framebuffer": {"width": 160, "height": 144},
+  "runtime": {"smoke_cycles": 70224, "verify_timeout_seconds": 1800},
+  "scoring_weights": {"correctness": 0.7, "determinism": 0.15, "performance": 0.1, "quality": 0.05},
+  "verification_cases": [
+    {"id": "dmg_blargg", "stage": "public", "kind": "rom_suite", "name": "blargg test ROMs", "expected_signal": "serial_pass", "source": "public"},
+    {"id": "dmg_mooneye", "stage": "public", "kind": "rom_suite", "name": "mooneye-gb", "expected_signal": "suite_pass_rate", "source": "public"},
+    {"id": "dmg_acid2", "stage": "public", "kind": "rom", "name": "dmg-acid2", "expected_signal": "framebuffer_hash", "source": "public"},
+    {"id": "dmg_mealybug", "stage": "public", "kind": "rom_suite", "name": "Mealybug Tearoom tests", "expected_signal": "framebuffer_hash", "source": "public"},
+    {"id": "dmg_samesuite", "stage": "public", "kind": "rom_suite", "name": "SameSuite", "expected_signal": "suite_pass_rate", "source": "public"},
+    {"id": "dmg_scanline_timing", "stage": "hidden", "kind": "generated_rom", "name": "Scanline timing", "expected_signal": "event_log_crc", "source": "generated"},
+    {"id": "dmg_oam_corruption", "stage": "hidden", "kind": "generated_rom", "name": "OAM corruption edge cases", "expected_signal": "memory_snapshot_hash", "source": "generated"},
+    {"id": "dmg_interrupt_races", "stage": "hidden", "kind": "generated_rom", "name": "Interrupt race conditions", "expected_signal": "trace_crc", "source": "generated"},
+    {"id": "dmg_pokemon_stability", "stage": "hidden", "kind": "long_run", "name": "Pokemon Red gameplay stability", "expected_signal": "stability_hash", "source": "user_supplied_by_hash"}
+  ]
+}

--- a/environments/emulator_gameboy_dmg/tasks/public_tests.json
+++ b/environments/emulator_gameboy_dmg/tasks/public_tests.json
@@ -1,0 +1,53 @@
+{
+  "environment_id": "emulator-gameboy-dmg",
+  "sources": [
+    {
+      "name": "c-sp Game Boy test ROM index",
+      "kind": "git",
+      "url": "https://github.com/c-sp/game-boy-test-roms",
+      "ref": "master",
+      "license": "mixed-see-upstream",
+      "covers": ["blargg test ROMs", "mooneye-gb", "dmg-acid2", "Mealybug Tearoom tests", "SameSuite"],
+      "notes": "Aggregates many GB/GBC public suites and expected-output documentation."
+    },
+    {
+      "name": "Mooneye test suite",
+      "kind": "git",
+      "url": "https://github.com/Gekkio/mooneye-test-suite",
+      "ref": "main",
+      "license": "MIT",
+      "covers": ["mooneye-gb"],
+      "notes": "Acceptance, emulator-only, and misc GB tests."
+    },
+    {
+      "name": "DMG Acid2",
+      "kind": "git",
+      "url": "https://github.com/mattcurrie/dmg-acid2",
+      "ref": "master",
+      "license": "MIT",
+      "covers": ["dmg-acid2"]
+    },
+    {
+      "name": "SameSuite",
+      "kind": "git",
+      "url": "https://github.com/LIJI32/SameSuite",
+      "ref": "master",
+      "license": "MIT",
+      "covers": ["SameSuite"]
+    }
+  ],
+  "private_artifacts": [
+    {
+      "name": "gameboy_dmg_public_test_roms",
+      "required_for": ["blargg test ROMs", "mooneye-gb", "dmg-acid2", "Mealybug Tearoom tests", "SameSuite"],
+      "storage": "private/generated artifact bucket or mounted secret volume",
+      "hash_policy": "sha256 manifest required before scoring"
+    },
+    {
+      "name": "pokemon_red_rom",
+      "required_for": ["Pokemon Red gameplay stability"],
+      "storage": "private artifact bucket or mounted secret volume",
+      "hash_policy": "sha256 required before scoring"
+    }
+  ]
+}

--- a/environments/emulator_gba/README.md
+++ b/environments/emulator_gba/README.md
@@ -1,0 +1,5 @@
+# emulator-gba
+
+Level 7 emulator implementation benchmark for Game Boy Advance hardware with
+ARM7TDMI CPU, ARM and Thumb modes, DMA, timers, interrupts, PPU rendering, BIOS
+support, and save states.

--- a/environments/emulator_gba/emulator_gba.py
+++ b/environments/emulator_gba/emulator_gba.py
@@ -1,0 +1,14 @@
+import sys
+from pathlib import Path
+
+ENVIRONMENTS_DIR = Path(__file__).resolve().parents[1]
+if str(ENVIRONMENTS_DIR) not in sys.path:
+    sys.path.insert(0, str(ENVIRONMENTS_DIR))
+
+from emulator_common import load_emulator_environment  # noqa: E402
+
+MANIFEST_PATH = Path(__file__).resolve().parent / "tasks" / "manifest.json"
+
+
+def load_environment(config=None, **kwargs):
+    return load_emulator_environment(MANIFEST_PATH, config=config, **kwargs)

--- a/environments/emulator_gba/pyproject.toml
+++ b/environments/emulator_gba/pyproject.toml
@@ -1,0 +1,24 @@
+[project]
+name = "emulator-gba"
+description = "Prime emulator benchmark env for Game Boy Advance"
+tags = ["emulator", "gba", "arm7tdmi", "systems", "sandbox", "rust", "eval"]
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = ["verifiers"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build]
+include = ["emulator_gba.py", "pyproject.toml", "README.md", "tasks/manifest.json", "tasks/public_tests.json"]
+
+[project.entry-points."verifiers.environments"]
+emulator-gba = "emulator_gba:load_environment"
+
+[tool.verifiers.eval]
+num_examples = 1
+rollouts_per_example = 1
+
+[tool.uv.sources]
+verifiers = { path = "../..", editable = true }

--- a/environments/emulator_gba/tasks/manifest.json
+++ b/environments/emulator_gba/tasks/manifest.json
@@ -1,0 +1,27 @@
+{
+  "environment_id": "emulator-gba",
+  "module_name": "emulator_gba",
+  "level": 7,
+  "slug": "gba",
+  "display_name": "Game Boy Advance",
+  "difficulty": "Hard",
+  "goal": "Implement a Game Boy Advance emulator.",
+  "base_prompt": "Implement a Game Boy Advance emulator.",
+  "core_concepts": ["ARM emulation", "DMA scheduling", "Event systems", "Pipeline timing"],
+  "requirements": ["ARM7TDMI CPU", "ARM and Thumb modes", "DMA", "Timers", "Interrupts", "PPU rendering", "BIOS support", "Save states"],
+  "exposed_api": ["step()", "frame stepping", "framebuffer access", "BIOS loading API", "save/load state"],
+  "public_verification": ["mGBA suite", "gba-suite", "TONC demos"],
+  "hidden_verification": ["DMA race conditions", "BIOS behavior", "Long-run commercial ROM stability"],
+  "success_criteria": ["ARM and Thumb CPU tests pass", "DMA and timer tests pass", "PPU framebuffer hashes match"],
+  "framebuffer": {"width": 240, "height": 160},
+  "runtime": {"smoke_cycles": 280896, "verify_timeout_seconds": 2400},
+  "scoring_weights": {"correctness": 0.72, "determinism": 0.13, "performance": 0.1, "quality": 0.05},
+  "verification_cases": [
+    {"id": "gba_mgba_suite", "stage": "public", "kind": "rom_suite", "name": "mGBA suite", "expected_signal": "suite_pass_rate", "source": "public"},
+    {"id": "gba_suite", "stage": "public", "kind": "rom_suite", "name": "gba-suite", "expected_signal": "suite_pass_rate", "source": "public"},
+    {"id": "gba_tonc", "stage": "public", "kind": "demo_suite", "name": "TONC demos", "expected_signal": "framebuffer_hash", "source": "public"},
+    {"id": "gba_dma_races", "stage": "hidden", "kind": "generated_rom", "name": "DMA race conditions", "expected_signal": "event_log_crc", "source": "generated"},
+    {"id": "gba_bios_behavior", "stage": "hidden", "kind": "generated_rom", "name": "BIOS behavior", "expected_signal": "swi_trace_crc", "source": "generated_or_user_bios_by_hash"},
+    {"id": "gba_commercial_stability", "stage": "hidden", "kind": "long_run", "name": "Long-run commercial ROM stability", "expected_signal": "stability_hash", "source": "user_supplied_by_hash"}
+  ]
+}

--- a/environments/emulator_gba/tasks/public_tests.json
+++ b/environments/emulator_gba/tasks/public_tests.json
@@ -1,0 +1,49 @@
+{
+  "environment_id": "emulator-gba",
+  "sources": [
+    {
+      "name": "mGBA suite",
+      "kind": "git",
+      "url": "https://github.com/mgba-emu/suite",
+      "ref": "master",
+      "license": "MPL-2.0",
+      "covers": ["mGBA suite"],
+      "notes": "Game Boy Advance test suite from the mGBA project."
+    },
+    {
+      "name": "jsmolka gba-tests",
+      "kind": "git",
+      "url": "https://github.com/jsmolka/gba-tests",
+      "ref": "master",
+      "license": "unknown",
+      "covers": ["gba-suite"],
+      "notes": "CPU and hardware edge-case tests commonly used by GBA emulator authors."
+    },
+    {
+      "name": "Tonc examples",
+      "kind": "git",
+      "url": "https://github.com/gbadev-org/tonc",
+      "ref": "master",
+      "license": "mixed-see-upstream",
+      "covers": ["TONC demos"],
+      "notes": "Tutorial examples and demos for GBA rendering/hardware behavior."
+    },
+    {
+      "name": "NBA hardware tests",
+      "kind": "git",
+      "url": "https://github.com/nba-emu/hw-test",
+      "ref": "master",
+      "license": "unknown",
+      "covers": ["mGBA suite", "gba-suite"],
+      "notes": "Additional hardware tests for hidden/private GBA timing coverage."
+    }
+  ],
+  "private_artifacts": [
+    {
+      "name": "gba_bios",
+      "required_for": ["BIOS behavior"],
+      "storage": "private artifact bucket or mounted secret volume",
+      "hash_policy": "known BIOS hash required before BIOS-mode scoring"
+    }
+  ]
+}

--- a/environments/emulator_genesis/README.md
+++ b/environments/emulator_genesis/README.md
@@ -1,0 +1,5 @@
+# emulator-genesis
+
+Level 8 emulator implementation benchmark for Sega Genesis / Mega Drive with
+Motorola 68000 CPU, Z80 audio CPU, VDP, PSG and FM audio, controllers, ROM
+loading, and deterministic execution.

--- a/environments/emulator_genesis/emulator_genesis.py
+++ b/environments/emulator_genesis/emulator_genesis.py
@@ -1,0 +1,14 @@
+import sys
+from pathlib import Path
+
+ENVIRONMENTS_DIR = Path(__file__).resolve().parents[1]
+if str(ENVIRONMENTS_DIR) not in sys.path:
+    sys.path.insert(0, str(ENVIRONMENTS_DIR))
+
+from emulator_common import load_emulator_environment  # noqa: E402
+
+MANIFEST_PATH = Path(__file__).resolve().parent / "tasks" / "manifest.json"
+
+
+def load_environment(config=None, **kwargs):
+    return load_emulator_environment(MANIFEST_PATH, config=config, **kwargs)

--- a/environments/emulator_genesis/pyproject.toml
+++ b/environments/emulator_genesis/pyproject.toml
@@ -1,0 +1,24 @@
+[project]
+name = "emulator-genesis"
+description = "Prime emulator benchmark env for Sega Genesis / Mega Drive"
+tags = ["emulator", "genesis", "mega-drive", "68000", "z80", "systems", "sandbox", "rust", "eval"]
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = ["verifiers"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build]
+include = ["emulator_genesis.py", "pyproject.toml", "README.md", "tasks/manifest.json", "tasks/public_tests.json"]
+
+[project.entry-points."verifiers.environments"]
+emulator-genesis = "emulator_genesis:load_environment"
+
+[tool.verifiers.eval]
+num_examples = 1
+rollouts_per_example = 1
+
+[tool.uv.sources]
+verifiers = { path = "../..", editable = true }

--- a/environments/emulator_genesis/tasks/manifest.json
+++ b/environments/emulator_genesis/tasks/manifest.json
@@ -1,0 +1,28 @@
+{
+  "environment_id": "emulator-genesis",
+  "module_name": "emulator_genesis",
+  "level": 8,
+  "slug": "genesis",
+  "display_name": "Sega Genesis / Mega Drive",
+  "difficulty": "Very Hard",
+  "goal": "Implement Genesis emulation with dual CPU coordination.",
+  "base_prompt": "Implement a Sega Genesis emulator.",
+  "core_concepts": ["Multi-CPU synchronization", "Bus arbitration", "FM synthesis", "Timing coordination"],
+  "requirements": ["Motorola 68000 CPU", "Z80 audio CPU", "VDP", "PSG + FM audio", "Controller input", "ROM loading", "Deterministic execution"],
+  "exposed_api": ["step()", "framebuffer()", "audio sample/register API", "controller input API", "ROM loading API"],
+  "public_verification": ["68k verifier", "VDP tests", "Z80 tests", "240p Test Suite"],
+  "hidden_verification": ["Bus arbitration timing", "Audio synchronization", "Sonic gameplay stability"],
+  "success_criteria": ["68k and Z80 diagnostics pass", "VDP frame hashes match", "Audio timing remains synchronized"],
+  "framebuffer": {"width": 320, "height": 224},
+  "runtime": {"smoke_cycles": 536931, "verify_timeout_seconds": 2400},
+  "scoring_weights": {"correctness": 0.72, "determinism": 0.13, "performance": 0.1, "quality": 0.05},
+  "verification_cases": [
+    {"id": "genesis_68k", "stage": "public", "kind": "rom_suite", "name": "68k verifier", "expected_signal": "trace_crc", "source": "public"},
+    {"id": "genesis_vdp", "stage": "public", "kind": "rom_suite", "name": "VDP tests", "expected_signal": "framebuffer_hash", "source": "public"},
+    {"id": "genesis_z80", "stage": "public", "kind": "rom_suite", "name": "Z80 tests", "expected_signal": "serial_pass", "source": "public"},
+    {"id": "genesis_240p", "stage": "public", "kind": "rom_suite", "name": "240p Test Suite", "expected_signal": "framebuffer_hash", "source": "public"},
+    {"id": "genesis_bus_arbitration", "stage": "hidden", "kind": "generated_rom", "name": "Bus arbitration timing", "expected_signal": "event_log_crc", "source": "generated"},
+    {"id": "genesis_audio_sync", "stage": "hidden", "kind": "generated_rom", "name": "Audio synchronization", "expected_signal": "audio_crc", "source": "generated"},
+    {"id": "genesis_sonic_stability", "stage": "hidden", "kind": "long_run", "name": "Sonic gameplay stability", "expected_signal": "stability_hash", "source": "user_supplied_by_hash"}
+  ]
+}

--- a/environments/emulator_genesis/tasks/public_tests.json
+++ b/environments/emulator_genesis/tasks/public_tests.json
@@ -1,0 +1,67 @@
+{
+  "environment_id": "emulator-genesis",
+  "sources": [
+    {
+      "name": "Tom Harte processor tests",
+      "kind": "git",
+      "url": "https://github.com/TomHarte/ProcessorTests",
+      "ref": "main",
+      "license": "MIT",
+      "sparse_paths": ["680x0/68000/v1"],
+      "artifact_globs": ["680x0/68000/v1/*.json.gz"],
+      "artifact_extensions": [".json.gz"],
+      "covers": ["68k verifier"],
+      "notes": "Machine-readable 68000 processor tests; fetched with sparse checkout so only the 68000 v1 JSON fixtures are mounted."
+    },
+    {
+      "name": "redcode Z80 test harness",
+      "kind": "git",
+      "url": "https://github.com/redcode/Z80",
+      "ref": "master",
+      "license": "BSD-3-Clause",
+      "artifact_globs": ["generated-roms/**/*.bin"],
+      "artifact_extensions": [".bin"],
+      "covers": ["Z80 tests"],
+      "notes": "Portable Z80 core test harness used as the public source for Genesis audio-CPU fixtures."
+    },
+    {
+      "name": "240p Test Suite",
+      "kind": "git",
+      "url": "https://github.com/ArtemioUrbina/240pTestSuite",
+      "ref": "master",
+      "license": "GPL-2.0",
+      "artifact_globs": ["240psuite/Genesis/**/*"],
+      "artifact_extensions": [".md", ".gen", ".smd"],
+      "covers": ["240p Test Suite", "VDP tests"],
+      "notes": "Genesis/Mega Drive video test patterns and hardware diagnostics."
+    },
+    {
+      "name": "Sega Retro sprite masking and overflow ROM page",
+      "kind": "http",
+      "url": "https://segaretro.org/Sprite_Masking_and_Overflow_Test_ROM",
+      "license": "documentation",
+      "covers": ["VDP tests"],
+      "notes": "Documents Nemesis' VDP sprite masking and overflow tests."
+    }
+  ],
+  "private_artifacts": [
+    {
+      "name": "genesis_240p_suite_rom",
+      "required_for": ["240p Test Suite", "VDP tests"],
+      "storage": "private/generated artifact bucket or mounted secret volume",
+      "hash_policy": "sha256 required before scoring"
+    },
+    {
+      "name": "genesis_z80_fixture_roms",
+      "required_for": ["Z80 tests"],
+      "storage": "private/generated artifact bucket or mounted secret volume",
+      "hash_policy": "sha256 required before scoring"
+    },
+    {
+      "name": "sonic_rom",
+      "required_for": ["Sonic gameplay stability"],
+      "storage": "private artifact bucket or mounted secret volume",
+      "hash_policy": "sha256 required before scoring"
+    }
+  ]
+}

--- a/environments/emulator_i8080_space_invaders/README.md
+++ b/environments/emulator_i8080_space_invaders/README.md
@@ -1,0 +1,5 @@
+# emulator-i8080-space-invaders
+
+Level 2 emulator implementation benchmark for Intel 8080 arcade hardware with a
+Space Invaders style IO and framebuffer contract. Commercial ROMs are not
+bundled; manifests describe public diagnostics and hidden synthetic fixtures.

--- a/environments/emulator_i8080_space_invaders/emulator_i8080_space_invaders.py
+++ b/environments/emulator_i8080_space_invaders/emulator_i8080_space_invaders.py
@@ -1,0 +1,14 @@
+import sys
+from pathlib import Path
+
+ENVIRONMENTS_DIR = Path(__file__).resolve().parents[1]
+if str(ENVIRONMENTS_DIR) not in sys.path:
+    sys.path.insert(0, str(ENVIRONMENTS_DIR))
+
+from emulator_common import load_emulator_environment  # noqa: E402
+
+MANIFEST_PATH = Path(__file__).resolve().parent / "tasks" / "manifest.json"
+
+
+def load_environment(config=None, **kwargs):
+    return load_emulator_environment(MANIFEST_PATH, config=config, **kwargs)

--- a/environments/emulator_i8080_space_invaders/pyproject.toml
+++ b/environments/emulator_i8080_space_invaders/pyproject.toml
@@ -1,0 +1,24 @@
+[project]
+name = "emulator-i8080-space-invaders"
+description = "Prime emulator benchmark env for Intel 8080 Space Invaders hardware"
+tags = ["emulator", "i8080", "space-invaders", "systems", "sandbox", "rust", "eval"]
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = ["verifiers"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build]
+include = ["emulator_i8080_space_invaders.py", "pyproject.toml", "README.md", "tasks/manifest.json", "tasks/public_tests.json"]
+
+[project.entry-points."verifiers.environments"]
+emulator-i8080-space-invaders = "emulator_i8080_space_invaders:load_environment"
+
+[tool.verifiers.eval]
+num_examples = 1
+rollouts_per_example = 1
+
+[tool.uv.sources]
+verifiers = { path = "../..", editable = true }

--- a/environments/emulator_i8080_space_invaders/tasks/manifest.json
+++ b/environments/emulator_i8080_space_invaders/tasks/manifest.json
@@ -1,0 +1,27 @@
+{
+  "environment_id": "emulator-i8080-space-invaders",
+  "module_name": "emulator_i8080_space_invaders",
+  "level": 2,
+  "slug": "i8080_space_invaders",
+  "display_name": "Intel 8080 / Space Invaders",
+  "difficulty": "Easy",
+  "goal": "Implement enough Intel 8080 emulation to run Space Invaders style arcade hardware.",
+  "base_prompt": "Implement an Intel 8080 emulator capable of running the original Space Invaders arcade ROM.",
+  "core_concepts": ["Real CPU emulation", "Interrupts", "Arcade hardware abstraction", "Memory-mapped IO"],
+  "requirements": ["Full 8080 instruction set", "Interrupt support", "Memory-mapped IO", "Video framebuffer output", "Input handling", "Deterministic execution"],
+  "exposed_api": ["step()", "reset()", "framebuffer()", "input port API", "interrupt API"],
+  "public_verification": ["8080 CPU exerciser", "Space Invaders attract mode", "Framebuffer hashes"],
+  "hidden_verification": ["Interrupt timing", "CPU flag correctness", "Long-run stability"],
+  "success_criteria": ["CPU exerciser passes", "Attract-mode framebuffer hashes match", "Stable long-run execution"],
+  "framebuffer": {"width": 224, "height": 256},
+  "runtime": {"smoke_cycles": 20000, "verify_timeout_seconds": 1200},
+  "scoring_weights": {"correctness": 0.7, "determinism": 0.15, "performance": 0.1, "quality": 0.05},
+  "verification_cases": [
+    {"id": "i8080_cpu_exerciser", "stage": "public", "kind": "rom_suite", "name": "8080 CPU exerciser", "expected_signal": "serial_pass", "source": "public"},
+    {"id": "i8080_attract_mode", "stage": "public", "kind": "hardware_fixture", "name": "Space Invaders attract mode", "expected_signal": "framebuffer_hash", "source": "user_supplied_or_synthetic"},
+    {"id": "i8080_frame_hashes", "stage": "public", "kind": "frame_suite", "name": "Framebuffer hashes", "expected_signal": "frame_sequence_hash", "source": "public"},
+    {"id": "i8080_interrupt_timing", "stage": "hidden", "kind": "generated_rom", "name": "Interrupt timing", "expected_signal": "event_log_crc", "source": "generated"},
+    {"id": "i8080_flag_matrix", "stage": "hidden", "kind": "generated_rom", "name": "CPU flag correctness", "expected_signal": "trace_crc", "source": "generated"},
+    {"id": "i8080_long_run", "stage": "hidden", "kind": "stability", "name": "Long-run stability", "expected_signal": "timeout_free_run", "source": "generated"}
+  ]
+}

--- a/environments/emulator_i8080_space_invaders/tasks/public_tests.json
+++ b/environments/emulator_i8080_space_invaders/tasks/public_tests.json
@@ -1,0 +1,40 @@
+{
+  "environment_id": "emulator-i8080-space-invaders",
+  "sources": [
+    {
+      "name": "PCjs 8080 exerciser sources",
+      "kind": "git",
+      "url": "https://github.com/jeffpar/pcjs",
+      "ref": "gh-pages",
+      "license": "MIT",
+      "artifact_globs": ["machines/pcx80/ram/exerciser/*"],
+      "artifact_extensions": [".json5", ".asm", ".mac"],
+      "covers": ["8080 CPU exerciser"],
+      "notes": "machines/pcx80/ram/exerciser contains 8080EX1, 8080EXER, 8080PRE, CPUTEST, and TEST sources/manifests."
+    },
+    {
+      "name": "PCjs 8080 exerciser page",
+      "kind": "http",
+      "url": "https://www.pcjs.org/machines/pcx80/ram/exerciser/",
+      "license": "MIT",
+      "covers": ["8080 CPU exerciser"],
+      "notes": "Documents the exerciser machine and links to source."
+    },
+    {
+      "name": "Private Space Invaders ROM artifact",
+      "kind": "private-artifact",
+      "url": "https://www.computerarcheology.com/Arcade/SpaceInvaders/",
+      "license": "copyrighted-user-supplied",
+      "covers": ["Space Invaders attract mode", "Framebuffer hashes"],
+      "notes": "Private eval can mount user-provided Space Invaders ROM by SHA256; git must not include ROM bytes."
+    }
+  ],
+  "private_artifacts": [
+    {
+      "name": "space_invaders_rom_set",
+      "required_for": ["Space Invaders attract mode", "Framebuffer hashes"],
+      "storage": "private artifact bucket or mounted secret volume",
+      "hash_policy": "sha256 required before scoring"
+    }
+  ]
+}

--- a/environments/emulator_nes/README.md
+++ b/environments/emulator_nes/README.md
@@ -1,0 +1,5 @@
+# emulator-nes
+
+Level 4 emulator implementation benchmark for the Nintendo Entertainment
+System with 6502 CPU, PPU rendering, controller input, NROM, MMC1, accurate
+frame timing, and save states.

--- a/environments/emulator_nes/emulator_nes.py
+++ b/environments/emulator_nes/emulator_nes.py
@@ -1,0 +1,14 @@
+import sys
+from pathlib import Path
+
+ENVIRONMENTS_DIR = Path(__file__).resolve().parents[1]
+if str(ENVIRONMENTS_DIR) not in sys.path:
+    sys.path.insert(0, str(ENVIRONMENTS_DIR))
+
+from emulator_common import load_emulator_environment  # noqa: E402
+
+MANIFEST_PATH = Path(__file__).resolve().parent / "tasks" / "manifest.json"
+
+
+def load_environment(config=None, **kwargs):
+    return load_emulator_environment(MANIFEST_PATH, config=config, **kwargs)

--- a/environments/emulator_nes/pyproject.toml
+++ b/environments/emulator_nes/pyproject.toml
@@ -1,0 +1,24 @@
+[project]
+name = "emulator-nes"
+description = "Prime emulator benchmark env for NES"
+tags = ["emulator", "nes", "6502", "ppu", "systems", "sandbox", "rust", "eval"]
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = ["verifiers"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build]
+include = ["emulator_nes.py", "pyproject.toml", "README.md", "tasks/manifest.json", "tasks/public_tests.json"]
+
+[project.entry-points."verifiers.environments"]
+emulator-nes = "emulator_nes:load_environment"
+
+[tool.verifiers.eval]
+num_examples = 1
+rollouts_per_example = 1
+
+[tool.uv.sources]
+verifiers = { path = "../..", editable = true }

--- a/environments/emulator_nes/tasks/manifest.json
+++ b/environments/emulator_nes/tasks/manifest.json
@@ -1,0 +1,29 @@
+{
+  "environment_id": "emulator-nes",
+  "module_name": "emulator_nes",
+  "level": 4,
+  "slug": "nes",
+  "display_name": "Nintendo Entertainment System",
+  "difficulty": "Medium-Hard",
+  "goal": "Implement an NES emulator with basic mapper support.",
+  "base_prompt": "Implement an NES emulator.",
+  "core_concepts": ["CPU/PPU synchronization", "Scanline rendering", "Mapper architecture", "Sprite timing"],
+  "requirements": ["MOS 6502 CPU", "PPU rendering", "Controller input", "NROM support", "MMC1 support", "Accurate frame timing", "Save states"],
+  "exposed_api": ["frame stepping", "framebuffer access", "controller input API", "save/load state"],
+  "public_verification": ["nestest", "blargg NES tests", "PPU timing tests", "Sprite hit tests", "VBlank timing tests"],
+  "hidden_verification": ["Scanline race conditions", "Mapper edge cases", "Long gameplay sessions"],
+  "success_criteria": ["nestest trace matches", "PPU timing tests pass", "Commercial-compatible long-run stability"],
+  "framebuffer": {"width": 256, "height": 240},
+  "runtime": {"smoke_cycles": 29780, "verify_timeout_seconds": 1800},
+  "scoring_weights": {"correctness": 0.7, "determinism": 0.15, "performance": 0.1, "quality": 0.05},
+  "verification_cases": [
+    {"id": "nes_nestest", "stage": "public", "kind": "trace_rom", "name": "nestest", "expected_signal": "cpu_trace_crc", "source": "public"},
+    {"id": "nes_blargg", "stage": "public", "kind": "rom_suite", "name": "blargg NES tests", "expected_signal": "suite_pass_rate", "source": "public"},
+    {"id": "nes_ppu_timing", "stage": "public", "kind": "rom_suite", "name": "PPU timing tests", "expected_signal": "event_log_crc", "source": "public"},
+    {"id": "nes_sprite_hit", "stage": "public", "kind": "rom_suite", "name": "Sprite hit tests", "expected_signal": "pass_marker", "source": "public"},
+    {"id": "nes_vblank", "stage": "public", "kind": "rom_suite", "name": "VBlank timing tests", "expected_signal": "event_log_crc", "source": "public"},
+    {"id": "nes_scanline_races", "stage": "hidden", "kind": "generated_rom", "name": "Scanline race conditions", "expected_signal": "event_log_crc", "source": "generated"},
+    {"id": "nes_mapper_edges", "stage": "hidden", "kind": "generated_rom", "name": "Mapper edge cases", "expected_signal": "mapper_event_hash", "source": "generated"},
+    {"id": "nes_long_gameplay", "stage": "hidden", "kind": "long_run", "name": "Long gameplay sessions", "expected_signal": "stability_hash", "source": "withheld"}
+  ]
+}

--- a/environments/emulator_nes/tasks/public_tests.json
+++ b/environments/emulator_nes/tasks/public_tests.json
@@ -1,0 +1,22 @@
+{
+  "environment_id": "emulator-nes",
+  "sources": [
+    {
+      "name": "christopherpow NES test ROM archive",
+      "kind": "git",
+      "url": "https://github.com/christopherpow/nes-test-roms",
+      "ref": "master",
+      "license": "mixed-see-upstream",
+      "covers": ["nestest", "blargg NES tests", "PPU timing tests", "Sprite hit tests", "VBlank timing tests"],
+      "notes": "Archive of many NESdev/blargg/kevtris validation ROMs."
+    },
+    {
+      "name": "NESdev emulator tests wiki",
+      "kind": "http",
+      "url": "https://www.nesdev.org/wiki/Emulator_tests",
+      "license": "documentation",
+      "covers": ["nestest", "blargg NES tests", "PPU timing tests", "Sprite hit tests", "VBlank timing tests"],
+      "notes": "Canonical index and descriptions for NES emulator validation ROMs."
+    }
+  ]
+}

--- a/environments/emulator_ps1/README.md
+++ b/environments/emulator_ps1/README.md
@@ -1,0 +1,5 @@
+# emulator-ps1
+
+Level 10 emulator implementation benchmark for Sony PlayStation hardware with
+MIPS R3000A CPU, DMA, GPU command processing, timers, input, CD-ROM, BIOS boot,
+and save states. BIOS and commercial discs are not bundled.

--- a/environments/emulator_ps1/emulator_ps1.py
+++ b/environments/emulator_ps1/emulator_ps1.py
@@ -1,0 +1,14 @@
+import sys
+from pathlib import Path
+
+ENVIRONMENTS_DIR = Path(__file__).resolve().parents[1]
+if str(ENVIRONMENTS_DIR) not in sys.path:
+    sys.path.insert(0, str(ENVIRONMENTS_DIR))
+
+from emulator_common import load_emulator_environment  # noqa: E402
+
+MANIFEST_PATH = Path(__file__).resolve().parent / "tasks" / "manifest.json"
+
+
+def load_environment(config=None, **kwargs):
+    return load_emulator_environment(MANIFEST_PATH, config=config, **kwargs)

--- a/environments/emulator_ps1/pyproject.toml
+++ b/environments/emulator_ps1/pyproject.toml
@@ -1,0 +1,24 @@
+[project]
+name = "emulator-ps1"
+description = "Prime emulator benchmark env for PlayStation 1"
+tags = ["emulator", "ps1", "mips", "gpu", "dma", "systems", "sandbox", "rust", "eval"]
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = ["verifiers"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build]
+include = ["emulator_ps1.py", "pyproject.toml", "README.md", "tasks/manifest.json", "tasks/public_tests.json"]
+
+[project.entry-points."verifiers.environments"]
+emulator-ps1 = "emulator_ps1:load_environment"
+
+[tool.verifiers.eval]
+num_examples = 1
+rollouts_per_example = 1
+
+[tool.uv.sources]
+verifiers = { path = "../..", editable = true }

--- a/environments/emulator_ps1/tasks/manifest.json
+++ b/environments/emulator_ps1/tasks/manifest.json
@@ -1,0 +1,28 @@
+{
+  "environment_id": "emulator-ps1",
+  "module_name": "emulator_ps1",
+  "level": 10,
+  "slug": "ps1",
+  "display_name": "Sony PlayStation",
+  "difficulty": "Research-Level",
+  "goal": "Implement a PlayStation emulator capable of booting commercial titles.",
+  "base_prompt": "Implement a Sony PlayStation emulator.",
+  "core_concepts": ["MIPS emulation", "DMA orchestration", "GPU command processing", "CD subsystem", "Geometry pipelines"],
+  "requirements": ["MIPS R3000A CPU", "DMA controller", "GPU command processor", "Timers", "Input subsystem", "CD-ROM support", "BIOS boot", "Save states"],
+  "exposed_api": ["step()", "framebuffer()", "DMA event API", "GPU command API", "BIOS loading API", "save/load state"],
+  "public_verification": ["ps1-tests", "CPU verification ROMs", "DMA tests", "GPU command tests"],
+  "hidden_verification": ["Geometry pipeline correctness", "CD timing", "Commercial game boot stability"],
+  "success_criteria": ["PS1 hardware tests pass", "BIOS boot path works with user-provided BIOS", "GPU command framebuffer hashes match"],
+  "framebuffer": {"width": 320, "height": 240},
+  "runtime": {"smoke_cycles": 33868800, "verify_timeout_seconds": 3600},
+  "scoring_weights": {"correctness": 0.75, "determinism": 0.1, "performance": 0.1, "quality": 0.05},
+  "verification_cases": [
+    {"id": "ps1_tests", "stage": "public", "kind": "homebrew_suite", "name": "ps1-tests", "expected_signal": "suite_pass_rate", "source": "public"},
+    {"id": "ps1_cpu", "stage": "public", "kind": "rom_suite", "name": "CPU verification ROMs", "expected_signal": "trace_crc", "source": "public"},
+    {"id": "ps1_dma", "stage": "public", "kind": "rom_suite", "name": "DMA tests", "expected_signal": "event_log_crc", "source": "public"},
+    {"id": "ps1_gpu", "stage": "public", "kind": "rom_suite", "name": "GPU command tests", "expected_signal": "framebuffer_hash", "source": "public"},
+    {"id": "ps1_gte", "stage": "hidden", "kind": "generated_homebrew", "name": "Geometry pipeline correctness", "expected_signal": "gte_trace_crc", "source": "generated"},
+    {"id": "ps1_cd_timing", "stage": "hidden", "kind": "generated_homebrew", "name": "CD timing", "expected_signal": "event_log_crc", "source": "generated"},
+    {"id": "ps1_boot_stability", "stage": "hidden", "kind": "long_run", "name": "Commercial game boot stability", "expected_signal": "stability_hash", "source": "user_supplied_by_hash"}
+  ]
+}

--- a/environments/emulator_ps1/tasks/public_tests.json
+++ b/environments/emulator_ps1/tasks/public_tests.json
@@ -1,0 +1,38 @@
+{
+  "environment_id": "emulator-ps1",
+  "sources": [
+    {
+      "name": "Peter Lemon PSX tests",
+      "kind": "git",
+      "url": "https://github.com/PeterLemon/PSX",
+      "ref": "master",
+      "license": "MIT",
+      "covers": ["ps1-tests", "CPU verification ROMs", "DMA tests", "GPU command tests"],
+      "notes": "PS1 CPU, DMA, GPU, GTE, and peripheral homebrew tests."
+    },
+    {
+      "name": "psxsdk",
+      "kind": "git",
+      "url": "https://github.com/ChrisRx/psxsdk",
+      "ref": "master",
+      "license": "GPL-2.0",
+      "covers": ["ps1-tests", "GPU command tests"],
+      "notes": "Open PS1 development SDK and examples for private generated tests."
+    },
+    {
+      "name": "psx-spx GPU specification",
+      "kind": "http",
+      "url": "https://psx-spx.consoledev.net/graphicsprocessingunitgpu/",
+      "license": "documentation",
+      "covers": ["GPU command tests", "DMA tests"]
+    }
+  ],
+  "private_artifacts": [
+    {
+      "name": "ps1_bios",
+      "required_for": ["BIOS boot", "Commercial game boot stability"],
+      "storage": "private artifact bucket or mounted secret volume",
+      "hash_policy": "known BIOS hash required before BIOS-mode scoring"
+    }
+  ]
+}

--- a/environments/emulator_sms/README.md
+++ b/environments/emulator_sms/README.md
@@ -1,0 +1,5 @@
+# emulator-sms
+
+Level 5 emulator implementation benchmark for Sega Master System hardware with
+Z80 CPU, VDP rendering, PSG audio, controller input, cartridge mappers, and
+deterministic stepping.

--- a/environments/emulator_sms/emulator_sms.py
+++ b/environments/emulator_sms/emulator_sms.py
@@ -1,0 +1,14 @@
+import sys
+from pathlib import Path
+
+ENVIRONMENTS_DIR = Path(__file__).resolve().parents[1]
+if str(ENVIRONMENTS_DIR) not in sys.path:
+    sys.path.insert(0, str(ENVIRONMENTS_DIR))
+
+from emulator_common import load_emulator_environment  # noqa: E402
+
+MANIFEST_PATH = Path(__file__).resolve().parent / "tasks" / "manifest.json"
+
+
+def load_environment(config=None, **kwargs):
+    return load_emulator_environment(MANIFEST_PATH, config=config, **kwargs)

--- a/environments/emulator_sms/pyproject.toml
+++ b/environments/emulator_sms/pyproject.toml
@@ -1,0 +1,24 @@
+[project]
+name = "emulator-sms"
+description = "Prime emulator benchmark env for Sega Master System"
+tags = ["emulator", "sms", "z80", "vdp", "systems", "sandbox", "rust", "eval"]
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = ["verifiers"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build]
+include = ["emulator_sms.py", "pyproject.toml", "README.md", "tasks/manifest.json", "tasks/public_tests.json"]
+
+[project.entry-points."verifiers.environments"]
+emulator-sms = "emulator_sms:load_environment"
+
+[tool.verifiers.eval]
+num_examples = 1
+rollouts_per_example = 1
+
+[tool.uv.sources]
+verifiers = { path = "../..", editable = true }

--- a/environments/emulator_sms/tasks/manifest.json
+++ b/environments/emulator_sms/tasks/manifest.json
@@ -1,0 +1,27 @@
+{
+  "environment_id": "emulator-sms",
+  "module_name": "emulator_sms",
+  "level": 5,
+  "slug": "sms",
+  "display_name": "Sega Master System",
+  "difficulty": "Medium-Hard",
+  "goal": "Implement Sega Master System emulation.",
+  "base_prompt": "Implement a Sega Master System emulator.",
+  "core_concepts": ["Z80 CPU", "VDP rendering", "Audio timing", "Cartridge mappers"],
+  "requirements": ["Z80 CPU", "VDP rendering", "PSG audio support", "Controller input", "Cartridge mapper support", "Deterministic stepping"],
+  "exposed_api": ["step()", "framebuffer()", "controller input API", "audio register API"],
+  "public_verification": ["ZEXDOC", "ZEXALL", "SMS Test Suite"],
+  "hidden_verification": ["Timing edge cases", "Audio synchronization", "Stability under long execution"],
+  "success_criteria": ["Z80 diagnostics pass", "VDP framebuffer hashes match", "Stable long execution"],
+  "framebuffer": {"width": 256, "height": 192},
+  "runtime": {"smoke_cycles": 50000, "verify_timeout_seconds": 1800},
+  "scoring_weights": {"correctness": 0.68, "determinism": 0.17, "performance": 0.1, "quality": 0.05},
+  "verification_cases": [
+    {"id": "sms_zexdoc", "stage": "public", "kind": "rom_suite", "name": "ZEXDOC", "expected_signal": "serial_pass", "source": "public"},
+    {"id": "sms_zexall", "stage": "public", "kind": "rom_suite", "name": "ZEXALL", "expected_signal": "serial_pass", "source": "public"},
+    {"id": "sms_test_suite", "stage": "public", "kind": "rom_suite", "name": "SMS Test Suite", "expected_signal": "suite_pass_rate", "source": "public"},
+    {"id": "sms_timing_edges", "stage": "hidden", "kind": "generated_rom", "name": "Timing edge cases", "expected_signal": "trace_crc", "source": "generated"},
+    {"id": "sms_audio_sync", "stage": "hidden", "kind": "generated_rom", "name": "Audio synchronization", "expected_signal": "audio_crc", "source": "generated"},
+    {"id": "sms_long_run", "stage": "hidden", "kind": "long_run", "name": "Stability under long execution", "expected_signal": "stability_hash", "source": "generated"}
+  ]
+}

--- a/environments/emulator_sms/tasks/public_tests.json
+++ b/environments/emulator_sms/tasks/public_tests.json
@@ -1,0 +1,44 @@
+{
+  "environment_id": "emulator-sms",
+  "sources": [
+    {
+      "name": "sverx SMS Test Suite",
+      "kind": "git",
+      "url": "https://github.com/sverx/SMSTestSuite",
+      "ref": "master",
+      "license": "GPL-3.0",
+      "covers": ["SMS Test Suite"],
+      "notes": "Sega Master System video/audio/input diagnostics."
+    },
+    {
+      "name": "redcode Z80 test harness",
+      "kind": "git",
+      "url": "https://github.com/redcode/Z80",
+      "ref": "master",
+      "license": "BSD-3-Clause",
+      "covers": ["ZEXDOC", "ZEXALL"],
+      "notes": "Fetches/runs ZEXDOC and ZEXALL through the Z80 test tool."
+    },
+    {
+      "name": "SMS Power TestSuite page",
+      "kind": "http",
+      "url": "https://www.smspower.org/Homebrew/TestSuite-SMS",
+      "license": "documentation",
+      "covers": ["SMS Test Suite"]
+    }
+  ],
+  "private_artifacts": [
+    {
+      "name": "sms_test_suite_roms",
+      "required_for": ["SMS Test Suite"],
+      "storage": "private/generated artifact bucket or mounted secret volume",
+      "hash_policy": "sha256 required before scoring"
+    },
+    {
+      "name": "zexdoc_zexall_roms",
+      "required_for": ["ZEXDOC", "ZEXALL"],
+      "storage": "private/generated artifact bucket or mounted secret volume",
+      "hash_policy": "sha256 required before scoring"
+    }
+  ]
+}

--- a/environments/emulator_snes/README.md
+++ b/environments/emulator_snes/README.md
@@ -1,0 +1,5 @@
+# emulator-snes
+
+Level 9 emulator implementation benchmark for a cycle-aware Super Nintendo
+emulator with 65C816 CPU, PPU, DMA/HDMA, SPC700 audio, controllers, LoROM,
+HiROM, and save states.

--- a/environments/emulator_snes/emulator_snes.py
+++ b/environments/emulator_snes/emulator_snes.py
@@ -1,0 +1,14 @@
+import sys
+from pathlib import Path
+
+ENVIRONMENTS_DIR = Path(__file__).resolve().parents[1]
+if str(ENVIRONMENTS_DIR) not in sys.path:
+    sys.path.insert(0, str(ENVIRONMENTS_DIR))
+
+from emulator_common import load_emulator_environment  # noqa: E402
+
+MANIFEST_PATH = Path(__file__).resolve().parent / "tasks" / "manifest.json"
+
+
+def load_environment(config=None, **kwargs):
+    return load_emulator_environment(MANIFEST_PATH, config=config, **kwargs)

--- a/environments/emulator_snes/pyproject.toml
+++ b/environments/emulator_snes/pyproject.toml
@@ -1,0 +1,24 @@
+[project]
+name = "emulator-snes"
+description = "Prime emulator benchmark env for Super Nintendo"
+tags = ["emulator", "snes", "65c816", "spc700", "systems", "sandbox", "rust", "eval"]
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = ["verifiers"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build]
+include = ["emulator_snes.py", "pyproject.toml", "README.md", "tasks/manifest.json", "tasks/public_tests.json"]
+
+[project.entry-points."verifiers.environments"]
+emulator-snes = "emulator_snes:load_environment"
+
+[tool.verifiers.eval]
+num_examples = 1
+rollouts_per_example = 1
+
+[tool.uv.sources]
+verifiers = { path = "../..", editable = true }

--- a/environments/emulator_snes/tasks/manifest.json
+++ b/environments/emulator_snes/tasks/manifest.json
@@ -1,0 +1,27 @@
+{
+  "environment_id": "emulator-snes",
+  "module_name": "emulator_snes",
+  "level": 9,
+  "slug": "snes",
+  "display_name": "Super Nintendo",
+  "difficulty": "Elite",
+  "goal": "Implement a cycle-aware SNES emulator.",
+  "base_prompt": "Implement a Super Nintendo emulator.",
+  "core_concepts": ["Coprocessors", "DMA/HDMA", "Synchronization", "Audio coprocessors"],
+  "requirements": ["65C816 CPU", "PPU rendering", "DMA/HDMA", "SPC700 audio subsystem", "Controller support", "LoROM/HiROM", "Save states"],
+  "exposed_api": ["step()", "framebuffer()", "audio subsystem API", "controller input API", "save/load state"],
+  "public_verification": ["blargg SNES tests", "SNESdev tests", "PPU timing suites"],
+  "hidden_verification": ["HDMA edge cases", "Audio synchronization", "Long gameplay stability"],
+  "success_criteria": ["CPU and DMA public tests pass", "PPU frame hashes match", "SPC700 audio timing remains stable"],
+  "framebuffer": {"width": 256, "height": 224},
+  "runtime": {"smoke_cycles": 357368, "verify_timeout_seconds": 3000},
+  "scoring_weights": {"correctness": 0.74, "determinism": 0.11, "performance": 0.1, "quality": 0.05},
+  "verification_cases": [
+    {"id": "snes_blargg", "stage": "public", "kind": "rom_suite", "name": "blargg SNES tests", "expected_signal": "suite_pass_rate", "source": "public"},
+    {"id": "snes_snesdev", "stage": "public", "kind": "rom_suite", "name": "SNESdev tests", "expected_signal": "suite_pass_rate", "source": "public"},
+    {"id": "snes_ppu_timing", "stage": "public", "kind": "rom_suite", "name": "PPU timing suites", "expected_signal": "frame_sequence_hash", "source": "public"},
+    {"id": "snes_hdma_edges", "stage": "hidden", "kind": "generated_rom", "name": "HDMA edge cases", "expected_signal": "event_log_crc", "source": "generated"},
+    {"id": "snes_audio_sync", "stage": "hidden", "kind": "generated_rom", "name": "Audio synchronization", "expected_signal": "audio_crc", "source": "generated"},
+    {"id": "snes_long_gameplay", "stage": "hidden", "kind": "long_run", "name": "Long gameplay stability", "expected_signal": "stability_hash", "source": "withheld"}
+  ]
+}

--- a/environments/emulator_snes/tasks/public_tests.json
+++ b/environments/emulator_snes/tasks/public_tests.json
@@ -1,0 +1,37 @@
+{
+  "environment_id": "emulator-snes",
+  "sources": [
+    {
+      "name": "Peter Lemon SNES tests",
+      "kind": "git",
+      "url": "https://github.com/PeterLemon/SNES",
+      "ref": "master",
+      "license": "MIT",
+      "covers": ["SNESdev tests", "PPU timing suites"],
+      "notes": "SNES CPU/PPU/DMA homebrew tests."
+    },
+    {
+      "name": "undisbeliever SNES test ROMs",
+      "kind": "git",
+      "url": "https://github.com/undisbeliever/snes-test-roms",
+      "ref": "master",
+      "license": "MIT",
+      "covers": ["SNESdev tests"],
+      "notes": "SNES homebrew validation ROMs."
+    },
+    {
+      "name": "SNESdev emulator tests wiki",
+      "kind": "http",
+      "url": "https://snes.nesdev.org/wiki/Emulator_tests",
+      "license": "documentation",
+      "covers": ["blargg SNES tests", "SNESdev tests", "PPU timing suites"]
+    },
+    {
+      "name": "Snes Central blargg hardware tests",
+      "kind": "http",
+      "url": "https://snescentral.com/article.php?id=1115",
+      "license": "mixed-see-upstream",
+      "covers": ["blargg SNES tests"]
+    }
+  ]
+}

--- a/tests/test_emulator_benchmark_envs.py
+++ b/tests/test_emulator_benchmark_envs.py
@@ -1,0 +1,491 @@
+import importlib.util
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ENVIRONMENTS_DIR = REPO_ROOT / "environments"
+if str(ENVIRONMENTS_DIR) not in sys.path:
+    sys.path.insert(0, str(ENVIRONMENTS_DIR))
+
+from emulator_common.graders import (  # noqa: E402
+    audio_crc,
+    frame_sequence_sha256,
+    framebuffer_sha256,
+    stable_within,
+    trace_crc,
+)
+from emulator_common.loader import load_manifest  # noqa: E402
+from emulator_common.runners import VERIFIER_SCRIPT  # noqa: E402
+from emulator_common.sandbox import build_sandbox_config  # noqa: E402
+from emulator_common.suite_adapters import (  # noqa: E402
+    ROM_EXTENSIONS_BY_PLATFORM,
+    discover_artifacts,
+    fetch_source,
+    verify_workspace,
+)
+from emulator_common.test_sources import load_public_test_manifest  # noqa: E402
+from verifiers.utils.import_utils import load_toml  # noqa: E402
+
+
+ENV_SPECS = [
+    (
+        "emulator_chip8",
+        "emulator-chip8",
+        1,
+        ["IBM Logo ROM", "Corax opcode test", "Timendus CHIP-8 suite"],
+    ),
+    (
+        "emulator_i8080_space_invaders",
+        "emulator-i8080-space-invaders",
+        2,
+        ["8080 CPU exerciser", "Space Invaders attract mode", "Framebuffer hashes"],
+    ),
+    (
+        "emulator_gameboy_dmg",
+        "emulator-gameboy-dmg",
+        3,
+        [
+            "blargg test ROMs",
+            "mooneye-gb",
+            "dmg-acid2",
+            "Mealybug Tearoom tests",
+            "SameSuite",
+        ],
+    ),
+    (
+        "emulator_nes",
+        "emulator-nes",
+        4,
+        [
+            "nestest",
+            "blargg NES tests",
+            "PPU timing tests",
+            "Sprite hit tests",
+            "VBlank timing tests",
+        ],
+    ),
+    ("emulator_sms", "emulator-sms", 5, ["ZEXDOC", "ZEXALL", "SMS Test Suite"]),
+    (
+        "emulator_gameboy_cgb",
+        "emulator-gameboy-cgb",
+        6,
+        ["cgb-acid2", "mooneye CGB tests", "SameSuite CGB"],
+    ),
+    ("emulator_gba", "emulator-gba", 7, ["mGBA suite", "gba-suite", "TONC demos"]),
+    (
+        "emulator_genesis",
+        "emulator-genesis",
+        8,
+        ["68k verifier", "VDP tests", "Z80 tests", "240p Test Suite"],
+    ),
+    (
+        "emulator_snes",
+        "emulator-snes",
+        9,
+        ["blargg SNES tests", "SNESdev tests", "PPU timing suites"],
+    ),
+    (
+        "emulator_ps1",
+        "emulator-ps1",
+        10,
+        ["ps1-tests", "CPU verification ROMs", "DMA tests", "GPU command tests"],
+    ),
+]
+
+EXPECTED_ENV_IDS = [env_id for _, env_id, _, _ in ENV_SPECS]
+
+
+def load_toml_path(path: Path):
+    with path.open("rb") as handle:
+        return load_toml(handle)
+
+
+def load_env_module(module_name: str):
+    module_path = ENVIRONMENTS_DIR / module_name / f"{module_name}.py"
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize("module_name,env_id,level,public_tests", ENV_SPECS)
+def test_manifest_matches_curriculum(module_name, env_id, level, public_tests):
+    manifest = load_manifest(ENVIRONMENTS_DIR / module_name / "tasks" / "manifest.json")
+    assert manifest.environment_id == env_id
+    assert manifest.level == level
+    assert list(manifest.public_verification) == public_tests
+    assert manifest.requirements
+    assert manifest.hidden_verification
+    assert manifest.success_criteria
+    assert manifest.public_cases()
+    assert manifest.hidden_cases()
+
+
+@pytest.mark.parametrize("module_name,env_id,level,public_tests", ENV_SPECS)
+def test_public_test_sources_cover_curriculum(module_name, env_id, level, public_tests):
+    _ = level
+    source_manifest = load_public_test_manifest(
+        ENVIRONMENTS_DIR / module_name / "tasks" / "public_tests.json"
+    )
+    assert source_manifest.environment_id == env_id
+    assert set(public_tests).issubset(source_manifest.covered_names())
+    assert all(
+        source.url.startswith(("https://", "http://"))
+        for source in source_manifest.sources
+    )
+    assert all(
+        source.kind in {"git", "http", "private-artifact"}
+        for source in source_manifest.sources
+    )
+
+
+@pytest.mark.parametrize("module_name,env_id,level,public_tests", ENV_SPECS)
+def test_environment_entrypoint_loads_taskset(module_name, env_id, level, public_tests):
+    _ = (level, public_tests)
+    module = load_env_module(module_name)
+    env = module.load_environment(
+        max_tasks=1,
+        sandbox_timeout_minutes=60,
+        environment_timeout=60,
+        agent_step_limit=5,
+        max_turns=1,
+    )
+    rows = env.taskset.load_rows()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["task_id"] == f"{env_id}__implementation"
+    assert row["info"]["environment_id"] == env_id
+    assert row["sandbox"]["timeout_minutes"] == 60
+    assert row["sandbox"]["command_timeout"] == 3600
+    assert "PRIME_TEAM_ID" not in repr(row["sandbox"])
+
+
+@pytest.mark.parametrize("module_name,env_id,level,public_tests", ENV_SPECS[:1])
+def test_environment_eval_smoke_mode_loads_without_sandbox(
+    module_name, env_id, level, public_tests
+):
+    _ = (level, public_tests)
+    module = load_env_module(module_name)
+    env = module.load_environment(max_tasks=1, eval_smoke=True)
+    rows = env.taskset.rows()
+    assert len(rows) == 1
+    assert rows[0]["task_id"] == f"{env_id}__implementation"
+    assert "sandbox" not in rows[0]
+    assert "program" not in rows[0]
+
+
+@pytest.mark.parametrize("module_name,env_id,level,public_tests", ENV_SPECS[:1])
+def test_environment_prime_smoke_mode_uses_sandbox_task(
+    module_name, env_id, level, public_tests
+):
+    _ = (level, public_tests)
+    module = load_env_module(module_name)
+    env = module.load_environment(
+        max_tasks=1,
+        prime_smoke=True,
+        sandbox_timeout_minutes=30,
+        environment_timeout=60,
+        agent_step_limit=1,
+        max_turns=1,
+    )
+    rows = env.taskset.rows()
+    assert len(rows) == 1
+    assert rows[0]["task_id"] == f"{env_id}__prime_smoke"
+    assert rows[0]["sandbox"]["timeout_minutes"] == 30
+    assert "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT" in rows[0]["question"]
+
+
+def test_implementation_harness_scores_after_agent_command_failure():
+    module = load_env_module("emulator_chip8")
+    env = module.load_environment(
+        max_tasks=1,
+        sandbox_timeout_minutes=30,
+        environment_timeout=60,
+        agent_step_limit=1,
+        max_turns=1,
+    )
+
+    program = env.harness.program
+    assert isinstance(program, dict)
+    command = program["command"]
+    assert isinstance(command, list)
+    assert "emulator_agent_exit_status" in command[2]
+    assert "running verifier anyway" in command[2]
+    assert command[2].rstrip().endswith("exit 0")
+    assert program["artifacts"]["emulator_agent_exit_status"]["path"] == (
+        "/tmp/emulator_agent_exit_status"
+    )
+
+
+def test_inline_system_prompt_mode_uses_user_message_for_prime_rl():
+    module = load_env_module("emulator_chip8")
+    env = module.load_environment(
+        max_tasks=1,
+        sandbox_timeout_minutes=30,
+        environment_timeout=60,
+        agent_step_limit=1,
+        max_turns=1,
+        inline_system_prompt=True,
+    )
+
+    row = env.taskset.load_rows()[0]
+    assert row["prompt"] == [{"role": "user", "content": row["instruction"]}]
+    assert row["instruction"].startswith(
+        "You are implementing a hardware emulator for a deterministic coding benchmark."
+    )
+    assert getattr(env.harness, "system_prompt", None) == []
+
+
+def test_prime_smoke_harness_preserves_agent_command_failure():
+    module = load_env_module("emulator_chip8")
+    env = module.load_environment(
+        max_tasks=1,
+        prime_smoke=True,
+        sandbox_timeout_minutes=30,
+        environment_timeout=60,
+        agent_step_limit=1,
+        max_turns=1,
+    )
+
+    program = env.harness.program
+    assert isinstance(program, dict)
+    command = program["command"]
+    assert isinstance(command, list)
+    assert "emulator_agent_exit_status" not in command[2]
+    assert "emulator_agent_exit_status" not in program["artifacts"]
+
+
+def test_sandbox_uses_prime_toolchain_env(monkeypatch):
+    monkeypatch.setenv("PRIME_TOOLCHAIN_IMAGE", "toolchain/from-env:latest")
+    config = build_sandbox_config(timeout_minutes=360)
+    assert config["image"] == "toolchain/from-env:latest"
+    assert config["timeout_minutes"] == 360
+    assert config["command_timeout"] == 21600
+    assert config["network_access"] is True
+
+
+def test_grader_helpers_are_deterministic():
+    assert framebuffer_sha256([1, 2, 3]) == framebuffer_sha256(bytes([1, 2, 3]))
+    assert frame_sequence_sha256([[1], [2, 3]]) == frame_sequence_sha256(
+        [b"\x01", b"\x02\x03"]
+    )
+    assert trace_crc([{"pc": 1, "a": 2}]) == trace_crc([{"a": 2, "pc": 1}])
+    assert audio_crc([0, 255, 1]) == audio_crc(bytes([0, 255, 1]))
+    assert stable_within([59.9, 60.0, 60.1], 0.2)
+    assert not stable_within([59.0, 61.0], 0.2)
+
+
+def test_hidden_verifier_script_is_valid_python():
+    compile(VERIFIER_SCRIPT, "emulator_verify.py", "exec")
+
+
+def test_test_source_verifier_script_is_valid_python():
+    script = ENVIRONMENTS_DIR / "emulator_common" / "scripts" / "verify_test_sources.py"
+    compile(script.read_text(encoding="utf-8"), str(script), "exec")
+
+
+def test_gpt54_smoke_eval_config_covers_all_emulator_envs():
+    config = load_toml_path(
+        REPO_ROOT / "configs" / "eval" / "emulator-gpt-5-4-mini-prime-smoke.toml"
+    )
+    assert config["model"] == "openai/gpt-5.4-mini"
+    assert config["num_examples"] == 1
+    assert config["rollouts_per_example"] == 1
+
+    evals = config["eval"]
+    assert [row["id"] for row in evals] == EXPECTED_ENV_IDS
+    assert all(row["args"]["prime_smoke"] is True for row in evals)
+    assert all(row["args"]["agent_step_limit"] == 1 for row in evals)
+    assert all(row["args"]["max_turns"] == 1 for row in evals)
+
+
+def test_gpt54_suite_eval_config_covers_all_emulator_envs():
+    config = load_toml_path(
+        REPO_ROOT / "configs" / "eval" / "emulator-gpt-5-4-mini-suite.toml"
+    )
+    assert config["model"] == "openai/gpt-5.4-mini"
+    assert config["max_concurrent"] == 1
+    assert [row["id"] for row in config["eval"]] == EXPECTED_ENV_IDS
+    assert all("prime_smoke" not in row["args"] for row in config["eval"])
+
+
+def test_chip8_suite_canary_config_matches_recorded_result_scope():
+    config = load_toml_path(
+        REPO_ROOT / "configs" / "eval" / "emulator-gpt-5-4-mini-chip8-suite.toml"
+    )
+    assert config["model"] == "openai/gpt-5.4-mini"
+    assert [row["id"] for row in config["eval"]] == ["emulator-chip8"]
+    assert config["eval"][0]["args"]["agent_step_limit"] == 1
+
+
+def test_minimal_emulator_training_config_uses_trainable_model():
+    config = load_toml_path(
+        REPO_ROOT / "configs" / "rl" / "emulator-chip8-minimal.toml"
+    )
+    assert config["model"] == "openai/gpt-oss-20b"
+    assert config["max_steps"] == 10
+    assert config["batch_size"] == 8
+    assert config["rollouts_per_example"] == 2
+    assert config["env"][0]["id"] == "emulator-chip8"
+    assert config["env"][0]["args"]["max_tasks"] == 1
+
+
+def test_self_managed_prime_rl_smoke_config_targets_two_gpu_node():
+    config = load_toml_path(
+        REPO_ROOT / "configs" / "rl" / "emulator-chip8-prime-rl-smoke.toml"
+    )
+
+    assert config["model"]["name"] == "Qwen/Qwen3-0.6B"
+    assert config["deployment"]["gpus_per_node"] == 2
+    assert config["deployment"]["num_train_gpus"] == 1
+    assert config["deployment"]["num_infer_gpus"] == 1
+    assert config["orchestrator"]["use_token_client"] is False
+    assert config["orchestrator"]["use_renderer"] is True
+    assert config["orchestrator"]["filters"][-1] == {
+        "type": "zero_advantage",
+        "enforce": False,
+    }
+    assert config["orchestrator"]["batch_size"] == 1
+    assert config["orchestrator"]["train"]["env"][0]["id"] == "emulator-chip8"
+    env_args = config["orchestrator"]["train"]["env"][0]["args"]
+    assert env_args["max_tasks"] == 1
+    assert env_args["inline_system_prompt"] is True
+    assert config["trainer"]["max_steps"] == 1
+
+
+def test_git_source_sparse_paths_and_compressed_artifacts(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, check=True, stdout=subprocess.PIPE)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"], cwd=repo, check=True
+    )
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True)
+    (repo / "wanted").mkdir()
+    (repo / "other").mkdir()
+    (repo / "wanted" / "ADD.json.gz").write_bytes(b"processor fixture")
+    (repo / "other" / "ignored.json.gz").write_bytes(b"ignored fixture")
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "-c", "commit.gpgsign=false", "commit", "-m", "fixtures"],
+        cwd=repo,
+        check=True,
+        stdout=subprocess.PIPE,
+    )
+
+    destination = tmp_path / "cache"
+    result = fetch_source(
+        {
+            "name": "processor tests",
+            "kind": "git",
+            "url": str(repo),
+            "sparse_paths": ["wanted"],
+            "artifact_globs": ["wanted/*.json.gz"],
+            "artifact_extensions": [".json.gz"],
+        },
+        destination,
+        timeout=30,
+    )
+
+    assert result["ok"] is True
+    artifacts = discover_artifacts("genesis", [Path(str(result["path"]))])
+    assert [artifact.name for artifact in artifacts] == ["ADD.json.gz"]
+
+
+@pytest.mark.parametrize("module_name,env_id,level,public_tests", ENV_SPECS)
+def test_suite_adapter_runs_minimal_fixture(
+    tmp_path: Path, module_name, env_id, level, public_tests
+):
+    _ = (env_id, level, public_tests)
+    manifest = load_manifest(ENVIRONMENTS_DIR / module_name / "tasks" / "manifest.json")
+    platform = manifest.slug
+    extension = ROM_EXTENSIONS_BY_PLATFORM[platform][0]
+
+    suite_dir = tmp_path / "suite"
+    suite_dir.mkdir()
+    (suite_dir / f"fixture{extension}").write_bytes(b"fixture-rom")
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    runner = workspace / "emulator-runner"
+    runner.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env python3
+            import argparse
+            import hashlib
+            import json
+            import sys
+
+            if "--contract-version" in sys.argv:
+                print("emulator-runner-v1")
+                raise SystemExit(0)
+            if "--self-test" in sys.argv:
+                print(json.dumps({"ok": True}))
+                raise SystemExit(0)
+
+            parser = argparse.ArgumentParser()
+            parser.add_argument("--platform", required=True)
+            parser.add_argument("--case", required=True)
+            parser.add_argument("--rom", required=True)
+            parser.add_argument("--cycles", required=True)
+            parser.add_argument("--frames", required=True)
+            parser.add_argument("--output", required=True)
+            args = parser.parse_args()
+            rom = open(args.rom, "rb").read()
+            digest = hashlib.sha256(rom + args.case.encode()).hexdigest()
+            payload = {
+                "platform": args.platform,
+                "case_id": args.case,
+                "passed": True,
+                "cycles": int(args.cycles),
+                "frames": int(args.frames),
+                "framebuffer_sha256": digest,
+                "frame_sequence_sha256": digest,
+                "trace_crc32": digest[:8],
+                "audio_crc32": digest[:8],
+                "serial": "Passed",
+                "perf": {"fps": 60.0},
+            }
+            open(args.output, "w", encoding="utf-8").write(json.dumps(payload))
+            print(json.dumps({"passed": True}))
+            """
+        ),
+        encoding="utf-8",
+    )
+    runner.chmod(0o755)
+
+    source_manifest = {
+        "environment_id": manifest.environment_id,
+        "sources": [
+            {
+                "name": "fixture suite",
+                "kind": "local",
+                "url": str(suite_dir),
+                "covers": list(manifest.public_verification),
+            }
+        ],
+        "private_artifacts": [],
+    }
+    result = verify_workspace(
+        workspace,
+        {
+            "platform": platform,
+            "public_cases": manifest.public_cases(),
+            "runtime": dict(manifest.runtime),
+        },
+        source_manifest,
+        skip_build=True,
+        timeout=30,
+    )
+    assert result["components"]["runner_contract_score"] == 1.0
+    assert result["components"]["public_source_score"] == 1.0
+    assert result["components"]["public_rom_pass_rate"] == 1.0
+    assert result["components"]["deterministic_replay_score"] == 1.0
+    assert result["score"] >= 0.9

--- a/tests/test_v1_runtime_lifecycle.py
+++ b/tests/test_v1_runtime_lifecycle.py
@@ -64,6 +64,24 @@ class FakeClient:
         self.closed = True
 
 
+def test_v1_env_apply_controls_mirrors_sampling_args_for_rollout_outputs():
+    env = vf.Env(taskset=vf.Taskset(source=[]), harness=vf.Harness())
+    state = vf.State()
+    sampling_args = {"temperature": 0.7, "max_completion_tokens": 128}
+
+    env.apply_controls(
+        [state],
+        {
+            "model": "test-model",
+            "sampling_args": sampling_args,
+            "score_rollout": True,
+        },
+    )
+
+    assert state["runtime"]["sampling_args"] == sampling_args
+    assert state["sampling_args"] == sampling_args
+
+
 class FakeModelClient:
     def __init__(self, responses: list[Response]):
         self.responses = responses

--- a/verifiers/v1/env.py
+++ b/verifiers/v1/env.py
@@ -131,4 +131,6 @@ class Env(vf.Environment):
                 else None,
             )
             state["runtime"].update(serializable_controls)
+            if "sampling_args" in serializable_controls:
+                state["sampling_args"] = serializable_controls["sampling_args"]
         return states


### PR DESCRIPTION
## Summary
- add ten Prime emulator benchmark environments for CHIP-8 through PS1
- add shared emulator harness, runner contract, suite adapters, public test manifests, and private artifact mount support
- add `openai/gpt-5.4-mini` eval configs for all-env Prime smoke, all-env suite, and CHIP-8 suite canary
- add Hosted Training and self-managed `prime-rl` CHIP-8 smoke configs
- add the GPT-5.4 Mini eval/training report at `environments/emulator_common/GPT_5_4_MINI_EVAL_REPORT.md`
- keep implementation-task verifier scoring reachable after MiniSWEAgent command-loop failures so partial/broken attempts produce reward components
- add `inline_system_prompt` and v1 sampling-args output compatibility needed for self-managed `prime-rl` rollouts

## Verification
- `uv run pytest tests/test_emulator_benchmark_envs.py tests/test_v1_runtime_lifecycle.py::test_v1_env_apply_controls_mirrors_sampling_args_for_rollout_outputs -q` -> 56 passed
- `uv run pytest tests/test_v1_runtime_lifecycle.py -q` -> 56 passed
- `uv run ruff check environments/emulator_common/env_factory.py tests/test_emulator_benchmark_envs.py tests/test_v1_runtime_lifecycle.py verifiers/v1/env.py` -> passed
- `uv run pre-commit run --files ...` on touched files -> passed
- `git diff --check` -> passed
- CPU node `root@86.38.238.176` (`pb-coordinator`) -> cloned/pulled branch at `125a9ce6`, `uv run pytest tests/test_emulator_benchmark_envs.py tests/test_v1_runtime_lifecycle.py::test_v1_env_apply_controls_mirrors_sampling_args_for_rollout_outputs -q` -> 56 passed
- all-env `openai/gpt-5.4-mini` Prime smoke -> 10/10 envs reward 1.00; plumbing only, not ROM correctness
- all-env `openai/gpt-5.4-mini` suite eval -> 10 envs run, mean reward 0.58, mean error 0.10, full public pass envs 1/10, nine envs with public ROM pass 0.00; GPT-5.4 Mini did not pass all emulator tests
- training node `root@31.22.104.54` (`chess-dagger-2xpro6000b`) -> repo cloned, envs installed editable, `prime-rl` set up, `renderers==0.1.8.dev0` installed in `prime-rl/.venv`
- real self-managed `prime-rl` smoke on 2 x RTX PRO 6000 node -> `Qwen/Qwen3-0.6B`, Step 0 reward 0.5400, trainer Step 0 loss 0.0000, entropy 0.5280, KL 0.0019, checkpoint and weights written under `/root/verifiers-emulator/outputs/emulator-chip8-smoke`

## Notes
- no ROM/BIOS bytes are committed
- private/commercial/generated artifacts are mounted through `EMULATOR_PRIVATE_ARTIFACT_DIR` or `/private/emulator`
- Genesis reached public pass 1.00 against the currently configured source manifest; keep private artifacts mounted before treating that as comprehensive Genesis coverage
- hard systems should stay eval-only until easier emulator tasks show nonzero public ROM pass rates under training
