### PR TITLE
Add dotted eval config CLI flags

### DIFF
--- a/assets/lab/environments/AGENTS.md
+++ b/assets/lab/environments/AGENTS.md
@@ -983,9 +983,10 @@ unregister_executor("my-env-client")
 self.my_executor.shutdown()
 ```
 
-In practice, you rarely need to call `set_concurrency()` yourself. Both `prime eval run` and `prime-rl` automatically compute the right worker count from the concurrency level. If you wish to override the automatic value during evaluation, you can do so with the `--extra-env-kwargs` flag:
+In practice, you rarely need to call `set_concurrency()` yourself. Both `prime eval run` and `prime-rl` automatically compute the right worker count from the concurrency level. If you wish to override the automatic value during evaluation, you can do so with `--extra-env-kwargs.concurrency` or the legacy JSON `--extra-env-kwargs` flag:
 
 ```bash
+prime eval run my-env --extra-env-kwargs.concurrency 256
 prime eval run my-env -x '{"concurrency": 256}'
 ```
 

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -976,9 +976,10 @@ unregister_executor("my-env-client")
 self.my_executor.shutdown()
 ```
 
-In practice, you rarely need to call `set_concurrency()` yourself. Both `prime eval run` and `prime-rl` automatically compute the right worker count from the concurrency level. If you wish to override the automatic value during evaluation, you can do so with the `--extra-env-kwargs` flag:
+In practice, you rarely need to call `set_concurrency()` yourself. Both `prime eval run` and `prime-rl` automatically compute the right worker count from the concurrency level. If you wish to override the automatic value during evaluation, you can do so with `--extra-env-kwargs.concurrency` or the legacy JSON `--extra-env-kwargs` flag:
 
 ```bash
+prime eval run my-env --extra-env-kwargs.concurrency 256
 prime eval run my-env -x '{"concurrency": 256}'
 ```
 

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -56,9 +56,13 @@ For the full hosted workflow and hosted-only flags such as `--follow`, `--timeou
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
 | `env_id_or_path` | (positional) | — | Environment ID(s) or path to TOML config |
-| `--env-args` | `-a` | `{}` | JSON object passed to `load_environment()` |
-| `--extra-env-kwargs` | `-x` | `{}` | JSON object passed to environment constructor |
-| `--timeout` | — | `None` | Per-rollout wall-clock timeout in seconds. Wins over equivalent values in `--extra-env-kwargs` or TOML `[eval.extra_env_kwargs]`. Bounds generation only — scoring is not bounded. |
+| `--args.<key>` | — | — | Argument passed to `load_environment()` |
+| `--env-args` | `-a` | `{}` | Legacy JSON object passed to `load_environment()` |
+| `--taskset.<key>` | — | — | v1 taskset config passed through `EnvConfig.taskset` |
+| `--harness.<key>` | — | — | v1 harness config passed through `EnvConfig.harness` |
+| `--extra-env-kwargs.<key>` | — | — | Argument passed to the loaded environment via `set_kwargs()` |
+| `--extra-env-kwargs` | `-x` | `{}` | Legacy JSON object passed to the loaded environment via `set_kwargs()` |
+| `--timeout` | — | `None` | Per-rollout wall-clock timeout in seconds. Wins over equivalent values in `--extra-env-kwargs.*`, `--extra-env-kwargs`, or TOML `[eval.extra_env_kwargs]`. Bounds generation only — scoring is not bounded. |
 | `--env-dir-path` | `-p` | `./environments` | Base path for saving output files |
 
 The positional argument accepts two formats:
@@ -67,20 +71,40 @@ The positional argument accepts two formats:
 
 Environment IDs are converted to Python module names (`my-env` → `my_env`) and imported after `prime eval run` resolves the environment package.
 
-For legacy or direct-constructor environments, the `--env-args` flag passes
+For legacy or direct-constructor environments, dotted `--args.*` flags pass
 arguments to your `load_environment()` function:
+
+```bash
+prime eval run my-env --args.difficulty hard --args.num-examples 100
+```
+
+The legacy JSON form remains accepted:
 
 ```bash
 prime eval run my-env -a '{"difficulty": "hard", "num_examples": 100}'
 ```
 
-The `--extra-env-kwargs` flag passes arguments directly to the environment constructor, useful for overriding defaults like `max_turns` which may not be exposed via `load_environment()`:
+For v1 environments, dotted `--taskset.*` and `--harness.*` flags populate the
+same config sections as TOML:
+
+```bash
+prime eval run my-v1-env --taskset.split test --harness.max-turns 4
+```
+
+The `--extra-env-kwargs.*` flags pass arguments to `set_kwargs()` on the loaded
+environment:
+
+```bash
+prime eval run my-env --extra-env-kwargs.max-turns 20
+```
+
+The legacy JSON form remains accepted:
 
 ```bash
 prime eval run my-env -x '{"max_turns": 20}'
 ```
 
-For per-rollout wall-clock timeouts, use the dedicated `--timeout` flag. It **wins over** equivalent values set via `--extra-env-kwargs` or TOML's `[eval.extra_env_kwargs]`:
+For per-rollout wall-clock timeouts, use the dedicated `--timeout` flag. It **wins over** equivalent values set via `--extra-env-kwargs.*`, `--extra-env-kwargs`, or TOML's `[eval.extra_env_kwargs]`:
 
 ```bash
 prime eval run my-env --timeout 600
