### PR TITLE
Add V1 harness type aliases

### DIFF
--- a/assets/lab/environments/AGENTS.md
+++ b/assets/lab/environments/AGENTS.md
@@ -711,6 +711,9 @@ by the framework; do not accept `None` or write `config = config or MyEnvConfig(
 `EnvConfig` is a lightweight envelope for the two child configs. Put environment
 knobs on `TasksetConfig` or `HarnessConfig`, not on `EnvConfig` itself.
 Environment packages should not subclass `Env`.
+Reusable taskset environments can type `harness` as `vf.HarnessConfig`; TOML can
+then select a registered harness with names like `type = "terminus2"` or
+`type = "pi"` inside the harness table.
 
 The taskset-only shape is:
 

--- a/docs/byo-harness.md
+++ b/docs/byo-harness.md
@@ -541,6 +541,12 @@ For environment-specific settings, define leaf fields on the taskset or harness
 config that owns them. An `EnvConfig` subclass only fixes the concrete taskset
 and harness config types for the loader.
 
+Reusable taskset environments can keep `harness` typed as `vf.HarnessConfig`.
+Then TOML may select a registered harness config with `type`, for example
+`type = "terminus2"` or `type = "pi"`, and pass that config's ordinary fields
+beside it. Use `harness = "pi"` when the selected harness needs no field
+overrides.
+
 ```python
 class MyTasksetConfig(vf.TasksetConfig):
     split: str = "train"

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -704,6 +704,9 @@ by the framework; do not accept `None` or write `config = config or MyEnvConfig(
 `EnvConfig` is a lightweight envelope for the two child configs. Put environment
 knobs on `TasksetConfig` or `HarnessConfig`, not on `EnvConfig` itself.
 Environment packages should not subclass `Env`.
+Reusable taskset environments can type `harness` as `vf.HarnessConfig`; TOML can
+then select a registered harness with names like `type = "terminus2"` or
+`type = "pi"` inside the harness table.
 
 The taskset-only shape is:
 

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -375,12 +375,33 @@ optional:
 | `name` | string | Optional eval label for display and saved result paths |
 | `args` | table | Arguments passed to `load_environment()` |
 | `taskset` | table | v1 taskset config passed through `EnvConfig.taskset` |
-| `harness` | table | v1 harness config passed through `EnvConfig.harness` |
+| `harness` | table | v1 harness config passed through `EnvConfig.harness`; set `type` to choose a registered harness config |
 | `num_examples` | integer | Number of dataset examples to evaluate |
 | `rollouts_per_example` | integer | Rollouts per example |
 | `extra_env_kwargs` | table | Arguments passed to environment constructor |
 | `model` | string | Model to evaluate |
 | `endpoint_id` | string | Endpoint registry id (requires TOML `endpoints_path`) |
+
+Use `harness.type` to choose a registered v1 harness config for reusable taskset
+environments. Bundled names include `opencode`, `mini-swe-agent`, `pi`, `rlm`,
+and `terminus2`:
+
+```toml
+[[eval]]
+id = "openthoughts-tblite"
+
+[eval.harness]
+type = "terminus2"
+max_turns = 4
+```
+
+If no harness fields need overrides, the shorthand is:
+
+```toml
+[[eval]]
+id = "openthoughts-tblite"
+harness = "pi"
+```
 
 Use `name` to run the same environment more than once with different args:
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1007,6 +1007,11 @@ typed as a `HarnessConfig` subclass.
 Nested config defaults should be explicit config objects, e.g.
 `taskset: MyTasksetConfig = MyTasksetConfig()`.
 
+When `harness` is typed as `HarnessConfig`, TOML can select a registered
+harness config with `type`, such as `type = "terminus2"` or `type = "pi"`, then
+pass the normal fields for that config in the same table. The shorthand form
+`harness = "pi"` is also accepted when no fields need to be overridden.
+
 `Config` subclasses are strict Pydantic config models. Validate raw mappings
 with `MyConfig.model_validate(...)` or use the typed object directly.
 

--- a/environments/AGENTS.md
+++ b/environments/AGENTS.md
@@ -710,6 +710,9 @@ by the framework; do not accept `None` or write `config = config or MyEnvConfig(
 `EnvConfig` is a lightweight envelope for the two child configs. Put environment
 knobs on `TasksetConfig` or `HarnessConfig`, not on `EnvConfig` itself.
 Environment packages should not subclass `Env`.
+Reusable taskset environments can type `harness` as `vf.HarnessConfig`; TOML can
+then select a registered harness with names like `type = "terminus2"` or
+`type = "pi"` inside the harness table.
 
 The taskset-only shape is:
 

--- a/skills/create-environments/SKILL.md
+++ b/skills/create-environments/SKILL.md
@@ -73,7 +73,8 @@ split = "train"
 [env.harness]
 max_turns = 8
 ```
-6. In code, use the current class-based config shape:
+6. For reusable taskset environments that should compose with packaged harnesses, type the env field as `harness: vf.HarnessConfig = vf.OpenCodeConfig()`; TOML can then select a registered harness with `harness = "pi"` or `[env.harness] type = "terminus2"`.
+7. In code, use the current class-based config shape:
 ```python
 import verifiers as vf
 
@@ -117,7 +118,7 @@ def load_environment(config: MyEnvConfig) -> vf.Env:
         harness=vf.Harness(config=config.harness),
     )
 ```
-7. Do not add root env config knobs. Put settings as leaf fields on the taskset or harness config that owns them.
+8. Do not add root env config knobs. Put settings as leaf fields on the taskset or harness config that owns them.
 
 ### 2. Port From Another Library, Project, or Paper
 1. Create a strict source-to-target mapping before coding:

--- a/skills/evaluate-environments/SKILL.md
+++ b/skills/evaluate-environments/SKILL.md
@@ -104,31 +104,32 @@ prime eval run configs/eval/my-benchmark.toml
 ```bash
 prime eval run my-env -a '{"config":{"taskset":{"difficulty":"hard"},"harness":{"max_turns":20}}}'
 ```
-2. Override legacy/v0 constructor kwargs only when the environment still exposes them; for v1, use `config.taskset` and `config.harness` instead:
+2. For reusable v1 taskset environments whose `EnvConfig.harness` is typed as `vf.HarnessConfig`, select a registered harness in TOML with `harness = "pi"` or with `[eval.harness] type = "terminus2"` plus that harness config's fields.
+3. Override legacy/v0 constructor kwargs only when the environment still exposes them; for v1, use `config.taskset` and `config.harness` instead:
 ```bash
 prime eval run my-env -x '{"max_turns":20}'
 ```
-3. Bound per-rollout wall-clock time (use the dedicated `--timeout` flag; wins over `-x` and TOML `[eval.extra_env_kwargs]`):
+4. Bound per-rollout wall-clock time (use the dedicated `--timeout` flag; wins over `-x` and TOML `[eval.extra_env_kwargs]`):
 ```bash
 prime eval run my-env --timeout 600
 ```
-4. Save extra state columns:
+5. Save extra state columns:
 ```bash
 prime eval run my-env -s -C "judge_response,parsed_answer"
 ```
-5. Resume interrupted runs:
+6. Resume interrupted runs:
 ```bash
 prime eval run my-env -n 1000 -s --resume
 ```
-6. Save results to a custom output directory:
+7. Save results to a custom output directory:
 ```bash
 prime eval run my-env -s -o /path/to/output
 ```
-7. Run multi-environment TOML suites:
+8. Run multi-environment TOML suites:
 ```bash
 prime eval run configs/eval/my-benchmark.toml
 ```
-8. Run the same environment more than once with different args by giving each entry a `name`:
+9. Run the same environment more than once with different args by giving each entry a `name`:
 ```toml
 [[eval]]
 id = "reverse-text"
