### PR TITLE
feat: add SciCode environment

### DIFF
--- a/environments/README.md
+++ b/environments/README.md
@@ -11,6 +11,7 @@ This folder contains installable example environments that showcase common usage
 ### SingleTurnEnv (prompt → single response)
 - **gsm8k**: Classic QA with exact-match reward and optional response-format reward.
 - **reverse_text**: XML formatting with non-binary LCS reward + format reward.
+- **scicode**: SciCode scientific research coding substeps with static rewards for valid Python, expected function/class, and response discipline.
 - **continuation_quality**: Completion-style generation (`message_type="completion"`) judged for prose quality with `JudgeRubric`.
 - **mmmu**: Multimodal inputs (image + text) packed in chat content; single-turn boxed-answer check.
 

--- a/environments/scicode/README.md
+++ b/environments/scicode/README.md
@@ -1,0 +1,32 @@
+# scicode
+
+### Overview
+- **Environment ID**: `scicode`
+- **Short description**: SciCode scientific Python coding tasks from research problems decomposed into executable substeps.
+- **Tags**: scicode, science, coding, python, research, single-turn, train, eval
+
+### Task
+Each sample prompts the model with a SciCode subproblem, prior step context, required dependencies, and the exact function/class header to implement. The response should be one fenced Python code block containing background comments and the implementation for the requested step only.
+
+### Quickstart
+```bash
+prime env install environments/scicode
+prime eval run scicode -n 1 -r 1
+```
+
+### Rubric
+The reward combines static checks that are available without the external numeric HDF5 answer file:
+
+- syntactically valid Python after stripping dependency imports,
+- expected function/class name is implemented,
+- response is in a fenced Python block,
+- no top-level examples, tests, prints, or asserts,
+- includes a `# Background:` comment,
+- includes at least one return statement.
+
+The environment loads `SciCode1/SciCode` from Hugging Face and falls back to a small local sample for offline smoke tests.
+
+### References
+- Algora bounty: https://algora.io/PrimeIntellect-ai/bounties/AG9a7bN3dkaFcVL3
+- Source benchmark: https://github.com/scicode-bench/SciCode
+- Dataset: https://huggingface.co/datasets/SciCode1/SciCode

--- a/environments/scicode/pyproject.toml
+++ b/environments/scicode/pyproject.toml
@@ -1,0 +1,21 @@
+[project]
+name = "scicode"
+description = "SciCode scientific research coding environment."
+tags = ["scicode", "science", "coding", "python", "research", "single-turn", "train", "eval"]
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+    "verifiers>=0.1.15.dev7",
+    "datasets",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build]
+include = ["scicode.py", "pyproject.toml", "README.md"]
+
+[tool.verifiers.eval]
+num_examples = 10
+rollouts_per_example = 3

