### PR TITLE
Add GSM-Infinite environment

### DIFF
--- a/environments/README.md
+++ b/environments/README.md
@@ -11,6 +11,7 @@ This folder contains installable example environments that showcase common usage
 
 ### SingleTurnEnv (prompt → single response)
 - **gsm8k**: Classic QA with exact-match reward and optional response-format reward.
+- **gsm_infinite**: GSM-Infinite arithmetic reasoning tasks with context-length/subset controls and exact answer rewards.
 - **reverse_text**: XML formatting with non-binary LCS reward + format reward.
 - **continuation_quality**: Completion-style generation (`message_type="completion"`) judged for prose quality with `JudgeRubric`.
 - **mmmu**: Multimodal inputs (image + text) packed in chat content; single-turn boxed-answer check.

--- a/environments/gsm_infinite/README.md
+++ b/environments/gsm_infinite/README.md
@@ -1,0 +1,34 @@
+# GSM-Infinite
+
+GSM-Infinite is a single-turn train/eval environment for long-context mathematical reasoning. It loads the public `InfiniAILab/gsm_infinite_*` Hugging Face datasets and scores model completions with deterministic answer extraction.
+
+```bash
+prime env install gsm_infinite
+prime eval run gsm_infinite
+```
+
+The environment exposes `load_environment(...)` with these arguments:
+
+- `subset`: One of `symbolic`, `medium`, or `hard`. Defaults to `medium`.
+- `context_length`: Dataset context length suffix such as `0`, `8k`, `16k`, `32k`, `64k`, or `128k`. Defaults to `0`.
+- `train_op_splits`: Comma-separated split names or an iterable of split names. Defaults to `ops_2`.
+- `eval_op_splits`: Comma-separated split names or an iterable of split names. Defaults to `ops_3`.
+- `num_train_examples`: Examples per train split. Defaults to `100`; set `-1` for all rows.
+- `num_eval_examples`: Examples per eval split. Defaults to `100`; set `-1` for all rows.
+- `system_prompt`: Optional system prompt prepended to each example.
+
+For `medium` and `hard`, the reward is `1.0` when the extracted integer answer matches the integer in the GSM-Infinite solution. For `symbolic`, the reward is `1.0` when the set of extracted variable names exactly matches `answer_list`.
+
+## Citation
+
+```bibtex
+@misc{zhou2025gsminfinitellmsbehaveinfinitely,
+    title={GSM-Infinite: How Do Your LLMs Behave over Infinitely Increasing Context Length and Reasoning Complexity?},
+    author={Yang Zhou and Hongyi Liu and Zhuoming Chen and Yuandong Tian and Beidi Chen},
+    year={2025},
+    eprint={2502.05252},
+    archivePrefix={arXiv},
+    primaryClass={cs.CL},
+    url={https://arxiv.org/abs/2502.05252},
+}
+```

--- a/environments/gsm_infinite/gsm_infinite.py
+++ b/environments/gsm_infinite/gsm_infinite.py
@@ -33,10 +33,10 @@ def _select_examples(dataset: Dataset, count: int) -> Dataset:
 
 
 def _solution_integer(solution: str) -> str:
-    match = re.search(r"answer:\s*(-?\d+)", solution, flags=re.IGNORECASE)
-    if not match:
+    matches = re.findall(r"answer:\s*(-?\d+)", solution, flags=re.IGNORECASE)
+    if not matches:
         raise ValueError("Could not extract integer answer from GSM-Infinite solution")
-    return match.group(1)
+    return matches[-1]
 
 
 def _extract_integer_answer(text: str) -> str | None:

