### PR TITLE
feat(eval): let env_args.model override --model in vf-eval

### DIFF
--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -127,6 +127,23 @@ env.set_concurrency(256)
 
 The `renderer` client type requires the optional renderer package. Install it with `uv add "verifiers[renderers]"` before running evals with `--api-client-type renderer`.
 
+#### Model precedence
+
+`--model` / `-m` sets the inference client's model. Custom environments that
+need to know that model can accept `model` in `load_environment()` / their
+constructor, or read the injected `model` environment kwarg, instead of
+requiring users to repeat the same value in `--env-args`.
+
+To use a different model inside the environment than the one driving inference,
+pass it explicitly via `--env-args`:
+
+```bash
+prime eval run my-env -m google/gemma-3-27b-it -a '{"model": "qwen/qwen3-14b"}'
+```
+
+That override changes only the environment's view of `model`; the inference
+client still uses `--model`.
+
 For convenience, define model endpoints in `./configs/endpoints.toml` to avoid repeating URL and key flags.
 
 ```toml

--- a/tests/scripts/test_eval_model_kwarg.py
+++ b/tests/scripts/test_eval_model_kwarg.py
@@ -1,0 +1,33 @@
+from verifiers.scripts.eval import build_eval_config
+
+
+def test_resolved_model_lands_in_extra_env_kwargs(monkeypatch):
+    raw = {
+        "env_id": "math-python",
+        "model": "openai/gpt-4.1-mini",
+        "api_base_url": "https://example.test/v1",
+        "api_key_var": "OPENAI_API_KEY",
+    }
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+    cfg = build_eval_config(raw)
+
+    assert cfg.model == "openai/gpt-4.1-mini"
+    assert cfg.extra_env_kwargs.get("model") == "openai/gpt-4.1-mini"
+
+
+def test_env_args_model_overrides_for_env_but_not_client(monkeypatch):
+    raw = {
+        "env_id": "math-python",
+        "model": "openai/gpt-4.1-mini",
+        "env_args": {"model": "qwen/qwen3-14b"},
+        "api_base_url": "https://example.test/v1",
+        "api_key_var": "OPENAI_API_KEY",
+    }
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+    cfg = build_eval_config(raw)
+
+    assert cfg.model == "openai/gpt-4.1-mini"
+    assert cfg.env_args.get("model") == "qwen/qwen3-14b"
+    assert cfg.extra_env_kwargs.get("model") is None

--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -499,6 +499,299 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def build_eval_config(raw: dict) -> EvalConfig:
+    """Build EvalConfig from a raw config dict."""
+    env_id = raw["env_id"]
+    name = raw.get("name")
+    if name is not None and (not isinstance(name, str) or not name):
+        raise ValueError("'name' must be a non-empty string when provided.")
+
+    # Resolve num_examples and rollouts_per_example with env defaults
+    env_defaults = get_env_eval_defaults(env_id)
+    raw_num_examples = raw.get("num_examples")
+    raw_rollouts = raw.get("rollouts_per_example")
+
+    num_examples = (
+        raw_num_examples
+        if raw_num_examples is not None
+        else env_defaults.get("num_examples", DEFAULT_NUM_EXAMPLES)
+    )
+    rollouts_per_example = (
+        raw_rollouts
+        if raw_rollouts is not None
+        else env_defaults.get("rollouts_per_example", DEFAULT_ROLLOUTS_PER_EXAMPLE)
+    )
+
+    if raw_num_examples is None:
+        source = (
+            "pyproject.toml" if "num_examples" in env_defaults else "global default"
+        )
+        logger.debug(f"Using num_examples={num_examples} from {source}")
+    if raw_rollouts is None:
+        source = (
+            "pyproject.toml"
+            if "rollouts_per_example" in env_defaults
+            else "global default"
+        )
+        logger.debug(f"Using rollouts_per_example={rollouts_per_example} from {source}")
+
+    raw_endpoint_id = raw.get("endpoint_id")
+    raw_model_field = raw.get("model")
+    if raw_endpoint_id is not None and raw_model_field is not None:
+        raise ValueError(
+            "Cannot set both 'endpoint_id' and 'model' in eval config; choose one."
+        )
+    if raw_endpoint_id is not None and not isinstance(raw_endpoint_id, str):
+        raise ValueError("'endpoint_id' must be a string when provided.")
+    if isinstance(raw_endpoint_id, str) and not raw_endpoint_id:
+        raise ValueError("'endpoint_id' must be a non-empty string when provided.")
+    endpoints_path = raw.get("endpoints_path", DEFAULT_ENDPOINTS_PATH)
+    resolved_endpoints_file = resolve_endpoints_file(str(endpoints_path))
+    if raw_endpoint_id is not None and (
+        resolved_endpoints_file is None or resolved_endpoints_file.suffix != ".toml"
+    ):
+        raise ValueError(
+            "'endpoint_id' is only supported with TOML endpoint registries. "
+            "Set endpoints_path to an endpoints.toml file."
+        )
+
+    raw_model = raw_model_field if raw_model_field is not None else DEFAULT_MODEL
+    endpoint_lookup_id = raw_endpoint_id if raw_endpoint_id is not None else raw_model
+    raw_client_type = raw.get("api_client_type")
+    raw_api_key_var = raw.get("api_key_var")
+    raw_api_base_url = raw.get("api_base_url")
+    if isinstance(raw_api_base_url, list):
+        raise ValueError(
+            "api_base_url lists are no longer supported. "
+            "Use endpoint_id + endpoints.toml for multi-endpoint configuration."
+        )
+
+    # Provider resolution:
+    #   - model IN registry:  registry -> provider overrides -> CLI overrides
+    #   - model NOT in registry: provider (default: prime) -> CLI overrides
+    raw_provider = raw.get("provider")
+    api_key_override = raw_api_key_var is not None
+    api_base_url_override = raw_api_base_url is not None
+    client_type_override = raw_client_type is not None
+    direct_endpoint_config = (
+        raw_endpoint_id is None and api_key_override and api_base_url_override
+    )
+    endpoints = {} if direct_endpoint_config else load_endpoints(endpoints_path)
+    endpoint_group: list[Endpoint] | None = None
+    resolved_endpoint_id: str | None = None
+
+    if endpoint_lookup_id in endpoints:
+        endpoint_group = endpoints[endpoint_lookup_id]
+        resolved_endpoint_id = endpoint_lookup_id
+        endpoint = endpoint_group[0]
+
+        # Start from registry values
+        api_key_var = endpoint["key"]
+        api_base_url = endpoint["url"]
+        client_type = endpoint.get("api_client_type", DEFAULT_CLIENT_TYPE)
+
+        endpoint_models = {entry["model"] for entry in endpoint_group}
+        if len(endpoint_models) > 1:
+            raise ValueError(
+                f"Endpoint alias '{endpoint_lookup_id}' maps to multiple model ids {sorted(endpoint_models)}, "
+                "which is not yet supported by EvalConfig."
+            )
+        model = endpoint["model"]
+
+        # Provider overrides registry
+        if raw_provider is not None:
+            provider_cfg = PROVIDER_CONFIGS[raw_provider]
+            api_key_var = provider_cfg["key"]
+            api_base_url = provider_cfg["url"]
+            if "client_type" in provider_cfg:
+                client_type = provider_cfg["client_type"]
+
+        # CLI overrides provider / registry
+        if api_key_override:
+            api_key_var = raw_api_key_var
+        if api_base_url_override:
+            api_base_url = raw_api_base_url
+        if client_type_override:
+            client_type = raw_client_type
+
+        if (
+            api_key_override
+            or api_base_url_override
+            or client_type_override
+            or raw_provider is not None
+        ):
+            logger.debug(
+                "Using endpoint registry for model '%s' with overrides (key: %s, url: %s, api_client_type: %s)",
+                model,
+                "override" if api_key_override or raw_provider else "registry",
+                "override" if api_base_url_override or raw_provider else "registry",
+                "override" if client_type_override or raw_provider else "registry",
+            )
+        else:
+            logger.debug(
+                "Using endpoint configuration for model '%s' from registry (%d endpoint variant(s))",
+                model,
+                len(endpoint_group),
+            )
+    else:
+        if raw_endpoint_id is not None:
+            raise ValueError(
+                f"Endpoint id '{raw_endpoint_id}' not found in endpoint registry at {endpoints_path}"
+            )
+        # Fall back to provider (default: prime)
+        provider_cfg = PROVIDER_CONFIGS[raw_provider or DEFAULT_PROVIDER]
+        logger.debug(
+            "Model '%s' not found in endpoint registry, using provider '%s'",
+            raw_model,
+            raw_provider or DEFAULT_PROVIDER,
+        )
+        model = raw_model
+        api_key_var = raw_api_key_var if api_key_override else provider_cfg["key"]
+        api_base_url = (
+            raw_api_base_url if api_base_url_override else provider_cfg["url"]
+        )
+        client_type = (
+            raw_client_type
+            if client_type_override
+            else provider_cfg.get("client_type", DEFAULT_CLIENT_TYPE)
+        )
+
+    # Merge sampling args
+    merged_sampling_args = merge_sampling_args(
+        raw.get("sampling_args"),
+        max_tokens=raw.get("max_tokens"),
+        temperature=raw.get("temperature"),
+        include_none_max_tokens=True,
+    )
+    # Build headers: registry < [[eval]] headers table < header list / --header
+    eval_headers_merged = build_extra_headers(raw)
+    # Default X-Session-ID → example_id for sticky DP-aware routing;
+    # user-supplied headers_from_state / --header-from-state override.
+    eval_headers_from_state = {
+        "X-Session-ID": "example_id",
+        **build_extra_headers_from_state(raw),
+    }
+
+    registry_headers_base: dict[str, str] = {}
+    if endpoint_group is not None:
+        registry_headers_base = dict(endpoint_group[0].get("extra_headers", {}))
+
+    merged_headers: dict[str, str] = {
+        **registry_headers_base,
+        **eval_headers_merged,
+    }
+
+    primary_api_base_url = api_base_url
+    if not isinstance(primary_api_base_url, str):
+        raise ValueError("api_base_url must be a single string URL")
+    assert api_key_var is not None
+    resolved_api_key_var = api_key_var
+
+    endpoint_configs: list[EndpointClientConfig] = []
+    if (
+        endpoint_group is not None
+        and not api_base_url_override
+        and raw_provider is None
+        and len(endpoint_group) > 1
+    ):
+        endpoint_configs = [
+            EndpointClientConfig(
+                api_key_var=(resolved_api_key_var if api_key_override else ep["key"]),
+                api_base_url=ep["url"],
+                extra_headers={
+                    **dict(ep.get("extra_headers", {})),
+                    **eval_headers_merged,
+                },
+            )
+            for ep in endpoint_group
+        ]
+
+    assert primary_api_base_url is not None
+    client_config = ClientConfig(
+        client_type=cast(ClientType, client_type),
+        api_key_var=resolved_api_key_var,
+        api_base_url=primary_api_base_url,
+        endpoint_configs=endpoint_configs,
+        extra_headers=merged_headers,
+        extra_headers_from_state=eval_headers_from_state,
+    )
+
+    # Backward-compatible TOML field: resume_path
+    if raw.get("resume") is None and raw.get("resume_path") is not None:
+        raw["resume"] = raw["resume_path"]
+
+    # handle resume path resolution
+    resume_arg = raw.get("resume")
+    resume_path: Path | None = None
+    if isinstance(resume_arg, str):
+        resume_path = Path(resume_arg)
+        if not is_valid_eval_results_path(resume_path):
+            raise ValueError(
+                f"Resume path {resume_path} is not a valid evaluation results path"
+            )
+        logger.info(f"Resuming from explicit path: {resume_path}")
+    elif resume_arg is True:
+        auto_resume_path = find_latest_incomplete_eval_results_path(
+            env_id=env_id,
+            model=model,
+            num_examples=num_examples,
+            rollouts_per_example=rollouts_per_example,
+            env_dir_path=raw.get("env_dir_path", DEFAULT_ENV_DIR_PATH),
+            output_dir=raw.get("output_dir"),
+            name=name,
+        )
+        if auto_resume_path is not None:
+            resume_path = auto_resume_path
+            logger.info(f"Auto-resuming from: {resume_path}")
+        else:
+            logger.info(
+                "No matching incomplete run found for --resume; starting a new run"
+            )
+    elif resume_arg in (None, False):
+        pass
+    else:
+        raise ValueError(f"Invalid value for --resume: {resume_arg!r}")
+
+    env_args = raw.get("env_args", {})
+    extra_env_kwargs = dict(raw.get("extra_env_kwargs", {}))
+    if "model" in env_args:
+        extra_env_kwargs.pop("model", None)
+    else:
+        # Make the resolved inference model available to custom envs without
+        # forcing users to repeat it in -a / env_args. Explicit
+        # extra_env_kwargs.model still wins for callers that set it directly.
+        extra_env_kwargs.setdefault("model", model)
+    if raw.get("timeout") is not None:
+        extra_env_kwargs["timeout_seconds"] = raw["timeout"]
+
+    return EvalConfig(
+        env_id=env_id,
+        name=name,
+        env_args=env_args,
+        env_dir_path=raw.get("env_dir_path", DEFAULT_ENV_DIR_PATH),
+        output_dir=raw.get("output_dir"),
+        extra_env_kwargs=extra_env_kwargs,
+        endpoint_id=resolved_endpoint_id,
+        model=model,
+        client_config=client_config,
+        sampling_args=merged_sampling_args,
+        num_examples=num_examples,
+        rollouts_per_example=rollouts_per_example,
+        max_concurrent=raw.get("max_concurrent", DEFAULT_MAX_CONCURRENT),
+        max_retries=raw.get("max_retries", 0),
+        num_workers=raw.get("num_workers", "auto"),
+        disable_env_server=raw.get("disable_env_server", False),
+        verbose=raw.get("verbose", False),
+        disable_tui=raw.get("disable_tui", False),
+        state_columns=raw.get("state_columns", []),
+        save_results=raw.get("save_results", False),
+        resume_path=resume_path,
+        independent_scoring=raw.get("independent_scoring", False),
+        save_to_hf_hub=raw.get("save_to_hf_hub", False),
+        hf_hub_dataset_name=raw.get("hf_hub_dataset_name", ""),
+    )
+
+
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = build_parser()
     if argv is None:
@@ -532,296 +825,6 @@ def main(argv: list[str] | None = None):
         raw_config = {"env_id": args.env_id_or_config}
         raw_config.update(vars(args))
         raw_eval_configs = [raw_config]
-
-    def build_eval_config(raw: dict) -> EvalConfig:
-        """Build EvalConfig from a raw config dict."""
-        env_id = raw["env_id"]
-        name = raw.get("name")
-        if name is not None and (not isinstance(name, str) or not name):
-            raise ValueError("'name' must be a non-empty string when provided.")
-
-        # Resolve num_examples and rollouts_per_example with env defaults
-        env_defaults = get_env_eval_defaults(env_id)
-        raw_num_examples = raw.get("num_examples")
-        raw_rollouts = raw.get("rollouts_per_example")
-
-        num_examples = (
-            raw_num_examples
-            if raw_num_examples is not None
-            else env_defaults.get("num_examples", DEFAULT_NUM_EXAMPLES)
-        )
-        rollouts_per_example = (
-            raw_rollouts
-            if raw_rollouts is not None
-            else env_defaults.get("rollouts_per_example", DEFAULT_ROLLOUTS_PER_EXAMPLE)
-        )
-
-        if raw_num_examples is None:
-            source = (
-                "pyproject.toml" if "num_examples" in env_defaults else "global default"
-            )
-            logger.debug(f"Using num_examples={num_examples} from {source}")
-        if raw_rollouts is None:
-            source = (
-                "pyproject.toml"
-                if "rollouts_per_example" in env_defaults
-                else "global default"
-            )
-            logger.debug(
-                f"Using rollouts_per_example={rollouts_per_example} from {source}"
-            )
-
-        raw_endpoint_id = raw.get("endpoint_id")
-        raw_model_field = raw.get("model")
-        if raw_endpoint_id is not None and raw_model_field is not None:
-            raise ValueError(
-                "Cannot set both 'endpoint_id' and 'model' in eval config; choose one."
-            )
-        if raw_endpoint_id is not None and not isinstance(raw_endpoint_id, str):
-            raise ValueError("'endpoint_id' must be a string when provided.")
-        if isinstance(raw_endpoint_id, str) and not raw_endpoint_id:
-            raise ValueError("'endpoint_id' must be a non-empty string when provided.")
-        endpoints_path = raw.get("endpoints_path", DEFAULT_ENDPOINTS_PATH)
-        resolved_endpoints_file = resolve_endpoints_file(str(endpoints_path))
-        if raw_endpoint_id is not None and (
-            resolved_endpoints_file is None or resolved_endpoints_file.suffix != ".toml"
-        ):
-            raise ValueError(
-                "'endpoint_id' is only supported with TOML endpoint registries. "
-                "Set endpoints_path to an endpoints.toml file."
-            )
-
-        raw_model = raw_model_field if raw_model_field is not None else DEFAULT_MODEL
-        endpoint_lookup_id = (
-            raw_endpoint_id if raw_endpoint_id is not None else raw_model
-        )
-        raw_client_type = raw.get("api_client_type")
-        raw_api_key_var = raw.get("api_key_var")
-        raw_api_base_url = raw.get("api_base_url")
-        if isinstance(raw_api_base_url, list):
-            raise ValueError(
-                "api_base_url lists are no longer supported. "
-                "Use endpoint_id + endpoints.toml for multi-endpoint configuration."
-            )
-
-        # Provider resolution:
-        #   - model IN registry:  registry -> provider overrides -> CLI overrides
-        #   - model NOT in registry: provider (default: prime) -> CLI overrides
-        raw_provider = raw.get("provider")
-        api_key_override = raw_api_key_var is not None
-        api_base_url_override = raw_api_base_url is not None
-        client_type_override = raw_client_type is not None
-        direct_endpoint_config = (
-            raw_endpoint_id is None and api_key_override and api_base_url_override
-        )
-        endpoints = {} if direct_endpoint_config else load_endpoints(endpoints_path)
-        endpoint_group: list[Endpoint] | None = None
-        resolved_endpoint_id: str | None = None
-
-        if endpoint_lookup_id in endpoints:
-            endpoint_group = endpoints[endpoint_lookup_id]
-            resolved_endpoint_id = endpoint_lookup_id
-            endpoint = endpoint_group[0]
-
-            # Start from registry values
-            api_key_var = endpoint["key"]
-            api_base_url = endpoint["url"]
-            client_type = endpoint.get("api_client_type", DEFAULT_CLIENT_TYPE)
-
-            endpoint_models = {entry["model"] for entry in endpoint_group}
-            if len(endpoint_models) > 1:
-                raise ValueError(
-                    f"Endpoint alias '{endpoint_lookup_id}' maps to multiple model ids {sorted(endpoint_models)}, "
-                    "which is not yet supported by EvalConfig."
-                )
-            model = endpoint["model"]
-
-            # Provider overrides registry
-            if raw_provider is not None:
-                provider_cfg = PROVIDER_CONFIGS[raw_provider]
-                api_key_var = provider_cfg["key"]
-                api_base_url = provider_cfg["url"]
-                if "client_type" in provider_cfg:
-                    client_type = provider_cfg["client_type"]
-
-            # CLI overrides provider / registry
-            if api_key_override:
-                api_key_var = raw_api_key_var
-            if api_base_url_override:
-                api_base_url = raw_api_base_url
-            if client_type_override:
-                client_type = raw_client_type
-
-            if (
-                api_key_override
-                or api_base_url_override
-                or client_type_override
-                or raw_provider is not None
-            ):
-                logger.debug(
-                    "Using endpoint registry for model '%s' with overrides (key: %s, url: %s, api_client_type: %s)",
-                    model,
-                    "override" if api_key_override or raw_provider else "registry",
-                    "override" if api_base_url_override or raw_provider else "registry",
-                    "override" if client_type_override or raw_provider else "registry",
-                )
-            else:
-                logger.debug(
-                    "Using endpoint configuration for model '%s' from registry (%d endpoint variant(s))",
-                    model,
-                    len(endpoint_group),
-                )
-        else:
-            if raw_endpoint_id is not None:
-                raise ValueError(
-                    f"Endpoint id '{raw_endpoint_id}' not found in endpoint registry at {endpoints_path}"
-                )
-            # Fall back to provider (default: prime)
-            provider_cfg = PROVIDER_CONFIGS[raw_provider or DEFAULT_PROVIDER]
-            logger.debug(
-                "Model '%s' not found in endpoint registry, using provider '%s'",
-                raw_model,
-                raw_provider or DEFAULT_PROVIDER,
-            )
-            model = raw_model
-            api_key_var = raw_api_key_var if api_key_override else provider_cfg["key"]
-            api_base_url = (
-                raw_api_base_url if api_base_url_override else provider_cfg["url"]
-            )
-            client_type = (
-                raw_client_type
-                if client_type_override
-                else provider_cfg.get("client_type", DEFAULT_CLIENT_TYPE)
-            )
-
-        # Merge sampling args
-        merged_sampling_args = merge_sampling_args(
-            raw.get("sampling_args"),
-            max_tokens=raw.get("max_tokens"),
-            temperature=raw.get("temperature"),
-            include_none_max_tokens=True,
-        )
-        # Build headers: registry < [[eval]] headers table < header list / --header
-        eval_headers_merged = build_extra_headers(raw)
-        # Default X-Session-ID → example_id for sticky DP-aware routing;
-        # user-supplied headers_from_state / --header-from-state override.
-        eval_headers_from_state = {
-            "X-Session-ID": "example_id",
-            **build_extra_headers_from_state(raw),
-        }
-
-        registry_headers_base: dict[str, str] = {}
-        if endpoint_group is not None:
-            registry_headers_base = dict(endpoint_group[0].get("extra_headers", {}))
-
-        merged_headers: dict[str, str] = {
-            **registry_headers_base,
-            **eval_headers_merged,
-        }
-
-        primary_api_base_url = api_base_url
-        if not isinstance(primary_api_base_url, str):
-            raise ValueError("api_base_url must be a single string URL")
-        assert api_key_var is not None
-        resolved_api_key_var = api_key_var
-
-        endpoint_configs: list[EndpointClientConfig] = []
-        if (
-            endpoint_group is not None
-            and not api_base_url_override
-            and raw_provider is None
-            and len(endpoint_group) > 1
-        ):
-            endpoint_configs = [
-                EndpointClientConfig(
-                    api_key_var=(
-                        resolved_api_key_var if api_key_override else ep["key"]
-                    ),
-                    api_base_url=ep["url"],
-                    extra_headers={
-                        **dict(ep.get("extra_headers", {})),
-                        **eval_headers_merged,
-                    },
-                )
-                for ep in endpoint_group
-            ]
-
-        assert primary_api_base_url is not None
-        client_config = ClientConfig(
-            client_type=cast(ClientType, client_type),
-            api_key_var=resolved_api_key_var,
-            api_base_url=primary_api_base_url,
-            endpoint_configs=endpoint_configs,
-            extra_headers=merged_headers,
-            extra_headers_from_state=eval_headers_from_state,
-        )
-
-        # Backward-compatible TOML field: resume_path
-        if raw.get("resume") is None and raw.get("resume_path") is not None:
-            raw["resume"] = raw["resume_path"]
-
-        # handle resume path resolution
-        resume_arg = raw.get("resume")
-        resume_path: Path | None = None
-        if isinstance(resume_arg, str):
-            resume_path = Path(resume_arg)
-            if not is_valid_eval_results_path(resume_path):
-                raise ValueError(
-                    f"Resume path {resume_path} is not a valid evaluation results path"
-                )
-            logger.info(f"Resuming from explicit path: {resume_path}")
-        elif resume_arg is True:
-            auto_resume_path = find_latest_incomplete_eval_results_path(
-                env_id=env_id,
-                model=model,
-                num_examples=num_examples,
-                rollouts_per_example=rollouts_per_example,
-                env_dir_path=raw.get("env_dir_path", DEFAULT_ENV_DIR_PATH),
-                output_dir=raw.get("output_dir"),
-                name=name,
-            )
-            if auto_resume_path is not None:
-                resume_path = auto_resume_path
-                logger.info(f"Auto-resuming from: {resume_path}")
-            else:
-                logger.info(
-                    "No matching incomplete run found for --resume; starting a new run"
-                )
-        elif resume_arg in (None, False):
-            pass
-        else:
-            raise ValueError(f"Invalid value for --resume: {resume_arg!r}")
-
-        extra_env_kwargs = dict(raw.get("extra_env_kwargs", {}))
-        if raw.get("timeout") is not None:
-            extra_env_kwargs["timeout_seconds"] = raw["timeout"]
-
-        return EvalConfig(
-            env_id=env_id,
-            name=name,
-            env_args=raw.get("env_args", {}),
-            env_dir_path=raw.get("env_dir_path", DEFAULT_ENV_DIR_PATH),
-            output_dir=raw.get("output_dir"),
-            extra_env_kwargs=extra_env_kwargs,
-            endpoint_id=resolved_endpoint_id,
-            model=model,
-            client_config=client_config,
-            sampling_args=merged_sampling_args,
-            num_examples=num_examples,
-            rollouts_per_example=rollouts_per_example,
-            max_concurrent=raw.get("max_concurrent", DEFAULT_MAX_CONCURRENT),
-            max_retries=raw.get("max_retries", 0),
-            num_workers=raw.get("num_workers", "auto"),
-            disable_env_server=raw.get("disable_env_server", False),
-            verbose=raw.get("verbose", False),
-            disable_tui=raw.get("disable_tui", False),
-            state_columns=raw.get("state_columns", []),
-            save_results=raw.get("save_results", False),
-            resume_path=resume_path,
-            independent_scoring=raw.get("independent_scoring", False),
-            save_to_hf_hub=raw.get("save_to_hf_hub", False),
-            hf_hub_dataset_name=raw.get("hf_hub_dataset_name", ""),
-        )
 
     # Check Hub environments are installed before running
     missing_envs = []

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -1,4 +1,6 @@
 import asyncio
+import importlib
+import inspect
 import itertools
 import json
 import logging
@@ -926,6 +928,20 @@ def quiet_datasets():
         enable_progress_bar()
 
 
+def _load_environment_accepts_arg(env_id: str, arg_name: str) -> bool:
+    module_name = env_id.replace("-", "_").split("/")[-1]
+    try:
+        module = importlib.import_module(module_name)
+        env_load_func = getattr(module, "load_environment")
+        sig = inspect.signature(env_load_func)
+    except Exception:
+        return False
+
+    return arg_name in sig.parameters or any(
+        param.kind == inspect.Parameter.VAR_KEYWORD for param in sig.parameters.values()
+    )
+
+
 async def run_evaluation(
     config: EvalConfig,
     on_start: StartCallback | None = None,
@@ -937,13 +953,22 @@ async def run_evaluation(
     maybe_suppress_logs = (
         log_level(logging.CRITICAL) if not config.disable_env_server else nullcontext()
     )
+    extra_env_kwargs = dict(config.extra_env_kwargs)
+    env_args = dict(config.env_args)
+    if "model" in config.env_args:
+        extra_env_kwargs.pop("model", None)
+    elif "model" in extra_env_kwargs and _load_environment_accepts_arg(
+        config.env_id, "model"
+    ):
+        env_args["model"] = extra_env_kwargs["model"]
+
     with maybe_suppress_logs:
-        vf_env = vf.load_environment(env_id=config.env_id, **config.env_args)
+        vf_env = vf.load_environment(env_id=config.env_id, **env_args)
 
     # set extra environment kwargs
-    if config.extra_env_kwargs:
-        logger.info(f"Setting extra environment kwargs: {config.extra_env_kwargs}")
-        vf_env.set_kwargs(**config.extra_env_kwargs)
+    if extra_env_kwargs:
+        logger.info(f"Setting extra environment kwargs: {extra_env_kwargs}")
+        vf_env.set_kwargs(**extra_env_kwargs)
 
     results_path = config.resume_path or get_eval_results_path(config)
     model_pricing = await _resolve_model_pricing(config)
@@ -951,7 +976,7 @@ async def run_evaluation(
 
     try:
         if not config.disable_env_server:
-            extra_env_kwargs = dict(config.extra_env_kwargs)
+            extra_env_kwargs = dict(extra_env_kwargs)
             # resolve total concurrency
             if "concurrency" not in extra_env_kwargs:
                 if config.max_concurrent <= 0:


### PR DESCRIPTION
## Summary

### `verifiers/scripts/eval.py`

In `build_eval_config()` immediately before the `extra_env_kwargs["timeout_seconds"] = raw["timeout"]` block (line ~796), insert:

```python
# Plumb the resolved -m / registry / provider model id into extra_env_kwargs so
# custom envs can opt-in (e.g. MyEnv(__init__).__init__(self, *, model: str, ...))
# without the user having to repeat it in -a / env_args. Users who want the env to
# use a different model than the inference client still set it via -a:
#     vf-eval -m google/gemma-3-27b-it -a '{"model": "qwen/qwen3-14b"}'
extra_env_kwargs.setdefault("model", model)
```

`setdefault` keeps any caller-injected value (from `[[eval]]` TOML configs that already set `extra_env_kwargs.model`) authoritative.

### `verifiers/utils/eval_utils.py::run_evaluations`

If `env_args` contains `"model"`, it should remain the source of truth at env-construction time. The current code already merges `env_args | extra_env_kwargs` when instantiating the env class. Verify the merge order:

```python
# Pseudocode at instantiation site
env = env_class(**env_args, **extra_env_kwargs)
```

If the existing merge order is `extra_env_kwargs` last, Python will raise `TypeError: multiple values for keyword argument 'model'` when both are set. Fix: drop `model` from `extra_env_kwargs` when present in `env_args`:

```python
if "model" in env_args and "model" in extra_env_kwargs:
    extra_env_kwargs = {k: v for k, v in extra_env_kwargs.items() if k != "model"}
