### PR TITLE
feat: add Rust Cargo feedback environment

### DIFF
--- a/environments/README.md
+++ b/environments/README.md
@@ -11,6 +11,7 @@ This folder contains installable example environments that showcase common usage
 ### SingleTurnEnv (prompt → single response)
 - **gsm8k**: Classic QA with exact-match reward and optional response-format reward.
 - **reverse_text**: XML formatting with non-binary LCS reward + format reward.
+- **rust_cargo**: Rust code-generation tasks scored with Cargo build, clippy, and test feedback.
 - **continuation_quality**: Completion-style generation (`message_type="completion"`) judged for prose quality with `JudgeRubric`.
 - **mmmu**: Multimodal inputs (image + text) packed in chat content; single-turn boxed-answer check.
 

--- a/environments/rust_cargo/README.md
+++ b/environments/rust_cargo/README.md
@@ -1,0 +1,37 @@
+# rust-cargo
+
+### Overview
+- **Environment ID**: `rust-cargo`
+- **Short description**: Rust coding tasks scored with `cargo build`, `cargo clippy`, and `cargo test` feedback.
+- **Tags**: rust, cargo, coding, single-turn, RL, train, eval
+
+### Task
+The model receives a Rust programming prompt and should return exactly one fenced
+Rust code block containing:
+
+- the requested function implementation,
+- a `#[cfg(test)] mod tests` module,
+- multiple `assert!` / `assert_eq!` checks,
+- no `main` function.
+
+### Quickstart
+Requires a local Rust toolchain with `cargo` available on `PATH` for executable
+Cargo rewards.
+
+```bash
+prime env install environments/rust_cargo
+prime eval run rust-cargo -n 1 -r 1
+```
+
+### Rubric
+The reward combines static and executable Cargo feedback:
+
+- response format / one Rust block,
+- required function signature present,
+- test assertions present,
+- `cargo build --quiet`,
+- `cargo clippy --quiet -- -D warnings`,
+- `cargo test --quiet` with extra weight.
+
+This ports the core idea from the Algora reference implementation: use Cargo as
+an objective signal for Rust code generation.

--- a/environments/rust_cargo/pyproject.toml
+++ b/environments/rust_cargo/pyproject.toml
@@ -1,0 +1,21 @@
+[project]
+name = "rust-cargo"
+description = "Rust coding environment with Cargo build, clippy, and test rewards."
+tags = ["rust", "cargo", "coding", "single-turn", "rl", "train", "eval"]
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+    "verifiers>=0.1.15.dev7",
+    "datasets",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build]
+include = ["rust_cargo.py", "pyproject.toml", "README.md"]
+
+[tool.verifiers.eval]
+num_examples = 5
+rollouts_per_example = 3

