### PR TITLE
Add SynLogic environment

### DIFF
--- a/environments/README.md
+++ b/environments/README.md
@@ -13,6 +13,7 @@ This folder contains installable example environments that showcase common usage
 - **reverse_text**: XML formatting with non-binary LCS reward + format reward.
 - **continuation_quality**: Completion-style generation (`message_type="completion"`) judged for prose quality with `JudgeRubric`.
 - **mmmu**: Multimodal inputs (image + text) packed in chat content; single-turn boxed-answer check.
+- **synlogic**: MiniMax SynLogic logical reasoning puzzles scored with the upstream task-specific verifiers.
 
 ### SingleTurnEnv subclass (custom dataset/scoring wrappers)
 - **reasoning_gym_env**: Wraps `reasoning_gym` procedural datasets, converts to HF datasets, and applies task-specific scoring.

--- a/environments/synlogic/README.md
+++ b/environments/synlogic/README.md
@@ -1,0 +1,54 @@
+# SynLogic
+
+SynLogic is a collection of synthetic reasoning and puzzle tasks from MiniMax. This environment wraps the Hugging Face dataset [`MiniMaxAI/SynLogic`](https://huggingface.co/datasets/MiniMaxAI/SynLogic) and the upstream verifier logic from [`MiniMax-AI/SynLogic`](https://github.com/MiniMax-AI/SynLogic) as a Verifiers `SingleTurnEnv`.
+
+Algora bounty: https://algora.io/PrimeIntellect-ai/bounties/g42D7Yrh5u25gjtb
+
+## Task
+
+Each example asks the model to solve one logic puzzle. The model should respond with:
+
+```xml
+<think>reasoning process here</think><answer>final answer here</answer>
+```
+
+The hidden `extra_info.game_data_str` payload from the dataset is used only by the reward functions, not shown separately to the model beyond the original prompt.
+
+## Rewards
+
+- `synlogic_reward` (weight `1.0`): requires the exact SynLogic response format and then runs the upstream verifier for the task type.
+- `format_reward` (weight `0.0`): tracks whether the response has exactly one `<think>...</think>` and one `<answer>...</answer>` block.
+- `accuracy_reward` (weight `0.0`): tracks verifier correctness independent of the format gate.
+
+Validation dataset sources such as `val/campsite` are normalized to the upstream verifier key `campsite`.
+
+## Usage
+
+```python
+import verifiers as vf
+
+env = vf.load_environment("synlogic", config="easy", max_examples=512, max_eval_examples=128)
+```
+
+Config options:
+
+- `config="easy"` or `config="hard"`
+- `max_examples=None` to load all training examples
+- `max_eval_examples=None` to load all validation examples
+- `shuffle=True`, `seed=0`
+
+## Local checks
+
+```bash
+uvx ruff check environments/synlogic
+uv run --no-dev vf-install synlogic
+uv run --no-dev python - <<'PY'
+import verifiers as vf
+env = vf.load_environment('synlogic', max_examples=1, max_eval_examples=1)
+print(type(env).__name__)
+print(len(env.get_dataset()), len(env.get_eval_dataset()))
+PY
+CHANGED_ENVS=synlogic uv run --no-dev --with pytest pytest tests/test_envs.py -q -k 'pyproject or readme'
+```
+
+The upstream SynLogic verifier code is vendored under `synlogic_src/` because the reference repository does not expose an installable Python package.

--- a/environments/synlogic/pyproject.toml
+++ b/environments/synlogic/pyproject.toml
@@ -1,0 +1,35 @@
+[project]
+name = "synlogic"
+description = "SynLogic logical reasoning benchmark environment"
+tags = ["logic", "reasoning", "puzzles", "train", "single-turn"]
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+    "verifiers>=0.1.15.dev0",
+    "datasets>=2.18.0",
+    "numpy",
+    "nltk",
+    "sympy",
+    "math-verify",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build]
+include = [
+    "synlogic.py",
+    "README.md",
+    "pyproject.toml",
+    "synlogic_src/**/*.py",
+    "synlogic_src/**/*.txt",
+    "synlogic_src/LICENSE",
+]
+
+[tool.ruff]
+extend-exclude = ["synlogic_src"]
+
+[tool.verifiers.eval]
+num_examples = 5
+rollouts_per_example = 3

--- a/environments/synlogic/synlogic.py
+++ b/environments/synlogic/synlogic.py
@@ -1,0 +1,228 @@
+"""Verifiers environment for the SynLogic reasoning benchmark.
+
+SynLogic examples are single-turn logic/puzzle tasks.  The Hugging Face dataset
+contains chat prompts plus ``extra_info.game_data_str`` payloads used by the
+upstream SynLogic verifier classes.  This wrapper keeps the upstream verifier
+logic local to the environment package and exposes the benchmark through a
+standard ``vf.SingleTurnEnv``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, cast
+
+from datasets import Dataset, load_dataset
+import verifiers as vf
+
+DATASET_NAME = "MiniMaxAI/SynLogic"
+DEFAULT_CONFIG = "easy"
+DEFAULT_TRAIN_SPLIT = "train"
+DEFAULT_EVAL_SPLIT = "validation"
+SYNLOGIC_SRC = Path(__file__).with_name("synlogic_src")
+ANSWER_RE = re.compile(r"<answer>(.*?)</answer>", re.DOTALL)
+
+SYSTEM_PROMPT = (
+    "Solve each SynLogic puzzle step by step. Put any reasoning inside "
+    "<think>...</think> and put only the final answer inside "
+    "<answer>...</answer>."
+)
+
+
+def _ensure_synlogic_import_path() -> None:
+    src = str(SYNLOGIC_SRC)
+    if src not in sys.path:
+        sys.path.insert(0, src)
+
+
+@lru_cache(maxsize=1)
+def _synlogic_runtime() -> tuple[type[Any], dict[str, type[Any]]]:
+    """Import the vendored SynLogic Data class and verifier registry lazily."""
+    _ensure_synlogic_import_path()
+    from base.data import Data  # type: ignore[import-not-found]
+    from task2verifier import verifier_classes  # type: ignore[import-not-found]
+
+    return Data, verifier_classes
+
+
+def _completion_text(completion: vf.Messages | list[dict[str, Any]] | str) -> str:
+    if isinstance(completion, str):
+        return completion
+    if not completion:
+        return ""
+    message = completion[-1]
+    content = message.get("content", "") if isinstance(message, dict) else ""
+    if isinstance(content, str):
+        return content
+    return json.dumps(content, ensure_ascii=False)
+
+
+def extract_answer(response: str) -> str:
+    """Extract the final answer, following SynLogic's post-</think> convention."""
+    model_output = response.split("</think>", 1)[1] if "</think>" in response else response
+    match = ANSWER_RE.search(model_output)
+    return match.group(1).strip() if match else ""
+
+
+def response_has_required_format(response: str) -> bool:
+    return (
+        response.startswith("<think>")
+        and response.endswith("</answer>")
+        and response.count("<think>") == 1
+        and response.count("</think>") == 1
+        and response.count("<answer>") == 1
+        and response.count("</answer>") == 1
+    )
+
+
+def normalize_data_source(data_source: str) -> str:
+    """Normalize validation sources such as ``val/campsite`` to ``campsite``."""
+    return data_source.split("/", 1)[1] if data_source.startswith("val/") else data_source
+
+
+def _info_from_row(row: dict[str, Any]) -> dict[str, Any]:
+    extra_info = row.get("extra_info") or {}
+    data_source = normalize_data_source(str(row.get("data_source", "")))
+    return {
+        "data_source": data_source,
+        "ability": row.get("ability"),
+        "game_data_str": extra_info.get("game_data_str", ""),
+        "source_file": extra_info.get("source_file"),
+        "index": extra_info.get("index"),
+        "metadata": extra_info.get("metadata"),
+        "original_answer": extra_info.get("original_answer"),
+        "original_question": extra_info.get("original_question"),
+    }
+
+
+def _row_to_example(row: dict[str, Any]) -> dict[str, Any]:
+    prompt = row.get("prompt")
+    if not isinstance(prompt, list):
+        prompt = [{"role": "user", "content": str(prompt or row.get("question", ""))}]
+    return {
+        "prompt": prompt,
+        "answer": str((row.get("extra_info") or {}).get("original_answer", "")),
+        "info": json.dumps(_info_from_row(row), ensure_ascii=False),
+    }
+
+
+def _load_synlogic_dataset(
+    *,
+    config: str,
+    split: str,
+    max_examples: int | None,
+    shuffle: bool,
+    seed: int,
+) -> Dataset:
+    ds = load_dataset(DATASET_NAME, config, split=split)
+    if shuffle:
+        ds = ds.shuffle(seed=seed)
+    if max_examples is not None and max_examples >= 0:
+        ds = ds.select(range(min(max_examples, len(ds))))
+    rows = [_row_to_example(cast(dict[str, Any], row)) for row in ds]
+    return Dataset.from_list(rows)
+
+
+def make_dataset_builder(
+    *,
+    config: str,
+    split: str,
+    max_examples: int | None,
+    shuffle: bool,
+    seed: int,
+) -> vf.DatasetBuilder:
+    def build() -> Dataset:
+        return _load_synlogic_dataset(
+            config=config,
+            split=split,
+            max_examples=max_examples,
+            shuffle=shuffle,
+            seed=seed,
+        )
+
+    return build
+
+
+def synlogic_accuracy(response: str, info: dict[str, Any]) -> float:
+    """Run the upstream verifier for one SynLogic response."""
+    Data, verifier_classes = _synlogic_runtime()
+    data_source = normalize_data_source(str(info.get("data_source", "")))
+    game_data_str = str(info.get("game_data_str", ""))
+    verifier_cls = verifier_classes.get(data_source)
+    if verifier_cls is None or not game_data_str:
+        return 0.0
+    try:
+        game_data = Data.from_json_str(game_data_str)
+        verifier = verifier_cls()
+        score = verifier.verify(game_data, extract_answer(response))
+        return max(0.0, min(1.0, float(score)))
+    except Exception:
+        return 0.0
+
+
+async def synlogic_reward(completion: vf.Messages, info: dict[str, Any]) -> float:
+    response = _completion_text(completion)
+    if not response_has_required_format(response):
+        return 0.0
+    return synlogic_accuracy(response, info)
+
+
+async def format_reward(completion: vf.Messages) -> float:
+    return 1.0 if response_has_required_format(_completion_text(completion)) else 0.0
+
+
+async def accuracy_reward(completion: vf.Messages, info: dict[str, Any]) -> float:
+    return synlogic_accuracy(_completion_text(completion), info)
+
+
+def load_environment(
+    config: str = DEFAULT_CONFIG,
+    train_split: str = DEFAULT_TRAIN_SPLIT,
+    eval_split: str = DEFAULT_EVAL_SPLIT,
+    max_examples: int | None = 512,
+    max_eval_examples: int | None = 128,
+    shuffle: bool = True,
+    seed: int = 0,
+    system_prompt: str = SYSTEM_PROMPT,
+) -> vf.Environment:
+    """Load the SynLogic environment.
+
+    Args:
+        config: Hugging Face dataset config, usually ``easy`` or ``hard``.
+        train_split: Dataset split used for training.
+        eval_split: Dataset split used for evaluation.
+        max_examples: Optional cap for training rows; ``None`` loads all rows.
+        max_eval_examples: Optional cap for eval rows; ``None`` loads all rows.
+        shuffle: Whether to shuffle before applying caps.
+        seed: Shuffle seed.
+        system_prompt: System prompt prepended by ``SingleTurnEnv`` when needed.
+    """
+    if config not in {"easy", "hard"}:
+        raise ValueError("config must be 'easy' or 'hard'")
+
+    rubric = vf.Rubric(
+        funcs=[synlogic_reward, format_reward, accuracy_reward],
+        weights=[1.0, 0.0, 0.0],
+    )
+    return vf.SingleTurnEnv(
+        dataset=make_dataset_builder(
+            config=config,
+            split=train_split,
+            max_examples=max_examples,
+            shuffle=shuffle,
+            seed=seed,
+        ),
+        eval_dataset=make_dataset_builder(
+            config=config,
+            split=eval_split,
+            max_examples=max_eval_examples,
+            shuffle=shuffle,
+            seed=seed + 1,
+        ),
+        system_prompt=system_prompt,
+        rubric=rubric,
+    )

--- a/environments/synlogic/synlogic_src/LICENSE
+++ b/environments/synlogic/synlogic_src/LICENSE
@@ -1,0 +1,5 @@
+MIT License
+Copyright (c) 2025 MiniMax
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/environments/synlogic/synlogic_src/base/data.py
+++ b/environments/synlogic/synlogic_src/base/data.py
@@ -1,0 +1,51 @@
+import json
+
+class Data:
+    """
+    Data class for game/corpus
+    @param question: question of the game/corpus
+    @param answer: answer of the game/corpus
+    @param difficulty: difficulty of the game/corpus, from 1 to 10
+    """
+    def __init__(self, question: str, answer: str, difficulty: int = 1, metadata: dict = None, **kwargs):
+        self.question = question
+        self.answer = answer
+        self.difficulty = difficulty
+        self.metadata = metadata
+        self.gpt_response = ""
+        
+    def to_json(self):
+        return {
+            "question": self.question,
+            "answer": self.answer,
+            "difficulty": self.difficulty,
+            "metadata": self.metadata,
+            "gpt_response": self.gpt_response
+        }
+    
+    def to_json_str(self):
+        return json.dumps(self.to_json(), ensure_ascii=False)
+    
+    @classmethod
+    def from_json_str(cls, json_str):
+        json_data = json.loads(json_str)
+        return cls(**json_data)
+    
+    @classmethod
+    def from_json_dict(cls, json_dict):
+        instance = cls(**json_dict)
+        if 'gpt_response' in json_dict:
+            instance.gpt_response = json_dict['gpt_response']
+        return instance
+    
+    @classmethod
+    def from_jsonl_file(cls, file_path):
+        data_list = []
+        with open(file_path, "r") as f:
+            for line in f:
+                json_data = json.loads(line)
+                instance = cls(**json_data)
+                if 'gpt_response' in json_data:
+                    instance.gpt_response = json_data['gpt_response']
+                data_list.append(instance)
+        return data_list

--- a/environments/synlogic/synlogic_src/base/verifier.py
+++ b/environments/synlogic/synlogic_src/base/verifier.py
@@ -1,0 +1,83 @@
+from abc import ABC, abstractmethod
+from base.data import Data
+
+class Verifier(ABC):
+    """
+    Base class for verifier
+    """
+    def __init__(self):
+        pass
+    
+    @abstractmethod
+    def verify(self, data: Data, test_answer: str):
+        """
+        Verify whether the test answer is consistent with the gold answer
+        @param data: Data
+        @param test_answer: str
+        @return: bool
+        """
+        raise NotImplementedError("Verifier.verify() is not implemented")
+
+    @abstractmethod
+    def extract_answer(self, test_solution: str):
+        """
+        Extract the answer from the test solution
+        @param test_solution: str
+        @return: str
+        """
+        raise NotImplementedError("Verifier.extract_answer() is not implemented")
+
+import re
+
+THOUGHT_DELIMITER_START = "<think>"
+THOUGHT_DELIMITER_END = "</think>"
+
+def _extract_answer(text):
+    # 定义正则表达式模式，匹配 <answer> 和 </answer> 之间的内容
+    pattern = r'<answer>(.*?)</answer>'
+    
+    # 使用 re.search 查找第一个匹配项
+    match = re.search(pattern, text, re.DOTALL)
+    
+    # 如果找到匹配项，返回匹配的内容
+    if match:
+        return match.group(1).strip()
+    else:
+        return None
+    
+def _extract_solution_with_thought(solution_str):
+    
+    model_output = solution_str
+    
+    if THOUGHT_DELIMITER_END in solution_str:
+        model_output = solution_str.split(THOUGHT_DELIMITER_END)[1]
+    
+    predict_answer = _extract_answer(model_output)
+    
+    
+    if predict_answer is not None:
+        return predict_answer
+    else:
+        return ""
+
+
+class ExactMatchVerifier(Verifier):
+    """
+    Verifier for Exact Match
+    """
+    def verify(self, data: Data, test_solution: str):
+        try:
+            test_answer = self.extract_answer(test_solution)
+            ground_truth = data.answer
+            correct = test_answer == ground_truth
+            if correct:
+                acc_score = 1.0
+            else:
+                acc_score = 0
+
+            return acc_score
+        except:
+            return False
+    
+    def extract_answer(self, test_solution: str):
+        return _extract_solution_with_thought(solution_str=test_solution)

--- a/environments/synlogic/synlogic_src/corpus/misc/tasks/arc_agi/scripts/arc_agi_verifier.py
+++ b/environments/synlogic/synlogic_src/corpus/misc/tasks/arc_agi/scripts/arc_agi_verifier.py
@@ -1,0 +1,62 @@
+from base.data import Data
+from base.verifier import Verifier
+import re
+import json
+
+
+def _preprocess_answer(answer: str) -> str:
+    """预处理答案文本"""
+    if not answer:
+        return None
+        
+    processed = answer.strip().lower()
+    processed = processed.split("```json")[-1]
+    processed = processed.split("```")[0].strip()
+    try:
+        processed = json.loads(processed)
+    except:
+        try:
+            processed = eval(processed)
+        except:
+            return None
+
+    return processed
+
+class ArcAGIVerifier(Verifier):
+    """ArcAGI任务的验证器"""
+    
+    def verify(self, data: Data, test_solution: str) -> float:
+        try:
+            # 提取和预处理模型答案
+            test_answer = self.extract_answer(test_solution)
+            
+            # 获取并预处理参考答案
+            ground_truth = data.answer
+            
+            # 进行模糊匹配
+            correct = test_answer == ground_truth
+            
+            return 1.0 if correct else 0.0
+        except:
+            return 0.0
+    
+    def extract_answer(self, test_solution: str) -> str:
+        """从完整答案中提取最终答案"""
+        # if THOUGHT_DELIMITER_END in test_solution:
+        #     test_solution = test_solution.split(THOUGHT_DELIMITER_END)[1]
+            
+        return _preprocess_answer(test_solution)
+
+if __name__ == '__main__':
+    # 测试用例
+    test_cases = [
+        ("<answer>```json\n[[7, 0, 7, 0, 0, 0, 7, 0, 7], [7, 0, 7, 0, 0, 0, 7, 0, 7], [7, 7, 0, 0, 0, 0, 7, 7, 0], [7, 0, 7, 0, 0, 0, 7, 0, 7], [7, 0, 7, 0, 0, 0, 7, 0, 7], [7, 7, 0, 0, 0, 0, 7, 7, 0], [7, 0, 7, 7, 0, 7, 0, 0, 0], [7, 0, 7, 7, 0, 7, 0, 0, 0], [7, 7, 0, 7, 7, 0, 0, 0, 0]]\n```</answer>", [[7, 0, 7, 0, 0, 0, 7, 0, 7], [7, 0, 7, 0, 0, 0, 7, 0, 7], [7, 7, 0, 0, 0, 0, 7, 7, 0], [7, 0, 7, 0, 0, 0, 7, 0, 7], [7, 0, 7, 0, 0, 0, 7, 0, 7], [7, 7, 0, 0, 0, 0, 7, 7, 0], [7, 0, 7, 7, 0, 7, 0, 0, 0], [7, 0, 7, 7, 0, 7, 0, 0, 0], [7, 7, 0, 7, 7, 0, 0, 0, 0]]),
+    ]
+    
+    verifier = ArcAGIVerifier()
+    for test_input, reference in test_cases:
+        result = verifier.extract_answer(test_input)
+        print(f"Input: {test_input}")
+        print(f"Reference: {reference}")
+        print(f"Extracted: {result}")
+        print(f"Match: {result == reference}\n")

--- a/environments/synlogic/synlogic_src/corpus/misc/tasks/zebra_puzzle/scripts/zebra_puzzle_verifier.py
+++ b/environments/synlogic/synlogic_src/corpus/misc/tasks/zebra_puzzle/scripts/zebra_puzzle_verifier.py
@@ -1,0 +1,132 @@
+from base.data import Data
+from base.verifier import Verifier
+import re
+from sympy.parsing.latex import parse_latex
+
+
+import json
+
+def _verifier(answer_str, user_response_str, type_safe=True):
+    """验证用户响应是否与答案一致。
+
+    Args:
+        answer_str (str): 标准答案字符串（可能是 JSON 序列化的字典或其他类型）。
+        user_response_str (str): 用户响应字符串。
+        type_safe (bool): 是否要求类型严格一致（默认 True）。
+
+    Returns:
+        bool: 验证结果是否一致。
+    """
+    try:
+        user_response_str = user_response_str.split("```json")[-1].split("```")[0].strip()
+    except:
+        return False
+    # 尝试解析答案字符串为 JSON 对象
+    try:
+        answer_obj = json.loads(answer_str)
+    except json.JSONDecodeError:
+        # 如果解析失败，直接比较原始字符串
+        # print("cannot load as dict, do string exact matching")
+        return answer_str == user_response_str
+    else:
+        if isinstance(answer_obj, dict):
+            # 尝试解析用户响应为 JSON 对象
+            try:
+                response_obj = json.loads(user_response_str)
+            except json.JSONDecodeError:
+                try:
+                    response_obj = eval(user_response_str)
+                except:
+                    return False
+            # 用户响应必须是字典类型才能继续比较
+            if not isinstance(response_obj, dict):
+                return False
+            # 深度比较字典结构
+            return _deep_compare(answer_obj, response_obj, type_safe)
+        else:
+            # 如果答案解析后不是字典，严格比较原始字符串
+            return answer_str == user_response_str
+
+
+def _deep_compare(a, b, type_safe):
+    """递归比较两个对象的结构和内容。
+
+    Args:
+        a: 期望值（标准答案）
+        b: 实际值（用户响应）
+        type_safe: 是否要求类型严格一致
+    """
+    # 检查类型是否一致（如果启用类型安全）
+    if type_safe and type(a) is not type(b):
+        return False
+    
+    # 处理字典类型
+    if isinstance(a, dict):
+        if not isinstance(b, dict) or a.keys() != b.keys():
+            return False
+        return all(_deep_compare(a[k], b[k], type_safe) for k in a)
+    
+    # 处理列表类型
+    elif isinstance(a, list):
+        if not isinstance(b, list) or len(a) != len(b):
+            return False
+        return all(_deep_compare(x, y, type_safe) for x, y in zip(a, b))
+    
+    # 处理基本类型（根据类型安全性决定是否转换）
+    else:
+        return _compare_values(a, b, type_safe)
+
+
+def _compare_values(a, b, type_safe):
+    """比较两个值（对数值类型做宽容处理）"""
+    if type_safe:
+        return a == b
+    else:
+        # 尝试将字符串转为数字进行比较
+        converted_a = _try_convert_number(a)
+        converted_b = _try_convert_number(b)
+        return converted_a == converted_b
+
+
+def _try_convert_number(value):
+    """尝试将字符串转为数字（int/float）"""
+    if isinstance(value, str):
+        try: return int(value)
+        except: pass
+        try: return float(value)
+        except: pass
+    return value
+
+class ZebraPuzzleVerifier(Verifier):
+    """
+    Verifier for Zebra Puzzle
+    """
+    def verify(self, data: Data, test_solution: str):
+        """The scoring function for zebra puzzle.
+
+        Reference: Trung, Luong, et al. "Reft: Reasoning with reinforced fine-tuning." Proceedings of the 62nd Annual Meeting of the Association for Computational Linguistics (Volume 1: Long Papers). 2024.
+
+        Args:
+            solution_str: the solution text
+            ground_truth: the ground truth
+            format_score: the score for the format
+            acc_score: the score for the correct answer
+        """
+
+        extracted_answer = self.extract_answer(test_solution)
+        ground_truth = data.answer
+        try:
+            correct = _verifier(answer_str=ground_truth, user_response_str=extracted_answer, type_safe=True)
+        except Exception as e:
+            print(f"Gold: {ground_truth} Response: {extracted_answer} Error: {str(e)}")
+            correct = False
+        
+        if correct:
+            acc_score = 1.0
+        else:
+            acc_score = 0
+
+        return acc_score
+    
+    def extract_answer(self, test_solution: str):
+        return test_solution

