### PR TITLE
Stop TextArena rollouts without guesses

### DIFF
--- a/packages/tasksets/tasksets/__init__.py
+++ b/packages/tasksets/tasksets/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 
 from .harbor import HarborTaskset, HarborTasksetConfig
 

--- a/packages/tasksets/tasksets/textarena.py
+++ b/packages/tasksets/tasksets/textarena.py
@@ -152,6 +152,11 @@ class TextArenaUser(vf.User[TextArenaUserConfig]):
         )
         matches = re.findall(r"<guess>(.*?)</guess>", last_text, re.DOTALL)
         guess = matches[-1].strip() if matches else ""
+        if not guess:
+            reason = "No <guess>...</guess> tag found."
+            state["final_env_response"] = reason
+            state.stop("textarena_no_guess")
+            return [vf.UserMessage(content=reason)]
         await asyncio.to_thread(ta_env.step, guess)
         if ta_env.state.done:
             reason = str(ta_env.state.game_info[0]["reason"])

--- a/packages/tasksets/tests/test_textarena.py
+++ b/packages/tasksets/tests/test_textarena.py
@@ -1,0 +1,98 @@
+import sys
+
+import pytest
+import verifiers as vf
+from tasksets import textarena
+
+
+class FakeTextArenaState:
+    def __init__(self):
+        self.game_state: dict[str, str] = {}
+        self.done = False
+        self.game_info: dict[int, dict[str, str]] = {}
+
+
+class FakeTextArenaEnv:
+    dictionary = {"words": {"apple", "berry", "cider"}}
+    word_list = ["apple", "berry", "cider"]
+
+    def __init__(self, env_id: str = "Wordle-v0"):
+        self.env_id = env_id
+        self.guesses: list[str] = []
+        self.reset_calls = 0
+        self.state = FakeTextArenaState()
+
+    def reset(self, num_players: int):
+        assert num_players == 1
+        self.reset_calls += 1
+        self.guesses = []
+        self.state = FakeTextArenaState()
+
+    def get_observation(self):
+        if not self.guesses:
+            return 0, "Guess the word. [GAME] Use <guess>[word]</guess>."
+        return 0, "Board [GAME] Feedback:\nmiss\nY----\ntry again"
+
+    def step(self, guess: str):
+        self.guesses.append(guess)
+        secret = self.state.game_state.get("secret_word")
+        if guess == f"[{secret}]":
+            self.state.done = True
+            self.state.game_info = {0: {"reason": "Solved."}}
+
+
+class FakeTextArenaModule:
+    Env = FakeTextArenaEnv
+    State = FakeTextArenaState
+
+    def __init__(self):
+        self.envs: list[FakeTextArenaEnv] = []
+
+    def make(self, env_id: str):
+        env = FakeTextArenaEnv(env_id=env_id)
+        self.envs.append(env)
+        return env
+
+
+@pytest.fixture
+def fake_textarena(monkeypatch):
+    fake_ta = FakeTextArenaModule()
+    monkeypatch.setitem(sys.modules, textarena.__name__, textarena)
+    monkeypatch.setattr(textarena, "ta", fake_ta)
+    return fake_ta
+
+
+@pytest.mark.asyncio
+async def test_textarena_user_stops_without_guess(fake_textarena):
+    taskset = textarena.TextArenaTaskset(
+        config=textarena.TextArenaTasksetConfig(
+            game="FakeWordle-v0",
+            answer_state_key="secret_word",
+            num_train_examples=1,
+            num_eval_examples=0,
+        )
+    )
+    task = taskset.to_task(
+        vf.Task(
+            {
+                "example_id": 0,
+                "prompt": [],
+                "answer": "apple",
+                "textarena": {
+                    "game": "FakeWordle-v0",
+                    "answer_state_key": "secret_word",
+                },
+            }
+        )
+    )
+    state = vf.State.for_task(task)
+    state["completion"] = [vf.AssistantMessage(content=None, reasoning_content="think")]
+
+    env = vf.Env(taskset=taskset, harness=vf.Harness(config=vf.HarnessConfig()))
+    state = await env.harness.setup_state(task, state)
+    messages = await env.harness.runtime.user_messages(task, state)
+    ta_env = fake_textarena.envs[-1]
+
+    assert ta_env.guesses == []
+    assert messages == [{"role": "user", "content": "No <guess>...</guess> tag found."}]
+    assert state["stop_condition"] == "textarena_no_guess"


### PR DESCRIPTION
## Summary
- stop TextArena rollouts when the assistant response has no non-empty <guess> tag
- avoid stepping TextArena with an empty action and asking the model for another turn after a reasoning-only response
- bump tasksets to 0.1.3 for a tasksets-only release
- add package-local regression coverage under packages/tasksets

## Scope
Tasksets-only: all changed files are under packages/tasksets.

## Tests
- uv run ruff check packages/tasksets/tasksets/textarena.py packages/tasksets/tasksets/__init__.py packages/tasksets/tests/test_textarena.py
- uv run ty check packages/tasksets/tasksets
- uv run pytest tests/test_v1_textarena_taskset.py packages/tasksets/tests/test_textarena.py -q
- uv build packages/tasksets

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to tasksets TextArena user handling and version bump; adds tests and avoids invalid env steps without touching auth or core infra.
> 
> **Overview**
> TextArena rollouts now **end immediately** when the latest assistant message has no non-empty `<guess>...</guess>` content (including reasoning-only replies), instead of calling `step` with an empty action and continuing the game.
> 
> The user turn returns a clear message, sets `final_env_response`, and stops with `textarena_no_guess`. **tasksets** is bumped to **0.1.3**, with a package-local async test using a fake TextArena env to lock in the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abbabbc6411925dbfc651730da884c75716b829d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop TextArena rollouts when no `<guess>` tag is present in assistant messages
> When `TextArenaUser.get_response` finds no `<guess>...</guess>` tag in the latest assistant message, it now stops the rollout with stop condition `textarena_no_guess` instead of calling `ta_env.step` with an empty guess. The final env response is set to `'No <guess>...</guess> tag found.'` and returned as the user message. A new test in [test_textarena.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1495/files#diff-b204b55c5fafd5e8ebceec2115070fe6ad33f58397491e00be1f812c8d97b26e) verifies this behavior using a fake environment.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized abbabbc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->