### PR TITLE
Avoid host imports during sandbox fn package discovery

### DIFF
--- a/tests/test_v1_runtime_lifecycle.py
+++ b/tests/test_v1_runtime_lifecycle.py
@@ -972,8 +972,11 @@ def test_sandbox_fn_program_resolves_package_module_root(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     package = tmp_path / "package_program"
+    marker = tmp_path / "import_marker"
     package.mkdir()
-    (package / "__init__.py").write_text("")
+    (package / "__init__.py").write_text(
+        f"from pathlib import Path\nPath({str(marker)!r}).write_text('imported')\n"
+    )
     (package / "worker.py").write_text("async def run(task, state): return state\n")
     (package / "pyproject.toml").write_text(
         """
@@ -993,6 +996,32 @@ build-backend = "hatchling.build"
     )
 
     assert package_root == SandboxPackage(local_root=package.resolve())
+    assert not marker.exists()
+    assert "package_program" not in sys.modules
+
+
+def test_sandbox_fn_program_resolves_nested_package_module_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    outer = tmp_path / "outer"
+    package = outer / "inner"
+    marker = tmp_path / "import_marker"
+    package.mkdir(parents=True)
+    (outer / "__init__.py").write_text(
+        f"from pathlib import Path\nPath({str(marker)!r}).write_text('imported')\n"
+    )
+    (package / "__init__.py").write_text("")
+    (package / "worker.py").write_text("async def run(task, state): return state\n")
+    (package / "pyproject.toml").write_text(
+        '[project]\nname = "nested-package-program"\nversion = "0.1.0"\n'
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    package_root = sandbox_program_package(mode="fn", fn_ref="outer.inner.worker:run")
+
+    assert package_root == SandboxPackage(local_root=package.resolve())
+    assert not marker.exists()
+    assert "outer" not in sys.modules
 
 
 def test_sandbox_fn_program_does_not_walk_to_parent_pyproject(
@@ -1018,8 +1047,31 @@ build-backend = "hatchling.build"
         sandbox_program_package(mode="fn", fn_ref="nested_program:run")
 
 
-def test_sandbox_fn_program_does_not_install_stdlib_packages() -> None:
-    assert sandbox_program_package(mode="fn", fn_ref="json:dumps") is None
+def test_sandbox_fn_program_rejects_dotted_child_of_local_module(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "plain_program.py").write_text(
+        "async def run(task, state): return state\n"
+    )
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "plain-program"\nversion = "0.1.0"\n'
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    with pytest.raises(ImportError, match="plain_program.child"):
+        sandbox_program_package(mode="fn", fn_ref="plain_program.child:run")
+
+
+@pytest.mark.parametrize(
+    "fn_ref",
+    [
+        "json:dumps",
+        "os.path:join",
+        "collections.abc:Mapping",
+    ],
+)
+def test_sandbox_fn_program_does_not_install_stdlib_packages(fn_ref: str) -> None:
+    assert sandbox_program_package(mode="fn", fn_ref=fn_ref) is None
 
 
 def test_sandbox_fn_program_requires_local_pyproject(

--- a/verifiers/v1/utils/sandbox_program_utils.py
+++ b/verifiers/v1/utils/sandbox_program_utils.py
@@ -192,7 +192,8 @@ def sandbox_program_package(*, mode: str, fn_ref: str | None) -> SandboxPackage 
     module_name, _, _ = fn_ref.partition(":")
     if not module_name:
         raise ValueError("program.fn must include a module path.")
-    spec = importlib.util.find_spec(module_name)
+    root_module_name, _, _ = module_name.partition(".")
+    spec = importlib.util.find_spec(root_module_name)
     if spec is None:
         raise ImportError(f"Cannot resolve program.fn module {module_name!r}.")
     roots = package_roots_for_module(module_name, spec)
@@ -224,7 +225,7 @@ def package_roots_for_module(
     module_name: str, spec: importlib.machinery.ModuleSpec
 ) -> set[Path]:
     roots = set()
-    for path in module_source_paths(spec):
+    for path in module_source_paths(module_name, spec):
         if is_external_import_path(path):
             continue
         root = module_package_root(path)
@@ -238,8 +239,34 @@ def package_roots_for_module(
     return roots
 
 
-def module_source_paths(spec: importlib.machinery.ModuleSpec) -> list[Path]:
+def module_source_paths(
+    module_name: str, spec: importlib.machinery.ModuleSpec
+) -> list[Path]:
+    _, _, nested_name = module_name.partition(".")
+    if nested_name and spec.submodule_search_locations:
+        parent_name = module_name.rpartition(".")[0].partition(".")[2]
+        parent_path = Path(*parent_name.split("."))
+        search_path = [
+            str(Path(path).resolve() / parent_path)
+            for path in spec.submodule_search_locations
+        ]
+        nested_spec = importlib.machinery.PathFinder.find_spec(module_name, search_path)
+        if nested_spec is None and all(
+            is_external_import_path(Path(path).resolve())
+            for path in spec.submodule_search_locations
+        ):
+            return []
+        if nested_spec is None:
+            raise ImportError(f"Cannot resolve program.fn module {module_name!r}.")
+        spec = nested_spec
     origin = spec.origin
+    if (
+        nested_name
+        and spec.name != module_name
+        and origin not in {None, "built-in", "frozen"}
+        and not is_external_import_path(Path(origin).resolve())
+    ):
+        raise ImportError(f"Cannot resolve program.fn module {module_name!r}.")
     if spec.submodule_search_locations:
         return [Path(path).resolve() for path in spec.submodule_search_locations]
     if origin in {None, "built-in", "frozen"}:


### PR DESCRIPTION
### Motivation

- `importlib.util.find_spec()` can import parent packages while resolving dotted `program.fn` refs, which lets local `__init__.py` code run on the host before the sandbox boundary.
- The fix should keep sandbox package discovery for nested local packages without host-side imports.

### Description

- Resolve only the top-level module from a dotted `program.fn` ref with `importlib.util.find_spec()`. This avoids the parent-import behavior because the name passed to `find_spec()` is not dotted.
- For nested local refs, compute the immediate parent search path from the top-level package locations and delegate the actual nested lookup to `importlib.machinery.PathFinder.find_spec()`.
- Reject dotted refs below a local non-package module, such as `plain_program.child:run`, instead of silently treating `plain_program.py` as the package root.
- Preserve stdlib/built-in/frozen refs such as `json`, `os.path`, and `collections.abc` as no-package cases.
- Cover top-level, nested package, stdlib alias, and invalid local dotted-module refs in regression tests.

### Testing

- `uv run ruff check --fix .`
- `uv run ruff format`
- `uv run ty check verifiers`
- `uv run pre-commit run semgrep-v1-policy --config .pre-commit-config.yaml --all-files`
- `uv run pytest tests/test_v1_runtime_lifecycle.py -k sandbox_fn_program`
- `uv run pre-commit run --all-files`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how `program.fn` dotted module refs are resolved (including new ImportError cases), which can affect which packages get installed into the sandbox and which refs are considered valid.
> 
> **Overview**
> **Prevents host-side imports during sandbox `program.fn` package discovery.** `sandbox_program_package` now calls `find_spec()` only on the top-level module and resolves dotted/nested modules via `PathFinder` over computed search paths, avoiding executing local `__init__.py` code on the host.
> 
> Tightens resolution behavior by **rejecting dotted children of single-file local modules** (raising `ImportError`) while preserving the existing behavior of treating stdlib/built-in/frozen modules (e.g. `json`, `os.path`, `collections.abc`) as *no local package to install*.
> 
> Tests add regression coverage ensuring package discovery does not create side effects (`sys.modules` entries or marker files) and validating nested-package resolution and new error cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cad4b9e8ae05d3c496ebd7231f97e5ef70de0a2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Avoid host imports during sandbox function package discovery
> - `sandbox_program_package` in [sandbox_program_utils.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1402/files#diff-650fad1707ec4b94d785f84962c51b4c8e27ffb169b46c1f15dc145b72913cde) now resolves the root package spec via `importlib.util.find_spec` without importing it, then uses `PathFinder.find_spec` to resolve nested dotted paths against the root's search locations.
> - `module_source_paths` now raises `ImportError` when a dotted child of a local module cannot be resolved, or when resolution yields a mismatched local module.
> - Returns an empty path list for stdlib or fully external modules, so `sandbox_program_package` correctly returns `None` for those cases.
> - Tests are extended to assert that no marker file is created and the package does not appear in `sys.modules` after resolution, confirming no imports occur.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cad4b9e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->