--- a/environments/synlogic/synlogic_src/games/tasks/arrow_maze/scripts/arrow_maze_verifier.py
+++ b/environments/synlogic/synlogic_src/games/tasks/arrow_maze/scripts/arrow_maze_verifier.py
@@ -1,0 +1,304 @@
+import json
+from typing import List, Dict, Tuple
+from base.verifier import Verifier
+from base.data import Data
+import re
+
+class ArrowMazeVerifier(Verifier):
+    """
+    箭头迷宫游戏验证器
+    
+    验证条件:
+    1. 判断answer grid的大小是否和question grid一致
+    2. 判断answer grid中数字格子是否和question grid中数字格子一致
+    3. 判断question grid空格（"X"）在answer grid中是否被箭头填满
+    4. 判断箭头符号是否合法：
+       上（↑）、下（↓）、左（←）、右（→）或对角线方向（↖、↗、↘、↙）
+    5. 判断answer grid中非空格（"X"）和非数字的部分，即预填的箭头，是否和question grid一致
+    6. 迷宫有个隐藏的条件是所有箭头都能被射线箭头串覆盖到
+    7. 每个数字起点发出的射线箭头串总长度等于该数字
+    """
+    
+    # 定义合法的箭头符号
+    VALID_ARROWS = {"↑", "↓", "←", "→", "↖", "↗", "↘", "↙"}
+    
+    # 定义箭头符号和其对应的方向
+    ARROWS_DIRECTIONS = {
+        "↑": (-1, 0),   # 上
+        "↓": (1, 0),    # 下
+        "←": (0, -1),   # 左
+        "→": (0, 1),    # 右
+        "↖": (-1, -1),  # 左上
+        "↗": (-1, 1),   # 右上
+        "↘": (1, 1),    # 右下
+        "↙": (1, -1)    # 左下
+    }
+    
+    def verify(self, data: Data, test_solution_str: str) -> bool:
+        """
+        验证箭头迷宫的答案是否正确
+        
+        @param data: 游戏数据
+        @param test_solution_str: 测试答案字符串 (JSON格式的二维数组)
+        @return: 答案是否正确
+        """
+        test_answer_str = self.extract_answer(test_solution_str)
+        if not test_answer_str:
+            print("答案为空，验证失败")
+            return False
+        
+        try:
+            # 解析测试答案
+            test_answer = json.loads(test_answer_str)
+            
+            # 获取原始迷宫
+            question_grid = data.metadata["maze"]
+            
+            # 检查答案是否符合要求
+            if not self._verify_grid_size(test_answer, question_grid):
+                print("答案网格大小与题目不匹配")
+                return False
+                
+            if not self._verify_number_positions(test_answer, question_grid):
+                print("答案中数字位置或值与题目不匹配")
+                return False
+                
+            if not self._verify_all_blanks_filled(test_answer, question_grid):
+                print("答案中有空格未被填满")
+                return False
+                
+            if not self._verify_arrow_symbols(test_answer):
+                print("答案中包含非法箭头符号")
+                return False
+                
+            if not self._verify_prefilled_arrows(test_answer, question_grid):
+                print("答案中预填箭头与题目不一致")
+                return False
+                
+            if not self._verify_arrow_rays(test_answer):
+                print("答案中存在未被射线覆盖的箭头")
+                return False
+                
+            if not self._verify_number_rays(test_answer):
+                print("答案中数字的射线箭头串总数不符合要求")
+                return False
+            
+            # 所有验证都通过
+            print("验证通过！")
+            return True
+            
+        except Exception as e:
+            print(f"验证过程中出错: {e}")
+            return False
+    
+    def _verify_grid_size(self, test_answer: List[List[str]], question_grid: List[List[str]]) -> bool:
+        """
+        验证答案网格大小是否与题目一致
+        
+        @param test_answer: 测试答案网格
+        @param question_grid: 题目网格
+        @return: 网格大小是否一致
+        """
+        if len(test_answer) != len(question_grid):
+            return False
+            
+        for i in range(len(test_answer)):
+            if len(test_answer[i]) != len(question_grid[i]):
+                return False
+                
+        return True
+    
+    def _verify_number_positions(self, test_answer: List[List[str]], question_grid: List[List[str]]) -> bool:
+        """
+        验证答案中数字位置和值是否与题目一致
+        
+        @param test_answer: 测试答案网格
+        @param question_grid: 题目网格
+        @return: 数字位置和值是否一致
+        """
+        for i in range(len(question_grid)):
+            for j in range(len(question_grid[i])):
+                if question_grid[i][j].isdigit():
+                    if test_answer[i][j] != question_grid[i][j]:
+                        return False
+        return True
+    
+    def _verify_all_blanks_filled(self, test_answer: List[List[str]], question_grid: List[List[str]]) -> bool:
+        """
+        验证所有空格是否都被填满
+        
+        @param test_answer: 测试答案网格
+        @param question_grid: 题目网格
+        @return: 所有空格是否被填满
+        """
+        for i in range(len(question_grid)):
+            for j in range(len(question_grid[i])):
+                if question_grid[i][j] == "X" and test_answer[i][j] == "X":
+                    return False
+        return True
+    
+    def _verify_arrow_symbols(self, test_answer: List[List[str]]) -> bool:
+        """
+        验证箭头符号是否合法
+        
+        @param test_answer: 测试答案网格
+        @return: 箭头符号是否合法
+        """
+        for i in range(len(test_answer)):
+            for j in range(len(test_answer[i])):
+                cell = test_answer[i][j]
+                if not cell.isdigit() and cell != "X" and cell not in self.VALID_ARROWS:
+                    return False
+        return True
+    
+    def _verify_prefilled_arrows(self, test_answer: List[List[str]], question_grid: List[List[str]]) -> bool:
+        """
+        验证预填的箭头是否与题目一致
+        
+        @param test_answer: 测试答案网格
+        @param question_grid: 题目网格
+        @return: 预填箭头是否一致
+        """
+        for i in range(len(question_grid)):
+            for j in range(len(question_grid[i])):
+                cell = question_grid[i][j]
+                if not cell.isdigit() and cell != "X":
+                    if test_answer[i][j] != cell:
+                        return False
+        return True
+    
+    def _verify_arrow_rays(self, test_answer: List[List[str]]) -> bool:
+        """
+        验证所有箭头是否都能被射线箭头串覆盖到
+        
+        @param test_answer: 测试答案网格
+        @return: 所有箭头是否都能被射线覆盖
+        """
+        n = len(test_answer)
+        m = len(test_answer[0]) if n > 0 else 0
+        
+        # 创建覆盖标记数组
+        covered = [[False for _ in range(m)] for _ in range(n)]
+        
+        # 标记数字位置为已覆盖
+        for i in range(n):
+            for j in range(m):
+                if test_answer[i][j].isdigit():
+                    covered[i][j] = True
+        
+        # 从每个数字出发，沿各个方向延伸射线，标记覆盖到的箭头
+        for i in range(n):
+            for j in range(m):
+                if test_answer[i][j].isdigit():
+                    # 检查所有方向
+                    for arrow_symbol, (di, dj) in self.ARROWS_DIRECTIONS.items():
+                        ni, nj = i + di, j + dj
+                        # 沿该方向延伸，直到边界或非匹配箭头
+                        while 0 <= ni < n and 0 <= nj < m and test_answer[ni][nj] == arrow_symbol:
+                            covered[ni][nj] = True
+                            ni += di
+                            nj += dj
+        
+        # 检查所有箭头是否都被覆盖
+        for i in range(n):
+            for j in range(m):
+                if test_answer[i][j] in self.VALID_ARROWS and not covered[i][j]:
+                    return False
+        
+        return True
+    
+    def _verify_number_rays(self, test_answer: List[List[str]]) -> bool:
+        """
+        验证每个数字起点发出的射线箭头串总长度是否等于该数字
+        
+        @param test_answer: 测试答案网格
+        @return: 每个数字的射线箭头串是否符合要求
+        """
+        n = len(test_answer)
+        m = len(test_answer[0]) if n > 0 else 0
+        
+        for i in range(n):
+            for j in range(m):
+                if test_answer[i][j].isdigit():
+                    number = int(test_answer[i][j])
+                    arrow_count = self._count_arrow_rays(test_answer, i, j)
+                    if arrow_count != number:
+                        return False
+        
+        return True
+    
+    def _count_arrow_rays(self, grid: List[List[str]], i: int, j: int) -> int:
+        """
+        计算从数字出发的所有射线箭头串中箭头总数
+        
+        @param grid: 网格
+        @param i: 数字行索引
+        @param j: 数字列索引
+        @return: 箭头总数
+        """
+        n = len(grid)
+        m = len(grid[0]) if n > 0 else 0
+        count = 0
+        
+        # 检查所有方向
+        for arrow_symbol, (di, dj) in self.ARROWS_DIRECTIONS.items():
+            ni, nj = i + di, j + dj
+            ray_length = 0
+            
+            # 沿该方向计数连续的相同箭头
+            while 0 <= ni < n and 0 <= nj < m and grid[ni][nj] == arrow_symbol:
+                ray_length += 1
+                ni += di
+                nj += dj
+            
+            count += ray_length
+        
+        return count 
+    
+    def extract_answer(self, test_solution: str) -> str:
+            """
+            从模型的回答中提取答案
+            
+            @param test_solution: 模型的完整回答
+            @return: 提取的答案 (JSON格式的二维数组)
+            """
+            if not test_solution:
+                return ""
+            # 尝试匹配Python代码块
+            import re
+            code_block_patterns = [
+                r'```python\s*\n(.*?\[.*?\].*?)\n```',  # 标准Python代码块
+                r'```\s*\n(.*?\[.*?\].*?)\n```',       # 无语言标记的代码块
+                r'```(.*?\[.*?\].*?)```'               # 无换行的代码块
+            ]
+            
+            for pattern in code_block_patterns:
+                matches = re.findall(pattern, test_solution, re.DOTALL)
+                if matches:
+                    # 获取最后一个匹配项
+                    code_block = matches[-1].strip()
+                    try:
+                        # 尝试解析为Python列表
+                        grid = eval(code_block)
+                        # 验证格式是否为二维数组
+                        if isinstance(grid, list) and all(isinstance(row, list) for row in grid):
+                            return json.dumps(grid)
+                    except Exception as e:
+                        print(f"解析代码块失败: {e}")
+                        continue
+            
+            # 如果没有找到有效的代码块，尝试直接寻找列表
+            list_pattern = r'\[\s*\[.*?\]\s*\]'
+            matches = re.findall(list_pattern, test_solution, re.DOTALL)
+            if matches:
+                try:
+                    # 尝试解析为Python列表
+                    grid = eval(matches[-1])
+                    # 验证格式是否为二维数组
+                    if isinstance(grid, list) and all(isinstance(row, list) for row in grid):
+                        return json.dumps(grid)
+                except Exception as e:
+                    print(f"解析列表失败: {e}")
+            
+            # 如果上述方法都失败，返回空字符串
+            return ""

--- a/environments/synlogic/synlogic_src/games/tasks/boolean_expressions/scripts/boolean_expressions_verifier.py
+++ b/environments/synlogic/synlogic_src/games/tasks/boolean_expressions/scripts/boolean_expressions_verifier.py
@@ -1,0 +1,54 @@
+import re
+from base.data import Data
+from base.verifier import Verifier
+    
+class BooleanExpressionsVerifier(Verifier):
+    """
+    验证器用于布尔表达式游戏的答案是否正确
+    """
+    def verify(self, data: Data, test_answer: str):
+        try:
+            test_answer = self.extract_answer(test_answer)
+            if test_answer is None:
+                return False
+            # 提取所有字母（a-z和A-Z）
+            test_answer_letters = re.findall(r'[a-zA-Z]', test_answer)
+            ground_truth_letters = re.findall(r'[a-zA-Z]', data.answer)
+            test_answer_letters = self.lower(test_answer_letters)
+            ground_truth_letters = self.lower(ground_truth_letters)
+            # 转换为集合进行比较
+            test_set = set(test_answer_letters)
+            ground_truth_set = set(ground_truth_letters)
+            
+            return test_set == ground_truth_set
+        except Exception as e:
+            print(e)
+            return False
+
+    def lower(self, answer_list):
+        return [answer.lower() for answer in answer_list]
+    def extract_answer(self, answer_str):
+        # 先找到最后一个\boxed{的位置
+        last_box_index = answer_str.rfind("\\boxed{")
+        
+        if last_box_index == -1:
+            return None
+        
+        # 从\boxed{开始截取到正确的闭合位置，处理嵌套括号
+        start_index = last_box_index + len("\\boxed{")
+        bracket_stack = 1  # 已经遇到了一个左括号
+        end_index = start_index
+        
+        while end_index < len(answer_str) and bracket_stack > 0:
+            if answer_str[end_index] == '{':
+                bracket_stack += 1
+            elif answer_str[end_index] == '}':
+                bracket_stack -= 1
+            end_index += 1
+        
+        if bracket_stack != 0:  # 括号不匹配
+            return None
+        
+        # 提取\boxed{}内的内容
+        latex_content = answer_str[start_index:end_index-1].strip()
+        return latex_content

--- a/environments/synlogic/synlogic_src/games/tasks/buggy_tables/scripts/game_of_buggy_tables_verifier.py
+++ b/environments/synlogic/synlogic_src/games/tasks/buggy_tables/scripts/game_of_buggy_tables_verifier.py
@@ -1,0 +1,126 @@
+from base.data import Data
+from base.verifier import Verifier, THOUGHT_DELIMITER_START, THOUGHT_DELIMITER_END
+import re
+
+class BuggyTableVerifier(Verifier):
+    """
+    Verifier for the BuggyTable game.
+    Checks if the submitted answer matches the expected answer.
+    """
+    def extract_answer(self, answer: str) -> str:
+        """
+        Public method to extract and normalize an answer string from LLM output.
+        Delegates to the private _extract_answer method.
+        
+        @param answer: The answer string to normalize
+        @return: The normalized answer string
+        """
+        return self._extract_answer(answer)
+
+    def verify(self, data: Data, test_answer: str) -> bool:
+        """
+        Verify whether the test answer is consistent with the expected answer
+        for the buggy table query.
+        
+        @param data: Data object containing the expected answer
+        @param test_answer: The answer provided by the LLM to verify
+        @return: bool indicating whether the answer is correct
+        """
+        # Extract the expected answer from the Data object
+        expected_answer = data.answer if data and hasattr(data, 'answer') else ""
+        
+        # For empty strings, compare directly
+        if not expected_answer and not test_answer:
+            return True
+            
+        # Extract and normalize both answers
+        normalized_expected = self._extract_answer(expected_answer)
+        normalized_test = self._extract_answer(test_answer)
+        
+        # Direct comparison of normalized answers
+        return normalized_expected == normalized_test
+        
+    def _is_raw_numeric_answer(self, value: str) -> bool:
+        """
+        Check if a string represents a plain numeric answer without additional context.
+        This is used to validate raw input format.
+        
+        @param value: The string to check
+        @return: True if the string is a simple numeric value
+        """
+        # Remove whitespace
+        value = value.strip()
+        
+        # Simple pattern match for a number (optionally with sign and decimal point)
+        import re
+        return bool(re.match(r'^-?\d+(\.\d+)?$', value))
+        
+    def _raw_has_exactly_two_decimals(self, value: str) -> bool:
+        """
+        Check if a raw numeric string has exactly 2 decimal places.
+        This is used to validate the format of the raw answer.
+        
+        @param value: The string to check
+        @return: True if the string has exactly 2 decimal places
+        """
+        # Remove whitespace
+        value = value.strip()
+        
+        # Split on decimal point
+        parts = value.replace('-', '', 1).split('.')
+        
+        # Check if there is exactly one decimal point and two digits after it
+        return len(parts) == 2 and len(parts[1]) == 2
+    
+    def _is_numeric(self, value: str) -> bool:
+        """
+        Check if a string represents a valid number (including negative numbers and decimals).
+        
+        @param value: The string to check
+        @return: True if the string represents a valid number
+        """
+        # Remove negative sign if present
+        value = value.strip()
+        if value.startswith('-'):
+            value = value[1:]
+        # Check if remaining string is a valid decimal number
+        return value.replace('.', '', 1).isdigit()
+    
+    def _has_exactly_two_decimals(self, value: str) -> bool:
+        """
+        Check if a number string has exactly 2 decimal places.
+        
+        @param value: The number string to check
+        @return: True if the number has exactly 2 decimal places
+        """
+        # Remove negative sign if present
+        value = value.strip()
+        if value.startswith('-'):
+            value = value[1:]
+            
+        # Split into whole and decimal parts
+        parts = value.split('.')
+        if len(parts) != 2:
+            return False
+            
+        # Check if decimal part has exactly 2 digits
+        return len(parts[1]) == 2
+    
+    def _extract_answer(self, answer: str) -> str:
+        """
+        Extract and normalize an answer string from LLM output.
+        Only finds values with exactly two decimal places.
+        
+        @param answer: The answer string to normalize
+        @return: The normalized answer string
+        """
+        # Convert to string and normalize
+        normalized = str(answer).strip() if answer is not None else ""
+        
+        # Try to find numbers with exactly two decimal places
+        exact_matches = re.findall(r'-?\d+\.\d{2}\b', normalized)
+        if exact_matches:
+            return exact_matches[-1]  # Return the last match with exactly two decimals
+            
+        # If no exact two-decimal match found, return the original string
+        return normalized

