### PR TITLE
Pipe chat_template_kwargs into typed RendererConfig

### DIFF
--- a/tests/test_renderer_client.py
+++ b/tests/test_renderer_client.py
@@ -1,3 +1,4 @@
+import asyncio
 from functools import lru_cache
 from unittest.mock import patch
 
@@ -79,6 +80,87 @@ def test_renderer_client_uses_renderer_model_name_override():
         cfg,
         size=1,
     )
+
+
+def test_renderer_client_merges_chat_template_kwargs_into_renderer_config():
+    """``sampling_args.extra_body.chat_template_kwargs`` flow into the typed
+    RendererConfig (the renderer pool is built with the merged config) and
+    are stripped from the params forwarded to /generate."""
+    from renderers import Qwen3RendererConfig
+
+    RendererClient._shared_pools.clear()
+
+    base_cfg = Qwen3RendererConfig(enable_thinking=True)
+    client = object.__new__(RendererClient)
+    client._renderer = None
+    client._pool_size = 1
+    client._config = vf.ClientConfig(client_type="renderer", renderer_config=base_cfg)
+    client._client = object()  # type: ignore[attr-defined]
+
+    sentinel_pool = RendererPool.__new__(RendererPool)
+    captured: dict = {}
+
+    async def _fake_generate(**kwargs):
+        captured.update(kwargs)
+        return {"content": "ok"}
+
+    with (
+        patch(
+            "verifiers.clients.renderer_client.create_renderer_pool",
+            return_value=sentinel_pool,
+        ) as create_pool_mock,
+        patch("verifiers.clients.renderer_client.generate", side_effect=_fake_generate),
+    ):
+        asyncio.run(
+            client.get_native_response(
+                prompt=[{"role": "user", "content": "hi"}],
+                model="Qwen/Qwen3-8B",
+                sampling_args={
+                    "extra_body": {
+                        "chat_template_kwargs": {"enable_thinking": False},
+                        "top_k": 20,
+                    }
+                },
+                tools=None,
+            )
+        )
+
+    create_pool_mock.assert_called_once_with(
+        "Qwen/Qwen3-8B",
+        Qwen3RendererConfig(enable_thinking=False),
+        size=1,
+    )
+    assert captured["sampling_params"] == {"top_k": 20}
+
+
+def test_renderer_client_rejects_invalid_chat_template_kwargs():
+    """Unknown / mistyped chat_template_kwargs surface as a clear ValueError
+    via pydantic's ``extra="forbid"`` on the typed RendererConfig."""
+    from renderers import Qwen3RendererConfig
+
+    RendererClient._shared_pools.clear()
+
+    client = object.__new__(RendererClient)
+    client._renderer = None
+    client._pool_size = 1
+    client._config = vf.ClientConfig(
+        client_type="renderer", renderer_config=Qwen3RendererConfig()
+    )
+    client._client = object()  # type: ignore[attr-defined]
+
+    with pytest.raises(ValueError, match="Qwen3RendererConfig"):
+        asyncio.run(
+            client.get_native_response(
+                prompt=[{"role": "user", "content": "hi"}],
+                model="Qwen/Qwen3-8B",
+                sampling_args={
+                    "extra_body": {
+                        "chat_template_kwargs": {"enable_thinkng": False},  # typo
+                    }
+                },
+                tools=None,
+            )
+        )
 
 
 # Provenance: Eli's review on PR #1068, comment 3150580768.

--- a/tests/test_renderer_client.py
+++ b/tests/test_renderer_client.py
@@ -82,108 +82,32 @@ def test_renderer_client_uses_renderer_model_name_override():
     )
 
 
