### PR TITLE
Re-add labels field to v1 SandboxConfig

### DIFF
--- a/verifiers/v1/sandbox.py
+++ b/verifiers/v1/sandbox.py
@@ -25,10 +25,11 @@ class SandboxConfig(Config):
     install_timeout: int = 300
     setup_commands: list[str] = []
     setup_timeout: int = 300
+    labels: list[str] = []
     scope: Literal["rollout", "group", "global"] = "rollout"
     prefer: Literal["program"] | None = None
 
-    @field_validator("packages", "setup_commands", mode="before")
+    @field_validator("packages", "setup_commands", "labels", mode="before")
     @classmethod
     def validate_string_list(cls, value: object) -> object:
         if isinstance(value, str):


### PR DESCRIPTION
## Description

The labels field and validate_string_list coercion from #1476 were dropped when SandboxConfig moved from config.py to sandbox.py. The create_sandbox passthrough to CreateSandboxRequest was unaffected, so this restores the config side and reconnects the chain.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only restoration with default empty list and existing list coercion pattern; no auth, security, or runtime logic changes.
> 
> **Overview**
> Restores **`labels`** on v1 **`SandboxConfig`** after the model was moved from `config.py` to `sandbox.py`, which had dropped the field and its string-to-list coercion from #1476.
> 
> The change adds `labels: list[str] = []` and extends **`validate_string_list`** so a single string label is accepted the same way as for `packages` and `setup_commands`, keeping config aligned with existing sandbox creation passthrough.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81fd507dcf711641f3a108259056777bcc2f177a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Re-add `labels` field to `SandboxConfig` in the v1 verifiers API
> Adds an optional `labels: list[str]` field (defaulting to `[]`) to the [`SandboxConfig`](https://github.com/PrimeIntellect-ai/verifiers/pull/1512/files#diff-7a963e1d7058b473a5bb944bea46753d023bcd7963cbb58776b188f344beba7e) Pydantic model. The existing `validate_string_list` field validator is extended to cover `labels`, so a single string value is coerced into a one-element list during validation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 81fd507.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->