--- a/environments/scicode/scicode.py
+++ b/environments/scicode/scicode.py
@@ -1,0 +1,228 @@
+import ast
+import json
+import re
+from textwrap import dedent
+
+from datasets import Dataset, load_dataset
+
+import verifiers as vf
+
+DEFAULT_PROMPT_TEMPLATE = """PROBLEM DESCRIPTION:
+You will be provided with a scientific research coding subproblem. Generate the disciplinary knowledge necessary for solving the next step, then develop a Python solution focused on this step.
+
+PREVIOUS STEPS DESCRIPTION:
+{problem_steps_str}
+
+NEXT STEP - PROBLEM DESCRIPTION AND FUNCTION HEADER:
+{next_step_str}
+
+DEPENDENCIES:
+Use only the following dependencies in your solution. Do not include these dependencies at the beginning of your code.
+{dependencies}
+
+RESPONSE GUIDELINES:
+1. Start with the scientific background required for the next step, formatted as a Python comment beginning with `# Background:`.
+2. Then write the complete Python implementation for this next step in one fenced ```python code block.
+3. Follow the supplied function/class header exactly.
+4. Do not include previous function code, example usage, or test code.
+"""
+
+FALLBACK_PROBLEMS = [
+    {
+        "problem_name": "Periodic boundary wrapping",
+        "problem_id": "fallback-1",
+        "required_dependencies": "import numpy as np",
+        "sub_steps": [
+            {
+                "step_number": "fallback-1.1",
+                "step_description_prompt": "Wrap coordinates into a periodic cubic simulation box.",
+                "step_background": "Use modulo arithmetic so each coordinate lies in [0, L).",
+                "function_header": dedent(
+                    '''
+                    def wrap(r, L):
+                        ''' + '"""Apply periodic boundary conditions to coordinates r for a cubic box of size L."""'
+                ).strip(),
+                "return_line": "    return coord",
+            }
+        ],
+    }
+]
+
+
+def extract_function_name(function_header: str) -> str:
+    match = re.search(r"\b(?:def|class)\s+(\w+)\s*[(:]", function_header)
+    if not match:
+        raise ValueError("Function or class name not found in header")
+    return match.group(1)
+
+
+def extract_python_code(completion: str) -> str:
+    if "```" not in completion:
+        return completion.strip()
+    python_block = re.search(r"```python\s*(.*?)```", completion, re.DOTALL | re.IGNORECASE)
+    if python_block:
+        return python_block.group(1).strip()
+    generic_block = re.search(r"```\s*(.*?)```", completion, re.DOTALL)
+    return generic_block.group(1).strip() if generic_block else completion.strip()
+
+
+def strip_imports(code: str) -> str:
+    lines = []
+    for line in code.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("import ") or stripped.startswith("from "):
+            continue
+        lines.append(line)
+    return "\n".join(lines).strip()
+
+
+def process_problem_code(problem: dict, step_index: int) -> str:
+    sub_step = problem["sub_steps"][step_index]
+    return f'{sub_step["function_header"]}\n\n{sub_step["return_line"]}'
+
+
+def build_prompt(problem: dict, step_index: int, with_background: bool = True) -> str:
+    sub_steps = problem["sub_steps"]
+    previous_chunks = []
+    for previous in sub_steps[:step_index]:
+        description = previous["step_description_prompt"]
+        if with_background and previous.get("step_background"):
+            description = f'{description}\n{previous["step_background"]}'
+        previous_chunks.append(description)
+        previous_chunks.append(previous["function_header"])
+        previous_chunks.append("------")
+
+    current = sub_steps[step_index]
+    next_step = current["step_description_prompt"]
+    if with_background and current.get("step_background"):
+        next_step = f'{next_step}\n{current["step_background"]}'
+    next_step = f"{next_step}\n\n{process_problem_code(problem, step_index)}"
+
+    return DEFAULT_PROMPT_TEMPLATE.format(
+        problem_steps_str="\n\n".join(previous_chunks[:-1]),
+        next_step_str=next_step,
+        dependencies=problem.get("required_dependencies", ""),
+    )
+
+
+def normalize_problem(problem: dict, max_steps_per_problem: int | None = None) -> list[dict]:
+    rows = []
+    sub_steps = problem.get("sub_steps") or []
+    if max_steps_per_problem is not None:
+        sub_steps = sub_steps[:max_steps_per_problem]
+    for step_index, sub_step in enumerate(sub_steps):
+        try:
+            function_name = extract_function_name(sub_step["function_header"])
+        except ValueError:
+            continue
+        rows.append(
+            {
+                "question": build_prompt(problem, step_index),
+                "answer": function_name,
+                "info": {
+                    "problem_id": problem.get("problem_id"),
+                    "problem_name": problem.get("problem_name"),
+                    "step_number": sub_step.get("step_number"),
+                    "function_header": sub_step.get("function_header"),
+                    "return_line": sub_step.get("return_line"),
+                    "required_dependencies": problem.get("required_dependencies", ""),
+                },
+            }
+        )
+    return rows
+
+
+def build_dataset(split: str = "validation", max_problems: int | None = 15, max_steps_per_problem: int | None = None) -> Dataset:
+    try:
+        raw = list(load_dataset("SciCode1/SciCode", split=split))
+    except Exception:
+        raw = FALLBACK_PROBLEMS
+
+    if max_problems is not None:
+        raw = raw[:max_problems]
+
+    rows = []
+    for problem in raw:
+        rows.extend(normalize_problem(problem, max_steps_per_problem=max_steps_per_problem))
+    return Dataset.from_list(rows)
+
+
+def syntax_reward(completion: str, answer: str, **kwargs) -> float:
+    _ = answer, kwargs
+    code = strip_imports(extract_python_code(completion))
+    try:
+        ast.parse(code)
+        return 1.0
+    except SyntaxError:
+        return 0.0
+
+
+def function_name_reward(completion: str, answer: str, **kwargs) -> float:
+    _ = kwargs
+    code = strip_imports(extract_python_code(completion))
+    try:
+        tree = ast.parse(code)
+    except SyntaxError:
+        return 0.0
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef) and node.name == answer:
+            return 1.0
+    return 0.0
+
+
+def code_block_reward(completion: str, answer: str, **kwargs) -> float:
+    _ = answer, kwargs
+    return 1.0 if re.search(r"```python\s+.*?```", completion, re.DOTALL | re.IGNORECASE) else 0.0
+
+
+def no_top_level_test_reward(completion: str, answer: str, **kwargs) -> float:
+    _ = answer, kwargs
+    code = strip_imports(extract_python_code(completion))
+    banned = [r"\bassert\b", r"if\s+__name__\s*==", r"print\s*\(", r"pytest", r"unittest"]
+    return 0.0 if any(re.search(pattern, code) for pattern in banned) else 1.0
+
+
+def background_comment_reward(completion: str, answer: str, **kwargs) -> float:
+    _ = answer, kwargs
+    code = extract_python_code(completion)
+    return 1.0 if re.search(r"^\s*#\s*Background\s*:", code, re.IGNORECASE | re.MULTILINE) else 0.0
+
+
+def return_statement_reward(completion: str, answer: str, **kwargs) -> float:
+    _ = answer, kwargs
+    code = strip_imports(extract_python_code(completion))
+    try:
+        tree = ast.parse(code)
+    except SyntaxError:
+        return 0.0
+    return 1.0 if any(isinstance(node, ast.Return) for node in ast.walk(tree)) else 0.0
+
+
+def load_environment(split: str = "validation", max_problems: int | None = 15) -> vf.Environment:
+    rubric = vf.Rubric(
+        funcs=[
+            syntax_reward,
+            function_name_reward,
+            code_block_reward,
+            no_top_level_test_reward,
+            background_comment_reward,
+            return_statement_reward,
+        ],
+        weights=[1.0, 2.0, 1.0, 1.0, 0.5, 0.5],
+    )
+    return vf.SingleTurnEnv(
+        dataset=build_dataset(split=split, max_problems=max_problems),
+        system_prompt="You are a careful scientific Python programmer. Return only one fenced Python code block.",
+        parser=vf.Parser(),
+        rubric=rubric,
+    )
+
+
+def main() -> None:
+    dataset = build_dataset(max_problems=1)
+    _ = load_environment(max_problems=1)
+    print(json.dumps({"environment": "scicode", "num_tasks": len(dataset)}))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add a packaged `scicode` environment for the Algora SciCode bounty.
- Load `SciCode1/SciCode` from Hugging Face and convert each scientific research substep into a SingleTurnEnv coding prompt.
- Preserve SciCode prompt structure: prior step context, next step description, required dependencies, exact function/class header, and response guidelines.
- Add static reward functions for valid Python syntax, expected function/class implementation, fenced Python code block formatting, no top-level examples/tests/prints/asserts, background comment, and return statements.
- Include a small fallback sample for offline smoke tests and document quickstart/source links.

