### PR TITLE
Add v1 sandbox labels config

### DIFF
--- a/packages/tasksets/tasksets/utils/harbor_utils.py
+++ b/packages/tasksets/tasksets/utils/harbor_utils.py
@@ -11,7 +11,7 @@ from importlib.resources import files
 from pathlib import Path
 from typing import cast
 
-from verifiers.v1.sandbox import SandboxConfig
+from verifiers.v1.sandbox import SandboxConfig, merge_sandbox_data
 from verifiers.v1.utils.sandbox_utils import SandboxClient
 
 TASKS_SUBDIR = "tasks"
@@ -31,7 +31,9 @@ def bundle_tasks_root(module_name: str) -> Path:
 
 def harbor_sandbox(default: SandboxConfig, configured: SandboxConfig) -> SandboxConfig:
     return SandboxConfig.model_validate(
-        {**default.data(fill_defaults=False), **configured.data(fill_defaults=False)}
+        merge_sandbox_data(
+            default.data(fill_defaults=False), configured.data(fill_defaults=False)
+        )
     )
 
 

--- a/tests/test_v1_config_extension.py
+++ b/tests/test_v1_config_extension.py
@@ -22,6 +22,7 @@ from verifiers import (
 )
 from verifiers.v1.toolset import normalize_toolset
 from verifiers.v1.types import ModelClient
+from verifiers.v1.utils.program_utils import merge_task_sandbox
 from harnesses import OpenCode
 from verifiers.utils.import_utils import load_toml
 from verifiers.v1.utils.config_utils import coerce_config, explicit_config_data
@@ -3406,6 +3407,7 @@ def test_nested_configs_validate_and_feed_runtime_objects() -> None:
         packages="numpy",
         setup_commands="echo ready",
         scope="group",
+        labels="config-label",
     )
     harness = make_harness(program={"sandbox": True}, sandbox=sandbox)
 
@@ -3414,6 +3416,7 @@ def test_nested_configs_validate_and_feed_runtime_objects() -> None:
     assert harness.sandbox.packages == ["numpy"]
     assert harness.sandbox.setup_commands == ["echo ready"]
     assert harness.sandbox.scope == "group"