@@ -144,18 +145,18 @@ name = "reverse-text-long"
 [eval.args]
 max_length = 256
 ```
-9. Pass extra HTTP headers via CLI (repeatable):
+10. Pass extra HTTP headers via CLI (repeatable):
 ```bash
 prime eval run my-env -m my-proxy --header "X-Custom-Header: value"
 ```
-10. Set headers in `[[eval]]` TOML configs as a table or list (merge order: registry row < `headers` table < `header` list / `--header`):
+11. Set headers in `[[eval]]` TOML configs as a table or list (merge order: registry row < `headers` table < `header` list / `--header`):
 ```toml
 [[eval]]
 env_id = "my-env"
 headers = { "X-Custom-Header" = "value" }
 header = ["X-Another: val"]
 ```
-11. Run ablation sweeps using `[[ablation]]` blocks in TOML configs:
+12. Run ablation sweeps using `[[ablation]]` blocks in TOML configs:
 ```toml
 [[ablation]]
 env_id = "my-env"

--- a/tests/test_eval_cli.py
+++ b/tests/test_eval_cli.py
@@ -778,6 +778,16 @@ def test_load_toml_config_with_args_taskset_harness():
     assert "harness" not in result[0]
 
 
+def test_load_toml_config_with_harness_name():
+    """harness may be a registered v1 harness name."""
+    with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
+        f.write('[[eval]]\nenv_id = "env1"\nharness = "pi"\n')
+        f.flush()
+        result = load_toml_config(Path(f.name))
+
+    assert result[0]["env_args"] == {"config": {"harness": "pi"}}
+
+
 def test_load_toml_config_missing_env_section():
     """TOML without [[eval]] section raises ValueError."""
     with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:

--- a/tests/test_v1_config_extension.py
+++ b/tests/test_v1_config_extension.py
@@ -1564,6 +1564,91 @@ def test_env_config_convenience_uses_bound_child_configs() -> None:
     assert env.harness.config.mode == "mapping"
 
 
+@pytest.mark.parametrize(
+    ("alias", "config_cls", "harness_cls"),
+    [
+        ("opencode", vf.OpenCodeConfig, vf.OpenCode),
+        ("open-code", vf.OpenCodeConfig, vf.OpenCode),
+        ("mini-swe-agent", vf.MiniSWEAgentConfig, vf.MiniSWEAgent),
+        ("pi", vf.PiConfig, vf.Pi),
+        ("rlm", vf.RLMConfig, vf.RLM),
+        ("terminus2", vf.Terminus2Config, vf.Terminus2),
+        ("terminus-2", vf.Terminus2Config, vf.Terminus2),
+    ],
+)
+def test_env_config_harness_type_selects_packaged_harness_config(
+    alias, config_cls, harness_cls
+) -> None:
+    class GenericEnvConfig(EnvConfig):
+        taskset: TasksetConfig = TasksetConfig(source=[])
+        harness: HarnessConfig = vf.OpenCodeConfig()
+
+    config = coerce_config(
+        GenericEnvConfig,
+        {"harness": {"type": alias, "max_turns": 4}},
+    )
+    env = Env(config=config)
+
+    assert isinstance(config.harness, config_cls)
+    assert config.harness.max_turns == 4
+    assert isinstance(env.harness, harness_cls)
+
+
+def test_env_config_harness_name_selects_packaged_harness_config() -> None:
+    class GenericEnvConfig(EnvConfig):
+        taskset: TasksetConfig = TasksetConfig(source=[])
+        harness: HarnessConfig = vf.OpenCodeConfig()
+
+    config = coerce_config(GenericEnvConfig, {"harness": "pi"})
+    env = Env(config=config)
+
+    assert isinstance(config.harness, vf.PiConfig)
+    assert isinstance(env.harness, vf.Pi)
+
+
+def test_env_config_harness_type_uses_registered_owner_aliases() -> None:
+    class AliasHarnessConfig(HarnessConfig):
+        mode: str = "default"
+
+    class AliasHarness(Harness[AliasHarnessConfig]):
+        pass
+
+    class GenericEnvConfig(EnvConfig):
+        taskset: TasksetConfig = TasksetConfig(source=[])
+        harness: HarnessConfig = HarnessConfig()
+
+    config = coerce_config(
+        GenericEnvConfig,
+        {"harness": {"type": "alias-harness", "mode": "selected"}},
+    )
+    env = Env(config=config)
+
+    assert isinstance(config.harness, AliasHarnessConfig)
+    assert config.harness.mode == "selected"
+    assert isinstance(env.harness, AliasHarness)
+
+
+def test_env_config_harness_type_requires_string() -> None:
+    class GenericEnvConfig(EnvConfig):
+        taskset: TasksetConfig = TasksetConfig(source=[])
+        harness: HarnessConfig = HarnessConfig()
+
+    with pytest.raises(
+        ValidationError, match="EnvConfig.harness.type must be a string"
+    ):
+        coerce_config(GenericEnvConfig, {"harness": {"type": 123}})
+
+
+def test_harness_config_aliases_reject_collisions() -> None:
+    class CollisionHarnessConfig(HarnessConfig):
+        pass
+
+    with pytest.raises(TypeError, match="already resolves"):
+
+        class CollisionHarness(Harness[CollisionHarnessConfig]):
+            _config_aliases = ("pi",)
+
+
 def test_env_config_convenience_accepts_base_taskset_config() -> None:
     env = Env(config=EnvConfig(taskset=TasksetConfig(source=[])))
 