-def test_renderer_client_merges_chat_template_kwargs_into_renderer_config():
-    """``sampling_args.extra_body.chat_template_kwargs`` flow into the typed
-    RendererConfig (the renderer pool is built with the merged config) and
-    are stripped from the params forwarded to /generate."""
-    from renderers import Qwen3RendererConfig
-
-    RendererClient._shared_pools.clear()
-
-    base_cfg = Qwen3RendererConfig(enable_thinking=True)
-    client = object.__new__(RendererClient)
-    client._renderer = None
-    client._pool_size = 1
-    client._config = vf.ClientConfig(client_type="renderer", renderer_config=base_cfg)
-    client._client = object()  # type: ignore[attr-defined]
-
-    sentinel_pool = RendererPool.__new__(RendererPool)
-    captured: dict = {}
-
-    async def _fake_generate(**kwargs):
-        captured.update(kwargs)
-        return {"content": "ok"}
-
-    with (
-        patch(
-            "verifiers.clients.renderer_client.create_renderer_pool",
-            return_value=sentinel_pool,
-        ) as create_pool_mock,
-        patch("verifiers.clients.renderer_client.generate", side_effect=_fake_generate),
-    ):
-        asyncio.run(
-            client.get_native_response(
-                prompt=[{"role": "user", "content": "hi"}],
-                model="Qwen/Qwen3-8B",
-                sampling_args={
-                    "extra_body": {
-                        "chat_template_kwargs": {"enable_thinking": False},
-                        "top_k": 20,
-                    }
-                },
-                tools=None,
-            )
-        )
-
-    create_pool_mock.assert_called_once_with(
-        "Qwen/Qwen3-8B",
-        Qwen3RendererConfig(enable_thinking=False),
-        size=1,
-    )
-    assert captured["sampling_params"] == {"top_k": 20}
-
-
-def test_renderer_client_rejects_invalid_chat_template_kwargs():
-    """Unknown / mistyped chat_template_kwargs surface as a clear ValueError
-    via pydantic's ``extra="forbid"`` on the typed RendererConfig."""
-    from renderers import Qwen3RendererConfig
-
-    RendererClient._shared_pools.clear()
-
-    client = object.__new__(RendererClient)
-    client._renderer = None
-    client._pool_size = 1
-    client._config = vf.ClientConfig(
-        client_type="renderer", renderer_config=Qwen3RendererConfig()
-    )
-    client._client = object()  # type: ignore[attr-defined]
-
-    with pytest.raises(ValueError, match="Qwen3RendererConfig"):
-        asyncio.run(
-            client.get_native_response(
-                prompt=[{"role": "user", "content": "hi"}],
-                model="Qwen/Qwen3-8B",
-                sampling_args={
-                    "extra_body": {
-                        "chat_template_kwargs": {"enable_thinkng": False},  # typo
-                    }
-                },
-                tools=None,
-            )
-        )
-
-
-def test_renderer_client_auto_resolves_for_chat_template_kwargs():
-    """With no explicit ``renderer_config`` (or ``AutoRendererConfig`` —
-    the prime-rl default), chat_template_kwargs still flow through:
-    ``MODEL_RENDERER_MAP`` is consulted up front so kwargs validate against
-    the concrete renderer's schema (``Qwen3RendererConfig`` here)."""
+def test_renderer_client_threads_chat_template_kwargs_into_pool():
+    """``sampling_args.extra_body.chat_template_kwargs`` land on the
+    concrete RendererConfig (resolving Auto/None against
+    ``MODEL_RENDERER_MAP`` when needed) and are stripped from the params
+    forwarded to /generate. Covers explicit / Auto / None bases."""
     from renderers import AutoRendererConfig, Qwen3RendererConfig
 
-    for base in (None, AutoRendererConfig(preserve_all_thinking=True)):
+    bases = [
+        Qwen3RendererConfig(enable_thinking=True),
+        AutoRendererConfig(preserve_all_thinking=True),
+        None,
+    ]
+    for base in bases:
         RendererClient._shared_pools.clear()
 
         client = object.__new__(RendererClient)
         client._renderer = None
         client._pool_size = 1
-        client._config = vf.ClientConfig(
-            client_type="renderer", renderer_config=base
-        )
+        client._config = vf.ClientConfig(client_type="renderer", renderer_config=base)
         client._client = object()  # type: ignore[attr-defined]
 
         sentinel_pool = RendererPool.__new__(RendererPool)
+        captured: dict = {}
 
         async def _fake_generate(**kwargs):