@@ -98,12 +122,12 @@ timeout = 600
 
 #### Executor autoscaling
 
-Thread-pool executors are automatically sized to match the evaluation concurrency. During `prime eval run`, if `concurrency` is not explicitly provided via `--extra-env-kwargs`, it is computed from the concurrency level (`max_concurrent`, or `num_examples * rollouts_per_example` when unlimited) using `recommended_max_workers()`. This value is passed to `Environment.set_concurrency()`, which resizes both the default event-loop executor and all registered executors.
+Thread-pool executors are automatically sized to match the evaluation concurrency. During `prime eval run`, if `concurrency` is not explicitly provided via `--extra-env-kwargs.concurrency`, it is computed from the concurrency level (`max_concurrent`, or `num_examples * rollouts_per_example` when unlimited) using `recommended_max_workers()`. This value is passed to `Environment.set_concurrency()`, which resizes both the default event-loop executor and all registered executors.
 
 To override the automatic value:
 
 ```bash
-prime eval run my-env -x '{"concurrency": 256}'
+prime eval run my-env --extra-env-kwargs.concurrency 256
 ```
 
 You can also call `set_concurrency()` directly at runtime:
@@ -186,9 +210,16 @@ When using eval TOML configs, you can set `endpoint_id` in `[[eval]]` sections t
 |------|-------|---------|-------------|
 | `--max-tokens` | `-t` | model default | Maximum tokens to generate |
 | `--temperature` | `-T` | model default | Sampling temperature |
-| `--sampling-args` | `-S` | — | JSON object for additional sampling parameters |
+| `--sampling.<key>` | — | — | Additional sampling parameter |
+| `--sampling-args` | `-S` | — | Legacy JSON object for additional sampling parameters |
 
-The `--sampling-args` flag accepts any parameters supported by the model's API:
+The `--sampling.*` flags accept any parameters supported by the model's API:
+
+```bash
+prime eval run my-env --sampling.temperature 0.7 --sampling.top-p 0.9
+```
+
+The legacy JSON form remains accepted:
 
 ```bash
 prime eval run my-env -S '{"temperature": 0.7, "top_p": 0.9}'
@@ -297,7 +328,7 @@ If all rollouts are already complete, the evaluation returns immediately with th
 
 **Configuration compatibility:**
 
-When resuming, the current run configuration should match the original run. Mismatches in parameters like `--model`, `--env-args`, or `--rollouts-per-example` can lead to undefined behavior. For reliable results, resume with the same configuration used to create the checkpoint, only increasing `--num-examples` if you need additional rollouts beyond the original target.
+When resuming, the current run configuration should match the original run. Mismatches in parameters like `--model`, `--args.*` / `--env-args`, or `--rollouts-per-example` can lead to undefined behavior. For reliable results, resume with the same configuration used to create the checkpoint, only increasing `--num-examples` if you need additional rollouts beyond the original target.
 
 **Example workflow:**
 

--- a/environments/AGENTS.md
+++ b/environments/AGENTS.md
@@ -982,9 +982,10 @@ unregister_executor("my-env-client")
 self.my_executor.shutdown()
 ```
 
