### PR TITLE
Preserve TextArena empty-guess behavior

### DIFF
--- a/packages/tasksets/tasksets/__init__.py
+++ b/packages/tasksets/tasksets/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.3"
+__version__ = "0.1.4"
 
 from .harbor import HarborTaskset, HarborTasksetConfig
 

--- a/packages/tasksets/tasksets/textarena.py
+++ b/packages/tasksets/tasksets/textarena.py
@@ -152,11 +152,6 @@ class TextArenaUser(vf.User[TextArenaUserConfig]):
         )
         matches = re.findall(r"<guess>(.*?)</guess>", last_text, re.DOTALL)
         guess = matches[-1].strip() if matches else ""
-        if not guess:
-            reason = "No <guess>...</guess> tag found."
-            state["final_env_response"] = reason
-            state.stop("textarena_no_guess")
-            return [vf.UserMessage(content=reason)]
         await asyncio.to_thread(ta_env.step, guess)
         if ta_env.state.done:
             reason = str(ta_env.state.game_info[0]["reason"])

--- a/packages/tasksets/tests/test_textarena.py
+++ b/packages/tasksets/tests/test_textarena.py
@@ -63,7 +63,7 @@ def fake_textarena(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_textarena_user_stops_without_guess(fake_textarena):
+async def test_textarena_user_steps_empty_guess_when_guess_tag_missing(fake_textarena):
     taskset = textarena.TextArenaTaskset(
         config=textarena.TextArenaTasksetConfig(
             game="FakeWordle-v0",
@@ -93,6 +93,11 @@ async def test_textarena_user_stops_without_guess(fake_textarena):
     messages = await env.harness.runtime.user_messages(task, state)
     ta_env = fake_textarena.envs[-1]
 
-    assert ta_env.guesses == []
-    assert messages == [{"role": "user", "content": "No <guess>...</guess> tag found."}]
-    assert state["stop_condition"] == "textarena_no_guess"
+    assert ta_env.guesses == [""]
+    assert messages == [
+        {
+            "role": "user",
+            "content": "Board [GAME] Feedback:\nmiss\nY----\ntry again",
+        }
+    ]
+    assert state.get("done") is None


### PR DESCRIPTION
## Summary
- Restore TextArena missing-guess behavior: submit an empty guess to TextArena and use its observation.
- Keep structured assistant content normalization before parsing guess tags.
- Bump tasksets to 0.1.4 for a tasksets-only release.

## Scope
All changed files are under packages/tasksets.

## Tests
- uv run ruff check packages/tasksets/tasksets/textarena.py packages/tasksets/tasksets/__init__.py packages/tasksets/tests/test_textarena.py
- uv run pytest packages/tasksets/tests/test_textarena.py tests/test_v1_textarena_taskset.py -q
- uv run ty check packages/tasksets/tasksets
- uv build packages/tasksets
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to TextArena turn handling in tasksets; tests cover the new path and there is no auth or data impact.
> 
> **Overview**
> **TextArena** no longer stops the episode when the assistant omits a `<guess>...</guess>` tag. The user step now always calls `ta_env.step` with an empty string if no tag is found, then returns TextArena’s normal observation instead of a hard-coded error and `textarena_no_guess` stop.
> 
> The **tasksets** package version is bumped to **0.1.4**. Tests are updated to expect an empty guess step and continued play rather than an immediate stop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 449a2359a6cb78cc458c64640ba4fc49ebd6b4e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve TextArena empty-guess behavior when `<guess>` tag is missing
> Previously, `TextArenaUser.get_response` would stop early with a `textarena_no_guess` stop condition when no `<guess>` tag was found in the assistant message. Now it steps the environment with an empty string instead, returning the resulting observation unless the environment reports done.
>
> - Updates the test in [test_textarena.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1496/files#diff-b204b55c5fafd5e8ebceec2115070fe6ad33f58397491e00be1f812c8d97b26e) to assert an empty guess is passed and board feedback is returned
> - Bumps `tasksets` version to `0.1.4`
> - Behavioral Change: missing `<guess>` tags no longer halt the episode; the environment now receives an empty guess and continues
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 449a235.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->