### PR TITLE
feat(env): mask all-tool-failed rollouts (SimpleTIR-style void turn masking)

### DIFF
--- a/tests/envs/test_tool_env_void_mask.py
+++ b/tests/envs/test_tool_env_void_mask.py
@@ -1,0 +1,125 @@
+import json
+
+import pytest
+
+import verifiers as vf
+from verifiers.envs.tool_env import ToolEnv
+
+
+def constant_reward(**kwargs) -> float:
+    return 2.0
+
+
+def good_tool() -> str:
+    return "ok"
+
+
+def bad_tool() -> str:
+    raise RuntimeError("boom")
+
+
+def make_env(*, mask: bool) -> ToolEnv:
+    return ToolEnv(
+        tools=[good_tool, bad_tool],
+        mask_all_failed_tool_calls=mask,
+        rubric=vf.Rubric(funcs=[constant_reward]),
+    )
+
+
+def make_tool_call(name: str, index: int) -> vf.ToolCall:
+    return vf.ToolCall(id=f"call_{index}", name=name, arguments=json.dumps({}))
+
+
+async def run_tool_calls(env: ToolEnv, tool_names: list[str]) -> vf.State:
+    tool_calls = [make_tool_call(name, index) for index, name in enumerate(tool_names)]
+    assistant = vf.AssistantMessage(content=None, tool_calls=tool_calls)
+    state = vf.State(
+        prompt=[vf.UserMessage(content="use tools")],
+        completion=[],
+        trajectory=[],
+    )
+    tool_messages = await env.env_response([assistant], state)
+    state["completion"] = [assistant, *tool_messages]
+    env._apply_tool_call_mask(state)
+    return state
+
+
+def run_assistant_only_no_tools(env: ToolEnv) -> vf.State:
+    assistant = vf.AssistantMessage(content="done")
+    state = vf.State(
+        prompt=[vf.UserMessage(content="answer")],
+        completion=[assistant],
+        trajectory=[],
+    )
+    env._apply_tool_call_mask(state)
+    return state
+
+
+@pytest.mark.asyncio
+async def test_flag_off_records_outcomes_without_masking():
+    env = make_env(mask=False)
+
+    state = await run_tool_calls(env, ["bad_tool", "bad_tool"])
+    await env.rubric.score_rollout(state)
+
+    assert state.get("masked") in (None, False)
+    assert state["tool_call_outcomes"] == ["error", "error"]
+    assert state["reward"] == 2.0
+
+
+@pytest.mark.asyncio
+async def test_flag_on_all_errors_masked_and_scores_zero():
+    env = make_env(mask=True)
+
+    state = await run_tool_calls(env, ["bad_tool", "bad_tool"])
+    await env.rubric.score_rollout(state)
+
+    assert state["masked"] is True
+    assert state["tool_call_outcomes"] == ["error", "error"]
+    assert state["reward"] == 0.0
+    assert state["metrics"]["constant_reward"] == 0.0
+    assert state["metrics"]["void_turn_rollouts"] == 1.0
+
+
+@pytest.mark.asyncio
+async def test_flag_on_mixed_outcomes_unmasked():
+    env = make_env(mask=True)
+
+    state = await run_tool_calls(env, ["good_tool", "bad_tool"])
+
+    assert state["masked"] is False
+    assert state["tool_call_outcomes"] == ["ok", "error"]
+
+
+def test_flag_on_no_tool_calls_unmasked():
+    env = make_env(mask=True)
+
+    state = run_assistant_only_no_tools(env)
+
+    assert state["masked"] is False
+    assert state.get("tool_call_outcomes") in (None, [])
+
+
+@pytest.mark.asyncio
+async def test_stateful_tool_env_tracks_outcomes_for_masking():
+    class ExampleStatefulToolEnv(vf.StatefulToolEnv):
+        def update_tool_args(
+            self,
+            tool_name: str,
+            tool_args: dict,
+            messages: vf.Messages,
+            state: vf.State,
+            **kwargs,
+        ) -> dict:
+            return tool_args
+
+    env = ExampleStatefulToolEnv(
+        tools=[good_tool, bad_tool],
+        mask_all_failed_tool_calls=True,
+        rubric=vf.Rubric(funcs=[constant_reward]),
+    )
+
+    state = await run_tool_calls(env, ["bad_tool"])
+
+    assert state["masked"] is True
+    assert state["tool_call_outcomes"] == ["error"]

