### PR TITLE
Remove stale pre-eval `prime env install` docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,16 +220,6 @@ prime env install my-env
 
 For self-managed training launch commands, use the `prime-rl` documentation.
 
-To install the environment module into your project, do:
-```bash
-prime env install my-env # installs from ./environments/my_env
-```
-
-To install an environment from the Environments Hub into your project, do:
-```bash
-prime env install primeintellect/math-python
-```
-
 To run a local evaluation with any OpenAI-compatible model, do:
 ```bash
 prime eval run my-env -m openai/gpt-5-nano # run and save eval results locally

--- a/assets/lab/environments/AGENTS.md
+++ b/assets/lab/environments/AGENTS.md
@@ -890,7 +890,7 @@ prime env install my-env                    # from ./environments/my_env
 prime env install my-env -p /path/to/environments   # custom path
 ```
 
-This runs `uv pip install -e` for local environments, making them importable by `prime eval run` and other integrations.
+This runs `uv pip install -e` for local environments when you want an explicit editable install for non-eval tooling. Evaluations do not require this separate step because environment resolution happens inside `prime eval run`.
 
 ## Environment Groups
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -260,9 +260,6 @@ prime env init my-environment
 # Include an explicit harness loader when needed
 prime env init my-environment --with-harness
 
-# Install locally for testing
-prime env install my-environment
-
 # Test your environment
 prime eval run my-environment -m openai/gpt-4.1-mini -n 5
 ```
@@ -321,7 +318,6 @@ uv run ty check verifiers             # Type check (matches CI Ty target)
 
 # Environment tools
 prime env init new-env                       # Create taskset-first v1 environment
-prime env install new-env                    # Install environment
 prime eval run new-env -m openai/gpt-4.1-mini -n 5  # Test environment
 prime eval view                              # Browse evals in the tree browser
 ```

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -883,7 +883,7 @@ prime env install my-env                    # from ./environments/my_env
 prime env install my-env -p /path/to/environments   # custom path
 ```
 
-This runs `uv pip install -e` for local environments, making them importable by `prime eval run` and other integrations.
+This runs `uv pip install -e` for local environments when you want an explicit editable install for non-eval tooling. Evaluations do not require this separate step because environment resolution happens inside `prime eval run`.
 
 ## Environment Groups
 

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -23,14 +23,13 @@ Use `prime eval` to execute rollouts against any supported model provider and re
 
 ## Basic Usage
 
-Environments must be installed as Python packages before evaluation. From a local environment:
+Run evaluations directly against a local or Hub environment:
 
 ```bash
-prime env install my-env           # installs ./environments/my_env as a package
 prime eval run my-env -m openai/gpt-4.1-mini -n 10
 ```
 
-`prime eval` imports the environment module using Python's import system, calls its `load_environment()` function, runs 5 examples with 3 rollouts each (the default), scores them using the environment's rubric, and prints aggregate metrics.
+`prime eval` resolves and installs the environment when needed, imports the environment module using Python's import system, calls its `load_environment()` function, runs 5 examples with 3 rollouts each (the default), scores them using the environment's rubric, and prints aggregate metrics.
 
 ## Hosted Evaluations
 
@@ -66,7 +65,7 @@ The positional argument accepts two formats:
 - **Single environment**: `gsm8k` — evaluates one environment
 - **TOML config path**: `configs/eval/benchmark.toml` — evaluates multiple environments defined in the config file
 
-Environment IDs are converted to Python module names (`my-env` → `my_env`) and imported. Modules must be installed (via `prime env install` or `uv pip install`).
+Environment IDs are converted to Python module names (`my-env` → `my_env`) and imported after `prime eval run` resolves the environment package.
 
 For legacy or direct-constructor environments, the `--env-args` flag passes
 arguments to your `load_environment()` function:

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -135,16 +135,6 @@ env = vf.Env(
 )
 ```
 
-To install the environment module into your project, do:
-```bash
-prime env install my-env # installs from ./environments/my_env
-```
-
-To install an environment from the Environments Hub into your project, do:
-```bash
-prime env install primeintellect/math-python
-```
-
 To run a local evaluation with any OpenAI-compatible model, do:
 ```bash
 prime eval run my-env -m openai/gpt-5-nano # run and save eval results locally

--- a/environments/AGENTS.md
+++ b/environments/AGENTS.md
@@ -889,7 +889,7 @@ prime env install my-env                    # from ./environments/my_env
 prime env install my-env -p /path/to/environments   # custom path
 ```
 
-This runs `uv pip install -e` for local environments, making them importable by `prime eval run` and other integrations.
+This runs `uv pip install -e` for local environments when you want an explicit editable install for non-eval tooling. Evaluations do not require this separate step because environment resolution happens inside `prime eval run`.
 
 ## Environment Groups
 

