### PR TITLE
Use Earendil Pi package

### DIFF
--- a/tests/test_v1_harbor_cli.py
+++ b/tests/test_v1_harbor_cli.py
@@ -13,6 +13,7 @@ import verifiers as root_vf
 import verifiers.v1 as vf
 from verifiers.v1.packages.harnesses.pi import pi_mcp_json, pi_models_json
 from verifiers.v1.packages.harnesses.configs import (
+    PI_DEFAULT_PACKAGE,
     TERMINUS_2_DEFAULT_API_BASE_URL,
     TERMINUS_2_DEFAULT_HARBOR_PACKAGE,
     TERMINUS_2_DEFAULT_MODEL_NAME,
@@ -299,6 +300,10 @@ def test_pi_harness_writes_intercepted_model_and_mcp_config() -> None:
 
     assert "apt-get -o Acquire::Retries=3 update" in setup
     assert "apt-get -o Acquire::Retries=3 install" in setup
+    assert harness.config.package == PI_DEFAULT_PACKAGE
+    assert PI_DEFAULT_PACKAGE == "@earendil-works/pi-coding-agent"
+    assert f"npm install -g --ignore-scripts {PI_DEFAULT_PACKAGE}" in setup
+    assert "mariozechner" not in setup
     provider = models["providers"]["verifiers"]
     assert provider["baseUrl"] == "http://127.0.0.1:1/rollout/key/v1"
     assert provider["api"] == "openai-completions"

--- a/verifiers/v1/packages/harnesses/configs.py
+++ b/verifiers/v1/packages/harnesses/configs.py
@@ -55,7 +55,7 @@ MINI_SWE_AGENT_DEFAULT_CONFIG_SPEC = "mini_textbased"
 MINI_SWE_AGENT_DEFAULT_MODEL_CLASS = "litellm_textbased"
 MINI_SWE_AGENT_DEFAULT_ENVIRONMENT_TIMEOUT = 120
 
-PI_DEFAULT_PACKAGE = "@mariozechner/pi-coding-agent"
+PI_DEFAULT_PACKAGE = "@earendil-works/pi-coding-agent"
 PI_DEFAULT_WORKDIR = "/app"
 PI_DEFAULT_INSTRUCTION_PATH = "/pi/instruction.txt"
 PI_DEFAULT_SYSTEM_PROMPT_PATH = "/pi/system.txt"

--- a/verifiers/v1/packages/harnesses/pi.py
+++ b/verifiers/v1/packages/harnesses/pi.py
@@ -75,7 +75,7 @@ def build_pi_install_script(package: str) -> str:
     return f"""\
 set -e
 apt-get -o Acquire::Retries=3 update -qq && apt-get -o Acquire::Retries=3 install -y -qq curl ca-certificates nodejs npm > /dev/null 2>&1
-npm install -g {shlex.quote(package)}
+npm install -g --ignore-scripts {shlex.quote(package)}
 """
 
 


### PR DESCRIPTION
## Summary
- switch Pi's default package from `@mariozechner/pi-coding-agent` to `@earendil-works/pi-coding-agent`
- install Pi with `npm install -g --ignore-scripts ...`
- cover the default package and generated install command in the Pi harness test

## Verification
- `npm view @earendil-works/pi-coding-agent version engines --json`
- `uv run ruff format verifiers/v1/packages/harnesses/configs.py verifiers/v1/packages/harnesses/pi.py tests/test_v1_harbor_cli.py`
- `uv run ruff check --fix verifiers/v1/packages/harnesses/configs.py verifiers/v1/packages/harnesses/pi.py tests/test_v1_harbor_cli.py`
- `uv run pytest tests/test_v1_harbor_cli.py -q`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Pi harness install behavior and default NPM package, which can affect runtime agent setup in sandboxes. Risk is moderate because it impacts dependency installation but is covered by updated unit tests.
> 
> **Overview**
> Updates the Pi harness to use `@earendil-works/pi-coding-agent` as the default package, replacing the previous `@mariozechner/pi-coding-agent`.
> 
> Hardens the Pi install script by adding `--ignore-scripts` to the global `npm install`, and extends the Pi harness test to assert the new default package and generated install command (and that the old package string is absent).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2faec2ce3e96b1fea231a8604e7c16c244da578a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Switch Pi coding agent package to `@earendil-works/pi-coding-agent` with `--ignore-scripts`
> - Updates `PI_DEFAULT_PACKAGE` in [configs.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1442/files#diff-db410523b8b7b11b23446409095c91b408258e777bb30b5942d3a86f6359e484) from `@mariozechner/pi-coding-agent` to `@earendil-works/pi-coding-agent`.
> - Adds `--ignore-scripts` flag to the `npm install -g` command in [pi.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1442/files#diff-68ea5dbc61392c14ea0fa11fa3c81714a2e09d89ffb0c98c5b23344b6f407b09), preventing npm lifecycle scripts from running during global install.
> - Updates tests to assert the new package name and flag are present, and that the legacy `mariozechner` name is absent.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2faec2c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->