### PR TITLE
Preserve standard rollout fields with state columns

### DIFF
--- a/tests/test_save_utils.py
+++ b/tests/test_save_utils.py
@@ -234,6 +234,22 @@ class TestSavingResults:
             "final_output_tokens": 5,
         }
 
+    def test_state_columns_do_not_overwrite_standard_output_fields(self, make_state):
+        state = make_state()
+        tracker = StateUsageTracker()
+        tracker.increment(input_tokens=3, output_tokens=4)
+        state["usage_tracker"] = tracker
+        state["usage"] = tracker.usage
+        state["trajectory"] = [{"step": 1}]
+
+        output = states_to_outputs(
+            [state], state_columns=["token_usage", "trajectory"]
+        )[0]
+
+        assert output["token_usage"]["input_tokens"] == 3.0
+        assert output["token_usage"]["output_tokens"] == 4.0
+        assert output["trajectory"] == [{"step": 1}]
+
     def test_states_to_outputs(self, make_state):
         states = [
             make_state(

--- a/verifiers/utils/save_utils.py
+++ b/verifiers/utils/save_utils.py
@@ -282,6 +282,8 @@ def state_to_output(
         output[k] = v
     # add state columns (must be serializable)
     for col in state_columns or []:
+        if col in output:
+            continue
         value = state.get(col)
         if col == "trajectory":
             # Renderer multimodal rollouts accumulate mm_data on every step


### PR DESCRIPTION
Avoid letting requested state columns overwrite already-serialized rollout fields such as token_usage while still allowing trajectory and custom state columns to be emitted.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small serialization guard plus a regression test; behavior only changes when a requested `state_columns` key collides with an existing standard output field.
> 
> **Overview**
> **Preserves standard rollout fields during output serialization.** `state_to_output` now skips any requested `state_columns` that would overwrite already-populated output keys (e.g., `token_usage`), instead leaving the standard serialized value intact.
> 
> Adds a regression test ensuring colliding columns like `token_usage` don’t replace computed usage, while non-colliding columns like `trajectory` are still included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b65e76c63eba01fdb0d98cf30ace9c2fc1831fc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `state_to_output` to preserve standard rollout fields when state columns overlap
> In [`save_utils.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1418/files#diff-e4491159a12a733bc8861a33ba9d2d09b27942f04c4baa1629f0806efa07547d), `state_to_output` previously overwrote already-populated output fields (e.g. `token_usage`, `answer`, `metrics`) when copying requested `state_columns`. A guard now skips any state column whose key already exists in the output, so standard fields computed before the loop are preserved. A new test in [`test_save_utils.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1418/files#diff-86cf3715cfa10e218bd9afed4a21aff00dc6b1f54368944c73eeac3c4782086f) covers the collision case with `token_usage` and `trajectory`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b65e76c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->