### PR TITLE
[Router Replay]: Improve performance by removing Pydantic validation

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -181,6 +181,14 @@ class TrajectoryStep(TypedDict):
 
 A single turn in a multi-turn rollout.
 
+### RoutedExpertsPayload
+
+```python
+class RoutedExpertsPayload(TypedDict):
+    data: Any  # actually memoryview; kept opaque so Pydantic skips schema validation
+    shape: list[int]
+```
+
 ### TrajectoryStepTokens
 
 ```python
@@ -192,7 +200,7 @@ class TrajectoryStepTokens(TypedDict):
     completion_logprobs: list[float]
     overlong_prompt: bool
     is_truncated: bool
-    routed_experts: list[list[list[int]]] | None  # [seq_len, layers, topk] to enable router replay
+    routed_experts: RoutedExpertsPayload | None
     multi_modal_data: NotRequired[Any]  # renderers.MultiModalData sidecar (pixel_values, placeholder ranges) — set only on multimodal rollouts
 ```
 

--- a/tests/test_client_auth_errors.py
+++ b/tests/test_client_auth_errors.py
@@ -130,6 +130,9 @@ class _OverlongOpenAIChatClient:
     def __init__(self, message: str) -> None:
         self.chat = self._Chat(message)
 
+    async def post(self, *args, **kwargs):  # noqa: ANN002, ANN003
+        return await self.chat.completions.create(*args, **kwargs)
+
 
 @pytest.mark.parametrize(
     "error_message",

--- a/tests/test_openai_chat_completions_token_client.py
+++ b/tests/test_openai_chat_completions_token_client.py
@@ -1,5 +1,6 @@
 from typing import Any, cast
 
+import httpx
 import pytest
 
 from verifiers.clients.openai_chat_completions_client import OpenAIChatCompletionsClient
@@ -24,7 +25,25 @@ class _RecordingClient(_NoopClient):
         self, path: str, body: dict[str, Any], cast_to: type, **kwargs: Any
     ) -> Any:
         self.calls.append({"path": path, "body": body, "cast_to": cast_to})
-        return {"ok": True, "path": path, "body": body}
+        return httpx.Response(
+            200,
+            json={
+                "id": path,
+                "object": "chat.completion",
+                "created": 1,
+                "model": body["model"],
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "ok"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "ok": True,
+                "path": path,
+                "body": body,
+            },
+        )
 
 
 class _PromptIdTestClient(OpenAIChatCompletionsTokenClient):
@@ -270,7 +289,7 @@ async def test_get_native_response_uses_token_route_when_prompt_ids_available(
         state=state,
     )
 
-    assert response["ok"] is True
+    assert response.model_extra["ok"] is True
     assert len(recording_client.calls) == 1
     assert recording_client.calls[0]["path"] == "/chat/completions/tokens"
     assert recording_client.calls[0]["body"]["tokens"] == [10, 20]

--- a/verifiers/clients/openai_chat_completions_client.py
+++ b/verifiers/clients/openai_chat_completions_client.py
@@ -56,8 +56,10 @@ from verifiers.types import (
     Usage,
     UserMessage,
 )
-from verifiers.utils.client_utils import setup_openai_client
-from verifiers.utils.response_utils import parse_routed_experts
+from verifiers.utils.client_utils import (
+    post_chat_completion_with_routed_experts_sidecar,
+    setup_openai_client,
+)
 
 
 def handle_openai_overlong_prompt(func):