--- a/environments/synlogic/synlogic_src/games/tasks/calcudoko/scripts/calcudoko_verifier.py
+++ b/environments/synlogic/synlogic_src/games/tasks/calcudoko/scripts/calcudoko_verifier.py
@@ -1,0 +1,444 @@
+from base.data import Data
+from base.verifier import Verifier
+import numpy as np
+from typing import List, Dict
+import re
+
+class CalcudokoVerifier(Verifier):
+    """
+    Calcudoko 游戏的验证器
+    """
+    
+    def extract_answer(self, test_solution: str):
+        """
+        从模型的回答中提取数独解答
+        
+        @param test_solution: 模型的完整回答
+        @return: 提取的答案 (元组形式的字符串)
+        """
+        if not test_solution:
+            return ""
+            
+        # 提取Python代码块中的内容
+        code_block_pattern = r"```python\s*([\s\S]*?)\s*```"
+        matches = re.findall(code_block_pattern, test_solution)
+        
+        if matches:
+            # 取最后一个Python代码块
+            python_code = matches[-1].strip()
+            return python_code
+            
+        # 如果没有找到Python代码块，尝试找到任何类似于元组的结构
+        tuple_pattern = r"\(\s*\(\s*\d+\s*,.*?\)\s*\)"
+        matches = re.findall(tuple_pattern, test_solution, re.DOTALL)
+        
+        if matches:
+            return matches[-1].strip()
+            
+        # 如果上面都没找到，直接返回原始答案
+        return test_solution
+    
+    def parse_grid_from_answer(self, test_solution: str, data: Data) -> np.ndarray:
+        """
+        从模型的回答中解析出网格数据
+        
+        @param test_solution: 模型的完整回答
+        @param data: 包含问题、元数据等信息的Data对象
+        @return: numpy数组形式的网格
+        """
+        try:
+            # 从data中获取grid_size
+            grid_size = data.metadata.get("grid_size", 4)  # 默认为4
+            
+            # 先提取答案
+            answer = self.extract_answer(test_solution)
+            
+            # 查找[[...]]格式的答案
+            bracket_pattern = r'\[\[(.*?)\]\]'
+            bracket_match = re.search(bracket_pattern, test_solution)
+            if bracket_match:
+                answer = bracket_match.group(1)
+                print(f"从双括号中提取的答案: {answer}")
+            
+            # 清理字符串，只保留必要字符
+            answer = ''.join(c for c in answer if c.isdigit() or c in '[],' or c.isspace())
+            
+            # 标准化分隔符
+            answer = answer.replace('，', ',')  # 中文逗号转英文逗号
+            
+            # 去掉最外层的括号
+            answer = answer.strip('[]')
+            
+            # 分割成行
+            rows = [row.strip() for row in answer.split(',')]
+            
+            # 转换成数字网格
+            grid = []
+            for row in rows:
+                # 分割并转换成整数
+                numbers = [int(n) for n in row.split() if n.strip()]
+                if len(numbers) != grid_size:
+                    # 尝试修复长度不正确的行
+                    print(f"警告: 行长度不正确 {len(numbers)} != {grid_size}, 尝试修复...")
+                    # 如果长度小于grid_size，尝试查找更多数字
+                    if len(numbers) < grid_size:
+                        # 在原始答案中查找类似于 "第x行：1 2 3 4 5" 的行描述
+                        row_patterns = [
+                            r'第\s*\d+\s*行\s*[:：]\s*([\d\s]+)', 
+                            r'行\s*\d+\s*[:：]\s*([\d\s]+)',
+                            r'Row\s*\d+\s*[:：]\s*([\d\s]+)',
+                            r'- 第\d+行[:：]?\s*([\d\s]+)',
+                            r'- 行\d+[:：]?\s*([\d\s]+)',
+                            r'- Row\d+[:：]?\s*([\d\s]+)'
+                        ]
+                        
+                        found_rows = []
+                        for pattern in row_patterns:
+                            matches = re.findall(pattern, test_solution)
+                            if matches:
+                                found_rows.extend(matches)
+                        
+                        print(f"找到的可能行: {found_rows}")
+                        
+                        if len(found_rows) == grid_size:
+                            # 如果找到的行数正好等于grid_size，使用这些行
+                            print("使用找到的行描述作为网格数据")
+                            grid = []
+                            for found_row in found_rows:
+                                numbers = [int(n) for n in found_row.split() if n.strip()]
+                                if len(numbers) != grid_size:
+                                    print(f"警告: 找到的行长度仍不正确: {len(numbers)} != {grid_size}")
+                                    # 如果长度不正确，填充或截断
+                                    if len(numbers) < grid_size:
+                                        numbers.extend([1] * (grid_size - len(numbers)))
+                                    else:
+                                        numbers = numbers[:grid_size]
+                                grid.append(numbers)
+                            break  # 成功处理，退出循环
+                    
+                    # 填充或截断使长度正确
+                    if len(numbers) < grid_size:
+                        numbers.extend([1] * (grid_size - len(numbers)))
+                    else:
+                        numbers = numbers[:grid_size]
+                
+                grid.append(numbers)
+            
+            # 检查行数
+            if len(grid) != grid_size:
+                print(f"警告: 列数不正确: {len(grid)} != {grid_size}, 尝试修复...")
+                # 如果行数小于grid_size，添加默认行
+                if len(grid) < grid_size:
+                    for _ in range(grid_size - len(grid)):
+                        grid.append([1] * grid_size)
+                else:
+                    # 如果行数大于grid_size，截断
+                    grid = grid[:grid_size]
+            
+            return np.array(grid)
+            
+        except Exception as e:
+            print(f"解析答案时出错: {str(e)}")
+            import traceback
+            traceback.print_exc()
+            
+            # 尝试直接搜索[[...]]格式
+            try:
+                bracket_pattern = r'\[\[(.*?)\]\]'
+                bracket_match = re.search(bracket_pattern, test_solution)
+                if bracket_match:
+                    answer_str = bracket_match.group(1)
+                    rows = answer_str.split(',')
+                    grid = []
+                    for row in rows:
+                        numbers = [int(n) for n in row.split() if n.strip()]
+                        if len(numbers) != grid_size:
+                            if len(numbers) < grid_size:
+                                numbers.extend([1] * (grid_size - len(numbers)))
+                            else:
+                                numbers = numbers[:grid_size]
+                        grid.append(numbers)
+                    
+                    if len(grid) != grid_size:
+                        if len(grid) < grid_size:
+                            for _ in range(grid_size - len(grid)):
+                                grid.append([1] * grid_size)
+                        else:
+                            grid = grid[:grid_size]
+                    
+                    print(f"已解析出最后的网格:\n{np.array(grid)}")
+                    return np.array(grid)
+            except:
+                pass
+            
+            # 最终失败，返回默认网格
+            print("无法解析答案，使用默认网格")
+            return np.array([[i % grid_size + 1 for i in range(grid_size)] for _ in range(grid_size)])
+    
+    def verify(self, data: Data, test_answer: str) -> bool:
+        """
+        验证模型的回答是否正确
+        
+        @param data: 包含问题、元数据等信息的Data对象
+        @param test_answer: 模型给出的答案字符串
+        @return: 回答是否正确的布尔值
+        """
+        try:
+            # 从元数据中获取必要信息
+            grid_size = data.metadata.get("grid_size", 4)  # 默认为4
+            regions = data.metadata.get("regions", [])
+            
+            print(f"验证: 网格大小 = {grid_size}x{grid_size}, 区域数量 = {len(regions)}")
+            print(f"验证: 模型答案='{test_answer[:100]}...'")
+            
+            # 从答案中提取网格
+            try:
+                grid = self.parse_grid_from_answer(test_answer, data)
+                print(f"提取的网格:\n{grid}")
+            except Exception as e:
+                print(f"验证结果: 错误 - 无法提取网格: {str(e)}")
+                return False
+            
+            # 验证数独规则
+            print("验证数独规则...")
+            # 检查每一行
+            for i, row in enumerate(grid):
+                if len(set(row)) != grid_size:
+                    print(f"验证结果: 错误 - 第{i+1}行包含重复数字: {row}")
+                    return False
+                if not all(1 <= n <= grid_size for n in row):
+                    print(f"验证结果: 错误 - 第{i+1}行包含超出范围的数字: {row}")
+                    return False
+                    
+            # 检查每一列
+            for i, col in enumerate(grid.T):
+                if len(set(col)) != grid_size:
+                    print(f"验证结果: 错误 - 第{i+1}列包含重复数字: {col}")
+                    return False
+                if not all(1 <= n <= grid_size for n in col):
+                    print(f"验证结果: 错误 - 第{i+1}列包含超出范围的数字: {col}")
+                    return False
+            
+            # 验证区域规则
+            print("验证区域规则...")
+            for i, region in enumerate(regions):
+                print(f"检查区域 {i+1}: {region}")
+                # 获取区域中的单元格
+                cells = region["cells"]
+                numbers = []
+                
+                # 提取数字
+                for cell in cells:
+                    try:
+                        if isinstance(cell, str):
+                            match = re.search(r'\((\d+)\s*,\s*(\d+)\)', cell)
+                            if match:
+                                r,c =  (int(match.group(1)), int(match.group(2)))
+                                
+                        # r, c = cell  # cell已经是元组了，直接解包
+                        # 转换为0基索引
+                        r, c = r-1, c-1
+                        # 检查坐标是否有效
+                        if r < 0 or r >= grid_size or c < 0 or c >= grid_size:
+                            print(f"无效坐标: {r+1},{c+1}")
+                            return False
+                        numbers.append(grid[r][c])
+                    except Exception as e:
+                        print(f"提取数字时出错: {str(e)}")
+                        return False
+                
+                print(f"区域 {i+1} 中的数字: {numbers}")
+                
+                # 检查数字是否有效（1到grid_size）
+                if not all(1 <= n <= grid_size for n in numbers):
+                    print(f"区域中有无效数字: {numbers}")
+                    return False
+                
+                # 检查区域内数字是否唯一
+                if len(set(numbers)) != len(numbers):
+                    print(f"区域中有重复数字: {numbers}")
+                    return False
+                
+                # 检查数字是否满足运算规则
+                target = region["target"]
+                operator = region["operator"]
+                
+                try:
+                    if operator == '+':
+                        result = sum(numbers)
+                        valid = (result == target)
+                        print(f"加法验证: {numbers} = {result}, 目标 = {target}, 结果: {'通过' if valid else '失败'}")
+                        if not valid:
+                            return False
+                    elif operator == '-':
+                        if len(numbers) != 2:
+                            print(f"减法操作数数量无效: {len(numbers)}")
+                            return False
+                        result1 = numbers[0] - numbers[1]
+                        result2 = numbers[1] - numbers[0]
+                        valid = (result1 == target or result2 == target)
+                        print(f"减法验证: {numbers[0]}-{numbers[1]}={result1} 或 {numbers[1]}-{numbers[0]}={result2}, 目标 = {target}, 结果: {'通过' if valid else '失败'}")
+                        if not valid:
+                            return False
+                    elif operator == '*':
+                        result = np.prod(numbers)
+                        valid = (result == target)
+                        print(f"乘法验证: {numbers} = {result}, 目标 = {target}, 结果: {'通过' if valid else '失败'}")
+                        if not valid:
+                            return False
+                    else:  # division
+                        if len(numbers) != 2:
+                            print(f"除法操作数数量无效: {len(numbers)}")
+                            return False
+                        if numbers[0] == 0 or numbers[1] == 0:
+                            print(f"除数为零: {numbers}")
+                            return False
+                        result1 = numbers[0] / numbers[1]
+                        result2 = numbers[1] / numbers[0]
+                        valid = (abs(result1 - target) < 0.001 or abs(result2 - target) < 0.001)
+                        print(f"除法验证: {numbers[0]}÷{numbers[1]}={result1} 或 {numbers[1]}÷{numbers[0]}={result2}, 目标 = {target}, 结果: {'通过' if valid else '失败'}")
+                        if not valid:
+                            return False
+                except Exception as e:
+                    print(f"检查运算时出错: {str(e)}")
+                    return False
+            
+            print("验证结果: 正确")
+            return True
+            
+        except Exception as e:
+            print(f"验证时出错: {e}")
+            import traceback
+            traceback.print_exc()
+            return False
+
+def main():
+    import argparse
+    import json
+    import os
+    
+    parser = argparse.ArgumentParser(description='Verify Calcudoko solutions')
+    parser.add_argument('--grid_size', type=int, default=4, help='Size of the grid (N)')
+    parser.add_argument('--input_file', type=str, required=True, help='Path to the input JSONL file')
+    parser.add_argument('--output_file', type=str, help='Path to save valid samples (optional)')
+    args = parser.parse_args()
+    
+    # Initialize verifier
+    verifier = CalcudokoVerifier()
+    
+    total_puzzles = 0
+    valid_answers = 0
+    invalid_answers = 0
+    valid_samples = []  # 用于存储有效样本
+    
+    def parse_regions_from_text(text):
+        """从文本中解析regions信息"""
+        regions = []
+        # 查找Regions:后面的内容
+        regions_text = re.search(r'Regions:\n(.*?)(?:\n\n|$)', text, re.DOTALL)
+        if regions_text:
+            for line in regions_text.group(1).strip().split('\n'):
+                if line.strip():
+                    # 解析每个region
+                    cells_part, target = line.split(':')
+                    # 使用正则表达式提取所有坐标对
+                    cells = re.findall(r'\((\d+),(\d+)\)', cells_part)
+                    # 将字符串转换为整数元组
+                    cells = [tuple(map(int, pair)) for pair in cells]
+                    # 处理target部分
+                    target_value, operator = target[:-1], target[-1]
+                    regions.append({
+                        'cells': cells,
+                        'target': int(target_value),
+                        'operator': operator
+                    })
+        return regions
+    
+    try:
+        with open(args.input_file, 'r') as f:
+            for line in f:
+                try:
+                    data = json.loads(line)
+                    total_puzzles += 1
+                    
+                    # 尝试从不同位置获取regions信息
+                    regions = None
+                    if 'regions' in data:
+                        regions = data['regions']
+                    elif 'regions' in data['metadata']:
+                        regions = data['metadata']['regions']
+                    elif 'question_data' in data:
+                        question_data = json.loads(data['question_data'])
+                        if 'regions' in question_data:
+                            regions = question_data['regions']
+                    elif 'question' in data:
+                        regions = parse_regions_from_text(data['question'])
+                    
+                    if not regions:
+                        print(f"错误 - 无法找到regions信息")
+                        continue
+                    
+                    # 获取答案
+                    answer = data.get('answer', '')
+                    if not answer:
+                        print(f"错误 - 无法找到答案")
+                        continue
+                    
+                    # 构造Data对象
+                    data_obj = Data(
+                        question=data['question'],
+                        answer=answer,  # 添加 answer 参数
+                        metadata={'grid_size': args.grid_size, 'regions': regions}
+                    )
+                    
+                    # 验证答案
+                    is_valid = verifier.verify(data_obj, answer)
+                    if is_valid:
+                        valid_answers += 1
+                        # 将有效样本添加到列表中
+                        valid_samples.append(data)
+                    else:
+                        invalid_answers += 1
+                        print(f"验证失败 - 答案不符合规则")
+                        print(f"模型答案: {answer}")
+                        print(f"区域规则: {regions}\n")
+                    
+                except Exception as e:
+                    print(f"处理答案时出错: {str(e)}")
+                    invalid_answers += 1
+                    
+    except Exception as e:
+        print(f"读取文件时出错: {str(e)}")
+        return
+    
+    # 保存有效样本
+    if args.output_file:
+        output_dir = os.path.dirname(args.output_file)
+        if output_dir and not os.path.exists(output_dir):
+            os.makedirs(output_dir)
+            
+        print(f"\n保存有效样本到: {args.output_file}")
+        with open(args.output_file, 'w', encoding='utf-8') as f:
+            for sample in valid_samples:
+                json.dump(sample, f, ensure_ascii=False)
+                f.write('\n')
+        print(f"成功保存 {len(valid_samples)} 个有效样本")
+    
+    # 输出统计信息
+    print("\n结果统计:")
+    print(f"总题目数: {total_puzzles}")
+    print(f"有效答案数: {valid_answers}")
+    print(f"无效答案数: {invalid_answers}")
+    print(f"通过率: {(valid_answers/total_puzzles*100):.2f}%")
+
+if __name__ == "__main__":
+    main() 
+    # response =  "[[2 3 4 6 1 5,1 2 3 4 5 6,3 1 2 5 6 4,4 5 6 1 2 3,5 6 1 3 4 2,6 4 5 2 3 1]]"
+    # metadata = {"grid_size": 6, "regions": [{"cells": ["(2,1)", "(1,1)", "(1,2)"], "target": 6, "operator": "*"}, {"cells": ["(3,5)", "(3,6)"], "target": 2, "operator": "-"}, {"cells": ["(1,5)", "(2,5)"], "target": 5, "operator": "÷"}, {"cells": ["(4,5)", "(4,4)"], "target": 2, "operator": "÷"}, {"cells": ["(5,6)", "(5,5)", "(6,5)"], "target": 9, "operator": "+"}, {"cells": ["(3,3)", "(2,3)", "(2,4)", "(3,4)"], "target": 120, "operator": "*"}, {"cells": ["(1,3)", "(1,4)"], "target": 2, "operator": "-"}, {"cells": ["(2,6)", "(1,6)"], "target": 1, "operator": "-"}, {"cells": ["(3,2)", "(3,1)", "(4,1)", "(5,1)"], "target": 60, "operator": "*"}, {"cells": ["(5,3)", "(5,2)", "(6,2)"], "target": 11, "operator": "+"}, {"cells": ["(5,4)", "(6,4)", "(6,3)"], "target": 10, "operator": "+"}, {"cells": ["(4,2)", "(4,3)"], "target": 1, "operator": "-"}, {"cells": ["(6,1)", "(2,2)"], "target": 3, "operator": "÷"}, {"cells": ["(6,6)", "(4,6)"], "target": 2, "operator": "-"}]}
+    # testClass = CalcudokoVerifier()
+    # dataClass = Data(question="", answer="")
+    # dataClass.metadata = metadata
+
+    # test_answer = testClass.parse_grid_from_answer(test_solution=response, data=dataClass)
+    # print(test_answer)
+    # print(testClass.verify(data=dataClass, test_answer=response))

--- a/environments/synlogic/synlogic_src/games/tasks/campsite/scripts/campsite_verifier.py
+++ b/environments/synlogic/synlogic_src/games/tasks/campsite/scripts/campsite_verifier.py
@@ -1,0 +1,183 @@
+from base.data import Data
+from base.verifier import Verifier
+import re
+import ast
+from typing import List, Set, Tuple, Dict
+
+
+class CampsiteVerifier(Verifier):
+    """
+    Verifier for Campsite game
+    """
+    def verify(self, data: Data, test_solution: str):
+        try:
+            test_answer = self.extract_answer(test_solution)
+            original_grid = data.metadata["grid"]
+            row_constraints = data.metadata["row_constraints"]
+            col_constraints = data.metadata["col_constraints"]
+            n = data.metadata["n"]
+            m = data.metadata["m"]
+            
+            if not test_answer:
+                return False
+            
+            if len(test_answer) != n or any(len(row) != m for row in test_answer):
+                return False
+            
+            if not self._check_trees_unchanged(original_grid, test_answer):
+                return False
+            
+            if not self._check_row_constraints(test_answer, row_constraints):
+                return False
+            
+            if not self._check_col_constraints(test_answer, col_constraints):
+                return False
+            
+            if not self._check_tents_not_adjacent(test_answer):
+                return False
+            
+            if not self._check_tent_tree_matching(test_answer):
+                return False
+            
+            return True
+            
+        except Exception as e:
+            print(f"Verification error: {e}")
+            return False
+    
+    def _extract_grid(self, test_answer: str) -> List[List[str]]:
+        """从回答中提取网格"""
+        grid_pattern = r'\[\s*\[.*?\]\s*\]'
+        match = re.search(grid_pattern, test_answer, re.DOTALL)
+        if match:
+            try:
+                grid_str = match.group(0)
+                return ast.literal_eval(grid_str)
+            except:
+                pass
+        
+        return None
+    
+    def _check_trees_unchanged(self, original_grid: List[List[str]], test_answer: List[List[str]]) -> bool:
+        """检查树木位置是否保持不变"""
+        for i in range(len(original_grid)):
+            for j in range(len(original_grid[0])):
+                if original_grid[i][j] == 'T' and test_answer[i][j] != 'T':
+                    return False
+                if original_grid[i][j] != 'T' and test_answer[i][j] == 'T':
+                    return False
+        return True
+    
+    def _check_row_constraints(self, grid: List[List[str]], row_constraints: List[int]) -> bool:
+        """检查行约束条件"""
+        for i in range(len(grid)):
+            tent_count = sum(1 for cell in grid[i] if cell == 'C')
+            if tent_count != row_constraints[i]:
+                return False
+        return True
+    
+    def _check_col_constraints(self, grid: List[List[str]], col_constraints: List[int]) -> bool:
+        """检查列约束条件"""
+        for j in range(len(grid[0])):
+            tent_count = sum(1 for i in range(len(grid)) if grid[i][j] == 'C')
+            if tent_count != col_constraints[j]:
+                return False
+        return True
+    
+    def _check_tents_not_adjacent(self, grid: List[List[str]]) -> bool:
+        """检查帐篷之间是否相邻（包括对角线）"""
+        n = len(grid)
+        m = len(grid[0]) if n > 0 else 0
+        
+        for i in range(n):
+            for j in range(m):
+                if grid[i][j] == 'C':
+                    # 检查周围8个方向是否有其他帐篷
+                    for di in [-1, 0, 1]:
+                        for dj in [-1, 0, 1]:
+                            if di == 0 and dj == 0:
+                                continue
+                            ni, nj = i + di, j + dj
+                            if 0 <= ni < n and 0 <= nj < m and grid[ni][nj] == 'C':
+                                return False
+        
+        return True
+    
+    def _check_tent_tree_matching(self, grid: List[List[str]]) -> bool:
+        """
+        检查帐篷与树木的一一匹配关系:
+        1. 每个帐篷必须与一棵树正交相邻
+        2. 每棵树只能与一个帐篷匹配
+        3. 每个帐篷只能与一棵树匹配
+        4. 帐篷和树的数量必须相等
+        """
+        n = len(grid)
+        m = len(grid[0]) if n > 0 else 0
+        
+        tents = []
+        trees = []
+        for i in range(n):
+            for j in range(m):
+                if grid[i][j] == 'C':
+                    tents.append((i, j))
+                elif grid[i][j] == 'T':
+                    trees.append((i, j))
+        
+        if len(tents) != len(trees):
+            return False
+        
+        tent_to_trees = {}
+        tree_to_tents = {}
+        
+        for tent_i, tent_j in tents:
+            tent_to_trees[(tent_i, tent_j)] = []
+            for di, dj in [(0, 1), (1, 0), (0, -1), (-1, 0)]:
+                tree_i, tree_j = tent_i + di, tent_j + dj
+                if 0 <= tree_i < n and 0 <= tree_j < m and grid[tree_i][tree_j] == 'T':
+                    tent_to_trees[(tent_i, tent_j)].append((tree_i, tree_j))
+        
+        for tree_i, tree_j in trees:
+            tree_to_tents[(tree_i, tree_j)] = []
+            for di, dj in [(0, 1), (1, 0), (0, -1), (-1, 0)]:
+                tent_i, tent_j = tree_i + di, tree_j + dj
+                if 0 <= tent_i < n and 0 <= tent_j < m and grid[tent_i][tent_j] == 'C':
+                    tree_to_tents[(tree_i, tree_j)].append((tent_i, tent_j))
+        
+        for tent in tents:
+            if not tent_to_trees[tent]:
+                return False
+        
+        tent_matched = {}
+        tree_matched = {}
+        
+        def dfs(tent):
+            for tree in tent_to_trees[tent]:
+                if tree in visited:
+                    continue
+                visited.add(tree)
+                
+                if tree not in tree_matched or dfs(tree_matched[tree]):
+                    tent_matched[tent] = tree
+                    tree_matched[tree] = tent
+                    return True
+            return False
+        
+        for tent in tents:
+            visited = set()
+            if tent not in tent_matched:
+                if not dfs(tent):
+                    return False
+        
+        return len(tent_matched) == len(tents) and len(tree_matched) == len(trees)
+    
+    def extract_answer(self, test_solution: str):
+        """从模型回答中提取解决方案"""
+        grid_pattern = r'\[\s*\[.*?\]\s*\]'
+        match = re.search(grid_pattern, test_solution, re.DOTALL)
+        if match:
+            try:
+                grid_str = match.group(0)
+                return ast.literal_eval(grid_str)
+            except:
+                pass
+        return ""

--- a/environments/synlogic/synlogic_src/games/tasks/cipher/scripts/cipher_verifier.py
+++ b/environments/synlogic/synlogic_src/games/tasks/cipher/scripts/cipher_verifier.py
@@ -1,0 +1,28 @@
+from base.data import Data
+from base.verifier import Verifier, THOUGHT_DELIMITER_START, THOUGHT_DELIMITER_END
+import re
+
+import json
+
+class CipherVerifier(Verifier):
+    """
+    Verifier for Cipher
+    """
+    def verify(self, data: Data, test_solution: str):
+        """The scoring function for cipher.
+        """
+        try:
+            answer = self.extract_answer(test_solution)
+            answer = answer.split("```python")[-1].split("```")[0].strip()
+            answer = eval(answer)
+            gold_answer = data.answer
+            gold_answer = [[gold_answer[2:-2]]]
+            if answer == gold_answer:
+                return 1.0
+            else:
+                return 0.0
+        except Exception as e:
+            return 0.0
+    
+    def extract_answer(self, test_solution: str):
+        return test_solution

--- a/environments/synlogic/synlogic_src/games/tasks/cryptarithm/scripts/cryptarithm_verifier.py
+++ b/environments/synlogic/synlogic_src/games/tasks/cryptarithm/scripts/cryptarithm_verifier.py
@@ -1,0 +1,134 @@
+import re
+from base.data import Data
+from base.verifier import Verifier, THOUGHT_DELIMITER_START, THOUGHT_DELIMITER_END
+
+
+
+    
+class CryptarithmVerifier(Verifier):
+    """
+    验证器用于检查密码算术游戏的答案是否正确
+    """
+    def verify(self, data: Data, test_solution: str):
+        """
+        验证模型的回答是否正确
+        
+        @param data: 包含问题、元数据等信息的Data对象
+        @param test_answer: 模型给出的回答字符串
+        @return: 回答是否正确的布尔值
+        """
+        try:
+            test_answer = self.extract_answer(test_solution)
+            # 获取元数据中的正确答案
+            correct_answer = data.answer
+            
+            print(f"验证: 模型答案='{test_answer}', 正确答案='{correct_answer}'")
+            
+            # 清理答案字符串
+            test_answer = test_answer.strip()
+            
+            # 标准化等式格式（移除空格）
+            test_answer = test_answer.replace(" ", "")
+            correct_answer = correct_answer.replace(" ", "")
+            
+            # 检查答案是否完全匹配
+            is_correct = (test_answer == correct_answer)
+            
+            if is_correct:
+                print("验证结果: 正确")
+            else:
+                print("验证结果: 错误")
+                
+            return is_correct
+            
+        except Exception as e:
+            print(f"验证时出错: {e}")
+            return False 
+        
+    def extract_answer(self, test_solution: str):
+        """
+        从模型的回答中提取答案
+        
+        @param test_solution: 模型的完整回答
+        @return: 提取的答案
+        """
+        if not test_solution:
+            return ""
+        # 首先规范化空格和其他格式
+        # 处理全大写的情况
+        test_solution = test_solution.replace("THE ANSWER IS", "The answer is")
+        test_solution = test_solution.replace("答案是：", "答案是:")
+        test_solution = test_solution.replace("答案：", "答案:")
+        
+        # 尝试匹配数字等式模式（支持多个操作符和负数）
+        # 例如：123 + 456 = 579 或 12 + 34 - 5 = 41 或 123 + 456 - 789 = -210
+        equation_patterns = [
+            r'(\d+(?:\s*(?:\+|\-|\*)\s*\d+)+\s*=\s*-?\d+)',  # 匹配包含多个操作符的等式，结果可能为负
+            r'(\d+(?:\s*(?:\+|\-|\*)\s*\d+)+\s*=\s*-?\d+)[.。]*$',  # 结尾的等式，结果可能为负
+            r'(\d+\s*(?:\+|\-|\*)\s*\d+\s*=\s*-?\d+)'  # 匹配简单等式，结果可能为负
+        ]
+        
+        for pattern in equation_patterns:
+            matches = re.findall(pattern, test_solution)
+            if matches:
+                # 取最后一个匹配结果
+                return matches[-1].strip()
+        
+        # 中文答案提取模式
+        cn_patterns = [
+            r'答案是[：:]\s*([0-9\s\+\-\*=]+)[.。]*$',
+            r'答案[：:]\s*([0-9\s\+\-\*=]+)[.。]*$',
+            r'我的答案是[：:]\s*([0-9\s\+\-\*=]+)[.。]*$',
+            r'正确答案[：:]\s*([0-9\s\+\-\*=]+)[.。]*$',
+            r'数字等式是[：:]\s*([0-9\s\+\-\*=]+)[.。]*$',
+            r'数字等式为[：:]\s*([0-9\s\+\-\*=]+)[.。]*$',
+            r'等式为[：:]\s*([0-9\s\+\-\*=]+)[.。]*$',
+            r'等式是[：:]\s*([0-9\s\+\-\*=]+)[.。]*$',
+            r'结果是[：:]\s*([0-9\s\+\-\*=]+)[.。]*$',
+            r'结果为[：:]\s*([0-9\s\+\-\*=]+)[.。]*$'
+        ]
+        
+        # 英文答案提取模式
+        en_patterns = [
+            r'[Tt]he answer is[：:=]\s*([0-9\s\+\-\*=]+)[.。]*$',
+            r'[Tt]he answer[：:=]\s*([0-9\s\+\-\*=]+)[.。]*$',
+            r'[Aa]nswer[：:=]\s*([0-9\s\+\-\*=]+)[.。]*$',
+            r'[Mm]y answer is[：:=]\s*([0-9\s\+\-\*=]+)[.。]*$',
+            r'[Tt]he final answer is[：:=]\s*([0-9\s\+\-\*=]+)[.。]*$',
+            r'[Tt]he equation is[：:=]\s*([0-9\s\+\-\*=]+)[.。]*$',
+            r'[Tt]he result is[：:=]\s*([0-9\s\+\-\*=]+)[.。]*$',
+            r'[Tt]he numeric equation is[：:=]\s*([0-9\s\+\-\*=]+)[.。]*$',
+            r'[Tt]herefore,\s*([0-9\s\+\-\*=]+)[.。]*$',
+            r'[Ss]o,\s*([0-9\s\+\-\*=]+)[.。]*$'
+        ]
+        
+        # 尝试匹配所有模式
+        patterns = cn_patterns + en_patterns
+        
+        for pattern in patterns:
+            matches = re.findall(pattern, test_solution, re.DOTALL)
+            if matches:
+                answer = matches[-1].strip()
+                # 移除美元符号（常用于标记LaTeX数学表达式）和句号
+                answer = answer.replace("$", "").replace("。", "").replace(".", "")
+                
+                # 检查是否是有效等式（结果可能为负）
+                if re.match(r'\d+(?:\s*(?:\+|\-|\*)\s*\d+)+\s*=\s*-?\d+', answer):
+                    return answer
+                
+        # 如果上述模式都没有匹配到，尝试从最后一行提取等式
+        lines = test_solution.strip().split('\n')
+        for line in reversed(lines):  # 从最后一行开始向上查找
+            equation_match = re.search(r'\d+(?:\s*(?:\+|\-|\*)\s*\d+)+\s*=\s*-?\d+', line)
+            if equation_match:
+                return equation_match.group(0)
+        
+        # 尝试从文本中提取任何看起来像等式的内容
+        general_equation_pattern = r'\d+\s*(?:\+|\-|\*)\s*\d+\s*=\s*-?\d+'
+        all_equations = re.findall(general_equation_pattern, test_solution)
+        if all_equations:
+            # 返回最后一个找到的等式
+            return all_equations[-1]
+        
+        # 如果没有匹配到任何模式，返回空字符串
+        return ""

