### PR TITLE
feat: add LisanBench environment

### DIFF
--- a/environments/README.md
+++ b/environments/README.md
@@ -11,6 +11,7 @@ This folder contains installable example environments that showcase common usage
 ### SingleTurnEnv (prompt → single response)
 - **gsm8k**: Classic QA with exact-match reward and optional response-format reward.
 - **reverse_text**: XML formatting with non-binary LCS reward + format reward.
+- **lisanbench**: LisanBench word-chain task scored on starting word, edit-distance-1 validity, prefix length, duplicates, and formatting.
 - **continuation_quality**: Completion-style generation (`message_type="completion"`) judged for prose quality with `JudgeRubric`.
 - **mmmu**: Multimodal inputs (image + text) packed in chat content; single-turn boxed-answer check.
 

--- a/environments/lisanbench/README.md
+++ b/environments/lisanbench/README.md
@@ -1,0 +1,30 @@
+# lisanbench
+
+### Overview
+- **Environment ID**: `lisanbench`
+- **Short description**: LisanBench-style open-ended word-chain task for planning, vocabulary depth, and constraint adherence.
+- **Tags**: word-chain, lisanbench, levenshtein, planning, vocabulary, single-turn, train, eval
+
+### Task
+The model receives a starting word and must output the longest possible comma-separated chain of English words. Each adjacent pair must have Levenshtein edit distance exactly 1, all words must be valid English words, and no word may repeat.
+
+### Quickstart
+```bash
+prime env install environments/lisanbench
+prime eval run lisanbench -n 1 -r 1
+```
+
+### Rubric
+The reward combines:
+
+- correct starting word,
+- valid edit-distance-1 transitions,
+- length of the valid prefix,
+- no duplicates,
+- list-only formatting.
+
+The dictionary is cached from `dwyl/english-words` on first use, matching the public LisanBench implementation. A small fallback dictionary is included for offline smoke tests.
+
+### References
+- Algora bounty: https://algora.io/PrimeIntellect-ai/bounties/dDffD24XfkQUaR7a
+- Source benchmark: https://github.com/voice-from-the-outer-world/lisan-bench