--- a/environments/gsm_infinite/gsm_infinite.py
+++ b/environments/gsm_infinite/gsm_infinite.py
@@ -1,0 +1,170 @@
+import re
+from collections.abc import Iterable
+from typing import Any
+
+from datasets import Dataset, concatenate_datasets, load_dataset
+
+import verifiers as vf
+
+
+DATASET_PREFIXES = {
+    "symbolic": "InfiniAILab/gsm_infinite_symbolic",
+    "medium": "InfiniAILab/gsm_infinite_medium",
+    "hard": "InfiniAILab/gsm_infinite_hard",
+}
+
+
+def _dataset_name(subset: str, context_length: str) -> str:
+    if subset not in DATASET_PREFIXES:
+        raise ValueError(f"Unknown GSM-Infinite subset: {subset}")
+    return f"{DATASET_PREFIXES[subset]}_{context_length}"
+
+
+def _normalize_op_splits(op_splits: str | Iterable[str]) -> list[str]:
+    if isinstance(op_splits, str):
+        return [split.strip() for split in op_splits.split(",") if split.strip()]
+    return [str(split) for split in op_splits]
+
+
+def _select_examples(dataset: Dataset, count: int) -> Dataset:
+    if count == -1:
+        return dataset
+    return dataset.select(range(min(count, len(dataset))))
+
+
+def _solution_integer(solution: str) -> str:
+    match = re.search(r"answer:\s*(-?\d+)", solution, flags=re.IGNORECASE)
+    if not match:
+        raise ValueError("Could not extract integer answer from GSM-Infinite solution")
+    return match.group(1)
+
+
+def _extract_integer_answer(text: str) -> str | None:
+    if "</think>" in text:
+        text = text.split("</think>")[-1].strip()
+    patterns = [
+        r"\\boxed\{\s*(-?\d+)\s*\}",
+        r"answer:\s*(-?\d+)",
+        r"solution:\s*(-?\d+)",
+        r"final answer:\s*(-?\d+)",
+        r"\\text\{answer:\s*\}\s*(-?\d+)",
+    ]
+    for pattern in patterns:
+        matches = re.findall(pattern, text, flags=re.IGNORECASE)
+        if matches:
+            return matches[-1]
+    numbers = re.findall(r"-?\d+", text)
+    return numbers[-1] if numbers else None
+
+
+def _extract_symbolic_answer(text: str) -> list[str]:
+    if "</think>" in text:
+        text = text.split("</think>")[-1].strip()
+    if re.search(r"\bnone\b", text, flags=re.IGNORECASE):
+        return []
+    return sorted(set(re.findall(r"\bV\d+\b", text)))
+
+
+def _format_row(example: dict[str, Any], subset: str) -> dict[str, Any]:
+    answer = (
+        sorted(example["answer_list"])
+        if subset == "symbolic"
+        else _solution_integer(example["solution"])
+    )
+    info = {
+        "subset": subset,
+        "op": example.get("op"),
+        "length": example.get("length"),
+        "id": example.get("id"),
+        "answer": answer,
+    }
+    if subset != "symbolic":
+        info.update(
+            {
+                "template": example.get("template"),
+                "mode": example.get("mode"),
+            }
+        )
+    return {
+        "prompt": example["messages"],
+        "answer": answer,
+        "info": info,
+    }
+
+
+def _load_gsm_infinite_dataset(
+    subset: str,
+    context_length: str,
+    op_splits: str | Iterable[str],
+    num_examples: int,
+) -> Dataset:
+    dataset_name = _dataset_name(subset, context_length)
+    datasets = []
+    for split in _normalize_op_splits(op_splits):
+        dataset = load_dataset(dataset_name, split=split)
+        remove_columns = [
+            column
+            for column in dataset.column_names
+            if column not in {"messages", "solution", "answer_list", "op", "length", "id"}
+        ]
+        if subset != "symbolic":
+            remove_columns = [
+                column
+                for column in remove_columns
+                if column not in {"template", "mode"}
+            ]
+        dataset = dataset.map(
+            lambda example, subset=subset: _format_row(example, subset),
+            remove_columns=remove_columns,
+        )
+        datasets.append(_select_examples(dataset, num_examples))
+    return concatenate_datasets(datasets) if len(datasets) > 1 else datasets[0]
+
+
+class GSMInfiniteRubric(vf.Rubric):
+    def __init__(self):
+        super().__init__(funcs=[self.gsm_infinite_reward])
+
+    def gsm_infinite_reward(self, parser, completion, info, **kwargs) -> float:
+        response = parser.parse_answer(completion) or ""
+        if info["subset"] == "symbolic":
+            predicted = _extract_symbolic_answer(response)
+            return float(predicted == sorted(info["answer"]))
+        predicted_integer = _extract_integer_answer(response)
+        return float(predicted_integer == str(info["answer"]))
+
+
+def load_environment(
+    subset: str = "medium",
+    context_length: str = "0",
+    train_op_splits: str | Iterable[str] = "ops_2",
+    eval_op_splits: str | Iterable[str] = "ops_3",
+    num_train_examples: int = 100,
+    num_eval_examples: int = 100,
+    system_prompt: str | None = None,
+) -> vf.Environment:
+    def build_dataset() -> Dataset:
+        return _load_gsm_infinite_dataset(
+            subset=subset,
+            context_length=context_length,
+            op_splits=train_op_splits,
+            num_examples=num_train_examples,
+        )
+
+    def build_eval_dataset() -> Dataset:
+        return _load_gsm_infinite_dataset(
+            subset=subset,
+            context_length=context_length,
+            op_splits=eval_op_splits,
+            num_examples=num_eval_examples,
+        )
+
+    parser = vf.Parser()
+    rubric = GSMInfiniteRubric()
+    return vf.SingleTurnEnv(
+        dataset=build_dataset,
+        eval_dataset=build_eval_dataset,
+        system_prompt=system_prompt,
+        parser=parser,
+        rubric=rubric,
+    )

--- a/environments/gsm_infinite/gsm_infinite.py
+++ b/environments/gsm_infinite/gsm_infinite.py
@@ -60,9 +60,12 @@ def _extract_integer_answer(text: str) -> str | None:
 def _extract_symbolic_answer(text: str) -> list[str]:
     if "</think>" in text:
         text = text.split("</think>")[-1].strip()