--- a/environments/synlogic/synlogic_src/games/tasks/dyck_language/scripts/dyck_language_verifier.py
+++ b/environments/synlogic/synlogic_src/games/tasks/dyck_language/scripts/dyck_language_verifier.py
@@ -1,0 +1,82 @@
+from base.data import Data
+from base.verifier import Verifier, THOUGHT_DELIMITER_START, THOUGHT_DELIMITER_END
+import re
+
+
+class DyckLanguageVerifier(Verifier):
+    """
+    验证器用于检查Dyck Language游戏的答案是否正确
+    """
+    def verify(self, data: Data, test_answer: str) -> bool:
+        """
+        验证模型的回答是否正确
+        
+        @param data: 包含问题、元数据等信息的Data对象
+        @param test_answer: 模型给出的回答字符串
+        @return: 回答是否正确的布尔值
+        """
+        try:
+            # 获取元数据中的完整序列
+            full_sequence = data.metadata["full_sequence"]
+            
+            print(f"验证: 模型答案='{test_answer}', 完整序列='{full_sequence}'")
+            
+            # 从模型回答中提取答案
+            extracted_answer = self.extract_answer(test_answer)
+            
+            # 检查答案是否完全匹配
+            is_correct = (extracted_answer == full_sequence)
+            
+            if is_correct:
+                print("验证结果: 正确")
+            else:
+                print("验证结果: 错误")
+                
+            return is_correct
+            
+        except Exception as e:
+            print(f"验证时出错: {e}")
+            return False 
+        
+    def extract_answer(self, test_solution: str) -> str:
+        """
+        从模型的回答中提取括号序列答案
+        
+        @param test_solution: 模型的完整回答
+        @return: 提取的答案
+        """
+        if not test_solution:
+            return ""
+        
+        # print(f"原始回答:\n{test_solution}")
+            
+        def clean_text(text: str) -> str:
+            """清理文本，处理转义字符和空白字符"""
+            # 移除所有空白字符（包括换行符、制表符等）
+            text = ''.join(text.split())
+            
+            # 处理转义序列
+            text = text.replace('\\n', '')
+            text = text.replace('\\t', '')
+            text = text.replace('\\r', '')
+            text = text.replace('\\\\', '\\')
+            
+            # 如果文本被引号包围，且引号不是括号序列的一部分，则移除外层引号
+            if len(text) >= 2:
+                if text.startswith('"') and text.endswith('"'):
+                    text = text[1:-1]
+                elif text.startswith("'") and text.endswith("'"):
+                    text = text[1:-1]
+            
+            return text
+        
+        return clean_text(test_solution)
+
+if __name__ == "__main__":
+    test_response = '''填写后的完整序列应为“([])({})([()])”。\n\n检查一下长度是否正确：\n\n原序列长度为11字符，补充3个字符，总长度14。\n\n这样，整个序列是合法的。\n</think>\n\n<answer>([])({})([()])</answer>'''
+    metadata = {"trace_id": "38aeede4-d5d7-4863-91d2-df1fd99f491b", "full_sequence": "([])({})([()])", "question_sequence": "([])({})([(", "n_types": 3, "total_length": 14, "fill_length": 3, "nesting_depth": 0}
+    test_data = Data(question="", answer="", metadata=metadata)
+    test_verifier = DyckLanguageVerifier()
+    extracted_answer = test_verifier.extract_answer(test_response)
+    print(extracted_answer)
+    print(test_verifier.verify(data=test_data, test_answer=test_response))

--- a/environments/synlogic/synlogic_src/games/tasks/dyck_language_errors/scripts/dyck_language_errors_verifier.py
+++ b/environments/synlogic/synlogic_src/games/tasks/dyck_language_errors/scripts/dyck_language_errors_verifier.py
@@ -1,0 +1,92 @@
+from base.data import Data
+from base.verifier import Verifier, THOUGHT_DELIMITER_START, THOUGHT_DELIMITER_END
+import re
+
+  
+class DyckLanguageErrorsVerifier(Verifier):
+    """
+    验证器用于检查括号闭合错误识别游戏的答案是否正确
+    """
+    def verify(self, data: Data, test_answer: str):
+        """
+        验证模型的回答是否正确
+        
+        @param data: 包含问题、元数据等信息的Data对象
+        @param test_answer: 模型给出的回答字符串
+        @return: 回答是否正确的布尔值
+        """
+        try:
+            test_answer = self.extract_answer(test_solution=test_answer)
+            # 获取正确答案
+            if data.metadata["is_valid"]:
+                correct_answer = "-1"  # 合法序列对应-1
+            else:
+                correct_answer = str(data.metadata["first_error_pos"])
+            
+            print(f"验证: 模型答案='{test_answer}', 正确答案='{correct_answer}'")
+            
+            # 清理和标准化答案
+            test_answer = test_answer.strip()
+            
+            # 检查-1答案（合法序列）
+            if correct_answer == "-1":
+                # 如果正确答案是-1（合法序列），只接受-1作为回答
+                if test_answer == "-1":
+                    is_correct = True
+                else:
+                    is_correct = False
+            else:
+                # 正确答案是位置数字，需要验证模型回答也是相同数字
+                try:
+                    is_correct = (int(test_answer) == int(correct_answer))
+                except (ValueError, TypeError):
+                    # 如果模型回答不是有效数字，验证失败
+                    is_correct = False
+            
+            if is_correct:
+                print("验证结果: 正确")
+            else:
+                print("验证结果: 错误")
+                
+            return is_correct
+            
+        except Exception as e:
+            print(f"验证时出错: {e}")
+            return False
+            
+    def extract_answer(self, test_solution: str):
+        """
+        从模型的回答中提取答案
+        
+        @param test_solution: 模型的完整回答
+        @return: 提取的答案
+        """
+        answer_str = test_solution
+        if answer_str is None:
+            import re 
+            # 清理回答文本
+            solution = test_solution.strip() if test_solution else ""
+            
+            # 提取所有数字（包括负数）
+            numbers = re.findall(r'-?\d+', solution)
+            if numbers:
+                # 优先返回"-1"（如果存在）
+                if "-1" in numbers:
+                    return "-1"
+                # 否则返回找到的第一个非负整数
+                for num in numbers:
+                    if num.isdigit() and int(num) >= 0:
+                        return num
+                # 如果只有负数，返回第一个
+                return numbers[0]
+            
+            # 检查是否表示合法
+            
+            
+            # 默认返回空字符串
+            return "" 
+        elif any(keyword in answer_str.lower() for keyword in ["合法", "valid", "correct"]):
+            return "-1"
+        else:
+            return answer_str
+

--- a/environments/synlogic/synlogic_src/games/tasks/dyck_language_reasoning_errors/scripts/dyck_language_reasoning_errors_verifier.py
+++ b/environments/synlogic/synlogic_src/games/tasks/dyck_language_reasoning_errors/scripts/dyck_language_reasoning_errors_verifier.py
@@ -1,0 +1,130 @@
+from base.data import Data
+from base.verifier import Verifier, THOUGHT_DELIMITER_START, THOUGHT_DELIMITER_END
+import re
+
+    
+class DyckLanguageReasoningErrorsVerifier(Verifier):
+    """
+    Dyck语言推理错误识别验证器
+    """
+    def verify(self, data: Data, test_answer: str):
+        """
+        验证模型的回答是否正确
+        
+        @param data: 包含问题、元数据等信息的Data对象
+        @param test_answer: 模型给出的答案字符串
+        @return: 回答是否正确的布尔值
+        """
+        try:
+            test_answer = self.extract_answer(test_solution=test_answer)
+            # 获取元数据中的正确答案
+            correct_indices = data.metadata["error_indices"]
+            # 格式化为正确的答案字符串格式
+            expected_answer = self._format_answer(correct_indices)
+            
+            print(f"验证: 模型答案='{test_answer}', 正确答案='{expected_answer}'")
+            
+            # 检查不明确的答案
+            if "不确定" in test_answer or "不知道" in test_answer or "unclear" in test_answer.lower():
+                print("验证结果: 错误")
+                return False
+            
+            # 清理模型答案，允许一定的格式变化
+            cleaned_test_answer = self._standardize_answer(test_answer)
+            
+            if not correct_indices and (cleaned_test_answer == "" or cleaned_test_answer.lower() in ["无问题", "no", "无错误", "no error", "no errors", "no mistakes", "all correct"]):
+                # 如果没有错误，且模型回答是空字符串或表示无问题，则正确
+                is_correct = True
+            else:
+                # 将两个答案转换为数字集合进行比较
+                test_error_indices = self._extract_error_indices(cleaned_test_answer)
+                expected_error_indices = set(correct_indices)
+                
+                # 检查两个集合是否相同
+                is_correct = test_error_indices == expected_error_indices
+            
+            if is_correct:
+                print("验证结果: 正确")
+            else:
+                print("验证结果: 错误")
+                
+            return is_correct
+            
+        except Exception as e:
+            print(f"验证时出错: {e}")
+            return False
+    
+    def _standardize_answer(self, answer: str) -> str:
+        """
+        标准化答案字符串
+        
+        @param answer: 原始答案字符串
+        @return: 标准化后的答案字符串
+        """
+        # 如果答案为空或仅包含空白字符
+        if not answer or answer.strip() == "":
+            return ""
+            
+        # 如果答案表示没有错误
+        if answer.lower() in ["无问题", "no", "无错误", "no error", "no errors", "no mistakes", "all correct"]:
+            return ""
+        
+        # 替换中文逗号为英文逗号
+        answer = answer.replace('，', ',')
+        # 移除所有非数字和逗号的字符
+        answer = re.sub(r'[^0-9,]', '', answer)
+        
+        return answer
+    
+    def _extract_error_indices(self, answer: str) -> set:
+        """
+        从答案字符串中提取错误索引集合
+        
+        @param answer: 答案字符串
+        @return: 错误索引集合
+        """
+        if not answer or answer.strip() == "":
+            return set()
+        
+        # 先替换中文逗号为英文逗号
+        answer = answer.replace('，', ',')
+        
+        # 分割逗号分隔的数字字符串，并转换为整数集合
+        try:
+            return set(int(idx) for idx in answer.split(',') if idx and idx.strip().isdigit())
+        except ValueError:
+            return set()
+    
+    def _format_answer(self, error_indices: list) -> str:
+        """
+        格式化答案字符串
+        
+        @param error_indices: 错误步骤的索引列表
+        @return: 格式化的答案字符串
+        """
+        if not error_indices:
+            return ""
+        
+        # 按照数字大小排序
+        sorted_indices = sorted(error_indices)
+        
+        # 转换为字符串，使用英文逗号分隔
+        return ",".join(map(str, sorted_indices)) 
+    
+    def extract_answer(self, test_solution: str) -> str:
+        """
+        从模型的回答中提取错误索引
+        
+        @param test_solution: 模型的完整回答
+        """
+        answer_str = test_solution
+        return answer_str
+
+if __name__ == "__main__":
+    test_response = '''<think>\nOkay, so I'm trying to figure out if there are any errors in the reasoning process provided for checking the proper closure of brackets in the sequence: {}[][][]{}{}([]). Let me go through each thought step by step and see where things might have gone wrong.\n\nStarting with Thought 2: the initial stack is empty, which makes sense because we haven't processed any characters yet. So that seems correct.\n\nThought 3: The first character is '{', so it's pushed onto the stack. The stack becomes '{'. Hmm, but in the thought, it's written as '{[', which is incorrect. The stack after the first character should only have '{'. So this thought is wrong because it adds an extra '[' that wasn't there yet. Wait, no, actually, the input sequence starts with '{', so maybe there's a mistake in the thought. Let me recheck. Oh, looking again, no, the input sequence is {}[][][]{}{}([)]}, so the first two characters are '{' and '}'. So after processing '{', the stack should be '{', not '{['. So Thought 3 is wrong because it mistakenly pushes '[' instead of just '{'.\n\nMoving to Thought 4: Next character is '}' which correctly matches the top '{' in the stack, so the stack becomes empty. This part is correct.\n\nThought 5: The next character is '[', so stack becomes '['. Correct.\n\nThought 6: Next is ']', which pops the '[', so stack is empty. Correct.\n\nThought 7: Next is '[', stack becomes '['. Correct.\n\nThought 8: Next is ']', so stack is empty. Correct.\n\nThought 9: Next is '[', stack becomes '['. Correct.\n\nThought 10: Next is ']' which pops the '[', so stack should be empty again. However, in the thought, it says the stack becomes ']', which is incorrect. So Thought 10 is wrong because it added a ']' instead of popping it off. Wait no, the character is ']', which should pop the top '[', so the stack should go from '[' to empty. But the thought says the stack becomes ']' which is wrong. So Thought 10 is incorrect.\n\nThought 11: Next is '{', stack is now '{'. Correct.\n\nThought 12: Next is '}', popping the '{', stack is empty. Correct.\n\nThought 13: Next is '{', stack becomes '{'. Correct.\n\nThought 14: Next is '}', stack is empty. Correct.\n\nThought 15: Next is '(', stack becomes '('. Correct.\n\nThought 16: Next is '[', so stack becomes '(['. Correct.\n\nThought 17: Next is ']', which pops the '[', so stack becomes '('. Correct.\n\nThought 18: Next is ')', which pops the '(', so stack is empty. Correct.\n\nThought 19: After processing all characters, stack is empty. So the sequence is balanced.\n\nWait, but the input sequence actually ends with ']})', right? The sequence given is {}[][][]{}{}([]). So after processing '(' and '[', we have '(', then '['. Then when we process ']', it pops the '[', stack becomes '('. Then next is ')', which pops '(', stack is empty. So everything is correct up to that point.\n\nBut in the earlier steps, the issue was in Thought 10. Because when processing the fifth character, which is '[', followed by ']', the stack should go back to empty. So Thought 10 says the stack becomes ']', which is incorrect. It should go back to empty.\n\nWait, let me recount the steps:\n\nThe input is {}[][][]{}{}([]). So let's break it down:\n\n1. '{' : stack becomes '{'\n2. '}' : stack empty\n3. '[' : stack becomes '['\n4. ']' : stack empty\n5. '[' : '['\n6. ']' : stack empty\n7. '[' : '['\n8. ']' : stack empty\n9. '{' : '{'\n10. '}' : stack empty\n11. '{' : '{'\n12. '}' : stack empty\n13. '(' : '('\n14. '[' : '(['\n15. ']' : '('\n16. ')' : stack empty.\n\nWait, but in the original thought process, after step 10, the character is ']' which pops the '[', making the stack empty, but the thought says stack is ']'. So that's definitely incorrect.\n\nAlso, in step 3, the thought says after '{' the stack is '{[', which is incorrect because the next character is '}', not another '['. So step 3 is wrong because it added an extra '[' instead of just '{' and then processing '}' in step 4 correctly.\n\nSo the errors are in Thought 3 and Thought 10.\n</think>\n\nThe errors are in Thought 3 and Thought 10 because Thought 3 incorrectly adds an extra '[' instead of just '{' and Thought 10 mistakenly leaves the stack as ']' instead of empty after popping.\n\n<answer>[3,20]</answer>'''
+    metadata = {"trace_id": "77db72eb-a9db-46cd-96ea-5a49eba78792", "dyck_sequence": "{}[][][]{}{}([])", "thoughts": ["Thought 1: 我们应该逐个处理输入并跟踪栈的配置。", "Thought 2: 栈: 空", "Thought 3: { ; 栈: {[", "Thought 4: } ; 栈: 空", "Thought 5: [ ; 栈: [", "Thought 6: ] ; 栈: 空", "Thought 7: [ ; 栈: [", "Thought 8: ] ; 栈: 空", "Thought 9: [ ; 栈: [", "Thought 10: ] ; 栈: ]", "Thought 11: { ; 栈: {", "Thought 12: } ; 栈: 空", "Thought 13: { ; 栈: {", "Thought 14: } ; 栈: 空", "Thought 15: ( ; 栈: (", "Thought 16: [ ; 栈: ([", "Thought 17: ] ; 栈: (", "Thought 18: ) ; 栈: 空", "Thought 19: 现在，我们已经到达结尾。最终栈是空的。"], "error_indices": [3, 10], "n_types": 3, "total_length": 15, "n_errors": 2}
+    test_data = Data(question="", answer="", metadata=metadata)
+    test_verifier = DyckLanguageReasoningErrorsVerifier()
+    extracted_answer = test_verifier.extract_answer(test_response)
+    print(extracted_answer)
+    print(test_verifier.verify(data=test_data, test_answer=test_response))

--- a/environments/synlogic/synlogic_src/games/tasks/futoshiki/scripts/futoshiki_verifier.py
+++ b/environments/synlogic/synlogic_src/games/tasks/futoshiki/scripts/futoshiki_verifier.py
@@ -1,0 +1,210 @@
+import numpy as np
+from typing import List, Tuple, Dict, Optional
+import re
+from base.data import Data
+from base.verifier import Verifier
+
+class FutoshikiVerifier(Verifier):
+    """Verifier for Futoshiki"""
+    def __init__(self):
+        """Initialize the verifier."""
+        pass
+    
+    def verify(self, data: Data, test_solution: str) -> bool:
+        """
+        验证模型提供的回答是否正确：
+        1. 数独规则：每行每列1-N各出现一次
+        2. 预填充数字：模型保留了题目中的预填充数字
+        3. 不等式约束：所有不等式约束都被满足
+        
+        注意：不需要和生成数据中的答案完全一致，只要满足上述三个条件即为正确。
+        
+        Args:
+            data: 包含题目和元数据的Data对象
+            test_solution: 模型给出的回答字符串
+            
+        Returns:
+            bool: 回答是否正确
+        """
+        # 从test_solution中提取答案
+        answer = self.extract_answer(test_solution)
+        if answer is None:
+            print("无法提取答案")
+            return False
+            
+        # 获取网格大小
+        grid_size = data.metadata["grid_size"]
+        
+        # 检查答案格式
+        if not self.check_answer_format(answer, grid_size):
+            print(f"答案格式不正确: 期望 {grid_size}x{grid_size} 矩阵，实际为 {answer.shape}")
+            return False
+            
+        # 检查每行和每列是否包含1到N的所有数字（数独规则）
+        if not self.check_rows_and_columns(answer, grid_size):
+            print("答案不满足数独规则（每行每列包含1到N的所有数字）")
+            return False
+            
+        # 检查预填充数字是否保留
+        prefilled_coords = data.metadata["prefilled_coords"]
+        
+        # 从数据中提取原始网格并解析预填充数字
+        question = data.question
+        prefilled_values = []
+        grid_lines = []
+        
+        # 从题目中解析原始网格
+        in_grid = False
+        for line in question.split('\n'):
+            if 'Current puzzle:' in line:
+                in_grid = True
+                continue
+            elif in_grid and line.strip() and 'X' in line:
+                grid_lines.append(line.strip())
+            elif in_grid and grid_lines and line.strip() and 'X' not in line:
+                in_grid = False
+        
+        # 提取预填充的值
+        for (row, col) in prefilled_coords:
+            # 确保网格行存在
+            if row < len(grid_lines):
+                grid_line = grid_lines[row].split()
+                if col < len(grid_line) and grid_line[col] != 'X':
+                    try:
+                        prefilled_values.append(int(grid_line[col]))
+                    except ValueError:
+                        prefilled_values.append(None)
+                else:
+                    prefilled_values.append(None)
+            else:
+                prefilled_values.append(None)
+        
+        if not self.check_prefilled_numbers(answer, prefilled_coords, prefilled_values):
+            print("答案未保留预填充数字")
+            return False
+            
+        # 检查不等式约束
+        constraints = data.metadata["constraints"]
+        if not self.check_inequality_constraints(answer, constraints):
+            print("答案不满足不等式约束")
+            return False
+            
+        return True
+    
+    def extract_answer(self, test_solution: str) -> Optional[np.ndarray]:
+        """Extract the answer from the test solution string."""
+        try:
+            # 移除所有空白字符
+            test_solution = test_solution.strip()
+            
+            # 尝试从GPT响应中提取最后一个[[...]]格式的内容
+            answer_matches = re.findall(r'\[\[([^\]]+)\]\]', test_solution)
+            if answer_matches:
+                # 获取最后一个匹配项，通常是最终答案
+                answer_str = answer_matches[-1]
+                
+                # 分割行
+                rows = answer_str.split(',')
+                
+                # 解析每一行
+                grid = []
+                for row in rows:
+                    # 分割数字
+                    numbers = re.findall(r'\d+', row)
+                    # 转换为整数
+                    row_numbers = [int(num) for num in numbers]
+                    grid.append(row_numbers)
+                
+                # 检查是否是有效的网格
+                if len(grid) > 0 and all(len(row) == len(grid) for row in grid):
+                    return np.array(grid)
+            
+            # 如果上面的方法失败，尝试直接解析 [[...]] 格式
+            if test_solution.startswith('[[') and test_solution.endswith(']]'):
+                # 移除[[和]]
+                test_solution = test_solution[2:-2]
+                
+                # 分割行
+                rows = test_solution.split(',')
+                
+                # 解析每一行
+                grid = []
+                for row in rows:
+                    # 分割数字
+                    numbers = row.strip().split()
+                    # 转换为整数
+                    row_numbers = [int(num) for num in numbers]
+                    grid.append(row_numbers)
+                
+                return np.array(grid)
+            
+            print(f"无法找到有效的答案格式，原始回答: {test_solution[:100]}...")
+            return None
+            
+        except Exception as e:
+            print(f"解析答案时出错: {e}，原始回答: {test_solution[:100]}...")
+            return None
+    
+    def check_answer_format(self, answer: np.ndarray, grid_size: int) -> bool:
+        """Check if the answer has the correct format."""
+        # 检查形状
+        if answer.shape != (grid_size, grid_size):
+            return False
+            
+        # 检查数据类型
+        if answer.dtype != np.int64:
+            return False
+            
+        return True
+    
+    def check_rows_and_columns(self, answer: np.ndarray, grid_size: int) -> bool:
+        """Check if each row and column contains all numbers from 1 to n."""
+        # 检查每一行
+        for i, row in enumerate(answer):
+            if not self.check_sequence(row, grid_size):
+                print(f"第 {i+1} 行不满足数独规则: {row}")
+                return False
+                
+        # 检查每一列
+        for i, col in enumerate(answer.T):
+            if not self.check_sequence(col, grid_size):
+                print(f"第 {i+1} 列不满足数独规则: {col}")
+                return False
+                
+        return True
+    
+    def check_sequence(self, sequence: np.ndarray, grid_size: int) -> bool:
+        """Check if a sequence contains all numbers from 1 to n."""
+        # 创建1到n的集合
+        required = set(range(1, grid_size + 1))
+        # 创建序列中的数字集合
+        actual = set(sequence)
+        # 检查是否相等
+        return required == actual
+    
+    def check_prefilled_numbers(self, answer: np.ndarray, prefilled_coords: List[Tuple[int, int]], prefilled_values: List[int]) -> bool:
+        """Check if the prefilled numbers are preserved in the answer."""
+        for (row, col), value in zip(prefilled_coords, prefilled_values):
+            if value is not None and answer[row, col] != value:
+                print(f"预填充位置 ({row+1},{col+1}) 的值被改变: 期望 {value}, 实际为 {answer[row, col]}")
+                return False
+        return True
+    
+    def check_inequality_constraints(self, answer: np.ndarray, constraints: List[Tuple[Tuple[int, int], Tuple[int, int], str]]) -> bool:
+        """Check if all inequality constraints are satisfied."""
+        for (coord1, coord2, sign) in constraints:
+            row1, col1 = coord1
+            row2, col2 = coord2
+            num1 = answer[row1, col1]
+            num2 = answer[row2, col2]
+            
+            if sign == '>':
+                if num1 <= num2:
+                    print(f"不等式约束不满足: ({row1+1},{col1+1}) > ({row2+1},{col2+1}), 实际值: {num1} <= {num2}")
+                    return False
+            elif sign == '<':
+                if num1 >= num2:
+                    print(f"不等式约束不满足: ({row1+1},{col1+1}) < ({row2+1},{col2+1}), 实际值: {num1} >= {num2}")
+                    return False
+                    
+        return True 

