### PR TITLE
Harden v1 sandbox lifecycle boundaries

### DIFF
--- a/tests/test_v1_runtime_lifecycle.py
+++ b/tests/test_v1_runtime_lifecycle.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import logging
 import os
 import shlex
 import sys
@@ -127,6 +128,7 @@ class FakeSandboxClient:
     command_timeouts: list[int | None] = []
     background_jobs: list[tuple[str, str, int | None, str | None]] = []
     uploads: list[tuple[str, str, bytes]] = []
+    wait_attempts: list[tuple[str, int]] = []
     closed = 0
 
     @classmethod
@@ -137,6 +139,7 @@ class FakeSandboxClient:
         cls.command_timeouts = []
         cls.background_jobs = []
         cls.uploads = []
+        cls.wait_attempts = []
         cls.closed = 0
 
     async def create(self, request: FakeCreateSandboxRequest) -> FakeSandboxResult:
@@ -145,8 +148,13 @@ class FakeSandboxClient:
         type(self).created.append(sandbox_id)
         return FakeSandboxResult(sandbox_id)
 
-    async def wait_for_creation(self, sandbox_id: str) -> None:
-        _ = sandbox_id
+    async def wait_for_creation(
+        self,
+        sandbox_id: str,
+        *,
+        max_attempts: int = sandbox_utils.SANDBOX_WAIT_FOR_CREATION_ATTEMPTS,
+    ) -> None:
+        type(self).wait_attempts.append((sandbox_id, max_attempts))
 
     async def execute_command(
         self, *args: object, **kwargs: object
@@ -400,6 +408,13 @@ def install_fake_sandboxes(monkeypatch: pytest.MonkeyPatch) -> None:
         "verifiers.utils.threaded_sandbox_client.ThreadedAsyncSandboxClient",
         FakeSandboxClient,
     )