## Verification
- `uv run --no-dev ruff check environments/scicode`
- `uv pip install -e environments/scicode`
- `uv run --no-dev python environments/scicode/scicode.py`
- `uv run --no-dev python - <<'PY' ... vf.load_environment('scicode') + reward smoke checks ... PY`
- `CHANGED_ENVS=scicode uv run --no-dev pytest tests/test_envs.py -q --tb=short` was attempted, but the Windows host cannot execute the test's hard-coded `/bin/bash` subprocess path.

Algora bounty: https://algora.io/PrimeIntellect-ai/bounties/AG9a7bN3dkaFcVL3
Reference implementation: https://github.com/scicode-bench/SciCode
Dataset: https://huggingface.co/datasets/SciCode1/SciCode

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive example environment and docs; no changes to core auth, training, or shared runtime paths.
> 
> **Overview**
> Adds a new **`scicode`** installable environment for SciCode-style scientific coding substeps, and lists it in the environments README under SingleTurnEnv examples.
> 
> The environment loads **`SciCode1/SciCode`** (with a small local fallback when HF is unavailable), expands each problem into per-step **`question` / `answer`** rows with SciCode-style prompts (prior steps, dependencies, exact header), and exposes **`load_environment`** as a **`SingleTurnEnv`** with a weighted rubric of **static** checks only—syntax, expected def/class name, fenced Python, no tests/prints/asserts, `# Background:` comment, and a return—without HDF5 numeric verification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f24882da63c76a022b5ab922f1684f0a216e07dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add SciCode environment for scientific research coding substep evaluation
> - Adds a new [`scicode`](https://github.com/PrimeIntellect-ai/verifiers/pull/1487/files#diff-af6f645906f687b1221d15047b5d7172e925f9f4fd4c1c902b7019812c099a17) environment that loads the [SciCode1/SciCode](https://huggingface.co/datasets/SciCode1/SciCode) dataset and presents individual substeps as single-turn prompts.
> - Implements prompt construction that chains prior substep descriptions and builds a structured instruction for the current step, including the function header and expected return.
> - Defines a static rubric with six reward functions: syntax validity, correct function/class name, fenced code block presence, no top-level test/debug statements, background comment, and return statement presence.
> - Falls back to a small inline problem list if the remote dataset cannot be loaded.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f24882d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->