+            captured.update(kwargs)
             return {"content": "ok"}
 
         with (
@@ -202,7 +126,8 @@ def test_renderer_client_auto_resolves_for_chat_template_kwargs():
                     model="Qwen/Qwen3-8B",
                     sampling_args={
                         "extra_body": {
-                            "chat_template_kwargs": {"enable_thinking": False}
+                            "chat_template_kwargs": {"enable_thinking": False},
+                            "top_k": 20,
                         }
                     },
                     tools=None,
@@ -210,7 +135,9 @@ def test_renderer_client_auto_resolves_for_chat_template_kwargs():
             )
 
         expected_preserve_all = (
-            base.preserve_all_thinking if base is not None else False
+            base.preserve_all_thinking
+            if isinstance(base, AutoRendererConfig)
+            else False
         )
         create_pool_mock.assert_called_once_with(
             "Qwen/Qwen3-8B",
@@ -219,6 +146,38 @@ def test_renderer_client_auto_resolves_for_chat_template_kwargs():
                 preserve_all_thinking=expected_preserve_all,
             ),
             size=1,
+        )
+        assert captured["sampling_params"] == {"top_k": 20}
+
+
+def test_renderer_client_rejects_invalid_chat_template_kwargs():
+    """Unknown / mistyped chat_template_kwargs surface as a pydantic
+    ``ValidationError`` (``extra="forbid"`` on the typed RendererConfig)."""
+    from pydantic import ValidationError
+    from renderers import Qwen3RendererConfig
+
+    RendererClient._shared_pools.clear()
+
+    client = object.__new__(RendererClient)
+    client._renderer = None
+    client._pool_size = 1
+    client._config = vf.ClientConfig(
+        client_type="renderer", renderer_config=Qwen3RendererConfig()
+    )
+    client._client = object()  # type: ignore[attr-defined]
+
+    with pytest.raises(ValidationError, match="enable_thinkng"):
+        asyncio.run(
+            client.get_native_response(
+                prompt=[{"role": "user", "content": "hi"}],
+                model="Qwen/Qwen3-8B",
+                sampling_args={
+                    "extra_body": {
+                        "chat_template_kwargs": {"enable_thinkng": False},  # typo
+                    }
+                },
+                tools=None,
+            )
         )
 
 

--- a/tests/test_renderer_client.py
+++ b/tests/test_renderer_client.py
@@ -163,6 +163,65 @@ def test_renderer_client_rejects_invalid_chat_template_kwargs():
         )
 
 
+def test_renderer_client_auto_resolves_for_chat_template_kwargs():
+    """With no explicit ``renderer_config`` (or ``AutoRendererConfig`` —
+    the prime-rl default), chat_template_kwargs still flow through:
+    ``MODEL_RENDERER_MAP`` is consulted up front so kwargs validate against
+    the concrete renderer's schema (``Qwen3RendererConfig`` here)."""
+    from renderers import AutoRendererConfig, Qwen3RendererConfig
+
+    for base in (None, AutoRendererConfig(preserve_all_thinking=True)):
+        RendererClient._shared_pools.clear()
+
+        client = object.__new__(RendererClient)
+        client._renderer = None
+        client._pool_size = 1
+        client._config = vf.ClientConfig(
+            client_type="renderer", renderer_config=base
+        )
+        client._client = object()  # type: ignore[attr-defined]
+
+        sentinel_pool = RendererPool.__new__(RendererPool)
+
+        async def _fake_generate(**kwargs):
+            return {"content": "ok"}
+
+        with (
+            patch(
+                "verifiers.clients.renderer_client.create_renderer_pool",
+                return_value=sentinel_pool,
+            ) as create_pool_mock,
+            patch(
+                "verifiers.clients.renderer_client.generate",
+                side_effect=_fake_generate,
+            ),
+        ):
+            asyncio.run(
+                client.get_native_response(
+                    prompt=[{"role": "user", "content": "hi"}],
+                    model="Qwen/Qwen3-8B",
+                    sampling_args={
+                        "extra_body": {
+                            "chat_template_kwargs": {"enable_thinking": False}
+                        }
+                    },
+                    tools=None,
+                )
+            )
+
+        expected_preserve_all = (
+            base.preserve_all_thinking if base is not None else False
+        )
+        create_pool_mock.assert_called_once_with(
+            "Qwen/Qwen3-8B",
+            Qwen3RendererConfig(
+                enable_thinking=False,
+                preserve_all_thinking=expected_preserve_all,
+            ),
+            size=1,
+        )
+
+
 # Provenance: Eli's review on PR #1068, comment 3150580768.
 #   "RendererClient parses the GPT-OSS assistant tool call into ToolCall(name=...),
 #   but ToolEnv returns ToolMessage with only content/tool_call_id, and