-    if re.search(r"\bnone\b", text, flags=re.IGNORECASE):
+    variables = sorted(set(re.findall(r"\bV\d+\b", text)))
+    if variables:
+        return variables
+    if re.fullmatch(r"\W*none\W*", text, flags=re.IGNORECASE):
         return []
-    return sorted(set(re.findall(r"\bV\d+\b", text)))
+    return []
 
 
 def _format_row(example: dict[str, Any], subset: str) -> dict[str, Any]:

--- a/environments/gsm_infinite/pyproject.toml
+++ b/environments/gsm_infinite/pyproject.toml
@@ -1,0 +1,21 @@
+[project]
+name = "gsm-infinite"
+version = "0.1.0"
+description = "GSM-Infinite train/eval environment for long-context mathematical reasoning"
+tags = ["gsm-infinite", "math", "long-context", "reasoning", "single-turn", "train", "eval"]
+requires-python = ">=3.10,<3.14"
+dependencies = [
+    "datasets>=3.0.0",
+    "verifiers>=0.1.8",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build]
+include = ["gsm_infinite.py", "README.md", "pyproject.toml"]
+
+[tool.verifiers.eval]
+num_examples = 5
+rollouts_per_example = 3


### PR DESCRIPTION
## Algora Custom Bounty Claim

- Bounty: GSM-Infinite custom bounty, $500
- Bounty URL: https://algora.io/PrimeIntellect-ai/bounties/m4592Ap5jB1qm9yd
- Claim: this PR is submitted for that Algora custom bounty.
- Preferred compliant payout if accepted: Claude Max $200 subscription gifts/codes/credits matching the bounty value as closely as possible, or equivalent Anthropic/Claude credit if that is easier for Prime Intellect or Algora. A good fit would be multiple Claude Max $200 gifts/months/credits plus any supported compliant remainder alternative.
- Claude gift recipient email: `qkrwjdgod100@gmail.com`
- Compliance boundary: I cannot bypass KYC or provide inaccurate identity information; if Claude Max gifting/credit is not supported, please let me know what compliant non-KYC alternative is available.


## Summary
- add a `gsm_infinite` train/eval environment backed by the public InfiniAILab GSM-Infinite Hugging Face datasets
- support medium, hard, and symbolic subsets across configurable context lengths and operation splits
- score medium/hard completions with deterministic integer answer extraction and symbolic completions with exact variable-set matching

## Validation
- `uv run ruff check environments/gsm_infinite tests/test_envs.py`
- `UV_PYTHON=/opt/homebrew/opt/python@3.11/bin/python3.11 CHANGED_ENVS=gsm_infinite uv run pytest tests/test_envs.py -q`
- local packaged smoke checks returned reward `1.0` on medium and hard examples with known correct answers

The `vf-eval` smoke test was skipped locally because no `OPENAI_API_KEY` or `PRIME_API_KEY` is configured.

Algora bounty context: https://algora.io/PrimeIntellect-ai/bounties/m4592Ap5jB1qm9yd

Payout preference if this is selected for the bounty: if Prime Intellect/Algora can support a non-cash equivalent, I would prefer an equivalent-value Claude subscription gift link/code or Anthropic/Claude credit. I cannot bypass KYC or provide inaccurate identity information; if this payout route is not supported, please let me know what compliant alternatives are available.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are additive (new environment package + docs) and do not modify core verifier/runtime logic, though reward correctness depends on dataset schema and regex-based answer extraction.
> 
> **Overview**
> Adds a new installable `gsm_infinite` `SingleTurnEnv` that loads `InfiniAILab/gsm_infinite_*` datasets with configurable subset/context length, split selection, and per-split example limits.
> 
> Implements `GSMInfiniteRubric` with deterministic scoring: integer extraction for `medium`/`hard` (multiple regex patterns with a numeric fallback) and exact variable-set matching for `symbolic`, plus environment packaging via a new `pyproject.toml` and a short entry in `environments/README.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f42b510c009dea0c0cafd84c3e0bb3c38238a61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add GSM-Infinite arithmetic reasoning environment
> - Adds [gsm_infinite.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1431/files#diff-e0ed6367bf4d8178c80c6c1ab7e65c0626a346fd7c90e4bd0c8e41c054ff9e03) implementing a `SingleTurnEnv` for long-context arithmetic reasoning using the GSM-Infinite Hugging Face dataset.
> - Supports three subsets (`symbolic`, `medium`, `hard`) with configurable context length, op splits, and per-split example counts.
> - Implements exact-match rewards: symbolic subsets compare variable-name sets; numeric subsets compare extracted integers from model completions.
> - Handles chain-of-thought completions by stripping content before `</think>` before answer extraction.
> - Adds packaging config in [pyproject.toml](https://github.com/PrimeIntellect-ai/verifiers/pull/1431/files#diff-907fb6de80497118c26bc771576cb952f7ff0aafe1f8fe44d2616f8f68d6993a) with `datasets>=3.0.0` and `verifiers>=0.1.8` dependencies.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8f42b51.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->