### PR TITLE
Make v1 harness max_turns unbounded by default

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1047,7 +1047,7 @@ class HarnessConfig(Config):
     bindings: BindingsConfig = BindingsConfig()
     objects: ObjectsConfig = ObjectsConfig()
     artifacts: ArtifactsConfig = ArtifactsConfig()
-    max_turns: int = 10
+    max_turns: int = -1  # <= 0 means unbounded (run until a stop condition)
 
 class ModelConfig(Config):
     name: str | None = None

--- a/verifiers/v1/harness.py
+++ b/verifiers/v1/harness.py
@@ -112,7 +112,7 @@ class HarnessConfig(LifecycleConfig):
     bindings: BindingsConfig = BindingsConfig()
     objects: ObjectsConfig = ObjectsConfig()
     artifacts: ArtifactsConfig = ArtifactsConfig()
-    max_turns: int = 10
+    max_turns: int = -1
 
     @classmethod
     def __pydantic_init_subclass__(cls, **kwargs: object) -> None:


### PR DESCRIPTION
## Summary

- Change the v1 `HarnessConfig.max_turns` default from `10` to `-1`, so the v1 base rollout loop runs until a stop condition fires (no tool calls, custom `@vf.stop`, error, token cap, etc.) unless a turn cap is explicitly configured.
- The loop already treats `max_turns <= 0` as unbounded (`verifiers/v1/harness.py`), and `-1` is the documented "unlimited" sentinel (`docs/faqs.md`), so this only changes the default — explicit per-task, runtime-state, and per-config `max_turns` values still take precedence and behave as before.
- Update the `HarnessConfig` reference in `docs/reference.md` to match.

Scope is v1 only; v0 environment classes (`MultiTurnEnv`/`ToolEnv`/`SingleTurnEnv`) are untouched.

## Breaking

- v1 `HarnessConfig.max_turns` now defaults to `-1` (unbounded) instead of `10`. Environments/configs that relied on the implicit 10-turn cap must now set `max_turns` explicitly (on the harness config, taskset-emitted task rows, or runtime state) to keep a bounded base loop.

## Test plan

- [ ] `uv run pytest tests/test_v1_runtime_lifecycle.py tests/test_v1_config_extension.py` (passes locally except pre-existing live-sandbox tests that require `PRIME_API_KEY`/tunnel auth)

Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Set `HarnessConfig.max_turns` default to -1 (unbounded) in v1 harness
> Changes the default value of `max_turns` in [`HarnessConfig`](https://github.com/PrimeIntellect-ai/verifiers/pull/1517/files#diff-05e981bb3680a934fbc6865d9dff3b25fc692d0c9970684bf8d41f4aea7ee384) from `10` to `-1`, where `<= 0` means the harness runs until a stop condition is met. Documentation in [`docs/reference.md`](https://github.com/PrimeIntellect-ai/verifiers/pull/1517/files#diff-e210870c197f23a0840de87fbe37e0803aaa4c48ac5108fb14e2bcee8855199b) is updated to reflect the new default and semantics. Risk: existing code that relies on the implicit 10-turn limit without setting `max_turns` explicitly will now run unbounded.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4096f16.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking default for v1 rollouts: workloads that implicitly depended on a 10-turn cap may run unbounded and increase cost/latency until another stop condition triggers.
> 
> **Overview**
> **v1 `HarnessConfig.max_turns`** now defaults to **`-1`** instead of **`10`**, so the default base rollout loop is **unbounded** until a stop condition (no tools, errors, custom stops, etc.) unless a cap is set explicitly on the harness, task, or runtime state.
> 
> The harness loop already treats **`max_turns <= 0`** as unlimited; this PR only changes the default and aligns **`docs/reference.md`** with that semantics. **v0** env defaults are unchanged.
> 
> **Breaking:** configs that relied on the implicit 10-turn cap without setting `max_turns` will run longer until another stop fires.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4096f16efb98636daa172b9c98656578bec85b8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->