### PR TITLE
Inline single-use verifier helpers

### DIFF
--- a/tests/test_harbor_env_mcp.py
+++ b/tests/test_harbor_env_mcp.py
@@ -239,83 +239,20 @@ class TestLaunchCommandResolution:
         )
 
 
-class TestStartStopCommands:
-    def test_start_cmd_tracks_process_group_leader_pid(self):
-        """Start command must capture `$!` (the backgrounded pgroup leader),
-        not `$$` (the outer shell), and must end with `wait` so the recorded
-        exit code reflects the launched daemon's.
-        """
-        cmd = _DummyEnv()._mcp_start_cmd("svc", "python -u /opt/x/server.py")
-        assert "echo $!" in cmd
-        assert "echo $$" not in cmd
-        assert cmd.rstrip().endswith("wait")
-        assert "/tmp/harbor-mcp-svc.pid" in cmd
-        assert "python -u /opt/x/server.py" in cmd
-
-    def test_start_cmd_wraps_in_setsid_for_process_group_semantics(self):
-        """Wrapping the user's command in `setsid sh -c ...` is what makes
-        `$!` a process-group leader, so `kill -9 -$PID` can reap the whole
-        daemon tree on stop. Compound commands (e.g. `cd /x && python y.py`)
-        must be preserved verbatim inside the sh -c payload so their own
-        semantics are unchanged."""
-        cmd = _DummyEnv()._mcp_start_cmd("svc", "cd /opt && python server.py")
-        assert "setsid sh -c " in cmd
-        assert "'cd /opt && python server.py'" in cmd
-
-    def test_stop_cmd_is_one_line_sigkill_plus_rm(self):
-        """Default: one SIGKILL to the process group, then unlink the
-        pidfile — no poll/sleep loop."""
-        cmd = _DummyEnv()._mcp_stop_cmd("svc")
-        assert "kill -9" in cmd
-        assert "rm -f" in cmd
-        assert "/tmp/harbor-mcp-svc.pid" in cmd
-        assert "kill -0" not in cmd
-        assert "sleep" not in cmd
-        assert "\n" not in cmd
-        assert len(cmd) < 120
-
-    def test_stop_cmd_targets_process_group_not_single_pid(self):
-        """The `-` prefix on the `$(cat …)` expansion is what turns kill(1)
-        into a process-group kill — without it, SIGKILL only lands on the
-        wrapping shell and e.g. a `python` child spawned via `cd && python`
-        leaks as an orphan."""
-        cmd = _DummyEnv()._mcp_stop_cmd("svc")
-        assert 'kill -9 -"$(cat' in cmd
-
-    def test_server_name_with_shell_metachars_is_quoted(self):
-        """Server name is task-author-controlled; every pidfile reference
-        must appear only inside single-quoted spans."""
-        env = _DummyEnv()
-        unquoted = "/tmp/harbor-mcp-evil$(whoami).pid"
-        quoted = f"'{unquoted}'"
-        for cmd in (
-            env._mcp_start_cmd("evil$(whoami)", "x"),
-            env._mcp_stop_cmd("evil$(whoami)"),
-        ):
-            assert quoted in cmd
-            # Every raw occurrence must be inside an already-quoted span.
-            assert cmd.count(unquoted) == cmd.count(quoted)
-
-    def test_launch_command_with_shell_metachars_is_quoted(self):
-        """Same for the user's launch command: it's task-author-controlled,
-        must land inside a single-quoted span once wrapped in `sh -c`."""
-        env = _DummyEnv()
-        evil_cmd = "python -c 'print(1)' && touch /pwned"
-        quoted = f"'{evil_cmd}'".replace("'", "'\"'\"'")
-        # shlex-quoted output contains the evil string only inside quotes.
-        cmd = env._mcp_start_cmd("svc", evil_cmd)
-        assert "setsid sh -c " in cmd
-        # No unquoted `&& touch /pwned` outside a single-quoted span.
-        assert cmd.count(evil_cmd) == 0 or quoted in cmd
-
-
 class TestLifecycle:
     @pytest.mark.asyncio
     async def test_starts_server_with_registered_launch_command(self):
-        env = _DummyEnv(mcp_launch_commands={"svc": "python server.py"})
+        env = _DummyEnv(mcp_launch_commands={"svc": "cd /opt && python server.py"})
         state: dict[str, Any] = {}
         await env.start_mcp_servers("sbx", _config_with_server(), state)
         assert set(state["harbor_mcp_jobs"].keys()) == {"svc"}
+        _, start_cmd = env.started_jobs[0]
+        assert "echo $!" in start_cmd
+        assert "echo $$" not in start_cmd
+        assert start_cmd.rstrip().endswith("wait")
+        assert "/tmp/harbor-mcp-svc.pid" in start_cmd
+        assert "setsid sh -c " in start_cmd
+        assert "'cd /opt && python server.py'" in start_cmd
 
     @pytest.mark.asyncio
     async def test_externally_managed_server_is_skipped(self):
@@ -342,8 +279,37 @@ class TestLifecycle:
             if "kill -9" in c.args[1]
         ]
         assert len(stop_calls) == 1
-        assert "harbor-mcp-svc.pid" in stop_calls[0]
+        stop_cmd = stop_calls[0]
+        assert "harbor-mcp-svc.pid" in stop_cmd
+        assert 'kill -9 -"$(cat' in stop_cmd
+        assert "rm -f" in stop_cmd
+        assert "kill -0" not in stop_cmd
+        assert "sleep" not in stop_cmd
+        assert "\n" not in stop_cmd
+        assert len(stop_cmd) < 120
         assert state["harbor_mcp_jobs"] == {}
+
+    @pytest.mark.asyncio
+    async def test_launch_and_stop_commands_quote_task_authored_shell_text(self):
+        env = _DummyEnv(
+            mcp_launch_commands={
+                "evil$(whoami)": "python -c 'print(1)' && touch /pwned"
+            }
+        )
+        state: dict[str, Any] = {"sandbox_id": "sbx"}
+        await env.start_mcp_servers(
+            "sbx", _config_with_server(name="evil$(whoami)"), state
+        )
+        _, start_cmd = env.started_jobs[0]
+        quoted_pidfile = "'/tmp/harbor-mcp-evil$(whoami).pid'"
+        assert quoted_pidfile in start_cmd
+        assert "setsid sh -c " in start_cmd
+        assert "'\"'\"'print(1)'\"'\"'" in start_cmd
+
+        env.sandbox_client.execute_command.reset_mock()
+        await env.stop_mcp_servers(state)
+        stop_cmd = env.sandbox_client.execute_command.call_args.args[1]
+        assert quoted_pidfile in stop_cmd
 
     @pytest.mark.asyncio
     async def test_stop_without_sandbox_id_is_a_noop(self):
@@ -530,22 +496,6 @@ class TestBackgroundJob:
 class TestHealthCheck:
     """Readiness probing — default `/proc/net/tcp` + user override."""
 
-    def test_default_probe_shape(self):
-        """Portable awk on /proc/net/tcp{,6}, matching LISTEN state only,
-        with no bash-ism dependency like /dev/tcp."""
-        cmd = HarborMCPMixin._default_mcp_health_cmd(8000)
-        assert "bash" not in cmd and "/dev/tcp" not in cmd
-        assert "/proc/net/tcp" in cmd and "/proc/net/tcp6" in cmd
-        assert '$4 == "0A"' in cmd  # LISTEN state
-
-    @pytest.mark.parametrize(
-        "port,hex_expected",
-        [(80, "0050"), (8000, "1F40"), (65535, "FFFF"), (1, "0001")],
-    )
-    def test_default_probe_encodes_port_as_uppercase_hex(self, port, hex_expected):
-        cmd = HarborMCPMixin._default_mcp_health_cmd(port)
-        assert f":{hex_expected}$" in cmd
-
     @pytest.mark.asyncio
     async def test_custom_healthcheck_command_templated_with_port(self):
         env = _DummyEnv(mcp_launch_commands={"svc": "python x"})
@@ -580,7 +530,11 @@ class TestHealthCheck:
             if "/proc/net/tcp" in c.args[1]
         ]
         assert len(health_calls) == 1
-        assert ":1F40$" in health_calls[0]
+        health_cmd = health_calls[0]
+        assert "bash" not in health_cmd and "/dev/tcp" not in health_cmd
+        assert "/proc/net/tcp6" in health_cmd
+        assert '$4 == "0A"' in health_cmd
+        assert ":1F40$" in health_cmd
 
     @pytest.mark.asyncio
     async def test_probe_timeout_is_respected(self):

--- a/tests/test_lean_task.py
+++ b/tests/test_lean_task.py
@@ -9,10 +9,8 @@ from verifiers.envs.experimental.composable.tasksets.lean.lean_task import (
     LEAN_GUARD_END_MARKER,
     LeanRubric,
     _build_starter_file,
-    _expected_protected_region,
     _extract_protected_region,
     _normalize_signature,
-    _wrap_with_lean_guard,
 )
 
 
@@ -80,11 +78,13 @@ class TestNormalizeSignature:
         )
 
 
-class TestWrapWithLeanGuard:
+class TestBuildStarterFileLeanGuardLayout:
     def test_marker_layout(self) -> None:
         signature = "theorem foo (x : ℝ) : x = x := by"