--- a/tests/test_renderer_client.py
+++ b/tests/test_renderer_client.py
@@ -150,6 +150,56 @@ def test_renderer_client_threads_chat_template_kwargs_into_pool():
         assert captured["sampling_params"] == {"top_k": 20}
 
 
+def test_renderer_client_auto_resolves_against_renderer_model_name_override():
+    """When ``ClientConfig.renderer_model_name`` overrides the API request
+    model, auto-resolution looks up the OVERRIDE in ``MODEL_RENDERER_MAP``
+    (it's what loads the tokenizer the renderer holds) — not the request
+    model, which may not be in the map at all."""
+    from renderers import Qwen3RendererConfig
+
+    RendererClient._shared_pools.clear()
+
+    client = object.__new__(RendererClient)
+    client._renderer = None
+    client._pool_size = 1
+    client._config = vf.ClientConfig(
+        client_type="renderer",
+        renderer_model_name="Qwen/Qwen3-8B",  # override
+    )
+    client._client = object()  # type: ignore[attr-defined]
+
+    sentinel_pool = RendererPool.__new__(RendererPool)
+
+    async def _fake_generate(**kwargs):
+        return {"content": "ok"}
+
+    with (
+        patch(
+            "verifiers.clients.renderer_client.create_renderer_pool",
+            return_value=sentinel_pool,
+        ) as create_pool_mock,
+        patch("verifiers.clients.renderer_client.generate", side_effect=_fake_generate),
+    ):
+        asyncio.run(
+            client.get_native_response(
+                prompt=[{"role": "user", "content": "hi"}],
+                model="r8-smoke",  # not in MODEL_RENDERER_MAP
+                sampling_args={
+                    "extra_body": {"chat_template_kwargs": {"enable_thinking": False}}
+                },
+                tools=None,
+            )
+        )
+
+    # Resolves against renderer_model_name (Qwen/Qwen3-8B → "qwen3") rather
+    # than the request "r8-smoke" (which would fall through to default).
+    create_pool_mock.assert_called_once_with(
+        "Qwen/Qwen3-8B",
+        Qwen3RendererConfig(enable_thinking=False),
+        size=1,
+    )
+
+
 def test_renderer_client_rejects_invalid_chat_template_kwargs():
     """Unknown / mistyped chat_template_kwargs surface as a pydantic
     ``ValidationError`` (``extra="forbid"`` on the typed RendererConfig)."""