--- a/environments/synlogic/synlogic_src/games/tasks/game_of_24/scripts/game_of_24_verifier.py
+++ b/environments/synlogic/synlogic_src/games/tasks/game_of_24/scripts/game_of_24_verifier.py
@@ -1,0 +1,55 @@
+from base.data import Data
+from base.verifier import Verifier
+import re
+
+class GameOf24Verifier(Verifier):
+    """
+    Verifier for Game of 24
+    """
+    def verify(self, data: Data, test_solution: str):
+        try:
+            test_answer = self.extract_answer(test_solution)
+            print("Extracted answer:", test_answer)
+            numbers = data.metadata["numbers"]
+            operators = data.metadata["operators"]
+            result = data.metadata["result"]
+            input_numbers = [str(num) for num in numbers]
+            answer_numbers_str = re.sub(r'[^0-9]', ' ', test_answer)
+            answer_numbers = [num for num in answer_numbers_str.split() if num]
+            answer_wo_numbers_str = re.sub(r'[0-9\s]', '', test_answer)
+            unknown_chars = []
+            for c in answer_wo_numbers_str:
+                if c in operators:
+                    continue
+                if c in ["(", ")"]:
+                    continue
+                unknown_chars.append(c)
+            if len(unknown_chars) > 0:
+                print("Found unknown characters in the answer:", unknown_chars)
+                return False
+
+            for num in answer_numbers:
+                if num not in input_numbers:
+                    print("Found unknown number in the answer:", num)
+                    return False
+                if answer_numbers.count(num) > input_numbers.count(num):
+                    print("Found more occurrences of number in the answer than in the input:", num)
+                    return False
+            
+            if len(answer_numbers) != len(input_numbers):
+                print("The number of numbers in the answer is not equal to the number of input numbers:", len(answer_numbers), len(input_numbers))
+                return False
+            print("Test answer:", test_answer)
+            result = eval(test_answer)
+            
+            return abs(result - result) < 1e-10  # Allow for floating-point precision
+        except:
+            return False
+        
+    def extract_answer(self, test_solution: str):
+        regex_pattern = "```python.*?```"
+        matches = re.findall(regex_pattern, test_solution, re.DOTALL)
+        if matches:
+            return matches[-1].replace("```python", "").replace("```", "").strip()
+        else:
+            return ""

--- a/environments/synlogic/synlogic_src/games/tasks/goods_exchange/scripts/goods_exchange_verifier.py
+++ b/environments/synlogic/synlogic_src/games/tasks/goods_exchange/scripts/goods_exchange_verifier.py
@@ -1,0 +1,217 @@
+import re
+from base.data import Data
+from base.verifier import Verifier
+
+class GoodsExchangeVerifier(Verifier):
+    """
+    验证器用于检查物品交换游戏的答案是否正确
+    """
+    def verify(self, data: Data, test_solution: str):
+        """
+        验证模型的回答是否正确
+        
+        @param data: 包含问题、元数据等信息的Data对象
+        @param test_answer: 模型给出的回答字符串
+        @return: 回答是否正确的布尔值
+        """
+        try:
+            test_answer = self.extract_answer(test_solution)
+            # 获取元数据中的正确答案
+            correct_answer = data.metadata["owns_after"]
+            
+            print(f"验证: 模型答案='{test_answer}', 正确答案='{correct_answer}'")
+            
+            # 解析模型答案
+            model_ownership = self._parse_answer(test_answer)
+            # 解析正确答案
+            correct_ownership = self._parse_answer(correct_answer)
+            
+            # 比较两个答案是否完全一致
+            is_correct = self._compare_answers(model_ownership, correct_ownership)
+            
+            if is_correct:
+                print("验证结果: 正确")
+            else:
+                print("验证结果: 错误")
+                # 打印详细的不匹配信息
+                self._print_difference(model_ownership, correct_ownership)
+                
+            return is_correct
+            
+        except Exception as e:
+            print(f"验证时出错: {e}")
+            return False
+    
+    def _parse_answer(self, answer_str):
+        """
+        解析答案字符串为物品归属字典
+        
+        @param answer_str: 答案字符串，格式为"(('人1','物品1'),('人2','物品2'),...)"或"(人1,物品1),(人2,物品2),..."
+        @return: 归属关系字典 {人: 物品}
+        """
+        if not answer_str:
+            return {}
+            
+        result = {}
+        try:
+            # 预处理：只处理最外层的空格，保留内部结构
+            answer_str = answer_str.strip()
+            
+            # 尝试使用 eval 解析 Python tuple 格式
+            pairs = eval(answer_str)
+            if isinstance(pairs, tuple):
+                for pair in pairs:
+                    if isinstance(pair, tuple) and len(pair) == 2:
+                        person, item = pair
+                        # 处理每个值中的空格：移除两端空格
+                        result[person.strip()] = item.strip()
+                return result
+        except Exception as e:
+            # 如果 eval 失败，记录错误并尝试解析旧格式
+            print(f"Eval解析失败: {e}，尝试手动解析")
+            
+            # 移除最外层的括号（如果有）
+            if answer_str.startswith('('):
+                answer_str = answer_str[1:]
+            if answer_str.endswith(')'):
+                answer_str = answer_str[:-1]
+            
+            # 更健壮的手动解析逻辑
+            person_item_pairs = []
+            current_pair = ""
+            bracket_count = 0
+            
+            # 更智能地分割答案字符串
+            for char in answer_str:
+                if char == '(':
+                    bracket_count += 1
+                    current_pair += char
+                elif char == ')':
+                    bracket_count -= 1
+                    current_pair += char
+                    if bracket_count == 0:
+                        person_item_pairs.append(current_pair)
+                        current_pair = ""
+                elif char == ',' and bracket_count == 0:
+                    # 跳过顶层逗号
+                    continue
+                else:
+                    current_pair += char
+            
+            # 处理每一对
+            for pair in person_item_pairs:
+                pair = pair.strip()
+                # 移除括号
+                if pair.startswith('('):
+                    pair = pair[1:]
+                if pair.endswith(')'):
+                    pair = pair[:-1]
+                    
+                # 拆分人和物品
+                try:
+                    # 使用更健壮的分割方法
+                    parts = []
+                    quote_count = 0
+                    current = ""
+                    
+                    for char in pair:
+                        if char in "\"'" and (len(current) == 0 or current[-1] != '\\'):
+                            quote_count = 1 - quote_count
+                        
+                        if char == ',' and quote_count == 0:
+                            parts.append(current.strip())
+                            current = ""
+                        else:
+                            current += char
+                    
+                    if current:
+                        parts.append(current.strip())
+                    
+                    if len(parts) >= 2:
+                        person = parts[0].strip().strip("'\"")
+                        item = parts[1].strip().strip("'\"")
+                        result[person] = item
+                except Exception as e:
+                    print(f"解析对 '{pair}' 时出错: {e}")
+                    
+        return result
+    
+    def _compare_answers(self, model_ownership, correct_ownership):
+        """
+        比较两个归属关系字典是否相同
+        
+        @param model_ownership: 模型回答的归属关系
+        @param correct_ownership: 正确的归属关系
+        @return: 是否完全一致
+        """
+        # 检查人数是否相同
+        if len(model_ownership) != len(correct_ownership):
+            return False
+        
+        # 创建小写人名到原始人名的映射
+        model_lower_to_original = {person.lower(): person for person in model_ownership}
+        
+        # 检查每个人的物品是否一致
+        for person in correct_ownership:
+            # 如果模型答案中没有这个人（不区分大小写）
+            if person.lower() not in model_lower_to_original:
+                return False
+                
+            # 获取模型答案中对应的原始人名
+            model_person = model_lower_to_original[person.lower()]
+                
+            # 如果人的物品不匹配（不区分大小写）
+            if model_ownership[model_person].lower() != correct_ownership[person].lower():
+                return False
+                
+        return True
+    
+    def _print_difference(self, model_ownership, correct_ownership):
+        """
+        打印两个归属关系之间的差异
+        
+        @param model_ownership: 模型回答的归属关系
+        @param correct_ownership: 正确的归属关系
+        """
+        print("\n差异详情:")
+        
+        # 创建小写人名到原始人名的映射
+        model_lower_to_original = {person.lower(): person for person in model_ownership}
+        correct_lower_to_original = {person.lower(): person for person in correct_ownership}
+        
+        # 检查正确答案中的每个人
+        for person in correct_ownership:
+            person_lower = person.lower()
+            if person_lower not in model_lower_to_original:
+                print(f"  - 模型答案中缺少: {person}")
+            else:
+                model_person = model_lower_to_original[person_lower]
+                if model_ownership[model_person].lower() != correct_ownership[person].lower():
+                    print(f"  - {person}: 模型答案={model_ownership[model_person]}, 正确答案={correct_ownership[person]}")
+        
+        # 检查模型答案中的额外人员
+        for person in model_ownership:
+            if person.lower() not in correct_lower_to_original:
+                print(f"  - 模型答案中多余: {person}") 
+                
+    def extract_answer(self, text):
+        """从文本中提取答案。
+        
+        Args:
+            text (str): 输入文本
+            
+        Returns:
+            str: 提取的答案，格式为 "(('人1','物品1'),('人2','物品2'),...)"
+        """
+        if not text:
+            return ""
+        
+        # 尝试从 Python markdown 代码块中提取
+        code_block_pattern = r'```python\s*\n(.*?)\n```'
+        code_blocks = re.findall(code_block_pattern, text, re.DOTALL)
+        if code_blocks:
+            # 使用最后一个代码块
+            last_block = code_blocks[-1].strip()
+            if last_block.startswith("(") and last_block.endswith(")"):
+                return last_block
+        return ""

--- a/environments/synlogic/synlogic_src/games/tasks/kukurasu/scripts/kukurasu_verifier.py
+++ b/environments/synlogic/synlogic_src/games/tasks/kukurasu/scripts/kukurasu_verifier.py
@@ -1,0 +1,87 @@
+from base.data import Data
+from base.verifier import Verifier, THOUGHT_DELIMITER_START, THOUGHT_DELIMITER_END
+import re
+import json
+
+
+class KukurasuVerifier(Verifier):
+    """
+    Verifier for Kukurasu puzzle
+    数独拼图验证器
+    """
+    def verify(self, data: Data, test_solution: str, **kwargs):
+        try:
+            grid = self.extract_answer(test_solution)
+            # Extract metadata from the data
+            row_sums = data.metadata["row_sums"]
+            col_sums = data.metadata["col_sums"]
+            print(row_sums, col_sums)
+            n = data.metadata["n"]
+            m = data.metadata["m"]
+            
+            # Check grid dimensions
+            if len(grid) != n:
+                return False
+                
+            for row in grid:
+                if len(row) != m:
+                    return False
+                    
+                # Check that each cell contains only "1" or "X"
+                for cell in row:
+                    if cell not in ["1", "X"]:
+                        return False
+            
+            # Calculate row sums based on the answer grid
+            calculated_row_sums = []
+            for i, row in enumerate(grid):
+                row_sum = 0
+                for j, cell in enumerate(row):
+                    if cell == "1":
+                        # Weight is column position (1-indexed)
+                        row_sum += (j + 1)
+                calculated_row_sums.append(row_sum)
+            
+            # Calculate column sums based on the answer grid
+            calculated_col_sums = []
+            for j in range(m):
+                col_sum = 0
+                for i in range(n):
+                    if grid[i][j] == "1":
+                        # Weight is row position (1-indexed)
+                        col_sum += (i + 1)
+                calculated_col_sums.append(col_sum)
+            
+            # Check if calculated sums match the expected sums
+            if calculated_row_sums != row_sums:
+                return False
+                
+            if calculated_col_sums != col_sums:
+                return False
+                
+            return True
+            
+        except Exception as e:
+            # If any error occurs during verification, return False
+            print(f"Verification error: {e}")
+            return False
+        
+        
+    def extract_answer(self, response: str):
+        """Extract the answer grid from the model's response
+        从模型的响应中提取答案网格"""
+        # Look for a grid representation in the response
+        # 在响应中寻找网格表示
+        grid_pattern = r'\[\s*\[(?:\s*"[X1]"\s*,\s*)*\s*"[X1]"\s*\]\s*(?:,\s*\[(?:\s*"[X1]"\s*,\s*)*\s*"[X1]"\s*\]\s*)*\]'
+        match = re.search(grid_pattern, response)
+        
+        if match:
+            try:
+                # Try to parse the grid as JSON
+                # 尝试将网格解析为JSON
+                grid_str = match.group(0)
+                return json.loads(grid_str)
+            except json.JSONDecodeError:
+                pass
+        
+        return ""

--- a/environments/synlogic/synlogic_src/games/tasks/math_path/scripts/math_path_verifier.py
+++ b/environments/synlogic/synlogic_src/games/tasks/math_path/scripts/math_path_verifier.py
@@ -1,0 +1,100 @@
+import re
+import json
+import numpy as np
+from base.data import Data
+from base.verifier import Verifier, THOUGHT_DELIMITER_START, THOUGHT_DELIMITER_END
+
+
+class MathPathVerifier(Verifier):
+    """
+    验证器用于检查math_path填充游戏的答案是否正确
+    """
+    def verify(self, data: Data, test_answer: str):
+        """
+        验证模型的回答是否正确
+        
+        @param data: 包含问题、元数据等信息的Data对象
+        @param test_answer: 模型给出的运算表达式
+        @return: 回答是否正确的布尔值
+        """
+        try:
+            test_answer = self.extract_answer(test_solution=test_answer)
+        except Exception as e:
+            print(f"答案抽取时出错: {e}")
+            return False 
+
+        try:
+            # 解析元数据
+            metadata = data.metadata
+            ref_expr = metadata["ref_expr"]
+            query_expr = metadata["query_expr"]
+
+            # 验证数字是否被篡改，数字是否在0-9之间。
+            test_tmp = test_answer.replace(' ', '').strip()
+            query_tmp = query_expr.replace(' ', '').strip()
+            ref_tmp = ref_expr.replace(' ', '').strip()
+            query_nums = [x for x in query_tmp if '0'<=x<='9' or x=='?']
+            test_nums = [x for x in test_tmp if '0'<=x<='9']
+            if len(query_nums)!=len(test_nums):
+                print(f"所填数字数量不匹配！原始：{ref_tmp}，query：{query_tmp}，模型：{test_tmp}")
+                return False
+            else:
+                for ind, x in enumerate(query_nums):
+                    if x=='?':
+                        continue
+                    if x!=test_nums[ind]:
+                        print(f"表达式数字被篡改！原始：{ref_tmp}，query：{query_tmp}，模型：{test_tmp}")
+                        return False
+                    
+            query_symbols = [x for x in query_tmp if x in ['+', '-', '*', '/', '%']]
+            test_symbols = [x for x in test_tmp if x in ['+', '-', '*', '/', '%']]
+            if len(query_symbols)!=len(test_symbols):
+                print(f"表达式运算符号数量不匹配！原始：{ref_tmp}，query：{query_tmp}，模型：{test_tmp}")
+                return False
+            else:
+                for ind, x in enumerate(query_symbols):
+                    if x!=test_symbols[ind]:
+                        print(f"表达式运算符号被篡改！原始：{ref_tmp}，query：{query_tmp}，模型：{test_tmp}")
+                        return False
+            
+            # 验证回答中的等式是否成立
+            try:
+                tmp = test_tmp.replace('=', '==')
+                if not eval(tmp):
+                    print(f"等式不成立！原始：{ref_tmp}，query：{query_tmp}，模型：{test_tmp}")
+                    return False
+            except:
+                print(f"运算表达式错误！原始：{ref_tmp}，query：{query_tmp}，模型：{test_tmp}")
+                return False
+            
+            
+            # 所有检查都通过
+            print("验证结果: 正确")
+            return True
+            
+        except Exception as e:
+            print(f"验证时出错: {e}")
+            return False 
+        
+
+    def extract_answer(self, test_solution: str):
+        """
+        从模型的回答中提取答案（字符表达式）
+        
+        @param test_solution: 模型的完整回答
+        @return: 提取的矩阵答案字符串
+        """
+        if not test_solution:
+            return ""
+        # 尝试提取Python代码块中的矩阵
+        code_block_pattern = r'\[\[(.*?)\]\]'
+        code_matches = re.findall(code_block_pattern, test_solution)
+        
+        if code_matches:
+            # 使用最后一个匹配内容
+            operation_expression = code_matches[-1].strip()
+            return operation_expression
+        
+        # 如果所有方法都失败，返回空字符串
+        return ""
+        

--- a/environments/synlogic/synlogic_src/games/tasks/minesweeper/scripts/minesweeper_verifier.py
+++ b/environments/synlogic/synlogic_src/games/tasks/minesweeper/scripts/minesweeper_verifier.py
@@ -1,0 +1,61 @@
+from base.data import Data
+from base.verifier import Verifier, THOUGHT_DELIMITER_START, THOUGHT_DELIMITER_END
+import re
+import json
+from typing import List, Tuple
+
+
+class MinesweeperVerifier(Verifier):
+    """
+    Verifier for Minesweeper puzzle
+    扫雷游戏验证器
+    """
+    def verify(self, data: Data, test_solution: str, **kwargs):
+        try:
+            # 从解答中提取地雷坐标
+            predicted_mines = self.extract_answer(test_solution)
+            
+            # 从metadata中获取确定性地雷坐标
+            expected_mines = data.metadata["current_mines"]
+            
+            # 验证提取的坐标是否正确
+            if set(tuple(mine) for mine in predicted_mines) == set(tuple(mine) for mine in expected_mines):
+                return True
+            
+            return False
+            
+        except Exception as e:
+            # 如果验证过程中发生任何错误，返回False
+            print(f"Verification error: {e}")
+            return False
+    
+    def extract_answer(self, response: str) -> List[Tuple[int, int]]:
+        """从模型的响应中提取地雷坐标
+        Extract mine coordinates from the model's response"""
+        patterns = [
+            r'\[\s*\(\s*(\d+)\s*,\s*(\d+)\s*\)(?:\s*,\s*\(\s*\d+\s*,\s*\d+\s*\))*\s*\]',  # [(0,1),(2,3)]
+            r'\[\s*\[\s*(\d+)\s*,\s*(\d+)\s*\](?:\s*,\s*\[\s*\d+\s*,\s*\d+\s*\])*\s*\]',  # [[0,1],[2,3]]
+            r'\(\s*(\d+)\s*,\s*(\d+)\s*\)(?:\s*,\s*\(\s*\d+\s*,\s*\d+\s*\))*',  # (0,1),(2,3)
+        ]
+        
+        for pattern in patterns:
+            coords = []
+            for match in re.finditer(pattern, response):
+                try:
+                    # 提取所有坐标对
+                    coord_pattern = r'(?:\(|\[)\s*(\d+)\s*,\s*(\d+)\s*(?:\)|\])'
+                    for coord_match in re.finditer(coord_pattern, match.group(0)):
+                        i, j = int(coord_match.group(1)), int(coord_match.group(2))
+                        coords.append((i, j))
+                except Exception:
+                    continue
+            
+            if coords:
+                return coords
+        
+        # 如果没有找到坐标，尝试查找可能是坐标的任何数字
+        number_pairs = re.findall(r'(\d+)[^\d]+(\d+)', response)
+        if number_pairs:
+            return [(int(i), int(j)) for i, j in number_pairs]
+        
+        return []

--- a/environments/synlogic/synlogic_src/games/tasks/norinori/scripts/norinori_verifier.py
+++ b/environments/synlogic/synlogic_src/games/tasks/norinori/scripts/norinori_verifier.py
@@ -1,0 +1,188 @@
+from base.data import Data
+from base.verifier import Verifier, THOUGHT_DELIMITER_START, THOUGHT_DELIMITER_END
+import re
+from collections import defaultdict
+
+class NorinoriVerifier(Verifier):
+    """
+    Norinori 游戏的验证器
+    检查提交的答案是否符合 Norinori 游戏规则
+    """
+    
+    def __init__(self):
+        super().__init__()
+
+    def verify(self, data: Data, test_solution: str):
+        """
+        验证 Norinori 游戏的答案
+        
+        参数:
+        data -- 游戏数据，包含区域网格等信息
+        test_solution -- 用户提交的答案，应为多米诺坐标列表
+        
+        返回:
+        bool -- 答案是否正确
+        """
+        try:
+            # 从游戏数据中获取区域网格
+            region_grid = data.metadata["region_grid"]
+            n = len(region_grid)
+            
+            # 解析答案
+            dominoes = self._parse_answer(test_solution)
+            if dominoes is None:
+                return False
+            
+            # 检查多米诺形状
+            if not self._check_domino_shapes(dominoes):
+                return False
+            
+            # 创建覆盖网格
+            covered = [[False for _ in range(n)] for _ in range(n)]
+            for domino in dominoes:
+                for i, j in domino:
+                    # 转换为0-indexed
+                    i -= 1
+                    j -= 1
+                    if i < 0 or i >= n or j < 0 or j >= n:
+                        return False  # 坐标超出范围
+                    if covered[i][j]:
+                        return False  # 格子被多次覆盖
+                    covered[i][j] = True
+            
+            # 检查多米诺之间是否相邻
+            if not self._check_domino_adjacency(dominoes, n):
+                return False
+            
+            # 检查每个区域是否恰好有两个格子被覆盖
+            region_coverage = defaultdict(int)
+            for i in range(n):
+                for j in range(n):
+                    if covered[i][j] and region_grid[i][j] != "X":
+                        region_coverage[region_grid[i][j]] += 1
+            
+            for region, count in region_coverage.items():
+                if count != 2:
+                    return False
+        
+            # 检查所有阴影格子是否被覆盖
+            for i in range(n):
+                for j in range(n):
+                    if region_grid[i][j] == "X" and not covered[i][j]:
+                        return False
+            
+            return True
+        except Exception as e:
+            print(f"验证过程中出错: {e}")
+            return False
+        
+    def _parse_answer(self, test_solution: str):
+        """
+        解析答案字符串，提取多米诺坐标
+        
+        参数:
+        test_solution -- 答案字符串
+        
+        返回:
+        list -- 多米诺坐标列表，如果格式不正确则返回None
+        """
+        try:
+            # 使用正则表达式提取坐标对
+            pattern = r'\[\((\d+),\s*(\d+)\),\s*\((\d+),\s*(\d+)\)\]'
+            matches = re.findall(pattern, test_solution)
+            
+            if not matches:
+                # 尝试另一种可能的格式
+                pattern = r'\(\s*(\d+)\s*,\s*(\d+)\s*\)\s*,\s*\(\s*(\d+)\s*,\s*(\d+)\s*\)'
+                matches = re.findall(pattern, test_solution)
+            
+            dominoes = []
+            for match in matches:
+                i1, j1, i2, j2 = map(int, match)
+                dominoes.append([(i1, j1), (i2, j2)])
+            
+            return dominoes
+        except Exception as e:
+            print(f"解析答案时出错: {e}")
+            return None
+    
+    def _check_domino_shapes(self, dominoes):
+        """
+        检查所有多米诺是否都是1×2或2×1的形状
+        
+        参数:
+        dominoes -- 多米诺坐标列表
+        
+        返回:
+        bool -- 是否所有多米诺都符合形状要求
+        """
+        for domino in dominoes:
+            if len(domino) != 2:
+                return False
+            
+            (i1, j1), (i2, j2) = domino
+            
+            # 检查是否为1×2或2×1
+            if not ((i1 == i2 and abs(j1 - j2) == 1) or 
+                    (j1 == j2 and abs(i1 - i2) == 1)):
+                return False
+        
+        return True
+    
+    def _check_domino_adjacency(self, dominoes, n):
+        """
+        检查多米诺之间是否相邻
+        
+        参数:
+        dominoes -- 多米诺坐标列表
+        n -- 网格大小
+        
+        返回:
+        bool -- 是否所有多米诺都不相邻
+        """
+        # 创建一个网格来标记每个多米诺的位置
+        grid = [[-1 for _ in range(n+2)] for _ in range(n+2)]  # 加2是为了处理边界
+        
+        for idx, domino in enumerate(dominoes):
+            for i, j in domino:
+                # 转换为0-indexed并考虑边界
+                grid[i][j] = idx
+        
+        # 检查每个多米诺是否与其他多米诺相邻
+        for idx, domino in enumerate(dominoes):
+            for i, j in domino:
+                for di, dj in [(0, 1), (1, 0), (0, -1), (-1, 0)]:
+                    ni, nj = i + di, j + dj
+                    if 1 <= ni <= n and 1 <= nj <= n:  # 检查是否在网格内
+                        if grid[ni][nj] != -1 and grid[ni][nj] != idx:
+                            return False  # 发现相邻的多米诺
+        
+        return True
+    
+    def extract_answer(self, test_solution: str, strict=False):
+        """
+        从回答中提取答案
+        
+        参数:
+        test_solution -- 用户的回答
+        strict -- 是否严格模式
+        
+        返回:
+        str -- 提取的答案
+        """
+        # 尝试找到答案部分
+        answer_patterns = [
+            r'\[\s*\[\s*\(\s*\d+\s*,\s*\d+\s*\)\s*,\s*\(\s*\d+\s*,\s*\d+\s*\)\s*\]',  # 寻找格式如 [[(1,2), (1,3)], ...] 的答案
+            r'答案是\s*(.*?)\s*$',  # 中文格式
+            r'answer is\s*(.*?)\s*$',  # 英文格式
+            r'solution is\s*(.*?)\s*$'  # 另一种英文格式
+        ]
+        
+        for pattern in answer_patterns:
+            matches = re.findall(pattern, test_solution, re.IGNORECASE | re.DOTALL)
+            if matches:
+                # 返回最后一个匹配项，通常是最终答案
+                return matches[-1]
+        
+        # 如果没有找到明确的答案格式，返回整个解答
+        return test_solution

