### PR TITLE
Expose V1 tools to the RLM harness

### DIFF
--- a/docs/byo-harness.md
+++ b/docs/byo-harness.md
@@ -485,8 +485,14 @@ CLI harnesses own CLI installation/config/run behavior and work with any
 taskset that supplies a prompt.
 Tasksets can expose package-owned upload directories with `get_upload_dirs()`.
 The base `Taskset` discovers a sibling `skills/` directory by default, and
-`RLM` uploads that directory to `/rlm/skills` unless `skills=` is passed
-explicitly to the harness.
+`RLM` uploads that directory to `/task/rlm-skills` unless `skills=` is passed
+explicitly to the harness. RLM also registers v1 rollout tools as generated
+skills in the same directory during setup. Generated skills run simple callable
+tools inside the RLM sandbox by default; tools that need verifier runtime state,
+toolset bindings, tool sandboxes, MCP sessions, borrowed handles, or other
+nonlocal resources fall back to `/vf/tools`. Explicit or taskset skill
+directories take precedence and generated tool skills get a suffixed name when
+there is a collision.
 Use `RLMConfig` in `env.harness` for RLM-specific settings such as
 `rlm_repo_ref`, `rlm_tools`, `rlm_max_turns`, and `summarize_at_tokens`.
 

--- a/tests/test_v1_rlm_swe.py
+++ b/tests/test_v1_rlm_swe.py
@@ -1,5 +1,6 @@
 import base64
 import io
+import inspect
 import sys
 import tarfile
 import types
@@ -129,7 +130,7 @@ async def test_rlm_harness_generates_skills_for_v1_tools():
             .decode()
         )
         skill_markdown = tar.extractfile("lookup_order/SKILL.md").read().decode()
-    assert "async def run(arguments: dict | None = None, **kwargs)" in source
+    assert "async def run(order_id, **kwargs)" in source
     assert "/vf/tools/" in source
     assert "'lookup_order'" in source
     assert "Look up an order by ID." in skill_markdown
@@ -241,6 +242,7 @@ async def test_vf_tool_skill_filters_extra_kwargs_for_closed_schemas(
     monkeypatch.setenv("OPENAI_BASE_URL", "https://example.test/v1")
     module.requests = Requests
 
+    assert list(inspect.signature(module.run).parameters) == ["date", "kwargs"]
     result = await module.run(user="Alice", date="2025-07-14")
 
     assert result == "ok"

--- a/tests/test_v1_rlm_swe.py
+++ b/tests/test_v1_rlm_swe.py
@@ -1,13 +1,20 @@
+import base64
+import io
 import sys
+import tarfile
 import types
 from collections.abc import Mapping
 from pathlib import Path
 
 import pytest
 from datasets import Dataset
+from verifiers.types import Tool
 
 import verifiers.v1 as vf
 from environments.rlm_swe_v1 import rlm_swe_v1
+from verifiers.v1.packages.harnesses.rlm import (
+    DEFAULT_RLM_TOOL_SKILLS_ARCHIVE_PATH,
+)
 from verifiers.v1.utils.program_utils import merge_task_program, merge_task_sandbox
 
 
@@ -64,9 +71,13 @@ def test_rlm_harness_can_upload_skills(tmp_path: Path):
     )
     program = as_mapping(harness.program)
     dirs = as_mapping(program["dirs"])
+    files = as_mapping(program["files"])
+    setup = program["setup"]
 
-    assert dirs["/task/rlm-skills"] == harness.load_skills_dir
-    assert harness._explicit_skills == skills
+    assert dirs["/task/rlm-skills"] == skills
+    assert files[DEFAULT_RLM_TOOL_SKILLS_ARCHIVE_PATH] == harness.vf_tool_skills_archive
+    assert isinstance(setup, list)
+    assert DEFAULT_RLM_TOOL_SKILLS_ARCHIVE_PATH in setup[1]
 
 
 def test_rlm_harness_uploads_taskset_skills_by_default(tmp_path: Path):
@@ -85,8 +96,7 @@ def test_rlm_harness_uploads_taskset_skills_by_default(tmp_path: Path):
     program = as_mapping(env.harness.program)
     dirs = as_mapping(program["dirs"])
 
-    assert dirs["/task/rlm-skills"] == env.harness.load_skills_dir
-    assert env.harness._taskset_skills == skills
+    assert dirs["/task/rlm-skills"] == skills
 
 
 @pytest.mark.asyncio
@@ -110,19 +120,78 @@ async def test_rlm_harness_generates_skills_for_v1_tools():
 
     await env.harness.runtime.ensure_rollout_toolsets(task, state)
     env.harness.runtime.prepare_state(task, state)
-    skills_dir = env.harness.load_skills_dir(task, state)
+    archive = base64.b64decode(env.harness.vf_tool_skills_archive(state))
 