--- a/verifiers/envs/AGENTS.md
+++ b/verifiers/envs/AGENTS.md
@@ -25,6 +25,15 @@ Base classes for building environments:
 - `SandboxEnv` - Sandboxed container execution using `prime` sandboxes. All sandbox setup logic should be included in the start command and queued via `setup_state`, but not awaited—await resources only when first needed to overlap provisioning with rollout. See `python_env.py` for an example.
 - `PythonEnv` - Persistent Python REPL in sandbox
 
+## Optional Flags
+
+`ToolEnv(mask_all_failed_tool_calls=True)` marks a rollout as
+`state["masked"] = True` when it made at least one tool call and every recorded
+tool call failed. Tool outcomes are recorded in `state["tool_call_outcomes"]` as
+`"ok"` or `"error"`, and masked rollouts receive zero reward while exposing the
+`void_turn_rollouts` metric. This follows the SimpleTIR void-turn masking pattern
+for skipping all-tool-failed rollouts during reward computation.
+
 ## Integrations
 
 Third-party library wrappers that require additional dependencies:

--- a/verifiers/envs/stateful_tool_env.py
+++ b/verifiers/envs/stateful_tool_env.py
@@ -148,6 +148,7 @@ class StatefulToolEnv(vf.ToolEnv):
             except Exception as e:
                 if self._should_stop_for_error(e):
                     raise vf.ToolParseError from e
