### PR TITLE
Serialize retryable rollout error policy

### DIFF
--- a/tests/test_error_chain.py
+++ b/tests/test_error_chain.py
@@ -4,9 +4,9 @@ import verifiers as vf
 from verifiers.utils.error_utils import (
     ErrorChain,
     error_info,
-    error_info_to_exception,
     get_vf_error_chain,
     is_retryable_error,
+    is_retryable_error_info,
 )
 
 
@@ -183,9 +183,7 @@ class TestErrorChain:
         assert info["is_retryable"] is False
         assert is_retryable_error(outer) is False
 
-    def test_error_info_to_exception_uses_retryable_flag_for_serialized_subclasses(
-        self,
-    ):
+    def test_is_retryable_error_info_uses_serialized_retryable_flag(self):
         """Serialized subclass names do not need to enumerate their base classes."""
         info = {
             "error": "SandboxError",
@@ -194,10 +192,20 @@ class TestErrorChain:
             "is_retryable": True,
         }
 
-        assert isinstance(
-            error_info_to_exception(
-                info,
-                (vf.InfraError, vf.InvalidModelResponseError),
-            ),
-            vf.InfraError,
+        assert is_retryable_error_info(
+            info,
+            (vf.InfraError, vf.InvalidModelResponseError),
+        )
+
+    def test_is_retryable_error_info_requires_flag_for_default_policy(self):
+        """Default serialized retryability comes from ErrorInfo, not class-name parsing."""
+        info = {
+            "error": "SandboxError",
+            "error_chain_repr": "SandboxError('sandbox unavailable')",
+            "error_chain_str": "SandboxError",
+        }
+
+        assert not is_retryable_error_info(
+            info,
+            (vf.InfraError, vf.InvalidModelResponseError),
         )

--- a/tests/test_error_chain.py
+++ b/tests/test_error_chain.py
@@ -1,13 +1,12 @@
 """Tests for verifiers.utils.error_utils.ErrorChain."""
 
 import verifiers as vf
+from verifiers.types import ErrorInfo
 from verifiers.utils.error_utils import (
     ErrorChain,
     error_info,
     get_vf_error_chain,
-    is_error_info,
     is_retryable_error,
-    is_retryable_error_info,
 )
 
 
@@ -184,40 +183,29 @@ class TestErrorChain:
         assert info["is_retryable"] is False
         assert is_retryable_error(outer) is False
 
-    def test_is_retryable_error_info_uses_serialized_retryable_flag(self):
+    def test_is_retryable_error_uses_serialized_retryable_flag(self):
         """Serialized subclass names do not need to enumerate their base classes."""
-        info = {
+        info: ErrorInfo = {
             "error": "SandboxError",
             "error_chain_repr": "SandboxError('sandbox unavailable')",
             "error_chain_str": "SandboxError",
             "is_retryable": True,
         }
 
-        assert is_retryable_error_info(
+        assert is_retryable_error(
             info,
             (vf.InfraError, vf.InvalidModelResponseError),
         )
 
-    def test_is_retryable_error_info_requires_flag_for_default_policy(self):
+    def test_is_retryable_error_requires_flag_for_serialized_errors(self):
         """Default serialized retryability comes from ErrorInfo, not class-name parsing."""
-        info = {
+        info: ErrorInfo = {
             "error": "SandboxError",
             "error_chain_repr": "SandboxError('sandbox unavailable')",
             "error_chain_str": "SandboxError",
         }
 
-        assert not is_retryable_error_info(
+        assert not is_retryable_error(
             info,
             (vf.InfraError, vf.InvalidModelResponseError),
         )
-
-    def test_is_error_info_requires_serialized_error_shape(self):
-        assert is_error_info(
-            {
-                "error": "SandboxError",
-                "error_chain_repr": "SandboxError('sandbox unavailable')",
-                "error_chain_str": "SandboxError",
-            }
-        )
-        assert not is_error_info(vf.SandboxError("live exception"))
-        assert not is_error_info({"error": "SandboxError"})

--- a/tests/test_error_chain.py
+++ b/tests/test_error_chain.py
@@ -1,7 +1,13 @@
 """Tests for verifiers.utils.error_utils.ErrorChain."""
 
 import verifiers as vf
-from verifiers.utils.error_utils import ErrorChain, get_vf_error_chain
+from verifiers.utils.error_utils import (
+    ErrorChain,
+    error_info,
+    error_info_to_exception,
+    get_vf_error_chain,
+    is_retryable_error,
+)
 
 
 class TestErrorChain:
@@ -147,3 +153,51 @@ class TestErrorChain:
         # error1 and error2 have same type, should be counted together
         assert counter[ErrorChain(ValueError("any"))] == 2
         assert counter[ErrorChain(TypeError("any"))] == 1
+
+    def test_error_info_marks_default_retryable_errors(self):
+        """Serialized errors carry verifiers' default retryability decision."""
+        retryable_errors = [
+            vf.InfraError("infra"),
+            vf.SandboxError("sandbox"),
+            vf.BrowserSandboxError("browser"),
+            vf.TunnelError("tunnel"),
+            vf.InvalidModelResponseError("invalid response"),
+            vf.EmptyModelResponseError("empty response"),
+        ]
+
+        for error in retryable_errors:
+            info = error_info(error)
+            assert info["is_retryable"] is True
+            assert is_retryable_error(error) is True
+
+    def test_error_info_marks_plain_model_errors_non_retryable(self):
+        """Plain model/provider errors are not retryable by default."""
+        outer = vf.ModelError()
+        outer.__cause__ = RuntimeError(
+            "No available workers (all circuits open or unhealthy)"
+        )
+
+        info = error_info(outer)
+
+        assert info["error_chain_str"] == "ModelError -> RuntimeError"
+        assert info["is_retryable"] is False
+        assert is_retryable_error(outer) is False
+
+    def test_error_info_to_exception_uses_retryable_flag_for_serialized_subclasses(
+        self,
+    ):
+        """Serialized subclass names do not need to enumerate their base classes."""
+        info = {
+            "error": "SandboxError",
+            "error_chain_repr": "SandboxError('sandbox unavailable')",
+            "error_chain_str": "SandboxError",
+            "is_retryable": True,
+        }
+
+        assert isinstance(
+            error_info_to_exception(
+                info,
+                (vf.InfraError, vf.InvalidModelResponseError),
+            ),
+            vf.InfraError,
+        )

--- a/tests/test_error_chain.py
+++ b/tests/test_error_chain.py
@@ -5,6 +5,7 @@ from verifiers.utils.error_utils import (
     ErrorChain,
     error_info,
     get_vf_error_chain,
+    is_error_info,
     is_retryable_error,
     is_retryable_error_info,
 )
@@ -209,3 +210,14 @@ class TestErrorChain:
             info,
             (vf.InfraError, vf.InvalidModelResponseError),
         )
+
+    def test_is_error_info_requires_serialized_error_shape(self):
+        assert is_error_info(
+            {
+                "error": "SandboxError",
+                "error_chain_repr": "SandboxError('sandbox unavailable')",
+                "error_chain_str": "SandboxError",
+            }
+        )
+        assert not is_error_info(vf.SandboxError("live exception"))
+        assert not is_error_info({"error": "SandboxError"})

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -365,6 +365,7 @@ class ErrorInfo(TypedDict):
     error: str
     error_chain_repr: str
     error_chain_str: str
+    is_retryable: NotRequired[bool]
 
 
 class RolloutOutput(dict):

--- a/verifiers/utils/async_utils.py
+++ b/verifiers/utils/async_utils.py
@@ -13,7 +13,6 @@ from pydantic import BaseModel
 
 import verifiers as vf
 from verifiers.utils.error_utils import ErrorChain
-from verifiers.utils.error_utils import is_error_info
 from verifiers.utils.error_utils import is_retryable_error_info
 from verifiers.utils.logging_utils import print_time
 
@@ -182,14 +181,14 @@ def maybe_retry(
             err = result.get("error")
             if err and any(isinstance(err, err_type) for err_type in error_types):
                 raise err
-            if is_error_info(err) and is_retryable_error_info(err, error_types):
+            if is_retryable_error_info(err, error_types):
                 raise retry_exception_from_error_info(err, error_types)
         elif isinstance(result, list):
             for state in result:
                 err = state.get("error")
                 if err and any(isinstance(err, err_type) for err_type in error_types):
                     raise err
-                if is_error_info(err) and is_retryable_error_info(err, error_types):
+                if is_retryable_error_info(err, error_types):
                     raise retry_exception_from_error_info(err, error_types)
 
     def log_retry(retry_state: tc.RetryCallState) -> None:

--- a/verifiers/utils/async_utils.py
+++ b/verifiers/utils/async_utils.py
@@ -176,41 +176,21 @@ def maybe_retry(
         detail = str(error.get("error_chain_repr") or error.get("error") or "")
         return error_types[0](detail)
 
+    def reraise_error(err: BaseException | ErrorInfo | None) -> None:
+        if isinstance(err, BaseException) and is_retryable_error(err, error_types):
+            raise err
+        if isinstance(err, Mapping):
+            error_info = cast(ErrorInfo, err)
+            if is_retryable_error(error_info, error_types):
+                raise retry_exception_from_error_info(error_info, error_types)
+
     def reraise_error_from_state(result, error_types: tuple[type[Exception], ...]):
         """Re-raise specified errors from state(s) to trigger tenacity retry."""
         if isinstance(result, dict):
-            err = result.get("error")
-            if isinstance(err, BaseException) and is_retryable_error(err, error_types):
-                raise err
-            if isinstance(err, Mapping):
-                serialized_error = cast(Mapping[str, str | bool], err)
-                if (
-                    isinstance(serialized_error.get("error"), str)
-                    and isinstance(serialized_error.get("error_chain_repr"), str)
-                    and isinstance(serialized_error.get("error_chain_str"), str)
-                ):
-                    error_info = cast(ErrorInfo, serialized_error)
-                    if is_retryable_error(error_info, error_types):
-                        raise retry_exception_from_error_info(error_info, error_types)
+            reraise_error(result.get("error"))
         elif isinstance(result, list):
             for state in result:
-                err = state.get("error")
-                if isinstance(err, BaseException) and is_retryable_error(
-                    err, error_types
-                ):
-                    raise err
-                if isinstance(err, Mapping):
-                    serialized_error = cast(Mapping[str, str | bool], err)
-                    if (
-                        isinstance(serialized_error.get("error"), str)
-                        and isinstance(serialized_error.get("error_chain_repr"), str)
-                        and isinstance(serialized_error.get("error_chain_str"), str)
-                    ):
-                        error_info = cast(ErrorInfo, serialized_error)
-                        if is_retryable_error(error_info, error_types):
-                            raise retry_exception_from_error_info(
-                                error_info, error_types
-                            )
+                reraise_error(state.get("error"))
 
     def log_retry(retry_state: tc.RetryCallState) -> None:
         """Log a warning with the exception and the number of attempts."""

--- a/verifiers/utils/async_utils.py
+++ b/verifiers/utils/async_utils.py
@@ -5,15 +5,16 @@ from collections import deque
 from collections.abc import Mapping
 from collections.abc import Coroutine
 from time import perf_counter
-from typing import Any, AsyncContextManager, Callable, Optional, TypeVar
+from typing import Any, AsyncContextManager, Callable, Optional, TypeVar, cast
 
 import numpy as np
 import tenacity as tc
 from pydantic import BaseModel
 
 import verifiers as vf
+from verifiers.types import ErrorInfo
 from verifiers.utils.error_utils import ErrorChain
-from verifiers.utils.error_utils import is_retryable_error_info
+from verifiers.utils.error_utils import is_retryable_error
 from verifiers.utils.logging_utils import print_time
 
 logger = logging.getLogger(__name__)
@@ -170,7 +171,7 @@ def maybe_retry(
         return func
 
     def retry_exception_from_error_info(
-        error: Mapping[str, object], error_types: tuple[type[Exception], ...]
+        error: ErrorInfo, error_types: tuple[type[Exception], ...]
     ) -> Exception:
         detail = str(error.get("error_chain_repr") or error.get("error") or "")
         return error_types[0](detail)
@@ -179,17 +180,37 @@ def maybe_retry(
         """Re-raise specified errors from state(s) to trigger tenacity retry."""
         if isinstance(result, dict):
             err = result.get("error")
-            if err and any(isinstance(err, err_type) for err_type in error_types):
+            if isinstance(err, BaseException) and is_retryable_error(err, error_types):
                 raise err
-            if is_retryable_error_info(err, error_types):
-                raise retry_exception_from_error_info(err, error_types)
+            if isinstance(err, Mapping):
+                serialized_error = cast(Mapping[str, str | bool], err)
+                if (
+                    isinstance(serialized_error.get("error"), str)
+                    and isinstance(serialized_error.get("error_chain_repr"), str)
+                    and isinstance(serialized_error.get("error_chain_str"), str)
+                ):
+                    error_info = cast(ErrorInfo, serialized_error)
+                    if is_retryable_error(error_info, error_types):
+                        raise retry_exception_from_error_info(error_info, error_types)
         elif isinstance(result, list):
             for state in result:
                 err = state.get("error")
-                if err and any(isinstance(err, err_type) for err_type in error_types):
+                if isinstance(err, BaseException) and is_retryable_error(
+                    err, error_types
+                ):
                     raise err
-                if is_retryable_error_info(err, error_types):
-                    raise retry_exception_from_error_info(err, error_types)
+                if isinstance(err, Mapping):
+                    serialized_error = cast(Mapping[str, str | bool], err)
+                    if (
+                        isinstance(serialized_error.get("error"), str)
+                        and isinstance(serialized_error.get("error_chain_repr"), str)
+                        and isinstance(serialized_error.get("error_chain_str"), str)
+                    ):
+                        error_info = cast(ErrorInfo, serialized_error)
+                        if is_retryable_error(error_info, error_types):
+                            raise retry_exception_from_error_info(
+                                error_info, error_types
+                            )
 
     def log_retry(retry_state: tc.RetryCallState) -> None:
         """Log a warning with the exception and the number of attempts."""

--- a/verifiers/utils/async_utils.py
+++ b/verifiers/utils/async_utils.py
@@ -2,10 +2,9 @@ import asyncio
 import inspect
 import logging
 from collections import deque
-from collections.abc import Mapping
 from collections.abc import Coroutine
 from time import perf_counter
-from typing import Any, AsyncContextManager, Callable, Optional, TypeVar, cast
+from typing import Any, AsyncContextManager, Callable, Optional, TypeVar
 
 import numpy as np
 import tenacity as tc
@@ -170,21 +169,15 @@ def maybe_retry(
     if max_retries <= 0:
         return func
 
-    def retry_exception_from_error_info(
-        error: ErrorInfo, error_types: tuple[type[Exception], ...]
-    ) -> Exception:
-        detail = str(error.get("error_chain_repr") or error.get("error") or "")
-        return error_types[0](detail)
-
     def reraise_error(err: BaseException | ErrorInfo | None) -> None:
-        if isinstance(err, BaseException) and is_retryable_error(err, error_types):
+        if err is None or not is_retryable_error(err, error_types):
+            return
+        if isinstance(err, BaseException):
             raise err
-        if isinstance(err, Mapping):
-            error_info = cast(ErrorInfo, err)
-            if is_retryable_error(error_info, error_types):
-                raise retry_exception_from_error_info(error_info, error_types)
+        detail = str(err.get("error_chain_repr") or err.get("error") or "")
+        raise error_types[0](detail)
 
-    def reraise_error_from_state(result, error_types: tuple[type[Exception], ...]):
+    def reraise_error_from_state(result):
         """Re-raise specified errors from state(s) to trigger tenacity retry."""
         if isinstance(result, dict):
             reraise_error(result.get("error"))
@@ -233,7 +226,7 @@ def maybe_retry(
         nonlocal last_result
         result = await func(*args, **kwargs)
         last_result = result  # store result
-        reraise_error_from_state(result, error_types)
+        reraise_error_from_state(result)
         return result
 
     wrapper.__name__ = getattr(func, "__name__", "unknown")

--- a/verifiers/utils/async_utils.py
+++ b/verifiers/utils/async_utils.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel
 
 import verifiers as vf
 from verifiers.utils.error_utils import ErrorChain
+from verifiers.utils.error_utils import is_error_info
 from verifiers.utils.error_utils import is_retryable_error_info
 from verifiers.utils.logging_utils import print_time
 
@@ -181,16 +182,14 @@ def maybe_retry(
             err = result.get("error")
             if err and any(isinstance(err, err_type) for err_type in error_types):
                 raise err
-            if isinstance(err, Mapping) and is_retryable_error_info(err, error_types):
+            if is_error_info(err) and is_retryable_error_info(err, error_types):
                 raise retry_exception_from_error_info(err, error_types)
         elif isinstance(result, list):
             for state in result:
                 err = state.get("error")
                 if err and any(isinstance(err, err_type) for err_type in error_types):
                     raise err
-                if isinstance(err, Mapping) and is_retryable_error_info(
-                    err, error_types
-                ):
+                if is_error_info(err) and is_retryable_error_info(err, error_types):
                     raise retry_exception_from_error_info(err, error_types)
 
     def log_retry(retry_state: tc.RetryCallState) -> None:

--- a/verifiers/utils/async_utils.py
+++ b/verifiers/utils/async_utils.py
@@ -13,7 +13,7 @@ from pydantic import BaseModel
 
 import verifiers as vf
 from verifiers.utils.error_utils import ErrorChain
-from verifiers.utils.error_utils import error_info_to_exception
+from verifiers.utils.error_utils import is_retryable_error_info
 from verifiers.utils.logging_utils import print_time
 
 logger = logging.getLogger(__name__)
@@ -169,25 +169,29 @@ def maybe_retry(
     if max_retries <= 0:
         return func
 
+    def retry_exception_from_error_info(
+        error: Mapping[str, object], error_types: tuple[type[Exception], ...]
+    ) -> Exception:
+        detail = str(error.get("error_chain_repr") or error.get("error") or "")
+        return error_types[0](detail)
+
     def reraise_error_from_state(result, error_types: tuple[type[Exception], ...]):
         """Re-raise specified errors from state(s) to trigger tenacity retry."""
         if isinstance(result, dict):
             err = result.get("error")
             if err and any(isinstance(err, err_type) for err_type in error_types):
                 raise err
-            if isinstance(err, Mapping):
-                retry_error = error_info_to_exception(err, error_types)
-                if retry_error is not None:
-                    raise retry_error
+            if isinstance(err, Mapping) and is_retryable_error_info(err, error_types):
+                raise retry_exception_from_error_info(err, error_types)
         elif isinstance(result, list):
             for state in result:
                 err = state.get("error")
                 if err and any(isinstance(err, err_type) for err_type in error_types):
                     raise err
-                if isinstance(err, Mapping):
-                    retry_error = error_info_to_exception(err, error_types)
-                    if retry_error is not None:
-                        raise retry_error
+                if isinstance(err, Mapping) and is_retryable_error_info(
+                    err, error_types
+                ):
+                    raise retry_exception_from_error_info(err, error_types)
 
     def log_retry(retry_state: tc.RetryCallState) -> None:
         """Log a warning with the exception and the number of attempts."""

--- a/verifiers/utils/error_utils.py
+++ b/verifiers/utils/error_utils.py
@@ -1,5 +1,5 @@
 from collections.abc import Mapping
-from typing import Callable, TypeGuard, cast
+from typing import Callable, cast
 
 import verifiers as vf
 from verifiers.types import ErrorInfo
@@ -90,7 +90,7 @@ def error_type_name(error: object) -> str | None:
     return None
 
 
-def is_error_info(error: object) -> TypeGuard[ErrorInfo]:
+def is_error_info(error: object) -> bool:
     """Return whether an object has the runtime shape of serialized ErrorInfo."""
     if not isinstance(error, Mapping):
         return False
@@ -102,10 +102,13 @@ def is_error_info(error: object) -> TypeGuard[ErrorInfo]:
 
 
 def is_retryable_error_info(
-    error: ErrorInfo,
+    error: object,
     error_types: tuple[type[Exception], ...] = DEFAULT_RETRYABLE_ERROR_TYPES,
 ) -> bool:
     """Return whether serialized ErrorInfo should trigger a retry."""
+    if not is_error_info(error):
+        return False
+
     if error_types == DEFAULT_RETRYABLE_ERROR_TYPES:
         return error.get("is_retryable") is True
 

--- a/verifiers/utils/error_utils.py
+++ b/verifiers/utils/error_utils.py
@@ -92,18 +92,13 @@ def error_type_name(error: object) -> str | None:
     return None
 
 
-def error_info_to_exception(
+def is_retryable_error_info(
     error: Mapping[str, object],
-    error_types: tuple[type[Exception], ...],
-) -> Exception | None:
+    error_types: tuple[type[Exception], ...] = DEFAULT_RETRYABLE_ERROR_TYPES,
+) -> bool:
+    """Return whether serialized ErrorInfo should trigger a retry."""
+    if error_types == DEFAULT_RETRYABLE_ERROR_TYPES:
+        return error.get("is_retryable") is True
+
     chain = str(error.get("error_chain_str") or error.get("error") or "")
-    detail = str(error.get("error_chain_repr") or error.get("error") or "")
-    if (
-        error_types == DEFAULT_RETRYABLE_ERROR_TYPES
-        and error.get("is_retryable") is True
-    ):
-        return vf.InfraError(detail)
-    for error_type in error_types:
-        if error_type.__name__ in chain:
-            return error_type(detail)
-    return None
+    return any(error_type.__name__ in chain for error_type in error_types)

--- a/verifiers/utils/error_utils.py
+++ b/verifiers/utils/error_utils.py
@@ -4,6 +4,11 @@ from typing import Callable, cast
 import verifiers as vf
 from verifiers.types import ErrorInfo
 
+DEFAULT_RETRYABLE_ERROR_TYPES: tuple[type[Exception], ...] = (
+    vf.InfraError,
+    vf.InvalidModelResponseError,
+)
+
 
 def get_error_chain(
     error: BaseException | None, parent_type: type[BaseException] | None = None
@@ -56,12 +61,24 @@ class ErrorChain:
         return " -> ".join([repr(e) for e in self.chain])
 
 
+def is_retryable_error(
+    error: BaseException,
+    error_types: tuple[type[Exception], ...] = DEFAULT_RETRYABLE_ERROR_TYPES,
+) -> bool:
+    """Return whether an error chain matches verifiers' retry policy."""
+    error_chain = ErrorChain(error)
+    return any(error_type in error_chain for error_type in error_types)
+
+
 def error_info(error: BaseException) -> ErrorInfo:
     error_chain = ErrorChain(error)
     return ErrorInfo(
         error=type(error).__name__,
         error_chain_repr=repr(error_chain),
         error_chain_str=str(error_chain),
+        is_retryable=any(
+            error_type in error_chain for error_type in DEFAULT_RETRYABLE_ERROR_TYPES
+        ),
     )
 
 
@@ -81,6 +98,11 @@ def error_info_to_exception(
 ) -> Exception | None:
     chain = str(error.get("error_chain_str") or error.get("error") or "")
     detail = str(error.get("error_chain_repr") or error.get("error") or "")
+    if (
+        error_types == DEFAULT_RETRYABLE_ERROR_TYPES
+        and error.get("is_retryable") is True
+    ):
+        return vf.InfraError(detail)
     for error_type in error_types:
         if error_type.__name__ in chain:
             return error_type(detail)

--- a/verifiers/utils/error_utils.py
+++ b/verifiers/utils/error_utils.py
@@ -1,5 +1,5 @@
 from collections.abc import Mapping
-from typing import Callable, cast
+from typing import Callable, TypeGuard, cast
 
 import verifiers as vf
 from verifiers.types import ErrorInfo
@@ -85,15 +85,24 @@ def error_info(error: BaseException) -> ErrorInfo:
 def error_type_name(error: object) -> str | None:
     if isinstance(error, BaseException):
         return type(error).__name__
-    if isinstance(error, Mapping):
-        raw_error = cast(Mapping[str, object], error).get("error")
-        if isinstance(raw_error, str):
-            return raw_error
+    if is_error_info(error):
+        return error["error"]
     return None
 
 
+def is_error_info(error: object) -> TypeGuard[ErrorInfo]:
+    """Return whether an object has the runtime shape of serialized ErrorInfo."""
+    if not isinstance(error, Mapping):
+        return False
+    return (
+        isinstance(error.get("error"), str)
+        and isinstance(error.get("error_chain_repr"), str)
+        and isinstance(error.get("error_chain_str"), str)
+    )
+
+
 def is_retryable_error_info(
-    error: Mapping[str, object],
+    error: ErrorInfo,
     error_types: tuple[type[Exception], ...] = DEFAULT_RETRYABLE_ERROR_TYPES,
 ) -> bool:
     """Return whether serialized ErrorInfo should trigger a retry."""

--- a/verifiers/utils/error_utils.py
+++ b/verifiers/utils/error_utils.py
@@ -1,4 +1,3 @@
-from collections.abc import Mapping
 from typing import Callable, cast
 
 import verifiers as vf
@@ -62,12 +61,15 @@ class ErrorChain:
 
 
 def is_retryable_error(
-    error: BaseException,
+    error: BaseException | ErrorInfo,
     error_types: tuple[type[Exception], ...] = DEFAULT_RETRYABLE_ERROR_TYPES,
 ) -> bool:
-    """Return whether an error chain matches verifiers' retry policy."""
-    error_chain = ErrorChain(error)
-    return any(error_type in error_chain for error_type in error_types)
+    """Return whether a live or serialized error matches verifiers' retry policy."""
+    if isinstance(error, BaseException):
+        error_chain = ErrorChain(error)
+        return any(error_type in error_chain for error_type in error_types)
+
+    return error.get("is_retryable") is True
 
 
 def error_info(error: BaseException) -> ErrorInfo:
@@ -82,35 +84,9 @@ def error_info(error: BaseException) -> ErrorInfo:
     )
 
 
-def error_type_name(error: object) -> str | None:
+def error_type_name(error: BaseException | ErrorInfo | None) -> str | None:
+    if error is None:
+        return None
     if isinstance(error, BaseException):
         return type(error).__name__
-    if is_error_info(error):
-        return error["error"]
-    return None
-
-
-def is_error_info(error: object) -> bool:
-    """Return whether an object has the runtime shape of serialized ErrorInfo."""
-    if not isinstance(error, Mapping):
-        return False
-    return (
-        isinstance(error.get("error"), str)
-        and isinstance(error.get("error_chain_repr"), str)
-        and isinstance(error.get("error_chain_str"), str)
-    )
-
-
-def is_retryable_error_info(
-    error: object,
-    error_types: tuple[type[Exception], ...] = DEFAULT_RETRYABLE_ERROR_TYPES,
-) -> bool:
-    """Return whether serialized ErrorInfo should trigger a retry."""
-    if not is_error_info(error):
-        return False
-
-    if error_types == DEFAULT_RETRYABLE_ERROR_TYPES:
-        return error.get("is_retryable") is True
-
-    chain = str(error.get("error_chain_str") or error.get("error") or "")
-    return any(error_type.__name__ in chain for error_type in error_types)
+    return error["error"]

--- a/verifiers/utils/save_utils.py
+++ b/verifiers/utils/save_utils.py
@@ -23,7 +23,7 @@ from verifiers.types import (
     TokenUsage,
     Tool,
 )
-from verifiers.utils.error_utils import ErrorChain
+from verifiers.utils.error_utils import error_info
 from verifiers.utils.message_utils import (
     sanitize_tool_calls,
     serialize_messages_for_output,
@@ -262,13 +262,10 @@ def state_to_output(
                 error_chain_repr=str(error["error_chain_repr"]),
                 error_chain_str=str(error["error_chain_str"]),
             )
+            if isinstance(error.get("is_retryable"), bool):
+                output["error"]["is_retryable"] = error["is_retryable"]
         else:
-            error_chain = ErrorChain(cast(BaseException, error))
-            output["error"] = ErrorInfo(
-                error=type(error).__name__,
-                error_chain_repr=repr(error_chain),
-                error_chain_str=str(error_chain),
-            )
+            output["error"] = error_info(cast(BaseException, error))
         output["error_chain"] = output["error"]["error_chain_repr"]
         output["long_error_chain"] = output["error"]["error_chain_str"]
     # only include optional fields if non-empty


### PR DESCRIPTION
## Summary
- Add optional `is_retryable` to serialized `ErrorInfo` payloads.
- Populate it from verifiers' default retry semantics: retry when the causal error chain contains `InfraError` or `InvalidModelResponseError`, including subclasses such as sandbox/tunnel/browser sandbox errors and empty model responses.
- Preserve `is_retryable` when reserializing existing `ErrorInfo` mappings through `state_to_output`.
- Update `maybe_retry` to use `is_retryable_error(error: BaseException | ErrorInfo, ...)` for both live exceptions and serialized `ErrorInfo`.
- Remove the old serialized-error string reconstruction path. Serialized errors now retry only when `is_retryable` is `true`.

## Coordinated Consumer
This is the producer-side change for PrimeIntellect-ai/prime-rl#2579. prime-rl receives rollout failures after verifiers serializes them into `ErrorInfo` dictionaries, so it cannot safely recover Python subclass relationships from error-name strings.

With this field, verifiers remains the source of truth for retry semantics and prime-rl can consume the serialized retry decision directly. prime-rl intentionally does not enumerate subclass names or fall back to string parsing; missing `is_retryable=true` is treated as terminal/no-reschedule.

## Why
Class-name strings preserve logging detail, but they do not preserve Python subclass relationships like `SandboxError <: InfraError`. Serializing the retryability decision keeps downstream consumers aligned with verifiers `maybe_retry` semantics and prevents plain model/provider errors from being mistaken for retryable infra failures.

Existing serialized `ErrorInfo` records remain valid because `is_retryable` is optional. The compatibility behavior is intentionally conservative: older serialized errors without the flag do not retry across the serialized boundary.

## Test Plan
- `uv run pytest tests/test_error_chain.py`
- `uv run ty check verifiers/utils/error_utils.py verifiers/utils/async_utils.py`
- `uv run ruff check verifiers/utils/error_utils.py verifiers/utils/async_utils.py tests/test_error_chain.py`
- `uv run ruff format --check verifiers/utils/error_utils.py verifiers/utils/async_utils.py tests/test_error_chain.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes retry behavior across the serialized-error boundary: previously some serialized errors could retry via class-name string parsing; now retries for serialized errors only happen when `ErrorInfo.is_retryable` is set, which could alter rollout scheduling/resilience if producers/consumers are mismatched.
> 
> **Overview**
> Adds an optional `is_retryable` flag to serialized `ErrorInfo` and populates it using verifiers’ default retry policy (error chain contains `InfraError` or `InvalidModelResponseError`).
> 
> Updates `maybe_retry` to use a new `is_retryable_error()` helper for both live exceptions and serialized `ErrorInfo`, and removes the prior string-based reconstruction path for serialized errors (missing `is_retryable=True` is treated as non-retryable). `state_to_output` now preserves `is_retryable` when re-serializing existing `ErrorInfo` mappings and otherwise emits errors via the shared `error_info()` serializer.
> 
> Extends tests to cover default retryability marking and the stricter behavior for serialized errors without the flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e710e01e62f4d7d62780bfa677564437a0c38cfd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->