### PR TITLE
feat(rlm-harness): pre-install common Python libs into rlm tool venv by default

### DIFF
--- a/tests/test_rlm_composable_env.py
+++ b/tests/test_rlm_composable_env.py
@@ -33,7 +33,6 @@ from verifiers.envs.experimental.utils.file_locks import (
     shared_path_lock,
 )
 from verifiers.envs.experimental.composable.harnesses.rlm import (
-    DEFAULT_RLM_EXTRA_UV_ARGS,
     build_install_script,
     rlm_harness,
     resolve_local_checkout,
@@ -181,20 +180,6 @@ def test_rlm_harness_install_script_requires_uploaded_checkout():
     assert 'test -f "$RLM_CHECKOUT_PATH/install.sh"' in script
     assert "git clone" not in script
     assert 'bash "$RLM_CHECKOUT_PATH/install.sh"' in script
-
-
-def test_rlm_harness_install_script_exports_default_extra_uv_args():
-    """The default agent-callable libs are baked in but stay overridable.
-
-    Sandbox-level ``RLM_EXTRA_UV_ARGS`` set via ``install_env`` wins via
-    ``${VAR:-default}``; the rlm-harness ``install.sh`` then forwards
-    whichever value reached it into ``uv tool install --with ...``.
-    """
-    script = build_install_script()
-    assert f"RLM_EXTRA_UV_ARGS:-{DEFAULT_RLM_EXTRA_UV_ARGS}" in script
-    # Sanity-check a few entries so an accidental empty default fails fast.
-    for pkg in ("requests", "pandas", "numpy", "pyyaml", "pydantic"):
-        assert f"--with {pkg}" in DEFAULT_RLM_EXTRA_UV_ARGS
 
 
 def test_rlm_harness_does_not_set_post_install_hooks(tmp_path):

--- a/tests/test_rlm_composable_env.py
+++ b/tests/test_rlm_composable_env.py
@@ -33,6 +33,7 @@ from verifiers.envs.experimental.utils.file_locks import (
     shared_path_lock,
 )
 from verifiers.envs.experimental.composable.harnesses.rlm import (
+    DEFAULT_RLM_EXTRA_UV_ARGS,
     build_install_script,
     rlm_harness,
     resolve_local_checkout,
@@ -180,6 +181,20 @@ def test_rlm_harness_install_script_requires_uploaded_checkout():
     assert 'test -f "$RLM_CHECKOUT_PATH/install.sh"' in script
     assert "git clone" not in script
     assert 'bash "$RLM_CHECKOUT_PATH/install.sh"' in script
+
+
+def test_rlm_harness_install_script_exports_default_extra_uv_args():
+    """The default agent-callable libs are baked in but stay overridable.
+
+    Sandbox-level ``RLM_EXTRA_UV_ARGS`` set via ``install_env`` wins via
+    ``${VAR:-default}``; the rlm-harness ``install.sh`` then forwards
+    whichever value reached it into ``uv tool install --with ...``.
+    """
+    script = build_install_script()
+    assert f"RLM_EXTRA_UV_ARGS:-{DEFAULT_RLM_EXTRA_UV_ARGS}" in script
+    # Sanity-check a few entries so an accidental empty default fails fast.
+    for pkg in ("requests", "pandas", "numpy", "pyyaml", "pydantic"):
+        assert f"--with {pkg}" in DEFAULT_RLM_EXTRA_UV_ARGS
 
 
 def test_rlm_harness_does_not_set_post_install_hooks(tmp_path):

--- a/verifiers/envs/experimental/composable/harnesses/rlm.py
+++ b/verifiers/envs/experimental/composable/harnesses/rlm.py
@@ -22,6 +22,18 @@ DEFAULT_RLM_MAX_DEPTH = 0
 DEFAULT_APPEND_TO_SYSTEM_PROMPT_PATH = "/task/append_to_system_prompt.txt"
 DEFAULT_RLM_CHECKOUT_PATH = "/tmp/rlm-checkout"
 DEFAULT_RLM_CHECKOUT_UPLOAD_NAME = "rlm_checkout"
+# Forwarded by ``rlm-harness/install.sh`` into ``uv tool install --with ...``
+# so the agent's ipython kernel can ``import`` these without ``pip install``
+# mid-rollout. Word-split on spaces by the shell — keep specs unversioned
+# (no ``>=``). Callers override by passing
+# ``ComposableEnv(install_env={"RLM_EXTRA_UV_ARGS": "..."})``.
+DEFAULT_RLM_EXTRA_UV_ARGS = (
+    "--with requests --with httpx "
+    "--with pyyaml --with tomli --with python-dotenv "
+    "--with pandas --with numpy --with scipy "
+    "--with beautifulsoup4 --with lxml "
+    "--with pydantic"
+)
 DEFAULT_RLM_LOCAL_CHECKOUT_CACHE_ROOT = (
     Path.home() / ".cache" / "verifiers" / "rlm-checkouts"
 )
@@ -101,6 +113,7 @@ def build_install_script() -> str:
     script = f"""\
 set -eo pipefail
 export RLM_CHECKOUT_PATH={shlex.quote(DEFAULT_RLM_CHECKOUT_PATH)}
+export RLM_EXTRA_UV_ARGS="${{RLM_EXTRA_UV_ARGS:-{DEFAULT_RLM_EXTRA_UV_ARGS}}}"
 test -f "$RLM_CHECKOUT_PATH/install.sh"
 bash "$RLM_CHECKOUT_PATH/install.sh"
 """

--- a/verifiers/envs/experimental/composable/harnesses/rlm.py
+++ b/verifiers/envs/experimental/composable/harnesses/rlm.py
@@ -29,7 +29,7 @@ DEFAULT_RLM_CHECKOUT_UPLOAD_NAME = "rlm_checkout"
 # ``ComposableEnv(install_env={"RLM_EXTRA_UV_ARGS": "..."})``.
 DEFAULT_RLM_EXTRA_UV_ARGS = (
     "--with requests --with httpx "
-    "--with pyyaml --with tomli --with python-dotenv "
+    "--with pyyaml --with tomli "
     "--with pandas --with numpy --with scipy "
     "--with beautifulsoup4 --with lxml "
     "--with pydantic"


### PR DESCRIPTION
## Summary

Bake a baseline set of agent-callable Python libraries into every `rlm_harness()` sandbox so the agent's ipython kernel can `import` them directly — no `pip install`-ing mid-rollout.

`build_install_script` now exports `RLM_EXTRA_UV_ARGS` with a sensible default; rlm-harness's `install.sh` forwards it into `uv tool install --with ...`. Override per-env via `ComposableEnv(install_env={"RLM_EXTRA_UV_ARGS": "..."})` — the `${VAR:-default}` form means caller-set values still win.

### Default libs

`requests`, `httpx`, `pyyaml`, `tomli`, `python-dotenv`, `pandas`, `numpy`, `scipy`, `beautifulsoup4`, `lxml`, `pydantic`.

Specs are unversioned because `install.sh` word-splits `$RLM_EXTRA_UV_ARGS` and shell metacharacters like `>=` break that.

### Motivation

Without this, every rlm-based environment in `research-environments` (~25 of them: `rlm_swe`, `rlm_math`, `rlm_deepdive`, `rlm_lean`, …) has to duplicate the same `install_env={"RLM_EXTRA_UV_ARGS": ...}` block — or worse, the agent ends up running `pip install` inside the kernel on every rollout. PR PrimeIntellect-ai/research-environments#400 added this to `rlm_swe`; this PR makes that PR (and 24 follow-ups) unnecessary.

### Test plan

- Added `test_rlm_harness_install_script_exports_default_extra_uv_args` to `tests/test_rlm_composable_env.py`
- `uv run pytest tests/test_rlm_composable_env.py` — 28 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pre-install common Python libraries into the rlm tool venv by default
> Adds a `DEFAULT_RLM_EXTRA_UV_ARGS` constant in [rlm.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1432/files#diff-ebc58f59c5ab399310ec60720cb96f5cbf1c76bac3291b6c8f49dff8a3a80b49) containing `--with` flags for packages like `requests`, `httpx`, `pandas`, `numpy`, `pydantic`, and others. The `build_install_script` function now exports `RLM_EXTRA_UV_ARGS` using shell parameter expansion (`${RLM_EXTRA_UV_ARGS:-<default>}`), so the default applies unless the caller pre-sets the variable.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1432 opened
>
> - Removed `DEFAULT_RLM_EXTRA_UV_ARGS` constant and its associated test verification from the RLM composable environment harness [11fa85e]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c6179e6.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes the harness install environment by exporting a new default `RLM_EXTRA_UV_ARGS`, primarily impacting startup time and dependency footprint rather than runtime logic.
> 
> **Overview**
> Pre-installs a baseline set of common Python libraries for `rlm_harness()` by introducing `DEFAULT_RLM_EXTRA_UV_ARGS` (a space-separated set of `uv tool install --with ...` flags).
> 
> `build_install_script()` now exports `RLM_EXTRA_UV_ARGS` using `${RLM_EXTRA_UV_ARGS:-<default>}`, so environments get the default dependencies unless they explicitly override the variable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11fa85e7210617fccb7c5ef26bad8714fd077682. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->