### PR TITLE
Fix wordle_v1 TextArena dependency

### DIFF
--- a/environments/wordle_v1/pyproject.toml
+++ b/environments/wordle_v1/pyproject.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
     "verifiers>=0.1.15.dev7",
-    "tasksets>=0.1.1",
+    "tasksets[ta]>=0.1.1",
 ]
 
 [build-system]


### PR DESCRIPTION
## Summary
- fix the wordle_v1 regression from switching to the standalone tasksets package
- depend on tasksets[ta] so tasksets.textarena installs nltk and textarena
- leave uv.lock untouched; this is only an environment dependency correction

## Testing
- CHANGED_ENVS=wordle_v1 uv run pytest -q tests/test_envs.py::test_env
- uv run pre-commit run --files environments/wordle_v1/pyproject.toml

Note: the local environment smoke exits 0 after importing/loading wordle_v1, then skips the live vf-eval leg because no model API key is configured locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line dependency fix in one environment’s pyproject.toml with no runtime logic changes.
> 
> **Overview**
> Fixes a **dependency regression** in `wordle_v1` after moving to the standalone `tasksets` package: the environment imports `tasksets.textarena`, but the base `tasksets` install no longer pulls TextArena extras.
> 
> The only code change is declaring **`tasksets[ta]>=0.1.1`** in `environments/wordle_v1/pyproject.toml` so the TextArena extra (e.g. `nltk`, `textarena`) is installed at resolve time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dc8dcb350c205a6f8abdf147954ca479aa973f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `tasksets` dependency in `wordle_v1` to include the `ta` extra
> Updates [pyproject.toml](https://github.com/PrimeIntellect-ai/verifiers/pull/1497/files#diff-172e083294751a96aff5a61dfcc6cd600164e051d71f1da953d1fadee0bed363) to change the `tasksets` dependency from `tasksets>=0.1.1` to `tasksets[ta]>=0.1.1`, ensuring the required extra dependencies are installed when building this environment.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8dc8dcb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->