### PR TITLE
Fix v1 sandbox client reuse and upload errors

### DIFF
--- a/tests/test_v1_runtime_lifecycle.py
+++ b/tests/test_v1_runtime_lifecycle.py
@@ -188,6 +188,9 @@ class FakeSandboxClient:
     async def aclose(self) -> None:
         type(self).closed += 1
 
+    def teardown(self) -> None:
+        type(self).closed += 1
+
 
 async def echo_tool(query: str) -> str:
     return f"echo:{query}"
@@ -376,9 +379,8 @@ def install_fake_sandboxes(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     monkeypatch.setitem(sys.modules, "prime_sandboxes", module)
     monkeypatch.setattr(
-        sandbox_utils,
-        "_SHARED_SANDBOX_CLIENT",
-        cast(sandbox_utils.SandboxClient, FakeSandboxClient()),
+        "verifiers.utils.threaded_sandbox_client.ThreadedAsyncSandboxClient",
+        FakeSandboxClient,
     )
 
 
@@ -2039,6 +2041,10 @@ async def test_program_sandbox_group_scope_reuses_and_cleans(
     assert "lease_key" not in state_a.get("runtime", {}).get("sandbox", {})
     assert "lease_key" not in state_b.get("runtime", {}).get("sandbox", {})
 
+    await harness.teardown()
+
+    assert FakeSandboxClient.closed == 1
+
 
 @pytest.mark.asyncio
 async def test_program_sandbox_global_scope_lives_until_teardown(
@@ -2062,7 +2068,7 @@ async def test_program_sandbox_global_scope_lives_until_teardown(
     await harness.teardown()
 
     assert FakeSandboxClient.deleted == ["sbx-1"]
-    assert FakeSandboxClient.closed == 0
+    assert FakeSandboxClient.closed == 1
     assert "resolved" not in state.get("runtime", {})
 
 

--- a/tests/test_v1_runtime_lifecycle.py
+++ b/tests/test_v1_runtime_lifecycle.py
@@ -163,7 +163,7 @@ class FakeSandboxClient:
     ) -> FakeCommandResult:
         sandbox_id = str(kwargs.get("sandbox_id") or args[0])
         command = str(kwargs.get("command") or args[1])
-        timeout = cast(int | None, kwargs.get("timeout"))
+        timeout = cast(int | None, kwargs.get("timeout", 900))
         working_dir = cast(str | None, kwargs.get("working_dir"))
         type(self).commands.append((sandbox_id, command))
         type(self).background_jobs.append((sandbox_id, command, timeout, working_dir))
@@ -1360,6 +1360,24 @@ async def test_program_setup_uses_program_setup_timeout(
 
 
 @pytest.mark.asyncio
+async def test_sandbox_command_uses_client_default_timeout_when_omitted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_fake_sandboxes(monkeypatch)
+    install_fake_endpoint_tunnel(monkeypatch)
+
+    harness = make_harness(
+        program={"command": ["true"], "sandbox": True},
+        sandbox={"image": "python:3.11-slim"},
+    )
+    task = vf.Task({"prompt": [{"role": "user", "content": "hi"}]}).freeze()
+
+    await harness.run(task)
+
+    assert FakeSandboxClient.background_jobs == [("sbx-1", "true", 900, None)]
+
+
+@pytest.mark.asyncio
 async def test_sandbox_state_input_upload_runs_after_rollout_setup(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1958,6 +1976,33 @@ async def test_mcp_lifetime_follows_toolset_scope(
 
     await harness.teardown()
     assert harness.runtime.mcp_exit_stacks == {}
+
+
+@pytest.mark.asyncio
+async def test_shared_sandbox_delete_surfaces_delete_failures() -> None:
+    class DeleteFailingClient:
+        closed = 0
+
+        async def delete(self, sandbox_id: str) -> None:
+            _ = sandbox_id
+            raise RuntimeError("delete failed")
+
+        async def aclose(self) -> None:
+            type(self).closed += 1
+
+    client = DeleteFailingClient()
+    lease = sandbox_utils.SandboxLease(
+        cast(sandbox_utils.SandboxClient, client),
+        "sbx-1",
+        "rollout",
+        "program",
+        owns_client=False,
+    )
+
+    with pytest.raises(RuntimeError, match="delete failed"):
+        await lease.delete()
+
+    assert client.closed == 0
 
 
 @pytest.mark.asyncio

--- a/tests/test_v1_runtime_lifecycle.py
+++ b/tests/test_v1_runtime_lifecycle.py
@@ -14,13 +14,14 @@ from pydantic import BaseModel
 
 import verifiers as vf
 from verifiers.clients import Client
+from verifiers.errors import SandboxError
 from verifiers.types import ClientConfig
 from verifiers.types import Response, ResponseMessage, ToolCall
 from verifiers.types import Tool
 from verifiers.types import Usage
 from verifiers.v1.runtime import Runtime
 from verifiers.v1.utils.endpoint_utils import endpoint_api_key
-from verifiers.v1.utils import mcp_utils
+from verifiers.v1.utils import mcp_utils, sandbox_utils
 from verifiers.v1.utils.mcp_proxy_utils import MCP_PROXY_CONFIG_PATH, MCP_PROXY_PATH
 from verifiers.v1.utils.mcp_proxy_utils import proxy_command, proxy_source
 from verifiers.v1.utils.program_utils import command_env
@@ -44,6 +45,7 @@ from verifiers.v1.utils.sandbox_utils import (
     VF_STATE_INPUT_PATH_KEY,
     collect_sandbox_artifacts,
     run_sandbox_command,
+    upload_program_files,
 )
 
 PROGRAM_REF_MODULE = "v1_runtime_lifecycle_refs"
@@ -99,6 +101,14 @@ class FakeCreateSandboxRequest:
         self.kwargs = kwargs
 
 
+class FakeAPIError(Exception):
+    pass
+
+
+class FakeUploadTimeoutError(Exception):
+    pass
+
+
 class FakeSandboxResult:
     def __init__(self, sandbox_id: str):
         self.id = sandbox_id
@@ -117,6 +127,7 @@ class FakeSandboxClient:
     command_timeouts: list[int | None] = []
     background_jobs: list[tuple[str, str, int | None, str | None]] = []
     uploads: list[tuple[str, str, bytes]] = []
+    closed = 0
 
     @classmethod
     def reset(cls) -> None:
@@ -126,6 +137,7 @@ class FakeSandboxClient:
         cls.command_timeouts = []
         cls.background_jobs = []
         cls.uploads = []
+        cls.closed = 0
 
     async def create(self, request: FakeCreateSandboxRequest) -> FakeSandboxResult:
         _ = request
@@ -174,7 +186,7 @@ class FakeSandboxClient:
         type(self).deleted.append(sandbox_id)
 
     async def aclose(self) -> None:
-        pass
+        type(self).closed += 1
 
 
 async def echo_tool(query: str) -> str:
@@ -358,9 +370,16 @@ def install_fake_sandboxes(monkeypatch: pytest.MonkeyPatch) -> None:
     FakeSandboxClient.reset()
     module = SimpleNamespace(
         AsyncSandboxClient=FakeSandboxClient,
+        APIError=FakeAPIError,
         CreateSandboxRequest=FakeCreateSandboxRequest,
+        UploadTimeoutError=FakeUploadTimeoutError,
     )
     monkeypatch.setitem(sys.modules, "prime_sandboxes", module)
+    monkeypatch.setattr(
+        sandbox_utils,
+        "_SHARED_SANDBOX_CLIENT",
+        cast(sandbox_utils.SandboxClient, FakeSandboxClient()),
+    )
 
 
 def install_fake_endpoint_tunnel(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1969,6 +1988,7 @@ async def test_program_sandbox_group_scope_reuses_and_cleans(
     await harness.cleanup_group([task, task], [state_a, state_b])
 
     assert FakeSandboxClient.deleted == ["sbx-1"]
+    assert FakeSandboxClient.closed == 0
     assert "resolved" not in state_a.get("runtime", {})
     assert "resolved" not in state_b.get("runtime", {})
     assert "lease_key" not in state_a.get("runtime", {}).get("sandbox", {})
@@ -1997,7 +2017,33 @@ async def test_program_sandbox_global_scope_lives_until_teardown(
     await harness.teardown()
 
     assert FakeSandboxClient.deleted == ["sbx-1"]
+    assert FakeSandboxClient.closed == 0
     assert "resolved" not in state.get("runtime", {})
+
+
+@pytest.mark.asyncio
+async def test_upload_program_files_wraps_sandbox_upload_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_fake_sandboxes(monkeypatch)
+
+    class TimeoutUploadClient:
+        async def upload_bytes(self, *args: object, **kwargs: object) -> None:
+            _ = args, kwargs
+            raise FakeUploadTimeoutError("timed out")
+
+    task = vf.Task({"prompt": [{"role": "user", "content": "hi"}]}).freeze()
+    state = vf.State.for_task(task)
+
+    with pytest.raises(SandboxError, match="Program file upload failed"):
+        await upload_program_files(
+            cast(sandbox_utils.SandboxClient, TimeoutUploadClient()),
+            "sbx-1",
+            {"files": {"/mini-swe-agent/prompt.txt": "hello"}},
+            task,
+            state,
+            cast(Runtime, SimpleNamespace()),
+        )
 
 
 @pytest.mark.asyncio

--- a/verifiers/v1/runtime.py
+++ b/verifiers/v1/runtime.py
@@ -73,7 +73,7 @@ if TYPE_CHECKING:
     from .harness import Harness
     from .taskset import Taskset
     from .utils.mcp_utils import MCPToolHandle
-    from .utils.sandbox_utils import SandboxLease
+    from .utils.sandbox_utils import SandboxClient, SandboxLease
 
 BindingOwner = Toolset | Literal["taskset"] | None
 BindingEntry = tuple[str, BindingSource, BindingOwner]
@@ -116,6 +116,7 @@ class Runtime:
         self.taskset_objects: dict[tuple[int, str, str], object] = {}
         self.model_clients: dict[str, Client] = {}
         self.owned_model_clients: set[str] = set()
+        self._sandbox_client = None
         self.sandbox_leases: dict[tuple[str, str], SandboxLease] = {}
         self.sandbox_lock = asyncio.Lock()
         self.mcp_exit_stacks: dict[str, AsyncExitStack] = {}
@@ -797,13 +798,35 @@ class Runtime:
         await self.release_objects("global")
         await self.release_user_objects("global")
         await self.release_taskset_objects()
-        for handle in list(self.sandbox_leases.values()):
-            await maybe_call_with_named_args(getattr(handle, "delete"))
-        self.sandbox_leases.clear()
+        try:
+            for handle in list(self.sandbox_leases.values()):
+                await maybe_call_with_named_args(getattr(handle, "delete"))
+            self.sandbox_leases.clear()
+        finally:
+            await self.teardown_sandbox_client()
         self.tool_handles.clear()
         await self.close_all_mcp_tools()
         await self.release_all_model_clients()
         unregister_runtime(self.runtime_id)
+
+    def sandbox_client(self) -> "SandboxClient":
+        if self._sandbox_client is None:
+            from verifiers.utils.threaded_sandbox_client import (
+                ThreadedAsyncSandboxClient,
+            )
+
+            from .utils.sandbox_utils import SandboxClient
+
+            self._sandbox_client = cast(SandboxClient, ThreadedAsyncSandboxClient())
+        return self._sandbox_client
+
+    async def teardown_sandbox_client(self) -> None:
+        if self._sandbox_client is None:
+            return
+        from .utils.sandbox_utils import close_sandbox_client
+
+        await close_sandbox_client(self._sandbox_client)
+        self._sandbox_client = None
 
     async def run_rollout_handlers(
         self,
@@ -1697,7 +1720,9 @@ class Runtime:
         async with self.sandbox_lock:
             lease = self.sandbox_leases.get(key)
             if lease is None:
-                lease = await create_tool_sandbox_lease(toolset)
+                lease = await create_tool_sandbox_lease(
+                    toolset, client=self.sandbox_client()
+                )
                 self.sandbox_leases[key] = lease
         return SandboxHandle(lease, state)
 
@@ -1740,7 +1765,9 @@ class Runtime:
         async with self.sandbox_lock:
             lease = self.sandbox_leases.get(key)
             if lease is None:
-                lease = await create_sandbox_lease(sandbox_config, key[1])
+                lease = await create_sandbox_lease(
+                    sandbox_config, key[1], client=self.sandbox_client()
+                )
                 self.sandbox_leases[key] = lease
             setattr(lease, "scope_key", key[0])
         return lease
@@ -1784,7 +1811,9 @@ class Runtime:
         async with self.sandbox_lock:
             lease = self.sandbox_leases.get(key)
             if lease is None:
-                lease = await create_scoped_sandbox_lease(user, key[1])
+                lease = await create_scoped_sandbox_lease(
+                    user, key[1], client=self.sandbox_client()
+                )
                 self.sandbox_leases[key] = lease
         return SandboxHandle(lease, state)
 
@@ -1824,10 +1853,12 @@ class Runtime:
                 if key in self.sandbox_leases:
                     continue
                 if isinstance(owner, Toolset):
-                    self.sandbox_leases[key] = await create_tool_sandbox_lease(owner)
+                    self.sandbox_leases[key] = await create_tool_sandbox_lease(
+                        owner, client=self.sandbox_client()
+                    )
                 else:
                     self.sandbox_leases[key] = await create_scoped_sandbox_lease(
-                        owner, sandbox_key
+                        owner, sandbox_key, client=self.sandbox_client()
                     )
 
     def bind_global_sandboxes(self, state: State) -> None:

--- a/verifiers/v1/utils/sandbox_utils.py
+++ b/verifiers/v1/utils/sandbox_utils.py
@@ -106,7 +106,14 @@ class SandboxClient(Protocol):
     ) -> SandboxCommandResult: ...
 
 
-_SHARED_SANDBOX_CLIENT: SandboxClient | None = None
+async def close_sandbox_client(client: SandboxClient) -> None:
+    teardown = getattr(client, "teardown", None)
+    if callable(teardown):
+        teardown()
+        return
+    aclose = getattr(client, "aclose", None)
+    if callable(aclose):
+        await aclose()
 
 
 class SandboxLease:
@@ -212,9 +219,7 @@ class SandboxLease:
             await self.client.delete(self.id)
         finally:
             if self.owns_client:
-                aclose = getattr(self.client, "aclose", None)
-                if callable(aclose):
-                    await aclose()
+                await close_sandbox_client(self.client)
 
 
 class SandboxHandle:
@@ -280,21 +285,28 @@ class SandboxHandle:
         await self.lease.delete()
 
 
-async def create_tool_sandbox_lease(toolset: "Toolset") -> SandboxLease:
-    return await create_scoped_sandbox_lease(toolset, tool_sandbox_key(toolset))
+async def create_tool_sandbox_lease(
+    toolset: "Toolset", client: SandboxClient | None = None
+) -> SandboxLease:
+    return await create_scoped_sandbox_lease(toolset, tool_sandbox_key(toolset), client)
 
 
-async def create_sandbox_lease(sandbox_config: ConfigMap, key: str) -> SandboxLease:
-    global _SHARED_SANDBOX_CLIENT
-
+async def create_sandbox_lease(
+    sandbox_config: ConfigMap, key: str, client: SandboxClient | None = None
+) -> SandboxLease:
     scope = sandbox_scope(sandbox_config)
-    if _SHARED_SANDBOX_CLIENT is None:
+    owns_client = client is None
+    if client is None:
         from verifiers.utils.threaded_sandbox_client import ThreadedAsyncSandboxClient
 
-        _SHARED_SANDBOX_CLIENT = cast(SandboxClient, ThreadedAsyncSandboxClient())
-    client = _SHARED_SANDBOX_CLIENT
-    sandbox_id = await create_sandbox(client, sandbox_config)
-    lease = SandboxLease(client, sandbox_id, scope, key, owns_client=False)
+        client = cast(SandboxClient, ThreadedAsyncSandboxClient())
+    try:
+        sandbox_id = await create_sandbox(client, sandbox_config)
+    except BaseException:
+        if owns_client:
+            await close_sandbox_client(client)
+        raise
+    lease = SandboxLease(client, sandbox_id, scope, key, owns_client=owns_client)
     try:
         await setup_sandbox(lease, sandbox_config)
     except BaseException:
@@ -304,12 +316,14 @@ async def create_sandbox_lease(sandbox_config: ConfigMap, key: str) -> SandboxLe
 
 
 async def create_scoped_sandbox_lease(
-    owner: object, key: str | None = None
+    owner: object, key: str | None = None, client: SandboxClient | None = None
 ) -> SandboxLease:
     sandbox_config = getattr(owner, "sandbox", None)
     if not isinstance(sandbox_config, Mapping):
         raise TypeError("Sandbox owner must define a sandbox mapping.")
-    return await create_sandbox_lease(sandbox_config, key or sandbox_owner_key(owner))
+    return await create_sandbox_lease(
+        sandbox_config, key or sandbox_owner_key(owner), client
+    )
 
 
 async def run_sandbox_command(

--- a/verifiers/v1/utils/sandbox_utils.py
+++ b/verifiers/v1/utils/sandbox_utils.py
@@ -106,6 +106,9 @@ class SandboxClient(Protocol):
     ) -> SandboxCommandResult: ...
 
 
+_SHARED_SANDBOX_CLIENT: SandboxClient | None = None
+
+
 class SandboxLease:
     def __init__(
         self,
@@ -113,11 +116,14 @@ class SandboxLease:
         sandbox_id: str,
         scope: str,
         key: str,
+        *,
+        owns_client: bool = True,
     ):
         self.client = client
         self.id = sandbox_id
         self.scope = scope
         self.key = key
+        self.owns_client = owns_client
         self.deleted = False
         self.lock = asyncio.Lock()
 
@@ -201,6 +207,8 @@ class SandboxLease:
         try:
             await self.client.delete(self.id)
         finally:
+            if not self.owns_client:
+                return
             aclose = getattr(self.client, "aclose", None)
             if callable(aclose):
                 await aclose()
@@ -274,18 +282,16 @@ async def create_tool_sandbox_lease(toolset: "Toolset") -> SandboxLease:
 
 
 async def create_sandbox_lease(sandbox_config: ConfigMap, key: str) -> SandboxLease:
-    from prime_sandboxes import AsyncSandboxClient
+    global _SHARED_SANDBOX_CLIENT
 
     scope = sandbox_scope(sandbox_config)
-    client = cast(SandboxClient, AsyncSandboxClient())
-    try:
-        sandbox_id = await create_sandbox(client, sandbox_config)
-    except BaseException:
-        aclose = getattr(client, "aclose", None)
-        if callable(aclose):
-            await aclose()
-        raise
-    lease = SandboxLease(client, sandbox_id, scope, key)
+    if _SHARED_SANDBOX_CLIENT is None:
+        from verifiers.utils.threaded_sandbox_client import ThreadedAsyncSandboxClient
+
+        _SHARED_SANDBOX_CLIENT = cast(SandboxClient, ThreadedAsyncSandboxClient())
+    client = _SHARED_SANDBOX_CLIENT
+    sandbox_id = await create_sandbox(client, sandbox_config)
+    lease = SandboxLease(client, sandbox_id, scope, key, owns_client=False)
     try:
         await setup_sandbox(lease, sandbox_config)
     except BaseException:
@@ -622,18 +628,25 @@ async def upload_program_files(
     state: State,
     runtime: Runtime,
 ) -> None:
+    from prime_sandboxes import APIError, UploadTimeoutError
+
     files = program_option_mapping(program.get("files"), "program.files")
     for path, source in files.items():
         content = await resolve_program_value(source, task, state, runtime, program)
         if not isinstance(content, str):
             content = str(content)
-        await maybe_call_with_named_args(
-            getattr(client, "upload_bytes"),
-            sandbox_id=sandbox_id,
-            file_path=path,
-            file_bytes=content.encode(),
-            filename=path.rsplit("/", 1)[-1] or "file",
-        )
+        try:
+            await maybe_call_with_named_args(
+                getattr(client, "upload_bytes"),
+                sandbox_id=sandbox_id,
+                file_path=path,
+                file_bytes=content.encode(),
+                filename=path.rsplit("/", 1)[-1] or "file",
+            )
+        except (APIError, UploadTimeoutError) as exc:
+            raise SandboxError(
+                f"Program file upload failed for {path!r} in sandbox {sandbox_id}: {exc}"
+            ) from exc
 
 
 async def upload_program_dirs(

--- a/verifiers/v1/utils/sandbox_utils.py
+++ b/verifiers/v1/utils/sandbox_utils.py
@@ -29,7 +29,7 @@ from .sandbox_python_utils import (
 from ..runtime import Runtime
 from ..state import State
 from ..task import Task
-from ..types import ConfigMap, Handler, JsonData, ProgramValue
+from ..types import ConfigData, ConfigMap, Handler, JsonData, ProgramValue
 
 if TYPE_CHECKING:
     from ..toolset import Toolset
@@ -191,13 +191,17 @@ class SandboxLease:
         working_dir: str | None = None,
         env: dict[str, str] | None = None,
     ) -> SandboxCommandResult:
+        call_args: ConfigData = {
+            "sandbox_id": self.id,
+            "command": command,
+            "working_dir": working_dir,
+            "env": env,
+        }
+        if timeout is not None:
+            call_args["timeout"] = timeout
         return await maybe_call_with_named_args(
             getattr(self.client, "run_background_job"),
-            sandbox_id=self.id,
-            command=command,
-            timeout=timeout,
-            working_dir=working_dir,
-            env=env,
+            **call_args,
         )
 
     async def delete(self) -> None:
@@ -207,11 +211,10 @@ class SandboxLease:
         try:
             await self.client.delete(self.id)
         finally:
-            if not self.owns_client:
-                return
-            aclose = getattr(self.client, "aclose", None)
-            if callable(aclose):
-                await aclose()
+            if self.owns_client:
+                aclose = getattr(self.client, "aclose", None)
+                if callable(aclose):
+                    await aclose()
 
 
 class SandboxHandle:


### PR DESCRIPTION
## Summary
- Reuse the threaded sandbox client for v1 sandbox leases instead of creating a fresh raw AsyncSandboxClient per sandbox
- Keep shared clients open when individual sandbox leases are deleted
- Wrap program file upload API/timeouts as SandboxError so a single rollout can fail without crashing the whole eval
- Add lifecycle coverage for shared client cleanup and upload timeout wrapping

## Validation
- uvx ruff format
- uvx ruff check --fix
- source /Users/xeophon/code/work/verifiers/.venv/bin/activate && PYTHONPATH=/Users/xeophon/code/work/verifiers-pr-fix python -m pytest tests/test_v1_runtime_lifecycle.py -k "program_sandbox_group_scope_reuses_and_cleans or program_sandbox_global_scope_lives_until_teardown or upload_program_files_wraps_sandbox_upload_timeout" -q
- source /Users/xeophon/code/work/verifiers/.venv/bin/activate && PYTHONPATH=/Users/xeophon/code/work/verifiers-pr-fix python -m pytest tests/test_v1_runtime_lifecycle.py -q
- source /Users/xeophon/code/work/verifiers/.venv/bin/activate && PYTHONPATH=/Users/xeophon/code/work/verifiers-pr-fix python -m py_compile verifiers/v1/utils/sandbox_utils.py tests/test_v1_runtime_lifecycle.py

Note: local 100x1 SWE-bench Pro smoke with max_concurrent=100 and num_workers=10 completed after this patch; one sandbox upload timeout was contained as a sample-level SandboxError instead of crashing the eval.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sandbox client lifetime and error handling on a hot path for evals; behavior is narrower than before (shared client, contained upload errors) and is covered by new lifecycle tests.
> 
> **Overview**
> The v1 **Runtime** now keeps one lazy **`ThreadedAsyncSandboxClient`** and passes it into every program/tool/user sandbox lease instead of spinning up a separate **`AsyncSandboxClient`** per lease. **`SandboxLease`** gains **`owns_client`**: shared-runtime leases skip closing the client on **`delete`**, and **`Runtime.teardown`** deletes leases then always shuts down the shared client via **`close_sandbox_client`** (prefers **`teardown()`**, else **`aclose()`**).
> 
> **`run_background_job`** only forwards **`timeout`** when set, so the backend default (e.g. 900s) applies. **`upload_program_files`** maps **`APIError`** / **`UploadTimeoutError`** to **`SandboxError`** so a failed upload fails one rollout instead of crashing the whole eval.
> 
> Lifecycle tests cover group/global cleanup (delete vs client close), default background-job timeout, upload timeout wrapping, and delete errors without closing a borrowed client.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04b8df1cae376732f88c5a7018a423c19c419e22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix v1 sandbox client reuse and surface upload errors
> - `Runtime` now lazily creates and caches a single `ThreadedAsyncSandboxClient` shared across all lease creation calls, replacing per-lease client instantiation in [runtime.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1483/files#diff-7c2c1b88c61b8a75e00bb82f7ece60290f886d4a3ed87e97a5e1cbf86b26973d).
> - `SandboxLease` gains an `owns_client` flag so shared clients are not closed when a non-owning lease is deleted; `teardown` closes the shared client after all leases are cleaned up.
> - `upload_program_files` in [sandbox_utils.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1483/files#diff-b1154f3be7f28191532de46fbe23a973a5f93e1450a71beb9c93910e358fda13) now catches `APIError` and `UploadTimeoutError` from `prime_sandboxes` and re-raises as `SandboxError` with path and sandbox ID context.
> - A new `close_sandbox_client` helper prefers a synchronous `teardown()` method on the client before falling back to `aclose()`.
> - Behavioral Change: sandbox client is now closed in a `finally` block during `Runtime.teardown`, so it is always closed even if lease deletions raise.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 04b8df1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->