### PR TITLE
Fix v1 MCP setup in task sandboxes

### DIFF
--- a/tests/test_v1_harbor_cli.py
+++ b/tests/test_v1_harbor_cli.py
@@ -22,6 +22,7 @@ from verifiers.v1.packages.harnesses.terminus_2 import (
     terminus_2_agent_script,
 )
 from verifiers.v1.packages.tasksets.harbor import harbor_reward
+from verifiers.v1.utils.mcp_proxy_utils import MCP_PROXY_PYTHON_PATH
 from verifiers.v1.utils.program_utils import merge_task_program, merge_task_sandbox
 
 
@@ -304,7 +305,10 @@ def test_pi_harness_writes_intercepted_model_and_mcp_config() -> None:
     assert provider["api"] == "openai-completions"
     assert provider["apiKey"] == "secret"
     assert provider["models"] == [{"id": "model", "name": "openai/gpt-5.4-mini"}]
-    assert mcp["mcpServers"]["verifiers-tools"]["command"] == "python3"
+    server = mcp["mcpServers"]["verifiers-tools"]
+    assert server["command"] == "/bin/sh"
+    assert server["args"][0] == "-lc"
+    assert MCP_PROXY_PYTHON_PATH in server["args"][1]
 
 
 def test_terminus_2_harness_builds_sandbox_program() -> None:

--- a/tests/test_v1_runtime_lifecycle.py
+++ b/tests/test_v1_runtime_lifecycle.py
@@ -22,6 +22,7 @@ from verifiers.v1.runtime import Runtime
 from verifiers.v1.utils.endpoint_utils import endpoint_api_key
 from verifiers.v1.utils import mcp_utils
 from verifiers.v1.utils.mcp_proxy_utils import MCP_PROXY_CONFIG_PATH, MCP_PROXY_PATH
