### PR TITLE
Add SWE-bench Verified patch environment

### DIFF
--- a/environments/README.md
+++ b/environments/README.md
@@ -61,6 +61,7 @@ This folder contains installable example environments that showcase common usage
   - **dspy_flights**: Sandboxed DSPy flight-support `program.fn` entrypoint installed from its package `pyproject.toml` and configured against the v1 interception endpoint.
   - **hello_group_reward_v1**: Deterministic v1 reference for group updates, metrics, rewards, advantages, and cleanup.
   - **nemo_gym_env**: Minimal v1 example that wraps a packaged NeMo Gym task with `NeMoGymTaskset` and `NeMoGymHarness`.
+  - **swe_bench_verified**: SWE-bench Verified patch-generation taskset with deterministic patch extraction, scoring, and official JSONL submission handoff.
   - **tau2_bench_v1**: `tau2-bench-v1` τ²-bench taskset/user/tool pattern on the v1 harness runtime.
   - **wordle_v1**: TextArena Wordle through the packaged v1 `TextArenaTaskset` boundary.
 
@@ -96,8 +97,8 @@ This folder contains installable example environments that showcase common usage
 - **CLI agent sandboxes**: `opencode_harbor`, `terminus_harbor`, `hello_mcp_harbor`
 - **MCP integration**: `mcp_search_env`, `hello_mcp_harbor`
 - **RLM (recursive LLM)**: `rlm_secrets`
-- **Taskset/Harness v1**: use this pattern for new environments that need reusable tasksets, reusable harnesses, framework programs, endpoint interception, or sandboxed Python/command programs. Examples include `dspy_rlm`, `openai_agents_env`, `langchain_deep_agents_wikispeedia`, `reverse_text`, `alphabet_sort`, `wiki_search`, `math_python`, `mcp_search_env`, `opencode_harbor`, `bfcl_v3`, `hello_subagent_v1`, `nested_harness_v1`, `hello_self_judge_v1`, `hello_parallel_sandbox_v1`, `hello_group_reward_v1`, `hello_rlm_v1`, `rlm_swe_v1`, `dspy_flights`, `tau2-bench-v1`, and `wordle-v1`.
-  - `opencode_harbor` uses the packaged `HarborTaskset` + `OpenCode` boundary from `tasksets` and `harnesses`.
+- **Taskset/Harness v1**: use this pattern for new environments that need reusable tasksets, reusable harnesses, framework programs, endpoint interception, or sandboxed Python/command programs. Examples include `dspy_rlm`, `openai_agents_env`, `langchain_deep_agents_wikispeedia`, `reverse_text`, `alphabet_sort`, `wiki_search`, `math_python`, `mcp_search_env`, `opencode_harbor`, `bfcl_v3`, `hello_subagent_v1`, `nested_harness_v1`, `hello_self_judge_v1`, `hello_parallel_sandbox_v1`, `hello_group_reward_v1`, `hello_rlm_v1`, `rlm_swe_v1`, `swe-bench-verified`, `dspy_flights`, `tau2-bench-v1`, and `wordle-v1`.
+  - `opencode_harbor` uses the packaged `HarborTaskset` + `OpenCode` boundary from `verifiers.v1.packages`.
 - **Environment and rubric composition**: `math_group`, `math_python`, `wiki_search`
 - **Procedural datasets**: `reasoning_gym_env`
 - **Multimodal**: `mmmu`

