### PR TITLE
Pass renderer chat template kwargs from sampling

### DIFF
--- a/tests/test_renderer_client.py
+++ b/tests/test_renderer_client.py
@@ -1,3 +1,4 @@
+import asyncio
 from functools import lru_cache
 from unittest.mock import patch
 
@@ -46,6 +47,7 @@ def test_renderer_client_honors_configured_renderer_name():
         size=1,
         tool_parser=None,
         reasoning_parser=None,
+        chat_template_kwargs={},
         preserve_all_thinking=False,
         preserve_thinking_between_tool_calls=False,
     )
@@ -77,9 +79,61 @@ def test_renderer_client_uses_renderer_model_name_override():
         size=1,
         tool_parser=None,
         reasoning_parser=None,
+        chat_template_kwargs={},
         preserve_all_thinking=False,
         preserve_thinking_between_tool_calls=False,
     )
+
+
+def test_renderer_client_consumes_sampling_chat_template_kwargs():
+    RendererClient._shared_pools.clear()
+
+    client = object.__new__(RendererClient)
+    client._renderer = None
+    client._pool_size = 1
+    client._config = vf.ClientConfig(client_type="renderer", renderer="qwen3")
+    client._client = object()  # type: ignore[attr-defined]
+
+    sentinel_pool = RendererPool.__new__(RendererPool)
+    captured: dict = {}
+
+    async def _fake_generate(**kwargs):
+        captured.update(kwargs)
+        return {"content": "ok"}
+
+    with (
+        patch(
+            "verifiers.clients.renderer_client.create_renderer_pool",
+            return_value=sentinel_pool,
+        ) as create_pool_mock,
+        patch("verifiers.clients.renderer_client.generate", side_effect=_fake_generate),
+    ):
+        response = asyncio.run(
+            client.get_native_response(
+                prompt=[{"role": "user", "content": "hi"}],
+                model="Qwen/Qwen3-8B",
+                sampling_args={
+                    "extra_body": {
+                        "chat_template_kwargs": {"enable_thinking": False},
+                        "top_k": 20,
+                    }
+                },
+                tools=None,
+            )
+        )
+
+    assert response == {"content": "ok"}
+    create_pool_mock.assert_called_once_with(
+        "Qwen/Qwen3-8B",
+        renderer="qwen3",
+        size=1,
+        tool_parser=None,
+        reasoning_parser=None,
+        chat_template_kwargs={"enable_thinking": False},
+        preserve_all_thinking=False,
+        preserve_thinking_between_tool_calls=False,
+    )
+    assert captured["sampling_params"] == {"top_k": 20}
 
 
 # Provenance: Eli's review on PR #1068, comment 3150580768.

--- a/verifiers/clients/renderer_client.py
+++ b/verifiers/clients/renderer_client.py
@@ -405,6 +405,23 @@ def _parse_finish_reason(raw: str | None) -> FinishReason:
             return None
 
 
