### PR TITLE
Fix EnvServer executor installation

### DIFF
--- a/verifiers/serve/server/env_server.py
+++ b/verifiers/serve/server/env_server.py
@@ -87,6 +87,10 @@ class EnvServer(ABC):
 
     async def run(self) -> None:
         """Run the server with signal-based graceful shutdown."""
+        from verifiers.utils.thread_utils import install_default_executor
+
+        install_default_executor()
+
         if self.death_pipe is not None:
             monitor_death_pipe(self.death_pipe)
 


### PR DESCRIPTION
## Issue

PR #1453 added `scale_executors(concurrency=512)` to `EnvServer.run_server()` so the router/server process could use a larger default executor for `asyncio.to_thread` work. The call happens before `asyncio.run(server.run())`, so there is no running event loop yet.

`verifiers.utils.thread_utils.scale_executors()` handles that case by creating/resizing the shared executor, but its documented contract says the caller must later call `install_default_executor()` from inside the real loop. `EnvWorker.run()` already does that. `EnvServer.run()` did not, so the server loop kept Python's default executor instead of the scaled one. In the local probe from the bug scan, the server-side loop was still at `before_install=20`, and only changed to `after_install=512` after `install_default_executor()`.

The practical bug is that the router/server half of #1453's event-loop-lag fix was only partially wired: `scale_executors(512)` created the intended executor, but the actual server event loop never used it. Any server-side `asyncio.to_thread` work would still be capped by the default executor rather than the configured 512-worker pool.

## Fix

Call `install_default_executor()` at the start of `EnvServer.run()`, which is the first point where `asyncio.run()` has created the real event loop. This mirrors the worker lifecycle and keeps `run_server()` responsible for pre-loop scaling/uvloop setup.

This PR intentionally does not touch `uv.lock` and does not add a test.

## Verification

- `uv run --frozen ruff format`
- `uv run --frozen ruff check --fix`
- `uv run --frozen pytest tests/test_env_server.py -q`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix executor installation in `EnvServer.run` by calling `install_default_executor` at startup
> Adds a call to `install_default_executor()` at the start of `EnvServer.run()` in [env_server.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1455/files#diff-ffbf52ba825710b29c0d7a94da599c570033ecd2b7ce2a0704491af1f07a14cc), before the death pipe monitor and signal handlers are set up. This ensures the process-wide default executor is installed before any async or threaded work begins.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 556c341.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->