### PR TITLE
Update taskset and harness release flows for untagged PyPI releases

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -36,8 +36,8 @@ This directory contains automated workflows for the verifiers project.
 
 **Workflows**:
 - `tag-and-release.yml` publishes `verifiers` from `v*` tags with trusted publishing.
-- `publish-tasksets.yml` publishes `tasksets` from `tasksets-v*` tags with trusted publishing.
-- `publish-harnesses.yml` publishes `harnesses` from `harnesses-v*` tags with trusted publishing.
+- `publish-tasksets.yml` publishes `tasksets` from `tasksets-v*` tags with `PYPI_TASKSETS_TOKEN`. On `main`, it creates `tasksets-v<version>` when the current package version has no matching remote tag and is not published on PyPI.
+- `publish-harnesses.yml` publishes `harnesses` from `harnesses-v*` tags with `PYPI_HARNESSES_TOKEN`. On `main`, it creates `harnesses-v<version>` when the current package version has no matching remote tag and is not published on PyPI.
 - `publish-verifiers-rl.yml` publishes `verifiers-rl` from `verifiers-rl-v*` tags.
 
 ## Setting Up

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -36,8 +36,8 @@ This directory contains automated workflows for the verifiers project.
 
 **Workflows**:
 - `tag-and-release.yml` publishes `verifiers` from `v*` tags with trusted publishing.
-- `publish-tasksets.yml` publishes `tasksets` from `tasksets-v*` tags with `PYPI_TASKSETS_TOKEN`. On `main`, it creates `tasksets-v<version>` when `packages/tasksets/tasksets/__init__.py` defines `__version__` and the matching remote tag does not already exist.
-- `publish-harnesses.yml` publishes `harnesses` from `harnesses-v*` tags with `PYPI_HARNESSES_TOKEN`. On `main`, it creates `harnesses-v<version>` when `packages/harnesses/harnesses/__init__.py` defines `__version__` and the matching remote tag does not already exist.
+- `publish-tasksets.yml` publishes `tasksets` from `tasksets-v*` tags with `PYPI_TASKSETS_TOKEN`. On `main`, it creates `tasksets-v<version>` when `packages/tasksets/tasksets/__init__.py` defines `__version__` and the matching remote tag does not already exist, then builds and publishes from that tag in the same workflow run.
+- `publish-harnesses.yml` publishes `harnesses` from `harnesses-v*` tags with `PYPI_HARNESSES_TOKEN`. On `main`, it creates `harnesses-v<version>` when `packages/harnesses/harnesses/__init__.py` defines `__version__` and the matching remote tag does not already exist, then builds and publishes from that tag in the same workflow run.
 - `publish-verifiers-rl.yml` publishes `verifiers-rl` from `verifiers-rl-v*` tags.
 
 ## Setting Up

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -36,8 +36,8 @@ This directory contains automated workflows for the verifiers project.
 
 **Workflows**:
 - `tag-and-release.yml` publishes `verifiers` from `v*` tags with trusted publishing.
-- `publish-tasksets.yml` publishes `tasksets` from `tasksets-v*` tags with `PYPI_TASKSETS_TOKEN`. On `main`, it creates `tasksets-v<version>` when the current package version has no matching remote tag and is not published on PyPI.
-- `publish-harnesses.yml` publishes `harnesses` from `harnesses-v*` tags with `PYPI_HARNESSES_TOKEN`. On `main`, it creates `harnesses-v<version>` when the current package version has no matching remote tag and is not published on PyPI.
+- `publish-tasksets.yml` publishes `tasksets` from `tasksets-v*` tags with `PYPI_TASKSETS_TOKEN`. On `main`, it creates `tasksets-v<version>` when `packages/tasksets/tasksets/__init__.py` defines `__version__` and the matching remote tag does not already exist.
+- `publish-harnesses.yml` publishes `harnesses` from `harnesses-v*` tags with `PYPI_HARNESSES_TOKEN`. On `main`, it creates `harnesses-v<version>` when `packages/harnesses/harnesses/__init__.py` defines `__version__` and the matching remote tag does not already exist.
 - `publish-verifiers-rl.yml` publishes `verifiers-rl` from `verifiers-rl-v*` tags.
 
 ## Setting Up

