### PR TITLE
Add typed v1 eval CLI overrides and bump dev version to 0.1.15.dev13

### DIFF
--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -73,8 +73,13 @@ taskset/harness overrides. These flags are parsed against the concrete child
 config types from `load_taskset(config: ...)` and `load_harness(config: ...)`:
 
 ```bash
-prime eval run my-v1-env --taskset.id my-id --harness.max-turns 4
+prime eval run my-v1-env --taskset.id my-taskset --harness.id my-harness --harness.max-turns 4
 ```
+
+The positional environment ID selects the environment package to load. Dotted
+taskset/harness flags are fields on that environment's typed child config; they
+do not select separate taskset or harness packages unless the environment's own
+loader implements that behavior.
 
 For legacy or direct-constructor environments, the `--env-args` flag passes
 arguments to your `load_environment()` function:

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -56,6 +56,7 @@ For the full hosted workflow and hosted-only flags such as `--follow`, `--timeou
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
 | `env_id_or_path` | (positional) | — | Environment ID(s) or path to TOML config |
+| `--taskset.FIELD` / `--harness.FIELD` | — | — | Typed v1 `EnvConfig` overrides for single-environment runs |
 | `--env-args` | `-a` | `{}` | JSON object passed to `load_environment()` |
 | `--extra-env-kwargs` | `-x` | `{}` | JSON object passed to environment constructor |
 | `--timeout` | — | `None` | Per-rollout wall-clock timeout in seconds. Wins over equivalent values in `--extra-env-kwargs` or TOML `[eval.extra_env_kwargs]`. Bounds generation only — scoring is not bounded. |
@@ -66,6 +67,14 @@ The positional argument accepts two formats:
 - **TOML config path**: `configs/eval/benchmark.toml` — evaluates multiple environments defined in the config file
 
 Environment IDs are converted to Python module names (`my-env` → `my_env`) and imported after `prime eval run` resolves the environment package.
+
+For v1 `load_environment(config: vf.EnvConfig)` loaders, prefer typed
+taskset/harness overrides. These flags are parsed against the concrete child
+config types from `load_taskset(config: ...)` and `load_harness(config: ...)`:
+
+```bash
+prime eval run my-v1-env --taskset.id my-id --harness.max-turns 4
+```
 
 For legacy or direct-constructor environments, the `--env-args` flag passes
 arguments to your `load_environment()` function:

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1020,11 +1020,12 @@ class EnvConfig(Config):
     harness: HarnessConfig
 
 class TasksetConfig(Config):
-    taskset_id: str | None = None
+    taskset_id: str | None = None  # `id` shorthand accepted
     system_prompt: object | None = None
     user: object | None = None
 
 class HarnessConfig(Config):
+    harness_id: str | None = None  # `id` shorthand accepted
     program: ProgramConfig = ProgramConfig()
     system_prompt: object | None = None
     sandbox: SandboxConfig | None = None

--- a/skills/evaluate-environments/SKILL.md
+++ b/skills/evaluate-environments/SKILL.md
@@ -100,35 +100,46 @@ prime eval run configs/eval/my-benchmark.toml
 4. Use `name` on individual `[[eval]]` entries when the same environment appears multiple times. `id` selects the environment to load; `name` labels the run in displays, summaries, metadata, and saved result paths.
 
 ## Common Evaluation Patterns
-1. Override v1 taskset and harness config through explicit child sections:
+1. For single-environment v1 smoke runs, override typed taskset and harness config with dotted flags:
 ```bash
-prime eval run my-env -a '{"config":{"taskset":{"difficulty":"hard"},"harness":{"max_turns":20}}}'
+prime eval run my-env --taskset.difficulty hard --harness.max-turns 20
 ```
-2. Override legacy/v0 constructor kwargs only when the environment still exposes them; for v1, use `config.taskset` and `config.harness` instead:
+2. For reproducible or multi-eval v1 config, put the same settings in TOML child sections:
+```toml
+[[eval]]
+id = "my-env"
+
+[eval.taskset]
+difficulty = "hard"
+
+[eval.harness]
+max_turns = 20
+```
+3. Override legacy/v0 constructor kwargs only when the environment still exposes them; for v1, use taskset/harness config instead:
 ```bash
 prime eval run my-env -x '{"max_turns":20}'
 ```
-3. Bound per-rollout wall-clock time (use the dedicated `--timeout` flag; wins over `-x` and TOML `[eval.extra_env_kwargs]`):
+4. Bound per-rollout wall-clock time (use the dedicated `--timeout` flag; wins over `-x` and TOML `[eval.extra_env_kwargs]`):
 ```bash
 prime eval run my-env --timeout 600
 ```
-4. Save extra state columns:
+5. Save extra state columns:
 ```bash
 prime eval run my-env -s -C "judge_response,parsed_answer"
 ```
-5. Resume interrupted runs:
+6. Resume interrupted runs:
 ```bash
 prime eval run my-env -n 1000 -s --resume
 ```
-6. Save results to a custom output directory:
+7. Save results to a custom output directory:
 ```bash
 prime eval run my-env -s -o /path/to/output
 ```
-7. Run multi-environment TOML suites:
+8. Run multi-environment TOML suites:
 ```bash
 prime eval run configs/eval/my-benchmark.toml
 ```
-8. Run the same environment more than once with different args by giving each entry a `name`:
+9. Run the same environment more than once with different args by giving each entry a `name`:
 ```toml
 [[eval]]
 id = "reverse-text"