--- a/environments/lisanbench/lisanbench.py
+++ b/environments/lisanbench/lisanbench.py
@@ -1,0 +1,298 @@
+import json
+import re
+import string
+import urllib.request
+from functools import lru_cache
+from pathlib import Path
+
+from datasets import Dataset
+
+import verifiers as vf
+
+DICTIONARY_URL = "https://raw.githubusercontent.com/dwyl/english-words/master/words_alpha.txt"
+DEFAULT_STARTING_WORDS = [
+    "hat",
+    "mine",
+    "lung",
+    "layer",
+    "pattern",
+    "camping",
+    "avoid",
+    "traveller",
+    "origin",
+    "abysmal",
+]
+
+# Small fallback used when the full dictionary cannot be downloaded in offline
+# smoke tests. The online path uses dwyl/english-words, matching LisanBench.
+FALLBACK_WORDS = {
+    "a",
+    "at",
+    "ate",
+    "bat",
+    "bit",
+    "bin",
+    "cat",
+    "cot",
+    "cut",
+    "hat",
+    "hit",
+    "hot",
+    "hut",
+    "mat",
+    "mine",
+    "mint",
+    "mind",
+    "minder",
+    "line",
+    "fine",
+    "lung",
+    "long",
+    "log",
+    "lag",
+    "layer",
+    "payer",
+    "player",
+    "slayer",
+    "pattern",
+    "patter",
+    "batter",
+    "better",
+    "camping",
+    "capping",
+    "mapping",
+    "avoid",
+    "void",
+    "voila",
+    "traveller",
+    "traveler",
+    "travel",
+    "origin",
+    "origins",
+    "abysmal",
+    "abyssal",
+    "sit",
+    "wit",
+    "win",
+    "pin",
+    "pit",
+    "pat",
+}
+
+SYSTEM_PROMPT = """You are playing LisanBench, an open-ended word-chain benchmark.
+Create the longest possible chain of valid English words.
+
+Rules:
+- Start with the given starting word.
+- Each next word must have Levenshtein edit distance exactly 1 from the previous word.
+- One step may add one letter, remove one letter, or substitute one letter.
+- Every word must be a valid English word.
+- Never repeat a word.
+- Output only a comma-separated list of words, with no explanation."""
+
+
+def create_prompt(starting_word: str) -> str:
+    return f"""Starting word: {starting_word}
+
+Return only the comma-separated word chain:
+{starting_word}, next_word, next_word, ..."""
+
+
+def build_dataset(starting_words: list[str] | None = None) -> Dataset:
+    words = starting_words or DEFAULT_STARTING_WORDS
+    return Dataset.from_list(
+        [
+            {
+                "question": create_prompt(word),
+                "answer": word,
+                "info": {"starting_word": word},
+            }
+            for word in words
+        ]
+    )
+
+
+def dictionary_cache_path() -> Path:
+    return Path.home() / ".cache" / "verifiers" / "lisanbench" / "words_alpha.txt"
+
+
+@lru_cache(maxsize=1)
+def load_word_dictionary() -> set[str]:
+    path = dictionary_cache_path()
+    if not path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            urllib.request.urlretrieve(DICTIONARY_URL, path)
+        except Exception:
+            return set(FALLBACK_WORDS)
+
+    try:
+        return {
+            word.strip().lower()
+            for word in path.read_text(encoding="utf-8").splitlines()
+            if word.strip().isalpha()
+        }
+    except Exception:
+        return set(FALLBACK_WORDS)
+
+
+def edit_distance(word1: str, word2: str) -> int:
+    word1 = word1.lower()
+    word2 = word2.lower()
+    if len(word1) == len(word2):
+        return sum(c1 != c2 for c1, c2 in zip(word1, word2))
+
+    m, n = len(word1), len(word2)
+    dp = [[0] * (n + 1) for _ in range(m + 1)]
+    for i in range(m + 1):
+        dp[i][0] = i
+    for j in range(n + 1):
+        dp[0][j] = j
+    for i in range(1, m + 1):
+        for j in range(1, n + 1):
+            if word1[i - 1] == word2[j - 1]:
+                dp[i][j] = dp[i - 1][j - 1]
+            else:
+                dp[i][j] = 1 + min(dp[i - 1][j], dp[i][j - 1], dp[i - 1][j - 1])
+    return dp[m][n]
+
+
+def is_valid_link(word1: str, word2: str) -> bool:
+    return edit_distance(word1, word2) == 1
+
+
+def extract_word_chain(completion: str) -> list[str]:
+    # Accept comma lists, arrows, numbered lists, or newline lists while stripping
+    # punctuation that often surrounds LLM answers.
+    normalized = completion.lower().replace("→", ",").replace("->", ",")
+    words: list[str] = []
+    for line in normalized.splitlines():
+        line = re.sub(r"^\s*\d+[.)]\s*", "", line)
+        line = line.translate(str.maketrans({ch: " " for ch in string.punctuation if ch not in {",", "'"}}))
+        for token in re.split(r"[,\s]+", line):
+            token = token.strip(" '").lower()
+            if token.isalpha():
+                words.append(token)
+    return words
+
+
+def validate_chain(word_chain: list[str], valid_words: set[str]) -> dict[str, int | float | bool]:
+    if not word_chain:
+        return {
+            "valid_prefix_length": 0,
+            "valid_links": 0,
+            "invalid_links": 0,
+            "duplicate_count": 0,
+            "all_words_valid": False,
+            "starts_correctly": False,
+        }
+
+    seen: set[str] = set()
+    valid_prefix_length = 0
+    valid_links = 0
+    invalid_links = 0
+    duplicate_count = 0
+
+    for idx, word in enumerate(word_chain):
+        if word in seen:
+            duplicate_count += 1
+            break
+        seen.add(word)
+        if word not in valid_words:
+            break
+        if idx == 0:
+            valid_prefix_length = 1
+            continue
+        previous = word_chain[idx - 1]
+        if is_valid_link(previous, word):
+            valid_prefix_length = idx + 1
+        else:
+            break
+
+    seen_links: set[str] = set()
+    for word1, word2 in zip(word_chain, word_chain[1:]):
+        duplicate = word1 in seen_links or word2 in seen_links
+        if duplicate:
+            invalid_links += 1
+        elif word1 in valid_words and word2 in valid_words and is_valid_link(word1, word2):
+            valid_links += 1
+        else:
+            invalid_links += 1
+        seen_links.add(word1)
+
+    return {
+        "valid_prefix_length": valid_prefix_length,
+        "valid_links": valid_links,
+        "invalid_links": invalid_links,
+        "duplicate_count": duplicate_count,
+        "all_words_valid": all(word in valid_words for word in word_chain),
+        "starts_correctly": bool(word_chain),
+    }
+
+
+def starting_word_reward(completion: str, answer: str, **kwargs) -> float:
+    _ = kwargs
+    chain = extract_word_chain(completion)
+    return 1.0 if chain and chain[0] == answer.lower() else 0.0
+
+
+def valid_chain_reward(completion: str, answer: str, **kwargs) -> float:
+    _ = answer, kwargs
+    chain = extract_word_chain(completion)
+    stats = validate_chain(chain, load_word_dictionary())
+    total = stats["valid_links"] + stats["invalid_links"]
+    if total == 0:
+        return 0.0
+    return stats["valid_links"] / total
+
+
+def length_reward(completion: str, answer: str, **kwargs) -> float:
+    _ = answer, kwargs
+    chain = extract_word_chain(completion)
+    prefix_length = validate_chain(chain, load_word_dictionary())["valid_prefix_length"]
+    # Reward longer valid prefixes, saturating at 25 words to keep reward bounded.
+    return min(float(prefix_length) / 25.0, 1.0)
+
+
+def no_duplicate_reward(completion: str, answer: str, **kwargs) -> float:
+    _ = answer, kwargs
+    chain = extract_word_chain(completion)
+    return 1.0 if len(chain) == len(set(chain)) and chain else 0.0
+
+
+def format_reward(completion: str, answer: str, **kwargs) -> float:
+    _ = answer, kwargs
+    chain = extract_word_chain(completion)
+    if len(chain) < 2:
+        return 0.0
+    has_explanation_markers = bool(re.search(r"\b(reason|because|explanation|steps?)\b", completion, re.I))
+    comma_like = "," in completion or "->" in completion or "→" in completion
+    return 1.0 if comma_like and not has_explanation_markers else 0.5 if comma_like else 0.0
+
+
+def load_environment(starting_words: list[str] | None = None) -> vf.Environment:
+    rubric = vf.Rubric(
+        funcs=[
+            starting_word_reward,
+            valid_chain_reward,
+            length_reward,
+            no_duplicate_reward,
+            format_reward,
+        ],
+        weights=[1.0, 2.0, 2.0, 1.0, 0.5],
+    )
+    return vf.SingleTurnEnv(
+        dataset=build_dataset(starting_words),
+        system_prompt=SYSTEM_PROMPT,
+        parser=vf.Parser(),
+        rubric=rubric,
+    )
+
+
+def main() -> None:
+    _ = load_environment()
+    print(json.dumps({"environment": "lisanbench", "num_tasks": len(build_dataset())}))
+
+
+if __name__ == "__main__":
+    main()