```

Before editing, grep for the actual instantiation site:

```bash
grep -nR "env_args" verifiers/utils/eval_utils.py | grep -i "extra_env_kwargs\|env_class\|load_env"
```

and adjust the snippet to match the local idiom.

### Docs

Append a short subsection to `README.md` (or the existing `docs/evaluation.md`) explaining precedence:

> ### Model precedence in vf-eval
>
> `-m / --model` sets the inference client's model. Custom envs that need to know
> the model (e.g. for prefix-cache routing, judge models, user-sim models) can
> read it from the `model` kwarg in their `__init__`. To use a different model
> inside the env than the one driving inference, pass it explicitly via
> `-a '{"model": "..."}'` — this overrides only the env's view; the inference
> client still uses `-m`.

## Why this matters

Issue #297 (filed by @damoonsh, NONE) reports that `vf-eval` requires the model name to be passed twice when a custom `MultiTurn`-extending env uses the model inside `env_response`: once with `-m` for the inference client, and again via `-a '{"model": "..."}'` so the env can read it. The user asks: "Could we give precedence to model arg instead of -m inside eval.py file?"

The clean resolution is the inverse — keep `-m` as the canonical CLI input for the inference client (its current role) but pass the resolved model into the env instantiation as a well-known kwarg so user-defined envs do not need to pull `model` out of `env_args` at all. As a fallback for envs that want a different model than the inference client (e.g. a separate user-sim model), keep `env_args.model` working and have it override only inside the env, leaving the inference client unaffected.

Acceptance:
- `vf-eval -m foo/bar` makes the resolved model id available to custom envs via `extra_env_kwargs["model"]` so `MyEnv(__init__).__init__(self, *, model: str, ...)` "just works" without duplicating in `-a`.
- If `env_args` already contains a `model` key, that value wins in the env (the user explicitly overrode it), but the inference client still uses `-m` (no behavior change there).
- A new short README section under "vf-eval" documents the precedence rules.
- Existing tests pass; new test confirms the resolved `-m` is plumbed into `extra_env_kwargs`.

## Testing

### `tests/scripts/test_eval_model_kwarg.py` (new)

```python
import pytest