--- a/environments/synlogic/synlogic_src/games/tasks/number_wall/scripts/number_wall_verifier.py
+++ b/environments/synlogic/synlogic_src/games/tasks/number_wall/scripts/number_wall_verifier.py
@@ -1,0 +1,225 @@
+from base.data import Data
+from base.verifier import Verifier, THOUGHT_DELIMITER_START, THOUGHT_DELIMITER_END
+import re
+import json
+from collections import deque
+
+class NumberWallVerifier(Verifier):
+    """
+    Verifier for Number Wall puzzle
+    数字墙拼图验证器
+    """
+    def verify(self, data: Data, test_solution: str, **kwargs):
+        try:
+            # 提取答案网格
+            solution_grid = self.extract_answer(test_solution)
+            if not solution_grid:
+                print("Failed to extract solution grid")
+                return False
+                
+            # 提取元数据
+            original_grid = data.metadata["grid"]
+            n = data.metadata["n"]
+            
+            # 检查网格尺寸
+            if len(solution_grid) != n:
+                print(f"Solution grid has incorrect number of rows: {len(solution_grid)} != {n}")
+                return False
+                
+            for row in solution_grid:
+                if len(row) != n:
+                    print(f"Solution grid has incorrect number of columns: {len(row)} != {n}")
+                    return False
+                    
+                # 检查每个单元格只包含数字、"X"或"A"
+                for cell in row:
+                    if not (isinstance(cell, int) or cell in ["X", "A"]):
+                        print(f"Invalid cell content: {cell}")
+                        return False
+            
+            # 检查原始数字是否保留
+            if not self._check_original_numbers(original_grid, solution_grid):
+                print("Original numbers not preserved")
+                return False
+                
+            # 检查墙壁布局是否有效（没有2×2或更大的连续墙块）
+            if not self._check_wall_layout(solution_grid):
+                print("Invalid wall layout (2x2 or larger continuous wall blocks found)")
+                return False
+                
+            # 检查岛屿划分是否有效
+            if not self._check_islands(solution_grid):
+                print("Invalid island division")
+                return False
+                
+            # 检查是否有斜线边
+            if not self._check_diagonal_borders(solution_grid):
+                print("Invalid solution: islands have diagonal borders")
+                return False
+                
+            return True
+            
+        except Exception as e:
+            # 如果验证过程中发生任何错误，返回False
+            print(f"Verification error: {e}")
+            return False
+    
+    def _check_original_numbers(self, original_grid, solution_grid):
+        """检查原始数字是否在解决方案中保留"""
+        for i in range(len(original_grid)):
+            for j in range(len(original_grid[i])):
+                if isinstance(original_grid[i][j], int):
+                    if original_grid[i][j] != solution_grid[i][j]:
+                        print(f"Original number at ({i},{j}) changed: {original_grid[i][j]} -> {solution_grid[i][j]}")
+                        return False
+        return True
+    
+    def _check_wall_layout(self, grid):
+        """检查墙壁布局是否有效（没有2×2或更大的连续墙块）"""
+        n = len(grid)
+        for i in range(n - 1):
+            for j in range(n - 1):
+                if (grid[i][j] == "A" and grid[i][j+1] == "A" and
+                    grid[i+1][j] == "A" and grid[i+1][j+1] == "A"):
+                    print(f"Found 2x2 wall block at ({i},{j})")
+                    return False
+        return True
+    
+    def _check_islands(self, grid):
+        """检查岛屿划分是否有效"""
+        n = len(grid)
+        visited = set()
+        
+        for i in range(n):
+            for j in range(n):
+                if (i, j) not in visited and grid[i][j] != "A":
+                    # 发现一个新岛屿
+                    island_cells = []
+                    island_number = None
+                    queue = deque([(i, j)])
+                    visited.add((i, j))
+                    
+                    while queue:
+                        r, c = queue.popleft()
+                        island_cells.append((r, c))
+                        
+                        if isinstance(grid[r][c], int):
+                            if island_number is not None:
+                                # 岛屿有多个数字
+                                print(f"Island contains multiple numbers: {island_number} and {grid[r][c]}")
+                                return False
+                            island_number = grid[r][c]
+                        
+                        for dr, dc in [(0, 1), (1, 0), (0, -1), (-1, 0)]:
+                            nr, nc = r + dr, c + dc
+                            if (0 <= nr < n and 0 <= nc < n and 
+                                (nr, nc) not in visited and 
+                                grid[nr][nc] != "A"):
+                                queue.append((nr, nc))
+                                visited.add((nr, nc))
+                    
+                    if island_number is None:
+                        # 岛屿没有数字
+                        print(f"Island at ({i},{j}) has no number")
+                        return False
+                    
+                    if len(island_cells) != island_number:
+                        # 岛屿大小与数字不匹配
+                        print(f"Island size ({len(island_cells)}) doesn't match number ({island_number})")
+                        return False
+        
+        return True
+    
+    def _check_diagonal_borders(self, grid):
+        """检查是否有斜线边（对角相邻的不同岛屿）"""
+        n = len(grid)
+        
+        # 标记所有岛屿
+        island_map = {}  # 映射格子坐标到岛屿ID
+        island_id = 0
+        visited = set()
+        
+        for i in range(n):
+            for j in range(n):
+                if grid[i][j] != "A" and (i, j) not in visited:
+                    # 发现一个新岛屿
+                    queue = deque([(i, j)])
+                    visited.add((i, j))
+                    
+                    while queue:
+                        r, c = queue.popleft()
+                        island_map[(r, c)] = island_id
+                        
+                        for dr, dc in [(0, 1), (1, 0), (0, -1), (-1, 0)]:
+                            nr, nc = r + dr, c + dc
+                            if (0 <= nr < n and 0 <= nc < n and 
+                                grid[nr][nc] != "A" and (nr, nc) not in visited):
+                                queue.append((nr, nc))
+                                visited.add((nr, nc))
+                    
+                    island_id += 1
+        
+        # 检查斜线边
+        for i in range(n - 1):
+            for j in range(n - 1):
+                # 检查2x2方格中的对角格子
+                if (grid[i][j] != "A" and grid[i+1][j+1] != "A" and
+                    grid[i][j+1] == "A" and grid[i+1][j] == "A"):
+                    # 对角格子属于不同岛屿，存在斜线边
+                    if island_map.get((i, j)) != island_map.get((i+1, j+1)):
+                        print(f"Found diagonal border at ({i},{j}) and ({i+1},{j+1})")
+                        return False
+                
+                # 检查另一对对角格子
+                if (grid[i][j+1] != "A" and grid[i+1][j] != "A" and
+                    grid[i][j] == "A" and grid[i+1][j+1] == "A"):
+                    # 对角格子属于不同岛屿，存在斜线边
+                    if island_map.get((i, j+1)) != island_map.get((i+1, j)):
+                        print(f"Found diagonal border at ({i},{j+1}) and ({i+1},{j})")
+                        return False
+        
+        return True
+        
+ 
+    def extract_answer(self, response: str):
+        """从模型的响应中提取答案网格"""    
+        # 在响应中寻找网格表示
+        # 修改正则表达式以匹配字符串形式的数字
+        grid_pattern = r'\[\s*\[(?:\s*(?:"[XA]"|\'[XA]\'|[0-9]+|"[0-9]+"|\'[0-9]+\')\s*,\s*)*\s*(?:"[XA]"|\'[XA]\'|[0-9]+|"[0-9]+"|\'[0-9]+\')\s*\]\s*(?:,\s*\[(?:\s*(?:"[XA]"|\'[XA]\'|[0-9]+|"[0-9]+"|\'[0-9]+\')\s*,\s*)*\s*(?:"[XA]"|\'[XA]\'|[0-9]+|"[0-9]+"|\'[0-9]+\')\s*\]\s*)*\]'
+        matches = re.findall(grid_pattern, response)
+        
+        if matches:
+            # 尝试解析最后一个匹配项
+            grid_str = matches[-1]
+            
+            try:
+                # 尝试清理字符串，替换可能导致问题的字符
+                cleaned_grid_str = grid_str.replace('\n', '').replace('\r', '').strip()
+                grid = json.loads(cleaned_grid_str)
+                
+                # 将字符串数字转换为整数
+                for i in range(len(grid)):
+                    for j in range(len(grid[i])):
+                        if isinstance(grid[i][j], str) and grid[i][j].isdigit():
+                            grid[i][j] = int(grid[i][j])
+                
+                return grid
+            except json.JSONDecodeError as e:
+                # 尝试使用 ast.literal_eval 作为备选方案
+                try:
+                    import ast
+                    grid = ast.literal_eval(cleaned_grid_str)
+                    
+                    # 将字符串数字转换为整数
+                    for i in range(len(grid)):
+                        for j in range(len(grid[i])):
+                            if isinstance(grid[i][j], str) and grid[i][j].isdigit():
+                                grid[i][j] = int(grid[i][j])
+                    
+                    return grid
+                except Exception as e2:
+                    print(f"ast.literal_eval also failed: {e2}")
+        else:
+            print("No grid pattern found in the response")
+        
+        return None

--- a/environments/synlogic/synlogic_src/games/tasks/numbrix/scripts/numbrix_verifier.py
+++ b/environments/synlogic/synlogic_src/games/tasks/numbrix/scripts/numbrix_verifier.py
@@ -1,0 +1,103 @@
+from base.data import Data
+from base.verifier import Verifier, THOUGHT_DELIMITER_START, THOUGHT_DELIMITER_END
+import re
+import ast
+import numpy as np
+
+class NumbrixVerifier(Verifier):
+    """
+    Numbrix 游戏的验证器
+    验证提交的解答是否符合 Numbrix 游戏规则
+    """
+    def verify(self, data: Data, test_solution: str):
+        try:
+            # 提取答案网格
+            test_grid = self.extract_answer(test_solution)
+            if not test_grid:
+                return False
+            
+            # 获取原始谜题和网格大小
+            original_grid = data.metadata["grid"]
+            n = len(original_grid)
+            n_squared = n * n
+            
+            # 检查网格大小是否正确
+            if len(test_grid) != n or any(len(row) != n for row in test_grid):
+                return False
+            
+            # 检查是否包含所有数字 1 到 n²
+            flattened_grid = [cell for row in test_grid for cell in row]
+            if sorted(flattened_grid) != list(range(1, n_squared + 1)):
+                return False
+            
+            # 检查是否保留了原始提示数字
+            for i in range(n):
+                for j in range(n):
+                    if original_grid[i][j] != "X" and test_grid[i][j] != original_grid[i][j]:
+                        return False
+            
+            # 检查连续数字是否正交相邻
+            for num in range(1, n_squared):
+                # 找到当前数字的位置
+                current_pos = None
+                next_pos = None
+                for i in range(n):
+                    for j in range(n):
+                        if test_grid[i][j] == num:
+                            current_pos = (i, j)
+                        elif test_grid[i][j] == num + 1:
+                            next_pos = (i, j)
+                
+                if current_pos is None or next_pos is None:
+                    return False
+                
+                # 检查是否正交相邻（曼哈顿距离为1）
+                i1, j1 = current_pos
+                i2, j2 = next_pos
+                manhattan_distance = abs(i1 - i2) + abs(j1 - j2)
+                if manhattan_distance != 1:
+                    return False
+            
+            return True
+        except Exception as e:
+            print(f"验证过程中出错: {e}")
+            return False
+        
+    def extract_answer(self, test_solution: str, strict=False):
+        """从模型回答中提取网格"""
+        try:
+            import ast
+            import re
+            # 尝试找到 Python 列表格式的答案
+            # 寻找形如 [[1, 2, 3], [4, 5, 6], [7, 8, 9]] 的模式
+            pattern = r'\[\s*\[\s*\d+.*?\]\s*\]'
+            matches = re.finditer(pattern, test_solution, re.DOTALL)
+            match = None
+            
+            # 获取最后一个匹配项
+            for m in matches:
+                match = m
+            if not match:
+                return None
+            
+            # 提取匹配的文本并尝试解析为 Python 对象
+            grid_text = match.group(0)
+            
+            # 清理文本，确保它是有效的 Python 列表
+            # 移除可能导致解析错误的字符
+            grid_text = grid_text.replace("'", "").replace('"', "")
+            
+            # 解析为 Python 对象
+            grid = ast.literal_eval(grid_text)
+            
+            # 确保是二维列表且所有元素都是整数
+            if not isinstance(grid, list) or not all(isinstance(row, list) for row in grid):
+                return None
+            
+            if not all(isinstance(cell, int) for row in grid for cell in row):
+                return None
+            
+            return grid
+        except Exception as e:
+            print(f"提取答案时出错: {e}")
+            return None

--- a/environments/synlogic/synlogic_src/games/tasks/object_counting/scripts/object_counting_verifier.py
+++ b/environments/synlogic/synlogic_src/games/tasks/object_counting/scripts/object_counting_verifier.py
@@ -1,0 +1,40 @@
+import re
+from base.data import Data
+from base.verifier import Verifier, THOUGHT_DELIMITER_START, THOUGHT_DELIMITER_END
+
+
+class ObjectCountingVerifier(Verifier):
+    """
+    验证器用于物品计数游戏的答案是否正确
+    """
+    def verify(self, data: Data, test_answer: str):
+        try:
+            ground_truth = int(data.answer)
+            parsed_answer = self.extract_answer(test_answer)
+            
+            if parsed_answer is None:
+                return False
+            return int(parsed_answer) == ground_truth
+
+        except Exception as e:
+            print(f"解析答案错误:{e}")
+            return False
+    
+    def extract_answer(self, answer_str):
+        # 先找到最后一个\boxed{的位置
+        last_box_index = answer_str.rfind("\\boxed{")
+        
+        if last_box_index == -1:
+            return None
+            
+        # 从最后一个\Box{开始截取字符串
+        last_box_substring = answer_str[last_box_index:]
+        
+        # 在截取的子字符串中进行正则匹配
+        box_pattern = r'\\boxed\{([^}]*)\}'
+        match = re.search(box_pattern, last_box_substring)
+        
+        if match:
+            return match.group(1).strip()
+        return answer_str
+        

--- a/environments/synlogic/synlogic_src/games/tasks/object_properties/scripts/object_properties_verifier.py
+++ b/environments/synlogic/synlogic_src/games/tasks/object_properties/scripts/object_properties_verifier.py
@@ -1,0 +1,40 @@
+import re
+from base.data import Data
+from base.verifier import Verifier, THOUGHT_DELIMITER_START, THOUGHT_DELIMITER_END
+
+
+class ObjectPropertiesVerifier(Verifier):
+    """
+    验证器用于物品拥有游戏的答案是否正确
+    """
+    def verify(self, data: Data, test_answer: str):
+        try:
+            ground_truth = int(data.answer)
+            parsed_answer = int(self.extract_answer(test_answer))
+            
+            if parsed_answer is None:
+                return False
+            return int(parsed_answer) == ground_truth
+
+        except Exception as e:
+            print(f"解析答案错误:{e}")
+            return False
+    
+    def extract_answer(self, answer_str):
+        # 先找到最后一个\Box{的位置
+        last_box_index = answer_str.rfind("\\boxed{")
+        
+        if last_box_index == -1:
+            return None
+            
+        # 从最后一个\Box{开始截取字符串
+        last_box_substring = answer_str[last_box_index:]
+        
+        # 在截取的子字符串中进行正则匹配
+        box_pattern = r'\\boxed\{([^}]*)\}'
+        match = re.search(box_pattern, last_box_substring)
+        
+        if match:
+            return match.group(1).strip()
+        return None
+        

--- a/environments/synlogic/synlogic_src/games/tasks/operation/scripts/operation_verifier.py
+++ b/environments/synlogic/synlogic_src/games/tasks/operation/scripts/operation_verifier.py
@@ -1,0 +1,47 @@
+import re
+from base.data import Data
+from base.verifier import Verifier, THOUGHT_DELIMITER_START, THOUGHT_DELIMITER_END
+import math_verify 
+
+
+class OperationVerifier(Verifier):
+    """
+    验证器用于物品计数游戏的答案是否正确
+    """
+    def verify(self, data: Data, test_answer: str):
+        try:
+            ground_truth = math_verify.parse(data.answer)
+            parsed_answer = math_verify.parse(test_answer)
+            
+            if parsed_answer is None:
+                return False
+            return math_verify.verify(parsed_answer, ground_truth)
+        except Exception as e:
+            print(f"解析答案错误:{e}")
+            return False
+    
+    def extract_answer(self, answer_str):
+        # 先找到最后一个\boxed{的位置
+        last_box_index = answer_str.rfind("\\boxed{")
+        
+        if last_box_index == -1:
+            return None
+        
+        # 从\boxed{开始截取到正确的闭合位置，处理嵌套括号
+        start_index = last_box_index + len("\\boxed{")
+        bracket_stack = 1  # 已经遇到了一个左括号
+        end_index = start_index
+        
+        while end_index < len(answer_str) and bracket_stack > 0:
+            if answer_str[end_index] == '{':
+                bracket_stack += 1
+            elif answer_str[end_index] == '}':
+                bracket_stack -= 1
+            end_index += 1
+        
+        if bracket_stack != 0:  # 括号不匹配
+            return None
+        
+        # 提取\boxed{}内的内容
+        latex_content = answer_str[start_index:end_index-1].strip()
+        return latex_content

--- a/environments/synlogic/synlogic_src/games/tasks/skyscraper_puzzle/scripts/skyscraper_puzzle_verifier.py
+++ b/environments/synlogic/synlogic_src/games/tasks/skyscraper_puzzle/scripts/skyscraper_puzzle_verifier.py
@@ -1,0 +1,169 @@
+from base.data import Data
+from base.verifier import Verifier, THOUGHT_DELIMITER_START, THOUGHT_DELIMITER_END
+import re
+import json
+import ast
+
+    
+class SkyscraperPuzzleVerifier(Verifier):
+    """
+    摩天楼游戏验证器，用于验证模型提供的解答是否正确
+    """
+    def verify(self, data: Data, test_solution: str):
+        """
+        验证模型的回答是否符合摩天楼游戏的规则
+
+        @param data: 包含游戏信息的Data对象
+        @param test_answer: 游戏类提取的网格数据
+        @return: 回答是否正确的布尔值
+        """
+        try:
+            # 获取游戏元数据
+            metadata = data.metadata
+            n = metadata['n']
+            top = metadata['top']
+            bottom = metadata['bottom']
+            left = metadata['left']
+            right = metadata['right']
+
+            self.n = n
+            test_answer = self.extract_answer(test_solution)
+            
+            print(f"验证: 游戏规模 {n}×{n}")
+            print(f"上方提示: {top}")
+            print(f"下方提示: {bottom}")
+            print(f"左侧提示: {left}")
+            print(f"右侧提示: {right}")
+            
+            # 使用提取好的网格数据
+            grid = test_answer
+            
+            # 检查网格是否是字符串，如果是，说明提取失败
+            if isinstance(grid, str):
+                print("无法提取有效网格")
+                return False
+                
+            print("提取的网格:")
+            for row in grid:
+                print(row)
+            
+            # 检查网格规模
+            if len(grid) != n or any(len(row) != n for row in grid):
+                print(f"网格规模不正确，应为 {n}×{n}")
+                return False
+            
+            # 检查数字范围 (1 到 n)
+            for i in range(n):
+                for j in range(n):
+                    if not isinstance(grid[i][j], int) or grid[i][j] < 1 or grid[i][j] > n:
+                        print(f"位置 ({i+1},{j+1}) 的值 {grid[i][j]} 不在有效范围内 (1-{n})")
+                        return False
+            
+            # 检查每行唯一性
+            for i in range(n):
+                if len(set(grid[i])) != n:
+                    print(f"第 {i+1} 行包含重复数字")
+                    return False
+            
+            # 检查每列唯一性
+            for j in range(n):
+                column = [grid[i][j] for i in range(n)]
+                if len(set(column)) != n:
+                    print(f"第 {j+1} 列包含重复数字")
+                    return False
+            
+            # 检查从上方观察
+            for j in range(n):
+                visible_count = self._count_visible_skyscrapers([grid[i][j] for i in range(n)])
+                if visible_count != top[j]:
+                    print(f"从上方看第 {j+1} 列可见楼数为 {visible_count}，应为 {top[j]}")
+                    return False
+            
+            # 检查从下方观察
+            for j in range(n):
+                visible_count = self._count_visible_skyscrapers([grid[i][j] for i in range(n-1, -1, -1)])
+                if visible_count != bottom[j]:
+                    print(f"从下方看第 {j+1} 列可见楼数为 {visible_count}，应为 {bottom[j]}")
+                    return False
+            
+            # 检查从左侧观察
+            for i in range(n):
+                visible_count = self._count_visible_skyscrapers(grid[i])
+                if visible_count != left[i]:
+                    print(f"从左侧看第 {i+1} 行可见楼数为 {visible_count}，应为 {left[i]}")
+                    return False
+            
+            # 检查从右侧观察
+            for i in range(n):
+                visible_count = self._count_visible_skyscrapers(grid[i][::-1])
+                if visible_count != right[i]:
+                    print(f"从右侧看第 {i+1} 行可见楼数为 {visible_count}，应为 {right[i]}")
+                    return False
+            
+            # 所有检查通过
+            print("所有验证规则通过!")
+            return True
+        
+        except Exception as e:
+            print(f"验证过程出错: {e}")
+            return False
+    
+    def _count_visible_skyscrapers(self, heights):
+        """
+        计算从一个方向看过去能看到的摩天楼数量
+        
+        @param heights: 从观察方向依次排列的摩天楼高度列表
+        @return: 可见的摩天楼数量
+        """
+        visible_count = 0
+        max_height = 0
+        
+        for height in heights:
+            if height > max_height:
+                visible_count += 1
+                max_height = height
+        
+        return visible_count 
+    
+    def extract_answer(self, test_solution: str):
+        """
+        从模型的回答中提取网格数据
+        
+        @param test_solution: 模型的完整回答
+        @return: 提取的解答网格数据
+        """
+        try:
+            n = self.n
+            
+            # 从 ```python 代码块中提取
+            code_block_pattern = r"```python\s*\n([\s\S]*?)\n\s*```"
+            code_blocks = re.findall(code_block_pattern, test_solution)
+            
+            if code_blocks:
+                # 取第一个代码块（通常只有一个）
+                code_block = code_blocks[0].strip()
+                try:
+                    # 直接解析代码块
+                    grid = ast.literal_eval(code_block)
+                    # 验证是否为有效的n×n网格
+                    if (isinstance(grid, list) and 
+                        len(grid) == n and 
+                        all(isinstance(row, list) and len(row) == n for row in grid)):
+                        return grid
+                except Exception:
+                    # 如果直接解析失败，尝试移除注释后再解析
+                    code_without_comments = re.sub(r'#.*$', '', code_block, flags=re.MULTILINE)
+                    try:
+                        grid = ast.literal_eval(code_without_comments.strip())
+                        if (isinstance(grid, list) and 
+                            len(grid) == n and 
+                            all(isinstance(row, list) and len(row) == n for row in grid)):
+                            return grid
+                    except Exception:
+                        pass
+            
+            # 如果提取失败，返回原始答案
+            return test_solution
+        except Exception as e:
+            print(f"提取网格时出错: {e}")
+            return test_solution

