### PR TITLE
renderers <-> v1: serializable RenderedTokens

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -219,7 +219,7 @@ class TrajectoryStepTokens(TypedDict):
     is_truncated: bool
     routed_experts: RoutedExpertsPayload | None
     multi_modal_data: NotRequired[Any]  # renderers.MultiModalData sidecar (pixel_values, placeholder ranges) — set only on multimodal rollouts
-    prompt_attribution: NotRequired[Any]  # renderers.RenderedTokens sidecar (per-token is_content / sampled_mask / message_indices / message_roles) — set only on RendererClient rollouts
+    prompt_attribution: NotRequired[Any]  # renderers.RenderedTokens fields as a dict (per-token is_content / sampled_mask / message_indices / message_roles) — set only on RendererClient rollouts
 ```
 
 Token-level data for training.

--- a/tests/test_trajectory_processing.py
+++ b/tests/test_trajectory_processing.py
@@ -256,6 +256,145 @@ async def test_parse_response_tokens_truncates_prompt_attribution_with_overlong_
     assert out_attr["message_roles"] == ["user", "tool"]
 
 
+@pytest.mark.asyncio
+async def test_parsed_prompt_attribution_survives_v1_assert_serializable():
+    """End-to-end regression for the v1 contract: a renderer-client
+    rollout that populates ``prompt_attribution`` must produce a state
+    whose ``trajectory`` survives ``State.assert_serializable``
+    (``json.dumps``-based). Reproduces the exact pipe v1 uses in
+    ``verifiers/v1/runtime.py::submit_model_request`` — ``parse_response_tokens``
+    output threaded through ``v1.utils.serialization_utils.serializable``
+    and appended to ``state["trajectory"]``.
+
+    Before the parse-boundary dataclass→dict conversion this test would
+    fail with ``TypeError: Object of type RenderedTokens is not JSON
+    serializable`` — that's the bug from PR #1414 that broke every
+    v1 + renderer rollout. Also matches what prime-rl's
+    ``_step_sft_mask`` consumer expects (``prompt_attribution: dict``
+    with ``["message_indices"]`` / ``["is_content"]`` access).
+    """
+    import json
+
+    from renderers.base import RenderedTokens
+
+    from verifiers.v1.utils.serialization_utils import serializable
+
+    attribution = RenderedTokens(
+        token_ids=[1, 2, 3, 4],
+        message_indices=[0, 0, 1, 1],
+        sampled_mask=[False, False, False, False],
+        is_content=[False, True, False, True],
+        message_roles=["user", "tool"],
+    )
+    response = Response(
+        id="test-id",
+        created=0,
+        model="test-model",
+        message=ResponseMessage(
+            role="assistant",
+            content="Hi",
+            reasoning_content=None,
+            tool_calls=None,
+            finish_reason="stop",
+            is_truncated=False,
+            tokens=ResponseTokens(
+                prompt_ids=[1, 2, 3, 4],
+                prompt_mask=[0, 0, 0, 0],
+                completion_ids=[5, 6],
+                completion_mask=[1, 1],
+                completion_logprobs=[-0.1, -0.2],
+                prompt_attribution=attribution,
+            ),
+        ),
+    )
+
+    parsed_tokens = await parse_response_tokens(response)
+
+    # Mirror v1/runtime.py::submit_model_request exactly: every field
+    # passes through ``serializable()`` before reaching the trajectory.
+    step = {
+        "prompt": serializable([]),
+        "completion": serializable([]),
+        "response": serializable(response),
+        "tokens": serializable(parsed_tokens),
+        "reward": None,
+        "advantage": None,
+        "is_truncated": False,
+        "trajectory_id": "t",
+        "extras": {},
+    }
+    state = State({"trajectory": [step], "metrics": {}, "reward": 0.0})
+
+    # The v1 gate. Pre-fix this raises on the RenderedTokens dataclass.
+    state.assert_serializable()
+    # And the dict shape downstream (prime-rl) reads.
+    attr_dict = step["tokens"]["prompt_attribution"]
+    assert isinstance(attr_dict, dict)
+    assert attr_dict["message_indices"] == [0, 0, 1, 1]
+    assert attr_dict["is_content"] == [False, True, False, True]
+    # Confirm the whole state really did round-trip through JSON.
+    rehydrated = json.loads(json.dumps(state))
+    assert rehydrated["trajectory"][0]["tokens"]["prompt_attribution"] == attr_dict
+
+
+@pytest.mark.asyncio
+async def test_parsed_prompt_attribution_survives_orchestrator_msgpack():
+    """Transport regression: the parsed step msgpack-round-trips through
+    the orchestrator encoder (``verifiers/serve/server/env_worker.py``
+    uses ``msgpack.packb(..., default=msgpack_encoder)``). After
+    unpacking, the trainer reads ``prompt_attribution`` dict-style
+    (matches prime-rl's ``_step_sft_mask`` access pattern) and
+    rehydrates the dataclass for any consumer that wants the typed
+    form. This locks the verifiers→trainer wire contract.
+    """
+    import msgpack
+    from renderers.base import RenderedTokens
+
+    from verifiers.utils.serve_utils import msgpack_encoder
+
+    attribution = RenderedTokens(
+        token_ids=[1, 2, 3, 4],
+        message_indices=[0, 0, 1, 1],
+        sampled_mask=[False, False, False, False],
+        is_content=[False, True, False, True],
+        message_roles=["user", "tool"],
+    )
+    response = Response(
+        id="test-id",
+        created=0,
+        model="test-model",
+        message=ResponseMessage(
+            role="assistant",
+            content="Hi",
+            reasoning_content=None,
+            tool_calls=None,
+            finish_reason="stop",
+            is_truncated=False,
+            tokens=ResponseTokens(
+                prompt_ids=[1, 2, 3, 4],
+                prompt_mask=[0, 0, 0, 0],
+                completion_ids=[5, 6],
+                completion_mask=[1, 1],
+                completion_logprobs=[-0.1, -0.2],
+                prompt_attribution=attribution,
+            ),
+        ),
+    )
+    parsed = await parse_response_tokens(response)
+    assert parsed is not None
+
+    packed = msgpack.packb(dict(parsed), default=msgpack_encoder, use_bin_type=True)
+    unpacked = msgpack.unpackb(packed, raw=False)
+
+    attr = unpacked["prompt_attribution"]
+    assert isinstance(attr, dict)
+    # Exact access pattern prime-rl's _step_sft_mask uses.
+    assert attr["message_indices"] == [0, 0, 1, 1]
+    assert attr["is_content"] == [False, True, False, True]
+    # And it rehydrates losslessly for typed consumers.
+    assert RenderedTokens(**attr) == attribution
+
+
 def test_process_trajectory_steps_for_training(make_input):
     """Test processing trajectory steps into training examples."""
     state1 = State(

--- a/tests/test_trajectory_processing.py
+++ b/tests/test_trajectory_processing.py
@@ -148,12 +148,9 @@ async def test_parse_response_tokens_with_overlong_prompt():
 
 @pytest.mark.asyncio
 async def test_parse_response_tokens_carries_prompt_attribution():
-    """``prompt_attribution`` moves from ResponseTokens to the parsed
-    TrajectoryStepTokens as a JSON-safe ``dict`` (so ``state.trajectory``
-    survives ``State.assert_serializable`` in the v1 contract); the
-    response-side ref is cleared (move-not-copy, same policy as
-    ``multi_modal_data``)."""
-    import json
+    """``prompt_attribution`` moves from ResponseTokens to the parsed step
+    as a JSON-safe dict (move-not-copy, same policy as ``multi_modal_data``)."""
+    import dataclasses
 
     from renderers.base import RenderedTokens
 
@@ -190,20 +187,7 @@ async def test_parse_response_tokens_carries_prompt_attribution():
     out = await parse_response_tokens(response)
 
     assert out is not None
-    out_attr = out["prompt_attribution"]
-    assert isinstance(out_attr, dict)
-    assert out_attr == {
-        "token_ids": [1, 2, 3, 4],
-        "message_indices": [0, 0, 1, 1],
-        "sampled_mask": [False, False, False, False],
-        "is_content": [False, True, False, True],
-        "message_roles": ["user", "tool"],
-        "multi_modal_data": None,
-    }
-    # JSON-serializable end-to-end (the whole point of the conversion).
-    json.dumps(out_attr)
-    # Round-trips back to the dataclass for downstream consumers.
-    assert RenderedTokens(**out_attr) == attribution
+    assert out["prompt_attribution"] == dataclasses.asdict(attribution)
     assert tokens_in.prompt_attribution is None
 
 
@@ -258,141 +242,44 @@ async def test_parse_response_tokens_truncates_prompt_attribution_with_overlong_
 
 @pytest.mark.asyncio
 async def test_parsed_prompt_attribution_survives_v1_assert_serializable():
-    """End-to-end regression for the v1 contract: a renderer-client
-    rollout that populates ``prompt_attribution`` must produce a state
-    whose ``trajectory`` survives ``State.assert_serializable``
-    (``json.dumps``-based). Reproduces the exact pipe v1 uses in
-    ``verifiers/v1/runtime.py::submit_model_request`` — ``parse_response_tokens``
-    output threaded through ``v1.utils.serialization_utils.serializable``
-    and appended to ``state["trajectory"]``.
-
-    Before the parse-boundary dataclass→dict conversion this test would
-    fail with ``TypeError: Object of type RenderedTokens is not JSON
-    serializable`` — that's the bug from PR #1414 that broke every
-    v1 + renderer rollout. Also matches what prime-rl's
-    ``_step_sft_mask`` consumer expects (``prompt_attribution: dict``
-    with ``["message_indices"]`` / ``["is_content"]`` access).
+    """Regression for PR #1414: a v1 state with ``prompt_attribution``
+    on a trajectory step must clear ``State.assert_serializable`` (the
+    ``json.dumps`` gate that pre-fix raised on the RenderedTokens dataclass).
     """
-    import json
-
     from renderers.base import RenderedTokens
 
     from verifiers.v1.utils.serialization_utils import serializable
 
-    attribution = RenderedTokens(
-        token_ids=[1, 2, 3, 4],
-        message_indices=[0, 0, 1, 1],
-        sampled_mask=[False, False, False, False],
-        is_content=[False, True, False, True],
-        message_roles=["user", "tool"],
-    )
     response = Response(
-        id="test-id",
+        id="t",
         created=0,
-        model="test-model",
+        model="m",
         message=ResponseMessage(
             role="assistant",
-            content="Hi",
+            content="hi",
             reasoning_content=None,
             tool_calls=None,
             finish_reason="stop",
             is_truncated=False,
             tokens=ResponseTokens(
-                prompt_ids=[1, 2, 3, 4],
-                prompt_mask=[0, 0, 0, 0],
-                completion_ids=[5, 6],
-                completion_mask=[1, 1],
-                completion_logprobs=[-0.1, -0.2],
-                prompt_attribution=attribution,
-            ),
-        ),
-    )
-
-    parsed_tokens = await parse_response_tokens(response)
-
-    # Mirror v1/runtime.py::submit_model_request exactly: every field
-    # passes through ``serializable()`` before reaching the trajectory.
-    step = {
-        "prompt": serializable([]),
-        "completion": serializable([]),
-        "response": serializable(response),
-        "tokens": serializable(parsed_tokens),
-        "reward": None,
-        "advantage": None,
-        "is_truncated": False,
-        "trajectory_id": "t",
-        "extras": {},
-    }
-    state = State({"trajectory": [step], "metrics": {}, "reward": 0.0})
-
-    # The v1 gate. Pre-fix this raises on the RenderedTokens dataclass.
-    state.assert_serializable()
-    # And the dict shape downstream (prime-rl) reads.
-    attr_dict = step["tokens"]["prompt_attribution"]
-    assert isinstance(attr_dict, dict)
-    assert attr_dict["message_indices"] == [0, 0, 1, 1]
-    assert attr_dict["is_content"] == [False, True, False, True]
-    # Confirm the whole state really did round-trip through JSON.
-    rehydrated = json.loads(json.dumps(state))
-    assert rehydrated["trajectory"][0]["tokens"]["prompt_attribution"] == attr_dict
-
-
-@pytest.mark.asyncio
-async def test_parsed_prompt_attribution_survives_orchestrator_msgpack():
-    """Transport regression: the parsed step msgpack-round-trips through
-    the orchestrator encoder (``verifiers/serve/server/env_worker.py``
-    uses ``msgpack.packb(..., default=msgpack_encoder)``). After
-    unpacking, the trainer reads ``prompt_attribution`` dict-style
-    (matches prime-rl's ``_step_sft_mask`` access pattern) and
-    rehydrates the dataclass for any consumer that wants the typed
-    form. This locks the verifiers→trainer wire contract.
-    """
-    import msgpack
-    from renderers.base import RenderedTokens
-
-    from verifiers.utils.serve_utils import msgpack_encoder
-
-    attribution = RenderedTokens(
-        token_ids=[1, 2, 3, 4],
-        message_indices=[0, 0, 1, 1],
-        sampled_mask=[False, False, False, False],
-        is_content=[False, True, False, True],
-        message_roles=["user", "tool"],
-    )
-    response = Response(
-        id="test-id",
-        created=0,
-        model="test-model",
-        message=ResponseMessage(
-            role="assistant",
-            content="Hi",
-            reasoning_content=None,
-            tool_calls=None,
-            finish_reason="stop",
-            is_truncated=False,
-            tokens=ResponseTokens(
-                prompt_ids=[1, 2, 3, 4],
-                prompt_mask=[0, 0, 0, 0],
-                completion_ids=[5, 6],
-                completion_mask=[1, 1],
-                completion_logprobs=[-0.1, -0.2],
-                prompt_attribution=attribution,
+                prompt_ids=[1, 2],
+                prompt_mask=[0, 0],
+                completion_ids=[3],
+                completion_mask=[1],
+                completion_logprobs=[-0.1],
+                prompt_attribution=RenderedTokens(
+                    token_ids=[1, 2],
+                    message_indices=[0, 0],
+                    sampled_mask=[False, False],
+                    is_content=[False, True],
+                    message_roles=["user"],
+                ),
             ),
         ),
     )
     parsed = await parse_response_tokens(response)
-    assert parsed is not None
-
-    packed = msgpack.packb(dict(parsed), default=msgpack_encoder, use_bin_type=True)
-    unpacked = msgpack.unpackb(packed, raw=False)
-
-    attr = unpacked["prompt_attribution"]
-    assert isinstance(attr, dict)
-    # Exact access pattern prime-rl's _step_sft_mask uses.
-    assert attr["message_indices"] == [0, 0, 1, 1]
-    assert attr["is_content"] == [False, True, False, True]
-    # And it rehydrates losslessly for typed consumers.
-    assert RenderedTokens(**attr) == attribution
+    step = {"tokens": serializable(parsed), "response": serializable(response)}
+    State({"trajectory": [step]}).assert_serializable()
 
 
 def test_process_trajectory_steps_for_training(make_input):

--- a/tests/test_trajectory_processing.py
+++ b/tests/test_trajectory_processing.py
@@ -149,8 +149,12 @@ async def test_parse_response_tokens_with_overlong_prompt():
 @pytest.mark.asyncio
 async def test_parse_response_tokens_carries_prompt_attribution():
     """``prompt_attribution`` moves from ResponseTokens to the parsed
-    TrajectoryStepTokens; response-side ref is cleared (move-not-copy,
-    same policy as ``multi_modal_data``)."""
+    TrajectoryStepTokens as a JSON-safe ``dict`` (so ``state.trajectory``
+    survives ``State.assert_serializable`` in the v1 contract); the
+    response-side ref is cleared (move-not-copy, same policy as
+    ``multi_modal_data``)."""
+    import json
+
     from renderers.base import RenderedTokens
 
     attribution = RenderedTokens(
@@ -186,7 +190,20 @@ async def test_parse_response_tokens_carries_prompt_attribution():
     out = await parse_response_tokens(response)
 
     assert out is not None
-    assert out["prompt_attribution"] is attribution
+    out_attr = out["prompt_attribution"]
+    assert isinstance(out_attr, dict)
+    assert out_attr == {
+        "token_ids": [1, 2, 3, 4],
+        "message_indices": [0, 0, 1, 1],
+        "sampled_mask": [False, False, False, False],
+        "is_content": [False, True, False, True],
+        "message_roles": ["user", "tool"],
+        "multi_modal_data": None,
+    }
+    # JSON-serializable end-to-end (the whole point of the conversion).
+    json.dumps(out_attr)
+    # Round-trips back to the dataclass for downstream consumers.
+    assert RenderedTokens(**out_attr) == attribution
     assert tokens_in.prompt_attribution is None
 
 
@@ -231,11 +248,12 @@ async def test_parse_response_tokens_truncates_prompt_attribution_with_overlong_
     assert tokens is not None
     assert tokens["overlong_prompt"] is True
     out_attr = tokens["prompt_attribution"]
-    assert out_attr.token_ids == [10, 11, 12]
-    assert out_attr.message_indices == [0, 0, 1]
-    assert out_attr.sampled_mask == [False, False, False]
-    assert out_attr.is_content == [False, True, False]
-    assert out_attr.message_roles == ["user", "tool"]
+    assert isinstance(out_attr, dict)
+    assert out_attr["token_ids"] == [10, 11, 12]
+    assert out_attr["message_indices"] == [0, 0, 1]
+    assert out_attr["sampled_mask"] == [False, False, False]
+    assert out_attr["is_content"] == [False, True, False]
+    assert out_attr["message_roles"] == ["user", "tool"]
 
 
 def test_process_trajectory_steps_for_training(make_input):

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -257,8 +257,12 @@ class TrajectoryStepTokens(TypedDict):
     # ``NotRequired`` because text-only rollouts (and non-renderer client
     # types) never populate it.
     multi_modal_data: NotRequired[Any]
-    # Renderer-emitted prompt attribution
-    # (``renderers.base.RenderedTokens``); ``NotRequired`` because only
+    # Renderer-emitted prompt attribution: ``dict`` form of
+    # ``renderers.base.RenderedTokens`` (converted via
+    # ``dataclasses.asdict`` at the ``parse_response_tokens`` boundary so
+    # the trajectory survives ``State.assert_serializable``'s
+    # ``json.dumps`` gate in the v1 contract). Downstream consumers
+    # rehydrate via ``RenderedTokens(**d)``. ``NotRequired`` because only
     # ``RendererClient`` rollouts populate it.
     prompt_attribution: NotRequired[Any]
 

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -257,13 +257,8 @@ class TrajectoryStepTokens(TypedDict):
     # ``NotRequired`` because text-only rollouts (and non-renderer client
     # types) never populate it.
     multi_modal_data: NotRequired[Any]
-    # Renderer-emitted prompt attribution: ``dict`` form of
-    # ``renderers.base.RenderedTokens`` (converted via
-    # ``dataclasses.asdict`` at the ``parse_response_tokens`` boundary so
-    # the trajectory survives ``State.assert_serializable``'s
-    # ``json.dumps`` gate in the v1 contract). Downstream consumers
-    # rehydrate via ``RenderedTokens(**d)``. ``NotRequired`` because only
-    # ``RendererClient`` rollouts populate it.
+    # ``RenderedTokens`` as dict (rehydrate via ``RenderedTokens(**d)``);
+    # only ``RendererClient`` rollouts populate it.
     prompt_attribution: NotRequired[Any]
 
 

--- a/verifiers/utils/response_utils.py
+++ b/verifiers/utils/response_utils.py
@@ -131,8 +131,12 @@ async def parse_response_tokens(
             tokens.routed_experts = None
         if prompt_attribution is not None:
             # Dataclass → dict so v1 State.assert_serializable (json.dumps) clears.
+            # ``multi_modal_data`` zeroed first: its tensors aren't JSON-native and
+            # the canonical copy already lives at ``out["multi_modal_data"]``.
             if dataclasses.is_dataclass(prompt_attribution):
-                prompt_attribution = dataclasses.asdict(prompt_attribution)
+                prompt_attribution = dataclasses.asdict(
+                    dataclasses.replace(prompt_attribution, multi_modal_data=None)
+                )
             out["prompt_attribution"] = prompt_attribution
             tokens.prompt_attribution = None
         return out

--- a/verifiers/utils/response_utils.py
+++ b/verifiers/utils/response_utils.py
@@ -64,24 +64,6 @@ def _truncate_prompt_attribution(attribution: Any, prompt_len: int) -> Any:
     )
 
 
-def _prompt_attribution_to_jsonable(attribution: Any) -> Any:
-    """Convert a ``renderers.base.RenderedTokens`` dataclass to a plain
-    ``dict`` so the parsed step survives ``State.assert_serializable``
-    (``json.dumps``-based) in the v1 contract. Idempotent: non-dataclass
-    inputs (already-dict, ``None``, etc.) pass through unchanged.
-
-    ``dataclasses.asdict`` recurses into nested dataclasses, so a
-    nested ``multi_modal_data`` MultiModalData is flattened in the same
-    pass. Note that the top-level ``multi_modal_data`` sidecar on the
-    step is left as-is — ``save_utils._delta_intermediate_mm_data``
-    reads its fields via ``getattr``, so converting it here would break
-    the per-step delta optimization for multimodal trajectories.
-    """
-    if dataclasses.is_dataclass(attribution) and not isinstance(attribution, type):
-        return dataclasses.asdict(attribution)
-    return attribution
-
-
 async def parse_response_tokens(
     response: Response, max_seq_len: int | None = None
 ) -> TrajectoryStepTokens | None:
@@ -148,9 +130,10 @@ async def parse_response_tokens(
         if routed_experts is not None:
             tokens.routed_experts = None
         if prompt_attribution is not None:
-            out["prompt_attribution"] = _prompt_attribution_to_jsonable(
-                prompt_attribution
-            )
+            # Dataclass → dict so v1 State.assert_serializable (json.dumps) clears.
+            if dataclasses.is_dataclass(prompt_attribution):
+                prompt_attribution = dataclasses.asdict(prompt_attribution)
+            out["prompt_attribution"] = prompt_attribution
             tokens.prompt_attribution = None
         return out
 

--- a/verifiers/utils/response_utils.py
+++ b/verifiers/utils/response_utils.py
@@ -1,4 +1,5 @@
 import asyncio
+import dataclasses
 from typing import Any
 
 from verifiers.types import (
@@ -61,6 +62,24 @@ def _truncate_prompt_attribution(attribution: Any, prompt_len: int) -> Any:
         message_roles=list(attribution.message_roles),
         multi_modal_data=attribution.multi_modal_data,
     )
+
+
+def _prompt_attribution_to_jsonable(attribution: Any) -> Any:
+    """Convert a ``renderers.base.RenderedTokens`` dataclass to a plain
+    ``dict`` so the parsed step survives ``State.assert_serializable``
+    (``json.dumps``-based) in the v1 contract. Idempotent: non-dataclass
+    inputs (already-dict, ``None``, etc.) pass through unchanged.
+
+    ``dataclasses.asdict`` recurses into nested dataclasses, so a
+    nested ``multi_modal_data`` MultiModalData is flattened in the same
+    pass. Note that the top-level ``multi_modal_data`` sidecar on the
+    step is left as-is — ``save_utils._delta_intermediate_mm_data``
+    reads its fields via ``getattr``, so converting it here would break
+    the per-step delta optimization for multimodal trajectories.
+    """
+    if dataclasses.is_dataclass(attribution) and not isinstance(attribution, type):
+        return dataclasses.asdict(attribution)
+    return attribution
 
 
 async def parse_response_tokens(
@@ -129,7 +148,9 @@ async def parse_response_tokens(
         if routed_experts is not None:
             tokens.routed_experts = None
         if prompt_attribution is not None:
-            out["prompt_attribution"] = prompt_attribution
+            out["prompt_attribution"] = _prompt_attribution_to_jsonable(
+                prompt_attribution
+            )
             tokens.prompt_attribution = None
         return out
 


### PR DESCRIPTION
## Description

1. RenderedTokens is a plain @dataclass (defined at renderers/base.py:159), which json.dumps cannot serialize.
2. PR #1414 puts it in state. In verifiers/utils/response_utils.py:131-133, parse_response_tokens writes the raw RenderedTokens dataclass onto the step:
  ```python
  if prompt_attribution is not None:
      out["prompt_attribution"] = prompt_attribution
      tokens.prompt_attribution = None
  ```
3. out is the TrajectoryStepTokens dict that MultiTurnEnv.add_model_response then appends to state["trajectory"] (verifiers/envs/multiturn_env.py:151-162).
4. The v1 path then asserts JSON-serializability of the entire state:
    - verifiers/v1/harness.py:184: state.assert_serializable() after rollout completion
    - verifiers/v1/env.py:123: state.assert_serializable() after group run
    - Both eventually call json.dumps(self) on the whole state (verifiers/types.py:898-902), traversing state["trajectory"][i]["tokens"]["prompt_attribution"].

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [x] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized serialization change in token parsing with tests; only consumers expecting a RenderedTokens object on trajectory steps need to rehydrate from dict.
> 
> **Overview**
> **`parse_response_tokens`** now stores renderer **`prompt_attribution`** on trajectory step tokens as a **JSON-safe dict** (`dataclasses.asdict`), stripping nested **`multi_modal_data`** from that dict because tensors already live on **`out["multi_modal_data"]`**. The sidecar is still **moved** off **`ResponseTokens`** (not duplicated), matching **`multi_modal_data`** policy.
> 
> **Callers** that read **`tokens["prompt_attribution"]`** get a **dict** instead of a **`RenderedTokens`** instance; docs note rehydration via **`RenderedTokens(**d)`**. Tests assert dict equality, dict-shaped truncation fields, and a **v1 regression** that **`State.assert_serializable()`** succeeds when attribution is on a trajectory step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2b4cbfc4591857c0bbec97247364731ec532420. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Serialize `prompt_attribution` as a plain dict in `parse_response_tokens`
> - `parse_response_tokens` in [response_utils.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1471/files#diff-792a30a7d072bc4ee79e8359e4f3019c438b479fc05325a1af4f11aef53ce920) now converts a `RenderedTokens` dataclass to a plain dict via `dataclasses.asdict`, clearing `multi_modal_data` before conversion to avoid non-serializable values.
> - The dict is rehydratable via `RenderedTokens(**d)`. The original `tokens.prompt_attribution` is still cleared (move semantics preserved).
> - A new regression test verifies that a trajectory step with `prompt_attribution` passes `State.assert_serializable`.
> - Behavioral Change: callers that previously received a `RenderedTokens` instance from `prompt_attribution` will now receive a plain dict.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b2b4cbf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->