-In practice, you rarely need to call `set_concurrency()` yourself. Both `prime eval run` and `prime-rl` automatically compute the right worker count from the concurrency level. If you wish to override the automatic value during evaluation, you can do so with the `--extra-env-kwargs` flag:
+In practice, you rarely need to call `set_concurrency()` yourself. Both `prime eval run` and `prime-rl` automatically compute the right worker count from the concurrency level. If you wish to override the automatic value during evaluation, you can do so with `--extra-env-kwargs.concurrency` or the legacy JSON `--extra-env-kwargs` flag:
 
 ```bash
+prime eval run my-env --extra-env-kwargs.concurrency 256
 prime eval run my-env -x '{"concurrency": 256}'
 ```
 

--- a/tests/test_eval_cli.py
+++ b/tests/test_eval_cli.py
@@ -26,6 +26,7 @@ def run_cli(make_metadata, make_state, make_input):
     def _run_cli(
         monkeypatch,
         overrides,
+        config_args: list[str] | None = None,
         capture_all_configs: bool = False,
         endpoints: dict | None = None,
         fail_on_load_endpoints: bool = False,
@@ -78,8 +79,8 @@ def run_cli(make_metadata, make_state, make_input):
 
         monkeypatch.setattr(
             argparse.ArgumentParser,
-            "parse_args",
-            lambda self: args_namespace,
+            "parse_known_args",
+            lambda self: (args_namespace, config_args or []),
         )
         monkeypatch.setattr(vf_eval, "setup_logging", lambda *_, **__: None)
         if fail_on_load_endpoints:
@@ -173,8 +174,48 @@ def test_get_env_eval_defaults_for_single_file_module(tmp_path: Path, monkeypatc
     assert defaults == {"num_examples": 20, "rollouts_per_example": 6}
 
 
-def test_cli_sampling_args_precedence_over_flags(monkeypatch, run_cli):
-    """sampling_args JSON takes precedence over individual flags."""
+def test_cli_sampling_section_precedence_over_flags(monkeypatch, run_cli):
+    """Dotted sampling config takes precedence over individual flags."""
+    captured = run_cli(
+        monkeypatch,
+        {
+            "max_tokens": 42,
+            "temperature": 0.9,
+        },
+        config_args=[
+            "--sampling.enable-thinking",
+            "false",
+            "--sampling.max-tokens",
+            "77",
+            "--sampling.temperature",
+            "0.1",
+        ],
+    )
+
+    sa = captured["sampling_args"]
+    assert sa["max_tokens"] == 77
+    assert sa["temperature"] == 0.1
+    assert sa["enable_thinking"] is False
+
+
+def test_cli_sampling_config_fills_from_flags_when_missing(monkeypatch, run_cli):
+    """Flags fill in missing dotted sampling config values."""
+    captured = run_cli(
+        monkeypatch,
+        {
+            "max_tokens": 55,
+            "temperature": 0.8,
+        },
+        config_args=["--sampling.enable-thinking", "true"],
+    )
+
+    sa = captured["sampling_args"]
+    assert sa["max_tokens"] == 55
+    assert sa["temperature"] == 0.8
+    assert sa["enable_thinking"] is True
+
+
+def test_cli_legacy_sampling_args_json_still_works(monkeypatch, run_cli):
     captured = run_cli(
         monkeypatch,
         {
@@ -192,29 +233,11 @@ def test_cli_sampling_args_precedence_over_flags(monkeypatch, run_cli):
     assert sa["enable_thinking"] is False
 
 
-def test_cli_sampling_args_fill_from_flags_when_missing(monkeypatch, run_cli):
-    """Flags fill in missing sampling_args values."""
-    captured = run_cli(
-        monkeypatch,
-        {
-            "sampling_args": {"enable_thinking": True},
-            "max_tokens": 55,
-            "temperature": 0.8,
-        },
-    )
-
-    sa = captured["sampling_args"]
-    assert sa["max_tokens"] == 55
-    assert sa["temperature"] == 0.8
-    assert sa["enable_thinking"] is True
-
-
 def test_cli_no_sampling_args_uses_flags(monkeypatch, run_cli):
     """When no sampling_args provided, uses flag values."""
     captured = run_cli(
         monkeypatch,
         {
-            "sampling_args": None,
             "max_tokens": 128,
             "temperature": 0.5,
         },
@@ -230,7 +253,6 @@ def test_cli_temperature_not_added_when_none(monkeypatch, run_cli):
     captured = run_cli(
         monkeypatch,
         {
-            "sampling_args": None,
             "max_tokens": 100,
             "temperature": None,
         },
@@ -244,9 +266,13 @@ def test_cli_temperature_not_added_when_none(monkeypatch, run_cli):
 def test_cli_extra_env_kwargs_support_timeout_seconds(monkeypatch, run_cli):
     captured = run_cli(
         monkeypatch,
-        {
-            "extra_env_kwargs": {"timeout_seconds": 30, "foo": "bar"},
-        },
+        {},
+        config_args=[
+            "--extra-env-kwargs.timeout-seconds",
+            "30",
+            "--extra-env-kwargs.foo",
+            "bar",
+        ],
     )
 
     assert captured["configs"][0].extra_env_kwargs == {
@@ -260,13 +286,65 @@ def test_cli_timeout_flag_overrides_extra_env_kwargs(monkeypatch, run_cli):
     captured = run_cli(
         monkeypatch,
         {
-            "extra_env_kwargs": {"timeout_seconds": 30, "foo": "bar"},
             "timeout": 600,
         },
+        config_args=[
+            "--extra-env-kwargs.timeout-seconds",
+            "30",
+            "--extra-env-kwargs.foo",
+            "bar",
+        ],
     )
 
     assert captured["configs"][0].extra_env_kwargs == {
         "timeout_seconds": 600,
+        "foo": "bar",
+    }
+
+
+def test_cli_dotted_env_config_sections(monkeypatch, run_cli):
+    captured = run_cli(
+        monkeypatch,
+        {},
+        config_args=[
+            "--args.split",
+            "train",
+            "--harness.max-turns",
+            "5",
+            "--taskset.scoring.exact-answer.weight",
+            "0.5",
+        ],
+    )
+
+    assert captured["configs"][0].env_args == {
+        "split": "train",
+        "config": {
+            "taskset": {"scoring": {"exact_answer": {"weight": "0.5"}}},
+            "harness": {"max_turns": 5},
+        },
+    }
+
+
+def test_cli_legacy_env_args_json_still_works(monkeypatch, run_cli):
+    captured = run_cli(
+        monkeypatch,
+        {"env_args": {"difficulty": "hard", "num_examples": 100}},
+    )
+
+    assert captured["configs"][0].env_args == {
+        "difficulty": "hard",
+        "num_examples": 100,
+    }
+
+
+def test_cli_legacy_extra_env_kwargs_json_still_works(monkeypatch, run_cli):
+    captured = run_cli(
+        monkeypatch,
+        {"extra_env_kwargs": {"timeout_seconds": 30, "foo": "bar"}},
+    )
+
+    assert captured["configs"][0].extra_env_kwargs == {
+        "timeout_seconds": 30,
         "foo": "bar",
     }
 

--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -13,8 +13,11 @@ import asyncio
 import importlib.util
 import json
 import logging
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, cast
+
+from pydantic_config import BaseConfig, ConfigFileError, cli as config_cli
 
 from verifiers import setup_logging
 from verifiers.types import (
@@ -30,10 +33,12 @@ from verifiers.utils.eval_utils import (
     get_log_level,
     load_endpoints,
     load_toml_config,
+    normalize_sampling_config,
     resolve_endpoints_file,
     run_evaluations,
     run_evaluations_tui,
 )
+from verifiers.utils.env_config_utils import normalize_env_config_sections
 from verifiers.utils.import_utils import load_toml
 from verifiers.utils.install_utils import check_hub_env_installed
 
@@ -88,6 +93,16 @@ PROVIDER_CONFIGS: dict[str, dict[str, str]] = {
     },
 }
 DEFAULT_PROVIDER = "prime"
+
+
+class DirectEvalConfig(BaseConfig):
+    args: dict[str, Any] = {}
+    env_args: dict[str, Any] = {}
+    taskset: dict[str, Any] = {}
+    harness: dict[str, Any] = {}
+    sampling: dict[str, Any] = {}
+    sampling_args: dict[str, Any] = {}
+    extra_env_kwargs: dict[str, Any] = {}
 
 
 def merge_sampling_args(
@@ -449,7 +464,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--timeout",
         type=float,
         default=None,
-        help="Per-rollout wall-clock timeout in seconds. Overrides timeout_seconds in --extra-env-kwargs.",
+        help="Per-rollout wall-clock timeout in seconds. Overrides timeout_seconds in --extra-env-kwargs.timeout-seconds.",
     )
     parser.add_argument(
         "--fullscreen",
@@ -499,6 +514,34 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def parse_direct_eval_config(args: list[str]) -> dict[str, Any]:
+    if not args:
+        return {}
+    try:
+        config = config_cli(DirectEvalConfig, args=args)
+    except ConfigFileError as exc:
+        raise SystemExit(f"error: {exc.message}") from exc
+    return config.model_dump(exclude_unset=True)
+
+
+def merge_direct_eval_config(
+    raw_config: dict[str, Any], config_args: list[str]
+) -> dict[str, Any]:
+    config = parse_direct_eval_config(config_args)
+    for key in ("env_args", "sampling_args", "extra_env_kwargs"):
+        old_value = raw_config.get(key)
+        new_value = config.get(key)
+        if isinstance(old_value, Mapping) and isinstance(new_value, Mapping):
+            config[key] = {**old_value, **new_value}
+    merged = {**raw_config, **config}
+    if merged.get("sampling_args") is None:
+        merged.pop("sampling_args")
+    merged = normalize_sampling_config(
+        merged, "CLI config", merge_sampling_with_existing=True
+    )
+    return normalize_env_config_sections(merged)
+
+
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = build_parser()
     if argv is None:
@@ -506,8 +549,17 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
+def parse_known_args(
+    argv: list[str] | None = None,
+) -> tuple[argparse.Namespace, list[str]]:
+    parser = build_parser()
+    if argv is None:
+        return parser.parse_known_args()
+    return parser.parse_known_args(argv)
+
+
 def main(argv: list[str] | None = None):
-    args = parse_args(argv)
+    args, config_args = parse_known_args(argv)
 
     if args.disable_tui and args.fullscreen:
         raise SystemExit(
@@ -521,6 +573,8 @@ def main(argv: list[str] | None = None):
 
     # Build raw configs: both paths produce list[dict]
     if args.env_id_or_config.endswith(".toml"):
+        if config_args:
+            raise SystemExit(f"error: unrecognized arguments: {' '.join(config_args)}")
         path = Path(args.env_id_or_config)
         if not path.is_file():
             raise FileNotFoundError(
@@ -539,6 +593,7 @@ def main(argv: list[str] | None = None):
         # CLI path: convert args to dict
         raw_config = {"env_id": args.env_id_or_config}
         raw_config.update(vars(args))
+        raw_config = merge_direct_eval_config(raw_config, config_args)
         raw_eval_configs = [raw_config]
 
     def build_eval_config(raw: dict) -> EvalConfig:

--- a/verifiers/v1/ENVIRONMENT_BEST_PRACTICES.md
+++ b/verifiers/v1/ENVIRONMENT_BEST_PRACTICES.md
@@ -193,8 +193,13 @@ split = "eval"
 max_turns = 20
 ```
 
-CLI `-a` passes loader kwargs. For v1 child config overrides, nest under the
-`config` loader argument:
+For direct CLI runs, use dotted v1 child config flags:
+
+```bash
+prime eval run my-env --taskset.split eval --harness.max-turns 20
+```
+
+The legacy JSON loader-args form remains accepted:
 
 ```bash
 prime eval run my-env -a '{"config":{"taskset":{"split":"eval"},"harness":{"max_turns":20}}}'


### PR DESCRIPTION
## Summary
- add dotted direct CLI config sections for args, taskset, harness, sampling, and extra env kwargs
- keep legacy JSON flags for backwards compatibility
- update eval/environment docs and generated environment AGENTS guides

## Examples
Legacy JSON flags still work:

```bash
prime eval run my-env \
  -a '{"split": "test"}' \
  -S '{"top_p": 0.9}' \
  -x '{"concurrency": 256}'
```

The new dotted flags provide the same config without JSON quoting:

```bash
prime eval run my-env \
  --args.split test \
  --sampling.top-p 0.9 \
  --extra-env-kwargs.concurrency 256
```

V1 taskset/harness config can be passed directly:

```bash
prime eval run my-v1-env \
  --taskset.split eval \
  --harness.max-turns 20 \
  --taskset.scoring.exact-answer.weight 0.5
```

## Tests
- uv run pytest tests/test_eval_cli.py -q
- uv run pytest tests/test_v1_config_extension.py -q -k 'load_environment_validates_typed_env_config_arg or load_environment_validates_env_config_subclass_sections or load_environment_uses_factory_annotations_for_child_config_types'
- uv run ruff check --fix
- uv run ruff format
- UV_FROZEN=1 git commit hooks: ruff, semgrep, sync-agents
- UV_FROZEN=1 git push hooks: ruff, semgrep, sync-agents, ty

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how eval CLI args are parsed and merged into run config; mistakes could misconfigure loads, sampling, or v1 env sections, though legacy JSON paths and new tests reduce regression risk.
> 
> **Overview**
> Adds **dotted CLI flags** for direct `prime eval run` configuration, aligned with TOML sections: `--args.*`, `--taskset.*`, `--harness.*`, `--sampling.*`, and `--extra-env-kwargs.*`. The eval entrypoint now uses `parse_known_args` plus `pydantic_config` (`DirectEvalConfig`) to parse trailing config tokens, merge them with legacy JSON flags (`-a`, `-x`, `-S`), and normalize into `env_args` / `sampling_args` / v1 `config` sections. **TOML eval configs reject** leftover unknown args.
> 
> Legacy `-a`, `-x`, and `-S` JSON remain supported. Docs and synced AGENTS guides document the new flags and examples (including concurrency override via `--extra-env-kwargs.concurrency`). CLI tests cover precedence, v1 nesting, and backward compatibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 824fc7d6d32d4f7e72cd0e89f3e5798a6766e9b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add dotted CLI flags for eval config sections in `verifiers/scripts/eval.py`
> - Introduces dotted CLI flags (`--args.<key>`, `--taskset.<key>`, `--harness.<key>`, `--extra-env-kwargs.<key>`, `--sampling.<key>`) as an alternative to legacy JSON flags for configuring eval runs.
> - Adds `parse_known_args` to separate standard flags from dotted config args, and `merge_direct_eval_config` to deep-merge dotted values with legacy JSON/flag-derived values with defined precedence.
> - Dotted flags are parsed via `pydantic_config` into a `DirectEvalConfig` struct, then normalized using `normalize_sampling_config` and `normalize_env_config_sections`.
> - Extra config args alongside a TOML config file now cause an immediate error exit.
> - Behavioral Change: `--timeout` flag takes precedence over `timeout_seconds` set via either dotted or legacy `--extra-env-kwargs`; dotted `--sampling.*` values take precedence over individual `--max-tokens`/`--temperature` flags.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 824fc7d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
