### PR TITLE
Fix RLM skills upload path

### DIFF
--- a/tests/test_v1_rlm_swe.py
+++ b/tests/test_v1_rlm_swe.py
@@ -65,7 +65,7 @@ def test_rlm_harness_can_upload_skills(tmp_path: Path):
     program = as_mapping(harness.program)
     dirs = as_mapping(program["dirs"])
 
-    assert dirs["/rlm/skills"] == skills
+    assert dirs["/task/rlm-skills"] == skills
 
 
 def test_rlm_harness_uploads_taskset_skills_by_default(tmp_path: Path):
@@ -84,7 +84,7 @@ def test_rlm_harness_uploads_taskset_skills_by_default(tmp_path: Path):
     program = as_mapping(env.harness.program)
     dirs = as_mapping(program["dirs"])
 
-    assert dirs["/rlm/skills"] == skills
+    assert dirs["/task/rlm-skills"] == skills
 
 
 def test_taskset_discovers_sibling_skills_dir_by_default(
@@ -131,7 +131,7 @@ def test_rlm_harness_explicit_skills_override_taskset_skills(tmp_path: Path):
     program = as_mapping(env.harness.program)
     dirs = as_mapping(program["dirs"])
 
-    assert dirs["/rlm/skills"] == explicit_skills
+    assert dirs["/task/rlm-skills"] == explicit_skills
 
 
 def test_rlm_swe_environment_uses_v1_r2e_taskset(monkeypatch):

--- a/verifiers/v1/packages/harnesses/rlm.py
+++ b/verifiers/v1/packages/harnesses/rlm.py
@@ -27,7 +27,7 @@ from .configs import (
 from ...types import ConfigMap, ProgramCommand, ProgramValue
 
 DEFAULT_RLM_CHECKOUT_PATH = "/tmp/rlm-checkout"
-DEFAULT_RLM_SKILLS_PATH = "/rlm/skills"
+DEFAULT_RLM_SKILLS_PATH = "/task/rlm-skills"
 DEFAULT_RLM_LOCAL_CHECKOUT_CACHE_ROOT = (
     Path.home() / ".cache" / "verifiers" / "rlm-checkouts"
 )


### PR DESCRIPTION
## Summary
- Upload v1 RLM skills to /task/rlm-skills, which is the path rlm-harness reads when registering skills.

## Testing
- uv run ruff format
- uv run ruff check --fix
- uv run --with-editable . /tmp/rlm_skills_smoke.py
- pre-push hooks: ruff check, ruff format, Semgrep v1 policy, generated AGENTS/CLAUDE check, ty ci parity

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the remote sandbox mount path for RLM skills, which can affect whether skills are discovered at runtime; scope is small but directly impacts harness execution behavior.
> 
> **Overview**
> Fixes v1 RLM skills mounting by changing the default remote skills directory from `/rlm/skills` to `/task/rlm-skills` in the RLM harness.
> 
> Updates the associated tests to assert the new upload path for explicit skills, taskset-provided skills, and explicit-overrides-taskset behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a6781c8d5ef4c327d31a55f989f80105df61ece. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix RLM skills upload path to use `/task/rlm-skills`
> Changes `DEFAULT_RLM_SKILLS_PATH` in [rlm.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1451/files#diff-ab1fe47f5f8e668f3f9356828ec781afac5bda206474365d3c76412bf4d88586) from `/rlm/skills` to `/task/rlm-skills`. Tests are updated to assert the corrected path in the harness program dirs mapping.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1a6781c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->