--- a/environments/swe_bench_verified/README.md
+++ b/environments/swe_bench_verified/README.md
@@ -1,0 +1,50 @@
+# swe-bench-verified
+
+SWE-bench Verified patch-generation taskset for Verifiers.
+
+## Overview
+
+- Environment ID: `swe-bench-verified`
+- Dataset: `princeton-nlp/SWE-bench_Verified`
+- Default split: `test`
+- Task type: single-turn patch generation
+
+Each task asks the model to produce a unified diff inside `<patch>...</patch>` tags.
+The task metadata preserves the SWE-bench `instance_id`, repository, base commit,
+environment setup commit, version, fail-to-pass tests, pass-to-pass tests, and test
+patch. The environment records the generated patch and the official SWE-bench JSONL
+submission row shape:
+
+```json
+{"instance_id": "...", "model_patch": "diff --git ..."}
+```
+
+## Quickstart
+
+```bash
+prime env install swe-bench-verified
+prime eval run swe-bench-verified -n 5 -r 1
+```
+
+Use environment args to cap local dataset loading during smoke tests:
+
+```bash
+prime eval run swe-bench-verified -a '{"taskset": {"max_examples": 5}}'
+```
+
+## Scoring
+
+The default reward is deterministic and local. It combines exact normalized patch
+match, patch text similarity, and changed-file overlap against the gold patch. This
+is a cheap training/evaluation signal and an official-submission handoff, not a
+replacement for the full SWE-bench execution harness.
+
+## Configuration
+
+| Field | Default | Description |
+| --- | --- | --- |
+| `dataset_name` | `princeton-nlp/SWE-bench_Verified` | Hugging Face dataset name. |
+| `dataset_split` | `test` | Dataset split to load. |
+| `max_examples` | `null` | Optional cap for smoke tests. |
+| `streaming` | `false` | Load the dataset through HF streaming. |
+| `include_test_names` | `true` | Include fail/pass test names in the prompt. |

--- a/environments/swe_bench_verified/pyproject.toml
+++ b/environments/swe_bench_verified/pyproject.toml
@@ -1,0 +1,28 @@
+[project]
+name = "swe-bench-verified"
+version = "0.1.0"
+description = "SWE-bench Verified patch-generation taskset for Verifiers"
+license = "Apache-2.0"
+tags = ["v1", "swe-bench", "patch-generation", "eval"]
+requires-python = ">=3.11"
+dependencies = [
+    "datasets",
+    "verifiers",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build]
+include = ["swe_bench_verified.py", "README.md", "pyproject.toml"]
+
+[project.entry-points."verifiers.environments"]
+swe-bench-verified = "swe_bench_verified:load_environment"
+
+[tool.verifiers.eval]
+num_examples = 5
+rollouts_per_example = 1
+
+[tool.uv.sources]
+verifiers = { path = "../..", editable = true }

