### PR TITLE
Use real parallel tool calls for mini-swe-agent

### DIFF
--- a/packages/harnesses/harnesses/mini_swe_agent.py
+++ b/packages/harnesses/harnesses/mini_swe_agent.py
@@ -18,8 +18,8 @@ MINI_SWE_AGENT_DEFAULT_PACKAGE_VERSION = "2.2.8"
 MINI_SWE_AGENT_DEFAULT_PACKAGE_SHA256 = (
     "694df4de1337e665e3cd82e99f93374f573bf52b8e7c362ac5d8045ad9f7c37c"
 )
-MINI_SWE_AGENT_DEFAULT_CONFIG_SPEC = "mini_textbased"
-MINI_SWE_AGENT_DEFAULT_MODEL_CLASS = "litellm_textbased"
+MINI_SWE_AGENT_DEFAULT_CONFIG_SPEC = "mini"
+MINI_SWE_AGENT_DEFAULT_MODEL_CLASS = "litellm"
 MINI_SWE_AGENT_DEFAULT_ENVIRONMENT_TIMEOUT = 120
 
 
@@ -71,6 +71,7 @@ class MiniSWEAgentProgramConfig(vf.ProgramConfig):
     config_spec: str = MINI_SWE_AGENT_DEFAULT_CONFIG_SPEC
     model_class: str = MINI_SWE_AGENT_DEFAULT_MODEL_CLASS
     environment_timeout: int = MINI_SWE_AGENT_DEFAULT_ENVIRONMENT_TIMEOUT
+    parallel_tool_calls: bool = True
     extra_config_specs: list[str] | None = None
     sandbox: vf.SandboxConfig | None = vf.SandboxConfig()
 
@@ -117,6 +118,8 @@ class MiniSWEAgentProgramConfig(vf.ProgramConfig):
             "model.cost_tracking=ignore_errors",
             "-c",
             "model.model_kwargs.custom_llm_provider=openai",
+            "-c",
+            f"model.model_kwargs.parallel_tool_calls={str(self.parallel_tool_calls).lower()}",
         ]
         for spec in self.extra_config_specs or []:
             config_args.extend(["-c", shlex.quote(spec)])

--- a/tests/test_v1_mini_swe_agent.py
+++ b/tests/test_v1_mini_swe_agent.py
@@ -69,10 +69,15 @@ def test_mini_swe_agent_builds_sandbox_program():
         )
     )
     program = cast(dict[str, Any], harness.config.program.data())
+    command = cast(list[str], program["command"])
+    script = command[-1]
 
     assert isinstance(harness, vf.Harness)
     assert program["sandbox"] is not False
     assert "OPENAI_MODEL" in cast(dict[str, object], program["env"])
+    assert "-c mini " in script
+    assert "model.model_class=litellm" in script
+    assert "model.model_kwargs.parallel_tool_calls=true" in script
     assert "apt-get -o Acquire::Retries=3 update" in cast(str, program["setup"])
     assert "apt-get -o Acquire::Retries=3 install" in cast(str, program["setup"])
     assert "/mini-swe-agent/prompt.txt" in cast(dict[str, object], program["files"])

--- a/verifiers/envs/experimental/composable/harnesses/mini_swe_agent.py
+++ b/verifiers/envs/experimental/composable/harnesses/mini_swe_agent.py
@@ -24,8 +24,8 @@ DEFAULT_LOG_DIR = "/logs/agent"
 DEFAULT_LOG_PATH = f"{DEFAULT_LOG_DIR}/mini-swe-agent.log"
 DEFAULT_TRAJECTORY_PATH = f"{DEFAULT_LOG_DIR}/mini-swe-agent.traj.json"
 DEFAULT_AGENT_WORKDIR = "${AGENT_WORKDIR:-/app}"
-DEFAULT_CONFIG_SPEC = "mini_textbased"
-DEFAULT_MODEL_CLASS = "litellm_textbased"
+DEFAULT_CONFIG_SPEC = "mini"
+DEFAULT_MODEL_CLASS = "litellm"
 DEFAULT_ENVIRONMENT_TIMEOUT = 120
 
 
