### PR TITLE
fix(save_utils): reset delta baseline on non-monotonic trajectories

### DIFF
--- a/tests/test_save_utils.py
+++ b/tests/test_save_utils.py
@@ -1170,3 +1170,34 @@ class TestDeltaIntermediateMmData:
         assert out[1] == "not-a-dict"
         # Delta of step 2 still computed against step 0 (last seen cumulative).
         assert out[2]["tokens"]["multi_modal_data"].mm_hashes == {"image": ["B"]}
+
+    def test_partial_compaction_preserves_preserved_images_in_delta(self):
+        """Compaction that keeps a subset of prior images must not drop them.
+
+        Multiset diff is lossless only when ``prior`` is a multiset-subset
+        of ``current``. A compaction that preserves *some* prior images
+        violates that precondition: walking ``current`` left-to-right
+        consumes the preserved images out of the delta (they "match" prior
+        occurrences) even though those images really do appear in the
+        post-compaction prompt. The fix detects the non-monotonic transition
+        and emits current's full cumulative as-is.
+        """
+        # Turn 0: image A.       Cumulative {A}.
+        # Turn 1: image B added. Cumulative {A, B}.
+        # ── partial compaction: drop A, keep B, add new image C ──
+        # Turn 2 (fresh render): Cumulative {B, C}.
+        traj = [
+            self._step(self._mm("A")),
+            self._step(self._mm("A", "B")),
+            self._step(self._mm("B", "C")),
+        ]
+        out = _delta_intermediate_mm_data(traj)
+
+        assert out[0]["tokens"]["multi_modal_data"].mm_hashes == {"image": ["A"]}
+        assert out[1]["tokens"]["multi_modal_data"].mm_hashes == {"image": ["B"]}
+        # Without the fix, a multiset diff vs prior={A, B} would drop B.
+        assert out[2]["tokens"]["multi_modal_data"].mm_hashes == {"image": ["B", "C"]}
+        assert out[2]["tokens"]["multi_modal_data"].mm_items["image"] == [
+            {"pixel_values": "px-B"},
+            {"pixel_values": "px-C"},
+        ]

--- a/verifiers/utils/save_utils.py
+++ b/verifiers/utils/save_utils.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import time
+from collections import Counter
 from collections.abc import Mapping
 from datetime import date, datetime
 from pathlib import Path
@@ -334,6 +335,15 @@ def _delta_intermediate_mm_data(trajectory: object) -> object:
     step-deltas in that window. Placeholder offsets stay relative to the
     step's own cumulative token sequence; the assembler shifts them.
 
+    Non-monotonic trajectories: the diff is lossless only when the prior
+    step's cumulative is a multiset-subset of the current step's. When
+    that breaks — e.g. a compaction step that preserves a subset of prior
+    images, a pruning harness that drops earlier turns, or a sliding-window
+    context that rolls items out — diffing against ``prior`` would drop
+    items that should have survived. Such steps emit their full cumulative
+    as-is and reset the prior baseline, so per-window assemblers always
+    see at least their window's images.
+
     Returns a new list of step dicts (shallow copies for rewritten
     entries) so the input state isn't mutated. Non-list inputs and
     empty / single-step trajectories pass through unchanged.
@@ -356,6 +366,13 @@ def _delta_intermediate_mm_data(trajectory: object) -> object:
         current_hashes = _read_mm_hashes(step_mm)
 
         if idx == 0:
+            out.append(step)
+            prior_hashes = current_hashes
+            continue
+
+        # Non-monotonic transition (e.g. partial compaction): emit
+        # cumulative as-is and reset the baseline. See helper docstring.
+        if not _is_monotonic_extension(prior_hashes, current_hashes):
             out.append(step)
             prior_hashes = current_hashes
             continue
@@ -392,6 +409,28 @@ def _read_mm_hashes(mm: object) -> dict[str, list[str]]:
     return {
         modality: list(hs) for modality, hs in hashes.items() if isinstance(hs, list)
     }
+
+
+def _is_monotonic_extension(
+    prior: dict[str, list[str]], current: dict[str, list[str]]
+) -> bool:
+    """Precondition for ``_diff_mm_data`` to be lossless against ``prior``.
+
+    True iff every prior occurrence of every hash has a matching current
+    occurrence to consume, per modality — i.e. ``prior`` is a multiset-subset
+    of ``current``. Equivalently: every image in prior is still in current,
+    so the trajectory grew monotonically from prior to current.
+
+    Returns ``False`` when a compaction step preserved a subset of prior
+    images, a pruning harness dropped earlier turns, a sliding-window
+    context rolled items out, or any other non-monotonic transition. The
+    caller must then emit current's full cumulative as-is and reset the
+    baseline instead of diffing.
+    """
+    for modality, prior_hashes in prior.items():
+        if Counter(prior_hashes) - Counter(current.get(modality, [])):
+            return False
+    return True
 
 
 def _diff_mm_data(mm: object, prior_hashes: dict[str, list[str]]) -> object:


