### PR TITLE
Prepare v0.1.15.dev9 release

### DIFF
--- a/assets/release/RELEASE_v0.1.15.dev9.md
+++ b/assets/release/RELEASE_v0.1.15.dev9.md
@@ -1,0 +1,26 @@
+# Verifiers v0.1.15.dev9 Release Notes
+
+*Date:* 05/22/2026
+
+## Highlights since v0.1.15.dev8
+
+- **v1 TextArena tasksets are now package-native.** `TextArenaTaskset` and `TextArenaTasksetConfig` are exported from the public v1 surfaces, and `wordle-v1` is bundled as a concrete TextArena-backed example with task-owned game mechanics, rewards, and eval defaults.
+- **v1 environment loading is simpler and stricter.** `load_environment` now derives taskset and harness config types from module loader annotations, validates child config objects at the boundary, and keeps package loading out of `EnvConfig` and `vf.Env` construction.
+- **Tool, harness, and API cleanup tightened the surface.** Callable tool schemas now propagate strict schema metadata, the Pi harness uses the Earendil package, and unused verifier helper APIs were removed.
+
+## Changes included in v0.1.15.dev9 (since v0.1.15.dev8)
+
+### v1 Tasksets and environment loading
+
+- Migrate textarena_taskset into the v1 tasksets package (#1446)
+
+### Tools and harnesses
+
+- Propagate strict callable tool schemas (#1445)
+- Use Earendil Pi package (#1442)
+
+### API cleanup
+
+- Remove unused verifier helpers (#1437)
+
+**Full Changelog**: https://github.com/PrimeIntellect-ai/verifiers/compare/v0.1.15.dev8...v0.1.15.dev9

--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.15.dev8"
+__version__ = "0.1.15.dev9"
 
 import importlib
 import os


### PR DESCRIPTION
## Summary
- Bump verifiers to 0.1.15.dev9
- Add release notes for changes since v0.1.15.dev8

## Validation
- uv run pre-commit run --files verifiers/__init__.py assets/release/RELEASE_v0.1.15.dev9.md
- env PYTHONDONTWRITEBYTECODE=1 uv run python -c "import verifiers; print(verifiers.__version__)"
- uv build --out-dir /private/tmp/verifiers-dist-0.1.15.dev9
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only change: bumps the package version and adds release notes, with no functional code modifications beyond the version string.
> 
> **Overview**
> Prepares the `v0.1.15.dev9` release by bumping `verifiers.__version__` from `0.1.15.dev8` to `0.1.15.dev9`.
> 
> Adds `RELEASE_v0.1.15.dev9.md` documenting highlights and included changes since `v0.1.15.dev8` (v1 TextArena tasksets, stricter `load_environment`, tool/harness cleanup, and removal of unused helpers).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf774e46df38e4e4a7dbdb53759c23a0a4bee86c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump version to v0.1.15.dev9
> Updates `__version__` in [verifiers/__init__.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1448/files#diff-3667172df996e6596aa8d26557b92b4cb78ee7d2280a3cae14623ce4677e781e) from `0.1.15.dev8` to `0.1.15.dev9` and adds release notes in [RELEASE_v0.1.15.dev9.md](https://github.com/PrimeIntellect-ai/verifiers/pull/1448/files#diff-f43e5b0ea4aabfacfa539d4c1e883dafa09620d5e25904f0d46a1fba7d63eb32).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bf774e4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->