@@ -52,6 +52,7 @@ def build_mini_swe_agent_run_command(
     config_spec: str = DEFAULT_CONFIG_SPEC,
     model_class: str = DEFAULT_MODEL_CLASS,
     environment_timeout: int = DEFAULT_ENVIRONMENT_TIMEOUT,
+    parallel_tool_calls: bool = True,
     extra_config_specs: list[str] | None = None,
 ) -> str:
     """Build the shell command that configures and runs mini-SWE-agent.
@@ -80,6 +81,8 @@ def build_mini_swe_agent_run_command(
         "model.cost_tracking=ignore_errors",
         "-c",
         "model.model_kwargs.custom_llm_provider=openai",
+        "-c",
+        f"model.model_kwargs.parallel_tool_calls={str(parallel_tool_calls).lower()}",
     ]
     # Config specs are the mini CLI's native override format; use them for cwd,
     # timeout, model class, and optional system prompt wiring.
@@ -141,6 +144,7 @@ def mini_swe_agent_harness(
     config_spec: str = DEFAULT_CONFIG_SPEC,
     model_class: str = DEFAULT_MODEL_CLASS,
     environment_timeout: int = DEFAULT_ENVIRONMENT_TIMEOUT,
+    parallel_tool_calls: bool = True,
     extra_config_specs: list[str] | None = None,
 ):
     """Create a Harness configured for mini-SWE-agent."""
@@ -168,6 +172,7 @@ def mini_swe_agent_harness(
             config_spec=config_spec,
             model_class=model_class,
             environment_timeout=environment_timeout,
+            parallel_tool_calls=parallel_tool_calls,
             extra_config_specs=extra_config_specs,
         ),
         system_prompt=system_prompt,


### PR DESCRIPTION
## Summary
- switch mini-swe-agent defaults from text/code-block parsing to the native `mini` + `litellm` tool-calling path
- enable `model.model_kwargs.parallel_tool_calls=true` by default
- mirror the setting in the legacy composable mini-swe-agent harness and add regression coverage

## Tests
- `uv run --frozen ruff format packages/harnesses/harnesses/mini_swe_agent.py verifiers/envs/experimental/composable/harnesses/mini_swe_agent.py tests/test_v1_mini_swe_agent.py`
- `uv run --frozen ruff check --fix packages/harnesses/harnesses/mini_swe_agent.py verifiers/envs/experimental/composable/harnesses/mini_swe_agent.py tests/test_v1_mini_swe_agent.py`
- `uv run --frozen pytest tests/test_v1_mini_swe_agent.py`
- `uv run --frozen pytest tests/test_v1_harbor_cli.py::test_packaged_command_harness_config_program_patch_precedence`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default agent execution and LLM invocation behavior for all mini-SWE-agent runs; misconfiguration could affect tool-call reliability or rollout compatibility with text-based setups.
> 
> **Overview**
> Switches mini-SWE-agent from the **text-based** config/model path (`mini_textbased`, `litellm_textbased`) to the native **`mini` + `litellm`** tool-calling stack, and turns on **`parallel_tool_calls`** by default via `model.model_kwargs.parallel_tool_calls=true` in the generated mini CLI config.
> 
> The v1 `MiniSWEAgentProgramConfig` and the legacy composable harness/run-command builder both expose `parallel_tool_calls` (default `True`). Tests assert the resolved sandbox script includes `-c mini`, `model.model_class=litellm`, and parallel tool calls enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cf5952c9a98f5529805e2a8ad0b67a01ae11808. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Switch mini-swe-agent to use parallel tool calls by default
> - Changes the default config spec from `mini_textbased` to `mini` and the default model class from `litellm_textbased` to `litellm` in both [mini_swe_agent.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1505/files#diff-7d7a34284596b8cbbfdca5f06547bac8257c81891fa7e66a0eb11c1a3b3015a8) and [composable/harnesses/mini_swe_agent.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1505/files#diff-91314aaa0a9d6bc048a9e15505ed9454e015e6fd2e8499f68db212d103444a89).
> - Adds a `parallel_tool_calls` boolean parameter (default `True`) that injects `-c model.model_kwargs.parallel_tool_calls=true` into the generated run command.
> - Behavioral Change: agents using default config will now run with the `mini` (tool-call-based) config instead of `mini_textbased`, changing how the model communicates with tools.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2cf5952.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->