### PR TITLE
Auto-publish .dev releases on every push to main

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -26,10 +26,12 @@ This directory contains automated workflows for the verifiers project.
 
 **What it does**:
 - Computes the next dev tag from the most recent `v*` tag.
-- Builds a synthetic commit on top of `main` HEAD that bumps `verifiers/__init__.py` to the new version, then annotates and pushes the tag (the bump commit is never pushed back to `main`).
-- Checks out the tag, runs `uv build`, and publishes the wheel + sdist to PyPI via Trusted Publisher (`pypi-prod` environment, OIDC).
+- Creates a lightweight tag pointing directly at `main` HEAD (no commit, no modification to `main`).
+- Checks out the tag, overrides `verifiers/__init__.py`'s `__version__` to the dev version **in the workflow checkout only** (uncommitted), runs `uv build`, and publishes the wheel + sdist to PyPI via Trusted Publisher (`pypi-prod` environment, OIDC).
 - Does **not** create a GitHub Release and does **not** require a hand-curated `assets/release/RELEASE_<tag>.md` file — those are reserved for stable releases.
 - Skips itself when the push already modifies `verifiers/__init__.py` (deferring to `tag-and-release.yml`'s `auto-tag-on-main` job for stable release-prep PRs).
+
+`verifiers/__init__.py`'s `__version__` is treated as the latest stable release version and is never modified by this workflow.
 
 See `assets/release/release_workflow.md` for the full release workflow.
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -17,7 +17,23 @@ This directory contains automated workflows for the verifiers project.
 - Runs Semgrep policy checks through pre-commit's isolated hook environment.
 - Uses configuration from `pyproject.toml`, `.pre-commit-config.yaml`, and `.semgrep/verifiers.yml`
 
-### 2. Test (`test.yml`)
+### 2. DevX Tag (`devx_tag.yml`)
+**Purpose**: Automatically publish a `.devN` release for every push to `main`.
+
+**Triggers**:
+- Pushes to `main`
+- Manual dispatch
+
+**What it does**:
+- Computes the next dev tag from the most recent `v*` tag.
+- Builds a synthetic commit on top of `main` HEAD that bumps `verifiers/__init__.py` and writes `assets/release/RELEASE_<tag>.md`.
+- Annotates and pushes the tag (the bump commit is never pushed back to `main`).
+- Dispatches `tag-and-release.yml` for that tag so the build + PyPI publish + GitHub Release jobs run unchanged.
+- Skips itself when the push already modifies `verifiers/__init__.py` (deferring to `tag-and-release.yml`'s `auto-tag-on-main` job for manual release-prep PRs).
+
+See `assets/release/release_workflow.md` for the full release workflow.
+
+### 3. Test (`test.yml`)
 **Purpose**: Comprehensive testing with coverage reports.
 
 **Triggers**:

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -18,7 +18,7 @@ This directory contains automated workflows for the verifiers project.
 - Uses configuration from `pyproject.toml`, `.pre-commit-config.yaml`, and `.semgrep/verifiers.yml`
 
 ### 2. DevX Tag (`devx_tag.yml`)
-**Purpose**: Automatically publish a `.devN` release for every push to `main`.
+**Purpose**: Automatically publish a `vX.Y.Z.devN` release to PyPI on every push to `main`.
 
 **Triggers**:
 - Pushes to `main`
@@ -26,14 +26,26 @@ This directory contains automated workflows for the verifiers project.
 
 **What it does**:
 - Computes the next dev tag from the most recent `v*` tag.
-- Builds a synthetic commit on top of `main` HEAD that bumps `verifiers/__init__.py` and writes `assets/release/RELEASE_<tag>.md`.
-- Annotates and pushes the tag (the bump commit is never pushed back to `main`).
-- Dispatches `tag-and-release.yml` for that tag so the build + PyPI publish + GitHub Release jobs run unchanged.
-- Skips itself when the push already modifies `verifiers/__init__.py` (deferring to `tag-and-release.yml`'s `auto-tag-on-main` job for manual release-prep PRs).
+- Builds a synthetic commit on top of `main` HEAD that bumps `verifiers/__init__.py` to the new version, then annotates and pushes the tag (the bump commit is never pushed back to `main`).
+- Checks out the tag, runs `uv build`, and publishes the wheel + sdist to PyPI via Trusted Publisher (`pypi-prod` environment, OIDC).
+- Does **not** create a GitHub Release and does **not** require a hand-curated `assets/release/RELEASE_<tag>.md` file — those are reserved for stable releases.
+- Skips itself when the push already modifies `verifiers/__init__.py` (deferring to `tag-and-release.yml`'s `auto-tag-on-main` job for stable release-prep PRs).
 
 See `assets/release/release_workflow.md` for the full release workflow.
 
-### 3. Test (`test.yml`)
+### 3. Tag and Release (`tag-and-release.yml`)
+**Purpose**: Publish a stable `vX.Y.Z` release to PyPI and create a GitHub Release.
+
+**Triggers**:
+- Pushes to `main` that change `verifiers/__init__.py` to a non-dev version (auto-tags `vX.Y.Z`).
+- Pushes of `v*` tags **excluding** `v*.dev*`.
+- Manual dispatch with an existing stable tag.
+
+**What it does**:
+- Validates that the tag does not contain `.dev` (dev releases are handled by `devx_tag.yml`).
+- Runs `uv build`, publishes to PyPI via Trusted Publisher (`pypi-prod` environment, OIDC), and creates a GitHub Release using `assets/release/RELEASE_<tag>.md` plus the built `dist/` artifacts.
+
+### 4. Test (`test.yml`)
 **Purpose**: Comprehensive testing with coverage reports.
 
 **Triggers**:

--- a/.github/workflows/devx_tag.yml
+++ b/.github/workflows/devx_tag.yml
@@ -7,11 +7,11 @@ name: DevX Tag
 # `assets/release/RELEASE_<tag>.md` file — that flow is reserved for
 # stable releases in `tag-and-release.yml`.
 #
-# The dev tag is an annotated tag pointing at a synthetic commit whose
-# parent is the current `main` HEAD. The synthetic commit only bumps
-# `verifiers/__init__.py` so that the wheel built from the tag carries
-# the correct version. The bump commit is never pushed back to `main`,
-# which keeps the branch free of bot churn and merge conflicts.
+# `verifiers/__init__.py`'s `__version__` is treated as the latest
+# *stable* release version and is never touched by this workflow. The
+# dev wheel built from each tag patches `__init__.py` in the workflow
+# checkout only (uncommitted) so the wheel carries the dev version,
+# while `main` keeps reporting the stable version for source installs.
 
 on:
   push:
@@ -19,7 +19,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -30,6 +30,8 @@ jobs:
     name: Create .dev tag
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       created: ${{ steps.tag.outputs.created }}
       tag: ${{ steps.tag.outputs.tag }}
@@ -60,13 +62,14 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Compute next dev version
+      - name: Compute next dev tag and create it
         if: steps.skip.outputs.skip != 'true'
-        id: ver
+        id: tag
         uses: actions/github-script@v7
         with:
           script: |
             const { owner, repo } = context.repo;
+            const sha = context.sha;
 
             const refs = await github.paginate(github.rest.git.listMatchingRefs, {
               owner,
@@ -90,7 +93,7 @@ jobs:
 
             if (parsed.length === 0) {
               core.notice("No v* tags found; skipping .dev tag creation.");
-              core.setOutput("skipped", "true");
+              core.setOutput("created", "false");
               return;
             }
 
@@ -122,41 +125,69 @@ jobs:
             const escapeRegex = (v) => v.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
             const devPattern = new RegExp(`^refs/tags/${escapeRegex(base)}\\.dev(\\d+)$`);
 
-            const existingDevRefs = await github.paginate(github.rest.git.listMatchingRefs, {
-              owner,
-              repo,
-              ref: `tags/${devPrefix}`,
-            });
-            let maxDev = startDev - 1;
-            for (const ref of existingDevRefs) {
-              const m = devPattern.exec(ref.ref);
-              if (m) {
-                const n = Number.parseInt(m[1], 10);
-                if (n > maxDev) maxDev = n;
+            for (let attempt = 0; attempt < 5; attempt += 1) {
+              const existingDevRefs = await github.paginate(github.rest.git.listMatchingRefs, {
+                owner,
+                repo,
+                ref: `tags/${devPrefix}`,
+              });
+              let maxDev = startDev - 1;
+              for (const ref of existingDevRefs) {
+                const m = devPattern.exec(ref.ref);
+                if (m) {
+                  const n = Number.parseInt(m[1], 10);
+                  if (n > maxDev) maxDev = n;
+                }
               }
+
+              const tag = `${devPrefix}${maxDev + 1}`;
+              const version = tag.replace(/^v/, "");
+
+              try {
+                await github.rest.git.createRef({
+                  owner,
+                  repo,
+                  ref: `refs/tags/${tag}`,
+                  sha,
+                });
+              } catch (error) {
+                if (error.status === 422) {
+                  core.warning(`Tag ${tag} already exists, retrying...`);
+                  continue;
+                }
+                throw error;
+              }
+
+              core.notice(`Created tag ${tag} at ${sha}`);
+              core.setOutput("created", "true");
+              core.setOutput("tag", tag);
+              core.setOutput("version", version);
+              return;
             }
 
-            const tag = `${devPrefix}${maxDev + 1}`;
-            const version = tag.replace(/^v/, "");
-            core.setOutput("skipped", "false");
-            core.setOutput("tag", tag);
-            core.setOutput("version", version);
-            core.notice(`Next dev tag: ${tag}`);
+            core.setFailed("Could not create a unique .dev tag after retries.");
 
-      - name: Build release commit and push tag
-        if: steps.skip.outputs.skip != 'true' && steps.ver.outputs.skipped != 'true'
-        id: tag
+  build-dev:
+    name: Build dev wheel
+    needs: create-dev-tag
+    if: needs.create-dev-tag.outputs.created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout dev tag
+        uses: actions/checkout@v4
+        with:
+          ref: refs/tags/${{ needs.create-dev-tag.outputs.tag }}
+
+      - name: Override __version__ for dev build
         env:
-          TAG: ${{ steps.ver.outputs.tag }}
-          VERSION: ${{ steps.ver.outputs.version }}
+          VERSION: ${{ needs.create-dev-tag.outputs.version }}
         run: |
-          set -euo pipefail
-
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          git checkout --detach HEAD
-
+          # `verifiers/__init__.py` on `main` tracks the latest stable
+          # version. Patch it in the workflow checkout only (uncommitted)
+          # so the wheel built from this tag is labeled with the dev
+          # version. The patch is never pushed anywhere.
           python - <<'PY'
           from pathlib import Path
           import os, re, sys
@@ -173,28 +204,6 @@ jobs:
               sys.exit("Failed to locate __version__ in verifiers/__init__.py")
           path.write_text(new_text)
           PY
-
-          git add verifiers/__init__.py
-          git commit -m "Prepare ${TAG} release"
-          git tag -a "${TAG}" -m "Release ${TAG}"
-          git push origin "refs/tags/${TAG}"
-
-          echo "created=true" >> "$GITHUB_OUTPUT"
-          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-
-  build-dev:
-    name: Build dev wheel
-    needs: create-dev-tag
-    if: needs.create-dev-tag.outputs.created == 'true'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout dev tag
-        uses: actions/checkout@v4
-        with:
-          ref: refs/tags/${{ needs.create-dev-tag.outputs.tag }}
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/devx_tag.yml
+++ b/.github/workflows/devx_tag.yml
@@ -1,17 +1,17 @@
 name: DevX Tag
 
-# Automatically create and publish a `.devN` release for every push to
-# `main`. The dev tag is created as an annotated tag pointing at a
-# synthetic commit (parent = current `main` HEAD) that bumps
-# `verifiers/__init__.py` to the new dev version and adds a stub
-# release-notes file at `assets/release/RELEASE_<tag>.md`. The tag is
-# then handed off to `tag-and-release.yml` via `workflow_dispatch` so the
-# build + PyPI publish + GitHub Release jobs run unchanged.
+# Automatically publish a `.devN` release to PyPI on every push to `main`.
 #
-# The bump commit only lives as the tag target; it is NOT pushed back to
-# `main`. The `main` branch's `__version__` therefore lags behind the
-# latest published dev tag by one increment, which is acceptable for dev
-# releases and avoids spurious commits / merge conflicts on the branch.
+# Dev releases are intentionally minimal: a git tag plus a PyPI upload.
+# They do not produce a GitHub Release and do not require a hand-curated
+# `assets/release/RELEASE_<tag>.md` file — that flow is reserved for
+# stable releases in `tag-and-release.yml`.
+#
+# The dev tag is an annotated tag pointing at a synthetic commit whose
+# parent is the current `main` HEAD. The synthetic commit only bumps
+# `verifiers/__init__.py` so that the wheel built from the tag carries
+# the correct version. The bump commit is never pushed back to `main`,
+# which keeps the branch free of bot churn and merge conflicts.
 
 on:
   push:
@@ -20,7 +20,6 @@ on:
 
 permissions:
   contents: write
-  actions: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -31,6 +30,10 @@ jobs:
     name: Create .dev tag
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    outputs:
+      created: ${{ steps.tag.outputs.created }}
+      tag: ${{ steps.tag.outputs.tag }}
+      version: ${{ steps.tag.outputs.version }}
     steps:
       - name: Checkout main
         uses: actions/checkout@v4
@@ -42,17 +45,16 @@ jobs:
         env:
           BEFORE_SHA: ${{ github.event.before }}
         run: |
-          # When a maintainer lands a manual release-prep PR (either a
-          # stable bump like `0.1.15` or a legacy `Prepare vX.Y.devN`
-          # PR), `tag-and-release.yml`'s `auto-tag-on-main` job already
-          # tags and publishes that version. Skip the auto-dev tag in
-          # that case so we do not create a second tag for the same SHA.
+          # When a maintainer lands a stable release-prep PR,
+          # `tag-and-release.yml`'s `auto-tag-on-main` job tags and
+          # publishes that version. Skip the auto-dev tag in that case
+          # so we do not create a second tag for the same SHA.
           if [ -z "$BEFORE_SHA" ] || [ "$BEFORE_SHA" = "0000000000000000000000000000000000000000" ]; then
             echo "skip=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           if git diff --name-only "$BEFORE_SHA" HEAD | grep -qx 'verifiers/__init__.py'; then
-            echo "verifiers/__init__.py was modified in this push; deferring to tag-and-release auto-tag flow."
+            echo "verifiers/__init__.py was modified in this push; deferring to tag-and-release."
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
@@ -78,7 +80,6 @@ jobs:
               const m = semverRe.exec(ref.ref);
               if (!m) continue;
               parsed.push({
-                raw: ref.ref.replace("refs/tags/", ""),
                 prefix: m[1] || "v",
                 major: Number.parseInt(m[2], 10),
                 minor: Number.parseInt(m[3], 10),
@@ -140,22 +141,20 @@ jobs:
             core.setOutput("skipped", "false");
             core.setOutput("tag", tag);
             core.setOutput("version", version);
-            core.setOutput("previous_tag", latest.raw);
-            core.notice(`Next dev tag: ${tag} (previous: ${latest.raw})`);
+            core.notice(`Next dev tag: ${tag}`);
 
       - name: Build release commit and push tag
         if: steps.skip.outputs.skip != 'true' && steps.ver.outputs.skipped != 'true'
+        id: tag
         env:
           TAG: ${{ steps.ver.outputs.tag }}
           VERSION: ${{ steps.ver.outputs.version }}
-          PREVIOUS_TAG: ${{ steps.ver.outputs.previous_tag }}
         run: |
           set -euo pipefail
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          # Detach so the bump commit lives only as the tag target.
           git checkout --detach HEAD
 
           python - <<'PY'
@@ -175,52 +174,60 @@ jobs:
           path.write_text(new_text)
           PY
 
-          mkdir -p assets/release
-          NOTES_PATH="assets/release/RELEASE_${TAG}.md"
-          DATE=$(date -u +%Y-%m-%d)
-          {
-            echo "# Verifiers ${TAG} Release Notes"
-            echo
-            echo "*Date:* ${DATE}"
-            echo
-            echo "Auto-generated dev release (see \`.github/workflows/devx_tag.yml\`)."
-            echo
-            if [ -n "${PREVIOUS_TAG}" ] && git rev-parse -q --verify "refs/tags/${PREVIOUS_TAG}" >/dev/null; then
-              echo "## Changes since ${PREVIOUS_TAG}"
-              echo
-              git log --no-merges --format='- %s' "${PREVIOUS_TAG}..HEAD" || true
-              echo
-              echo "**Full Changelog**: https://github.com/${GITHUB_REPOSITORY}/compare/${PREVIOUS_TAG}...${TAG}"
-            fi
-          } > "${NOTES_PATH}"
-
-          git add verifiers/__init__.py "${NOTES_PATH}"
+          git add verifiers/__init__.py
           git commit -m "Prepare ${TAG} release"
           git tag -a "${TAG}" -m "Release ${TAG}"
-
-          # Push the tag (which also publishes the bump commit as its
-          # target). GITHUB_TOKEN-created tags do not retrigger
-          # workflows, so the build/publish flow is dispatched
-          # explicitly in the next step.
           git push origin "refs/tags/${TAG}"
 
-      - name: Dispatch tag-and-release for new tag
-        if: steps.skip.outputs.skip != 'true' && steps.ver.outputs.skipped != 'true'
-        uses: actions/github-script@v7
-        env:
-          TAG: ${{ steps.ver.outputs.tag }}
+          echo "created=true" >> "$GITHUB_OUTPUT"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+  build-dev:
+    name: Build dev wheel
+    needs: create-dev-tag
+    if: needs.create-dev-tag.outputs.created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout dev tag
+        uses: actions/checkout@v4
         with:
-          script: |
-            const tag = process.env.TAG;
-            try {
-              await github.rest.actions.createWorkflowDispatch({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                workflow_id: "tag-and-release.yml",
-                ref: "main",
-                inputs: { tag },
-              });
-              core.notice(`Dispatched tag-and-release.yml for ${tag}`);
-            } catch (error) {
-              core.setFailed(`Failed to dispatch tag-and-release.yml: ${error.message}`);
-            }
+          ref: refs/tags/${{ needs.create-dev-tag.outputs.tag }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Build sdist and wheel
+        run: uv build
+
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+          retention-days: 7
+
+  publish-dev:
+    name: Publish dev to PyPI
+    needs: [create-dev-tag, build-dev]
+    runs-on: ubuntu-latest
+    environment: pypi-prod
+    permissions:
+      id-token: write
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/.github/workflows/devx_tag.yml
+++ b/.github/workflows/devx_tag.yml
@@ -1,0 +1,226 @@
+name: DevX Tag
+
+# Automatically create and publish a `.devN` release for every push to
+# `main`. The dev tag is created as an annotated tag pointing at a
+# synthetic commit (parent = current `main` HEAD) that bumps
+# `verifiers/__init__.py` to the new dev version and adds a stub
+# release-notes file at `assets/release/RELEASE_<tag>.md`. The tag is
+# then handed off to `tag-and-release.yml` via `workflow_dispatch` so the
+# build + PyPI publish + GitHub Release jobs run unchanged.
+#
+# The bump commit only lives as the tag target; it is NOT pushed back to
+# `main`. The `main` branch's `__version__` therefore lags behind the
+# latest published dev tag by one increment, which is acceptable for dev
+# releases and avoids spurious commits / merge conflicts on the branch.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  actions: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  create-dev-tag:
+    name: Create .dev tag
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Skip if push modified verifiers/__init__.py
+        id: skip
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          # When a maintainer lands a manual release-prep PR (either a
+          # stable bump like `0.1.15` or a legacy `Prepare vX.Y.devN`
+          # PR), `tag-and-release.yml`'s `auto-tag-on-main` job already
+          # tags and publishes that version. Skip the auto-dev tag in
+          # that case so we do not create a second tag for the same SHA.
+          if [ -z "$BEFORE_SHA" ] || [ "$BEFORE_SHA" = "0000000000000000000000000000000000000000" ]; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if git diff --name-only "$BEFORE_SHA" HEAD | grep -qx 'verifiers/__init__.py'; then
+            echo "verifiers/__init__.py was modified in this push; deferring to tag-and-release auto-tag flow."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Compute next dev version
+        if: steps.skip.outputs.skip != 'true'
+        id: ver
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+
+            const refs = await github.paginate(github.rest.git.listMatchingRefs, {
+              owner,
+              repo,
+              ref: "tags/v",
+            });
+
+            const semverRe = /^refs\/tags\/(v?)(\d+)\.(\d+)\.(\d+)(?:\.dev(\d+))?$/;
+            const parsed = [];
+            for (const ref of refs) {
+              const m = semverRe.exec(ref.ref);
+              if (!m) continue;
+              parsed.push({
+                raw: ref.ref.replace("refs/tags/", ""),
+                prefix: m[1] || "v",
+                major: Number.parseInt(m[2], 10),
+                minor: Number.parseInt(m[3], 10),
+                patch: Number.parseInt(m[4], 10),
+                dev: m[5] !== undefined ? Number.parseInt(m[5], 10) : null,
+              });
+            }
+
+            if (parsed.length === 0) {
+              core.notice("No v* tags found; skipping .dev tag creation.");
+              core.setOutput("skipped", "true");
+              return;
+            }
+
+            parsed.sort((a, b) => {
+              if (a.major !== b.major) return b.major - a.major;
+              if (a.minor !== b.minor) return b.minor - a.minor;
+              if (a.patch !== b.patch) return b.patch - a.patch;
+              if (a.dev === null && b.dev !== null) return -1;
+              if (a.dev !== null && b.dev === null) return 1;
+              if (a.dev !== null && b.dev !== null) return b.dev - a.dev;
+              return 0;
+            });
+
+            const latest = parsed[0];
+            const prefix = latest.prefix;
+            let baseMajor = latest.major;
+            let baseMinor = latest.minor;
+            let basePatch = latest.patch;
+            let startDev;
+            if (latest.dev === null) {
+              basePatch += 1;
+              startDev = 1;
+            } else {
+              startDev = latest.dev + 1;
+            }
+
+            const base = `${prefix}${baseMajor}.${baseMinor}.${basePatch}`;
+            const devPrefix = `${base}.dev`;
+            const escapeRegex = (v) => v.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+            const devPattern = new RegExp(`^refs/tags/${escapeRegex(base)}\\.dev(\\d+)$`);
+
+            const existingDevRefs = await github.paginate(github.rest.git.listMatchingRefs, {
+              owner,
+              repo,
+              ref: `tags/${devPrefix}`,
+            });
+            let maxDev = startDev - 1;
+            for (const ref of existingDevRefs) {
+              const m = devPattern.exec(ref.ref);
+              if (m) {
+                const n = Number.parseInt(m[1], 10);
+                if (n > maxDev) maxDev = n;
+              }
+            }
+
+            const tag = `${devPrefix}${maxDev + 1}`;
+            const version = tag.replace(/^v/, "");
+            core.setOutput("skipped", "false");
+            core.setOutput("tag", tag);
+            core.setOutput("version", version);
+            core.setOutput("previous_tag", latest.raw);
+            core.notice(`Next dev tag: ${tag} (previous: ${latest.raw})`);
+
+      - name: Build release commit and push tag
+        if: steps.skip.outputs.skip != 'true' && steps.ver.outputs.skipped != 'true'
+        env:
+          TAG: ${{ steps.ver.outputs.tag }}
+          VERSION: ${{ steps.ver.outputs.version }}
+          PREVIOUS_TAG: ${{ steps.ver.outputs.previous_tag }}
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Detach so the bump commit lives only as the tag target.
+          git checkout --detach HEAD
+
+          python - <<'PY'
+          from pathlib import Path
+          import os, re, sys
+
+          path = Path("verifiers/__init__.py")
+          text = path.read_text()
+          new_text, count = re.subn(
+              r'__version__\s*=\s*"[^"]+"',
+              f'__version__ = "{os.environ["VERSION"]}"',
+              text,
+              count=1,
+          )
+          if count != 1:
+              sys.exit("Failed to locate __version__ in verifiers/__init__.py")
+          path.write_text(new_text)
+          PY
+
+          mkdir -p assets/release
+          NOTES_PATH="assets/release/RELEASE_${TAG}.md"
+          DATE=$(date -u +%Y-%m-%d)
+          {
+            echo "# Verifiers ${TAG} Release Notes"
+            echo
+            echo "*Date:* ${DATE}"
+            echo
+            echo "Auto-generated dev release (see \`.github/workflows/devx_tag.yml\`)."
+            echo
+            if [ -n "${PREVIOUS_TAG}" ] && git rev-parse -q --verify "refs/tags/${PREVIOUS_TAG}" >/dev/null; then
+              echo "## Changes since ${PREVIOUS_TAG}"
+              echo
+              git log --no-merges --format='- %s' "${PREVIOUS_TAG}..HEAD" || true
+              echo
+              echo "**Full Changelog**: https://github.com/${GITHUB_REPOSITORY}/compare/${PREVIOUS_TAG}...${TAG}"
+            fi
+          } > "${NOTES_PATH}"
+
+          git add verifiers/__init__.py "${NOTES_PATH}"
+          git commit -m "Prepare ${TAG} release"
+          git tag -a "${TAG}" -m "Release ${TAG}"
+
+          # Push the tag (which also publishes the bump commit as its
+          # target). GITHUB_TOKEN-created tags do not retrigger
+          # workflows, so the build/publish flow is dispatched
+          # explicitly in the next step.
+          git push origin "refs/tags/${TAG}"
+
+      - name: Dispatch tag-and-release for new tag
+        if: steps.skip.outputs.skip != 'true' && steps.ver.outputs.skipped != 'true'
+        uses: actions/github-script@v7
+        env:
+          TAG: ${{ steps.ver.outputs.tag }}
+        with:
+          script: |
+            const tag = process.env.TAG;
+            try {
+              await github.rest.actions.createWorkflowDispatch({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: "tag-and-release.yml",
+                ref: "main",
+                inputs: { tag },
+              });
+              core.notice(`Dispatched tag-and-release.yml for ${tag}`);
+            } catch (error) {
+              core.setFailed(`Failed to dispatch tag-and-release.yml: ${error.message}`);
+            }

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -1,15 +1,21 @@
 name: Tag and Release
 
+# Stable release flow: tag + push to PyPI + GitHub Release with hand-curated
+# notes from `assets/release/RELEASE_<tag>.md`. Dev releases (`v*.dev*`) are
+# excluded from this workflow — they are handled by `devx_tag.yml`, which
+# publishes to PyPI without producing a GitHub Release.
+
 on:
   push:
     branches:
       - main
     tags:
       - 'v*'
+      - '!v*.dev*'
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Existing tag to release (e.g. v1.2.3)'
+        description: 'Existing stable tag to release (e.g. v1.2.3). `.dev` tags are not accepted.'
         required: true
         type: string
 
@@ -63,6 +69,14 @@ jobs:
             echo "No __version__ change detected in verifiers/__init__.py; skipping auto-tag."
             exit 0
           fi
+
+          case "$NEW_VERSION" in
+            *.dev*)
+              echo "verifiers/__init__.py bumped to dev version '$NEW_VERSION'; this flow is reserved for stable releases."
+              echo "Dev releases are produced automatically by devx_tag.yml — do not bump __version__ to a dev value manually."
+              exit 0
+              ;;
+          esac
 
           TAG="v${NEW_VERSION}"
 
@@ -204,6 +218,10 @@ jobs:
           fi
 
           case "$TAG" in
+            v*.dev*)
+              echo "Dev tags are not accepted by this workflow (received '$TAG'). Dev releases are handled by devx_tag.yml." >&2
+              exit 1
+              ;;
             v*)
               ;;
             *)

--- a/assets/release/release_workflow.md
+++ b/assets/release/release_workflow.md
@@ -1,40 +1,89 @@
 # Release workflow
 
-The `Tag and Release` GitHub Actions workflow (`.github/workflows/tag-and-release.yml`) publishes a new `verifiers`
-version whenever a maintainer pushes a `v*` tag. Follow the checklist below to guarantee the workflow only runs once per
-version and finishes cleanly.
+`verifiers` ships two kinds of releases:
 
-## Before triggering a release
+- **Automatic dev releases** (`vX.Y.Z.devN`) — published from every push to
+  `main` by the `DevX Tag` workflow (`.github/workflows/devx_tag.yml`).
+- **Manual stable releases** (`vX.Y.Z`) — prepared by a maintainer via a
+  release-prep PR and published by `Tag and Release`
+  (`.github/workflows/tag-and-release.yml`).
 
-- Land a release prep PR on `main` with:
-  - `verifiers/__init__.py` set to the final version (for example `0.1.4`).
-  - Updated release notes in `assets/release/RELEASE_vX.Y.Z.md`.
-  - Any ancillary artifacts or documentation updates that belong with the release.
-- Verify CI is green on the commit you intend to tag.
-- Confirm the `verifiers` project on PyPI has a Trusted Publisher configured for repository `PrimeIntellect-ai/verifiers`, workflow `tag-and-release.yml`, environment `pypi-prod`. The publish job authenticates via OIDC — no PyPI token is required for `verifiers`.
+Both flows ultimately go through `tag-and-release.yml`, which runs the
+`uv build` → `pypa/gh-action-pypi-publish` (Trusted Publisher, OIDC,
+environment `pypi-prod`) → `softprops/action-gh-release` pipeline.
 
-## Triggering the workflow
+## Automatic dev releases
 
-1. From `main`, create an annotated tag that matches the version string (for example `git tag -a v0.1.4 -m "Release v0.1.4"`).
-2. Push the tag to GitHub with `git push origin v0.1.4`. The push is the only automatic trigger for the workflow, so each
-   version runs exactly once.
-3. Watch the **Actions → Tag and Release** run to confirm `uv build`, the PyPI publish (via `pypa/gh-action-pypi-publish` using OIDC), and the GitHub Release creation succeed. The job runs in the `pypi-prod` environment.
+`devx_tag.yml` runs on every push to `main`. For each push it:
 
-> Optional: To republish an older tag without pushing again, start **Actions → Tag and Release** manually and provide the
-> existing tag (for example `v0.1.4`). The job checks out that tag and performs the same build and publish steps.
+1. Computes the next dev tag from the most recent `v*` tag. If the latest
+   tag is stable (`vX.Y.Z`) the next dev tag is `vX.Y.(Z+1).dev1`. If the
+   latest tag is already a dev release (`vX.Y.Z.devN`) the next dev tag is
+   `vX.Y.Z.dev(N+1)`.
+2. Creates a synthetic commit on top of the current `main` HEAD that bumps
+   `verifiers/__init__.py` to the new version and writes a stub release
+   notes file at `assets/release/RELEASE_<tag>.md`.
+3. Annotates and pushes that tag (the bump commit only ever lives as the
+   tag's target — it is **not** pushed back to `main`).
+4. Dispatches `tag-and-release.yml` with the new tag as input. The
+   build/publish/GitHub-release jobs check out the tag, validate that
+   `verifiers/__init__.py` matches the tag, build the wheel + sdist,
+   publish to PyPI, and create the GitHub Release using the auto-generated
+   notes file.
 
-## After the release
+`devx_tag.yml` defers to the manual flow when a push already modifies
+`verifiers/__init__.py`, so a release-prep PR never produces two tags for
+the same commit.
 
-- Verify the new version appears on PyPI and that the GitHub Release contains the built `dist/` artifacts.
-- Draft follow-up communication (blog post, changelog announcement) if needed.
-- Open a short PR that bumps `verifiers/__init__.py` to the next development version (for example `0.1.5.dev0`).
+To trigger a dev release manually (for example after a workflow rerun),
+use **Actions → DevX Tag → Run workflow** against `main`.
+
+## Manual stable releases
+
+For a `vX.Y.Z` cut, prepare a release-prep PR on `main` with:
+
+- `verifiers/__init__.py` set to the final version (for example `0.1.16`,
+  no `.dev` suffix).
+- Hand-curated release notes at `assets/release/RELEASE_vX.Y.Z.md`.
+- Any ancillary artifacts or documentation updates that belong with the
+  release.
+
+Verify CI is green and confirm the `verifiers` project on PyPI has a
+Trusted Publisher configured for repository `PrimeIntellect-ai/verifiers`,
+workflow `tag-and-release.yml`, environment `pypi-prod`.
+
+When the PR is merged, `tag-and-release.yml`'s `auto-tag-on-main` job
+detects the version change in `verifiers/__init__.py`, creates and pushes
+`vX.Y.Z`, and runs build → PyPI publish → GitHub Release. The
+`devx_tag.yml` workflow skips this push (because `__init__.py` changed)
+and resumes producing `vX.Y.(Z+1).devN` tags on subsequent pushes.
+
+> Optional: To republish an existing tag without pushing again, start
+> **Actions → Tag and Release** manually and provide the existing tag
+> (for example `v0.1.4`). The job checks out that tag and performs the
+> same build and publish steps.
+
+## After a stable release
+
+- Verify the new version appears on PyPI and that the GitHub Release
+  contains the built `dist/` artifacts.
+- Draft follow-up communication (blog post, changelog announcement) if
+  needed.
+- No follow-up bump PR is required — the next push to `main` will create
+  the first `vX.Y.(Z+1).devN` tag automatically.
 
 ## Troubleshooting
 
-- **Workflow failed before publishing to PyPI**: fix the underlying issue and re-run the failed job from the Actions UI. The
-  rerun builds from the same tag.
-- **PyPI publish failed**: address the error locally, then re-run the workflow manually with the same tag once the issue is
-  resolved. PyPI will reject duplicate uploads, so delete the partially uploaded files (if any) from the failed run before
-  retrying.
-- **Version mismatch error**: ensure the tag you pushed (e.g. `v0.1.4`) matches the version string committed to
-  `verifiers/__init__.py` before retrying.
+- **`devx_tag.yml` failed before pushing the tag**: re-run the workflow
+  from the Actions UI. The job is idempotent: it always recomputes the
+  next dev number against the live tag list.
+- **`devx_tag.yml` succeeded but the dispatched `Tag and Release` run
+  failed**: fix the underlying issue and trigger
+  **Actions → Tag and Release → Run workflow** manually with the same tag.
+- **PyPI publish failed**: address the error locally, then re-run the
+  workflow manually with the same tag once the issue is resolved. PyPI
+  will reject duplicate uploads, so delete the partially uploaded files
+  (if any) from the failed run before retrying.
+- **Version mismatch error**: ensure the tag you pushed (e.g. `v0.1.4`)
+  matches the version string committed to `verifiers/__init__.py` at the
+  tag.

--- a/assets/release/release_workflow.md
+++ b/assets/release/release_workflow.md
@@ -1,62 +1,66 @@
 # Release workflow
 
-`verifiers` ships two kinds of releases:
+`verifiers` ships two kinds of releases, each owned by its own workflow:
 
-- **Automatic dev releases** (`vX.Y.Z.devN`) — published from every push to
-  `main` by the `DevX Tag` workflow (`.github/workflows/devx_tag.yml`).
-- **Manual stable releases** (`vX.Y.Z`) — prepared by a maintainer via a
-  release-prep PR and published by `Tag and Release`
-  (`.github/workflows/tag-and-release.yml`).
+| Kind | Tag shape | Workflow | What it produces |
+| --- | --- | --- | --- |
+| Dev | `vX.Y.Z.devN` | `.github/workflows/devx_tag.yml` | git tag + PyPI upload |
+| Stable | `vX.Y.Z` | `.github/workflows/tag-and-release.yml` | git tag + PyPI upload + GitHub Release with `assets/release/RELEASE_<tag>.md` |
 
-Both flows ultimately go through `tag-and-release.yml`, which runs the
-`uv build` → `pypa/gh-action-pypi-publish` (Trusted Publisher, OIDC,
-environment `pypi-prod`) → `softprops/action-gh-release` pipeline.
+Both workflows publish to PyPI via Trusted Publisher (`pypi-prod`
+environment, OIDC). Trusted Publisher entries on PyPI must exist for
+**both** workflow file names.
 
-## Automatic dev releases
+## Automatic dev releases (`devx_tag.yml`)
 
 `devx_tag.yml` runs on every push to `main`. For each push it:
 
 1. Computes the next dev tag from the most recent `v*` tag. If the latest
    tag is stable (`vX.Y.Z`) the next dev tag is `vX.Y.(Z+1).dev1`. If the
-   latest tag is already a dev release (`vX.Y.Z.devN`) the next dev tag is
-   `vX.Y.Z.dev(N+1)`.
-2. Creates a synthetic commit on top of the current `main` HEAD that bumps
-   `verifiers/__init__.py` to the new version and writes a stub release
-   notes file at `assets/release/RELEASE_<tag>.md`.
-3. Annotates and pushes that tag (the bump commit only ever lives as the
-   tag's target — it is **not** pushed back to `main`).
-4. Dispatches `tag-and-release.yml` with the new tag as input. The
-   build/publish/GitHub-release jobs check out the tag, validate that
-   `verifiers/__init__.py` matches the tag, build the wheel + sdist,
-   publish to PyPI, and create the GitHub Release using the auto-generated
-   notes file.
+   latest tag is already a dev release (`vX.Y.Z.devN`) the next dev tag
+   is `vX.Y.Z.dev(N+1)`.
+2. Creates a synthetic commit on top of the current `main` HEAD that
+   bumps `verifiers/__init__.py` to the new version. The commit is the
+   parent of the annotated tag — it is **not** pushed back to `main`.
+3. Pushes the tag, then checks out the tagged commit, runs `uv build`,
+   and publishes the wheel + sdist to PyPI.
 
-`devx_tag.yml` defers to the manual flow when a push already modifies
-`verifiers/__init__.py`, so a release-prep PR never produces two tags for
-the same commit.
+Dev releases intentionally do **not** create a GitHub Release and do
+**not** require a hand-curated release-notes file. They are best
+consumed via `pip install verifiers==X.Y.Z.devN` or
+`pip install verifiers --pre`.
+
+`devx_tag.yml` defers to the stable flow when a push already modifies
+`verifiers/__init__.py`, so a release-prep PR never produces two tags
+for the same commit.
 
 To trigger a dev release manually (for example after a workflow rerun),
 use **Actions → DevX Tag → Run workflow** against `main`.
 
-## Manual stable releases
+## Manual stable releases (`tag-and-release.yml`)
+
+`tag-and-release.yml` only handles non-dev tags. It rejects `v*.dev*`
+tags both on push and on `workflow_dispatch`.
 
 For a `vX.Y.Z` cut, prepare a release-prep PR on `main` with:
 
-- `verifiers/__init__.py` set to the final version (for example `0.1.16`,
-  no `.dev` suffix).
+- `verifiers/__init__.py` set to the final version (for example
+  `0.1.16`, no `.dev` suffix).
 - Hand-curated release notes at `assets/release/RELEASE_vX.Y.Z.md`.
 - Any ancillary artifacts or documentation updates that belong with the
   release.
 
 Verify CI is green and confirm the `verifiers` project on PyPI has a
-Trusted Publisher configured for repository `PrimeIntellect-ai/verifiers`,
-workflow `tag-and-release.yml`, environment `pypi-prod`.
+Trusted Publisher configured for repository
+`PrimeIntellect-ai/verifiers`, workflow `tag-and-release.yml`,
+environment `pypi-prod`.
 
 When the PR is merged, `tag-and-release.yml`'s `auto-tag-on-main` job
-detects the version change in `verifiers/__init__.py`, creates and pushes
-`vX.Y.Z`, and runs build → PyPI publish → GitHub Release. The
-`devx_tag.yml` workflow skips this push (because `__init__.py` changed)
-and resumes producing `vX.Y.(Z+1).devN` tags on subsequent pushes.
+detects the version change in `verifiers/__init__.py`, creates and
+pushes `vX.Y.Z`, runs `uv build`, publishes to PyPI, and creates the
+GitHub Release from `assets/release/RELEASE_vX.Y.Z.md`. `devx_tag.yml`
+skips this push (because `__init__.py` changed) and resumes producing
+`vX.Y.(Z+1).devN` tags on subsequent pushes.
 
 > Optional: To republish an existing tag without pushing again, start
 > **Actions → Tag and Release** manually and provide the existing tag
@@ -69,21 +73,22 @@ and resumes producing `vX.Y.(Z+1).devN` tags on subsequent pushes.
   contains the built `dist/` artifacts.
 - Draft follow-up communication (blog post, changelog announcement) if
   needed.
-- No follow-up bump PR is required — the next push to `main` will create
-  the first `vX.Y.(Z+1).devN` tag automatically.
+- No follow-up bump PR is required — the next push to `main` will
+  create the first `vX.Y.(Z+1).devN` tag automatically.
 
 ## Troubleshooting
 
 - **`devx_tag.yml` failed before pushing the tag**: re-run the workflow
   from the Actions UI. The job is idempotent: it always recomputes the
   next dev number against the live tag list.
-- **`devx_tag.yml` succeeded but the dispatched `Tag and Release` run
-  failed**: fix the underlying issue and trigger
-  **Actions → Tag and Release → Run workflow** manually with the same tag.
-- **PyPI publish failed**: address the error locally, then re-run the
-  workflow manually with the same tag once the issue is resolved. PyPI
-  will reject duplicate uploads, so delete the partially uploaded files
-  (if any) from the failed run before retrying.
+- **`devx_tag.yml` pushed the tag but PyPI publish failed**: re-run the
+  failed job from the Actions UI. PyPI rejects duplicate uploads, so if
+  the wheel actually made it through, delete the partial upload first.
+- **`tag-and-release.yml` reported "Dev tags are not accepted by this
+  workflow"**: this is expected — use `devx_tag.yml` for dev releases.
+- **`tag-and-release.yml` reported "verifiers/__init__.py bumped to dev
+  version"**: never bump `__init__.py` to a `.devN` value manually; the
+  auto-dev flow owns dev versions.
 - **Version mismatch error**: ensure the tag you pushed (e.g. `v0.1.4`)
-  matches the version string committed to `verifiers/__init__.py` at the
-  tag.
+  matches the version string committed to `verifiers/__init__.py` at
+  the tag.

--- a/assets/release/release_workflow.md
+++ b/assets/release/release_workflow.md
@@ -13,22 +13,32 @@ environment, OIDC). Trusted Publisher entries on PyPI must exist for
 
 ## Automatic dev releases (`devx_tag.yml`)
 
+`verifiers/__init__.py`'s `__version__` is treated as the **latest
+stable release version** and is only ever changed by a stable
+release-prep PR (see below). The dev flow leaves it alone.
+
 `devx_tag.yml` runs on every push to `main`. For each push it:
 
-1. Computes the next dev tag from the most recent `v*` tag. If the latest
-   tag is stable (`vX.Y.Z`) the next dev tag is `vX.Y.(Z+1).dev1`. If the
-   latest tag is already a dev release (`vX.Y.Z.devN`) the next dev tag
-   is `vX.Y.Z.dev(N+1)`.
-2. Creates a synthetic commit on top of the current `main` HEAD that
-   bumps `verifiers/__init__.py` to the new version. The commit is the
-   parent of the annotated tag — it is **not** pushed back to `main`.
-3. Pushes the tag, then checks out the tagged commit, runs `uv build`,
-   and publishes the wheel + sdist to PyPI.
+1. Computes the next dev tag from the most recent `v*` tag. If the
+   latest tag is stable (`vX.Y.Z`) the next dev tag is
+   `vX.Y.(Z+1).dev1`. If the latest tag is already a dev release
+   (`vX.Y.Z.devN`) the next dev tag is `vX.Y.Z.dev(N+1)`.
+2. Creates a lightweight tag pointing directly at the current `main`
+   HEAD. No commit is created and `main` is not modified.
+3. Checks out the tag, overrides `verifiers/__init__.py`'s `__version__`
+   to the dev version **in the workflow checkout only** (uncommitted),
+   runs `uv build`, and publishes the wheel + sdist to PyPI via Trusted
+   Publisher.
 
 Dev releases intentionally do **not** create a GitHub Release and do
 **not** require a hand-curated release-notes file. They are best
 consumed via `pip install verifiers==X.Y.Z.devN` or
 `pip install verifiers --pre`.
+
+Because the override is never committed, a `git checkout vX.Y.Z.devN`
+will show `__version__` equal to the latest stable, not the dev value.
+That is intentional — the only place the dev version exists is on the
+published wheel.
 
 `devx_tag.yml` defers to the stable flow when a push already modifies
 `verifiers/__init__.py`, so a release-prep PR never produces two tags
@@ -73,8 +83,10 @@ skips this push (because `__init__.py` changed) and resumes producing
   contains the built `dist/` artifacts.
 - Draft follow-up communication (blog post, changelog announcement) if
   needed.
-- No follow-up bump PR is required — the next push to `main` will
-  create the first `vX.Y.(Z+1).devN` tag automatically.
+- Leave `verifiers/__init__.py` at the just-published stable version —
+  it should always reflect the latest stable release. The next push to
+  `main` will automatically produce the first `vX.Y.(Z+1).devN` tag
+  without modifying the file.
 
 ## Troubleshooting
 

--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.15.dev11"
+__version__ = "0.1.14"
 
 import importlib
 import os


### PR DESCRIPTION
## Summary

Split the release pipeline into two independent flows so dev and stable releases never share infrastructure:

- **Dev releases (`.github/workflows/devx_tag.yml`)** — self-contained. On every push to `main`, the workflow enumerates `v*` tags to pick the next `vX.Y.(Z+1).dev1` (from a stable parent) or `vX.Y.Z.dev(N+1)` (from a dev parent), creates a lightweight tag at `main` HEAD via the git-refs API, checks out the tag, overrides `verifiers/__init__.py`'s `__version__` to the dev value **in the workflow checkout only (uncommitted)**, runs `uv build`, and publishes to PyPI via Trusted Publisher (`pypi-prod` environment, OIDC). No release-notes file, no GitHub Release — dev releases are just "tag + build + push to PyPI". Modeled on prime-rl's `devx_tag.yaml`.
- **Stable releases (`.github/workflows/tag-and-release.yml`)** — unchanged in shape, but reserved for non-dev tags only. Push trigger excludes `v*.dev*`, `auto-tag-on-main` skips with an explanatory message when `verifiers/__init__.py` is bumped to a `.dev` value, and the dispatched / pushed-tag flow errors on `.dev` tags. Still requires `assets/release/RELEASE_<tag>.md` and still creates a GitHub Release.

`verifiers/__init__.py`'s `__version__` is treated as the **latest stable release version** and is only ever modified by a stable release-prep PR. `devx_tag.yml` never touches it. As part of this PR `__version__` is reset from the legacy `0.1.15.dev11` to `0.1.14` (the actual latest stable on PyPI) so the invariant holds from day one.

`devx_tag.yml` defers to the stable flow when a push already modifies `verifiers/__init__.py`, so a stable release-prep PR never produces two tags for the same SHA. After a stable cut, the next push to `main` automatically produces the first `.dev1` of the next patch cycle without touching `main`.

Docs in `assets/release/release_workflow.md` and `.github/workflows/README.md` are rewritten around the two flows and the new `__init__.py = latest stable` invariant.

## Breaking

- `tag-and-release.yml` no longer accepts `.dev` tags via push trigger or `workflow_dispatch`. Use `devx_tag.yml` instead (runs automatically on every push to `main`; can also be dispatched manually).
- Manually bumping `verifiers/__init__.py` to a `vX.Y.Z.devN` value is no longer how dev releases ship. `auto-tag-on-main` now skips that case with an explanatory log line so it does not race with `devx_tag.yml`. The convention going forward is: `__version__` only ever changes when shipping a stable release.
- New dev tags do not produce a GitHub Release entry. Dev releases are consumed via PyPI (`pip install verifiers==X.Y.Z.devN` or `pip install verifiers --pre`).
- A `git checkout vX.Y.Z.devN` will show `__version__` equal to the latest stable, not the dev value, because the dev override is never committed. The wheel installed from PyPI still reports the dev version correctly.
- `verifiers/__init__.py` is reset from `0.1.15.dev11` to `0.1.14`. Source installs (e.g. `pip install -e .` from a `main` clone) will now report `0.1.14` instead of `0.1.15.dev11`. Wheels installed from PyPI continue to report their own dev/stable version.

## Setup required

Before merging, add a PyPI Trusted Publisher entry for the new workflow:

- Project: `verifiers`
- Owner: `PrimeIntellect-ai`
- Repository: `verifiers`
- Workflow file: `devx_tag.yml`
- Environment: `pypi-prod`

(The existing entry for `tag-and-release.yml` stays in place for stable releases.)

## Test plan

- [ ] Add the PyPI Trusted Publisher entry for `devx_tag.yml` + `pypi-prod` before merging.
- [ ] After merge, verify the next push to `main` produces a `vX.Y.Z.devN` tag (lightweight, pointing at `main` HEAD) and that the `DevX Tag` workflow publishes the wheel to PyPI labeled with that version.
- [ ] Verify a stable release-prep PR that bumps `verifiers/__init__.py` to a non-dev version is handled only by `tag-and-release.yml`'s `auto-tag-on-main` and that `devx_tag.yml` skips it.
- [ ] Verify `workflow_dispatch` on `tag-and-release.yml` with a `.devN` tag errors with "Dev tags are not accepted by this workflow".

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes production PyPI publishing and tagging on every merge to main; misconfiguration or tag logic bugs could publish wrong versions or collide with stable releases.
> 
> **Overview**
> Splits **dev** and **stable** publishing into separate GitHub Actions flows and documents the maintainer workflow end-to-end.
> 
> A new **`devx_tag.yml`** runs on every push to `main` (and manual dispatch): it skips when `verifiers/__init__.py` changed (stable prep), computes the next `vX.Y.Z.devN` tag from existing `v*` tags, creates a lightweight tag at HEAD, patches `__version__` only in the CI checkout for `uv build`, and publishes to PyPI via OIDC—**no** GitHub Release or `RELEASE_*.md`.
> 
> **`tag-and-release.yml`** is narrowed to stable releases: tag pushes ignore `v*.dev*`, `auto-tag-on-main` refuses a dev `__version__` bump, and manual/tag resolution errors on dev tags. **`assets/release/release_workflow.md`** and **`.github/workflows/README.md`** describe the two pipelines and PyPI Trusted Publisher setup for both workflows.
> 
> **`verifiers/__init__.py`** is reset to **`0.1.14`** as the on-`main` stable version string (replacing `0.1.15.dev11`), matching the model where dev numbers live on tags/wheels, not on `main`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 713fa0550f55716f0f23300665182122513787fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Auto-publish `.dev` releases to PyPI on every push to main
> - Adds [devx_tag.yml](https://github.com/PrimeIntellect-ai/verifiers/pull/1472/files#diff-1aff3db9bcab39e2886af278c52afb997b391ac2426ad0ebcbeefb26db27fcf0), a new workflow that runs on every push to main, computes the next `vX.Y.Z.devN` tag, creates it at the push SHA, builds a wheel and sdist, and publishes them to PyPI via OIDC Trusted Publisher.
> - Skips the dev release flow when the push modifies [verifiers/__init__.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1472/files#diff-3667172df996e6596aa8d26557b92b4cb78ee7d2280a3cae14623ce4677e781e), which always reflects the latest stable version and is not bumped for dev releases.
> - Updates [tag-and-release.yml](https://github.com/PrimeIntellect-ai/verifiers/pull/1472/files#diff-6e8eee63270ffaf5495c09121513fafa86d351cf0fefeeec6152000a281b42e1) to exclude `v*.dev*` tags and exit early if `__version__` is set to a dev value, so only stable `vX.Y.Z` tags go through the stable release path.
> - Resets `__version__` to `0.1.14` (from `0.1.15.dev11`) to reflect the latest stable release in the repo.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 713fa05.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->