-    skill_module = (
-        skills_dir / "lookup_order" / "src" / "lookup_order" / "lookup_order.py"
+    with tarfile.open(fileobj=io.BytesIO(archive), mode="r:gz") as tar:
+        source = (
+            tar.extractfile("lookup_order/src/lookup_order/lookup_order.py")
+            .read()
+            .decode()
+        )
+        skill_markdown = tar.extractfile("lookup_order/SKILL.md").read().decode()
+    assert "async def run(arguments: dict | None = None, **kwargs)" in source
+    assert "/vf/tools/" in source
+    assert "'lookup_order'" in source
+    assert "Look up an order by ID." in skill_markdown
+    assert "result = await lookup_order" in skill_markdown
+
+
+def test_vf_tool_skills_archive_avoids_base_skill_name_collisions(tmp_path: Path):
+    skills = tmp_path / "skills"
+    (skills / "lookup_order").mkdir(parents=True)
+    harness = vf.RLM(
+        config=vf.RLMConfig(local_checkout="/tmp/checkout", skills=str(skills))
     )
-    assert skill_module.exists()
-    source = skill_module.read_text()
-    assert "async def run(order_id: str)" in source
-    assert "_call_vf_tool('lookup_order'" in source
-    assert (
-        "Look up an order by ID."
-        in (skills_dir / "lookup_order" / "SKILL.md").read_text()
+    tool_def = Tool(
+        name="lookup_order",
+        description="Look up an order.",
+        parameters={"type": "object", "properties": {}},
     )
+    setattr(harness.runtime, "tool_defs", lambda state: [tool_def])
+
+    archive = base64.b64decode(harness.vf_tool_skills_archive(vf.State({})))
+
+    with tarfile.open(fileobj=io.BytesIO(archive), mode="r:gz") as tar:
+        names = tar.getnames()
+        source = (
+            tar.extractfile("lookup_order_2/src/lookup_order_2/lookup_order_2.py")
+            .read()
+            .decode()
+        )
+
+    assert "lookup_order_2/SKILL.md" in names
+    assert "/vf/tools/" in source
+    assert "'lookup_order'" in source
+
+
+def test_vf_tool_skill_uses_arguments_dict_for_tool_parameters():
+    harness = vf.RLM(config=vf.RLMConfig(local_checkout="/tmp/checkout"))
+    tool_def = Tool(
+        name="reserved_param",
+        description="Reserved parameter.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "_call_vf_tool": {"type": "string"},
+                "limit": {"type": "integer", "default": 10},
+            },
+            "required": ["_call_vf_tool"],
+        },
+    )
+    setattr(harness.runtime, "tool_defs", lambda state: [tool_def])
+    archive = base64.b64decode(harness.vf_tool_skills_archive(vf.State({})))
+
+    with tarfile.open(fileobj=io.BytesIO(archive), mode="r:gz") as tar:
+        source = (
+            tar.extractfile("reserved_param/src/reserved_param/reserved_param.py")
+            .read()
+            .decode()
+        )
+
+    assert "async def run(arguments: dict | None = None, **kwargs)" in source
+    assert "arguments = {**(arguments or {}), **kwargs}" in source
+    assert 'json={"arguments": arguments}' in source
+    assert "limit=None" not in source
 
 
 def test_taskset_discovers_sibling_skills_dir_by_default(
@@ -169,9 +238,7 @@ def test_rlm_harness_explicit_skills_override_taskset_skills(tmp_path: Path):
     program = as_mapping(env.harness.program)
     dirs = as_mapping(program["dirs"])
 
-    assert dirs["/task/rlm-skills"] == env.harness.load_skills_dir
-    assert env.harness._explicit_skills == explicit_skills
-    assert env.harness._taskset_skills is None
+    assert dirs["/task/rlm-skills"] == explicit_skills
 
 
 def test_rlm_swe_environment_uses_v1_r2e_taskset(monkeypatch):

--- a/tests/test_v1_rlm_swe.py
+++ b/tests/test_v1_rlm_swe.py
@@ -65,7 +65,8 @@ def test_rlm_harness_can_upload_skills(tmp_path: Path):
     program = as_mapping(harness.program)
     dirs = as_mapping(program["dirs"])
 
-    assert dirs["/task/rlm-skills"] == skills
+    assert dirs["/task/rlm-skills"] == harness.load_skills_dir
+    assert harness._explicit_skills == skills
 
 
 def test_rlm_harness_uploads_taskset_skills_by_default(tmp_path: Path):
@@ -84,7 +85,44 @@ def test_rlm_harness_uploads_taskset_skills_by_default(tmp_path: Path):
     program = as_mapping(env.harness.program)
     dirs = as_mapping(program["dirs"])
 
-    assert dirs["/task/rlm-skills"] == skills
+    assert dirs["/task/rlm-skills"] == env.harness.load_skills_dir
+    assert env.harness._taskset_skills == skills
+
+
+@pytest.mark.asyncio
+async def test_rlm_harness_generates_skills_for_v1_tools():
+    async def lookup_order(order_id: str) -> str:
+        """Look up an order by ID."""
+        return f"order:{order_id}"
+
+    taskset = vf.Taskset(
+        config=vf.TasksetConfig(
+            source=[{"prompt": [{"role": "user", "content": "Find order A-1."}]}]
+        )
+    )
+    taskset.add_toolset(vf.Toolset(tools=[lookup_order]))
+    env = vf.Env(
+        taskset=taskset,
+        harness=vf.RLM(config=vf.RLMConfig(local_checkout="/tmp/checkout")),
+    )
+    task = next(iter(env.taskset))
+    state = vf.State({"task": dict(task), "runtime": {}, "prompt": task["prompt"]})
+
+    await env.harness.runtime.ensure_rollout_toolsets(task, state)
+    env.harness.runtime.prepare_state(task, state)
+    skills_dir = env.harness.load_skills_dir(task, state)
+
+    skill_module = (
+        skills_dir / "lookup_order" / "src" / "lookup_order" / "lookup_order.py"
+    )
+    assert skill_module.exists()
+    source = skill_module.read_text()
+    assert "async def run(order_id: str)" in source
+    assert "_call_vf_tool('lookup_order'" in source
+    assert (
+        "Look up an order by ID."
+        in (skills_dir / "lookup_order" / "SKILL.md").read_text()
+    )
 
 
 def test_taskset_discovers_sibling_skills_dir_by_default(
@@ -131,7 +169,9 @@ def test_rlm_harness_explicit_skills_override_taskset_skills(tmp_path: Path):
     program = as_mapping(env.harness.program)
     dirs = as_mapping(program["dirs"])
 
-    assert dirs["/task/rlm-skills"] == explicit_skills
+    assert dirs["/task/rlm-skills"] == env.harness.load_skills_dir
+    assert env.harness._explicit_skills == explicit_skills
+    assert env.harness._taskset_skills is None
 
 
 def test_rlm_swe_environment_uses_v1_r2e_taskset(monkeypatch):

--- a/tests/test_v1_rlm_swe.py
+++ b/tests/test_v1_rlm_swe.py
@@ -189,9 +189,111 @@ def test_vf_tool_skill_uses_arguments_dict_for_tool_parameters():
         )
 
     assert "async def run(arguments: dict | None = None, **kwargs)" in source
-    assert "arguments = {**(arguments or {}), **kwargs}" in source
+    assert "arguments = _tool_arguments(arguments, kwargs)" in source
     assert 'json={"arguments": arguments}' in source
     assert "limit=None" not in source
+
+
+@pytest.mark.asyncio
+async def test_vf_tool_skill_filters_extra_kwargs_for_closed_schemas(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    harness = vf.RLM(config=vf.RLMConfig(local_checkout="/tmp/checkout"))
+    tool_def = Tool(
+        name="list_events",
+        description="List calendar events.",
+        parameters={
+            "type": "object",
+            "properties": {"date": {"type": "string"}},
+            "required": ["date"],
+            "additionalProperties": False,
+        },
+    )
+    setattr(harness.runtime, "tool_defs", lambda state: [tool_def])
+    archive = base64.b64decode(harness.vf_tool_skills_archive(vf.State({})))
+
+    with tarfile.open(fileobj=io.BytesIO(archive), mode="r:gz") as tar:
+        source = (
+            tar.extractfile("list_events/src/list_events/list_events.py")
+            .read()
+            .decode()
+        )
+
+    module = types.ModuleType("list_events")
+    exec(source, module.__dict__)
+    calls: list[dict[str, object]] = []
+
+    class Response:
+        content = b"{}"
+
+        def json(self):
+            return {"result": "ok"}
+
+        def raise_for_status(self):
+            return None
+
+    class Requests:
+        @staticmethod
+        def post(url, json, headers, timeout):
+            calls.append(json)
+            return Response()
+
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://example.test/v1")
+    module.requests = Requests
+
+    result = await module.run(user="Alice", date="2025-07-14")
+
+    assert result == "ok"
+    assert calls == [{"arguments": {"date": "2025-07-14"}}]
+
+
+@pytest.mark.asyncio
+async def test_vf_tool_skill_surfaces_verifier_tool_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    harness = vf.RLM(config=vf.RLMConfig(local_checkout="/tmp/checkout"))
+    tool_def = Tool(
+        name="list_events",
+        description="List calendar events.",
+        parameters={
+            "type": "object",
+            "properties": {"date": {"type": "string"}},
+            "required": ["date"],
+            "additionalProperties": False,
+        },
+    )
+    setattr(harness.runtime, "tool_defs", lambda state: [tool_def])
+    archive = base64.b64decode(harness.vf_tool_skills_archive(vf.State({})))
+
+    with tarfile.open(fileobj=io.BytesIO(archive), mode="r:gz") as tar:
+        source = (
+            tar.extractfile("list_events/src/list_events/list_events.py")
+            .read()
+            .decode()
+        )
+
+    module = types.ModuleType("list_events")
+    exec(source, module.__dict__)
+
+    class Response:
+        content = b"{}"
+
+        def json(self):
+            return {"error": "unexpected keyword argument 'user'"}
+
+        def raise_for_status(self):
+            raise AssertionError("JSON tool errors should be raised first")
+
+    class Requests:
+        @staticmethod
+        def post(url, json, headers, timeout):
+            return Response()
+
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://example.test/v1")
+    module.requests = Requests
+
+    with pytest.raises(RuntimeError, match="unexpected keyword argument"):
+        await module.run(date="2025-07-14")
 
 
 def test_taskset_discovers_sibling_skills_dir_by_default(

--- a/tests/test_v1_rlm_swe.py
+++ b/tests/test_v1_rlm_swe.py
@@ -14,7 +14,9 @@ from verifiers.types import Tool
 import verifiers.v1 as vf
 from environments.rlm_swe_v1 import rlm_swe_v1
 from verifiers.v1.packages.harnesses.rlm import (
+    DEFAULT_RLM_TOOL_SKILL_MARKER,
     DEFAULT_RLM_TOOL_SKILLS_ARCHIVE_PATH,
+    DEFAULT_RLM_TOOL_SKILLS_MANIFEST_NAME,
 )
 from verifiers.v1.utils.program_utils import merge_task_program, merge_task_sandbox
 
@@ -62,6 +64,44 @@ def test_rlm_harness_accepts_typed_config_surface():
     assert program_env["CUSTOM"] == "1"
 
 
+def test_rlm_harness_preserves_program_setup_timeout_override():
+    harness = vf.RLM(
+        config=vf.RLMConfig(
+            local_checkout="/tmp/checkout",
+            program={"setup_timeout": 123},
+        )
+    )
+    program = as_mapping(harness.program)
+
+    assert program["setup_timeout"] == 123
+
+
+def test_rlm_harness_uses_sandbox_setup_timeout_default():
+    harness = vf.RLM(
+        config=vf.RLMConfig(
+            local_checkout="/tmp/checkout",
+            sandbox={"setup_timeout": "777"},
+        )
+    )
+    program = as_mapping(harness.program)
+
+    assert program["setup_timeout"] == 777
+
+
+def test_rlm_harness_keeps_minimum_setup_timeout_for_default_sandbox_config():
+    harness = vf.RLM(
+        config=vf.RLMConfig(
+            local_checkout="/tmp/checkout",
+            sandbox=vf.SandboxConfig(),
+        )
+    )
+    program = as_mapping(harness.program)
+    sandbox = as_mapping(harness.sandbox)
+
+    assert program["setup_timeout"] == 600
+    assert sandbox["setup_timeout"] == 600
+
+
 def test_rlm_harness_can_upload_skills(tmp_path: Path):
     skills = tmp_path / "skills"
     (skills / "edit").mkdir(parents=True)
@@ -79,6 +119,10 @@ def test_rlm_harness_can_upload_skills(tmp_path: Path):
     assert files[DEFAULT_RLM_TOOL_SKILLS_ARCHIVE_PATH] == harness.vf_tool_skills_archive
     assert isinstance(setup, list)
     assert DEFAULT_RLM_TOOL_SKILLS_ARCHIVE_PATH in setup[1]
+    assert DEFAULT_RLM_TOOL_SKILLS_MANIFEST_NAME in setup[1]
+    assert DEFAULT_RLM_TOOL_SKILL_MARKER in setup[1]
+    assert "rm -rf" in setup[1]
+    assert "tar -tzf" in setup[1]
 
 
 def test_rlm_harness_uploads_taskset_skills_by_default(tmp_path: Path):
@@ -98,6 +142,39 @@ def test_rlm_harness_uploads_taskset_skills_by_default(tmp_path: Path):
     dirs = as_mapping(program["dirs"])
 
     assert dirs["/task/rlm-skills"] == skills
+
+
+def test_rlm_harness_recomputes_taskset_skills(tmp_path: Path):
+    first_skills = tmp_path / "first-skills"
+    second_skills = tmp_path / "second-skills"
+    first_skills.mkdir()
+    second_skills.mkdir()
+
+    class SkillTaskset(vf.Taskset):
+        def __init__(self, skills: Path):
+            super().__init__(config=vf.TasksetConfig(source=[]))
+            self.skills = skills
+
+        def get_upload_dirs(self):
+            return {"skills": self.skills}
+
+    class NoSkillTaskset(vf.Taskset):
+        def get_upload_dirs(self):
+            return {}
+
+    harness = vf.RLM(config=vf.RLMConfig(local_checkout="/tmp/checkout"))
+    vf.Env(taskset=SkillTaskset(first_skills), harness=harness)
+    vf.Env(taskset=SkillTaskset(second_skills), harness=harness)
+    program = as_mapping(harness.program)
+    dirs = as_mapping(program["dirs"])
+
+    assert dirs["/task/rlm-skills"] == second_skills
+
+    vf.Env(taskset=NoSkillTaskset(config=vf.TasksetConfig(source=[])), harness=harness)
+    program = as_mapping(harness.program)
+    dirs = as_mapping(program["dirs"])
+
+    assert "/task/rlm-skills" not in dirs
 
 
 @pytest.mark.asyncio
@@ -130,11 +207,55 @@ async def test_rlm_harness_generates_skills_for_v1_tools():
             .decode()
         )
         skill_markdown = tar.extractfile("lookup_order/SKILL.md").read().decode()
-    assert "async def run(order_id, **kwargs)" in source
-    assert "/vf/tools/" in source
-    assert "'lookup_order'" in source
+        marker = (
+            tar.extractfile(f"lookup_order/{DEFAULT_RLM_TOOL_SKILL_MARKER}")
+            .read()
+            .decode()
+        )
+    assert "async def run(order_id: str, **kwargs) -> object" in source
+    assert "/vf/tools/" not in source
+    assert "dill.loads" in source
     assert "Look up an order by ID." in skill_markdown
     assert "result = await lookup_order" in skill_markdown
+    assert marker == "1\n"
+
+    module = types.ModuleType("lookup_order")
+    exec(source, module.__dict__)
+    assert await module.run(order_id="A-1") == "order:A-1"
+
+
+@pytest.mark.asyncio
+async def test_vf_tool_skill_falls_back_for_runtime_bound_tools():
+    async def stateful_lookup(order_id: str, state: vf.State) -> str:
+        """Look up an order with rollout state."""
+        return f"{state['tenant']}:{order_id}"
+
+    taskset = vf.Taskset(
+        config=vf.TasksetConfig(
+            source=[{"prompt": [{"role": "user", "content": "Find order A-1."}]}]
+        )
+    )
+    taskset.add_toolset(vf.Toolset(tools=[stateful_lookup]))
+    env = vf.Env(
+        taskset=taskset,
+        harness=vf.RLM(config=vf.RLMConfig(local_checkout="/tmp/checkout")),
+    )
+    task = next(iter(env.taskset))
+    state = vf.State({"task": dict(task), "runtime": {}, "prompt": task["prompt"]})
+
+    await env.harness.runtime.ensure_rollout_toolsets(task, state)
+    env.harness.runtime.prepare_state(task, state)
+    archive = base64.b64decode(env.harness.vf_tool_skills_archive(state))
+
+    with tarfile.open(fileobj=io.BytesIO(archive), mode="r:gz") as tar:
+        source = (
+            tar.extractfile("stateful_lookup/src/stateful_lookup/stateful_lookup.py")
+            .read()
+            .decode()
+        )
+
+    assert "/vf/tools/" in source
+    assert "dill.loads" not in source
 
 
 def test_vf_tool_skills_archive_avoids_base_skill_name_collisions(tmp_path: Path):
@@ -189,9 +310,10 @@ def test_vf_tool_skill_uses_arguments_dict_for_tool_parameters():
             .decode()
         )
 
-    assert "async def run(arguments: dict | None = None, **kwargs)" in source
-    assert "arguments = _tool_arguments(arguments, kwargs)" in source
+    assert "async def run(arguments: dict | None = None, **kwargs) -> object" in source
+    assert "arguments = {**(arguments or {}), **kwargs}" in source
     assert 'json={"arguments": arguments}' in source
+    assert "def _tool_arguments" not in source
     assert "limit=None" not in source
 
 
@@ -247,6 +369,63 @@ async def test_vf_tool_skill_filters_extra_kwargs_for_closed_schemas(
 
     assert result == "ok"
     assert calls == [{"arguments": {"date": "2025-07-14"}}]
+
+
+@pytest.mark.asyncio
+async def test_vf_tool_skill_omits_unset_optional_arguments(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    harness = vf.RLM(config=vf.RLMConfig(local_checkout="/tmp/checkout"))
+    tool_def = Tool(
+        name="search",
+        description="Search documents.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "query": {"type": "string"},
+                "limit": {"type": "integer"},
+            },
+            "required": ["query"],
+        },
+    )
+    setattr(harness.runtime, "tool_defs", lambda state: [tool_def])
+    archive = base64.b64decode(harness.vf_tool_skills_archive(vf.State({})))
+
+    with tarfile.open(fileobj=io.BytesIO(archive), mode="r:gz") as tar:
+        source = tar.extractfile("search/src/search/search.py").read().decode()
+
+    module = types.ModuleType("search")
+    exec(source, module.__dict__)
+    calls: list[dict[str, object]] = []
+
+    class Response:
+        content = b"{}"
+
+        def json(self):
+            return {"result": "ok"}
+
+        def raise_for_status(self):
+            return None
+
+    class Requests:
+        @staticmethod
+        def post(url, json, headers, timeout):
+            calls.append(json)
+            return Response()
+
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://example.test/v1")
+    module.requests = Requests
+
+    assert (
+        "async def run(query: str, limit: int | None = None, **kwargs) -> object"
+        in source
+    )
+    assert "if limit is not None:" in source
+    assert "limit=None" not in source
+    result = await module.run(query="docs")
+
+    assert result == "ok"
+    assert calls == [{"arguments": {"query": "docs"}}]
 
 
 @pytest.mark.asyncio

--- a/tests/test_v1_runtime_lifecycle.py
+++ b/tests/test_v1_runtime_lifecycle.py
@@ -109,6 +109,7 @@ class FakeSandboxClient:
     created: list[str] = []
     deleted: list[str] = []
     commands: list[tuple[str, str]] = []
+    command_timeouts: list[int | None] = []
     background_jobs: list[tuple[str, str, int | None, str | None]] = []
     uploads: list[tuple[str, str, bytes]] = []
 
@@ -117,6 +118,7 @@ class FakeSandboxClient:
         cls.created = []
         cls.deleted = []
         cls.commands = []
+        cls.command_timeouts = []
         cls.background_jobs = []
         cls.uploads = []
 
@@ -134,7 +136,9 @@ class FakeSandboxClient:
     ) -> FakeCommandResult:
         sandbox_id = str(kwargs.get("sandbox_id") or args[0])
         command = str(kwargs.get("command") or args[1])
