### PR TITLE
Add composable Codex harness

### DIFF
--- a/tests/test_cli_agent_env.py
+++ b/tests/test_cli_agent_env.py
@@ -244,6 +244,11 @@ class TestCliAgentEnv:
                     "content": [{"type": "input_text", "text": "solve it"}],
                 },
                 {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"text": "", "output_text": "must not win"}],
+                },
+                {
                     "type": "function_call",
                     "call_id": "call_1",
                     "name": "shell",
@@ -259,10 +264,12 @@ class TestCliAgentEnv:
         assert messages[0]["content"] == "rules"
         assert messages[1]["role"] == "user"
         assert messages[1]["content"] == "solve it"
-        assert messages[2]["role"] == "assistant"
-        assert messages[2]["tool_calls"][0]["name"] == "shell"
-        assert messages[3]["role"] == "tool"
-        assert messages[3]["content"] == "ok"
+        assert messages[2]["role"] == "user"
+        assert messages[2]["content"] == ""
+        assert messages[3]["role"] == "assistant"
+        assert messages[3]["tool_calls"][0]["name"] == "shell"
+        assert messages[4]["role"] == "tool"
+        assert messages[4]["content"] == "ok"
 
 
 @pytest.mark.asyncio

--- a/tests/test_cli_agent_env.py
+++ b/tests/test_cli_agent_env.py
@@ -223,6 +223,47 @@ class TestCliAgentEnv:
         assert kwargs["tools"] is not None
         assert kwargs["tools"][0].name == "echo"
 
+    @pytest.mark.asyncio
+    async def test_get_prompt_messages_normalizes_openai_responses_input(
+        self, sample_dataset
+    ):
+        env = vf.CliAgentEnv(
+            run_command="python agent.py",
+            dataset=sample_dataset,
+            rubric=vf.Rubric(),
+        )
+        state = {"request_id_queue": asyncio.Queue()}
+        await state["request_id_queue"].put("req-responses")
+        env._interception_server.intercepts["req-responses"] = {
+            "protocol": "openai_responses",
+            "input": [
+                {"type": "message", "role": "developer", "content": "rules"},
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "solve it"}],
+                },
+                {
+                    "type": "function_call",
+                    "call_id": "call_1",
+                    "name": "shell",
+                    "arguments": '{"cmd":"ls"}',
+                },
+                {"type": "function_call_output", "call_id": "call_1", "output": "ok"},
+            ],
+        }
+
+        messages = await env.get_prompt_messages(state)
+
+        assert messages[0]["role"] == "system"
+        assert messages[0]["content"] == "rules"
+        assert messages[1]["role"] == "user"
+        assert messages[1]["content"] == "solve it"
+        assert messages[2]["role"] == "assistant"
+        assert messages[2]["tool_calls"][0]["name"] == "shell"
+        assert messages[3]["role"] == "tool"
+        assert messages[3]["content"] == "ok"
+
 
 @pytest.mark.asyncio
 async def test_cli_agent_env_delivers_intercepted_tool_call_response(

--- a/tests/test_codex_composable_harness.py
+++ b/tests/test_codex_composable_harness.py
@@ -40,10 +40,14 @@ def test_codex_run_command_uses_verifiers_proxy_and_prompt_stdin():
 
 
 def test_codex_goal_run_command_uses_goal_prompt():
-    command = build_codex_run_command(goal_mode=True, agent_workdir="/workspace/src")
+    command = build_codex_run_command(
+        goal_mode=True,
+        agent_workdir="/workspace/src",
+        goal_prompt="/goal Read /codex/goal.md and finish.",
+    )
 
     assert "--enable goals" in command
-    assert "/goal Read /codex/goal.md and complete the task." in command
+    assert "/goal Read /codex/goal.md and finish." in command
     assert "< /codex/prompt.md" not in command
 
 

--- a/tests/test_codex_composable_harness.py
+++ b/tests/test_codex_composable_harness.py
@@ -1,0 +1,64 @@
+from verifiers.envs.experimental.composable import Harness
+from verifiers.envs.experimental.composable.harnesses import (
+    DEFAULT_CODEX_VERSION,
+    build_codex_install_script,
+    build_codex_run_command,
+    codex_harness,
+)
+
+
+def test_codex_install_script_downloads_pinned_release_with_retries():
+    script = build_codex_install_script()
+
+    assert DEFAULT_CODEX_VERSION in script
+    assert "github.com/openai/codex/releases/download" in script
+    assert "CODEX_TARGET=x86_64-unknown-linux-musl" in script
+    assert "CODEX_TARGET=aarch64-unknown-linux-musl" in script
+    assert "for attempt in range(1, 6)" in script
+    assert "time.sleep(delay)" in script
+    assert "ln -sf /opt/codex/codex /usr/local/bin/codex" in script
+
+
+def test_codex_run_command_uses_verifiers_proxy_and_prompt_stdin():
+    command = build_codex_run_command(
+        agent_workdir="/workspace/src",
+        timeout_seconds=600,
+        model_reasoning_effort="xhigh",
+    )
+
+    assert "timeout --kill-after=30s 600s /opt/codex/codex" in command
+    assert 'model_provider="vf_proxy"' in command
+    assert "model_providers.vf_proxy.base_url" in command
+    assert "OPENAI_BASE_URL" in command
+    assert 'model_reasoning_effort="xhigh"' in command
+    assert "--dangerously-bypass-approvals-and-sandbox" in command
+    assert "exec --ignore-user-config --ignore-rules --skip-git-repo-check" in command
+    assert "CODEX_AGENT_WORKDIR=/workspace/src" in command
+    assert "CODEX_PROMPT=-" in command
+    assert "< /codex/prompt.md" in command
+    assert "--enable goals" not in command
+
+
+def test_codex_goal_run_command_uses_goal_prompt():
+    command = build_codex_run_command(goal_mode=True, agent_workdir="/workspace/src")
+
+    assert "--enable goals" in command
+    assert "/goal Read /codex/goal.md and complete the task." in command
+    assert "< /codex/prompt.md" not in command
+
+
+def test_codex_harness_wires_files_and_prompt():
+    harness = codex_harness(
+        system_prompt="Use shell commands.",
+        goal_mode=True,
+        agent_workdir="/workspace/src",
+        timeout_seconds=600,
+    )
+
+    assert isinstance(harness, Harness)
+    assert harness.system_prompt == "Use shell commands."
+    assert harness.instruction_path == "/codex/instruction.md"
+    assert harness.system_prompt_path == "/codex/system.md"
+    assert harness.log_path == "/logs/agent/codex.log"
+    assert "/goal Read /codex/goal.md" in harness.run_command
+    assert "rust-v0.132.0" in harness.install_script

--- a/tests/test_interception_utils.py
+++ b/tests/test_interception_utils.py
@@ -309,3 +309,52 @@ async def test_non_streaming_response_future_failure_surfaces_to_state(monkeypat
     assert "Intercepted request failed" in msg
     assert "RuntimeError" in msg
     assert "vLLM raised" in msg
+
+
+async def test_synthesize_stream_emits_openai_responses_events():
+    chunk_queue: asyncio.Queue = asyncio.Queue()
+    response_future: asyncio.Future = asyncio.Future()
+    intercept = {
+        "protocol": "openai_responses",
+        "chunk_queue": chunk_queue,
+        "response_future": response_future,
+    }
+    response = Response(
+        id="resp_1",
+        created=123,
+        model="m",
+        usage=Usage(
+            prompt_tokens=1,
+            reasoning_tokens=0,
+            completion_tokens=1,
+            total_tokens=2,
+        ),
+        message=ResponseMessage(
+            content=None,
+            finish_reason="tool_calls",
+            is_truncated=False,
+            tool_calls=[ToolCall(id="call_1", name="search", arguments='{"q":"x"}')],
+        ),
+    )
+
+    await interception_utils.synthesize_stream(intercept, response)
+
+    events = []
+    while True:
+        event = await chunk_queue.get()
+        if event is None:
+            break
+        events.append(event)
+
+    assert [event["type"] for event in events] == [
+        "response.output_item.added",
+        "response.function_call_arguments.delta",
+        "response.function_call_arguments.done",
+        "response.output_item.done",
+        "response.completed",
+    ]
+    assert events[0]["item"]["type"] == "function_call"
+    assert events[2]["arguments"] == '{"q":"x"}'
+    assert events[-1]["response"]["object"] == "response"
+    assert response_future.done()
+    assert response_future.result() is response

--- a/verifiers/envs/experimental/cli_agent_env.py
+++ b/verifiers/envs/experimental/cli_agent_env.py
@@ -73,13 +73,12 @@ def _response_input_content_to_text(content: Any) -> str:
             if isinstance(part, str):
                 parts.append(part)
             elif isinstance(part, dict):
-                text = (
-                    part.get("text")
-                    or part.get("output_text")
-                    or part.get("input_text")
-                )
-                if isinstance(text, str):
-                    parts.append(text)
+                for key in ("text", "output_text", "input_text"):
+                    text = part.get(key)
+                    if text is not None:
+                        if isinstance(text, str):
+                            parts.append(text)
+                        break
         return "\n".join(parts)
     return json.dumps(content, sort_keys=True)
 

--- a/verifiers/envs/experimental/cli_agent_env.py
+++ b/verifiers/envs/experimental/cli_agent_env.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import logging
 import os
 import time
@@ -59,6 +60,81 @@ def make_agent_error(state: State, message: str) -> AgentError:
     if instance_id:
         context_parts.append(f"instance_id={instance_id}")
     return AgentError(f"{message} ({', '.join(context_parts)})")
+
+
+def _response_input_content_to_text(content: Any) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for part in content:
+            if isinstance(part, str):
+                parts.append(part)
+            elif isinstance(part, dict):
+                text = (
+                    part.get("text")
+                    or part.get("output_text")
+                    or part.get("input_text")
+                )
+                if isinstance(text, str):
+                    parts.append(text)
+        return "\n".join(parts)
+    return json.dumps(content, sort_keys=True)
+
+
+def openai_responses_input_to_messages(value: Any) -> list[dict[str, Any]]:
+    """Normalize OpenAI Responses input items into chat-style messages."""
+    if isinstance(value, str):
+        return [{"role": "user", "content": value}]
+    if not isinstance(value, list):
+        return []
+
+    messages: list[dict[str, Any]] = []
+    for item in value:
+        if isinstance(item, str):
+            messages.append({"role": "user", "content": item})
+            continue
+        if not isinstance(item, dict):
+            continue
+        item_type = item.get("type")
+        role = item.get("role")
+        if role == "developer":
+            role = "system"
+        if item_type == "function_call":
+            messages.append(
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": item.get("call_id") or item.get("id") or "",
+                            "type": "function",
+                            "function": {
+                                "name": item.get("name") or "",
+                                "arguments": item.get("arguments") or "{}",
+                            },
+                        }
+                    ],
+                }
+            )
+        elif item_type == "function_call_output":
+            messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": item.get("call_id") or item.get("id") or "",
+                    "content": _response_input_content_to_text(item.get("output")),
+                }
+            )
+        elif item_type == "message" or role:
+            messages.append(
+                {
+                    "role": role or "user",
+                    "content": _response_input_content_to_text(item.get("content")),
+                }
+            )
+    return messages
 
 
 class CliAgentMonitorRubric(vf.Rubric):
