### PR TITLE
Prepare v0.1.15.dev18 release

### DIFF
--- a/assets/release/RELEASE_v0.1.15.dev18.md
+++ b/assets/release/RELEASE_v0.1.15.dev18.md
@@ -1,0 +1,22 @@
+# Verifiers v0.1.15.dev18 Release Notes
+
+*Date:* 06/01/2026
+
+## Highlights since v0.1.15.dev17
+
+- **v1 interception and sandbox config.** The interception server now accepts request bodies up to 24 MB, and the v1 `SandboxConfig` regains its `labels` field.
+- **Standalone packages and agents.** The `tasksets` and `harnesses` packages move to OIDC trusted publishing, and the mini-swe-agent harness issues real parallel tool calls.
+
+## Changes included in v0.1.15.dev18 (since v0.1.15.dev17)
+
+### v1 runtime and interception
+
+- Re-add labels field to v1 SandboxConfig (#1512)
+- Raise interception server request body limit to 24 MB (#1504)
+
+### Harnesses and packaging
+
+- Use real parallel tool calls for mini-swe-agent (#1505)
+- Set trusted publishing for tasksets and harnesses (#1508)
+
+**Full Changelog**: https://github.com/PrimeIntellect-ai/verifiers/compare/v0.1.15.dev17...v0.1.15.dev18

--- a/verifiers/__init__.py
+++ b/verifiers/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.15.dev17"
+__version__ = "0.1.15.dev18"
 
 import importlib
 import os


### PR DESCRIPTION
## Description

Bump __version__ to 0.1.15.dev18 and add release notes for the changes since the v0.1.15.dev17 tag (#1504, #1505, #1508, #1512).

### Highlights since v0.1.15.dev17

- **v1 interception and sandbox config.** The interception server now accepts request bodies up to 24 MB, and the v1 `SandboxConfig` regains its `labels` field.
- **Standalone packages and agents.** The `tasksets` and `harnesses` packages move to OIDC trusted publishing, and the mini-swe-agent harness issues real parallel tool calls.

### Changes included in v0.1.15.dev18 (since v0.1.15.dev17)

#### v1 runtime and interception

- Re-add labels field to v1 SandboxConfig (#1512)
- Raise interception server request body limit to 24 MB (#1504)

#### Harnesses and packaging

- Use real parallel tool calls for mini-swe-agent (#1505)
- Set trusted publishing for tasksets and harnesses (#1508)

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement
- [x] dev release

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version string and release documentation only; no runtime or library behavior changes in this diff.
> 
> **Overview**
> Prepares the **v0.1.15.dev18** dev release by bumping `verifiers.__version__` from `0.1.15.dev17` to `0.1.15.dev18` and adding `assets/release/RELEASE_v0.1.15.dev18.md`.
> 
> The new release notes document what shipped since **v0.1.15.dev17**: interception request body limit raised to 24 MB, `labels` restored on v1 `SandboxConfig`, OIDC trusted publishing for `tasksets` and `harnesses`, and real parallel tool calls in the mini-swe-agent harness (PRs #1504, #1505, #1508, #1512).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 804073543f88e6f539c3fcbe853f1773dea76817. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump version to v0.1.15.dev18
> Updates `__version__` in [verifiers/__init__.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1514/files#diff-3667172df996e6596aa8d26557b92b4cb78ee7d2280a3cae14623ce4677e781e) from `0.1.15.dev17` to `0.1.15.dev18` and adds release notes in [RELEASE_v0.1.15.dev18.md](https://github.com/PrimeIntellect-ai/verifiers/pull/1514/files#diff-8b803a35c7a38be7130f15f6908246033191bdaaa23484589bd2ed1e85481cd1).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8040735.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->