--- a/environments/synlogic/synlogic_src/games/tasks/space_reasoning/scripts/space_reasoning_verifier.py
+++ b/environments/synlogic/synlogic_src/games/tasks/space_reasoning/scripts/space_reasoning_verifier.py
@@ -1,0 +1,41 @@
+import re
+from base.data import Data
+from base.verifier import Verifier, THOUGHT_DELIMITER_START, THOUGHT_DELIMITER_END
+import math_verify 
+
+
+class SpaceReasoningVerifier(Verifier):
+    """
+    验证器用于空间推理游戏的答案是否正确
+    """
+    def verify(self, data: Data, test_answer: str):
+        test_answer = self.extract_answer(test_answer)
+        if test_answer is None:
+            return False
+        return test_answer.lower() == data.answer.lower()
+    
+    def extract_answer(self, answer_str):
+        # 先找到最后一个\boxed{的位置
+        last_box_index = answer_str.rfind("\\boxed{")
+        
+        if last_box_index == -1:
+            return None
+        
+        # 从\boxed{开始截取到正确的闭合位置，处理嵌套括号
+        start_index = last_box_index + len("\\boxed{")
+        bracket_stack = 1  # 已经遇到了一个左括号
+        end_index = start_index
+        
+        while end_index < len(answer_str) and bracket_stack > 0:
+            if answer_str[end_index] == '{':
+                bracket_stack += 1
+            elif answer_str[end_index] == '}':
+                bracket_stack -= 1
+            end_index += 1
+        
+        if bracket_stack != 0:  # 括号不匹配
+            return None
+        
+        # 提取\boxed{}内的内容
+        latex_content = answer_str[start_index:end_index-1].strip()
+        return latex_content

--- a/environments/synlogic/synlogic_src/games/tasks/space_reasoning_tree/scripts/space_reasoning_tree_verifier.py
+++ b/environments/synlogic/synlogic_src/games/tasks/space_reasoning_tree/scripts/space_reasoning_tree_verifier.py
@@ -1,0 +1,44 @@
+import re
+from base.data import Data
+from base.verifier import Verifier, THOUGHT_DELIMITER_START, THOUGHT_DELIMITER_END
+import math_verify 
+
+class SpaceReasoningTreeVerifier(Verifier):
+    """
+    验证器用于空间推理树游戏的答案是否正确
+    """
+    def verify(self, data: Data, test_answer: str):
+        test_answer = self.extract_answer(test_answer)
+        if test_answer is None:
+            return False
+        test_answer = test_answer.replace("，", ",").replace(" ", "")
+        ground_truth = data.answer.replace("，", ",").replace(" ", "")
+        test_set = set(test_answer.split(","))
+        ground_truth_set = set(ground_truth.split(","))
+        return test_set == ground_truth_set
+    
+    def extract_answer(self, answer_str):
+        # 先找到最后一个\boxed{的位置
+        last_box_index = answer_str.rfind("\\boxed{")
+        
+        if last_box_index == -1:
+            return None
+        
+        # 从\boxed{开始截取到正确的闭合位置，处理嵌套括号
+        start_index = last_box_index + len("\\boxed{")
+        bracket_stack = 1  # 已经遇到了一个左括号
+        end_index = start_index
+        
+        while end_index < len(answer_str) and bracket_stack > 0:
+            if answer_str[end_index] == '{':
+                bracket_stack += 1
+            elif answer_str[end_index] == '}':
+                bracket_stack -= 1
+            end_index += 1
+        
+        if bracket_stack != 0:  # 括号不匹配
+            return None
+        
+        # 提取\boxed{}内的内容
+        latex_content = answer_str[start_index:end_index-1].strip()
+        return latex_content

--- a/environments/synlogic/synlogic_src/games/tasks/star_placement_puzzle/scripts/star_placement_puzzle_verifier.py
+++ b/environments/synlogic/synlogic_src/games/tasks/star_placement_puzzle/scripts/star_placement_puzzle_verifier.py
@@ -1,0 +1,160 @@
+from base.data import Data
+from base.verifier import Verifier, THOUGHT_DELIMITER_START, THOUGHT_DELIMITER_END
+import re
+import json
+import ast
+
+import re
+
+class StarPlacementPuzzleVerifier(Verifier):
+    """
+    星星放置游戏验证器，用于验证模型提供的解答是否正确
+    """
+    def verify(self, data: Data, test_solution: str):
+        """
+        验证模型的回答是否符合星星放置游戏的规则
+
+        @param data: 包含游戏信息的Data对象
+        @param star_coords: 通过extract_answer提取的星星坐标字典 {区域: [(行,列), ...]}
+        @return: 回答是否正确的布尔值
+        """
+        try:
+            star_coords = self.extract_answer(test_solution)
+            # 获取游戏元数据
+            metadata = data.metadata
+            n = metadata['n']
+            k = metadata['k']
+            region_grid = metadata['region_grid']
+            
+            print(f"验证: 游戏规模 {n}×{n}, 每行/列/区域星星数量: {k}")
+            
+            # 检查是否有有效的星星坐标
+            if not star_coords:
+                print("无法从回答中提取有效的星星坐标")
+                return False
+            
+            # 创建一个表示星星位置的网格
+            star_grid = [[0 for _ in range(n)] for _ in range(n)]
+            for region, coords in star_coords.items():
+                for coord in coords:
+                    row, col = coord
+                    if row < 0 or row >= n or col < 0 or col >= n:
+                        print(f"无效坐标: ({row},{col}) - 超出网格范围")
+                        return False
+                    star_grid[row][col] = 1
+            
+            # 打印星星网格以便调试
+            print("星星网格:")
+            for row in star_grid:
+                print(''.join(['* ' if cell == 1 else '. ' for cell in row]))
+            
+            # 1. 检查每行是否有k颗星星
+            for i in range(n):
+                stars_in_row = sum(star_grid[i])
+                if stars_in_row != k:
+                    print(f"行 {i+1} 有 {stars_in_row} 颗星星，应该有 {k} 颗")
+                    return False
+            
+            # 2. 检查每列是否有k颗星星
+            for j in range(n):
+                stars_in_col = sum(star_grid[i][j] for i in range(n))
+                if stars_in_col != k:
+                    print(f"列 {j+1} 有 {stars_in_col} 颗星星，应该有 {k} 颗")
+                    return False
+            
+            # 3. 检查每个区域是否有k颗星星
+            regions = {}
+            for i in range(n):
+                for j in range(n):
+                    region = region_grid[i][j]
+                    if region not in regions:
+                        regions[region] = []
+                    regions[region].append((i, j))
+            
+            for region, cells in regions.items():
+                stars_in_region = sum(star_grid[i][j] for i, j in cells)
+                if stars_in_region != k:
+                    print(f"区域 {region} 有 {stars_in_region} 颗星星，应该有 {k} 颗")
+                    return False
+            
+            # 4. 检查星星是否互不相邻（水平、垂直、对角线）
+            for i in range(n):
+                for j in range(n):
+                    if star_grid[i][j] == 1:
+                        # 检查周围8个方向
+                        for di in [-1, 0, 1]:
+                            for dj in [-1, 0, 1]:
+                                if di == 0 and dj == 0:
+                                    continue  # 跳过自身
+                                ni, nj = i + di, j + dj
+                                if 0 <= ni < n and 0 <= nj < n and star_grid[ni][nj] == 1:
+                                    print(f"星星在 ({i},{j}) 与星星在 ({ni},{nj}) 相邻")
+                                    return False
+            
+            # 所有检查通过
+            print("所有验证规则通过!")
+            return True
+            
+        except Exception as e:
+            print(f"验证过程出错: {e}")
+            return False 
+        
+    def extract_answer(self, test_solution: str):
+        """
+        从模型的回答中提取星星坐标
+        
+        @param test_solution: 模型的完整回答
+        @return: 提取的星星坐标字典 {区域: [(行,列), ...]}
+        """
+        try:
+            # 从Python代码块中提取
+            python_match = re.search(r'```python\s*\n(.*?)\n\s*```', test_solution, re.DOTALL)
+            if not python_match:
+                print("回答中没有找到```python代码块")
+                return None
+                
+            code_content = python_match.group(1)
+            
+            # 尝试从Python代码中提取字典
+            try:
+                # 先尝试直接提取字典内容
+                dict_match = re.search(r'\{[^{}]*\}', code_content, re.DOTALL)
+                if dict_match:
+                    dict_str = dict_match.group(0)
+                    try:
+                        # 将字符串转换为字典
+                        coords_dict = ast.literal_eval(dict_str)
+                        # 如果成功且是字典类型，继续处理
+                        if isinstance(coords_dict, dict):
+                            # 将坐标减1（因为用户输入的坐标是1-索引）
+                            result = {}
+                            for region, coords in coords_dict.items():
+                                result[region] = [(row-1, col-1) for row, col in coords]
+                            return result
+                    except (ValueError, SyntaxError) as e:
+                        print(f"解析字典字符串时出错: {e}")
+                
+                # 如果上面的方法失败，尝试解析变量赋值
+                assign_match = re.search(r'(\w+)\s*=\s*(\{[^{}]*\})', code_content, re.DOTALL)
+                if assign_match:
+                    dict_str = assign_match.group(2)
+                    try:
+                        # 将字符串转换为字典
+                        coords_dict = ast.literal_eval(dict_str)
+                        # 如果成功且是字典类型，继续处理
+                        if isinstance(coords_dict, dict):
+                            # 将坐标减1（因为用户输入的坐标是1-索引）
+                            result = {}
+                            for region, coords in coords_dict.items():
+                                result[region] = [(row-1, col-1) for row, col in coords]
+                            return result
+                    except (ValueError, SyntaxError) as e:
+                        print(f"解析变量赋值字典时出错: {e}")
+            except Exception as e:
+                print(f"从Python代码中提取字典时出错: {e}")
+            
+            return None
+            
+        except Exception as e:
+            print(f"提取星星坐标时出错: {e}")
+            return None

--- a/environments/synlogic/synlogic_src/games/tasks/sudoku/scripts/sudoku_verifier.py
+++ b/environments/synlogic/synlogic_src/games/tasks/sudoku/scripts/sudoku_verifier.py
@@ -1,0 +1,146 @@
+from base.data import Data
+from base.verifier import Verifier
+import re
+import ast
+
+class SudokuVerifier(Verifier):
+    """
+    验证器用于检查数独游戏的答案是否正确
+    """
+    def verify(self, data: Data, test_solution: str):
+        """
+        验证模型提供的数独解答是否正确
+        
+        @param data: 包含问题、元数据等信息的Data对象
+        @param test_answer: 模型给出的数独解答字符串，应该是一个9x9的二维数组
+        @return: 回答是否正确的布尔值
+        """
+        try:
+            test_answer = self.extract_answer(test_solution)
+            # 将字符串转换为Python元组（二维数组）
+            if not test_answer or test_answer == "":
+                print("验证失败：答案为空")
+                return False
+            
+            # 尝试将答案字符串转换为二维数组
+            try:
+                # 将字符串转换为Python数据结构
+                sudoku_solution = ast.literal_eval(test_answer)
+                
+                # 检查解答是否为9x9的二维数组
+                if (not isinstance(sudoku_solution, tuple) and not isinstance(sudoku_solution, list)) or len(sudoku_solution) != 9:
+                    print(f"验证失败：解答格式不正确，应为9x9数组，实际为: {type(sudoku_solution)}, 长度: {len(sudoku_solution)}")
+                    return False
+                
+                for row in sudoku_solution:
+                    if (not isinstance(row, tuple) and not isinstance(row, list)) or len(row) != 9:
+                        print(f"验证失败：解答格式不正确，行应为长度9的数组，实际为: {type(row)}, 长度: {len(row)}")
+                        return False
+                    
+                    for num in row:
+                        if not isinstance(num, int) or num < 1 or num > 9:
+                            print(f"验证失败：解答包含非法数字 {num}，应为1-9的整数")
+                            return False
+            except (SyntaxError, ValueError) as e:
+                print(f"验证失败：无法解析答案 '{test_answer}', 错误: {e}")
+                return False
+            
+            # 从元数据中获取原始数独题目
+            original_sudoku = data.metadata.get("original_sudoku", [])
+            if not original_sudoku:
+                print("验证失败：元数据中缺少原始数独题目")
+                return False
+            
+            # 1. 验证解答是否符合数独规则
+            if not self._is_valid_sudoku(sudoku_solution):
+                print("验证失败：解答不符合数独规则")
+                return False
+            
+            # 2. 验证解答是否与原始数独题目一致（已填数字部分）
+            if not self._is_consistent_with_original(original_sudoku, sudoku_solution):
+                print("验证失败：解答与原始数独不一致")
+                return False
+            
+            print("验证成功：解答正确")
+            return True
+            
+        except Exception as e:
+            print(f"验证时出错: {e}")
+            return False
+    
+    def _is_valid_sudoku(self, sudoku):
+        """
+        验证数独解答是否符合规则：每行、每列、每个3x3子网格包含1-9的数字且不重复
+        
+        @param sudoku: 数独解答，9x9的二维数组
+        @return: 是否符合数独规则
+        """
+        # 检查每一行
+        for row in sudoku:
+            if set(row) != set(range(1, 10)):
+                return False
+        
+        # 检查每一列
+        for col in range(9):
+            column = [sudoku[row][col] for row in range(9)]
+            if set(column) != set(range(1, 10)):
+                return False
+        
+        # 检查每个3x3子网格
+        for box_row in range(0, 9, 3):
+            for box_col in range(0, 9, 3):
+                box = []
+                for r in range(box_row, box_row + 3):
+                    for c in range(box_col, box_col + 3):
+                        box.append(sudoku[r][c])
+                if set(box) != set(range(1, 10)):
+                    return False
+        
+        return True
+    
+    def _is_consistent_with_original(self, original_sudoku, solution_sudoku):
+        """
+        验证解答是否与原始数独题目一致（已填数字部分）
+        
+        @param original_sudoku: 原始数独题目，9x9的二维数组，0或'X'表示空格
+        @param solution_sudoku: 数独解答，9x9的二维数组
+        @return: 是否与原始数独一致
+        """
+        for i in range(9):
+            for j in range(9):
+                original_value = original_sudoku[i][j]
+                # 如果原始数独中的位置不是空的（不是0或'X'），则检查解答是否与之一致
+                if original_value not in [0, 'X', 'x']:
+                    if solution_sudoku[i][j] != int(original_value):
+                        print(f"位置 ({i},{j}) 不一致: 原始值 {original_value}, 解答值 {solution_sudoku[i][j]}")
+                        return False
+        
+        return True 
+    
+    def extract_answer(self, test_solution: str):
+        """
+        从模型的回答中提取数独解答
+        
+        @param test_solution: 模型的完整回答
+        @return: 提取的答案（元组形式的字符串）
+        """
+        if not test_solution:
+            return ""
+        
+        # 提取Python代码块中的内容
+        code_block_pattern = r"```python\s*([\s\S]*?)\s*```"
+        matches = re.findall(code_block_pattern, test_solution)
+        
+        if matches:
+            # 取最后一个Python代码块
+            python_code = matches[-1].strip()
+            return python_code
+        
+        # 如果没有找到Python代码块，尝试找到任何类似于元组的结构
+        tuple_pattern = r"\(\s*\(\s*\d+\s*,.*?\)\s*\)"
+        matches = re.findall(tuple_pattern, test_solution, re.DOTALL)
+        
+        if matches:
+            return matches[-1].strip()
+        
+        return ""

--- a/environments/synlogic/synlogic_src/games/tasks/survo/scripts/survo_verifier.py
+++ b/environments/synlogic/synlogic_src/games/tasks/survo/scripts/survo_verifier.py
@@ -1,0 +1,139 @@
+import json
+import numpy as np
+from base.data import Data
+from base.verifier import Verifier
+import re
+
+class SurvoVerifier(Verifier):
+    """
+    验证器用于检查Survo矩阵填充游戏的答案是否正确
+    """
+    def verify(self, data: Data, test_solution: str):
+        """
+        验证模型的回答是否正确
+        
+        @param data: 包含问题、元数据等信息的Data对象
+        @param test_answer: 模型给出的矩阵答案字符串，格式为二维列表
+        @return: 回答是否正确的布尔值
+        """
+        try:
+            test_answer = self.extract_answer(test_solution)
+            # 解析元数据
+            metadata = data.metadata
+            original_matrix = np.array(metadata["original_matrix"])
+            candidate_numbers = metadata["candidate_numbers"]
+            n = metadata["n"]
+            
+            # 解析模型给出的矩阵
+            try:
+                # 尝试直接解析JSON格式的矩阵
+                test_matrix = json.loads(test_answer.replace("'", "\""))
+                test_matrix = np.array(test_matrix)
+            except:
+                # 如果直接解析失败，尝试清理并手动解析
+                test_answer = test_answer.strip()
+                # 移除前后的括号和Python语法
+                if test_answer.startswith("[") and test_answer.endswith("]"):
+                    # 替换所有单引号为双引号以符合JSON格式
+                    cleaned_answer = test_answer.replace("'", "\"")
+                    try:
+                        test_matrix = json.loads(cleaned_answer)
+                        test_matrix = np.array(test_matrix)
+                    except:
+                        print(f"无法解析矩阵答案: {test_answer}")
+                        return False
+                else:
+                    print(f"答案格式不正确: {test_answer}")
+                    return False
+            
+            # 验证矩阵维度
+            if test_matrix.shape != original_matrix.shape:
+                print(f"矩阵维度不匹配: 期望 {original_matrix.shape}, 实际 {test_matrix.shape}")
+                return False
+            
+            # 验证矩阵中的元素是否正确填充
+            # 1. 检查原始矩阵中已填充的元素是否被保留
+            for i in range(n):
+                for j in range(n):
+                    if original_matrix[i, j] != 0 and original_matrix[i, j] != test_matrix[i, j]:
+                        print(f"原始矩阵中的元素被篡改: 位置 ({i}, {j}), 原值 {original_matrix[i, j]}, 新值 {test_matrix[i, j]}")
+                        return False
+            
+            # 2. 收集填充的数字并验证它们是否与候选数字一致
+            filled_numbers = []
+            for i in range(n):
+                for j in range(n):
+                    if original_matrix[i, j] == 0:
+                        filled_numbers.append(test_matrix[i, j])
+            
+            # 排序后比较是否一致
+            sorted_filled = sorted(filled_numbers)
+            sorted_candidates = sorted(candidate_numbers)
+            
+            if sorted_filled != sorted_candidates:
+                print(f"填充的数字与候选数字不匹配: 填充 {sorted_filled}, 候选 {sorted_candidates}")
+                return False
+            
+            # 3. 验证每行和每列的和是否正确
+            # 检查每行的和
+            for i in range(n-1):
+                row_sum = sum(test_matrix[i, 0:n-1])
+                expected_sum = test_matrix[i, n-1]
+                if row_sum != expected_sum:
+                    print(f"第 {i+1} 行的和不正确: 实际和 {row_sum}, 期望和 {expected_sum}")
+                    return False
+            
+            # 检查每列的和
+            for j in range(n-1):
+                col_sum = sum(test_matrix[0:n-1, j])
+                expected_sum = test_matrix[n-1, j]
+                if col_sum != expected_sum:
+                    print(f"第 {j+1} 列的和不正确: 实际和 {col_sum}, 期望和 {expected_sum}")
+                    return False
+            
+            # 所有检查都通过
+            print("验证结果: 正确")
+            return True
+            
+        except Exception as e:
+            print(f"验证时出错: {e}")
+            return False 
+        
+    def extract_answer(self, test_solution: str):
+        """
+        从模型的回答中提取答案（矩阵）
+        
+        @param test_solution: 模型的完整回答
+        @return: 提取的矩阵答案字符串
+        """
+        if not test_solution:
+            return ""
+        
+        # 尝试提取Python代码块中的矩阵
+        code_block_pattern = r'```python\s*([\s\S]*?)\s*```'
+        code_matches = re.findall(code_block_pattern, test_solution)
+        
+        if code_matches:
+            # 使用最后一个Python代码块
+            matrix_str = code_matches[-1].strip()
+            return matrix_str
+        
+        # 如果没有找到Python代码块，尝试提取任何代码块
+        general_code_block = r'```([\s\S]*?)```'
+        general_matches = re.findall(general_code_block, test_solution)
+        
+        if general_matches:
+            # 使用最后一个代码块
+            matrix_str = general_matches[-1].strip()
+            return matrix_str
+        
+        # 如果没有找到代码块，尝试提取可能的矩阵表示
+        matrix_pattern = r'\[\s*\[.*?\]\s*\]'
+        matrix_matches = re.findall(matrix_pattern, test_solution, re.DOTALL)
+        
+        if matrix_matches:
+            # 使用最后一个匹配的矩阵
+            return matrix_matches[-1].strip()
+        
+        # 如果所有方法都失败，返回空字符串
+        return ""

--- a/environments/synlogic/synlogic_src/games/tasks/time_sequence/scripts/time_sequence_verifier.py
+++ b/environments/synlogic/synlogic_src/games/tasks/time_sequence/scripts/time_sequence_verifier.py
@@ -1,0 +1,69 @@
+import json
+import numpy as np
+from base.data import Data
+from base.verifier import Verifier
+import re
+
+class TimeSequenceVerifier(Verifier):
+    """
+    验证器用于验证 time sequence 的答案是否正确
+    """
+    def verify(self, data: Data, test_solution: str):
+        """
+        验证模型的回答是否正确
+        
+        @param data: 包含问题、元数据等信息的Data对象
+        @param test_answer: 模型给出的答案，格式为数字列表
+        @return: 回答是否正确的布尔值
+        """
+        try:
+            test_answer = self.extract_answer(test_solution)
+            # 解析元数据
+            metadata = data.metadata
+            true_answers = metadata['records']['answers']
+            
+            # 解析模型给出的列表
+            try:
+                test_list = json.loads(test_answer.replace("，", ","))
+            except:
+                print(f"无法解析答案: {test_answer}")
+                return False
+            
+            try:
+                if test_list[0]!=true_answers['answer_maxLen']:
+                    print(f"最长会议时间不正确。model:{test_answer} *** true:[{true_answers['answer_maxLen']}, {true_answers['answer_nums']}]")
+                    return False
+                if test_list[1]!=true_answers['answer_nums']:
+                    print(f"可选会议数量不正确。model:{test_answer} *** true:[{true_answers['answer_maxLen']}, {true_answers['answer_nums']}]")
+                    return False
+            except:
+                print(f"答案判断出错了！")
+                return False
+            
+            # 所有检查都通过
+            print("验证结果: 正确")
+            return True
+        except Exception as e:
+            print(f"验证时出错: {e}")
+            return False 
+        
+    def extract_answer(self, test_solution: str):
+        """
+        从模型的回答中提取答案（矩阵）
+        
+        @param test_solution: 模型的完整回答
+        @return: 提取答案列表
+        """
+        if not test_solution:
+            return ""
+        
+        # 尝试提取列表
+        matrix_pattern = r'\[.*?\]'
+        matrix_matches = re.findall(matrix_pattern, test_solution, re.DOTALL)
+        if matrix_matches:
+            # 使用最后一个匹配的列表
+            print(matrix_matches)
+            return matrix_matches[-1].strip()
+        
+        # 如果失败，返回空字符串
+        return ""