+
+
+def disable_sandbox_retry_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def no_sleep(seconds: float) -> None:
+        _ = seconds
+
+    monkeypatch.setattr(sandbox_utils, "sandbox_retry_sleep", no_sleep)
 
 
 def install_fake_endpoint_tunnel(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1236,6 +1251,159 @@ def test_sandbox_package_install_bootstraps_managed_python() -> None:
     assert SANDBOX_PYTHON in command
     assert SANDBOX_UV in command
     assert "mcp>=1.14.1 requests" in command
+
+
+@pytest.mark.asyncio
+async def test_create_sandbox_retries_create_and_bounds_wait(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_fake_sandboxes(monkeypatch)
+    disable_sandbox_retry_sleep(monkeypatch)
+
+    class FlakyCreateClient:
+        def __init__(self) -> None:
+            self.create_calls = 0
+            self.wait_calls: list[tuple[str, int]] = []
+            self.deleted: list[str] = []
+
+        async def create(self, request: FakeCreateSandboxRequest) -> FakeSandboxResult:
+            _ = request
+            self.create_calls += 1
+            if self.create_calls == 1:
+                raise RuntimeError("transient create")
+            return FakeSandboxResult("sbx-retry")
+
+        async def wait_for_creation(
+            self,
+            sandbox_id: str,
+            *,
+            max_attempts: int = sandbox_utils.SANDBOX_WAIT_FOR_CREATION_ATTEMPTS,
+        ) -> None:
+            self.wait_calls.append((sandbox_id, max_attempts))
+
+        async def delete(self, sandbox_id: str) -> None:
+            self.deleted.append(sandbox_id)
+
+    client = FlakyCreateClient()
+
+    sandbox_id = await sandbox_utils.create_sandbox(
+        cast(sandbox_utils.SandboxClient, client),
+        {"image": "python:3.11-slim"},
+    )
+
+    assert sandbox_id == "sbx-retry"
+    assert client.create_calls == 2
+    assert client.wait_calls == [
+        ("sbx-retry", sandbox_utils.SANDBOX_WAIT_FOR_CREATION_ATTEMPTS)
+    ]
+    assert client.deleted == []
+
+
+@pytest.mark.asyncio
+async def test_create_sandbox_cleans_up_wait_failure_with_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_fake_sandboxes(monkeypatch)
+    disable_sandbox_retry_sleep(monkeypatch)
+
+    class WaitFailingClient:
+        def __init__(self) -> None:
+            self.delete_calls = 0
+
+        async def create(self, request: FakeCreateSandboxRequest) -> FakeSandboxResult:
+            _ = request
+            return FakeSandboxResult("sbx-wait")
+
+        async def wait_for_creation(
+            self,
+            sandbox_id: str,
+            *,
+            max_attempts: int = sandbox_utils.SANDBOX_WAIT_FOR_CREATION_ATTEMPTS,
+        ) -> None:
+            assert sandbox_id == "sbx-wait"
+            assert max_attempts == sandbox_utils.SANDBOX_WAIT_FOR_CREATION_ATTEMPTS
+            raise RuntimeError("wait failed")
+
+        async def delete(self, sandbox_id: str) -> None:
+            assert sandbox_id == "sbx-wait"
+            self.delete_calls += 1
+            if self.delete_calls == 1:
+                raise RuntimeError("transient delete")
+
+    client = WaitFailingClient()
+
+    with pytest.raises(RuntimeError, match="wait failed"):
+        await sandbox_utils.create_sandbox(
+            cast(sandbox_utils.SandboxClient, client),
+            {"image": "python:3.11-slim"},
+        )
+
+    assert client.delete_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_setup_sandbox_wraps_package_install_exceptions() -> None:
+    class ExecuteFailingLease:
+        async def execute(self, command: str, timeout: int | None = None):
+            _ = command, timeout
+            raise RuntimeError("gateway down")
+
+    with pytest.raises(
+        SandboxError, match="Sandbox package install failed: gateway down"
+    ):
+        await sandbox_utils.setup_sandbox(
+            cast(sandbox_utils.SandboxLease, ExecuteFailingLease()),
+            {"packages": ["requests"]},
+        )
+
+
+@pytest.mark.asyncio
+async def test_setup_sandbox_wraps_setup_command_exceptions() -> None:
+    class ExecuteFailingLease:
+        async def execute(self, command: str, timeout: int | None = None):
+            _ = command, timeout
+            raise RuntimeError("gateway down")
+
+    with pytest.raises(
+        SandboxError, match="Sandbox setup command failed: gateway down"
+    ):
+        await sandbox_utils.setup_sandbox(
+            cast(sandbox_utils.SandboxLease, ExecuteFailingLease()),
+            {"setup_commands": ["echo setup"]},
+        )
+
+
+@pytest.mark.asyncio
+async def test_program_setup_handler_wraps_unexpected_exceptions() -> None:
+    class ExecuteFailingClient:
+        async def execute_command(self, *args: object, **kwargs: object) -> None:
+            _ = args, kwargs
+            raise RuntimeError("gateway down")
+
+    lease = sandbox_utils.SandboxLease(
+        cast(sandbox_utils.SandboxClient, ExecuteFailingClient()),
+        "sbx-1",
+        "rollout",
+        "program",
+        owns_client=False,
+    )
+    handler = next(
+        handler
+        for handler in sandbox_utils.program_setup_handlers(
+            lease,
+            {"setup": "echo setup"},
+            Runtime(),
+        )
+        if handler.__name__ == "program_setup"
+    )
+    task = vf.Task({"prompt": [{"role": "user", "content": "hi"}]}).freeze()
+    state = vf.State.for_task(task)
+
+    with pytest.raises(
+        SandboxError,
+        match="Sandbox setup handler program_setup failed: gateway down",
+    ):
+        await handler(task, state)
 
 
 @pytest.mark.asyncio
@@ -2109,12 +2277,54 @@ async def test_mcp_lifetime_follows_toolset_scope(
 
 
 @pytest.mark.asyncio
-async def test_shared_sandbox_delete_surfaces_delete_failures() -> None:
+async def test_shared_sandbox_delete_retries_transient_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    disable_sandbox_retry_sleep(monkeypatch)
+
+    class FlakyDeleteClient:
+        closed = 0
+
+        def __init__(self) -> None:
+            self.delete_calls = 0
+
+        async def delete(self, sandbox_id: str) -> None:
+            assert sandbox_id == "sbx-1"
+            self.delete_calls += 1
+            if self.delete_calls == 1:
+                raise RuntimeError("transient delete")
+
+        async def aclose(self) -> None:
+            type(self).closed += 1
+
+    client = FlakyDeleteClient()
+    lease = sandbox_utils.SandboxLease(
+        cast(sandbox_utils.SandboxClient, client),
+        "sbx-1",
+        "rollout",
+        "program",
+    )
+
+    await lease.delete()
+    await lease.delete()
+
+    assert client.delete_calls == 2
+    assert client.closed == 1
+
+
+@pytest.mark.asyncio
+async def test_shared_sandbox_delete_surfaces_delete_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    disable_sandbox_retry_sleep(monkeypatch)
+
     class DeleteFailingClient:
         closed = 0
+        delete_calls = 0
 
         async def delete(self, sandbox_id: str) -> None:
             _ = sandbox_id
+            type(self).delete_calls += 1
             raise RuntimeError("delete failed")
 
         async def aclose(self) -> None:
@@ -2132,7 +2342,41 @@ async def test_shared_sandbox_delete_surfaces_delete_failures() -> None:
     with pytest.raises(RuntimeError, match="delete failed"):
         await lease.delete()
 
+    assert client.delete_calls == sandbox_utils.SANDBOX_RETRY_ATTEMPTS
     assert client.closed == 0
+
+
+@pytest.mark.asyncio
+async def test_release_sandboxes_logs_and_removes_delete_failures(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    class DeleteFailingLease:
+        id = "sbx-1"
+        scope = "rollout"
+
+        async def delete(self) -> None:
+            raise RuntimeError("delete failed")
+
+    task = vf.Task({"prompt": [{"role": "user", "content": "hi"}]}).freeze()
+    state = vf.State.for_task(task)
+    runtime = Runtime()
+    key = (runtime.scope_key("rollout", state), "program")
+    runtime.sandbox_leases[key] = cast(sandbox_utils.SandboxLease, DeleteFailingLease())
+
+    package_logger = logging.getLogger("verifiers")
+    package_logger.addHandler(caplog.handler)
+    try:
+        with caplog.at_level(logging.WARNING, logger="verifiers.v1.runtime"):
+            await runtime.release_sandboxes("rollout", state)
+    finally:
+        package_logger.removeHandler(caplog.handler)
+
+    assert key not in runtime.sandbox_leases
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("Failed to delete rollout sandbox sbx-1" in msg for msg in messages)
+    assert any(
+        "1/1 rollout sandbox deletions failed during cleanup" in msg for msg in messages
+    )
 
 
 @pytest.mark.asyncio

--- a/verifiers/v1/runtime.py
+++ b/verifiers/v1/runtime.py
@@ -1,6 +1,7 @@
 import asyncio
 import glob
 import inspect
+import logging
 import time
 import uuid
 from collections.abc import Awaitable, Callable, Iterable, Sequence
@@ -88,6 +89,8 @@ from .types import (
     RuntimeData,
     RuntimeObject,
 )
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from .harness import Harness
@@ -2180,14 +2183,32 @@ class Runtime:
 
     async def release_sandboxes(self, scope: str, state: State) -> None:
         scope_key = self.scope_key(scope, state)
-        for key, handle in list(self.sandbox_leases.items()):
-            lease_scope_key, _ = key
-            if lease_scope_key != scope_key:
-                continue
-            if handle.scope != scope:
-                continue
-            await close_object(handle)
+        scoped_leases = [
+            (key, handle)
+            for key, handle in self.sandbox_leases.items()
+            if key[0] == scope_key and handle.scope == scope
+        ]
+        deletion_failures = 0
+        for key, handle in scoped_leases:
+            try:
+                await close_object(handle)
+            except Exception as exc:
+                deletion_failures += 1
+                logger.warning(
+                    "Failed to delete %s sandbox %s for scope key %s: %s",
+                    scope,
+                    handle.id,
+                    key[0],
+                    exc,
+                )
             del self.sandbox_leases[key]
+        if deletion_failures:
+            logger.error(
+                "%s/%s %s sandbox deletions failed during cleanup",
+                deletion_failures,
+                len(scoped_leases),
+                scope,
+            )
 
     async def ensure_global_sandboxes(self, state: State | None = None) -> None:
         from .utils.sandbox_utils import (

--- a/verifiers/v1/utils/sandbox_utils.py
+++ b/verifiers/v1/utils/sandbox_utils.py
@@ -2,6 +2,7 @@ import asyncio
 import hashlib
 import importlib.resources as resources
 import json
+import logging
 import shlex
 import tarfile
 import tempfile
@@ -9,10 +10,12 @@ import uuid
 from collections.abc import Awaitable, Callable
 from importlib.abc import Traversable
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal, Protocol, cast
+from typing import TYPE_CHECKING, Literal, Protocol, TypeVar, cast
 
-from verifiers.errors import SandboxError
+import tenacity as tc
+
 from verifiers.decorators import setup as setup_handler
+from verifiers.errors import Error, SandboxError
 from verifiers.utils.async_utils import maybe_call_with_named_args
 
 from .program_utils import command_argv, command_env, float_config, int_config
@@ -36,6 +39,16 @@ if TYPE_CHECKING:
     from ..toolset import Toolset
 
 VF_STATE_INPUT_PATH_KEY = "_vf_state_input_path"
+SANDBOX_RETRY_ATTEMPTS = 6
+SANDBOX_WAIT_FOR_CREATION_ATTEMPTS = 120
+T = TypeVar("T")
+logger = logging.getLogger(__name__)
+
+
+class RetryLogger(Protocol):
+    def log(
+        self, level: int, msg: str, /, *args: object, **kwargs: object
+    ) -> object: ...
 
 
 class SandboxRecord(Protocol):
@@ -56,7 +69,12 @@ class SandboxOwner(Protocol):
 class SandboxClient(Protocol):
     async def create(self, request: object) -> SandboxRecord: ...
 
-    async def wait_for_creation(self, sandbox_id: str) -> object: ...
+    async def wait_for_creation(
+        self,
+        sandbox_id: str,
+        *,
+        max_attempts: int = SANDBOX_WAIT_FOR_CREATION_ATTEMPTS,
+    ) -> object: ...
 
     async def delete(self, sandbox_id: str) -> object: ...
 
@@ -110,6 +128,24 @@ class SandboxClient(Protocol):
         working_dir: str | None = None,
         env: dict[str, str] | None = None,
     ) -> SandboxCommandResult: ...
+
+
+async def with_sandbox_retry(operation: Callable[[], Awaitable[T]]) -> T:
+    retry_logger = cast(RetryLogger, logger)
+    async for attempt in tc.AsyncRetrying(
+        stop=tc.stop_after_attempt(SANDBOX_RETRY_ATTEMPTS),
+        wait=tc.wait_exponential_jitter(initial=0.5, max=30, jitter=1e-3),
+        before_sleep=tc.before_sleep_log(retry_logger, logging.WARNING),
+        sleep=sandbox_retry_sleep,
+        reraise=True,
+    ):
+        with attempt:
+            return await operation()
+    raise AssertionError("sandbox retry loop exited without running")
+
+
+async def sandbox_retry_sleep(seconds: float) -> None:
+    await asyncio.sleep(seconds)
 
 
 async def close_sandbox_client(client: SandboxClient) -> None:
@@ -223,7 +259,7 @@ class SandboxLease:
             return
         self.deleted = True
         try:
-            await self.client.delete(self.id)
+            await with_sandbox_retry(lambda: self.client.delete(self.id))
         finally:
             if self.owns_client:
                 await close_sandbox_client(self.client)
@@ -472,16 +508,21 @@ def _program_setup_handler(
     use_sandbox_python_path: bool = False,
 ) -> Handler:
     async def handler(task: Task, state: State) -> None:
-        await maybe_call_with_named_args(
-            fn,
-            client=lease.client,
-            sandbox_id=lease.id,
-            program=program,
-            task=task,
-            state=state,
-            runtime=runtime,
-            use_sandbox_python_path=use_sandbox_python_path,
-        )
+        try:
+            await maybe_call_with_named_args(
+                fn,
+                client=lease.client,
+                sandbox_id=lease.id,
+                program=program,
+                task=task,
+                state=state,
+                runtime=runtime,
+                use_sandbox_python_path=use_sandbox_python_path,
+            )
+        except Error:
+            raise
+        except Exception as exc:
+            raise SandboxError(f"Sandbox setup handler {name} failed: {exc}") from exc
 
     handler.__name__ = name
     return setup_handler(handler, priority=priority)
@@ -497,17 +538,25 @@ def _program_channel_setup_handler(
     use_sandbox_python_path: bool = False,
 ) -> Handler:
     async def handler(task: Task, state: State) -> None:
-        await run_program_items(
-            lease.client,
-            lease.id,
-            program,
-            task,
-            state,
-            runtime,
-            items=[setup_item],
-            error_prefix=f"Program {channel} channel setup failed",
-            use_sandbox_python_path=use_sandbox_python_path,
-        )
+        name = f"program_{channel}_channel_setup"
+        try:
+            await run_program_items(
+                lease.client,
+                lease.id,
+                program,
+                task,
+                state,
+                runtime,
+                items=[setup_item],
+                error_prefix=f"Program {channel} channel setup failed",
+                use_sandbox_python_path=use_sandbox_python_path,
+            )
+        except Error:
+            raise
+        except Exception as exc:
+            raise SandboxError(
+                f"Sandbox channel setup handler {name} failed: {exc}"
+            ) from exc
 
     handler.__name__ = f"program_{channel}_channel_setup"
     return setup_handler(handler, priority=priority)
@@ -529,12 +578,22 @@ async def create_sandbox(client: SandboxClient, sandbox_config: ConfigData) -> s
         timeout_minutes=int_config(sandbox_config, "timeout_minutes", 60),
         labels=[str(label) for label in labels] if isinstance(labels, list) else [],
     )
-    sandbox = await client.create(request)
+    sandbox = await with_sandbox_retry(lambda: client.create(request))
     sandbox_id = str(sandbox.id)
     try:
-        await client.wait_for_creation(sandbox_id)
+        await client.wait_for_creation(
+            sandbox_id,
+            max_attempts=SANDBOX_WAIT_FOR_CREATION_ATTEMPTS,
+        )
     except BaseException:
-        await client.delete(sandbox_id)
+        try:
+            await with_sandbox_retry(lambda: client.delete(sandbox_id))
+        except Exception as cleanup_exc:
+            logger.warning(
+                "Failed to delete sandbox %s after creation failure: %s",
+                sandbox_id,
+                cleanup_exc,
+            )
         raise
     return sandbox_id
 
@@ -543,10 +602,15 @@ async def setup_sandbox(handle: SandboxLease, sandbox_config: ConfigData) -> Non
     packages = python_package_list(sandbox_config.get("packages"))
     if packages:
         package_args = " ".join(shlex.quote(str(package)) for package in packages)
-        result = await handle.execute(
-            python_package_install_command(package_args),
-            timeout=int_config(sandbox_config, "install_timeout", 300),
-        )
+        try:
+            result = await handle.execute(
+                python_package_install_command(package_args),
+                timeout=int_config(sandbox_config, "install_timeout", 300),
+            )
+        except Error:
+            raise
+        except Exception as exc:
+            raise SandboxError(f"Sandbox package install failed: {exc}") from exc
         if result.exit_code:
             raise SandboxError(f"Sandbox package install failed: {result.stderr}")
     commands = sandbox_config.get("setup_commands") or []
@@ -559,10 +623,15 @@ async def setup_sandbox(handle: SandboxLease, sandbox_config: ConfigData) -> Non
         command = str(command)
         if use_sandbox_python_path:
             command = sandbox_python_path_command(command)
-        result = await handle.execute(
-            command,
-            timeout=int_config(sandbox_config, "setup_timeout", 300),
-        )
+        try:
+            result = await handle.execute(
+                command,
+                timeout=int_config(sandbox_config, "setup_timeout", 300),
+            )
+        except Error:
+            raise
+        except Exception as exc:
+            raise SandboxError(f"Sandbox setup command failed: {exc}") from exc
         if result.exit_code:
             raise SandboxError(f"Sandbox setup command failed: {result.stderr}")
 


### PR DESCRIPTION
## Summary
- Add retry/backoff for sandbox create and lease delete, with bounded `wait_for_creation` calls.
- Normalize unexpected setup/package/setup-command failures into `SandboxError` at the v1 lifecycle boundary.
- Log and continue past sandbox cleanup failures in `Runtime.release_sandboxes` while removing the lease entry.
- Add focused lifecycle tests for retry behavior, creation wait bounds, wrapped setup errors, and cleanup logging.

## Testing
- `uv run ruff format --check . && uv run ruff check .`
- `uv run ty check verifiers packages/tasksets/tasksets packages/harnesses/harnesses`
- `env PYTHONWARNINGS=ignore::SyntaxWarning uv run --no-dev --group policy semgrep --metrics=off --disable-version-check --config .semgrep/verifiers.yml --error --quiet`
- `uv run pytest tests/test_v1_runtime_lifecycle.py -q`
- `uv run pytest tests/ -v --ignore=tests/test_envs.py -m "not prime_sandbox" --cov=verifiers --cov-report=xml --cov-report=term`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden v1 sandbox lifecycle boundaries with retries, error wrapping, and cleanup logging
> - `create_sandbox` in [sandbox_utils.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1490/files#diff-b1154f3be7f28191532de46fbe23a973a5f93e1450a71beb9c93910e358fda13) now retries transient create failures via a new `with_sandbox_retry` helper (tenacity exponential backoff), bounds `wait_for_creation` attempts via `SANDBOX_WAIT_FOR_CREATION_ATTEMPTS`, and retries sandbox deletion on wait failure while logging if cleanup itself fails.
> - `SandboxLease.delete` retries transient delete failures through `with_sandbox_retry` before closing the client.
> - `_program_setup_handler` and `_program_channel_setup_handler` now catch unexpected exceptions and re-raise them as `SandboxError` with descriptive messages; `setup_sandbox` applies the same wrapping to package installation and setup command failures.
> - `Runtime.release_sandboxes` in [runtime.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1490/files#diff-7c2c1b88c61b8a75e00bb82f7ece60290f886d4a3ed87e97a5e1cbf86b26973d) now suppresses individual deletion exceptions, logs per-sandbox warnings and a final error summary, and always removes leases from `sandbox_leases`.
> - Behavioral Change: sandbox leases are now unconditionally removed from `runtime.sandbox_leases` even when deletion fails, and previously unhandled exceptions in setup handlers now surface as `SandboxError` instead of propagating as-is.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b137593.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->