from verifiers.scripts.eval import build_eval_config


def test_resolved_model_lands_in_extra_env_kwargs(tmp_path, monkeypatch):
    # Build a minimal raw config dict that exercises the resolver
    raw = {
        "env_id": "math-python",
        "model": "openai/gpt-4.1-mini",
        "api_base_url": "https://example.test/v1",
        "api_key_var": "OPENAI_API_KEY",
    }
    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
    cfg = build_eval_config(raw)  # signature: dict -> EvalConfig
    assert cfg.model == "openai/gpt-4.1-mini"
    assert cfg.extra_env_kwargs.get("model") == "openai/gpt-4.1-mini"


def test_env_args_model_overrides_for_env_but_not_client(tmp_path, monkeypatch):
    raw = {
        "env_id": "math-python",
        "model": "openai/gpt-4.1-mini",
        "env_args": {"model": "qwen/qwen3-14b"},
        "api_base_url": "https://example.test/v1",
        "api_key_var": "OPENAI_API_KEY",
    }
    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
    cfg = build_eval_config(raw)
    # inference client model = -m
    assert cfg.model == "openai/gpt-4.1-mini"
    # env-side override survives in env_args
    assert cfg.env_args.get("model") == "qwen/qwen3-14b"
    # extra_env_kwargs.model is dropped (or absent) so kwargs do not collide
    assert cfg.extra_env_kwargs.get("model") is None
