### PR TITLE
Restore trusted PyPI publishing for tasksets and harnesses

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -36,8 +36,8 @@ This directory contains automated workflows for the verifiers project.
 
 **Workflows**:
 - `tag-and-release.yml` publishes `verifiers` from `v*` tags with trusted publishing.
-- `publish-tasksets.yml` publishes `tasksets` from `tasksets-v*` tags with `PYPI_TASKSETS_TOKEN`. On `main`, it creates `tasksets-v<version>` when `packages/tasksets/tasksets/__init__.py` defines `__version__` and the matching remote tag does not already exist, then builds and publishes from that tag in the same workflow run.
-- `publish-harnesses.yml` publishes `harnesses` from `harnesses-v*` tags with `PYPI_HARNESSES_TOKEN`. On `main`, it creates `harnesses-v<version>` when `packages/harnesses/harnesses/__init__.py` defines `__version__` and the matching remote tag does not already exist, then builds and publishes from that tag in the same workflow run.
+- `publish-tasksets.yml` publishes `tasksets` from `tasksets-v*` tags with trusted publishing. On `main`, it creates `tasksets-v<version>` when `packages/tasksets/tasksets/__init__.py` defines `__version__` and the matching remote tag does not already exist, then builds and publishes from that tag in the same workflow run.
+- `publish-harnesses.yml` publishes `harnesses` from `harnesses-v*` tags with trusted publishing. On `main`, it creates `harnesses-v<version>` when `packages/harnesses/harnesses/__init__.py` defines `__version__` and the matching remote tag does not already exist, then builds and publishes from that tag in the same workflow run.
 - `publish-verifiers-rl.yml` publishes `verifiers-rl` from `verifiers-rl-v*` tags.
 
 ## Setting Up

--- a/.github/workflows/publish-harnesses.yml
+++ b/.github/workflows/publish-harnesses.yml
@@ -102,11 +102,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: pypi-prod
     permissions:
-      contents: read
+      id-token: write
     steps:
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-
       - name: Download dist artifacts
         uses: actions/download-artifact@v4
         with:
@@ -114,14 +111,7 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        env:
-          PYPI_HARNESSES_TOKEN: ${{ secrets.PYPI_HARNESSES_TOKEN }}
-        run: |
-          if [ -z "$PYPI_HARNESSES_TOKEN" ]; then
-            echo "Missing PYPI_HARNESSES_TOKEN secret" >&2
-            exit 1
-          fi
-          uv publish --token "$PYPI_HARNESSES_TOKEN" dist/*
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
 
   build-tag:
     if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/harnesses-v')
@@ -206,11 +196,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: pypi-prod
     permissions:
-      contents: read
+      id-token: write
     steps:
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-
       - name: Download dist artifacts
         uses: actions/download-artifact@v4
         with:
@@ -218,11 +205,4 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        env:
-          PYPI_HARNESSES_TOKEN: ${{ secrets.PYPI_HARNESSES_TOKEN }}
-        run: |
-          if [ -z "$PYPI_HARNESSES_TOKEN" ]; then
-            echo "Missing PYPI_HARNESSES_TOKEN secret" >&2
-            exit 1
-          fi
-          uv publish --token "$PYPI_HARNESSES_TOKEN" dist/*
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/.github/workflows/publish-tasksets.yml
+++ b/.github/workflows/publish-tasksets.yml
@@ -102,11 +102,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: pypi-prod
     permissions:
-      contents: read
+      id-token: write
     steps:
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-
       - name: Download dist artifacts
         uses: actions/download-artifact@v4
         with:
@@ -114,14 +111,7 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        env:
-          PYPI_TASKSETS_TOKEN: ${{ secrets.PYPI_TASKSETS_TOKEN }}
-        run: |
-          if [ -z "$PYPI_TASKSETS_TOKEN" ]; then
-            echo "Missing PYPI_TASKSETS_TOKEN secret" >&2
-            exit 1
-          fi
-          uv publish --token "$PYPI_TASKSETS_TOKEN" dist/*
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
 
   build-tag:
     if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/tasksets-v')
@@ -206,11 +196,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: pypi-prod
     permissions:
-      contents: read
+      id-token: write
     steps:
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-
       - name: Download dist artifacts
         uses: actions/download-artifact@v4
         with:
@@ -218,11 +205,4 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        env:
-          PYPI_TASKSETS_TOKEN: ${{ secrets.PYPI_TASKSETS_TOKEN }}
-        run: |
-          if [ -z "$PYPI_TASKSETS_TOKEN" ]; then
-            echo "Missing PYPI_TASKSETS_TOKEN secret" >&2
-            exit 1
-          fi
-          uv publish --token "$PYPI_TASKSETS_TOKEN" dist/*
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0


### PR DESCRIPTION
### Motivation
- A recent change began publishing `tasksets` and `harnesses` using long-lived `PYPI_*_TOKEN` secrets passed to an executable installed by an unpinned third-party action, which exposes reusable PyPI credentials to supply-chain risk. 
- The intent of this change is to restore the safer trusted-publishing / OIDC pattern used elsewhere in the repo and avoid handing long-lived tokens to tooling installed from a mutable action tag. 

### Description
- In `/.github/workflows/publish-tasksets.yml` and `/.github/workflows/publish-harnesses.yml` the publish jobs no longer inject `PYPI_TASKSETS_TOKEN` / `PYPI_HARNESSES_TOKEN` or run `uv publish --token ...`; they now use the pinned `pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b` action and set `permissions: id-token: write` for trusted publishing. 
- The steps that installed `uv` immediately before the publish step have been removed from the publish jobs so the publish action is the trusted publisher. 
- The corresponding documentation in `.github/workflows/README.md` was updated to indicate that `publish-tasksets.yml` and `publish-harnesses.yml` use trusted publishing rather than `PYPI_*_TOKEN` secrets. 

### Testing
- Ran a repository search to validate removal/insertion patterns with `rg -n "PYPI_(TASKSETS|HARNESSES)_TOKEN|uv publish --token|pypa/gh-action-pypi-publish|id-token: write"` and verified the publish jobs now use the pinned `pypa/gh-action-pypi-publish` action and have `id-token: write` (success). 
- Parsed both workflow YAML files with Ruby (`YAML.load_file`) to ensure they remain valid (success). 
- Ran `uv run pre-commit run --files .github/workflows/README.md .github/workflows/publish-tasksets.yml .github/workflows/publish-harnesses.yml` where linter/format hooks were skipped, but the Semgrep policy hook failed due to a network dependency download error unrelated to the workflow YAML changes (policy hook failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a2d3246008332915ab9d896304965)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how production packages are uploaded to PyPI; releases depend on PyPI trusted-publisher/OIDC setup for these workflows instead of the removed secrets.
> 
> **Overview**
> **tasksets** and **harnesses** PyPI publish jobs no longer use long-lived `PYPI_TASKSETS_TOKEN` / `PYPI_HARNESSES_TOKEN` with `uv publish --token ...`. They now match **verifiers**: `permissions: id-token: write`, the `pypi-prod` environment, and the pinned `pypa/gh-action-pypi-publish` action after downloading build artifacts. The extra `setup-uv` step was removed from those publish jobs only (build jobs still use `uv build`).
> 
> `.github/workflows/README.md` now documents trusted publishing for both packages instead of the `PYPI_*_TOKEN` secrets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fbcafe03055d4ae3a55891272ca8c2cf9ef0462. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore OIDC trusted publishing for tasksets and harnesses PyPI workflows
> Replaces token-based PyPI publishing with OIDC trusted publishing in [publish-tasksets.yml](https://github.com/PrimeIntellect-ai/verifiers/pull/1508/files#diff-7422ccb387d22dbfc3162090045a7b489038820749c65233cf4d4d935ddc699b) and [publish-harnesses.yml](https://github.com/PrimeIntellect-ai/verifiers/pull/1508/files#diff-652e8310ab9b02acbc8e1665ac93f92c1ce71af151454f79ecb4704aff7d13ff).
>
> - Swaps `id-token: write` for `contents: read` permissions in both publish jobs of each workflow
> - Removes `uv` installation steps and `uv publish` calls along with the `PYPI_TASKSETS_TOKEN` and `PYPI_HARNESSES_TOKEN` secrets
> - Adds `pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b` (v1.14.0) to handle artifact upload via OIDC
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4fbcafe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->