--- a/environments/swe_bench_verified/swe_bench_verified.py
+++ b/environments/swe_bench_verified/swe_bench_verified.py
@@ -1,0 +1,286 @@
+import difflib
+import json
+import re
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from datasets import load_dataset
+
+import verifiers as vf
+from verifiers.v1.utils.config_utils import coerce_config
+
+DEFAULT_DATASET_NAME = "princeton-nlp/SWE-bench_Verified"
+DEFAULT_DATASET_SPLIT = "test"
+DEFAULT_TASKSET_ID = "swe-bench/verified"
+
+PATCH_TAG_RE = re.compile(r"<patch>\s*(.*?)\s*</patch>", re.DOTALL | re.IGNORECASE)
+FENCED_PATCH_RE = re.compile(
+    r"```(?:diff|patch)?\s*(diff --git[\s\S]*?)```", re.IGNORECASE
+)
+DIFF_HEADER_RE = re.compile(r"^diff --git a/(.*?) b/(.*?)$", re.MULTILINE)
+PLUS_FILE_RE = re.compile(r"^\+\+\+ b/(.*?)$", re.MULTILINE)
+
+
+class SWEBenchVerifiedTasksetConfig(vf.TasksetConfig):
+    taskset_id: str = DEFAULT_TASKSET_ID
+    dataset_name: str = DEFAULT_DATASET_NAME
+    dataset_split: str = DEFAULT_DATASET_SPLIT
+    max_examples: int | None = None
+    streaming: bool = False
+    include_test_names: bool = True
+
+
+class SWEBenchVerifiedTaskset(vf.Taskset[SWEBenchVerifiedTasksetConfig]):
+    def __init__(self, config: SWEBenchVerifiedTasksetConfig | None = None):
+        config = coerce_config(SWEBenchVerifiedTasksetConfig, config)
+        self.dataset_name = config.dataset_name
+        self.dataset_split = config.dataset_split
+        self.max_examples = config.max_examples
+        self.streaming = config.streaming
+        self.include_test_names = config.include_test_names
+        super().__init__(config=config)
+
+    def load_tasks(self) -> list[vf.ConfigData]:
+        return load_swe_bench_verified_tasks(
+            dataset_name=self.dataset_name,
+            dataset_split=self.dataset_split,
+            max_examples=self.max_examples,
+            streaming=self.streaming,
+            include_test_names=self.include_test_names,
+        )
+
+    @vf.reward(weight=1.0)
+    async def patch_reward(self, task, state) -> float:
+        prediction = extract_patch(state.get("completion") or "")
+        gold_patch = str(task.get("answer") or "")
+        exact = normalize_patch(prediction) == normalize_patch(gold_patch)
+        similarity = patch_similarity(prediction, gold_patch)
+        overlap = changed_file_overlap(prediction, gold_patch)
+        reward = 1.0 if exact and prediction.strip() else min(
+            0.99, 0.75 * similarity + 0.25 * overlap
+        )
+
+        state["swe_bench_verified_patch"] = prediction
+        state["swe_bench_verified_submission"] = official_submission(task, prediction)
+        state["swe_bench_verified_exact_match"] = exact
+        state["swe_bench_verified_patch_similarity"] = similarity
+        state["swe_bench_verified_changed_file_overlap"] = overlap
+        return reward
+
+
+def load_swe_bench_verified_tasks(
+    *,
+    dataset_name: str = DEFAULT_DATASET_NAME,
+    dataset_split: str = DEFAULT_DATASET_SPLIT,
+    max_examples: int | None = None,
+    streaming: bool = False,
+    include_test_names: bool = True,
+) -> list[vf.ConfigData]:
+    dataset = load_dataset(dataset_name, split=dataset_split, streaming=streaming)
+    rows: list[vf.ConfigData] = []
+    for row in limited_rows(dataset, max_examples):
+        rows.append(
+            process_swe_bench_row(
+                row,
+                dataset_name=dataset_name,
+                include_test_names=include_test_names,
+            )
+        )
+    return rows
+
+
+def limited_rows(dataset: Iterable[Mapping[str, Any]], limit: int | None):
+    if limit is None:
+        yield from dataset
+        return
+
+    if hasattr(dataset, "select") and hasattr(dataset, "__len__"):
+        count = min(limit, len(dataset))  # type: ignore[arg-type]
+        yield from dataset.select(range(count))  # type: ignore[attr-defined]
+        return
+
+    for index, row in enumerate(dataset):
+        if index >= limit:
+            break
+        yield row
+
+
+def process_swe_bench_row(
+    row: Mapping[str, Any],
+    *,
+    dataset_name: str = DEFAULT_DATASET_NAME,
+    include_test_names: bool = True,
+) -> vf.ConfigData:
+    info = {
+        "instance_id": str(row.get("instance_id") or ""),
+        "repo": str(row.get("repo") or ""),
+        "base_commit": str(row.get("base_commit") or ""),
+        "environment_setup_commit": str(row.get("environment_setup_commit") or ""),
+        "version": str(row.get("version") or ""),
+        "problem_statement": str(row.get("problem_statement") or ""),
+        "hints_text": str(row.get("hints_text") or ""),
+        "fail_to_pass": normalize_test_names(row.get("FAIL_TO_PASS")),
+        "pass_to_pass": normalize_test_names(row.get("PASS_TO_PASS")),
+        "test_patch": str(row.get("test_patch") or ""),
+        "dataset_name": dataset_name,
+        "official_submission_format": {
+            "instance_id": str(row.get("instance_id") or ""),
+            "model_patch": "<generated unified diff>",
+        },
+    }
+    prompt = build_prompt(info, include_test_names=include_test_names)
+    return {
+        "task_id": info["instance_id"],
+        "prompt": [{"role": "user", "content": prompt}],
+        "answer": str(row.get("patch") or ""),
+        "info": info,
+    }
+
+
+def normalize_test_names(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, list | tuple):
+        return [str(item) for item in value]
+    if isinstance(value, str):
+        value = value.strip()
+        if not value:
+            return []
+        try:
+            decoded = json.loads(value)
+        except json.JSONDecodeError:
+            return [value]
+        if isinstance(decoded, list):
+            return [str(item) for item in decoded]
+        return [str(decoded)]
+    return [str(value)]
+
+
+def build_prompt(info: Mapping[str, Any], *, include_test_names: bool = True) -> str:
+    lines = [
+        "You are fixing a SWE-bench Verified repository issue.",
+        "",
+        f"Repository: {info.get('repo')}",
+        f"Base commit: {info.get('base_commit')}",
+        f"Instance ID: {info.get('instance_id')}",
+        "",
+        "Issue:",
+        str(info.get("problem_statement") or "").strip(),
+    ]
+    hints = str(info.get("hints_text") or "").strip()
+    if hints:
+        lines.extend(["", "Hints:", hints])
+    if include_test_names:
+        fail_to_pass = info.get("fail_to_pass") or []
+        pass_to_pass = info.get("pass_to_pass") or []
+        if fail_to_pass:
+            lines.extend(["", "Fail-to-pass tests:", json.dumps(fail_to_pass)])
+        if pass_to_pass:
+            lines.extend(["", "Pass-to-pass tests:", json.dumps(pass_to_pass)])
+    lines.extend(
+        [
+            "",
+            "Return only a unified diff that applies to the base commit.",
+            "Wrap the diff in <patch>...</patch> tags.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def completion_to_text(completion: object) -> str:
+    if isinstance(completion, str):
+        return completion
+    if isinstance(completion, Mapping):
+        return str(completion.get("content") or "")
+    if isinstance(completion, list | tuple):
+        for message in reversed(completion):
+            if isinstance(message, Mapping):
+                role = message.get("role")
+                if role is None or role == "assistant":
+                    return str(message.get("content") or "")
+            content = getattr(message, "content", None)
+            if content is not None:
+                return str(content)
+    return str(completion or "")
+
+
+def extract_patch(completion: object) -> str:
+    text = completion_to_text(completion)
+    tagged = PATCH_TAG_RE.search(text)
+    if tagged:
+        return tagged.group(1).strip()
+
+    fenced = FENCED_PATCH_RE.search(text)
+    if fenced:
+        return fenced.group(1).strip()
+
+    marker = text.find("diff --git ")
+    if marker >= 0:
+        return text[marker:].strip()
+    return text.strip()
+
+
+def normalize_patch(patch: str) -> str:
+    lines = patch.replace("\r\n", "\n").splitlines()
+    return "\n".join(line.rstrip() for line in lines).strip()
+
+
+def changed_files(patch: str) -> set[str]:
+    normalized = normalize_patch(patch)
+    files: set[str] = set()
+    for match in DIFF_HEADER_RE.finditer(normalized):
+        files.add(match.group(2))
+    for match in PLUS_FILE_RE.finditer(normalized):
+        path = match.group(1)
+        if path != "/dev/null":
+            files.add(path)
+    return files
+
+
+def changed_file_overlap(prediction: str, gold_patch: str) -> float:
+    predicted_files = changed_files(prediction)
+    gold_files = changed_files(gold_patch)
+    if not predicted_files and not gold_files:
+        return 1.0
+    if not predicted_files or not gold_files:
+        return 0.0
+    return len(predicted_files & gold_files) / len(predicted_files | gold_files)
+
+
+def patch_similarity(prediction: str, gold_patch: str) -> float:
+    predicted = normalize_patch(prediction)
+    gold = normalize_patch(gold_patch)
+    if not predicted and not gold:
+        return 1.0
+    if not predicted or not gold:
+        return 0.0
+    return difflib.SequenceMatcher(None, predicted, gold).ratio()
+
+
+def official_submission(task: Mapping[str, Any], model_patch: str) -> dict[str, str]:
+    info = task.get("info") or {}
+    if not isinstance(info, Mapping):
+        info = {}
+    instance_id = str(info.get("instance_id") or task.get("task_id") or "")
+    return {
+        "instance_id": instance_id,
+        "model_patch": model_patch,
+    }
+
+
+def load_taskset(
+    config: SWEBenchVerifiedTasksetConfig,
+) -> SWEBenchVerifiedTaskset:
+    return SWEBenchVerifiedTaskset(config=config)
+
+
+class SWEBenchVerifiedEnvConfig(vf.EnvConfig):
+    taskset: SWEBenchVerifiedTasksetConfig = SWEBenchVerifiedTasksetConfig()
+    harness: vf.HarnessConfig = vf.HarnessConfig(max_turns=1)
+
+
+def load_environment(config: SWEBenchVerifiedEnvConfig) -> vf.Env:
+    return vf.Env(
+        taskset=load_taskset(config=config.taskset),
+        harness=vf.Harness(config=config.harness),
+    )

--- a/environments/swe_bench_verified/swe_bench_verified.py
+++ b/environments/swe_bench_verified/swe_bench_verified.py
@@ -40,7 +40,10 @@ class SWEBenchVerifiedTaskset(vf.Taskset[SWEBenchVerifiedTasksetConfig]):
         self.include_test_names = config.include_test_names
         super().__init__(config=config)
 
-    def load_tasks(self) -> list[vf.ConfigData]:
+    def load_tasks(self, split: vf.TaskSplit = "train") -> vf.Tasks:
+        # The v1 taskset API passes train/eval here; the HF dataset split remains
+        # configurable because SWE-bench Verified commonly uses the "test" split.
+        _ = split
         return load_swe_bench_verified_tasks(
             dataset_name=self.dataset_name,
             dataset_split=self.dataset_split,

--- a/tests/test_swe_bench_verified_environment.py
+++ b/tests/test_swe_bench_verified_environment.py
@@ -25,7 +25,7 @@ def fake_dataset() -> Dataset:
                 "version": "1.0",
                 "problem_statement": "Fix the demo behavior.",
                 "hints_text": "Look at src/demo.py.",
-                "FAIL_TO_PASS": '["tests/test_demo.py::test_fix"]',
+                "FAIL_TO_PASS": ["tests/test_demo.py::test_fix"],
                 "PASS_TO_PASS": ["tests/test_demo.py::test_existing"],
                 "patch": GOLD_PATCH,
                 "test_patch": "diff --git a/tests/test_demo.py b/tests/test_demo.py\n",
@@ -87,6 +87,12 @@ def test_extract_patch_supports_tags_fences_and_raw_diff():
     assert swe_bench_verified.extract_patch(f"Here is the patch:\n{GOLD_PATCH}") == (
         GOLD_PATCH.strip()
     )
+
+
+def test_normalize_test_names_supports_json_strings():
+    assert swe_bench_verified.normalize_test_names(
+        '["tests/test_demo.py::test_fix"]'
+    ) == ["tests/test_demo.py::test_fix"]
 
 
 def test_patch_metrics_and_official_submission():

--- a/tests/test_swe_bench_verified_environment.py
+++ b/tests/test_swe_bench_verified_environment.py
@@ -1,0 +1,137 @@
+import pytest
+from datasets import Dataset
+
+import verifiers as vf
+from environments.swe_bench_verified import swe_bench_verified
+
+
+GOLD_PATCH = """diff --git a/src/demo.py b/src/demo.py
+--- a/src/demo.py
++++ b/src/demo.py
+@@ -1 +1 @@
+-old
++new
+"""
+
+
+def fake_dataset() -> Dataset:
+    return Dataset.from_list(
+        [
+            {
+                "instance_id": "demo__repo-1",
+                "repo": "demo/repo",
+                "base_commit": "abc123",
+                "environment_setup_commit": "setup123",
+                "version": "1.0",
+                "problem_statement": "Fix the demo behavior.",
+                "hints_text": "Look at src/demo.py.",
+                "FAIL_TO_PASS": '["tests/test_demo.py::test_fix"]',
+                "PASS_TO_PASS": ["tests/test_demo.py::test_existing"],
+                "patch": GOLD_PATCH,
+                "test_patch": "diff --git a/tests/test_demo.py b/tests/test_demo.py\n",
+            },
+            {
+                "instance_id": "demo__repo-2",
+                "repo": "demo/repo",
+                "base_commit": "def456",
+                "environment_setup_commit": "setup456",
+                "version": "1.0",
+                "problem_statement": "Fix another behavior.",
+                "hints_text": "",
+                "FAIL_TO_PASS": [],
+                "PASS_TO_PASS": [],
+                "patch": "diff --git a/src/other.py b/src/other.py\n",
+                "test_patch": "",
+            },
+        ]
+    )
+
+
+def test_load_environment_builds_limited_taskset(monkeypatch):
+    calls = {}
+
+    def fake_load_dataset(dataset_name: str, **kwargs):
+        calls["dataset_name"] = dataset_name
+        calls["kwargs"] = kwargs
+        return fake_dataset()
+
+    monkeypatch.setattr(swe_bench_verified, "load_dataset", fake_load_dataset)
+
+    env = swe_bench_verified.load_environment(
+        config=swe_bench_verified.SWEBenchVerifiedEnvConfig(
+            taskset=swe_bench_verified.SWEBenchVerifiedTasksetConfig(max_examples=1)
+        )
+    )
+    task = next(iter(env.taskset))
+
+    assert isinstance(env, vf.Env)
+    assert isinstance(env.taskset, swe_bench_verified.SWEBenchVerifiedTaskset)
+    assert calls["dataset_name"] == swe_bench_verified.DEFAULT_DATASET_NAME
+    assert calls["kwargs"]["split"] == "test"
+    assert task["taskset_id"] == "swe-bench/verified"
+    assert task["task_id"] == "demo__repo-1"
+    assert task["answer"] == GOLD_PATCH
+    assert task["info"]["repo"] == "demo/repo"
+    assert task["info"]["fail_to_pass"] == ["tests/test_demo.py::test_fix"]
+    assert "<patch>...</patch>" in task["prompt"][0]["content"]
+    assert "tests/test_demo.py::test_existing" in task["prompt"][0]["content"]
+
+
+def test_extract_patch_supports_tags_fences_and_raw_diff():
+    assert swe_bench_verified.extract_patch(
+        [{"role": "assistant", "content": f"<patch>\n{GOLD_PATCH}\n</patch>"}]
+    ) == GOLD_PATCH.strip()
+    assert swe_bench_verified.extract_patch(
+        [{"role": "assistant", "content": f"```diff\n{GOLD_PATCH}\n```"}]
+    ) == GOLD_PATCH.strip()
+    assert swe_bench_verified.extract_patch(f"Here is the patch:\n{GOLD_PATCH}") == (
+        GOLD_PATCH.strip()
+    )
+
+
+def test_patch_metrics_and_official_submission():
+    partial_patch = """diff --git a/src/demo.py b/src/demo.py
+--- a/src/demo.py
++++ b/src/demo.py
+@@ -1 +1 @@
+-old
++newer
+"""
+    task = {
+        "task_id": "fallback-id",
+        "info": {"instance_id": "demo__repo-1"},
+    }
+
+    assert swe_bench_verified.changed_files(partial_patch) == {"src/demo.py"}
+    assert swe_bench_verified.changed_file_overlap(partial_patch, GOLD_PATCH) == 1.0
+    assert 0.0 < swe_bench_verified.patch_similarity(partial_patch, GOLD_PATCH) < 1.0
+    assert swe_bench_verified.official_submission(task, partial_patch) == {
+        "instance_id": "demo__repo-1",
+        "model_patch": partial_patch,
+    }
+
+
+@pytest.mark.asyncio
+async def test_patch_reward_records_submission_and_scores_exact_match(monkeypatch):
+    monkeypatch.setattr(
+        swe_bench_verified, "load_dataset", lambda *args, **kwargs: fake_dataset()
+    )
+    taskset = swe_bench_verified.load_taskset(
+        config=swe_bench_verified.SWEBenchVerifiedTasksetConfig(max_examples=1)
+    )
+    env = vf.Env(taskset=taskset)
+    task = next(iter(taskset))
+    state = await env.harness.setup_state(task, vf.State.for_task(task))
+    state["completion"] = [
+        {"role": "assistant", "content": f"<patch>{GOLD_PATCH}</patch>"}
+    ]
+
+    await env.harness.runtime.score_rollout(task, state)
+
+    assert state["reward"] == 1.0
+    assert state["swe_bench_verified_patch"] == GOLD_PATCH.strip()
+    assert state["swe_bench_verified_submission"] == {
+        "instance_id": "demo__repo-1",
+        "model_patch": GOLD_PATCH.strip(),
+    }
+    assert state["swe_bench_verified_exact_match"] is True

--- a/tests/test_swe_bench_verified_environment.py
+++ b/tests/test_swe_bench_verified_environment.py
@@ -77,6 +77,26 @@ def test_load_environment_builds_limited_taskset(monkeypatch):
     assert "tests/test_demo.py::test_existing" in task["prompt"][0]["content"]
 
 
+def test_taskset_load_tasks_accepts_v1_split_keyword(monkeypatch):
+    calls = {}
+
+    def fake_load_dataset(dataset_name: str, **kwargs):
+        calls["dataset_name"] = dataset_name
+        calls["kwargs"] = kwargs
+        return fake_dataset()
+
+    monkeypatch.setattr(swe_bench_verified, "load_dataset", fake_load_dataset)
+
+    taskset = swe_bench_verified.load_taskset(
+        config=swe_bench_verified.SWEBenchVerifiedTasksetConfig(max_examples=1)
+    )
+    tasks = taskset.load_tasks(split="eval")
+
+    assert calls["dataset_name"] == swe_bench_verified.DEFAULT_DATASET_NAME
+    assert calls["kwargs"]["split"] == "test"
+    assert tasks[0]["task_id"] == "demo__repo-1"
+
+
 def test_extract_patch_supports_tags_fences_and_raw_diff():
     assert swe_bench_verified.extract_patch(
         [{"role": "assistant", "content": f"<patch>\n{GOLD_PATCH}\n</patch>"}]


### PR DESCRIPTION
/claim https://algora.io/PrimeIntellect-ai/bounties/znaiNF1eEZzF62SD

## Summary
- Adds an installable `swe-bench-verified` v1 taskset/environment for `princeton-nlp/SWE-bench_Verified`.
- Builds patch-generation tasks that preserve instance/repo/base-commit/test metadata and ask for a unified diff in `<patch>...</patch>` tags.
- Records the official SWE-bench JSONL submission row shape with `instance_id` and `model_patch`.
- Adds deterministic local scoring for normalized exact patch match, patch similarity, and changed-file overlap.
- Documents quickstart/configuration and adds unit coverage for loading, patch extraction, metrics, submission handoff, and reward scoring.

## Validation
- `git diff --check` passed.
- Not run: `uv run pytest tests/test_swe_bench_verified_environment.py -q` (`uv` is not on PATH in this environment).
- Not run: `python -m pytest tests/test_swe_bench_verified_environment.py -q` / `python -m py_compile ...` (`python` is not on PATH in this environment).
- Not run: `ruff` (`ruff` is not on PATH in this environment).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New optional example environment and tests only; no changes to core auth, training, or existing environment behavior beyond README documentation tweaks.
> 
> **Overview**
> Adds a new installable **`swe-bench-verified`** v1 environment that loads **`princeton-nlp/SWE-bench_Verified`** into single-turn patch-generation tasks (default HF **`test`** split, optional **`max_examples`** / streaming).
> 
> Each task prompts for a unified diff in **`<patch>...</patch>`** tags while keeping SWE-bench metadata (instance, repo, commits, tests, gold patch). A **`patch_reward`** extracts diffs from tags, fenced blocks, or raw **`diff --git`**, scores with normalized exact match or a blend of text similarity and changed-file overlap, and writes rollout state including the official **`{instance_id, model_patch}`** submission shape.
> 
> Registers via **`verifiers.environments`** entry point, documents quickstart/config in **`environments/swe_bench_verified`**, lists the env in **`environments/README.md`** (and fixes the Harbor import path note to **`verifiers.v1.packages`**). Unit tests cover loading, extraction, metrics, and end-to-end scoring with a mocked dataset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b60dd52c4954a8816142e67bd8025495d203c6d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add SWE-bench Verified patch-generation environment
> - Adds a new `swe-bench-verified` environment in [environments/swe_bench_verified/](https://github.com/PrimeIntellect-ai/verifiers/pull/1482/files#diff-7c06254f2adf06f8e93b197fc1a2b6e2e27e776b80a3d8ea8d7af9c9f4ea06ea) that loads tasks from the SWE-bench Verified HuggingFace dataset and prompts models to produce unified diffs wrapped in `<patch>` tags.
> - Implements a `patch_reward` function that scores completions using a combination of exact patch match, `difflib` text similarity, and Jaccard-like changed-file overlap against the gold patch.
> - Stores an official SWE-bench submission record (`instance_id` + `model_patch`) in rollout state for downstream evaluation.
> - Adds a pytest suite covering patch extraction, metric computation, test-name normalization, and reward behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b60dd52.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->