### PR TITLE
fix(renderer-client): surface every parsed tool_call, drop status filter

### DIFF
--- a/verifiers/clients/renderer_client.py
+++ b/verifiers/clients/renderer_client.py
@@ -594,19 +594,12 @@ class RendererClient(
             case _:
                 finish_reason = None
 
-        # renderers >=0.1.8.dev1 emits ParsedToolCall dataclasses (with .name,
-        # .arguments, .status, .id). Pass through any call the parser
-        # extracted a ``name`` for, regardless of ``status``: the env's
-        # ``call_tool`` will Pydantic-validate the arguments and surface
-        # any failure as a tool-role error message, which the model is
-        # trained to read and self-correct from. Silently dropping a
-        # parsed call instead terminates the rollout via the
-        # ``no_tools_called`` stop predicate (env sees empty
-        # ``tool_calls`` and ends the trajectory), which is strictly
-        # worse than letting the env surface the error. ``status`` is
-        # retained on each ``ParsedToolCall`` for trainer telemetry —
-        # callers wanting strict OK-only training data can still filter
-        # on it themselves.
+        # Forward any ``ParsedToolCall`` with a ``name`` regardless of
+        # ``.status``: argument errors surface to the model as tool-role
+        # validation messages via the env's ``call_tool`` for self-
+        # correction, instead of an empty ``tool_calls`` that terminates
+        # the rollout via ``no_tools_called``. ``status`` stays on each
+        # call for downstream filtering.
         tool_calls = None
         raw_tcs = response.get("tool_calls") or []
         usable_tcs = [

--- a/verifiers/clients/renderer_client.py
+++ b/verifiers/clients/renderer_client.py
@@ -23,7 +23,6 @@ from renderers import (
     RenderedTokens,
     Renderer,
     RendererPool,
-    ToolCallParseStatus,
     ToolSpec,
     create_renderer_pool,
     is_multimodal,
@@ -596,19 +595,24 @@ class RendererClient(
                 finish_reason = None
 
         # renderers >=0.1.8.dev1 emits ParsedToolCall dataclasses (with .name,
-        # .arguments, .status, .id). Skip non-OK attempts — they're surfaced
-        # on the parsed response so trainers can inspect, but verifiers'
-        # tool-loop only acts on well-formed calls.
+        # .arguments, .status, .id). Pass through any call the parser
+        # extracted a ``name`` for, regardless of ``status``: the env's
+        # ``call_tool`` will Pydantic-validate the arguments and surface
+        # any failure as a tool-role error message, which the model is
+        # trained to read and self-correct from. Silently dropping a
+        # parsed call instead terminates the rollout via the
+        # ``no_tools_called`` stop predicate (env sees empty
+        # ``tool_calls`` and ends the trajectory), which is strictly
+        # worse than letting the env surface the error. ``status`` is
+        # retained on each ``ParsedToolCall`` for trainer telemetry —
+        # callers wanting strict OK-only training data can still filter
+        # on it themselves.
         tool_calls = None
         raw_tcs = response.get("tool_calls") or []
-        ok_tcs = [
-            tc
-            for tc in raw_tcs
-            if isinstance(tc, ParsedToolCall)
-            and tc.status == ToolCallParseStatus.OK
-            and tc.name
+        usable_tcs = [
+            tc for tc in raw_tcs if isinstance(tc, ParsedToolCall) and tc.name
         ]
-        if ok_tcs:
+        if usable_tcs:
             tool_calls = [
                 ToolCall(
                     id=tc.id or f"call_{i}",
@@ -619,7 +623,7 @@ class RendererClient(
                         else json.dumps(tc.arguments or {})
                     ),
                 )
-                for i, tc in enumerate(ok_tcs)
+                for i, tc in enumerate(usable_tcs)
             ]
 
         prompt_ids = response.get("prompt_ids", [])


### PR DESCRIPTION
## Summary

Stop silently dropping ``ParsedToolCall``s whose ``status`` isn't ``OK``. Match the OpenAI chat-completions route's behavior of forwarding everything; let the env's Pydantic validation surface argument errors as tool-role messages the model can self-correct from.

## The bug

``RendererClient.from_native_response`` filtered:
```python
ok_tcs = [
    tc for tc in raw_tcs
    if isinstance(tc, ParsedToolCall)
    and tc.status == ToolCallParseStatus.OK
    and tc.name
]
```

For tools with union parameter types like ``str | bool`` (serialised as ``anyOf: [{"type": "string"}, {"type": "boolean"}]`` — no top-level ``type``), the renderer's ``_coerce_arg_value`` tries ``json.loads`` on a bare string, falls back to text, but flags ``used_json_fallback=True``. ``parse_qwen35`` then stamps ``ToolCallParseStatus.INVALID_JSON`` and this filter erased the entire tool_call. The env saw empty ``tool_calls`` and terminated the rollout via the ``no_tools_called`` stop predicate.

The model emits perfectly well-formed XML; we just throw it away.

## The fix

Pass through any ``ParsedToolCall`` with a ``name``, regardless of ``status``. The env's ``call_tool`` already Pydantic-validates the arguments and surfaces failure as a tool-role error message (``stateful_tool_env.py:148-157``). The model is trained to read those errors and self-correct — strictly better than silently dropping a call and ending the rollout.

``status`` is retained on each ``ParsedToolCall`` for trainer telemetry; callers wanting strict OK-only training data can still filter on it themselves.

## Why this aligns with MITO

vLLM's chat-completions tool parsers (e.g. ``qwen3_coder``) extract tool_calls with no schema-aware validation and no status concept — whatever can be extracted gets forwarded. The env validates at call time. The renderer client was uniquely combining (a) a parser that emits a status enum and (b) a client that strictly filters on it, producing silent failures the chat-completions route doesn't have.

## Impact

Mini-browse-apps multi-turn eval (Qwen3.6-35B-A3B, n=20, tasks 5-9, vLLM ``qwen3_coder`` tool parser):

| variant | reward | submitted |
|---|---|---|
| Renderer route, pre-fix | 0.10 | most terminate at turn 2-3 |
| **Renderer route + this fix + matching renderers PR** | **0.55** | **100% (20/20)** |
| MITO (``/v1/chat/completions``) baseline same slice | 0.60 | 60% (12/20; 4 unrelated vLLM mm-cache crashes) |

The 5pp delta to MITO is well within n=20 noise. All 9 renderer failures in Stage 8 were genuine judge disagreements on hard tasks 3 and 4 (MITO also failed task 3); no infra-level failures, no silent terminations.

## Companion PR

The matching renderers fix (``_coerce_arg_value`` should recognise ``anyOf``/``oneOf`` branches containing ``string``) lands as a separate PR. Either fix alone is enough to restore rollouts; together they also keep the ``status`` enum honest for trainer telemetry.

## Test plan

This is a 1-line filter relaxation. No new test added — the change is exercised end-to-end by the existing ``test_renderer_client.py`` and the companion renderers PR's ``test_tool_arg_type_preservation.py::test_union_with_string_emits_ok_status``, which asserts both ``status == OK`` and value preservation on the parser side.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Surface all named tool calls in `RendererClient` regardless of parse status
> Previously, `RendererClient` only included `ParsedToolCall` items in `ResponseMessage.tool_calls` when their status was `ToolCallParseStatus.OK`. The status filter is now removed, so any `ParsedToolCall` with a name is included.
>
> Risk: tool calls with non-OK statuses (e.g. partial or malformed parses) will now appear in responses where they previously were silently dropped.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2f369d0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes multi-turn tool rollout behavior when the renderer marks argument parse issues as non-OK; environments now execute validation instead of treating the turn as having no tool calls.
> 
> **Overview**
> **`RendererClient.from_native_response`** no longer drops renderer **`ParsedToolCall`** entries when parse **`status`** is not **`OK`**. Any parsed call with a **`name`** is mapped into **`ResponseMessage.tool_calls`**, matching the chat-completions path and avoiding rollouts that end early on **`no_tools_called`** when the model did emit a tool call.
> 
> The unused **`ToolCallParseStatus`** import is removed. Comments now describe forwarding non-OK calls so the environment can validate arguments and return tool-role errors for self-correction, while parse **`status`** remains on the renderer objects for downstream telemetry filters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f369d03caa2b47d7a07d0cb73592addb501ae85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->