### PR TITLE
Fix v1 endpoint port pre-probe race (bind 0.0.0.0:0 + readback)

### DIFF
--- a/verifiers/v1/utils/endpoint_utils.py
+++ b/verifiers/v1/utils/endpoint_utils.py
@@ -137,9 +137,6 @@ class Endpoint:
     ):
         self.use_tunnel = use_tunnel
         self.logger = logger or logging.getLogger(__name__)
-        # Pass port 0 unless one was requested: the server binds 0.0.0.0:0 and
-        # reads back the OS-assigned port — no pre-probe gap, no 127.0.0.1 vs
-        # 0.0.0.0 split.
         self.server = InterceptionServer(
             port if port is not None else 0,
             secret=secret or os.environ.get("ENDPOINT_SECRET"),

--- a/verifiers/v1/utils/endpoint_utils.py
+++ b/verifiers/v1/utils/endpoint_utils.py
@@ -30,7 +30,6 @@ from verifiers.utils.interception_utils import (
     synthesize_stream,
 )
 from verifiers.utils.message_utils import normalize_messages
-from verifiers.utils.serve_utils import get_free_port
 
 from ..runtime import ModelRequestContext, Runtime, TrajectoryVisibility
 from ..state import State
@@ -136,11 +135,14 @@ class Endpoint:
         use_tunnel: bool = False,
         logger: logging.Logger | None = None,
     ):
-        self.port = get_free_port() if port is None else port
         self.use_tunnel = use_tunnel
         self.logger = logger or logging.getLogger(__name__)
+        # Pass port 0 unless one was requested: the server binds 0.0.0.0:0 and
+        # reads back the OS-assigned port — no pre-probe gap, no 127.0.0.1 vs
+        # 0.0.0.0 split.
         self.server = InterceptionServer(
-            self.port, secret=secret or os.environ.get("ENDPOINT_SECRET")
+            port if port is not None else 0,
+            secret=secret or os.environ.get("ENDPOINT_SECRET"),
         )
         self.secret = self.server.secret
         self._tunnel: TunnelHandle | None = None
@@ -261,7 +263,7 @@ class Endpoint:
     async def url_base(self) -> str:
         if self.use_tunnel:
             return await self.get_tunnel_url()
-        return f"http://127.0.0.1:{self.port}"
+        return f"http://127.0.0.1:{self.server.port}"
 
     async def get_tunnel_url(self) -> str:
         from prime_tunnel import Tunnel
@@ -282,7 +284,7 @@ class Endpoint:
                         self._tunnel = None
 
             if self._tunnel is None:
-                tunnel = cast(TunnelHandle, Tunnel(local_port=self.port))
+                tunnel = cast(TunnelHandle, Tunnel(local_port=self.server.port))
                 url = await tunnel.start()
                 self._tunnel = tunnel
                 self._tunnel_last_checked = time.time()


### PR DESCRIPTION
## Description

Endpoint pre-allocated its interception-server port at construction via get_free_port(), which binds a throwaway socket to 127.0.0.1:0, reads the number, and closes it. InterceptionServer then bound that cached port on 0.0.0.0 at the first rollout. That left two defects on the shared v1 path:

- the port was unreserved between Endpoint construction and the first rollout (a TOCTOU race — another port consumer can take it), and
- it was validated on 127.0.0.1 but bound on 0.0.0.0, so a port free on loopback could already be taken on another interface and the real bind could collide.

Fix: stop pre-probing. Hand InterceptionServer port 0 so it binds 0.0.0.0:0 and adopts the OS-assigned port via the getsockname() readback that already existed in InterceptionServer.start() (previously dead code on the v1 path). Endpoint.port is now a property over server.port, so it always reflects the live socket and is 0 only in the construct->start() window, which the rollout path never observes. Probe and bind become the same held operation on the same interface.

Explicit Endpoint(port=...) construction is unchanged. This matches the bind-and-readback pattern already used by cli_agent_env and rlm_env.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to how the interception server picks and exposes its listen port; explicit port construction is unchanged and rollout paths already start the server before URLs are built.
> 
> **Overview**
> Fixes a **port allocation race** on the v1 `Endpoint` path by stopping the upfront `get_free_port()` probe and letting `InterceptionServer` bind **`0.0.0.0:0`** (or an explicit port) and adopt the OS-assigned port via the existing `getsockname()` readback in `start()`.
> 
> **Local URLs and tunnels** now use **`self.server.port`** after the server is listening, so the advertised port matches the live socket instead of a number that was only reserved briefly on loopback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 994e4bbc73238ee9dc98cd214248b61668de4b7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix pre-probe port race in v1 `Endpoint` by binding to `0.0.0.0:0` and reading back the assigned port
> Previously, `Endpoint.__init__` called `get_free_port()` to select a port before binding, creating a race window where another process could claim that port. Now, `InterceptionServer` is started with port `0` so the OS assigns an ephemeral port, and `url_base` and `get_tunnel_url` read the actual bound port from `self.server.port`. The `self.port` attribute and `get_free_port` import are removed from [endpoint_utils.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1513/files#diff-a70063758e2336829655d3b4801af8a67bd77ded23d6e95bc1beb922a56c4ca8).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 994e4bb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->