### PR TITLE
Add gpt-oss eval and GEPA config templates

### DIFF
--- a/configs/eval/gpt-oss.toml
+++ b/configs/eval/gpt-oss.toml
@@ -1,0 +1,24 @@
+# gpt-oss models. Uncomment exactly one model.
+model = "openai/gpt-oss-20b"
+# model = "openai/gpt-oss-120b"
+
+num_examples = 20
+rollouts_per_example = 1
+max_tokens = 1024
+
+[[eval]]
+env_id = "primeintellect/reverse-text"
+
+# [[eval]]
+# env_id = "primeintellect/wordle"
+
+# [[eval]]
+# env_id = "primeintellect/wiki-search"
+
+# [[eval]]
+# env_id = "primeintellect/dspy-flights"
+
+# [[eval]]
+# env_id = "primeintellect/opencode-harbor"
+
+# Hosted Training docs: https://docs.primeintellect.ai/hosted-training

--- a/configs/gepa/gpt-oss.toml
+++ b/configs/gepa/gpt-oss.toml
@@ -1,0 +1,33 @@
+# gpt-oss models. Update both fields when switching sizes.
+model = "openai/gpt-oss-20b"
+reflection_model = "openai/gpt-oss-20b"
+# model = "openai/gpt-oss-120b"
+# reflection_model = "openai/gpt-oss-120b"
+
+[[env]]
+env_id = "primeintellect/reverse-text"
+
+# [[env]]
+# env_id = "primeintellect/wordle"
+
+# [[env]]
+# env_id = "primeintellect/wiki-search"
+
+# [[env]]
+# env_id = "primeintellect/dspy-flights"
+
+# [[env]]
+# env_id = "primeintellect/opencode-harbor"
+
+[gepa]
+max_calls = 500
+num_train = 100
+num_val = 50
+minibatch_size = 3
+max_concurrent = 32
+
+[sampling]
+max_tokens = 1024
+reasoning_effort = "low"
+
+# Hosted Training docs: https://docs.primeintellect.ai/hosted-training


### PR DESCRIPTION
## Summary
- add gpt-oss templates for eval and GEPA alongside the existing RL template
- keep defaults aligned with the existing gpt-oss RL config: gpt-oss-20b, reverse-text, 1024 max tokens
- include low reasoning effort for GEPA sampling to match the RL family default

## Validation
- parsed both TOML files with Python tomllib
- pre-commit on commit passed
- push hook ty parity passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only config additions with no runtime or security impact.
> 
> **Overview**
> Adds **gpt-oss** starter TOML configs for **eval** and **GEPA**, matching the existing **`configs/rl/gpt-oss.toml`** pattern (default **gpt-oss-20b**, **reverse-text**, **1024** max tokens, optional **120b** commented).
> 
> **`configs/eval/gpt-oss.toml`** sets eval globals (`num_examples`, `rollouts_per_example`, `max_tokens`) and a default `[[eval]]` on `primeintellect/reverse-text`, with other envs commented for copy-paste.
> 
> **`configs/gepa/gpt-oss.toml`** wires the same model pair for `model` and `reflection_model`, default `[[env]]`, GEPA train/val limits, and `[sampling]` with **`reasoning_effort = "low"`** like the RL template.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43b5c14e395e3d99f0c15af175dfccca8f7338c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add gpt-oss eval and GEPA config templates
> - Adds [configs/eval/gpt-oss.toml](https://github.com/PrimeIntellect-ai/verifiers/pull/1500/files#diff-29ab3c90c7442adadc9da43fef5182ed7a76e88cfa3e5241328018d0e056f6e6): runs the `primeintellect/reverse-text` env using `openai/gpt-oss-20b` with `num_examples=20`, `rollouts_per_example=1`, and `max_tokens=1024`.
> - Adds [configs/gepa/gpt-oss.toml](https://github.com/PrimeIntellect-ai/verifiers/pull/1500/files#diff-6be46bbb322f7f60e05d5eafd8b261de80fcec6c877b9869a137a0e825935f04): GEPA training config using `openai/gpt-oss-20b` for both `model` and `reflection_model`, with `max_calls=500`, `num_train=100`, `num_val=50`, `minibatch_size=3`, `max_concurrent=32`, and `reasoning_effort="low"`.
> - Both configs target `primeintellect/reverse-text` by default; additional envs and the 120b model variant are available as commented-out options.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 43b5c14.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->