### PR TITLE
Log routed_experts_prompt_start at debug level

### DIFF
--- a/verifiers/clients/renderer_client.py
+++ b/verifiers/clients/renderer_client.py
@@ -9,6 +9,7 @@ concurrent rollouts tokenize in parallel instead of blocking the event loop.
 """
 
 import json
+import logging
 import threading
 from collections.abc import Mapping
 from typing import Any, ClassVar, cast
@@ -59,6 +60,8 @@ from verifiers.types import (
     UserMessage,
 )
 from verifiers.utils.client_utils import setup_openai_client
+
+logger = logging.getLogger(__name__)
 
 # Module-level bridge counters. Incremented by every RendererClient instance
 # that tries to stitch a multi-turn prompt; callers (e.g. prime-rl's
@@ -598,6 +601,14 @@ class RendererClient(
             multi_modal_data = bridged.multi_modal_data
             prompt_attribution = bridged
             sampling_params["routed_experts_prompt_start"] = routed_experts_prompt_start
+            if routed_experts_prompt_start:
+                logger.debug(
+                    "Using routed_experts_prompt_start=%d for bridged renderer prompt "
+                    "(prompt_len=%d, trajectory_len=%d)",
+                    routed_experts_prompt_start,
+                    len(prompt_ids),
+                    len(_get_value(kwargs.get("state"), "trajectory", []) or []),
+                )
         else:
             prompt_ids = None
             multi_modal_data = None


### PR DESCRIPTION
## Summary

- The renderer client emits a per-turn `Using routed_experts_prompt_start=... for bridged renderer prompt (...)` message for every bridged multi-turn prompt. This is high-frequency rollout noise that shouldn't be at info level.
- This change adds the log to `RendererClient.get_native_response` and emits it at `logger.debug` instead of `logger.info`, so it's available when debugging routed-experts replay but stays out of normal training logs.

## Context

The info-level version of this log was originally introduced on `feat/routed-experts-delta-replay` (commit `8868716b`) but was dropped during a later merge of `main`, while it lives on in pinned downstream copies (e.g. prime-rl's vendored `deps/verifiers`), which is where it surfaces as info spam. This re-adds it on `main` at debug level so the quiet behavior is the one that propagates downstream.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change; no changes to bridging, tokenization, or sampling behavior.
> 
> **Overview**
> Adds **debug-only** logging in `RendererClient.get_native_response` when a bridged multi-turn prompt sets `routed_experts_prompt_start` on the sampling params. Each such turn can log the replay start index, bridged prompt length, and trajectory step count.
> 
> Also wires a module `logger` via `logging.getLogger(__name__)`. The message is gated on a truthy `routed_experts_prompt_start` so normal first-turn renders stay silent. Intent is to keep routed-experts replay visibility for debugging without **info**-level spam during high-volume rollouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71c344da3e2f771d55f8e233984c4230a5533bad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Log `routed_experts_prompt_start` at debug level in `RendererClient`
> Adds a module-level logger to [renderer_client.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1481/files#diff-4309037b1656944b1991edc5baa1d16760d74155d7adc9fef41a2080ce8605e1) and emits a DEBUG log when `routed_experts_prompt_start` is set on a bridged renderer prompt. The log includes the start index, prompt token count, and trajectory length from the request state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 71c344d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->