+    assert harness.sandbox.labels == ["config-label"]
 
     toolset = Toolset(
         config=vf.ToolsetConfig(
@@ -3429,6 +3432,28 @@ def test_nested_configs_validate_and_feed_runtime_objects() -> None:
     assert toolset.write is True
     assert isinstance(toolset.sandbox, vf.SandboxConfig)
     assert toolset.sandbox.prefer == "program"
+
+
+def test_sandbox_labels_merge_across_harness_program_and_task() -> None:
+    harness = make_harness(
+        program={
+            "sandbox": {
+                "image": "python:3.12-slim",
+                "labels": ["program", "shared"],
+            },
+            "command": ["python", "-c", "print('ok')"],
+        },
+        sandbox={"labels": ["harness", "shared"], "scope": "group"},
+    )
+
+    assert harness.sandbox is not None
+    assert harness.sandbox.labels == ["harness", "shared", "program"]
+
+    task = Task({"sandbox": {"labels": ["task", "program"]}}).freeze()
+    merged = merge_task_sandbox(harness.sandbox, task)
+
+    assert task["sandbox"]["labels"] == ["task", "program"]
+    assert merged.labels == ["harness", "shared", "program", "task"]
 
 
 def test_nested_configs_reject_unknown_fields() -> None:

--- a/tests/test_v1_harbor_cli.py
+++ b/tests/test_v1_harbor_cli.py
@@ -99,7 +99,9 @@ def test_harbor_taskset_loads_package_tasks_with_program_patch(
     package = write_harbor_package(tmp_path, monkeypatch)
     write_harbor_task(cast(Path, getattr(package, "tasks_root")))
 
-    taskset = getattr(package, "load_taskset")(config=HarborTasksetConfig())
+    taskset = getattr(package, "load_taskset")(
+        config=HarborTasksetConfig(sandbox=vf.SandboxConfig(labels=["taskset"]))
+    )
     task = next(iter(taskset))
 
     assert task["taskset_id"] == "harbor"
@@ -111,13 +113,13 @@ def test_harbor_taskset_loads_package_tasks_with_program_patch(
     assert task["sandbox"]["memory_gb"] == 2.0
     assert task["sandbox"]["disk_size_gb"] == 8.0
     assert task["sandbox"]["command_timeout"] == 600
+    assert task["sandbox"]["labels"] == ["taskset"]
     assert "network_access" not in task["sandbox"]
-    assert (
-        merge_task_sandbox(
-            vf.SandboxConfig(network_access=False, scope="rollout"), task
-        ).network_access
-        is False
+    merged_sandbox = merge_task_sandbox(
+        vf.SandboxConfig(network_access=False, scope="rollout", labels=["run"]), task
     )
+    assert merged_sandbox.network_access is False
+    assert merged_sandbox.labels == ["run", "taskset"]
     assert task["harbor"]["test_timeout"] == 300.0
     assert task["program"]["files"] == {
         "/task/instruction.md": {"task": "instruction"},

--- a/tests/test_v1_runtime_lifecycle.py
+++ b/tests/test_v1_runtime_lifecycle.py
@@ -124,6 +124,7 @@ class FakeCommandResult:
 class FakeSandboxClient:
     created: list[str] = []
     deleted: list[str] = []
+    requests: list[FakeCreateSandboxRequest] = []
     commands: list[tuple[str, str]] = []
     command_timeouts: list[int | None] = []
     background_jobs: list[tuple[str, str, int | None, str | None]] = []
@@ -135,6 +136,7 @@ class FakeSandboxClient:
     def reset(cls) -> None:
         cls.created = []
         cls.deleted = []
+        cls.requests = []
         cls.commands = []
         cls.command_timeouts = []
         cls.background_jobs = []
@@ -143,9 +145,9 @@ class FakeSandboxClient:
         cls.closed = 0
 
     async def create(self, request: FakeCreateSandboxRequest) -> FakeSandboxResult:
-        _ = request
         sandbox_id = f"sbx-{len(type(self).created) + 1}"
         type(self).created.append(sandbox_id)
+        type(self).requests.append(request)
         return FakeSandboxResult(sandbox_id)
 
     async def wait_for_creation(
@@ -1297,6 +1299,22 @@ async def test_create_sandbox_retries_create_and_bounds_wait(
         ("sbx-retry", sandbox_utils.SANDBOX_WAIT_FOR_CREATION_ATTEMPTS)
     ]
     assert client.deleted == []
+
+
+@pytest.mark.asyncio
+async def test_create_sandbox_passes_labels(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_fake_sandboxes(monkeypatch)
+    disable_sandbox_retry_sleep(monkeypatch)
+
+    sandbox_id = await sandbox_utils.create_sandbox(
+        cast(sandbox_utils.SandboxClient, FakeSandboxClient()),
+        {"image": "python:3.11-slim", "labels": ["run", "config"]},
+    )
+
+    assert sandbox_id == "sbx-1"
+    assert FakeSandboxClient.requests[0].kwargs["labels"] == ["run", "config"]
 
 
 @pytest.mark.asyncio

--- a/verifiers/v1/harness.py
+++ b/verifiers/v1/harness.py
@@ -30,7 +30,7 @@ from .program import (
     ProgramConfig,
 )
 from .model import ModelConfig, model_config_from_task
-from .sandbox import SandboxConfig
+from .sandbox import SandboxConfig, merge_sandbox_data
 from .user import UserConfig
 from .utils.binding_utils import (
     BindingSources,
@@ -226,7 +226,7 @@ class Harness(RuntimeOwnerMixin[ConfigT], Generic[ConfigT]):
         base = config.data() if config is not None else {}
         if sandbox is True:
             return SandboxConfig.model_validate(base)
-        return SandboxConfig.model_validate({**base, **sandbox.data()})
+        return SandboxConfig.model_validate(merge_sandbox_data(base, sandbox.data()))
 
     def load_model(self, config: ModelConfig) -> ModelConfig:
         return config

--- a/verifiers/v1/program.py
+++ b/verifiers/v1/program.py
@@ -5,7 +5,7 @@ from typing_extensions import TypeAliasType
 
 from .artifact import ArtifactsConfig
 from .config import Config
-from .sandbox import SandboxConfig
+from .sandbox import SandboxConfig, merge_sandbox_data
 from .types import ConfigData, ConfigValue
 from .utils.binding_utils import BindingsConfig
 from .utils.config_utils import explicit_config_data, string_mapping
@@ -227,7 +227,7 @@ def command_sandbox_config(
     base = {**COMMAND_SANDBOX_DEFAULTS, **dict(defaults or {})}
     if sandbox is True:
         return SandboxConfig.model_validate(base)
-    return SandboxConfig.model_validate({**base, **sandbox.data()})
+    return SandboxConfig.model_validate(merge_sandbox_data(base, sandbox.data()))
 
 
 def merge_command_program_config(

--- a/verifiers/v1/sandbox.py
+++ b/verifiers/v1/sandbox.py
@@ -44,16 +44,9 @@ class SandboxConfig(Config):
 
 def merge_sandbox_data(base: ConfigData, override: ConfigData) -> ConfigData:
     merged = {**base, **override}
-    labels = merged_sandbox_labels(base.get("labels"), override.get("labels"))
-    if labels or "labels" in base or "labels" in override:
-        merged["labels"] = labels
-    return merged
-
-
-def merged_sandbox_labels(*values: object) -> list[str]:
     labels: list[str] = []
     seen: set[str] = set()
-    for value in values:
+    for value in (base.get("labels"), override.get("labels")):
         if not isinstance(value, list):
             continue
         for label in value:
@@ -61,4 +54,6 @@ def merged_sandbox_labels(*values: object) -> list[str]:
             if text not in seen:
                 labels.append(text)
                 seen.add(text)
-    return labels
+    if labels or "labels" in base or "labels" in override:
+        merged["labels"] = labels
+    return merged

--- a/verifiers/v1/sandbox.py
+++ b/verifiers/v1/sandbox.py
@@ -27,8 +27,9 @@ class SandboxConfig(Config):
     setup_timeout: int = 300
     scope: Literal["rollout", "group", "global"] = "rollout"
     prefer: Literal["program"] | None = None
+    labels: list[str] = []
 
-    @field_validator("packages", "setup_commands", mode="before")
+    @field_validator("packages", "setup_commands", "labels", mode="before")
     @classmethod
     def validate_string_list(cls, value: object) -> object:
         if isinstance(value, str):
@@ -39,3 +40,25 @@ class SandboxConfig(Config):
         if fill_defaults:
             return resolved_config_data(self)
         return explicit_config_data(self, SandboxConfig)
+
+
+def merge_sandbox_data(base: ConfigData, override: ConfigData) -> ConfigData:
+    merged = {**base, **override}
+    labels = merged_sandbox_labels(base.get("labels"), override.get("labels"))
+    if labels or "labels" in base or "labels" in override:
+        merged["labels"] = labels
+    return merged
+
+
+def merged_sandbox_labels(*values: object) -> list[str]:
+    labels: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        if not isinstance(value, list):
+            continue
+        for label in value:
+            text = str(label)
+            if text not in seen:
+                labels.append(text)
+                seen.add(text)
+    return labels

--- a/verifiers/v1/utils/program_utils.py
+++ b/verifiers/v1/utils/program_utils.py
@@ -22,7 +22,7 @@ from ..task import Task
 from .mcp_proxy_utils import validate_program_channels
 from ..artifact import ArtifactsConfig
 from ..program import ProgramChannel, ProgramValue
-from ..sandbox import SandboxConfig
+from ..sandbox import SandboxConfig, merge_sandbox_data
 from ..types import ConfigData, Handler, RuntimeData
 
 PROGRAM_KIND_KEYS = {"base", "fn", "command"}
@@ -430,7 +430,9 @@ def merge_task_sandbox(sandbox_config: SandboxConfig, task: Task) -> SandboxConf
         validate_program_sandbox_scope(sandbox_config)
         return sandbox_config
     config = SandboxConfig.model_validate(
-        {**sandbox_config.data(), **task_sandbox.data(fill_defaults=False)}
+        merge_sandbox_data(
+            sandbox_config.data(), task_sandbox.data(fill_defaults=False)
+        )
     )
     validate_program_sandbox_scope(config)
     return config


### PR DESCRIPTION
## Description

Add sandbox labels to v1.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [x] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive config field and localized merge helper; main behavior change is labels accumulating across layers instead of last-writer-wins, covered by new tests.
> 
> **Overview**
> Adds **`labels`** to v1 **`SandboxConfig`** (list of strings, with a single string coerced to one element) and wires them through sandbox creation so the runtime client receives merged label lists.
> 
> **Merge behavior:** New **`merge_sandbox_data`** replaces plain `{**base, **override}` wherever sandbox configs are combined (harness/program/task, Harbor defaults, command sandbox defaults). Non-label fields still follow override-wins; **`labels`** are **unioned in order** with **deduplication** instead of being overwritten by the more specific layer.
> 
> Tests cover config validation, harness → program → task label stacking, Harbor taskset labels, and **`create_sandbox`** forwarding labels to the client request.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60ef16c724d37efed56dbb9fd5506a04e48e5d88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `labels` field to `SandboxConfig` with merge-aware combining across harness, program, and task levels
> - Adds a `labels: list[str]` field to [`SandboxConfig`](https://github.com/PrimeIntellect-ai/verifiers/pull/1509/files#diff-7a963e1d7058b473a5bb944bea46753d023bcd7963cbb58776b188f344beba7e), coercing string inputs to single-item lists.
> - Introduces `merge_sandbox_data` in [`sandbox.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1509/files#diff-7a963e1d7058b473a5bb944bea46753d023bcd7963cbb58776b188f344beba7e) to merge two sandbox config dicts, concatenating and de-duplicating `labels` (order-preserving) instead of overwriting.
> - Replaces plain dict merges with `merge_sandbox_data` in [`harness.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1509/files#diff-05e981bb3680a934fbc6865d9dff3b25fc692d0c9970684bf8d41f4aea7ee384), [`program.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1509/files#diff-282200816a86dc37bf6ab9996ee5a61841bc173cf230f5f810251893de81c95d), [`program_utils.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1509/files#diff-5d8102f08cbe8a87ba9c63416d3037ad6f39d86e4cdf6c41448e8ece703446e9), and [`harbor_utils.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1509/files#diff-3f5a74cbcb4c283a79a751542234a2f2221b66dcc87a20a512d4dd2126b403b6) so labels accumulate across harness, program, and task config layers.
> - Behavioral Change: previously, a more-specific sandbox config's `labels` would silently overwrite a less-specific one; they are now merged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 60ef16c.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->