+        timeout = cast(int | None, kwargs.get("timeout"))
         type(self).commands.append((sandbox_id, command))
+        type(self).command_timeouts.append(timeout)
         return FakeCommandResult()
 
     async def run_background_job(
@@ -1250,6 +1254,39 @@ async def test_rollout_setup_receives_program_sandbox_before_program_setup(
     assert state["early_setup_sandbox_id"] == "sbx-1"
     assert early_setup_index < program_setup_index
     assert program_setup_index < lifecycle_setup_index < command_index
+
+
+@pytest.mark.asyncio
+async def test_program_setup_uses_program_setup_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_fake_sandboxes(monkeypatch)
+    install_fake_endpoint_tunnel(monkeypatch)
+
+    harness = make_harness(
+        program={
+            "command": ["true"],
+            "sandbox": True,
+            "setup": "echo program-setup",
+            "setup_timeout": 777,
+        },
+        sandbox={"image": "python:3.11-slim"},
+    )
+    task = vf.Task({"prompt": [{"role": "user", "content": "hi"}]}).freeze()
+
+    await harness.run(task)
+
+    setup_commands = FakeSandboxClient.commands[
+        : len(FakeSandboxClient.command_timeouts)
+    ]
+    command_timeouts = dict(
+        zip(
+            [command for _, command in setup_commands],
+            FakeSandboxClient.command_timeouts,
+            strict=True,
+        )
+    )
+    assert command_timeouts["echo program-setup"] == 777
 
 
 @pytest.mark.asyncio

--- a/verifiers/serve/server/env_server.py
+++ b/verifiers/serve/server/env_server.py
@@ -126,7 +126,7 @@ class EnvServer(ABC):
     @classmethod
     def run_server(cls, *args, **kwargs):
         try:
-            import uvloop  # type: ignore
+            import uvloop
 
             uvloop.install()
         except ImportError:

--- a/verifiers/serve/server/env_worker.py
+++ b/verifiers/serve/server/env_worker.py
@@ -397,7 +397,7 @@ class EnvWorker:
     @classmethod
     def run_worker(cls, *args, **kwargs) -> None:
         try:
-            import uvloop  # type: ignore
+            import uvloop
 
             uvloop.install()
         except ImportError:

--- a/verifiers/v1/README.md
+++ b/verifiers/v1/README.md
@@ -607,13 +607,16 @@ and log/trajectory artifacts.
 artifacts.
 `RLM` follows the same boundary for recursive LLM runs: `HarborTaskset` owns
 the task directory and tests, while `RLM` owns RLM installation, optional skill
-upload to `/rlm/skills`, endpoint wiring, and trajectory filtering.
+upload to `/task/rlm-skills`, generated tool skills, endpoint wiring, and
+trajectory filtering.
 Use `RLMConfig` in `env.harness` for RLM-specific settings such as
 `rlm_repo_ref`, `rlm_tools`, `rlm_max_turns`, and `summarize_at_tokens`.
 Tasksets can expose package-owned upload directories with `get_upload_dirs()`.
 The base `Taskset` discovers a sibling `skills/` directory by default, and
-`RLM` uploads that directory to `/rlm/skills` unless `skills=` is passed
-explicitly to the harness.
+`RLM` uploads that directory to `/task/rlm-skills` unless `skills=` is passed
+explicitly to the harness. Generated tool skills run simple callable tools
+inside the RLM sandbox by default and fall back to `/vf/tools` for tools that
+need verifier runtime resources.
 
 ## State Helpers
 
@@ -1459,7 +1462,7 @@ mcp = true
 `program.channels` is deliberately limited to `callable` and `mcp`.
 Harness-specific tool carriers belong on the harness or taskset contract; for
 example, RLM reads `Taskset.get_upload_dirs()["skills"]` and uploads it to
-`/rlm/skills`.
+`/task/rlm-skills`.
 
 `program.setup` prepares the process. `program.channels.mcp` registers resolved
 tool or endpoint config after the interception endpoint is live and before the

--- a/verifiers/v1/config.py
+++ b/verifiers/v1/config.py
@@ -139,6 +139,7 @@ class ProgramConfig(Config):
     files: ProgramOptionMap = {}
     dirs: ProgramOptionMap = {}
     setup: ProgramSetup = []
+    setup_timeout: int = 300
     bindings: Bindings = {}
     env: ProgramOptionMap = {}
     artifacts: ProgramOptionMap = {}

--- a/verifiers/v1/packages/harnesses/rlm.py
+++ b/verifiers/v1/packages/harnesses/rlm.py
@@ -1,19 +1,19 @@
+import base64
 import hashlib
+import io
 import json
+import keyword
 import os
 import random
 import re
-import shutil
 import shlex
-import tempfile
+import tarfile
 import textwrap
-from importlib import resources
 from collections.abc import Callable, Mapping
 from importlib.abc import Traversable
 from pathlib import Path
 from typing import cast
 
-from verifiers.types import Tool
 from verifiers.envs.experimental.utils.git_checkout_cache import (
     resolve_git_checkout,
     validate_git_checkout,
@@ -25,7 +25,6 @@ from ...state import State
 from ...task import Task
 from ...taskset import Taskset
 from ...utils.prompt_utils import task_text
-from ...utils.runtime_registry import load_runtime_from_state
 from .command import command_program
 from .configs import (
     RLM_DEFAULT_APPEND_TO_SYSTEM_PROMPT_PATH,
@@ -35,11 +34,9 @@ from ...types import ConfigData, ConfigMap, ProgramCommand, ProgramValue
 
 DEFAULT_RLM_CHECKOUT_PATH = "/tmp/rlm-checkout"
 DEFAULT_RLM_SKILLS_PATH = "/task/rlm-skills"
+DEFAULT_RLM_TOOL_SKILLS_ARCHIVE_PATH = "/tmp/vf-rlm-tool-skills.tar.gz.b64"
 DEFAULT_RLM_LOCAL_CHECKOUT_CACHE_ROOT = (
     Path.home() / ".cache" / "verifiers" / "rlm-checkouts"
-)
-DEFAULT_RLM_VF_SKILLS_CACHE_ROOT = (
-    Path(tempfile.gettempdir()) / "verifiers-rlm-vf-skills"
 )
 REQUIRED_RLM_CHECKOUT_FILES = ("install.sh", "pyproject.toml")
 ProgramDir = str | Path | Traversable
@@ -98,11 +95,11 @@ class RLM(Harness):
                 gh_token=harness_config.gh_token,
             )
         }
-        dirs[DEFAULT_RLM_SKILLS_PATH] = self.load_skills_dir
-        self._explicit_skills = (
+        self._skills_dir: ProgramDir | None = (
             Path(harness_config.skills) if harness_config.skills is not None else None
         )
-        self._taskset_skills: ProgramDir | None = None
+        if self._skills_dir is not None:
+            dirs[DEFAULT_RLM_SKILLS_PATH] = self._skills_dir
         command: ProgramCommand = [
             "bash",
             "-lc",
@@ -117,12 +114,20 @@ class RLM(Harness):
                     RLM_DEFAULT_APPEND_TO_SYSTEM_PROMPT_PATH: (
                         harness_config.append_to_system_prompt
                     ),
+                    DEFAULT_RLM_TOOL_SKILLS_ARCHIVE_PATH: self.vf_tool_skills_archive,
                 },
                 dirs=dirs,
                 setup=[
                     "apt-get -o Acquire::Retries=3 update && "
                     "apt-get -o Acquire::Retries=3 install -y --no-install-recommends "
                     "ca-certificates curl git && rm -rf /var/lib/apt/lists/*",
+                    (
+                        f"if [ -s {shlex.quote(DEFAULT_RLM_TOOL_SKILLS_ARCHIVE_PATH)} ]; then "
+                        f"mkdir -p {shlex.quote(DEFAULT_RLM_SKILLS_PATH)} && "
+                        f"base64 -d {shlex.quote(DEFAULT_RLM_TOOL_SKILLS_ARCHIVE_PATH)} | "
+                        f"tar -xzf - -C {shlex.quote(DEFAULT_RLM_SKILLS_PATH)}; "
+                        "fi"
+                    ),
                     "bash -lc "
                     + shlex.quote(
                         f"""
@@ -153,216 +158,99 @@ bash "$RLM_CHECKOUT_PATH/install.sh"
         )
 
     def attach_taskset(self, taskset: Taskset) -> None:
-        if self._explicit_skills is None:
+        if self._skills_dir is None:
             upload_dirs = taskset.get_upload_dirs()
             if not isinstance(upload_dirs, Mapping):
                 raise TypeError("Taskset.get_upload_dirs() must return a mapping.")
-            self._taskset_skills = cast(ProgramDir | None, upload_dirs.get("skills"))
+            self._skills_dir = cast(ProgramDir | None, upload_dirs.get("skills"))
+            if self._skills_dir is not None:
+                if not isinstance(self.program, Mapping):
+                    raise TypeError("RLM program must be a mapping.")
+                program = dict(cast(ConfigMap, self.program))
+                dirs = dict(cast(ConfigMap, program.get("dirs") or {}))
+                dirs[DEFAULT_RLM_SKILLS_PATH] = self._skills_dir
+                program["dirs"] = dirs
+                self.program = program
         super().attach_taskset(taskset)
         self._program = self.compile_program(self.program)
 
-    def load_skills_dir(self, task: Task, state: State) -> Path:
-        _ = task
-        base_skills = self._explicit_skills or self._taskset_skills
-        tool_defs = load_runtime_from_state(state).tool_defs(state) or []
+    def vf_tool_skills_archive(self, state: State) -> str:
+        tool_defs = self.runtime.tool_defs(state) or []
         if not tool_defs:
-            if base_skills is None:
-                return empty_skills_dir()
-            return materialize_skills_dir(base_skills)
-        return build_vf_tool_skills_dir(tool_defs, base_skills)
-
-    def set_program_dir(
-        self, remote_path: str, local_source: ProgramDir | None
-    ) -> None:
-        if not isinstance(self.program, Mapping):
-            raise TypeError("RLM program must be a mapping.")
-        program = dict(cast(ConfigMap, self.program))
-        dirs = dict(cast(ConfigMap, program.get("dirs") or {}))
-        if local_source is None:
-            dirs.pop(remote_path, None)
-        else:
-            dirs[remote_path] = local_source
-        program["dirs"] = dirs
-        self.program = program
-
-
-def load_harness(config: RLMConfig) -> RLM:
-    return RLM(config=config)
-
-
-def empty_skills_dir() -> Path:
-    path = DEFAULT_RLM_VF_SKILLS_CACHE_ROOT / "empty"
-    path.mkdir(parents=True, exist_ok=True)
-    return path
-
-
-def materialize_skills_dir(source: ProgramDir) -> Path:
-    if isinstance(source, str):
-        return Path(source)
-    if isinstance(source, Path):
-        return source
-    with resources.as_file(source) as path:
-        return path
-
-
-def build_vf_tool_skills_dir(
-    tool_defs: list[Tool], base_skills: ProgramDir | None
-) -> Path:
-    key = vf_tool_skills_key(tool_defs, base_skills)
-    target = DEFAULT_RLM_VF_SKILLS_CACHE_ROOT / key
-    if target.exists():
-        return target
-    tmp = target.with_name(
-        f".{target.name}-{os.getpid()}-{random.randint(0, 1_000_000)}"
-    )
-    tmp.mkdir(parents=True, exist_ok=False)
-    if base_skills is not None:
-        copy_skill_packages(materialize_skills_dir(base_skills), tmp)
-    used_names: set[str] = set()
-    for tool_def in tool_defs:
-        write_vf_tool_skill(tmp, tool_def_mapping(tool_def), used_names)
-    tmp.rename(target)
-    return target
+            return ""
+        used_names: set[str] = set()
+        if self._skills_dir is not None:
+            root = (
+                Path(self._skills_dir)
+                if isinstance(self._skills_dir, str)
+                else self._skills_dir
+            )
+            used_names.update(child.name for child in root.iterdir() if child.is_dir())
+        buffer = io.BytesIO()
+        with tarfile.open(fileobj=buffer, mode="w:gz") as tar:
+            for raw_tool_def in tool_defs:
+                tool_def = cast(ConfigData, raw_tool_def.model_dump())
+                tool_name = str(tool_def["name"])
+                skill_name = re.sub(r"\W", "_", tool_name)
+                if not skill_name or skill_name[0].isdigit():
+                    skill_name = f"tool_{skill_name}"
+                if keyword.iskeyword(skill_name):
+                    skill_name = f"{skill_name}_tool"
+                base_name = skill_name
+                index = 2
+                while skill_name in used_names:
+                    skill_name = f"{base_name}_{index}"
+                    index += 1
+                used_names.add(skill_name)
+                description = str(
+                    tool_def.get("description")
+                    or f"Call the {tool_name} verifier tool."
+                )
+                schema = json.dumps(
+                    tool_def.get("parameters") or {}, indent=2, sort_keys=True
+                )
+                module = textwrap.dedent(
+                    f"""\
+                    import os
+                    import requests
 
 
-def vf_tool_skills_key(tool_defs: list[Tool], base_skills: ProgramDir | None) -> str:
-    payload = {
-        "version": 4,
-        "tools": [tool_def_mapping(tool_def) for tool_def in tool_defs],
-        "base": str(base_skills) if base_skills is not None else None,
-    }
-    digest = hashlib.sha256(
-        json.dumps(payload, sort_keys=True, default=str).encode()
-    ).hexdigest()
-    return digest[:16]
-
-
-def tool_def_mapping(tool_def: Tool | ConfigMap) -> ConfigData:
-    if isinstance(tool_def, Tool):
-        return cast(ConfigData, tool_def.model_dump())
-    return dict(tool_def)
-
-
-def copy_skill_packages(source: Path, target: Path) -> None:
-    if not source.exists():
-        return
-    for child in source.iterdir():
-        if child.is_dir():
-            shutil.copytree(child, target / child.name, dirs_exist_ok=True)
-        elif child.name == "SKILL.md":
-            shutil.copy2(child, target / child.name)
-
-
-def write_vf_tool_skill(root: Path, tool_def: ConfigData, used_names: set[str]) -> None:
-    tool_name = str(tool_def["name"])
-    skill_name = unique_skill_name(python_name(tool_name), used_names)
-    skill_dir = root / skill_name
-    package_dir = skill_dir / "src" / skill_name
-    package_dir.mkdir(parents=True)
-    (skill_dir / "SKILL.md").write_text(render_skill_markdown(tool_def, skill_name))
-    (skill_dir / "pyproject.toml").write_text(render_skill_pyproject(skill_name))
-    (package_dir / "__init__.py").write_text(
-        f"from .{skill_name} import run\n\n__all__ = ['run']\n"
-    )
-    (package_dir / f"{skill_name}.py").write_text(render_skill_module(tool_def))
-
-
-def unique_skill_name(name: str, used_names: set[str]) -> str:
-    candidate = name
-    index = 2
-    while candidate in used_names:
-        candidate = f"{name}_{index}"
-        index += 1
-    used_names.add(candidate)
-    return candidate
-
-
-PYTHON_RESERVED_WORDS = {
-    "False",
-    "None",
-    "True",
-    "and",
-    "as",
-    "assert",
-    "async",
-    "await",
-    "break",
-    "class",
-    "continue",
-    "def",
-    "del",
-    "elif",
-    "else",
-    "except",
-    "finally",
-    "for",
-    "from",
-    "global",
-    "if",
-    "import",
-    "in",
-    "is",
-    "lambda",
-    "nonlocal",
-    "not",
-    "or",
-    "pass",
-    "raise",
-    "return",
-    "try",
-    "while",
-    "with",
-    "yield",
-}
-
-
-def python_name(name: str) -> str:
-    normalized = re.sub(r"\W", "_", name)
-    if not normalized or normalized[0].isdigit():
-        normalized = f"tool_{normalized}"
-    if normalized in PYTHON_RESERVED_WORDS:
-        normalized = f"{normalized}_tool"
-    return normalized
-
-
-def render_skill_pyproject(skill_name: str) -> str:
-    distribution_name = skill_name.replace("_", "-")
-    return textwrap.dedent(
-        f"""\
-        [project]
-        name = "rlm-skill-{distribution_name}"
-        version = "0.0.0"
-        dependencies = ["requests", "rlm"]
-
-        [project.scripts]
-        {skill_name} = "rlm.skill:cli"
-
-        [build-system]
-        requires = ["hatchling"]
-        build-backend = "hatchling.build"
-
-        [tool.hatch.build.targets.wheel]
-        packages = ["src/{skill_name}"]
-        """
-    )
-
-
-def render_skill_markdown(tool_def: ConfigMap, skill_name: str) -> str:
-    tool_name = str(tool_def["name"])
-    description = str(
-        tool_def.get("description") or f"Call the {tool_name} verifier tool."
-    )
-    schema = json.dumps(tool_def.get("parameters") or {}, indent=2, sort_keys=True)
-    return f"""# {skill_name}
+                    async def run(arguments: dict | None = None, **kwargs):
+                        {json.dumps(description)}
+                        arguments = {{**(arguments or {{}}), **kwargs}}
+                        base = os.environ.get("ANTHROPIC_BASE_URL") or os.environ.get("OPENAI_BASE_URL")
+                        if not base:
+                            raise RuntimeError("No Verifiers endpoint URL is configured.")
+                        api_key = (
+                            os.environ.get("OPENAI_API_KEY")
+                            or os.environ.get("ANTHROPIC_API_KEY")
+                            or "intercepted"
+                        )
+                        response = requests.post(
+                            f"{{base.rsplit('/v1', 1)[0].rstrip('/')}}/vf/tools/" + {tool_name!r},
+                            json={{"arguments": arguments}},
+                            headers={{"Authorization": f"Bearer {{api_key}}"}},
+                            timeout=300,
+                        )
+                        response.raise_for_status()
+                        payload = response.json() if response.content else {{}}
+                        if "error" in payload:
+                            raise RuntimeError(str(payload["error"]))
+                        return payload.get("result")
+                    """
+                )
+                distribution_name = skill_name.replace("_", "-")
+                files = {
+                    f"{skill_name}/SKILL.md": f"""# {skill_name}
 
 {description}
 
 This skill calls the Verifiers V1 tool `{tool_name}` for the current rollout.
 
-Use it from IPython:
+Pass tool arguments as a dictionary:
 
 ```python
-result = await {skill_name}(...)
+result = await {skill_name}({{"argument_name": "value"}})
 ```
 
 Tool schema:
@@ -370,131 +258,40 @@ Tool schema:
 ```json
 {schema}
 ```
-"""
+""",
+                    f"{skill_name}/pyproject.toml": textwrap.dedent(
+                        f"""\
+                        [project]
+                        name = "rlm-skill-{distribution_name}"
+                        version = "0.0.0"
+                        dependencies = ["requests", "rlm"]
+
+                        [project.scripts]
+                        {skill_name} = "rlm.skill:cli"
+
+                        [build-system]
+                        requires = ["hatchling"]
+                        build-backend = "hatchling.build"
+
+                        [tool.hatch.build.targets.wheel]
+                        packages = ["src/{skill_name}"]
+                        """
+                    ),
+                    f"{skill_name}/src/{skill_name}/__init__.py": (
+                        f"from .{skill_name} import run\n\n__all__ = ['run']\n"
+                    ),
+                    f"{skill_name}/src/{skill_name}/{skill_name}.py": module,
+                }
+                for path, content in files.items():
+                    data = content.encode()
+                    info = tarfile.TarInfo(path)
+                    info.size = len(data)
+                    tar.addfile(info, io.BytesIO(data))
+        return base64.b64encode(buffer.getvalue()).decode()
 
 
-def render_skill_module(tool_def: ConfigMap) -> str:
-    tool_name = str(tool_def["name"])
-    signature, arguments = render_run_signature_and_arguments(tool_def)
-    description = str(tool_def.get("description") or f"Call {tool_name}.")
-    docstring = json.dumps(description)
-    return textwrap.dedent(
-        f"""\
-        from __future__ import annotations
-
-        import os
-        import requests
-
-
-        async def run({signature}):
-            {docstring}
-            return _call_vf_tool({tool_name!r}, {arguments})
-
-
-        def _call_vf_tool(name: str, arguments: dict):
-            root = _endpoint_root()
-            api_key = (
-                os.environ.get("OPENAI_API_KEY")
-                or os.environ.get("ANTHROPIC_API_KEY")
-                or "intercepted"
-            )
-            response = requests.post(
-                f"{{root}}/vf/tools/{{name}}",
-                json={{"arguments": arguments}},
-                headers={{"Authorization": f"Bearer {{api_key}}"}},
-                timeout=300,
-            )
-            response.raise_for_status()
-            payload = response.json() if response.content else {{}}
-            if "error" in payload:
-                raise RuntimeError(str(payload["error"]))
-            return payload.get("result")
-
-
-        def _endpoint_root() -> str:
-            base = os.environ.get("ANTHROPIC_BASE_URL") or os.environ.get(
-                "OPENAI_BASE_URL"
-            )
-            if not base:
-                raise RuntimeError("No Verifiers endpoint URL is configured.")
-            return base.rsplit("/v1", 1)[0].rstrip("/")
-        """
-    )
-
-
-def render_run_signature_and_arguments(
-    tool_def: ConfigMap,
-) -> tuple[str, str]:
-    parameters = cast(ConfigData, tool_def.get("parameters") or {})
-    properties = cast(ConfigData, parameters.get("properties") or {})
-    required = set(cast(list[str], parameters.get("required") or []))
-    if not properties:
-        return "", "{}"
-    if any(not valid_python_parameter(name) for name in properties):
-        return "arguments: dict", "arguments"
-    items = sorted(
-        properties.items(),
-        key=lambda item: (
-            "default" in cast(ConfigData, item[1]) or item[0] not in required
-        ),
-    )
-    signature_parts: list[str] = []
-    argument_parts: list[str] = []
-    for name, raw_schema in items:
-        schema = cast(ConfigData, raw_schema)
-        annotation = schema_annotation(schema)
-        if "default" in schema:
-            signature_parts.append(f"{name}: {annotation} = {schema['default']!r}")
-        elif schema_allows_null(schema):
-            signature_parts.append(f"{name}: {annotation} = None")
-        elif name not in required:
-            signature_parts.append(f"{name}: {annotation} | None = None")
-        else:
-            signature_parts.append(f"{name}: {annotation}")
-        argument_parts.append(f"{name!r}: {name}")
-    return ", ".join(signature_parts), "{" + ", ".join(argument_parts) + "}"
-
-
-def valid_python_parameter(name: str) -> bool:
-    return name.isidentifier() and name not in PYTHON_RESERVED_WORDS
-
-
-def schema_annotation(schema: ConfigMap) -> str:
-    any_of = schema.get("anyOf")
-    if isinstance(any_of, list):
-        annotations = [
-            schema_annotation(cast(ConfigData, item))
-            for item in any_of
-            if isinstance(item, Mapping) and cast(ConfigMap, item).get("type") != "null"
-        ]
-        if not annotations:
-            return "object"
-        annotation = (
-            annotations[0] if len(set(annotations)) == 1 else " | ".join(annotations)
-        )
-        return f"{annotation} | None" if schema_allows_null(schema) else annotation
-    schema_type = schema.get("type")
-    if schema_type == "string":
-        return "str"
-    if schema_type == "integer":
-        return "int"
-    if schema_type == "number":
-        return "float"
-    if schema_type == "boolean":
-        return "bool"
-    if schema_type == "array":
-        return "list"
-    if schema_type == "object":
-        return "dict"
-    return "object"
-
-
-def schema_allows_null(schema: ConfigMap) -> bool:
-    any_of = schema.get("anyOf")
-    return isinstance(any_of, list) and any(
-        isinstance(item, Mapping) and cast(ConfigMap, item).get("type") == "null"
-        for item in any_of
-    )
+def load_harness(config: RLMConfig) -> RLM:
+    return RLM(config=config)
 
 
 def build_run_script(instruction_path: str, workdir: str) -> str:

--- a/verifiers/v1/packages/harnesses/rlm.py
+++ b/verifiers/v1/packages/harnesses/rlm.py
@@ -209,15 +209,25 @@ bash "$RLM_CHECKOUT_PATH/install.sh"
                 schema = json.dumps(
                     tool_def.get("parameters") or {}, indent=2, sort_keys=True
                 )
+                parameters = cast(ConfigData, tool_def.get("parameters") or {})
+                properties = cast(ConfigData, parameters.get("properties") or {})
+                allowed_arguments = (
+                    sorted(properties)
+                    if parameters.get("additionalProperties") is False
+                    else None
+                )
                 module = textwrap.dedent(
                     f"""\
                     import os
                     import requests
 
 
+                    TOOL_ALLOWED_ARGUMENTS = {allowed_arguments!r}
+
+
                     async def run(arguments: dict | None = None, **kwargs):
                         {json.dumps(description)}
-                        arguments = {{**(arguments or {{}}), **kwargs}}
+                        arguments = _tool_arguments(arguments, kwargs)
                         base = os.environ.get("ANTHROPIC_BASE_URL") or os.environ.get("OPENAI_BASE_URL")
                         if not base:
                             raise RuntimeError("No Verifiers endpoint URL is configured.")
@@ -232,11 +242,26 @@ bash "$RLM_CHECKOUT_PATH/install.sh"
                             headers={{"Authorization": f"Bearer {{api_key}}"}},
                             timeout=300,
                         )
-                        response.raise_for_status()
-                        payload = response.json() if response.content else {{}}
+                        payload = _response_payload(response)
+                        return payload.get("result")
+
+
+                    def _tool_arguments(arguments: dict | None, kwargs: dict) -> dict:
+                        merged = {{**(arguments or {{}}), **kwargs}}
+                        if TOOL_ALLOWED_ARGUMENTS is None:
+                            return merged
+                        return {{key: merged[key] for key in TOOL_ALLOWED_ARGUMENTS if key in merged}}
+
+
+                    def _response_payload(response):
+                        if not response.content:
+                            response.raise_for_status()
+                            return {{}}
+                        payload = response.json()
                         if "error" in payload:
                             raise RuntimeError(str(payload["error"]))
-                        return payload.get("result")
+                        response.raise_for_status()
+                        return payload
                     """
                 )
                 distribution_name = skill_name.replace("_", "-")

--- a/verifiers/v1/packages/harnesses/rlm.py
+++ b/verifiers/v1/packages/harnesses/rlm.py
@@ -1,6 +1,7 @@
 import base64
 import hashlib
 import io
+import inspect
 import json
 import keyword
 import os
@@ -25,6 +26,7 @@ from ...state import State
 from ...task import Task
 from ...taskset import Taskset
 from ...utils.prompt_utils import task_text
+from ...utils.program_utils import int_config
 from .command import command_program
 from .configs import (
     RLM_DEFAULT_APPEND_TO_SYSTEM_PROMPT_PATH,
@@ -35,6 +37,8 @@ from ...types import ConfigData, ConfigMap, ProgramCommand, ProgramValue
 DEFAULT_RLM_CHECKOUT_PATH = "/tmp/rlm-checkout"
 DEFAULT_RLM_SKILLS_PATH = "/task/rlm-skills"
 DEFAULT_RLM_TOOL_SKILLS_ARCHIVE_PATH = "/tmp/vf-rlm-tool-skills.tar.gz.b64"
+DEFAULT_RLM_TOOL_SKILLS_MANIFEST_NAME = ".vf-generated-tool-skills"
+DEFAULT_RLM_TOOL_SKILL_MARKER = ".vf-generated-tool-skill"
 DEFAULT_RLM_LOCAL_CHECKOUT_CACHE_ROOT = (
     Path.home() / ".cache" / "verifiers" / "rlm-checkouts"
 )
@@ -85,13 +89,18 @@ class RLM(Harness):
             }
         elif sandbox_config is not False:
             sandbox_options = sandbox_config_mapping(sandbox_config) or {}
-            if isinstance(sandbox_options.get("setup_timeout"), int):
-                setup_timeout = cast(int, sandbox_options["setup_timeout"])
+            explicit_sandbox_options = (
+                sandbox_config_mapping(sandbox_config, fill_defaults=False) or {}
+            )
+            if explicit_sandbox_options.get("setup_timeout") is not None:
+                setup_timeout = int_config(
+                    explicit_sandbox_options, "setup_timeout", setup_timeout
+                )
             sandbox_config = {
                 "workdir": harness_config.workdir,
                 "command_timeout": max(harness_config.rlm_exec_timeout + 120, 600),
-                "setup_timeout": setup_timeout,
                 **sandbox_options,
+                "setup_timeout": setup_timeout,
             }
         dirs: dict[str, ProgramValue] = {
             DEFAULT_RLM_CHECKOUT_PATH: rlm_checkout_loader(
@@ -104,6 +113,7 @@ class RLM(Harness):
         self._skills_dir: ProgramDir | None = (
             Path(harness_config.skills) if harness_config.skills is not None else None
         )
+        self._explicit_skills = self._skills_dir is not None
         if self._skills_dir is not None:
             dirs[DEFAULT_RLM_SKILLS_PATH] = self._skills_dir
         command: ProgramCommand = [
@@ -126,12 +136,33 @@ class RLM(Harness):
                 "apt-get -o Acquire::Retries=3 update && "
                 "apt-get -o Acquire::Retries=3 install -y --no-install-recommends "
                 "ca-certificates curl git && rm -rf /var/lib/apt/lists/*",
-                (
-                    f"if [ -s {shlex.quote(DEFAULT_RLM_TOOL_SKILLS_ARCHIVE_PATH)} ]; then "
-                    f"mkdir -p {shlex.quote(DEFAULT_RLM_SKILLS_PATH)} && "
-                    f"base64 -d {shlex.quote(DEFAULT_RLM_TOOL_SKILLS_ARCHIVE_PATH)} | "
-                    f"tar -xzf - -C {shlex.quote(DEFAULT_RLM_SKILLS_PATH)}; "
-                    "fi"
+                "bash -lc "
+                + shlex.quote(
+                    f"""
+set -eo pipefail
+skills_path={shlex.quote(DEFAULT_RLM_SKILLS_PATH)}
+archive_path={shlex.quote(DEFAULT_RLM_TOOL_SKILLS_ARCHIVE_PATH)}
+manifest_path="$skills_path/{DEFAULT_RLM_TOOL_SKILLS_MANIFEST_NAME}"
+mkdir -p "$skills_path"
+if [ -f "$manifest_path" ]; then
+  while IFS= read -r skill_name; do
+    case "$skill_name" in ""|.*|*/*|*..*) continue ;; esac
+    if [ -f "$skills_path/$skill_name/{DEFAULT_RLM_TOOL_SKILL_MARKER}" ]; then
+      rm -rf "$skills_path/$skill_name"
+    fi
+  done < "$manifest_path"
+  rm -f "$manifest_path"
+fi
+if [ -s "$archive_path" ]; then
+  tmp_archive="$(mktemp)"
+  trap 'rm -f "$tmp_archive"' EXIT
+  base64 -d "$archive_path" > "$tmp_archive"
+  tar -tzf "$tmp_archive" \\
+    | awk -F/ 'NF > 1 && $1 != "" {{print $1}}' \\
+    | sort -u > "$manifest_path"
+  tar -xzf "$tmp_archive" -C "$skills_path"
+fi
+"""
                 ),
                 "bash -lc "
                 + shlex.quote(
@@ -154,7 +185,7 @@ bash "$RLM_CHECKOUT_PATH/install.sh"
             },
             program=harness_config.program,
         )
-        program["setup_timeout"] = setup_timeout
+        program.setdefault("setup_timeout", setup_timeout)
         self._configure_runtime(
             program=program,
             sandbox=None if sandbox_config is False else sandbox_config,
@@ -166,19 +197,24 @@ bash "$RLM_CHECKOUT_PATH/install.sh"
         )
 
     def attach_taskset(self, taskset: Taskset) -> None:
-        if self._skills_dir is None:
+        if not self._explicit_skills:
             upload_dirs = taskset.get_upload_dirs()
             if not isinstance(upload_dirs, Mapping):
                 raise TypeError("Taskset.get_upload_dirs() must return a mapping.")
             self._skills_dir = cast(ProgramDir | None, upload_dirs.get("skills"))
-            if self._skills_dir is not None:
-                if not isinstance(self.program, Mapping):
-                    raise TypeError("RLM program must be a mapping.")
-                program = dict(cast(ConfigMap, self.program))
-                dirs = dict(cast(ConfigMap, program.get("dirs") or {}))
+            if not isinstance(self.program, Mapping):
+                raise TypeError("RLM program must be a mapping.")
+            program = dict(cast(ConfigMap, self.program))
+            dirs = dict(cast(ConfigMap, program.get("dirs") or {}))
+            if self._skills_dir is None:
+                dirs.pop(DEFAULT_RLM_SKILLS_PATH, None)
+            else:
                 dirs[DEFAULT_RLM_SKILLS_PATH] = self._skills_dir
+            if dirs:
                 program["dirs"] = dirs
-                self.program = program
+            else:
+                program.pop("dirs", None)
+            self.program = program
         super().attach_taskset(taskset)
         self._program = self.compile_program(self.program)
 
@@ -186,6 +222,7 @@ bash "$RLM_CHECKOUT_PATH/install.sh"
         tool_defs = self.runtime.tool_defs(state) or []
         if not tool_defs:
             return ""
+        tools = self.runtime.all_exposed_tools(state)
         used_names: set[str] = set()
         if self._skills_dir is not None:
             root = (
@@ -224,53 +261,175 @@ bash "$RLM_CHECKOUT_PATH/install.sh"
                     if parameters.get("additionalProperties") is False
                     else None
                 )
-                signature, arguments = render_run_signature_and_arguments(tool_def)
+                required = set(cast(list[str], parameters.get("required") or []))
+                type_names = {
+                    "array": "list",
+                    "boolean": "bool",
+                    "integer": "int",
+                    "null": "None",
+                    "number": "float",
+                    "object": "dict",
+                    "string": "str",
+                }
+                typed_parameters = all(
+                    name.isidentifier()
+                    and not name.startswith("_")
+                    and not keyword.iskeyword(name)
+                    and name
+                    not in {
+                        "arguments",
+                        "kwargs",
+                    }
+                    for name in properties
+                )
+                if typed_parameters:
+                    signature_parts: list[str] = []
+                    argument_lines = ["arguments = {}"]
+                    for name, raw_schema in sorted(
+                        properties.items(),
+                        key=lambda item: (
+                            "default" in cast(ConfigData, item[1])
+                            or item[0] not in required
+                        ),
+                    ):
+                        field_schema = cast(ConfigData, raw_schema)
+                        raw_type = field_schema.get("type")
+                        if isinstance(raw_type, str):
+                            annotation_parts = [type_names.get(raw_type, "object")]
+                        elif isinstance(raw_type, list):
+                            annotation_parts = [
+                                type_names.get(str(item), "object") for item in raw_type
+                            ]
+                        else:
+                            annotation_parts = ["object"]
+                        annotation = " | ".join(dict.fromkeys(annotation_parts))
+                        if name not in required and "default" not in field_schema:
+                            if "None" not in annotation_parts:
+                                annotation = f"{annotation} | None"
+                            signature_parts.append(f"{name}: {annotation} = None")
+                            argument_lines.append(f"if {name} is not None:")
+                            argument_lines.append(f"    arguments[{name!r}] = {name}")
+                        elif "default" in field_schema:
+                            default = field_schema["default"]
+                            if default is None and "None" not in annotation_parts:
+                                annotation = f"{annotation} | None"
+                            signature_parts.append(
+                                f"{name}: {annotation} = {default!r}"
+                            )
+                            argument_lines.append(f"arguments[{name!r}] = {name}")
+                        else:
+                            signature_parts.append(f"{name}: {annotation}")
+                            argument_lines.append(f"arguments[{name!r}] = {name}")
+                    signature_parts.append("**kwargs")
+                    signature = ", ".join(signature_parts)
+                    argument_lines.append("arguments.update(kwargs)")
+                    argument_source = textwrap.indent(
+                        "\n".join(argument_lines), " " * 24
+                    )
+                    call_example = f'result = await {skill_name}(argument_name="value")'
+                else:
+                    signature = "arguments: dict | None = None, **kwargs"
+                    argument_source = textwrap.indent(
+                        "arguments = {**(arguments or {}), **kwargs}", " " * 24
+                    )
+                    call_example = (
+                        f"result = await {skill_name}({{'argument_name': 'value'}})"
+                    )
+                local_tool_payload: str | None = None
+                tool = tools.get(tool_name)
+                owner = self.runtime.tool_owner(tool_name, state)
+                if owner is not None and owner.sandbox is None and callable(tool):
+                    try:
+                        tool_signature = inspect.signature(tool)
+                    except (TypeError, ValueError):
+                        tool_signature = None
+                    if tool_signature is not None and not any(
+                        binding_key.partition(".")[0] == tool_name
+                        for binding_key in owner.bindings
+                    ):
+                        hidden_args = self.runtime.hidden_tool_args(tool_name, state)
+                        if not any(
+                            arg_name in tool_signature.parameters
+                            for arg_name in hidden_args
+                        ):
+                            try:
+                                import dill
+
+                                local_tool_payload = base64.b64encode(
+                                    dill.dumps(tool)
+                                ).decode()
+                            except Exception:
+                                local_tool_payload = None
+                if local_tool_payload is None:
+                    module_imports = "os, requests"
+                    tool_setup = ""
+                    dependencies = ["requests", "rlm"]
+                    call_source = textwrap.indent(
+                        textwrap.dedent(
+                            f"""\
+                            base = os.environ.get("ANTHROPIC_BASE_URL") or os.environ.get("OPENAI_BASE_URL")
+                            if not base:
+                                raise RuntimeError("No Verifiers endpoint URL is configured.")
+                            api_key = (
+                                os.environ.get("OPENAI_API_KEY")
+                                or os.environ.get("ANTHROPIC_API_KEY")
+                                or "intercepted"
+                            )
+                            # Runtime-bound tools fall back to the verifier endpoint.
+                            response = requests.post(
+                                f"{{base.rsplit('/v1', 1)[0].rstrip('/')}}/vf/tools/" + {tool_name!r},
+                                json={{"arguments": arguments}},
+                                headers={{"Authorization": f"Bearer {{api_key}}"}},
+                                timeout=300,
+                            )
+                            if not response.content:
+                                response.raise_for_status()
+                                return None
+                            payload = response.json()
+                            if "error" in payload:
+                                raise RuntimeError(str(payload["error"]))
+                            response.raise_for_status()
+                            return payload.get("result")
+                            """
+                        ),
+                        " " * 24,
+                    )
+                else:
+                    module_imports = "base64, dill, inspect"
+                    tool_setup = (
+                        f"TOOL = dill.loads(base64.b64decode({local_tool_payload!r}))"
+                    )
+                    dependencies = ["dill", "rlm"]
+                    call_source = textwrap.indent(
+                        textwrap.dedent(
+                            """\
+                            result = TOOL(**arguments)
+                            if inspect.isawaitable(result):
+                                return await result
+                            return result
+                            """
+                        ),
+                        " " * 24,
+                    )
                 module = textwrap.dedent(
                     f"""\
-                    import os
-                    import requests
+                    import {module_imports}
 
 
                     TOOL_ALLOWED_ARGUMENTS = {allowed_arguments!r}
+                    {tool_setup}
 
 
-                    async def run({signature}):
+                    async def run({signature}) -> object:
                         {json.dumps(description)}
-                        arguments = _tool_arguments({arguments}, kwargs)
-                        base = os.environ.get("ANTHROPIC_BASE_URL") or os.environ.get("OPENAI_BASE_URL")
-                        if not base:
-                            raise RuntimeError("No Verifiers endpoint URL is configured.")
-                        api_key = (
-                            os.environ.get("OPENAI_API_KEY")
-                            or os.environ.get("ANTHROPIC_API_KEY")
-                            or "intercepted"
-                        )
-                        response = requests.post(
-                            f"{{base.rsplit('/v1', 1)[0].rstrip('/')}}/vf/tools/" + {tool_name!r},
-                            json={{"arguments": arguments}},
-                            headers={{"Authorization": f"Bearer {{api_key}}"}},
-                            timeout=300,
-                        )
-                        payload = _response_payload(response)
-                        return payload.get("result")
-
-
-                    def _tool_arguments(arguments: dict | None, kwargs: dict) -> dict:
-                        merged = {{**(arguments or {{}}), **kwargs}}
-                        if TOOL_ALLOWED_ARGUMENTS is None:
-                            return merged
-                        return {{key: merged[key] for key in TOOL_ALLOWED_ARGUMENTS if key in merged}}
-
-
-                    def _response_payload(response):
-                        if not response.content:
-                            response.raise_for_status()
-                            return {{}}
-                        payload = response.json()
-                        if "error" in payload:
-                            raise RuntimeError(str(payload["error"]))
-                        response.raise_for_status()
-                        return payload
+{argument_source}
+                        if TOOL_ALLOWED_ARGUMENTS is not None:
+                            arguments = {{
+                                key: arguments[key]
+                                for key in TOOL_ALLOWED_ARGUMENTS
+                                if key in arguments
+                            }}
+{call_source}
                     """
                 )
                 distribution_name = skill_name.replace("_", "-")
@@ -279,12 +438,12 @@ bash "$RLM_CHECKOUT_PATH/install.sh"
 
 {description}
 
-This skill calls the Verifiers V1 tool `{tool_name}` for the current rollout.
+This skill calls `{tool_name}`.
 
-Pass tool arguments as a dictionary:
+Call it with tool arguments:
 
 ```python
-result = await {skill_name}({{"argument_name": "value"}})
+{call_example}
 ```
 
 Tool schema:
@@ -293,12 +452,13 @@ Tool schema:
 {schema}
 ```
 """,
+                    f"{skill_name}/{DEFAULT_RLM_TOOL_SKILL_MARKER}": "1\n",
                     f"{skill_name}/pyproject.toml": textwrap.dedent(
                         f"""\
                         [project]
                         name = "rlm-skill-{distribution_name}"
                         version = "0.0.0"
-                        dependencies = ["requests", "rlm"]
+                        dependencies = {json.dumps(dependencies)}
 
                         [project.scripts]
                         {skill_name} = "rlm.skill:cli"
@@ -322,46 +482,6 @@ Tool schema:
                     info.size = len(data)
                     tar.addfile(info, io.BytesIO(data))
         return base64.b64encode(buffer.getvalue()).decode()
-
-
-def render_run_signature_and_arguments(tool_def: ConfigMap) -> tuple[str, str]:
-    parameters = cast(ConfigData, tool_def.get("parameters") or {})
-    properties = cast(ConfigData, parameters.get("properties") or {})
-    required = set(cast(list[str], parameters.get("required") or []))
-    if any(not valid_tool_parameter(name) for name in properties):
-        return "arguments: dict | None = None, **kwargs", "arguments"
-    items = sorted(
-        properties.items(),
-        key=lambda item: (
-            "default" in cast(ConfigData, item[1]) or item[0] not in required
-        ),
-    )
-    signature_parts: list[str] = []
-    argument_parts: list[str] = []
-    for name, raw_schema in items:
-        schema = cast(ConfigData, raw_schema)
-        if "default" in schema:
-            signature_parts.append(f"{name}={schema['default']!r}")
-        elif name in required:
-            signature_parts.append(name)
-        else:
-            signature_parts.append(f"{name}=None")
-        argument_parts.append(f"{name!r}: {name}")
-    signature_parts.append("**kwargs")
-    return ", ".join(signature_parts), "{" + ", ".join(argument_parts) + "}"
-
-
-def valid_tool_parameter(name: str) -> bool:
-    return (
-        name.isidentifier()
-        and not name.startswith("_")
-        and not keyword.iskeyword(name)
-        and name
-        not in {
-            "arguments",
-            "kwargs",
-        }
-    )
 
 
 def load_harness(config: RLMConfig) -> RLM:

--- a/verifiers/v1/packages/harnesses/rlm.py
+++ b/verifiers/v1/packages/harnesses/rlm.py
@@ -69,6 +69,7 @@ class RLM(Harness):
         if summarize_resolver is not None:
             env["RLM_SUMMARIZE_AT_TOKENS"] = summarize_resolver
         sandbox_config: ConfigMap | SandboxConfig | bool
+        setup_timeout = max(harness_config.rlm_exec_timeout + 120, 600)
         sandbox_config = harness_config.sandbox or True
         if sandbox_config is True:
             sandbox_config = {
@@ -80,12 +81,17 @@ class RLM(Harness):
                 "network_access": True,
                 "timeout_minutes": 60,
                 "command_timeout": max(harness_config.rlm_exec_timeout + 120, 600),
+                "setup_timeout": setup_timeout,
             }
         elif sandbox_config is not False:
+            sandbox_options = sandbox_config_mapping(sandbox_config) or {}
+            if isinstance(sandbox_options.get("setup_timeout"), int):
+                setup_timeout = cast(int, sandbox_options["setup_timeout"])
             sandbox_config = {
                 "workdir": harness_config.workdir,
                 "command_timeout": max(harness_config.rlm_exec_timeout + 120, 600),
-                **(sandbox_config_mapping(sandbox_config) or {}),
+                "setup_timeout": setup_timeout,
+                **sandbox_options,
             }
         dirs: dict[str, ProgramValue] = {
             DEFAULT_RLM_CHECKOUT_PATH: rlm_checkout_loader(
@@ -105,50 +111,52 @@ class RLM(Harness):
             "-lc",
             build_run_script(harness_config.instruction_path, harness_config.workdir),
         ]
-        self._configure_runtime(
-            program=command_program(
-                command=command,
-                sandbox=sandbox_config,
-                files={
-                    harness_config.instruction_path: task_instruction_text,
-                    RLM_DEFAULT_APPEND_TO_SYSTEM_PROMPT_PATH: (
-                        harness_config.append_to_system_prompt
-                    ),
-                    DEFAULT_RLM_TOOL_SKILLS_ARCHIVE_PATH: self.vf_tool_skills_archive,
-                },
-                dirs=dirs,
-                setup=[
-                    "apt-get -o Acquire::Retries=3 update && "
-                    "apt-get -o Acquire::Retries=3 install -y --no-install-recommends "
-                    "ca-certificates curl git && rm -rf /var/lib/apt/lists/*",
-                    (
-                        f"if [ -s {shlex.quote(DEFAULT_RLM_TOOL_SKILLS_ARCHIVE_PATH)} ]; then "
-                        f"mkdir -p {shlex.quote(DEFAULT_RLM_SKILLS_PATH)} && "
-                        f"base64 -d {shlex.quote(DEFAULT_RLM_TOOL_SKILLS_ARCHIVE_PATH)} | "
-                        f"tar -xzf - -C {shlex.quote(DEFAULT_RLM_SKILLS_PATH)}; "
-                        "fi"
-                    ),
-                    "bash -lc "
-                    + shlex.quote(
-                        f"""
+        program = command_program(
+            command=command,
+            sandbox=sandbox_config,
+            files={
+                harness_config.instruction_path: task_instruction_text,
+                RLM_DEFAULT_APPEND_TO_SYSTEM_PROMPT_PATH: (
+                    harness_config.append_to_system_prompt
+                ),
+                DEFAULT_RLM_TOOL_SKILLS_ARCHIVE_PATH: self.vf_tool_skills_archive,
+            },
+            dirs=dirs,
+            setup=[
+                "apt-get -o Acquire::Retries=3 update && "
+                "apt-get -o Acquire::Retries=3 install -y --no-install-recommends "
+                "ca-certificates curl git && rm -rf /var/lib/apt/lists/*",
+                (
+                    f"if [ -s {shlex.quote(DEFAULT_RLM_TOOL_SKILLS_ARCHIVE_PATH)} ]; then "
+                    f"mkdir -p {shlex.quote(DEFAULT_RLM_SKILLS_PATH)} && "
+                    f"base64 -d {shlex.quote(DEFAULT_RLM_TOOL_SKILLS_ARCHIVE_PATH)} | "
+                    f"tar -xzf - -C {shlex.quote(DEFAULT_RLM_SKILLS_PATH)}; "
+                    "fi"
+                ),
+                "bash -lc "
+                + shlex.quote(
+                    f"""
 set -eo pipefail
 export RLM_CHECKOUT_PATH={shlex.quote(DEFAULT_RLM_CHECKOUT_PATH)}
 test -f "$RLM_CHECKOUT_PATH/install.sh"
 bash "$RLM_CHECKOUT_PATH/install.sh"
 """
-                    ),
-                ],
-                env=env,
-                artifacts={
-                    "rlm_metrics": {
-                        "path": f"{harness_config.workdir}/.rlm/sessions/*/meta.json",
-                        "format": "json",
-                        "key": "metrics",
-                        "optional": True,
-                    }
-                },
-                program=harness_config.program,
-            ),
+                ),
+            ],
+            env=env,
+            artifacts={
+                "rlm_metrics": {
+                    "path": f"{harness_config.workdir}/.rlm/sessions/*/meta.json",
+                    "format": "json",
+                    "key": "metrics",
+                    "optional": True,
+                }
+            },
+            program=harness_config.program,
+        )
+        program["setup_timeout"] = setup_timeout
+        self._configure_runtime(
+            program=program,
             sandbox=None if sandbox_config is False else sandbox_config,
             metrics=[
                 rlm_sub_llm_call_count,
@@ -216,6 +224,7 @@ bash "$RLM_CHECKOUT_PATH/install.sh"
                     if parameters.get("additionalProperties") is False
                     else None
                 )
+                signature, arguments = render_run_signature_and_arguments(tool_def)
                 module = textwrap.dedent(
                     f"""\
                     import os
@@ -225,9 +234,9 @@ bash "$RLM_CHECKOUT_PATH/install.sh"
                     TOOL_ALLOWED_ARGUMENTS = {allowed_arguments!r}
 
 
-                    async def run(arguments: dict | None = None, **kwargs):
+                    async def run({signature}):
                         {json.dumps(description)}
-                        arguments = _tool_arguments(arguments, kwargs)
+                        arguments = _tool_arguments({arguments}, kwargs)
                         base = os.environ.get("ANTHROPIC_BASE_URL") or os.environ.get("OPENAI_BASE_URL")
                         if not base:
                             raise RuntimeError("No Verifiers endpoint URL is configured.")
@@ -313,6 +322,46 @@ Tool schema:
                     info.size = len(data)
                     tar.addfile(info, io.BytesIO(data))
         return base64.b64encode(buffer.getvalue()).decode()
+
+
+def render_run_signature_and_arguments(tool_def: ConfigMap) -> tuple[str, str]:
+    parameters = cast(ConfigData, tool_def.get("parameters") or {})
+    properties = cast(ConfigData, parameters.get("properties") or {})
+    required = set(cast(list[str], parameters.get("required") or []))
+    if any(not valid_tool_parameter(name) for name in properties):
+        return "arguments: dict | None = None, **kwargs", "arguments"
+    items = sorted(
+        properties.items(),
+        key=lambda item: (
+            "default" in cast(ConfigData, item[1]) or item[0] not in required
+        ),
+    )
+    signature_parts: list[str] = []
+    argument_parts: list[str] = []
+    for name, raw_schema in items:
+        schema = cast(ConfigData, raw_schema)
+        if "default" in schema:
+            signature_parts.append(f"{name}={schema['default']!r}")
+        elif name in required:
+            signature_parts.append(name)
+        else:
+            signature_parts.append(f"{name}=None")
+        argument_parts.append(f"{name!r}: {name}")
+    signature_parts.append("**kwargs")
+    return ", ".join(signature_parts), "{" + ", ".join(argument_parts) + "}"
+
+
+def valid_tool_parameter(name: str) -> bool:
+    return (
+        name.isidentifier()
+        and not name.startswith("_")
+        and not keyword.iskeyword(name)
+        and name
+        not in {
+            "arguments",
+            "kwargs",
+        }
+    )
 
 
 def load_harness(config: RLMConfig) -> RLM:

--- a/verifiers/v1/packages/harnesses/rlm.py
+++ b/verifiers/v1/packages/harnesses/rlm.py
@@ -2,12 +2,18 @@ import hashlib
 import json
 import os
 import random
+import re
+import shutil
 import shlex
+import tempfile
+import textwrap
+from importlib import resources
 from collections.abc import Callable, Mapping
 from importlib.abc import Traversable
 from pathlib import Path
 from typing import cast
 
+from verifiers.types import Tool
 from verifiers.envs.experimental.utils.git_checkout_cache import (
     resolve_git_checkout,
     validate_git_checkout,
@@ -19,17 +25,21 @@ from ...state import State
 from ...task import Task
 from ...taskset import Taskset
 from ...utils.prompt_utils import task_text
+from ...utils.runtime_registry import load_runtime_from_state
 from .command import command_program
 from .configs import (
     RLM_DEFAULT_APPEND_TO_SYSTEM_PROMPT_PATH,
     RLMConfig,
 )
-from ...types import ConfigMap, ProgramCommand, ProgramValue
+from ...types import ConfigData, ConfigMap, ProgramCommand, ProgramValue
 
 DEFAULT_RLM_CHECKOUT_PATH = "/tmp/rlm-checkout"
 DEFAULT_RLM_SKILLS_PATH = "/task/rlm-skills"
 DEFAULT_RLM_LOCAL_CHECKOUT_CACHE_ROOT = (
     Path.home() / ".cache" / "verifiers" / "rlm-checkouts"
+)
+DEFAULT_RLM_VF_SKILLS_CACHE_ROOT = (
+    Path(tempfile.gettempdir()) / "verifiers-rlm-vf-skills"
 )
 REQUIRED_RLM_CHECKOUT_FILES = ("install.sh", "pyproject.toml")
 ProgramDir = str | Path | Traversable
@@ -88,9 +98,11 @@ class RLM(Harness):
                 gh_token=harness_config.gh_token,
             )
         }
-        if harness_config.skills is not None:
-            dirs[DEFAULT_RLM_SKILLS_PATH] = Path(harness_config.skills)
-        self._explicit_skills = harness_config.skills is not None
+        dirs[DEFAULT_RLM_SKILLS_PATH] = self.load_skills_dir
+        self._explicit_skills = (
+            Path(harness_config.skills) if harness_config.skills is not None else None
+        )
+        self._taskset_skills: ProgramDir | None = None
         command: ProgramCommand = [
             "bash",
             "-lc",
@@ -141,17 +153,23 @@ bash "$RLM_CHECKOUT_PATH/install.sh"
         )
 
     def attach_taskset(self, taskset: Taskset) -> None:
-        if not self._explicit_skills:
+        if self._explicit_skills is None:
             upload_dirs = taskset.get_upload_dirs()
             if not isinstance(upload_dirs, Mapping):
                 raise TypeError("Taskset.get_upload_dirs() must return a mapping.")
-            skills = upload_dirs.get("skills")
-            self.set_program_dir(
-                DEFAULT_RLM_SKILLS_PATH,
-                cast(ProgramDir | None, skills),
-            )
+            self._taskset_skills = cast(ProgramDir | None, upload_dirs.get("skills"))
         super().attach_taskset(taskset)
         self._program = self.compile_program(self.program)
+
+    def load_skills_dir(self, task: Task, state: State) -> Path:
+        _ = task
+        base_skills = self._explicit_skills or self._taskset_skills
+        tool_defs = load_runtime_from_state(state).tool_defs(state) or []
+        if not tool_defs:
+            if base_skills is None:
+                return empty_skills_dir()
+            return materialize_skills_dir(base_skills)
+        return build_vf_tool_skills_dir(tool_defs, base_skills)
 
     def set_program_dir(
         self, remote_path: str, local_source: ProgramDir | None
@@ -170,6 +188,313 @@ bash "$RLM_CHECKOUT_PATH/install.sh"
 
 def load_harness(config: RLMConfig) -> RLM:
     return RLM(config=config)
+
+
+def empty_skills_dir() -> Path:
+    path = DEFAULT_RLM_VF_SKILLS_CACHE_ROOT / "empty"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def materialize_skills_dir(source: ProgramDir) -> Path:
+    if isinstance(source, str):
+        return Path(source)
+    if isinstance(source, Path):
+        return source
+    with resources.as_file(source) as path:
+        return path
+
+
+def build_vf_tool_skills_dir(
+    tool_defs: list[Tool], base_skills: ProgramDir | None
+) -> Path:
+    key = vf_tool_skills_key(tool_defs, base_skills)
+    target = DEFAULT_RLM_VF_SKILLS_CACHE_ROOT / key
+    if target.exists():
+        return target
+    tmp = target.with_name(
+        f".{target.name}-{os.getpid()}-{random.randint(0, 1_000_000)}"
+    )
+    tmp.mkdir(parents=True, exist_ok=False)
+    if base_skills is not None:
+        copy_skill_packages(materialize_skills_dir(base_skills), tmp)
+    used_names: set[str] = set()
+    for tool_def in tool_defs:
+        write_vf_tool_skill(tmp, tool_def_mapping(tool_def), used_names)
+    tmp.rename(target)
+    return target
+
+
+def vf_tool_skills_key(tool_defs: list[Tool], base_skills: ProgramDir | None) -> str:
+    payload = {
+        "version": 4,
+        "tools": [tool_def_mapping(tool_def) for tool_def in tool_defs],
+        "base": str(base_skills) if base_skills is not None else None,
+    }
+    digest = hashlib.sha256(
+        json.dumps(payload, sort_keys=True, default=str).encode()
+    ).hexdigest()
+    return digest[:16]
+
+
+def tool_def_mapping(tool_def: Tool | ConfigMap) -> ConfigData:
+    if isinstance(tool_def, Tool):
+        return cast(ConfigData, tool_def.model_dump())
+    return dict(tool_def)
+
+
+def copy_skill_packages(source: Path, target: Path) -> None:
+    if not source.exists():
+        return
+    for child in source.iterdir():
+        if child.is_dir():
+            shutil.copytree(child, target / child.name, dirs_exist_ok=True)
+        elif child.name == "SKILL.md":
+            shutil.copy2(child, target / child.name)
+
+
+def write_vf_tool_skill(root: Path, tool_def: ConfigData, used_names: set[str]) -> None:
+    tool_name = str(tool_def["name"])
+    skill_name = unique_skill_name(python_name(tool_name), used_names)
+    skill_dir = root / skill_name
+    package_dir = skill_dir / "src" / skill_name
+    package_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(render_skill_markdown(tool_def, skill_name))
+    (skill_dir / "pyproject.toml").write_text(render_skill_pyproject(skill_name))
+    (package_dir / "__init__.py").write_text(
+        f"from .{skill_name} import run\n\n__all__ = ['run']\n"
+    )
+    (package_dir / f"{skill_name}.py").write_text(render_skill_module(tool_def))
+
+
+def unique_skill_name(name: str, used_names: set[str]) -> str:
+    candidate = name
+    index = 2
+    while candidate in used_names:
+        candidate = f"{name}_{index}"
+        index += 1
+    used_names.add(candidate)
+    return candidate
+
+
+PYTHON_RESERVED_WORDS = {
+    "False",
+    "None",
+    "True",
+    "and",
+    "as",
+    "assert",
+    "async",
+    "await",
+    "break",
+    "class",
+    "continue",
+    "def",
+    "del",
+    "elif",
+    "else",
+    "except",
+    "finally",
+    "for",
+    "from",
+    "global",
+    "if",
+    "import",
+    "in",
+    "is",
+    "lambda",
+    "nonlocal",
+    "not",
+    "or",
+    "pass",
+    "raise",
+    "return",
+    "try",
+    "while",
+    "with",
+    "yield",
+}
+
+
+def python_name(name: str) -> str:
+    normalized = re.sub(r"\W", "_", name)
+    if not normalized or normalized[0].isdigit():
+        normalized = f"tool_{normalized}"
+    if normalized in PYTHON_RESERVED_WORDS:
+        normalized = f"{normalized}_tool"
+    return normalized
+
+
+def render_skill_pyproject(skill_name: str) -> str:
+    distribution_name = skill_name.replace("_", "-")
+    return textwrap.dedent(
+        f"""\
+        [project]
+        name = "rlm-skill-{distribution_name}"
+        version = "0.0.0"
+        dependencies = ["requests", "rlm"]
+
+        [project.scripts]
+        {skill_name} = "rlm.skill:cli"
+
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+
+        [tool.hatch.build.targets.wheel]
+        packages = ["src/{skill_name}"]
+        """
+    )
+
+
+def render_skill_markdown(tool_def: ConfigMap, skill_name: str) -> str:
+    tool_name = str(tool_def["name"])
+    description = str(
+        tool_def.get("description") or f"Call the {tool_name} verifier tool."
+    )
+    schema = json.dumps(tool_def.get("parameters") or {}, indent=2, sort_keys=True)
+    return f"""# {skill_name}
+
+{description}
+
+This skill calls the Verifiers V1 tool `{tool_name}` for the current rollout.
+
+Use it from IPython:
+
+```python
+result = await {skill_name}(...)
+```
+
+Tool schema:
+
+```json
+{schema}
+```
+"""
+
+
+def render_skill_module(tool_def: ConfigMap) -> str:
+    tool_name = str(tool_def["name"])
+    signature, arguments = render_run_signature_and_arguments(tool_def)
+    description = str(tool_def.get("description") or f"Call {tool_name}.")
+    docstring = json.dumps(description)
+    return textwrap.dedent(
+        f"""\
+        from __future__ import annotations
+
+        import os
+        import requests
+
+
+        async def run({signature}):
+            {docstring}
+            return _call_vf_tool({tool_name!r}, {arguments})
+
+
+        def _call_vf_tool(name: str, arguments: dict):
+            root = _endpoint_root()
+            api_key = (
+                os.environ.get("OPENAI_API_KEY")
+                or os.environ.get("ANTHROPIC_API_KEY")
+                or "intercepted"
+            )
+            response = requests.post(
+                f"{{root}}/vf/tools/{{name}}",
+                json={{"arguments": arguments}},
+                headers={{"Authorization": f"Bearer {{api_key}}"}},
+                timeout=300,
+            )
+            response.raise_for_status()
+            payload = response.json() if response.content else {{}}
+            if "error" in payload:
+                raise RuntimeError(str(payload["error"]))
+            return payload.get("result")
+
+
+        def _endpoint_root() -> str:
+            base = os.environ.get("ANTHROPIC_BASE_URL") or os.environ.get(
+                "OPENAI_BASE_URL"
+            )
+            if not base:
+                raise RuntimeError("No Verifiers endpoint URL is configured.")
+            return base.rsplit("/v1", 1)[0].rstrip("/")
+        """
+    )
+
+
+def render_run_signature_and_arguments(
+    tool_def: ConfigMap,
+) -> tuple[str, str]:
+    parameters = cast(ConfigData, tool_def.get("parameters") or {})
+    properties = cast(ConfigData, parameters.get("properties") or {})
+    required = set(cast(list[str], parameters.get("required") or []))
+    if not properties:
+        return "", "{}"
+    if any(not valid_python_parameter(name) for name in properties):
+        return "arguments: dict", "arguments"
+    items = sorted(
+        properties.items(),
+        key=lambda item: (
+            "default" in cast(ConfigData, item[1]) or item[0] not in required
+        ),
+    )
+    signature_parts: list[str] = []
+    argument_parts: list[str] = []
+    for name, raw_schema in items:
+        schema = cast(ConfigData, raw_schema)
+        annotation = schema_annotation(schema)
+        if "default" in schema:
+            signature_parts.append(f"{name}: {annotation} = {schema['default']!r}")
+        elif schema_allows_null(schema):
+            signature_parts.append(f"{name}: {annotation} = None")
+        elif name not in required:
+            signature_parts.append(f"{name}: {annotation} | None = None")
+        else:
+            signature_parts.append(f"{name}: {annotation}")
+        argument_parts.append(f"{name!r}: {name}")
+    return ", ".join(signature_parts), "{" + ", ".join(argument_parts) + "}"
+
+
+def valid_python_parameter(name: str) -> bool:
+    return name.isidentifier() and name not in PYTHON_RESERVED_WORDS
+
+
+def schema_annotation(schema: ConfigMap) -> str:
+    any_of = schema.get("anyOf")
+    if isinstance(any_of, list):
+        annotations = [
+            schema_annotation(cast(ConfigData, item))
+            for item in any_of
+            if isinstance(item, Mapping) and cast(ConfigMap, item).get("type") != "null"
+        ]
+        if not annotations:
+            return "object"
+        annotation = (
+            annotations[0] if len(set(annotations)) == 1 else " | ".join(annotations)
+        )
+        return f"{annotation} | None" if schema_allows_null(schema) else annotation
+    schema_type = schema.get("type")
+    if schema_type == "string":
+        return "str"
+    if schema_type == "integer":
+        return "int"
+    if schema_type == "number":
+        return "float"
+    if schema_type == "boolean":
+        return "bool"
+    if schema_type == "array":
+        return "list"
+    if schema_type == "object":
+        return "dict"
+    return "object"
+
+
+def schema_allows_null(schema: ConfigMap) -> bool:
+    any_of = schema.get("anyOf")
+    return isinstance(any_of, list) and any(
+        isinstance(item, Mapping) and cast(ConfigMap, item).get("type") == "null"
+        for item in any_of
+    )
 
 
 def build_run_script(instruction_path: str, workdir: str) -> str:

--- a/verifiers/v1/utils/program_utils.py
+++ b/verifiers/v1/utils/program_utils.py
@@ -30,13 +30,14 @@ PROGRAM_OPTION_KEYS = {
     "files",
     "dirs",
     "setup",
+    "setup_timeout",
     "bindings",
     "env",
     "artifacts",
     "channels",
 }
 PROGRAM_KEYS = PROGRAM_KIND_KEYS | PROGRAM_OPTION_KEYS | {"args"}
-SANDBOX_ONLY_PROGRAM_KEYS = {"files", "dirs", "setup", "artifacts"}
+SANDBOX_ONLY_PROGRAM_KEYS = {"files", "dirs", "setup", "setup_timeout", "artifacts"}
 TASK_PROGRAM_KEYS = {
     "files",
     "dirs",

--- a/verifiers/v1/utils/sandbox_utils.py
+++ b/verifiers/v1/utils/sandbox_utils.py
@@ -807,6 +807,7 @@ async def run_program_items(
     error_prefix: str,
 ) -> None:
     env = await command_env(program, task, state, runtime, include_base=False)
+    timeout = int_config(program, "setup_timeout", 300)
     for command in items:
         command = await resolve_program_value(command, task, state, runtime, program)
         result = await maybe_call_with_named_args(
@@ -814,6 +815,7 @@ async def run_program_items(
             sandbox_id=sandbox_id,
             command=str(command),
             env=env,
+            timeout=timeout,
         )
         if result.exit_code:
             raise SandboxError(f"{error_prefix}: {result.stderr}")


### PR DESCRIPTION
## Summary
- generate RLM skill packages from V1 rollout tool definitions
- merge explicit/taskset RLM skills with generated V1 tool skills
- cover V1 tool skill generation in the RLM harness tests

## Validation
- uv run --frozen ruff check
- uv run --frozen ruff format --check
- uv run --frozen pytest tests/test_v1_rlm_swe.py
- uv run --frozen --group policy semgrep --metrics=off --disable-version-check --config .semgrep/verifiers.yml --error --quiet
- uv run --frozen --python 3.13 ty check verifiers/v1/packages/harnesses/rlm.py

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes RLM sandbox setup, skill paths, and dynamic tool packaging with dill/HTTP fallbacks; setup timeouts affect long-running installs but scope is mostly harness-local.
> 
> **Overview**
> The **RLM** harness now exposes v1 rollout tools to the agent as generated skill packages under **`/task/rlm-skills`** (replacing **`/rlm/skills`**). At rollout time it builds a base64 gzipped archive of per-tool skills, uploads it during sandbox setup, and merges them with explicit or taskset skill dirs—refreshing prior generated skills via a manifest/marker and suffixing names on collisions.
> 
> Each generated skill’s **`run`** either executes a simple callable in-sandbox (via **dill**) or POSTs to **`/vf/tools/{name}`** when the tool needs verifier runtime, bindings, sandboxes, or MCP. Argument handling follows JSON Schema (typed params, closed schemas, reserved names, optional omission, API errors as **`RuntimeError`**).
> 
> **`ProgramConfig.setup_timeout`** (default 300s) is new and applied to sandbox **`program.setup`** commands; RLM defaults to at least **600s** and honors program/sandbox overrides. Docs and broad tests cover skill generation, taskset skill rebinding, and setup timeouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89a7966b6ac9820ebc495e51ab5d58e3d69a49f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose V1 tools to the RLM harness as generated skills installed at `/task/rlm-skills`
> - The RLM harness now generates a base64-encoded tar.gz archive of skills derived from V1 tool definitions, installed into `/task/rlm-skills` during program setup via [`rlm.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1456/files#diff-ab1fe47f5f8e668f3f9356828ec781afac5bda206474365d3c76412bf4d88586).
> - Simple callable tools are serialized with dill and run directly inside the sandbox; tools requiring runtime resources fall back to posting to the `/vf/tools/{tool_name}` verifier endpoint.
> - Skill name collisions with existing skills directories are resolved by suffixing the generated skill name (e.g. `lookup_order_2`).
> - Adds `setup_timeout` to `ProgramConfig` (default 300s), used by `run_program_items` for each setup command; the RLM harness enforces a minimum of 600s for program and sandbox setup timeouts.
> - Behavioral Change: the RLM skills upload path changes from `/rlm/skills` to `/task/rlm-skills`, affecting any harness configuration or docs referencing the old path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 89a7966.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->