--- a/.github/workflows/publish-harnesses.yml
+++ b/.github/workflows/publish-harnesses.yml
@@ -19,6 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      created: ${{ steps.tag.outputs.created }}
+      tag: ${{ steps.tag.outputs.tag }}
+      version: ${{ steps.tag.outputs.version }}
     steps:
       - name: Checkout main
         uses: actions/checkout@v4
@@ -26,7 +30,10 @@ jobs:
           fetch-depth: 0
 
       - name: Create release tag for untagged version
+        id: tag
         run: |
+          echo "created=false" >> "$GITHUB_OUTPUT"
+
           VERSION=$(python - <<'PY'
           from pathlib import Path
           import re
@@ -55,6 +62,66 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag -a "$TAG" -m "Release $TAG"
           git push origin "$TAG"
+
+          echo "created=true" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+  build-from-auto-tag:
+    needs: auto-tag-on-main
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.auto-tag-on-main.outputs.created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      tag: ${{ needs.auto-tag-on-main.outputs.tag }}
+      version: ${{ needs.auto-tag-on-main.outputs.version }}
+    steps:
+      - name: Checkout auto-created tag
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: refs/tags/${{ needs.auto-tag-on-main.outputs.tag }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Build harnesses
+        run: uv build packages/harnesses
+
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: harnesses-dist
+          path: packages/harnesses/dist/
+          if-no-files-found: error
+          retention-days: 7
+
+  publish-from-auto-tag:
+    needs: build-from-auto-tag
+    runs-on: ubuntu-latest
+    environment: pypi-prod
+    permissions:
+      contents: read
+    steps:
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: harnesses-dist
+          path: dist/
+
+      - name: Publish to PyPI
+        env:
+          PYPI_HARNESSES_TOKEN: ${{ secrets.PYPI_HARNESSES_TOKEN }}
+        run: |
+          if [ -z "$PYPI_HARNESSES_TOKEN" ]; then
+            echo "Missing PYPI_HARNESSES_TOKEN secret" >&2
+            exit 1
+          fi
+          uv publish --token "$PYPI_HARNESSES_TOKEN" dist/*
 
   build-tag:
     if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/harnesses-v')

--- a/.github/workflows/publish-harnesses.yml
+++ b/.github/workflows/publish-harnesses.yml
@@ -29,20 +29,23 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Create release tag for unreleased version
+      - name: Create release tag for untagged version
         id: tag
         run: |
           echo "created=false" >> "$GITHUB_OUTPUT"
 
           VERSION=$(python - <<'PY'
-          import tomllib
           from pathlib import Path
+          import re
+          import sys
 
-          with Path("packages/harnesses/pyproject.toml").open("rb") as f:
-              data = tomllib.load(f)
-          print(data["project"]["version"])
+          match = re.search(r'__version__\s*=\s*"([^"]+)"', Path("packages/harnesses/harnesses/__init__.py").read_text())
+          if not match:
+              sys.exit("Could not find __version__ in packages/harnesses/harnesses/__init__.py")
+          print(match.group(1))
           PY
           )
+
           TAG="harnesses-v${VERSION}"
 
           if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
@@ -52,30 +55,6 @@ jobs:
 
           if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
             echo "Tag ${TAG} already exists on origin; skipping."
-            exit 0
-          fi
-
-          PYPI_STATUS=$(python - <<PY
-          from urllib.error import HTTPError
-          from urllib.request import Request, urlopen
-
-          request = Request(
-              "https://pypi.org/pypi/harnesses/${VERSION}/json",
-              headers={"Accept": "application/json"},
-          )
-          try:
-              with urlopen(request, timeout=10):
-                  print("released")
-          except HTTPError as exc:
-              if exc.code == 404:
-                  print("unreleased")
-              else:
-                  raise SystemExit(f"PyPI returned HTTP {exc.code}")
-          PY
-          )
-
-          if [ "$PYPI_STATUS" = "released" ]; then
-            echo "harnesses ${VERSION} is already published on PyPI; skipping."
             exit 0
           fi
 
@@ -189,17 +168,19 @@ jobs:
 
           VERSION="${TAG#harnesses-v}"
           FILE_VERSION=$(python - <<'PY'
-          import tomllib
           from pathlib import Path
+          import re
+          import sys
 
-          with Path("packages/harnesses/pyproject.toml").open("rb") as f:
-              data = tomllib.load(f)
-          print(data["project"]["version"])
+          match = re.search(r'__version__\s*=\s*"([^"]+)"', Path("packages/harnesses/harnesses/__init__.py").read_text())
+          if not match:
+              sys.exit("Could not find __version__ in packages/harnesses/harnesses/__init__.py")
+          print(match.group(1))
           PY
           )
 
           if [ "$FILE_VERSION" != "$VERSION" ]; then
-            echo "Version mismatch: tag requests '$VERSION' but packages/harnesses/pyproject.toml defines '$FILE_VERSION'" >&2
+            echo "Version mismatch: tag requests '$VERSION' but packages/harnesses/harnesses/__init__.py defines '$FILE_VERSION'" >&2
             exit 1
           fi
 

--- a/.github/workflows/publish-harnesses.yml
+++ b/.github/workflows/publish-harnesses.yml
@@ -19,10 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    outputs:
-      created: ${{ steps.tag.outputs.created }}
-      tag: ${{ steps.tag.outputs.tag }}
-      version: ${{ steps.tag.outputs.version }}
     steps:
       - name: Checkout main
         uses: actions/checkout@v4
@@ -30,10 +26,7 @@ jobs:
           fetch-depth: 0
 
       - name: Create release tag for untagged version
-        id: tag
         run: |
-          echo "created=false" >> "$GITHUB_OUTPUT"
-
           VERSION=$(python - <<'PY'
           from pathlib import Path
           import re
@@ -62,66 +55,6 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag -a "$TAG" -m "Release $TAG"
           git push origin "$TAG"
-
-          echo "created=true" >> "$GITHUB_OUTPUT"
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-
-  build-from-auto-tag:
-    needs: auto-tag-on-main
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.auto-tag-on-main.outputs.created == 'true'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    outputs:
-      tag: ${{ needs.auto-tag-on-main.outputs.tag }}
-      version: ${{ needs.auto-tag-on-main.outputs.version }}
-    steps:
-      - name: Checkout auto-created tag
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: refs/tags/${{ needs.auto-tag-on-main.outputs.tag }}
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-
-      - name: Build harnesses
-        run: uv build packages/harnesses
-
-      - name: Upload dist artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: harnesses-dist
-          path: packages/harnesses/dist/
-          if-no-files-found: error
-          retention-days: 7
-
-  publish-from-auto-tag:
-    needs: build-from-auto-tag
-    runs-on: ubuntu-latest
-    environment: pypi-prod
-    permissions:
-      contents: read
-    steps:
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-
-      - name: Download dist artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: harnesses-dist
-          path: dist/
-
-      - name: Publish to PyPI
-        env:
-          PYPI_HARNESSES_TOKEN: ${{ secrets.PYPI_HARNESSES_TOKEN }}
-        run: |
-          if [ -z "$PYPI_HARNESSES_TOKEN" ]; then
-            echo "Missing PYPI_HARNESSES_TOKEN secret" >&2
-            exit 1
-          fi
-          uv publish --token "$PYPI_HARNESSES_TOKEN" dist/*
 
   build-tag:
     if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/harnesses-v')

--- a/.github/workflows/publish-harnesses.yml
+++ b/.github/workflows/publish-harnesses.yml
@@ -8,11 +8,144 @@ on:
         required: true
         type: string
   push:
+    branches:
+      - main
     tags:
       - "harnesses-v*"
 
 jobs:
-  build:
+  auto-tag-on-main:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      created: ${{ steps.tag.outputs.created }}
+      tag: ${{ steps.tag.outputs.tag }}
+      version: ${{ steps.tag.outputs.version }}
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create release tag for unreleased version
+        id: tag
+        run: |
+          echo "created=false" >> "$GITHUB_OUTPUT"
+
+          VERSION=$(python - <<'PY'
+          import tomllib
+          from pathlib import Path
+
+          with Path("packages/harnesses/pyproject.toml").open("rb") as f:
+              data = tomllib.load(f)
+          print(data["project"]["version"])
+          PY
+          )
+          TAG="harnesses-v${VERSION}"
+
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            echo "Tag ${TAG} already exists locally; skipping."
+            exit 0
+          fi
+
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "Tag ${TAG} already exists on origin; skipping."
+            exit 0
+          fi
+
+          PYPI_STATUS=$(python - <<PY
+          from urllib.error import HTTPError
+          from urllib.request import Request, urlopen
+
+          request = Request(
+              "https://pypi.org/pypi/harnesses/${VERSION}/json",
+              headers={"Accept": "application/json"},
+          )
+          try:
+              with urlopen(request, timeout=10):
+                  print("released")
+          except HTTPError as exc:
+              if exc.code == 404:
+                  print("unreleased")
+              else:
+                  raise SystemExit(f"PyPI returned HTTP {exc.code}")
+          PY
+          )
+
+          if [ "$PYPI_STATUS" = "released" ]; then
+            echo "harnesses ${VERSION} is already published on PyPI; skipping."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "Release $TAG"
+          git push origin "$TAG"
+
+          echo "created=true" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+  build-from-auto-tag:
+    needs: auto-tag-on-main
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.auto-tag-on-main.outputs.created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      tag: ${{ needs.auto-tag-on-main.outputs.tag }}
+      version: ${{ needs.auto-tag-on-main.outputs.version }}
+    steps:
+      - name: Checkout auto-created tag
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: refs/tags/${{ needs.auto-tag-on-main.outputs.tag }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Build harnesses
+        run: uv build packages/harnesses
+
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: harnesses-dist
+          path: packages/harnesses/dist/
+          if-no-files-found: error
+          retention-days: 7
+
+  publish-from-auto-tag:
+    needs: build-from-auto-tag
+    runs-on: ubuntu-latest
+    environment: pypi-prod
+    permissions:
+      contents: read
+    steps:
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: harnesses-dist
+          path: dist/
+
+      - name: Publish to PyPI
+        env:
+          PYPI_HARNESSES_TOKEN: ${{ secrets.PYPI_HARNESSES_TOKEN }}
+        run: |
+          if [ -z "$PYPI_HARNESSES_TOKEN" ]; then
+            echo "Missing PYPI_HARNESSES_TOKEN secret" >&2
+            exit 1
+          fi
+          uv publish --token "$PYPI_HARNESSES_TOKEN" dist/*
+
+  build-tag:
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/harnesses-v')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -87,14 +220,16 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
-  publish:
-    needs: build
+  publish-tag:
+    needs: build-tag
     runs-on: ubuntu-latest
     environment: pypi-prod
     permissions:
       contents: read
-      id-token: write
     steps:
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
       - name: Download dist artifacts
         uses: actions/download-artifact@v4
         with:
@@ -102,6 +237,11 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
-        with:
-          packages-dir: dist/
+        env:
+          PYPI_HARNESSES_TOKEN: ${{ secrets.PYPI_HARNESSES_TOKEN }}
+        run: |
+          if [ -z "$PYPI_HARNESSES_TOKEN" ]; then
+            echo "Missing PYPI_HARNESSES_TOKEN secret" >&2
+            exit 1
+          fi
+          uv publish --token "$PYPI_HARNESSES_TOKEN" dist/*

--- a/.github/workflows/publish-tasksets.yml
+++ b/.github/workflows/publish-tasksets.yml
@@ -8,11 +8,144 @@ on:
         required: true
         type: string
   push:
+    branches:
+      - main
     tags:
       - "tasksets-v*"
 
 jobs:
-  build:
+  auto-tag-on-main:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      created: ${{ steps.tag.outputs.created }}
+      tag: ${{ steps.tag.outputs.tag }}
+      version: ${{ steps.tag.outputs.version }}
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create release tag for unreleased version
+        id: tag
+        run: |
+          echo "created=false" >> "$GITHUB_OUTPUT"
+
+          VERSION=$(python - <<'PY'
+          import tomllib
+          from pathlib import Path
+
+          with Path("packages/tasksets/pyproject.toml").open("rb") as f:
+              data = tomllib.load(f)
+          print(data["project"]["version"])
+          PY
+          )
+          TAG="tasksets-v${VERSION}"
+
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            echo "Tag ${TAG} already exists locally; skipping."
+            exit 0
+          fi
+
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "Tag ${TAG} already exists on origin; skipping."
+            exit 0
+          fi
+
+          PYPI_STATUS=$(python - <<PY
+          from urllib.error import HTTPError
+          from urllib.request import Request, urlopen
+
+          request = Request(
+              "https://pypi.org/pypi/tasksets/${VERSION}/json",
+              headers={"Accept": "application/json"},
+          )
+          try:
+              with urlopen(request, timeout=10):
+                  print("released")
+          except HTTPError as exc:
+              if exc.code == 404:
+                  print("unreleased")
+              else:
+                  raise SystemExit(f"PyPI returned HTTP {exc.code}")
+          PY
+          )
+
+          if [ "$PYPI_STATUS" = "released" ]; then
+            echo "tasksets ${VERSION} is already published on PyPI; skipping."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "Release $TAG"
+          git push origin "$TAG"
+
+          echo "created=true" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+  build-from-auto-tag:
+    needs: auto-tag-on-main
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.auto-tag-on-main.outputs.created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      tag: ${{ needs.auto-tag-on-main.outputs.tag }}
+      version: ${{ needs.auto-tag-on-main.outputs.version }}
+    steps:
+      - name: Checkout auto-created tag
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: refs/tags/${{ needs.auto-tag-on-main.outputs.tag }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Build tasksets
+        run: uv build packages/tasksets
+
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: tasksets-dist
+          path: packages/tasksets/dist/
+          if-no-files-found: error
+          retention-days: 7
+
+  publish-from-auto-tag:
+    needs: build-from-auto-tag
+    runs-on: ubuntu-latest
+    environment: pypi-prod
+    permissions:
+      contents: read
+    steps:
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: tasksets-dist
+          path: dist/
+
+      - name: Publish to PyPI
+        env:
+          PYPI_TASKSETS_TOKEN: ${{ secrets.PYPI_TASKSETS_TOKEN }}
+        run: |
+          if [ -z "$PYPI_TASKSETS_TOKEN" ]; then
+            echo "Missing PYPI_TASKSETS_TOKEN secret" >&2
+            exit 1
+          fi
+          uv publish --token "$PYPI_TASKSETS_TOKEN" dist/*
+
+  build-tag:
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/tasksets-v')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -87,14 +220,16 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
-  publish:
-    needs: build
+  publish-tag:
+    needs: build-tag
     runs-on: ubuntu-latest
     environment: pypi-prod
     permissions:
       contents: read
-      id-token: write
     steps:
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
       - name: Download dist artifacts
         uses: actions/download-artifact@v4
         with:
@@ -102,6 +237,11 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
-        with:
-          packages-dir: dist/
+        env:
+          PYPI_TASKSETS_TOKEN: ${{ secrets.PYPI_TASKSETS_TOKEN }}
+        run: |
+          if [ -z "$PYPI_TASKSETS_TOKEN" ]; then
+            echo "Missing PYPI_TASKSETS_TOKEN secret" >&2
+            exit 1
+          fi
+          uv publish --token "$PYPI_TASKSETS_TOKEN" dist/*

--- a/.github/workflows/publish-tasksets.yml
+++ b/.github/workflows/publish-tasksets.yml
@@ -19,10 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    outputs:
-      created: ${{ steps.tag.outputs.created }}
-      tag: ${{ steps.tag.outputs.tag }}
-      version: ${{ steps.tag.outputs.version }}
     steps:
       - name: Checkout main
         uses: actions/checkout@v4
@@ -30,10 +26,7 @@ jobs:
           fetch-depth: 0
 
       - name: Create release tag for untagged version
-        id: tag
         run: |
-          echo "created=false" >> "$GITHUB_OUTPUT"
-
           VERSION=$(python - <<'PY'
           from pathlib import Path
           import re
@@ -62,66 +55,6 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag -a "$TAG" -m "Release $TAG"
           git push origin "$TAG"
-
-          echo "created=true" >> "$GITHUB_OUTPUT"
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-
-  build-from-auto-tag:
-    needs: auto-tag-on-main
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.auto-tag-on-main.outputs.created == 'true'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    outputs:
-      tag: ${{ needs.auto-tag-on-main.outputs.tag }}
-      version: ${{ needs.auto-tag-on-main.outputs.version }}
-    steps:
-      - name: Checkout auto-created tag
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: refs/tags/${{ needs.auto-tag-on-main.outputs.tag }}
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-
-      - name: Build tasksets
-        run: uv build packages/tasksets
-
-      - name: Upload dist artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: tasksets-dist
-          path: packages/tasksets/dist/
-          if-no-files-found: error
-          retention-days: 7
-
-  publish-from-auto-tag:
-    needs: build-from-auto-tag
-    runs-on: ubuntu-latest
-    environment: pypi-prod
-    permissions:
-      contents: read
-    steps:
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-
-      - name: Download dist artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: tasksets-dist
-          path: dist/
-
-      - name: Publish to PyPI
-        env:
-          PYPI_TASKSETS_TOKEN: ${{ secrets.PYPI_TASKSETS_TOKEN }}
-        run: |
-          if [ -z "$PYPI_TASKSETS_TOKEN" ]; then
-            echo "Missing PYPI_TASKSETS_TOKEN secret" >&2
-            exit 1
-          fi
-          uv publish --token "$PYPI_TASKSETS_TOKEN" dist/*
 
   build-tag:
     if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/tasksets-v')

--- a/.github/workflows/publish-tasksets.yml
+++ b/.github/workflows/publish-tasksets.yml
@@ -29,20 +29,23 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Create release tag for unreleased version
+      - name: Create release tag for untagged version
         id: tag
         run: |
           echo "created=false" >> "$GITHUB_OUTPUT"
 
           VERSION=$(python - <<'PY'
-          import tomllib
           from pathlib import Path
+          import re
+          import sys
 
-          with Path("packages/tasksets/pyproject.toml").open("rb") as f:
-              data = tomllib.load(f)
-          print(data["project"]["version"])
+          match = re.search(r'__version__\s*=\s*"([^"]+)"', Path("packages/tasksets/tasksets/__init__.py").read_text())
+          if not match:
+              sys.exit("Could not find __version__ in packages/tasksets/tasksets/__init__.py")
+          print(match.group(1))
           PY
           )
+
           TAG="tasksets-v${VERSION}"
 
           if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
@@ -52,30 +55,6 @@ jobs:
 
           if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
             echo "Tag ${TAG} already exists on origin; skipping."
-            exit 0
-          fi
-
-          PYPI_STATUS=$(python - <<PY
-          from urllib.error import HTTPError
-          from urllib.request import Request, urlopen
-
-          request = Request(
-              "https://pypi.org/pypi/tasksets/${VERSION}/json",
-              headers={"Accept": "application/json"},
-          )
-          try:
-              with urlopen(request, timeout=10):
-                  print("released")
-          except HTTPError as exc:
-              if exc.code == 404:
-                  print("unreleased")
-              else:
-                  raise SystemExit(f"PyPI returned HTTP {exc.code}")
-          PY
-          )
-
-          if [ "$PYPI_STATUS" = "released" ]; then
-            echo "tasksets ${VERSION} is already published on PyPI; skipping."
             exit 0
           fi
 
@@ -189,17 +168,19 @@ jobs:
 
           VERSION="${TAG#tasksets-v}"
           FILE_VERSION=$(python - <<'PY'
-          import tomllib
           from pathlib import Path
+          import re
+          import sys
 
-          with Path("packages/tasksets/pyproject.toml").open("rb") as f:
-              data = tomllib.load(f)
-          print(data["project"]["version"])
+          match = re.search(r'__version__\s*=\s*"([^"]+)"', Path("packages/tasksets/tasksets/__init__.py").read_text())
+          if not match:
+              sys.exit("Could not find __version__ in packages/tasksets/tasksets/__init__.py")
+          print(match.group(1))
           PY
           )
 
           if [ "$FILE_VERSION" != "$VERSION" ]; then
-            echo "Version mismatch: tag requests '$VERSION' but packages/tasksets/pyproject.toml defines '$FILE_VERSION'" >&2
+            echo "Version mismatch: tag requests '$VERSION' but packages/tasksets/tasksets/__init__.py defines '$FILE_VERSION'" >&2
             exit 1
           fi
 

--- a/.github/workflows/publish-tasksets.yml
+++ b/.github/workflows/publish-tasksets.yml
@@ -19,6 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      created: ${{ steps.tag.outputs.created }}
+      tag: ${{ steps.tag.outputs.tag }}
+      version: ${{ steps.tag.outputs.version }}
     steps:
       - name: Checkout main
         uses: actions/checkout@v4
@@ -26,7 +30,10 @@ jobs:
           fetch-depth: 0
 
       - name: Create release tag for untagged version
+        id: tag
         run: |
+          echo "created=false" >> "$GITHUB_OUTPUT"
+
           VERSION=$(python - <<'PY'
           from pathlib import Path
           import re
@@ -55,6 +62,66 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag -a "$TAG" -m "Release $TAG"
           git push origin "$TAG"
+
+          echo "created=true" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+  build-from-auto-tag:
+    needs: auto-tag-on-main
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.auto-tag-on-main.outputs.created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      tag: ${{ needs.auto-tag-on-main.outputs.tag }}
+      version: ${{ needs.auto-tag-on-main.outputs.version }}
+    steps:
+      - name: Checkout auto-created tag
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: refs/tags/${{ needs.auto-tag-on-main.outputs.tag }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Build tasksets
+        run: uv build packages/tasksets
+
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: tasksets-dist
+          path: packages/tasksets/dist/
+          if-no-files-found: error
+          retention-days: 7
+
+  publish-from-auto-tag:
+    needs: build-from-auto-tag
+    runs-on: ubuntu-latest
+    environment: pypi-prod
+    permissions:
+      contents: read
+    steps:
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: tasksets-dist
+          path: dist/
+
+      - name: Publish to PyPI
+        env:
+          PYPI_TASKSETS_TOKEN: ${{ secrets.PYPI_TASKSETS_TOKEN }}
+        run: |
+          if [ -z "$PYPI_TASKSETS_TOKEN" ]; then
+            echo "Missing PYPI_TASKSETS_TOKEN secret" >&2
+            exit 1
+          fi
+          uv publish --token "$PYPI_TASKSETS_TOKEN" dist/*
 
   build-tag:
     if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/tasksets-v')

--- a/packages/harnesses/harnesses/__init__.py
+++ b/packages/harnesses/harnesses/__init__.py
@@ -1,3 +1,5 @@
+__version__ = "0.1.1"
+
 from .mini_swe_agent import MiniSWEAgent, MiniSWEAgentConfig, MiniSWEAgentProgramConfig
 from .opencode import OpenCode, OpenCodeConfig, OpenCodeProgramConfig
 from .pi import Pi, PiConfig, PiProgramConfig

--- a/packages/harnesses/pyproject.toml
+++ b/packages/harnesses/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "harnesses"
-version = "0.1.1"
+dynamic = ["version"]  # load from harnesses/__init__.py
 authors = [
     {name = "William Brown", email = "williambrown97@gmail.com"},
 ]
@@ -33,6 +33,9 @@ default = true
 [tool.uv.exclude-newer-package]
 # PrimeIntellect-published on PyPI (trusted publisher)
 verifiers = false
+
+[tool.hatch.version]
+path = "harnesses/__init__.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["harnesses"]

--- a/packages/tasksets/pyproject.toml
+++ b/packages/tasksets/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tasksets"
-version = "0.1.1"
+dynamic = ["version"]  # load from tasksets/__init__.py
 authors = [
     {name = "William Brown", email = "williambrown97@gmail.com"},
 ]
@@ -37,6 +37,9 @@ default = true
 [tool.uv.exclude-newer-package]
 # PrimeIntellect-published on PyPI (trusted publisher)
 verifiers = false
+
+[tool.hatch.version]
+path = "tasksets/__init__.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["tasksets"]

--- a/packages/tasksets/tasksets/__init__.py
+++ b/packages/tasksets/tasksets/__init__.py
@@ -1,3 +1,5 @@
+__version__ = "0.1.1"
+
 from .harbor import HarborTaskset, HarborTasksetConfig
 
 LAZY_EXPORTS = {

--- a/uv.lock
+++ b/uv.lock
@@ -1913,7 +1913,6 @@ wheels = [
 
 [[package]]
 name = "harnesses"
-version = "0.1.1"
 source = { editable = "packages/harnesses" }
 dependencies = [
     { name = "verifiers" },
@@ -6213,7 +6212,6 @@ wheels = [
 
 [[package]]
 name = "tasksets"
-version = "0.1.1"
 source = { editable = "packages/tasksets" }
 dependencies = [
     { name = "nltk" },


### PR DESCRIPTION
## Summary
- Switch tasksets and harnesses publishing to use `PYPI_TASKSETS_TOKEN` and `PYPI_HARNESSES_TOKEN`
- Auto-create release tags on `main` when `__version__` is present and the matching tag is still missing
- Move tasksets and harnesses to `__version__`-driven package metadata, matching the core `verifiers` release pattern
- Update workflow docs and the lockfile metadata for the dynamic package versions

## Testing
- `uv build packages/tasksets`
- `uv build packages/harnesses`
- `uv lock --locked`
- Targeted `pre-commit` checks on the changed workflow and package files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release and supply-chain behavior (auto tags on main, token publishing, version source of truth); misconfiguration could publish wrong versions or duplicate releases if tags are not managed carefully.
> 
> **Overview**
> Aligns **tasksets** and **harnesses** release automation with an `__version__`-driven flow: package version moves from `pyproject.toml` into each package’s `__init__.py`, Hatch reads it via `dynamic` version config, and CI validates tags against that file instead of `tomllib` on `pyproject.toml`.
> 
> **Publish workflows** now trigger on pushes to `main` as well as version tags. On `main`, a job can create `tasksets-v*` / `harnesses-v*` when the version in `__init__.py` has no matching remote tag, then build and publish in the same run from that new tag. PyPI upload switches from OIDC (`pypa/gh-action-pypi-publish`) to `uv publish` with `PYPI_TASKSETS_TOKEN` / `PYPI_HARNESSES_TOKEN`. Manual tag/dispatch releases are unchanged in spirit but renamed (`build-tag` / `publish-tag`) and use the same token-based publish path.
> 
> Workflow README documents the new behavior; `uv.lock` drops pinned version fields for the editable `tasksets` and `harnesses` entries to match dynamic versioning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cab738b5e6f084ac539a00d974a7066b90e8fc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Automate version tagging and switch to token-based PyPI publishing for tasksets and harnesses
> - Adds a push-to-main trigger to both [publish-tasksets.yml](.github/workflows/publish-tasksets.yml) and [publish-harnesses.yml](.github/workflows/publish-harnesses.yml); on each push, a new `auto-tag-on-main` job reads `__version__` from the respective package `__init__.py` and creates an annotated tag (e.g. `tasksets-v0.1.1`) if one does not already exist on origin.
> - Replaces `pypa/gh-action-pypi-publish` (OIDC) with `uv publish` authenticated via `PYPI_TASKSETS_TOKEN` / `PYPI_HARNESSES_TOKEN`; publishing fails early if the token secret is absent.
> - Switches both packages to dynamic versioning via `[tool.hatch.version]` in `pyproject.toml`, sourcing the version from `__init__.py` instead of a static inline value.
> - Behavioral Change: publishing is now triggered automatically on every main push (when the version is new) rather than requiring a manually pushed tag.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4cab738.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->