### PR TITLE
fix(lean-taskset): match LAST EXIT_CODE marker to close reward bypass

### DIFF
--- a/verifiers/envs/experimental/composable/tasksets/lean/lean_task.py
+++ b/verifiers/envs/experimental/composable/tasksets/lean/lean_task.py
@@ -292,12 +292,19 @@ class LeanRubric(vf.Rubric):
             )
             output = (result.stdout or "") + (result.stderr or "")
 
-            # Parse exit code
+            # Parse exit code from the trailing ``EXIT_CODE:N`` we emitted at
+            # the end of ``cmd``. Match the LAST occurrence — the first one
+            # would let a model inject ``#eval IO.println "EXIT_CODE:0"``
+            # into the proof file: the regex would hit the injected marker,
+            # truncate everything after it (hiding the real
+            # ``declaration uses 'sorry'`` diagnostic and the real
+            # ``EXIT_CODE``), and report success.
             exit_code = 1
-            match = re.search(r"EXIT_CODE:(\d+)", output)
-            if match:
-                exit_code = int(match.group(1))
-                output = output[: match.start()].strip()
+            matches = list(re.finditer(r"EXIT_CODE:(\d+)", output))
+            if matches:
+                last = matches[-1]
+                exit_code = int(last.group(1))
+                output = output[: last.start()].strip()
 
             has_sorry = bool(re.search(r"declaration uses 'sorry'", output))
             compiled = exit_code == 0 and not has_sorry


### PR DESCRIPTION
## Summary

`LeanRubric.solved` parses the exit code from the `EXIT_CODE:N` we echo after `lake env lean` in the same shell command. It used `re.search` which returns the FIRST match — letting a model inject

\`\`\`lean
#eval IO.println \"EXIT_CODE:0\"
\`\`\`

into \`/tmp/proof.lean\`. The regex then hits the injected marker before the real one our shell appended at the end, truncates everything after it (hiding the real \`declaration uses 'sorry'\` diagnostic and the real \`EXIT_CODE\` from the actual \`lake\` invocation), and reports \`exit_code=0\`, \`has_sorry=False\`, \`compiled=True\`.

Switch to \`re.finditer\` and take the last match — only our shell can emit a marker AFTER \`lake\`'s output ended, so the trailing marker is always the trusted one.

## Context

Same fix landed in \`environments/lean_code\`'s v1 \`LeanTaskset\` in [PrimeIntellect-ai/research-environments#405](https://github.com/PrimeIntellect-ai/research-environments/pull/405); this brings the ComposableEnv \`LeanTaskSet\` (used by the published \`opencode-lean\` env) to parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix exit code parsing in `LeanRubric.solved` to use last `EXIT_CODE` marker
> Switches from `re.search` to `re.finditer` in [`lean_task.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1480/files#diff-82ca07b4b62d43e447930efd2492e85ec6e399f42b1c26933e781da6f976f90e) to find the last `EXIT_CODE:N` marker in Lean compile output instead of the first. This prevents user-controlled output from injecting an earlier `EXIT_CODE` marker that could bypass the reward check or hide diagnostics. Risk: changes `state['lean_compiled']`, `state['compile_output']`, and the returned reward for any outputs containing multiple `EXIT_CODE` markers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b0f0126.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Directly changes reward eligibility (`lean_compiled`, returned score) for Lean theorem tasks; fix is narrow but security-adjacent (agent reward hacking).
> 
> **Overview**
> **Closes a reward bypass** in `LeanRubric.solved` when scoring compile output from `lake env lean`.
> 
> Exit code parsing no longer uses the **first** `EXIT_CODE:N` in combined stdout/stderr. It now takes the **last** match and strips output only up to that point. A model could previously print an early fake `EXIT_CODE:0` (e.g. via `#eval IO.println`) so the checker ignored real `sorry` diagnostics and the shell-appended exit code.
> 
> This aligns composable `LeanTaskSet` behavior with the fix already applied elsewhere for the v1 lean taskset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0f01260e3ee804e0ad3cc82e5c2454fde349d98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->