### PR TITLE
Harden sandbox bundle upload paths

### DIFF
--- a/tests/test_sandbox_mixin.py
+++ b/tests/test_sandbox_mixin.py
@@ -440,6 +440,33 @@ def test_upload_bundle_uses_extract_timeout(mixin):
     assert kwargs["timeout"] == mixin.timeouts.extract
 
 
+def test_upload_bundle_rejects_traversal_paths(mixin):
+    mixin.upload_file = AsyncMock()
+    mixin.sandbox_client.execute_command = AsyncMock()
+
+    with pytest.raises(ValueError, match="Unsafe bundle path"):
+        asyncio.run(mixin.upload_bundle("sb-1", {"../escape.txt": "x"}, "/tmp/dest"))
+
+    mixin.upload_file.assert_not_awaited()
+    mixin.sandbox_client.execute_command.assert_not_awaited()
+
+
+def test_upload_bundle_quotes_remote_paths(mixin):
+    async def _noop_upload(sandbox_id, remote_path, local_path):
+        return None
+
+    mixin.upload_file = _noop_upload
+    mixin.sandbox_client.execute_command = AsyncMock(
+        return_value=MagicMock(exit_code=0, stderr="")
+    )
+
+    asyncio.run(mixin.upload_bundle("sb-1", {"a.txt": "x"}, "/tmp/dest with spaces"))
+
+    _, command = mixin.sandbox_client.execute_command.await_args.args
+    assert "mkdir -p '/tmp/dest with spaces'" in command
+    assert "rm -f '/tmp/dest with spaces/_bundle.tar.gz'" in command
+
+
 def test_upload_bundle_respects_custom_extract_timeout():
     obj = ConcreteMixin(
         max_retries=1,

--- a/verifiers/envs/experimental/sandbox_mixin.py
+++ b/verifiers/envs/experimental/sandbox_mixin.py
@@ -3,11 +3,12 @@ import io
 import logging
 import math
 import os
+import shlex
 import tarfile
 import tempfile
 import time
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Callable, Optional, cast
 
 import httpx
@@ -38,6 +39,17 @@ if _httpx_log_level:
     httpx_logger.setLevel(getattr(logging, _httpx_log_level, logging.DEBUG))
     httpcore_logger = logging.getLogger("httpcore")
     httpcore_logger.setLevel(getattr(logging, _httpx_log_level, logging.DEBUG))
+
+
+def _bundle_member_name(rel_path: str) -> str:
+    member_path = PurePosixPath(rel_path.replace("\\", "/"))
+    if (
+        member_path.is_absolute()
+        or ".." in member_path.parts
+        or member_path.as_posix() in {"", "."}
+    ):
+        raise ValueError(f"Unsafe bundle path: {rel_path}")
+    return member_path.as_posix()
 
 
 class SandboxCreationError(vf.SandboxError): ...
@@ -408,8 +420,9 @@ class SandboxMixin:
             buf = io.BytesIO()
             with tarfile.open(fileobj=buf, mode="w:gz") as tar:
                 for rel_path, content in file_map.items():
+                    member_name = _bundle_member_name(rel_path)
                     data = content.encode("utf-8")
-                    info = tarfile.TarInfo(name=rel_path)
+                    info = tarfile.TarInfo(name=member_name)
                     info.size = len(data)
                     tar.addfile(info, io.BytesIO(data))
             with tempfile.NamedTemporaryFile(delete=False, suffix=".tar.gz") as f:
@@ -423,11 +436,14 @@ class SandboxMixin:
         finally:
             await asyncio.to_thread(Path(tmp_path).unlink, missing_ok=True)
 
+        extract_script = (
+            f"import tarfile; "
+            f"tarfile.open({archive_remote!r}, 'r:gz').extractall({dest_dir!r})"
+        )
         extract_cmd = (
-            f"mkdir -p {dest_dir} && "
-            f'python3 -c "import tarfile; '
-            f"tarfile.open('{archive_remote}', 'r:gz').extractall('{dest_dir}')\" && "
-            f"rm -f {archive_remote}"
+            f"mkdir -p {shlex.quote(dest_dir)} && "
+            f"python3 -c {shlex.quote(extract_script)} && "
+            f"rm -f {shlex.quote(archive_remote)}"
         )
         result = await self.sandbox_client.execute_command(
             sandbox_id,


### PR DESCRIPTION
## Description
Validate sandbox bundle member paths before building the tar archive and quote remote extraction paths before passing them through the sandbox shell command. This prevents traversal entries from reaching the uploaded archive and keeps destination/archive paths with shell metacharacters literal.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Test improvement

## Testing
- [ ] All existing tests pass when running `uv run pytest` locally.
- [x] New tests have been added to cover the changes

Focused checks run:
- `uv run pytest -q tests/test_sandbox_mixin.py`
- `uv run ruff check verifiers/envs/experimental/sandbox_mixin.py tests/test_sandbox_mixin.py`
- `python3 -m py_compile verifiers/envs/experimental/sandbox_mixin.py tests/test_sandbox_mixin.py`
- `git diff --check`
- `UV_FROZEN=1 git commit ...` pre-commit hooks: ruff check, ruff format, Semgrep v1 policy, generated AGENTS/CLAUDE check
- `UV_FROZEN=1 git push ...` pre-push hooks: ruff check, ruff format, Semgrep v1 policy, generated AGENTS/CLAUDE check, ty

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
No docs update needed; this only hardens existing sandbox bundle upload behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sandbox file upload/extraction by adding path validation and stronger shell quoting; low surface-area change but could break callers relying on previously-accepted paths or unusual destination strings.
> 
> **Overview**
> **Hardens `SandboxMixin.upload_bundle`** by validating tar member paths to reject absolute paths, `..` traversal, and empty/`.` entries before building the archive.
> 
> **Improves remote extraction safety** by quoting `dest_dir` and archive paths via `shlex.quote` and embedding the Python extract snippet as a single quoted script, preventing spaces/metacharacters from being interpreted by the sandbox shell.
> 
> Adds tests ensuring traversal paths are rejected (with no upload/exec attempted) and that remote commands correctly quote destinations containing spaces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76078059b418b3acbf98ff6ddaa7c23e778b22e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden `SandboxMixin.upload_bundle` against path traversal and unquoted shell paths
> - Adds a `_bundle_member_name` helper in [`sandbox_mixin.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1428/files#diff-fd5c38b06fdd2489747e61c09c12dde4e5d106dac6f2eb0329b02f81f1d549a1) that validates bundle member names, raising `ValueError` for absolute paths, `..` segments, or empty/`.` paths, and returns a normalized POSIX path.
> - `upload_bundle` now validates all `file_map` keys via `_bundle_member_name` before any upload or remote command is executed.
> - Remote shell commands for `mkdir`, extraction, and `rm` now use `shlex.quote` to correctly handle `dest_dir` and archive paths containing spaces or special characters.
> - Behavioral Change: `upload_bundle` now raises `ValueError` on unsafe bundle keys instead of silently proceeding.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7607805.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->