### PR TITLE
fix: parse renderer object tool calls

### DIFF
--- a/tests/test_renderer_client.py
+++ b/tests/test_renderer_client.py
@@ -1,4 +1,6 @@
+import asyncio
 from functools import lru_cache
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -231,6 +233,47 @@ async def test_from_native_response_uses_request_id_and_token_lengths():
     assert response.usage.prompt_tokens == 3
     assert response.usage.completion_tokens == 2
     assert response.usage.total_tokens == 5
+
+
+def test_from_native_response_accepts_dict_tool_calls():
+    client = object.__new__(RendererClient)
+
+    response = asyncio.run(
+        client.from_native_response(
+            {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_lookup",
+                        "function": {
+                            "name": "lookup",
+                            "arguments": {"query": "prime"},
+                        },
+                    }
+                ],
+            }
+        )
+    )
+
+    assert response.message.tool_calls == [
+        ToolCall(id="call_lookup", name="lookup", arguments='{"query": "prime"}')
+    ]
+
+
+def test_from_native_response_accepts_object_tool_calls():
+    client = object.__new__(RendererClient)
+    tool_call = SimpleNamespace(
+        id="call_lookup",
+        function=SimpleNamespace(name="lookup", arguments={"query": "prime"}),
+    )
+
+    response = asyncio.run(
+        client.from_native_response({"content": "", "tool_calls": [tool_call]})
+    )
+
+    assert response.message.tool_calls == [
+        ToolCall(id="call_lookup", name="lookup", arguments='{"query": "prime"}')
+    ]
 
 
 class _BridgeRenderer:

--- a/verifiers/clients/renderer_client.py
+++ b/verifiers/clients/renderer_client.py
@@ -612,18 +612,28 @@ class RendererClient(
         tool_calls = None
         raw_tcs = response.get("tool_calls")
         if raw_tcs:
-            tool_calls = [
-                ToolCall(
-                    id=f"call_{i}",
-                    name=tc["function"]["name"],
-                    arguments=(
-                        tc["function"]["arguments"]
-                        if isinstance(tc["function"]["arguments"], str)
-                        else json.dumps(tc["function"]["arguments"])
-                    ),
+            tool_calls = []
+            for i, tc in enumerate(raw_tcs):
+                function = _get_value(tc, "function")
+                name = _get_value(function, "name") if function is not None else None
+                arguments = (
+                    _get_value(function, "arguments")
+                    if function is not None
+                    else None
                 )
-                for i, tc in enumerate(raw_tcs)
-            ]
+                if name is None:
+                    name = _get_value(tc, "name")
+                if arguments is None:
+                    arguments = _get_value(tc, "arguments")
+                if not isinstance(arguments, str):
+                    arguments = json.dumps(arguments)
+                tool_calls.append(
+                    ToolCall(
+                        id=_get_value(tc, "id") or f"call_{i}",
+                        name=name,
+                        arguments=arguments,
+                    )
+                )
 
         prompt_ids = response.get("prompt_ids", [])
         completion_ids = response.get("completion_ids", [])


### PR DESCRIPTION
## Summary
- Support renderer tool calls returned as objects with function attributes, not just dicts
- Preserve explicit tool call IDs and JSON-encode non-string arguments
- Add renderer client regression coverage for dict and object-shaped tool calls

## Test Plan
- uv run --with pytest-asyncio pytest deps/verifiers/tests/test_renderer_client.py -q
- uv run ruff check deps/verifiers/verifiers/clients/renderer_client.py deps/verifiers/tests/test_renderer_client.py

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `RendererClient.from_native_response` to parse object-based tool calls
> Updates tool call parsing in [`renderer_client.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1405/files#diff-4309037b1656944b1991edc5baa1d16760d74155d7adc9fef41a2080ce8605e1) to handle both dict and object (attribute-access) formats. Uses a `_get_value` helper to extract `function`, `name`, `arguments`, and `id` from either format, falls back to top-level `name`/`arguments` when `function` is absent, uses provided `id` when available, and JSON-stringifies non-string arguments. Tests covering both dict and object tool call inputs are added in [`test_renderer_client.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1405/files#diff-200d7102e1d9ee4b5d7756e0d748c586744886e7ef4ee6d662af15348f4f84be).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2ea6c1c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->