-        wrapped = _wrap_with_lean_guard(signature)
-        assert wrapped == (
+        starter = _build_starter_file(
+            {"formal_statement": signature, "header": "", "imports": ""}
+        )
+        assert starter == (
             "-- lean-guard: begin protected\n"
             "theorem foo (x : ℝ) : x = x := by\n"
             "-- lean-guard: end protected\n"
@@ -93,8 +93,10 @@ class TestWrapWithLeanGuard:
 
     def test_round_trip_via_extract(self) -> None:
         signature = "theorem foo : True := by"
-        wrapped = _wrap_with_lean_guard(signature)
-        region = _extract_protected_region(wrapped)
+        starter = _build_starter_file(
+            {"formal_statement": signature, "header": "", "imports": ""}
+        )
+        region = _extract_protected_region(starter)
         assert region is not None
         assert LEAN_GUARD_BEGIN_MARKER in region
         assert LEAN_GUARD_END_MARKER in region
@@ -212,7 +214,7 @@ class TestBuildStarterFile:
             "header": "import Mathlib",
         }
         starter = _build_starter_file(info)
-        expected = _expected_protected_region(info)
+        expected = _extract_protected_region(_build_starter_file(info)) or ""
         actual = _extract_protected_region(starter)
         assert expected == actual
         assert expected != ""

--- a/tests/test_opencode_rlm_env.py
+++ b/tests/test_opencode_rlm_env.py
@@ -1,5 +1,6 @@
 """Tests for the OpenCodeRLMEnv class."""
 
+import asyncio
 import json
 import subprocess
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -7,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from datasets import Dataset
 
+import verifiers as vf
 from verifiers.envs.experimental.opencode_rlm_env import (
     OpenCodeRLMEnv,
     OpenCodeRLMMonitorRubric,
@@ -240,45 +242,6 @@ class TestBuildEnvVars:
 
 
 # =============================================================================
-# Sub-LLM detection (header-based)
-# =============================================================================
-
-
-class TestIsSubLLMRequest:
-    def test_detects_sub_header(self):
-        assert (
-            OpenCodeRLMEnv._is_sub_llm_request({"headers": {"x-rlm-role": "sub"}})
-            is True
-        )
-
-    def test_rejects_no_headers(self):
-        assert OpenCodeRLMEnv._is_sub_llm_request({}) is False
-
-    def test_rejects_empty_headers(self):
-        assert OpenCodeRLMEnv._is_sub_llm_request({"headers": {}}) is False
-
-    def test_rejects_wrong_value(self):
-        assert (
-            OpenCodeRLMEnv._is_sub_llm_request({"headers": {"x-rlm-role": "main"}})
-            is False
-        )
-
-    def test_ignores_model_field(self):
-        """Model name should NOT be used for detection."""
-        assert (
-            OpenCodeRLMEnv._is_sub_llm_request({"model": "sub", "headers": {}}) is False
-        )
-
-    def test_header_takes_precedence(self):
-        assert (
-            OpenCodeRLMEnv._is_sub_llm_request(
-                {"model": "openai/gpt-5-mini", "headers": {"x-rlm-role": "sub"}}
-            )
-            is True
-        )
-
-
-# =============================================================================
 # State setup
 # =============================================================================
 
@@ -330,17 +293,45 @@ class TestMetrics:
         response = MagicMock(spec=[])  # no usage attr
         assert OpenCodeRLMEnv._extract_token_counts(response) == (0, 0)
 
-    def test_update_sub_metrics(self):
+    @pytest.mark.asyncio
+    async def test_handle_sub_llm_request_updates_sub_metrics(self):
         env = build_env()
         state = {
+            "trajectory": [],
+            "model": "main-model",
             "sub_llm_turns": 0,
             "sub_llm_prompt_tokens": 0,
             "sub_llm_completion_tokens": 0,
         }
-        response = MagicMock()
-        response.usage.prompt_tokens = 50
-        response.usage.completion_tokens = 20
-        env._update_sub_metrics(state, response)
+        response = vf.Response(
+            id="resp",
+            created=0,
+            model="sub-model",
+            message=vf.ResponseMessage(
+                content="ok", finish_reason="stop", is_truncated=False
+            ),
+            usage=vf.Usage(
+                prompt_tokens=50,
+                completion_tokens=20,
+                reasoning_tokens=0,
+                total_tokens=70,
+            ),
+        )
+        future = asyncio.get_running_loop().create_future()
+        intercept = {
+            "messages": [{"role": "user", "content": "hello"}],
+            "headers": {"x-rlm-role": "sub"},
+            "response_future": future,
+        }
+        env._require_interception_server().intercepts["req"] = intercept
+        with patch.object(
+            vf.Environment,
+            "get_model_response",
+            new=AsyncMock(return_value=response),
+        ):
+            await env._handle_sub_llm_request(state, "req", intercept)
+
+        assert future.result() is response
         assert state["sub_llm_turns"] == 1
         assert state["sub_llm_prompt_tokens"] == 50
         assert state["sub_llm_completion_tokens"] == 20

--- a/tests/test_openenv_client.py
+++ b/tests/test_openenv_client.py
@@ -84,16 +84,25 @@ def render_prompt(observation: Any, **kwargs: Any):
     return [UserMessage(content=str(observation["prompt"]))]
 
 
-async def test_openenv_uses_public_async_generic_client(monkeypatch):
+async def test_openenv_uses_public_async_generic_client(monkeypatch, tmp_path):
     FakeGenericEnvClient.instances.clear()
     monkeypatch.setattr(openenv_env, "GenericEnvClient", FakeGenericEnvClient)
     env = vf.OpenEnvEnv(
+        openenv_project=tmp_path,
         num_train_examples=1,
         num_eval_examples=0,
         prompt_renderer=render_prompt,
     )
 
-    async def create_server():
+    async def launch_image_server(
+        image: str, port: int, start_command: str, contract: str
+    ):
+        assert (image, port, start_command, contract) == (
+            "image",
+            8000,
+            "run",
+            "gym",
+        )
         return openenv_env.OpenEnvServer(
             sandbox_id="sandbox",
             exposure_id="exposure",
@@ -102,34 +111,56 @@ async def test_openenv_uses_public_async_generic_client(monkeypatch):
             contract="gym",
         )
 
-    async def fetch_action_schema(base_url: str) -> dict[str, object]:
-        return {"type": "object", "properties": {}}
+    async def fetch_schema(base_url: str) -> dict[str, object]:
+        assert base_url == "http://localhost:8000"
+        return {"action": {"type": "object", "properties": {}}}
 
-    monkeypatch.setattr(env, "_create_server", create_server)
-    monkeypatch.setattr(env, "_fetch_action_schema", fetch_action_schema)
+    async def cleanup_server(server: openenv_env.OpenEnvServer) -> None:
+        env._active_servers.pop(server.sandbox_id, None)
+
+    monkeypatch.setattr(
+        env,
+        "_resolve_runtime_config",
+        lambda project_path: ("image", 8000, "run", "gym"),
+    )
+    monkeypatch.setattr(env, "_launch_image_server", launch_image_server)
+    monkeypatch.setattr(env, "_fetch_schema", fetch_schema)
+    monkeypatch.setattr(env, "_cleanup_server", cleanup_server)
 
     state = vf.State({"info": {"seed": 7}, "trajectory": []})
-    await env.setup_state(state)
+    try:
+        await env.setup_state(state)
 
-    assert state["prompt"] == [UserMessage(content="seed-7")]
-    assert len(FakeGenericEnvClient.instances) == 1
-    client = FakeGenericEnvClient.instances[0]
-    assert client.base_url == "http://localhost:8000"
-    assert client.connected is True
-    assert client.reset_seeds == [7]
+        assert state["prompt"] == [UserMessage(content="seed-7")]
+        assert len(FakeGenericEnvClient.instances) == 1
+        client = FakeGenericEnvClient.instances[0]
+        assert client.base_url == "http://localhost:8000"
+        assert client.connected is True
+        assert client.reset_seeds == [7]
+    finally:
+        await env.cleanup_openenv(state)
 
 
-async def test_openenv_uses_public_async_mcp_client(monkeypatch):
+async def test_openenv_uses_public_async_mcp_client(monkeypatch, tmp_path):
     FakeMCPToolClient.instances.clear()
     monkeypatch.setattr(openenv_env, "MCPToolClient", FakeMCPToolClient)
     monkeypatch.setattr(openenv_env, "CallToolAction", FakeCallToolAction)
     env = vf.OpenEnvEnv(
+        openenv_project=tmp_path,
         num_train_examples=1,
         num_eval_examples=0,
         prompt_renderer=render_prompt,
     )
 
-    async def create_server():
+    async def launch_image_server(
+        image: str, port: int, start_command: str, contract: str
+    ):
+        assert (image, port, start_command, contract) == (
+            "image",
+            8000,
+            "run",
+            "mcp",
+        )
         return openenv_env.OpenEnvServer(
             sandbox_id="sandbox",
             exposure_id="exposure",
@@ -138,25 +169,52 @@ async def test_openenv_uses_public_async_mcp_client(monkeypatch):
             contract="mcp",
         )
 
-    async def fetch_action_schema(base_url: str) -> dict[str, object]:
+    async def fetch_schema(base_url: str) -> dict[str, object]:
+        assert base_url == "http://localhost:8000"
         return {
-            "type": "object",
-            "properties": {"type": {"enum": ["list_tools", "call_tool"]}},
+            "action": {
+                "type": "object",
+                "properties": {"type": {"enum": ["list_tools", "call_tool"]}},
+            }
         }
 
-    monkeypatch.setattr(env, "_create_server", create_server)
-    monkeypatch.setattr(env, "_fetch_action_schema", fetch_action_schema)
+    async def cleanup_server(server: openenv_env.OpenEnvServer) -> None:
+        env._active_servers.pop(server.sandbox_id, None)
+
+    monkeypatch.setattr(
+        env,
+        "_resolve_runtime_config",
+        lambda project_path: ("image", 8000, "run", "mcp"),
+    )
+    monkeypatch.setattr(env, "_launch_image_server", launch_image_server)
+    monkeypatch.setattr(env, "_fetch_schema", fetch_schema)
+    monkeypatch.setattr(env, "_cleanup_server", cleanup_server)
 
     state = vf.State({"info": {"seed": 9}, "trajectory": []})
-    await env.setup_state(state)
-    result = await env._mcp_step_tool(
-        state["openenv_mcp_client"], "echo", {"message": "hi"}
-    )
+    try:
+        await env.setup_state(state)
+        state["trajectory"].append({})
+        tool_messages = await env._mcp_env_response(
+            [
+                vf.AssistantMessage(
+                    content=None,
+                    tool_calls=[
+                        vf.ToolCall(
+                            id="call-1", name="echo", arguments='{"message": "hi"}'
+                        )
+                    ],
+                )
+            ],
+            state,
+        )
 
-    assert state["prompt"] == [UserMessage(content="mcp-9")]
-    assert state["tool_defs"][0].name == "echo"
-    assert result.reward == 1.0
-    client = FakeMCPToolClient.instances[0]
-    action = client.step_actions[0]
-    assert action.tool_name == "echo"
-    assert action.arguments == {"message": "hi"}
+        assert state["prompt"] == [UserMessage(content="mcp-9")]
+        assert state["tool_defs"][0].name == "echo"
+        assert state["trajectory"][-1]["reward"] == 1.0
+        assert tool_messages == [vf.ToolMessage(content="ok", tool_call_id="call-1")]
+        client = FakeMCPToolClient.instances[0]
+        action = client.step_actions[0]
+        assert action.tool_name == "echo"
+        assert action.arguments == {"message": "hi"}
+    finally:
+        await env.cleanup_openenv(state)

--- a/tests/test_prime_plugin.py
+++ b/tests/test_prime_plugin.py
@@ -48,7 +48,7 @@ def test_build_module_command_install_adds_workspace_env_path(
     workspace, env_dir = _make_workspace(tmp_path)
     plugin = prime_plugin.PrimeCLIPlugin()
 
-    monkeypatch.setattr(prime_plugin, "_current_cwd", lambda: env_dir)
+    monkeypatch.chdir(env_dir)
     monkeypatch.setattr(prime_plugin, "_resolve_workspace_python", lambda *_: "python")
 
     command = plugin.build_module_command(plugin.install_module, ["my-env"])
@@ -69,7 +69,7 @@ def test_build_module_command_eval_rewrites_relative_env_dir_path(
     workspace, env_dir = _make_workspace(tmp_path)
     plugin = prime_plugin.PrimeCLIPlugin()
 
-    monkeypatch.setattr(prime_plugin, "_current_cwd", lambda: env_dir)
+    monkeypatch.chdir(env_dir)
     monkeypatch.setattr(prime_plugin, "_resolve_workspace_python", lambda *_: "python")
 
     command = plugin.build_module_command(
@@ -93,7 +93,7 @@ def test_build_module_command_gepa_adds_workspace_env_dir_path(
     workspace, env_dir = _make_workspace(tmp_path)
     plugin = prime_plugin.PrimeCLIPlugin()
 
-    monkeypatch.setattr(prime_plugin, "_current_cwd", lambda: env_dir)
+    monkeypatch.chdir(env_dir)
     monkeypatch.setattr(prime_plugin, "_resolve_workspace_python", lambda *_: "python")
 
     command = plugin.build_module_command(plugin.gepa_module, ["my-env"])
@@ -114,7 +114,7 @@ def test_build_module_command_build_adds_workspace_env_path(
     workspace, env_dir = _make_workspace(tmp_path)
     plugin = prime_plugin.PrimeCLIPlugin()
 
-    monkeypatch.setattr(prime_plugin, "_current_cwd", lambda: env_dir)
+    monkeypatch.chdir(env_dir)
     monkeypatch.setattr(prime_plugin, "_resolve_workspace_python", lambda *_: "python")
 
     command = plugin.build_module_command(plugin.build_module, ["my-env"])
@@ -133,7 +133,7 @@ def test_build_module_command_init_adds_workspace_env_path(tmp_path: Path, monke
     workspace, env_dir = _make_workspace(tmp_path)
     plugin = prime_plugin.PrimeCLIPlugin()
 
-    monkeypatch.setattr(prime_plugin, "_current_cwd", lambda: env_dir)
+    monkeypatch.chdir(env_dir)
     monkeypatch.setattr(prime_plugin, "_resolve_workspace_python", lambda *_: "python")
 
     command = plugin.build_module_command(plugin.init_module, ["my-env"])

--- a/tests/test_rlm_env.py
+++ b/tests/test_rlm_env.py
@@ -2134,30 +2134,6 @@ class TestRootLLMMaxCompletionTokens:
         assert env.root_max_completion_tokens == 20000
 
     @pytest.mark.asyncio
-    async def test_is_root_budget_exhausted_false_when_none(self, rlm_env):
-        assert rlm_env.root_max_completion_tokens is None
-        state = {"root_llm_completion_tokens": 999999}
-        assert rlm_env._is_root_budget_exhausted(state) is False
-
-    @pytest.mark.asyncio
-    async def test_is_root_budget_exhausted_false_when_under(self, rlm_env):
-        rlm_env.root_max_completion_tokens = 1000
-        state = {"root_llm_completion_tokens": 500}
-        assert rlm_env._is_root_budget_exhausted(state) is False
-
-    @pytest.mark.asyncio
-    async def test_is_root_budget_exhausted_true_when_at(self, rlm_env):
-        rlm_env.root_max_completion_tokens = 1000
-        state = {"root_llm_completion_tokens": 1000}
-        assert rlm_env._is_root_budget_exhausted(state) is True
-
-    @pytest.mark.asyncio
-    async def test_is_root_budget_exhausted_true_when_over(self, rlm_env):
-        rlm_env.root_max_completion_tokens = 1000
-        state = {"root_llm_completion_tokens": 1500}
-        assert rlm_env._is_root_budget_exhausted(state) is True
-
-    @pytest.mark.asyncio
     async def test_system_prompt_includes_root_budget_when_set(self):
         dataset = make_dataset({})
         env = build_env(

--- a/verifiers/cli/plugins/prime.py
+++ b/verifiers/cli/plugins/prime.py
@@ -88,10 +88,6 @@ def _find_workspace_root(start: Path) -> Path | None:
     return None
 
 
-def _current_cwd() -> Path:
-    return Path.cwd().resolve()
-
-
 def _resolve_dir_arg(value: str, cwd: Path) -> str:
     path = Path(value)
     if path.is_absolute():
@@ -153,7 +149,7 @@ class PrimeCLIPlugin:
     def build_module_command(
         self, module_name: str, args: Sequence[str] | None = None
     ) -> list[str]:
-        cwd = _current_cwd()
+        cwd = Path.cwd().resolve()
         workspace_root = _find_workspace_root(cwd)
         workspace_env_dir: str | None = None
         if workspace_root is not None:

--- a/verifiers/clients/anthropic_messages_client.py
+++ b/verifiers/clients/anthropic_messages_client.py
@@ -102,24 +102,6 @@ class AnthropicMessagesClient(
     async def to_native_prompt(
         self, messages: Messages
     ) -> tuple[list[AnthropicMessageParam], dict]:
-        def parse_data_url(url: str) -> tuple[str, str] | None:
-            if not url.startswith("data:"):
-                return None
-            if "," not in url:
-                return None
-            header, data = url.split(",", 1)
-            if ";base64" not in header:
-                return None
-            media_type = header[5:].split(";")[0] or "image/png"
-            return media_type, data
-
-        def normalize_content_block(block: Any) -> dict[str, Any]:
-            if isinstance(block, Mapping):
-                return dict(block)
-            if hasattr(block, "model_dump"):
-                return block.model_dump()
-            raise ValueError(f"Invalid content block type: {type(block)}")
-
         def normalize_anthropic_content(content: Any) -> Any:
             if isinstance(content, str):
                 return content
@@ -128,7 +110,12 @@ class AnthropicMessagesClient(
 
             blocks: list[dict[str, Any]] = []
             for raw_part in content:
-                part = normalize_content_block(raw_part)
+                if isinstance(raw_part, Mapping):
+                    part = dict(raw_part)
+                elif hasattr(raw_part, "model_dump"):
+                    part = raw_part.model_dump()
+                else:
+                    raise ValueError(f"Invalid content block type: {type(raw_part)}")
                 part_type = part.get("type")
                 if part_type == "text":
                     text = part.get("text")
@@ -140,9 +127,12 @@ class AnthropicMessagesClient(
                         image_url.get("url") if isinstance(image_url, Mapping) else None
                     )
                     if isinstance(url, str):
-                        parsed = parse_data_url(url)
-                        if parsed is not None:
-                            media_type, data = parsed
+                        if url.startswith("data:") and "," in url:
+                            header, data = url.split(",", 1)
+                        else:
+                            header, data = "", ""
+                        if ";base64" in header:
+                            media_type = header[5:].split(";")[0] or "image/png"
                             blocks.append(
                                 {
                                     "type": "image",
@@ -295,16 +285,11 @@ class AnthropicMessagesClient(
             else:
                 raise ValueError(f"Invalid chat message: {message}")
 
-        def extract_system_content(messages: Messages) -> str:
-            """Extract and concatenate system message contents."""
-            system_contents = []
-            for msg in messages:
-                if isinstance(msg, SystemMessage):
-                    content = msg.content
-                    system_contents.append(" ".join(content_to_text_chunks(content)))
-            return "\n\n".join(system_contents)
-
-        system = extract_system_content(messages)
+        system_contents = []
+        for msg in messages:
+            if isinstance(msg, SystemMessage):
+                system_contents.append(" ".join(content_to_text_chunks(msg.content)))
+        system = "\n\n".join(system_contents)
         prompt: list[AnthropicMessageParam] = []
         pending_tool_results: list[ToolResultBlockParam] = []
 

--- a/verifiers/clients/client.py
+++ b/verifiers/clients/client.py
@@ -99,17 +99,6 @@ class Client(ABC, Generic[ClientT, MessagesT, ResponseT, ToolT]):
             native_tools.append(await self.to_native_tool(tool))
         return native_tools
 
-    def _build_state_headers(self, state) -> dict[str, str] | None:
-        """Build per-request HTTP headers from state using extra_headers_from_state mapping."""
-        if not self._config or not self._config.extra_headers_from_state or not state:
-            return None
-        headers = {}
-        for header_name, state_key in self._config.extra_headers_from_state.items():
-            val = state.get(state_key)
-            if val is not None:
-                headers[header_name] = str(val)
-        return headers or None
-
     async def get_response(
         self,
         prompt: Messages,
@@ -120,9 +109,18 @@ class Client(ABC, Generic[ClientT, MessagesT, ResponseT, ToolT]):
     ) -> Response:
         """Get the response from the client."""
         try:
-            extra_headers = self._build_state_headers(kwargs.get("state"))
-            if extra_headers:
-                kwargs["extra_headers"] = extra_headers
+            state = kwargs.get("state")
+            if self._config and self._config.extra_headers_from_state and state:
+                state_headers = {}
+                for (
+                    header_name,
+                    state_key,
+                ) in self._config.extra_headers_from_state.items():
+                    val = state.get(state_key)
+                    if val is not None:
+                        state_headers[header_name] = str(val)
+                if state_headers:
+                    kwargs["extra_headers"] = state_headers
 
             native_prompt, extra_kwargs = await self.to_native_prompt(prompt)
             native_tools = await self.to_native_tools(tools)

--- a/verifiers/clients/openai_chat_completions_client.py
+++ b/verifiers/clients/openai_chat_completions_client.py
@@ -495,11 +495,6 @@ class OpenAIChatCompletionsClient(
                 routed_experts=choice_extra.get("routed_experts"),
             )
 
-        def parse_reasoning_content_from_response(
-            response: OpenAIChatResponse,
-        ) -> str | None:
-            return parse_reasoning_content(response.choices[0].message)
-
         response_id = getattr(response, "id", "")
         if not isinstance(response_id, str):
             response_id = ""
@@ -517,7 +512,7 @@ class OpenAIChatCompletionsClient(
             usage=parse_usage(response),
             message=ResponseMessage(
                 content=response.choices[0].message.content,
-                reasoning_content=parse_reasoning_content_from_response(response),
+                reasoning_content=parse_reasoning_content(response.choices[0].message),
                 finish_reason=parse_finish_reason(response),
                 is_truncated=parse_is_truncated(response),
                 tokens=parse_tokens(response),

--- a/verifiers/clients/openai_chat_completions_token_client.py
+++ b/verifiers/clients/openai_chat_completions_token_client.py
@@ -42,21 +42,6 @@ def _has_multimodal_content(messages) -> bool:
     return False
 
 
-def _get_role(msg) -> str | None:
-    return msg.get("role") if hasattr(msg, "get") else getattr(msg, "role", None)
-
-
-def _is_valid_env_tail(messages: list) -> bool:
-    """Validate that messages follow env response patterns:
-    all tool messages, with optionally a single user message last."""
-    if not messages:
-        return False
-    for msg in messages[:-1]:
-        if _get_role(msg) != "tool":
-            return False
-    return _get_role(messages[-1]) in ("tool", "user")
-
-
 # copy from vllm/entrypoints/openai/protocol.py
 class TokenizeResponse(BaseModel):
     count: int
@@ -253,7 +238,16 @@ class OpenAIChatCompletionsTokenClient(OpenAIChatCompletionsClient):
 
         # The env messages are everything after the prefix match.
         env_messages: OpenAIChatMessages = list(prompt_messages[prefix_len:])
-        if not _is_valid_env_tail(env_messages):
+        if not env_messages:
+            return None
+        env_roles = [
+            msg.get("role") if hasattr(msg, "get") else getattr(msg, "role", None)
+            for msg in env_messages
+        ]
+        if any(role != "tool" for role in env_roles[:-1]) or env_roles[-1] not in (
+            "tool",
+            "user",
+        ):
             return None
 
         # Extract the bridge tokens using a minimal dual-tokenization that
@@ -272,7 +266,10 @@ class OpenAIChatCompletionsTokenClient(OpenAIChatCompletionsClient):
         # follow an assistant message with a tool call").
         tool_call_ids: list[str] = []
         for msg in env_messages:
-            if _get_role(msg) != "tool":
+            role = (
+                msg.get("role") if hasattr(msg, "get") else getattr(msg, "role", None)
+            )
+            if role != "tool":
                 break
             tc_id = (
                 msg.get("tool_call_id")

--- a/verifiers/clients/openai_responses_client.py
+++ b/verifiers/clients/openai_responses_client.py
@@ -37,15 +37,6 @@ OpenAIResponsesTool: TypeAlias = dict[str, Any]
 OPENAI_RESPONSES_OUTPUT_FIELD = "openai_responses_output"
 
 
-def _as_mapping(value: Any) -> Mapping[str, Any] | None:
-    if isinstance(value, Mapping):
-        return value
-    if hasattr(value, "model_dump"):
-        dumped = value.model_dump(exclude_none=True)
-        return dumped if isinstance(dumped, Mapping) else None
-    return None
-
-
 def _get_field(value: Any, key: str, default: Any = None) -> Any:
     if isinstance(value, Mapping):
         return value.get(key, default)
@@ -82,8 +73,14 @@ class OpenAIResponsesClient(
         self, messages: Messages
     ) -> tuple[OpenAIResponsesInput, dict]:
         def normalize_content_part(part: Any) -> dict[str, Any]:
-            part_map = _as_mapping(part)
-            if part_map is None:
+            if isinstance(part, Mapping):
+                part_map = part
+            elif hasattr(part, "model_dump"):
+                dumped = part.model_dump(exclude_none=True)
+                part_map = dumped if isinstance(dumped, Mapping) else None
+            else:
+                part_map = None
+            if not isinstance(part_map, Mapping):
                 raise ValueError(f"Invalid content part type: {type(part)}")
 
             part_type = part_map.get("type")
@@ -118,12 +115,6 @@ class OpenAIResponsesClient(
             if content is None:
                 return ""
             return str(content)
-
-        def tool_output_content(content: Any) -> str:
-            if isinstance(content, str):
-                return content
-            text = content_to_text(content)
-            return text if text else str(content)
 
         def raw_output_items(message: AssistantMessage) -> list[dict[str, Any]]:
             raw = getattr(message, OPENAI_RESPONSES_OUTPUT_FIELD, None)
@@ -163,11 +154,15 @@ class OpenAIResponsesClient(
             if isinstance(message, TextMessage):
                 return [{"type": "message", "role": "user", "content": message.content}]
             if isinstance(message, ToolMessage):
+                output = message.content
+                if not isinstance(output, str):
+                    text = content_to_text(output)
+                    output = text if text else str(output)
                 return [
                     {
                         "type": "function_call_output",
                         "call_id": message.tool_call_id,
-                        "output": tool_output_content(message.content),
+                        "output": output,
                     }
                 ]
             if isinstance(message, AssistantMessage):

--- a/verifiers/clients/renderer_client.py
+++ b/verifiers/clients/renderer_client.py
@@ -79,12 +79,6 @@ def reset_bridge_metrics() -> None:
             _bridge_metrics[k] = 0
 
 
-def _record_bridge(success: bool) -> None:
-    with _bridge_metrics_lock:
-        _bridge_metrics["attempts"] += 1
-        _bridge_metrics["successes" if success else "failures"] += 1
-
-
 # Size 1 by default. HF fast tokenizers encode a short chat prompt in a few
 # tens of microseconds, so even 2k rollouts tokenize serially in ~100ms — far
 # cheaper than dispatching each one through asyncio.to_thread and queueing on
@@ -96,17 +90,6 @@ _DEFAULT_POOL_SIZE = 1
 
 
 # ── Helpers ─────────────────────────────────────────────────────────
-
-
-async def _maybe_offload(renderer: Renderer | RendererPool, fn):
-    """Run sync renderer work on a thread iff ``renderer`` is a pool.
-
-    Pool methods can block on the internal queue/lock; we offload to keep
-    the event loop responsive. A bare ``Renderer`` runs inline.
-    """
-    if isinstance(renderer, RendererPool):
-        return await asyncio.to_thread(fn)
-    return fn()
 
 
 def _get_value(obj: Any, key: str, default: Any = None) -> Any:
@@ -244,16 +227,14 @@ def _coerce_renderer_message(message: Any) -> RendererMessage:
     return _to_renderer_message(cast(Message, message))
 
 
-def _message_role(message: Any) -> str | None:
-    role = _get_value(message, "role")
-    return role if isinstance(role, str) else None
-
-
 def _is_valid_incremental_tail(messages: list[RendererMessage]) -> bool:
     if not messages:
         return False
 
-    roles = [_message_role(message) for message in messages]
+    roles = []
+    for message in messages:
+        role = _get_value(message, "role")
+        roles.append(role if isinstance(role, str) else None)
     if roles[-1] == "user":
         return all(role == "tool" for role in roles[:-1])
     return all(role == "tool" for role in roles)
@@ -308,14 +289,6 @@ def _step_multi_modal_data(step: Any):
     return _get_value(raw_tokens, "multi_modal_data")
 
 
-def _step_rendered_messages(step: Any) -> list[RendererMessage]:
-    prompt = list(_get_value(step, "prompt", []) or [])
-    completion = list(_get_value(step, "completion", []) or [])
-    return _attach_tool_call_names(
-        [_coerce_renderer_message(message) for message in prompt + completion]
-    )
-
-
 async def _get_incremental_prompt_ids(
     *,
     renderer: Renderer | RendererPool,
@@ -348,7 +321,14 @@ async def _get_incremental_prompt_ids(
         if token_ids is None:
             continue
 
-        previous_messages = _step_rendered_messages(step)
+        step_prompt = list(_get_value(step, "prompt", []) or [])
+        step_completion = list(_get_value(step, "completion", []) or [])
+        previous_messages = _attach_tool_call_names(
+            [
+                _coerce_renderer_message(message)
+                for message in step_prompt + step_completion
+            ]
+        )
         if not previous_messages or len(previous_messages) >= len(prompt):
             continue
         prefix_len = len(previous_messages)
@@ -386,23 +366,16 @@ async def _get_incremental_prompt_ids(
                 tail,
                 tools=tools,
             )
-        bridged = await _maybe_offload(renderer, bridge)
-        _record_bridge(success=bridged is not None)
+        if isinstance(renderer, RendererPool):
+            bridged = await asyncio.to_thread(bridge)
+        else:
+            bridged = bridge()
+        with _bridge_metrics_lock:
+            _bridge_metrics["attempts"] += 1
+            _bridge_metrics["successes" if bridged is not None else "failures"] += 1
         return bridged
 
     return None
-
-
-def _parse_finish_reason(raw: str | None) -> FinishReason:
-    match raw:
-        case "stop":
-            return "stop"
-        case "length":
-            return "length"
-        case "tool_calls":
-            return "tool_calls"
-        case _:
-            return None
 
 
 class RendererClient(
@@ -612,7 +585,15 @@ class RendererClient(
         """Parse the generate() result dict into a verifiers Response."""
         content = response.get("content", "")
         reasoning_content = response.get("reasoning_content")
-        finish_reason = _parse_finish_reason(response.get("finish_reason"))
+        match response.get("finish_reason"):
+            case "stop":
+                finish_reason: FinishReason = "stop"
+            case "length":
+                finish_reason = "length"
+            case "tool_calls":
+                finish_reason = "tool_calls"
+            case _:
+                finish_reason = None
 
         # renderers >=0.1.8.dev1 emits ParsedToolCall dataclasses (with .name,
         # .arguments, .status, .id). Skip non-OK attempts — they're surfaced

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -274,16 +274,6 @@ class Environment(ABC):
         )
         signal.signal(signal.SIGTERM, lambda _, __: (_sync_teardown(), exit(143)))
 
-    def _ensure_example_id(self, dataset: "Dataset") -> "Dataset":
-        """Ensure example_id column exists and is integer type."""
-        if "example_id" in dataset.column_names and not isinstance(
-            dataset["example_id"][0], int
-        ):
-            dataset = dataset.rename_column("example_id", "src_id")
-        if "example_id" not in dataset.column_names:
-            dataset = dataset.add_column("example_id", range(len(dataset)))
-        return dataset
-
     def _ensure_prompt(
         self,
         dataset: "Dataset",
@@ -365,7 +355,12 @@ class Environment(ABC):
         """
         if "env_id" in dataset.column_names:
             dataset = dataset.remove_columns(["env_id"])
-        dataset = self._ensure_example_id(dataset)
+        if "example_id" in dataset.column_names and not isinstance(
+            dataset["example_id"][0], int
+        ):
+            dataset = dataset.rename_column("example_id", "src_id")
+        if "example_id" not in dataset.column_names:
+            dataset = dataset.add_column("example_id", range(len(dataset)))
         dataset = self._ensure_prompt(
             dataset, system_prompt, few_shot, question_key, answer_key, map_kwargs
         )

--- a/verifiers/envs/experimental/composable/composable_env.py
+++ b/verifiers/envs/experimental/composable/composable_env.py
@@ -259,9 +259,20 @@ class ComposableEnv(CliAgentEnv):
         onto the installed agent."""
         sandbox_id = state["sandbox_id"]
 
-        await self._populate_sandbox_context(state)
+        state["sandbox_client"] = self.sandbox_client
+        spec = self._get_spec(state) or self.harness.sandbox_spec
+        if spec and spec.timeout_minutes is not None:
+            state["test_timeout"] = spec.timeout_minutes * 60
+        else:
+            state["test_timeout"] = self.compute_sandbox_timeout_minutes() * 60
         await self.taskset.setup(state)
-        await self._create_harness_input_dirs(sandbox_id)
+        dirs = {self.harness.instruction_path.rsplit("/", 1)[0]}
+        if self.harness.system_prompt:
+            dirs.add(self.harness.system_prompt_path.rsplit("/", 1)[0])
+        mkdir_args = " ".join(shlex.quote(path) for path in sorted(dirs))
+        await self.sandbox_client.execute_command(
+            sandbox_id, f"mkdir -p {mkdir_args}", timeout=self.timeouts.mkdir
+        )
         await self._upload_harness_inputs(sandbox_id, state)
         await self._after_harness_inputs_uploaded(state)
         await self._install_agent(sandbox_id)
@@ -291,25 +302,6 @@ class ComposableEnv(CliAgentEnv):
             await self._collect_harness_metrics(sandbox_id, state)
 
         await super().post_rollout(state)
-
-    async def _populate_sandbox_context(self, state: State) -> None:
-        """Populate sandbox-specific context used by setup/evaluate hooks."""
-        state["sandbox_client"] = self.sandbox_client
-        spec = self._get_spec(state) or self.harness.sandbox_spec
-        if spec and spec.timeout_minutes is not None:
-            state["test_timeout"] = spec.timeout_minutes * 60
-        else:
-            state["test_timeout"] = self.compute_sandbox_timeout_minutes() * 60
-
-    async def _create_harness_input_dirs(self, sandbox_id: str) -> None:
-        """Create parent directories for harness-managed task assets."""
-        dirs = {self.harness.instruction_path.rsplit("/", 1)[0]}
-        if self.harness.system_prompt:
-            dirs.add(self.harness.system_prompt_path.rsplit("/", 1)[0])
-        mkdir_args = " ".join(shlex.quote(path) for path in sorted(dirs))
-        await self.sandbox_client.execute_command(
-            sandbox_id, f"mkdir -p {mkdir_args}", timeout=self.timeouts.mkdir
-        )
 
     async def _upload_harness_inputs(self, sandbox_id: str, state: State) -> None:
         """Upload instruction and optional system prompt to harness-declared paths."""

--- a/verifiers/envs/experimental/composable/harnesses/rlm.py
+++ b/verifiers/envs/experimental/composable/harnesses/rlm.py
@@ -296,18 +296,17 @@ def _build_summarize_resolver(
             raise ValueError(
                 f"summarize_at_tokens lo must be <= hi (got lo={lo}, hi={hi})"
             )
-        return lambda state: str(_draw_threshold(state, lo, hi))
+
+        def sampled_threshold(state: State) -> str:
+            prompt = _state_prompt_string(state)
+            digest = hashlib.sha256(prompt.encode("utf-8")).hexdigest()
+            return str(random.Random(int(digest[:16], 16)).randint(lo, hi))
+
+        return sampled_threshold
     raise ValueError(
         f"summarize_at_tokens must be int, (lo, hi), or None "
         f"(got {type(value).__name__})"
     )
-
-
-def _draw_threshold(state: State, lo: int, hi: int) -> int:
-    """Stable per-prompt uniform draw from ``[lo, hi]``."""
-    prompt = _state_prompt_string(state)
-    digest = hashlib.sha256(prompt.encode("utf-8")).hexdigest()
-    return random.Random(int(digest[:16], 16)).randint(lo, hi)
 
 
 def _state_prompt_string(state: State) -> str:

--- a/verifiers/envs/experimental/composable/swe_debug_env.py
+++ b/verifiers/envs/experimental/composable/swe_debug_env.py
@@ -164,12 +164,21 @@ class SWEDebugEnv(SandboxMixin, vf.MultiTurnEnv):
         if self.debug_step == "gold_patch":
             await self._apply_gold_patch(state)
         elif self.debug_step == "command":
-            valid = await self._run_debug_command(state, self.debug_command or "")
+            valid = await self._execute_debug_command(state, self.debug_command or "")
             if not valid:
                 state["body_s"] = time.perf_counter() - t0
                 return False
         elif self.debug_step == "script":
-            valid = await self._run_debug_script(state)
+            sandbox_id = state["sandbox_id"]
+            remote_path = "/tmp/swe_debug_script.sh"
+            if self.debug_script_path:
+                await self.upload_file(sandbox_id, remote_path, self.debug_script_path)
+            else:
+                await self.upload_content(
+                    sandbox_id, self.debug_script or "", remote_path
+                )
+            command = f"chmod +x {remote_path} && {shlex.quote(remote_path)}"
+            valid = await self._execute_debug_command(state, command)
             if not valid:
                 state["body_s"] = time.perf_counter() - t0
                 return False
@@ -190,25 +199,12 @@ class SWEDebugEnv(SandboxMixin, vf.MultiTurnEnv):
         await apply_gold_patch(state["sandbox_client"], state["sandbox_id"], state)
         state["gold_apply_s"] = time.perf_counter() - t0
 
-    async def _run_debug_command(self, state: State, command: str) -> bool:
-        return await self._execute_debug_command(state, command)
-
-    async def _run_debug_script(self, state: State) -> bool:
-        sandbox_id = state["sandbox_id"]
-        remote_path = "/tmp/swe_debug_script.sh"
-        if self.debug_script_path:
-            await self.upload_file(sandbox_id, remote_path, self.debug_script_path)
-        else:
-            await self.upload_content(sandbox_id, self.debug_script or "", remote_path)
-        command = f"chmod +x {remote_path} && {shlex.quote(remote_path)}"
-        return await self._execute_debug_command(state, command)
-
     async def _execute_debug_command(self, state: State, command: str) -> bool:
         t0 = time.perf_counter()
         result = await self.sandbox_client.execute_command(
             state["sandbox_id"],
             command,
-            working_dir=self._workdir(state),
+            working_dir=self.taskset.get_workdir(state.get("info") or {}),
             timeout=(
                 self.debug_timeout
                 if self.debug_timeout is not None
@@ -248,9 +244,6 @@ class SWEDebugEnv(SandboxMixin, vf.MultiTurnEnv):
         valid = reward > 0
         state["reason"] = "pass" if valid else "test_failed"
         return valid
-
-    def _workdir(self, state: State) -> str:
-        return self.taskset.get_workdir(state.get("info") or {})
 
     def _classify_outcome(
         self, valid: bool, exc: BaseException | None, state: State

--- a/verifiers/envs/experimental/composable/task.py
+++ b/verifiers/envs/experimental/composable/task.py
@@ -29,19 +29,10 @@ import importlib.resources as resources
 from dataclasses import dataclass
 from importlib.abc import Traversable
 from pathlib import Path
-from types import ModuleType
 from typing import Any, Callable
 
 from verifiers.envs.experimental.composable._filter import _resolve_filter_fn
 from verifiers.types import DatasetBuilder, Messages, State
-
-
-def _module_package_name(module: ModuleType) -> str | None:
-    """Return the package name for a module, or None if not in a package."""
-    if hasattr(module, "__path__"):
-        return module.__name__
-    package_name = getattr(module, "__package__", None)
-    return package_name or None
 
 
 def discover_sibling_dir(taskset_cls: type, dirname: str) -> Traversable | Path | None:
@@ -55,7 +46,11 @@ def discover_sibling_dir(taskset_cls: type, dirname: str) -> Traversable | Path 
     """
     module = importlib.import_module(taskset_cls.__module__)
 
-    package_name = _module_package_name(module)
+    package_name = (
+        module.__name__
+        if hasattr(module, "__path__")
+        else getattr(module, "__package__", None)
+    )
     if package_name:
         try:
             candidate = resources.files(package_name) / dirname
@@ -434,13 +429,6 @@ class TaskSet:
             with path.open("a") as f:
                 f.write(line)
 
-        async def _append_jsonl(row: dict) -> None:
-            if out_path_p is None:
-                return
-            line = json.dumps(row, default=str) + "\n"
-            async with write_lock:
-                await asyncio.to_thread(_write_line, out_path_p, line)
-
         # Sandbox-specific exception types — imported lazily so pure-LLM
         # tasksets don't pull in prime_sandboxes. Dispatch is via isinstance
         # so pytest output containing the substring "timeout" never looks
@@ -657,7 +645,10 @@ class TaskSet:
                 for fut in asyncio.as_completed(tasks):
                     r = await fut
                     results.append(r)
-                    await _append_jsonl(r)
+                    if out_path_p is not None:
+                        line = json.dumps(r, default=str) + "\n"
+                        async with write_lock:
+                            await asyncio.to_thread(_write_line, out_path_p, line)
                     if r["valid"]:
                         passed += 1
                     rate = passed / len(results)

--- a/verifiers/envs/experimental/composable/tasksets/lean/lean_task.py
+++ b/verifiers/envs/experimental/composable/tasksets/lean/lean_task.py
@@ -190,11 +190,6 @@ def _split_imports_and_signature(stmt: str) -> tuple[str, str]:
     return stmt[: decl_match.start()].rstrip(), stmt[decl_match.start() :]
 
 
-def _wrap_with_lean_guard(signature: str) -> str:
-    """Wrap a normalized ``... := by`` signature with lean-guard markers."""
-    return f"{LEAN_GUARD_BEGIN_MARKER}\n{signature}\n{LEAN_GUARD_END_MARKER}\n  sorry\n"
-
-
 def _extract_protected_region(content: str) -> str | None:
     """Return the text from the begin marker through the end-of-end-line.
 
@@ -231,22 +226,13 @@ def _build_starter_file(info: dict) -> str:
         signature_raw = stmt
 
     signature = _normalize_signature(signature_raw)
-    wrapped = _wrap_with_lean_guard(signature)
+    wrapped = (
+        f"{LEAN_GUARD_BEGIN_MARKER}\n{signature}\n{LEAN_GUARD_END_MARKER}\n  sorry\n"
+    )
 
     if preamble:
         return preamble.rstrip() + "\n\n" + wrapped
     return wrapped
-
-
-def _expected_protected_region(info: dict) -> str:
-    """Compute the protected region for a task instance from its ``info`` dict.
-
-    Re-runs ``_build_starter_file`` so the rubric and the setup step share
-    the exact same wrapping logic — no separate state plumbing needed.
-    """
-    starter = _build_starter_file(info)
-    region = _extract_protected_region(starter)
-    return region or ""
 
 
 # ---------------------------------------------------------------------------
@@ -275,7 +261,8 @@ class LeanRubric(vf.Rubric):
         timeout = state.get("test_timeout", 900)
 
         info = state.get("info") or {}
-        expected_region = _expected_protected_region(info)
+        starter = _build_starter_file(info)
+        expected_region = _extract_protected_region(starter) or ""
         if expected_region:
             try:
                 cat_result = await sandbox_client.execute_command(

--- a/verifiers/envs/experimental/composable/tasksets/swe/log_parser.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/log_parser.py
@@ -28,15 +28,6 @@ def parse_log_pytest(log: str | None) -> dict[str, str]:
     return test_status_map
 
 
-def parse_log_fn(repo_name: str):
-    """Return repo-specific log parser. Currently all repos use pytest parser."""
-    return parse_log_pytest
-
-
 def decolor_dict_keys(d: dict) -> dict:
     """Strip ANSI escape codes from dict keys."""
-
-    def decolor(key: str) -> str:
-        return re.sub(r"\u001b\[\d+m", "", key)
-
-    return {decolor(k): v for k, v in d.items()}
+    return {re.sub(r"\u001b\[\d+m", "", k): v for k, v in d.items()}

--- a/verifiers/envs/experimental/composable/tasksets/swe/multi_swe.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/multi_swe.py
@@ -16,12 +16,6 @@ _TEST_FIELDS = ("fixed_tests", "p2p_tests", "f2p_tests", "s2p_tests", "n2p_tests
 _TASK_META_PREFIX = "_task_"
 
 
-def _drop_task_meta(row: dict) -> dict:
-    return {
-        k: v for k, v in dict(row).items() if not str(k).startswith(_TASK_META_PREFIX)
-    }
-
-
 def _columnar_to_tests(entry: dict | None) -> dict[str, dict[str, str]]:
     if not entry:
         return {}
@@ -51,7 +45,9 @@ def _columnar_to_resolved_issues(entry: dict | list | None) -> list[dict[str, An
 
 
 def restore_row(row: dict) -> dict:
-    restored = _drop_task_meta(row)
+    restored = {
+        k: v for k, v in dict(row).items() if not str(k).startswith(_TASK_META_PREFIX)
+    }
     for field in _TEST_FIELDS:
         if field in restored:
             restored[field] = _columnar_to_tests(restored[field])

--- a/verifiers/envs/experimental/composable/tasksets/swe/r2e_gym.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/r2e_gym.py
@@ -7,7 +7,7 @@ from typing import Any
 import verifiers as vf
 from verifiers.envs.experimental.composable import SandboxSpec, SandboxTaskSet
 
-from .log_parser import decolor_dict_keys, parse_log_fn
+from .log_parser import decolor_dict_keys, parse_log_pytest
 
 logger = logging.getLogger(__name__)
 
@@ -390,7 +390,7 @@ class R2EGymTaskSet(SandboxTaskSet):
 
     def _calculate_reward(self, test_output: str, info: dict) -> float:
         """Parse test log, compare to expected_output_json."""
-        parse = parse_log_fn(info["repo_name"])(test_output)
+        parse = parse_log_pytest(test_output)
         parse = decolor_dict_keys(parse)
         expected: dict = json.loads(info["expected_output_json"])
         expected = decolor_dict_keys(expected)

--- a/verifiers/envs/experimental/composable/tasksets/swe/swe_rebench_v2.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/swe_rebench_v2.py
@@ -92,15 +92,6 @@ def _process_example(x: dict) -> dict:
     }
 
 
-def _resolve_parser(parser_name: str):
-    parser = _lp.NAME_TO_PARSER.get(parser_name)
-    if parser is None:
-        parser = getattr(_lp, parser_name, None)
-    if parser is None:
-        raise ValueError(f"Unknown SWE-rebench-V2 log parser: {parser_name!r}")
-    return parser
-
-
 def _repo_workdir(repo: str) -> str:
     """Mirror upstream eval.py: ``workdir = f'/{repo.split("/")[1]}'``."""
     if "/" not in repo:
@@ -116,18 +107,6 @@ def _extract_install_config(info: dict) -> dict:
     if isinstance(cfg, dict):
         return cfg
     raise ValueError("install_config missing or wrong type")
-
-
-def _normalize_test_cmds(test_cmd: Any) -> list[str]:
-    if isinstance(test_cmd, str):
-        cmds = [test_cmd]
-    elif isinstance(test_cmd, list):
-        cmds = [c for c in test_cmd if isinstance(c, str) and c.strip()]
-    else:
-        raise ValueError(f"install_config.test_cmd unsupported type: {type(test_cmd)}")
-    if not cmds:
-        raise ValueError("install_config.test_cmd is empty")
-    return cmds
 
 
 def _build_eval_script(test_cmds: list[str], workdir: str) -> str:
@@ -156,16 +135,6 @@ def _build_eval_script(test_cmds: list[str], workdir: str) -> str:
         "",
     ]
     return "\n".join(lines)
-
-
-def _slice_test_region(output: str) -> str:
-    start = "SWEREBENCH_V2_TEST_OUTPUT_START"
-    end = "SWEREBENCH_V2_TEST_OUTPUT_END"
-    if start in output:
-        output = output.split(start, 1)[1]
-    if end in output:
-        output = output.rsplit(end, 1)[0]
-    return output
 
 
 def _is_resolved(
@@ -345,7 +314,17 @@ class SWERebenchV2TaskSet(SandboxTaskSet):
     ) -> str:
         info = state["info"]
         cfg = _extract_install_config(info)
-        test_cmds = _normalize_test_cmds(cfg.get("test_cmd"))
+        raw_test_cmd = cfg.get("test_cmd")
+        if isinstance(raw_test_cmd, str):
+            test_cmds = [raw_test_cmd]
+        elif isinstance(raw_test_cmd, list):
+            test_cmds = [c for c in raw_test_cmd if isinstance(c, str) and c.strip()]
+        else:
+            raise ValueError(
+                f"install_config.test_cmd unsupported type: {type(raw_test_cmd)}"
+            )
+        if not test_cmds:
+            raise ValueError("install_config.test_cmd is empty")
         workdir = _repo_workdir(info["repo"])
 
         # Canonical SWE-bench grading dance: revert any agent edits to
@@ -399,11 +378,22 @@ class SWERebenchV2TaskSet(SandboxTaskSet):
             return 0.0
         try:
             cfg = _extract_install_config(info)
-            parser = _resolve_parser(cfg["log_parser"])
+            parser_name = cfg["log_parser"]
+            parser = _lp.NAME_TO_PARSER.get(parser_name)
+            if parser is None:
+                parser = getattr(_lp, parser_name, None)
+            if parser is None:
+                raise ValueError(f"Unknown SWE-rebench-V2 log parser: {parser_name!r}")
         except (KeyError, ValueError) as e:
             logger.warning(f"Could not resolve parser: {e}")
             return 0.0
-        region = _slice_test_region(test_output)
+        start = "SWEREBENCH_V2_TEST_OUTPUT_START"
+        end = "SWEREBENCH_V2_TEST_OUTPUT_END"
+        region = test_output
+        if start in region:
+            region = region.split(start, 1)[1]
+        if end in region:
+            region = region.rsplit(end, 1)[0]
         try:
             status_map = parser(region) or {}
         except Exception as e:

--- a/verifiers/envs/experimental/composable/tasksets/swe/swe_rebench_v2_log_parsers.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/swe_rebench_v2_log_parsers.py
@@ -503,16 +503,6 @@ def parse_log_ruby_v1(log: str) -> dict[str, str]:
 
     severity_rank = {"PASSED": 0, "SKIPPED": 0, "FAILED": 1, "ERROR": 2}
 
-    def norm(status: str) -> str:
-        s = status.upper()
-        if s in ("PASS", "PASSED"):
-            return "PASSED"
-        if s in ("FAIL", "FAILURE"):
-            return "FAILED"
-        if s in ("SKIP", "SKIPPED"):
-            return "SKIPPED"
-        return s  # ERROR
-
     current_suite: str | None = None
 
     for raw in log.splitlines():
@@ -530,7 +520,13 @@ def parse_log_ruby_v1(log: str) -> dict[str, str]:
             continue
         test_name, status_token = m.group(1).strip(), m.group(2)
         full_name = f"{current_suite}::{test_name}" if current_suite else test_name
-        status_norm = norm(status_token)
+        status_norm = status_token.upper()
+        if status_norm in ("PASS", "PASSED"):
+            status_norm = "PASSED"
+        elif status_norm in ("FAIL", "FAILURE"):
+            status_norm = "FAILED"
+        elif status_norm in ("SKIP", "SKIPPED"):
+            status_norm = "SKIPPED"
         prev = results.get(full_name)
         if prev is None or severity_rank.get(status_norm, 0) > severity_rank.get(
             prev, 0
@@ -1065,15 +1061,6 @@ def parse_log_p5js(log: str) -> dict[str, str]:
             match = xml_pat.search(log_content)
         return log_content
 
-    def is_valid_fail(match: re.Match) -> bool:
-        last_line_indent = 0
-        for line in match.group(2).split("\n"):
-            line_indent = len(line) - len(line.lstrip())
-            if line_indent <= last_line_indent:
-                return False
-            last_line_indent = line_indent
-        return True
-
     log = ansi_escape(log)
     log = remove_json_blocks(log)
     log = remove_xml_blocks(log)
@@ -1082,7 +1069,15 @@ def parse_log_p5js(log: str) -> dict[str, str]:
     # Parse failing tests
     fail_pattern = re.compile(r"^\s*(\d+)\)(.{0,1000}?):", re.MULTILINE | re.DOTALL)
     for match in fail_pattern.finditer(log):
-        if is_valid_fail(match):
+        last_line_indent = 0
+        valid_fail = True
+        for line in match.group(2).split("\n"):
+            line_indent = len(line) - len(line.lstrip())
+            if line_indent <= last_line_indent:
+                valid_fail = False
+                break
+            last_line_indent = line_indent
+        if valid_fail:
             test_names = list(map(str.strip, match.group(2).split("\n")))
             full_name = ":".join(test_names)
             test_results[full_name] = TestStatus.FAILED.value
@@ -1513,26 +1508,6 @@ def parse_lue_nvim(log: str) -> dict[str, str]:
     return results
 
 
-def _mvn_failure_status(line: str) -> str:
-    if "Exception" in line and "AssertionError" not in line:
-        return TestStatus.ERROR.value
-    return TestStatus.FAILED.value
-
-
-def _mvn_summary_class(line: str, current_running: str | None) -> str | None:
-    if " in " in line:
-        return line.rsplit(" in ", 1)[-1].strip().rstrip(".:;")
-    return current_running
-
-
-def _mvn_status_from_summary_counts(failures: int, errors: int, skipped: int) -> str:
-    if failures == 0 and errors == 0:
-        if skipped == 0:
-            return TestStatus.PASSED.value
-        return TestStatus.SKIPPED.value
-    return TestStatus.FAILED.value
-
-
 def parse_java_mvn(log: str) -> dict[str, str]:
     """Parse Maven logs into {identifier: status}.
 
@@ -1572,16 +1547,31 @@ def parse_java_mvn(log: str) -> dict[str, str]:
             clazz = fm.group("class")
             method = fm.group("method")
             test_id = f"{clazz}.{method}"
-            results[test_id] = _mvn_failure_status(line)
+            results[test_id] = (
+                TestStatus.ERROR.value
+                if "Exception" in line and "AssertionError" not in line
+                else TestStatus.FAILED.value
+            )
             results.setdefault(clazz, TestStatus.FAILED.value)
             continue
 
         sm = summary_re.search(line)
         if sm:
             _tests_run, failures, errors, skipped = map(int, sm.groups())
-            clazz = _mvn_summary_class(line, current_running)
+            clazz = (
+                line.rsplit(" in ", 1)[-1].strip().rstrip(".:;")
+                if " in " in line
+                else current_running
+            )
             if clazz:
-                status = _mvn_status_from_summary_counts(failures, errors, skipped)
+                if failures == 0 and errors == 0:
+                    status = (
+                        TestStatus.PASSED.value
+                        if skipped == 0
+                        else TestStatus.SKIPPED.value
+                    )
+                else:
+                    status = TestStatus.FAILED.value
                 results.setdefault(clazz, status)
             current_running = None
 

--- a/verifiers/envs/experimental/gym_env.py
+++ b/verifiers/envs/experimental/gym_env.py
@@ -30,27 +30,10 @@ class StepResetEnv(Protocol):
     step: Callable[..., Any]
 
 
-ResetOut: TypeAlias = Any | tuple[Any, dict[str, Any]]
 StepOut: TypeAlias = (
     tuple[Any, float, bool, bool, dict[str, Any]]
     | tuple[Any, float, bool, dict[str, Any]]
 )
-
-
-def normalize_reset(out: ResetOut) -> tuple[Any, dict[str, Any]]:
-    if isinstance(out, tuple) and len(out) == 2:
-        return cast(tuple[Any, dict[str, Any]], out)
-    return out, {}
-
-
-def normalize_step(out: StepOut) -> tuple[Any, float, bool, bool, dict[str, Any]]:
-    assert isinstance(out, (tuple, list)) and len(out) in (4, 5), (
-        f"env.step() returned {type(out)} of length {len(out) if isinstance(out, (tuple, list)) else 'N/A'}, expected tuple of length 4 or 5"
-    )
-    if len(out) == 5:
-        return cast(tuple[Any, float, bool, bool, dict[str, Any]], out)
-    obs, reward, done, info = cast(tuple[Any, float, bool, dict[str, Any]], out)
-    return obs, float(reward), bool(done), False, info
 
 
 def sum_step_rewards(state: State) -> float:
@@ -118,7 +101,11 @@ class GymEnv(vf.MultiTurnEnv):
 
         try:
             for i in range(total):
-                obs, _ = normalize_reset(env.reset(seed=self.seed + i))
+                reset_out = env.reset(seed=self.seed + i)
+                if isinstance(reset_out, tuple) and len(reset_out) == 2:
+                    obs, _ = reset_out
+                else:
+                    obs = reset_out
                 question = self.obs_to_text(obs)
                 row = {"question": question, "answer": str(self.seed + i)}
                 if i < self.num_train_episodes:
@@ -171,7 +158,23 @@ class GymEnv(vf.MultiTurnEnv):
             err_text = f"Action Parsing Error: {e}"
             return self.wrap_response(err_text)
 
-        obs, reward, term, trunc, info = normalize_step(env.step(action))
+        step_out = env.step(action)
+        assert isinstance(step_out, (tuple, list)) and len(step_out) in (4, 5), (
+            f"env.step() returned {type(step_out)} of length "
+            f"{len(step_out) if isinstance(step_out, (tuple, list)) else 'N/A'}, "
+            "expected tuple of length 4 or 5"
+        )
+        if len(step_out) == 5:
+            obs, reward, term, trunc, info = cast(
+                tuple[Any, float, bool, bool, dict[str, Any]], step_out
+            )
+        else:
+            obs, reward, term, info = cast(
+                tuple[Any, float, bool, dict[str, Any]], step_out
+            )
+            reward = float(reward)
+            term = bool(term)
+            trunc = False
 
         state["trajectory"][-1]["reward"] = reward
         state["trajectory"][-1]["extras"]["gym_info"] = info

--- a/verifiers/envs/experimental/harbor_env/mcp.py
+++ b/verifiers/envs/experimental/harbor_env/mcp.py
@@ -179,8 +179,11 @@ class HarborMCPMixin:
         jobs: dict[str, Any] = state.get("harbor_mcp_jobs") or {}
         for name in list(jobs):
             try:
+                pid_file = shlex.quote(self._mcp_pid_file(name))
                 await self.sandbox_client.execute_command(  # type: ignore[attr-defined]
-                    sandbox_id, self._mcp_stop_cmd(name), working_dir=None
+                    sandbox_id,
+                    f'kill -9 -"$(cat {pid_file} 2>/dev/null)" 2>/dev/null; rm -f {pid_file}',
+                    working_dir=None,
                 )
             except Exception as e:  # noqa: BLE001 — best-effort cleanup
                 logger.debug("Failed to stop MCP server %r: %s", name, e)
@@ -202,7 +205,10 @@ class HarborMCPMixin:
 
         job = await self.sandbox_client.start_background_job(  # type: ignore[attr-defined]
             sandbox_id=sandbox_id,
-            command=self._mcp_start_cmd(server.name, command),
+            command=(
+                f"setsid sh -c {shlex.quote(command)} & "
+                f"echo $! > {shlex.quote(self._mcp_pid_file(server.name))}; wait"
+            ),
             working_dir=None,
         )
         jobs: dict[str, Any] = state.setdefault("harbor_mcp_jobs", {})
@@ -216,11 +222,15 @@ class HarborMCPMixin:
     ) -> None:
         """Poll until the server is ready on localhost:port."""
         hc = self.mcp_healthcheck
-        health_cmd = (
-            hc.command.format(port=port)
-            if hc.command
-            else self._default_mcp_health_cmd(port)
-        )
+        if hc.command:
+            health_cmd = hc.command.format(port=port)
+        else:
+            port_hex = f"{port:04X}"
+            health_cmd = (
+                f'awk \'$4 == "0A" && $2 ~ /:{port_hex}$/ '
+                f"{{ok=1}} END {{exit !ok}}' "
+                f"/proc/net/tcp /proc/net/tcp6 2>/dev/null"
+            )
         probe_timeout = max(1, int(hc.timeout_sec))
 
         loop_time = asyncio.get_event_loop().time
@@ -319,24 +329,3 @@ class HarborMCPMixin:
     @staticmethod
     def _mcp_pid_file(name: str) -> str:
         return f"/tmp/harbor-mcp-{name}.pid"
-
-    def _mcp_start_cmd(self, name: str, command: str) -> str:
-        """Launch `command` in its own process group and record the group leader."""
-        pid_file = shlex.quote(self._mcp_pid_file(name))
-        quoted_cmd = shlex.quote(command)
-        return f"setsid sh -c {quoted_cmd} & echo $! > {pid_file}; wait"
-
-    def _mcp_stop_cmd(self, name: str) -> str:
-        """SIGKILL the recorded process group and remove the pidfile."""
-        pid_file = shlex.quote(self._mcp_pid_file(name))
-        return f'kill -9 -"$(cat {pid_file} 2>/dev/null)" 2>/dev/null; rm -f {pid_file}'
-
-    @staticmethod
-    def _default_mcp_health_cmd(port: int) -> str:
-        """Exit 0 iff some TCP listener is in LISTEN state on `port` (awk on `/proc/net/tcp{,6}`)."""
-        port_hex = f"{port:04X}"
-        return (
-            f'awk \'$4 == "0A" && $2 ~ /:{port_hex}$/ '
-            f"{{ok=1}} END {{exit !ok}}' "
-            f"/proc/net/tcp /proc/net/tcp6 2>/dev/null"
-        )

--- a/verifiers/envs/experimental/mcp_env.py
+++ b/verifiers/envs/experimental/mcp_env.py
@@ -249,21 +249,14 @@ class MCPEnv(vf.ToolEnv):
                 },
             )
 
-    async def _disconnect_servers(self):
-        for connection in self.server_connections.values():
-            await connection.disconnect()
-
-        self.server_connections.clear()
-        self.mcp_tools.clear()
-
     @vf.teardown
     async def teardown_mcp_servers(self):
-        fut = asyncio.run_coroutine_threadsafe(
-            self._disconnect_servers(), self._bg_loop
-        )
-        await asyncio.wrap_future(fut)
-        self._shutdown_loop()
-
-    def _shutdown_loop(self):
+        for connection in self.server_connections.values():
+            fut = asyncio.run_coroutine_threadsafe(
+                connection.disconnect(), self._bg_loop
+            )
+            await asyncio.wrap_future(fut)
+        self.server_connections.clear()
+        self.mcp_tools.clear()
         self._bg_loop.call_soon_threadsafe(self._bg_loop.stop)
         self._bg_thread.join(timeout=5)

--- a/verifiers/envs/experimental/opencode_rlm_env.py
+++ b/verifiers/envs/experimental/opencode_rlm_env.py
@@ -267,10 +267,6 @@ class OpenCodeRLMEnv(OpenCodeEnv):
         state.setdefault("_sub_llm_tasks", set())
         return state
 
-    @staticmethod
-    def _is_sub_llm_request(intercept: dict[str, Any]) -> bool:
-        return intercept.get("headers", {}).get("x-rlm-role") == "sub"
-
     async def get_prompt_messages(self, state: State) -> Messages:
         """Extends parent to route sub-LLM requests concurrently.
 
@@ -291,7 +287,7 @@ class OpenCodeRLMEnv(OpenCodeEnv):
 
             intercept = interception_server.intercepts[request_id]
 
-            if self._is_sub_llm_request(intercept):
+            if intercept.get("headers", {}).get("x-rlm-role") == "sub":
                 task = asyncio.create_task(
                     self._handle_sub_llm_request(state, request_id, intercept)
                 )
@@ -362,7 +358,14 @@ class OpenCodeRLMEnv(OpenCodeEnv):
                 raise error
 
             if response is not None:
-                self._update_sub_metrics(state, response)
+                prompt_tokens, completion_tokens = self._extract_token_counts(response)
+                state["sub_llm_turns"] = state.get("sub_llm_turns", 0) + 1
+                state["sub_llm_prompt_tokens"] = (
+                    state.get("sub_llm_prompt_tokens", 0) + prompt_tokens
+                )
+                state["sub_llm_completion_tokens"] = (
+                    state.get("sub_llm_completion_tokens", 0) + completion_tokens
+                )
                 if self.include_sub_llm_in_trajectory:
                     completion = [response.message] if response.message else []
                     prompt_tokens, completion_tokens = self._extract_token_counts(
@@ -423,14 +426,4 @@ class OpenCodeRLMEnv(OpenCodeEnv):
         return (
             int(getattr(usage, "prompt_tokens", 0) or 0),
             int(getattr(usage, "completion_tokens", 0) or 0),
-        )
-
-    def _update_sub_metrics(self, state: State, response: Response) -> None:
-        prompt_tokens, completion_tokens = self._extract_token_counts(response)
-        state["sub_llm_turns"] = state.get("sub_llm_turns", 0) + 1
-        state["sub_llm_prompt_tokens"] = (
-            state.get("sub_llm_prompt_tokens", 0) + prompt_tokens
-        )
-        state["sub_llm_completion_tokens"] = (
-            state.get("sub_llm_completion_tokens", 0) + completion_tokens
         )

--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -304,16 +304,6 @@ def _ensure_rlm_metric_state(state: State) -> None:
     state.setdefault("_summarize_at_root_llm_turns", [])
 
 
-def _update_rlm_repl_metrics(state: State, execution_seconds: float) -> None:
-    _ensure_rlm_metric_state(state)
-    state["repl_total_time_seconds"] += execution_seconds
-    state["repl_call_count"] += 1
-    if state["repl_call_count"] > 0:
-        state["repl_mean_time_seconds"] = (
-            state["repl_total_time_seconds"] / state["repl_call_count"]
-        )
-
-
 def update_rlm_metrics_from_step(state: State, step: TrajectoryStep) -> None:
     _ensure_rlm_metric_state(state)
     extras = step.get("extras", {}) or {}
@@ -361,14 +351,6 @@ def update_rlm_metrics_from_step(state: State, step: TrajectoryStep) -> None:
         state["root_llm_turns"] += 1
         state["root_llm_prompt_tokens"] += prompt_tokens
         state["root_llm_completion_tokens"] += completion_tokens
-
-
-def _update_root_tool_metrics(state: State, tool_name: str) -> None:
-    _ensure_rlm_metric_state(state)
-    state["root_tool_call_count"] += 1
-    tool_calls: dict[str, int] = state.get("root_tool_calls", {})
-    tool_calls[tool_name] = tool_calls.get(tool_name, 0) + 1
-    state["root_tool_calls"] = tool_calls
 
 
 def _update_root_tool_time_metrics(
@@ -2924,17 +2906,6 @@ class RLMEnv(vf.StatefulToolEnv):
             max_turns_reached=True,
         )
 
-    def _sub_llm_budget_exhausted_message(self, state_ref: State) -> str:
-        """Build a human-readable budget-exhausted message."""
-        used = state_ref.get("sub_llm_completion_tokens", 0)
-        budget = self.sub_max_completion_tokens
-        return (
-            f"llm_batch token budget exhausted "
-            f"(used {used}/{budget} completion tokens). "
-            f"No further llm_batch calls are available. "
-            f"Finalize your answer with the information you have."
-        )
-
     async def _root_llm_batch(
         self,
         context: dict[str, Any],
@@ -2955,7 +2926,12 @@ class RLMEnv(vf.StatefulToolEnv):
         if self.sub_max_completion_tokens is not None:
             used = state_ref.get("sub_llm_completion_tokens", 0)
             if used >= self.sub_max_completion_tokens:
-                msg = self._sub_llm_budget_exhausted_message(state_ref)
+                msg = (
+                    f"llm_batch token budget exhausted "
+                    f"(used {used}/{self.sub_max_completion_tokens} completion tokens). "
+                    f"No further llm_batch calls are available. "
+                    f"Finalize your answer with the information you have."
+                )
                 return [msg] * len(prompts)
 
         rid = state_ref.get("rollout_id", "?")
@@ -2974,18 +2950,17 @@ class RLMEnv(vf.StatefulToolEnv):
         ] * len(prompts)
         semaphore = asyncio.Semaphore(self.max_sub_llm_parallelism)
 
-        def _coerce_prompt_messages(prompt: Any, index: int) -> Messages:
-            if isinstance(prompt, str):
-                return [UserMessage(content=prompt)]
-            raise ValueError(
-                "llm_batch prompt at index " + str(index) + " must be a string."
-            )
-
         async def _call_one(index: int, prompt: Any) -> None:
             async with semaphore:
                 request_id = uuid.uuid4().hex[:8]
                 try:
-                    messages = _coerce_prompt_messages(prompt, index)
+                    if not isinstance(prompt, str):
+                        raise ValueError(
+                            "llm_batch prompt at index "
+                            + str(index)
+                            + " must be a string."
+                        )
+                    messages: Messages = [UserMessage(content=prompt)]
                     response_dict = await self._run_sub_llm_request(
                         state_ref=state_ref,
                         client=client,
@@ -3287,7 +3262,11 @@ class RLMEnv(vf.StatefulToolEnv):
         token = self._root_tool_context_var.set(root_tool_context)
         tool_start = perf_counter()
         try:
-            _update_root_tool_metrics(state_ref, tool_name)
+            _ensure_rlm_metric_state(state_ref)
+            state_ref["root_tool_call_count"] += 1
+            tool_calls: dict[str, int] = state_ref.get("root_tool_calls", {})
+            tool_calls[tool_name] = tool_calls.get(tool_name, 0) + 1
+            state_ref["root_tool_calls"] = tool_calls
             tool_func = self.root_tool_map[tool_name]
             if tool_name == "llm_batch":
                 if args and "prompts" in kwargs:
@@ -3566,10 +3545,6 @@ class RLMEnv(vf.StatefulToolEnv):
     # Code Execution
     # =========================================================================
 
-    async def _recover_from_code_timeout(self, state: State) -> bool:
-        """Attempt to recover from a code execution timeout via the active backend."""
-        return await self._executor.recover_from_timeout(state)
-
     async def _execute_code(self, code: str, state: State) -> dict[str, Any]:
         """Execute code in worker and return result."""
         if not state.get("rlm_worker_ready", False):
@@ -3648,6 +3623,10 @@ class RLMEnv(vf.StatefulToolEnv):
             }
 
         return parsed_result
+
+    async def _recover_from_code_timeout(self, state: State) -> bool:
+        """Attempt to recover from a code execution timeout via the active backend."""
+        return await self._executor.recover_from_timeout(state)
 
     def _format_execution_output(self, result: dict[str, Any]) -> str:
         """Format execution result for display to model."""
@@ -3809,7 +3788,13 @@ class RLMEnv(vf.StatefulToolEnv):
         execution_time = perf_counter() - execution_start
         output = self._format_execution_output(result)
 
-        _update_rlm_repl_metrics(state, execution_time)
+        _ensure_rlm_metric_state(state)
+        state["repl_total_time_seconds"] += execution_time
+        state["repl_call_count"] += 1
+        if state["repl_call_count"] > 0:
+            state["repl_mean_time_seconds"] = (
+                state["repl_total_time_seconds"] / state["repl_call_count"]
+            )
 
         answer = result.get("answer", {})
         answer_ready = answer.get("ready", False)
@@ -4224,30 +4209,23 @@ class RLMEnv(vf.StatefulToolEnv):
             self._append_observable_messages(state, tool_messages)
         if "final_answer" in state:
             state["final_env_response"] = tool_messages
-        elif self._is_root_budget_exhausted(state):
+        elif (
+            self.root_max_completion_tokens is not None
+            and state.get("root_llm_completion_tokens", 0)
+            >= self.root_max_completion_tokens
+        ):
             await self._ensure_final_answer(state)
             state["final_env_response"] = tool_messages
-        elif self._is_max_turns_in_context_reached(state):
+        elif (
+            self.max_turns_in_context is not None
+            and self._main_turn_count(state)
+            - state.get("_keep_from_assistant_index", 0)
+            >= self.max_turns_in_context
+        ):
             state["max_turns_in_context_stopped"] = True
             await self._ensure_final_answer(state)
             state["final_env_response"] = tool_messages
         return tool_messages
-
-    def _is_root_budget_exhausted(self, state: State) -> bool:
-        """Check if root model completion token budget is exhausted."""
-        if self.root_max_completion_tokens is None:
-            return False
-        used = state.get("root_llm_completion_tokens", 0)
-        return used >= self.root_max_completion_tokens
-
-    def _is_max_turns_in_context_reached(self, state: State) -> bool:
-        """Check if visible turns in context exceed max_turns_in_context."""
-        if self.max_turns_in_context is None:
-            return False
-        visible = self._main_turn_count(state) - state.get(
-            "_keep_from_assistant_index", 0
-        )
-        return visible >= self.max_turns_in_context
 
     # =========================================================================
     # Stop Conditions

--- a/verifiers/envs/experimental/utils/git_checkout_cache.py
+++ b/verifiers/envs/experimental/utils/git_checkout_cache.py
@@ -46,28 +46,12 @@ def validate_git_checkout(
     return path
 
 
-def _slugify_cache_component(text: str) -> str:
-    slug = "".join(char.lower() if char.isalnum() else "-" for char in text)
-    slug = slug.strip("-")
-    return slug or "repo"
-
-
-def _repo_cache_dir(cache_root: Path, repo_url: str) -> Path:
-    repo_name = repo_url.rstrip("/").rsplit("/", 1)[-1].removesuffix(".git")
-    fingerprint = hashlib.sha256(repo_url.encode()).hexdigest()[:12]
-    return cache_root / f"{_slugify_cache_component(repo_name)}-{fingerprint}"
-
-
 def _mirror_dir(repo_cache_dir: Path) -> Path:
     return repo_cache_dir / "mirror.git"
 
 
 def _worktrees_dir(repo_cache_dir: Path) -> Path:
     return repo_cache_dir / "worktrees"
-
-
-def _checkout_dir_for_commit(repo_cache_dir: Path, commit_sha: str) -> Path:
-    return _worktrees_dir(repo_cache_dir) / commit_sha.lower()
 
 
 def _build_clone_url(repo_url: str, gh_token: str | None = None) -> str:
@@ -101,17 +85,6 @@ def _redact_clone_error_detail(detail: str, gh_token: str | None = None) -> str:
     return redacted
 
 
-def _git_env(gh_token: str | None) -> dict[str, str]:
-    env = os.environ.copy()
-    if gh_token:
-        env.setdefault("GH_TOKEN", gh_token)
-    return env
-
-
-def _git_required_error() -> RuntimeError:
-    return RuntimeError("git is required to populate the local checkout cache")
-
-
 def _run_git(
     args: list[str],
     *,
@@ -120,16 +93,21 @@ def _run_git(
     failure: str,
 ) -> subprocess.CompletedProcess[str]:
     try:
+        env = os.environ.copy()
+        if gh_token:
+            env.setdefault("GH_TOKEN", gh_token)
         return subprocess.run(
             args,
             cwd=cwd,
             check=True,
             capture_output=True,
             text=True,
-            env=_git_env(gh_token),
+            env=env,
         )
     except FileNotFoundError as exc:
-        raise _git_required_error() from exc
+        raise RuntimeError(
+            "git is required to populate the local checkout cache"
+        ) from exc
     except subprocess.CalledProcessError as exc:
         detail = exc.stderr.strip() or exc.stdout.strip() or str(exc)
         detail = _redact_clone_error_detail(detail, gh_token)
@@ -270,7 +248,7 @@ def _materialize_worktree(
     required_files: tuple[str, ...] = (),
 ) -> Path:
     mirror_dir = _mirror_dir(repo_cache_dir)
-    checkout_dir = _checkout_dir_for_commit(repo_cache_dir, commit_sha)
+    checkout_dir = _worktrees_dir(repo_cache_dir) / commit_sha.lower()
     try:
         return validate_git_checkout(checkout_dir, required_files=required_files)
     except ValueError:
@@ -387,7 +365,11 @@ def resolve_git_checkout(
             Path(local_checkout), required_files=required_files
         )
 
-    repo_cache_dir = _repo_cache_dir(cache_root.expanduser().resolve(), repo_url)
+    repo_name = repo_url.rstrip("/").rsplit("/", 1)[-1].removesuffix(".git")
+    slug = "".join(char.lower() if char.isalnum() else "-" for char in repo_name)
+    slug = slug.strip("-") or "repo"
+    fingerprint = hashlib.sha256(repo_url.encode()).hexdigest()[:12]
+    repo_cache_dir = cache_root.expanduser().resolve() / f"{slug}-{fingerprint}"
     repo_cache_dir.mkdir(parents=True, exist_ok=True)
     with exclusive_file_lock(repo_cache_dir / ".repo.lock"):
         mirror_dir = _ensure_mirror(

--- a/verifiers/envs/integrations/openenv_env.py
+++ b/verifiers/envs/integrations/openenv_env.py
@@ -56,24 +56,6 @@ def _missing_openenv(component: str) -> ImportError:
     )
 
 
-def _generic_client_class() -> type[Any]:
-    if GenericEnvClient is None:
-        raise _missing_openenv("gym rollouts")
-    return GenericEnvClient
-
-
-def _mcp_client_class() -> type[Any]:
-    if MCPToolClient is None:
-        raise _missing_openenv("MCP rollouts")
-    return MCPToolClient
-
-
-def _call_tool_action_class() -> type[Any]:
-    if CallToolAction is None:
-        raise _missing_openenv("MCP tool calls")
-    return CallToolAction
-
-
 @dataclass
 class OpenEnvServer:
     sandbox_id: str
@@ -128,7 +110,16 @@ class OpenEnvEnv(vf.MultiTurnEnv):
         jitter: float = 1e-3,
         **kwargs: Any,
     ):
-        self.openenv_project = self._resolve_openenv_project(openenv_project)
+        if openenv_project is not None:
+            self.openenv_project = str(openenv_project)
+        else:
+            current_file = Path(__file__).resolve()
+            self.openenv_project = str(Path.cwd() / "proj")
+            for frame_info in inspect.stack()[1:]:
+                frame_path = Path(frame_info.filename).resolve()
+                if frame_path != current_file:
+                    self.openenv_project = str(frame_path.parent / "proj")
+                    break
         self.num_train_examples = num_train_examples
         self.num_eval_examples = num_eval_examples
         self.seed = seed
@@ -172,18 +163,6 @@ class OpenEnvEnv(vf.MultiTurnEnv):
             message_type="chat",
             **kwargs,
         )
-
-    def _resolve_openenv_project(self, openenv_project: str | Path | None) -> str:
-        if openenv_project is not None:
-            return str(openenv_project)
-
-        current_file = Path(__file__).resolve()
-        for frame_info in inspect.stack()[1:]:
-            frame_path = Path(frame_info.filename).resolve()
-            if frame_path != current_file:
-                return str(frame_path.parent / "proj")
-
-        return str(Path.cwd() / "proj")
 
     async def start_server(
         self,
@@ -271,10 +250,27 @@ class OpenEnvEnv(vf.MultiTurnEnv):
 
     async def setup_state(self, state: vf.State) -> vf.State:
         try:
-            server = await self._create_server()
+            project_path = Path(self.openenv_project).expanduser().resolve()
+            if not project_path.exists() or not project_path.is_dir():
+                raise ValueError(
+                    "OpenEnvEnv requires a local OpenEnv project directory. "
+                    f"Got: {self.openenv_project}"
+                )
+            image, port, start_command, contract = self._resolve_runtime_config(
+                project_path
+            )
+            server = await self._launch_image_server(
+                image, port, start_command, contract
+            )
+            self._active_servers[server.sandbox_id] = server
             state["openenv_server"] = server
             state["openenv_contract"] = server.contract
-            action_schema = await self._fetch_action_schema(server.base_url)
+            if self._action_schema is None:
+                schema = await self._fetch_schema(server.base_url)
+                self._action_schema = (
+                    schema.get("action", {}) if isinstance(schema, dict) else {}
+                )
+            action_schema = self._action_schema
             self._assert_contract_matches_schema(server.contract, action_schema)
             state["openenv_action_schema"] = action_schema
             if self._contract is None:
@@ -288,11 +284,16 @@ class OpenEnvEnv(vf.MultiTurnEnv):
                 seed = int(info.get("seed", 0))
 
             if server.contract == "mcp":
-                mcp_client = _mcp_client_class()(base_url=server.base_url)
+                if MCPToolClient is None:
+                    raise _missing_openenv("MCP rollouts")
+                mcp_client = MCPToolClient(base_url=server.base_url)
                 await mcp_client.connect()
                 state["openenv_mcp_client"] = mcp_client
                 if self._mcp_tools is None:
-                    self._mcp_tools = await self._mcp_list_tools(mcp_client)
+                    tools = await mcp_client.list_tools()
+                    if not isinstance(tools, list) or not tools:
+                        raise RuntimeError("MCP tools/list returned no usable tools.")
+                    self._mcp_tools = tools
                 state["tool_defs"] = self._convert_mcp_tools(self._mcp_tools)
                 result = await mcp_client.reset(seed=seed)
                 state["openenv_done"] = bool(result.done)
@@ -305,7 +306,9 @@ class OpenEnvEnv(vf.MultiTurnEnv):
                 )
                 return state
 
-            client = _generic_client_class()(base_url=server.base_url)
+            if GenericEnvClient is None:
+                raise _missing_openenv("gym rollouts")
+            client = GenericEnvClient(base_url=server.base_url)
             await client.connect()
             state["openenv_client"] = client
             result = await client.reset(seed=seed)
@@ -322,12 +325,6 @@ class OpenEnvEnv(vf.MultiTurnEnv):
             await self._cleanup_openenv_state(state)
             raise
 
-    def _make_user_message(self, content: str) -> Message:
-        return UserMessage(content=content)
-
-    def _make_tool_message(self, content: Any, tool_call_id: str) -> Message:
-        return ToolMessage(content=content, tool_call_id=tool_call_id)
-
     async def env_response(
         self, messages: vf.Messages, state: vf.State, **kwargs: Any
     ) -> vf.Messages:
@@ -342,7 +339,7 @@ class OpenEnvEnv(vf.MultiTurnEnv):
         assert isinstance(messages, list)
         last_msg = messages[-1]
         if not isinstance(last_msg, AssistantMessage):
-            return [self._make_user_message("Expected assistant response.")]
+            return [UserMessage(content="Expected assistant response.")]
 
         raw_text = str(last_msg.content or "").strip()
         action_schema = state.get("openenv_action_schema") or self._action_schema or {}
@@ -387,30 +384,31 @@ class OpenEnvEnv(vf.MultiTurnEnv):
                     raise ValueError("tool arguments must be an object")
                 if not tool_name:
                     raise ValueError("tool name cannot be empty")
-                result = await self._mcp_step_tool(
-                    mcp_client, tool_name=tool_name, arguments=tool_args
+                if CallToolAction is None:
+                    raise _missing_openenv("MCP tool calls")
+                result = await mcp_client.step(
+                    CallToolAction(tool_name=tool_name, arguments=tool_args)
                 )
                 if isinstance(result.reward, (int, float)):
                     total_reward += float(result.reward)
                 done = done or bool(result.done)
-                content = self._format_tool_content(
-                    self._extract_mcp_tool_content(result.observation)
-                )
+                content = self._extract_mcp_tool_content(result.observation)
+                if not is_valid_tool_content_parts(content):
+                    content = (
+                        content
+                        if isinstance(content, str)
+                        else json.dumps(content, ensure_ascii=True)
+                    )
             except Exception as e:
                 content = f"Error: {e}"
 
-            tool_messages.append(self._make_tool_message(content, tool_call_id))
+            tool_messages.append(
+                ToolMessage(content=content, tool_call_id=tool_call_id)
+            )
         if state["trajectory"]:
             state["trajectory"][-1]["reward"] = total_reward
         state["openenv_done"] = done
         return tool_messages
-
-    def _format_tool_content(self, result: Any) -> Any:
-        if is_valid_tool_content_parts(result):
-            return result
-        if isinstance(result, str):
-            return result
-        return json.dumps(result, ensure_ascii=True)
 
     @vf.stop
     async def openenv_done(self, state: vf.State) -> bool:
@@ -480,9 +478,6 @@ class OpenEnvEnv(vf.MultiTurnEnv):
             logs = await sandboxes.get_logs(sandbox_id)
         except Exception:
             return None
-        return self._trim_logs(logs)
-
-    def _trim_logs(self, logs: Any) -> str | None:
         if not logs:
             return None
         logs_str = str(logs)
@@ -521,24 +516,6 @@ class OpenEnvEnv(vf.MultiTurnEnv):
                 await self._cleanup_server(server)
             except Exception:
                 pass
-
-    async def _create_server(self) -> OpenEnvServer:
-        project_path = self._resolve_project_path()
-        image, port, start_command, contract = self._resolve_runtime_config(
-            project_path
-        )
-        server = await self._launch_image_server(image, port, start_command, contract)
-        self._active_servers[server.sandbox_id] = server
-        return server
-
-    def _resolve_project_path(self) -> Path:
-        path = Path(self.openenv_project).expanduser().resolve()
-        if path.exists() and path.is_dir():
-            return path
-        raise ValueError(
-            "OpenEnvEnv requires a local OpenEnv project directory. "
-            f"Got: {self.openenv_project}"
-        )
 
     def _resolve_runtime_config(self, project_path: Path) -> tuple[str, int, str, str]:
         manifest = self._read_build_manifest(project_path)
@@ -678,18 +655,6 @@ class OpenEnvEnv(vf.MultiTurnEnv):
             "OpenEnv sandbox exposure did not provide a usable endpoint URL."
         )
 
-    async def _mcp_list_tools(self, client: Any) -> list[Any]:
-        tools = await client.list_tools()
-        if not isinstance(tools, list) or not tools:
-            raise RuntimeError("MCP tools/list returned no usable tools.")
-        return tools
-
-    async def _mcp_step_tool(
-        self, client: Any, tool_name: str, arguments: dict[str, Any]
-    ) -> Any:
-        action = _call_tool_action_class()(tool_name=tool_name, arguments=arguments)
-        return await client.step(action)
-
     def _extract_mcp_tool_content(self, observation: Any) -> Any:
         if hasattr(observation, "model_dump"):
             try:
@@ -700,9 +665,7 @@ class OpenEnvEnv(vf.MultiTurnEnv):
             return observation
         if observation.get("error") is not None:
             return {"error": observation.get("error")}
-        return self._unwrap_mcp_result(observation.get("result"))
-
-    def _unwrap_mcp_result(self, value: Any) -> Any:
+        value = observation.get("result")
         if hasattr(value, "data"):
             return cast(Any, value).data
         if isinstance(value, dict) and "data" in value:
@@ -755,18 +718,17 @@ class OpenEnvEnv(vf.MultiTurnEnv):
         except Exception as e:
             return False, f"{type(e).__name__}: {e}"
 
-    async def _fetch_action_schema(self, base_url: str) -> dict[str, Any]:
-        if self._action_schema is not None:
-            return self._action_schema
-        schema = await self._fetch_schema(base_url)
-        action_schema = schema.get("action", {}) if isinstance(schema, dict) else {}
-        self._action_schema = action_schema
-        return action_schema
-
     def _assert_contract_matches_schema(
         self, contract: str, action_schema: dict[str, Any]
     ) -> None:
-        looks_mcp = self._looks_like_mcp_schema(action_schema)
+        props = (
+            action_schema.get("properties", {})
+            if isinstance(action_schema, dict)
+            else {}
+        )
+        looks_mcp = (
+            isinstance(props, dict) and "tool_name" in props and "arguments" in props
+        ) or self._schema_contains_values(action_schema, {"list_tools", "call_tool"})
         if contract == "mcp" and not looks_mcp:
             raise RuntimeError(
                 "OpenEnv contract mismatch: manifest contract is 'mcp' but action schema "
@@ -792,14 +754,6 @@ class OpenEnvEnv(vf.MultiTurnEnv):
 
         return await self._with_retry(_run_once)()
 
-    def _looks_like_mcp_schema(self, schema: dict[str, Any]) -> bool:
-        if not isinstance(schema, dict):
-            return False
-        props = schema.get("properties", {})
-        if isinstance(props, dict) and "tool_name" in props and "arguments" in props:
-            return True
-        return self._schema_contains_values(schema, {"list_tools", "call_tool"})
-
     def _schema_contains_values(self, obj: Any, values: set[str]) -> bool:
         if isinstance(obj, dict):
             for k, v in obj.items():
@@ -813,7 +767,10 @@ class OpenEnvEnv(vf.MultiTurnEnv):
         return False
 
     def _parse_action(self, text: str, schema: dict[str, Any]) -> dict[str, Any]:
-        cleaned = self._strip_code_fence(text)
+        if text.startswith("```") and text.endswith("```"):
+            cleaned = "\n".join(text.split("\n")[1:-1]).strip()
+        else:
+            cleaned = text
         try:
             action = json.loads(cleaned)
             if isinstance(action, dict):
@@ -827,11 +784,6 @@ class OpenEnvEnv(vf.MultiTurnEnv):
         raise ValueError(
             "Failed to parse action JSON. Provide a JSON object matching the action schema."
         )
-
-    def _strip_code_fence(self, text: str) -> str:
-        if text.startswith("```") and text.endswith("```"):
-            return "\n".join(text.split("\n")[1:-1]).strip()
-        return text
 
     def _single_string_field(self, schema: dict[str, Any]) -> str | None:
         if not isinstance(schema, dict):
@@ -856,14 +808,6 @@ class OpenEnvEnv(vf.MultiTurnEnv):
                 return field_name
         return None
 
-    def _normalize_observation(self, obs: Any) -> Any:
-        if hasattr(obs, "model_dump"):
-            try:
-                return obs.model_dump()
-            except Exception:
-                return obs
-        return obs
-
     def _render_observation_messages(
         self,
         obs: Any,
@@ -873,7 +817,12 @@ class OpenEnvEnv(vf.MultiTurnEnv):
         contract: str | None = None,
         seed: int | None = None,
     ) -> Messages:
-        normalized_obs = self._normalize_observation(obs)
+        normalized_obs = obs
+        if hasattr(obs, "model_dump"):
+            try:
+                normalized_obs = obs.model_dump()
+            except Exception:
+                normalized_obs = obs
         renderer_kwargs = {
             "context": context,
             "action_schema": action_schema,

--- a/verifiers/envs/multiturn_env.py
+++ b/verifiers/envs/multiturn_env.py
@@ -136,10 +136,6 @@ class MultiTurnEnv(vf.Environment):
         """Override to set intermediate rewards, advantages, or extra metadata."""
         state["trajectory"].append(trajectory_step)
 
-    async def _finalize_rollout(self, state: State) -> None:
-        """Finalize rollout state and run cleanup handlers exactly once."""
-        await self.cleanup(state)
-
     async def add_model_response(
         self,
         state: State,
@@ -222,5 +218,5 @@ class MultiTurnEnv(vf.Environment):
         except asyncio.TimeoutError:
             self.mark_timed_out(state)
         finally:
-            await self._finalize_rollout(state)
+            await self.cleanup(state)
         return state

--- a/verifiers/gepa/gepa_utils.py
+++ b/verifiers/gepa/gepa_utils.py
@@ -97,15 +97,6 @@ def _normalize_parents(parents: Any, candidate_idx: int) -> list[int]:
     return normalized
 
 
-def _jsonable_scores(scores: dict[Any, Any]) -> dict[str, float]:
-    jsonable = {}
-    for key, value in scores.items():
-        score = _to_float(value)
-        if score is not None:
-            jsonable[str(key)] = score
-    return jsonable
-
-
 def _as_list(value: Any) -> list[Any]:
     if value is None:
         return []
@@ -136,11 +127,12 @@ def _build_candidate_records(
     for candidate_idx, candidate in enumerate(candidates):
         system_prompt = _prompt_from_candidate(candidate)
         score = _candidate_score(candidate_idx, val_scores, val_subscores)
-        subscores = (
-            _jsonable_scores(val_subscores[candidate_idx])
-            if candidate_idx < len(val_subscores)
-            else {}
-        )
+        subscores = {}
+        if candidate_idx < len(val_subscores):
+            for key, value in val_subscores[candidate_idx].items():
+                subscore = _to_float(value)
+                if subscore is not None:
+                    subscores[str(key)] = subscore
         info: dict[str, Any] = {
             "schema_version": GEPA_SCHEMA_VERSION,
             "eval_kind": GEPA_EVAL_KIND,

--- a/verifiers/rubrics/rubric.py
+++ b/verifiers/rubrics/rubric.py
@@ -179,16 +179,6 @@ class Rubric:
         return None
 
     # individual-level reward helpers
-    def _get_individual_reward_funcs(self) -> list[RewardFunc]:
-        return [func for func in self.funcs if not self._is_group_func(func)]
-
-    def _get_individual_reward_weights(self) -> list[float]:
-        return [
-            weight
-            for func, weight in zip(self.funcs, self.weights)
-            if not self._is_group_func(func)
-        ]
-
     async def _call_individual_reward_func(
         self,
         func: RewardFunc,
@@ -328,7 +318,7 @@ class Rubric:
         """
         Evaluate all reward functions for a single rollout.
         """
-        reward_funcs = self._get_individual_reward_funcs()
+        reward_funcs = [func for func in self.funcs if not self._is_group_func(func)]
         group_reward_funcs = self._get_group_reward_funcs()
         assert len(reward_funcs) > 0 and len(group_reward_funcs) == 0, (
             "Rubric.score_rollout requires at least one individual-level reward function and no group-level reward functions"
@@ -350,7 +340,12 @@ class Rubric:
                 [
                     reward * weight
                     for reward, weight in zip(
-                        reward_scores, self._get_individual_reward_weights()
+                        reward_scores,
+                        [
+                            weight
+                            for func, weight in zip(self.funcs, self.weights)
+                            if not self._is_group_func(func)
+                        ],
                     )
                 ]
             ),

--- a/verifiers/scripts/build.py
+++ b/verifiers/scripts/build.py
@@ -34,15 +34,6 @@ def _normalize_env_id(raw_env_id: str) -> tuple[str, str]:
     return env_id_dash, env_id_underscore
 
 
-def _find_dockerfile(project_dir: Path) -> Path:
-    dockerfile = project_dir / "server" / "Dockerfile"
-    if dockerfile.exists():
-        return dockerfile
-    raise FileNotFoundError(
-        f"No Dockerfile found at {dockerfile}. Expected enforced layout with proj/server/Dockerfile."
-    )
-
-
 def _resolve_project_dir(environments_root: Path, env_id_underscore: str) -> Path:
     env_path = environments_root / env_id_underscore
     if not env_path.exists() or not env_path.is_dir():
@@ -99,15 +90,6 @@ def _read_project_app(project_dir: Path) -> str:
         if isinstance(app, str) and app.strip():
             return app.strip()
     return "server.app:app"
-
-
-def _build_start_command(app: str, port: int) -> str:
-    # Prime sandboxes default to `tail -f /dev/null` unless start_command is explicit.
-    # Also avoid relying on image-level PATH, which may not be propagated by sandbox runtime.
-    return (
-        "sh -lc "
-        f'"cd /app/env && /app/.venv/bin/uvicorn {app} --host 0.0.0.0 --port {int(port)}"'
-    )
 
 
 def _resolve_app_module(project_dir: Path, app: str) -> Path:
@@ -268,14 +250,6 @@ def _resolve_fully_qualified_image(image: str) -> tuple[str | None, str | None]:
     return None, None
 
 
-def _parse_image_from_push_output(output: str) -> str | None:
-    for line in output.splitlines():
-        match = re.search(r"Image:\s*(\S+)", line)
-        if match:
-            return match.group(1).strip()
-    return None
-
-
 def _get_image_status(image_ref: str) -> str | None:
     items = _get_images_list()
     if not items:
@@ -372,7 +346,11 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         project_dir = _resolve_project_dir(env_path.parent, env_id_underscore)
-        dockerfile = _find_dockerfile(project_dir)
+        dockerfile = project_dir / "server" / "Dockerfile"
+        if not dockerfile.exists():
+            raise FileNotFoundError(
+                f"No Dockerfile found at {dockerfile}. Expected enforced layout with proj/server/Dockerfile."
+            )
     except FileNotFoundError as e:
         print(str(e), file=sys.stderr)
         return 2
@@ -389,7 +367,12 @@ def main(argv: list[str] | None = None) -> int:
     port = _read_project_port(project_dir)
     app = _read_project_app(project_dir)
     contract = _detect_contract(project_dir, app)
-    start_command = _build_start_command(app=app, port=port)
+    # Prime sandboxes default to `tail -f /dev/null` unless start_command is explicit.
+    # Also avoid relying on image-level PATH, which may not be propagated by sandbox runtime.
+    start_command = (
+        "sh -lc "
+        f'"cd /app/env && /app/.venv/bin/uvicorn {app} --host 0.0.0.0 --port {int(port)}"'
+    )
 
     cmd = [
         "prime",
@@ -423,7 +406,12 @@ def main(argv: list[str] | None = None) -> int:
         return e.returncode or 1
 
     output = ((result.stdout or "") + "\n" + (result.stderr or "")).strip()
-    resolved_image = _parse_image_from_push_output(output)
+    resolved_image = None
+    for line in output.splitlines():
+        match = re.search(r"Image:\s*(\S+)", line)
+        if match:
+            resolved_image = match.group(1).strip()
+            break
     status = None
     if resolved_image is None:
         resolved_image, status = _resolve_fully_qualified_image(image)

--- a/verifiers/utils/client_utils.py
+++ b/verifiers/utils/client_utils.py
@@ -94,16 +94,6 @@ def _build_http_client(
     )
 
 
-def parse_chat_completion_with_routed_experts_sidecar(raw: bytes) -> ChatCompletion:
-    stripped, routed_data = strip_routed_experts_data(raw)
-    response = ChatCompletion.model_validate_json(stripped)
-    if routed_data is not None:
-        choice_extra = response.choices[0].model_extra
-        assert choice_extra is not None
-        choice_extra["routed_experts"]["data"] = routed_data
-    return response
-
-
 async def post_chat_completion_with_routed_experts_sidecar(
     client: AsyncOpenAI,
     path: str,
@@ -117,36 +107,34 @@ async def post_chat_completion_with_routed_experts_sidecar(
         cast_to=httpx.Response,
         options={"headers": extra_headers} if extra_headers else {},
     )
-    return parse_chat_completion_with_routed_experts_sidecar(raw_response.content)
-
-
-def _setup_openai_client_from_resolved(config: ClientConfig) -> AsyncOpenAI:
-    headers, api_key = _build_headers_and_api_key(config)
-    return AsyncOpenAI(
-        api_key=api_key or "EMPTY",
-        base_url=config.api_base_url,
-        max_retries=config.max_retries,
-        http_client=_build_http_client(config, headers),
-    )
+    stripped, routed_data = strip_routed_experts_data(raw_response.content)
+    response = ChatCompletion.model_validate_json(stripped)
+    if routed_data is not None:
+        choice_extra = response.choices[0].model_extra
+        assert choice_extra is not None
+        choice_extra["routed_experts"]["data"] = routed_data
+    return response
 
 
 def setup_openai_client(config: ClientConfig) -> AsyncOpenAI:
     """Setup an AsyncOpenAI client from config."""
     resolved_config = resolve_client_config(config)
-    return _setup_openai_client_from_resolved(resolved_config)
-
-
-def _setup_anthropic_client_from_resolved(config: ClientConfig) -> AsyncAnthropic:
-    headers, api_key = _build_headers_and_api_key(config)
-    return AsyncAnthropic(
+    headers, api_key = _build_headers_and_api_key(resolved_config)
+    return AsyncOpenAI(
         api_key=api_key or "EMPTY",
-        base_url=config.api_base_url,
-        max_retries=config.max_retries,
-        http_client=_build_http_client(config, headers),
+        base_url=resolved_config.api_base_url,
+        max_retries=resolved_config.max_retries,
+        http_client=_build_http_client(resolved_config, headers),
     )
 
 
 def setup_anthropic_client(config: ClientConfig) -> AsyncAnthropic:
     """Setup an AsyncAnthropic client from config."""
     resolved_config = resolve_client_config(config)
-    return _setup_anthropic_client_from_resolved(resolved_config)
+    headers, api_key = _build_headers_and_api_key(resolved_config)
+    return AsyncAnthropic(
+        api_key=api_key or "EMPTY",
+        base_url=resolved_config.api_base_url,
+        max_retries=resolved_config.max_retries,
+        http_client=_build_http_client(resolved_config, headers),
+    )

--- a/verifiers/utils/data_utils.py
+++ b/verifiers/utils/data_utils.py
@@ -29,33 +29,26 @@ def extract_boxed_answer(text: str, strict: bool = False) -> str:
             as a general text extractor).
     """
 
-    def find_matching_brace(s: str, start: int) -> int:
-        count = 1
-        i = start
-        while i < len(s) and count > 0:
-            if s[i] == "{":
-                count += 1
-            elif s[i] == "}":
-                count -= 1
-            i += 1
-        return i - 1 if count == 0 else -1
-
     # Find last \boxed{
     boxed_start = text.rfind("\\boxed{")
     if boxed_start == -1:
         return "" if strict else text
     # Find the content between the braces
     content_start = boxed_start + 7  # len('\\boxed{')
-    closing_brace = find_matching_brace(text, content_start)
+    brace_count = 1
+    closing_brace = content_start
+    while closing_brace < len(text) and brace_count > 0:
+        if text[closing_brace] == "{":
+            brace_count += 1
+        elif text[closing_brace] == "}":
+            brace_count -= 1
+        closing_brace += 1
+    closing_brace = closing_brace - 1 if brace_count == 0 else -1
 
     if closing_brace == -1:
         return "" if strict else text
 
     return text[content_start:closing_brace]
-
-
-def strip_non_numeric(text: str) -> str:
-    return "".join(c for c in text if c.isdigit() or c == ".")
 
 
 def extract_hash_answer(text: str) -> str:
@@ -79,7 +72,7 @@ def get_preprocess_fn(name: str) -> Callable[[dict], dict]:
         def preprocess_aime2025(x: dict[str, Any]) -> dict[str, Any]:
             return {
                 "question": x["question"],
-                "answer": strip_non_numeric(x["answer"]),
+                "answer": "".join(c for c in x["answer"] if c.isdigit() or c == "."),
             }
 
         return preprocess_aime2025

--- a/verifiers/utils/display_utils.py
+++ b/verifiers/utils/display_utils.py
@@ -433,11 +433,6 @@ class BaseDisplay:
         fd = sys.stdin.fileno()
         old_settings = termios_module.tcgetattr(fd)
 
-        def drain_escape_sequence() -> None:
-            """Consume remaining chars of an escape sequence (mouse events, etc)."""
-            while select_module.select([sys.stdin], [], [], 0.01)[0]:
-                sys.stdin.read(1)
-
         try:
             # Use cbreak mode (not raw) - allows single char input without corrupting display
             tty_module.setcbreak(fd)
@@ -456,7 +451,8 @@ class BaseDisplay:
                         # Check if more chars follow (escape sequence vs standalone Esc)
                         if select_module.select([sys.stdin], [], [], 0.05)[0]:
                             # Escape sequence - drain it and ignore
-                            drain_escape_sequence()
+                            while select_module.select([sys.stdin], [], [], 0.01)[0]:
+                                sys.stdin.read(1)
                             continue
                         else:
                             # Standalone Escape key - exit

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -18,7 +18,6 @@ from datasets.utils import logging as ds_logging
 
 import verifiers as vf
 from verifiers.types import (
-    ClientConfig,
     ClientType,
     Endpoint,
     Endpoints,
@@ -56,23 +55,6 @@ from verifiers.utils.save_utils import save_metadata
 logger = logging.getLogger(__name__)
 FREEFORM_ABLATION_SWEEP_FIELDS = {"args", "env_args"}
 CHAT_TEMPLATE_KWARG_FIELDS = ("reasoning_effort", "enable_thinking")
-
-
-def _client_config_uses_prime_inference(config: ClientConfig) -> bool:
-    if config.endpoint_configs:
-        urls = [endpoint.api_base_url for endpoint in config.endpoint_configs]
-    else:
-        urls = [config.api_base_url]
-
-    return bool(urls) and all(is_prime_inference_url(url) for url in urls)
-
-
-async def _resolve_model_pricing(config: EvalConfig) -> ModelPricing | None:
-    if not _client_config_uses_prime_inference(config.client_config):
-        return None
-
-    pricing_by_model = await fetch_prime_pricing()
-    return pricing_by_model.get(config.model)
 
 
 def _sum_output_usage(outputs: list[RolloutOutput]) -> TokenUsage | None:
@@ -788,14 +770,6 @@ def filter_inputs(
     return filtered_inputs
 
 
-def to_col_order(
-    list_of_dicts: list[Mapping[str, float]],
-) -> dict[str, list[float | None]]:
-    """Convert a list of mappings to a dictionary of lists."""
-    keys = sorted({key for mapping in list_of_dicts for key in mapping})
-    return {key: [mapping.get(key) for mapping in list_of_dicts] for key in keys}
-
-
 def output_env_id(output: Mapping[str, Any]) -> str:
     info = output.get("info") or {}
     if isinstance(info, str):
@@ -806,15 +780,6 @@ def output_env_id(output: Mapping[str, Any]) -> str:
     if value is not None:
         return str(value)
     return str(output.get("env_id", "default"))
-
-
-def get_env_outputs(results: GenerateOutputs, env_id: str) -> GenerateOutputs:
-    """Get only the rollouts for a given env_id."""
-    outputs = [o for o in results["outputs"] if output_env_id(o) == env_id]
-    return GenerateOutputs(
-        outputs=outputs,
-        metadata=results["metadata"],  # duplicate metadata
-    )
 
 
 def print_rewards(results: GenerateOutputs):
@@ -847,7 +812,10 @@ def print_rewards(results: GenerateOutputs):
         print(f"pass^k: {', '.join(parts)}")
 
     metrics = [o["metrics"] for o in results["outputs"]]
-    metrics_col = to_col_order(metrics)
+    metric_keys = sorted({key for mapping in metrics for key in mapping})
+    metrics_col = {
+        key: [mapping.get(key) for mapping in metrics] for key in metric_keys
+    }
     for k in metrics_col.keys():
         v = metrics_col[k]
         present_values = [value for value in v if value is not None]
@@ -1008,7 +976,14 @@ def print_results(results: GenerateOutputs, num_samples: int = 1):
     env_ids = {output_env_id(o) for o in results["outputs"]}
     if len(env_ids) > 1:
         for env_id in env_ids:
-            env_results = get_env_outputs(results, env_id)
+            env_results = GenerateOutputs(
+                outputs=[
+                    output
+                    for output in results["outputs"]
+                    if output_env_id(output) == env_id
+                ],
+                metadata=results["metadata"],
+            )
             print(f"\n--- {env_id} ---")
             print_rewards(env_results)
             print_info(env_results)
@@ -1052,7 +1027,15 @@ async def run_evaluation(
         vf_env.set_kwargs(**config.extra_env_kwargs)
 
     results_path = config.resume_path or get_eval_results_path(config)
-    model_pricing = await _resolve_model_pricing(config)
+    if config.client_config.endpoint_configs:
+        pricing_urls = [
+            endpoint.api_base_url for endpoint in config.client_config.endpoint_configs
+        ]
+    else:
+        pricing_urls = [config.client_config.api_base_url]
+    model_pricing = None
+    if pricing_urls and all(is_prime_inference_url(url) for url in pricing_urls):
+        model_pricing = (await fetch_prime_pricing()).get(config.model)
     on_progress = _with_eval_metadata(on_progress, model_pricing, config.name)
 
     try:

--- a/verifiers/utils/import_utils.py
+++ b/verifiers/utils/import_utils.py
@@ -1,15 +1,10 @@
 import importlib
 from typing import Any, cast
 
-
-def _load_toml_module() -> Any:
-    try:
-        return importlib.import_module("tomllib")
-    except ModuleNotFoundError:
-        return importlib.import_module("tomli")
-
-
-_TOML = _load_toml_module()
+try:
+    _TOML = importlib.import_module("tomllib")
+except ModuleNotFoundError:
+    _TOML = importlib.import_module("tomli")
 
 
 def load_toml(file_obj: Any) -> dict[str, Any]:

--- a/verifiers/utils/install_utils.py
+++ b/verifiers/utils/install_utils.py
@@ -105,15 +105,6 @@ def check_hub_env_installed(env_id: str) -> bool:
     return is_installed(name, version)
 
 
-def _is_valid_url(url: str) -> bool:
-    """Check if a string is a valid HTTP(S) URL."""
-    try:
-        result = urlparse(url)
-        return all([result.scheme in ("http", "https"), result.netloc])
-    except Exception:
-        return False
-
-
 def install_from_hub(env_id: str) -> bool:
     """Install an environment from the Environments Hub.
 
@@ -143,8 +134,16 @@ def install_from_hub(env_id: str) -> bool:
 
     simple_index_url = details.get("simple_index_url")
     wheel_url = details.get("wheel_url")
-    if wheel_url and not _is_valid_url(wheel_url):
-        wheel_url = None
+    if wheel_url:
+        try:
+            parsed_wheel_url = urlparse(wheel_url)
+            if (
+                parsed_wheel_url.scheme not in ("http", "https")
+                or not parsed_wheel_url.netloc
+            ):
+                wheel_url = None
+        except Exception:
+            wheel_url = None
 
     if not simple_index_url and not wheel_url:
         if details.get("visibility") == "PRIVATE":

--- a/verifiers/utils/interception_utils.py
+++ b/verifiers/utils/interception_utils.py
@@ -60,16 +60,6 @@ class InterceptionError(InfraError):
     """
 
 
-def protocol_from_path(path: str) -> str:
-    if path.endswith("/v1/messages"):
-        return "anthropic_messages"
-    if path.endswith("/v1/responses"):
-        return "openai_responses"
-    if path.endswith("/v1/completions"):
-        return "openai_completions"
-    return "openai_chat_completions"
-
-
 class InterceptionServer:
     """
     HTTP server that intercepts API requests from agents.
@@ -261,7 +251,15 @@ class InterceptionServer:
             asyncio.Queue() if is_streaming else None
         )
 
-        protocol = protocol_from_path(str(request.path))
+        path = str(request.path)
+        if path.endswith("/v1/messages"):
+            protocol = "anthropic_messages"
+        elif path.endswith("/v1/responses"):
+            protocol = "openai_responses"
+        elif path.endswith("/v1/completions"):
+            protocol = "openai_completions"
+        else:
+            protocol = "openai_chat_completions"
         intercept = {
             "request_id": request_id,
             "rollout_id": rollout_id,

--- a/verifiers/utils/logging_utils.py
+++ b/verifiers/utils/logging_utils.py
@@ -18,18 +18,13 @@ LOGGER_NAME = "verifiers"
 _seen_once_keys: set[tuple[str, str]] = set()
 
 
-def log_once(logger: logging.Logger, level: int, msg: str) -> None:
-    """Log a message only once per (logger name, message) pair for the process lifetime."""
+def warning_once(logger: logging.Logger, msg: str) -> None:
+    """Log a warning only once per (logger name, message) pair for the process lifetime."""
     key = (logger.name, msg)
     if key in _seen_once_keys:
         return
     _seen_once_keys.add(key)
-    logger.log(level, msg)
-
-
-def warning_once(logger: logging.Logger, msg: str) -> None:
-    """Shorthand for ``log_once(logger, logging.WARNING, ...)``."""
-    log_once(logger, logging.WARNING, msg)
+    logger.warning(msg)
 
 
 class JsonFormatter(logging.Formatter):
@@ -168,14 +163,6 @@ def print_prompt_completions_sample(
 ) -> None:
     from verifiers.utils.message_utils import format_messages
 
-    def format_error(error: ErrorInfo | BaseException) -> Text:
-        out = Text()
-        if isinstance(error, BaseException):
-            out.append(f"error: {ErrorChain(error)}", style="bold red")
-        else:
-            out.append(f"error: {error['error_chain_repr']}", style="bold red")
-        return out
-
     console = Console()
     table = Table(show_header=True, header_style="bold white", expand=True)
 
@@ -197,7 +184,14 @@ def print_prompt_completions_sample(
         formatted_prompt = format_messages(prompt)
         formatted_completion = format_messages(completion)
         if error is not None:
-            formatted_completion += Text("\n\n") + format_error(error)
+            formatted_error = Text()
+            if isinstance(error, BaseException):
+                formatted_error.append(f"error: {ErrorChain(error)}", style="bold red")
+            else:
+                formatted_error.append(
+                    f"error: {error['error_chain_repr']}", style="bold red"
+                )
+            formatted_completion += Text("\n\n") + formatted_error
 
         table.add_row(formatted_prompt, formatted_completion, Text(f"{reward:.2f}"))
         if i < samples_to_show - 1:

--- a/verifiers/utils/message_utils.py
+++ b/verifiers/utils/message_utils.py
@@ -8,7 +8,6 @@ from rich.text import Text
 
 from verifiers.types import (
     AssistantMessage,
-    ContentPart,
     ImageUrlContentPart,
     InputAudioContentPart,
     Message,
@@ -27,25 +26,21 @@ MessageInput: TypeAlias = str | Sequence[MessageLike]
 MessageRole: TypeAlias = Literal["text", "system", "user", "assistant", "tool"]
 
 
-def from_raw_content_part(part: dict[str, Any]) -> ContentPart:
-    """Convert a raw content-part dict to a typed content part when possible."""
-    part_type = part.get("type")
-    if part_type == "text":
-        return TextContentPart.model_validate(part)
-    if part_type == "image_url":
-        return ImageUrlContentPart.model_validate(part)
-    if part_type == "input_audio":
-        return InputAudioContentPart.model_validate(part)
-    return part
-
-
 def _normalize_raw_message_content(message: dict[str, Any]) -> dict[str, Any]:
     content = message.get("content")
     if isinstance(content, list):
         normalized_parts = []
         for part in content:
             if isinstance(part, dict):
-                normalized_parts.append(from_raw_content_part(part))
+                part_type = part.get("type")
+                if part_type == "text":
+                    normalized_parts.append(TextContentPart.model_validate(part))
+                elif part_type == "image_url":
+                    normalized_parts.append(ImageUrlContentPart.model_validate(part))
+                elif part_type == "input_audio":
+                    normalized_parts.append(InputAudioContentPart.model_validate(part))
+                else:
+                    normalized_parts.append(part)
             else:
                 normalized_parts.append(part)
         message = dict(message)

--- a/verifiers/utils/save_utils.py
+++ b/verifiers/utils/save_utils.py
@@ -209,6 +209,15 @@ def state_to_output(
     Raises:
         ValueError: If a state_columns value is not JSON-serializable.
     """
+    timing = state["timing"]
+    timing_model_dump = getattr(timing, "model_dump", None)
+    if callable(timing_model_dump):
+        timing_output = cast(dict[str, Any], timing_model_dump())
+    elif isinstance(timing, Mapping):
+        timing_output = dict(cast(Mapping[str, Any], timing))
+    else:
+        raise TypeError("state['timing'] must be a RolloutTiming or mapping.")
+
     output = RolloutOutput(
         example_id=state.get("example_id", 0),
         prompt=state.get("prompt"),
@@ -217,7 +226,7 @@ def state_to_output(
         info=state.get("info", {}),
         reward=state.get("reward", 0.0),
         error=state.get("error", None),
-        timing=serialize_timing(state["timing"]),
+        timing=timing_output,
         is_completed=state.get("is_completed", False),
         is_truncated=state.get("is_truncated", False),
         stop_condition=state.get("stop_condition", None),
@@ -510,15 +519,6 @@ def _diff_mm_data(mm: object, prior_hashes: dict[str, list[str]]) -> object:
         )
     except TypeError:
         return mm
-
-
-def serialize_timing(timing: object) -> dict[str, Any]:
-    model_dump = getattr(timing, "model_dump", None)
-    if callable(model_dump):
-        return cast(dict[str, Any], model_dump())
-    if isinstance(timing, Mapping):
-        return dict(cast(Mapping[str, Any], timing))
-    raise TypeError("state['timing'] must be a RolloutTiming or mapping.")
 
 
 def states_to_outputs(
@@ -845,22 +845,14 @@ def save_new_outputs(new_outputs: list[RolloutOutput], results_path: Path):
     save_outputs(new_outputs, results_path, mode="a")
 
 
-def sanitize_metadata(metadata: GenerateMetadata) -> dict:
-    """Sanitizes metadata before saving to disk."""
-
-    metadata_dict = dict(metadata)
-    metadata_dict.pop("path_to_save")
-    metadata_dict.pop("date")
-
-    return metadata_dict
-
-
 def save_metadata(metadata: GenerateMetadata, result_path: Path):
     """Saves metadata to disk."""
 
     result_path.mkdir(parents=True, exist_ok=True)
     metadata_path = result_path / "metadata.json"
-    metadata_dict = sanitize_metadata(metadata)
+    metadata_dict = dict(metadata)
+    metadata_dict.pop("path_to_save")
+    metadata_dict.pop("date")
     with open(metadata_path, "w") as f:
         try:
             json.dump(metadata_dict, f, default=make_serializable)

--- a/verifiers/utils/thread_utils.py
+++ b/verifiers/utils/thread_utils.py
@@ -9,28 +9,15 @@ logger = logging.getLogger(__name__)
 THREAD_LOCAL_STORAGE = threading.local()
 
 
-def get_thread_local_storage() -> threading.local:
-    """Get the thread-local storage for the current thread."""
-    return THREAD_LOCAL_STORAGE
-
-
 def get_or_create_thread_attr(
     key: str, factory: Callable[..., Any], *args, **kwargs
 ) -> Any:
     """Get value from thread-local storage, creating it if it doesn't exist."""
-    thread_local = get_thread_local_storage()
-    value = getattr(thread_local, key, None)
+    value = getattr(THREAD_LOCAL_STORAGE, key, None)
     if value is None:
         value = factory(*args, **kwargs)
-        setattr(thread_local, key, value)
+        setattr(THREAD_LOCAL_STORAGE, key, value)
     return value
-
-
-def get_or_create_thread_loop() -> asyncio.AbstractEventLoop:
-    """Get or create event loop for current thread. Reuses loop to avoid closing it."""
-    thread_local_loop = get_or_create_thread_attr("loop", asyncio.new_event_loop)
-    asyncio.set_event_loop(thread_local_loop)
-    return thread_local_loop
 
 
 # --- Executor registry & scaling ---

--- a/verifiers/utils/threaded_sandbox_client.py
+++ b/verifiers/utils/threaded_sandbox_client.py
@@ -9,7 +9,6 @@ from prime_sandboxes import AsyncSandboxClient, CommandTimeoutError
 
 from verifiers.utils.thread_utils import (
     get_or_create_thread_attr,
-    get_or_create_thread_loop,
     register_executor,
     unregister_executor,
 )
@@ -61,7 +60,8 @@ class ThreadedAsyncSandboxClient:
         @functools.wraps(getattr(AsyncSandboxClient, name, lambda: None))
         async def wrapper(*args, **kwargs):
             def run_in_thread():
-                loop = get_or_create_thread_loop()
+                loop = get_or_create_thread_attr("loop", asyncio.new_event_loop)
+                asyncio.set_event_loop(loop)
                 sandbox_client = get_or_create_thread_attr(
                     "sandbox_client",
                     AsyncSandboxClient,

--- a/verifiers/v1/packages/harnesses/command.py
+++ b/verifiers/v1/packages/harnesses/command.py
@@ -49,12 +49,27 @@ def configure_command_harness(
     artifacts: ProgramOptionMap | None = None,
     channels: ProgramChannels | None = None,
 ) -> None:
-    sandbox_value = command_sandbox_value(config, sandbox)
+    sandbox_value = (
+        sandbox
+        if sandbox is not None
+        else config.sandbox
+        if config.sandbox is not None
+        else True
+    )
+    program_files: ProgramOptionMap = {}
+    instruction_path = getattr(config, "instruction_path", None)
+    system_prompt_path = getattr(config, "system_prompt_path", None)
+    if instruction_path:
+        program_files[str(instruction_path)] = cast(ProgramValue, task_instruction_text)
+    if system_prompt_path and config.system_prompt is not None:
+        program_files[str(system_prompt_path)] = cast(
+            ProgramValue, state_system_prompt_text
+        )
     harness._configure_runtime(
         program=command_program(
             command=command,
             sandbox=sandbox_value,
-            files=files if files is not None else command_files(config),
+            files=files if files is not None else program_files,
             setup=setup,
             bindings=bindings,
             env=env,
@@ -65,25 +80,6 @@ def configure_command_harness(
         sandbox=command_sandbox(sandbox_value),
         system_prompt=config.system_prompt,
     )
-
-
-def command_sandbox_value(
-    config: HarnessConfig, sandbox: bool | ConfigMap | SandboxConfig | None = None
-) -> bool | ConfigMap | SandboxConfig:
-    if sandbox is not None:
-        return sandbox
-    return config.sandbox if config.sandbox is not None else True
-
-
-def command_files(config: HarnessConfig) -> ProgramOptionMap:
-    files: ProgramOptionMap = {}
-    instruction_path = getattr(config, "instruction_path", None)
-    system_prompt_path = getattr(config, "system_prompt_path", None)
-    if instruction_path:
-        files[str(instruction_path)] = cast(ProgramValue, task_instruction_text)
-    if system_prompt_path and config.system_prompt is not None:
-        files[str(system_prompt_path)] = cast(ProgramValue, state_system_prompt_text)
-    return files
 
 
 def command_program(

--- a/verifiers/v1/packages/harnesses/pi.py
+++ b/verifiers/v1/packages/harnesses/pi.py
@@ -42,7 +42,11 @@ class Pi(Harness[PiConfig]):
         ]
 
     def setup(self, config: PiConfig) -> str:
-        return build_pi_install_script(package=config.package)
+        return f"""\
+set -e
+apt-get -o Acquire::Retries=3 update -qq && apt-get -o Acquire::Retries=3 install -y -qq curl ca-certificates nodejs npm > /dev/null 2>&1
+npm install -g {shlex.quote(config.package)}
+"""
 
     def artifacts(self, config: PiConfig) -> ProgramOptionMap:
         return {
@@ -65,14 +69,6 @@ class Pi(Harness[PiConfig]):
 
     def bindings_value(self, config: PiConfig) -> Bindings:
         return {"setup_pi.endpoint_config": pi_endpoint_config}
-
-
-def build_pi_install_script(package: str) -> str:
-    return f"""\
-set -e
-apt-get -o Acquire::Retries=3 update -qq && apt-get -o Acquire::Retries=3 install -y -qq curl ca-certificates nodejs npm > /dev/null 2>&1
-npm install -g {shlex.quote(package)}
-"""
 
 
 def build_pi_mcp_setup(

--- a/verifiers/v1/packages/harnesses/rlm.py
+++ b/verifiers/v1/packages/harnesses/rlm.py
@@ -109,7 +109,15 @@ class RLM(Harness[RLMConfig]):
                     "apt-get -o Acquire::Retries=3 update && "
                     "apt-get -o Acquire::Retries=3 install -y --no-install-recommends "
                     "ca-certificates curl git && rm -rf /var/lib/apt/lists/*",
-                    build_install_command(),
+                    "bash -lc "
+                    + shlex.quote(
+                        f"""
+set -eo pipefail
+export RLM_CHECKOUT_PATH={shlex.quote(DEFAULT_RLM_CHECKOUT_PATH)}
+test -f "$RLM_CHECKOUT_PATH/install.sh"
+bash "$RLM_CHECKOUT_PATH/install.sh"
+"""
+                    ),
                 ],
                 env=env,
                 artifacts={
@@ -156,16 +164,6 @@ class RLM(Harness[RLMConfig]):
             dirs[remote_path] = local_source
         program["dirs"] = dirs
         self.program = program
-
-
-def build_install_command() -> str:
-    script = f"""
-set -eo pipefail
-export RLM_CHECKOUT_PATH={shlex.quote(DEFAULT_RLM_CHECKOUT_PATH)}
-test -f "$RLM_CHECKOUT_PATH/install.sh"
-bash "$RLM_CHECKOUT_PATH/install.sh"
-"""
-    return f"bash -lc {shlex.quote(script)}"
 
 
 def build_run_script(instruction_path: str, workdir: str) -> str:
@@ -273,13 +271,9 @@ def build_summarize_resolver(
             raise ValueError("summarize_at_tokens pair must satisfy 0 < lo <= hi")
 
         def sampled_threshold(state: State) -> str:
-            return str(draw_threshold(state, lo, hi))
+            prompt = json.dumps(state.get("prompt"), sort_keys=True, default=str)
+            digest = hashlib.sha256(prompt.encode("utf-8")).hexdigest()
+            return str(random.Random(int(digest[:16], 16)).randint(lo, hi))
 
         return sampled_threshold
     raise ValueError("summarize_at_tokens must be int, (lo, hi), or None")
-
-
-def draw_threshold(state: ConfigMap, lo: int, hi: int) -> int:
-    prompt = json.dumps(state.get("prompt"), sort_keys=True, default=str)
-    digest = hashlib.sha256(prompt.encode("utf-8")).hexdigest()
-    return random.Random(int(digest[:16], 16)).randint(lo, hi)

--- a/verifiers/v1/packages/harnesses/terminus_2.py
+++ b/verifiers/v1/packages/harnesses/terminus_2.py
@@ -48,7 +48,14 @@ class Terminus2(Harness[Terminus2Config]):
         ]
 
     def setup(self, config: Terminus2Config) -> str:
-        return build_terminus_2_install_script()
+        return """\
+set -e
+apt-get -o Acquire::Retries=3 update -qq
+apt-get -o Acquire::Retries=3 install -y -qq curl ca-certificates > /dev/null 2>&1
+if ! command -v uv >/dev/null 2>&1; then
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
+"""
 
     def artifacts(self, config: Terminus2Config) -> ProgramOptionMap:
         return {
@@ -58,17 +65,6 @@ class Terminus2(Harness[Terminus2Config]):
                 "optional": True,
             }
         }
-
-
-def build_terminus_2_install_script() -> str:
-    return """\
-set -e
-apt-get -o Acquire::Retries=3 update -qq
-apt-get -o Acquire::Retries=3 install -y -qq curl ca-certificates > /dev/null 2>&1
-if ! command -v uv >/dev/null 2>&1; then
-  curl -LsSf https://astral.sh/uv/install.sh | sh
-fi
-"""
 
 
 def build_terminus_2_run_script(
@@ -247,7 +243,6 @@ asyncio.run(main())
 
 __all__ = [
     "Terminus2",
-    "build_terminus_2_install_script",
     "build_terminus_2_run_script",
     "terminus_2_agent_script",
 ]

--- a/verifiers/v1/runtime.py
+++ b/verifiers/v1/runtime.py
@@ -104,7 +104,11 @@ class Runtime:
         register_runtime(self.runtime_id, self)
         self.taskset = taskset
         self.harness = harness
-        self.toolsets = self._collect_toolsets()
+        owners = (self.taskset, self.harness)
+        self.toolsets = []
+        for owner in owners:
+            if owner is not None:
+                self.toolsets.extend(iter_toolsets(getattr(owner, "toolsets", ())))
         self.named_toolsets = self._collect_named_toolsets()
         self.rollout_toolsets: dict[str, list[Toolset]] = {}
         self.objects: dict[tuple[int, str, str], object] = {}
@@ -149,7 +153,10 @@ class Runtime:
             self.rollout_update, {"task", "state"}, "update", "rollout"
         )
         validate_handler_args(self.group_update, {"tasks", "states"}, "update", "group")
-        signals = self._build_signals()
+        signals = collect_signals(
+            self._owner_signals(self.taskset),
+            self._owner_signals(self.harness),
+        )
         self.rollout_signals = [
             signal for signal in signals if signal["stage"] == "rollout"
         ]
@@ -1083,7 +1090,14 @@ class Runtime:
         key = self.scope_key("rollout", state)
         if key in self.rollout_toolsets:
             return
-        self.rollout_toolsets[key] = await self._task_toolset_additions(task, state)
+        toolsets: list[Toolset] = []
+        for name, spec in self._task_toolsets_config(task).items():
+            if name in {"show", "hide"}:
+                continue
+            if name in self.named_toolsets:
+                raise ValueError(f"Task toolset {name!r} is already defined.")
+            toolsets.append(await self._runtime_named_toolset(name, spec, task, state))
+        self.rollout_toolsets[key] = toolsets
 
     def validate_bindings(self, state: State) -> None:
         for owner in (self.taskset, self.harness):
@@ -1118,7 +1132,10 @@ class Runtime:
                     "callable."
                 )
             target_kind, fn = target
-            protected_args = self._binding_target_framework_args(target_kind, fn)
+            stage = str(getattr(fn, f"{target_kind}_stage", "rollout"))
+            protected_args = (
+                GROUP_FRAMEWORK_ARGS if stage == "group" else ROLLOUT_FRAMEWORK_ARGS
+            )
             if arg_name in protected_args:
                 continue
             validate_bound_arg(
@@ -1141,10 +1158,6 @@ class Runtime:
                         f"Binding {binding_key!r} references unknown Taskset object "
                         f"{object_name!r}."
                     )
-
-    def _binding_target_framework_args(self, kind: str, fn: Handler) -> frozenset[str]:
-        stage = str(getattr(fn, f"{kind}_stage", "rollout"))
-        return GROUP_FRAMEWORK_ARGS if stage == "group" else ROLLOUT_FRAMEWORK_ARGS
 
     def _validate_toolset_bindings(self, toolset: Toolset) -> None:
         targets = self._toolset_binding_targets(toolset)
@@ -1304,17 +1317,6 @@ class Runtime:
             raise TypeError("task.toolsets must be a mapping.")
         return cast(ConfigMap, raw_toolsets)
 
-    async def _task_toolset_additions(self, task: Task, state: State) -> list[Toolset]:
-        toolsets: list[Toolset] = []
-        config = self._task_toolsets_config(task)
-        for name, spec in config.items():
-            if name in {"show", "hide"}:
-                continue
-            if name in self.named_toolsets:
-                raise ValueError(f"Task toolset {name!r} is already defined.")
-            toolsets.append(await self._runtime_named_toolset(name, spec, task, state))
-        return toolsets
-
     async def _runtime_named_toolset(
         self, name: str, spec: object, task: Task, state: State
     ) -> Toolset:
@@ -1393,20 +1395,6 @@ class Runtime:
                 raise KeyError(f"Unknown hidden toolsets: {unknown}.")
             return names - hidden
         return names
-
-    def _build_signals(self) -> list[SignalRecord]:
-        taskset_signals = self._owner_signals(self.taskset)
-        harness_signals = self._owner_signals(self.harness)
-        return collect_signals(taskset_signals, harness_signals)
-
-    def _collect_toolsets(self) -> list[Toolset]:
-        owners = (self.taskset, self.harness)
-        groups: list[Toolset] = []
-        for owner in owners:
-            if owner is None:
-                continue
-            groups.extend(iter_toolsets(getattr(owner, "toolsets", ())))
-        return groups
 
     def _collect_named_toolsets(self) -> dict[str, Toolset]:
         named: dict[str, Toolset] = {}

--- a/verifiers/v1/taskset.py
+++ b/verifiers/v1/taskset.py
@@ -93,12 +93,9 @@ class Taskset(ConfigBound[TasksetConfigT], RuntimeOwnerMixin):
         skills = self.get_skills_dir()
         return {} if skills is None else {"skills": skills}
 
-    def _refresh_attached_harnesses(self) -> None:
+    def _runtime_owner_changed(self) -> None:
         for harness in list(self._attached_harnesses):
             harness.runtime = harness.resolve_runtime()
-
-    def _runtime_owner_changed(self) -> None:
-        self._refresh_attached_harnesses()
 
     def rows(self) -> list[ConfigData]:
         if self._rows is None:


### PR DESCRIPTION
## Summary
- inline safe single-use helpers under 10 LoC across clients, envs, utilities, scripts, and v1 harness plumbing
- move tests that previously reached into removed private helpers up to public behavior paths
- preserve downstream-used surfaces and override hooks, including the RLM timeout recovery hook found in research envs
- leave the pre-existing `uv.lock` drift unstaged and out of the PR

## Verification
- `UV_FROZEN=1 uv run ruff check --fix`
- `UV_FROZEN=1 uv run ruff format`
- `git diff --check`
- `UV_FROZEN=1 uv run pytest tests/test_prime_plugin.py tests/test_lean_task.py tests/test_opencode_rlm_env.py tests/test_openenv_client.py tests/test_rlm_env.py tests/test_composable_env.py tests/test_harbor_env_mcp.py tests/test_v1_harbor_cli.py tests/test_v1_mini_swe_agent.py tests/test_v1_rlm_swe.py tests/test_rlm_composable_env.py tests/test_renderer_client.py tests/test_openai_responses_client.py tests/test_eval_cli.py tests/test_gepa_cli.py tests/test_save_utils.py tests/test_sandbox_mixin.py` (591 passed)
- `UV_FROZEN=1 uv run pre-commit run --all-files`
- `UV_FROZEN=1` pre-push hooks: ruff check, ruff format, Semgrep v1 policy, generated AGENTS/CLAUDE check, ty pre-push check

## Downstream audit
Checked platform, prime, research environments, and community/prime environment checkouts for removed symbols. The final audit found `mini_swe_agent_plus_rlm` overrides RLM `_recover_from_code_timeout`, so this stack keeps that hook and only folds helpers with no downstream usage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad refactor across clients/envs/utilities with many small logic inlines, including lifecycle/teardown, OpenEnv startup, and MCP process management; while intended to be behavior-preserving, the surface area is large and could introduce subtle regressions in runtime environments.
> 
> **Overview**
> Refactors the codebase by **inlining a large set of small private helper functions** across clients, envs, utilities, scripts, and v1 harness plumbing, and updates tests to assert behavior via public entrypoints rather than reaching into removed internals.
> 
> Notable behavior-affecting adjustments include: **Harbor MCP** start/stop now builds the `setsid`/pidfile/`kill -9 -$PID` commands inline with stronger shell-quoting; **MCP env teardown** now disconnects each server connection via the background loop before stopping/joining the thread; **OpenEnv integration** now validates the local project path up front, resolves runtime config and schema caching in `setup_state`, and hardens MCP tool-call formatting.
> 
> Several other modules fold single-use helpers into call sites (e.g., dataset example-id creation, routed-experts response parsing, log parsing and SWE-rebench parsing, RLM metric updates/stop conditions), keeping external-facing hooks intact while simplifying internal structure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc00ff3b3c53b1545c4c795dafec5ca94a2ed222. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Inline single-use private helper functions across the verifiers codebase
> Removes dozens of single-use private helper functions across utilities, clients, environments, and harnesses by inlining their logic directly at the call site. No behavioral changes are intended — this is a pure refactor to reduce indirection and simplify reading individual functions without needing to trace through private helpers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9c4ae18.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->