--- a/environments/rust_cargo/rust_cargo.py
+++ b/environments/rust_cargo/rust_cargo.py
@@ -1,0 +1,220 @@
+import json
+import re
+import shutil
+import subprocess
+import tempfile
+import textwrap
+from pathlib import Path
+
+from datasets import Dataset
+
+import verifiers as vf
+
+SYSTEM_PROMPT = """You are a pragmatic Rust programmer who practices test-driven development.
+Given the prompt, write one self-contained Rust solution using only the standard library.
+
+Requirements:
+- Respond with exactly one ```rust code block.
+- Include the requested function implementation.
+- Include a #[cfg(test)] mod tests block using super::*.
+- Include multiple assert!/assert_eq! statements.
+- Do not add a main function."""
+
+TASKS: list[dict[str, str]] = [
+    {
+        "task_id": "sum_even_numbers",
+        "rust_prompt": "Write fn sum_even_numbers(nums: &[i32]) -> i32 that returns the sum of the even integers in nums.",
+        "required_function": "sum_even_numbers",
+    },
+    {
+        "task_id": "is_palindrome",
+        "rust_prompt": "Write fn is_palindrome(s: &str) -> bool that returns true when s is a palindrome ignoring case and non-alphanumeric characters.",
+        "required_function": "is_palindrome",
+    },
+    {
+        "task_id": "dedup_sorted",
+        "rust_prompt": "Write fn dedup_sorted(nums: Vec<i32>) -> Vec<i32> that removes duplicate values from an already-sorted vector while preserving order.",
+        "required_function": "dedup_sorted",
+    },
+    {
+        "task_id": "word_count",
+        "rust_prompt": "Write fn word_count(text: &str) -> usize that counts whitespace-separated words.",
+        "required_function": "word_count",
+    },
+    {
+        "task_id": "fibonacci",
+        "rust_prompt": "Write fn fibonacci(n: u32) -> u64 that returns the nth Fibonacci number with fibonacci(0)=0 and fibonacci(1)=1.",
+        "required_function": "fibonacci",
+    },
+]
+
+
+def build_dataset() -> Dataset:
+    return Dataset.from_list(
+        [
+            {
+                "question": task["rust_prompt"],
+                "answer": task["required_function"],
+                "info": {"task_id": task["task_id"]},
+            }
+            for task in TASKS
+        ]
+    )
+
+
+def extract_rust_code(response: str) -> str:
+    match = re.search(r"```rust\s*(.*?)\s*```", response, re.DOTALL | re.IGNORECASE)
+    if match:
+        return match.group(1).strip()
+    return response.strip()
+
+
+def extract_test_module(code: str) -> str | None:
+    match = re.search(r"#\[cfg\(test\)\]\s*mod\s+tests\s*\{", code)
+    if not match:
+        return None
+    return code[match.start() :]
+
+
+def count_assertions(code: str) -> int:
+    return len(re.findall(r"\bassert(?:_eq|_ne)?!\s*\(", code))
+
+
+def has_single_rust_block(response: str) -> bool:
+    blocks = re.findall(r"```rust\s*.*?\s*```", response, re.DOTALL | re.IGNORECASE)
+    return len(blocks) == 1
+
+
+def rust_project_files(code: str) -> dict[str, str]:
+    return {
+        "Cargo.toml": textwrap.dedent(
+            """
+            [package]
+            name = "rust-cargo-verifier"
+            version = "0.1.0"
+            edition = "2021"
+
+            [dependencies]
+            """
+        ).strip()
+        + "\n",
+        "src/lib.rs": textwrap.dedent(
+            f"""
+            #![allow(dead_code)]
+
+            {code}
+            """
+        ).strip()
+        + "\n",
+    }
+
+
+def run_cargo_tool(code: str, tool: str, timeout: int = 20) -> tuple[bool, str]:
+    if shutil.which("cargo") is None:
+        return False, "cargo executable not found"
+
+    with tempfile.TemporaryDirectory(prefix="vf-rust-cargo-") as tmpdir:
+        root = Path(tmpdir)
+        for relative_path, content in rust_project_files(code).items():
+            path = root / relative_path
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(content)
+
+        command = ["cargo", tool, "--quiet"]
+        if tool == "clippy":
+            command.extend(["--", "-D", "warnings"])
+        try:
+            result = subprocess.run(
+                command,
+                cwd=root,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+        except Exception as exc:
+            return False, str(exc)
+
+    output = (result.stdout + "\n" + result.stderr).strip()
+    return result.returncode == 0, output
+
+
+def format_reward(completion: str, answer: str, **kwargs) -> float:
+    _ = answer, kwargs
+    code = extract_rust_code(completion)
+    score = 0.0
+    if has_single_rust_block(completion):
+        score += 0.35
+    if "fn " in code:
+        score += 0.20
+    if "fn main" not in code:
+        score += 0.15
+    if extract_test_module(code) is not None:
+        score += 0.20
+    if count_assertions(code) >= 2:
+        score += 0.10
+    return score
+
+
+def required_function_reward(completion: str, answer: str, **kwargs) -> float:
+    _ = kwargs
+    code = extract_rust_code(completion)
+    return 1.0 if re.search(rf"\bfn\s+{re.escape(answer)}\s*\(", code) else 0.0
+
+
+def assertions_reward(completion: str, answer: str, **kwargs) -> float:
+    _ = answer, kwargs
+    code = extract_rust_code(completion)
+    assertions = count_assertions(code)
+    if assertions >= 4:
+        return 1.0
+    return 0.25 * assertions
+
+
+def cargo_build_reward(completion: str, answer: str, **kwargs) -> float:
+    _ = answer, kwargs
+    passed, _output = run_cargo_tool(extract_rust_code(completion), "build")
+    return 1.0 if passed else 0.0
+
+
+def cargo_clippy_reward(completion: str, answer: str, **kwargs) -> float:
+    _ = answer, kwargs
+    passed, _output = run_cargo_tool(extract_rust_code(completion), "clippy")
+    return 1.0 if passed else 0.0
+
+
+def cargo_test_reward(completion: str, answer: str, **kwargs) -> float:
+    _ = answer, kwargs
+    code = extract_rust_code(completion)
+    if extract_test_module(code) is None:
+        return 0.0
+    passed, _output = run_cargo_tool(code, "test")
+    return 1.0 if passed else 0.0
+
+
+def load_environment() -> vf.Environment:
+    rubric = vf.Rubric(
+        funcs=[
+            format_reward,
+            required_function_reward,
+            assertions_reward,
+            cargo_build_reward,
+            cargo_clippy_reward,
+            cargo_test_reward,
+        ],
+        weights=[0.5, 0.5, 0.5, 1.0, 1.0, 2.0],
+    )
+    return vf.SingleTurnEnv(
+        dataset=build_dataset,
+        system_prompt=SYSTEM_PROMPT,
+        parser=vf.Parser(),
+        rubric=rubric,
+    )
+
+
+def main() -> None:
+    _ = load_environment()
+    print(json.dumps({"environment": "rust-cargo", "num_tasks": len(build_dataset())}))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add a packaged `rust-cargo` environment for the Algora Rust w/ Cargo feedback bounty.
- Provide Rust coding prompts that ask for one fenced Rust solution with implementation and tests.
- Score completions with static rewards for format/function/assertions plus executable rewards for `cargo build`, `cargo clippy -- -D warnings`, and `cargo test`.
- Document quickstart and Cargo toolchain requirement.

## Verification
- `uv run --no-dev ruff check environments/rust_cargo`
- `uv pip install -e environments/rust_cargo`
- `uv run --no-dev python environments/rust_cargo/rust_cargo.py`
- `uv run --no-dev python - <<'PY' ... vf.load_environment('rust-cargo') ... PY`
- `CHANGED_ENVS=rust_cargo uv run --no-dev pytest tests/test_envs.py -q --tb=short` was attempted, but the Windows host cannot execute the test's hard-coded `/bin/bash` subprocess path.

Note: this Windows host does not have `cargo` installed, so local smoke verification covered environment loading and static reward helpers. The executable reward functions run Cargo when it is available on `PATH`.

Algora bounty: https://algora.io/PrimeIntellect-ai/bounties/FDaU5Y9iKeE8qfk3
Reference: https://github.com/Oxen-AI/GRPO-With-Cargo-Feedback/blob/main/train.py

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Eval runners execute model-generated Rust via subprocess in ephemeral directories (timeouts, no `cargo` → zero reward); hosts need a trusted toolchain and should treat this like other code-exec envs, not a security boundary.
> 
> **Overview**
> Adds a new installable **`rust-cargo`** single-turn environment for Rust code generation, aligned with the Algora Cargo-feedback bounty pattern.
> 
> The model gets Rust prompts and must answer with one fenced `rust` block (implementation, `#[cfg(test)]` module, assertions, no `main`). A built-in dataset covers five small tasks. Scoring uses a **`vf.Rubric`** mixing static checks (single block, required `fn`, assertion count) with executable feedback: extracted code is written to a temp crate and run through **`cargo build`**, **`cargo clippy -D warnings`**, and **`cargo test`** (tests weighted highest). **`load_environment()`** wires this into **`vf.SingleTurnEnv`** with a TDD-oriented system prompt. Package metadata, quickstart, and the root **`environments/README.md`** catalog entry document the env and the **`cargo` on PATH** requirement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c155d4c201b924d7575e32a1d0c63a2ef227b938. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Rust Cargo feedback environment for code-generation scoring
> - Adds a new `rust-cargo` single-turn environment in [rust_cargo.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1485/files#diff-d340238cfc524d202073b5956b8dc85035bddcf84c3a78bcbb78901ec2f06bcd) that scores model-generated Rust code using a weighted rubric of static checks and live Cargo tool execution.
> - Static rewards check for a single `rust` code block, presence of the required function, no `main` function, a `#[cfg(test)]` module, and assertion count (up to 4).
> - Cargo-based rewards run `cargo build`, `cargo clippy` (zero warnings), and `cargo test` in a temporary workspace via `run_cargo_tool`.
> - Includes five built-in Rust tasks and a dataset builder, with a README and `pyproject.toml` for packaging.
> - Risk: reward functions that invoke Cargo will fail gracefully if Cargo is not installed, returning 0.0 with an error message rather than raising.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c155d4c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->