### PR TITLE
[codex] Default eval session header to trajectory_id

### DIFF
--- a/tests/test_eval_cli.py
+++ b/tests/test_eval_cli.py
@@ -288,6 +288,25 @@ def test_cli_headers_table_and_list_merge(monkeypatch, run_cli):
     }
 
 
+def test_cli_defaults_session_header_to_trajectory_id(monkeypatch, run_cli):
+    captured = run_cli(monkeypatch, {})
+
+    assert captured["configs"][0].client_config.extra_headers_from_state == {
+        "X-Session-ID": "trajectory_id"
+    }
+
+
+def test_cli_header_from_state_overrides_default_session_header(monkeypatch, run_cli):
+    captured = run_cli(
+        monkeypatch,
+        {"header_from_state": ["X-Session-ID: example_id"]},
+    )
+
+    assert captured["configs"][0].client_config.extra_headers_from_state == {
+        "X-Session-ID": "example_id"
+    }
+
+
 def test_cli_registry_headers_merged_with_eval_toml(tmp_path, monkeypatch, run_cli):
     cfg = tmp_path / "eval.toml"
     cfg.write_text(

--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -330,7 +330,7 @@ def build_parser() -> argparse.ArgumentParser:
         help=(
             "Per-request HTTP header whose value is read from the rollout state. "
             "'Name: state_key' (e.g. 'X-Session-ID: trajectory_id'). Repeatable. "
-            "Defaults to X-Session-ID=example_id if unset."
+            "Defaults to X-Session-ID=trajectory_id if unset."
         ),
     )
     parser.add_argument(
@@ -711,10 +711,10 @@ def main(argv: list[str] | None = None):
         )
         # Build headers: registry < [[eval]] headers table < header list / --header
         eval_headers_merged = build_extra_headers(raw)
-        # Default X-Session-ID → example_id for sticky DP-aware routing;
+        # Default X-Session-ID → trajectory_id for sticky DP-aware routing;
         # user-supplied headers_from_state / --header-from-state override.
         eval_headers_from_state = {
-            "X-Session-ID": "example_id",
+            "X-Session-ID": "trajectory_id",
             **build_extra_headers_from_state(raw),
         }
 


### PR DESCRIPTION
## Summary

Change the `vf-eval` default sticky-routing header mapping from `X-Session-ID = example_id` to `X-Session-ID = trajectory_id`.

This makes eval routing match the intended per-rollout behavior: each rollout gets a stable session id without pinning every rollout for the same dataset example to the same backend. User-provided `headers_from_state` / `--header-from-state` still override the default.

## Validation

- `uv run pytest tests/test_eval_cli.py -q`
- `uv run ruff check verifiers/scripts/eval.py tests/test_eval_cli.py`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default eval session header to `trajectory_id` instead of `example_id`
> Changes the default value for `X-Session-ID` in `extra_headers_from_state` from `example_id` to `trajectory_id` in [eval.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1460/files#diff-6b37997f6eb279df06f6c885920ff82ac5940e25ca859a9dd445bdc4028277b6). The `--header-from-state` help text is updated to reflect the new default. User-supplied headers still override this default.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d687fc1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Routing header default changes inference stickiness per rollout; explicit header-from-state overrides remain and scope is limited to eval CLI defaults.
> 
> **Overview**
> **`vf-eval`** now maps the default sticky-routing header **`X-Session-ID`** from rollout state key **`example_id`** to **`trajectory_id`**, so each rollout (including multiple rollouts per example) can get its own session id instead of sharing one per dataset example. **`--header-from-state`** help text and inline comments in **`eval.py`** were updated to match.
> 
> New CLI tests assert the default **`extra_headers_from_state`** mapping and that an explicit **`--header-from-state`** entry still overrides the default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d687fc1c4a47955a7aa6db9add58e3a5680c5990. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->