### PR TITLE
Forward reasoning kwargs from eval TOML sampling sections

### DIFF
--- a/docs/byo-harness.md
+++ b/docs/byo-harness.md
@@ -528,7 +528,9 @@ rollouts_per_example = 3
 
 [[eval]]
 env_id = "my-v1-env"
-sampling_args = { max_tokens = 4096 }
+
+[eval.sampling]
+max_tokens = 4096
 
 [eval.harness]
 max_turns = 4

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -195,6 +195,24 @@ The `--sampling-args` flag accepts any parameters supported by the model's API:
 prime eval run my-env -S '{"temperature": 0.7, "top_p": 0.9}'
 ```
 
+In eval TOML configs, put generation parameters under `[sampling]`:
+
+```toml
+[sampling]
+max_tokens = 1024
+temperature = 0.7
+reasoning_effort = "medium"
+enable_thinking = true
+
+[[eval]]
+id = "my-env"
+```
+
+`reasoning_effort` and `enable_thinking` stay in `sampling_args` and are also
+mirrored into `extra_body.chat_template_kwargs` for OpenAI-compatible servers
+that read chat template options there. Keeping the top-level values lets the
+client translate them for the selected provider.
+
 ### Evaluation Scope
 
 | Flag | Short | Default | Description |
@@ -381,6 +399,7 @@ optional:
 | `extra_env_kwargs` | table | Arguments passed to environment constructor |
 | `model` | string | Model to evaluate |
 | `endpoint_id` | string | Endpoint registry id (requires TOML `endpoints_path`) |
+| `sampling` | table | Shorthand for `sampling_args` generation parameters |
 
 Use `name` to run the same environment more than once with different args:
 
@@ -418,7 +437,9 @@ For v1 BYO Harness environments, pass taskset/harness config through sibling
 ```toml
 [[eval]]
 id = "my-v1-env"
-sampling_args = { max_tokens = 4096 }
+
+[eval.sampling]
+max_tokens = 4096
 
 [eval.harness]
 max_turns = 4
