### PR TITLE
Support GPU type in v1 sandbox config

### DIFF
--- a/tests/test_v1_config_extension.py
+++ b/tests/test_v1_config_extension.py
@@ -2964,6 +2964,9 @@ def test_nested_configs_validate_and_feed_runtime_objects() -> None:
         image="python:3.12-slim",
         packages="numpy",
         setup_commands="echo ready",
+        gpu_count=1,
+        gpu_type="H200_141GB",
+        vm=True,
         scope="group",
     )
     harness = make_harness(program={"sandbox": True}, sandbox=sandbox)
@@ -2972,6 +2975,9 @@ def test_nested_configs_validate_and_feed_runtime_objects() -> None:
     assert harness.sandbox["image"] == "python:3.12-slim"
     assert harness.sandbox["packages"] == ["numpy"]
     assert harness.sandbox["setup_commands"] == ["echo ready"]
+    assert harness.sandbox["gpu_count"] == 1
+    assert harness.sandbox["gpu_type"] == "H200_141GB"
+    assert harness.sandbox["vm"] is True
     assert harness.sandbox["scope"] == "group"
 
     toolset = Toolset(

--- a/tests/test_v1_runtime_lifecycle.py
+++ b/tests/test_v1_runtime_lifecycle.py
@@ -38,6 +38,7 @@ from verifiers.v1.utils.sandbox_program_utils import (
 from verifiers.v1.utils.sandbox_utils import (
     VF_STATE_INPUT_PATH_KEY,
     collect_sandbox_artifacts,
+    create_sandbox,
     run_sandbox_command,
 )
 
@@ -107,6 +108,7 @@ class FakeCommandResult:
 
 class FakeSandboxClient:
     created: list[str] = []
+    create_requests: list[FakeCreateSandboxRequest] = []
     deleted: list[str] = []
     commands: list[tuple[str, str]] = []
     command_timeouts: list[int | None] = []
@@ -116,6 +118,7 @@ class FakeSandboxClient:
     @classmethod
     def reset(cls) -> None:
         cls.created = []
+        cls.create_requests = []
         cls.deleted = []
         cls.commands = []
         cls.command_timeouts = []
@@ -123,8 +126,8 @@ class FakeSandboxClient:
         cls.uploads = []
 
     async def create(self, request: FakeCreateSandboxRequest) -> FakeSandboxResult:
-        _ = request
         sandbox_id = f"sbx-{len(type(self).created) + 1}"
+        type(self).create_requests.append(request)
         type(self).created.append(sandbox_id)
         return FakeSandboxResult(sandbox_id)
 
@@ -347,6 +350,29 @@ async def child_reads_program_sandbox(task, state) -> dict[str, object]:
     tools = state.get_tools()
     state["borrowed_sandbox_id"] = await tools["program_sandbox_id"]()
     return state
+
+
+@pytest.mark.asyncio
+async def test_create_sandbox_forwards_gpu_type_and_vm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_fake_sandboxes(monkeypatch)
+
+    sandbox_id = await create_sandbox(
+        FakeSandboxClient(),
+        {
+            "image": "gpu-image:latest",
+            "gpu_count": 1,
+            "gpu_type": "H200_141GB",
+        },
+    )
+
+    request = FakeSandboxClient.create_requests[0]
+    assert sandbox_id == "sbx-1"
+    assert request.kwargs["docker_image"] == "gpu-image:latest"
+    assert request.kwargs["gpu_count"] == 1
+    assert request.kwargs["gpu_type"] == "H200_141GB"
+    assert request.kwargs["vm"] is True
 
 
 def install_fake_sandboxes(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/verifiers/v1/config.py
+++ b/verifiers/v1/config.py
@@ -98,6 +98,8 @@ class SandboxConfig(Config):
     memory_gb: float = 2.0
     disk_size_gb: float = 5.0
     gpu_count: int = 0
+    gpu_type: str | None = None
+    vm: bool | None = None
     network_access: bool = True
     timeout_minutes: int = 60
     workdir: str | None = None

--- a/verifiers/v1/utils/sandbox_utils.py
+++ b/verifiers/v1/utils/sandbox_utils.py
@@ -455,6 +455,8 @@ def _program_channel_setup_handler(
 async def create_sandbox(client: SandboxClient, sandbox_config: ConfigMap) -> str:
     from prime_sandboxes import CreateSandboxRequest
 
+    gpu_count = int_config(sandbox_config, "gpu_count", 0)
+    vm = sandbox_config.get("vm")
     request = CreateSandboxRequest(
         name=f"vf-v1-{uuid.uuid4().hex[:8]}",
         docker_image=str(sandbox_config.get("image") or "python:3.11-slim"),
@@ -462,7 +464,9 @@ async def create_sandbox(client: SandboxClient, sandbox_config: ConfigMap) -> st
         cpu_cores=float_config(sandbox_config, "cpu_cores", 1.0),
         memory_gb=float_config(sandbox_config, "memory_gb", 2.0),
         disk_size_gb=float_config(sandbox_config, "disk_size_gb", 5.0),
-        gpu_count=int_config(sandbox_config, "gpu_count", 0),
+        gpu_count=gpu_count,
+        gpu_type=cast(str | None, sandbox_config.get("gpu_type")),
+        vm=bool(vm) if vm is not None else gpu_count > 0,
         network_access=bool(sandbox_config.get("network_access", True)),
         timeout_minutes=int_config(sandbox_config, "timeout_minutes", 60),
     )


### PR DESCRIPTION
## Summary
- add `gpu_type` and optional `vm` to v1 `SandboxConfig`
- pass `gpu_type` and `vm` through to `prime_sandboxes.CreateSandboxRequest`
- default VM-backed sandbox creation to true when `gpu_count > 0` and `vm` is unset

This is stacked on #1401 so Harbor v1 tasksets can request GPU VM sandboxes without carrying those fields as out-of-band metadata.

## Validation
- `uv run --no-sync ruff check --fix verifiers/v1/config.py verifiers/v1/utils/sandbox_utils.py tests/test_v1_config_extension.py tests/test_v1_runtime_lifecycle.py`
- `uv run --no-sync ruff format verifiers/v1/config.py verifiers/v1/utils/sandbox_utils.py tests/test_v1_config_extension.py tests/test_v1_runtime_lifecycle.py`
- `uv run --no-sync pytest tests/test_v1_config_extension.py::test_nested_configs_validate_and_feed_runtime_objects tests/test_v1_config_extension.py::test_nested_configs_reject_unknown_fields tests/test_v1_runtime_lifecycle.py::test_create_sandbox_forwards_gpu_type_and_vm tests/test_v1_harbor_cli.py::test_harbor_reward_uses_fresh_separate_verifier_sandbox`
- `uv run --no-sync pytest tests/test_v1_harbor_cli.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sandbox provisioning inputs (GPU/VM flags) used when creating remote sandboxes; mis-defaulting vm could affect non-GPU workloads if gpu_count is set incorrectly.
> 
> **Overview**
> Extends v1 **`SandboxConfig`** with optional **`gpu_type`** and **`vm`**, and threads them through **`create_sandbox`** into **`prime_sandboxes.CreateSandboxRequest`**. When **`vm`** is omitted, sandbox creation defaults to VM mode if **`gpu_count > 0`**, so GPU Harbor-style tasksets can request typed GPU VMs without extra metadata.
> 
> Tests assert nested config validation surfaces the new fields and that **`create_sandbox`** passes **`gpu_type`** and the derived **`vm`** flag to the client.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23fa4c721c13a204e23cd0311a185f3c79323dd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `gpu_type` and `vm` fields to v1 `SandboxConfig` and forward them in `create_sandbox`
> - Adds optional `gpu_type: str | None` and `vm: bool | None` fields to [`SandboxConfig`](https://github.com/PrimeIntellect-ai/verifiers/pull/1478/files#diff-d17c297fa8f1e3e9544f51280f3cdd0d95d1cae73e82d10d56f4b361a3bf0487).
> - Updates [`create_sandbox`](https://github.com/PrimeIntellect-ai/verifiers/pull/1478/files#diff-b1154f3be7f28191532de46fbe23a973a5f93e1450a71beb9c93910e358fda13) to pass `gpu_type` and `vm` to `CreateSandboxRequest`; `vm` defaults to `True` when `gpu_count > 0` and `False` otherwise if not explicitly set.
> - Adds tests covering propagation of `gpu_type` and `vm` through config and sandbox creation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 23fa4c7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->