### PR TITLE
Serialize reasoning-only assistant messages with content

### DIFF
--- a/tests/test_client_multimodal_types.py
+++ b/tests/test_client_multimodal_types.py
@@ -53,6 +53,22 @@ async def test_openai_to_native_prompt_with_typed_multimodal_content_parts():
 
 
 @pytest.mark.asyncio
+async def test_openai_to_native_prompt_preserves_reasoning_only_assistant_message():
+    client = OpenAIChatCompletionsClient(object())
+    messages = [
+        UserMessage(content="continue"),
+        AssistantMessage(content=None, reasoning_content="thinking"),
+        UserMessage(content="next"),
+    ]
+
+    prompt, kwargs = await client.to_native_prompt(messages)
+    assert kwargs == {}
+    assert prompt[1]["role"] == "assistant"
+    assert prompt[1]["content"] == ""
+    assert prompt[1]["reasoning_content"] == "thinking"
+
+
+@pytest.mark.asyncio
 async def test_anthropic_to_native_prompt_with_typed_multimodal_content_parts():
     pytest.importorskip("anthropic")
     from verifiers.clients.anthropic_messages_client import AnthropicMessagesClient

--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.15.dev14"
+__version__ = "0.1.15.dev15"
 
 import importlib
 import os

--- a/verifiers/clients/openai_chat_completions_client.py
+++ b/verifiers/clients/openai_chat_completions_client.py
@@ -201,9 +201,16 @@ class OpenAIChatCompletionsClient(
                     ]
                 else:
                     oai_tool_calls = None
+                content = normalize_content(message.content)
+                if (
+                    content is None
+                    and oai_tool_calls is None
+                    and message.reasoning_content is not None
+                ):
+                    content = ""
                 return ChatCompletionAssistantMessageParam(
                     role="assistant",
-                    content=cast(Any, normalize_content(message.content)),
+                    content=cast(Any, content),
                     tool_calls=cast(Any, oai_tool_calls),
                     reasoning_content=message.reasoning_content,  # type: ignore[arg-type]
                 )


### PR DESCRIPTION
## Summary
- send empty string content when replaying reasoning-only assistant messages to OpenAI-compatible chat completions providers
- preserve reasoning_content on the replayed assistant message
- add regression coverage for the prompt normalization case
- bump verifiers to 0.1.15.dev15 so cookbook evals can consume the fix

## Tests
- uv run ruff check verifiers/clients/openai_chat_completions_client.py tests/test_client_multimodal_types.py verifiers/__init__.py
- uv run ty check verifiers/clients/openai_chat_completions_client.py
- uv run pytest tests/test_client_multimodal_types.py -q

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow prompt-serialization change with a targeted regression test; no auth, data, or API surface changes beyond message shaping.
> 
> **Overview**
> Fixes replay of **reasoning-only** assistant turns when building OpenAI-compatible chat completion prompts: if `content` is missing and there are no tool calls but `reasoning_content` is set, the client now sends **`content=""`** instead of leaving content unset, while still passing through **`reasoning_content`**.
> 
> Adds a regression test in `test_client_multimodal_types.py` and bumps the package to **0.1.15.dev15**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c167f9b661972facd8cccb8305f9d5771507472. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Serialize reasoning-only assistant messages with empty string content in `to_native_prompt`
> When an `AssistantMessage` has `content=None`, no tool calls, and `reasoning_content` set, [openai_chat_completions_client.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1494/files#diff-025b956ea9171f7b691b13e0e1ce59d1b1ec6d71bbbde418bf55dc53c2daf7fd) previously passed `None` as the content field. It now passes an empty string instead, satisfying the OpenAI API requirement that assistant messages with reasoning content have a non-null content value.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9c167f9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->