### PR TITLE
VER-105 Add generic v1 Harbor Dockerfile environment setup support

### DIFF
--- a/tests/test_v1_harbor_cli.py
+++ b/tests/test_v1_harbor_cli.py
@@ -19,7 +19,11 @@ from verifiers.v1.packages.harnesses.terminus_2 import (
     Terminus2,
     terminus_2_agent_script,
 )
-from verifiers.v1.packages.tasksets.harbor import harbor_reward
+from verifiers.v1.packages.tasksets.harbor import (
+    HARBOR_BUILD_CONTEXT,
+    harbor_reward,
+    parse_harbor_dockerfile,
+)
 from verifiers.v1.utils.program_utils import merge_task_program, merge_task_sandbox
 
 
@@ -107,6 +111,136 @@ def test_harbor_taskset_loads_package_tasks_with_program_patch(
     }
     assert task["program"]["env"]["HARBOR_TASK_NAME"] == "task-a"
     assert task["program"]["env"]["AGENT_WORKDIR"] == "/app"
+
+
+def test_harbor_taskset_replays_environment_dockerfile(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    package = write_harbor_package(tmp_path, monkeypatch)
+    task_dir = cast(Path, getattr(package, "tasks_root")) / "docker-task"
+    environment_dir = task_dir / "environment"
+    (environment_dir / "data").mkdir(parents=True)
+    (task_dir / "tests").mkdir(parents=True)
+    (task_dir / "solution").mkdir()
+    (task_dir / "instruction.md").write_text("Inspect /workspace/data/value.txt\n")
+    (task_dir / "task.toml").write_text(
+        """
+version = "1.0"
+
+[environment]
+cpus = 1
+memory = "2G"
+storage = "8G"
+
+[agent]
+timeout_sec = 600
+
+[verifier]
+timeout_sec = 300
+""".strip()
+    )
+    (environment_dir / "Dockerfile").write_text(
+        """
+FROM python:3.13-slim-bookworm
+ENV FOO=bar BAZ=qux
+WORKDIR /workspace
+COPY data /workspace/data
+RUN python3 -m compileall .
+""".strip()
+    )
+    (environment_dir / "data" / "value.txt").write_text("42")
+    (task_dir / "tests" / "test.sh").write_text("echo 1 > /logs/verifier/reward.txt")
+    (task_dir / "solution" / "solve.sh").write_text("true")
+
+    taskset = getattr(package, "load_taskset")()
+    task = next(iter(taskset))
+    program = cast(dict[str, object], task["program"])
+
+    assert task["sandbox"]["image"] == "python:3.13-slim-bookworm"
+    assert task["sandbox"]["workdir"] == "/workspace"
+    assert cast(dict[str, object], program["dirs"]) == {
+        HARBOR_BUILD_CONTEXT: str(environment_dir)
+    }
+    assert cast(dict[str, str], program["env"])["FOO"] == "bar"
+    assert cast(dict[str, str], program["env"])["AGENT_WORKDIR"] == "/workspace"
+    assert program["setup"] == [
+        "mkdir -p /workspace",
+        f"mkdir -p /workspace/data && "
+        f"cp -R {HARBOR_BUILD_CONTEXT}/data/. /workspace/data",
+        "cd /workspace && python3 -m compileall .",
+    ]
+
+
+def test_harbor_dockerfile_copy_dot_copies_context_contents(tmp_path: Path) -> None:
+    environment_dir = tmp_path / "environment"
+    environment_dir.mkdir()
+    dockerfile = environment_dir / "Dockerfile"
+    dockerfile.write_text(
+        """
+FROM ubuntu:24.04
+WORKDIR /app
+COPY . .
+""".strip()
+    )
+
+    program = parse_harbor_dockerfile(dockerfile)
+
+    assert program["setup"] == [
+        "mkdir -p /app",
+        f"mkdir -p /app && cp -R {HARBOR_BUILD_CONTEXT}/. /app",
+    ]
+
+
+def test_harbor_dockerfile_keeps_legacy_env_value_words(tmp_path: Path) -> None:
+    environment_dir = tmp_path / "environment"
+    environment_dir.mkdir()
+    dockerfile = environment_dir / "Dockerfile"
+    dockerfile.write_text(
+        """
+FROM ubuntu:24.04
+ENV GREETING hello beautiful world
+""".strip()
+    )
+
+    program = parse_harbor_dockerfile(dockerfile)
+
+    assert program["env"] == {"GREETING": "hello beautiful world"}
+
+
+def test_harbor_dockerfile_ignores_comment_continuations(tmp_path: Path) -> None:
+    environment_dir = tmp_path / "environment"
+    environment_dir.mkdir()
+    dockerfile = environment_dir / "Dockerfile"
+    dockerfile.write_text(
+        """
+# comment with trailing slash \\
+FROM ubuntu:24.04
+WORKDIR /app
+RUN echo ok
+""".strip()
+    )
+
+    program = parse_harbor_dockerfile(dockerfile)
+
+    assert program["image"] == "ubuntu:24.04"
+    assert program["setup"] == ["mkdir -p /app", "cd /app && echo ok"]
+
+
+def test_harbor_dockerfile_rejects_multi_stage_builds(tmp_path: Path) -> None:
+    environment_dir = tmp_path / "environment"
+    environment_dir.mkdir()
+    dockerfile = environment_dir / "Dockerfile"
+    dockerfile.write_text(
+        """
+FROM alpine:3.20 AS builder
+RUN touch /built
+FROM ubuntu:24.04
+COPY --from=builder /built /built
+""".strip()
+    )
+
+    with pytest.raises(ValueError, match="multi-stage Dockerfile.*does not support"):
+        parse_harbor_dockerfile(dockerfile)
 
 
 def test_harbor_taskset_rejects_malformed_package_task(

--- a/verifiers/v1/__init__.py
+++ b/verifiers/v1/__init__.py
@@ -63,6 +63,7 @@ from .taskset import Taskset, discover_sibling_dir
 from .packages.tasksets import (
     HarborTaskset,
     HarborTasksetConfig,
+    parse_harbor_dockerfile,
 )
 from .toolset import MCPTool, Toolset
 from .types import (
@@ -133,6 +134,7 @@ __all__ = [
     "collect_signals",
     "discover_sibling_dir",
     "metric",
+    "parse_harbor_dockerfile",
     "get_messages",
     "reward",
     "score_group",

--- a/verifiers/v1/packages/tasksets/__init__.py
+++ b/verifiers/v1/packages/tasksets/__init__.py
@@ -1,3 +1,3 @@
-from .harbor import HarborTaskset, HarborTasksetConfig
+from .harbor import HarborTaskset, HarborTasksetConfig, parse_harbor_dockerfile
 
-__all__ = ["HarborTaskset", "HarborTasksetConfig"]
+__all__ = ["HarborTaskset", "HarborTasksetConfig", "parse_harbor_dockerfile"]

--- a/verifiers/v1/packages/tasksets/harbor.py
+++ b/verifiers/v1/packages/tasksets/harbor.py
@@ -1,7 +1,9 @@
 import inspect
 import json
 import os
+import posixpath
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -21,6 +23,7 @@ from verifiers.decorators import reward
 from ...types import ConfigData
 
 TASKS_SUBDIR = "tasks"
+HARBOR_BUILD_CONTEXT = "/tmp/harbor_environment"
 
 
 def _resolve_caller_package() -> str | None:
@@ -134,6 +137,8 @@ class HarborTaskset(Taskset[HarborTasksetConfig]):
     def task_row(self, task_dir: Path, index: int) -> ConfigData:
         task_toml_path = task_dir / "task.toml"
         instruction_path = task_dir / "instruction.md"
+        environment_dir = task_dir / "environment"
+        dockerfile_path = environment_dir / "Dockerfile"
         with task_toml_path.open("rb") as f:
             config = load_toml(f)
         environment = config.get("environment", {}) or {}
@@ -143,8 +148,15 @@ class HarborTaskset(Taskset[HarborTasksetConfig]):
         verifier_config = config.get("verifier", {}) or {}
         instruction = instruction_path.read_text().strip()
         task_remote_dir = self.task_dir.rstrip("/") or "/task"
+        docker_image = environment.get("docker_image") or self.docker_image
+        workdir = self.workdir
+        dockerfile_program: ConfigData | None = None
+        if environment.get("docker_image") is None and dockerfile_path.exists():
+            dockerfile_program = parse_harbor_dockerfile(dockerfile_path)
+            docker_image = dockerfile_program["image"]
+            workdir = str(dockerfile_program["workdir"])
         sandbox = {
-            "image": environment.get("docker_image") or self.docker_image,
+            "image": docker_image,
             "cpu_cores": parse_number(environment.get("cpus"), self.cpu_cores),
             "memory_gb": parse_gb(environment.get("memory"), self.memory_gb),
             "disk_size_gb": parse_gb(environment.get("storage"), self.disk_size_gb),
@@ -154,11 +166,30 @@ class HarborTaskset(Taskset[HarborTasksetConfig]):
                     agent_config.get("timeout_sec"), self.agent_timeout_seconds
                 )
             ),
-            "workdir": self.workdir,
+            "workdir": workdir,
             "scope": self.scope,
         }
         if "allow_internet" in environment:
             sandbox["network_access"] = bool(environment["allow_internet"])
+        program: ConfigData = {
+            "files": {
+                f"{task_remote_dir}/instruction.md": {"task": "instruction"},
+                f"{task_remote_dir}/task.toml": {"task": "task_toml"},
+            },
+            "env": {
+                "HARBOR_TASK_NAME": task_dir.name,
+                "HARBOR_TASK_DIR": task_remote_dir,
+                "HARBOR_INSTRUCTION_PATH": f"{task_remote_dir}/instruction.md",
+                "AGENT_WORKDIR": workdir,
+                **self.env,
+            },
+        }
+        if dockerfile_program is not None:
+            program["dirs"] = {HARBOR_BUILD_CONTEXT: str(environment_dir)}
+            cast(dict[str, str], program["env"]).update(
+                cast(dict[str, str], dockerfile_program["env"])
+            )
+            program["setup"] = dockerfile_program["setup"]
         return {
             "example_id": index,
             "task_name": task_dir.name,
@@ -167,24 +198,12 @@ class HarborTaskset(Taskset[HarborTasksetConfig]):
             "task_dir": str(task_dir),
             "prompt": [{"role": "user", "content": instruction}],
             "sandbox": sandbox,
-            "program": {
-                "files": {
-                    f"{task_remote_dir}/instruction.md": {"task": "instruction"},
-                    f"{task_remote_dir}/task.toml": {"task": "task_toml"},
-                },
-                "env": {
-                    "HARBOR_TASK_NAME": task_dir.name,
-                    "HARBOR_TASK_DIR": task_remote_dir,
-                    "HARBOR_INSTRUCTION_PATH": f"{task_remote_dir}/instruction.md",
-                    "AGENT_WORKDIR": self.workdir,
-                    **self.env,
-                },
-            },
+            "program": program,
             "harbor": {
                 "task_dir": str(task_dir),
                 "task_name": task_dir.name,
                 "config": config,
-                "docker_image": environment.get("docker_image"),
+                "docker_image": docker_image,
                 "test_timeout": parse_number(
                     verifier_config.get("timeout_sec"),
                     self.verifier_timeout_seconds,
@@ -193,10 +212,99 @@ class HarborTaskset(Taskset[HarborTasksetConfig]):
             "info": {
                 "harbor": {
                     "task_name": task_dir.name,
-                    "docker_image": environment.get("docker_image"),
+                    "docker_image": docker_image,
                 }
             },
         }
+
+
+def parse_harbor_dockerfile(
+    dockerfile_path: Path, build_context: str = HARBOR_BUILD_CONTEXT
+) -> ConfigData:
+    image: str | None = None
+    workdir = "/"
+    env: dict[str, str] = {}
+    setup: list[str] = []
+    pending = ""
+
+    for raw_line in dockerfile_path.read_text().splitlines():
+        line = raw_line.rstrip()
+        if not pending and (not line.strip() or line.lstrip().startswith("#")):
+            continue
+        if line.endswith("\\"):
+            pending += line[:-1].rstrip() + " "
+            continue
+        line = (pending + line).strip()
+        pending = ""
+        if not line or line.startswith("#"):
+            continue
+
+        parts = line.split(None, 1)
+        if len(parts) < 2:
+            continue
+        kind, value = parts[0].upper(), parts[1].strip()
+        if kind == "FROM":
+            if image is not None:
+                raise ValueError(
+                    f"{dockerfile_path} uses a multi-stage Dockerfile, which "
+                    "HarborTaskset Dockerfile replay does not support. Set "
+                    "[environment].docker_image to a prebuilt image instead."
+                )
+            image = next(
+                token
+                for token in value.split()
+                if not token.startswith("--") and token.upper() != "AS"
+            )
+        elif kind == "WORKDIR":
+            path = value if value.startswith("/") else posixpath.join(workdir, value)
+            workdir = posixpath.normpath(path)
+            setup.append(f"mkdir -p {shlex.quote(workdir)}")
+        elif kind == "ENV":
+            tokens = shlex.split(value)
+            if tokens and "=" in tokens[0]:
+                for token in tokens:
+                    if "=" in token:
+                        key, _, val = token.partition("=")
+                        env[key] = val
+            elif len(tokens) >= 2:
+                env[tokens[0]] = " ".join(tokens[1:])
+        elif kind == "RUN":
+            setup.append(f"cd {shlex.quote(workdir)} && {value}")
+        elif kind in {"COPY", "ADD"}:
+            tokens = json.loads(value) if value.startswith("[") else shlex.split(value)
+            if any(str(token).startswith("--from") for token in tokens):
+                continue
+            paths = [str(token) for token in tokens if not str(token).startswith("--")]
+            if len(paths) < 2:
+                continue
+            target = paths[-1]
+            if not target.startswith("/"):
+                target = posixpath.normpath(posixpath.join(workdir, target))
+            for source in paths[:-1]:
+                source = source[2:] if source.startswith("./") else source.lstrip("/")
+                local_source = dockerfile_path.parent / source.rstrip("/")
+                copy_contents = (
+                    source in {"", "."} or source.endswith("/") or local_source.is_dir()
+                )
+                source_path = (
+                    build_context
+                    if source in {"", "."}
+                    else f"{build_context}/{source.rstrip('/')}"
+                )
+                if copy_contents:
+                    source_path = f"{source_path}/."
+                mkdir_path = (
+                    target
+                    if copy_contents or target.endswith("/") or len(paths) > 2
+                    else posixpath.dirname(target)
+                )
+                setup.append(
+                    f"mkdir -p {shlex.quote(mkdir_path)} && "
+                    f"cp -R {shlex.quote(source_path)} {shlex.quote(target)}"
+                )
+    if image is None:
+        raise ValueError(f"{dockerfile_path} must contain a FROM instruction.")
+    return {"image": image, "workdir": workdir, "env": env, "setup": setup}
 
 
 def harbor_task_dirs(root: Path, task_names: Iterable[str] | None = None) -> list[Path]:


### PR DESCRIPTION
## Summary
- add v1 Harbor Dockerfile replay for tasks with `environment/Dockerfile` and no explicit `environment.docker_image`
- upload the Harbor `environment/` build context and translate `FROM`, `WORKDIR`, `ENV`, `RUN`, and `COPY`/`ADD` into sandbox/program setup
- export the small parser helper from the v1 taskset package

Stacked on #1392.

## Testing
- `uv run pytest tests/test_v1_harbor_cli.py -q`
- `uv run pytest tests/test_v1_mini_swe_agent.py -q`
- `uv run ruff check --fix verifiers/v1/packages/tasksets/harbor.py tests/test_v1_harbor_cli.py verifiers/v1/packages/tasksets/__init__.py verifiers/v1/__init__.py`
- `uv run ruff format --check verifiers/v1/packages/tasksets/harbor.py tests/test_v1_harbor_cli.py verifiers/v1/packages/tasksets/__init__.py verifiers/v1/__init__.py`
- `uv run ty check verifiers/v1/packages/tasksets/harbor.py`
- OpenThoughts row smoke for `broken-python`, `jq-data-processing`, `log-summary`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new Dockerfile parsing and command-generation that affects how Harbor tasks provision their sandbox (image/workdir/env/setup), which could break task execution if parsing or path handling is wrong.
> 
> **Overview**
> **Harbor v1 tasks can now derive their runtime environment from an `environment/Dockerfile`** when `[environment].docker_image` is not set. `HarborTaskset.task_row` parses the Dockerfile to set `sandbox.image`/`sandbox.workdir`, uploads the `environment/` directory as a build context (`HARBOR_BUILD_CONTEXT`), and injects translated `ENV`/`RUN`/`COPY`/`ADD` steps into `program.env` and `program.setup`.
> 
> Introduces a public `parse_harbor_dockerfile` helper (re-exported via `verifiers.v1` / tasksets) with guardrails like rejecting multi-stage builds, and adds focused tests covering Dockerfile replay behavior and edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d73cc35ba2aee182aef7f4b3542aec80dc2efdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `parse_harbor_dockerfile` to replay Dockerfile environment setup in Harbor tasks
> - Adds `parse_harbor_dockerfile` in [harbor.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1407/files#diff-255f9b42c2be25db663bd7e76249d9390726ff47909524e0bb5169b6bc7611e9) that converts a single-stage Dockerfile into a replayable config: base image, workdir, ENV variables, and shell setup steps (RUN, COPY, ADD, WORKDIR).
> - Updates `HarborTaskset.task_row` to detect an `environment/Dockerfile` when no `docker_image` is configured and apply the parsed image, workdir, env, and setup steps to the sandbox and program.
> - COPY/ADD instructions are resolved relative to `HARBOR_BUILD_CONTEXT` (`/tmp/harbor_environment`), with `program.dirs` mapping the build context to the environment directory.
> - Multi-stage Dockerfiles (more than one `FROM`) are rejected with a `ValueError`.
> - Exports `parse_harbor_dockerfile` from `verifiers.v1` and `verifiers.v1.packages.tasksets`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3d73cc3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->