@@ -540,6 +616,10 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
 
         state["current_request_id"] = request_id
         intercept = interception_server.intercepts[request_id]
+        if intercept.get("protocol") == "openai_responses":
+            return await self.normalize_intercepted_messages(
+                openai_responses_input_to_messages(intercept.get("input"))
+            )
         return await self.normalize_intercepted_messages(intercept["messages"])
 
     async def get_model_response(

--- a/verifiers/envs/experimental/composable/harnesses/__init__.py
+++ b/verifiers/envs/experimental/composable/harnesses/__init__.py
@@ -24,6 +24,12 @@ from verifiers.envs.experimental.composable.harnesses.mini_swe_agent import (
     build_mini_swe_agent_run_command,
     mini_swe_agent_harness,
 )
+from verifiers.envs.experimental.composable.harnesses.codex import (
+    DEFAULT_CODEX_VERSION,
+    build_codex_install_script,
+    build_codex_run_command,
+    codex_harness,
+)
 
 __all__ = [
     "rlm_harness",
@@ -46,4 +52,8 @@ __all__ = [
     "build_mini_swe_agent_run_command",
     "MINI_SWE_AGENT_INSTALL_SCRIPT",
     "MINI_SWE_AGENT_CONFIG",
+    "codex_harness",
+    "build_codex_install_script",
+    "build_codex_run_command",
+    "DEFAULT_CODEX_VERSION",
 ]

--- a/verifiers/envs/experimental/composable/harnesses/codex.py
+++ b/verifiers/envs/experimental/composable/harnesses/codex.py
@@ -1,0 +1,167 @@
+"""Codex CLI harness configuration."""
+
+from pathlib import PurePosixPath
+import json
+import shlex
+
+from verifiers.envs.experimental.composable import Harness
+
+DEFAULT_CODEX_VERSION = "0.132.0"
+DEFAULT_CODEX_RELEASE_TAG = f"rust-v{DEFAULT_CODEX_VERSION}"
+DEFAULT_CODEX_INSTALL_DIR = "/opt/codex"
+DEFAULT_CODEX_BIN = f"{DEFAULT_CODEX_INSTALL_DIR}/codex"
+DEFAULT_INSTRUCTION_PATH = "/codex/instruction.md"
+DEFAULT_SYSTEM_PROMPT_PATH = "/codex/system.md"
+DEFAULT_LOG_PATH = "/logs/agent/codex.log"
+DEFAULT_GOAL_PATH = "/codex/goal.md"
+DEFAULT_AGENT_WORKDIR = "${AGENT_WORKDIR:-/app}"
+DEFAULT_TIMEOUT_SECONDS = 3600
+
+
+def build_codex_install_script(
+    codex_version: str = DEFAULT_CODEX_VERSION,
+    install_dir: str = DEFAULT_CODEX_INSTALL_DIR,
+    codex_bin: str = DEFAULT_CODEX_BIN,
+) -> str:
+    """Build the shell script that installs the Codex CLI."""
+    release_tag = f"rust-v{codex_version}"
+    return f"""\
+set -eu
+mkdir -p {shlex.quote(install_dir)} /logs/agent /codex
+case "$(uname -m)" in
+  x86_64|amd64) CODEX_TARGET=x86_64-unknown-linux-musl ;;
+  aarch64|arm64) CODEX_TARGET=aarch64-unknown-linux-musl ;;
+  *) echo "Unsupported architecture: $(uname -m)"; exit 1 ;;
+esac
+CODEX_URL="https://github.com/openai/codex/releases/download/{release_tag}/codex-$CODEX_TARGET.tar.gz"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+python3 - "$CODEX_URL" "$tmpdir/codex.tar.gz" <<'PY'
+import sys, time, urllib.request
+
+url, dest = sys.argv[1], sys.argv[2]
+delay = 1.0
+for attempt in range(1, 6):
+    try:
+        urllib.request.urlretrieve(url, dest)
+        break
+    except Exception:
+        if attempt == 5:
+            raise
+        time.sleep(delay)
+        delay = min(delay * 2, 8.0)
+PY
+tar -xzf "$tmpdir/codex.tar.gz" -C "$tmpdir"
+install -m 755 "$tmpdir"/codex-* {shlex.quote(codex_bin)}
+ln -sf {shlex.quote(codex_bin)} /usr/local/bin/codex
+codex --version
+"""
+
+
+def build_codex_run_command(
+    *,
+    goal_mode: bool = False,
+    agent_workdir: str = DEFAULT_AGENT_WORKDIR,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+    codex_bin: str = DEFAULT_CODEX_BIN,
+    instruction_path: str = DEFAULT_INSTRUCTION_PATH,
+    system_prompt_path: str = DEFAULT_SYSTEM_PROMPT_PATH,
+    log_path: str = DEFAULT_LOG_PATH,
+    goal_path: str = DEFAULT_GOAL_PATH,
+    model_reasoning_effort: str | None = None,
+    extra_args: list[str] | None = None,
+) -> str:
+    """Build the shell command that runs Codex against intercepted model traffic."""
+    log_dir = str(PurePosixPath(log_path).parent)
+    if agent_workdir == DEFAULT_AGENT_WORKDIR:
+        workdir_assignment = f"CODEX_AGENT_WORKDIR={DEFAULT_AGENT_WORKDIR}"
+    else:
+        workdir_assignment = f"CODEX_AGENT_WORKDIR={shlex.quote(agent_workdir)}"
+
+    if goal_mode:
+        prompt_setup = (
+            f"cat {shlex.quote(system_prompt_path)} {shlex.quote(instruction_path)} > "
+            f"{shlex.quote(goal_path)}\n"
+            f"CODEX_PROMPT='/goal Read {goal_path} and complete the task.'"
+        )
+        prompt_redirect = ""
+        goals_arg = "  --enable goals \\\n"
+    else:
+        prompt_path = "/codex/prompt.md"
+        prompt_setup = (
+            f"cat {shlex.quote(system_prompt_path)} {shlex.quote(instruction_path)} > "
+            f"{prompt_path}\nCODEX_PROMPT=-"
+        )
+        prompt_redirect = f" < {prompt_path}"
+        goals_arg = ""
+
+    reasoning_config = ""
+    if model_reasoning_effort:
+        config_value = f"model_reasoning_effort={json.dumps(model_reasoning_effort)}"
+        reasoning_config = f"  -c {shlex.quote(config_value)} \\\n"
+
+    extra = ""
+    if extra_args:
+        extra = "".join(f"  {shlex.quote(arg)} \\\n" for arg in extra_args)
+
+    script = f"""\
+set -euo pipefail
+export HOME="${{HOME:-/root}}"
+export CODEX_HOME="${{CODEX_HOME:-$HOME/.codex}}"
+export OPENAI_API_KEY="${{OPENAI_API_KEY:-intercepted}}"
+export CODEX_UNSAFE_ALLOW_NO_SANDBOX=1
+{workdir_assignment}
+mkdir -p "$CODEX_HOME" /codex {shlex.quote(log_dir)} "$CODEX_AGENT_WORKDIR"
+{prompt_setup}
+cd "$CODEX_AGENT_WORKDIR"
+timeout --kill-after=30s {int(timeout_seconds)}s {shlex.quote(codex_bin)} \\
+{goals_arg}\
+  --dangerously-bypass-approvals-and-sandbox \\
+  -c 'web_search="disabled"' \\
+  -c 'tools.web_search=false' \\
+  -c 'model_provider="vf_proxy"' \\
+  -c 'model_providers.vf_proxy.name="Verifiers Proxy"' \\
+  -c "model_providers.vf_proxy.base_url=\\"$OPENAI_BASE_URL\\"" \\
+  -c 'model_providers.vf_proxy.env_key="OPENAI_API_KEY"' \\
+{reasoning_config}\
+{extra}\
+  --model model \\
+  exec --ignore-user-config --ignore-rules --skip-git-repo-check --ephemeral --cd "$CODEX_AGENT_WORKDIR" "$CODEX_PROMPT"{prompt_redirect} \\
+  2>&1 | tee -a {shlex.quote(log_path)}
+"""
+    return f"bash -lc {shlex.quote(script)}"
+
+
+def codex_harness(
+    system_prompt: str | None = None,
+    goal_mode: bool = False,
+    agent_workdir: str = DEFAULT_AGENT_WORKDIR,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+    model_reasoning_effort: str | None = None,
+    instruction_path: str = DEFAULT_INSTRUCTION_PATH,
+    system_prompt_path: str = DEFAULT_SYSTEM_PROMPT_PATH,
+    log_path: str = DEFAULT_LOG_PATH,
+    goal_path: str = DEFAULT_GOAL_PATH,
+    codex_version: str = DEFAULT_CODEX_VERSION,
+    extra_args: list[str] | None = None,
+) -> Harness:
+    """Create a Harness configured for the Codex CLI."""
+    return Harness(
+        install_script=build_codex_install_script(codex_version=codex_version),
+        install_timeout=300,
+        run_command=build_codex_run_command(
+            goal_mode=goal_mode,
+            agent_workdir=agent_workdir,
+            timeout_seconds=timeout_seconds,
+            instruction_path=instruction_path,
+            system_prompt_path=system_prompt_path,
+            log_path=log_path,
+            goal_path=goal_path,
+            model_reasoning_effort=model_reasoning_effort,
+            extra_args=extra_args,
+        ),
+        system_prompt=system_prompt,
+        instruction_path=instruction_path,
+        system_prompt_path=system_prompt_path,
+        log_path=log_path,
+    )

--- a/verifiers/envs/experimental/composable/harnesses/codex.py
+++ b/verifiers/envs/experimental/composable/harnesses/codex.py
@@ -68,6 +68,7 @@ def build_codex_run_command(
     system_prompt_path: str = DEFAULT_SYSTEM_PROMPT_PATH,
     log_path: str = DEFAULT_LOG_PATH,
     goal_path: str = DEFAULT_GOAL_PATH,
+    goal_prompt: str | None = None,
     model_reasoning_effort: str | None = None,
     extra_args: list[str] | None = None,
 ) -> str:
@@ -79,10 +80,11 @@ def build_codex_run_command(
         workdir_assignment = f"CODEX_AGENT_WORKDIR={shlex.quote(agent_workdir)}"
 
     if goal_mode:
+        prompt = goal_prompt or f"/goal Read {goal_path} and complete the task."
         prompt_setup = (
             f"cat {shlex.quote(system_prompt_path)} {shlex.quote(instruction_path)} > "
             f"{shlex.quote(goal_path)}\n"
-            f"CODEX_PROMPT='/goal Read {goal_path} and complete the task.'"
+            f"CODEX_PROMPT={shlex.quote(prompt)}"
         )
         prompt_redirect = ""
         goals_arg = "  --enable goals \\\n"
@@ -142,6 +144,7 @@ def codex_harness(
     system_prompt_path: str = DEFAULT_SYSTEM_PROMPT_PATH,
     log_path: str = DEFAULT_LOG_PATH,
     goal_path: str = DEFAULT_GOAL_PATH,
+    goal_prompt: str | None = None,
     codex_version: str = DEFAULT_CODEX_VERSION,
     extra_args: list[str] | None = None,
 ) -> Harness:
@@ -157,6 +160,7 @@ def codex_harness(
             system_prompt_path=system_prompt_path,
             log_path=log_path,
             goal_path=goal_path,
+            goal_prompt=goal_prompt,
             model_reasoning_effort=model_reasoning_effort,
             extra_args=extra_args,
         ),

--- a/verifiers/utils/interception_utils.py
+++ b/verifiers/utils/interception_utils.py
@@ -587,6 +587,14 @@ async def synthesize_stream(
     if chunk_queue is None:
         raise RuntimeError("Missing chunk_queue for streaming interception")
 
+    if intercept.get("protocol") == "openai_responses":
+        for event in _openai_responses_stream_events(response):
+            await chunk_queue.put(event)
+        await chunk_queue.put(None)
+        if future and not future.done():
+            future.set_result(response)
+        return
+
     message = response.message
 
     # Chunk 1: content + tool_calls in delta
@@ -927,6 +935,93 @@ def serialize_openai_responses_response(response: Response) -> dict[str, Any]:
         "tools": [],
         "usage": usage,
     }
+
+
+def _openai_responses_stream_events(response: Response) -> list[dict[str, Any]]:
+    payload = serialize_openai_responses_response(response)
+    events: list[dict[str, Any]] = []
+    sequence_number = 1
+
+    def append(event: dict[str, Any]) -> None:
+        nonlocal sequence_number
+        event.setdefault("response_id", payload["id"])
+        event["sequence_number"] = sequence_number
+        sequence_number += 1
+        events.append(event)
+
+    for output_index, item in enumerate(payload.get("output") or []):
+        item_id = item.get("id")
+        if item.get("type") == "function_call":
+            pending_item = {**item, "status": "in_progress", "arguments": ""}
+            append(
+                {
+                    "type": "response.output_item.added",
+                    "output_index": output_index,
+                    "item": pending_item,
+                }
+            )
+            arguments = item.get("arguments") or ""
+            if arguments:
+                append(
+                    {
+                        "type": "response.function_call_arguments.delta",
+                        "item_id": item_id,
+                        "output_index": output_index,
+                        "delta": arguments,
+                    }
+                )
+            append(
+                {
+                    "type": "response.function_call_arguments.done",
+                    "item_id": item_id,
+                    "call_id": item.get("call_id"),
+                    "name": item.get("name"),
+                    "output_index": output_index,
+                    "arguments": arguments,
+                }
+            )
+        else:
+            pending_item = {**item, "status": "in_progress", "content": []}
+            append(
+                {
+                    "type": "response.output_item.added",
+                    "output_index": output_index,
+                    "item": pending_item,
+                }
+            )
+            for content_index, content in enumerate(item.get("content") or []):
+                if content.get("type") != "output_text":
+                    continue
+                text = content.get("text") or ""
+                if text:
+                    append(
+                        {
+                            "type": "response.output_text.delta",
+                            "item_id": item_id,
+                            "output_index": output_index,
+                            "content_index": content_index,
+                            "delta": text,
+                        }
+                    )
+                append(
+                    {
+                        "type": "response.output_text.done",
+                        "item_id": item_id,
+                        "output_index": output_index,
+                        "content_index": content_index,
+                        "text": text,
+                    }
+                )
+        append(
+            {
+                "type": "response.output_item.done",
+                "output_index": output_index,
+                "item": item,
+            }
+        )
+
+    append({"type": "response.completed", "response": payload})
+    return events
 
 
 def _log_request(rollout_id: str, body: dict) -> None:


### PR DESCRIPTION
## Summary
- Add a reusable composable Codex CLI harness with regular and `/goal` prompt modes.
- Export Codex harness builders from `verifiers.envs.experimental.composable.harnesses`.
- Teach CLI-agent interception to normalize OpenAI Responses input and synthesize Responses-style streaming events, which Codex needs when using the Responses endpoint.

## Validation
- `uv run ruff check verifiers/envs/experimental/cli_agent_env.py verifiers/envs/experimental/composable/harnesses/codex.py verifiers/envs/experimental/composable/harnesses/__init__.py verifiers/utils/interception_utils.py tests/test_codex_composable_harness.py tests/test_interception_utils.py tests/test_cli_agent_env.py`
- `uv run ruff format --check verifiers/envs/experimental/cli_agent_env.py verifiers/envs/experimental/composable/harnesses/codex.py verifiers/envs/experimental/composable/harnesses/__init__.py verifiers/utils/interception_utils.py tests/test_codex_composable_harness.py tests/test_interception_utils.py tests/test_cli_agent_env.py`
- `uv run pytest tests/test_codex_composable_harness.py tests/test_interception_utils.py tests/test_cli_agent_env.py -q`
- `uv run pre-commit run --files verifiers/envs/experimental/cli_agent_env.py verifiers/envs/experimental/composable/harnesses/codex.py verifiers/envs/experimental/composable/harnesses/__init__.py verifiers/utils/interception_utils.py tests/test_codex_composable_harness.py tests/test_interception_utils.py tests/test_cli_agent_env.py`