--- a/environments/synlogic/synlogic_src/games/tasks/web_of_lies/scripts/web_of_lies_verifier.py
+++ b/environments/synlogic/synlogic_src/games/tasks/web_of_lies/scripts/web_of_lies_verifier.py
@@ -1,0 +1,135 @@
+import re
+from base.data import Data
+from base.verifier import Verifier, THOUGHT_DELIMITER_START, THOUGHT_DELIMITER_END
+
+class WebOfLiesVerifier(Verifier):
+    """
+    验证器用于检查谎言之网游戏的答案是否正确
+    """
+    def verify(self, data: Data, test_solution: str):
+        """
+        验证模型的回答是否正确
+        
+        @param data: 包含问题、元数据等信息的Data对象
+        @param test_answer: 模型给出的回答字符串
+        @return: 回答是否正确的布尔值
+        """
+        try:
+            test_answer = self.extract_answer(test_solution)
+            # 获取预期答案和测试答案
+            expected_answer = data.answer.lower()
+            
+            # 清理测试答案
+            test_answer = test_answer.lower()
+            
+            # 提取预期答案中的真假值
+            expected_truths = self._parse_answer(expected_answer)
+            
+            # 提取测试答案中的真假值
+            test_truths = self._parse_answer(test_answer)
+            
+            print(f"验证: 预期答案={expected_truths}, 模型答案={test_truths}")
+            
+            # 检查答案列表长度是否匹配
+            if len(expected_truths) != len(test_truths):
+                print(f"验证失败: 答案长度不匹配，预期 {len(expected_truths)}，实际 {len(test_truths)}")
+                return False
+            
+            # 检查每个位置的答案是否匹配
+            for i, (expected, actual) in enumerate(zip(expected_truths, test_truths)):
+                if expected != actual:
+                    print(f"验证失败: 第 {i+1} 个答案不匹配，预期 {expected}，实际 {actual}")
+                    return False
+            
+            print("验证成功: 所有答案匹配")
+            return True
+            
+        except Exception as e:
+            print(f"验证时出错: {e}")
+            return False
+    
+    def _parse_answer(self, answer_str):
+        """
+        从答案字符串中解析出真假值列表
+        
+        @param answer_str: 答案字符串
+        @return: 真假值列表，True表示说真话，False表示说谎话
+        """
+        # 尝试匹配英文答案格式 (yes/no)
+        yes_pattern = r'yes|true|truth'
+        no_pattern = r'no|false|lie'
+        
+        # 尝试匹配中文答案格式 (是/否)
+        cn_yes_pattern = r'是|真话|真'
+        cn_no_pattern = r'否|假话|假|谎'
+        
+        # 组合模式
+        yes_patterns = f'({yes_pattern}|{cn_yes_pattern})'
+        no_patterns = f'({no_pattern}|{cn_no_pattern})'
+        
+        # 根据答案字符串中的关键词确定真假值
+        truths = []
+        
+        # 寻找所有可能的yes/no或是/否答案
+        all_answers = re.findall(rf'{yes_patterns}|{no_patterns}', answer_str)
+        
+        for match in all_answers:
+            # match是一个元组，需要找到非空的元素
+            match_str = next((m for m in match if m), '')
+            
+            if re.search(yes_pattern, match_str) or re.search(cn_yes_pattern, match_str):
+                truths.append(True)
+            elif re.search(no_pattern, match_str) or re.search(cn_no_pattern, match_str):
+                truths.append(False)
+        
+        return truths 
+    
+    def extract_answer(self, test_solution: str) -> str:
+        """
+        从模型的回答中提取答案
+        
+        @param test_solution: 模型的完整回答
+        @return: 提取的答案
+        """
+        if not test_solution:
+            return ""
+        # 中文模式
+        cn_patterns = [
+            r'答案是[：:]\s*\*\*([^*]+)\*\*[.。]*$',  # 匹配"答案是：**是，否，是**"格式
+        ]
+        
+        # 英文模式
+        en_patterns = [
+            r'[Tt]he answer is[：:=]\s*\*\*([^*]+)\*\*[.。]*$',  # 匹配"The answer is: **yes, no, yes**"格式
+        ]
+        
+        # 尝试匹配所有模式
+        patterns = cn_patterns + en_patterns
+        
+        for pattern in patterns:
+            matches = re.findall(pattern, test_solution, re.DOTALL)
+            if matches:
+                return matches[-1].strip()
+        
+        # 如果上面的模式都没匹配到，尝试更宽松的匹配
+        # 查找最后一行中的加粗文本
+        lines = test_solution.strip().split('\n')
+        if lines:
+            last_line = lines[-1].strip()
+            bold_match = re.search(r'\*\*([^*]+)\*\*', last_line)
+            if bold_match:
+                return bold_match.group(1).strip()
+            
+            # 尝试匹配"答案是"或"The answer is"后面的文本
+            answer_match = re.search(r'(?:答案是|[Tt]he answer is)[：:=]?\s*(.*?)(?:[.。]|$)', last_line)
+            if answer_match:
+                return answer_match.group(1).strip()
+        
+        # 如果没有找到格式化的答案，尝试直接匹配yes/no或是/否序列
+        yes_no_pattern = r'(?:\b(?:yes|no|是|否)\b[,，\s]*)+' 
+        matches = re.findall(yes_no_pattern, test_solution.lower())
+        if matches:
+            return matches[-1].strip()
+        
+        # 如果没有匹配到任何模式，返回空字符串
+        return ""

--- a/environments/synlogic/synlogic_src/games/tasks/word_sorting/scripts/word_sorting_verifier.py
+++ b/environments/synlogic/synlogic_src/games/tasks/word_sorting/scripts/word_sorting_verifier.py
@@ -1,0 +1,43 @@
+import re
+from base.data import Data
+from base.verifier import Verifier
+
+class WordSortingVerifier(Verifier):
+    """
+    验证器用于单词排序游戏的答案是否正确
+    """
+    def str2list(self, answer_str):
+        # 替换中文逗号为英文逗号，并删除所有空格
+        answer_str = answer_str.replace("，", ",").replace(" ", "")
+        return [w.strip() for w in answer_str.split(",")]
+
+    def verify(self, data: Data, test_answer: str):
+        try:
+            ground_truth = self.str2list(data.answer)
+            parsed_answer = self.str2list(self.extract_answer(test_answer))
+            
+            if parsed_answer is None:
+                return False
+            return parsed_answer == ground_truth
+
+        except Exception as e:
+            print(f"解析答案错误:{e}")
+            return False
+    
+    def extract_answer(self, answer_str):
+        # 先找到最后一个\Box{的位置
+        last_box_index = answer_str.rfind("\\boxed{")
+        
+        if last_box_index == -1:
+            return None
+            
+        # 从最后一个\Box{开始截取字符串
+        last_box_substring = answer_str[last_box_index:]
+        
+        # 在截取的子字符串中进行正则匹配
+        box_pattern = r'\\boxed\{([^}]*)\}'
+        match = re.search(box_pattern, last_box_substring)
+        
+        if match:
+            return match.group(1).strip()
+        return None

--- a/environments/synlogic/synlogic_src/games/tasks/word_sorting_mistake/scripts/word_sorting_mistake_verifier.py
+++ b/environments/synlogic/synlogic_src/games/tasks/word_sorting_mistake/scripts/word_sorting_mistake_verifier.py
@@ -1,0 +1,45 @@
+import re
+from base.data import Data
+from base.verifier import Verifier
+
+class WordSortingMistakeVerifier(Verifier):
+    """
+    验证器用于word sorting mistake的答案是否正确
+    """
+    def verify(self, data: Data, test_answer: str):
+        try:
+            ground_truth = data.answer if data.answer is not None else "No"
+            parsed_answer = self.extract_answer(test_answer)
+            
+            if parsed_answer is None:
+                return False
+            
+            if parsed_answer.isdigit():
+                try:
+                    return int(parsed_answer) == int(ground_truth)
+                except Exception as e:
+                    return False
+            else:
+                return parsed_answer.lower() == ground_truth.lower()
+        except Exception as e:
+            print(f"解析答案错误:{e}")
+            return False
+    
+    def extract_answer(self, answer_str):
+        # 先找到最后一个\boxed{的位置
+        last_box_index = answer_str.rfind("\\boxed{")
+        
+        if last_box_index == -1:
+            return None
+            
+        # 从最后一个\boxed{开始截取字符串
+        last_box_substring = answer_str[last_box_index:]
+        
+        # 在截取的子字符串中进行正则匹配
+        box_pattern = r'\\boxed\{([^}]*)\}'
+        match = re.search(box_pattern, last_box_substring)
+        
+        if match:
+            return match.group(1).strip()
+        return None
+        

--- a/environments/synlogic/synlogic_src/games/tasks/wordscapes/scripts/wordscapes_verifier.py
+++ b/environments/synlogic/synlogic_src/games/tasks/wordscapes/scripts/wordscapes_verifier.py
@@ -1,0 +1,159 @@
+"""
+Wordscapes verifier module for the reasonreason framework.
+"""
+
+import json
+import re
+from base.verifier import Verifier, THOUGHT_DELIMITER_START, THOUGHT_DELIMITER_END
+
+debug_mode = False
+
+class WordscapesVerifier(Verifier):
+    """
+    Verifier for Wordscapes game
+    """
+    def verify(self, data, test_solution: str):
+        """
+        Verify whether the test answer is consistent with the gold answer
+        
+        Args:
+            data: WordscapesData
+            test_solution: str containing the solution
+            
+        Returns:
+            float: Score between 0 and 1
+        """
+        try:
+            extracted_answer = self.extract_answer(test_solution)
+            if not extracted_answer:
+                print("Failed to extract answer from test solution")
+                return False
+            
+            if debug_mode:
+                for row in extracted_answer:
+                    print(" ".join(cell if cell != " " else "_" for cell in row))
+            
+            # Get grid, across_words, and down_words from data
+            grid = data.metadata["grid"]
+            across_words = data.metadata["across_words"]
+            down_words = data.metadata["down_words"]
+            
+            # Validate grid dimensions
+            if len(extracted_answer) != len(grid):
+                print(f"Grid height mismatch: expected {len(grid)}, got {len(extracted_answer)}")
+                return False
+            
+            for i in range(len(grid)):
+                if len(extracted_answer[i]) != len(grid[i]):
+                    print(f"Grid width mismatch at row {i}: expected {len(grid[i])}, got {len(extracted_answer[i])}")
+                    return False
+            
+            # Check if the answer respects the grid layout (X for letters, 0 for empty)
+            for i in range(len(grid)):
+                for j in range(len(grid[i])):
+                    if grid[i][j] == "0" and extracted_answer[i][j].strip():
+                        print(f"Expected empty space at position ({i},{j}), got '{extracted_answer[i][j]}'")
+                        return False
+                    if grid[i][j] == "X" and not extracted_answer[i][j].strip():
+                        print(f"Expected letter at position ({i},{j}), got empty space")
+                        return False
+            
+            # Verify across words
+            for word in across_words:
+                found = False
+                for i in range(len(extracted_answer)):
+                    row_str = ''.join(extracted_answer[i]).replace(' ', '').lower()
+                    if word.lower() in row_str:
+                        found = True
+                        break
+                if not found and word:
+                    print(f"Across word '{word}' not found in the grid")
+                    return 0
+            
+            # Verify down words
+            for word in down_words:
+                found = False
+                for j in range(len(extracted_answer[0])):
+                    col = []
+                    for i in range(len(extracted_answer)):
+                        if j < len(extracted_answer[i]):
+                            col.append(extracted_answer[i][j])
+                    col_str = ''.join(col).replace(' ', '').lower()
+                    if word.lower() in col_str:
+                        found = True
+                        break
+                if not found and word:  # Only check if word is not empty
+                    print(f"Down word '{word}' not found in the grid")
+                    return False
+            
+            # All checks passed
+            return True
+        except Exception as e:
+            print(f"Error in verification: {str(e)}")
+            return False
+    
+    def extract_answer(self, test_solution: str):
+        """
+        Extract the answer from the test solution
+        
+        Args:
+            test_solution: str
+            
+        Returns:
+            list: 2D grid of the answer or None if extraction fails
+        """
+        try:
+            # Remove thoughts if present
+            if THOUGHT_DELIMITER_START in test_solution and THOUGHT_DELIMITER_END in test_solution:
+                # Extract only the part after the thoughts
+                thought_end_pos = test_solution.rfind(THOUGHT_DELIMITER_END)
+                if thought_end_pos >= 0:
+                    test_solution = test_solution[thought_end_pos + len(THOUGHT_DELIMITER_END):]
+            
+            # Clean up the response and find the grid pattern
+            # Look for a pattern like [[...]] or [[[...]]]
+            grid_pattern = re.search(r'\[\s*\[(?:\s*\[)?(.+?)(?:\]\s*)?\]\s*\]', test_solution, re.DOTALL)
+            if not grid_pattern:
+                return None
+                
+            grid_text = grid_pattern.group(1)
+            
+            # Handle various formats
+            rows = []
+            
+            # Check if rows are separated by commas
+            split_rows = re.split(r'\],\s*\[', grid_text)
+            
+            for row_text in split_rows:
+                # Clean the row text and extract characters
+                row_text = row_text.strip().strip('[],')
+                
+                # Extract quoted characters: "X" or 'X' or just X
+                chars = []
+                
+                # Look for quoted strings or standalone characters
+                char_matches = re.findall(r'\"([^\"]*)\"|\'([^\']*)\'|([^,\s]+)', row_text)
+                
+                for match in char_matches:
+                    # Take the first non-empty group from each match
+                    char = next((x for x in match if x), "")
+                    
+                    # Handle numeric or empty values (0, "", '')
+                    if char == "0" or char == "":
+                        char = " "
+                        
+                    chars.append(char)
+                
+                if chars:  # Only add non-empty rows
+                    rows.append(chars)
+            
+            # Make sure we have a valid grid
+            if not rows or not all(rows):
+                return None
+                
+            return rows
+                
+        except Exception as e:
+            print(f"Error extracting answer: {str(e)}")
+            return None
+       

--- a/environments/synlogic/synlogic_src/task2verifier.py
+++ b/environments/synlogic/synlogic_src/task2verifier.py
@@ -1,0 +1,78 @@
+import os
+import sys
+
+if os.path.dirname(os.path.abspath(__file__)) not in sys.path:
+    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from games.tasks.game_of_24.scripts.game_of_24_verifier import GameOf24Verifier
+from games.tasks.cryptarithm.scripts.cryptarithm_verifier import CryptarithmVerifier
+from games.tasks.survo.scripts.survo_verifier import SurvoVerifier
+from games.tasks.campsite.scripts.campsite_verifier import CampsiteVerifier
+from games.tasks.skyscraper_puzzle.scripts.skyscraper_puzzle_verifier import SkyscraperPuzzleVerifier
+from games.tasks.web_of_lies.scripts.web_of_lies_verifier import WebOfLiesVerifier
+from games.tasks.goods_exchange.scripts.goods_exchange_verifier import GoodsExchangeVerifier
+from games.tasks.sudoku.scripts.sudoku_verifier import SudokuVerifier
+from corpus.misc.tasks.zebra_puzzle.scripts.zebra_puzzle_verifier import ZebraPuzzleVerifier
+from corpus.misc.tasks.arc_agi.scripts.arc_agi_verifier import ArcAGIVerifier
+from games.tasks.object_properties.scripts.object_properties_verifier import ObjectPropertiesVerifier
+from games.tasks.object_counting.scripts.object_counting_verifier import ObjectCountingVerifier
+from games.tasks.star_placement_puzzle.scripts.star_placement_puzzle_verifier import StarPlacementPuzzleVerifier
+from games.tasks.arrow_maze.scripts.arrow_maze_verifier import ArrowMazeVerifier
+from games.tasks.kukurasu.scripts.kukurasu_verifier import KukurasuVerifier
+from games.tasks.number_wall.scripts.number_wall_verifier import NumberWallVerifier
+from games.tasks.numbrix.scripts.numbrix_verifier import NumbrixVerifier
+from games.tasks.norinori.scripts.norinori_verifier import NorinoriVerifier
+from games.tasks.minesweeper.scripts.minesweeper_verifier import MinesweeperVerifier
+from games.tasks.operation.scripts.operation_verifier import OperationVerifier
+from games.tasks.word_sorting_mistake.scripts.word_sorting_mistake_verifier import WordSortingMistakeVerifier
+from games.tasks.math_path.scripts.math_path_verifier import MathPathVerifier
+from games.tasks.boolean_expressions.scripts.boolean_expressions_verifier import BooleanExpressionsVerifier
+from games.tasks.space_reasoning.scripts.space_reasoning_verifier import SpaceReasoningVerifier
+from games.tasks.space_reasoning_tree.scripts.space_reasoning_tree_verifier import SpaceReasoningTreeVerifier
+from games.tasks.word_sorting.scripts.word_sorting_verifier import WordSortingVerifier
+from games.tasks.cipher.scripts.cipher_verifier import CipherVerifier
+from games.tasks.time_sequence.scripts.time_sequence_verifier import TimeSequenceVerifier
+from games.tasks.wordscapes.scripts.wordscapes_verifier import WordscapesVerifier
+from games.tasks.buggy_tables.scripts.game_of_buggy_tables_verifier import BuggyTableVerifier
+from games.tasks.calcudoko.scripts.calcudoko_verifier import CalcudokoVerifier
+from games.tasks.dyck_language.scripts.dyck_language_verifier import DyckLanguageVerifier
+from games.tasks.dyck_language_errors.scripts.dyck_language_errors_verifier import DyckLanguageErrorsVerifier
+from games.tasks.dyck_language_reasoning_errors.scripts.dyck_language_reasoning_errors_verifier import DyckLanguageReasoningErrorsVerifier
+from games.tasks.futoshiki.scripts.futoshiki_verifier import FutoshikiVerifier
+
+verifier_classes = {
+    "arc_agi": ArcAGIVerifier,
+    "arrow_maze": ArrowMazeVerifier,
+    "boolean_expressions": BooleanExpressionsVerifier,
+    "buggy_tables": BuggyTableVerifier,
+    "calcudoko": CalcudokoVerifier,
+    "campsite": CampsiteVerifier,
+    "cipher": CipherVerifier,
+    "cryptarithm": CryptarithmVerifier,
+    "dyck_language": DyckLanguageVerifier,
+    "dyck_language_errors": DyckLanguageErrorsVerifier,
+    "dyck_language_reasoning_errors": DyckLanguageReasoningErrorsVerifier,
+    "futoshiki": FutoshikiVerifier,
+    "goods_exchange": GoodsExchangeVerifier,
+    "kukurasu": KukurasuVerifier,
+    "math_path": MathPathVerifier,
+    "mathador": GameOf24Verifier,
+    "minesweeper": MinesweeperVerifier,
+    "norinori": NorinoriVerifier,
+    "number_wall": NumberWallVerifier,
+    "numbrix": NumbrixVerifier,
+    "object_counting": ObjectCountingVerifier,
+    "object_properties": ObjectPropertiesVerifier,
+    "operation": OperationVerifier,
+    "skyscraper_puzzle": SkyscraperPuzzleVerifier,
+    "space_reasoning": SpaceReasoningVerifier,
+    "space_reasoning_tree": SpaceReasoningTreeVerifier,
+    "star_placement_puzzle": StarPlacementPuzzleVerifier,
+    "sudoku": SudokuVerifier,
+    "survo": SurvoVerifier,
+    "time_sequence": TimeSequenceVerifier,
+    "web_of_lies": WebOfLiesVerifier,
+    "word_sorting": WordSortingVerifier,
+    "word_sorting_mistake": WordSortingMistakeVerifier,
+    "wordscapes": WordscapesVerifier,
+    "zebra_puzzle": ZebraPuzzleVerifier,
+}


### PR DESCRIPTION
## Summary
- Add a new `synlogic` installable environment for the MiniMax SynLogic benchmark.
- Load `MiniMaxAI/SynLogic` from Hugging Face with `easy` / `hard` configs and train / validation splits.
- Score responses with upstream SynLogic task-specific verifiers while enforcing the benchmark `<think>...</think><answer>...</answer>` format.
- Vendor only the verifier/runtime files needed for SynLogic dataset sources (35 verifier keys), avoiding the large generation assets from the reference repo.

## Bounty / references
- Algora bounty: https://algora.io/PrimeIntellect-ai/bounties/g42D7Yrh5u25gjtb
- Reference repo: https://github.com/MiniMax-AI/SynLogic
- Dataset: https://huggingface.co/datasets/MiniMaxAI/SynLogic

## Local verification
- `uvx ruff check environments/synlogic` ✅
- `CHANGED_ENVS=synlogic uv run --no-dev --with pytest pytest tests/test_envs.py -q -k 'pyproject or readme'` ✅
- `uv run --no-dev vf-install synlogic` ✅
- Smoke load:
  ```bash
  uv run --no-dev python - <<'PY'
  import verifiers as vf
  env = vf.load_environment('synlogic', max_examples=1, max_eval_examples=1, shuffle=False)
  print(type(env).__name__, len(env.get_dataset()), len(env.get_eval_dataset()))
  PY
  ```
  Output: `SingleTurnEnv 1 1` ✅
- Lazy verifier import smoke: `verifier_count 35`, required sources present ✅
- Wheel build: `uv build environments/synlogic --wheel --out-dir /tmp/synlogic_wheel3` ✅

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New optional environment package and vendored third-party verifier code; no changes to core auth, APIs, or existing env behavior.
> 
> **Overview**
> Adds a new installable **`synlogic`** environment that exposes the MiniMax SynLogic benchmark as a **`SingleTurnEnv`**, loading **`MiniMaxAI/SynLogic`** from Hugging Face with **`easy` / `hard`** configs and separate train/validation splits (with optional caps, shuffle, and seeds).
> 
> The wrapper maps dataset rows into Verifiers examples, keeps verifier-only metadata in **`info`**, and scores completions with a rubric whose primary reward enforces the **`...<answer>...</answer>`** format before dispatching to **upstream task-specific verifiers** (with **`val/...`** sources normalized to verifier keys). Optional **`format_reward`** and **`accuracy_reward`** hooks are included at zero weight for metrics.
> 
> Upstream verifier/runtime code is **vendored under `synlogic_src/`** (35 verifier keys via **`task2verifier`**, lazy import) because the reference repo is not an installable package; **`environments/README.md`** documents the new example.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8829f6447736359baade958713436af56404f0b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add SynLogic environment with task-specific verifiers for logical reasoning puzzles
> - Adds a new `synlogic` environment in [synlogic.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1503/files#diff-c0bfbb9f8737e3e3b4cafabab54cc5ced25a399fbe96f59abc0348a369ea6237) that loads the MiniMax SynLogic dataset (easy/hard config), builds train/eval splits, and exposes a `SingleTurnEnv` with format and accuracy reward functions.
> - Implements `synlogic_accuracy` as a bridge to a vendored verifier registry in [task2verifier.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1503/files#diff-cd3e47f05f73b4520312acc887ba6b4453ace86317ee987fe052e84b21f31016), dispatching each task to its corresponding verifier class at runtime.
> - Adds 25+ task-specific verifier classes covering puzzles such as Sudoku, Futoshiki, Campsite, Minesweeper, Norinori, Star Placement, Skyscraper, Numbrix, Arrow Maze, Game of 24, Zebra Puzzle, Wordscapes, and others under `environments/synlogic/synlogic_src/`.
> - Rewards are split into `format_reward` (1.0 for correct `<think>`/`<answer>` structure) and `accuracy_reward` (verifier score); `synlogic_reward` gates accuracy on format.
> - Risk: Several vendored verifiers contain noted syntax errors (e.g. `goods_exchange_verifier.py` and `numbrix_verifier.py`) that will cause import-time failures for those specific tasks.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8829f64.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->