### PR TITLE
Raise interception server request body limit to 24 MB

### DIFF
--- a/verifiers/utils/interception_utils.py
+++ b/verifiers/utils/interception_utils.py
@@ -37,7 +37,7 @@ logger = logging.getLogger(__name__)
 KEEPALIVE_INTERVAL_SECONDS = float(
     os.environ.get("INTERCEPTION_SERVER_KEEPALIVE_INTERVAL_SECONDS", "3.0")
 )
-DEFAULT_CLIENT_MAX_SIZE_BYTES = 16 * 1024 * 1024
+DEFAULT_CLIENT_MAX_SIZE_BYTES = 24 * 1024 * 1024
 
 
 class StreamInterrupted(InfraError):


### PR DESCRIPTION
## Summary
- Increase `DEFAULT_CLIENT_MAX_SIZE_BYTES` from 16 MB to 24 MB on the sandbox interception server (`InterceptionServer`).
- Browser eval agents sending screenshot-heavy chat completion payloads from sandboxes were hitting aiohttp `HTTPRequestEntityTooLarge` (413) before token-based compaction could help.

## Test plan
- [ ] Run a browser eval with large first-turn payloads (system prompt + initial screenshot) and confirm requests below 24 MB are accepted by the interception server.
- [ ] Confirm existing eval flows still start the interception server normally.


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant change to aiohttp body size; no auth, data model, or control-flow changes.
> 
> **Overview**
> Raises the sandbox **interception server** aiohttp `client_max_size` cap from **16 MB to 24 MB** via `DEFAULT_CLIENT_MAX_SIZE_BYTES` in `interception_utils.py`.
> 
> This lets browser eval agents post larger first-turn chat completion bodies (e.g. system prompt plus screenshots) without **HTTP 413** before downstream token compaction can run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a97699060210085494fa210e2f1917093639acd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Raise interception server request body limit to 24 MB
> Increases `DEFAULT_CLIENT_MAX_SIZE_BYTES` in [interception_utils.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1504/files#diff-ef080b90140e72f3d7e2a9d41a24c81e05204ced0d633125a3d66240df58af73) from 16 MiB to 24 MiB. Any caller importing this constant will now use the larger limit.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3a97699.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->