### PR TITLE
Add aime2026 dataset to load_example_dataset

### DIFF
--- a/verifiers/utils/data_utils.py
+++ b/verifiers/utils/data_utils.py
@@ -135,6 +135,18 @@ def get_preprocess_fn(name: str) -> Callable[[dict], dict]:
             }
 
         return preprocess_aime2025
+    elif name == "aime2026":
+
+        def preprocess_aime2026(x: dict[str, Any]) -> dict[str, Any]:
+            # ``answer`` in the source dataset is int64; renaming to
+            # ``temp_answer`` so the int->str cast survives ``.map`` type
+            # inference (see the rename hook at the end of ``load_example_dataset``).
+            return {
+                "question": x["problem"],
+                "temp_answer": str(x["answer"]),
+            }
+
+        return preprocess_aime2026
     elif name == "amc2023":
 
         def preprocess_amc2023(x: dict[str, Any]) -> dict[str, Any]:
@@ -286,6 +298,10 @@ def load_example_dataset(
             Dataset, load_dataset("opencompass/AIME2025", "AIME2025-II")[split]
         )
         dataset = concatenate_datasets([aime_i, aime_ii])
+    elif name == "aime2026":
+        if split is None:
+            split = "train"
+        dataset = load_dataset("MathArena/aime_2026")[split]
     elif name == "amc2023":
         if split is None:
             split = "train"


### PR DESCRIPTION
## What

Registers `MathArena/aime_2026` (30 problems from the 2026 AIME I + II) in `verifiers/utils/data_utils.py` alongside the existing `aime2024` / `aime2025` entries.

## Why

AIME 2026 was released after most current models' training cutoffs, which makes it a useful held-out math benchmark for evaluating top-tier models. Including it here means anyone running a math env via verifiers can grab it with the standard one-liner:

```python
from verifiers.utils.data_utils import load_example_dataset
ds = load_example_dataset("aime2026")
```

## How

Two small additions matching the surrounding pattern:

1. `get_preprocess_fn`: new `aime2026` branch returning `{"question": x["problem"], "temp_answer": str(x["answer"])}`.
2. `load_example_dataset`: new `aime2026` branch calling `load_dataset("MathArena/aime_2026")["train"]`.

## Implementation note

The source dataset's `answer` column is typed `int64`. The new preprocessor returns the renamed key `temp_answer` (which gets renamed back to `answer` by the existing hook at the end of `load_example_dataset`) so the int-to-string cast survives `.map`'s type inference. Same workaround the existing `mmlu` preprocessor already uses for its int-typed answer column — no new mechanism introduced.

## Verification

```bash
python -c "
from verifiers.utils.data_utils import load_example_dataset
ds = load_example_dataset('aime2026')
print(ds.features)  # {'question': Value('string'), 'answer': Value('string')}
print(ds[0])        # {'question': '...', 'answer': '277'}
print(len(ds))      # 30
"
```

Ruff passes on the modified file (`uv run ruff check verifiers/utils/data_utils.py`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, additive dataset registration and preprocessing changes with no impact to core evaluation logic beyond enabling a new dataset name.
> 
> **Overview**
> Adds a new `aime2026` option to `load_example_dataset` that loads `MathArena/aime_2026` (default `train`) and wires it into `get_preprocess_fn`.
> 
> The new preprocessor maps `problem` to `question` and stringifies the int-typed `answer` via a `temp_answer` field that is later renamed back to `answer` to preserve the cast through `.map`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 663e71484354f9feac8f5150553763d49ced2ceb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `aime2026` dataset support to `load_example_dataset`
> Adds the `MathArena/aime_2026` dataset as a loadable option in [data_utils.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1399/files#diff-5a104488173286e4475a2bad1ef1eb6e1b6ae0b33db94003ad185c7d57ac4b2c). The preprocessor maps `problem` to `question` and casts the integer `answer` to a string via a `temp_answer` intermediate column, which is then renamed to `answer` post-map to avoid type conflicts during dataset mapping.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 663e714.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->