@@ -429,6 +450,9 @@ weight = 0.5
 
 See [BYO Harness](byo-harness.md#toml-config) for the matching RL config shape
 and v1 callable/toolset patterns.
+
+The legacy inline `sampling_args = { ... }` spelling is still accepted and
+normalizes the same way as `[sampling]` / `[eval.sampling]`.
 
 ### Ablation Sweeps
 

--- a/skills/evaluate-environments/SKILL.md
+++ b/skills/evaluate-environments/SKILL.md
@@ -144,18 +144,30 @@ name = "reverse-text-long"
 [eval.args]
 max_length = 256
 ```
-9. Pass extra HTTP headers via CLI (repeatable):
+9. Put generation parameters in TOML sampling sections:
+```toml
+[sampling]
+max_tokens = 1024
+temperature = 0.7
+reasoning_effort = "medium"
+enable_thinking = true
+
+[[eval]]
+env_id = "my-env"
+```
+Use `[eval.sampling]` for per-eval overrides. `[sampling]` is shorthand for `sampling_args`; `reasoning_effort` and `enable_thinking` stay top-level and are mirrored into `extra_body.chat_template_kwargs`.
+10. Pass extra HTTP headers via CLI (repeatable):
 ```bash
 prime eval run my-env -m my-proxy --header "X-Custom-Header: value"
 ```
-10. Set headers in `[[eval]]` TOML configs as a table or list (merge order: registry row < `headers` table < `header` list / `--header`):
+11. Set headers in `[[eval]]` TOML configs as a table or list (merge order: registry row < `headers` table < `header` list / `--header`):
 ```toml
 [[eval]]
 env_id = "my-env"
 headers = { "X-Custom-Header" = "value" }
 header = ["X-Another: val"]
 ```
-11. Run ablation sweeps using `[[ablation]]` blocks in TOML configs:
+12. Run ablation sweeps using `[[ablation]]` blocks in TOML configs:
 ```toml
 [[ablation]]
 env_id = "my-env"

--- a/tests/test_eval_cli.py
+++ b/tests/test_eval_cli.py
@@ -749,6 +749,92 @@ def test_load_toml_config_with_env_args():
         assert result[0]["env_args"]["max_examples"] == 100
 
 
+def test_load_toml_config_sampling_section_mirrors_chat_template_kwargs():
+    with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
+        f.write(
+            "[sampling]\n"
+            "max_tokens = 1024\n"
+            'reasoning_effort = "medium"\n'
+            "enable_thinking = false\n\n"
+            "[sampling.extra_body]\n"
+            'custom = "value"\n\n'
+            "[sampling.extra_body.chat_template_kwargs]\n"
+            "clear_thinking = true\n\n"
+            "[[eval]]\n"
+            'env_id = "env1"\n'
+        )
+        f.flush()
+        result = load_toml_config(Path(f.name))
+
+    assert result[0]["sampling_args"] == {
+        "max_tokens": 1024,
+        "reasoning_effort": "medium",
+        "enable_thinking": False,
+        "extra_body": {
+            "custom": "value",
+            "chat_template_kwargs": {
+                "clear_thinking": True,
+                "reasoning_effort": "medium",
+                "enable_thinking": False,
+            },
+        },
+    }
+
+
+def test_load_toml_config_sampling_args_mirrors_chat_template_kwargs():
+    with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
+        f.write(
+            "[[eval]]\n"
+            'env_id = "env1"\n'
+            'sampling_args = { max_tokens = 256, reasoning_effort = "high", enable_thinking = true }\n'
+        )
+        f.flush()
+        result = load_toml_config(Path(f.name))
+
+    assert result[0]["sampling_args"] == {
+        "max_tokens": 256,
+        "reasoning_effort": "high",
+        "enable_thinking": True,
+        "extra_body": {
+            "chat_template_kwargs": {
+                "reasoning_effort": "high",
+                "enable_thinking": True,
+            }
+        },
+    }
+
+
+def test_cli_toml_eval_sampling_section_pipes_thinking_args(monkeypatch, run_cli):
+    with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
+        f.write(
+            "[[eval]]\n"
+            'env_id = "env1"\n\n'
+            "[eval.sampling]\n"
+            "max_tokens = 512\n"
+            'reasoning_effort = "low"\n'
+            "enable_thinking = true\n"
+        )
+        f.flush()
+        captured = run_cli(
+            monkeypatch,
+            {
+                "env_id_or_config": f.name,
+            },
+        )
+
+    assert captured["sampling_args"] == {
+        "max_tokens": 512,
+        "reasoning_effort": "low",
+        "enable_thinking": True,
+        "extra_body": {
+            "chat_template_kwargs": {
+                "reasoning_effort": "low",
+                "enable_thinking": True,
+            }
+        },
+    }
+
+
 def test_load_toml_config_with_args_taskset_harness():
     """args/taskset/harness sections normalize into load_environment kwargs."""
     with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
@@ -1261,6 +1347,44 @@ def test_ablation_global_defaults_apply():
 
     assert len(configs) == 2
     assert all(c["num_examples"] == 100 for c in configs)
+
+
+def test_ablation_sampling_sweep_merges_with_global_sampling_defaults():
+    with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
+        f.write(
+            "[sampling]\n"
+            "max_tokens = 1024\n"
+            'reasoning_effort = "medium"\n\n'
+            '[[ablation]]\nenv_id = "my-env"\n\n'
+            "[ablation.sweep]\n"
+            "sampling = [{ temperature = 0.0 }, { temperature = 1.0, enable_thinking = false }]\n"
+        )
+        f.flush()
+        configs = load_toml_config(Path(f.name))
+
+    assert len(configs) == 2
+    assert configs[0]["sampling_args"] == {
+        "max_tokens": 1024,
+        "reasoning_effort": "medium",
+        "temperature": 0.0,
+        "extra_body": {
+            "chat_template_kwargs": {
+                "reasoning_effort": "medium",
+            }
+        },
+    }
+    assert configs[1]["sampling_args"] == {
+        "max_tokens": 1024,
+        "reasoning_effort": "medium",
+        "temperature": 1.0,
+        "enable_thinking": False,
+        "extra_body": {
+            "chat_template_kwargs": {
+                "reasoning_effort": "medium",
+                "enable_thinking": False,
+            }
+        },
+    }
 
 
 def test_ablation_endpoint_id_override_removes_global_model():

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -55,6 +55,7 @@ from verifiers.utils.save_utils import save_metadata
 
 logger = logging.getLogger(__name__)
 FREEFORM_ABLATION_SWEEP_FIELDS = {"args", "env_args"}
+CHAT_TEMPLATE_KWARG_FIELDS = ("reasoning_effort", "enable_thinking")
 
 
 def _client_config_uses_prime_inference(config: ClientConfig) -> bool:
@@ -455,6 +456,99 @@ def normalize_env_id_alias(config: Mapping[str, Any], section: str) -> dict[str,
     return normalized
 
 
+def _merge_sampling_arg_tables(
+    base: Mapping[str, Any],
+    override: Mapping[str, Any],
+) -> dict[str, Any]:
+    merged = {**dict(base), **dict(override)}
+    base_extra_body = base.get("extra_body")
+    override_extra_body = override.get("extra_body")
+    if isinstance(base_extra_body, Mapping) and isinstance(
+        override_extra_body, Mapping
+    ):
+        extra_body = {**dict(base_extra_body), **dict(override_extra_body)}
+        base_chat_template_kwargs = base_extra_body.get("chat_template_kwargs")
+        override_chat_template_kwargs = override_extra_body.get("chat_template_kwargs")
+        if isinstance(base_chat_template_kwargs, Mapping) and isinstance(
+            override_chat_template_kwargs, Mapping
+        ):
+            extra_body["chat_template_kwargs"] = {
+                **dict(base_chat_template_kwargs),
+                **dict(override_chat_template_kwargs),
+            }
+        merged["extra_body"] = extra_body
+    return merged
+
+
+def normalize_sampling_args(
+    sampling_args: Mapping[str, Any], section: str
+) -> dict[str, Any]:
+    normalized = dict(sampling_args)
+    chat_template_kwargs = {
+        key: normalized[key] for key in CHAT_TEMPLATE_KWARG_FIELDS if key in normalized
+    }
+    if not chat_template_kwargs:
+        return normalized
+
+    raw_extra_body = normalized.get("extra_body", {})
+    if raw_extra_body is None:
+        raw_extra_body = {}
+    if not isinstance(raw_extra_body, Mapping):
+        raise ValueError(f"{section}.extra_body must be a table.")
+    extra_body = dict(cast(Mapping[str, Any], raw_extra_body))
+
+    raw_chat_template_kwargs = extra_body.get("chat_template_kwargs", {})
+    if raw_chat_template_kwargs is None:
+        raw_chat_template_kwargs = {}
+    if not isinstance(raw_chat_template_kwargs, Mapping):
+        raise ValueError(f"{section}.extra_body.chat_template_kwargs must be a table.")
+    extra_body["chat_template_kwargs"] = {
+        **dict(cast(Mapping[str, Any], raw_chat_template_kwargs)),
+        **chat_template_kwargs,
+    }
+    normalized["extra_body"] = extra_body
+    return normalized
+
+
+def normalize_sampling_config(
+    config: Mapping[str, Any],
+    section: str,
+    *,
+    merge_sampling_with_existing: bool = False,
+) -> dict[str, Any]:
+    normalized = dict(config)
+    if "sampling_args" in normalized:
+        raw_sampling_args = normalized["sampling_args"]
+        if not isinstance(raw_sampling_args, Mapping):
+            raise ValueError(f"{section}.sampling_args must be a table.")
+        normalized["sampling_args"] = normalize_sampling_args(
+            cast(Mapping[str, Any], raw_sampling_args), f"{section}.sampling_args"
+        )
+
+    if "sampling" not in normalized:
+        return normalized
+
+    if "sampling_args" in normalized:
+        if not merge_sampling_with_existing:
+            raise ValueError(
+                f"{section} cannot contain both sampling and sampling_args."
+            )
+        existing_sampling_args = cast(Mapping[str, Any], normalized["sampling_args"])
+    else:
+        existing_sampling_args = {}
+
+    sampling = normalized.pop("sampling")
+    if not isinstance(sampling, Mapping):
+        raise ValueError(f"{section}.sampling must be a table.")
+    normalized["sampling_args"] = _merge_sampling_arg_tables(
+        existing_sampling_args,
+        normalize_sampling_args(
+            cast(Mapping[str, Any], sampling), f"{section}.sampling"
+        ),
+    )
+    return normalized
+
+
 def invalid_ablation_sweep_fields(
     sweep: Mapping[str, Any], valid_fields: set[str]
 ) -> set[str]:
@@ -556,6 +650,7 @@ def load_toml_config(
         "header_from_state",
         "headers_from_state",
         # sampling
+        "sampling",
         "sampling_args",
         "max_tokens",
         "temperature",
@@ -591,6 +686,7 @@ def load_toml_config(
                 f"Invalid global field(s) {invalid_global}. "
                 f"Valid fields are: {sorted(global_valid_fields)}"
             )
+    global_defaults = normalize_sampling_config(global_defaults, "global config")
 
     # merge global defaults with per-eval configs
     merged_eval_list: list[dict] = []
@@ -601,6 +697,9 @@ def load_toml_config(
                 f"Invalid field(s) {invalid_fields} for {eval_config.get('env_id', 'unknown')}. "
                 f"Valid fields are: {sorted(valid_fields)}"
             )
+        eval_config = normalize_sampling_config(
+            eval_config, f"[[eval]] {eval_config['env_id']}"
+        )
         # global defaults, then per-eval overrides
         merged = {**global_defaults, **eval_config}
         if "endpoint_id" in eval_config and "model" not in eval_config:
@@ -627,6 +726,7 @@ def load_toml_config(
                 f"Invalid field(s) {invalid_fields} in [[ablation]] block. "
                 f"Valid fields are: {sorted(valid_fields)}"
             )
+        ablation = normalize_sampling_config(ablation, "[[ablation]] block")
         # Validate sweep keys (except arg tables, which have freeform sub-keys)
         sweep = ablation.get("sweep", {})
         invalid_sweep = invalid_ablation_sweep_fields(sweep, valid_fields)
@@ -636,7 +736,13 @@ def load_toml_config(
                 f"Valid fields are: {sorted(valid_fields)}"
             )
         expanded = [
-            normalize_env_config_sections(config)
+            normalize_env_config_sections(
+                normalize_sampling_config(
+                    config,
+                    "expanded [[ablation]] config",
+                    merge_sampling_with_existing=True,
+                )
+            )
             for config in _expand_ablation(ablation, global_defaults)
         ]
         merged_eval_list.extend(expanded)


### PR DESCRIPTION
## Summary

- Accept `[sampling]` / `[eval.sampling]` tables in eval TOML configs as shorthand for `sampling_args`.
- Normalize direct `sampling_args = { ... }` through the same path, so both spellings mirror `reasoning_effort` and `enable_thinking` into `extra_body.chat_template_kwargs`.
- Keep those shorthand fields at the top of `sampling_args` so provider-specific client mappings from #1338 continue to apply.
- Merge ablation `sampling` sweep entries over global sampling defaults instead of treating shorthand and canonical keys as conflicting.
- Keep the TOML-only deep-merge helper private so it does not collide with the existing public CLI `merge_sampling_args` helper.
- Document the eval TOML sampling shape in eval and BYO Harness docs, update the eval skill guidance, and rebase onto current `main`.

## Validation

- `uv run pre-commit install`
- `uv run ruff format verifiers/utils/eval_utils.py tests/test_eval_cli.py`
- `uv run ruff format verifiers/utils/eval_utils.py`
- `uv run ruff check verifiers/utils/eval_utils.py tests/test_eval_cli.py docs/evaluation.md`
- `uv run pytest tests/test_eval_cli.py -q`
- `uv run pytest tests/test_client_multimodal_types.py -q`
- `uv run pre-commit run --files verifiers/utils/eval_utils.py tests/test_eval_cli.py docs/evaluation.md skills/evaluate-environments/SKILL.md`
- `uv run pre-commit run --files docs/byo-harness.md docs/evaluation.md skills/evaluate-environments/SKILL.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes eval TOML parsing/normalization and sampling arg merging, which can alter runtime request payloads and ablation expansion behavior. Coverage is improved via new CLI/config tests, but mis-merges could impact evaluations across providers.
> 
> **Overview**
> **Eval TOML configs now accept `[sampling]` and `[eval.sampling]` tables** as shorthand for `sampling_args`, with validation and normalization applied consistently across global defaults, per-eval blocks, and expanded `[[ablation]]` configs.
> 
> **`reasoning_effort` and `enable_thinking` are automatically mirrored** from `sampling_args` into `sampling_args.extra_body.chat_template_kwargs` (while keeping the top-level keys), and ablation sweeps can now merge `sampling` overrides over global sampling defaults with a TOML-specific deep-merge for `extra_body`.
> 
> Docs and the eval skill guide are updated to show the new TOML sampling shape, and tests are added to assert normalization/mirroring and ablation merge behavior (while keeping legacy inline `sampling_args = { ... }` accepted).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4848b6adca4dbca54af7ece0df479a1f22844ec3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Forward `reasoning_effort` and `enable_thinking` from eval TOML `[sampling]` sections into `extra_body.chat_template_kwargs`
> - Adds `normalize_sampling_args` and `normalize_sampling_config` helpers in [`eval_utils.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1404/files#diff-f34b0fdb8a911d38b3281a5e56703ba2cf1a748d49bdbcc46254824fd7de04cb) that mirror `reasoning_effort` and `enable_thinking` into `extra_body.chat_template_kwargs` for OpenAI-compatible servers.
> - Allows eval TOML configs to use a `[sampling]` or `[eval.sampling]` table as a shorthand for `sampling_args`, with deep-merging of `extra_body.chat_template_kwargs` across global defaults and per-eval overrides.
> - Ablation sweeps can now override sampling args via `[sampling]` tables, which merge with pre-existing `sampling_args` rather than replacing them.
> - Raises `ValueError` when `sampling` and `sampling_args` are both present (outside ablation expansion), or when `extra_body`/`chat_template_kwargs` are not tables.
> - Updates docs and skill guides to document the `[sampling]` table pattern with examples.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4848b6a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->