### PR TITLE
Use renderers offload helper in renderer client

### DIFF
--- a/verifiers/clients/renderer_client.py
+++ b/verifiers/clients/renderer_client.py
@@ -8,7 +8,6 @@ A shared RendererPool (one per model) offloads sync tokenization to threads so
 concurrent rollouts tokenize in parallel instead of blocking the event loop.
 """
 
-import asyncio
 import json
 import threading
 from collections.abc import Mapping
@@ -31,7 +30,7 @@ from renderers import (
 )
 from renderers import ToolCall as RendererToolCall
 from renderers import ToolCallFunction
-from renderers.client import generate
+from renderers.client import _maybe_offload, generate
 
 from verifiers.clients.client import Client
 from verifiers.clients.openai_chat_completions_client import (
@@ -96,17 +95,6 @@ _DEFAULT_POOL_SIZE = 1
 
 
 # ── Helpers ─────────────────────────────────────────────────────────
-
-
-async def _maybe_offload(renderer: Renderer | RendererPool, fn):
-    """Run sync renderer work on a thread iff ``renderer`` is a pool.
-
-    Pool methods can block on the internal queue/lock; we offload to keep
-    the event loop responsive. A bare ``Renderer`` runs inline.
-    """
-    if isinstance(renderer, RendererPool):
-        return await asyncio.to_thread(fn)
-    return fn()
 
 
 def _get_value(obj: Any, key: str, default: Any = None) -> Any:


### PR DESCRIPTION
## Summary
- import the renderer package's private _maybe_offload helper instead of reimplementing it in Verifiers
- remove the now-unused asyncio import and local helper

## Tests
- uv run --frozen ruff check verifiers/clients/renderer_client.py tests/test_renderer_client.py
- uv run --frozen pytest tests/test_renderer_client.py
- pre-commit/pre-push hooks via git commit and git push

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only changes where `_maybe_offload` comes from (and drops an unused `asyncio` import), with no functional changes expected beyond matching upstream behavior.
> 
> **Overview**
> Switches `verifiers/clients/renderer_client.py` to import and use `renderers.client._maybe_offload` instead of maintaining a local async offload helper.
> 
> Removes the now-unused local `_maybe_offload` implementation and the `asyncio` dependency from this module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2b06857a7757715a9a26151a4721bfee845b79b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove duplicate `_maybe_offload` helper from `renderer_client` in favor of shared import
> Deletes the local `_maybe_offload` definition in [renderer_client.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1452/files#diff-4309037b1656944b1991edc5baa1d16760d74155d7adc9fef41a2080ce8605e1) and imports it directly from `renderers.client` instead. This deduplicates the helper and ensures both modules use the same offload logic.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e2b0685.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->