### PR TITLE
docs: fix inaccurate content and grammar errors in documentation

### DIFF
--- a/docs/environments.md
+++ b/docs/environments.md
@@ -800,7 +800,7 @@ state, or output field. Metrics from all environments are tracked together.
 
 ## Performance
 
-Verifiers runs rollouts concurrently on a single `asyncio` event loop. Any synchronous operation in environment code blocks **all** concurrent rollouts for its duration. At scale this adds up quickly — a 10ms sync call in at 2,000 concurrent rollouts serializes into 20 seconds of wall-clock blocking where no other rollout can make progress. The most impactful optimization is eliminating sync operations on the hot path rollout execution code, i.e. any method that runs _for each rollout_ (e.g. `setup_state`, `env_response`, or reward functions).
+Verifiers runs rollouts concurrently on a single `asyncio` event loop. Any synchronous operation in environment code blocks **all** concurrent rollouts for its duration. At scale this adds up quickly — a 10ms sync call at 2,000 concurrent rollouts serializes into 20 seconds of wall-clock blocking where no other rollout can make progress. The most impactful optimization is eliminating sync operations on the hot path rollout execution code, i.e. any method that runs _for each rollout_ (e.g. `setup_state`, `env_response`, or reward functions).
 
 ### Avoiding Sync Operations
 

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -10,8 +10,6 @@ Use `prime eval run` with a small sample:
 prime eval run my-environment -m openai/gpt-4.1-mini -n 5
 ```
 
-The `-s` flag prints sample outputs so you can see what's happening.
-
 ### How do I see what the model is outputting?
 
 **If using `prime eval run`**: Results are saved automatically. Browse them interactively with:


### PR DESCRIPTION
## Description
Fix inaccurate content and grammar errors across documentation pages.

- environments.md: removed duplicate preposition `in` — `a 10ms sync call in at 2,000 concurrent rollouts` → `a 10ms sync call at 2,000 concurrent rollouts`
- faqs.md: removed incorrect statement about the `-s` flag. The flag saves results to disk (`--save-results`), not prints sample outputs, as documented in the evaluation.md command reference.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Test improvement

## Testing
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes
Documentation-only change; no code paths affected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only edits that correct wording and remove an inaccurate CLI flag description; no runtime behavior changes.
> 
> **Overview**
> Fixes minor documentation inaccuracies.
> 
> Updates `docs/environments.md` to correct the concurrency example wording in the performance section, and removes an incorrect claim in `docs/faqs.md` about the `-s` flag printing sample outputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 799f997b6a3cc4dd498f7e997ea19de642e4bf9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix inaccurate content and grammar errors in documentation
> - Removes an extra word in [docs/environments.md](https://github.com/PrimeIntellect-ai/verifiers/pull/1411/files#diff-b507f7ced6135767fe75d523b5cb228befea15ec6d4433dd255c4e7b4356878e) so the Performance section reads 'a 10ms sync call at 2,000 concurrent rollouts'.
> - Removes an inaccurate sentence about the `-s` flag printing sample outputs from the quickstart section in [docs/faqs.md](https://github.com/PrimeIntellect-ai/verifiers/pull/1411/files#diff-9a0d263d27f331b7f71ed0a2f4e39864d4e1ba6df602130a0094d84b52109612).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 799f997.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->