### PR TITLE
Revert "[Router Replay]: Improve performance by removing Pydantic validation"

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -181,14 +181,6 @@ class TrajectoryStep(TypedDict):
 
 A single turn in a multi-turn rollout.
 
-### RoutedExpertsPayload
-
-```python
-class RoutedExpertsPayload(TypedDict):
-    data: Any  # actually memoryview; kept opaque so Pydantic skips schema validation
-    shape: list[int]
-```
-
 ### TrajectoryStepTokens
 
 ```python
@@ -200,7 +192,7 @@ class TrajectoryStepTokens(TypedDict):
     completion_logprobs: list[float]
     overlong_prompt: bool
     is_truncated: bool
-    routed_experts: RoutedExpertsPayload | None
+    routed_experts: list[list[list[int]]] | None  # [seq_len, layers, topk] to enable router replay
     multi_modal_data: NotRequired[Any]  # renderers.MultiModalData sidecar (pixel_values, placeholder ranges) — set only on multimodal rollouts
 ```
 

--- a/tests/test_client_auth_errors.py
+++ b/tests/test_client_auth_errors.py
@@ -130,9 +130,6 @@ class _OverlongOpenAIChatClient:
     def __init__(self, message: str) -> None:
         self.chat = self._Chat(message)
 
-    async def post(self, *args, **kwargs):  # noqa: ANN002, ANN003
-        return await self.chat.completions.create(*args, **kwargs)
-
 
 @pytest.mark.parametrize(
     "error_message",

--- a/tests/test_openai_chat_completions_token_client.py
+++ b/tests/test_openai_chat_completions_token_client.py
@@ -1,6 +1,5 @@
 from typing import Any, cast
 
-import httpx
 import pytest
 
 from verifiers.clients.openai_chat_completions_client import OpenAIChatCompletionsClient
@@ -25,25 +24,7 @@ class _RecordingClient(_NoopClient):
         self, path: str, body: dict[str, Any], cast_to: type, **kwargs: Any
     ) -> Any:
         self.calls.append({"path": path, "body": body, "cast_to": cast_to})
-        return httpx.Response(
-            200,
-            json={
-                "id": path,
-                "object": "chat.completion",
-                "created": 1,
-                "model": body["model"],
-                "choices": [
-                    {
-                        "index": 0,
-                        "message": {"role": "assistant", "content": "ok"},
-                        "finish_reason": "stop",
-                    }
-                ],
-                "ok": True,
-                "path": path,
-                "body": body,
-            },
-        )
+        return {"ok": True, "path": path, "body": body}
 
 
 class _PromptIdTestClient(OpenAIChatCompletionsTokenClient):
@@ -289,7 +270,7 @@ async def test_get_native_response_uses_token_route_when_prompt_ids_available(
         state=state,
     )
 
-    assert response.model_extra["ok"] is True
+    assert response["ok"] is True
     assert len(recording_client.calls) == 1
     assert recording_client.calls[0]["path"] == "/chat/completions/tokens"
     assert recording_client.calls[0]["body"]["tokens"] == [10, 20]

--- a/verifiers/clients/openai_chat_completions_client.py
+++ b/verifiers/clients/openai_chat_completions_client.py
@@ -56,10 +56,8 @@ from verifiers.types import (
     Usage,
     UserMessage,
 )
-from verifiers.utils.client_utils import (
-    post_chat_completion_with_routed_experts_sidecar,
-    setup_openai_client,
-)
+from verifiers.utils.client_utils import setup_openai_client
+from verifiers.utils.response_utils import parse_routed_experts
 
 
 def handle_openai_overlong_prompt(func):
