### PR TITLE
Bridge offline sandboxes to Verifiers interception

### DIFF
--- a/docs/byo-harness.md
+++ b/docs/byo-harness.md
@@ -237,7 +237,7 @@ Common task fields:
 | `toolsets` | Toolset visibility: `{"show": [...]}` or `{"hide": [...]}`. |
 | `tools` | Per-toolset tool visibility: `{"search": {"show": [...]}}`. |
 | `sandbox` | Per-task sandbox override. |
-| `program` | Task-owned files, dirs, setup, env, artifacts, bindings, and args. |
+| `program` | Task-owned files, dirs, setup, post_setup, env, artifacts, bindings, and args. |
 | `artifacts` | Task-owned artifacts collected after program execution. |
 
 Users should not manage task/example IDs. Preserve upstream IDs only as ordinary
@@ -428,18 +428,17 @@ class PythonHarnessConfig(vf.HarnessConfig):
 Put sandbox overrides on tasks only when the taskset owns per-task images,
 files, resource sizing, or setup.
 
-Use `program.sandbox=False` when the agent should run on the host but still own
-a primary task sandbox. In that mode model/API calls stay on the host endpoint,
-while tools configured with `sandbox="program"` operate on the sandbox, including
-offline sandboxes with `network_access=False`. Host commands receive the primary
-sandbox id as `VF_SANDBOX_ID`.
+Sandboxed programs use a Verifiers interception bridge for model, user, stop,
+and tool traffic. The command sees local endpoint URLs such as
+`http://127.0.0.1:13131/...` inside the sandbox, while the host forwards those
+requests into the rollout's normal interception server. This keeps offline
+sandboxes offline without cutting the program off from model calls or `/vf`
+tool endpoints.
 
-Program setup is staged for offline installation: `program.files` and
-`program.dirs` upload first, `program.setup` runs next, then
-`program.post_setup` runs before state input, channel setup, and the command.
-Upload wheelhouses, archives, binaries, or local checkouts with `program.dirs`
-and install from those local paths in `setup`; use `post_setup` for runtime
-configuration that must happen after the agent is installed.
+Program `setup` commands run after files and dirs are uploaded. `post_setup`
+commands run after `setup` and before the per-rollout state input is uploaded,
+which is useful for installing an agent first and then writing rollout-specific
+configuration that points at the bridge.
 
 ## Lifecycle And Scoring
 

--- a/docs/byo-harness.md
+++ b/docs/byo-harness.md
@@ -428,6 +428,19 @@ class PythonHarnessConfig(vf.HarnessConfig):
 Put sandbox overrides on tasks only when the taskset owns per-task images,
 files, resource sizing, or setup.
 
+Use `program.sandbox=False` when the agent should run on the host but still own
+a primary task sandbox. In that mode model/API calls stay on the host endpoint,
+while tools configured with `sandbox="program"` operate on the sandbox, including
+offline sandboxes with `network_access=False`. Host commands receive the primary
+sandbox id as `VF_SANDBOX_ID`.
+
+Program setup is staged for offline installation: `program.files` and
+`program.dirs` upload first, `program.setup` runs next, then
+`program.post_setup` runs before state input, channel setup, and the command.
+Upload wheelhouses, archives, binaries, or local checkouts with `program.dirs`
+and install from those local paths in `setup`; use `post_setup` for runtime
+configuration that must happen after the agent is installed.
+
 ## Lifecycle And Scoring
 
 Lifecycle decorators attach behavior to the owning class:

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -632,9 +632,14 @@ Common top-level fields:
 | `toolsets` | Toolset visibility: `{"show": [...]}` or `{"hide": [...]}`. |
 | `sandbox` | Per-task sandbox overrides for sandboxed programs. |
 | `artifacts` | Per-task text/JSON files collected after program execution. |
-| `program` | Task-owned files, dirs, env, setup, artifacts, bindings, and command args. |
+| `program` | Task-owned files, dirs, env, setup, post_setup, artifacts, bindings, and command args. |
 
 `task.runtime` is not public schema. Runtime metadata belongs on `State`.
+
+Sandboxed programs get bridge-backed endpoint URLs inside the sandbox, so
+offline sandboxes can still reach Verifiers model interception, `/vf/tools`,
+`/vf/user`, and `/vf/stop` over the sandbox control plane. `program.post_setup`
+runs after `program.setup` and before rollout state is uploaded.
 
 #### State
 
@@ -735,16 +740,6 @@ module root: single-file modules use `pyproject.toml` in the same directory as
 the module file, and package modules use `pyproject.toml` inside the package
 directory. v1 uploads and installs that package in the program sandbox. Package
 dependencies come from normal `[project.dependencies]`.
-
-Set `program.sandbox=False` to keep the program or command on the host while
-still preparing a primary sandbox from `HarnessConfig.sandbox` or
-`task["sandbox"]`. Host-side programs can call models through the local
-interception endpoint and use tools bound with `sandbox="program"` to edit an
-offline sandbox; host commands also receive the primary sandbox id as
-`VF_SANDBOX_ID`. For sandbox setup, `files` and `dirs` upload first, `setup` runs
-next, then `post_setup` runs before state input, channels, and command execution;
-local archives and wheelhouses can be uploaded through `dirs` and installed
-without sandbox network access.
 
 #### Env
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -736,6 +736,16 @@ the module file, and package modules use `pyproject.toml` inside the package
 directory. v1 uploads and installs that package in the program sandbox. Package
 dependencies come from normal `[project.dependencies]`.
 
