### PR TITLE
Make harness setup scripts POSIX sh compatible

### DIFF
--- a/verifiers/v1/packages/harnesses/opencode.py
+++ b/verifiers/v1/packages/harnesses/opencode.py
@@ -222,7 +222,7 @@ set -e
 export PATH="$HOME/.opencode/bin:$PATH"
 
 OPENCODE_WORKDIR="${{AGENT_WORKDIR:-}}"
-if [[ -z "$OPENCODE_WORKDIR" ]]; then
+if [ -z "$OPENCODE_WORKDIR" ]; then
     OPENCODE_WORKDIR={shlex.quote(agent_workdir)}
 fi
 

--- a/verifiers/v1/packages/harnesses/pi.py
+++ b/verifiers/v1/packages/harnesses/pi.py
@@ -110,7 +110,7 @@ EOFMCP
 set -e
 
 PI_WORKDIR="${{AGENT_WORKDIR:-}}"
-if [[ -z "$PI_WORKDIR" ]]; then
+if [ -z "$PI_WORKDIR" ]; then
     PI_WORKDIR={shlex.quote(agent_workdir)}
 fi
 


### PR DESCRIPTION
## Summary

- Make OpenCode and PI MCP setup scripts use POSIX `[ ... ]` checks for fallback workdir handling.
- Add regression coverage that executes both generated setup scripts with `/bin/sh`.

## Tests

- `.venv/bin/python -m pytest tests/test_v1_harness_setup_scripts.py -q`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Two-line conditional syntax swaps in generated setup scripts with identical control flow; no auth, data, or runtime logic changes.
> 
> **Overview**
> Updates the **MCP channel setup** shell snippets emitted by `build_opencode_mcp_setup_script` and `build_pi_mcp_setup_script` so empty `AGENT_WORKDIR` fallbacks use POSIX `[ -z ... ]` instead of Bash `[[ -z ... ]]`.
> 
> Behavior is unchanged: when `AGENT_WORKDIR` is unset or empty, the scripts still default `OPENCODE_WORKDIR` / `PI_WORKDIR` to the configured `agent_workdir` before creating config dirs and writing MCP-related files. This aligns those setup fragments with `/bin/sh` where the harness may run them outside `bash -lc` (run scripts are unchanged and still use `[[`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b25a1cc1b186a4d6a4842525b8725630e0fe3d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make harness setup scripts POSIX sh compatible
> Replaces bash-specific `[[ -z ... ]]` double-bracket tests with POSIX-compliant `[ -z ... ]` single-bracket tests in the embedded shell scripts in [opencode.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1457/files#diff-b97fae3522049a4b491cffe50dca7b19c7d50b137fa220497e3f787699069ba0) and [pi.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1457/files#diff-68ea5dbc61392c14ea0fa11fa3c81714a2e09d89ffb0c98c5b23344b6f407b09).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3b25a1c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->