### PR TITLE
Default TOML eval runs to save results

### DIFF
--- a/tests/test_eval_cli.py
+++ b/tests/test_eval_cli.py
@@ -129,7 +129,6 @@ def test_cli_single_env_id(monkeypatch, run_cli):
     configs = captured["configs"]
     assert len(configs) == 1
     assert configs[0].env_id == "env1"
-    assert configs[0].save_results is False
 
 
 def test_get_env_eval_defaults_for_package_module(tmp_path: Path, monkeypatch):
@@ -890,15 +889,7 @@ def test_cli_toml_ignores_cli_args(monkeypatch, run_cli):
         assert config.rollouts_per_example == 3  # DEFAULT_ROLLOUTS_PER_EXAMPLE
         assert config.max_concurrent == 32  # default
         assert config.sampling_args["max_tokens"] is None  # default
-
-
-def test_cli_toml_defaults_save_results_true(monkeypatch, run_cli):
-    with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
-        f.write('[[eval]]\nenv_id = "env1"\n')
-        f.flush()
-        captured = run_cli(monkeypatch, {"env_id_or_config": f.name})
-
-    assert captured["configs"][0].save_results is True
+        assert config.save_results is True
 
 
 def test_cli_toml_respects_save_results_false(monkeypatch, run_cli):
@@ -908,18 +899,6 @@ def test_cli_toml_respects_save_results_false(monkeypatch, run_cli):
         captured = run_cli(monkeypatch, {"env_id_or_config": f.name})
 
     assert captured["configs"][0].save_results is False
-
-
-def test_cli_toml_save_results_flag_overrides_config(monkeypatch, run_cli):
-    with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
-        f.write('[[eval]]\nenv_id = "env1"\nsave_results = false\n')
-        f.flush()
-        captured = run_cli(
-            monkeypatch,
-            {"env_id_or_config": f.name, "save_results": True},
-        )
-
-    assert captured["configs"][0].save_results is True
 
 
 def test_cli_toml_per_env_num_examples(monkeypatch, run_cli):

--- a/tests/test_eval_cli.py
+++ b/tests/test_eval_cli.py
@@ -129,6 +129,7 @@ def test_cli_single_env_id(monkeypatch, run_cli):
     configs = captured["configs"]
     assert len(configs) == 1
     assert configs[0].env_id == "env1"
+    assert configs[0].save_results is False
 
 
 def test_get_env_eval_defaults_for_package_module(tmp_path: Path, monkeypatch):
@@ -889,6 +890,36 @@ def test_cli_toml_ignores_cli_args(monkeypatch, run_cli):
         assert config.rollouts_per_example == 3  # DEFAULT_ROLLOUTS_PER_EXAMPLE
         assert config.max_concurrent == 32  # default
         assert config.sampling_args["max_tokens"] is None  # default
+
+
+def test_cli_toml_defaults_save_results_true(monkeypatch, run_cli):
+    with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
+        f.write('[[eval]]\nenv_id = "env1"\n')
+        f.flush()
+        captured = run_cli(monkeypatch, {"env_id_or_config": f.name})
+
+    assert captured["configs"][0].save_results is True
+
+
+def test_cli_toml_respects_save_results_false(monkeypatch, run_cli):
+    with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
+        f.write('[[eval]]\nenv_id = "env1"\nsave_results = false\n')
+        f.flush()
+        captured = run_cli(monkeypatch, {"env_id_or_config": f.name})
+
+    assert captured["configs"][0].save_results is False
+
+
+def test_cli_toml_save_results_flag_overrides_config(monkeypatch, run_cli):
+    with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
+        f.write('[[eval]]\nenv_id = "env1"\nsave_results = false\n')
+        f.flush()
+        captured = run_cli(
+            monkeypatch,
+            {"env_id_or_config": f.name, "save_results": True},
+        )
+
+    assert captured["configs"][0].save_results is True
 
 
 def test_cli_toml_per_env_num_examples(monkeypatch, run_cli):

--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -527,6 +527,14 @@ def main(argv: list[str] | None = None):
                 f"TOML config file not found: {path}\nPlease check the path is correct."
             )
         raw_eval_configs = load_toml_config(path)
+        raw_eval_configs = [
+            (
+                {**raw_config, "save_results": True}
+                if args.save_results or "save_results" not in raw_config
+                else raw_config
+            )
+            for raw_config in raw_eval_configs
+        ]
     else:
         # CLI path: convert args to dict
         raw_config = {"env_id": args.env_id_or_config}

--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -832,9 +832,11 @@ def main(argv: list[str] | None = None):
         )
 
     # Check Hub environments are installed before running
-    missing_envs = []
+    missing_envs: list[str] = []
     for raw in raw_eval_configs:
         env_id = raw["env_id"]
+        if not isinstance(env_id, str):
+            raise ValueError("All eval configs must contain a string env_id.")
         if not check_hub_env_installed(env_id):
             missing_envs.append(env_id)
 


### PR DESCRIPTION
## Summary
- Make TOML-driven eval runs save results by default when `save_results` is omitted.
- Preserve `save_results = false` as an explicit opt-out.
- Keep direct env-id runs unchanged.
- Add coverage for the default, explicit false, and override cases.

## Testing
- `uv run pytest tests/test_eval_cli.py -q`
- `uv run ruff check verifiers/scripts/eval.py tests/test_eval_cli.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the default persistence behavior for TOML-based eval runs, which can affect disk usage and downstream workflows; direct CLI env-id runs remain unchanged.
> 
> **Overview**
> TOML-driven eval runs now **save results by default** when `save_results` is omitted, while still respecting an explicit `save_results = false` opt-out. If `--save-results` is passed, it forces `save_results=True` for all TOML entries.
> 
> Also adds validation that each TOML entry has a string `env_id`, and extends CLI tests to cover the new `save_results` default and opt-out behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4d9be0d7ed4bc204a54738944c4d2cadf715152. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default TOML eval runs to save results unless explicitly disabled
> - In [eval.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1435/files#diff-6b37997f6eb279df06f6c885920ff82ac5940e25ca859a9dd445bdc4028277b6), TOML-based eval configs now default `save_results` to `True` if the key is absent, and force it to `True` when `--save-results` is passed via CLI; explicit `save_results = false` in the TOML is respected.
> - Adds a `ValueError` if any eval config has a non-string `env_id`.
> - Tests in [test_eval_cli.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1435/files#diff-464cc707678b356bc1fc629cea465230cd9144d10314550c2c6cf26f45edd187) cover the new default behavior and the opt-out case.
> - Behavioral Change: TOML runs that previously omitted `save_results` will now save results by default.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b4d9be0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->