+Set `program.sandbox=False` to keep the program or command on the host while
+still preparing a primary sandbox from `HarnessConfig.sandbox` or
+`task["sandbox"]`. Host-side programs can call models through the local
+interception endpoint and use tools bound with `sandbox="program"` to edit an
+offline sandbox; host commands also receive the primary sandbox id as
+`VF_SANDBOX_ID`. For sandbox setup, `files` and `dirs` upload first, `setup` runs
+next, then `post_setup` runs before state input, channels, and command execution;
+local archives and wheelhouses can be uploaded through `dirs` and installed
+without sandbox network access.
+
 #### Env
 
 ```python

--- a/tests/test_v1_config_extension.py
+++ b/tests/test_v1_config_extension.py
@@ -758,8 +758,19 @@ async def test_sandbox_program_ref_uses_config_module(
         mode: str,
         fn_ref: str | None,
         max_turns: int,
+        endpoint: object | None = None,
+        prepare_program: object | None = None,
     ) -> State:
-        _ = program, sandbox_config, task, runtime, mode, max_turns
+        _ = (
+            program,
+            sandbox_config,
+            task,
+            runtime,
+            mode,
+            max_turns,
+            endpoint,
+            prepare_program,
+        )
         captured["fn_ref"] = fn_ref
         return state
 

--- a/tests/test_v1_harbor_cli.py
+++ b/tests/test_v1_harbor_cli.py
@@ -420,6 +420,7 @@ def test_task_program_merges_into_command_program_without_collisions() -> None:
                 sandbox=True,
                 files={"/harness.txt": "harness"},
                 setup="echo harness",
+                post_setup="echo harness post",
                 channels={"mcp": "echo harness tools"},
                 env={"HARNESS": "1"},
                 artifacts=vf.ArtifactsConfig.model_validate(
@@ -436,6 +437,7 @@ def test_task_program_merges_into_command_program_without_collisions() -> None:
             "program": {
                 "files": {"/task/instruction.md": "task"},
                 "setup": "echo task",
+                "post_setup": "echo task post",
                 "env": {"TASK": "1"},
                 "artifacts": {"task_log": {"path": "/logs/task.log", "format": "text"}},
                 "args": ["--task"],
@@ -452,6 +454,7 @@ def test_task_program_merges_into_command_program_without_collisions() -> None:
         "/task/instruction.md": "task",
     }
     assert program["setup"] == ["echo harness", "echo task"]
+    assert program["post_setup"] == ["echo harness post", "echo task post"]
     assert program["channels"] == {"mcp": "echo harness tools"}
     assert program["env"] == {"HARNESS": "1", "TASK": "1"}
     assert program["args"] == ["--base", "--task"]

--- a/tests/test_v1_harbor_cli.py
+++ b/tests/test_v1_harbor_cli.py
@@ -420,7 +420,6 @@ def test_task_program_merges_into_command_program_without_collisions() -> None:
                 sandbox=True,
                 files={"/harness.txt": "harness"},
                 setup="echo harness",
-                post_setup="echo harness post",
                 channels={"mcp": "echo harness tools"},
                 env={"HARNESS": "1"},
                 artifacts=vf.ArtifactsConfig.model_validate(
@@ -437,7 +436,6 @@ def test_task_program_merges_into_command_program_without_collisions() -> None:
             "program": {
                 "files": {"/task/instruction.md": "task"},
                 "setup": "echo task",
-                "post_setup": "echo task post",
                 "env": {"TASK": "1"},
                 "artifacts": {"task_log": {"path": "/logs/task.log", "format": "text"}},
                 "args": ["--task"],
@@ -454,7 +452,6 @@ def test_task_program_merges_into_command_program_without_collisions() -> None:
         "/task/instruction.md": "task",
     }
     assert program["setup"] == ["echo harness", "echo task"]
-    assert program["post_setup"] == ["echo harness post", "echo task post"]
     assert program["channels"] == {"mcp": "echo harness tools"}
     assert program["env"] == {"HARNESS": "1", "TASK": "1"}
     assert program["args"] == ["--base", "--task"]

--- a/tests/test_v1_runtime_lifecycle.py
+++ b/tests/test_v1_runtime_lifecycle.py
@@ -1781,6 +1781,21 @@ async def test_local_command_prepares_offline_task_sandbox(
 
 
 @pytest.mark.asyncio
+async def test_local_program_setup_requires_primary_sandbox() -> None:
+    harness = make_harness(
+        program={
+            "command": ["true"],
+            "sandbox": False,
+            "setup": "echo install-agent",
+        },
+    )
+    task = vf.Task({"prompt": [{"role": "user", "content": "hi"}]}).freeze()
+
+    with pytest.raises(ValueError, match="harness.sandbox or task.sandbox"):
+        await harness.run(task)
+
+
+@pytest.mark.asyncio
 async def test_program_channels_mcp_setup_accepts_config_ref_mappings(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_v1_runtime_lifecycle.py
+++ b/tests/test_v1_runtime_lifecycle.py
@@ -1,4 +1,5 @@
 import asyncio
+import base64
 import json
 import logging
 import os
@@ -22,8 +23,10 @@ from verifiers.types import ClientConfig
 from verifiers.types import Response, ResponseMessage, ToolCall
 from verifiers.types import Tool
 from verifiers.types import Usage
+from verifiers.utils.interception_utils import deliver_response
 from verifiers.v1.runtime import Runtime
 from verifiers.v1.utils import mcp_utils, sandbox_utils
+from verifiers.v1.utils.endpoint_utils import Endpoint
 from verifiers.v1.utils.mcp_proxy_utils import MCP_PROXY_CONFIG_PATH, MCP_PROXY_PATH
 from verifiers.v1.utils.mcp_proxy_utils import proxy_command, proxy_program
 from verifiers.v1.utils.program_utils import command_env
@@ -44,7 +47,9 @@ from verifiers.v1.utils.sandbox_program_utils import (
     sandbox_runner_program,
 )
 from verifiers.v1.utils.sandbox_utils import (
+    BRIDGE_PORT,
     VF_STATE_INPUT_PATH_KEY,
+    forward_sandbox_bridge_request,
     run_sandbox_command,
     upload_program_files,
 )
@@ -209,6 +214,33 @@ class FakeSandboxClient:
 
     def teardown(self) -> None:
         type(self).closed += 1
+
+
+class FakeBridgeLease:
+    def __init__(self, files: dict[str, str]):
+        self.files = files
+        self.uploads: dict[str, bytes] = {}
+        self.commands: list[str] = []
+
+    async def read_file(self, path: str) -> str:
+        return self.files[path]
+
+    async def upload_bytes(
+        self, path: str, content: bytes, filename: str | None = None
+    ) -> None:
+        _ = filename
+        self.uploads[path] = content
+
+    async def execute(
+        self,
+        command: str,
+        timeout: int | None = None,
+        working_dir: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> FakeCommandResult:
+        _ = timeout, working_dir, env
+        self.commands.append(command)
+        return FakeCommandResult()
 
 
 async def echo_tool(query: str) -> str:
@@ -403,13 +435,6 @@ async def child_reads_program_sandbox(task, state) -> dict[str, object]:
     _ = task
     tools = state.get_tools()
     state["borrowed_sandbox_id"] = await tools["program_sandbox_id"]()
-    return state
-
-
-async def host_reads_program_sandbox(task, state) -> dict[str, object]:
-    _ = task
-    tools = state.get_tools()
-    state["host_sandbox_id"] = await tools["program_sandbox_id"]()
     return state
 
 
@@ -689,7 +714,6 @@ for _name, _value in {
     "configure_cli_endpoint": configure_cli_endpoint,
     "initialize_from_taskset": initialize_from_taskset,
     "child_reads_program_sandbox": child_reads_program_sandbox,
-    "host_reads_program_sandbox": host_reads_program_sandbox,
     "endpoint_program": endpoint_program,
     "endpoint_trajectory_program": endpoint_trajectory_program,
     "mcp_proxy_program": mcp_proxy_program,
@@ -1071,6 +1095,54 @@ async def test_command_env_endpoint_auth_overrides_inherited_keys(monkeypatch) -
     assert env["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:1/rollout/test"
     assert env["ANTHROPIC_API_KEY"] == harness.endpoint.secret
     assert explicit_env["OPENAI_API_KEY"] == "program-key"
+
+
+@pytest.mark.asyncio
+async def test_sandbox_bridge_forwards_model_requests_to_vf_interception() -> None:
+    endpoint = Endpoint()
+    task = vf.Task({"prompt": [{"role": "user", "content": "hi"}]}).freeze()
+    state = vf.State.for_task(task)
+    await endpoint.register_rollout(state, tool_defs=[])
+    rollout_key = state["endpoint_rollout_key"]
+    request_body = {
+        "model": "fake",
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+    request_path = f"{sandbox_utils.BRIDGE_ROOT}/requests/request.json"
+    response_path = f"{sandbox_utils.BRIDGE_ROOT}/responses/request.json"
+    lease = FakeBridgeLease(
+        {
+            request_path: json.dumps(
+                {
+                    "method": "POST",
+                    "path": f"/rollout/{rollout_key}/v1/chat/completions",
+                    "headers": {
+                        "authorization": f"Bearer {endpoint.secret}",
+                        "content-type": "application/json",
+                    },
+                    "body": base64.b64encode(
+                        json.dumps(request_body).encode()
+                    ).decode(),
+                }
+            )
+        }
+    )
+
+    forward = asyncio.create_task(
+        forward_sandbox_bridge_request(
+            cast(Any, lease), endpoint, request_path, response_path
+        )
+    )
+    request_id = await asyncio.wait_for(endpoint.rollout_queue(rollout_key).get(), 1)
+    request = endpoint.get_request(request_id)
+    deliver_response(request, fake_response(content="ok"), None)
+    await forward
+    await endpoint.teardown()
+
+    response = json.loads(lease.uploads[response_path].decode())
+    response_body = json.loads(base64.b64decode(response["body"]))
+    assert response["status"] == 200
+    assert response_body["choices"][0]["message"]["content"] == "ok"
 
 
 def test_sandbox_base_program_uses_openai_tool_payloads() -> None:
@@ -1646,6 +1718,32 @@ async def test_program_post_setup_runs_after_setup_before_state_input(
 
 
 @pytest.mark.asyncio
+async def test_sandbox_bridge_sets_local_endpoint_for_program_setup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_fake_sandboxes(monkeypatch)
+
+    harness = make_harness(
+        program={
+            "command": ["true"],
+            "sandbox": True,
+            "setup": "echo program-setup",
+        },
+        sandbox={"image": "python:3.11-slim", "network_access": False},
+    )
+    task = vf.Task({"prompt": [{"role": "user", "content": "hi"}]}).freeze()
+
+    await harness.run(task)
+
+    setup_index = FakeSandboxClient.commands.index(("sbx-1", "echo program-setup"))
+    setup_env = FakeSandboxClient.command_envs[setup_index]
+    assert setup_env is not None
+    assert setup_env["OPENAI_BASE_URL"].startswith(
+        f"http://127.0.0.1:{BRIDGE_PORT}/rollout/"
+    )
+
+
+@pytest.mark.asyncio
 async def test_program_setup_uses_program_setup_timeout(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1747,108 +1845,6 @@ async def test_task_command_uses_background_job(
     await harness.run(task)
 
     assert ("sbx-1", "sleep 120", 120, "/app") in FakeSandboxClient.background_jobs
-
-
-@pytest.mark.asyncio
-async def test_local_command_prepares_offline_task_sandbox(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    install_fake_sandboxes(monkeypatch)
-    install_fake_endpoint_tunnel(monkeypatch)
-
-    harness = make_harness(
-        program={
-            "command": [
-                "sh",
-                "-c",
-                'printf \'%s/%s\' "$VF_SANDBOX_ID" "$SEES_SANDBOX"',
-            ],
-            "sandbox": False,
-            "setup": "echo install-agent",
-            "post_setup": "echo inject-runtime",
-            "env": {"SEES_SANDBOX": "runtime.sandbox.id"},
-        },
-    )
-    task = vf.Task(
-        {
-            "prompt": [{"role": "user", "content": "hi"}],
-            "sandbox": {"network_access": False},
-        }
-    ).freeze()
-
-    state = await harness.run(task)
-
-    assert state["command"]["stdout"] == "sbx-1/sbx-1"
-    assert FakeSandboxClient.requests[0]["network_access"] is False
-    assert FakeSandboxClient.background_jobs == []
-    assert ("sbx-1", "echo install-agent") in FakeSandboxClient.commands
-    assert ("sbx-1", "echo inject-runtime") in FakeSandboxClient.commands
-    setup_index = FakeSandboxClient.commands.index(("sbx-1", "echo install-agent"))
-    setup_env = FakeSandboxClient.command_envs[setup_index]
-    assert setup_env is not None
-    assert setup_env["OPENAI_BASE_URL"].startswith("http://127.0.0.1:1/rollout/")
-
-
-@pytest.mark.asyncio
-async def test_local_program_sandbox_setup_uses_tunneled_endpoint(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    install_fake_sandboxes(monkeypatch)
-    install_fake_endpoint_tunnel(monkeypatch)
-
-    harness = make_harness(
-        program={
-            "command": ["true"],
-            "sandbox": False,
-            "setup": "printenv OPENAI_BASE_URL",
-        },
-        sandbox={"network_access": False},
-    )
-    task = vf.Task({"prompt": [{"role": "user", "content": "hi"}]}).freeze()
-
-    await harness.run(task)
-
-    setup_index = FakeSandboxClient.commands.index(
-        ("sbx-1", "printenv OPENAI_BASE_URL")
-    )
-    setup_env = FakeSandboxClient.command_envs[setup_index]
-    assert setup_env is not None
-    assert setup_env["OPENAI_BASE_URL"].startswith("http://127.0.0.1:1/rollout/")
-
-
-@pytest.mark.asyncio
-async def test_local_program_setup_requires_primary_sandbox() -> None:
-    harness = make_harness(
-        program={
-            "command": ["true"],
-            "sandbox": False,
-            "setup": "echo install-agent",
-        },
-    )
-    task = vf.Task({"prompt": [{"role": "user", "content": "hi"}]}).freeze()
-
-    with pytest.raises(ValueError, match="harness.sandbox or task.sandbox"):
-        await harness.run(task)
-
-
-@pytest.mark.asyncio
-async def test_local_program_task_args_do_not_require_primary_sandbox() -> None:
-    harness = make_harness(
-        program={
-            "command": ["printf", "%s"],
-            "sandbox": False,
-        },
-    )
-    task = vf.Task(
-        {
-            "prompt": [{"role": "user", "content": "hi"}],
-            "program": {"args": ["ok"]},
-        }
-    ).freeze()
-
-    state = await harness.run(task)
-
-    assert state["command"]["stdout"] == "ok"
 
 
 @pytest.mark.asyncio
@@ -2754,25 +2750,6 @@ async def test_toolset_can_bind_to_primary_program_sandbox(
     assert result == state["sandbox_id"]
 
     await harness.cleanup_group([task], [state])
-
-
-@pytest.mark.asyncio
-async def test_host_program_can_use_offline_primary_program_sandbox(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    install_fake_sandboxes(monkeypatch)
-
-    harness = make_harness(
-        program={"fn": program_ref("host_reads_program_sandbox"), "sandbox": False},
-        sandbox={"image": "python:3.11-slim", "network_access": False},
-        toolsets=[vf.Toolset(tools=[program_sandbox_id], sandbox="program")],
-    )
-    task = vf.Task({"prompt": [{"role": "user", "content": "hi"}]}).freeze()
-
-    state = await harness.run(task)
-
-    assert state["host_sandbox_id"] == "sbx-1"
-    assert FakeSandboxClient.requests[0]["network_access"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_v1_runtime_lifecycle.py
+++ b/tests/test_v1_runtime_lifecycle.py
@@ -1,5 +1,4 @@
 import asyncio
-import base64
 import json
 import os
 import shlex
@@ -23,10 +22,8 @@ from verifiers.types import ClientConfig
 from verifiers.types import Response, ResponseMessage, ToolCall
 from verifiers.types import Tool
 from verifiers.types import Usage
-from verifiers.utils.interception_utils import deliver_response
 from verifiers.v1.runtime import Runtime
 from verifiers.v1.utils import mcp_utils, sandbox_utils
-from verifiers.v1.utils.endpoint_utils import Endpoint
 from verifiers.v1.utils.mcp_proxy_utils import MCP_PROXY_CONFIG_PATH, MCP_PROXY_PATH
 from verifiers.v1.utils.mcp_proxy_utils import proxy_command, proxy_program
 from verifiers.v1.utils.program_utils import command_env
@@ -50,7 +47,6 @@ from verifiers.v1.utils.sandbox_program_utils import (
 from verifiers.v1.utils.sandbox_utils import (
     BRIDGE_PORT,
     VF_STATE_INPUT_PATH_KEY,
-    forward_sandbox_bridge_request,
     run_sandbox_command,
     upload_program_dirs,
 )
@@ -221,33 +217,6 @@ class FakeSandboxClient:
 
     def teardown(self) -> None:
         type(self).closed += 1
-
-
-class FakeBridgeLease:
-    def __init__(self, files: dict[str, str]):
-        self.files = files
-        self.uploads: dict[str, bytes] = {}
-        self.commands: list[str] = []
-
-    async def read_file(self, path: str) -> str:
-        return self.files[path]
-
-    async def upload_bytes(
-        self, path: str, content: bytes, filename: str | None = None
-    ) -> None:
-        _ = filename
-        self.uploads[path] = content
-
-    async def execute(
-        self,
-        command: str,
-        timeout: int | None = None,
-        working_dir: str | None = None,
-        env: dict[str, str] | None = None,
-    ) -> FakeCommandResult:
-        _ = timeout, working_dir, env
-        self.commands.append(command)
-        return FakeCommandResult()
 
 
 async def echo_tool(query: str) -> str:
@@ -1103,54 +1072,6 @@ async def test_command_env_endpoint_auth_overrides_inherited_keys(monkeypatch) -
     assert env["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:1/rollout/test"
     assert env["ANTHROPIC_API_KEY"] == harness.endpoint.secret
     assert explicit_env["OPENAI_API_KEY"] == "program-key"
-
-
-@pytest.mark.asyncio
-async def test_sandbox_bridge_forwards_model_requests_to_vf_interception() -> None:
-    endpoint = Endpoint()
-    task = vf.Task({"prompt": [{"role": "user", "content": "hi"}]}).freeze()
-    state = vf.State.for_task(task)
-    await endpoint.register_rollout(state, tool_defs=[])
-    rollout_key = state["endpoint_rollout_key"]
-    request_body = {
-        "model": "fake",
-        "messages": [{"role": "user", "content": "hi"}],
-    }
-    request_path = f"{sandbox_utils.BRIDGE_ROOT}/requests/request.json"
-    response_path = f"{sandbox_utils.BRIDGE_ROOT}/responses/request.json"
-    lease = FakeBridgeLease(
-        {
-            request_path: json.dumps(
-                {
-                    "method": "POST",
-                    "path": f"/rollout/{rollout_key}/v1/chat/completions",
-                    "headers": {
-                        "authorization": f"Bearer {endpoint.secret}",
-                        "content-type": "application/json",
-                    },
-                    "body": base64.b64encode(
-                        json.dumps(request_body).encode()
-                    ).decode(),
-                }
-            )
-        }
-    )
-
-    forward = asyncio.create_task(
-        forward_sandbox_bridge_request(
-            cast(Any, lease), endpoint, request_path, response_path
-        )
-    )
-    request_id = await asyncio.wait_for(endpoint.rollout_queue(rollout_key).get(), 1)
-    request = endpoint.get_request(request_id)
-    deliver_response(request, fake_response(content="ok"), None)
-    await forward
-    await endpoint.teardown()
-
-    response = json.loads(lease.uploads[response_path].decode())
-    response_body = json.loads(base64.b64decode(response["body"]))
-    assert response["status"] == 200
-    assert response_body["choices"][0]["message"]["content"] == "ok"
 
 
 def test_sandbox_base_program_uses_openai_tool_payloads() -> None:
@@ -3070,12 +2991,12 @@ async def test_clear_creation_tasks_keeps_failed_delete_retryable(
 
 
 @pytest.mark.asyncio
-async def test_teardown_cleans_client_and_registry_after_failed_delete(
+async def test_teardown_keeps_failed_delete_retryable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     disable_sandbox_retry_sleep(monkeypatch)
 
-    class FailingDeleteClient:
+    class DeleteFailsThenSucceeds:
         def __init__(self, sandbox_id: str):
             self.sandbox_id = sandbox_id
             self.delete_calls = 0
@@ -3084,13 +3005,14 @@ async def test_teardown_cleans_client_and_registry_after_failed_delete(
         async def delete(self, sandbox_id: str) -> None:
             assert sandbox_id == self.sandbox_id
             self.delete_calls += 1
-            raise RuntimeError("delete failed")
+            if self.delete_calls <= sandbox_utils.SANDBOX_RETRY_ATTEMPTS:
+                raise RuntimeError("delete failed")
 
         async def aclose(self) -> None:
             self.closed = True
 
-    client = FailingDeleteClient("sbx-terminal-fail")
-    owned_client = FailingDeleteClient("sbx-owned-terminal-fail")
+    client = DeleteFailsThenSucceeds("sbx-terminal-fail")
+    owned_client = DeleteFailsThenSucceeds("sbx-owned-terminal-fail")
     runtime = Runtime()
     runtime._sandbox_client = cast(sandbox_utils.SandboxClient, client)
     key = ("rollout:test", "program")
@@ -3113,8 +3035,18 @@ async def test_teardown_cleans_client_and_registry_after_failed_delete(
     await runtime.teardown()
 
     assert client.delete_calls == sandbox_utils.SANDBOX_RETRY_ATTEMPTS
-    assert client.closed is True
+    assert client.closed is False
     assert owned_client.delete_calls == sandbox_utils.SANDBOX_RETRY_ATTEMPTS
+    assert owned_client.closed is False
+    assert runtime.sandbox_leases[key] is lease
+    assert owned_key in runtime.sandbox_leases
+    assert load_runtime(runtime.runtime_id) is runtime
+
+    await runtime.teardown()
+
+    assert client.delete_calls == sandbox_utils.SANDBOX_RETRY_ATTEMPTS + 1
+    assert client.closed is True
+    assert owned_client.delete_calls == sandbox_utils.SANDBOX_RETRY_ATTEMPTS + 1
     assert owned_client.closed is True
     assert runtime.sandbox_leases == {}
     with pytest.raises(RuntimeError, match="No live v1 runtime registered"):

--- a/tests/test_v1_runtime_lifecycle.py
+++ b/tests/test_v1_runtime_lifecycle.py
@@ -127,6 +127,7 @@ class FakeSandboxClient:
     deleted: list[str] = []
     commands: list[tuple[str, str]] = []
     command_timeouts: list[int | None] = []
+    command_envs: list[dict[str, str] | None] = []
     background_jobs: list[tuple[str, str, int | None, str | None]] = []
     uploads: list[tuple[str, str, bytes]] = []
     events: list[tuple[str, str, str]] = []
@@ -140,6 +141,7 @@ class FakeSandboxClient:
         cls.deleted = []
         cls.commands = []
         cls.command_timeouts = []
+        cls.command_envs = []
         cls.background_jobs = []
         cls.uploads = []
         cls.events = []
@@ -166,8 +168,10 @@ class FakeSandboxClient:
         sandbox_id = str(kwargs.get("sandbox_id") or args[0])
         command = str(kwargs.get("command") or args[1])
         timeout = cast(int | None, kwargs.get("timeout"))
+        env = cast(dict[str, str] | None, kwargs.get("env"))
         type(self).commands.append((sandbox_id, command))
         type(self).command_timeouts.append(timeout)
+        type(self).command_envs.append(env)
         type(self).events.append(("command", sandbox_id, command))
         return FakeCommandResult()
 
@@ -1750,6 +1754,7 @@ async def test_local_command_prepares_offline_task_sandbox(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     install_fake_sandboxes(monkeypatch)
+    install_fake_endpoint_tunnel(monkeypatch)
 
     harness = make_harness(
         program={
@@ -1778,6 +1783,37 @@ async def test_local_command_prepares_offline_task_sandbox(
     assert FakeSandboxClient.background_jobs == []
     assert ("sbx-1", "echo install-agent") in FakeSandboxClient.commands
     assert ("sbx-1", "echo inject-runtime") in FakeSandboxClient.commands
+    setup_index = FakeSandboxClient.commands.index(("sbx-1", "echo install-agent"))
+    setup_env = FakeSandboxClient.command_envs[setup_index]
+    assert setup_env is not None
+    assert setup_env["OPENAI_BASE_URL"].startswith("http://127.0.0.1:1/rollout/")
+
+
+@pytest.mark.asyncio
+async def test_local_program_sandbox_setup_uses_tunneled_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_fake_sandboxes(monkeypatch)
+    install_fake_endpoint_tunnel(monkeypatch)
+
+    harness = make_harness(
+        program={
+            "command": ["true"],
+            "sandbox": False,
+            "setup": "printenv OPENAI_BASE_URL",
+        },
+        sandbox={"network_access": False},
+    )
+    task = vf.Task({"prompt": [{"role": "user", "content": "hi"}]}).freeze()
+
+    await harness.run(task)
+
+    setup_index = FakeSandboxClient.commands.index(
+        ("sbx-1", "printenv OPENAI_BASE_URL")
+    )
+    setup_env = FakeSandboxClient.command_envs[setup_index]
+    assert setup_env is not None
+    assert setup_env["OPENAI_BASE_URL"].startswith("http://127.0.0.1:1/rollout/")
 
 
 @pytest.mark.asyncio
@@ -1793,6 +1829,26 @@ async def test_local_program_setup_requires_primary_sandbox() -> None:
 
     with pytest.raises(ValueError, match="harness.sandbox or task.sandbox"):
         await harness.run(task)
+
+
+@pytest.mark.asyncio
+async def test_local_program_task_args_do_not_require_primary_sandbox() -> None:
+    harness = make_harness(
+        program={
+            "command": ["printf", "%s"],
+            "sandbox": False,
+        },
+    )
+    task = vf.Task(
+        {
+            "prompt": [{"role": "user", "content": "hi"}],
+            "program": {"args": ["ok"]},
+        }
+    ).freeze()
+
+    state = await harness.run(task)
+
+    assert state["command"]["stdout"] == "ok"
 
 
 @pytest.mark.asyncio

--- a/tests/test_v1_runtime_lifecycle.py
+++ b/tests/test_v1_runtime_lifecycle.py
@@ -123,27 +123,31 @@ class FakeCommandResult:
 
 class FakeSandboxClient:
     created: list[str] = []
+    requests: list[dict[str, object]] = []
     deleted: list[str] = []
     commands: list[tuple[str, str]] = []
     command_timeouts: list[int | None] = []
     background_jobs: list[tuple[str, str, int | None, str | None]] = []
     uploads: list[tuple[str, str, bytes]] = []
+    events: list[tuple[str, str, str]] = []
     wait_attempts: list[tuple[str, int]] = []
     closed = 0
 
     @classmethod
     def reset(cls) -> None:
         cls.created = []
+        cls.requests = []
         cls.deleted = []
         cls.commands = []
         cls.command_timeouts = []
         cls.background_jobs = []
         cls.uploads = []
+        cls.events = []
         cls.wait_attempts = []
         cls.closed = 0
 
     async def create(self, request: FakeCreateSandboxRequest) -> FakeSandboxResult:
-        _ = request
+        type(self).requests.append(dict(request.kwargs))
         sandbox_id = f"sbx-{len(type(self).created) + 1}"
         type(self).created.append(sandbox_id)
         return FakeSandboxResult(sandbox_id)
@@ -164,6 +168,7 @@ class FakeSandboxClient:
         timeout = cast(int | None, kwargs.get("timeout"))
         type(self).commands.append((sandbox_id, command))
         type(self).command_timeouts.append(timeout)
+        type(self).events.append(("command", sandbox_id, command))
         return FakeCommandResult()
 
     async def run_background_job(
@@ -175,6 +180,7 @@ class FakeSandboxClient:
         working_dir = cast(str | None, kwargs.get("working_dir"))
         type(self).commands.append((sandbox_id, command))
         type(self).background_jobs.append((sandbox_id, command, timeout, working_dir))
+        type(self).events.append(("background", sandbox_id, command))
         return FakeCommandResult()
 
     async def upload_bytes(self, *args: object, **kwargs: object) -> None:
@@ -182,6 +188,7 @@ class FakeSandboxClient:
         path = str(kwargs.get("file_path") or kwargs.get("path") or args[1])
         data = cast(bytes, kwargs.get("file_bytes") or args[2])
         type(self).uploads.append((sandbox_id, path, data))
+        type(self).events.append(("upload", sandbox_id, path))
 
     async def upload_file(self, *args: object, **kwargs: object) -> None:
         _ = args, kwargs
@@ -392,6 +399,13 @@ async def child_reads_program_sandbox(task, state) -> dict[str, object]:
     _ = task
     tools = state.get_tools()
     state["borrowed_sandbox_id"] = await tools["program_sandbox_id"]()
+    return state
+
+
+async def host_reads_program_sandbox(task, state) -> dict[str, object]:
+    _ = task
+    tools = state.get_tools()
+    state["host_sandbox_id"] = await tools["program_sandbox_id"]()
     return state
 
 
@@ -671,6 +685,7 @@ for _name, _value in {
     "configure_cli_endpoint": configure_cli_endpoint,
     "initialize_from_taskset": initialize_from_taskset,
     "child_reads_program_sandbox": child_reads_program_sandbox,
+    "host_reads_program_sandbox": host_reads_program_sandbox,
     "endpoint_program": endpoint_program,
     "endpoint_trajectory_program": endpoint_trajectory_program,
     "mcp_proxy_program": mcp_proxy_program,
@@ -1587,6 +1602,46 @@ async def test_rollout_setup_receives_program_sandbox_before_program_setup(
 
 
 @pytest.mark.asyncio
+async def test_program_post_setup_runs_after_setup_before_state_input(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_fake_sandboxes(monkeypatch)
+
+    harness = make_harness()
+    task = vf.Task({"prompt": [{"role": "user", "content": "hi"}]}).freeze()
+    state = vf.State.for_task(task)
+
+    await run_sandbox_command(
+        {
+            "command": ["true"],
+            "setup": "echo install-agent",
+            "post_setup": "echo inject-runtime",
+            VF_STATE_INPUT_PATH_KEY: "/tmp/vf_state_in.json",
+        },
+        vf.SandboxConfig(image="python:3.11-slim"),
+        task,
+        state,
+        harness.runtime,
+    )
+
+    events = [
+        value if value != "/tmp/vf_state_in.json" else "upload-state"
+        for event, _, value in FakeSandboxClient.events
+        if (
+            event in {"command", "background"}
+            and value in {"echo install-agent", "echo inject-runtime", "true"}
+        )
+        or (event == "upload" and value == "/tmp/vf_state_in.json")
+    ]
+    assert events == [
+        "echo install-agent",
+        "echo inject-runtime",
+        "upload-state",
+        "true",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_program_setup_uses_program_setup_timeout(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1688,6 +1743,41 @@ async def test_task_command_uses_background_job(
     await harness.run(task)
 
     assert ("sbx-1", "sleep 120", 120, "/app") in FakeSandboxClient.background_jobs
+
+
+@pytest.mark.asyncio
+async def test_local_command_prepares_offline_task_sandbox(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_fake_sandboxes(monkeypatch)
+
+    harness = make_harness(
+        program={
+            "command": [
+                "sh",
+                "-c",
+                'printf \'%s/%s\' "$VF_SANDBOX_ID" "$SEES_SANDBOX"',
+            ],
+            "sandbox": False,
+            "setup": "echo install-agent",
+            "post_setup": "echo inject-runtime",
+            "env": {"SEES_SANDBOX": "runtime.sandbox.id"},
+        },
+    )
+    task = vf.Task(
+        {
+            "prompt": [{"role": "user", "content": "hi"}],
+            "sandbox": {"network_access": False},
+        }
+    ).freeze()
+
+    state = await harness.run(task)
+
+    assert state["command"]["stdout"] == "sbx-1/sbx-1"
+    assert FakeSandboxClient.requests[0]["network_access"] is False
+    assert FakeSandboxClient.background_jobs == []
+    assert ("sbx-1", "echo install-agent") in FakeSandboxClient.commands
+    assert ("sbx-1", "echo inject-runtime") in FakeSandboxClient.commands
 
 
 @pytest.mark.asyncio
@@ -2593,6 +2683,25 @@ async def test_toolset_can_bind_to_primary_program_sandbox(
     assert result == state["sandbox_id"]
 
     await harness.cleanup_group([task], [state])
+
+
+@pytest.mark.asyncio
+async def test_host_program_can_use_offline_primary_program_sandbox(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_fake_sandboxes(monkeypatch)
+
+    harness = make_harness(
+        program={"fn": program_ref("host_reads_program_sandbox"), "sandbox": False},
+        sandbox={"image": "python:3.11-slim", "network_access": False},
+        toolsets=[vf.Toolset(tools=[program_sandbox_id], sandbox="program")],
+    )
+    task = vf.Task({"prompt": [{"role": "user", "content": "hi"}]}).freeze()
+
+    state = await harness.run(task)
+
+    assert state["host_sandbox_id"] == "sbx-1"
+    assert FakeSandboxClient.requests[0]["network_access"] is False
 
 
 @pytest.mark.asyncio

--- a/verifiers/v1/harness.py
+++ b/verifiers/v1/harness.py
@@ -233,8 +233,12 @@ class Harness(RuntimeOwnerMixin[ConfigT], Generic[ConfigT]):
         return config
 
     def load_endpoint(self) -> Endpoint:
+        local_program_sandbox = (
+            self.program_config.resolve().sandbox is False and self.sandbox is not None
+        )
         return Endpoint(
             use_tunnel=self.program_sandbox_config(self.program_config) is not None
+            or local_program_sandbox
         )
 
     def rebuild_runtime(self) -> None:
@@ -395,6 +399,11 @@ class Harness(RuntimeOwnerMixin[ConfigT], Generic[ConfigT]):
 
     async def run_program(self, task: Task, state: State) -> State:
         endpoint = self.resolved_endpoint(state)
+        if (
+            self.program_config.resolve().sandbox is False
+            and task.sandbox_config() is not None
+        ):
+            endpoint.use_tunnel = True
         result = await run_intercepted_program(
             self.program, endpoint, self.runtime, task, state
         )
@@ -670,7 +679,11 @@ class Harness(RuntimeOwnerMixin[ConfigT], Generic[ConfigT]):
             return merge_task_sandbox(self.sandbox, task)
         if task.sandbox_config() is not None:
             return merge_task_sandbox(SandboxConfig(), task)
-        sandbox_only = sorted(set(program) & SANDBOX_ONLY_PROGRAM_KEYS)
+        sandbox_only = sorted(
+            key
+            for key in SANDBOX_ONLY_PROGRAM_KEYS
+            if key in program and program[key] not in (None, {}, [])
+        )
         if sandbox_only:
             raise ValueError(
                 f"Program keys {sandbox_only} require harness.sandbox or "

--- a/verifiers/v1/harness.py
+++ b/verifiers/v1/harness.py
@@ -62,12 +62,11 @@ from .utils.program_utils import (
     program_channels,
     program_kind,
     run_local_command,
-    SANDBOX_ONLY_PROGRAM_KEYS,
     validate_program_options,
     validate_program_sandbox_scope,
 )
 from .runtime import Runtime
-from .utils.sandbox_utils import prepared_program_sandbox, run_sandbox_command
+from .utils.sandbox_utils import run_sandbox_command
 from .utils.sandbox_program_utils import (
     python_program_sandbox,
     run_sandbox_python_program,
@@ -233,13 +232,7 @@ class Harness(RuntimeOwnerMixin[ConfigT], Generic[ConfigT]):
         return config
 
     def load_endpoint(self) -> Endpoint:
-        local_program_sandbox = (
-            self.program_config.resolve().sandbox is False and self.sandbox is not None
-        )
-        return Endpoint(
-            use_tunnel=self.program_sandbox_config(self.program_config) is not None
-            or local_program_sandbox
-        )
+        return Endpoint()
 
     def rebuild_runtime(self) -> None:
         self.runtime = Runtime(taskset=self.taskset, harness=self)
@@ -399,11 +392,6 @@ class Harness(RuntimeOwnerMixin[ConfigT], Generic[ConfigT]):
 
     async def run_program(self, task: Task, state: State) -> State:
         endpoint = self.resolved_endpoint(state)
-        if (
-            self.program_config.resolve().sandbox is False
-            and task.sandbox_config() is not None
-        ):
-            endpoint.use_tunnel = True
         result = await run_intercepted_program(
             self.program, endpoint, self.runtime, task, state
         )
@@ -439,7 +427,7 @@ class Harness(RuntimeOwnerMixin[ConfigT], Generic[ConfigT]):
             validate_program_options(program_data, kind, sandbox_config)
             if sandbox_config is not None:
                 return self.sandbox_base_program(program_data, sandbox_config)
-            return self.local_base_program(program_data)
+            return self.base_program
         if kind == "fn":
             sandbox_config = self.program_sandbox_config(program)
             validate_program_options(program_data, kind, sandbox_config)
@@ -453,28 +441,16 @@ class Harness(RuntimeOwnerMixin[ConfigT], Generic[ConfigT]):
             fn = import_config_ref(fn_ref)
             if not callable(fn):
                 raise TypeError("program.fn did not resolve to a callable.")
-            return self.local_callable_program(cast(Handler, fn), program_data)
+            return self.local_callable_program(cast(Handler, fn))
         if kind == "command":
             sandbox_config = self.program_sandbox_config(program)
             validate_program_options(program_data, kind, sandbox_config)
             return self.command_program(program_data, sandbox_config)
         raise AssertionError(f"Unhandled program kind: {kind}")
 
-    def local_callable_program(
-        self, fn: Handler, program: ConfigData | None = None
-    ) -> ProgramRunner:
+    def local_callable_program(self, fn: Handler) -> ProgramRunner:
         async def run(task: Task, state: State) -> ProgramResult:
-            program_data = merge_task_program(program or {}, task, kind="fn")
-            sandbox_config = self.local_program_sandbox_config(program_data, task)
-            if sandbox_config is None:
-                await self.runtime.setup_rollout(task, state)
-                return await call_program(task, state)
-            async with prepared_program_sandbox(
-                program_data, sandbox_config, task, state, self.runtime
-            ):
-                return await call_program(task, state)
-
-        async def call_program(task: Task, state: State) -> ProgramResult:
+            await self.runtime.setup_rollout(task, state)
             result = await maybe_call_with_named_args(
                 fn, task=task, state=state, runtime=self.runtime, harness=self
             )
@@ -484,24 +460,8 @@ class Harness(RuntimeOwnerMixin[ConfigT], Generic[ConfigT]):
 
         return run
 
-    def local_base_program(self, program: ConfigData) -> ProgramRunner:
-        async def run(task: Task, state: State) -> State:
-            program_data = merge_task_program(program, task, kind="base")
-            sandbox_config = self.local_program_sandbox_config(program_data, task)
-            if sandbox_config is None:
-                return await self.base_program(task, state)
-            async with prepared_program_sandbox(
-                program_data, sandbox_config, task, state, self.runtime
-            ):
-                return await self.base_program(task, state, setup_rollout=False)
-
-        return run
-
-    async def base_program(
-        self, task: Task, state: State, *, setup_rollout: bool = True
-    ) -> State:
-        if setup_rollout:
-            await self.runtime.setup_rollout(task, state)
+    async def base_program(self, task: Task, state: State) -> State:
+        await self.runtime.setup_rollout(task, state)
         prompt = normalize_messages(
             cast(
                 Messages,
@@ -595,22 +555,16 @@ class Harness(RuntimeOwnerMixin[ConfigT], Generic[ConfigT]):
             merged_program = merge_task_program(program, task, kind="command")
             if sandbox_config is not None:
                 return await run_sandbox_command(
-                    self.prepare_sandbox_program(merged_program, state),
+                    merged_program,
                     self.prepare_sandbox_config(
-                        merge_task_sandbox(sandbox_config, task), program
+                        merge_task_sandbox(sandbox_config, task), merged_program
                     ),
                     task,
                     state,
                     runtime,
+                    endpoint=self.resolved_endpoint(state),
+                    prepare_program=self.prepare_sandbox_program,
                 )
-            local_sandbox_config = self.local_program_sandbox_config(
-                merged_program, task
-            )
-            if local_sandbox_config is not None:
-                async with prepared_program_sandbox(
-                    merged_program, local_sandbox_config, task, state, runtime
-                ):
-                    return await run_local_command(merged_program, task, state, runtime)
             await runtime.setup_rollout(task, state)
             return await run_local_command(merged_program, task, state, runtime)
 
@@ -632,6 +586,8 @@ class Harness(RuntimeOwnerMixin[ConfigT], Generic[ConfigT]):
                 mode="base",
                 fn_ref=None,
                 max_turns=state.get_max_turns(self.config.max_turns),
+                endpoint=self.resolved_endpoint(state),
+                prepare_program=self.prepare_sandbox_program,
             )
 
         return run
@@ -655,6 +611,8 @@ class Harness(RuntimeOwnerMixin[ConfigT], Generic[ConfigT]):
                 mode="fn",
                 fn_ref=fn_ref,
                 max_turns=state.get_max_turns(self.config.max_turns),
+                endpoint=self.resolved_endpoint(state),
+                prepare_program=self.prepare_sandbox_program,
             )
 
         return run
@@ -669,27 +627,6 @@ class Harness(RuntimeOwnerMixin[ConfigT], Generic[ConfigT]):
             return None
         validate_program_sandbox_scope(self.sandbox)
         return self.sandbox
-
-    def local_program_sandbox_config(
-        self, program: ConfigData, task: Task
-    ) -> SandboxConfig | None:
-        if program.get("sandbox") is not False:
-            return None
-        if self.sandbox is not None:
-            return merge_task_sandbox(self.sandbox, task)
-        if task.sandbox_config() is not None:
-            return merge_task_sandbox(SandboxConfig(), task)
-        sandbox_only = sorted(
-            key
-            for key in SANDBOX_ONLY_PROGRAM_KEYS
-            if key in program and program[key] not in (None, {}, [])
-        )
-        if sandbox_only:
-            raise ValueError(
-                f"Program keys {sandbox_only} require harness.sandbox or "
-                "task.sandbox when program.sandbox=False."
-            )
-        return None
 
     def prepare_sandbox_program(self, program: ConfigData, state: State) -> ConfigData:
         if "mcp" in program_channels(program):

--- a/verifiers/v1/harness.py
+++ b/verifiers/v1/harness.py
@@ -62,6 +62,7 @@ from .utils.program_utils import (
     program_channels,
     program_kind,
     run_local_command,
+    SANDBOX_ONLY_PROGRAM_KEYS,
     validate_program_options,
     validate_program_sandbox_scope,
 )
@@ -667,9 +668,15 @@ class Harness(RuntimeOwnerMixin[ConfigT], Generic[ConfigT]):
             return None
         if self.sandbox is not None:
             return merge_task_sandbox(self.sandbox, task)
-        if task.sandbox_config() is None:
-            return None
-        return merge_task_sandbox(SandboxConfig(), task)
+        if task.sandbox_config() is not None:
+            return merge_task_sandbox(SandboxConfig(), task)
+        sandbox_only = sorted(set(program) & SANDBOX_ONLY_PROGRAM_KEYS)
+        if sandbox_only:
+            raise ValueError(
+                f"Program keys {sandbox_only} require harness.sandbox or "
+                "task.sandbox when program.sandbox=False."
+            )
+        return None
 
     def prepare_sandbox_program(self, program: ConfigData, state: State) -> ConfigData:
         if "mcp" in program_channels(program):

--- a/verifiers/v1/harness.py
+++ b/verifiers/v1/harness.py
@@ -66,7 +66,7 @@ from .utils.program_utils import (
     validate_program_sandbox_scope,
 )
 from .runtime import Runtime
-from .utils.sandbox_utils import run_sandbox_command
+from .utils.sandbox_utils import prepared_program_sandbox, run_sandbox_command
 from .utils.sandbox_program_utils import (
     python_program_sandbox,
     run_sandbox_python_program,
@@ -429,7 +429,7 @@ class Harness(RuntimeOwnerMixin[ConfigT], Generic[ConfigT]):
             validate_program_options(program_data, kind, sandbox_config)
             if sandbox_config is not None:
                 return self.sandbox_base_program(program_data, sandbox_config)
-            return self.base_program
+            return self.local_base_program(program_data)
         if kind == "fn":
             sandbox_config = self.program_sandbox_config(program)
             validate_program_options(program_data, kind, sandbox_config)
@@ -443,16 +443,28 @@ class Harness(RuntimeOwnerMixin[ConfigT], Generic[ConfigT]):
             fn = import_config_ref(fn_ref)
             if not callable(fn):
                 raise TypeError("program.fn did not resolve to a callable.")
-            return self.local_callable_program(cast(Handler, fn))
+            return self.local_callable_program(cast(Handler, fn), program_data)
         if kind == "command":
             sandbox_config = self.program_sandbox_config(program)
             validate_program_options(program_data, kind, sandbox_config)
             return self.command_program(program_data, sandbox_config)
         raise AssertionError(f"Unhandled program kind: {kind}")
 
-    def local_callable_program(self, fn: Handler) -> ProgramRunner:
+    def local_callable_program(
+        self, fn: Handler, program: ConfigData | None = None
+    ) -> ProgramRunner:
         async def run(task: Task, state: State) -> ProgramResult:
-            await self.runtime.setup_rollout(task, state)
+            program_data = merge_task_program(program or {}, task, kind="fn")
+            sandbox_config = self.local_program_sandbox_config(program_data, task)
+            if sandbox_config is None:
+                await self.runtime.setup_rollout(task, state)
+                return await call_program(task, state)
+            async with prepared_program_sandbox(
+                program_data, sandbox_config, task, state, self.runtime
+            ):
+                return await call_program(task, state)
+
+        async def call_program(task: Task, state: State) -> ProgramResult:
             result = await maybe_call_with_named_args(
                 fn, task=task, state=state, runtime=self.runtime, harness=self
             )
@@ -462,8 +474,24 @@ class Harness(RuntimeOwnerMixin[ConfigT], Generic[ConfigT]):
 
         return run
 
-    async def base_program(self, task: Task, state: State) -> State:
-        await self.runtime.setup_rollout(task, state)
+    def local_base_program(self, program: ConfigData) -> ProgramRunner:
+        async def run(task: Task, state: State) -> State:
+            program_data = merge_task_program(program, task, kind="base")
+            sandbox_config = self.local_program_sandbox_config(program_data, task)
+            if sandbox_config is None:
+                return await self.base_program(task, state)
+            async with prepared_program_sandbox(
+                program_data, sandbox_config, task, state, self.runtime
+            ):
+                return await self.base_program(task, state, setup_rollout=False)
+
+        return run
+
+    async def base_program(
+        self, task: Task, state: State, *, setup_rollout: bool = True
+    ) -> State:
+        if setup_rollout:
+            await self.runtime.setup_rollout(task, state)
         prompt = normalize_messages(
             cast(
                 Messages,
@@ -565,6 +593,14 @@ class Harness(RuntimeOwnerMixin[ConfigT], Generic[ConfigT]):
                     state,
                     runtime,
                 )
+            local_sandbox_config = self.local_program_sandbox_config(
+                merged_program, task
+            )
+            if local_sandbox_config is not None:
+                async with prepared_program_sandbox(
+                    merged_program, local_sandbox_config, task, state, runtime
+                ):
+                    return await run_local_command(merged_program, task, state, runtime)
             await runtime.setup_rollout(task, state)
             return await run_local_command(merged_program, task, state, runtime)
 
@@ -623,6 +659,17 @@ class Harness(RuntimeOwnerMixin[ConfigT], Generic[ConfigT]):
             return None
         validate_program_sandbox_scope(self.sandbox)
         return self.sandbox
+
+    def local_program_sandbox_config(
+        self, program: ConfigData, task: Task
+    ) -> SandboxConfig | None:
+        if program.get("sandbox") is not False:
+            return None
+        if self.sandbox is not None:
+            return merge_task_sandbox(self.sandbox, task)
+        if task.sandbox_config() is None:
+            return None
+        return merge_task_sandbox(SandboxConfig(), task)
 
     def prepare_sandbox_program(self, program: ConfigData, state: State) -> ConfigData:
         if "mcp" in program_channels(program):

--- a/verifiers/v1/program.py
+++ b/verifiers/v1/program.py
@@ -40,6 +40,7 @@ COMMAND_PROGRAM_PATCH_KEYS = {
     "files",
     "dirs",
     "setup",
+    "post_setup",
     "setup_timeout",
     "bindings",
     "env",
@@ -47,7 +48,7 @@ COMMAND_PROGRAM_PATCH_KEYS = {
     "args",
 }
 COMMAND_PROGRAM_MAP_PATCH_KEYS = {"files", "dirs", "bindings", "env", "artifacts"}
-COMMAND_PROGRAM_LIST_PATCH_KEYS = {"setup", "args"}
+COMMAND_PROGRAM_LIST_PATCH_KEYS = {"setup", "post_setup", "args"}
 
 __all__ = [
     "ProgramArgs",
@@ -73,6 +74,7 @@ class ProgramConfig(Config):
     files: ProgramFiles = {}
     dirs: ProgramDirs = {}
     setup: ProgramSetup = []
+    post_setup: ProgramSetup = []
     setup_timeout: int = 300
     bindings: BindingsConfig = BindingsConfig()
     env: ProgramEnv = {}
@@ -121,6 +123,7 @@ class ProgramConfig(Config):
             ("files", self.files),
             ("dirs", self.dirs),
             ("setup", self.setup),
+            ("post_setup", self.post_setup),
             ("env", self.env),
             ("artifacts", self.artifacts),
             ("channels", self.channels),
@@ -149,6 +152,7 @@ class ProgramConfig(Config):
         files: ProgramFiles | None = None,
         dirs: ProgramDirs | None = None,
         setup: ProgramSetup | None = None,
+        post_setup: ProgramSetup | None = None,
         setup_timeout: int | None = None,
         bindings: ConfigData | None = None,
         env: ProgramEnv | None = None,
@@ -180,6 +184,8 @@ class ProgramConfig(Config):
             data["dirs"] = dict(dirs)
         if setup is not None:
             data["setup"] = setup
+        if post_setup is not None:
+            data["post_setup"] = post_setup
         if setup_timeout is not None:
             data["setup_timeout"] = setup_timeout
         if bindings is not None:

--- a/verifiers/v1/runtime.py
+++ b/verifiers/v1/runtime.py
@@ -1053,6 +1053,7 @@ class Runtime:
     async def teardown(self) -> None:
         await run_handlers(self.teardown_handlers)
         await self.release_runtime_objects()
+        failed_sandbox_deletions = []
         try:
             if self.sandbox_creation_tasks:
                 await self.clear_sandbox_creation_tasks(
@@ -1068,29 +1069,24 @@ class Runtime:
                         exc,
                         exc_info=True,
                     )
-                    if handle.owns_client:
-                        from .utils.sandbox_utils import close_sandbox_client
-
-                        try:
-                            await close_sandbox_client(handle.client)
-                        except Exception as close_exc:
-                            logger.warning(
-                                "Failed to close sandbox client for %s during teardown: %s",
-                                handle.id,
-                                close_exc,
-                                exc_info=True,
-                            )
-                async with self.sandbox_lock:
-                    if self.sandbox_leases.get(key) is handle:
-                        del self.sandbox_leases[key]
+                    failed_sandbox_deletions.append(handle)
+                else:
+                    async with self.sandbox_lock:
+                        if self.sandbox_leases.get(key) is handle:
+                            del self.sandbox_leases[key]
         finally:
-            await self.teardown_sandbox_client()
+            if not any(
+                handle.client is self._sandbox_client
+                for handle in failed_sandbox_deletions
+            ):
+                await self.teardown_sandbox_client()
             await self.cleanup_upload_archives()
         self.tool_handles.clear()
         self.scoped_tools.clear()
         await self.close_all_mcp_tools()
         await self.release_all_model_clients()
-        unregister_runtime(self.runtime_id)
+        if not failed_sandbox_deletions:
+            unregister_runtime(self.runtime_id)
 
     def sandbox_client(self) -> "SandboxClient":
         if self._sandbox_client is None:

--- a/verifiers/v1/utils/program_utils.py
+++ b/verifiers/v1/utils/program_utils.py
@@ -31,6 +31,7 @@ PROGRAM_OPTION_KEYS = {
     "files",
     "dirs",
     "setup",
+    "post_setup",
     "setup_timeout",
     "bindings",
     "env",
@@ -38,11 +39,19 @@ PROGRAM_OPTION_KEYS = {
     "channels",
 }
 PROGRAM_KEYS = PROGRAM_KIND_KEYS | PROGRAM_OPTION_KEYS | {"args"}
-SANDBOX_ONLY_PROGRAM_KEYS = {"files", "dirs", "setup", "setup_timeout", "artifacts"}
+SANDBOX_ONLY_PROGRAM_KEYS = {
+    "files",
+    "dirs",
+    "setup",
+    "post_setup",
+    "setup_timeout",
+    "artifacts",
+}
 TASK_PROGRAM_KEYS = {
     "files",
     "dirs",
     "setup",
+    "post_setup",
     "bindings",
     "env",
     "artifacts",
@@ -130,6 +139,9 @@ async def command_env(
         if isinstance(endpoint_root_url, str):
             env["ANTHROPIC_BASE_URL"] = endpoint_root_url
             env["ANTHROPIC_API_KEY"] = api_key
+    sandbox_record = state.runtime_state().get("sandbox")
+    if isinstance(sandbox_record, dict) and isinstance(sandbox_record.get("id"), str):
+        env["VF_SANDBOX_ID"] = sandbox_record["id"]
     raw_env = program.get("env", {})
     if not isinstance(raw_env, dict):
         raise TypeError("program.env must be a mapping.")
@@ -299,13 +311,14 @@ def program_binding_targets(
 
 def program_setup_callable_names(program: ConfigData) -> set[str]:
     names: set[str] = set()
-    setup = program.get("setup")
-    items = setup if isinstance(setup, list) else [setup]
-    for item in items:
-        callable_spec = program_value_callable(item)
-        if callable_spec is not None:
-            fn, _ = callable_spec
-            names.add(function_name(fn))
+    for key in ("setup", "post_setup"):
+        setup = program.get(key)
+        items = setup if isinstance(setup, list) else [setup]
+        for item in items:
+            callable_spec = program_value_callable(item)
+            if callable_spec is not None:
+                fn, _ = callable_spec
+                names.add(function_name(fn))
     return names
 
 
@@ -362,7 +375,7 @@ def validate_program_options(
     if unknown:
         raise ValueError(f"Unknown program keys: {unknown}.")
     validate_program_bindings(program)
-    if sandbox_config is None:
+    if sandbox_config is None and program.get("sandbox") is not False:
         sandbox_only = sorted(set(program) & SANDBOX_ONLY_PROGRAM_KEYS)
         if sandbox_only:
             raise ValueError(f"Program keys {sandbox_only} require sandbox placement.")
@@ -378,7 +391,11 @@ def validate_program_options(
         raise ValueError(
             "program.channels='callable' is only supported for base and fn programs."
         )
-    if kind == "base" and sandbox_config is None:
+    if (
+        kind == "base"
+        and sandbox_config is None
+        and program.get("sandbox") is not False
+    ):
         inert = sorted(set(program) & (PROGRAM_OPTION_KEYS - {"sandbox"}))
         if inert:
             raise ValueError(f"Base program keys {inert} require sandbox placement.")
@@ -399,7 +416,7 @@ def merge_task_program(program: ConfigData, task: Task, *, kind: str) -> ConfigD
     unknown = sorted(set(task_program) - TASK_PROGRAM_KEYS)
     if unknown:
         raise ValueError(
-            "task.program can only define files, dirs, setup, bindings, env, "
+            "task.program can only define files, dirs, setup, post_setup, bindings, env, "
             f"artifacts, and args; got {unknown}."
         )
     if kind != "command" and "args" in task_program:
@@ -415,6 +432,10 @@ def merge_task_program(program: ConfigData, task: Task, *, kind: str) -> ConfigD
     merged["setup"] = [
         *program_list_items(program.get("setup"), "program.setup"),
         *program_list_items(task_program.get("setup"), "task.program.setup"),
+    ]
+    merged["post_setup"] = [
+        *program_list_items(program.get("post_setup"), "program.post_setup"),
+        *program_list_items(task_program.get("post_setup"), "task.program.post_setup"),
     ]
     if kind == "command":
         merged["args"] = [

--- a/verifiers/v1/utils/program_utils.py
+++ b/verifiers/v1/utils/program_utils.py
@@ -376,7 +376,11 @@ def validate_program_options(
         raise ValueError(f"Unknown program keys: {unknown}.")
     validate_program_bindings(program)
     if sandbox_config is None and program.get("sandbox") is not False:
-        sandbox_only = sorted(set(program) & SANDBOX_ONLY_PROGRAM_KEYS)
+        sandbox_only = sorted(
+            key
+            for key in SANDBOX_ONLY_PROGRAM_KEYS
+            if key in program and program[key] not in (None, {}, [])
+        )
         if sandbox_only:
             raise ValueError(f"Program keys {sandbox_only} require sandbox placement.")
     channels = set(program_channels(program))

--- a/verifiers/v1/utils/program_utils.py
+++ b/verifiers/v1/utils/program_utils.py
@@ -139,9 +139,6 @@ async def command_env(
         if isinstance(endpoint_root_url, str):
             env["ANTHROPIC_BASE_URL"] = endpoint_root_url
             env["ANTHROPIC_API_KEY"] = api_key
-    sandbox_record = state.runtime_state().get("sandbox")
-    if isinstance(sandbox_record, dict) and isinstance(sandbox_record.get("id"), str):
-        env["VF_SANDBOX_ID"] = sandbox_record["id"]
     raw_env = program.get("env", {})
     if not isinstance(raw_env, dict):
         raise TypeError("program.env must be a mapping.")
@@ -311,14 +308,13 @@ def program_binding_targets(
 
 def program_setup_callable_names(program: ConfigData) -> set[str]:
     names: set[str] = set()
-    for key in ("setup", "post_setup"):
-        setup = program.get(key)
-        items = setup if isinstance(setup, list) else [setup]
-        for item in items:
-            callable_spec = program_value_callable(item)
-            if callable_spec is not None:
-                fn, _ = callable_spec
-                names.add(function_name(fn))
+    setup = program.get("setup")
+    items = setup if isinstance(setup, list) else [setup]
+    for item in items:
+        callable_spec = program_value_callable(item)
+        if callable_spec is not None:
+            fn, _ = callable_spec
+            names.add(function_name(fn))
     return names
 
 
@@ -375,12 +371,8 @@ def validate_program_options(
     if unknown:
         raise ValueError(f"Unknown program keys: {unknown}.")
     validate_program_bindings(program)
-    if sandbox_config is None and program.get("sandbox") is not False:
-        sandbox_only = sorted(
-            key
-            for key in SANDBOX_ONLY_PROGRAM_KEYS
-            if key in program and program[key] not in (None, {}, [])
-        )
+    if sandbox_config is None:
+        sandbox_only = sorted(set(program) & SANDBOX_ONLY_PROGRAM_KEYS)
         if sandbox_only:
             raise ValueError(f"Program keys {sandbox_only} require sandbox placement.")
     channels = set(program_channels(program))
@@ -395,11 +387,7 @@ def validate_program_options(
         raise ValueError(
             "program.channels='callable' is only supported for base and fn programs."
         )
-    if (
-        kind == "base"
-        and sandbox_config is None
-        and program.get("sandbox") is not False
-    ):
+    if kind == "base" and sandbox_config is None:
         inert = sorted(set(program) & (PROGRAM_OPTION_KEYS - {"sandbox"}))
         if inert:
             raise ValueError(f"Base program keys {inert} require sandbox placement.")
@@ -420,8 +408,8 @@ def merge_task_program(program: ConfigData, task: Task, *, kind: str) -> ConfigD
     unknown = sorted(set(task_program) - TASK_PROGRAM_KEYS)
     if unknown:
         raise ValueError(
-            "task.program can only define files, dirs, setup, post_setup, bindings, env, "
-            f"artifacts, and args; got {unknown}."
+            "task.program can only define files, dirs, setup, post_setup, bindings, "
+            f"env, artifacts, and args; got {unknown}."
         )
     if kind != "command" and "args" in task_program:
         raise ValueError("task.program.args is only supported for command programs.")

--- a/verifiers/v1/utils/sandbox_program_utils.py
+++ b/verifiers/v1/utils/sandbox_program_utils.py
@@ -4,6 +4,7 @@ import json
 import shlex
 import sys
 import sysconfig
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import cast
@@ -11,7 +12,6 @@ from typing import cast
 from verifiers.utils.interception_utils import serialize_tool_defs
 
 from .endpoint_utils import Endpoint
-from .sandbox_utils import ProgramPrepare
 from ..runtime import Runtime
 from ..sandbox import SandboxConfig
 from ..state import State
@@ -74,7 +74,7 @@ async def run_sandbox_python_program(
     fn_ref: str | None,
     max_turns: int,
     endpoint: Endpoint | None = None,
-    prepare_program: ProgramPrepare | None = None,
+    prepare_program: Callable[[ConfigData, State], ConfigData] | None = None,
 ) -> State:
     runner_program = sandbox_runner_program(
         program=program,

--- a/verifiers/v1/utils/sandbox_program_utils.py
+++ b/verifiers/v1/utils/sandbox_program_utils.py
@@ -10,6 +10,8 @@ from typing import cast
 
 from verifiers.utils.interception_utils import serialize_tool_defs
 
+from .endpoint_utils import Endpoint
+from .sandbox_utils import ProgramPrepare
 from ..runtime import Runtime
 from ..sandbox import SandboxConfig
 from ..state import State
@@ -71,6 +73,8 @@ async def run_sandbox_python_program(
     mode: str,
     fn_ref: str | None,
     max_turns: int,
+    endpoint: Endpoint | None = None,
+    prepare_program: ProgramPrepare | None = None,
 ) -> State:
     runner_program = sandbox_runner_program(
         program=program,
@@ -82,7 +86,15 @@ async def run_sandbox_python_program(
         tool_defs=runtime.tool_defs(state),
     )
     command_record = state.get("command")
-    await run_sandbox_command(runner_program, sandbox_config, task, state, runtime)
+    await run_sandbox_command(
+        runner_program,
+        sandbox_config,
+        task,
+        state,
+        runtime,
+        endpoint=endpoint,
+        prepare_program=prepare_program,
+    )
     lease = runtime.active_program_sandbox_lease(state)
     if lease is None:
         raise RuntimeError("Sandbox Python program has no active sandbox lease.")

--- a/verifiers/v1/utils/sandbox_utils.py
+++ b/verifiers/v1/utils/sandbox_utils.py
@@ -1,5 +1,7 @@
 import asyncio
+import base64
 import hashlib
+import inspect
 import importlib.resources as resources
 import json
 import logging
@@ -13,6 +15,7 @@ from importlib.abc import Traversable
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, Protocol, TypeVar, cast
 
+import httpx
 import tenacity as tc
 
 from verifiers.decorators import setup as setup_handler
@@ -37,13 +40,18 @@ from ..task import Task
 from ..types import ConfigData, Handler
 
 if TYPE_CHECKING:
+    from .endpoint_utils import Endpoint
     from ..toolset import Toolset
 
 VF_STATE_INPUT_PATH_KEY = "_vf_state_input_path"
+BRIDGE_ROOT = "/tmp/vf_interception_bridge"
+BRIDGE_PROXY_PATH = "/tmp/vf_interception_bridge.py"
+BRIDGE_PORT = 13131
 SANDBOX_RETRY_ATTEMPTS = 6
 SANDBOX_WAIT_FOR_CREATION_ATTEMPTS = 120
 T = TypeVar("T")
 logger = logging.getLogger(__name__)
+ProgramPrepare = Callable[[ConfigData, State], ConfigData]
 
 
 class RetryLogger(Protocol):
@@ -185,7 +193,7 @@ class SandboxLease:
         working_dir: str | None = None,
         env: dict[str, str] | None = None,
     ) -> SandboxCommandResult:
-        result = await maybe_call_with_named_args(
+        result = await call_sandbox_client(
             self.client.execute_command,
             sandbox_id=self.id,
             command=command,
@@ -198,7 +206,7 @@ class SandboxLease:
     async def upload_bytes(
         self, path: str, content: bytes, filename: str | None = None
     ) -> object:
-        return await maybe_call_with_named_args(
+        return await call_sandbox_client(
             self.client.upload_bytes,
             sandbox_id=self.id,
             file_path=path,
@@ -209,7 +217,7 @@ class SandboxLease:
     async def upload_file(
         self, path: str, local_path: str, timeout: int | None = None
     ) -> object:
-        return await maybe_call_with_named_args(
+        return await call_sandbox_client(
             self.client.upload_file,
             sandbox_id=self.id,
             file_path=path,
@@ -220,7 +228,7 @@ class SandboxLease:
     async def download_file(
         self, path: str, local_path: str, timeout: int | None = None
     ) -> object:
-        return await maybe_call_with_named_args(
+        return await call_sandbox_client(
             self.client.download_file,
             sandbox_id=self.id,
             file_path=path,
@@ -229,9 +237,10 @@ class SandboxLease:
         )
 
     async def read_file(self, path: str) -> object:
-        return await maybe_call_with_named_args(
+        return await call_sandbox_client(
             self.client.read_file,
             sandbox_id=self.id,
+            file_path=path,
             path=path,
         )
 
@@ -250,10 +259,11 @@ class SandboxLease:
         }
         if timeout is not None:
             call_args["timeout"] = timeout
-        return await maybe_call_with_named_args(
+        result = await call_sandbox_client(
             getattr(self.client, "run_background_job"),
             **call_args,
         )
+        return cast(SandboxCommandResult, result)
 
     async def delete(self) -> None:
         if self.deleted:
@@ -264,6 +274,22 @@ class SandboxLease:
         finally:
             if self.owns_client:
                 await close_sandbox_client(self.client)
+
+
+async def call_sandbox_client(func: Callable, **objects: object) -> object:
+    sig = inspect.signature(func)
+    if any(p.kind == p.VAR_KEYWORD for p in sig.parameters.values()):
+        call_args = objects
+    else:
+        call_args = {
+            key: value for key, value in objects.items() if key in sig.parameters
+        }
+    if inspect.iscoroutinefunction(func):
+        return await func(**call_args)
+    result = await asyncio.to_thread(func, **call_args)
+    if inspect.isawaitable(result):
+        return await result
+    return result
 
 
 class SandboxHandle:
@@ -378,28 +404,56 @@ async def run_sandbox_command(
     task: Task,
     state: State,
     runtime: Runtime,
+    endpoint: "Endpoint | None" = None,
+    prepare_program: ProgramPrepare | None = None,
 ) -> State:
-    async with prepared_program_sandbox(
-        program, sandbox_config, task, state, runtime
-    ) as prepared:
-        lease, use_sandbox_python_path = prepared
-        workdir = sandbox_config.workdir
-        if workdir:
-            await lease.client.execute_command(
-                lease.id, f"mkdir -p {shlex.quote(workdir)}"
-            )
-        argv = await command_argv(program, task, state, runtime)
-        env = await command_env(program, task, state, runtime, include_base=False)
-        command = shlex.join(argv)
-        if use_sandbox_python_path or "mcp" in program_channels(program):
-            command = sandbox_python_path_command(command)
-        command_timeout = sandbox_config.command_timeout
-        result = await lease.run_background_job(
-            command,
-            timeout=command_timeout,
-            working_dir=workdir,
-            env=env,
+    sandbox_data = sandbox_config.data()
+    lease = await runtime.resolve_program_sandbox(sandbox_config, task, state)
+    async with lease.lock:
+        state["sandbox_id"] = lease.id
+        runtime_state = state.runtime_state()
+        lease_scope_key = lease.scope_key or runtime.scope_key(lease.scope, state)
+        lease.scope_key = lease_scope_key
+        runtime_state["sandbox"] = {
+            "id": lease.id,
+            "scope": lease.scope,
+            "key": lease.key,
+            "lease_key": [lease_scope_key, lease.key],
+        }
+        handle = SandboxHandle(lease, state)
+        use_sandbox_python_path = bool(
+            python_package_list(sandbox_data.get("packages"))
         )
+        async with sandbox_interception_bridge(lease, endpoint, state):
+            if prepare_program is not None:
+                program = prepare_program(program, state)
+            validate_program_bindings(program)
+            await runtime.setup_rollout(
+                task,
+                state,
+                setup_handlers=program_setup_handlers(
+                    lease,
+                    program,
+                    runtime,
+                    use_sandbox_python_path=use_sandbox_python_path,
+                ),
+                sandbox=handle,
+            )
+            workdir = sandbox_config.workdir
+            if workdir:
+                await lease.execute(f"mkdir -p {shlex.quote(workdir)}")
+            argv = await command_argv(program, task, state, runtime)
+            env = await command_env(program, task, state, runtime, include_base=False)
+            command = shlex.join(argv)
+            if use_sandbox_python_path or "mcp" in program_channels(program):
+                command = sandbox_python_path_command(command)
+            command_timeout = sandbox_config.command_timeout
+            result = await lease.run_background_job(
+                command,
+                timeout=command_timeout,
+                working_dir=workdir,
+                env=env,
+            )
         state["command"] = {
             "argv": argv,
             "returncode": result.exit_code,
@@ -418,43 +472,264 @@ async def run_sandbox_command(
 
 
 @asynccontextmanager
-async def prepared_program_sandbox(
-    program: ConfigData,
-    sandbox_config: SandboxConfig,
-    task: Task,
+async def sandbox_interception_bridge(
+    lease: SandboxLease,
+    endpoint: "Endpoint | None",
     state: State,
-    runtime: Runtime,
-) -> AsyncIterator[tuple[SandboxLease, bool]]:
-    validate_program_bindings(program)
-    sandbox_data = sandbox_config.data()
-    lease = await runtime.resolve_program_sandbox(sandbox_config, task, state)
-    async with lease.lock:
-        state["sandbox_id"] = lease.id
-        runtime_state = state.runtime_state()
-        lease_scope_key = lease.scope_key or runtime.scope_key(lease.scope, state)
-        lease.scope_key = lease_scope_key
-        runtime_state["sandbox"] = {
-            "id": lease.id,
-            "scope": lease.scope,
-            "key": lease.key,
-            "lease_key": [lease_scope_key, lease.key],
+) -> AsyncIterator[None]:
+    rollout_key = state.get("endpoint_rollout_key")
+    if endpoint is None or not isinstance(rollout_key, str):
+        yield
+        return
+
+    original_root = state.get("endpoint_root_url")
+    original_base = state.get("endpoint_base_url")
+    await start_sandbox_bridge_proxy(lease)
+    stop = asyncio.Event()
+    forwarder = asyncio.create_task(run_sandbox_bridge_forwarder(lease, endpoint, stop))
+    state["endpoint_root_url"] = f"http://127.0.0.1:{BRIDGE_PORT}/rollout/{rollout_key}"
+    state["endpoint_base_url"] = f"{state['endpoint_root_url']}/v1"
+    try:
+        yield
+    finally:
+        stop.set()
+        await asyncio.gather(forwarder, return_exceptions=True)
+        await stop_sandbox_bridge_proxy(lease)
+        if isinstance(original_root, str):
+            state["endpoint_root_url"] = original_root
+        if isinstance(original_base, str):
+            state["endpoint_base_url"] = original_base
+
+
+async def start_sandbox_bridge_proxy(lease: SandboxLease) -> None:
+    await lease.upload_bytes(BRIDGE_PROXY_PATH, sandbox_bridge_proxy_source().encode())
+    root = shlex.quote(BRIDGE_ROOT)
+    proxy_path = shlex.quote(BRIDGE_PROXY_PATH)
+    command = (
+        f"mkdir -p {root}/requests {root}/responses && "
+        f"rm -f {root}/requests/*.json {root}/responses/*.json && "
+        "PYTHON=$(command -v python3 || command -v python) && "
+        f'(nohup "$PYTHON" {proxy_path} --root {root} --port {BRIDGE_PORT} '
+        f"> {root}/proxy.log 2>&1 & echo $! > {root}/proxy.pid)"
+    )
+    result = await lease.execute(command, timeout=10)
+    if result.exit_code:
+        raise SandboxError(f"Sandbox interception bridge failed: {result.stderr}")
+    await wait_for_sandbox_bridge_proxy(lease)
+
+
+async def wait_for_sandbox_bridge_proxy(lease: SandboxLease) -> None:
+    command = (
+        "PYTHON=$(command -v python3 || command -v python) && "
+        '"$PYTHON" -c '
+        + shlex.quote(
+            "import socket, sys, time\n"
+            "deadline = time.time() + 10\n"
+            "while time.time() < deadline:\n"
+            "    try:\n"
+            f"        socket.create_connection(('127.0.0.1', {BRIDGE_PORT}), 1).close()\n"
+            "        sys.exit(0)\n"
+            "    except OSError:\n"
+            "        time.sleep(0.1)\n"
+            "sys.exit(1)\n"
+        )
+    )
+    result = await lease.execute(command, timeout=15)
+    if result.exit_code:
+        raise SandboxError("Sandbox interception bridge did not become ready.")
+
+
+async def stop_sandbox_bridge_proxy(lease: SandboxLease) -> None:
+    root = shlex.quote(BRIDGE_ROOT)
+    await lease.execute(
+        f"if [ -f {root}/proxy.pid ]; then kill $(cat {root}/proxy.pid) 2>/dev/null || true; fi",
+        timeout=10,
+    )
+
+
+async def run_sandbox_bridge_forwarder(
+    lease: SandboxLease,
+    endpoint: "Endpoint",
+    stop: asyncio.Event,
+) -> None:
+    pending: set[asyncio.Task[None]] = set()
+    seen: set[str] = set()
+    while not stop.is_set():
+        for path in await list_sandbox_bridge_requests(lease):
+            if path in seen:
+                continue
+            seen.add(path)
+            pending.add(
+                asyncio.create_task(
+                    forward_sandbox_bridge_request(
+                        lease,
+                        endpoint,
+                        path,
+                        bridge_response_path(path),
+                    )
+                )
+            )
+        done = {task for task in pending if task.done()}
+        for task in done:
+            pending.remove(task)
+            await task
+        await asyncio.sleep(0.05)
+    if pending:
+        await asyncio.gather(*pending)
+
+
+async def list_sandbox_bridge_requests(lease: SandboxLease) -> list[str]:
+    root = shlex.quote(f"{BRIDGE_ROOT}/requests")
+    result = await lease.execute(
+        f"find {root} -maxdepth 1 -type f -name '*.json' -print 2>/dev/null || true",
+        timeout=5,
+    )
+    return [
+        line
+        for line in (result.stdout or "").splitlines()
+        if line.startswith(f"{BRIDGE_ROOT}/requests/") and line.endswith(".json")
+    ]
+
+
+def bridge_response_path(request_path: str) -> str:
+    return f"{BRIDGE_ROOT}/responses/{Path(request_path).name}"
+
+
+async def forward_sandbox_bridge_request(
+    lease: SandboxLease,
+    endpoint: "Endpoint",
+    request_path: str,
+    response_path: str,
+) -> None:
+    raw_request = await lease.read_file(request_path)
+    if hasattr(raw_request, "content"):
+        raw_request = raw_request.content
+    request = json.loads(str(raw_request))
+    body = base64.b64decode(str(request.get("body") or ""))
+    headers = bridge_request_headers(request.get("headers"))
+    method = str(request.get("method") or "POST")
+    path = str(request.get("path") or "/")
+    timeout = httpx.Timeout(None)
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            response = await client.request(
+                method,
+                f"http://127.0.0.1:{endpoint.port}{path}",
+                headers=headers,
+                content=body,
+            )
+        payload = {
+            "status": response.status_code,
+            "headers": dict(response.headers),
+            "body": base64.b64encode(response.content).decode(),
         }
-        handle = SandboxHandle(lease, state)
-        use_sandbox_python_path = bool(
-            python_package_list(sandbox_data.get("packages"))
-        )
-        await runtime.setup_rollout(
-            task,
-            state,
-            setup_handlers=program_setup_handlers(
-                lease,
-                program,
-                runtime,
-                use_sandbox_python_path=use_sandbox_python_path,
-            ),
-            sandbox=handle,
-        )
-        yield lease, use_sandbox_python_path
+    except Exception as exc:
+        payload = {
+            "status": 500,
+            "headers": {"content-type": "application/json"},
+            "body": base64.b64encode(json.dumps({"error": str(exc)}).encode()).decode(),
+        }
+    await lease.upload_bytes(response_path, json.dumps(payload).encode())
+    await lease.execute(f"rm -f {shlex.quote(request_path)}", timeout=5)
+
+
+def bridge_request_headers(value: object) -> dict[str, str]:
+    headers = dict(cast(ConfigData, value or {}))
+    for key in ("host", "content-length", "connection", "transfer-encoding"):
+        headers.pop(key, None)
+        headers.pop(key.title(), None)
+    return {str(key): str(item) for key, item in headers.items()}
+
+
+def sandbox_bridge_proxy_source() -> str:
+    return r"""
+import argparse
+import base64
+import json
+import os
+import time
+import uuid
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+
+class BridgeHandler(BaseHTTPRequestHandler):
+    server_version = "vf-interception-bridge"
+
+    def do_GET(self):
+        self.forward()
+
+    def do_POST(self):
+        self.forward()
+
+    def do_OPTIONS(self):
+        self.forward()
+
+    def forward(self):
+        if self.path == "/health":
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"ok")
+            return
+        length = int(self.headers.get("Content-Length") or "0")
+        body = self.rfile.read(length) if length else b""
+        request_id = uuid.uuid4().hex
+        root = Path(self.server.bridge_root)
+        request_path = root / "requests" / f"{request_id}.json"
+        response_path = root / "responses" / f"{request_id}.json"
+        payload = {
+            "id": request_id,
+            "method": self.command,
+            "path": self.path,
+            "headers": {k: v for k, v in self.headers.items()},
+            "body": base64.b64encode(body).decode(),
+        }
+        tmp_path = request_path.with_suffix(".tmp")
+        tmp_path.write_text(json.dumps(payload))
+        os.replace(tmp_path, request_path)
+        deadline = time.time() + self.server.bridge_timeout
+        while time.time() < deadline:
+            if response_path.exists():
+                response = json.loads(response_path.read_text())
+                response_path.unlink(missing_ok=True)
+                self.send_response(int(response.get("status") or 500))
+                for key, value in dict(response.get("headers") or {}).items():
+                    if key.lower() in {"content-length", "connection", "transfer-encoding"}:
+                        continue
+                    self.send_header(str(key), str(value))
+                data = base64.b64decode(str(response.get("body") or ""))
+                self.send_header("Content-Length", str(len(data)))
+                self.end_headers()
+                self.wfile.write(data)
+                return
+            time.sleep(0.05)
+        self.send_response(504)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(b'{"error":"Verifiers bridge timed out"}')
+
+    def log_message(self, format, *args):
+        return
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", required=True)
+    parser.add_argument("--port", type=int, required=True)
+    parser.add_argument("--timeout", type=float, default=3600.0)
+    args = parser.parse_args()
+    root = Path(args.root)
+    (root / "requests").mkdir(parents=True, exist_ok=True)
+    (root / "responses").mkdir(parents=True, exist_ok=True)
+    server = ThreadingHTTPServer(("127.0.0.1", args.port), BridgeHandler)
+    server.bridge_root = str(root)
+    server.bridge_timeout = args.timeout
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()
+"""
 
 
 def program_setup_handlers(
@@ -945,12 +1220,15 @@ async def run_program_items(
         command = str(command)
         if use_sandbox_python_path:
             command = sandbox_python_path_command(command)
-        result = await maybe_call_with_named_args(
-            client.execute_command,
-            sandbox_id=sandbox_id,
-            command=command,
-            env=env,
-            timeout=timeout,
+        result = cast(
+            SandboxCommandResult,
+            await call_sandbox_client(
+                client.execute_command,
+                sandbox_id=sandbox_id,
+                command=command,
+                env=env,
+                timeout=timeout,
+            ),
         )
         if result.exit_code:
             raise SandboxError(f"{error_prefix}: {result.stderr}")

--- a/verifiers/v1/utils/sandbox_utils.py
+++ b/verifiers/v1/utils/sandbox_utils.py
@@ -1,7 +1,6 @@
 import asyncio
 import base64
 import hashlib
-import inspect
 import importlib.resources as resources
 import json
 import logging
@@ -229,7 +228,7 @@ class SandboxLease:
         working_dir: str | None = None,
         env: dict[str, str] | None = None,
     ) -> SandboxCommandResult:
-        result = await call_sandbox_client(
+        result = await maybe_call_with_named_args(
             self.client.execute_command,
             sandbox_id=self.id,
             command=command,
@@ -242,7 +241,7 @@ class SandboxLease:
     async def upload_bytes(
         self, path: str, content: bytes, filename: str | None = None
     ) -> object:
-        return await call_sandbox_client(
+        return await maybe_call_with_named_args(
             self.client.upload_bytes,
             sandbox_id=self.id,
             file_path=path,
@@ -253,7 +252,7 @@ class SandboxLease:
     async def upload_file(
         self, path: str, local_path: str, timeout: int | None = None
     ) -> object:
-        return await call_sandbox_client(
+        return await maybe_call_with_named_args(
             self.client.upload_file,
             sandbox_id=self.id,
             file_path=path,
@@ -264,7 +263,7 @@ class SandboxLease:
     async def download_file(
         self, path: str, local_path: str, timeout: int | None = None
     ) -> object:
-        return await call_sandbox_client(
+        return await maybe_call_with_named_args(
             self.client.download_file,
             sandbox_id=self.id,
             file_path=path,
@@ -273,7 +272,7 @@ class SandboxLease:
         )
 
     async def read_file(self, path: str) -> object:
-        return await call_sandbox_client(
+        return await maybe_call_with_named_args(
             self.client.read_file,
             sandbox_id=self.id,
             file_path=path,
@@ -297,7 +296,7 @@ class SandboxLease:
         }
         if timeout is not None:
             call_args["timeout"] = timeout
-        result = await call_sandbox_client(
+        result = await maybe_call_with_named_args(
             getattr(self.client, "run_background_job"),
             **call_args,
         )
@@ -315,22 +314,6 @@ class SandboxLease:
                 raise
             if self.owns_client:
                 await close_sandbox_client(self.client)
-
-
-async def call_sandbox_client(func: Callable, **objects: object) -> object:
-    sig = inspect.signature(func)
-    if any(p.kind == p.VAR_KEYWORD for p in sig.parameters.values()):
-        call_args = objects
-    else:
-        call_args = {
-            key: value for key, value in objects.items() if key in sig.parameters
-        }
-    if inspect.iscoroutinefunction(func):
-        return await func(**call_args)
-    result = await asyncio.to_thread(func, **call_args)
-    if inspect.isawaitable(result):
-        return await result
-    return result
 
 
 class SandboxHandle:
@@ -557,27 +540,23 @@ async def sandbox_interception_bridge(
         yield
         return
 
-    original_root = state.get("endpoint_root_url")
-    original_base = state.get("endpoint_base_url")
+    original_root = str(state["endpoint_root_url"])
+    original_base = str(state["endpoint_base_url"])
     root = shlex.quote(BRIDGE_ROOT)
     proxy_path = shlex.quote(BRIDGE_PROXY_PATH)
-    started = False
-    stop: asyncio.Event | None = None
-    forwarder: asyncio.Task[None] | None = None
-    try:
-        await lease.upload_bytes(BRIDGE_PROXY_PATH, BRIDGE_PROXY_SOURCE.encode())
-        command = (
-            f"mkdir -p {root}/requests {root}/responses && "
-            f"rm -f {root}/requests/*.json {root}/responses/*.json && "
-            "PYTHON=$(command -v python3 || command -v python) && "
-            f'(nohup "$PYTHON" {proxy_path} --root {root} --port {BRIDGE_PORT} '
-            f"> {root}/proxy.log 2>&1 & echo $! > {root}/proxy.pid)"
-        )
-        result = await lease.execute(command, timeout=10)
-        if result.exit_code:
-            raise SandboxError(f"Sandbox interception bridge failed: {result.stderr}")
-        started = True
+    await lease.upload_bytes(BRIDGE_PROXY_PATH, BRIDGE_PROXY_SOURCE.encode())
+    command = (
+        f"mkdir -p {root}/requests {root}/responses && "
+        f"rm -f {root}/requests/*.json {root}/responses/*.json && "
+        "PYTHON=$(command -v python3 || command -v python) && "
+        f'(nohup "$PYTHON" {proxy_path} --root {root} --port {BRIDGE_PORT} '
+        f"> {root}/proxy.log 2>&1 & echo $! > {root}/proxy.pid)"
+    )
+    result = await lease.execute(command, timeout=10)
+    if result.exit_code:
+        raise SandboxError(f"Sandbox interception bridge failed: {result.stderr}")
 
+    try:
         ready_check = (
             "import socket, sys, time\n"
             "deadline = time.time() + 10\n"
@@ -605,20 +584,18 @@ async def sandbox_interception_bridge(
             f"http://127.0.0.1:{BRIDGE_PORT}/rollout/{rollout_key}"
         )
         state["endpoint_base_url"] = f"{state['endpoint_root_url']}/v1"
-        yield
-    finally:
-        if stop is not None and forwarder is not None:
+        try:
+            yield
+        finally:
             stop.set()
             await asyncio.gather(forwarder, return_exceptions=True)
-        if started:
-            await lease.execute(
-                f"if [ -f {root}/proxy.pid ]; then kill $(cat {root}/proxy.pid) 2>/dev/null || true; fi",
-                timeout=10,
-            )
-        if isinstance(original_root, str):
             state["endpoint_root_url"] = original_root
-        if isinstance(original_base, str):
             state["endpoint_base_url"] = original_base
+    finally:
+        await lease.execute(
+            f"if [ -f {root}/proxy.pid ]; then kill $(cat {root}/proxy.pid) 2>/dev/null || true; fi",
+            timeout=10,
+        )
 
 
 async def run_sandbox_bridge_forwarder(
@@ -669,15 +646,14 @@ async def forward_sandbox_bridge_request(
     response_path: str,
 ) -> None:
     raw_request = await lease.read_file(request_path)
-    if hasattr(raw_request, "content"):
-        raw_request = raw_request.content
-    request = json.loads(str(raw_request))
+    request = json.loads(str(getattr(raw_request, "content", raw_request)))
     body = base64.b64decode(str(request.get("body") or ""))
-    headers = dict(cast(ConfigData, request.get("headers") or {}))
-    for key in ("host", "content-length", "connection", "transfer-encoding"):
-        headers.pop(key, None)
-        headers.pop(key.title(), None)
-    headers = {str(key): str(item) for key, item in headers.items()}
+    excluded_headers = {"host", "content-length", "connection", "transfer-encoding"}
+    headers = {
+        str(key): str(value)
+        for key, value in dict(cast(ConfigData, request.get("headers") or {})).items()
+        if str(key).lower() not in excluded_headers
+    }
     method = str(request.get("method") or "POST")
     path = str(request.get("path") or "/")
     timeout = httpx.Timeout(None)
@@ -1310,7 +1286,7 @@ async def run_program_items(
             command = sandbox_python_path_command(command)
         result = cast(
             SandboxCommandResult,
-            await call_sandbox_client(
+            await maybe_call_with_named_args(
                 client.execute_command,
                 sandbox_id=sandbox_id,
                 command=command,

--- a/verifiers/v1/utils/sandbox_utils.py
+++ b/verifiers/v1/utils/sandbox_utils.py
@@ -7,7 +7,8 @@ import shlex
 import tarfile
 import tempfile
 import uuid
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable
+from contextlib import asynccontextmanager
 from importlib.abc import Traversable
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, Protocol, TypeVar, cast
@@ -378,35 +379,10 @@ async def run_sandbox_command(
     state: State,
     runtime: Runtime,
 ) -> State:
-    validate_program_bindings(program)
-    sandbox_data = sandbox_config.data()
-    lease = await runtime.resolve_program_sandbox(sandbox_config, task, state)
-    async with lease.lock:
-        state["sandbox_id"] = lease.id
-        runtime_state = state.runtime_state()
-        lease_scope_key = lease.scope_key or runtime.scope_key(lease.scope, state)
-        lease.scope_key = lease_scope_key
-        runtime_state["sandbox"] = {
-            "id": lease.id,
-            "scope": lease.scope,
-            "key": lease.key,
-            "lease_key": [lease_scope_key, lease.key],
-        }
-        handle = SandboxHandle(lease, state)
-        use_sandbox_python_path = bool(
-            python_package_list(sandbox_data.get("packages"))
-        )
-        await runtime.setup_rollout(
-            task,
-            state,
-            setup_handlers=program_setup_handlers(
-                lease,
-                program,
-                runtime,
-                use_sandbox_python_path=use_sandbox_python_path,
-            ),
-            sandbox=handle,
-        )
+    async with prepared_program_sandbox(
+        program, sandbox_config, task, state, runtime
+    ) as prepared:
+        lease, use_sandbox_python_path = prepared
         workdir = sandbox_config.workdir
         if workdir:
             await lease.client.execute_command(
@@ -441,6 +417,46 @@ async def run_sandbox_command(
         return state
 
 
+@asynccontextmanager
+async def prepared_program_sandbox(
+    program: ConfigData,
+    sandbox_config: SandboxConfig,
+    task: Task,
+    state: State,
+    runtime: Runtime,
+) -> AsyncIterator[tuple[SandboxLease, bool]]:
+    validate_program_bindings(program)
+    sandbox_data = sandbox_config.data()
+    lease = await runtime.resolve_program_sandbox(sandbox_config, task, state)
+    async with lease.lock:
+        state["sandbox_id"] = lease.id
+        runtime_state = state.runtime_state()
+        lease_scope_key = lease.scope_key or runtime.scope_key(lease.scope, state)
+        lease.scope_key = lease_scope_key
+        runtime_state["sandbox"] = {
+            "id": lease.id,
+            "scope": lease.scope,
+            "key": lease.key,
+            "lease_key": [lease_scope_key, lease.key],
+        }
+        handle = SandboxHandle(lease, state)
+        use_sandbox_python_path = bool(
+            python_package_list(sandbox_data.get("packages"))
+        )
+        await runtime.setup_rollout(
+            task,
+            state,
+            setup_handlers=program_setup_handlers(
+                lease,
+                program,
+                runtime,
+                use_sandbox_python_path=use_sandbox_python_path,
+            ),
+            sandbox=handle,
+        )
+        yield lease, use_sandbox_python_path
+
+
 def program_setup_handlers(
     lease: SandboxLease,
     program: ConfigData,
@@ -472,6 +488,15 @@ def program_setup_handlers(
             run_program_setup,
             "program_setup",
             100,
+            use_sandbox_python_path=use_sandbox_python_path,
+        ),
+        _program_setup_handler(
+            lease,
+            program,
+            runtime,
+            run_program_post_setup,
+            "program_post_setup",
+            50,
             use_sandbox_python_path=use_sandbox_python_path,
         ),
         _program_setup_handler(
@@ -823,6 +848,28 @@ async def run_program_setup(
         runtime,
         key="setup",
         error_prefix="Program setup failed",
+        use_sandbox_python_path=use_sandbox_python_path,
+    )
+
+
+async def run_program_post_setup(
+    client: SandboxClient,
+    sandbox_id: str,
+    program: ConfigData,
+    task: Task,
+    state: State,
+    runtime: Runtime,
+    use_sandbox_python_path: bool = False,
+) -> None:
+    await run_program_commands(
+        client,
+        sandbox_id,
+        program,
+        task,
+        state,
+        runtime,
+        key="post_setup",
+        error_prefix="Program post_setup failed",
         use_sandbox_python_path=use_sandbox_python_path,
     )
 

--- a/verifiers/v1/utils/sandbox_utils.py
+++ b/verifiers/v1/utils/sandbox_utils.py
@@ -51,7 +51,6 @@ SANDBOX_RETRY_ATTEMPTS = 6
 SANDBOX_WAIT_FOR_CREATION_ATTEMPTS = 120
 T = TypeVar("T")
 logger = logging.getLogger(__name__)
-ProgramPrepare = Callable[[ConfigData, State], ConfigData]
 
 
 class SandboxRecord(Protocol):
@@ -462,7 +461,7 @@ async def run_sandbox_command(
     state: State,
     runtime: Runtime,
     endpoint: "Endpoint | None" = None,
-    prepare_program: ProgramPrepare | None = None,
+    prepare_program: Callable[[ConfigData, State], ConfigData] | None = None,
 ) -> State:
     sandbox_data = sandbox_config.data()
     try:
@@ -560,45 +559,26 @@ async def sandbox_interception_bridge(
 
     original_root = state.get("endpoint_root_url")
     original_base = state.get("endpoint_base_url")
-    await start_sandbox_bridge_proxy(lease)
-    stop = asyncio.Event()
-    forwarder = asyncio.create_task(run_sandbox_bridge_forwarder(lease, endpoint, stop))
-    state["endpoint_root_url"] = f"http://127.0.0.1:{BRIDGE_PORT}/rollout/{rollout_key}"
-    state["endpoint_base_url"] = f"{state['endpoint_root_url']}/v1"
-    try:
-        yield
-    finally:
-        stop.set()
-        await asyncio.gather(forwarder, return_exceptions=True)
-        await stop_sandbox_bridge_proxy(lease)
-        if isinstance(original_root, str):
-            state["endpoint_root_url"] = original_root
-        if isinstance(original_base, str):
-            state["endpoint_base_url"] = original_base
-
-
-async def start_sandbox_bridge_proxy(lease: SandboxLease) -> None:
-    await lease.upload_bytes(BRIDGE_PROXY_PATH, sandbox_bridge_proxy_source().encode())
     root = shlex.quote(BRIDGE_ROOT)
     proxy_path = shlex.quote(BRIDGE_PROXY_PATH)
-    command = (
-        f"mkdir -p {root}/requests {root}/responses && "
-        f"rm -f {root}/requests/*.json {root}/responses/*.json && "
-        "PYTHON=$(command -v python3 || command -v python) && "
-        f'(nohup "$PYTHON" {proxy_path} --root {root} --port {BRIDGE_PORT} '
-        f"> {root}/proxy.log 2>&1 & echo $! > {root}/proxy.pid)"
-    )
-    result = await lease.execute(command, timeout=10)
-    if result.exit_code:
-        raise SandboxError(f"Sandbox interception bridge failed: {result.stderr}")
-    await wait_for_sandbox_bridge_proxy(lease)
+    started = False
+    stop: asyncio.Event | None = None
+    forwarder: asyncio.Task[None] | None = None
+    try:
+        await lease.upload_bytes(BRIDGE_PROXY_PATH, BRIDGE_PROXY_SOURCE.encode())
+        command = (
+            f"mkdir -p {root}/requests {root}/responses && "
+            f"rm -f {root}/requests/*.json {root}/responses/*.json && "
+            "PYTHON=$(command -v python3 || command -v python) && "
+            f'(nohup "$PYTHON" {proxy_path} --root {root} --port {BRIDGE_PORT} '
+            f"> {root}/proxy.log 2>&1 & echo $! > {root}/proxy.pid)"
+        )
+        result = await lease.execute(command, timeout=10)
+        if result.exit_code:
+            raise SandboxError(f"Sandbox interception bridge failed: {result.stderr}")
+        started = True
 
-
-async def wait_for_sandbox_bridge_proxy(lease: SandboxLease) -> None:
-    command = (
-        "PYTHON=$(command -v python3 || command -v python) && "
-        '"$PYTHON" -c '
-        + shlex.quote(
+        ready_check = (
             "import socket, sys, time\n"
             "deadline = time.time() + 10\n"
             "while time.time() < deadline:\n"
@@ -609,18 +589,36 @@ async def wait_for_sandbox_bridge_proxy(lease: SandboxLease) -> None:
             "        time.sleep(0.1)\n"
             "sys.exit(1)\n"
         )
-    )
-    result = await lease.execute(command, timeout=15)
-    if result.exit_code:
-        raise SandboxError("Sandbox interception bridge did not become ready.")
+        result = await lease.execute(
+            "PYTHON=$(command -v python3 || command -v python) && "
+            f'"$PYTHON" -c {shlex.quote(ready_check)}',
+            timeout=15,
+        )
+        if result.exit_code:
+            raise SandboxError("Sandbox interception bridge did not become ready.")
 
-
-async def stop_sandbox_bridge_proxy(lease: SandboxLease) -> None:
-    root = shlex.quote(BRIDGE_ROOT)
-    await lease.execute(
-        f"if [ -f {root}/proxy.pid ]; then kill $(cat {root}/proxy.pid) 2>/dev/null || true; fi",
-        timeout=10,
-    )
+        stop = asyncio.Event()
+        forwarder = asyncio.create_task(
+            run_sandbox_bridge_forwarder(lease, endpoint, stop)
+        )
+        state["endpoint_root_url"] = (
+            f"http://127.0.0.1:{BRIDGE_PORT}/rollout/{rollout_key}"
+        )
+        state["endpoint_base_url"] = f"{state['endpoint_root_url']}/v1"
+        yield
+    finally:
+        if stop is not None and forwarder is not None:
+            stop.set()
+            await asyncio.gather(forwarder, return_exceptions=True)
+        if started:
+            await lease.execute(
+                f"if [ -f {root}/proxy.pid ]; then kill $(cat {root}/proxy.pid) 2>/dev/null || true; fi",
+                timeout=10,
+            )
+        if isinstance(original_root, str):
+            state["endpoint_root_url"] = original_root
+        if isinstance(original_base, str):
+            state["endpoint_base_url"] = original_base
 
 
 async def run_sandbox_bridge_forwarder(
@@ -630,18 +628,28 @@ async def run_sandbox_bridge_forwarder(
 ) -> None:
     pending: set[asyncio.Task[None]] = set()
     seen: set[str] = set()
+    request_dir = f"{BRIDGE_ROOT}/requests"
+    find_requests = (
+        f"find {shlex.quote(request_dir)} -maxdepth 1 -type f "
+        "-name '*.json' -print 2>/dev/null || true"
+    )
     while not stop.is_set():
-        for path in await list_sandbox_bridge_requests(lease):
-            if path in seen:
+        result = await lease.execute(find_requests, timeout=5)
+        for request_path in (result.stdout or "").splitlines():
+            if request_path in seen:
                 continue
-            seen.add(path)
+            if not request_path.startswith(request_dir) or not request_path.endswith(
+                ".json"
+            ):
+                continue
+            seen.add(request_path)
             pending.add(
                 asyncio.create_task(
                     forward_sandbox_bridge_request(
                         lease,
                         endpoint,
-                        path,
-                        bridge_response_path(path),
+                        request_path,
+                        f"{BRIDGE_ROOT}/responses/{Path(request_path).name}",
                     )
                 )
             )
@@ -652,23 +660,6 @@ async def run_sandbox_bridge_forwarder(
         await asyncio.sleep(0.05)
     if pending:
         await asyncio.gather(*pending)
-
-
-async def list_sandbox_bridge_requests(lease: SandboxLease) -> list[str]:
-    root = shlex.quote(f"{BRIDGE_ROOT}/requests")
-    result = await lease.execute(
-        f"find {root} -maxdepth 1 -type f -name '*.json' -print 2>/dev/null || true",
-        timeout=5,
-    )
-    return [
-        line
-        for line in (result.stdout or "").splitlines()
-        if line.startswith(f"{BRIDGE_ROOT}/requests/") and line.endswith(".json")
-    ]
-
-
-def bridge_response_path(request_path: str) -> str:
-    return f"{BRIDGE_ROOT}/responses/{Path(request_path).name}"
 
 
 async def forward_sandbox_bridge_request(
@@ -682,7 +673,11 @@ async def forward_sandbox_bridge_request(
         raw_request = raw_request.content
     request = json.loads(str(raw_request))
     body = base64.b64decode(str(request.get("body") or ""))
-    headers = bridge_request_headers(request.get("headers"))
+    headers = dict(cast(ConfigData, request.get("headers") or {}))
+    for key in ("host", "content-length", "connection", "transfer-encoding"):
+        headers.pop(key, None)
+        headers.pop(key.title(), None)
+    headers = {str(key): str(item) for key, item in headers.items()}
     method = str(request.get("method") or "POST")
     path = str(request.get("path") or "/")
     timeout = httpx.Timeout(None)
@@ -709,16 +704,7 @@ async def forward_sandbox_bridge_request(
     await lease.execute(f"rm -f {shlex.quote(request_path)}", timeout=5)
 
 
-def bridge_request_headers(value: object) -> dict[str, str]:
-    headers = dict(cast(ConfigData, value or {}))
-    for key in ("host", "content-length", "connection", "transfer-encoding"):
-        headers.pop(key, None)
-        headers.pop(key.title(), None)
-    return {str(key): str(item) for key, item in headers.items()}
-
-
-def sandbox_bridge_proxy_source() -> str:
-    return r"""
+BRIDGE_PROXY_SOURCE = r"""
 import argparse
 import base64
 import json

--- a/verifiers/v1/utils/sandbox_utils.py
+++ b/verifiers/v1/utils/sandbox_utils.py
@@ -657,7 +657,7 @@ async def run_sandbox_bridge_forwarder(
         for task in done:
             pending.remove(task)
             await task
-        await asyncio.sleep(0.05)
+        await asyncio.sleep(0.2)
     if pending:
         await asyncio.gather(*pending)
 
@@ -721,31 +721,21 @@ class BridgeHandler(BaseHTTPRequestHandler):
     def do_GET(self):
         self.forward()
 
-    def do_POST(self):
-        self.forward()
-
-    def do_OPTIONS(self):
-        self.forward()
+    do_POST = do_GET
+    do_OPTIONS = do_GET
 
     def forward(self):
-        if self.path == "/health":
-            self.send_response(200)
-            self.end_headers()
-            self.wfile.write(b"ok")
-            return
-        length = int(self.headers.get("Content-Length") or "0")
-        body = self.rfile.read(length) if length else b""
+        body = self.rfile.read(int(self.headers.get("Content-Length") or "0"))
         request_id = uuid.uuid4().hex
         root = Path(self.server.bridge_root)
         request_path = root / "requests" / f"{request_id}.json"
         response_path = root / "responses" / f"{request_id}.json"
-        payload = {
-            "id": request_id,
-            "method": self.command,
-            "path": self.path,
-            "headers": {k: v for k, v in self.headers.items()},
-            "body": base64.b64encode(body).decode(),
-        }
+        payload = dict(
+            method=self.command,
+            path=self.path,
+            headers={k: v for k, v in self.headers.items()},
+            body=base64.b64encode(body).decode(),
+        )
         tmp_path = request_path.with_suffix(".tmp")
         tmp_path.write_text(json.dumps(payload))
         os.replace(tmp_path, request_path)
@@ -759,12 +749,12 @@ class BridgeHandler(BaseHTTPRequestHandler):
                     if key.lower() in {"content-length", "connection", "transfer-encoding"}:
                         continue
                     self.send_header(str(key), str(value))
-                data = base64.b64decode(str(response.get("body") or ""))
-                self.send_header("Content-Length", str(len(data)))
+                body = base64.b64decode(str(response.get("body") or ""))
+                self.send_header("Content-Length", str(len(body)))
                 self.end_headers()
-                self.wfile.write(data)
+                self.wfile.write(body)
                 return
-            time.sleep(0.05)
+            time.sleep(0.1)
         self.send_response(504)
         self.send_header("Content-Type", "application/json")
         self.end_headers()
@@ -781,8 +771,8 @@ def main():
     parser.add_argument("--timeout", type=float, default=3600.0)
     args = parser.parse_args()
     root = Path(args.root)
-    (root / "requests").mkdir(parents=True, exist_ok=True)
-    (root / "responses").mkdir(parents=True, exist_ok=True)
+    for name in ("requests", "responses"):
+        (root / name).mkdir(parents=True, exist_ok=True)
     server = ThreadingHTTPServer(("127.0.0.1", args.port), BridgeHandler)
     server.bridge_root = str(root)
     server.bridge_timeout = args.timeout
@@ -822,19 +812,23 @@ def program_setup_handlers(
             lease,
             program,
             runtime,
-            run_program_setup,
+            run_program_commands,
             "program_setup",
             100,
             use_sandbox_python_path=use_sandbox_python_path,
+            key="setup",
+            error_prefix="Program setup failed",
         ),
         _program_setup_handler(
             lease,
             program,
             runtime,
-            run_program_post_setup,
+            run_program_commands,
             "program_post_setup",
             50,
             use_sandbox_python_path=use_sandbox_python_path,
+            key="post_setup",
+            error_prefix="Program post_setup failed",
         ),
         _program_setup_handler(
             lease,
@@ -868,6 +862,7 @@ def _program_setup_handler(
     name: str,
     priority: int,
     use_sandbox_python_path: bool = False,
+    **extra: object,
 ) -> Handler:
     async def handler(task: Task, state: State) -> None:
         try:
@@ -880,6 +875,7 @@ def _program_setup_handler(
                 state=state,
                 runtime=runtime,
                 use_sandbox_python_path=use_sandbox_python_path,
+                **extra,
             )
         except Error:
             raise
@@ -1239,50 +1235,6 @@ def upload_tar_filter(tarinfo: tarfile.TarInfo) -> tarfile.TarInfo | None:
     if any(part in UPLOAD_IGNORE_PARTS for part in Path(tarinfo.name).parts):
         return None
     return tarinfo
-
-
-async def run_program_setup(
-    client: SandboxClient,
-    sandbox_id: str,
-    program: ConfigData,
-    task: Task,
-    state: State,
-    runtime: Runtime,
-    use_sandbox_python_path: bool = False,
-) -> None:
-    await run_program_commands(
-        client,
-        sandbox_id,
-        program,
-        task,
-        state,
-        runtime,
-        key="setup",
-        error_prefix="Program setup failed",
-        use_sandbox_python_path=use_sandbox_python_path,
-    )
-
-
-async def run_program_post_setup(
-    client: SandboxClient,
-    sandbox_id: str,
-    program: ConfigData,
-    task: Task,
-    state: State,
-    runtime: Runtime,
-    use_sandbox_python_path: bool = False,
-) -> None:
-    await run_program_commands(
-        client,
-        sandbox_id,
-        program,
-        task,
-        state,
-        runtime,
-        key="post_setup",
-        error_prefix="Program post_setup failed",
-        use_sandbox_python_path=use_sandbox_python_path,
-    )
 
 
 async def upload_state_input(


### PR DESCRIPTION
## Summary
- replace the host-side `program.sandbox=false` approach with a sandbox-local interception bridge on `127.0.0.1:13131`
- forward sandbox HTTP requests back into the existing Verifiers rollout endpoint, so `/v1/...`, `/vf/tools`, `/vf/user`, and `/vf/stop` all reuse the normal interception path
- keep `program.post_setup` as a sandbox-only phase after `setup` and before rollout state/channel setup, so offline images can install an agent first and then write bridge-aware runtime config
- remove the endpoint tunnel mutation and host command `VF_SANDBOX_ID` path from the final tree

## Validation
- `uv run ruff check --fix .`
- `uv run ruff format`
- `uv run pytest tests/test_v1_runtime_lifecycle.py`
- `uv run pytest tests/test_v1_harbor_cli.py`
- focused real-sandbox bridge coverage: callable tool interception and MCP proxy communication both pass

Note: the pre-existing local `uv.lock` change is still not included.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bridge offline sandboxes to Verifier endpoint interception via in-sandbox HTTP proxy
> - Introduces `sandbox_interception_bridge` in [sandbox_utils.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1507/files#diff-b1154f3be7f28191532de46fbe23a973a5f93e1450a71beb9c93910e358fda13), an async context manager that uploads and starts a lightweight HTTP proxy inside the sandbox, rewrites state endpoint URLs to a local bridge address for the duration, and tears down on exit.
> - Adds `run_sandbox_bridge_forwarder` and `forward_sandbox_bridge_request` to poll the sandbox request directory and relay HTTP requests to the host endpoint server, returning responses back into the sandbox.
> - Adds `post_setup` field to `ProgramConfig` and related utilities, executed after `setup` and before state input is uploaded, allowing additional in-sandbox preparation steps.
> - Reworks `Runtime.teardown` so failed sandbox deletions retain their leases and keep the client and runtime live for retry; only successful deletions remove leases and close the client.
> - Risk: the bridge introduces an async forwarder loop and file-based request/response passing inside the sandbox, adding latency and a new failure mode if the proxy or forwarder stalls.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 86802ee.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes sandbox networking, endpoint URLs seen by programs, and teardown/registry behavior for failed deletes—security- and reliability-sensitive execution paths.
> 
> **Overview**
> Adds **`program.post_setup`**, a sandbox-only command phase that runs after **`setup`** and before rollout state is uploaded, so agents can be installed first and then configured for the bridge.
> 
> Sandboxed command and Python programs now run inside **`sandbox_interception_bridge`**: an in-sandbox HTTP proxy on **`127.0.0.1:13131`** with host-side forwarding into the normal rollout interception server. **`Harness`** passes **`endpoint`** and defers **`prepare_program`** until the bridge is active, so **`OPENAI_BASE_URL`** (and related env) inside setup/command point at the local bridge URL instead of relying on **`Endpoint(use_tunnel=...)`**.
> 
> **Runtime teardown** keeps sandbox leases and the registered runtime when sandbox delete fails after retries, allowing a later teardown to succeed. Docs and tests cover ordering, bridge env, and delete retry behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cfcd27763f9c32c1387b7283abd331fdb393247. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Fixes VER-108

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. `v1-sandbox-runtime-scalability`
2. **#1507** 👈 current
<!-- stack:links:end -->