### PR TITLE
[codex] Forward renderer request headers

### DIFF
--- a/tests/test_renderer_client.py
+++ b/tests/test_renderer_client.py
@@ -233,6 +233,38 @@ async def test_from_native_response_uses_request_id_and_token_lengths():
     assert response.usage.total_tokens == 5
 
 
+@pytest.mark.asyncio
+async def test_get_native_response_forwards_extra_headers_to_generate():
+    captured: dict = {}
+    client = object.__new__(RendererClient)
+    client._renderer = object()
+    client._pool_size = 1
+    client._config = vf.ClientConfig(client_type="renderer")
+    client._client = object()  # type: ignore[attr-defined]
+
+    async def _fake_generate(**kwargs):
+        captured.update(kwargs)
+        return {"content": "ok"}
+
+    with (
+        patch.object(RendererClient, "_get_renderer_or_pool", return_value=object()),
+        patch("verifiers.clients.renderer_client.generate", side_effect=_fake_generate),
+    ):
+        response = await client.get_native_response(
+            prompt=[{"role": "user", "content": "hi"}],
+            model="test-model",
+            sampling_args={"extra_headers": {"X-Static": "static"}},
+            tools=None,
+            extra_headers={"X-Session-ID": "trajectory-123", "X-Static": "state"},
+        )
+
+    assert response == {"content": "ok"}
+    assert captured["extra_headers"] == {
+        "X-Static": "state",
+        "X-Session-ID": "trajectory-123",
+    }
+
+
 class _BridgeRenderer:
     supports_tools = True
 

--- a/verifiers/clients/renderer_client.py
+++ b/verifiers/clients/renderer_client.py
@@ -500,6 +500,10 @@ class RendererClient(
         renderer = self._get_renderer_or_pool(model)
 
         args = dict(sampling_args)
+        extra_headers = {
+            **dict(args.pop("extra_headers", None) or {}),
+            **dict(kwargs.pop("extra_headers", None) or {}),
+        }
         sampling_params: dict[str, Any] = dict(args.pop("extra_body", None) or {})
         for key in (
             "temperature",
@@ -557,7 +561,7 @@ class RendererClient(
                 cache_salt=args.get("cache_salt")
                 or sampling_params.pop("cache_salt", None),
                 priority=args.get("priority") or sampling_params.pop("priority", None),
-                extra_headers=args.get("extra_headers"),
+                extra_headers=extra_headers or None,
             )
         except RendererOverlongPromptError as exc:
             raise OverlongPromptError(str(exc)) from exc


### PR DESCRIPTION
## Summary

Forward caller-provided renderer request headers through the `RendererClient` generate path.

`Client.get_response()` can derive per-request headers from rollout state via `extra_headers_from_state`, but `RendererClient.get_native_response()` only forwarded headers present in `sampling_args`. That meant state-derived headers such as `X-Session-ID` were dropped before reaching `renderers.client.generate`, breaking sticky routing through the vLLM router on the renderer path.

This merges static sampling headers with kwargs/state-derived headers, with kwargs taking precedence, then passes the result to `generate`.

## Validation

- `uv run pytest tests/test_renderer_client.py -q`
- `uv run ruff check verifiers/clients/renderer_client.py tests/test_renderer_client.py`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Forward merged extra headers to renderer in `RendererClient.get_native_response`
> Previously, only `extra_headers` from `sampling_args` was forwarded to the downstream `generate` call. Now, `extra_headers` from both `sampling_args` and `kwargs` are merged, with `kwargs`-provided headers taking precedence on key conflicts. A new test in [test_renderer_client.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1459/files#diff-200d7102e1d9ee4b5d7756e0d748c586744886e7ef4ee6d662af15348f4f84be) verifies the merge and override behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 626ed75.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted forwarding fix in the renderer client with a unit test; no auth or data-model changes.
> 
> **Overview**
> **`RendererClient.get_native_response`** now merges HTTP **`extra_headers`** from **`sampling_args`** and from **`kwargs`** (where **`Client.get_response`** injects per-rollout headers via **`extra_headers_from_state`**, e.g. **`X-Session-ID`**), with **`kwargs`** winning on duplicate keys, and passes the combined map into **`renderers.client.generate`**.
> 
> Previously only headers nested in **`sampling_args`** reached the renderer path, so state-derived sticky-routing headers were dropped compared to the chat-completions client.
> 
> A focused async test asserts the merged header dict forwarded to **`generate`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 626ed7568660a7f8f2a1ddc96054c4bbecc85f52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->