### PR TITLE
Propagate strict tool schemas from callable tools

### DIFF
--- a/tests/test_tool_utils.py
+++ b/tests/test_tool_utils.py
@@ -7,6 +7,10 @@ from pydantic import Field
 from verifiers.utils.tool_utils import convert_func_to_tool_def
 
 
+def tool_dump_without_strict(tool):
+    return tool.model_dump(exclude={"strict"}, exclude_none=True)
+
+
 class TestToolUtils:
     """Test cases for the tool_utils module."""
 
@@ -28,7 +32,8 @@ class TestToolUtils:
             return 1.0
 
         result = convert_func_to_tool_def(test_func)
-        assert result.model_dump(exclude_none=True) == {
+        assert result.strict is True
+        assert tool_dump_without_strict(result) == {
             "name": "test_func",
             "description": "This is a test function.",
             "parameters": {
@@ -63,7 +68,7 @@ class TestToolUtils:
             return 1.0
 
         result = convert_func_to_tool_def(test_func)
-        assert result.model_dump(exclude_none=True) == {
+        assert tool_dump_without_strict(result) == {
             "name": "test_func",
             "description": "",
             "parameters": {
@@ -94,7 +99,7 @@ class TestToolUtils:
             return None
 
         result = convert_func_to_tool_def(test_func)
-        assert result.model_dump(exclude_none=True) == {
+        assert tool_dump_without_strict(result) == {
             "name": "test_func",
             "description": "",
             "parameters": {
@@ -121,7 +126,7 @@ class TestToolUtils:
             return None
 
         result = convert_func_to_tool_def(test_func)
-        assert result.model_dump(exclude_none=True) == {
+        assert tool_dump_without_strict(result) == {
             "name": "test_func",
             "description": "",
             "parameters": {
@@ -147,7 +152,7 @@ class TestToolUtils:
             return None
 
         result = convert_func_to_tool_def(test_func)
-        assert result.model_dump(exclude_none=True) == {
+        assert tool_dump_without_strict(result) == {
             "name": "test_func",
             "description": "This is a test function.",
             "parameters": {
@@ -171,7 +176,7 @@ class TestToolUtils:
             return None
 
         result = convert_func_to_tool_def(test_func)
-        assert result.model_dump(exclude_none=True) == {
+        assert tool_dump_without_strict(result) == {
             "name": "test_func",
             "description": "Search pages.",
             "parameters": {

--- a/verifiers/utils/tool_utils.py
+++ b/verifiers/utils/tool_utils.py
@@ -29,4 +29,5 @@ def convert_func_to_tool_def(func: Any) -> Tool:
         name=func.__name__,
         description=function_schema_obj.description or "",
         parameters=function_schema_obj.params_json_schema,
+        strict=function_schema_obj.strict_json_schema,
     )


### PR DESCRIPTION
## Summary
- Propagate `agents.function_schema(...).strict_json_schema` into `vf.Tool.strict` for callable tools.

## Scope
This PR is limited to the generic Verifiers callable tool-schema path. Response compaction remains env/package-specific and is not part of this PR.

## Compatibility
Inspected the callable tool conversion paths for `ToolEnv`, `StatefulToolEnv`, v1 runtime toolsets, endpoint export, and experimental RLM. Hidden or bound framework args are filtered before schema generation in the stateful and v1 paths.

## Tests
- `uv run pytest tests/test_tool_utils.py tests/test_renderer_client.py::test_to_native_tool_propagates_strict_flag tests/test_openai_responses_client.py::test_get_native_response_normalizes_sampling_args_and_tools tests/test_openai_responses_client.py::test_to_native_tool_omits_strict_when_unset tests/test_tool_env.py tests/test_stateful_tool_env.py tests/test_v1_config_extension.py::test_tool_bindings_inject_owner_private_objects tests/test_v1_config_extension.py::test_bindings_must_match_declared_callable_args tests/test_v1_config_extension.py::test_tool_bindings_do_not_leak_to_same_named_handlers tests/test_v1_runtime_lifecycle.py::test_endpoint_exposes_tool_user_and_stop_surfaces tests/test_v1_runtime_lifecycle.py::test_state_helpers_load_runtime_tools_while_rollout_is_active tests/test_rlm_env.py::TestRLMEnvInitialization::test_custom_configuration tests/test_rlm_env.py::TestToolSplitConfiguration::test_standard_tools_exposed_repl_tools_not`
- `.venv/bin/ruff check tests/test_tool_utils.py verifiers/errors.py verifiers/utils/tool_utils.py`
- `.venv/bin/ruff format --check tests/test_tool_utils.py verifiers/errors.py verifiers/utils/tool_utils.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the serialized tool definition by populating `Tool.strict` from callable-derived schemas, which can alter downstream provider/tool behavior and validation expectations.
> 
> **Overview**
> Callable-to-`Tool` conversion now forwards `function_schema(...).strict_json_schema` into `Tool.strict`, making strictness explicit on generated tool definitions.
> 
> `tests/test_tool_utils.py` is adjusted to assert `strict` propagation and to compare tool dumps while excluding `strict` so existing schema-shape assertions remain stable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3674e8b34056d67323b4ac168b63f1aca5b307a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Propagate `strict` field from callable tool schemas in `convert_func_to_tool_def`
> Sets `Tool.strict` based on `function_schema_obj.strict_json_schema` when building a tool definition from a callable. Tests are updated to assert `strict=True` and exclude the `strict` field from remaining comparisons using a new `tool_dump_without_strict` helper.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e3674e8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->