--- a/environments/lisanbench/pyproject.toml
+++ b/environments/lisanbench/pyproject.toml
@@ -1,0 +1,21 @@
+[project]
+name = "lisanbench"
+description = "LisanBench word-chain environment for evaluating planning, vocabulary, and constraint adherence."
+tags = ["word-chain", "lisanbench", "levenshtein", "planning", "vocabulary", "single-turn", "train", "eval"]
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+    "verifiers>=0.1.15.dev7",
+    "datasets",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build]
+include = ["lisanbench.py", "pyproject.toml", "README.md"]
+
+[tool.verifiers.eval]
+num_examples = 10
+rollouts_per_example = 3


### PR DESCRIPTION
## Summary
- Add a packaged `lisanbench` environment for the Algora LisanBench bounty.
- Port the core LisanBench word-chain task: start from a word, generate a longest possible chain, require Levenshtein distance 1 between adjacent words, valid English words, and no repeats.
- Add reward functions for correct start word, edit-distance transition validity, valid-prefix length, duplicate avoidance, and comma-list formatting.
- Cache the `dwyl/english-words` dictionary on first use with a small offline fallback for smoke tests.
- Document quickstart and source/bounty references.

## Verification
- `uv run --no-dev ruff check environments/lisanbench`
- `uv pip install -e environments/lisanbench`
- `uv run --no-dev python environments/lisanbench/lisanbench.py`
- `uv run --no-dev python - <<'PY' ... vf.load_environment('lisanbench') + reward smoke checks ... PY`
- `CHANGED_ENVS=lisanbench uv run --no-dev pytest tests/test_envs.py -q --tb=short` was attempted, but the Windows host cannot execute the test's hard-coded `/bin/bash` subprocess path.

Algora bounty: https://algora.io/PrimeIntellect-ai/bounties/dDffD24XfkQUaR7a
Reference implementation: https://github.com/voice-from-the-outer-world/lisan-bench

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Self-contained new environment under `environments/lisanbench` with no changes to core auth, data pipelines, or shared runtime beyond documentation.
> 
> **Overview**
> Adds a new installable **`lisanbench`** single-turn environment and documents it in the environments index.
> 
> The model must extend a given starting word into a comma-separated English word chain where each step has Levenshtein distance 1, words are dictionary-valid, and repeats are forbidden. Scoring uses a weighted rubric (start word, transition validity, valid-prefix length capped at 25 words, no duplicates, list-only formatting). The English lexicon is loaded from **`dwyl/english-words`** into `~/.cache/verifiers/lisanbench/` on first use, with a small embedded fallback when download or read fails. The package includes **`load_environment`**, default starting-word tasks, and eval defaults in **`pyproject.toml`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 700bf83e9800710532f5507fb02b504d9063ed45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add LisanBench single-turn word-chain environment
> - Adds a new `lisanbench` environment in [lisanbench.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1486/files#diff-54b742c8a5ee2054e6c6d6ca41cd76eac48b8a2aec176a342dc650e5fe9026dd) implementing a word-chain task where a model must produce a comma-separated chain of English words each differing by edit distance 1 from the previous.
> - Loads a word dictionary from a cached copy of `words_alpha.txt` (stored at `~/.cache/verifiers/lisanbench/words_alpha.txt`), falling back to a small in-module word set on download failure.
> - Scores completions with a weighted rubric (total weight 6.5) covering: correct starting word, valid-link ratio, valid-prefix length (capped at 25), duplicate avoidance, and list-like formatting.
> - Exposes a `load_environment()` function returning a `vf.SingleTurnEnv` and documents the environment in [environments/README.md](https://github.com/PrimeIntellect-ai/verifiers/pull/1486/files#diff-38667e0c3afd93d3f9dafe9ea36add3e24c9638795679b83c34d4f345065460f).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 700bf83.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->