### PR TITLE
[codex] Align SystemPrompt alias with config fields

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -77,7 +77,7 @@ v1 task loader return types. Override `load_tasks(split=...)` on a
 ### SystemPrompt
 
 ```python
-SystemPrompt = str | Sequence[Message | JsonData]
+SystemPrompt = PromptInput | SystemPromptConfig | None
 SystemPromptStrategy = Literal["HT", "TH", "H_OR_T", "T_OR_H", "H", "T", "REJECT"]
 
 class SystemPromptConfig:
@@ -1030,7 +1030,7 @@ class EnvConfig(Config):
 
 class TasksetConfig(Config):
     taskset_id: str | None = None  # `id` shorthand accepted
-    system_prompt: PromptInput | SystemPromptConfig | None = None
+    system_prompt: SystemPrompt = None
     user: UserConfig | None = None
     bindings: BindingsConfig = BindingsConfig()
     objects: ObjectsConfig = ObjectsConfig()
@@ -1040,7 +1040,7 @@ class HarnessConfig(Config):
     harness_id: str | None = None  # `id` shorthand accepted
     program: ProgramConfig = ProgramConfig()
     model: ModelConfig = ModelConfig()
-    system_prompt: PromptInput | SystemPromptConfig | None = None
+    system_prompt: SystemPrompt = None
     system_prompt_strategy: SystemPromptStrategy = "HT"
     sandbox: SandboxConfig | None = None
     user: UserConfig | None = None

--- a/tests/test_v1_config_extension.py
+++ b/tests/test_v1_config_extension.py
@@ -2310,16 +2310,14 @@ def test_taskset_subclasses_inherit_registered_config_type() -> None:
 
 def test_taskset_class_loader_owns_split_loading() -> None:
     class LoaderTasksetConfig(TasksetConfig):
-        system_prompt: vf.SystemPrompt | None = "class prompt"
+        system_prompt: vf.SystemPrompt = "class prompt"
 
     class LoaderTaskset(Taskset[LoaderTasksetConfig]):
         def load_tasks(self, split: vf.TaskSplit = "train") -> vf.Tasks:
             answer = "class eval" if split == "eval" else "class tasks"
             return [{"prompt": [], "answer": answer}]
 
-        def load_system_prompt(
-            self, config: LoaderTasksetConfig
-        ) -> vf.SystemPrompt | None:
+        def load_system_prompt(self, config: LoaderTasksetConfig) -> vf.SystemPrompt:
             return config.system_prompt
 
     defaulted = LoaderTaskset(config=LoaderTasksetConfig())
@@ -2339,6 +2337,25 @@ def test_taskset_class_loader_owns_split_loading() -> None:
         {"role": "system", "content": ref("load_system_prompt")}
     ]
     assert disabled_prompt.system_prompt == []
+
+
+def test_system_prompt_alias_accepts_config_data(tmp_path) -> None:
+    prompt_path = tmp_path / "system_prompt.txt"
+    prompt_path.write_text("alias path system prompt", encoding="utf-8")
+
+    class PromptTasksetConfig(TasksetConfig):
+        system_prompt: vf.SystemPrompt = None
+
+    config = PromptTasksetConfig.model_validate(
+        {"system_prompt": {"path": str(prompt_path)}}
+    )
+    assert isinstance(config.system_prompt, vf.SystemPromptConfig)
+
+    taskset = Taskset(config=config)
+
+    assert taskset.system_prompt == [
+        {"role": "system", "content": "alias path system prompt"}
+    ]
 
 
 def test_taskset_load_tasks_can_return_empty_dataset() -> None:

--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.15.dev16"
+__version__ = "0.1.15.dev17"
 
 import importlib
 import os

--- a/verifiers/v1/__init__.py
+++ b/verifiers/v1/__init__.py
@@ -59,14 +59,13 @@ from .toolset import (
 )
 from .utils.endpoint_utils import Endpoint
 from .utils.binding_utils import BindingsConfig, ObjectsConfig
-from .utils.prompt_utils import SystemPromptConfig, SystemPromptStrategy
+from .utils.prompt_utils import SystemPrompt, SystemPromptConfig, SystemPromptStrategy
 from .types import (
     ConfigData,
     Handler,
     JsonData,
     Objects,
     PromptInput,
-    SystemPrompt,
     TaskSplit,
     Tasks,
 )

--- a/verifiers/v1/harness.py
+++ b/verifiers/v1/harness.py
@@ -72,8 +72,8 @@ from .utils.sandbox_program_utils import (
     run_sandbox_python_program,
 )
 from .utils.prompt_utils import (
+    SystemPrompt,
     SystemPromptStrategy,
-    SystemPromptConfig,
     normalize_prompt,
     normalize_system_prompt,
     resolve_system_prompt,
@@ -88,7 +88,6 @@ from .types import (
     ConfigData,
     JsonData,
     Objects,
-    PromptInput,
 )
 
 if TYPE_CHECKING:
@@ -106,7 +105,7 @@ class HarnessConfig(LifecycleConfig):
     )
     program: ProgramConfig = ProgramConfig()
     model: ModelConfig = ModelConfig()
-    system_prompt: PromptInput | SystemPromptConfig | None = None
+    system_prompt: SystemPrompt = None
     system_prompt_strategy: SystemPromptStrategy = "HT"
     sandbox: SandboxConfig | None = None
     user: UserConfig | None = None
@@ -217,9 +216,7 @@ class Harness(RuntimeOwnerMixin[ConfigT], Generic[ConfigT]):
             self.endpoint = self.load_endpoint()
             self.program = self.compile_program(self.program_config)
 
-    def load_system_prompt(
-        self, config: ConfigT
-    ) -> PromptInput | SystemPromptConfig | None:
+    def load_system_prompt(self, config: ConfigT) -> SystemPrompt:
         return config.system_prompt
 
     def load_sandbox(self, config: SandboxConfig | None) -> SandboxConfig | None:

--- a/verifiers/v1/taskset.py
+++ b/verifiers/v1/taskset.py
@@ -18,7 +18,7 @@ from .utils.binding_utils import (
     BindingsConfig,
     ObjectsConfig,
 )
-from .utils.prompt_utils import SystemPromptConfig, normalize_system_prompt
+from .utils.prompt_utils import SystemPrompt, normalize_system_prompt
 from .utils.config_utils import (
     coerce_config,
     config_ref_context,
@@ -36,7 +36,6 @@ from .utils.taskset_utils import (
 from .types import (
     JsonData,
     Objects,
-    PromptInput,
     TaskSplit,
     Tasks,
 )
@@ -48,7 +47,7 @@ class TasksetConfig(LifecycleConfig):
         default=None,
         validation_alias=AliasChoices("taskset_id", "id"),
     )
-    system_prompt: PromptInput | SystemPromptConfig | None = None
+    system_prompt: SystemPrompt = None
     user: UserConfig | None = None
     bindings: BindingsConfig = BindingsConfig()
     objects: ObjectsConfig = ObjectsConfig()
@@ -152,7 +151,5 @@ class Taskset(RuntimeOwnerMixin[ConfigT], Generic[ConfigT]):
     def __len__(self) -> int:
         return len(self.get_dataset())
 
-    def load_system_prompt(
-        self, config: ConfigT
-    ) -> PromptInput | SystemPromptConfig | None:
+    def load_system_prompt(self, config: ConfigT) -> SystemPrompt:
         return config.system_prompt

--- a/verifiers/v1/types.py
+++ b/verifiers/v1/types.py
@@ -41,7 +41,6 @@ Tasks: TypeAlias = Dataset | Iterable[JsonData] | Iterable["Task"]
 
 PromptMessage: TypeAlias = Message | JsonData
 PromptInput: TypeAlias = str | Sequence[PromptMessage]
-SystemPrompt: TypeAlias = PromptInput
 
 ModelClient: TypeAlias = Client | ClientConfig
 RuntimeObject: TypeAlias = object

--- a/verifiers/v1/utils/prompt_utils.py
+++ b/verifiers/v1/utils/prompt_utils.py
@@ -1,7 +1,7 @@
 import importlib.util
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal, cast
+from typing import TYPE_CHECKING, Literal, TypeAlias, cast
 
 from pydantic import model_validator
 from typing_extensions import Self
@@ -9,7 +9,7 @@ from verifiers.types import Messages, SystemMessage
 from verifiers.utils.message_utils import normalize_messages
 
 from ..config import Config
-from ..types import JsonData, PromptInput, SystemPrompt
+from ..types import JsonData, PromptInput
 from .config_utils import current_config_ref_module
 
 if TYPE_CHECKING:
@@ -64,13 +64,15 @@ class SystemPromptConfig(Config):
     messages: list[JsonData] = []
 
     @model_validator(mode="after")
-    def validate_one_source(self) -> Self:
-        sources = [
+    def validate_one_input(self) -> Self:
+        inputs = [
             self.path is not None,
             bool(self.messages),
         ]
-        if sum(sources) != 1:
-            raise ValueError("SystemPromptConfig requires exactly one source.")
+        if sum(inputs) != 1:
+            raise ValueError(
+                "SystemPromptConfig requires exactly one of path or messages."
+            )
         return self
 
     def load(self, field_name: str) -> PromptInput | None:
@@ -79,6 +81,9 @@ class SystemPromptConfig(Config):
                 resolve_system_prompt_path(self.path), field_name=field_name
             )
         return self.messages
+
+
+SystemPrompt: TypeAlias = PromptInput | SystemPromptConfig | None
 
 
 def normalize_prompt(
@@ -95,7 +100,7 @@ def normalize_prompt(
 
 
 def normalize_system_prompt(
-    value: SystemPrompt | SystemPromptConfig | None,
+    value: SystemPrompt,
     field_name: str = "system_prompt",
 ) -> list[JsonData]:
     value = resolve_system_prompt_input(value, field_name=field_name)
@@ -111,7 +116,7 @@ def normalize_system_prompt(
 
 
 def resolve_system_prompt_input(
-    value: PromptInput | SystemPromptConfig | None,
+    value: SystemPrompt,
     *,
     field_name: str,
 ) -> PromptInput | None:


### PR DESCRIPTION
## Summary
- Defines `vf.SystemPrompt` as `PromptInput | SystemPromptConfig | None` at the prompt-utils boundary.
- Uses `SystemPrompt` directly on v1 taskset and harness config fields and docs.
- Adds a regression for Pydantic config data resolving into `SystemPromptConfig` and bumps the dev version to `0.1.15.dev17`.

## Validation
- `uv run pytest tests/test_v1_config_extension.py::test_system_prompt_alias_accepts_config_data tests/test_v1_config_extension.py::test_taskset_class_loader_owns_split_loading -q`
- `uv run pytest tests/test_v1_config_extension.py -q`
- `uv run pre-commit run --all-files`
- pre-push hooks via `git push -u origin codex/system-prompt-alias`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Typing and documentation alignment with a small validator message change; behavior is covered by existing and new config tests.
> 
> **Overview**
> Introduces a single **`SystemPrompt`** alias as `PromptInput | SystemPromptConfig | None` in `prompt_utils` and uses it on **`TasksetConfig`**, **`HarnessConfig`**, **`load_system_prompt`**, and the API reference instead of repeating the union inline.
> 
> **`SystemPrompt`** is exported from the v1/public surface from prompt utils (removed from `types`). **`SystemPromptConfig`** validation is renamed/clarified (`validate_one_input`, clearer error). A regression test checks config dicts like `{"path": "..."}` coerce to **`SystemPromptConfig`** and load correctly. Dev version **`0.1.15.dev17`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afcde7bc051f29bab439e167b8ce1f8d54e63342. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Align `SystemPrompt` type alias with config fields in `TasksetConfig` and `HarnessConfig`
> - Moves the `SystemPrompt` type alias (`PromptInput | SystemPromptConfig | None`) from [types.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1501/files#diff-88a4e4ee0c58ac5dc7344161a011374082a3767eda2ad32af97c942dca982112) into [prompt_utils.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1501/files#diff-0a90fe58290e4506ef07288da4b0493e022f5669b005dd3fbbacb5751c425ad9) so it co-locates with the related config and normalization logic.
> - Updates `system_prompt` field annotations in `TasksetConfig` and `HarnessConfig`, and the return types of their `load_system_prompt` methods, to use the new alias instead of repeating the union.
> - Renames the `SystemPromptConfig` validator from `validate_one_source` to `validate_one_input` and updates its error message to `'SystemPromptConfig requires exactly one of path or messages.'`
> - Adds a test validating that a dict with a `path` key is correctly aliased to `SystemPromptConfig` and produces normalized content.
> - Behavioral Change: `verifiers.v1.types.SystemPrompt` is no longer defined; callers importing it from `types` will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized afcde7b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->