--- a/tests/test_eval_cli.py
+++ b/tests/test_eval_cli.py
@@ -10,7 +10,7 @@ import pytest
 
 import verifiers.scripts.eval as vf_eval
 import verifiers.utils.eval_utils
-from verifiers.types import EndpointConfig, GenerateOutputs
+from verifiers.types import EndpointConfig, EvalConfig, GenerateOutputs
 from verifiers.utils.eval_utils import load_toml_config
 from verifiers.utils.path_utils import get_eval_results_path
 from verifiers.utils.save_utils import states_to_outputs
@@ -22,6 +22,24 @@ def fail_load_endpoints(*_: object) -> dict:
 
 def endpoint(**values: object) -> EndpointConfig:
     return EndpointConfig.model_validate(values)
+
+
+def test_eval_config_accepts_id_shorthand():
+    config = EvalConfig.model_validate(
+        {
+            "id": "env1",
+            "env_args": {},
+            "env_dir_path": "./environments",
+            "model": "openai/gpt-4.1-mini",
+            "client_config": {},
+            "sampling_args": {},
+            "num_examples": 1,
+            "rollouts_per_example": 1,
+            "max_concurrent": 1,
+        }
+    )
+
+    assert config.env_id == "env1"
 
 
 @pytest.fixture
@@ -137,6 +155,8 @@ def test_parse_args_accepts_v1_env_config_overrides():
             "env1",
             "--taskset.id",
             "my-id",
+            "--harness.id",
+            "my-harness",
             "--harness.max-turns",
             "4",
         ]
@@ -145,6 +165,8 @@ def test_parse_args_accepts_v1_env_config_overrides():
     assert args.env_config_overrides == [
         "--taskset.id",
         "my-id",
+        "--harness.id",
+        "my-harness",
         "--harness.max-turns",
         "4",
     ]
@@ -165,7 +187,6 @@ import verifiers as vf
 
 
 class DemoTasksetConfig(vf.TasksetConfig):
-    id: str = "default-id"
     count: int = 1
     enabled: bool = True
 
@@ -199,6 +220,8 @@ def load_environment(config: vf.EnvConfig):
                 "--taskset.id",
                 "override-id",
                 "--no-taskset.enabled",
+                "--harness.id",
+                "demo-harness",
                 "--harness.max-turns",
                 "4",
             ],
@@ -207,8 +230,12 @@ def load_environment(config: vf.EnvConfig):
 
     assert captured["configs"][0].env_args == {
         "config": {
-            "taskset": {"id": "override-id", "count": 2, "enabled": False},
-            "harness": {"max_turns": 4},
+            "taskset": {
+                "taskset_id": "override-id",
+                "count": 2,
+                "enabled": False,
+            },
+            "harness": {"harness_id": "demo-harness", "max_turns": 4},
         }
     }
 

--- a/tests/test_eval_cli.py
+++ b/tests/test_eval_cli.py
@@ -155,7 +155,7 @@ def test_parse_args_rejects_unknown_eval_flags():
         vf_eval.parse_args(["env1", "--unknown-flag", "value"])
 
 
