### PR TITLE
feat: add NYT Connections environment

### DIFF
--- a/environments/README.md
+++ b/environments/README.md
@@ -23,6 +23,7 @@ This folder contains installable example environments that showcase common usage
 - **sentence_repeater**: Multi-turn Q/A over a paragraph; rewards compare assistant messages to expected answers.
 - **wordle**: Game-style interaction via `TextArenaEnv`; multiple rewards (correctness, partial credit, few-turn bonus) and XML formatting.
 - **wordle_v1**: Wordle on the reusable v1 `TextArenaTaskset`, with Wordle-specific prompt, feedback, and rewards kept in the environment package.
+- **nyt_connections**: NYT Connections multi-turn word puzzle implemented as a v1 Taskset with a stateful user function and progress/format rewards.
 - **openenv_echo**: OpenEnv MCP integration example using upstream `echo_env`.
 - **openenv_textarena**: OpenEnv gym integration example using upstream `textarena_env` (default `Wordle-v0`).
 

--- a/environments/nyt_connections/README.md
+++ b/environments/nyt_connections/README.md
@@ -1,0 +1,37 @@
+# nyt-connections
+
+<a href="https://github.com/PrimeIntellect-ai/verifiers/tree/main/environments/nyt_connections">
+  <img src="https://primeintellect.ai/prime.svg" alt="Prime Intellect" width="120" />
+</a>
+
+### Overview
+- **Environment ID**: `nyt-connections`
+- **Short description**: Multi-turn NYT Connections word puzzle environment.
+- **Tags**: connections, nyt, word-game, multi-turn, reasoning, v1, taskset
+- **Primary dataset**: [Eyefyre/NYT-Connections-Answers](https://github.com/Eyefyre/NYT-Connections-Answers)
+
+### Task
+The model receives 16 words and must find four hidden groups of four connected
+words. It has four lives. Each assistant turn should contain a short rationale
+and a guess in this format:
+
+```xml
+<think>These four words share a theme.</think>
+<guess>WORD1, WORD2, WORD3, WORD4</guess>
+```
+
+Correct guesses reveal the group and remove those words from the board.
+Incorrect or invalid guesses cost one life.
+
+### Quickstart
+```bash
+prime env install environments/nyt_connections
+prime eval run nyt-connections -n 1 -r 1
+```
+
+### Rubric
+The environment combines:
+- success reward for solving all four groups,
+- progress reward for each solved group,
+- efficiency reward for solving with lives remaining,
+- format reward for valid `<think>` and `<guess>` tags.

--- a/environments/nyt_connections/nyt_connections.py
+++ b/environments/nyt_connections/nyt_connections.py
@@ -1,0 +1,294 @@
+import json
+import random
+import re
+from functools import lru_cache
+from urllib.request import urlopen
+
+import verifiers as vf
+
+NYT_CONNECTIONS_URL = (
+    "https://raw.githubusercontent.com/Eyefyre/NYT-Connections-Answers/refs/heads/main/"
+    "connections.json"
+)
+
+NYT_CONNECTIONS_SYSTEM_PROMPT = """You are playing NYT Connections.
+
+Rules:
+- The board has 16 words split into 4 hidden groups of 4.
+- Each hidden group has a shared theme.
+- You have 4 lives; incorrect or invalid guesses cost 1 life.
+- Each turn, reason briefly and submit exactly 4 comma-separated words.
+- Put your final guess for the turn inside <guess>...</guess> tags.
+
+Example format:
+<think>These four words are all wet weather events.</think>
+<guess>HAIL, RAIN, SLEET, SNOW</guess>"""
+
+
+def normalize_word(word: str) -> str:
+    return " ".join(str(word).upper().split())
+
+
+def parse_guess(content: str) -> list[str] | None:
+    matches = re.findall(r"<guess>\s*(.*?)\s*</guess>", content, re.DOTALL | re.IGNORECASE)
+    if not matches:
+        return None
+    words = [normalize_word(word) for word in matches[-1].split(",") if word.strip()]
+    if len(words) != 4 or len(set(words)) != 4:
+        return None
+    return words
+
+
+def normalize_group(group: dict) -> set[str]:
+    return {normalize_word(str(word)) for word in group["members"]}
+
+
+def format_group(group: dict) -> str:
+    return f"{group['group']}: {', '.join(normalize_word(str(word)) for word in group['members'])}"
+
+
+def format_board(game: dict) -> str:
+    lines: list[str] = []
+    if game["found_groups"]:
+        lines.append("SOLVED GROUPS:")
+        lines.extend(format_group(group) for group in game["found_groups"])
+        lines.append("")
+        lines.append("REMAINING WORDS:")
+    else:
+        lines.append("WORDS ON THE BOARD:")
+    lines.append(", ".join(game["remaining_words"]))
+    lines.append("")
+    lines.append(f"Lives remaining: {game['lives']}")
+    return "\n".join(lines)
+
+
+def make_game(task: vf.Task) -> dict:
+    groups = [dict(group) for group in task["groups"]]
+    remaining_words = [word for group in groups for word in normalize_group(group)]
+    random.Random(int(task["seed"])).shuffle(remaining_words)
+    return {
+        "groups": groups,
+        "remaining_words": remaining_words,
+        "found_groups": [],
+        "lives": 4,
+        "turns": 0,
+        "invalid_guesses": 0,
+        "incorrect_guesses": 0,
+    }
+
+
+@lru_cache(maxsize=4)
+def fetch_connections_rows(dataset_url: str) -> list[dict]:
+    with urlopen(dataset_url, timeout=30) as response:
+        rows = json.loads(response.read().decode("utf-8"))
+    if not isinstance(rows, list):
+        raise ValueError("NYT Connections dataset must be a list of puzzles.")
+    return rows
+
+
+def build_tasks(
+    dataset_url: str,
+    seed: int,
+    max_turns: int,
+    num_train_examples: int,
+    num_eval_examples: int,
+) -> tuple[list[vf.ConfigData], list[vf.ConfigData]]:
+    rows = fetch_connections_rows(dataset_url)
+    tasks: list[vf.ConfigData] = []
+    for row in rows:
+        groups = row.get("answers")
+        if not isinstance(groups, list) or len(groups) != 4:
+            continue
+        if any(not isinstance(group, dict) or len(group.get("members", [])) != 4 for group in groups):
+            continue
+
+        puzzle_id = int(row["id"])
+        puzzle_seed = seed + puzzle_id
+        words = [word for group in groups for word in normalize_group(group)]
+        random.Random(puzzle_seed).shuffle(words)
+        question = (
+            "Find the four NYT Connections groups. Submit each turn as "
+            "<guess>WORD1, WORD2, WORD3, WORD4</guess>.\n\n"
+            "WORDS ON THE BOARD:\n"
+            f"{', '.join(words)}\n\nLives remaining: 4"
+        )
+        tasks.append(
+            {
+                "example_id": puzzle_id,
+                "prompt": [{"role": "user", "content": question}],
+                "answer": json.dumps(groups),
+                "groups": groups,
+                "date": str(row.get("date", "")),
+                "seed": puzzle_seed,
+                "max_turns": max_turns,
+                "info": {
+                    "date": str(row.get("date", "")),
+                    "dataset_url": dataset_url,
+                    "groups": groups,
+                },
+            }
+        )
+
+    rng = random.Random(seed)
+    rng.shuffle(tasks)
+    train = tasks[:num_train_examples]
+    eval_start = num_train_examples
+    eval_end = eval_start + num_eval_examples
+    eval_tasks = tasks[eval_start:eval_end]
+    return train, eval_tasks
+
+
+async def connections_user(
+    task: vf.Task, state: vf.State, messages: list[dict]
+) -> list[dict[str, str]]:
+    game = state.setdefault("connections", make_game(task))
+    assistant_messages = vf.get_messages(messages, role="assistant")
+    if not assistant_messages:
+        return []
+
+    game["turns"] += 1
+    content = str(assistant_messages[-1].content or "")
+    guess = parse_guess(content)
+    if guess is None:
+        game["lives"] -= 1
+        game["invalid_guesses"] += 1
+        response = (
+            "Invalid guess. Use exactly four comma-separated remaining board words "
+            "inside <guess>...</guess>."
+        )
+    elif not set(guess).issubset(set(game["remaining_words"])):
+        game["lives"] -= 1
+        game["invalid_guesses"] += 1
+        response = "Invalid guess. Every guessed word must still be on the board."
+    else:
+        guess_set = set(guess)
+        matched_group = next(
+            (
+                group
+                for group in game["groups"]
+                if group not in game["found_groups"] and guess_set == normalize_group(group)
+            ),
+            None,
+        )
+        if matched_group is None:
+            game["lives"] -= 1
+            game["incorrect_guesses"] += 1
+            response = "Incorrect guess."
+        else:
+            game["found_groups"].append(matched_group)
+            found_words = normalize_group(matched_group)
+            game["remaining_words"] = [
+                word for word in game["remaining_words"] if word not in found_words
+            ]
+            response = f"Correct! You found {format_group(matched_group)}."
+
+    if len(game["found_groups"]) == 4:
+        state.stop("solved")
+        return [
+            {
+                "role": "user",
+                "content": response + "\n\nCongratulations, you solved the puzzle!",
+            }
+        ]
+
+    if game["lives"] <= 0:
+        state.stop("out_of_lives")
+        answers = "\n".join(format_group(group) for group in game["groups"])
+        return [
+            {
+                "role": "user",
+                "content": response + "\n\nGame over. Correct groups:\n" + answers,
+            }
+        ]
+
+    return [{"role": "user", "content": response + "\n\n" + format_board(game)}]
+
+
+@vf.reward(weight=1.0)
+async def success_reward(task: vf.Task, state: vf.State) -> float:
+    _ = task
+    game = state.get("connections") or {}
+    return 1.0 if len(game.get("found_groups", [])) == 4 else 0.0
+
+
+@vf.reward(weight=0.3)
+async def progress_reward(task: vf.Task, state: vf.State) -> float:
+    _ = task
+    game = state.get("connections") or {}
+    return len(game.get("found_groups", [])) / 4
+
+
+@vf.reward(weight=0.2)
+async def efficiency_reward(task: vf.Task, state: vf.State) -> float:
+    _ = task
+    game = state.get("connections") or {}
+    if len(game.get("found_groups", [])) != 4:
+        return 0.0
+    return max(float(game.get("lives", 0)), 0.0) / 4
+
+
+@vf.reward(weight=0.1)
+async def format_reward(task: vf.Task, state: vf.State) -> float:
+    _ = task
+    completion = state.get("completion") or []
+    assistant_messages = vf.get_messages(completion, role="assistant")
+    if not assistant_messages:
+        return 0.0
+    scores: list[float] = []
+    for message in assistant_messages:
+        content = str(message.content or "")
+        has_think = bool(re.search(r"<think>.*?</think>", content, re.DOTALL | re.IGNORECASE))
+        has_guess = parse_guess(content) is not None
+        scores.append((0.3 if has_think else 0.0) + (0.7 if has_guess else 0.0))
+    return sum(scores) / len(scores)
+
+
+class NYTConnectionsTasksetConfig(vf.TasksetConfig):
+    dataset_url: str = NYT_CONNECTIONS_URL
+    num_train_examples: int = 900
+    num_eval_examples: int = 100
+    seed: int = 42
+    max_turns: int = 8
+    system_prompt: str | None = NYT_CONNECTIONS_SYSTEM_PROMPT
+    user: str | None = "connections_user"
+    rewards: list[str] = [
+        "success_reward",
+        "progress_reward",
+        "efficiency_reward",
+        "format_reward",
+    ]
+
+
+class NYTConnectionsEnvConfig(vf.EnvConfig):
+    taskset: NYTConnectionsTasksetConfig = NYTConnectionsTasksetConfig()
+    harness: vf.HarnessConfig = vf.HarnessConfig()
+
+
+class NYTConnectionsTaskset(vf.Taskset[NYTConnectionsTasksetConfig]):
+    def _tasks(self) -> tuple[list[vf.ConfigData], list[vf.ConfigData]]:
+        return build_tasks(
+            dataset_url=self.config.dataset_url,
+            seed=self.config.seed,
+            max_turns=self.config.max_turns,
+            num_train_examples=self.config.num_train_examples,
+            num_eval_examples=self.config.num_eval_examples,
+        )
+
+    def load_tasks(self) -> vf.Tasks:
+        train_tasks, _ = self._tasks()
+        return train_tasks
+
+    def load_eval_tasks(self) -> vf.Tasks:
+        _, eval_tasks = self._tasks()
+        return eval_tasks
+
+
+def load_taskset(config: NYTConnectionsTasksetConfig) -> NYTConnectionsTaskset:
+    return NYTConnectionsTaskset(config=config)
+
+
+def load_environment(config: NYTConnectionsEnvConfig) -> vf.Env:
+    return vf.Env(
+        taskset=NYTConnectionsTaskset(config=config.taskset),
+        harness=vf.Harness(config=config.harness),
+    )

--- a/environments/nyt_connections/pyproject.toml
+++ b/environments/nyt_connections/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+name = "nyt-connections"
+description = "NYT Connections multi-turn word puzzle environment."
+tags = ["connections", "nyt", "word-game", "multi-turn", "reasoning", "train", "eval", "v1", "taskset"]
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+    "verifiers>=0.1.15.dev7",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build]
+include = ["nyt_connections.py", "pyproject.toml", "README.md"]
+
+[tool.verifiers.eval]
+num_examples = 5
+rollouts_per_example = 3