--- a/environments/README.md
+++ b/environments/README.md
@@ -4,7 +4,6 @@ This folder contains installable example environments that showcase common usage
 
 ## Quick start
 
-- **Install an environment from this GitHub repo**: `prime env install math-python --from-repo`
 - **Evaluate**: `prime eval run math-python` (defaults to openai/gpt-4.1-mini, small sample)
 
 ## Common usage patterns and examples
@@ -113,7 +112,6 @@ results = vf_env.evaluate(client=AsyncOpenAI(), model="gpt-4.1-mini", num_exampl
 
 CLI usage:
 ```bash
-prime env install reverse-text --from-repo
 prime eval run reverse-text -n 50 -r 1
 ```
 

--- a/environments/bfcl_v3/README.md
+++ b/environments/bfcl_v3/README.md
@@ -3,7 +3,6 @@
 Berkeley Function Calling Leaderboard v3 on the v1 Taskset/Harness runtime.
 
 ```bash
-prime env install bfcl-v3 --from-repo
 prime eval run bfcl-v3 -a '{"test_category": "simple_python"}'
 ```
 

--- a/environments/hello_mcp_harbor/README.md
+++ b/environments/hello_mcp_harbor/README.md
@@ -18,9 +18,6 @@ Adapted from Harbor's own [`examples/tasks/hello-mcp`](https://github.com/laude-
 ## Running it
 
 ```bash
-# Install the env locally
-prime env install hello-mcp-harbor
-
 # Single rollout against your configured agent
 prime eval run hello-mcp-harbor
 ```

--- a/environments/hello_parallel_sandbox_v1/README.md
+++ b/environments/hello_parallel_sandbox_v1/README.md
@@ -17,7 +17,6 @@ program sandbox instead of creating a separate tool sandbox. The parent writes
    score.
 
 ```bash
-prime env install hello-parallel-sandbox-v1
 prime eval run hello-parallel-sandbox-v1 -m openai/gpt-5.4-mini -n 3 -r 1 -t 4096
 ```
 

--- a/environments/hello_self_judge_v1/README.md
+++ b/environments/hello_self_judge_v1/README.md
@@ -17,7 +17,6 @@ taskset then:
    score.
 
 ```bash
-prime env install hello-self-judge-v1
 prime eval run hello-self-judge-v1 -m openai/gpt-5.4-mini -n 3 -r 1 -t 4096
 ```
 

--- a/environments/langchain_deep_agents_wikispeedia/README.md
+++ b/environments/langchain_deep_agents_wikispeedia/README.md
@@ -20,11 +20,6 @@ LangChain deep-agents trained on Wikispeedia navigation through a v1 `Taskset`/`
 
 ### Quickstart
 
-Install the env locally:
-```bash
-prime env install ./environments/langchain_deep_agents_wikispeedia
-```
-
 Run an evaluation with default settings:
 ```bash
 prime eval run langchain-deep-agents-wikispeedia

--- a/uv.lock
+++ b/uv.lock
@@ -19,8 +19,6 @@ conflicts = [[
 ]]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
-exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
 prime-tunnel = false

--- a/verifiers/AGENTS.md
+++ b/verifiers/AGENTS.md
@@ -107,8 +107,7 @@ uv add 'verifiers[all]'     # + training
 # Scaffold new environment
 prime env init new-environment
 
-# Install + test
-prime env install new-environment
+# Smoke test
 prime eval run new-environment -n 5 -m openai/gpt-4.1-mini
 ```
 


### PR DESCRIPTION
## Summary
- Remove docs and example README instructions that told users to run `prime env install` right before `prime eval run`
- Reword evaluation guidance to say `prime eval run` handles environment resolution/install itself
- Regenerate the mirrored `AGENTS.md` files under `environments/`

## Testing
- `uv run python scripts/sync.py --check`
- `git diff --check`
- Searched the docs for remaining install-then-eval snippets

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates plus a minor `uv.lock` metadata tweak; no runtime logic changes.
> 
> **Overview**
> Updates docs and example environment READMEs to **stop instructing users to run `prime env install` immediately before `prime eval run`**, clarifying that `prime eval run` handles environment resolution/installation automatically.
> 
> Regenerates mirrored `AGENTS.md` guidance under `assets/lab/environments/` and `environments/` to match the updated environments documentation, and removes a couple legacy `uv.lock` `exclude-newer*` options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cc7075a415d7c8229a6a70e6e720fef91438f38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove stale `prime env install` prerequisite steps from docs
> Removes `prime env install` commands from quickstart guides, READMEs, and CLI examples across the repo. The docs now reflect that `prime eval run` resolves and installs environments internally, so a separate install step is not required for evaluations. `prime env install` is retained where relevant but reframed as an editable install tool for non-eval local tooling only.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4cc7075.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->