### PR TITLE
chore: drop rlm_max_turns from RLM harness config

### DIFF
--- a/packages/harnesses/harnesses/rlm.py
+++ b/packages/harnesses/harnesses/rlm.py
@@ -12,7 +12,6 @@ from .utils.rlm_utils import (
 
 RLM_DEFAULT_REPO_URL = "github.com/PrimeIntellect-ai/rlm-harness.git"
 RLM_DEFAULT_REPO_REF = "main"
-RLM_DEFAULT_MAX_TURNS = 100
 RLM_DEFAULT_EXEC_TIMEOUT = 300
 RLM_DEFAULT_MAX_DEPTH = 0
 RLM_DEFAULT_INSTRUCTION_PATH = "/rlm/instruction.txt"
@@ -27,7 +26,6 @@ class RLMProgramConfig(vf.ProgramConfig):
     instruction_path: str = RLM_DEFAULT_INSTRUCTION_PATH
     rlm_repo_url: str = RLM_DEFAULT_REPO_URL
     rlm_repo_ref: str = RLM_DEFAULT_REPO_REF
-    rlm_max_turns: int = RLM_DEFAULT_MAX_TURNS
     rlm_exec_timeout: int = RLM_DEFAULT_EXEC_TIMEOUT
     rlm_max_depth: int = RLM_DEFAULT_MAX_DEPTH
     summarize_at_tokens: int | None = None
@@ -74,7 +72,6 @@ class RLMProgramConfig(vf.ProgramConfig):
             "OPENAI_MODEL": "runtime.model",
             "RLM_MODEL": "runtime.model",
             "RLM_TOOLS": ",".join(self.rlm_tools),
-            "RLM_MAX_TURNS": str(self.rlm_max_turns),
             "RLM_EXEC_TIMEOUT": str(self.rlm_exec_timeout),
             "RLM_MAX_DEPTH": str(self.rlm_max_depth),
             **self.env_vars,

--- a/tests/test_v1_rlm_swe.py
+++ b/tests/test_v1_rlm_swe.py
@@ -82,7 +82,6 @@ def test_rlm_harness_accepts_typed_config_surface():
             program=RLMProgramConfig(
                 local_checkout="/tmp/checkout",
                 rlm_tools=["bash", "edit"],
-                rlm_max_turns=7,
                 rlm_exec_timeout=11,
                 env_vars={"CUSTOM": "1"},
             )
@@ -93,7 +92,6 @@ def test_rlm_harness_accepts_typed_config_surface():
 
     assert harness.config.program.rlm_tools == ["bash", "edit"]
     assert program_env["RLM_TOOLS"] == "bash,edit"
-    assert program_env["RLM_MAX_TURNS"] == "7"
     assert program_env["RLM_EXEC_TIMEOUT"] == "11"
     assert program_env["CUSTOM"] == "1"
 


### PR DESCRIPTION
## Summary

- Companion to PrimeIntellect-ai/rlm-harness#83, which removes the `max_turns` turn cap from the RLM harness entirely (it no longer reads `RLM_MAX_TURNS`).
- Stop wiring a turn cap into the RLM program: remove the `RLM_DEFAULT_MAX_TURNS` constant, the `rlm_max_turns` field on `RLMProgramConfig`, and the `RLM_MAX_TURNS` entry from the program env.
- Update `tests/test_v1_rlm_swe.py` to drop the `rlm_max_turns`/`RLM_MAX_TURNS` assertions.

Should land after rlm-harness#83 so the harness and its config stay in sync.

## Breaking

- **`RLMProgramConfig.rlm_max_turns` removed.** Configs passing `rlm_max_turns=...` will raise a Pydantic validation error. There is no replacement — runs are bounded by the other stop conditions (token budget, depth limit, no-tool-call completion). Set a token budget instead if you need to cap a run.
- **`RLM_DEFAULT_MAX_TURNS` constant removed** from `harnesses.rlm`.
- **`RLM_MAX_TURNS` no longer set** in the RLM program env.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `rlm_max_turns` field and `RLM_MAX_TURNS` env var from `RLMProgramConfig`
> Drops the `rlm_max_turns` attribute from [`RLMProgramConfig`](https://github.com/PrimeIntellect-ai/verifiers/pull/1511/files#diff-0f9ff970b858120ce10a63abd11ccc74b91c4666d3988dd257e7aa71f5044570) and removes the corresponding `RLM_MAX_TURNS` environment variable from the resolved env dict. The `RLM_DEFAULT_MAX_TURNS = 100` module constant is also removed. The test in [`test_v1_rlm_swe.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1511/files#diff-aa8ee72ace9e7fe928e845479510841a6ac9fab1f5832f264ce6293fec0b1fea) is updated to match.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4d40490.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking API change for anyone setting `rlm_max_turns`; behavior shifts from an explicit turn cap to other limits only.
> 
> **Overview**
> Removes the **turn cap** from the v1 `RLMProgramConfig` surface so it matches upstream **rlm-harness**, which no longer reads `RLM_MAX_TURNS`.
> 
> **Breaking:** `RLMProgramConfig.rlm_max_turns`, `RLM_DEFAULT_MAX_TURNS`, and the `RLM_MAX_TURNS` program env entry are deleted. Configs that still pass `rlm_max_turns` will fail Pydantic validation; runs should rely on other stop conditions (e.g. token budget via `summarize_at_tokens`, depth, completion). Tests no longer assert `RLM_MAX_TURNS` in the resolved env.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d4049025dd549b07023eb3c45e00845cbe543f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->