+def _freeze_json_like(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return tuple(sorted((str(k), _freeze_json_like(v)) for k, v in value.items()))
+    if isinstance(value, list):
+        return tuple(_freeze_json_like(v) for v in value)
+    return value
+
+
+def _pop_chat_template_kwargs(sampling_params: dict[str, Any]) -> dict[str, Any]:
+    raw = sampling_params.pop("chat_template_kwargs", None)
+    if raw is None:
+        return {}
+    if not isinstance(raw, Mapping):
+        raise ValueError("extra_body.chat_template_kwargs must be a mapping")
+    return dict(raw)
+
+
 class RendererClient(
     Client[AsyncOpenAI, list[RendererMessage], dict[str, Any], ToolSpec]
 ):
@@ -418,13 +435,22 @@ class RendererClient(
     """
 
     # Cache key is (renderer_model_name, renderer_name, tool_parser,
-    # reasoning_parser, pool_size, preserve_all_thinking,
-    # preserve_thinking_between_tool_calls) so that different parser configs,
-    # pool sizes, or preserve-thinking bindings for the same model don't
-    # collide.
+    # reasoning_parser, pool_size, chat_template_kwargs,
+    # preserve_all_thinking, preserve_thinking_between_tool_calls) so that
+    # different parser configs, pool sizes, template kwargs, or
+    # preserve-thinking bindings for the same model don't collide.
     _shared_pools: ClassVar[
         dict[
-            tuple[str, str, str | None, str | None, int, bool, bool],
+            tuple[
+                str,
+                str,
+                str | None,
+                str | None,
+                int,
+                Any,
+                bool,
+                bool,
+            ],
             RendererPool,
         ]
     ] = {}
@@ -451,7 +477,9 @@ class RendererClient(
 
     # ── Renderer management ─────────────────────────────────────────
 
-    def _get_renderer_or_pool(self, model: str) -> Renderer | RendererPool:
+    def _get_renderer_or_pool(
+        self, model: str, chat_template_kwargs: dict[str, Any] | None = None
+    ) -> Renderer | RendererPool:
         if self._renderer is not None:
             return self._renderer
 
@@ -473,12 +501,14 @@ class RendererClient(
             if self._config is not None
             else False
         )
+        renderer_chat_template_kwargs = dict(chat_template_kwargs or {})
         cache_key = (
             renderer_model,
             renderer_name,
             tool_parser,
             reasoning_parser,
             self._pool_size,
+            _freeze_json_like(renderer_chat_template_kwargs),
             preserve_all_thinking,
             preserve_thinking_between_tool_calls,
         )
@@ -491,6 +521,7 @@ class RendererClient(
                     size=self._pool_size,
                     tool_parser=tool_parser,
                     reasoning_parser=reasoning_parser,
+                    chat_template_kwargs=renderer_chat_template_kwargs,
                     preserve_all_thinking=preserve_all_thinking,
                     preserve_thinking_between_tool_calls=preserve_thinking_between_tool_calls,
                 )
@@ -528,10 +559,10 @@ class RendererClient(
         tools: list[ToolSpec] | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
-        renderer = self._get_renderer_or_pool(model)
-
         args = dict(sampling_args)
         sampling_params: dict[str, Any] = dict(args.pop("extra_body", None) or {})
+        chat_template_kwargs = _pop_chat_template_kwargs(sampling_params)
+        renderer = self._get_renderer_or_pool(model, chat_template_kwargs)
         for key in (
             "temperature",
             "top_p",


### PR DESCRIPTION
## Summary
- Teach `RendererClient` to consume `sampling_args.extra_body.chat_template_kwargs`.
- Remove those kwargs from the `/generate` sampling params and pass them into renderer pool construction instead.
- Include the kwargs in the shared renderer-pool cache key so different template settings do not collide.

We are extracting renderer template controls from `chat_template_kwargs` in sampling `extra_body`, which matches the hosted config path. Longer term, this should move toward typed pydantic config models with explicit renderer-specific template args; for now, renderers validate accepted kwargs and alert on unsupported keys.

## Companion PRs
- Prime RL: https://github.com/PrimeIntellect-ai/prime-rl/pull/2605
- Renderers: https://github.com/PrimeIntellect-ai/renderers/pull/60

## Validation
- `uv run ruff check verifiers/clients/renderer_client.py tests/test_renderer_client.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest tests/test_renderer_client.py -k "renderer_client_honors_configured_renderer_name or renderer_client_uses_renderer_model_name_override or renderer_client_consumes_sampling_chat_template_kwargs"`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pass `chat_template_kwargs` from sampling args to renderer pool in `RendererClient`
> - `RendererClient.get_native_response` now extracts `chat_template_kwargs` from `extra_body` in sampling args and passes them to `_get_renderer_or_pool`, rather than forwarding them downstream in `sampling_params`.
> - Distinct `chat_template_kwargs` values produce separate renderer pool cache entries, using a deterministic frozen representation as the cache key.
> - A `_pop_chat_template_kwargs` helper removes the key from `sampling_params` and raises `ValueError` if the value is present but not a mapping.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3443fdf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->