--- a/verifiers/clients/renderer_client.py
+++ b/verifiers/clients/renderer_client.py
@@ -20,6 +20,7 @@ from pydantic import ValidationError
 from renderers import Message as RendererMessage
 from renderers import OverlongPromptError as RendererOverlongPromptError
 from renderers import (
+    AutoRendererConfig,
     MultimodalRenderer,
     ParsedToolCall,
     RenderedTokens,
@@ -28,11 +29,13 @@ from renderers import (
     RendererPool,
     ToolCallParseStatus,
     ToolSpec,
+    config_from_name,
     create_renderer_pool,
     is_multimodal,
 )
 from renderers import ToolCall as RendererToolCall
 from renderers import ToolCallFunction
+from renderers.base import MODEL_RENDERER_MAP
 from renderers.client import _maybe_offload, generate
 
 from verifiers.clients.client import Client
@@ -380,23 +383,43 @@ async def _get_incremental_prompt_ids(
 def _resolve_renderer_config(
     base: RendererConfig | None,
     chat_template_kwargs: Mapping[str, Any] | None,
+    *,
+    model: str,
 ) -> RendererConfig | None:
     """Merge ``chat_template_kwargs`` into a typed ``RendererConfig``.
 
-    Pydantic re-validates the merged dict against the discriminated-union
-    variant: typed configs (``extra="forbid"``) reject unknown keys with a
-    field-path error; ``DefaultRendererConfig`` (``extra="allow"``) accepts
-    arbitrary jinja kwargs. Kwargs override fields with the same name on
-    the base config.
+    When ``base`` is ``None`` or ``AutoRendererConfig`` (would auto-resolve
+    inside ``renderers.create_renderer``), we pull resolution forward via
+    ``MODEL_RENDERER_MAP`` so kwargs land on the concrete config variant
+    and pydantic validates them against the actual renderer's schema —
+    ``AutoRendererConfig`` intentionally carries only ``preserve_*`` and
+    would reject template kwargs like ``enable_thinking``.
+
+    Kwargs override fields with the same name on the (resolved) base.
+    Typed configs (``extra="forbid"``) reject unknown keys with a
+    field-path error; ``DefaultRendererConfig`` (``extra="allow"``) keeps
+    the escape hatch for arbitrary jinja kwargs.
     """
     if not chat_template_kwargs:
         return base
-    if base is None:
-        raise ValueError(
-            "sampling_args.extra_body.chat_template_kwargs require a typed "
-            "renderer_config; set ClientConfig.renderer_config to use them "
-            "on the renderer route."
-        )
+
+    # Resolve auto → concrete (mirrors ``renderers._resolve_auto``) so
+    # ``enable_thinking`` etc. validate against the right schema instead of
+    # ``AutoRendererConfig``'s minimal one.
+    if base is None or isinstance(base, AutoRendererConfig):
+        renderer_name = MODEL_RENDERER_MAP.get(model, "default")
+        resolved = config_from_name(renderer_name)
+        assert resolved is not None  # only "auto" returns None; excluded above
+        if isinstance(base, AutoRendererConfig):
+            resolved = type(resolved).model_validate(
+                {
+                    **resolved.model_dump(),
+                    "preserve_all_thinking": base.preserve_all_thinking,
+                    "preserve_thinking_between_tool_calls": base.preserve_thinking_between_tool_calls,
+                }
+            )
+        base = resolved
+
     merged = {**base.model_dump(), **chat_template_kwargs}
     try:
         return type(base).model_validate(merged)
@@ -530,6 +553,7 @@ class RendererClient(
         effective_cfg = _resolve_renderer_config(
             self._config.renderer_config if self._config is not None else None,
             chat_template_kwargs,
+            model=model,
         )
         renderer = self._get_renderer_or_pool(model, renderer_config=effective_cfg)
 

--- a/verifiers/clients/renderer_client.py
+++ b/verifiers/clients/renderer_client.py
@@ -382,7 +382,7 @@ def _resolve_renderer_config(
     base: RendererConfig | None,
     chat_template_kwargs: Mapping[str, Any] | None,
     *,
-    model: str,
+    renderer_model: str,
 ) -> RendererConfig | None:
     """Merge ``chat_template_kwargs`` into a typed ``RendererConfig``.
 
@@ -391,7 +391,10 @@ def _resolve_renderer_config(
     ``MODEL_RENDERER_MAP`` so kwargs land on the concrete config variant
     and pydantic validates them against the actual renderer's schema —
     ``AutoRendererConfig`` intentionally carries only ``preserve_*`` and
-    would reject template kwargs like ``enable_thinking``.
+    would reject template kwargs like ``enable_thinking``. ``renderer_model``
+    must match what the pool will tokenize with (i.e.
+    ``ClientConfig.renderer_model_name`` when set, else the request model),
+    so resolution agrees with the tokenizer the renderer will hold.
 
     Kwargs override fields with the same name on the (resolved) base.
     Typed configs (``extra="forbid"``) reject unknown keys with a
@@ -405,8 +408,11 @@ def _resolve_renderer_config(
     # ``enable_thinking`` etc. validate against the right schema instead of
     # ``AutoRendererConfig``'s minimal one. Carries ``preserve_*`` across.
     if base is None or isinstance(base, AutoRendererConfig):
-        renderer_name = MODEL_RENDERER_MAP.get(model, "default")
+        renderer_name = MODEL_RENDERER_MAP.get(renderer_model, "default")
+        # ``config_from_name`` returns ``None`` only for ``"auto"``, which
+        # ``MODEL_RENDERER_MAP.get(..., "default")`` excludes — assert for ty.
         concrete = config_from_name(renderer_name)
+        assert concrete is not None
         if isinstance(base, AutoRendererConfig):
             concrete = concrete.model_copy(
                 update={
@@ -414,7 +420,7 @@ def _resolve_renderer_config(
                     "preserve_thinking_between_tool_calls": base.preserve_thinking_between_tool_calls,
                 }
             )
-        base = concrete
+        base = cast(RendererConfig, concrete)
 
     return type(base).model_validate({**base.model_dump(), **chat_template_kwargs})
 
@@ -540,10 +546,18 @@ class RendererClient(
         # typed RendererConfig. Pool cache key already includes the
         # effective config so identical kwargs reuse the same renderer.
         chat_template_kwargs = sampling_params.pop("chat_template_kwargs", None)
+        # Auto-resolution must agree with the model the pool will tokenize
+        # against — ``renderer_model_name`` overrides the request ``model``
+        # when set (same precedence ``_get_renderer_or_pool`` uses below).
+        renderer_model = (
+            self._config.renderer_model_name
+            if self._config is not None and self._config.renderer_model_name is not None
+            else model
+        )
         effective_cfg = _resolve_renderer_config(
             self._config.renderer_config if self._config is not None else None,
             chat_template_kwargs,
-            model=model,
+            renderer_model=renderer_model,
         )
         renderer = self._get_renderer_or_pool(model, renderer_config=effective_cfg)
 

--- a/verifiers/clients/renderer_client.py
+++ b/verifiers/clients/renderer_client.py
@@ -15,6 +15,8 @@ from typing import Any, ClassVar, cast
 
 from openai import AsyncOpenAI
 
+from pydantic import ValidationError
+
 from renderers import Message as RendererMessage
 from renderers import OverlongPromptError as RendererOverlongPromptError
 from renderers import (
@@ -22,6 +24,7 @@ from renderers import (
     ParsedToolCall,
     RenderedTokens,
     Renderer,
+    RendererConfig,
     RendererPool,
     ToolCallParseStatus,
     ToolSpec,
@@ -374,6 +377,35 @@ async def _get_incremental_prompt_ids(
     return None
 
 
+def _resolve_renderer_config(
+    base: RendererConfig | None,
+    chat_template_kwargs: Mapping[str, Any] | None,
+) -> RendererConfig | None:
+    """Merge ``chat_template_kwargs`` into a typed ``RendererConfig``.
+
+    Pydantic re-validates the merged dict against the discriminated-union
+    variant: typed configs (``extra="forbid"``) reject unknown keys with a
+    field-path error; ``DefaultRendererConfig`` (``extra="allow"``) accepts
+    arbitrary jinja kwargs. Kwargs override fields with the same name on
+    the base config.
+    """
+    if not chat_template_kwargs:
+        return base
+    if base is None:
+        raise ValueError(
+            "sampling_args.extra_body.chat_template_kwargs require a typed "
+            "renderer_config; set ClientConfig.renderer_config to use them "
+            "on the renderer route."
+        )
+    merged = {**base.model_dump(), **chat_template_kwargs}
+    try:
+        return type(base).model_validate(merged)
+    except ValidationError as e:
+        raise ValueError(
+            f"chat_template_kwargs are incompatible with {type(base).__name__}: {e}"
+        ) from e
+
+
 class RendererClient(
     Client[AsyncOpenAI, list[RendererMessage], dict[str, Any], ToolSpec]
 ):
@@ -419,13 +451,19 @@ class RendererClient(
 
     # ── Renderer management ─────────────────────────────────────────
 
-    def _get_renderer_or_pool(self, model: str) -> Renderer | RendererPool:
+    def _get_renderer_or_pool(
+        self,
+        model: str,
+        *,
+        renderer_config: RendererConfig | None = None,
+    ) -> Renderer | RendererPool:
         if self._renderer is not None:
             return self._renderer
 
-        renderer_config = (
-            self._config.renderer_config if self._config is not None else None
-        )
+        if renderer_config is None:
+            renderer_config = (
+                self._config.renderer_config if self._config is not None else None
+            )
         renderer_model = (
             self._config.renderer_model_name
             if self._config is not None and self._config.renderer_model_name is not None
@@ -477,14 +515,24 @@ class RendererClient(
         tools: list[ToolSpec] | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
-        renderer = self._get_renderer_or_pool(model)
-
         args = dict(sampling_args)
         extra_headers = {
             **dict(args.pop("extra_headers", None) or {}),
             **dict(kwargs.pop("extra_headers", None) or {}),
         }
         sampling_params: dict[str, Any] = dict(args.pop("extra_body", None) or {})
+
+        # ``chat_template_kwargs`` belong to the renderer, not the engine —
+        # peel them off the per-request sampling and fold them into the
+        # typed RendererConfig. Pool cache key already includes the
+        # effective config so identical kwargs reuse the same renderer.
+        chat_template_kwargs = sampling_params.pop("chat_template_kwargs", None)
+        effective_cfg = _resolve_renderer_config(
+            self._config.renderer_config if self._config is not None else None,
+            chat_template_kwargs,
+        )
+        renderer = self._get_renderer_or_pool(model, renderer_config=effective_cfg)
+
         for key in (
             "temperature",
             "top_p",

--- a/verifiers/clients/renderer_client.py
+++ b/verifiers/clients/renderer_client.py
@@ -15,8 +15,6 @@ from typing import Any, ClassVar, cast
 
 from openai import AsyncOpenAI
 
-from pydantic import ValidationError
-
 from renderers import Message as RendererMessage
 from renderers import OverlongPromptError as RendererOverlongPromptError
 from renderers import (
@@ -405,28 +403,20 @@ def _resolve_renderer_config(
 
     # Resolve auto → concrete (mirrors ``renderers._resolve_auto``) so
     # ``enable_thinking`` etc. validate against the right schema instead of
-    # ``AutoRendererConfig``'s minimal one.
+    # ``AutoRendererConfig``'s minimal one. Carries ``preserve_*`` across.
     if base is None or isinstance(base, AutoRendererConfig):
         renderer_name = MODEL_RENDERER_MAP.get(model, "default")
-        resolved = config_from_name(renderer_name)
-        assert resolved is not None  # only "auto" returns None; excluded above
+        concrete = config_from_name(renderer_name)
         if isinstance(base, AutoRendererConfig):
-            resolved = type(resolved).model_validate(
-                {
-                    **resolved.model_dump(),
+            concrete = concrete.model_copy(
+                update={
                     "preserve_all_thinking": base.preserve_all_thinking,
                     "preserve_thinking_between_tool_calls": base.preserve_thinking_between_tool_calls,
                 }
             )
-        base = resolved
+        base = concrete
 
-    merged = {**base.model_dump(), **chat_template_kwargs}
-    try:
-        return type(base).model_validate(merged)
-    except ValidationError as e:
-        raise ValueError(
-            f"chat_template_kwargs are incompatible with {type(base).__name__}: {e}"
-        ) from e
+    return type(base).model_validate({**base.model_dump(), **chat_template_kwargs})
 
 
 class RendererClient(


### PR DESCRIPTION
## Summary

Pipe `sampling_args.extra_body.chat_template_kwargs` through to the typed `RendererConfig` so users can set `enable_thinking` etc. in sampling and have it land on the right renderer — no `[renderer]` block needed.

- Pop `chat_template_kwargs` from sampling in `RendererClient.get_native_response`.
- Resolve `None` / `AutoRendererConfig` → concrete config via `MODEL_RENDERER_MAP` *before* merging, so kwargs validate against the actual renderer's schema (`Qwen3RendererConfig.enable_thinking`) instead of `AutoRendererConfig`'s intentionally-minimal one. Mirrors `renderers._resolve_auto`'s `preserve_*` carry.
- Validation comes for free: typed configs (`extra="forbid"`) reject unknown keys with a field-path error; `DefaultRendererConfig` (`extra="allow"`) keeps the escape hatch for arbitrary jinja kwargs.
- Kwargs override fields with the same name on the (resolved) base (last-write-wins, matches MITO's per-request override semantics).
- Pool cache already keys on effective `renderer_config_json`, so identical kwargs across requests reuse a single renderer.

Replaces #1447 (pre-typed-config era).

## Effective truth table

| `ClientConfig.renderer_config` | `chat_template_kwargs` | Result |
|---|---|---|
| `Qwen3RendererConfig(...)` (explicit) | `{enable_thinking: False}` | merges → pool built with `enable_thinking=False` |
| `Qwen3RendererConfig(...)` (explicit) | `{enable_thinkng: False}` (typo) | `ValueError(... Qwen3RendererConfig ... extra_forbidden)` |
| `AutoRendererConfig()` (prime-rl default) | `{enable_thinking: False}` | auto-resolves Qwen3 from `MODEL_RENDERER_MAP[model]`, then merges |
| `None` (verifiers eval CLI default) | `{enable_thinking: False}` | same as above |
| any | none | unchanged from main |

## Companion PRs

- prime-rl: nothing required — already passes `renderer` + `sampling_args` through unchanged.
- renderers: nothing required — `MODEL_RENDERER_MAP` + `config_from_name` + `extra="forbid"` / `extra="allow"` cover everything we need.

## Test plan

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest tests/test_renderer_client.py -k "honors_configured_renderer_config or renderer_model_name_override or merges_chat_template_kwargs or rejects_invalid_chat_template or auto_resolves_for_chat_template"` — 5 passed
- `uvx ruff check verifiers/clients/renderer_client.py tests/test_renderer_client.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes per-request renderer pool selection and sampling param forwarding; mis-merged kwargs could affect tokenization across rollouts, though behavior is covered by new unit tests.
> 
> **Overview**
> **`RendererClient`** now treats `sampling_args.extra_body.chat_template_kwargs` as renderer configuration instead of engine sampling: they are removed from params sent to `/generate` and merged into the effective **`RendererConfig`** used when building or selecting a shared renderer pool.
> 
> A new **`_resolve_renderer_config`** path resolves **`None`** / **`AutoRendererConfig`** to the concrete config for the tokenizer model (via **`MODEL_RENDERER_MAP`**, honoring **`ClientConfig.renderer_model_name`** when set), carries **`preserve_*`** fields from auto config, then applies kwargs with pydantic validation (unknown keys fail on strict configs). **`_get_renderer_or_pool`** accepts a per-request resolved config so pool cache keys reflect merged settings.
> 
> Tests cover explicit/auto/`None` bases, **`renderer_model_name`** override during auto-resolution, stripping kwargs from forwarded sampling params, and **`ValidationError`** on typos.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14ab2a7620fa01e4d3365d27ec0c8f8a571c1eba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pipe `chat_template_kwargs` from `extra_body` into a typed `RendererConfig` before generation
> - Extracts `chat_template_kwargs` from `sampling_params.extra_body` in `RendererClient.get_native_response` and removes them before forwarding to `/generate`.
> - Introduces `_resolve_renderer_config` in [renderer_client.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1468/files#diff-4309037b1656944b1991edc5baa1d16760d74155d7adc9fef41a2080ce8605e1) to merge kwargs into a concrete `RendererConfig`, resolving `Auto`/`None` bases via `MODEL_RENDERER_MAP` and `config_from_name`.
> - When `ClientConfig.renderer_model_name` is set, auto-resolution uses that override instead of the request model name.
> - `_get_renderer_or_pool` now accepts an optional `renderer_config` parameter so the resolved config drives pool selection.
> - Risk: unknown `chat_template_kwargs` keys now raise a pydantic `ValidationError` before generation, which is a breaking change for callers passing unrecognized keys.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 14ab2a7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->