### PR DESCRIPTION
## Summary
- Add a packaged `nyt-connections` v1 Taskset/Harness environment for the Algora NYT Connections bounty.
- Load NYT Connections puzzle data from the public Eyefyre answers dataset and convert it into train/eval tasks.
- Implement a stateful user loop that validates `<guess>...</guess>` turns, tracks found groups/lives, and stops on solve or game over.
- Add success, progress, efficiency, and format rewards plus README documentation.

## Verification
- `uv run --no-dev ruff check environments/nyt_connections`
- `uv run --no-dev python - <<'PY' ... vf.load_environment('nyt-connections') ... PY`
- `CHANGED_ENVS=nyt_connections uv run --no-dev pytest tests/test_envs.py -q --tb=short` was attempted, but the Windows host cannot execute the test's hard-coded `/bin/bash` subprocess path.

Algora bounty: https://algora.io/PrimeIntellect-ai/bounties/xXmkMERgdxQbUgsX

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Self-contained new environment with no changes to auth or core runtime; main operational note is runtime dependency on fetching the external puzzle JSON URL.
> 
> **Overview**
> Adds a new installable **`nyt-connections`** v1 environment: puzzles are built from the public Eyefyre NYT Connections JSON (fetched at task-build time), shuffled into default **900 train / 100 eval** splits, and exposed via **`NYTConnectionsTaskset`** + **`load_environment`**.
> 
> Gameplay is driven by **`connections_user`**, which keeps per-rollout state (remaining words, found groups, lives), parses **`guess`** tags from assistant turns, and ends the episode on solve or out of lives with board feedback.
> 
> Scoring adds weighted **success**, **progress**, **efficiency**, and **format** (think + guess) rewards. The root **`environments/README.md`** and package **README** / **`pyproject.toml`** document install and eval defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 804a3f4d82c82272b21c6cfd3abbe7af9adcd137. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add NYT Connections multi-turn puzzle environment
> - Adds a new `nyt_connections` environment in [nyt_connections.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1484/files#diff-438feae5e8073c3f23f0fa90b5f541b3e45a788ad2f4ca59c3a60624b99a2e34) that simulates NYT Connections gameplay: the agent guesses 4-word groups from a 16-word board with 4 lives, up to 8 turns.
> - Fetches puzzle data from the Eyefyre GitHub dataset, builds deterministic train (900) and eval (100) task splits, and validates puzzles for exactly 4 groups of 4 words.
> - Rewards combine success (weight 1.0), progress (0.3), efficiency (0.2), and format compliance for `<think>`/`<guess>` tags (0.1).
> - Registers the environment as `nyt-connections` with factory functions `load_taskset` and `load_environment` following the existing verifiers pattern.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 804a3f4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->