### PR TITLE
Add v1 sandbox labels

### DIFF
--- a/verifiers/v1/config.py
+++ b/verifiers/v1/config.py
@@ -106,10 +106,11 @@ class SandboxConfig(Config):
     install_timeout: int = 300
     setup_commands: list[str] = []
     setup_timeout: int = 300
+    labels: list[str] = []
     scope: Literal["rollout", "group", "global"] = "rollout"
     prefer: Literal["program"] | None = None
 
-    @field_validator("packages", "setup_commands", mode="before")
+    @field_validator("packages", "setup_commands", "labels", mode="before")
     @classmethod
     def validate_string_list(cls, value: object) -> object:
         if isinstance(value, str):

--- a/verifiers/v1/utils/sandbox_utils.py
+++ b/verifiers/v1/utils/sandbox_utils.py
@@ -491,6 +491,7 @@ def _program_channel_setup_handler(
 async def create_sandbox(client: SandboxClient, sandbox_config: ConfigMap) -> str:
     from prime_sandboxes import CreateSandboxRequest
 
+    labels = sandbox_config.get("labels")
     request = CreateSandboxRequest(
         name=f"vf-v1-{uuid.uuid4().hex[:8]}",
         docker_image=str(sandbox_config.get("image") or "python:3.11-slim"),
@@ -501,6 +502,7 @@ async def create_sandbox(client: SandboxClient, sandbox_config: ConfigMap) -> st
         gpu_count=int_config(sandbox_config, "gpu_count", 0),
         network_access=bool(sandbox_config.get("network_access", True)),
         timeout_minutes=int_config(sandbox_config, "timeout_minutes", 60),
+        labels=[str(label) for label in labels] if isinstance(labels, list) else [],
     )
     sandbox = await client.create(request)
     sandbox_id = str(sandbox.id)


### PR DESCRIPTION
## Summary
- add labels to v1 SandboxConfig
- pass labels through to prime_sandboxes CreateSandboxRequest

## Checks
- UV_FROZEN=1 uv run ruff check --fix verifiers/v1/config.py verifiers/v1/utils/sandbox_utils.py
- UV_FROZEN=1 uv run ruff format verifiers/v1/config.py verifiers/v1/utils/sandbox_utils.py
- UV_FROZEN=1 uv run --python 3.13 ty check verifiers
- pre-commit hooks during commit
- pre-push hooks during push

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive config and API passthrough with safe defaults (empty labels); no auth or existing behavior changes beyond optional metadata on sandbox creation.
> 
> **Overview**
> Adds optional **sandbox labels** to v1 sandbox configuration so environments can tag sandboxes when they are provisioned.
> 
> `SandboxConfig` gains a `labels` field (default empty list) with the same string-to-list coercion as `packages` and `setup_commands`. When a sandbox is created, configured labels are forwarded to `prime_sandboxes` `CreateSandboxRequest`; non-list values are treated as no labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d6b91555e558ba27d762dd193156f6f5e793f7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `labels` field to `SandboxConfig` and pass it to `CreateSandboxRequest`
> Adds an optional `labels: list[str]` field to [`SandboxConfig`](https://github.com/PrimeIntellect-ai/verifiers/pull/1476/files#diff-d17c297fa8f1e3e9544f51280f3cdd0d95d1cae73e82d10d56f4b361a3bf0487), coercing a bare string to a single-element list. [`create_sandbox`](https://github.com/PrimeIntellect-ai/verifiers/pull/1476/files#diff-b1154f3be7f28191532de46fbe23a973a5f93e1450a71beb9c93910e358fda13) now reads this field and forwards it to `CreateSandboxRequest`, defaulting to an empty list if not set.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6d6b915.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->