### PR DESCRIPTION
## Summary

`_delta_intermediate_mm_data` computes per-step `mm_data` deltas against
the prior step's cumulative `mm_hashes` using multiset semantics. The
diff is lossless only when the prior step's cumulative is a multiset-subset
of the current step's — i.e. the trajectory is monotonic extension.
Trajectories that compact, prune, or sliding-window a subset of prior
images out of the context break this precondition: walking `current`
left-to-right consumes the preserved images out of the delta (they
"match" prior occurrences) even though they really do appear in the
post-compaction prompt. Per-window training-sample assemblers
(prime-rl's `interleave_rollout`) then receive placeholder runs with no
matching `pixel_values`, and the trainer errors with `Image features
and image tokens do not match`.

In tree today this is masked because the only compaction harness
(`rlm`) compacts to a text-only summary, so post-compaction images are
always brand new and the multiset diff has nothing to drop. The bug
fires the moment any future harness preserves any image across a
compaction / pruning / context-window boundary.

## Repro (3-step trajectory)

| step | render's cumulative `mm_hashes` | old delta | new delta (this PR) |
|---|---|---|---|
| 0 | `[A]` | `[A]` | `[A]` |
| 1 | `[A, B]` | `[B]` | `[B]` |
| 2 (compaction drops A, keeps B, adds C) | `[B, C]` | `[C]` ❌ | `[B, C]` ✅ |

A naive multiset diff at step 2 consumes B out of the delta because prior had B too — even though B is still visibly in the post-compaction prompt. A per-window assembler unioning `[step 2]` ends up missing B's `pixel_values`.

## Fix

Add `_is_monotonic_extension(prior, current)` checking whether `prior`
is a multiset-subset of `current` per modality. When the check fails,
emit `current`'s full cumulative as-is and reset the baseline — the
encoder maintains its own invariant rather than relying on caller
cooperation, so any non-monotonic transition (regardless of cause) is
handled correctly.

Design choice — the alternative was to have the renderer client mark
"fresh re-render" steps explicitly when `bridge_to_next_turn` returns
`None`. The invariant-check approach is more general: it catches any
non-monotonic transition (pruning harnesses that never invoke the
bridge, sliding-window contexts, etc.) and doesn't add a cross-package
contract.

## Test plan

- Added `test_partial_compaction_preserves_preserved_images_in_delta`
  in `TestDeltaIntermediateMmData`. Models the partial-compaction
  trajectory directly: `{A}` → `{A, B}` → `{B, C}`. Verified the test
  **fails** on `main` (step 2 delta is `['C']` instead of `['B', 'C']`)
  and **passes** with the fix.
- All 7 existing `TestDeltaIntermediateMmData` tests still pass —
  monotonic extension, rlm-style total-drop compaction, image
  reintroduction, multiset semantics, no-new-items, non-Mapping steps.
- Full `tests/test_save_utils.py`: 60/60 passing.
- `ruff check` / `ruff format` / Semgrep / pre-commit: clean.

Fixes #1397.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `_delta_intermediate_mm_data` to reset delta baseline on non-monotonic trajectories
> - When prior cumulative hashes are not a multiset-subset of current hashes (non-monotonic step), the function now emits the full current cumulative data without diffing and resets the prior baseline to current hashes.
> - Adds `_is_monotonic_extension` helper in [save_utils.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1400/files#diff-e4491159a12a733bc8861a33ba9d2d09b27942f04c4baa1629f0806efa07547d) that compares per-modality `Counter` objects to detect this condition.
> - Behavioral Change: steps that previously produced incorrect diffs against an incompatible baseline now emit full cumulative data instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ac929a1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how multimodal `trajectory` sidecars are delta-encoded, which can affect what image bytes reach downstream training/sample assembly in compaction or pruning scenarios.
> 
> **Overview**
> Fixes `_delta_intermediate_mm_data` so multimodal deltas remain correct when a step is **non-monotonic** (e.g., compaction/pruning drops some prior images but preserves others). The function now detects when prior `mm_hashes` are not a multiset-subset of the current step and, in that case, emits the step’s full cumulative `multi_modal_data` and resets the diff baseline.
> 
> Adds `_is_monotonic_extension` (per-modality multiset check via `Counter`) and a new regression test covering partial compaction where an image must remain present in the emitted delta.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac929a17936829ad71446180c3ad3276ca2c10e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->