### PR TITLE
Handle structured TextArena assistant content

### DIFF
--- a/packages/tasksets/tasksets/__init__.py
+++ b/packages/tasksets/tasksets/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 from .harbor import HarborTaskset, HarborTasksetConfig
 

--- a/packages/tasksets/tasksets/textarena.py
+++ b/packages/tasksets/tasksets/textarena.py
@@ -1,6 +1,7 @@
 import asyncio
 import random
 import re
+from collections.abc import Sequence
 from typing import Generic, TypeVar
 from typing import Protocol, cast
 
@@ -48,6 +49,24 @@ class TextArenaTasksetConfig(vf.TasksetConfig):
 
 
 TextArenaConfigT = TypeVar("TextArenaConfigT", bound=TextArenaTasksetConfig)
+
+
+def _content_text(content: object) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, Sequence) and not isinstance(
+        content, (str, bytes, bytearray)
+    ):
+        chunks: list[str] = []
+        for part in content:
+            if isinstance(part, vf.TextContentPart):
+                chunks.append(part.text)
+            elif isinstance(part, dict):
+                text = cast(dict[str, object], part).get("text")
+                if isinstance(text, str):
+                    chunks.append(text)
+        return "\n".join(chunks)
+    return ""
 
 
 class TextArenaTaskset(vf.Taskset[TextArenaConfigT], Generic[TextArenaConfigT]):
@@ -128,8 +147,9 @@ class TextArenaUser(vf.User[TextArenaUserConfig]):
         ta_env.state.game_state[answer_state_key] = answer
 
         assistant_messages = vf.get_messages(messages, role="assistant")
-        last_text = assistant_messages[-1].content if assistant_messages else ""
-        assert isinstance(last_text, str)
+        last_text = (
+            _content_text(assistant_messages[-1].content) if assistant_messages else ""
+        )
         matches = re.findall(r"<guess>(.*?)</guess>", last_text, re.DOTALL)
         guess = matches[-1].strip() if matches else ""
         await asyncio.to_thread(ta_env.step, guess)

--- a/tests/test_v1_textarena_taskset.py
+++ b/tests/test_v1_textarena_taskset.py
@@ -199,6 +199,50 @@ async def test_textarena_user_steps_env_and_stops_when_game_finishes(fake_textar
 
 
 @pytest.mark.asyncio
+async def test_textarena_user_accepts_structured_assistant_content(fake_textarena):
+    _, fake_ta = fake_textarena
+    taskset = textarena.TextArenaTaskset(
+        config=textarena.TextArenaTasksetConfig(
+            game="FakeWordle-v0",
+            answer_state_key="secret_word",
+            num_train_examples=1,
+            num_eval_examples=0,
+        )
+    )
+    task = taskset.to_task(
+        vf.Task(
+            {
+                "example_id": 0,
+                "prompt": [],
+                "answer": "apple",
+                "textarena": {
+                    "game": "FakeWordle-v0",
+                    "answer_state_key": "secret_word",
+                },
+            }
+        )
+    )
+    state = vf.State.for_task(task)
+    state["completion"] = [
+        vf.AssistantMessage(
+            content=[
+                vf.TextContentPart(text="I will guess "),
+                vf.TextContentPart(text="<guess>[apple]</guess>."),
+            ]
+        )
+    ]
+
+    env = vf.Env(taskset=taskset, harness=vf.Harness(config=vf.HarnessConfig()))
+    state = await env.harness.setup_state(task, state)
+    messages = await env.harness.runtime.user_messages(task, state)
+    ta_env = fake_ta.envs[-1]
+
+    assert ta_env.guesses == ["[apple]"]
+    assert messages == [{"role": "user", "content": "Solved."}]
+    assert state["stop_condition"] == "textarena_done"
+
+
+@pytest.mark.asyncio
 async def test_textarena_user_returns_wordle_feedback_for_unfinished_game(
     fake_textarena,
 ):

--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.15.dev13"
+__version__ = "0.1.15.dev14"
 
 import importlib
 import os


### PR DESCRIPTION
## Summary
- normalize structured assistant message content before TextArena guess extraction
- add regression coverage for TextContentPart completions
- bump verifiers to 0.1.15.dev14 and tasksets to 0.1.2 for release tagging

## Tests
- uv run ruff check packages/tasksets/tasksets/textarena.py tests/test_v1_textarena_taskset.py packages/tasksets/tasksets/__init__.py verifiers/__init__.py
- uv run ty check packages/tasksets/tasksets tests/test_v1_textarena_taskset.py
- uv run pytest tests/test_v1_textarena_taskset.py -q
- uv build packages/tasksets

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to TextArena user-step guess extraction plus version bumps; no auth, security, or broad API surface changes.
> 
> **Overview**
> TextArena guess parsing no longer assumes assistant `content` is a plain string. A new **`_content_text`** helper flattens string or multi-part content (`TextContentPart` and dict `text` fields) into one string before the existing `<guess>...</guess>` regex runs in **`TextArenaUser`**.
> 
> Regression coverage was added for completions built from multiple **`TextContentPart`** segments. **`tasksets`** is bumped to **0.1.2** and **`verifiers`** to **0.1.15.dev14** for release tagging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39dfbf00612977b60815a51418c923e191d00363. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Handle structured assistant message content in `TextArenaUser.get_response`
> Previously, `TextArenaUser.get_response` in [textarena.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1493/files#diff-a821240ec601e3b124ad97d07c5e091b3b5e5ec1c93675cfc81b127c6df1dfcf) assumed assistant message content was always a plain string. This adds a `_content_text` helper that converts structured content (a sequence of `vf.TextContentPart` objects or dicts with a `text` key) into a single string, and updates `get_response` to use it instead of asserting on string type.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 39dfbf0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->