+from verifiers.v1.utils.mcp_proxy_utils import MCP_PROXY_PYTHON_PATH
 from verifiers.v1.utils.mcp_proxy_utils import proxy_command, proxy_source
 from verifiers.v1.utils.program_utils import command_env
 from verifiers.v1.utils.sandbox_program_utils import (
@@ -38,6 +39,7 @@ from verifiers.v1.utils.sandbox_program_utils import (
 from verifiers.v1.utils.sandbox_utils import (
     VF_STATE_INPUT_PATH_KEY,
     collect_sandbox_artifacts,
+    python_package_install_command,
     run_sandbox_command,
 )
 
@@ -1019,6 +1021,30 @@ build-backend = "hatchling.build"
     assert command[2].endswith(" /tmp/vf_program_runner.py fn local_program:run")
 
 
+def test_python_package_install_command_ignores_image_pip_config() -> None:
+    command = python_package_install_command("'mcp>=1.14.1' requests")
+
+    assert "export PIP_CONFIG_FILE=/dev/null" in command
+    assert (
+        "unset PIP_INDEX_URL PIP_EXTRA_INDEX_URL PIP_FIND_LINKS PIP_NO_INDEX "
+        "PIP_REQUIRE_VIRTUALENV"
+    ) in command
+    assert "UV_TOOL_DIR=/tmp/vf-tools" in command
+    assert "UV_DEFAULT_INDEX=https://pypi.org/simple" in command
+    assert "uv --no-config tool install" in command
+    assert "--python 3.11 --with requests 'mcp>=1.14.1'" in command
+    assert "$UV_TOOL_DIR/mcp/bin/python" in command
+    assert MCP_PROXY_PYTHON_PATH in command
+    assert (
+        "pip install --disable-pip-version-check --break-system-packages requests"
+        in command
+    )
+    assert (
+        "pip install --disable-pip-version-check --break-system-packages 'mcp>=1.14.1'"
+        not in command
+    )
+
+
 def test_sandbox_fn_program_resolves_local_module_package(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1208,7 +1234,11 @@ def test_program_channels_mcp_injects_proxy_into_sandbox_program() -> None:
         "tool_base_url": "http://127.0.0.1:1/rollout/test/vf/tools",
         "tool_api_key": harness.endpoint.secret,
     }
-    assert proxy_command() == ["python3", MCP_PROXY_PATH, MCP_PROXY_CONFIG_PATH]
+    command = proxy_command()
+    assert command[:2] == ["/bin/sh", "-lc"]
+    assert MCP_PROXY_PYTHON_PATH in command[2]
+    assert MCP_PROXY_PATH in command[2]
+    assert MCP_PROXY_CONFIG_PATH in command[2]
     packages = sandbox["packages"]
     assert isinstance(packages, list)
     assert "mcp>=1.14.1" in packages
@@ -1417,6 +1447,7 @@ async def write_real_sandbox_file(text: str, sandbox, state) -> str:
 REAL_MCP_PROXY_SCRIPT = r"""
 import asyncio
 import json
+import sys
 
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
@@ -1424,7 +1455,7 @@ from mcp.client.stdio import stdio_client
 
 async def main():
     server = StdioServerParameters(
-        command="python3",
+        command=sys.executable,
         args=["/tmp/vf_mcp_tools.py", "/tmp/vf_mcp_tools.json"],
     )
     async with stdio_client(server) as (read_stream, write_stream):
@@ -1505,7 +1536,11 @@ async def test_real_sandbox_command_program_uses_mcp_tool_proxy() -> None:
     harness = make_harness(
         program={
             "sandbox": True,
-            "command": ["python", "/tmp/call_mcp.py"],
+            "command": [
+                "/bin/sh",
+                "-lc",
+                f'exec "$(cat {MCP_PROXY_PYTHON_PATH})" /tmp/call_mcp.py',
+            ],
             "channels": "mcp",
             "files": {"/tmp/call_mcp.py": REAL_MCP_PROXY_SCRIPT},
         },

--- a/verifiers/v1/utils/mcp_proxy_utils.py
+++ b/verifiers/v1/utils/mcp_proxy_utils.py
@@ -7,6 +7,7 @@ from ..types import ConfigData, ConfigMap, ProgramChannel
 
 MCP_PROXY_PATH = "/tmp/vf_mcp_tools.py"
 MCP_PROXY_CONFIG_PATH = "/tmp/vf_mcp_tools.json"
+MCP_PROXY_PYTHON_PATH = "/tmp/vf_mcp_python"
 MCP_PACKAGE = "mcp>=1.14.1"
 REQUESTS_PACKAGE = "requests"
 
@@ -69,7 +70,13 @@ def proxy_program(
 
 
 def proxy_command() -> list[str]:
-    return ["python3", MCP_PROXY_PATH, MCP_PROXY_CONFIG_PATH]
+    command = (
+        f"PYTHON=$(cat {shlex.quote(MCP_PROXY_PYTHON_PATH)} 2>/dev/null || "
+        "command -v python3); "
+        f'exec "$PYTHON" {shlex.quote(MCP_PROXY_PATH)} '
+        f"{shlex.quote(MCP_PROXY_CONFIG_PATH)}"
+    )
+    return ["/bin/sh", "-lc", command]
 
 
 def proxy_sandbox(sandbox_config: ConfigMap) -> ConfigData:

--- a/verifiers/v1/utils/sandbox_utils.py
+++ b/verifiers/v1/utils/sandbox_utils.py
@@ -16,6 +16,7 @@ from verifiers.utils.async_utils import maybe_call_with_named_args
 
 from .artifact_utils import artifact_format, artifact_key, artifact_optional
 from .artifact_utils import artifact_path
+from .mcp_proxy_utils import MCP_PROXY_PYTHON_PATH
 from .program_utils import command_argv, command_env, float_config, int_config
 from .program_utils import program_option_mapping, program_channel_setup
 from .program_utils import resolve_program_value
@@ -511,8 +512,45 @@ def sandbox_scope(sandbox_config: ConfigMap) -> str:
 
 
 def python_package_install_command(package_args: str) -> str:
+    packages = shlex.split(package_args)
+    pip_packages = [package for package in packages if not package.startswith("mcp")]
+    pip_package_args = " ".join(shlex.quote(package) for package in pip_packages)
+    mcp_python_setup = ""
+    if any(package.startswith("mcp") for package in packages):
+        mcp_packages = [package for package in packages if package.startswith("mcp")]
+        mcp_package_args = " ".join(shlex.quote(package) for package in mcp_packages)
+        requests_packages = [
+            package for package in packages if package.startswith("requests")
+        ]
+        requests_package = requests_packages[0] if requests_packages else "requests"
+        mcp_python_setup = (
+            "VF_UV_SITE_PACKAGES=/tmp/vf-uv-site-packages\n"
+            "export UV_TOOL_DIR=/tmp/vf-tools\n"
+            "export UV_PYTHON_INSTALL_DIR=/tmp/vf-python\n"
+            "export UV_CACHE_DIR=/tmp/vf-uv-cache\n"
+            "export UV_DEFAULT_INDEX=https://pypi.org/simple\n"
+            "unset UV_INDEX UV_INDEX_URL UV_EXTRA_INDEX_URL UV_FIND_LINKS UV_NO_INDEX UV_CONFIG_FILE\n"
+            'mkdir -p "$VF_UV_SITE_PACKAGES" "$UV_TOOL_DIR" "$UV_PYTHON_INSTALL_DIR" "$UV_CACHE_DIR"\n'
+            '"$PYTHON" -m pip install --disable-pip-version-check --break-system-packages '
+            '  --target "$VF_UV_SITE_PACKAGES" uv==0.11.7 || '
+            '"$PYTHON" -m pip install --disable-pip-version-check '
+            '  --target "$VF_UV_SITE_PACKAGES" uv==0.11.7\n'
+            'env PYTHONPATH="$VF_UV_SITE_PACKAGES" "$PYTHON" -m uv --no-config tool install '
+            f"--python 3.11 --with {shlex.quote(requests_package)} {mcp_package_args}\n"
+            f'printf "%s\\n" "$UV_TOOL_DIR/mcp/bin/python" > {shlex.quote(MCP_PROXY_PYTHON_PATH)}\n'
+        )
+    pip_install = ""
+    if pip_package_args:
+        pip_install = (
+            "$PYTHON -m pip install --disable-pip-version-check --break-system-packages "
+            f"{pip_package_args} || "
+            "$PYTHON -m pip install --disable-pip-version-check "
+            f"{pip_package_args}"
+        )
     return (
         "set -e\n"
+        "export PIP_CONFIG_FILE=/dev/null\n"
+        "unset PIP_INDEX_URL PIP_EXTRA_INDEX_URL PIP_FIND_LINKS PIP_NO_INDEX PIP_REQUIRE_VIRTUALENV\n"
         "if command -v python3 >/dev/null 2>&1; then PYTHON=python3; "
         "elif command -v python >/dev/null 2>&1; then PYTHON=python; "
         "elif command -v apt-get >/dev/null 2>&1; then "
@@ -525,10 +563,8 @@ def python_package_install_command(package_args: str) -> str:
         "(command -v apt-get >/dev/null 2>&1 && "
         "apt-get -o Acquire::Retries=3 update && "
         "apt-get -o Acquire::Retries=3 install -y python3-pip)\n"
-        "$PYTHON -m pip install --disable-pip-version-check --break-system-packages "
-        f"{package_args} || "
-        "$PYTHON -m pip install --disable-pip-version-check "
-        f"{package_args}"
+        f"{mcp_python_setup}"
+        f"{pip_install}"
     )
 
 


### PR DESCRIPTION
## Summary
- make v1 sandbox package installs ignore image-level pip config/env settings
- provision Python 3.11 for MCP proxy packages when a task image has python3 < 3.10
- have MCP proxy commands use the recorded interpreter path

## Testing
- uv run ruff format
- uv run ruff check --fix
- uv run pytest tests/test_v1_runtime_lifecycle.py -q
- uv run pytest tests/test_v1_harbor_cli.py -q
- uv run pre-commit run --files tests/test_v1_runtime_lifecycle.py tests/test_v1_harbor_cli.py verifiers/v1/utils/sandbox_utils.py verifiers/v1/utils/mcp_proxy_utils.py
- targeted old-Python SWE-bench Pro sandbox setup: installed mcp/requests and imported both with /tmp/vf_mcp_python
- 3x1 GPT-5.5 + OpenCode smoke got past the original pip-index failure and ran real rollouts; remaining 0-turn failure was traced to python3 < 3.10 and fixed by the targeted setup check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sandbox package installation and MCP proxy invocation logic, which can affect how user programs/tools run inside task sandboxes (dependency resolution and interpreter selection). Risk is mitigated by added/updated unit tests but could still surface in diverse base images/environments.
> 
> **Overview**
> Fixes v1 MCP execution in task sandboxes by **recording and reusing a sandbox-resolved Python interpreter** for the MCP proxy instead of hardcoding `python3`. `proxy_command()` now runs via `/bin/sh -lc`, reads the interpreter path from `MCP_PROXY_PYTHON_PATH` (fallback to `python3`), and tests are updated to assert the new command shape.
> 
> Hardens sandbox dependency installation: `python_package_install_command()` now **ignores image-level pip configuration** (clears `PIP_CONFIG_FILE` and related `PIP_*` env vars) and, when `mcp` is requested, bootstraps `uv` to install MCP under Python 3.11, writing that interpreter path to `MCP_PROXY_PYTHON_PATH`. Adds targeted tests plus a real-sandbox test that runs MCP via the recorded interpreter path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 284a2cc0757346063b1984396165c5b64b0f6df1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix MCP proxy setup in v1 task sandboxes to use a dynamically installed Python interpreter
> - Refactors `python_package_install_command` in [sandbox_utils.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1391/files#diff-b1154f3be7f28191532de46fbe23a973a5f93e1450a71beb9c93910e358fda13) to separate `mcp*` packages from others: `mcp` packages are installed via `uv tool install` with a pinned Python 3.11, while non-mcp packages use `pip`.
> - Writes the resulting tool interpreter path to `/tmp/vf_mcp_python` (constant `MCP_PROXY_PYTHON_PATH`) so it can be referenced at runtime.
> - Rewrites `proxy_command` in [mcp_proxy_utils.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1391/files#diff-58e51a8281c309941fb0f21cf2365d4bc7315bac192a4a986ae89fe452e21125) to wrap execution in `/bin/sh -lc`, reading the interpreter path from `MCP_PROXY_PYTHON_PATH` and falling back to `python3` if missing.
> - Adds a preamble to the install command that exports `PIP_CONFIG_FILE=/dev/null` and unsets pip index env vars to prevent image-level pip config from interfering.
> - Behavioral Change: MCP proxy commands are now shell-wrapped (`/bin/sh -lc`) instead of direct `python3` invocations, and pip config from the sandbox image is explicitly ignored during package installation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 284a2cc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->