```

The `build_eval_config` function is currently a closure inside `main()` (per the surrounding code shape). If it remains a closure, refactor it to a module-level helper (or expose a thin wrapper) so it is unit-testable. This refactor is itself worth doing — it is a small, well-bounded improvement that also makes the rest of `build_eval_config` testable.

If extracting the closure is rejected by the maintainer, fall back to a CLI integration test that invokes `python -m verifiers.scripts.eval --dry-run ...` (if such a mode exists) or asserts via a smoke-test fixture env that records the kwargs it was constructed with.

Run with `uv run pytest tests/scripts/test_eval_model_kwarg.py -v`.

Fixes #297

AI was used for assistance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches evaluation config construction and environment instantiation plumbing, which can subtly change how envs receive kwargs (especially around `model`) and could break custom env `load_environment()` signatures if assumptions differ.
> 
> **Overview**
> **Model/kwarg precedence for eval environments is formalized.** `build_eval_config()` is extracted to module scope and now injects the resolved inference `model` into `extra_env_kwargs` by default, but drops it when the user explicitly sets `env_args.model`.
> 
> **Environment construction avoids `model` kwarg collisions.** `run_evaluation()` detects whether `load_environment()` can accept `model` and, when appropriate, passes the injected `model` via `env_args` while keeping it out of `set_kwargs`.
> 
> Docs add a short *Model precedence* section, and new unit tests assert that (1) resolved `-m` lands in `extra_env_kwargs`, and (2) `env_args.model` overrides only the environment view, not the inference client model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf5f00ad6ccace320316b2e408747b23bd8b7440. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Let `env_args.model` override `--model` for the environment in `vf-eval`
> - By default, `build_eval_config` now sets `extra_env_kwargs['model']` to the resolved client model so environments receive the inference model without extra flags.
> - If `--env-args model=<value>` is provided, that value is used as the environment's model instead, while the inference client continues using `--model`.
> - `run_evaluation` uses a new `_load_environment_accepts_arg` helper to introspect whether `load_environment` accepts a `model` kwarg before passing it, avoiding errors on environments that don't support it.
> - Behavioral Change: environments that accept a `model` kwarg will now receive it automatically from the resolved `--model` value unless overridden via `--env-args`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cf5f00a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->