### PR TITLE
Prepare v0.1.15.dev10 release

### DIFF
--- a/assets/release/RELEASE_v0.1.15.dev10.md
+++ b/assets/release/RELEASE_v0.1.15.dev10.md
@@ -1,0 +1,32 @@
+# Verifiers v0.1.15.dev10 Release Notes
+
+*Date:* 05/25/2026
+
+## Highlights since v0.1.15.dev9
+
+- **v1 environment authoring has clearer component loading.** `prime env init` is back to a v0 stub by default, `--v1` emits the thin Taskset/Harness loader templates, and public `vf.load_taskset` / `vf.load_harness` helpers now handle annotation-driven config coercion.
+- **Serve and eval routing paths are smoother under load.** Env worker/server CPU-heavy work moves off the event loop with scaled executors and uvloop support, `EnvServer` now installs the scaled executor correctly, renderer requests preserve state-derived headers, and eval sticky routing defaults to per-trajectory sessions.
+- **Harness and client behavior got targeted fixes.** RLM skills upload to the path the harness reads, generated MCP setup scripts are POSIX `sh` compatible, Anthropic mixed text/image conversion preserves unsupported image markers, and duplicate/single-use helper code was simplified.
+
+## Changes included in v0.1.15.dev10 (since v0.1.15.dev9)
+
+### v1 loaders and harnesses
+
+- [codex] Revise v1 init taskset loaders (#1449)
+- Fix RLM skills upload path (#1451)
+- Make harness setup scripts POSIX sh compatible (#1457)
+
+### Serve, eval, and renderer runtime
+
+- perf(serve): reduce worker/router event-loop lag (#1453)
+- Fix EnvServer executor installation (#1455)
+- Use renderers offload helper in renderer client (#1452)
+- [codex] Forward renderer request headers (#1459)
+- [codex] Default eval session header to trajectory_id (#1460)
+
+### Client behavior and cleanup
+
+- Inline single-use verifier helpers (#1443)
+- Fix Anthropic unsupported image markers (#1461)
+
+**Full Changelog**: https://github.com/PrimeIntellect-ai/verifiers/compare/v0.1.15.dev9...v0.1.15.dev10

--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.15.dev9"
+__version__ = "0.1.15.dev10"
 
 import importlib
 import os


### PR DESCRIPTION
## Summary
- Bump `verifiers` to `0.1.15.dev10`.
- Add release notes for changes since `v0.1.15.dev9`.

## Validation
- `uv run ruff format`
- `uv run ruff check --fix`
- `uv run pre-commit run --files verifiers/__init__.py assets/release/RELEASE_v0.1.15.dev10.md`
- `env PYTHONDONTWRITEBYTECODE=1 uv run python3 -c "import verifiers; print(verifiers.__version__)"`
- `uv build --out-dir /private/tmp/verifiers-dist-0.1.15.dev10`
- `git diff --check`
- `env UV_FROZEN=1 git push -u origin codex/v0.1.15-dev10-release` (pre-push hooks: ruff check, ruff format, Semgrep v1 policy, generated AGENTS/CLAUDE check, ty ci parity)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates the version constant and release documentation; no application logic changes in the diff.
> 
> **Overview**
> Prepares the **v0.1.15.dev10** release by bumping `verifiers.__version__` from `0.1.15.dev9` to **`0.1.15.dev10`** and adding **`assets/release/RELEASE_v0.1.15.dev10.md`**.
> 
> The new release notes summarize work already merged since dev9 (v1 init/loaders, serve/eval/renderer performance and routing, harness and client fixes) with links to the compare range **v0.1.15.dev9…v0.1.15.dev10**—this PR does not change runtime code beyond the version string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f665e7737a43e07749754556b57699846d7a1e24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump version to v0.1.15.dev10
> Updates `__version__` in [verifiers/__init__.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1465/files#diff-3667172df996e6596aa8d26557b92b4cb78ee7d2280a3cae14623ce4677e781e) from `0.1.15.dev9` to `0.1.15.dev10` and adds release notes in [RELEASE_v0.1.15.dev10.md](https://github.com/PrimeIntellect-ai/verifiers/pull/1465/files#diff-53557df702b3bb8144843365c90eb03c1541ba099970e0148f59b9d82772489f).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f665e77.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->