### PR TITLE
RLMEnv: keep the shared tunnel alive across batches

### DIFF
--- a/verifiers/envs/experimental/rlm_env.py
+++ b/verifiers/envs/experimental/rlm_env.py
@@ -3527,18 +3527,13 @@ class RLMEnv(vf.StatefulToolEnv):
             _ensure_rlm_metric_state(state)
             return state
         except Exception:
-            # Best-effort cleanup to avoid leaking tunnels/sandboxes on setup failure.
+            # Best-effort cleanup of the per-rollout executor state on setup failure.
             if rollout_id in self.active_rollouts:
                 del self.active_rollouts[rollout_id]
             try:
                 await self._executor.cleanup(state)
             except Exception:
                 logger.exception("Failed to cleanup RLM executor after setup error")
-            if not self.active_rollouts:
-                try:
-                    await self._teardown_interception_server()
-                finally:
-                    await self._teardown_tunnel()
             raise
 
     # =========================================================================
@@ -4279,12 +4274,7 @@ class RLMEnv(vf.StatefulToolEnv):
 
         if rollout_id and rollout_id in self.active_rollouts:
             del self.active_rollouts[rollout_id]
-        try:
-            await self._executor.cleanup(state)
-        finally:
-            if not self.active_rollouts:
-                await self._teardown_interception_server()
-                await self._teardown_tunnel()
+        await self._executor.cleanup(state)
 
     async def render_completion(self, state: State):
         """Render the tracked observable main-model rollout."""


### PR DESCRIPTION
## Description

RLMEnv tore down its shared tunnel + interception server every time active_rollouts dropped to zero.

Removed the eager if not self.active_rollouts: teardown of the tunnel + interception server from cleanup_rlm_state and from the setup_state failure path. The shared tunnel and interception server are now kept alive for the env's lifetime and reused across rollouts/batches and released exactly once at env shutdown via the already-present @vf.teardown handlers (teardown_tunnel / teardown_interception_server).

v1 Endpoint and CliAgentEnv already do this:
  - v1 Endpoint (v1/utils/endpoint_utils.py): one tunnel per env, reused across rollouts, torn down only at @vf.teardown (harness.teardown() -> endpoint.teardown()).
  - cli_agent_env.py: tunnel released only in @vf.teardown teardown_resources; its @vf.cleanup just unregisters the rollout from the interception server.

RLMEnv was the outlier. Its @vf.cleanup (cleanup_rlm_state) also tore down the tunnel whenever the env went momentarily idle.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Shared tunnel/interception lifetime changes rollout/batch behavior and could leave resources open longer if teardown is skipped, but aligns with other envs and reduces churn between batches.
> 
> **Overview**
> **RLMEnv** no longer tears down the shared **Prime Tunnel** and **interception HTTP server** when the last rollout finishes or when `setup_state` fails. Those paths used to call `_teardown_interception_server` and `_teardown_tunnel` whenever `active_rollouts` was empty.
> 
> Per-rollout **`@vf.cleanup`** (`cleanup_rlm_state`) still unregisters the rollout and runs **`_executor.cleanup`**; env shutdown still releases tunnel and server via existing **`@vf.teardown`** handlers (`teardown_tunnel`, `teardown_interception_server`). The shared tunnel can be reused across batches instead of being recreated after every idle gap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96c97f870c588f4fccefe5986c641b3902fc4f94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep shared tunnel alive across batches in `RLMEnv`
> Previously, `RLMEnv` would tear down the interception server and tunnel whenever the last active rollout was cleaned up or setup failed. This caused the shared tunnel to be destroyed between batches, requiring re-establishment for each new batch.
>
> - `setup_state` no longer calls `_teardown_interception_server()` or `_teardown_tunnel()` on setup failure; only per-rollout executor cleanup runs.
> - `cleanup_rlm_state` no longer tears down the server or tunnel when the last rollout exits; executor cleanup is the only teardown step.
> - Behavioral Change: the interception server and tunnel now persist beyond individual rollout lifetimes and are no longer cleaned up on setup errors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 96c97f8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->