-def test_cli_v1_env_config_overrides_use_child_config_annotations(
+def test_cli_v1_env_config_overrides_preserve_env_args_config(
     tmp_path: Path, monkeypatch, run_cli
 ):
     module_name = f"cli_override_env_{time.time_ns()}"
@@ -198,8 +198,6 @@ def load_environment(config: vf.EnvConfig):
             "env_config_overrides": [
                 "--taskset.id",
                 "override-id",
-                "--taskset.count",
-                "7",
                 "--no-taskset.enabled",
                 "--harness.max-turns",
                 "4",
@@ -209,7 +207,7 @@ def load_environment(config: vf.EnvConfig):
 
     assert captured["configs"][0].env_args == {
         "config": {
-            "taskset": {"id": "override-id", "count": 7, "enabled": False},
+            "taskset": {"id": "override-id", "count": 2, "enabled": False},
             "harness": {"max_turns": 4},
         }
     }

--- a/tests/test_eval_cli.py
+++ b/tests/test_eval_cli.py
@@ -1,4 +1,3 @@
-import argparse
 import importlib
 import os
 import sys
@@ -69,6 +68,7 @@ def run_cli(make_metadata, make_state, make_input):
             "save_to_hf_hub": False,
             "hf_hub_dataset_name": "",
             "extra_env_kwargs": {},
+            "env_config_overrides": [],
             "max_retries": 0,
             "fullscreen": False,
             "disable_tui": False,
@@ -80,11 +80,7 @@ def run_cli(make_metadata, make_state, make_input):
 
         captured: dict = {"sampling_args": None, "configs": []}
 
-        monkeypatch.setattr(
-            argparse.ArgumentParser,
-            "parse_args",
-            lambda self: args_namespace,
-        )
+        monkeypatch.setattr(vf_eval, "parse_args", lambda argv=None: args_namespace)
         monkeypatch.setattr(vf_eval, "setup_logging", lambda *_, **__: None)
         if fail_on_load_endpoints:
             monkeypatch.setattr(vf_eval, "load_endpoints", fail_load_endpoints)
@@ -133,6 +129,90 @@ def test_cli_single_env_id(monkeypatch, run_cli):
     configs = captured["configs"]
     assert len(configs) == 1
     assert configs[0].env_id == "env1"
+
+
+def test_parse_args_accepts_v1_env_config_overrides():
+    args = vf_eval.parse_args(
+        [
+            "env1",
+            "--taskset.id",
+            "my-id",
+            "--harness.max-turns",
+            "4",
+        ]
+    )
+
+    assert args.env_config_overrides == [
+        "--taskset.id",
+        "my-id",
+        "--harness.max-turns",
+        "4",
+    ]
+
+
+def test_parse_args_rejects_unknown_eval_flags():
+    with pytest.raises(SystemExit):
+        vf_eval.parse_args(["env1", "--unknown-flag", "value"])
+
+
+def test_cli_v1_env_config_overrides_use_child_config_annotations(
+    tmp_path: Path, monkeypatch, run_cli
+):
+    module_name = f"cli_override_env_{time.time_ns()}"
+    (tmp_path / f"{module_name}.py").write_text(
+        """
+import verifiers as vf
+
+
+class DemoTasksetConfig(vf.TasksetConfig):
+    id: str = "default-id"
+    count: int = 1
+    enabled: bool = True
+
+
+class DemoHarnessConfig(vf.HarnessConfig):
+    label: str = "base"
+
+
+def load_taskset(config: DemoTasksetConfig):
+    raise RuntimeError("not used")
+
+
+def load_harness(config: DemoHarnessConfig):
+    raise RuntimeError("not used")
+
+
+def load_environment(config: vf.EnvConfig):
+    raise RuntimeError("not used")
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    importlib.invalidate_caches()
+
+    captured = run_cli(
+        monkeypatch,
+        {
+            "env_id_or_config": module_name,
+            "env_args": {"config": {"taskset": {"count": 2}}},
+            "env_config_overrides": [
+                "--taskset.id",
+                "override-id",
+                "--taskset.count",
+                "7",
+                "--no-taskset.enabled",
+                "--harness.max-turns",
+                "4",
+            ],
+        },
+    )
+
+    assert captured["configs"][0].env_args == {
+        "config": {
+            "taskset": {"id": "override-id", "count": 7, "enabled": False},
+            "harness": {"max_turns": 4},
+        }
+    }
 
 
 def test_get_env_eval_defaults_for_package_module(tmp_path: Path, monkeypatch):

--- a/tests/test_v1_config_extension.py
+++ b/tests/test_v1_config_extension.py
@@ -2027,6 +2027,28 @@ def test_env_config_tracks_prebuilt_children() -> None:
     assert env.config.harness.max_turns == 3
 
 
+def test_taskset_and_harness_configs_accept_id_shorthand() -> None:
+    class CustomTasksetConfig(TasksetConfig):
+        taskset_id: str | None = "default-taskset"
+
+    class CustomHarnessConfig(HarnessConfig):
+        harness_id: str | None = "default-harness"
+
+    taskset_config = CustomTasksetConfig.model_validate({"id": "taskset-short"})
+    harness_config = CustomHarnessConfig.model_validate({"id": "harness-short"})
+
+    assert taskset_config.taskset_id == "taskset-short"
+    assert harness_config.harness_id == "harness-short"
+    assert explicit_config_data(taskset_config) == {"taskset_id": "taskset-short"}
+    assert explicit_config_data(harness_config) == {"harness_id": "harness-short"}
+
+    taskset = Taskset(config={"id": "taskset-short"})
+    harness = Harness(config={"id": "harness-short"})
+
+    assert taskset.taskset_id == "taskset-short"
+    assert harness.harness_id == "harness-short"
+
+
 def test_env_rejects_taskset_builders() -> None:
     def load_taskset() -> Taskset:
         return Taskset(config=TasksetConfig())

--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.15.dev12"
+__version__ = "0.1.15.dev13"
 
 import importlib
 import os

--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -48,6 +48,7 @@ from verifiers.utils.env_utils import (
 from verifiers.utils.import_utils import load_toml
 from verifiers.utils.install_utils import check_hub_env_installed
 from verifiers.v1.env import EnvConfig
+from verifiers.v1.utils.config_utils import explicit_config_data
 
 logger = logging.getLogger(__name__)
 
@@ -282,6 +283,20 @@ def validate_env_config_override_args(
         parser.error(f"unrecognized arguments: {' '.join(invalid_flags)}")
 
 
+def merge_config_data(
+    base: dict[str, Any],
+    overrides: dict[str, Any],
+) -> dict[str, Any]:
+    merged = dict(base)
+    for key, value in overrides.items():
+        existing = merged.get(key)
+        if isinstance(existing, dict) and isinstance(value, dict):
+            merged[key] = merge_config_data(existing, value)
+        else:
+            merged[key] = value
+    return merged
+
+
 def env_config_cli_type(
     env_id: str,
     config_type: type[EnvConfig],
@@ -293,9 +308,10 @@ def env_config_cli_type(
         field_name: (child_type, getattr(default_config, field_name))
         for field_name, child_type in child_types.items()
     }
+    create_env_model = cast(Any, create_model)
     return cast(
         type[EnvConfig],
-        create_model(
+        create_env_model(
             f"{config_type.__name__}CliOverrides",
             __base__=config_type,
             **fields,
@@ -336,12 +352,16 @@ def apply_env_config_cli_overrides(
             cli_type,
             args=override_args,
             default=base_config,
-            prog=f"prime eval run {env_id}",
         )
     except ConfigFileError as exc:
         raise ValueError(f"Invalid taskset/harness override: {exc}") from exc
 
-    merged_env_args["config"] = config.model_dump(exclude_unset=True)
+    base_config_data = explicit_config_data(merged_env_args.get("config", {}))
+    override_config_data = explicit_config_data(config)
+    merged_env_args["config"] = merge_config_data(
+        base_config_data,
+        override_config_data,
+    )
     return merged_env_args
 
 

--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -10,11 +10,16 @@ os.environ.setdefault("TOKENIZERS_PARALLELISM", "true")
 
 import argparse
 import asyncio
+import inspect
 import importlib.util
 import json
 import logging
 from pathlib import Path
 from typing import Any, cast
+
+from pydantic import create_model
+from pydantic_config import ConfigFileError
+from pydantic_config import cli as parse_pydantic_config_cli
 
 from verifiers import setup_logging
 from verifiers.types import (
@@ -34,8 +39,15 @@ from verifiers.utils.eval_utils import (
     run_evaluations,
     run_evaluations_tui,
 )
+from verifiers.utils.env_utils import (
+    env_config_annotation,
+    env_config_child_types,
+    import_env_module,
+    load_env_config,
+)
 from verifiers.utils.import_utils import load_toml
 from verifiers.utils.install_utils import check_hub_env_installed
+from verifiers.v1.env import EnvConfig
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +58,13 @@ DEFAULT_NUM_EXAMPLES = 5
 DEFAULT_ROLLOUTS_PER_EXAMPLE = 3
 DEFAULT_MAX_CONCURRENT = 32
 DEFAULT_CLIENT_TYPE = "openai_chat_completions"
+ENV_CONFIG_OVERRIDE_FLAG_PREFIXES = (
+    "--taskset.",
+    "--harness.",
+    "--no-taskset.",
+    "--no-harness.",
+)
+ENV_CONFIG_OVERRIDE_GROUP_FLAGS = {"--taskset", "--harness"}
 
 # Provider shorthand configs: maps provider name to (base_url, api_key_var[, client_type])
 PROVIDER_CONFIGS: dict[str, dict[str, str]] = {
@@ -238,6 +257,92 @@ def get_env_eval_defaults(env_id: str) -> dict[str, Any]:
         )
 
     return defaults
+
+
+def is_env_config_override_flag(token: str) -> bool:
+    return token in ENV_CONFIG_OVERRIDE_GROUP_FLAGS or token.startswith(
+        ENV_CONFIG_OVERRIDE_FLAG_PREFIXES
+    )
+
+
+def validate_env_config_override_args(
+    parser: argparse.ArgumentParser,
+    override_args: list[str],
+) -> None:
+    if not override_args:
+        return
+    if not is_env_config_override_flag(override_args[0]):
+        parser.error(f"unrecognized arguments: {' '.join(override_args)}")
+    invalid_flags = [
+        token
+        for token in override_args
+        if token.startswith("--") and not is_env_config_override_flag(token)
+    ]
+    if invalid_flags:
+        parser.error(f"unrecognized arguments: {' '.join(invalid_flags)}")
+
+
+def env_config_cli_type(
+    env_id: str,
+    config_type: type[EnvConfig],
+    default_config: EnvConfig,
+) -> type[EnvConfig]:
+    module = import_env_module(env_id)
+    child_types = env_config_child_types(module, config_type)
+    fields = {
+        field_name: (child_type, getattr(default_config, field_name))
+        for field_name, child_type in child_types.items()
+    }
+    return cast(
+        type[EnvConfig],
+        create_model(
+            f"{config_type.__name__}CliOverrides",
+            __base__=config_type,
+            **fields,
+        ),
+    )
+
+
+def apply_env_config_cli_overrides(
+    env_id: str,
+    env_args: dict[str, Any],
+    override_args: list[str],
+) -> dict[str, Any]:
+    if not override_args:
+        return dict(env_args)
+
+    module = import_env_module(env_id)
+    env_load_func = getattr(module, "load_environment", None)
+    if env_load_func is None:
+        raise ValueError(f"Environment '{env_id}' does not expose load_environment.")
+
+    sig = inspect.signature(env_load_func)
+    config_type = env_config_annotation(env_load_func, sig)
+    if config_type is None:
+        raise ValueError(
+            "Taskset/harness CLI overrides require a v1 loader shaped as "
+            "load_environment(config: vf.EnvConfig)."
+        )
+
+    merged_env_args = dict(env_args)
+    base_config = load_env_config(
+        module,
+        config_type,
+        merged_env_args.get("config", {}),
+    )
+    cli_type = env_config_cli_type(env_id, config_type, base_config)
+    try:
+        config = parse_pydantic_config_cli(
+            cli_type,
+            args=override_args,
+            default=base_config,
+            prog=f"prime eval run {env_id}",
+        )
+    except ConfigFileError as exc:
+        raise ValueError(f"Invalid taskset/harness override: {exc}") from exc
+
+    merged_env_args["config"] = config.model_dump(exclude_unset=True)
+    return merged_env_args
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -502,8 +607,12 @@ def build_parser() -> argparse.ArgumentParser:
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = build_parser()
     if argv is None:
-        return parser.parse_args()
-    return parser.parse_args(argv)
+        args, env_config_overrides = parser.parse_known_args()
+    else:
+        args, env_config_overrides = parser.parse_known_args(argv)
+    validate_env_config_override_args(parser, env_config_overrides)
+    args.env_config_overrides = env_config_overrides
+    return args
 
 
 def main(argv: list[str] | None = None):
@@ -521,6 +630,10 @@ def main(argv: list[str] | None = None):
 
     # Build raw configs: both paths produce list[dict]
     if args.env_id_or_config.endswith(".toml"):
+        if args.env_config_overrides:
+            raise ValueError(
+                "Taskset/harness CLI overrides are only supported with a single environment id, not TOML config files."
+            )
         path = Path(args.env_id_or_config)
         if not path.is_file():
             raise FileNotFoundError(
@@ -800,6 +913,12 @@ def main(argv: list[str] | None = None):
         else:
             raise ValueError(f"Invalid value for --resume: {resume_arg!r}")
 
+        env_args = apply_env_config_cli_overrides(
+            env_id,
+            dict(raw.get("env_args", {})),
+            list(raw.get("env_config_overrides", [])),
+        )
+
         extra_env_kwargs = dict(raw.get("extra_env_kwargs", {}))
         if raw.get("timeout") is not None:
             extra_env_kwargs["timeout_seconds"] = raw["timeout"]
@@ -807,7 +926,7 @@ def main(argv: list[str] | None = None):
         return EvalConfig(
             env_id=env_id,
             name=name,
-            env_args=raw.get("env_args", {}),
+            env_args=env_args,
             env_dir_path=raw.get("env_dir_path", DEFAULT_ENV_DIR_PATH),
             output_dir=raw.get("output_dir"),
             extra_env_kwargs=extra_env_kwargs,

--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -17,7 +17,7 @@ import logging
 from pathlib import Path
 from typing import Any, cast
 
-from pydantic import create_model
+from pydantic import BaseModel, create_model
 from pydantic_config import ConfigFileError
 from pydantic_config import cli as parse_pydantic_config_cli
 
@@ -298,12 +298,10 @@ def merge_config_data(
 
 
 def env_config_cli_type(
-    env_id: str,
     config_type: type[EnvConfig],
     default_config: EnvConfig,
+    child_types: dict[str, type[BaseModel]],
 ) -> type[EnvConfig]:
-    module = import_env_module(env_id)
-    child_types = env_config_child_types(module, config_type)
     fields = {
         field_name: (child_type, getattr(default_config, field_name))
         for field_name, child_type in child_types.items()
@@ -341,12 +339,14 @@ def apply_env_config_cli_overrides(
         )
 
     merged_env_args = dict(env_args)
+    child_types = env_config_child_types(module, config_type)
     base_config = load_env_config(
         module,
         config_type,
         merged_env_args.get("config", {}),
+        child_types=child_types,
     )
-    cli_type = env_config_cli_type(env_id, config_type, base_config)
+    cli_type = env_config_cli_type(config_type, base_config, child_types)
     try:
         config = parse_pydantic_config_cli(
             cli_type,

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -17,7 +17,14 @@ from typing import (
     cast,
 )
 
-from pydantic import BaseModel, ConfigDict, Field, computed_field, field_validator
+from pydantic import (
+    AliasChoices,
+    BaseModel,
+    ConfigDict,
+    Field,
+    computed_field,
+    field_validator,
+)
 
 if TYPE_CHECKING:
     from anthropic.types import RedactedThinkingBlock
@@ -1307,7 +1314,7 @@ class EvalConfig(BaseModel):
     """Pydantic model for evaluation configuration."""
 
     # environment
-    env_id: str
+    env_id: str = Field(validation_alias=AliasChoices("env_id", "id"))
     name: str | None = None
     env_args: dict
     env_dir_path: str

--- a/verifiers/utils/env_utils.py
+++ b/verifiers/utils/env_utils.py
@@ -235,8 +235,14 @@ def load_env_config(
     module: ModuleType,
     config_type: type[EnvConfig],
     value: object,
+    *,
+    child_types: Mapping[str, type[BaseModel]] | None = None,
 ) -> EnvConfig:
-    child_types = env_config_child_types(module, config_type)
+    resolved_child_types = (
+        env_config_child_types(module, config_type)
+        if child_types is None
+        else child_types
+    )
 
     data: dict[str, object]
     if isinstance(value, config_type):
@@ -251,7 +257,7 @@ def load_env_config(
     else:
         data = dict(explicit_config_data(value))
     defaults: EnvConfig | None = None
-    for field_name, child_type in child_types.items():
+    for field_name, child_type in resolved_child_types.items():
         if field_name not in data:
             defaults = config_type() if defaults is None else defaults
             child = getattr(defaults, field_name)
@@ -264,7 +270,7 @@ def load_env_config(
             raise TypeError(f"config.{field_name} cannot be None.")
         data[field_name] = child_type.model_validate(explicit_config_data(child))
     config = config_type.model_validate(data)
-    for field_name, child_type in child_types.items():
+    for field_name, child_type in resolved_child_types.items():
         child = getattr(config, field_name)
         if not isinstance(child, child_type):
             raise TypeError(

--- a/verifiers/utils/env_utils.py
+++ b/verifiers/utils/env_utils.py
@@ -236,27 +236,7 @@ def load_env_config(
     config_type: type[EnvConfig],
     value: object,
 ) -> EnvConfig:
-    child_types: dict[str, type[BaseModel]] = {}
-    for field_name, factory_name, base_type in (
-        ("taskset", "load_taskset", TasksetConfig),
-        ("harness", "load_harness", HarnessConfig),
-    ):
-        field_type = config_type_from_annotation(
-            config_type.model_fields[field_name].annotation,
-            base_type,
-            f"{config_type.__name__}.{field_name}",
-        )
-        factory_type = factory_config_type(module, factory_name, base_type)
-        if factory_type is not None:
-            if not issubclass(factory_type, field_type):
-                raise TypeError(
-                    f"{module.__name__}.{factory_name} config type "
-                    f"{factory_type.__name__} does not match "
-                    f"{config_type.__name__}.{field_name}: {field_type.__name__}."
-                )
-            child_types[field_name] = factory_type
-        else:
-            child_types[field_name] = field_type
+    child_types = env_config_child_types(module, config_type)
 
     data: dict[str, object]
     if isinstance(value, config_type):
@@ -292,6 +272,34 @@ def load_env_config(
                 f"got {type(child).__name__}."
             )
     return config
+
+
+def env_config_child_types(
+    module: ModuleType,
+    config_type: type[EnvConfig],
+) -> dict[str, type[BaseModel]]:
+    child_types: dict[str, type[BaseModel]] = {}
+    for field_name, factory_name, base_type in (
+        ("taskset", "load_taskset", TasksetConfig),
+        ("harness", "load_harness", HarnessConfig),
+    ):
+        field_type = config_type_from_annotation(
+            config_type.model_fields[field_name].annotation,
+            base_type,
+            f"{config_type.__name__}.{field_name}",
+        )
+        factory_type = factory_config_type(module, factory_name, base_type)
+        if factory_type is not None:
+            if not issubclass(factory_type, field_type):
+                raise TypeError(
+                    f"{module.__name__}.{factory_name} config type "
+                    f"{factory_type.__name__} does not match "
+                    f"{config_type.__name__}.{field_name}: {field_type.__name__}."
+                )
+            child_types[field_name] = factory_type
+        else:
+            child_types[field_name] = field_type
+    return child_types
 
 
 def factory_config_type(

--- a/verifiers/v1/harness.py
+++ b/verifiers/v1/harness.py
@@ -2,6 +2,8 @@ import asyncio
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Generic, TypeAlias, TypeVar, cast, final
 
+from pydantic import AliasChoices, Field
+
 import verifiers as vf
 from verifiers.clients.client import Client
 from verifiers.errors import Error, OverlongPromptError
@@ -97,6 +99,10 @@ ProgramRunner: TypeAlias = Callable[[Task, State], Awaitable[ProgramResult]]
 
 class HarnessConfig(LifecycleConfig):
     # Core fields configure harness-owned runtime behavior.
+    harness_id: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("harness_id", "id"),
+    )
     program: ProgramConfig = ProgramConfig()
     model: ModelConfig = ModelConfig()
     system_prompt: PromptInput | SystemPromptConfig | None = None
@@ -107,6 +113,14 @@ class HarnessConfig(LifecycleConfig):
     objects: ObjectsConfig = ObjectsConfig()
     artifacts: ArtifactsConfig = ArtifactsConfig()
     max_turns: int = 10
+
+    @classmethod
+    def __pydantic_init_subclass__(cls, **kwargs: object) -> None:
+        super().__pydantic_init_subclass__(**kwargs)
+        field = cls.model_fields.get("harness_id")
+        if field is not None:
+            field.validation_alias = AliasChoices("harness_id", "id")
+            cls.model_rebuild(force=True)
 
 
 ConfigT = TypeVar("ConfigT", bound=HarnessConfig)
@@ -168,6 +182,12 @@ class Harness(RuntimeOwnerMixin[ConfigT], Generic[ConfigT]):
         self.config = cast(ConfigT, coerce_config(config_type, config))
         with config_ref_context(self.config):
             self.initialize_runtime_refresh()
+            resolved_harness_id = self.config.harness_id
+            if resolved_harness_id is not None and not isinstance(
+                resolved_harness_id, str
+            ):
+                raise TypeError("harness_id must be a string.")
+            self.harness_id = resolved_harness_id or type(self).__name__
             self.program_config = self.config.program.resolve()
             system_prompt_value = self.load_system_prompt(self.config)
             self.system_prompt = normalize_system_prompt(

--- a/verifiers/v1/taskset.py
+++ b/verifiers/v1/taskset.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Generic, TypeVar, cast, final
 
 from datasets import Dataset
+from pydantic import AliasChoices, Field
 
 from .config import (
     ConfigSource,
@@ -43,12 +44,23 @@ from .types import (
 
 class TasksetConfig(LifecycleConfig):
     # Core fields configure taskset-owned loaders and runtime behavior.
-    taskset_id: str | None = None
+    taskset_id: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("taskset_id", "id"),
+    )
     system_prompt: PromptInput | SystemPromptConfig | None = None
     user: UserConfig | None = None
     bindings: BindingsConfig = BindingsConfig()
     objects: ObjectsConfig = ObjectsConfig()
     artifacts: ArtifactsConfig = ArtifactsConfig()
+
+    @classmethod
+    def __pydantic_init_subclass__(cls, **kwargs: object) -> None:
+        super().__pydantic_init_subclass__(**kwargs)
+        field = cls.model_fields.get("taskset_id")
+        if field is not None:
+            field.validation_alias = AliasChoices("taskset_id", "id")
+            cls.model_rebuild(force=True)
 
 
 ConfigT = TypeVar("ConfigT", bound=TasksetConfig)


### PR DESCRIPTION
## Summary
- Added typed v1 eval CLI overrides for single-environment runs using `--taskset.*` and `--harness.*`, routed through the annotated `EnvConfig` child types.
- Kept legacy `--env-args` / `--extra-env-kwargs` behavior intact and blocked dotted v1 overrides for TOML multi-eval configs.
- Updated eval docs and tests to cover the new override path.
- Bumped `verifiers` to `0.1.15.dev13`.

## Testing
- `uv run ruff check` on the touched Python files
- `uv run pytest tests/test_eval_cli.py tests/test_v1_config_extension.py -q`
- `uv run pre-commit run --files ...`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes eval CLI argument parsing and `env_args` merging for v1 loaders; mis-merged overrides could affect run configuration, though behavior is covered by new tests and TOML paths are explicitly blocked.
> 
> **Overview**
> Adds **typed v1 eval CLI overrides** for single-environment runs: `--taskset.*`, `--harness.*`, and `--no-taskset.*` / `--no-harness.*` flags are collected via `parse_known_args`, validated, and merged into `env_args["config"]` using each environment’s concrete `EnvConfig` child types (same pydantic-config CLI path as TOML). **TOML multi-eval configs cannot use these dotted flags**; unknown CLI tokens that are not recognized eval flags now error instead of being ignored.
> 
> **Config ergonomics:** `TasksetConfig` / `HarnessConfig` (and `EvalConfig`) accept **`id` as shorthand** for `taskset_id` / `harness_id` / `env_id`. `env_config_child_types()` is factored out of `load_env_config` for reuse by the CLI merge logic.
> 
> **Docs & tests** document the new flags and TOML `[eval.taskset]` / `[eval.harness]` patterns; CLI tests cover parsing, rejection of bad flags, and deep-merge with existing `env_args.config`. Version bump to **`0.1.15.dev13`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca01e915208eb1ff1d15772ce6ab63c683041044. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add typed v1 EnvConfig CLI overrides via `--taskset.*` / `--harness.*` flags to the eval script
> - Adds support for dotted CLI flags (e.g. `--taskset.FIELD`, `--harness.FIELD`, including `--no-` negation and hyphenated names) in single-env `vf-eval` runs; overrides are merged into `env_args['config']` before evaluation via `apply_env_config_cli_overrides` in [eval.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1492/files#diff-6b37997f6eb279df06f6c885920ff82ac5940e25ca859a9dd445bdc4028277b6).
> - Uses `parse_known_args` in `parse_args` to collect override tokens, validates them against allowed patterns via `validate_env_config_override_args`, and rejects unrecognized flags as CLI errors.
> - Extracts `env_config_child_types` into a standalone helper in [env_utils.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1492/files#diff-55b6352da7741e80b93a7b4d9f45b50934a57a258cf7025977566a375daa8f60) and updates `load_env_config` to accept an optional `child_types` mapping.
> - Raises an error if `--taskset.*` / `--harness.*` overrides are combined with a TOML config file.
> - Behavioral Change: unknown CLI flags that do not match the v1 override prefix patterns now produce a CLI error rather than being silently passed through.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1492 opened
>
> - Added field aliasing to `TasksetConfig`, `HarnessConfig`, and `EvalConfig` pydantic models to accept `id` as validation shorthand for `taskset_id`, `harness_id`, and `env_id` respectively [ca01e91]
> - Added `harness_id` attribute resolution and validation to `Harness.__init__` constructor [ca01e91]
> - Updated documentation examples to demonstrate explicit harness and taskset id flags using dotted notation for typed child config fields [ca01e91]
> - Added tests validating `id` shorthand acceptance in config models and updated existing CLI tests to reflect renamed fields [ca01e91]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b1e5bd1.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->