### PR TITLE
Increase Scale-SWE restore timeout

### DIFF
--- a/verifiers/envs/experimental/composable/tasksets/swe/scale_swe.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/scale_swe.py
@@ -335,7 +335,7 @@ exit "$fail"
         ]
         for command in commands:
             await sandbox_client.execute_command(
-                sandbox_id, command, working_dir=workdir, timeout=60
+                sandbox_id, command, working_dir=workdir, timeout=120
             )
 
     def _calculate_reward(self, test_output: str, info: dict) -> float:


### PR DESCRIPTION
## Summary
- Double the Scale-SWE restore-test-file command timeout from 60 seconds to 120 seconds.

## Context
- The full no-op validation rerun surfaced restore commands that can exceed 60 seconds on larger repositories.
- This keeps the setup behavior the same while giving the two git checkout restore commands more room to complete.

## Validation
- `uv run ruff check verifiers/envs/experimental/composable/tasksets/swe/scale_swe.py`
- Commit and push hooks: ruff check, ruff format, Semgrep v1 policy, ty ci parity

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single timeout constant change in an experimental SWE taskset; no logic, auth, or scoring changes.
> 
> **Overview**
> Raises the sandbox **command timeout** for Scale-SWE’s pre-evaluation **test file restore** step from **60s to 120s** in `_restore_test_files`.
> 
> The two existing `git checkout HEAD -- …` restore commands are unchanged; only the per-command `execute_command` limit is doubled so large repos are less likely to fail setup during validation reruns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20b4e0e076aa847a1b092634cc381661297394ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Increase `restore-tests` git checkout timeout from 60s to 120s in Scale-SWE
> Doubles the per-command timeout for `git checkout` calls in the `restore-tests` step of [scale_swe.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1479/files#diff-53fa2dabc8829142f232c104f98a2db825644327726f20ef38b8c2b682193c21) to prevent timeouts on slower repositories.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 20b4e0e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->