--- a/tests/test_v1_harbor_cli.py
+++ b/tests/test_v1_harbor_cli.py
@@ -2,6 +2,7 @@ import importlib
 import json
 import sys
 import types
+from collections.abc import Callable
 from pathlib import Path
 from types import ModuleType
 from typing import cast
@@ -11,12 +12,12 @@ import pytest
 
 import verifiers as root_vf
 import verifiers.v1 as vf
-from verifiers.v1.packages.harnesses.pi import pi_mcp_json, pi_models_json
 from verifiers.v1.packages.harnesses.configs import (
     TERMINUS_2_DEFAULT_API_BASE_URL,
     TERMINUS_2_DEFAULT_HARBOR_PACKAGE,
     TERMINUS_2_DEFAULT_MODEL_NAME,
 )
+from verifiers.v1.packages.harnesses.pi import pi_mcp_json, pi_models_json
 from verifiers.v1.packages.harnesses.terminus_2 import (
     Terminus2,
     terminus_2_agent_script,
@@ -243,7 +244,10 @@ def test_opencode_config_owns_opencode_harness_fields() -> None:
     assert "apt-get -o Acquire::Retries=3 update" in setup
     assert "apt-get -o Acquire::Retries=3 install" in setup
     assert "/workspace" in cast(str, command[2])
+    assert 'if [[ -z "$OPENCODE_WORKDIR" ]]; then' in cast(str, command[2])
     assert '"webfetch": false' in cast(str, mcp_setup)
+    assert 'if [ -z "$OPENCODE_WORKDIR" ]; then' in cast(str, mcp_setup)
+    assert "[[" not in cast(str, mcp_setup)
     assert "/opencode/system.txt" not in cast(dict[str, object], program["files"])
 
 
@@ -285,20 +289,21 @@ def test_pi_harness_writes_intercepted_model_and_mcp_config() -> None:
     harness = vf.Pi()
     program = cast(dict[str, object], harness.program)
     setup = cast(str, program["setup"])
-    models = json.loads(
-        pi_models_json(
-            {
-                "base_url": "http://127.0.0.1:1/rollout/key/v1",
-                "api_key": "secret",
-                "api_client_type": "openai_chat_completions",
-                "model": "openai/gpt-5.4-mini",
-            }
-        )
-    )
+    channel_setup = cast(dict[str, object], program["channels"])["mcp"]
+    endpoint_config = {
+        "base_url": "http://127.0.0.1:1/rollout/key/v1",
+        "api_key": "secret",
+        "api_client_type": "openai_chat_completions",
+        "model": "openai/gpt-5.4-mini",
+    }
+    mcp_setup = cast(Callable[[dict[str, object]], str], channel_setup)(endpoint_config)
+    models = json.loads(pi_models_json(endpoint_config))
     mcp = json.loads(pi_mcp_json())
 
     assert "apt-get -o Acquire::Retries=3 update" in setup
     assert "apt-get -o Acquire::Retries=3 install" in setup
+    assert 'if [ -z "$PI_WORKDIR" ]; then' in mcp_setup
+    assert "[[" not in mcp_setup
     provider = models["providers"]["verifiers"]
     assert provider["baseUrl"] == "http://127.0.0.1:1/rollout/key/v1"
     assert provider["api"] == "openai-completions"

--- a/verifiers/utils/env_config_utils.py
+++ b/verifiers/utils/env_config_utils.py
@@ -27,7 +27,9 @@ def normalize_env_config_sections(raw: Mapping[str, object]) -> dict[str, object
     if taskset is not None:
         child_config["taskset"] = config_table(taskset, "taskset")
     if harness is not None:
-        child_config["harness"] = config_table(harness, "harness")
+        child_config["harness"] = (
+            harness if isinstance(harness, str) else config_table(harness, "harness")
+        )
 
     if child_config:
         existing_config = config_table(env_args.get("config", {}), "env_args.config")

--- a/verifiers/v1/ENVIRONMENT_BEST_PRACTICES.md
+++ b/verifiers/v1/ENVIRONMENT_BEST_PRACTICES.md
@@ -41,7 +41,9 @@ your loader runs. The type annotation is not cosmetic.
    `TasksetConfig` subclass. Otherwise those TOML fields are rejected before
    your loader can convert or forward them.
 3. If your environment has custom harness fields, the same rule applies to the
-   `harness` annotation.
+   `harness` annotation unless TOML selects a registered harness config with
+   `[env.harness] type = "terminus2"`, `[env.harness] type = "pi"`, or another
+   owner/config alias.
 4. The config object that reaches `load_environment` is already validated and
    typed. Do not reconstruct child config objects just to recover their type.
 5. `vf.Env(taskset=MyTaskset(config=config.taskset), harness=MyHarness(config=config.harness))`

--- a/verifiers/v1/README.md
+++ b/verifiers/v1/README.md
@@ -1241,6 +1241,12 @@ For environment-specific settings, define leaf fields on the taskset or harness
 config that owns them. An `EnvConfig` subclass only fixes the concrete taskset
 and harness config types for the loader.
 
+Reusable taskset environments can keep `harness` typed as `vf.HarnessConfig`.
+Then TOML may select a registered harness config with `type`, for example
+`type = "terminus2"` or `type = "pi"`, and pass that config's ordinary fields
+beside it. Use `harness = "pi"` when the selected harness needs no field
+overrides.
+
 ```python
 class MyTasksetConfig(vf.TasksetConfig):
     split: str = "train"

--- a/verifiers/v1/config.py
+++ b/verifiers/v1/config.py
@@ -1,3 +1,4 @@
+import importlib
 from collections.abc import Mapping
 from os import PathLike
 from typing import Literal, TypeAlias, cast
@@ -16,6 +17,7 @@ from .utils.config_callable_utils import (
 from .utils.config_utils import (
     annotation_text,
     coerce_config,
+    config_type_alias,
     default_text,
     explicit_config_data,
     import_config_ref as import_config_ref,
@@ -330,6 +332,22 @@ class EnvConfig(Config):
                 f"EnvConfig.{info.field_name} cannot be None. "
                 "Omit the section to use the default config."
             )
+        if (
+            info.field_name == "harness"
+            and cls.model_fields["harness"].annotation is HarnessConfig
+        ):
+            if isinstance(value, str):
+                importlib.import_module(".packages.harnesses", __package__)
+                return config_type_alias(value, HarnessConfig)()
+            if isinstance(value, Mapping) and "type" in value:
+                importlib.import_module(".packages.harnesses", __package__)
+                data = string_mapping(cast(ConfigInputMap, value))
+                harness_type = data.pop("type")
+                if not isinstance(harness_type, str):
+                    raise ValueError("EnvConfig.harness.type must be a string.")
+                return config_type_alias(harness_type, HarnessConfig).model_validate(
+                    data
+                )
         try:
             explicit_config_data(value)
         except TypeError as exc:

--- a/verifiers/v1/packages/harnesses/opencode.py
+++ b/verifiers/v1/packages/harnesses/opencode.py
@@ -218,7 +218,7 @@ set -e
 export PATH="$HOME/.opencode/bin:$PATH"
 
 OPENCODE_WORKDIR="${{AGENT_WORKDIR:-}}"
-if [[ -z "$OPENCODE_WORKDIR" ]]; then
+if [ -z "$OPENCODE_WORKDIR" ]; then
     OPENCODE_WORKDIR={shlex.quote(agent_workdir)}
 fi
 

--- a/verifiers/v1/packages/harnesses/pi.py
+++ b/verifiers/v1/packages/harnesses/pi.py
@@ -110,7 +110,7 @@ EOFMCP
 set -e
 
 PI_WORKDIR="${{AGENT_WORKDIR:-}}"
-if [[ -z "$PI_WORKDIR" ]]; then
+if [ -z "$PI_WORKDIR" ]; then
     PI_WORKDIR={shlex.quote(agent_workdir)}
 fi
 

--- a/verifiers/v1/utils/config_utils.py
+++ b/verifiers/v1/utils/config_utils.py
@@ -10,11 +10,13 @@ ConfigT = TypeVar("ConfigT", bound=BaseModel)
 ConfigOwnerT = TypeVar("ConfigOwnerT", bound="ConfigBound")
 
 _CONFIG_OWNERS: dict[tuple[type[BaseModel], type[BaseModel]], type["ConfigBound"]] = {}
+_CONFIG_TYPE_ALIASES: dict[tuple[type[BaseModel], str], type[BaseModel]] = {}
 
 
 class ConfigBound(Generic[ConfigT]):
     _config_base_cls: ClassVar[type[BaseModel]] = BaseModel
     _config_cls: ClassVar[type[BaseModel]] = BaseModel
+    _config_aliases: ClassVar[tuple[str, ...]] = ()
 
     def __init_subclass__(cls, **kwargs: object) -> None:
         super().__init_subclass__(**kwargs)
@@ -61,6 +63,20 @@ def register_config_owner(
             f"define a distinct config class for {owner_cls.__name__}."
         )
     _CONFIG_OWNERS[key] = owner_cls
+    for alias in (owner_cls.__name__, config_cls.__name__.removesuffix("Config")):
+        key = "".join(char for char in alias.lower() if char.isalnum())
+        _CONFIG_TYPE_ALIASES.setdefault((base_cls, key), config_cls)
+    for alias in (
+        *getattr(owner_cls, "_config_aliases", ()),
+        *getattr(config_cls, "_config_aliases", ()),
+    ):
+        key = "".join(char for char in alias.lower() if char.isalnum())
+        existing = _CONFIG_TYPE_ALIASES.get((base_cls, key))
+        if existing is not None and existing is not config_cls:
+            raise TypeError(
+                f"Config alias {alias!r} already resolves to {existing.__name__}."
+            )
+        _CONFIG_TYPE_ALIASES[(base_cls, key)] = config_cls
 
 
 def config_owner(
@@ -74,6 +90,17 @@ def config_owner(
         if owner is not None:
             return owner
     return None
+
+
+def config_type_alias(
+    alias: str,
+    base_cls: type[BaseModel],
+) -> type[BaseModel]:
+    key = (base_cls, "".join(char for char in alias.lower() if char.isalnum()))
+    config_cls = _CONFIG_TYPE_ALIASES.get(key)
+    if config_cls is None:
+        raise ValueError(f"Unknown config type {alias!r}.")
+    return config_cls
 
 
 def explicit_config_data(


### PR DESCRIPTION
## Summary
- add a first-class V1 harness type alias registry so generic `harness: vf.HarnessConfig` fields can resolve TOML aliases like `harness = "pi"` and `[eval.harness] type = "terminus2"`
- register aliases for existing packaged harness configs so reusable taskset environments can select OpenCode, mini-swe-agent, Pi, RLM, or Terminus 2 by name
- document the TOML forms and add regression coverage for eval config normalization, alias coercion, command harness construction, and generated environment guides

## Testing
- `uv run pytest tests/test_v1_config_extension.py tests/test_v1_harbor_cli.py tests/test_eval_cli.py -q`
- `uv run pre-commit run --all-files`
- `git diff --check`
- live 1x1 smoke: `harness = "pi"` with `prime eval run` completed with reward `1.0`
- live 1x1 smoke: `[eval.harness] type = "pi"` with `prime eval run` completed with reward `1.0`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new alias-based coercion paths for v1 harness config parsing from TOML/CLI, which can affect environment loading and validation behavior for existing configs. Also tweaks generated shell snippets for packaged harnesses, with low runtime risk but potential for regressions in command execution if misquoted.
> 
> **Overview**
> Enables **selecting packaged v1 harness configs by name** when an environment keeps `EnvConfig.harness: vf.HarnessConfig` generic, supporting both `harness = "pi"` and `[eval.harness] type = "terminus2"` style TOML.
> 
> Implements a first-class **config type-alias registry** (`config_type_alias`) and extends `EnvConfig` validation to resolve these aliases (including collision checks and type validation). Updates eval TOML normalization to pass string harness selections through, adds regression tests for alias selection, and adjusts OpenCode/Pi harness shell guards to be POSIX-compatible (`[ -z ... ]`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3f0633ea77380c469fa20dcdf001053890c558d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add V1 harness type alias resolution to `EnvConfig`
> - `EnvConfig.validate_child_config` now resolves `harness` from a bare alias string (e.g., `"pi"`) or a mapping with a `type` key (e.g., `{type = "terminus2"}`) when `harness` is annotated as the base `HarnessConfig`.
> - [config_utils.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1425/files#diff-e6ee788f8c7bfe0da672894145be52be8a4443eb77727f03f0ea707b630ea7c9) adds `_config_aliases`, a per-class alias registry, and a new `config_type_alias()` lookup function; alias collisions raise `TypeError` at registration time.
> - [env_config_utils.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1425/files#diff-27e6c943addb6bc8adf53b0671d0658ef6fca2096cd2464e81597d6b686203fd) is updated to pass a bare string `harness` value through to `env_args.config.harness` without table normalization, supporting TOML shorthand like `harness = "pi"`.
> - Shell setup scripts in the OpenCode and Pi harnesses are fixed to use POSIX-compatible `[ -z ]` instead of `[[ -z ]]`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b3f0633.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->