+                self._record_tool_call_outcome(state, "error")
                 tool_messages.append(
                     ToolMessage(
                         role="tool",
@@ -162,10 +163,12 @@ class StatefulToolEnv(vf.ToolEnv):
             )
             try:
                 tool_message = await self.call_tool(tool_name, tool_args, tool_call_id)
+                self._record_tool_call_outcome(state, "ok")
                 tool_messages.append(tool_message)
             except Exception as e:
                 if self._should_stop_for_error(e):
                     raise vf.ToolCallError from e
+                self._record_tool_call_outcome(state, "error")
                 tool_messages.append(
                     ToolMessage(
                         role="tool",

--- a/verifiers/envs/tool_env.py
+++ b/verifiers/envs/tool_env.py
@@ -1,5 +1,5 @@
 import json
-from typing import Callable, cast
+from typing import Callable, Literal, cast
 
 import verifiers as vf
 from verifiers.types import AssistantMessage, Messages, ToolCall, ToolMessage
@@ -8,6 +8,8 @@ from verifiers.utils.tool_utils import (
     convert_func_to_tool_def,
     is_valid_tool_content_parts,
 )
+
+ToolCallOutcome = Literal["ok", "error"]
 
 
 class ToolMonitorRubric(vf.Rubric):
@@ -78,12 +80,14 @@ class ToolEnv(vf.MultiTurnEnv):
         max_turns: int = 10,
         error_formatter: Callable[[Exception], str] = lambda e: f"{e}",
         stop_errors: list[type[Exception]] | None = None,
+        mask_all_failed_tool_calls: bool = False,
         **kwargs,
     ):
         self.tools = tools or []
         self.max_turns = max_turns
         self.error_formatter = error_formatter
         self.stop_errors: list[type[Exception]] = stop_errors or []
+        self.mask_all_failed_tool_calls = mask_all_failed_tool_calls
         self.tool_defs = [convert_func_to_tool_def(tool) for tool in self.tools]
         self.tool_map = {
             getattr(tool, "__name__", tool.__class__.__name__): tool
@@ -94,11 +98,41 @@ class ToolEnv(vf.MultiTurnEnv):
         self.tool_monitor_rubric = ToolMonitorRubric(
             tool_names=list(self.tool_map.keys())
         )
+        if self.mask_all_failed_tool_calls:
+            self.tool_monitor_rubric.add_metric(self.void_turn_rollouts)
         self.add_rubric(self.tool_monitor_rubric)
 
     def _should_stop_for_error(self, err: Exception) -> bool:
         """Check if error is in stop_errors."""
         return any(isinstance(err, err_type) for err_type in self.stop_errors)
+
+    def _tool_call_outcomes(self, state: vf.State) -> list[ToolCallOutcome]:
+        outcomes = state.setdefault("tool_call_outcomes", [])
+        return cast(list[ToolCallOutcome], outcomes)
+
+    def _record_tool_call_outcome(
+        self, state: vf.State, outcome: ToolCallOutcome
+    ) -> None:
+        self._tool_call_outcomes(state).append(outcome)
+
+    def _should_mask(self, state: vf.State) -> bool:
+        outcomes = state.get("tool_call_outcomes") or []
+        return (
+            self.mask_all_failed_tool_calls
+            and len(outcomes) > 0
+            and all(outcome == "error" for outcome in outcomes)
+        )
+
+    def _apply_tool_call_mask(self, state: vf.State) -> None:
+        if self.mask_all_failed_tool_calls:
+            state["masked"] = self._should_mask(state)
+
+    async def void_turn_rollouts(self, state: vf.State) -> float:
+        return 1.0 if state.get("masked") else 0.0
+
+    async def _finalize_rollout(self, state: vf.State) -> None:
+        self._apply_tool_call_mask(state)
+        await super()._finalize_rollout(state)
 
     def add_tool(self, tool: Callable):
         self.tools.append(tool)
@@ -156,6 +190,7 @@ class ToolEnv(vf.MultiTurnEnv):
             except Exception as e:
                 if self._should_stop_for_error(e):
                     raise vf.ToolParseError from e
+                self._record_tool_call_outcome(state, "error")
                 tool_messages.append(
                     ToolMessage(
                         role="tool",
@@ -167,10 +202,12 @@ class ToolEnv(vf.MultiTurnEnv):
 
             try:
                 tool_message = await self.call_tool(tool_name, tool_args, tool_call_id)
+                self._record_tool_call_outcome(state, "ok")
                 tool_messages.append(tool_message)
             except Exception as e:
                 if self._should_stop_for_error(e):
                     raise vf.ToolCallError from e
+                self._record_tool_call_outcome(state, "error")
                 tool_messages.append(
                     ToolMessage(
                         role="tool",

--- a/verifiers/rubrics/rubric.py
+++ b/verifiers/rubrics/rubric.py
@@ -351,6 +351,26 @@ class Rubric:
         """
         reward_funcs = self._get_individual_reward_funcs()
         group_reward_funcs = self._get_group_reward_funcs()
+        if state.get("masked"):
+            reward_scores = []
+            for func, weight in zip(
+                reward_funcs, self._get_individual_reward_weights()
+            ):
+                if weight == 0.0:
+                    reward_scores.append(
+                        await self._call_individual_reward_func(
+                            func=func,
+                            state=state,
+                        )
+                    )
+                else:
+                    reward_scores.append(0.0)
+            state["reward"] = 0.0
+            state["metrics"] = {
+                func.__name__: reward
+                for func, reward in zip(reward_funcs, reward_scores)
+            }
+            return
         assert len(reward_funcs) > 0 and len(group_reward_funcs) == 0, (
             "Rubric.score_rollout requires at least one individual-level reward function and no group-level reward functions"
         )
@@ -427,6 +447,12 @@ class Rubric:
                     aggregated_rewards[i] += score_value * weight
                     aggregated_metrics[func_name][i] = score_value
 
+        for i, state in enumerate(states):
+            if state.get("masked"):
+                aggregated_rewards[i] = 0.0
+                for func, weight in zip(self.funcs, self.weights):
+                    if weight != 0.0 and func.__name__ in aggregated_metrics:
+                        aggregated_metrics[func.__name__][i] = 0.0
         avg_reward = sum(aggregated_rewards) / num_states
         for i, state in enumerate(states):
             state["reward"] = aggregated_rewards[i]


### PR DESCRIPTION
## Summary

### `verifiers/envs/tool_env.py`

1. Extend `ToolEnv.__init__` signature with `mask_all_failed_tool_calls: bool = False`. Store it as `self.mask_all_failed_tool_calls`. Append `if mask_all_failed_tool_calls: self.add_metric(self.void_turn_rollouts_metric)`.

2. Add a new method that records outcomes inside `env_response`. Diff against the existing function (only the two `tool_messages.append(...)` sites change — one for success, one for the exception path):

```python
async def env_response(self, messages, state, **kwargs):
    last_msg = cast(vf.AssistantMessage, messages[-1])
    assert last_msg.tool_calls is not None
    outcomes = state.setdefault("tool_call_outcomes", [])
    tool_messages = []
    for tool_call in last_msg.tool_calls:
        tool_call_id = tool_call.id
        try:
            tool_name = tool_call.name
            tool_args = json.loads(tool_call.arguments)
        except Exception as e:
            if self._should_stop_for_error(e):
                raise vf.ToolParseError from e
            outcomes.append("error")
            tool_messages.append(ToolMessage(role="tool",
                content=self.error_formatter(e), tool_call_id=tool_call_id))
            continue
        try:
            tool_message = await self.call_tool(tool_name, tool_args, tool_call_id)
            outcomes.append("ok")
            tool_messages.append(tool_message)
        except Exception as e:
            if self._should_stop_for_error(e):
                raise vf.ToolCallError from e
            outcomes.append("error")
            tool_messages.append(ToolMessage(role="tool",
                content=self.error_formatter(e), tool_call_id=tool_call_id))
    return tool_messages
```

3. Add a `_finalize_state` hook that runs after the rollout loop — set `state["masked"]` when the flag is on and all outcomes are `"error"`. Override the base `Environment.rollout` post-step OR add this logic at the start of `score_objects` via the rubric (decided in step 4). For minimal blast radius, do it inside `ToolEnv` via overriding `_post_rollout_hook` if it exists, otherwise compute lazily in the metric callable + in the base rubric mask check.

Concretely: add a method on `ToolEnv`:

```python
def _should_mask(self, state) -> bool:
    outcomes = state.get("tool_call_outcomes") or []
    return (
        self.mask_all_failed_tool_calls
        and len(outcomes) > 0
        and all(o == "error" for o in outcomes)
    )
```

Wire this into the existing rollout finalization by setting `state["masked"] = self._should_mask(state)` after the `MultiTurnEnv.rollout` loop completes. In `verifiers/envs/multiturn_env.py::MultiTurnEnv.rollout` there is already a finalization section — `ToolEnv` overrides nothing today, so add `async def rollout(self, *args, **kwargs):` that calls `super().rollout(...)` and post-processes `state["masked"]`. (Confirm signature by reading multiturn_env.py before editing.)

4. Add the metric callable:

```python
async def void_turn_rollouts_metric(self, state: vf.State) -> float:
    return 1.0 if state.get("masked") else 0.0
```

### `verifiers/rubrics/rubric.py`

In `Rubric.score_objects(state)`, before computing rewards, short-circuit when `state.get("masked")` is truthy:

```python
def score_objects(self, state: State) -> dict[str, Any]:
    if state.get("masked"):
        # Preserve reward-func key shape for stable downstream schema.
        return {
            "reward": 0.0,
            "masked": True,
            **{name: 0.0 for name in self._get_individual_reward_func_names()},
        }
    # ...existing body...
```

This keeps the JSON output schema stable (downstream parsers will not see missing keys) and sets a single explicit zero reward.

### Docs

Add a short paragraph to `verifiers/envs/AGENTS.md` under "Optional flags" describing the new flag and pointing at the SimpleTIR reference.

## Why this matters

Issue #315 (filed by @faresobeid, COLLABORATOR) asks for an option to "mask rollouts where all tool calls failed," referencing the SimpleTIR paper ([arXiv:2509.02479](https://arxiv.org/abs/2509.02479)). In RL training, a trajectory in which every tool invocation failed contributes near-zero signal and can destabilize the gradient. SimpleTIR's contribution is to skip ("mask") these void turns when computing rewards. The verifiers `ToolEnv` and `StatefulToolEnv` already track tool calls, catch exceptions, and reply with an `error_formatter`ed `ToolMessage` — but they do not surface a "this rollout produced only failed tool calls" signal that downstream consumers (rubrics, trainers) can use.

Acceptance:
- `ToolEnv` (and by inheritance `StatefulToolEnv`) tracks per-rollout tool call outcomes in `state` as `state["tool_call_outcomes"]: list[Literal["ok","error"]]`.
- `ToolEnv` gains a constructor flag `mask_all_failed_tool_calls: bool = False` (default off — opt-in, non-breaking).
- When the flag is on AND every recorded tool call outcome is `"error"` (and `len(outcomes) > 0`), the rollout state is marked `state["masked"] = True` and the rubric returns `reward = 0.0` with no per-reward-func contributions, AND a new boolean metric `void_turn_rollouts` is exposed via `add_metric`.
- Existing rollouts (without the flag) behave identically. No public API removed or renamed.
- Tests cover: (a) flag off → unchanged behavior, (b) flag on + all errors → masked + reward 0, (c) flag on + mixed outcomes → unmasked, (d) flag on + no tool calls → unmasked.

## Testing

### `tests/envs/test_tool_env_void_mask.py` (new)

```python
import pytest

import verifiers as vf
from verifiers.envs.tool_env import ToolEnv


def make_env(*, mask: bool):
    def good_tool() -> str:
        return "ok"

    def bad_tool() -> str:
        raise RuntimeError("boom")

    return ToolEnv(
        tools=[good_tool, bad_tool],
        mask_all_failed_tool_calls=mask,
        # ... minimal dataset / rubric fixture
    )


@pytest.mark.asyncio
async def test_flag_off_no_mask_key(monkeypatch):
    env = make_env(mask=False)
    state = await run_two_failing_tool_calls(env)
    assert state.get("masked") in (None, False)


@pytest.mark.asyncio
async def test_flag_on_all_errors_masked(monkeypatch):
    env = make_env(mask=True)
    state = await run_two_failing_tool_calls(env)
    assert state["masked"] is True
    assert state["tool_call_outcomes"] == ["error", "error"]


@pytest.mark.asyncio
async def test_flag_on_mixed_outcomes_unmasked(monkeypatch):
    env = make_env(mask=True)
    state = await run_one_good_one_bad(env)
    assert state["masked"] is False
    assert state["tool_call_outcomes"] == ["ok", "error"]


@pytest.mark.asyncio
async def test_flag_on_no_tool_calls_unmasked(monkeypatch):
    env = make_env(mask=True)
    state = await run_assistant_only_no_tools(env)
    # Empty outcomes list MUST NOT trigger mask
    assert state.get("masked") in (None, False)


@pytest.mark.asyncio
async def test_masked_rollout_scores_zero():
    env = make_env(mask=True)
    state = await run_two_failing_tool_calls(env)
    scored = env.rubric.score_objects(state)
    assert scored["reward"] == 0.0
    assert scored["masked"] is True
```

`run_two_failing_tool_calls` / `run_one_good_one_bad` / `run_assistant_only_no_tools` are async helpers that drive a synthetic single rollout through `env.env_response()` directly with hand-crafted `AssistantMessage` containing `ToolCall` objects, mirroring the style of existing tests under `tests/envs/`.

Run with `uv run pytest tests/envs/test_tool_env_void_mask.py -v`.

Fixes #315

AI was used for assistance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Opt-in masking changes reward computation (zeroing rewards/metrics) and adds new state fields that downstream training/eval pipelines may implicitly rely on; behavior is gated by a new flag but touches core env/rubric scoring paths.
> 
> **Overview**
> Adds `mask_all_failed_tool_calls` to `ToolEnv` (and thus `StatefulToolEnv`) to record per-tool-call outcomes in `state["tool_call_outcomes"]`, set `state["masked"]` when at least one tool was called and *all* outcomes are errors, and emit a new `void_turn_rollouts` metric.
> 
> Updates `Rubric.score_rollout` and `Rubric.score_group` to short-circuit masked rollouts to **zero reward** (and zero out non-metric function contributions), while keeping metric-weight (`weight==0`) functions evaluable. Adds tests covering flag on/off, mixed/no tool calls, and `StatefulToolEnv` behavior, plus docs in `AGENTS.md` describing the new flag and masking semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d54ffee5bc84c29af2aa0bca02508ca5d58200ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `mask_all_failed_tool_calls` flag to `ToolEnv` for SimpleTIR-style void turn masking
> - Adds a `mask_all_failed_tool_calls` constructor parameter to [`ToolEnv`](https://github.com/PrimeIntellect-ai/verifiers/pull/1416/files#diff-e4d0a071b75cb6e4946c06cef3a928527fee309c5773cb87bb022347075244dd) and [`StatefulToolEnv`](https://github.com/PrimeIntellect-ai/verifiers/pull/1416/files#diff-895f101aa1fef5046e347a7533b02a1b1c5cb6cef2c697319b622c834dba8347); when enabled, rollouts where every tool call fails are marked `state['masked'] = True`.
> - Per-call outcomes (`'ok'`/`'error'`) are recorded in `state['tool_call_outcomes']` during `env_response` for both env types.
> - Masked rollouts receive a reward of 0.0 and zero out non-zero-weight metrics in [`Rubric.score_rollout`](https://github.com/PrimeIntellect-ai/verifiers/pull/1416/files#diff-93524b7f0aef49ccda32abbb52371781199c6551aed59a94957e5f432d6e7145) and `score_rollouts`; zero-weight metrics still execute.
> - Exposes a `void_turn_rollouts` metric (1.0 when masked, 0.0 otherwise) when the flag is enabled.
> - Behavioral Change: rollouts with all-failed tool calls now return reward 0.0 instead of their computed reward when `mask_all_failed_tool_calls=True`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d54ffee.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->