### PR TITLE
perf(serve): reduce worker/router event-loop lag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,6 @@ dependencies = [
     "regex<2026.4.4",
     "httpx>=0.27.0",
     "prime-pydantic-config[toml]",
-    "uvloop>=0.21.0",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dependencies = [
     "regex<2026.4.4",
     "httpx>=0.27.0",
     "prime-pydantic-config[toml]",
+    "uvloop>=0.21.0",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dependencies = [
     "regex<2026.4.4",
     "httpx>=0.27.0",
     "prime-pydantic-config[toml]",
-    "uvloop>=0.21.0",
+    "uvloop>=0.21.0; sys_platform != 'win32' and sys_platform != 'cygwin' and platform_python_implementation != 'PyPy'",
 ]
 
 [dependency-groups]

--- a/tests/test_v1_runtime_lifecycle.py
+++ b/tests/test_v1_runtime_lifecycle.py
@@ -523,43 +523,6 @@ async def update_child_uses_borrowed_tool(task, state):
     state["child_trajectory_id"] = child_state["trajectory_id"]
 
 
-async def update_parallel_children_use_borrowed_tool(task, state):
-    _ = task
-
-    async def run_child(label: str) -> vf.State:
-        child_task = vf.Task(
-            {"prompt": [{"role": "user", "content": f"inspect {label}"}]}
-        ).freeze()
-        child_state = state.for_task(
-            child_task,
-            borrow="model",
-            tools="borrowed_stage_tool",
-            transcript="append",
-        )
-        return await make_harness(max_turns=2).run(child_task, child_state)
-
-    children = await asyncio.gather(run_child("a"), run_child("b"))
-    state["update_child_trajectory_ids"] = [
-        child["trajectory_id"] for child in children
-    ]
-
-
-async def reward_child_uses_borrowed_tool(task, state) -> float:
-    _ = task
-    child_task = vf.Task(
-        {"prompt": [{"role": "user", "content": "score sandbox state"}]}
-    ).freeze()
-    child_state = state.for_task(
-        child_task,
-        borrow="model",
-        tools="borrowed_stage_tool",
-    )
-    child_state = await make_harness(max_turns=2).run(child_task, child_state)
-    state["reward_child_completion"] = child_state["completion"][-1]["content"]
-    state["reward_child_requests"] = child_state["num_model_requests"]
-    return float("reward" in state.get("borrowed_stage_values", []))
-
-
 async def submitted(task, state) -> bool:
     _ = task
     return bool(state.get("submitted"))
@@ -1653,75 +1616,6 @@ async def test_update_child_harness_can_borrow_live_tools() -> None:
     assert state["trajectory"][2]["trajectory_id"] == state["child_trajectory_id"]
     assert state["num_model_requests"] == 3
     assert state["completion"][-1]["content"] == "child judged"
-
-
-@pytest.mark.asyncio
-async def test_update_and_reward_children_can_share_borrowed_live_tools() -> None:
-    client = CapturingModelClient(
-        [
-            fake_response("parent answer"),
-            fake_response(
-                tool_calls=[
-                    ToolCall(
-                        id="call_update_a",
-                        name="borrowed_stage_tool",
-                        arguments='{"value": "update-a"}',
-                    )
-                ]
-            ),
-            fake_response("update a done"),
-            fake_response(
-                tool_calls=[
-                    ToolCall(
-                        id="call_update_b",
-                        name="borrowed_stage_tool",
-                        arguments='{"value": "update-b"}',
-                    )
-                ]
-            ),
-            fake_response("update b done"),
-            fake_response(
-                tool_calls=[
-                    ToolCall(
-                        id="call_reward",
-                        name="borrowed_stage_tool",
-                        arguments='{"value": "reward"}',
-                    )
-                ]
-            ),
-            fake_response('{"score": 1.0}'),
-        ]
-    )
-    harness = make_harness(
-        updates=[update_parallel_children_use_borrowed_tool],
-        rewards=[reward_child_uses_borrowed_tool],
-        toolsets=[vf.Toolset(tools=[borrowed_stage_tool], write=True)],
-    )
-    task = vf.Task({"prompt": [{"role": "user", "content": "parent"}]}).freeze()
-    state = vf.State.for_task(task)
-    state["runtime"]["model"] = "model-a"
-    harness.runtime.bind_model_client(state, cast(Client, client))
-
-    state = await harness.run(task, state)
-
-    assert state["borrowed_stage_values"] == ["update-a", "update-b", "reward"]
-    assert state["reward"] == 1.0
-    assert state["reward_child_completion"] == '{"score": 1.0}'
-    assert len(client.requests) == 7
-    assert len(state["trajectory"]) == 5
-    assert state["trajectory"][0]["trajectory_id"] == state["trajectory_id"]
-    update_trajectory_ids = set(state["update_child_trajectory_ids"])
-    assert len(update_trajectory_ids) == 2
-    assert {
-        str(record["trajectory_id"]) for record in state["trajectory"][1:]
-    } == update_trajectory_ids
-    assert all(
-        record["completion"] != [{"role": "assistant", "content": '{"score": 1.0}'}]
-        for record in state["trajectory"]
-    )
-    assert "runtime" not in state or "resolved" not in state.get("runtime", {})
-    assert state["num_model_requests"] == 5
-    assert state["reward_child_requests"] == 2
 
 
 @pytest.mark.asyncio

--- a/tests/test_v1_runtime_lifecycle.py
+++ b/tests/test_v1_runtime_lifecycle.py
@@ -1618,6 +1618,132 @@ async def test_update_child_harness_can_borrow_live_tools() -> None:
     assert state["completion"][-1]["content"] == "child judged"
 
 
+async def update_parallel_children_use_borrowed_tool(task, state):
+    _ = task
+
+    async def run_child(label: str) -> vf.State:
+        child_task = vf.Task(
+            {"prompt": [{"role": "user", "content": f"inspect {label}"}]}
+        ).freeze()
+        child_state = state.for_task(
+            child_task,
+            borrow="model",
+            tools="borrowed_stage_tool",
+            transcript="append",
+        )
+        return await make_harness(max_turns=2).run(child_task, child_state)
+
+    children = await asyncio.gather(run_child("a"), run_child("b"))
+    state["update_child_trajectory_ids"] = [
+        child["trajectory_id"] for child in children
+    ]
+
+
+async def reward_child_uses_borrowed_tool(task, state) -> float:
+    _ = task
+    child_task = vf.Task(
+        {"prompt": [{"role": "user", "content": "score sandbox state"}]}
+    ).freeze()
+    child_state = state.for_task(
+        child_task,
+        borrow="model",
+        tools="borrowed_stage_tool",
+    )
+    child_state = await make_harness(max_turns=2).run(child_task, child_state)
+    state["reward_child_completion"] = child_state["completion"][-1]["content"]
+    state["reward_child_requests"] = child_state["num_model_requests"]
+    return float("reward" in state.get("borrowed_stage_values", []))
+
+
+class RoutedModelClient:
+    """Routes responses by inspecting the request's conversation, not call order.
+
+    Robust to event-loop interleaving (e.g. asyncio.gather): each rollout's
+    request carries its own conversation context, so we never depend on which
+    coroutine happens to wake first.
+    """
+
+    def __init__(self) -> None:
+        self.requests: list[dict[str, object]] = []
+
+    async def get_response(self, **kwargs: object) -> Response:
+        prompt = kwargs.get("prompt") or []
+        self.requests.append(dict(kwargs))
+
+        # First user message identifies the rollout (parent / update-a / update-b / reward).
+        first_user = next(
+            (m.get("content") for m in prompt if m.get("role") == "user"), ""
+        )
+        # Presence of a tool-role message tells us we're past turn 1 (tool already executed).
+        has_tool_msg = any(m.get("role") == "tool" for m in prompt)
+
+        if first_user == "parent":
+            return fake_response("parent answer")
+        if first_user.startswith("inspect "):
+            label = first_user.split(" ", 1)[1]
+            if not has_tool_msg:
+                return fake_response(
+                    tool_calls=[
+                        ToolCall(
+                            id=f"call_update_{label}",
+                            name="borrowed_stage_tool",
+                            arguments=f'{{"value": "update-{label}"}}',
+                        )
+                    ]
+                )
+            return fake_response(f"update {label} done")
+        if first_user == "score sandbox state":
+            if not has_tool_msg:
+                return fake_response(
+                    tool_calls=[
+                        ToolCall(
+                            id="call_reward",
+                            name="borrowed_stage_tool",
+                            arguments='{"value": "reward"}',
+                        )
+                    ]
+                )
+            return fake_response('{"score": 1.0}')
+        raise AssertionError(f"Unexpected first_user: {first_user!r}")
+
+
+@pytest.mark.asyncio
+async def test_update_and_reward_children_can_share_borrowed_live_tools() -> None:
+    client = RoutedModelClient()
+    harness = make_harness(
+        updates=[update_parallel_children_use_borrowed_tool],
+        rewards=[reward_child_uses_borrowed_tool],
+        toolsets=[vf.Toolset(tools=[borrowed_stage_tool], write=True)],
+    )
+    task = vf.Task({"prompt": [{"role": "user", "content": "parent"}]}).freeze()
+    state = vf.State.for_task(task)
+    state["runtime"]["model"] = "model-a"
+    harness.runtime.bind_model_client(state, cast(Client, client))
+
+    state = await harness.run(task, state)
+
+    # All three borrowed-tool invocations should have landed; order is not
+    # asserted because parallel `asyncio.gather` may interleave them.
+    assert sorted(state["borrowed_stage_values"]) == ["reward", "update-a", "update-b"]
+    assert state["reward"] == 1.0
+    assert state["reward_child_completion"] == '{"score": 1.0}'
+    assert len(client.requests) == 7
+    assert len(state["trajectory"]) == 5
+    assert state["trajectory"][0]["trajectory_id"] == state["trajectory_id"]
+    update_trajectory_ids = set(state["update_child_trajectory_ids"])
+    assert len(update_trajectory_ids) == 2
+    assert {
+        str(record["trajectory_id"]) for record in state["trajectory"][1:]
+    } == update_trajectory_ids
+    assert all(
+        record["completion"] != [{"role": "assistant", "content": '{"score": 1.0}'}]
+        for record in state["trajectory"]
+    )
+    assert "runtime" not in state or "resolved" not in state.get("runtime", {})
+    assert state["num_model_requests"] == 5
+    assert state["reward_child_requests"] == 2
+
+
 @pytest.mark.asyncio
 async def test_toolset_can_contribute_stop_condition() -> None:
     harness = make_harness(

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -767,9 +767,6 @@ class Environment(ABC):
             )
 
         state = await maybe_retry(run_rollout_attempt, max_retries=max_retries)()
-        # E2: state_to_output walks the full trajectory dict + sanitizes messages;
-        # per-rollout cost can be 100s of ms on long rollouts. Offload so it
-        # doesn't block the worker's event loop right before the response pack.
         output = await asyncio.to_thread(state_to_output, state, state_columns or [])
         return output
 
@@ -817,8 +814,6 @@ class Environment(ABC):
             )
 
         group_states = await maybe_retry(run_group_attempt, max_retries=max_retries)()
-        # E2: same as run_rollout — offload the trajectory walk + message
-        # sanitization to a thread so the event loop stays responsive.
         outputs = await asyncio.gather(
             *(
                 asyncio.to_thread(state_to_output, state, state_columns or [])

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -767,7 +767,10 @@ class Environment(ABC):
             )
 
         state = await maybe_retry(run_rollout_attempt, max_retries=max_retries)()
-        output = state_to_output(state, state_columns or [])
+        # E2: state_to_output walks the full trajectory dict + sanitizes messages;
+        # per-rollout cost can be 100s of ms on long rollouts. Offload so it
+        # doesn't block the worker's event loop right before the response pack.
+        output = await asyncio.to_thread(state_to_output, state, state_columns or [])
         return output
 
     @final
@@ -814,10 +817,15 @@ class Environment(ABC):
             )
 
         group_states = await maybe_retry(run_group_attempt, max_retries=max_retries)()
-        outputs = [
-            state_to_output(state, state_columns or []) for state in group_states
-        ]
-        return outputs
+        # E2: same as run_rollout — offload the trajectory walk + message
+        # sanitization to a thread so the event loop stays responsive.
+        outputs = await asyncio.gather(
+            *(
+                asyncio.to_thread(state_to_output, state, state_columns or [])
+                for state in group_states
+            )
+        )
+        return list(outputs)
 
     async def generate(
         self,

--- a/verifiers/serve/server/env_router.py
+++ b/verifiers/serve/server/env_router.py
@@ -249,6 +249,12 @@ class EnvRouter:
 
                 # ── worker responses ───────────────────────────────
                 if self.response_pull in events:
+                    # R4: drain all ready frames first, then dispatch on_response
+                    # concurrently. The prior serial loop awaited a TCP send per
+                    # response which compounds when 256 workers all finish near
+                    # simultaneously. asyncio.gather lets the loop pipeline the
+                    # frontend sends and return to the poller sooner.
+                    pending: list = []
                     while True:
                         try:
                             frames = await self.response_pull.recv_multipart(
@@ -260,7 +266,12 @@ class EnvRouter:
                             continue
                         client_id, request_id, response_bytes = frames
                         self.complete_request(request_id)
-                        await on_response(client_id, request_id, response_bytes)
+                        pending.append((client_id, request_id, response_bytes))
+                    if pending:
+                        await asyncio.gather(
+                            *(on_response(c, r, b) for c, r, b in pending),
+                            return_exceptions=True,
+                        )
 
                 # ── worker stats ───────────────────────────────────
                 if self.stats_pull in events:

--- a/verifiers/serve/server/env_router.py
+++ b/verifiers/serve/server/env_router.py
@@ -249,12 +249,6 @@ class EnvRouter:
 
                 # ── worker responses ───────────────────────────────
                 if self.response_pull in events:
-                    # R4: drain all ready frames first, then dispatch on_response
-                    # concurrently. The prior serial loop awaited a TCP send per
-                    # response which compounds when 256 workers all finish near
-                    # simultaneously. asyncio.gather lets the loop pipeline the
-                    # frontend sends and return to the poller sooner.
-                    pending: list = []
                     while True:
                         try:
                             frames = await self.response_pull.recv_multipart(
@@ -266,12 +260,7 @@ class EnvRouter:
                             continue
                         client_id, request_id, response_bytes = frames
                         self.complete_request(request_id)
-                        pending.append((client_id, request_id, response_bytes))
-                    if pending:
-                        await asyncio.gather(
-                            *(on_response(c, r, b) for c, r, b in pending),
-                            return_exceptions=True,
-                        )
+                        await on_response(client_id, request_id, response_bytes)
 
                 # ── worker stats ───────────────────────────────────
                 if self.stats_pull in events:

--- a/verifiers/serve/server/env_server.py
+++ b/verifiers/serve/server/env_server.py
@@ -125,19 +125,14 @@ class EnvServer(ABC):
 
     @classmethod
     def run_server(cls, *args, **kwargs):
-        # E4: env router shares one asyncio loop with the stats RX socket
-        # and the response RX from workers. Default selector loop is the
-        # latency floor for the "Server | Lag" metric we observe in prod;
-        # uvloop drops the floor materially.
         try:
             import uvloop  # type: ignore
             uvloop.install()
         except ImportError:
             pass
 
-        # R1: same pool scaling as workers — the router is just one async
-        # loop juggling stats, response-receiving, and request-dispatching
-        # across all workers. Defaulting to 32 threads silently caps to_thread.
+        # Router juggles stats, worker responses, and request dispatch on a
+        # single loop; the default 32-thread executor silently caps to_thread.
         from verifiers.utils.thread_utils import scale_executors
 
         scale_executors(concurrency=512)

--- a/verifiers/serve/server/env_server.py
+++ b/verifiers/serve/server/env_server.py
@@ -134,5 +134,13 @@ class EnvServer(ABC):
             uvloop.install()
         except ImportError:
             pass
+
+        # R1: same pool scaling as workers — the router is just one async
+        # loop juggling stats, response-receiving, and request-dispatching
+        # across all workers. Defaulting to 32 threads silently caps to_thread.
+        from verifiers.utils.thread_utils import scale_executors
+
+        scale_executors(concurrency=512)
+
         server = cls(*args, **kwargs)
         return asyncio.run(server.run())

--- a/verifiers/serve/server/env_server.py
+++ b/verifiers/serve/server/env_server.py
@@ -125,5 +125,14 @@ class EnvServer(ABC):
 
     @classmethod
     def run_server(cls, *args, **kwargs):
+        # E4: env router shares one asyncio loop with the stats RX socket
+        # and the response RX from workers. Default selector loop is the
+        # latency floor for the "Server | Lag" metric we observe in prod;
+        # uvloop drops the floor materially.
+        try:
+            import uvloop  # type: ignore
+            uvloop.install()
+        except ImportError:
+            pass
         server = cls(*args, **kwargs)
         return asyncio.run(server.run())

--- a/verifiers/serve/server/env_server.py
+++ b/verifiers/serve/server/env_server.py
@@ -127,6 +127,7 @@ class EnvServer(ABC):
     def run_server(cls, *args, **kwargs):
         try:
             import uvloop  # type: ignore
+
             uvloop.install()
         except ImportError:
             pass

--- a/verifiers/serve/server/env_worker.py
+++ b/verifiers/serve/server/env_worker.py
@@ -387,5 +387,14 @@ class EnvWorker:
 
     @classmethod
     def run_worker(cls, *args, **kwargs) -> None:
+        # E4: install uvloop. Lower scheduler overhead matters here because
+        # each worker juggles many concurrent rollouts × many turns; the
+        # default selector loop becomes a bottleneck before any single op
+        # does.
+        try:
+            import uvloop  # type: ignore
+            uvloop.install()
+        except ImportError:
+            pass
         worker = cls(*args, **kwargs)
         asyncio.run(worker.run())

--- a/verifiers/serve/server/env_worker.py
+++ b/verifiers/serve/server/env_worker.py
@@ -190,10 +190,6 @@ class EnvWorker:
                 pass
 
         try:
-            # msgpack.unpackb + Pydantic model_validate are CPU-only and the
-            # request payload is non-trivial (sampling_args + client_config +
-            # prompt); keeping them off the asyncio loop stops the unpack
-            # stampede from blocking ZMQ recv when many requests land at once.
             raw = await asyncio.to_thread(msgpack.unpackb, payload_bytes, raw=False)
             request_type = raw.get("request_type")
             request_id = raw.get("request_id", request_id)
@@ -400,9 +396,6 @@ class EnvWorker:
 
     @classmethod
     def run_worker(cls, *args, **kwargs) -> None:
-        # Install uvloop. Each worker juggles many concurrent rollouts × many
-        # turns; default selector loop scheduler overhead becomes the
-        # bottleneck before any single op does.
         try:
             import uvloop  # type: ignore
 

--- a/verifiers/serve/server/env_worker.py
+++ b/verifiers/serve/server/env_worker.py
@@ -190,10 +190,10 @@ class EnvWorker:
                 pass
 
         try:
-            # R2: msgpack unpack + Pydantic validate run on the asyncio loop in
-            # the prior code path. Both are CPU-only and the request size is
-            # non-trivial (sampling_args + client_config + prompt). Offload so
-            # the loop stays responsive when many requests land at once.
+            # msgpack.unpackb + Pydantic model_validate are CPU-only and the
+            # request payload is non-trivial (sampling_args + client_config +
+            # prompt); keeping them off the asyncio loop stops the unpack
+            # stampede from blocking ZMQ recv when many requests land at once.
             raw = await asyncio.to_thread(msgpack.unpackb, payload_bytes, raw=False)
             request_type = raw.get("request_type")
             request_id = raw.get("request_id", request_id)
@@ -367,13 +367,11 @@ class EnvWorker:
 
         from verifiers.utils.thread_utils import install_default_executor, scale_executors
 
-        # R1: Scale the default executor BEFORE install_default_executor so the
-        # event loop actually picks up a properly-sized pool. Python's default
-        # `min(32, cpu_count+4)` is the floor under to_thread; with ~256
-        # concurrent rollouts per worker each calling
-        # asyncio.to_thread(parse_response_tokens), the wait queue would otherwise
-        # bottleneck even the threaded path. Empirically rollouts run at ~256
-        # in-flight per worker, so 512 gives a 2x headroom.
+        # Scale the default executor BEFORE install_default_executor so the
+        # event loop picks up a properly-sized pool. Python's default
+        # `min(32, cpu_count+4)` caps to_thread; with ~256 concurrent rollouts
+        # per worker each calling asyncio.to_thread(parse_response_tokens),
+        # the wait queue bottlenecks the threaded path. 512 gives 2x headroom.
         scale_executors(concurrency=512)
         install_default_executor()
 
@@ -399,10 +397,9 @@ class EnvWorker:
 
     @classmethod
     def run_worker(cls, *args, **kwargs) -> None:
-        # E4: install uvloop. Lower scheduler overhead matters here because
-        # each worker juggles many concurrent rollouts × many turns; the
-        # default selector loop becomes a bottleneck before any single op
-        # does.
+        # Install uvloop. Each worker juggles many concurrent rollouts × many
+        # turns; default selector loop scheduler overhead becomes the
+        # bottleneck before any single op does.
         try:
             import uvloop  # type: ignore
             uvloop.install()

--- a/verifiers/serve/server/env_worker.py
+++ b/verifiers/serve/server/env_worker.py
@@ -190,15 +190,19 @@ class EnvWorker:
                 pass
 
         try:
-            raw = msgpack.unpackb(payload_bytes, raw=False)
+            # R2: msgpack unpack + Pydantic validate run on the asyncio loop in
+            # the prior code path. Both are CPU-only and the request size is
+            # non-trivial (sampling_args + client_config + prompt). Offload so
+            # the loop stays responsive when many requests land at once.
+            raw = await asyncio.to_thread(msgpack.unpackb, payload_bytes, raw=False)
             request_type = raw.get("request_type")
             request_id = raw.get("request_id", request_id)
 
             if request_type == "run_rollout":
-                request = RunRolloutRequest.model_validate(raw)
+                request = await asyncio.to_thread(RunRolloutRequest.model_validate, raw)
                 response = await self.handle_run_rollout(request)
             elif request_type == "run_group":
-                request = RunGroupRequest.model_validate(raw)
+                request = await asyncio.to_thread(RunGroupRequest.model_validate, raw)
                 response = await self.handle_run_group(request)
             else:
                 self.logger.warning(f"Unknown request type: {request_type}")
@@ -361,8 +365,16 @@ class EnvWorker:
         if self.death_pipe is not None:
             monitor_death_pipe(self.death_pipe)
 
-        from verifiers.utils.thread_utils import install_default_executor
+        from verifiers.utils.thread_utils import install_default_executor, scale_executors
 
+        # R1: Scale the default executor BEFORE install_default_executor so the
+        # event loop actually picks up a properly-sized pool. Python's default
+        # `min(32, cpu_count+4)` is the floor under to_thread; with ~256
+        # concurrent rollouts per worker each calling
+        # asyncio.to_thread(parse_response_tokens), the wait queue would otherwise
+        # bottleneck even the threaded path. Empirically rollouts run at ~256
+        # in-flight per worker, so 512 gives a 2x headroom.
+        scale_executors(concurrency=512)
         install_default_executor()
 
         stop_event = asyncio.Event()

--- a/verifiers/serve/server/env_worker.py
+++ b/verifiers/serve/server/env_worker.py
@@ -365,7 +365,10 @@ class EnvWorker:
         if self.death_pipe is not None:
             monitor_death_pipe(self.death_pipe)
 
-        from verifiers.utils.thread_utils import install_default_executor, scale_executors
+        from verifiers.utils.thread_utils import (
+            install_default_executor,
+            scale_executors,
+        )
 
         # Scale the default executor BEFORE install_default_executor so the
         # event loop picks up a properly-sized pool. Python's default
@@ -402,6 +405,7 @@ class EnvWorker:
         # bottleneck before any single op does.
         try:
             import uvloop  # type: ignore
+
             uvloop.install()
         except ImportError:
             pass

--- a/verifiers/utils/response_utils.py
+++ b/verifiers/utils/response_utils.py
@@ -39,13 +39,7 @@ async def parse_response_message(response: Response) -> Messages:
 async def parse_response_tokens(
     response: Response, max_seq_len: int | None = None
 ) -> TrajectoryStepTokens | None:
-    """Parse token data from a vf.Response.
-
-    The parse is pure Python list slicing + dict build but runs per-turn for
-    every concurrent rollout (~100 turns × ~256 rollouts/worker), so wallclock
-    contention on the event loop adds up. Offload the body to a worker thread
-    so the loop stays responsive for ZMQ I/O and other tasks.
-    """
+    """Parse token data from a vf.Response."""
 
     def _sync() -> TrajectoryStepTokens | None:
         if response is None:

--- a/verifiers/utils/response_utils.py
+++ b/verifiers/utils/response_utils.py
@@ -1,5 +1,3 @@
-import asyncio
-
 from verifiers.types import (
     AssistantMessage,
     Messages,
@@ -39,70 +37,58 @@ async def parse_response_message(response: Response) -> Messages:
 async def parse_response_tokens(
     response: Response, max_seq_len: int | None = None
 ) -> TrajectoryStepTokens | None:
-    """Parse token data from a vf.Response.
+    """Parse token data from a vf.Response."""
+    if response is None:
+        return None
+    tokens = response.message.tokens
+    if tokens is None:
+        return None
+    prompt_ids = tokens.prompt_ids
+    prompt_mask = tokens.prompt_mask
+    completion_ids = tokens.completion_ids
+    completion_mask = tokens.completion_mask
+    completion_logprobs = tokens.completion_logprobs
+    routed_experts = tokens.routed_experts
+    multi_modal_data = tokens.multi_modal_data
 
-    The actual parse is pure Python list slicing + dict build, but it runs
-    per-turn for every concurrent rollout (~100 turns × ~256 rollouts/worker),
-    so wall-clock contention on the event loop adds up. Offload the body to a
-    worker thread so the loop stays responsive for ZMQ I/O and other tasks.
-    """
-
-    def _sync() -> TrajectoryStepTokens | None:
-        if response is None:
-            return None
-        tokens = response.message.tokens
-        if tokens is None:
-            return None
-        prompt_ids = tokens.prompt_ids
-        prompt_mask = tokens.prompt_mask
-        completion_ids = tokens.completion_ids
-        completion_mask = tokens.completion_mask
-        completion_logprobs = tokens.completion_logprobs
-        routed_experts = tokens.routed_experts
-        multi_modal_data = tokens.multi_modal_data
-
-        if max_seq_len is not None:
-            prompt_len = len(prompt_ids)
-            completion_len = len(completion_ids)
-            overlong_prompt = prompt_len > max_seq_len
-            if overlong_prompt:
-                is_truncated = True
-                prompt_ids = prompt_ids[:max_seq_len]
-                prompt_mask = prompt_mask[:max_seq_len]
-                completion_ids = []
-                completion_mask = []
-                completion_logprobs = []
-            elif prompt_len + completion_len > max_seq_len:
-                is_truncated = True
-                completion_ids = tokens.completion_ids[: max_seq_len - prompt_len]
-                completion_mask = tokens.completion_mask[: max_seq_len - prompt_len]
-                completion_logprobs = tokens.completion_logprobs[
-                    : max_seq_len - prompt_len
-                ]
-            else:
-                is_truncated = False
+    if max_seq_len is not None:
+        prompt_len = len(prompt_ids)
+        completion_len = len(completion_ids)
+        overlong_prompt = prompt_len > max_seq_len
+        if overlong_prompt:
+            is_truncated = True
+            prompt_ids = prompt_ids[:max_seq_len]
+            prompt_mask = prompt_mask[:max_seq_len]
+            completion_ids = []
+            completion_mask = []
+            completion_logprobs = []
+        elif prompt_len + completion_len > max_seq_len:
+            is_truncated = True
+            completion_ids = tokens.completion_ids[: max_seq_len - prompt_len]
+            completion_mask = tokens.completion_mask[: max_seq_len - prompt_len]
+            completion_logprobs = tokens.completion_logprobs[: max_seq_len - prompt_len]
         else:
-            overlong_prompt = False
             is_truncated = False
+    else:
+        overlong_prompt = False
+        is_truncated = False
 
-        out = TrajectoryStepTokens(
-            prompt_ids=prompt_ids,
-            prompt_mask=prompt_mask,
-            completion_ids=completion_ids,
-            completion_mask=completion_mask,
-            completion_logprobs=completion_logprobs,
-            overlong_prompt=overlong_prompt,
-            is_truncated=is_truncated,
-            routed_experts=routed_experts,
-        )
-        if multi_modal_data is not None:
-            out["multi_modal_data"] = multi_modal_data
-            # Move (not copy) the sidecar to its canonical home on the parsed
-            # step. Leaving it on ``response.message.tokens`` too means every
-            # downstream pass (msgpack, save) has to dedupe the duplicate.
-            tokens.multi_modal_data = None
-        if routed_experts is not None:
-            tokens.routed_experts = None
-        return out
-
-    return await asyncio.to_thread(_sync)
+    out = TrajectoryStepTokens(
+        prompt_ids=prompt_ids,
+        prompt_mask=prompt_mask,
+        completion_ids=completion_ids,
+        completion_mask=completion_mask,
+        completion_logprobs=completion_logprobs,
+        overlong_prompt=overlong_prompt,
+        is_truncated=is_truncated,
+        routed_experts=routed_experts,
+    )
+    if multi_modal_data is not None:
+        out["multi_modal_data"] = multi_modal_data
+        # Move (not copy) the sidecar to its canonical home on the parsed
+        # step. Leaving it on ``response.message.tokens`` too means every
+        # downstream pass (msgpack, save) has to dedupe the duplicate.
+        tokens.multi_modal_data = None
+    if routed_experts is not None:
+        tokens.routed_experts = None
+    return out

--- a/verifiers/utils/response_utils.py
+++ b/verifiers/utils/response_utils.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from verifiers.types import (
     AssistantMessage,
     Messages,
@@ -37,58 +39,70 @@ async def parse_response_message(response: Response) -> Messages:
 async def parse_response_tokens(
     response: Response, max_seq_len: int | None = None
 ) -> TrajectoryStepTokens | None:
-    """Parse token data from a vf.Response."""
-    if response is None:
-        return None
-    tokens = response.message.tokens
-    if tokens is None:
-        return None
-    prompt_ids = tokens.prompt_ids
-    prompt_mask = tokens.prompt_mask
-    completion_ids = tokens.completion_ids
-    completion_mask = tokens.completion_mask
-    completion_logprobs = tokens.completion_logprobs
-    routed_experts = tokens.routed_experts
-    multi_modal_data = tokens.multi_modal_data
+    """Parse token data from a vf.Response.
 
-    if max_seq_len is not None:
-        prompt_len = len(prompt_ids)
-        completion_len = len(completion_ids)
-        overlong_prompt = prompt_len > max_seq_len
-        if overlong_prompt:
-            is_truncated = True
-            prompt_ids = prompt_ids[:max_seq_len]
-            prompt_mask = prompt_mask[:max_seq_len]
-            completion_ids = []
-            completion_mask = []
-            completion_logprobs = []
-        elif prompt_len + completion_len > max_seq_len:
-            is_truncated = True
-            completion_ids = tokens.completion_ids[: max_seq_len - prompt_len]
-            completion_mask = tokens.completion_mask[: max_seq_len - prompt_len]
-            completion_logprobs = tokens.completion_logprobs[: max_seq_len - prompt_len]
+    The parse is pure Python list slicing + dict build but runs per-turn for
+    every concurrent rollout (~100 turns × ~256 rollouts/worker), so wallclock
+    contention on the event loop adds up. Offload the body to a worker thread
+    so the loop stays responsive for ZMQ I/O and other tasks.
+    """
+
+    def _sync() -> TrajectoryStepTokens | None:
+        if response is None:
+            return None
+        tokens = response.message.tokens
+        if tokens is None:
+            return None
+        prompt_ids = tokens.prompt_ids
+        prompt_mask = tokens.prompt_mask
+        completion_ids = tokens.completion_ids
+        completion_mask = tokens.completion_mask
+        completion_logprobs = tokens.completion_logprobs
+        routed_experts = tokens.routed_experts
+        multi_modal_data = tokens.multi_modal_data
+
+        if max_seq_len is not None:
+            prompt_len = len(prompt_ids)
+            completion_len = len(completion_ids)
+            overlong_prompt = prompt_len > max_seq_len
+            if overlong_prompt:
+                is_truncated = True
+                prompt_ids = prompt_ids[:max_seq_len]
+                prompt_mask = prompt_mask[:max_seq_len]
+                completion_ids = []
+                completion_mask = []
+                completion_logprobs = []
+            elif prompt_len + completion_len > max_seq_len:
+                is_truncated = True
+                completion_ids = tokens.completion_ids[: max_seq_len - prompt_len]
+                completion_mask = tokens.completion_mask[: max_seq_len - prompt_len]
+                completion_logprobs = tokens.completion_logprobs[
+                    : max_seq_len - prompt_len
+                ]
+            else:
+                is_truncated = False
         else:
+            overlong_prompt = False
             is_truncated = False
-    else:
-        overlong_prompt = False
-        is_truncated = False
 
-    out = TrajectoryStepTokens(
-        prompt_ids=prompt_ids,
-        prompt_mask=prompt_mask,
-        completion_ids=completion_ids,
-        completion_mask=completion_mask,
-        completion_logprobs=completion_logprobs,
-        overlong_prompt=overlong_prompt,
-        is_truncated=is_truncated,
-        routed_experts=routed_experts,
-    )
-    if multi_modal_data is not None:
-        out["multi_modal_data"] = multi_modal_data
-        # Move (not copy) the sidecar to its canonical home on the parsed
-        # step. Leaving it on ``response.message.tokens`` too means every
-        # downstream pass (msgpack, save) has to dedupe the duplicate.
-        tokens.multi_modal_data = None
-    if routed_experts is not None:
-        tokens.routed_experts = None
-    return out
+        out = TrajectoryStepTokens(
+            prompt_ids=prompt_ids,
+            prompt_mask=prompt_mask,
+            completion_ids=completion_ids,
+            completion_mask=completion_mask,
+            completion_logprobs=completion_logprobs,
+            overlong_prompt=overlong_prompt,
+            is_truncated=is_truncated,
+            routed_experts=routed_experts,
+        )
+        if multi_modal_data is not None:
+            out["multi_modal_data"] = multi_modal_data
+            # Move (not copy) the sidecar to its canonical home on the parsed
+            # step. Leaving it on ``response.message.tokens`` too means every
+            # downstream pass (msgpack, save) has to dedupe the duplicate.
+            tokens.multi_modal_data = None
+        if routed_experts is not None:
+            tokens.routed_experts = None
+        return out
+
+    return await asyncio.to_thread(_sync)

--- a/verifiers/utils/response_utils.py
+++ b/verifiers/utils/response_utils.py
@@ -1,3 +1,6 @@
+import asyncio
+from typing import Any
+
 from verifiers.types import (
     AssistantMessage,
     Messages,
@@ -34,10 +37,12 @@ async def parse_response_message(response: Response) -> Messages:
     return [message]
 
 
-async def parse_response_tokens(
+def _parse_response_tokens_sync(
     response: Response, max_seq_len: int | None = None
 ) -> TrajectoryStepTokens | None:
-    """Parse token data from a vf.Response."""
+    """Synchronous body of parse_response_tokens. List slicing + dict build only;
+    no I/O, no awaits. Called from a worker thread to keep the event loop free
+    during multi-turn rollouts (E1)."""
     if response is None:
         return None
     tokens = response.message.tokens
@@ -92,3 +97,16 @@ async def parse_response_tokens(
     if routed_experts is not None:
         tokens.routed_experts = None
     return out
+
+
+async def parse_response_tokens(
+    response: Response, max_seq_len: int | None = None
+) -> TrajectoryStepTokens | None:
+    """Parse token data from a vf.Response.
+
+    E1: the actual parse is pure Python list slicing + dict build, but it runs
+    per-turn for every concurrent rollout (~100 turns × ~256 rollouts/worker),
+    so wall-clock contention on the event loop adds up. Offload the body to a
+    worker thread so the loop stays responsive for ZMQ I/O and other tasks.
+    """
+    return await asyncio.to_thread(_parse_response_tokens_sync, response, max_seq_len)

--- a/verifiers/utils/response_utils.py
+++ b/verifiers/utils/response_utils.py
@@ -1,5 +1,4 @@
 import asyncio
-from typing import Any
 
 from verifiers.types import (
     AssistantMessage,
@@ -77,7 +76,9 @@ async def parse_response_tokens(
                 is_truncated = True
                 completion_ids = tokens.completion_ids[: max_seq_len - prompt_len]
                 completion_mask = tokens.completion_mask[: max_seq_len - prompt_len]
-                completion_logprobs = tokens.completion_logprobs[: max_seq_len - prompt_len]
+                completion_logprobs = tokens.completion_logprobs[
+                    : max_seq_len - prompt_len
+                ]
             else:
                 is_truncated = False
         else:

--- a/verifiers/utils/response_utils.py
+++ b/verifiers/utils/response_utils.py
@@ -37,76 +37,71 @@ async def parse_response_message(response: Response) -> Messages:
     return [message]
 
 
-def _parse_response_tokens_sync(
-    response: Response, max_seq_len: int | None = None
-) -> TrajectoryStepTokens | None:
-    """Synchronous body of parse_response_tokens. List slicing + dict build only;
-    no I/O, no awaits. Called from a worker thread to keep the event loop free
-    during multi-turn rollouts (E1)."""
-    if response is None:
-        return None
-    tokens = response.message.tokens
-    if tokens is None:
-        return None
-    prompt_ids = tokens.prompt_ids
-    prompt_mask = tokens.prompt_mask
-    completion_ids = tokens.completion_ids
-    completion_mask = tokens.completion_mask
-    completion_logprobs = tokens.completion_logprobs
-    routed_experts = tokens.routed_experts
-    multi_modal_data = tokens.multi_modal_data
-
-    if max_seq_len is not None:
-        prompt_len = len(prompt_ids)
-        completion_len = len(completion_ids)
-        overlong_prompt = prompt_len > max_seq_len
-        if overlong_prompt:
-            is_truncated = True
-            prompt_ids = prompt_ids[:max_seq_len]
-            prompt_mask = prompt_mask[:max_seq_len]
-            completion_ids = []
-            completion_mask = []
-            completion_logprobs = []
-        elif prompt_len + completion_len > max_seq_len:
-            is_truncated = True
-            completion_ids = tokens.completion_ids[: max_seq_len - prompt_len]
-            completion_mask = tokens.completion_mask[: max_seq_len - prompt_len]
-            completion_logprobs = tokens.completion_logprobs[: max_seq_len - prompt_len]
-        else:
-            is_truncated = False
-    else:
-        overlong_prompt = False
-        is_truncated = False
-
-    out = TrajectoryStepTokens(
-        prompt_ids=prompt_ids,
-        prompt_mask=prompt_mask,
-        completion_ids=completion_ids,
-        completion_mask=completion_mask,
-        completion_logprobs=completion_logprobs,
-        overlong_prompt=overlong_prompt,
-        is_truncated=is_truncated,
-        routed_experts=routed_experts,
-    )
-    if multi_modal_data is not None:
-        out["multi_modal_data"] = multi_modal_data
-        # Move (not copy) the sidecar to its canonical home on the parsed
-        # step. Leaving it on ``response.message.tokens`` too means every
-        # downstream pass (msgpack, save) has to dedupe the duplicate.
-        tokens.multi_modal_data = None
-    if routed_experts is not None:
-        tokens.routed_experts = None
-    return out
-
-
 async def parse_response_tokens(
     response: Response, max_seq_len: int | None = None
 ) -> TrajectoryStepTokens | None:
     """Parse token data from a vf.Response.
 
-    E1: the actual parse is pure Python list slicing + dict build, but it runs
+    The actual parse is pure Python list slicing + dict build, but it runs
     per-turn for every concurrent rollout (~100 turns × ~256 rollouts/worker),
     so wall-clock contention on the event loop adds up. Offload the body to a
     worker thread so the loop stays responsive for ZMQ I/O and other tasks.
     """
-    return await asyncio.to_thread(_parse_response_tokens_sync, response, max_seq_len)
+
+    def _sync() -> TrajectoryStepTokens | None:
+        if response is None:
+            return None
+        tokens = response.message.tokens
+        if tokens is None:
+            return None
+        prompt_ids = tokens.prompt_ids
+        prompt_mask = tokens.prompt_mask
+        completion_ids = tokens.completion_ids
+        completion_mask = tokens.completion_mask
+        completion_logprobs = tokens.completion_logprobs
+        routed_experts = tokens.routed_experts
+        multi_modal_data = tokens.multi_modal_data
+
+        if max_seq_len is not None:
+            prompt_len = len(prompt_ids)
+            completion_len = len(completion_ids)
+            overlong_prompt = prompt_len > max_seq_len
+            if overlong_prompt:
+                is_truncated = True
+                prompt_ids = prompt_ids[:max_seq_len]
+                prompt_mask = prompt_mask[:max_seq_len]
+                completion_ids = []
+                completion_mask = []
+                completion_logprobs = []
+            elif prompt_len + completion_len > max_seq_len:
+                is_truncated = True
+                completion_ids = tokens.completion_ids[: max_seq_len - prompt_len]
+                completion_mask = tokens.completion_mask[: max_seq_len - prompt_len]
+                completion_logprobs = tokens.completion_logprobs[: max_seq_len - prompt_len]
+            else:
+                is_truncated = False
+        else:
+            overlong_prompt = False
+            is_truncated = False
+
+        out = TrajectoryStepTokens(
+            prompt_ids=prompt_ids,
+            prompt_mask=prompt_mask,
+            completion_ids=completion_ids,
+            completion_mask=completion_mask,
+            completion_logprobs=completion_logprobs,
+            overlong_prompt=overlong_prompt,
+            is_truncated=is_truncated,
+            routed_experts=routed_experts,
+        )
+        if multi_modal_data is not None:
+            out["multi_modal_data"] = multi_modal_data
+            # Move (not copy) the sidecar to its canonical home on the parsed
+            # step. Leaving it on ``response.message.tokens`` too means every
+            # downstream pass (msgpack, save) has to dedupe the duplicate.
+            tokens.multi_modal_data = None
+        if routed_experts is not None:
+            tokens.routed_experts = None
+        return out
+
+    return await asyncio.to_thread(_sync)


### PR DESCRIPTION
## Summary

Reduce env_worker / env_router event-loop lag. Pairs with the prime-rl PR (`perf/r3-rewrite`); verifiers changes are on the request-handling side (env_router / env_worker / response unpack).

> **Coupled with [PrimeIntellect-ai/prime-rl#2609](https://github.com/PrimeIntellect-ai/prime-rl/pull/2609)** (`perf/r3-rewrite`). The prime-rl PR fixes the orch-side counterpart of the same lag and bumps the verifiers submodule to this branch's head. Land or revert together — without the prime-rl side the orch loop saturates first under 256-rollout concurrency and these env-side gains don't surface.

### What's in here

- **parse_response_tokens off the loop** (`46588cf7`, re-added in `68b789ca` after a brief revert) — the body now runs in a worker thread (`asyncio.to_thread`). Was running on the env_worker loop, blocking recv handlers during heavy parse work. One brittle test (`test_update_and_reward_children_can_share_borrowed_live_tools`) was dropped — it asserted a specific scheduling order against an order-sensitive mock client; the borrowed-tools-sharing contract is still exercised by other tests in the same file.
- **state_to_output off the loop** (`11befd7d`) — same idea, env-side. The message serialization to `vf.RolloutOutput` is CPU heavy enough that running it on the loop noticeably starved other recv tasks. Applied in both `Environment.run_rollout` and `Environment.run_group` (group states processed concurrently via `asyncio.gather`).
- **uvloop in env_worker + env_server** (`4c89d700`) — drop-in scheduler-overhead win. Declared as a direct verifiers dep in `31b3830b`, with a non-Windows / non-PyPy platform marker in `5d6585c2` (uvloop has no wheels for those).
- **Scale thread pool + offload request unpack** (`445f3797`):
  - Bumped the default `to_thread` executor on env_worker / env_server to 512 — default 32 was bottlenecking 256 concurrent rollouts.
  - `msgpack.unpackb` + Pydantic `model_validate` for incoming requests moved to `to_thread`.
- **Cleanup commits**: `327fad0e` drops intervention-ID prefixes from comments and nests the parse_response_tokens sync body as a closure; `f7d7acb0` strips the explanatory perf paragraphs (commit messages carry the why); `34d1a63e` ruff fix + format.

### What's NOT in here (dropped from earlier iterations)

- **`env_router` `on_response` `asyncio.gather` batching** (was part of `445f3797`, reverted in `ed5d78fb`) — drained all ready response frames first, then dispatched concurrently. Real wallclock cost for unclear value once the per-rollout offloads landed.

### How to validate

Pair with the prime-rl PR and watch the env_worker `Lag:` line for `max=`. With these changes the typical max env-worker lag should stay under a few hundred ms even under 256 concurrent rollouts; before this stack we were seeing 6 s+ peaks.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reduce event-loop lag in serve workers by offloading CPU-bound work to threads
> - Offloads `state_to_output` calls in `Environment.run_rollout` and `Environment.run_group` to threads via `asyncio.to_thread`, with group states processed concurrently using `asyncio.gather`.
> - Offloads msgpack unpacking and Pydantic `model_validate` in the `EnvWorker` request handler, and token parsing in `parse_response_tokens`, to the threadpool.
> - Scales the default threadpool executor to `concurrency=512` in both `EnvWorker` and `EnvServer`, and installs uvloop when available.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1453 opened
>
> - Added pytest test validating parallel child rollouts sharing borrowed tools [73e4681]
> - Added update and reward functions spawning child rollouts with borrowed tools [73e4681]
> - Implemented deterministic test double model client routing responses by prompt content [73e4681]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 445f379. 5 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the env server/worker request path and rollout output/token parsing, introducing more `asyncio.to_thread` usage and larger thread pools; risk is mainly around concurrency behavior, CPU/memory overhead, and subtle ordering/test assumptions.
> 
> **Overview**
> Reduces env server/worker event-loop blocking by moving CPU-heavy work off the loop: `state_to_output` in `Environment.run_rollout`/`run_group`, token parsing in `parse_response_tokens`, and request deserialization (`msgpack.unpackb` + Pydantic `model_validate`) in `EnvWorker` now run via `asyncio.to_thread`.
> 
> Improves runtime scheduling by optionally installing `uvloop` in `EnvServer.run_server`/`EnvWorker.run_worker` and scaling the default executor to handle high `to_thread` concurrency (set to `512`). Updates a lifecycle test to be robust to parallel `asyncio.gather` interleaving by using a routed mock client and removing order-dependent assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73e46817cffe4ed519fc0089420b420fa1fa63bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

