### PR TITLE
[codex] Prepare v0.1.15.dev8 release

### DIFF
--- a/assets/release/RELEASE_v0.1.15.dev8.md
+++ b/assets/release/RELEASE_v0.1.15.dev8.md
@@ -1,0 +1,40 @@
+# Verifiers v0.1.15.dev8 Release Notes
+
+*Date:* 05/22/2026
+
+## Highlights since v0.1.15.dev7
+
+- **v1 Taskset/Harness loading is stricter and more package-native.** v1 configs now keep taskset and harness child config objects, package component loading is explicit, and the BYO Harness docs, generated agent guidance, and create-environments skill describe reusable tasksets and harnesses as the golden path.
+- **Eval configuration defaults are cleaner.** TOML-backed eval runs save results by default, sampling sections forward reasoning kwargs to clients, and stale pre-eval install docs were removed.
+- **Rollout and client behavior is more robust.** SWE rollouts with sandbox errors skip scoring, save deltas reset cleanly on non-monotonic trajectories, renderer overlong-prompt failures normalize to `vf.OverlongPromptError`, and routed expert responses can carry sidecar data.
+- **Developer tooling is tighter.** The eval viewer TUI was modernized, the legacy `vf-tui` entrypoint was retired, renderer client error handling was tightened, and the router replay performance experiment was reverted.
+
+## Changes included in v0.1.15.dev8 (since v0.1.15.dev7)
+
+### v1 Taskset/Harness
+
+- Rework v1 harness and taskset config classes (#1392)
+- Add strict package loaders for v1 tasksets and harnesses (#1429)
+
+### Evals and rollouts
+
+- Modernize eval viewer TUI (#1393)
+- Forward reasoning kwargs from eval TOML sampling sections (#1404)
+- Skip SWE sandbox scoring for errored rollouts (#1412)
+- Support routed experts response sidecar (#1423)
+- Remove stale pre-eval `prime env install` docs (#1434)
+- Default TOML eval runs to save results (#1435)
+
+### Runtime and client fixes
+
+- chore: bump renderers to 0.1.8.dev2 (supersedes #1366) (#1395)
+- fix(save_utils): reset delta baseline on non-monotonic trajectories (#1400)
+- fix(renderer-client): translate renderers.OverlongPromptError into vf.OverlongPromptError and require renderers>=0.1.8.dev4 (#1408)
+- [Router Replay]: Improve performance by removing Pydantic validation (#1394)
+- Revert "[Router Replay]: Improve performance by removing Pydantic validation" (#1422)
+
+### Tooling and docs
+
+- Retire vf-tui entrypoint (#1398)
+
+**Full Changelog**: https://github.com/PrimeIntellect-ai/verifiers/compare/v0.1.15.dev7...v0.1.15.dev8

--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.15.dev7"
+__version__ = "0.1.15.dev8"
 
 import importlib
 import os


### PR DESCRIPTION
## Summary
- bump verifiers to 0.1.15.dev8
- add release notes for changes since v0.1.15.dev7

## Notes
- This release is prepared assuming #1429 merges first; the release notes include #1429 in the intended release range.

## Validation
- uv run pre-commit run --files verifiers/__init__.py assets/release/RELEASE_v0.1.15.dev8.md
- env PYTHONDONTWRITEBYTECODE=1 uv run python -c 'import verifiers; print(verifiers.__version__)'
- uv build --out-dir /private/tmp/verifiers-dist-0.1.15.dev8
- pre-push hook: ruff, semgrep, generated guidance check, ty

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only bumps the package version and adds release notes, with no runtime logic changes.
> 
> **Overview**
> Prepares the `v0.1.15.dev8` release by bumping `verifiers.__version__` from `0.1.15.dev7` to `0.1.15.dev8`.
> 
> Adds `RELEASE_v0.1.15.dev8.md` documenting highlights and the changelog entries included in this release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05799cf8fd0176718aa2dbac646a52aba8380662. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump `verifiers` version to v0.1.15.dev8
> Updates `__version__` in [verifiers/__init__.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1436/files#diff-3667172df996e6596aa8d26557b92b4cb78ee7d2280a3cae14623ce4677e781e) from `0.1.15.dev7` to `0.1.15.dev8` and adds release notes at [assets/release/RELEASE_v0.1.15.dev8.md](https://github.com/PrimeIntellect-ai/verifiers/pull/1436/files#diff-17183c6840dbf2d6858ae6e621c4832eb4f57f4df7e6b3b3144735b131435085) covering v1 Taskset/Harness, Evals and rollouts, Runtime and client fixes, and Tooling and docs changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 05799cf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->