@@ -300,23 +302,24 @@ class OpenAIChatCompletionsClient(
             sampling_args = {**sampling_args, "modalities": ["text"]}
 
         extra_headers = kwargs.pop("extra_headers", None)
+        request_args = normalize_sampling_args(sampling_args)
+        extra_body = request_args.pop("extra_body", {})
 
+        body: dict[str, Any] = {
+            "model": model,
+            "messages": prompt,
+            **request_args,
+            **extra_body,
+        }
         if tools:
-            response = await self.client.chat.completions.create(
-                model=model,
-                messages=prompt,
-                tools=tools,
-                extra_headers=extra_headers,
-                **normalize_sampling_args(sampling_args),
-            )
-        else:
-            response = await self.client.chat.completions.create(
-                model=model,
-                messages=prompt,
-                extra_headers=extra_headers,
-                **normalize_sampling_args(sampling_args),
-            )
-        return response
+            body["tools"] = tools
+
+        return await post_chat_completion_with_routed_experts_sidecar(
+            self.client,
+            "/chat/completions",
+            body=body,
+            extra_headers=extra_headers,
+        )
 
     async def raise_from_native_response(self, response: OpenAIChatResponse) -> None:
         if response is None:
@@ -483,14 +486,13 @@ class OpenAIChatCompletionsClient(
                 completion_logprobs = [token["logprob"] for token in logprobs_content]
 
             choice_extra = choice.model_extra or {}
-            routed_experts = parse_routed_experts(choice_extra.get("routed_experts"))
             return ResponseTokens(
                 prompt_ids=prompt_ids,
                 prompt_mask=prompt_mask,
                 completion_ids=completion_ids,
                 completion_mask=completion_mask,
                 completion_logprobs=completion_logprobs,
-                routed_experts=routed_experts,
+                routed_experts=choice_extra.get("routed_experts"),
             )
 
         def parse_reasoning_content_from_response(

--- a/verifiers/clients/openai_chat_completions_token_client.py
+++ b/verifiers/clients/openai_chat_completions_token_client.py
@@ -3,7 +3,6 @@ from typing import Any, Optional, cast
 
 from openai import AsyncOpenAI, BaseModel
 from openai.types.chat import (
-    ChatCompletion,
     ChatCompletionAssistantMessageParam,
 )
 from openai.types.chat.chat_completion_message_function_tool_call_param import (
@@ -20,6 +19,9 @@ from verifiers.clients.openai_chat_completions_client import (
     handle_openai_overlong_prompt,
 )
 from verifiers.types import SamplingArgs, State
+from verifiers.utils.client_utils import (
+    post_chat_completion_with_routed_experts_sidecar,
+)
 
 
 def _has_multimodal_content(messages) -> bool:
@@ -140,20 +142,20 @@ class OpenAIChatCompletionsTokenClient(OpenAIChatCompletionsClient):
             )
 
         extra_body = sampling_args.pop("extra_body", {})
-        body = dict(
-            model=model,
-            messages=prompt,
-            tools=tools,
-            tokens=prompt_ids,
+        body = {
+            "model": model,
+            "messages": prompt,
+            "tools": tools,
+            "tokens": prompt_ids,
             **sampling_args,
             **extra_body,
-        )
+        }
 
-        return await self.client.post(
+        return await post_chat_completion_with_routed_experts_sidecar(
+            self.client,
             "/chat/completions/tokens",
             body=body,
-            cast_to=ChatCompletion,
-            options={"headers": extra_headers} if extra_headers else {},
+            extra_headers=extra_headers,
         )
 
     async def get_prompt_ids(

--- a/verifiers/clients/openai_completions_client.py
+++ b/verifiers/clients/openai_completions_client.py
@@ -25,7 +25,6 @@ from verifiers.types import (
     Usage,
 )
 from verifiers.utils.client_utils import setup_openai_client
-from verifiers.utils.response_utils import parse_routed_experts
 
 OpenAITextMessages = str
 OpenAITextResponse = Completion
@@ -170,15 +169,12 @@ class OpenAICompletionsClient(
             )
             if completion_logprobs is None:
                 return None
-            choice_extra = response.choices[0].model_extra or {}
-            routed_experts = parse_routed_experts(choice_extra.get("routed_experts"))
             return ResponseTokens(
                 prompt_ids=prompt_ids,
                 prompt_mask=prompt_mask,
                 completion_ids=completion_ids,
                 completion_mask=completion_mask,
                 completion_logprobs=completion_logprobs,
-                routed_experts=routed_experts,
             )
 
         return Response(

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -183,13 +183,19 @@ class Usage(CustomBaseModel):
     total_tokens: int
 
 
+class RoutedExpertsPayload(TypedDict):
+    # Keep the raw response sidecar opaque so Pydantic does not validate memoryview.
+    data: Any
+    shape: list[int]
+
+
 class ResponseTokens(CustomBaseModel):
     prompt_ids: list[int]
     prompt_mask: list[int]
     completion_ids: list[int]
     completion_mask: list[int]
     completion_logprobs: list[float]
-    routed_experts: str | None = None  # base64 NumPy [seq_len, layers, topk]
+    routed_experts: RoutedExpertsPayload | None = None
     # Renderer-emitted multimodal sidecar (renderers.base.MultiModalData)
     # carrying processed pixel_values / placeholder ranges per modality.
     # Populated by the renderer client when the rollout went through a
@@ -232,7 +238,7 @@ class TrajectoryStepTokens(TypedDict):
     completion_logprobs: list[float]
     overlong_prompt: bool
     is_truncated: bool
-    routed_experts: str | None  # base64 NumPy [seq_len, layers, topk]
+    routed_experts: RoutedExpertsPayload | None
     # Renderer-emitted multimodal sidecar (renderers.base.MultiModalData)
     # carrying processed pixel_values / placeholder ranges per modality.
     # ``NotRequired`` because text-only rollouts (and non-renderer client

--- a/verifiers/utils/client_utils.py
+++ b/verifiers/utils/client_utils.py
@@ -1,16 +1,20 @@
 import json
 import logging
 import os
+from collections.abc import Mapping
+from typing import Any
 from pathlib import Path
 
 import httpx
 from anthropic import AsyncAnthropic
 from openai import AsyncOpenAI
+from openai.types.chat import ChatCompletion
 
 from verifiers.types import (
     ClientConfig,
     EndpointClientConfig,
 )
+from verifiers.utils.response_utils import strip_routed_experts_data
 
 logger = logging.getLogger(__name__)
 
@@ -95,6 +99,32 @@ def setup_http_client(config: ClientConfig) -> httpx.AsyncClient:
     resolved_config = resolve_client_config(config)
     headers, _ = _build_headers_and_api_key(resolved_config)
     return _build_http_client(resolved_config, headers)
+
+
+def parse_chat_completion_with_routed_experts_sidecar(raw: bytes) -> ChatCompletion:
+    stripped, routed_data = strip_routed_experts_data(raw)
+    response = ChatCompletion.model_validate_json(stripped)
+    if routed_data is not None:
+        choice_extra = response.choices[0].model_extra
+        assert choice_extra is not None
+        choice_extra["routed_experts"]["data"] = routed_data
+    return response
+
+
+async def post_chat_completion_with_routed_experts_sidecar(
+    client: AsyncOpenAI,
+    path: str,
+    *,
+    body: dict[str, Any],
+    extra_headers: Mapping[str, str] | None = None,
+) -> ChatCompletion:
+    raw_response = await client.post(
+        path,
+        body=body,
+        cast_to=httpx.Response,
+        options={"headers": extra_headers} if extra_headers else {},
+    )
+    return parse_chat_completion_with_routed_experts_sidecar(raw_response.content)
 
 
 def _setup_openai_client_from_resolved(config: ClientConfig) -> AsyncOpenAI:

--- a/verifiers/utils/response_utils.py
+++ b/verifiers/utils/response_utils.py
@@ -1,9 +1,3 @@
-import base64
-from io import BytesIO
-from typing import Any, cast
-
-import numpy as np
-
 from verifiers.types import (
     AssistantMessage,
     Messages,
@@ -11,24 +5,19 @@ from verifiers.types import (
     TrajectoryStepTokens,
 )
 
-
-def parse_routed_experts(raw: Any) -> str | None:
-    if raw is None:
-        return None
-    return cast(str, raw)
+ROUTED_EXPERTS_DATA_PREFIX = b'"routed_experts":{"data":"'
 
 
-def truncate_routed_experts(routed_experts: str | None, seq_len: int) -> str | None:
-    if routed_experts is None:
-        return None
+def strip_routed_experts_data(raw: bytes) -> tuple[bytes, memoryview | None]:
+    data_start = raw.find(ROUTED_EXPERTS_DATA_PREFIX)
+    if data_start < 0:
+        return raw, None
 
-    array = np.load(BytesIO(base64.b64decode(routed_experts)), allow_pickle=False)
-    assert array.ndim == 3
-    assert 0 <= seq_len <= array.shape[0]
-
-    buffer = BytesIO()
-    np.save(buffer, np.ascontiguousarray(array[:seq_len]), allow_pickle=False)
-    return base64.b64encode(buffer.getvalue()).decode("ascii")
+    data_start += len(ROUTED_EXPERTS_DATA_PREFIX)
+    data_end = raw.index(b'"', data_start)
+    routed_data = memoryview(raw)[data_start:data_end]
+    stripped = raw[:data_start] + raw[data_end:]
+    return stripped, routed_data
 
 
 async def parse_response_message(response: Response) -> Messages:
@@ -73,15 +62,11 @@ async def parse_response_tokens(
             completion_ids = []
             completion_mask = []
             completion_logprobs = []
-            routed_experts = truncate_routed_experts(routed_experts, len(prompt_ids))
         elif prompt_len + completion_len > max_seq_len:
             is_truncated = True
             completion_ids = tokens.completion_ids[: max_seq_len - prompt_len]
             completion_mask = tokens.completion_mask[: max_seq_len - prompt_len]
             completion_logprobs = tokens.completion_logprobs[: max_seq_len - prompt_len]
-            routed_experts = truncate_routed_experts(
-                routed_experts, prompt_len + len(completion_ids)
-            )
         else:
             is_truncated = False
     else:
@@ -104,4 +89,6 @@ async def parse_response_tokens(
         # step. Leaving it on ``response.message.tokens`` too means every
         # downstream pass (msgpack, save) has to dedupe the duplicate.
         tokens.multi_modal_data = None
+    if routed_experts is not None:
+        tokens.routed_experts = None
     return out


### PR DESCRIPTION
## Summary

- represent `routed_experts` as one internal payload shape: `{"data": Any, "shape": list[int]}`; `data` is intentionally opaque because it carries the raw response sidecar memoryview
- parse OpenAI chat raw responses through the fixed compact sidecar schema `"routed_experts":{"data":"...","shape":[...]}` and attach `data` back without decoding it
- keep the raw routed-experts strip helper in `response_utils` and place chat parse/post helpers in `client_utils`
- remove the old verifier-side routed-experts base64/NumPy decode and truncation path; prime-rl orchestrator remains the decode/align/truncate owner
- move `routed_experts` off `response.message.tokens` once copied into parsed trajectory tokens so downstream serialization sees a single copy

## Verification

- `uv run ruff check docs/reference.md tests/test_client_auth_errors.py tests/test_openai_chat_completions_token_client.py verifiers/clients/openai_chat_completions_client.py verifiers/clients/openai_chat_completions_token_client.py verifiers/clients/openai_completions_client.py verifiers/types.py verifiers/utils/response_utils.py`
- `uv run ruff format --check tests/test_client_auth_errors.py tests/test_openai_chat_completions_token_client.py verifiers/clients/openai_chat_completions_client.py verifiers/clients/openai_chat_completions_token_client.py verifiers/clients/openai_completions_client.py verifiers/types.py verifiers/utils/response_utils.py`
- `uv run ty check verifiers/clients/openai_chat_completions_client.py verifiers/clients/openai_completions_client.py verifiers/types.py verifiers/utils/response_utils.py`
- `uv run pytest tests/test_openai_chat_completions_token_client.py tests/test_client_auth_errors.py -q`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OpenAI chat request/response handling to parse raw HTTP bytes and reattach `routed_experts`, which could break compatibility with non-standard response shapes or multi-choice responses. Also alters the public token schema for `routed_experts`, impacting any downstream consumers expecting a base64 string.
> 
> **Overview**
> **Router replay sidecar parsing is refactored to avoid Pydantic validation overhead.** `routed_experts` is now represented as a structured `RoutedExpertsPayload` (`{data, shape}`) and is stripped from raw chat completion JSON bytes (as a `memoryview`) before model validation, then reattached via `model_extra`.
> 
> **OpenAI chat clients now post via a shared raw-response helper.** `OpenAIChatCompletionsClient` and `OpenAIChatCompletionsTokenClient` switch from `chat.completions.create`/typed `cast_to` parsing to `post_chat_completion_with_routed_experts_sidecar`, and token parsing now passes through the new payload without base64/NumPy decode/truncation. `parse_response_tokens` additionally clears `tokens.routed_experts` after copying into `TrajectoryStepTokens` to avoid duplicate serialization, and tests/docs are updated to reflect the new response shape and raw `httpx.Response` mocking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d99e731fbe6645bc66bcd10a4116b92fb87d8fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove Pydantic validation from routed experts parsing by switching to a byte-level sidecar approach
> - Replaces base64/NumPy-based routed experts decoding with a byte-level sidecar extraction in [`response_utils.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1394/files#diff-792a30a7d072bc4ee79e8359e4f3019c438b479fc05325a1af4f11aef53ce920): `strip_routed_experts_data` scans raw JSON bytes and returns a `(stripped_json, memoryview)` tuple, bypassing Pydantic validation overhead.
> - Adds `post_chat_completion_with_routed_experts_sidecar` in [`client_utils.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1394/files#diff-115f7c6465eb15fbfda8768948af933ae7033df60ce7bc69865346c3e88894a0), a shared helper that issues a low-level HTTP POST and injects the extracted sidecar into `choices[0].model_extra`, used by both the standard and token chat completion clients.
> - Introduces `RoutedExpertsPayload` TypedDict in [`types.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1394/files#diff-8bc45ba080ed8ff01ee6adbafb54c0346181c6f292928e53c2a94dd9ed5156c3) with `data: Any` and `shape: list[int]`; `ResponseTokens.routed_experts` and `TrajectoryStepTokens.routed_experts` are changed from `str | None` to `RoutedExpertsPayload | None`.
> - Behavioral Change: `routed_experts` is now a structured payload (including a raw `memoryview`) instead of a base64 string; the Completions API (`openai_completions_client.py`) no longer populates `routed_experts` at all.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2d99e73.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->