@@ -302,24 +300,23 @@ class OpenAIChatCompletionsClient(
             sampling_args = {**sampling_args, "modalities": ["text"]}
 
         extra_headers = kwargs.pop("extra_headers", None)
-        request_args = normalize_sampling_args(sampling_args)
-        extra_body = request_args.pop("extra_body", {})
 
-        body: dict[str, Any] = {
-            "model": model,
-            "messages": prompt,
-            **request_args,
-            **extra_body,
-        }
         if tools:
-            body["tools"] = tools
-
-        return await post_chat_completion_with_routed_experts_sidecar(
-            self.client,
-            "/chat/completions",
-            body=body,
-            extra_headers=extra_headers,
-        )
+            response = await self.client.chat.completions.create(
+                model=model,
+                messages=prompt,
+                tools=tools,
+                extra_headers=extra_headers,
+                **normalize_sampling_args(sampling_args),
+            )
+        else:
+            response = await self.client.chat.completions.create(
+                model=model,
+                messages=prompt,
+                extra_headers=extra_headers,
+                **normalize_sampling_args(sampling_args),
+            )
+        return response
 
     async def raise_from_native_response(self, response: OpenAIChatResponse) -> None:
         if response is None:
@@ -486,13 +483,14 @@ class OpenAIChatCompletionsClient(
                 completion_logprobs = [token["logprob"] for token in logprobs_content]
 
             choice_extra = choice.model_extra or {}
+            routed_experts = parse_routed_experts(choice_extra.get("routed_experts"))
             return ResponseTokens(
                 prompt_ids=prompt_ids,
                 prompt_mask=prompt_mask,
                 completion_ids=completion_ids,
                 completion_mask=completion_mask,
                 completion_logprobs=completion_logprobs,
-                routed_experts=choice_extra.get("routed_experts"),
+                routed_experts=routed_experts,
             )
 
         def parse_reasoning_content_from_response(

--- a/verifiers/clients/openai_chat_completions_token_client.py
+++ b/verifiers/clients/openai_chat_completions_token_client.py
@@ -3,6 +3,7 @@ from typing import Any, Optional, cast
 
 from openai import AsyncOpenAI, BaseModel
 from openai.types.chat import (
+    ChatCompletion,
     ChatCompletionAssistantMessageParam,
 )
 from openai.types.chat.chat_completion_message_function_tool_call_param import (
@@ -19,9 +20,6 @@ from verifiers.clients.openai_chat_completions_client import (
     handle_openai_overlong_prompt,
 )
 from verifiers.types import SamplingArgs, State
-from verifiers.utils.client_utils import (
-    post_chat_completion_with_routed_experts_sidecar,
-)
 
 
 def _has_multimodal_content(messages) -> bool:
@@ -142,20 +140,20 @@ class OpenAIChatCompletionsTokenClient(OpenAIChatCompletionsClient):
             )
 
         extra_body = sampling_args.pop("extra_body", {})
-        body = {
-            "model": model,
-            "messages": prompt,
-            "tools": tools,
-            "tokens": prompt_ids,
+        body = dict(
+            model=model,
+            messages=prompt,
+            tools=tools,
+            tokens=prompt_ids,
             **sampling_args,
             **extra_body,
-        }
+        )
 
-        return await post_chat_completion_with_routed_experts_sidecar(
-            self.client,
+        return await self.client.post(
             "/chat/completions/tokens",
             body=body,
-            extra_headers=extra_headers,
+            cast_to=ChatCompletion,
+            options={"headers": extra_headers} if extra_headers else {},
         )
 
     async def get_prompt_ids(

--- a/verifiers/clients/openai_completions_client.py
+++ b/verifiers/clients/openai_completions_client.py
@@ -25,6 +25,7 @@ from verifiers.types import (
     Usage,
 )
 from verifiers.utils.client_utils import setup_openai_client
+from verifiers.utils.response_utils import parse_routed_experts
 
 OpenAITextMessages = str
 OpenAITextResponse = Completion
@@ -169,12 +170,15 @@ class OpenAICompletionsClient(
             )
             if completion_logprobs is None:
                 return None
+            choice_extra = response.choices[0].model_extra or {}
+            routed_experts = parse_routed_experts(choice_extra.get("routed_experts"))
             return ResponseTokens(
                 prompt_ids=prompt_ids,
                 prompt_mask=prompt_mask,
                 completion_ids=completion_ids,
                 completion_mask=completion_mask,
                 completion_logprobs=completion_logprobs,
+                routed_experts=routed_experts,
             )
 
         return Response(

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -183,19 +183,13 @@ class Usage(CustomBaseModel):
     total_tokens: int
 
 
-class RoutedExpertsPayload(TypedDict):
-    # Keep the raw response sidecar opaque so Pydantic does not validate memoryview.
-    data: Any
-    shape: list[int]
-
-
 class ResponseTokens(CustomBaseModel):
     prompt_ids: list[int]
     prompt_mask: list[int]
     completion_ids: list[int]
     completion_mask: list[int]
     completion_logprobs: list[float]
-    routed_experts: RoutedExpertsPayload | None = None
+    routed_experts: str | None = None  # base64 NumPy [seq_len, layers, topk]
     # Renderer-emitted multimodal sidecar (renderers.base.MultiModalData)
     # carrying processed pixel_values / placeholder ranges per modality.
     # Populated by the renderer client when the rollout went through a
@@ -238,7 +232,7 @@ class TrajectoryStepTokens(TypedDict):
     completion_logprobs: list[float]
     overlong_prompt: bool
     is_truncated: bool
-    routed_experts: RoutedExpertsPayload | None
+    routed_experts: str | None  # base64 NumPy [seq_len, layers, topk]
     # Renderer-emitted multimodal sidecar (renderers.base.MultiModalData)
     # carrying processed pixel_values / placeholder ranges per modality.
     # ``NotRequired`` because text-only rollouts (and non-renderer client

--- a/verifiers/utils/client_utils.py
+++ b/verifiers/utils/client_utils.py
@@ -1,20 +1,16 @@
 import json
 import logging
 import os
-from collections.abc import Mapping
-from typing import Any
 from pathlib import Path
 
 import httpx
 from anthropic import AsyncAnthropic
 from openai import AsyncOpenAI
-from openai.types.chat import ChatCompletion
 
 from verifiers.types import (
     ClientConfig,
     EndpointClientConfig,
 )
-from verifiers.utils.response_utils import strip_routed_experts_data
 
 logger = logging.getLogger(__name__)
 
@@ -99,32 +95,6 @@ def setup_http_client(config: ClientConfig) -> httpx.AsyncClient:
     resolved_config = resolve_client_config(config)
     headers, _ = _build_headers_and_api_key(resolved_config)
     return _build_http_client(resolved_config, headers)
-
-
-def parse_chat_completion_with_routed_experts_sidecar(raw: bytes) -> ChatCompletion:
-    stripped, routed_data = strip_routed_experts_data(raw)
-    response = ChatCompletion.model_validate_json(stripped)
-    if routed_data is not None:
-        choice_extra = response.choices[0].model_extra
-        assert choice_extra is not None
-        choice_extra["routed_experts"]["data"] = routed_data
-    return response
-
-
-async def post_chat_completion_with_routed_experts_sidecar(
-    client: AsyncOpenAI,
-    path: str,
-    *,
-    body: dict[str, Any],
-    extra_headers: Mapping[str, str] | None = None,
-) -> ChatCompletion:
-    raw_response = await client.post(
-        path,
-        body=body,
-        cast_to=httpx.Response,
-        options={"headers": extra_headers} if extra_headers else {},
-    )
-    return parse_chat_completion_with_routed_experts_sidecar(raw_response.content)
 
 
 def _setup_openai_client_from_resolved(config: ClientConfig) -> AsyncOpenAI:

--- a/verifiers/utils/response_utils.py
+++ b/verifiers/utils/response_utils.py
@@ -1,3 +1,9 @@
+import base64
+from io import BytesIO
+from typing import Any, cast
+
+import numpy as np
+
 from verifiers.types import (
     AssistantMessage,
     Messages,
@@ -5,19 +11,24 @@ from verifiers.types import (
     TrajectoryStepTokens,
 )
 
-ROUTED_EXPERTS_DATA_PREFIX = b'"routed_experts":{"data":"'
+
+def parse_routed_experts(raw: Any) -> str | None:
+    if raw is None:
+        return None
+    return cast(str, raw)
 
 
-def strip_routed_experts_data(raw: bytes) -> tuple[bytes, memoryview | None]:
-    data_start = raw.find(ROUTED_EXPERTS_DATA_PREFIX)
-    if data_start < 0:
-        return raw, None
+def truncate_routed_experts(routed_experts: str | None, seq_len: int) -> str | None:
+    if routed_experts is None:
+        return None
 
-    data_start += len(ROUTED_EXPERTS_DATA_PREFIX)
-    data_end = raw.index(b'"', data_start)
-    routed_data = memoryview(raw)[data_start:data_end]
-    stripped = raw[:data_start] + raw[data_end:]
-    return stripped, routed_data
+    array = np.load(BytesIO(base64.b64decode(routed_experts)), allow_pickle=False)
+    assert array.ndim == 3
+    assert 0 <= seq_len <= array.shape[0]
+
+    buffer = BytesIO()
+    np.save(buffer, np.ascontiguousarray(array[:seq_len]), allow_pickle=False)
+    return base64.b64encode(buffer.getvalue()).decode("ascii")
 
 
 async def parse_response_message(response: Response) -> Messages:
@@ -62,11 +73,15 @@ async def parse_response_tokens(
             completion_ids = []
             completion_mask = []
             completion_logprobs = []
+            routed_experts = truncate_routed_experts(routed_experts, len(prompt_ids))
         elif prompt_len + completion_len > max_seq_len:
             is_truncated = True
             completion_ids = tokens.completion_ids[: max_seq_len - prompt_len]
             completion_mask = tokens.completion_mask[: max_seq_len - prompt_len]
             completion_logprobs = tokens.completion_logprobs[: max_seq_len - prompt_len]
+            routed_experts = truncate_routed_experts(
+                routed_experts, prompt_len + len(completion_ids)
+            )
         else:
             is_truncated = False
     else:
@@ -89,6 +104,4 @@ async def parse_response_tokens(
         # step. Leaving it on ``response.message.tokens`` too means every
         # downstream pass (msgpack, save) has to dedupe the duplicate.
         tokens.multi_modal_data = None
-    if routed_experts is not None:
-        tokens.routed_experts = None
     return out


### PR DESCRIPTION
Reverts PrimeIntellect-ai/verifiers#1394

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core OpenAI client request/response handling and changes the `routed_experts` token sidecar representation, which can affect router-replay data and truncation behavior across training pipelines.
> 
> **Overview**
> Reverts the previous “opaque sidecar” approach for `routed_experts` by removing the custom `post_chat_completion_with_routed_experts_sidecar` plumbing and switching OpenAI chat completions back to direct `client.chat.completions.create(...)` calls.
> 
> Updates token schemas and parsing so `routed_experts` is treated as a base64-encoded NumPy blob (`str | None`) across `ResponseTokens`/`TrajectoryStepTokens`, adds truncation support for this blob when enforcing `max_seq_len`, and adjusts token-route client/tests to use the OpenAI SDK’s `cast_to=ChatCompletion` path with simpler mock responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a046c6df1aed296daca2e054fcb997e49086646. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Revert removal of Pydantic validation in Router Replay by restoring base64-encoded routed_experts handling
> - Reverts a prior refactor that removed Pydantic validation; `routed_experts` on `ResponseTokens` and `TrajectoryStepTokens` is now a base64-encoded NumPy string (`str | None`) instead of a `RoutedExpertsPayload` TypedDict.
> - Removes `post_chat_completion_with_routed_experts_sidecar` and related helpers from [`client_utils.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1422/files#diff-115f7c6465eb15fbfda8768948af933ae7033df60ce7bc69865346c3e88894a0); `get_native_response` in both chat completions clients now calls the OpenAI client directly.
> - Adds NumPy/base64 encode and parse utilities in [`response_utils.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1422/files#diff-792a30a7d072bc4ee79e8359e4f3019c438b479fc05325a1af4f11aef53ce920) and truncates `routed_experts` alongside prompt/completion tokens when `max_seq_len` is applied.
> - `RoutedExpertsPayload` TypedDict is removed from [`verifiers/types.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1422/files#diff-8bc45ba080ed8ff01ee6adbafb54c0346181c6f292928e53c2a94dd9ed5156c3).
> - Behavioral Change: callers that previously read `routed_experts` as a structured dict with `data`/`shape` keys must now decode a base64 NumPy string.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 5a046c6. 6 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->