### PR TITLE
Scale V1 sandbox runtime lifecycle

### DIFF
--- a/tests/test_v1_config_extension.py
+++ b/tests/test_v1_config_extension.py
@@ -3406,6 +3406,10 @@ def test_nested_configs_validate_and_feed_runtime_objects() -> None:
         packages="numpy",
         setup_commands="echo ready",
         scope="group",
+        create_concurrency=7,
+        create_rate_per_second=1.5,
+        delete_concurrency=3,
+        delete_rate_per_second=2.5,
     )
     harness = make_harness(program={"sandbox": True}, sandbox=sandbox)
 
@@ -3414,6 +3418,10 @@ def test_nested_configs_validate_and_feed_runtime_objects() -> None:
     assert harness.sandbox.packages == ["numpy"]
     assert harness.sandbox.setup_commands == ["echo ready"]
     assert harness.sandbox.scope == "group"
+    assert harness.sandbox.create_concurrency == 7
+    assert harness.sandbox.create_rate_per_second == 1.5
+    assert harness.sandbox.delete_concurrency == 3
+    assert harness.sandbox.delete_rate_per_second == 2.5
 
     toolset = Toolset(
         config=vf.ToolsetConfig(
@@ -3434,6 +3442,9 @@ def test_nested_configs_validate_and_feed_runtime_objects() -> None:
 def test_nested_configs_reject_unknown_fields() -> None:
     with pytest.raises(ValueError):
         vf.SandboxConfig.model_validate({"image": "python:3.11", "unknown": True})
+
+    with pytest.raises(ValueError):
+        HarnessConfig.model_validate({"sandbox_create_concurrency": 2})
 
     with pytest.raises(ValueError):
         vf.ToolsetConfig.model_validate({"tools": [], "show": ["a"], "hide": ["b"]})

--- a/tests/test_v1_runtime_lifecycle.py
+++ b/tests/test_v1_runtime_lifecycle.py
@@ -2791,6 +2791,80 @@ async def test_release_sandboxes_keeps_failed_delete_retryable(
 
 
 @pytest.mark.asyncio
+async def test_resolve_sandbox_lease_rejects_lease_being_deleted() -> None:
+    delete_started = asyncio.Event()
+    finish_delete = asyncio.Event()
+
+    class SlowDeleteClient:
+        async def delete(self, sandbox_id: str) -> None:
+            assert sandbox_id == "sbx-deleting"
+            delete_started.set()
+            await finish_delete.wait()
+
+    async def create_replacement() -> sandbox_utils.SandboxLease:
+        raise AssertionError("resolve should not create a replacement")
+
+    runtime = Runtime()
+    key = ("rollout:test", "program")
+    lease = sandbox_utils.SandboxLease(
+        cast(sandbox_utils.SandboxClient, SlowDeleteClient()),
+        "sbx-deleting",
+        "rollout",
+        "program",
+        owns_client=False,
+    )
+    runtime.sandbox_leases[key] = lease
+    deletion = asyncio.create_task(runtime.close_sandbox_lease(lease))
+    await delete_started.wait()
+
+    with pytest.raises(RuntimeError, match="being deleted"):
+        await runtime.resolve_sandbox_lease(key, create_replacement)
+
+    finish_delete.set()
+    await deletion
+
+
+@pytest.mark.asyncio
+async def test_resolve_sandbox_lease_rejects_creation_claimed_by_cleanup() -> None:
+    deleted: list[str] = []
+
+    class DeleteClient:
+        async def delete(self, sandbox_id: str) -> None:
+            deleted.append(sandbox_id)
+
+    runtime = Runtime()
+    key = ("rollout:test", "program")
+    create_started = asyncio.Event()
+    lease = sandbox_utils.SandboxLease(
+        cast(sandbox_utils.SandboxClient, DeleteClient()),
+        "sbx-cleanup-claimed",
+        "rollout",
+        "program",
+        owns_client=False,
+    )
+
+    async def create_lease() -> sandbox_utils.SandboxLease:
+        create_started.set()
+        try:
+            await asyncio.sleep(10)
+        except asyncio.CancelledError:
+            return lease
+        raise AssertionError("creation should be cancelled by cleanup")
+
+    resolver = asyncio.create_task(runtime.resolve_sandbox_lease(key, create_lease))
+    await create_started.wait()
+    creation_task = runtime.sandbox_creation_tasks[key]
+
+    await runtime.clear_sandbox_creation_tasks([(key, creation_task)])
+
+    with pytest.raises(RuntimeError, match="cancelled before"):
+        await resolver
+    assert deleted == ["sbx-cleanup-claimed"]
+    assert key not in runtime.sandbox_creation_tasks
+    assert key not in runtime.sandbox_leases
+
+
+@pytest.mark.asyncio
 async def test_clear_creation_tasks_keeps_failed_delete_retryable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -3079,6 +3153,36 @@ async def test_cached_upload_archive_cancelled_awaiter_still_cleans_archive(
 
     assert runtime.upload_archive_tasks == {}
     assert not archive_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_upload_archives_logs_unlink_errors(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    archive_path = tmp_path / "cached.tar.gz"
+    archive_path.write_bytes(b"archive")
+    runtime = Runtime()
+    runtime.upload_archive_tasks[("remote", "source", "digest")] = asyncio.create_task(
+        asyncio.sleep(0, result=archive_path)
+    )
+    warnings: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+    def raise_unlink(path: Path, missing_ok: bool = False) -> None:
+        assert path == archive_path
+        assert missing_ok is True
+        raise PermissionError("locked")
+
+    def record_warning(*args: object, **kwargs: object) -> None:
+        warnings.append((args, kwargs))
+
+    monkeypatch.setattr(Path, "unlink", raise_unlink)
+    monkeypatch.setattr("verifiers.v1.runtime.logger.warning", record_warning)
+
+    await runtime.cleanup_upload_archives()
+
+    assert runtime.upload_archive_tasks == {}
+    assert warnings[0][0][0] == "Failed to delete cached upload archive %s: %s"
+    assert warnings[0][1]["exc_info"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_v1_runtime_lifecycle.py
+++ b/tests/test_v1_runtime_lifecycle.py
@@ -2915,12 +2915,12 @@ async def test_clear_creation_tasks_keeps_failed_delete_retryable(
 
 
 @pytest.mark.asyncio
-async def test_teardown_cleans_client_and_registry_after_failed_delete(
+async def test_teardown_keeps_failed_delete_retryable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     disable_sandbox_retry_sleep(monkeypatch)
 
-    class FailingDeleteClient:
+    class DeleteFailsThenSucceeds:
         def __init__(self, sandbox_id: str):
             self.sandbox_id = sandbox_id
             self.delete_calls = 0
@@ -2929,13 +2929,14 @@ async def test_teardown_cleans_client_and_registry_after_failed_delete(
         async def delete(self, sandbox_id: str) -> None:
             assert sandbox_id == self.sandbox_id
             self.delete_calls += 1
-            raise RuntimeError("delete failed")
+            if self.delete_calls <= sandbox_utils.SANDBOX_RETRY_ATTEMPTS:
+                raise RuntimeError("delete failed")
 
         async def aclose(self) -> None:
             self.closed = True
 
-    client = FailingDeleteClient("sbx-terminal-fail")
-    owned_client = FailingDeleteClient("sbx-owned-terminal-fail")
+    client = DeleteFailsThenSucceeds("sbx-terminal-fail")
+    owned_client = DeleteFailsThenSucceeds("sbx-owned-terminal-fail")
     runtime = Runtime()
     runtime._sandbox_client = cast(sandbox_utils.SandboxClient, client)
     key = ("rollout:test", "program")
@@ -2958,8 +2959,18 @@ async def test_teardown_cleans_client_and_registry_after_failed_delete(
     await runtime.teardown()
 
     assert client.delete_calls == sandbox_utils.SANDBOX_RETRY_ATTEMPTS
-    assert client.closed is True
+    assert client.closed is False
     assert owned_client.delete_calls == sandbox_utils.SANDBOX_RETRY_ATTEMPTS
+    assert owned_client.closed is False
+    assert runtime.sandbox_leases[key] is lease
+    assert owned_key in runtime.sandbox_leases
+    assert load_runtime(runtime.runtime_id) is runtime
+
+    await runtime.teardown()
+
+    assert client.delete_calls == sandbox_utils.SANDBOX_RETRY_ATTEMPTS + 1
+    assert client.closed is True
+    assert owned_client.delete_calls == sandbox_utils.SANDBOX_RETRY_ATTEMPTS + 1
     assert owned_client.closed is True
     assert runtime.sandbox_leases == {}
     with pytest.raises(RuntimeError, match="No live v1 runtime registered"):

--- a/tests/test_v1_runtime_lifecycle.py
+++ b/tests/test_v1_runtime_lifecycle.py
@@ -1,10 +1,11 @@
 import asyncio
 import json
-import logging
 import os
 import shlex
 import sys
 import tempfile
+import threading
+import time
 import urllib.request
 from contextlib import AsyncExitStack
 from pathlib import Path
@@ -17,7 +18,6 @@ from pydantic import BaseModel
 
 import verifiers as vf
 from verifiers.clients import Client
-from verifiers.errors import SandboxError
 from verifiers.types import ClientConfig
 from verifiers.types import Response, ResponseMessage, ToolCall
 from verifiers.types import Tool
@@ -27,6 +27,7 @@ from verifiers.v1.utils import mcp_utils, sandbox_utils
 from verifiers.v1.utils.mcp_proxy_utils import MCP_PROXY_CONFIG_PATH, MCP_PROXY_PATH
 from verifiers.v1.utils.mcp_proxy_utils import proxy_command, proxy_program
 from verifiers.v1.utils.program_utils import command_env
+from verifiers.v1.utils.runtime_registry import load_runtime
 from verifiers.v1.utils.sandbox_python_utils import (
     SANDBOX_PYTHON,
     SANDBOX_UV,
@@ -46,7 +47,7 @@ from verifiers.v1.utils.sandbox_program_utils import (
 from verifiers.v1.utils.sandbox_utils import (
     VF_STATE_INPUT_PATH_KEY,
     run_sandbox_command,
-    upload_program_files,
+    upload_program_dirs,
 )
 
 PROGRAM_REF_MODULE = "v1_runtime_lifecycle_refs"
@@ -123,17 +124,22 @@ class FakeCommandResult:
 
 class FakeSandboxClient:
     created: list[str] = []
+    requests: list[dict[str, object]] = []
     deleted: list[str] = []
     commands: list[tuple[str, str]] = []
     command_timeouts: list[int | None] = []
-    background_jobs: list[tuple[str, str, int | None, str | None]] = []
+    background_jobs: list[tuple[str, str, int | None, str | None, int]] = []
     uploads: list[tuple[str, str, bytes]] = []
     wait_attempts: list[tuple[str, int]] = []
     closed = 0
 
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        _ = args, kwargs
+
     @classmethod
     def reset(cls) -> None:
         cls.created = []
+        cls.requests = []
         cls.deleted = []
         cls.commands = []
         cls.command_timeouts = []
@@ -143,7 +149,7 @@ class FakeSandboxClient:
         cls.closed = 0
 
     async def create(self, request: FakeCreateSandboxRequest) -> FakeSandboxResult:
-        _ = request
+        type(self).requests.append(dict(request.kwargs))
         sandbox_id = f"sbx-{len(type(self).created) + 1}"
         type(self).created.append(sandbox_id)
         return FakeSandboxResult(sandbox_id)
@@ -173,8 +179,11 @@ class FakeSandboxClient:
         command = str(kwargs.get("command") or args[1])
         timeout = cast(int | None, kwargs.get("timeout", 900))
         working_dir = cast(str | None, kwargs.get("working_dir"))
+        poll_interval = cast(int, kwargs.get("poll_interval", 3))
         type(self).commands.append((sandbox_id, command))
-        type(self).background_jobs.append((sandbox_id, command, timeout, working_dir))
+        type(self).background_jobs.append(
+            (sandbox_id, command, timeout, working_dir, poll_interval)
+        )
         return FakeCommandResult()
 
     async def upload_bytes(self, *args: object, **kwargs: object) -> None:
@@ -411,10 +420,11 @@ def install_fake_sandboxes(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def disable_sandbox_retry_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
-    async def no_sleep(seconds: float) -> None:
+    async def no_sleep(seconds: float, result: object | None = None) -> object | None:
         _ = seconds
+        return result
 
-    monkeypatch.setattr(sandbox_utils, "sandbox_retry_sleep", no_sleep)
+    monkeypatch.setattr(sandbox_utils.asyncio, "sleep", no_sleep)
 
 
 def install_fake_endpoint_tunnel(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1342,68 +1352,133 @@ async def test_create_sandbox_cleans_up_wait_failure_with_retry(
 
 
 @pytest.mark.asyncio
-async def test_setup_sandbox_wraps_package_install_exceptions() -> None:
-    class ExecuteFailingLease:
-        async def execute(self, command: str, timeout: int | None = None):
-            _ = command, timeout
-            raise RuntimeError("gateway down")
+async def test_create_sandbox_cancellation_deletes_late_provider_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_fake_sandboxes(monkeypatch)
+    disable_sandbox_retry_sleep(monkeypatch)
+    started = asyncio.Event()
+    finish = asyncio.Event()
+    deleted: list[str] = []
 
-    with pytest.raises(
-        SandboxError, match="Sandbox package install failed: gateway down"
-    ):
-        await sandbox_utils.setup_sandbox(
-            cast(sandbox_utils.SandboxLease, ExecuteFailingLease()),
-            {"packages": ["requests"]},
+    class SlowCreateClient:
+        async def create(self, request: FakeCreateSandboxRequest) -> FakeSandboxResult:
+            _ = request
+            started.set()
+            await finish.wait()
+            return FakeSandboxResult("sbx-created-after-cancel")
+
+        async def wait_for_creation(
+            self,
+            sandbox_id: str,
+            *,
+            max_attempts: int = sandbox_utils.SANDBOX_WAIT_FOR_CREATION_ATTEMPTS,
+        ) -> None:
+            _ = sandbox_id, max_attempts
+
+        async def delete(self, sandbox_id: str) -> None:
+            deleted.append(sandbox_id)
+
+    task = asyncio.create_task(
+        sandbox_utils.create_sandbox(
+            cast(sandbox_utils.SandboxClient, SlowCreateClient()),
+            {"image": "python:3.11-slim"},
         )
+    )
+    await started.wait()
+
+    task.cancel()
+    finish.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert deleted == ["sbx-created-after-cancel"]
 
 
 @pytest.mark.asyncio
-async def test_setup_sandbox_wraps_setup_command_exceptions() -> None:
-    class ExecuteFailingLease:
-        async def execute(self, command: str, timeout: int | None = None):
-            _ = command, timeout
-            raise RuntimeError("gateway down")
+async def test_create_sandbox_wait_cancellation_deletes_known_sandbox(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_fake_sandboxes(monkeypatch)
+    disable_sandbox_retry_sleep(monkeypatch)
+    waiting = asyncio.Event()
+    deleted: list[str] = []
 
-    with pytest.raises(
-        SandboxError, match="Sandbox setup command failed: gateway down"
-    ):
-        await sandbox_utils.setup_sandbox(
-            cast(sandbox_utils.SandboxLease, ExecuteFailingLease()),
-            {"setup_commands": ["echo setup"]},
+    class WaitingClient:
+        async def create(self, request: FakeCreateSandboxRequest) -> FakeSandboxResult:
+            _ = request
+            return FakeSandboxResult("sbx-wait-cancel")
+
+        async def wait_for_creation(
+            self,
+            sandbox_id: str,
+            *,
+            max_attempts: int = sandbox_utils.SANDBOX_WAIT_FOR_CREATION_ATTEMPTS,
+        ) -> None:
+            _ = sandbox_id, max_attempts
+            waiting.set()
+            await asyncio.Event().wait()
+
+        async def delete(self, sandbox_id: str) -> None:
+            deleted.append(sandbox_id)
+
+    task = asyncio.create_task(
+        sandbox_utils.create_sandbox(
+            cast(sandbox_utils.SandboxClient, WaitingClient()),
+            {"image": "python:3.11-slim"},
         )
+    )
+    await waiting.wait()
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert deleted == ["sbx-wait-cancel"]
 
 
 @pytest.mark.asyncio
-async def test_program_setup_handler_wraps_unexpected_exceptions() -> None:
-    class ExecuteFailingClient:
-        async def execute_command(self, *args: object, **kwargs: object) -> None:
-            _ = args, kwargs
-            raise RuntimeError("gateway down")
+async def test_create_sandbox_threads_v1_request_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_fake_sandboxes(monkeypatch)
 
-    lease = sandbox_utils.SandboxLease(
-        cast(sandbox_utils.SandboxClient, ExecuteFailingClient()),
-        "sbx-1",
-        "rollout",
-        "program",
-        owns_client=False,
+    await sandbox_utils.create_sandbox(
+        cast(sandbox_utils.SandboxClient, FakeSandboxClient()),
+        {
+            "image": "custom:latest",
+            "start_command": "sleep infinity",
+            "cpu_cores": 2,
+            "memory_gb": 8,
+            "disk_size_gb": 20,
+            "gpu_count": 1,
+            "gpu_type": "a10",
+            "vm": True,
+            "network_access": False,
+            "timeout_minutes": 30,
+            "environment_vars": {"NUMBER": 7},
+            "secrets": {"TOKEN": "secret"},
+            "team_id": "team",
+            "region": "us",
+            "registry_credentials_id": "registry",
+            "guaranteed": True,
+            "labels": ["v1"],
+        },
     )
-    handler = next(
-        handler
-        for handler in sandbox_utils.program_setup_handlers(
-            lease,
-            {"setup": "echo setup"},
-            Runtime(),
-        )
-        if handler.__name__ == "program_setup"
-    )
-    task = vf.Task({"prompt": [{"role": "user", "content": "hi"}]}).freeze()
-    state = vf.State.for_task(task)
 
-    with pytest.raises(
-        SandboxError,
-        match="Sandbox setup handler program_setup failed: gateway down",
-    ):
-        await handler(task, state)
+    request = FakeSandboxClient.requests[0]
+    assert request["docker_image"] == "custom:latest"
+    assert request["memory_gb"] == 8.0
+    assert request["disk_size_gb"] == 20.0
+    assert request["gpu_type"] == "a10"
+    assert request["vm"] is True
+    assert request["network_access"] is False
+    assert request["environment_vars"] == {"NUMBER": "7"}
+    assert request["secrets"] == {"TOKEN": "secret"}
+    assert request["team_id"] == "team"
+    assert request["region"] == "us"
+    assert request["registry_credentials_id"] == "registry"
+    assert request["guaranteed"] is True
 
 
 @pytest.mark.asyncio
@@ -1620,7 +1695,7 @@ async def test_program_setup_uses_program_setup_timeout(
 
 
 @pytest.mark.asyncio
-async def test_sandbox_command_uses_client_default_timeout_when_omitted(
+async def test_sandbox_command_uses_configured_poll_interval(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     install_fake_sandboxes(monkeypatch)
@@ -1628,13 +1703,86 @@ async def test_sandbox_command_uses_client_default_timeout_when_omitted(
 
     harness = make_harness(
         program={"command": ["true"], "sandbox": True},
-        sandbox={"image": "python:3.11-slim"},
+        sandbox={"image": "python:3.11-slim", "poll_interval": 11},
     )
     task = vf.Task({"prompt": [{"role": "user", "content": "hi"}]}).freeze()
 
     await harness.run(task)
 
-    assert FakeSandboxClient.background_jobs == [("sbx-1", "true", 900, None)]
+    assert FakeSandboxClient.background_jobs == [("sbx-1", "true", 900, None, 11)]
+
+
+@pytest.mark.asyncio
+async def test_sandbox_handle_forwards_background_job_poll_interval() -> None:
+    class BackgroundJobClient:
+        poll_intervals: list[int] = []
+
+        async def run_background_job(
+            self,
+            sandbox_id: str,
+            command: str,
+            *,
+            poll_interval: int = 3,
+            **kwargs: object,
+        ) -> FakeCommandResult:
+            _ = sandbox_id, command, kwargs
+            self.poll_intervals.append(poll_interval)
+            return FakeCommandResult()
+
+    client = BackgroundJobClient()
+    lease = sandbox_utils.SandboxLease(
+        cast(sandbox_utils.SandboxClient, client),
+        "sbx-1",
+        "rollout",
+        "program",
+        owns_client=False,
+    )
+    task = vf.Task({"prompt": [{"role": "user", "content": "hi"}]}).freeze()
+    state = vf.State.for_task(task)
+    handle = sandbox_utils.SandboxHandle(lease, state)
+
+    await handle.run_background_job("true", poll_interval=11)
+
+    assert client.poll_intervals == [11]
+
+
+@pytest.mark.asyncio
+async def test_sandbox_command_marks_oom_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_fake_sandboxes(monkeypatch)
+    install_fake_endpoint_tunnel(monkeypatch)
+
+    class SandboxOOMError(Exception):
+        pass
+
+    class OOMSandboxClient(FakeSandboxClient):
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            _ = args, kwargs
+
+        async def run_background_job(
+            self, *args: object, **kwargs: object
+        ) -> FakeCommandResult:
+            _ = args, kwargs
+            raise SandboxOOMError("Container exceeded memory limit")
+
+    monkeypatch.setattr(
+        "verifiers.utils.threaded_sandbox_client.ThreadedAsyncSandboxClient",
+        OOMSandboxClient,
+    )
+
+    harness = make_harness(
+        program={"command": ["true"], "sandbox": True},
+        sandbox={"image": "python:3.11-slim"},
+    )
+    task = vf.Task({"prompt": [{"role": "user", "content": "hi"}]}).freeze()
+
+    state = await harness.run(task)
+
+    assert state["sandbox_oom"] is True
+    assert state["sandbox_failures"][0]["kind"] == "oom"
+    assert state["sandbox_failures"][0]["phase"] == "command"
+    assert state["error"]["error"] == "SandboxError"
 
 
 @pytest.mark.asyncio
@@ -1687,7 +1835,7 @@ async def test_task_command_uses_background_job(
 
     await harness.run(task)
 
-    assert ("sbx-1", "sleep 120", 120, "/app") in FakeSandboxClient.background_jobs
+    assert ("sbx-1", "sleep 120", 120, "/app", 3) in FakeSandboxClient.background_jobs
 
 
 @pytest.mark.asyncio
@@ -2220,6 +2368,36 @@ async def test_runtime_owned_model_clients_close_after_rollout(
 
 
 @pytest.mark.asyncio
+async def test_runtime_owned_model_clients_live_until_group_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = Runtime()
+    client = FakeClient()
+    state = vf.State.for_task(vf.Task({}).freeze())
+    state["runtime"]["group_key"] = "group"
+
+    monkeypatch.setattr("verifiers.v1.runtime.resolve_client", lambda config: client)
+
+    runtime.bind_model_client(
+        state,
+        ClientConfig(
+            client_type="openai_chat_completions",
+            api_base_url="https://example.com/v1",
+            api_key_var="KEY",
+        ),
+    )
+    await runtime.release_model_client(state)
+
+    assert client.closed is False
+    assert len(runtime.model_clients) == 1
+
+    await runtime.release_model_client(state, group=True)
+
+    assert client.closed is True
+    assert runtime.model_clients == {}
+
+
+@pytest.mark.asyncio
 async def test_mcp_lifetime_follows_toolset_scope(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -2313,24 +2491,21 @@ async def test_shared_sandbox_delete_retries_transient_failures(
 
 
 @pytest.mark.asyncio
-async def test_shared_sandbox_delete_surfaces_delete_failures(
+async def test_sandbox_delete_failure_leaves_lease_retryable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     disable_sandbox_retry_sleep(monkeypatch)
 
-    class DeleteFailingClient:
-        closed = 0
-        delete_calls = 0
+    class DeleteFailsThenSucceeds:
+        calls = 0
 
         async def delete(self, sandbox_id: str) -> None:
             _ = sandbox_id
-            type(self).delete_calls += 1
-            raise RuntimeError("delete failed")
+            self.calls += 1
+            if self.calls <= sandbox_utils.SANDBOX_RETRY_ATTEMPTS:
+                raise RuntimeError("delete failed")
 
-        async def aclose(self) -> None:
-            type(self).closed += 1
-
-    client = DeleteFailingClient()
+    client = DeleteFailsThenSucceeds()
     lease = sandbox_utils.SandboxLease(
         cast(sandbox_utils.SandboxClient, client),
         "sbx-1",
@@ -2342,41 +2517,379 @@ async def test_shared_sandbox_delete_surfaces_delete_failures(
     with pytest.raises(RuntimeError, match="delete failed"):
         await lease.delete()
 
-    assert client.delete_calls == sandbox_utils.SANDBOX_RETRY_ATTEMPTS
-    assert client.closed == 0
+    assert lease.deleted is False
+
+    await lease.delete()
+
+    assert lease.deleted is True
+    assert client.calls == sandbox_utils.SANDBOX_RETRY_ATTEMPTS + 1
 
 
 @pytest.mark.asyncio
-async def test_release_sandboxes_logs_and_removes_delete_failures(
-    caplog: pytest.LogCaptureFixture,
+async def test_owned_sandbox_delete_failure_keeps_client_retryable(
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    class DeleteFailingLease:
-        id = "sbx-1"
-        scope = "rollout"
+    disable_sandbox_retry_sleep(monkeypatch)
 
-        async def delete(self) -> None:
-            raise RuntimeError("delete failed")
+    class DeleteFailsThenSucceeds:
+        calls = 0
+        closed = 0
 
+        async def delete(self, sandbox_id: str) -> None:
+            _ = sandbox_id
+            self.calls += 1
+            if self.calls <= sandbox_utils.SANDBOX_RETRY_ATTEMPTS:
+                raise RuntimeError("delete failed")
+
+        async def aclose(self) -> None:
+            self.closed += 1
+
+    client = DeleteFailsThenSucceeds()
+    lease = sandbox_utils.SandboxLease(
+        cast(sandbox_utils.SandboxClient, client),
+        "sbx-1",
+        "rollout",
+        "program",
+    )
+
+    with pytest.raises(RuntimeError, match="delete failed"):
+        await lease.delete()
+
+    assert lease.deleted is False
+    assert client.calls == sandbox_utils.SANDBOX_RETRY_ATTEMPTS
+    assert client.closed == 0
+
+    await lease.delete()
+
+    assert lease.deleted is True
+    assert client.calls == sandbox_utils.SANDBOX_RETRY_ATTEMPTS + 1
+    assert client.closed == 1
+
+
+@pytest.mark.asyncio
+async def test_program_sandbox_creations_are_concurrent_and_bounded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_fake_sandboxes(monkeypatch)
+
+    class SlowSandboxClient(FakeSandboxClient):
+        active = 0
+        max_active = 0
+
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            _ = args, kwargs
+
+        async def create(self, request: FakeCreateSandboxRequest) -> FakeSandboxResult:
+            type(self).active += 1
+            type(self).max_active = max(type(self).max_active, type(self).active)
+            await asyncio.sleep(0.01)
+            try:
+                return await super().create(request)
+            finally:
+                type(self).active -= 1
+
+    monkeypatch.setattr(
+        "verifiers.utils.threaded_sandbox_client.ThreadedAsyncSandboxClient",
+        SlowSandboxClient,
+    )
+
+    class RecordingRateLimiter:
+        wait_calls = 0
+
+        async def wait(self) -> None:
+            self.wait_calls += 1
+
+    harness = make_harness(sandbox={"create_concurrency": 2})
+    limiter = RecordingRateLimiter()
+    harness.runtime.sandbox_create_rate_limiter = limiter
+    sandbox = vf.SandboxConfig(image="python:3.11-slim")
+    task = vf.Task({"prompt": [{"role": "user", "content": "hi"}]}).freeze()
+    states = [vf.State.for_task(task) for _ in range(4)]
+
+    await asyncio.gather(
+        *(
+            harness.runtime.resolve_program_sandbox(sandbox, task, state)
+            for state in states
+        )
+    )
+
+    assert SlowSandboxClient.max_active == 2
+    assert len(FakeSandboxClient.created) == 4
+    assert limiter.wait_calls == 4
+
+    await harness.teardown()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_sandbox_awaiter_teardown_deletes_completed_creation() -> None:
+    deleted: list[str] = []
+    started = asyncio.Event()
+    finish = asyncio.Event()
+
+    class DeleteClient:
+        async def delete(self, sandbox_id: str) -> None:
+            deleted.append(sandbox_id)
+
+    async def create_late_lease() -> sandbox_utils.SandboxLease:
+        started.set()
+        await finish.wait()
+        return sandbox_utils.SandboxLease(
+            cast(sandbox_utils.SandboxClient, DeleteClient()),
+            "sbx-late",
+            "rollout",
+            "program",
+            owns_client=False,
+        )
+
+    runtime = Runtime()
+    key = ("rollout:test", "program")
+    waiter = asyncio.create_task(runtime.resolve_sandbox_lease(key, create_late_lease))
+    await started.wait()
+
+    waiter.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await waiter
+
+    assert key in runtime.sandbox_creation_tasks
+    finish.set()
+    await asyncio.wait_for(runtime.sandbox_creation_tasks[key], timeout=1)
+
+    await runtime.teardown()
+
+    assert deleted == ["sbx-late"]
+    assert key not in runtime.sandbox_creation_tasks
+
+
+@pytest.mark.asyncio
+async def test_teardown_deletes_late_provider_create_before_closing_client() -> None:
+    started = asyncio.Event()
+    finish = asyncio.Event()
+    delete_closed_states: list[bool] = []
+
+    class SlowCreateClient:
+        closed = False
+
+        async def create(self, request: FakeCreateSandboxRequest) -> FakeSandboxResult:
+            _ = request
+            started.set()
+            await finish.wait()
+            return FakeSandboxResult("sbx-late-provider")
+
+        async def wait_for_creation(
+            self,
+            sandbox_id: str,
+            *,
+            max_attempts: int = sandbox_utils.SANDBOX_WAIT_FOR_CREATION_ATTEMPTS,
+        ) -> None:
+            _ = sandbox_id, max_attempts
+
+        async def delete(self, sandbox_id: str) -> None:
+            assert sandbox_id == "sbx-late-provider"
+            delete_closed_states.append(self.closed)
+
+        async def aclose(self) -> None:
+            self.closed = True
+
+    client = SlowCreateClient()
+    runtime = Runtime()
+    runtime._sandbox_client = cast(sandbox_utils.SandboxClient, client)
+    sandbox = vf.SandboxConfig(image="python:3.11-slim")
+    key = ("rollout:test", "program")
+    waiter = asyncio.create_task(
+        runtime.resolve_sandbox_lease(
+            key,
+            lambda: sandbox_utils.create_sandbox_lease(
+                sandbox,
+                key[1],
+                client=cast(sandbox_utils.SandboxClient, client),
+            ),
+        )
+    )
+    await started.wait()
+
+    teardown = asyncio.create_task(runtime.teardown())
+    await asyncio.sleep(0)
+    assert teardown.done() is False
+
+    finish.set()
+    await teardown
+
+    assert delete_closed_states == [False]
+    assert client.closed is True
+    with pytest.raises(asyncio.CancelledError):
+        await waiter
+
+
+@pytest.mark.asyncio
+async def test_release_sandboxes_deletes_completed_unclaimed_creation() -> None:
+    deleted: list[str] = []
+
+    class DeleteClient:
+        async def delete(self, sandbox_id: str) -> None:
+            deleted.append(sandbox_id)
+
+    runtime = Runtime()
     task = vf.Task({"prompt": [{"role": "user", "content": "hi"}]}).freeze()
     state = vf.State.for_task(task)
-    runtime = Runtime()
     key = (runtime.scope_key("rollout", state), "program")
-    runtime.sandbox_leases[key] = cast(sandbox_utils.SandboxLease, DeleteFailingLease())
+    lease = sandbox_utils.SandboxLease(
+        cast(sandbox_utils.SandboxClient, DeleteClient()),
+        "sbx-unclaimed",
+        "rollout",
+        "program",
+        owns_client=False,
+    )
+    runtime.sandbox_creation_tasks[key] = asyncio.create_task(
+        asyncio.sleep(0, result=lease)
+    )
+    await runtime.sandbox_creation_tasks[key]
 
-    package_logger = logging.getLogger("verifiers")
-    package_logger.addHandler(caplog.handler)
-    try:
-        with caplog.at_level(logging.WARNING, logger="verifiers.v1.runtime"):
-            await runtime.release_sandboxes("rollout", state)
-    finally:
-        package_logger.removeHandler(caplog.handler)
+    await runtime.release_sandboxes("rollout", state)
+    await runtime.teardown()
+
+    assert deleted == ["sbx-unclaimed"]
+    assert key not in runtime.sandbox_creation_tasks
+
+
+@pytest.mark.asyncio
+async def test_release_sandboxes_keeps_failed_delete_retryable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    disable_sandbox_retry_sleep(monkeypatch)
+
+    class RetryableDeleteClient:
+        calls = 0
+
+        async def delete(self, sandbox_id: str) -> None:
+            assert sandbox_id == "sbx-retryable-delete"
+            self.calls += 1
+            if self.calls <= sandbox_utils.SANDBOX_RETRY_ATTEMPTS:
+                raise RuntimeError("delete failed")
+
+    runtime = Runtime()
+    task = vf.Task({"prompt": [{"role": "user", "content": "hi"}]}).freeze()
+    state = vf.State.for_task(task)
+    key = (runtime.scope_key("rollout", state), "program")
+    lease = sandbox_utils.SandboxLease(
+        cast(sandbox_utils.SandboxClient, RetryableDeleteClient()),
+        "sbx-retryable-delete",
+        "rollout",
+        "program",
+        owns_client=False,
+    )
+    runtime.sandbox_leases[key] = lease
+
+    await runtime.release_sandboxes("rollout", state)
+
+    assert runtime.sandbox_leases[key] is lease
+    assert len(state["cleanup_errors"]) == 1
+
+    await runtime.release_sandboxes("rollout", state)
+    await runtime.teardown()
 
     assert key not in runtime.sandbox_leases
-    messages = [record.getMessage() for record in caplog.records]
-    assert any("Failed to delete rollout sandbox sbx-1" in msg for msg in messages)
-    assert any(
-        "1/1 rollout sandbox deletions failed during cleanup" in msg for msg in messages
+
+
+@pytest.mark.asyncio
+async def test_clear_creation_tasks_keeps_failed_delete_retryable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    disable_sandbox_retry_sleep(monkeypatch)
+
+    class RetryableDeleteClient:
+        calls = 0
+
+        async def delete(self, sandbox_id: str) -> None:
+            assert sandbox_id == "sbx-unclaimed-retry"
+            self.calls += 1
+            if self.calls <= sandbox_utils.SANDBOX_RETRY_ATTEMPTS:
+                raise RuntimeError("delete failed")
+
+    runtime = Runtime()
+    task = vf.Task({"prompt": [{"role": "user", "content": "hi"}]}).freeze()
+    state = vf.State.for_task(task)
+    key = (runtime.scope_key("rollout", state), "program")
+    lease = sandbox_utils.SandboxLease(
+        cast(sandbox_utils.SandboxClient, RetryableDeleteClient()),
+        "sbx-unclaimed-retry",
+        "rollout",
+        "program",
+        owns_client=False,
     )
+
+    async def finished_creation() -> sandbox_utils.SandboxLease:
+        return lease
+
+    creation_task = asyncio.create_task(finished_creation())
+    runtime.sandbox_creation_tasks[key] = creation_task
+    await creation_task
+
+    await runtime.clear_sandbox_creation_tasks(
+        [(key, creation_task)],
+        state=state,
+        scope="rollout",
+    )
+
+    assert key not in runtime.sandbox_creation_tasks
+    assert runtime.sandbox_leases[key] is lease
+    assert len(state["cleanup_errors"]) == 1
+
+    await runtime.release_sandboxes("rollout", state)
+    await runtime.teardown()
+
+    assert key not in runtime.sandbox_leases
+
+
+@pytest.mark.asyncio
+async def test_teardown_cleans_client_and_registry_after_failed_delete(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    disable_sandbox_retry_sleep(monkeypatch)
+
+    class FailingDeleteClient:
+        def __init__(self, sandbox_id: str):
+            self.sandbox_id = sandbox_id
+            self.delete_calls = 0
+            self.closed = False
+
+        async def delete(self, sandbox_id: str) -> None:
+            assert sandbox_id == self.sandbox_id
+            self.delete_calls += 1
+            raise RuntimeError("delete failed")
+
+        async def aclose(self) -> None:
+            self.closed = True
+
+    client = FailingDeleteClient("sbx-terminal-fail")
+    owned_client = FailingDeleteClient("sbx-owned-terminal-fail")
+    runtime = Runtime()
+    runtime._sandbox_client = cast(sandbox_utils.SandboxClient, client)
+    key = ("rollout:test", "program")
+    lease = sandbox_utils.SandboxLease(
+        cast(sandbox_utils.SandboxClient, client),
+        "sbx-terminal-fail",
+        "rollout",
+        "program",
+        owns_client=False,
+    )
+    runtime.sandbox_leases[key] = lease
+    owned_key = ("rollout:test", "owned")
+    runtime.sandbox_leases[owned_key] = sandbox_utils.SandboxLease(
+        cast(sandbox_utils.SandboxClient, owned_client),
+        "sbx-owned-terminal-fail",
+        "rollout",
+        "owned",
+    )
+
+    await runtime.teardown()
+
+    assert client.delete_calls == sandbox_utils.SANDBOX_RETRY_ATTEMPTS
+    assert client.closed is True
+    assert owned_client.delete_calls == sandbox_utils.SANDBOX_RETRY_ATTEMPTS
+    assert owned_client.closed is True
+    assert runtime.sandbox_leases == {}
+    with pytest.raises(RuntimeError, match="No live v1 runtime registered"):
+        load_runtime(runtime.runtime_id)
 
 
 @pytest.mark.asyncio
@@ -2396,8 +2909,10 @@ async def test_program_sandbox_group_scope_reuses_and_cleans(
     state_b = vf.State.for_task(task)
     state_b["runtime"]["group_key"] = "group"
 
-    state_a = await harness.run(task, state_a)
-    state_b = await harness.run(task, state_b)
+    state_a, state_b = await asyncio.gather(
+        harness.run(task, state_a),
+        harness.run(task, state_b),
+    )
 
     assert FakeSandboxClient.created == ["sbx-1"]
     assert state_a["sandbox_id"] == "sbx-1"
@@ -2445,28 +2960,125 @@ async def test_program_sandbox_global_scope_lives_until_teardown(
 
 
 @pytest.mark.asyncio
-async def test_upload_program_files_wraps_sandbox_upload_timeout(
-    monkeypatch: pytest.MonkeyPatch,
+async def test_upload_program_dirs_reuses_runtime_archive_cache(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    install_fake_sandboxes(monkeypatch)
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    (source_dir / "module.py").write_text("VALUE = 1\n")
+    archive_path = tmp_path / "cached.tar.gz"
+    build_calls = 0
 
-    class TimeoutUploadClient:
-        async def upload_bytes(self, *args: object, **kwargs: object) -> None:
-            _ = args, kwargs
-            raise FakeUploadTimeoutError("timed out")
+    def fake_build_dir_archive(local_source: Path, remote_path: str) -> Path:
+        nonlocal build_calls
+        assert local_source == source_dir
+        assert remote_path == "/remote/pkg"
+        build_calls += 1
+        time.sleep(0.05)
+        archive_path.write_bytes(b"archive")
+        return archive_path
 
+    class UploadClient:
+        uploads: list[tuple[str, str, str]] = []
+        commands: list[tuple[str, str]] = []
+
+        async def upload_file(self, *args: object, **kwargs: object) -> None:
+            sandbox_id = str(kwargs.get("sandbox_id") or args[0])
+            file_path = str(kwargs.get("file_path") or args[1])
+            local_path = str(kwargs.get("local_file_path") or args[2])
+            self.uploads.append((sandbox_id, file_path, local_path))
+
+        async def execute_command(
+            self, *args: object, **kwargs: object
+        ) -> FakeCommandResult:
+            sandbox_id = str(kwargs.get("sandbox_id") or args[0])
+            command = str(kwargs.get("command") or args[1])
+            self.commands.append((sandbox_id, command))
+            return FakeCommandResult()
+
+    monkeypatch.setattr(sandbox_utils, "build_dir_archive", fake_build_dir_archive)
+    runtime = Runtime()
+    client = UploadClient()
     task = vf.Task({"prompt": [{"role": "user", "content": "hi"}]}).freeze()
-    state = vf.State.for_task(task)
+    program = {"dirs": {"/remote/pkg": str(source_dir)}}
+    states = [vf.State.for_task(task), vf.State.for_task(task)]
 
-    with pytest.raises(SandboxError, match="Program file upload failed"):
-        await upload_program_files(
-            cast(sandbox_utils.SandboxClient, TimeoutUploadClient()),
-            "sbx-1",
-            {"files": {"/mini-swe-agent/prompt.txt": "hello"}},
-            task,
-            state,
-            cast(Runtime, SimpleNamespace()),
+    await asyncio.gather(
+        *(
+            upload_program_dirs(
+                cast(sandbox_utils.SandboxClient, client),
+                sandbox_id,
+                program,
+                task,
+                state,
+                runtime,
+            )
+            for sandbox_id, state in zip(["sbx-1", "sbx-2"], states, strict=True)
         )
+    )
+
+    assert build_calls == 1
+    assert client.uploads == [
+        ("sbx-1", "/tmp/_vf_upload_remote_pkg.tar.gz", str(archive_path)),
+        ("sbx-2", "/tmp/_vf_upload_remote_pkg.tar.gz", str(archive_path)),
+    ]
+    assert archive_path.exists()
+
+    (source_dir / "module.py").write_text("VALUE = 2\n")
+    await upload_program_dirs(
+        cast(sandbox_utils.SandboxClient, client),
+        "sbx-3",
+        program,
+        task,
+        vf.State.for_task(task),
+        runtime,
+    )
+
+    assert build_calls == 2
+    assert client.uploads[-1] == (
+        "sbx-3",
+        "/tmp/_vf_upload_remote_pkg.tar.gz",
+        str(archive_path),
+    )
+
+    await runtime.teardown()
+
+    assert not archive_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_cached_upload_archive_cancelled_awaiter_still_cleans_archive(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    (source_dir / "module.py").write_text("VALUE = 1\n")
+    archive_path = tmp_path / "cached.tar.gz"
+    started = threading.Event()
+    finish = threading.Event()
+
+    def fake_build_dir_archive(local_source: Path, remote_path: str) -> Path:
+        assert local_source == source_dir
+        assert remote_path == "/remote/pkg"
+        started.set()
+        finish.wait(timeout=1)
+        archive_path.write_bytes(b"archive")
+        return archive_path
+
+    monkeypatch.setattr(sandbox_utils, "build_dir_archive", fake_build_dir_archive)
+    runtime = Runtime()
+    task = asyncio.create_task(runtime.cached_upload_archive(source_dir, "/remote/pkg"))
+    await asyncio.to_thread(started.wait)
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    finish.set()
+    await runtime.teardown()
+
+    assert runtime.upload_archive_tasks == {}
+    assert not archive_path.exists()
 
 
 @pytest.mark.asyncio
@@ -2489,38 +3101,6 @@ async def test_sandbox_program_artifact_collected_by_runtime(
     state = await harness.run(task)
 
     assert state["artifacts"]["command_log"] == "ok\n"
-
-
-@pytest.mark.asyncio
-async def test_optional_sandbox_program_artifact_records_none() -> None:
-    task = vf.Task({"prompt": [{"role": "user", "content": "hi"}]}).freeze()
-    state = vf.State.for_task(task)
-    client = SimpleNamespace(
-        execute_command=lambda **kwargs: SimpleNamespace(
-            exit_code=2, stdout="", stderr=""
-        )
-    )
-    sandbox_lease = SimpleNamespace(client=client, id="sbx")
-    runtime = Runtime()
-
-    result = await runtime.collect_artifact(
-        vf.ArtifactConfig(path="/tmp/missing.log", format="text", optional=True),
-        task,
-        state,
-        sandbox_lease=cast(Any, sandbox_lease),
-    )
-
-    await runtime.teardown()
-
-    assert result is None
-
-
-@pytest.mark.asyncio
-async def test_sandbox_program_artifact_optional_must_be_boolean() -> None:
-    with pytest.raises(ValueError, match="optional"):
-        vf.ArtifactConfig.model_validate(
-            {"path": "/tmp/missing.log", "optional": "true"}
-        )
 
 
 @pytest.mark.asyncio

--- a/verifiers/v1/runtime.py
+++ b/verifiers/v1/runtime.py
@@ -1053,6 +1053,7 @@ class Runtime:
     async def teardown(self) -> None:
         await run_handlers(self.teardown_handlers)
         await self.release_runtime_objects()
+        failed_sandbox_deletions = []
         try:
             if self.sandbox_creation_tasks:
                 await self.clear_sandbox_creation_tasks(
@@ -1068,29 +1069,24 @@ class Runtime:
                         exc,
                         exc_info=True,
                     )
-                    if handle.owns_client:
-                        from .utils.sandbox_utils import close_sandbox_client
-
-                        try:
-                            await close_sandbox_client(handle.client)
-                        except Exception as close_exc:
-                            logger.warning(
-                                "Failed to close sandbox client for %s during teardown: %s",
-                                handle.id,
-                                close_exc,
-                                exc_info=True,
-                            )
-                async with self.sandbox_lock:
-                    if self.sandbox_leases.get(key) is handle:
-                        del self.sandbox_leases[key]
+                    failed_sandbox_deletions.append(handle)
+                else:
+                    async with self.sandbox_lock:
+                        if self.sandbox_leases.get(key) is handle:
+                            del self.sandbox_leases[key]
         finally:
-            await self.teardown_sandbox_client()
+            if not any(
+                handle.client is self._sandbox_client
+                for handle in failed_sandbox_deletions
+            ):
+                await self.teardown_sandbox_client()
             await self.cleanup_upload_archives()
         self.tool_handles.clear()
         self.scoped_tools.clear()
         await self.close_all_mcp_tools()
         await self.release_all_model_clients()
-        unregister_runtime(self.runtime_id)
+        if not failed_sandbox_deletions:
+            unregister_runtime(self.runtime_id)
 
     def sandbox_client(self) -> "SandboxClient":
         if self._sandbox_client is None:

--- a/verifiers/v1/runtime.py
+++ b/verifiers/v1/runtime.py
@@ -1163,8 +1163,17 @@ class Runtime:
         results = await asyncio.gather(*tasks, return_exceptions=True)
         self.upload_archive_tasks.clear()
         for result in results:
-            if isinstance(result, Path):
+            if not isinstance(result, Path):
+                continue
+            try:
                 result.unlink(missing_ok=True)
+            except Exception as exc:
+                logger.warning(
+                    "Failed to delete cached upload archive %s: %s",
+                    result,
+                    exc,
+                    exc_info=True,
+                )
 
     async def close_sandbox_lease(self, lease: "SandboxLease") -> None:
         async with self.sandbox_delete_semaphore:
@@ -1180,26 +1189,30 @@ class Runtime:
     ) -> None:
         from .utils.sandbox_utils import SandboxLease as SandboxLeaseClass
 
-        for _, task in creations:
-            if not task.done():
-                task.cancel()
-        results = await asyncio.gather(
-            *(task for _, task in creations), return_exceptions=True
-        )
+        claimed_creations = []
         async with self.sandbox_lock:
             for key, task in creations:
                 if self.sandbox_creation_tasks.get(key) is task:
                     del self.sandbox_creation_tasks[key]
+                    claimed_creations.append((key, task))
 
-        for (key, _), result in zip(creations, results, strict=True):
+        for _, task in claimed_creations:
+            if not task.done():
+                task.cancel()
+        results = await asyncio.gather(
+            *(task for _, task in claimed_creations), return_exceptions=True
+        )
+
+        for (key, _), result in zip(claimed_creations, results, strict=True):
             if not isinstance(result, SandboxLeaseClass):
                 continue
-            async with self.sandbox_lock:
-                result.scope_key = key[0]
-                self.sandbox_leases[key] = result
+            result.scope_key = key[0]
             try:
                 await self.close_sandbox_lease(result)
             except Exception as exc:
+                async with self.sandbox_lock:
+                    if not result.deleted:
+                        self.sandbox_leases[key] = result
                 logger.warning(
                     "Failed to delete sandbox %s from cancelled creation: %s",
                     result.id,
@@ -1217,10 +1230,6 @@ class Runtime:
                             "scope": scope,
                         }
                     )
-            else:
-                async with self.sandbox_lock:
-                    if self.sandbox_leases.get(key) is result:
-                        del self.sandbox_leases[key]
 
     async def resolve_sandbox_lease(
         self, key: tuple[str, str], factory: Callable[[], Awaitable["SandboxLease"]]
@@ -1228,6 +1237,8 @@ class Runtime:
         async with self.sandbox_lock:
             lease = self.sandbox_leases.get(key)
             if lease is not None:
+                if lease.deleted:
+                    raise RuntimeError("Sandbox lease is being deleted.")
                 return lease
             task = self.sandbox_creation_tasks.get(key)
             if task is None:
@@ -1256,9 +1267,18 @@ class Runtime:
         async with self.sandbox_lock:
             existing = self.sandbox_leases.get(key)
             if existing is not None:
+                if existing.deleted:
+                    raise RuntimeError("Sandbox lease is being deleted.")
                 return existing
-            if self.sandbox_creation_tasks.get(key) is task:
-                del self.sandbox_creation_tasks[key]
+            if self.sandbox_creation_tasks.get(key) is not task:
+                raise RuntimeError(
+                    "Sandbox creation was cancelled before the lease was resolved."
+                )
+            del self.sandbox_creation_tasks[key]
+            if lease.deleted:
+                raise RuntimeError(
+                    "Sandbox lease was deleted before it could be resolved."
+                )
             lease.scope_key = key[0]
             self.sandbox_leases[key] = lease
             return lease

--- a/verifiers/v1/runtime.py
+++ b/verifiers/v1/runtime.py
@@ -1,5 +1,6 @@
 import asyncio
 import glob
+import hashlib
 import inspect
 import logging
 import time
@@ -7,6 +8,8 @@ import uuid
 from collections.abc import Awaitable, Callable, Iterable, Sequence
 from contextlib import AsyncExitStack
 from dataclasses import dataclass, field
+from importlib.abc import Traversable
+from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Literal,
@@ -62,8 +65,6 @@ from .runtime_handles import (
     RuntimeHandleConfig,
     SandboxRuntimeHandleConfig,
     SandboxRuntimeStateConfig,
-    ToolsRuntimeHandleConfig,
-    TrajectoryRuntimeHandleConfig,
 )
 from .utils.tool_utils import schema_callable, tool_schema, tool_visible
 from .utils.tool_utils import toolset_object_scope
@@ -193,6 +194,24 @@ class BorrowedTool:
         )
 
 
+class AsyncRateLimiter:
+    def __init__(self, rate_per_second: float | None):
+        self.interval = 0.0 if rate_per_second is None else 1.0 / rate_per_second
+        self.next_at = 0.0
+        self.lock = asyncio.Lock()
+
+    async def wait(self) -> None:
+        if not self.interval:
+            return
+        async with self.lock:
+            now = time.monotonic()
+            delay = self.next_at - now
+            if delay > 0:
+                await asyncio.sleep(delay)
+                now = time.monotonic()
+            self.next_at = max(now, self.next_at) + self.interval
+
+
 class Runtime:
     def __init__(
         self, taskset: "Taskset | None" = None, harness: "Harness | None" = None
@@ -218,7 +237,24 @@ class Runtime:
         self.owned_model_clients: set[str] = set()
         self._sandbox_client = None
         self.sandbox_leases: dict[tuple[str, str], SandboxLease] = {}
+        self.sandbox_creation_tasks: dict[
+            tuple[str, str], asyncio.Task[SandboxLease]
+        ] = {}
+        self.upload_archive_tasks: dict[tuple[str, str, str], asyncio.Task[Path]] = {}
         self.sandbox_lock = asyncio.Lock()
+        sandbox_config = (
+            self.harness.sandbox
+            if self.harness is not None and self.harness.sandbox is not None
+            else SandboxConfig()
+        )
+        create_concurrency = sandbox_config.create_concurrency
+        create_rate = sandbox_config.create_rate_per_second
+        delete_concurrency = sandbox_config.delete_concurrency
+        delete_rate = sandbox_config.delete_rate_per_second
+        self.sandbox_create_semaphore = asyncio.Semaphore(create_concurrency)
+        self.sandbox_create_rate_limiter = AsyncRateLimiter(create_rate)
+        self.sandbox_delete_semaphore = asyncio.Semaphore(delete_concurrency)
+        self.sandbox_delete_rate_limiter = AsyncRateLimiter(delete_rate)
         self.mcp_exit_stacks: dict[str, AsyncExitStack] = {}
         self.mcp_tools: dict[str, RuntimeTools] = {}
         self.mcp_tool_parents: dict[str, dict[str, tuple[Toolset, ...]]] = {}
@@ -416,23 +452,11 @@ class Runtime:
     def endpoint_handle(self, state: State) -> RuntimeHandleConfig | None:
         return self.resolved_handles(state).endpoint
 
-    def trajectory_handle(self, state: State) -> TrajectoryRuntimeHandleConfig | None:
-        return self.resolved_handles(state).trajectory
-
     def sandbox_handle(self, state: State) -> SandboxRuntimeHandleConfig | None:
         return self.resolved_handles(state).sandbox
 
-    def tools_handle(self, state: State) -> ToolsRuntimeHandleConfig | None:
-        return self.resolved_handles(state).tools
-
-    def sandbox_state(self, state: State) -> SandboxRuntimeStateConfig | None:
-        sandbox_record = state.runtime_state().get("sandbox")
-        if sandbox_record is None:
-            return None
-        return SandboxRuntimeStateConfig.model_validate(sandbox_record)
-
     def resolve_trajectory(self, state: State) -> None:
-        handle = self.trajectory_handle(state)
+        handle = self.resolved_handles(state).trajectory
         if handle is None:
             state.setdefault("trajectory", [])
             self.register_trajectory(state)
@@ -969,6 +993,7 @@ class Runtime:
             await self.release_sandboxes(scope="group", state=state)
             await self.close_mcp_tools(state, scope="group")
             self.release_scoped_tools("group", state)
+            await self.release_model_client(state, group=True)
 
     async def collect_artifacts(self, task: Task, state: State) -> None:
         artifacts = self.runtime_artifacts(task, state)
@@ -1029,11 +1054,38 @@ class Runtime:
         await run_handlers(self.teardown_handlers)
         await self.release_runtime_objects()
         try:
-            for handle in list(self.sandbox_leases.values()):
-                await close_object(handle)
-            self.sandbox_leases.clear()
+            if self.sandbox_creation_tasks:
+                await self.clear_sandbox_creation_tasks(
+                    list(self.sandbox_creation_tasks.items())
+                )
+            for key, handle in list(self.sandbox_leases.items()):
+                try:
+                    await self.close_sandbox_lease(handle)
+                except Exception as exc:
+                    logger.warning(
+                        "Failed to delete sandbox %s during teardown: %s",
+                        handle.id,
+                        exc,
+                        exc_info=True,
+                    )
+                    if handle.owns_client:
+                        from .utils.sandbox_utils import close_sandbox_client
+
+                        try:
+                            await close_sandbox_client(handle.client)
+                        except Exception as close_exc:
+                            logger.warning(
+                                "Failed to close sandbox client for %s during teardown: %s",
+                                handle.id,
+                                close_exc,
+                                exc_info=True,
+                            )
+                async with self.sandbox_lock:
+                    if self.sandbox_leases.get(key) is handle:
+                        del self.sandbox_leases[key]
         finally:
             await self.teardown_sandbox_client()
+            await self.cleanup_upload_archives()
         self.tool_handles.clear()
         self.scoped_tools.clear()
         await self.close_all_mcp_tools()
@@ -1048,7 +1100,10 @@ class Runtime:
 
             from .utils.sandbox_utils import SandboxClient
 
-            self._sandbox_client = cast(SandboxClient, ThreadedAsyncSandboxClient())
+            self._sandbox_client = cast(
+                SandboxClient,
+                ThreadedAsyncSandboxClient(),
+            )
         return self._sandbox_client
 
     async def teardown_sandbox_client(self) -> None:
@@ -1058,6 +1113,155 @@ class Runtime:
 
         await close_sandbox_client(self._sandbox_client)
         self._sandbox_client = None
+
+    async def cached_upload_archive(
+        self, local_source: Path | Traversable, remote_path: str
+    ) -> Path:
+        from .utils.sandbox_utils import UPLOAD_IGNORE_PARTS, build_dir_archive
+
+        if isinstance(local_source, Path):
+            root = local_source.resolve()
+            digest = hashlib.sha256()
+            paths = [root]
+            if root.is_dir():
+                paths = []
+                directories = [root]
+                while directories:
+                    for path in sorted(directories.pop().iterdir()):
+                        if path.name in UPLOAD_IGNORE_PARTS:
+                            continue
+                        paths.append(path)
+                        if path.is_dir():
+                            directories.append(path)
+            for path in paths:
+                relative = (
+                    path.relative_to(root).as_posix() if path != root else path.name
+                )
+                stat = path.stat()
+                kind = "d" if path.is_dir() else "f"
+                digest.update(
+                    f"{kind}:{relative}:{stat.st_mtime_ns}:{stat.st_size}\0".encode()
+                )
+            key = (remote_path, str(root), digest.hexdigest())
+        else:
+            key = (remote_path, str(local_source), "resource")
+        task = self.upload_archive_tasks.get(key)
+        if task is None:
+            task = asyncio.create_task(
+                asyncio.to_thread(build_dir_archive, local_source, remote_path)
+            )
+            self.upload_archive_tasks[key] = task
+        try:
+            return await asyncio.shield(task)
+        except Exception:
+            if self.upload_archive_tasks.get(key) is task:
+                del self.upload_archive_tasks[key]
+            raise
+
+    async def cleanup_upload_archives(self) -> None:
+        tasks = list(self.upload_archive_tasks.values())
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        self.upload_archive_tasks.clear()
+        for result in results:
+            if isinstance(result, Path):
+                result.unlink(missing_ok=True)
+
+    async def close_sandbox_lease(self, lease: "SandboxLease") -> None:
+        async with self.sandbox_delete_semaphore:
+            await self.sandbox_delete_rate_limiter.wait()
+            await close_object(lease)
+
+    async def clear_sandbox_creation_tasks(
+        self,
+        creations: Sequence[tuple[tuple[str, str], asyncio.Task["SandboxLease"]]],
+        *,
+        state: State | None = None,
+        scope: str | None = None,
+    ) -> None:
+        from .utils.sandbox_utils import SandboxLease as SandboxLeaseClass
+
+        for _, task in creations:
+            if not task.done():
+                task.cancel()
+        results = await asyncio.gather(
+            *(task for _, task in creations), return_exceptions=True
+        )
+        async with self.sandbox_lock:
+            for key, task in creations:
+                if self.sandbox_creation_tasks.get(key) is task:
+                    del self.sandbox_creation_tasks[key]
+
+        for (key, _), result in zip(creations, results, strict=True):
+            if not isinstance(result, SandboxLeaseClass):
+                continue
+            async with self.sandbox_lock:
+                result.scope_key = key[0]
+                self.sandbox_leases[key] = result
+            try:
+                await self.close_sandbox_lease(result)
+            except Exception as exc:
+                logger.warning(
+                    "Failed to delete sandbox %s from cancelled creation: %s",
+                    result.id,
+                    exc,
+                    exc_info=True,
+                )
+                if state is not None and scope is not None:
+                    cleanup_errors = cast(
+                        list[ConfigData], state.setdefault("cleanup_errors", [])
+                    )
+                    cleanup_errors.append(
+                        {
+                            "type": type(exc).__name__,
+                            "message": str(exc),
+                            "scope": scope,
+                        }
+                    )
+            else:
+                async with self.sandbox_lock:
+                    if self.sandbox_leases.get(key) is result:
+                        del self.sandbox_leases[key]
+
+    async def resolve_sandbox_lease(
+        self, key: tuple[str, str], factory: Callable[[], Awaitable["SandboxLease"]]
+    ) -> "SandboxLease":
+        async with self.sandbox_lock:
+            lease = self.sandbox_leases.get(key)
+            if lease is not None:
+                return lease
+            task = self.sandbox_creation_tasks.get(key)
+            if task is None:
+
+                async def create_sandbox_lease() -> "SandboxLease":
+                    async with self.sandbox_create_semaphore:
+                        await self.sandbox_create_rate_limiter.wait()
+                        return await factory()
+
+                task = asyncio.create_task(create_sandbox_lease())
+                self.sandbox_creation_tasks[key] = task
+
+        try:
+            lease = await asyncio.shield(task)
+        except asyncio.CancelledError:
+            if task.cancelled():
+                async with self.sandbox_lock:
+                    if self.sandbox_creation_tasks.get(key) is task:
+                        del self.sandbox_creation_tasks[key]
+            raise
+        except BaseException:
+            async with self.sandbox_lock:
+                if self.sandbox_creation_tasks.get(key) is task:
+                    del self.sandbox_creation_tasks[key]
+            raise
+        async with self.sandbox_lock:
+            existing = self.sandbox_leases.get(key)
+            if existing is not None:
+                return existing
+            if self.sandbox_creation_tasks.get(key) is task:
+                del self.sandbox_creation_tasks[key]
+            lease.scope_key = key[0]
+            self.sandbox_leases[key] = lease
+            return lease
 
     async def run_rollout_handlers(
         self,
@@ -2052,8 +2256,10 @@ class Runtime:
             return str(state.get("trajectory_id"))
         raise ValueError("Object scope must be 'rollout', 'group', or 'global'.")
 
-    async def release_model_client(self, state: State) -> None:
+    async def release_model_client(self, state: State, *, group: bool = False) -> None:
         if self.model_handle(state) is not None:
+            return
+        if not group and "group_key" in state.runtime_state():
             return
         key = state.runtime_state().get("client_key")
         if not isinstance(key, str):
@@ -2077,7 +2283,7 @@ class Runtime:
     ) -> object:
         from .utils.sandbox_utils import (
             SandboxHandle,
-            create_tool_sandbox_lease,
+            create_scoped_sandbox_lease,
             tool_sandbox_key,
         )
 
@@ -2101,22 +2307,24 @@ class Runtime:
                 return SandboxHandle(lease, state)
         scope = sandbox.scope
         key = (self.scope_key(scope, state), tool_sandbox_key(toolset))
-        async with self.sandbox_lock:
-            lease = self.sandbox_leases.get(key)
-            if lease is None:
-                lease = await create_tool_sandbox_lease(
-                    toolset, client=self.sandbox_client()
-                )
-                self.sandbox_leases[key] = lease
+        lease = await self.resolve_sandbox_lease(
+            key,
+            lambda: create_scoped_sandbox_lease(
+                toolset,
+                key[1],
+                client=self.sandbox_client(),
+            ),
+        )
         return SandboxHandle(lease, state)
 
     def active_program_sandbox_lease(self, state: State) -> "SandboxLease | None":
         sandbox_handle = self.sandbox_handle(state)
         if sandbox_handle is not None:
             return self.sandbox_lease_from_handle(sandbox_handle, "sandbox")
-        sandbox_record = self.sandbox_state(state)
-        if sandbox_record is None:
+        sandbox_state = state.runtime_state().get("sandbox")
+        if sandbox_state is None:
             return None
+        sandbox_record = SandboxRuntimeStateConfig.model_validate(sandbox_state)
         resolved_lease_key = sandbox_record.lease_key
         lease = self.sandbox_leases.get(resolved_lease_key)
         if lease is None:
@@ -2137,14 +2345,14 @@ class Runtime:
             return self.sandbox_lease_from_handle(sandbox_handle, "sandbox")
         scope = sandbox_config.scope
         key = (self.scope_key(scope, state), program_sandbox_key(sandbox_config))
-        async with self.sandbox_lock:
-            lease = self.sandbox_leases.get(key)
-            if lease is None:
-                lease = await create_sandbox_lease(
-                    sandbox_config, key[1], client=self.sandbox_client()
-                )
-                self.sandbox_leases[key] = lease
-                lease.scope_key = key[0]
+        lease = await self.resolve_sandbox_lease(
+            key,
+            lambda: create_sandbox_lease(
+                sandbox_config,
+                key[1],
+                client=self.sandbox_client(),
+            ),
+        )
         return lease
 
     def sandbox_lease_from_handle(
@@ -2172,26 +2380,37 @@ class Runtime:
             raise TypeError("User sandbox must be configured.")
         scope = sandbox.scope
         key = (self.scope_key(scope, state), sandbox_owner_key(user))
-        async with self.sandbox_lock:
-            lease = self.sandbox_leases.get(key)
-            if lease is None:
-                lease = await create_scoped_sandbox_lease(
-                    user, key[1], client=self.sandbox_client()
-                )
-                self.sandbox_leases[key] = lease
+        lease = await self.resolve_sandbox_lease(
+            key,
+            lambda: create_scoped_sandbox_lease(
+                user,
+                key[1],
+                client=self.sandbox_client(),
+            ),
+        )
         return SandboxHandle(lease, state)
 
     async def release_sandboxes(self, scope: str, state: State) -> None:
         scope_key = self.scope_key(scope, state)
-        scoped_leases = [
-            (key, handle)
-            for key, handle in self.sandbox_leases.items()
-            if key[0] == scope_key and handle.scope == scope
-        ]
+        async with self.sandbox_lock:
+            pending_creations = [
+                (key, task)
+                for key, task in self.sandbox_creation_tasks.items()
+                if key[0] == scope_key
+            ]
+            scoped_leases = [
+                (key, handle)
+                for key, handle in self.sandbox_leases.items()
+                if key[0] == scope_key and handle.scope == scope
+            ]
+        if pending_creations:
+            await self.clear_sandbox_creation_tasks(
+                pending_creations, state=state, scope=scope
+            )
         deletion_failures = 0
         for key, handle in scoped_leases:
             try:
-                await close_object(handle)
+                await self.close_sandbox_lease(handle)
             except Exception as exc:
                 deletion_failures += 1
                 logger.warning(
@@ -2202,16 +2421,20 @@ class Runtime:
                     exc,
                     exc_info=True,
                 )
-                cleanup_errors = state.setdefault("cleanup_errors", [])
-                if isinstance(cleanup_errors, list):
-                    cleanup_errors.append(
-                        {
-                            "type": type(exc).__name__,
-                            "message": str(exc),
-                            "scope": scope,
-                        }
-                    )
-            del self.sandbox_leases[key]
+                cleanup_errors = cast(
+                    list[ConfigData], state.setdefault("cleanup_errors", [])
+                )
+                cleanup_errors.append(
+                    {
+                        "type": type(exc).__name__,
+                        "message": str(exc),
+                        "scope": scope,
+                    }
+                )
+            else:
+                async with self.sandbox_lock:
+                    if self.sandbox_leases.get(key) is handle:
+                        del self.sandbox_leases[key]
         if deletion_failures:
             logger.error(
                 "%s/%s %s sandbox deletions failed during cleanup",
@@ -2223,35 +2446,47 @@ class Runtime:
     async def ensure_global_sandboxes(self, state: State | None = None) -> None:
         from .utils.sandbox_utils import (
             create_scoped_sandbox_lease,
-            create_tool_sandbox_lease,
             sandbox_owner_key,
             tool_sandbox_key,
         )
 
-        async with self.sandbox_lock:
-            for owner in self.sandbox_owners(state):
-                sandbox = owner.sandbox
-                if sandbox is None or sandbox == "program":
-                    continue
-                if not isinstance(sandbox, SandboxConfig):
-                    raise TypeError("Owner sandbox must be SandboxConfig or 'program'.")
-                if sandbox.scope != "global":
-                    continue
-                if isinstance(owner, Toolset):
-                    sandbox_key = tool_sandbox_key(owner)
-                else:
-                    sandbox_key = sandbox_owner_key(owner)
-                key = ("global", sandbox_key)
-                if key in self.sandbox_leases:
-                    continue
-                if isinstance(owner, Toolset):
-                    self.sandbox_leases[key] = await create_tool_sandbox_lease(
-                        owner, client=self.sandbox_client()
-                    )
-                else:
-                    self.sandbox_leases[key] = await create_scoped_sandbox_lease(
-                        owner, sandbox_key, client=self.sandbox_client()
-                    )
+        toolsets = self.active_toolsets(state) if state is not None else self.toolsets
+        owners: list[Toolset | User] = [*iter_toolsets(toolsets)]
+        user = self.active_user()
+        if user is not None:
+            owners.append(user)
+        for owner in owners:
+            sandbox = owner.sandbox
+            if sandbox is None or sandbox == "program":
+                continue
+            if not isinstance(sandbox, SandboxConfig):
+                raise TypeError("Owner sandbox must be SandboxConfig or 'program'.")
+            if sandbox.scope != "global":
+                continue
+            if isinstance(owner, Toolset):
+                sandbox_key = tool_sandbox_key(owner)
+                await self.resolve_sandbox_lease(
+                    ("global", sandbox_key),
+                    lambda owner=owner, sandbox_key=sandbox_key: (
+                        create_scoped_sandbox_lease(
+                            owner,
+                            sandbox_key,
+                            client=self.sandbox_client(),
+                        )
+                    ),
+                )
+            else:
+                sandbox_key = sandbox_owner_key(owner)
+                await self.resolve_sandbox_lease(
+                    ("global", sandbox_key),
+                    lambda owner=owner, sandbox_key=sandbox_key: (
+                        create_scoped_sandbox_lease(
+                            owner,
+                            sandbox_key,
+                            client=self.sandbox_client(),
+                        )
+                    ),
+                )
 
     def bind_global_sandboxes(self, state: State) -> None:
         from .utils.sandbox_utils import attach_sandbox_ref
@@ -2261,14 +2496,6 @@ class Runtime:
             if scope_key != "global":
                 continue
             attach_sandbox_ref(state, lease)
-
-    def sandbox_owners(self, state: State | None = None) -> list[Toolset | User]:
-        toolsets = self.active_toolsets(state) if state is not None else self.toolsets
-        owners: list[Toolset | User] = [*iter_toolsets(toolsets)]
-        user = self.active_user()
-        if user is not None:
-            owners.append(user)
-        return owners
 
     async def ensure_mcp_tools(self, state: State) -> None:
         from .utils.mcp_utils import connect_mcp_tool
@@ -2396,7 +2623,7 @@ class Runtime:
         return tools
 
     def borrowed_tools_for_state(self, state: State) -> RuntimeTools:
-        handle = self.tools_handle(state)
+        handle = self.resolved_handles(state).tools
         if handle is None:
             return {}
         source_runtime = self.resolved_runtime(handle)
@@ -2416,7 +2643,12 @@ class Runtime:
     ) -> dict[str, VisibilityConfig]:
         task = self.task_for_state(state)
         task_tools = task.tools_config()
-        active_named_toolsets = self._active_named_toolsets(active_toolsets)
+        active_ids = {id(toolset) for toolset in iter_toolsets(active_toolsets)}
+        active_named_toolsets = {
+            name: toolset
+            for name, toolset in self.named_toolsets.items()
+            if id(toolset) in active_ids
+        }
         filters: dict[str, VisibilityConfig] = {}
         for name, filter_config in task_tools.items():
             if name not in active_named_toolsets:
@@ -2433,16 +2665,6 @@ class Runtime:
                     raise KeyError(f"Unknown tools for toolset {name!r}: {unknown}.")
             filters[name] = filter_config
         return filters
-
-    def _active_named_toolsets(
-        self, active_toolsets: Sequence[Toolset]
-    ) -> dict[str, Toolset]:
-        active_ids = {id(toolset) for toolset in iter_toolsets(active_toolsets)}
-        return {
-            name: toolset
-            for name, toolset in self.named_toolsets.items()
-            if id(toolset) in active_ids
-        }
 
     def _tool_names_for_toolset(self, toolset: Toolset, state: State) -> list[str]:
         names: list[str] = []

--- a/verifiers/v1/runtime.py
+++ b/verifiers/v1/runtime.py
@@ -2483,30 +2483,21 @@ class Runtime:
                 raise TypeError("Owner sandbox must be SandboxConfig or 'program'.")
             if sandbox.scope != "global":
                 continue
-            if isinstance(owner, Toolset):
-                sandbox_key = tool_sandbox_key(owner)
-                await self.resolve_sandbox_lease(
-                    ("global", sandbox_key),
-                    lambda owner=owner, sandbox_key=sandbox_key: (
-                        create_scoped_sandbox_lease(
-                            owner,
-                            sandbox_key,
-                            client=self.sandbox_client(),
-                        )
-                    ),
-                )
-            else:
-                sandbox_key = sandbox_owner_key(owner)
-                await self.resolve_sandbox_lease(
-                    ("global", sandbox_key),
-                    lambda owner=owner, sandbox_key=sandbox_key: (
-                        create_scoped_sandbox_lease(
-                            owner,
-                            sandbox_key,
-                            client=self.sandbox_client(),
-                        )
-                    ),
-                )
+            sandbox_key = (
+                tool_sandbox_key(owner)
+                if isinstance(owner, Toolset)
+                else sandbox_owner_key(owner)
+            )
+            await self.resolve_sandbox_lease(
+                ("global", sandbox_key),
+                lambda owner=owner, sandbox_key=sandbox_key: (
+                    create_scoped_sandbox_lease(
+                        owner,
+                        sandbox_key,
+                        client=self.sandbox_client(),
+                    )
+                ),
+            )
 
     def bind_global_sandboxes(self, state: State) -> None:
         from .utils.sandbox_utils import attach_sandbox_ref

--- a/verifiers/v1/sandbox.py
+++ b/verifiers/v1/sandbox.py
@@ -1,6 +1,6 @@
 from typing import Literal
 
-from pydantic import field_validator
+from pydantic import Field, field_validator
 
 from .config import Config
 from .types import ConfigData
@@ -17,10 +17,21 @@ class SandboxConfig(Config):
     memory_gb: float = 2.0
     disk_size_gb: float = 5.0
     gpu_count: int = 0
+    gpu_type: str | None = None
+    vm: bool | None = None
     network_access: bool = True
     timeout_minutes: int = 60
+    create_timeout: int | None = None
+    wait_timeout: int | None = None
+    environment_vars: dict[str, str] = {}
+    secrets: dict[str, str] = {}
+    team_id: str | None = None
+    region: str | None = None
+    registry_credentials_id: str | None = None
+    guaranteed: bool = False
     workdir: str | None = None
     command_timeout: int | None = None
+    poll_interval: int = 3
     packages: list[str] = []
     install_timeout: int = 300
     setup_commands: list[str] = []
@@ -28,12 +39,25 @@ class SandboxConfig(Config):
     labels: list[str] = []
     scope: Literal["rollout", "group", "global"] = "rollout"
     prefer: Literal["program"] | None = None
+    create_concurrency: int = Field(default=128, ge=1)
+    create_rate_per_second: float | None = Field(default=None, gt=0)
+    delete_concurrency: int = Field(default=128, ge=1)
+    delete_rate_per_second: float | None = Field(default=None, gt=0)
 
     @field_validator("packages", "setup_commands", "labels", mode="before")
     @classmethod
     def validate_string_list(cls, value: object) -> object:
         if isinstance(value, str):
             return [value]
+        return value
+
+    @field_validator("environment_vars", "secrets", mode="before")
+    @classmethod
+    def validate_string_mapping(cls, value: object) -> object:
+        if value is None:
+            return {}
+        if isinstance(value, dict):
+            return {str(key): str(item) for key, item in value.items()}
         return value
 
     def data(self, *, fill_defaults: bool = True) -> ConfigData:

--- a/verifiers/v1/utils/sandbox_utils.py
+++ b/verifiers/v1/utils/sandbox_utils.py
@@ -173,7 +173,7 @@ def mark_sandbox_failure(
     exc: BaseException,
     *,
     phase: str | None = None,
-) -> None:
+) -> str | None:
     kind = sandbox_failure_kind(exc)
     if kind == "oom":
         state["sandbox_oom"] = True
@@ -191,6 +191,7 @@ def mark_sandbox_failure(
             failure["sandbox_id"] = lease.id
             failure["scope"] = lease.scope
         state.setdefault("sandbox_failures", []).append(failure)
+    return kind
 
 
 class SandboxLease:
@@ -296,8 +297,12 @@ class SandboxLease:
         async with self.delete_lock:
             if self.deleted:
                 return
-            await with_sandbox_retry(lambda: self.client.delete(self.id))
             self.deleted = True
+            try:
+                await with_sandbox_retry(lambda: self.client.delete(self.id))
+            except BaseException:
+                self.deleted = False
+                raise
             if self.owns_client:
                 await close_sandbox_client(self.client)
 
@@ -328,8 +333,7 @@ class SandboxHandle:
         except Error:
             raise
         except Exception as exc:
-            mark_sandbox_failure(self.state, self.lease, exc, phase="execute")
-            kind = sandbox_failure_kind(exc)
+            kind = mark_sandbox_failure(self.state, self.lease, exc, phase="execute")
             if kind is not None:
                 raise SandboxError(
                     f"Sandbox {self.lease.id} failed during execute ({kind}): {exc}"
@@ -375,8 +379,9 @@ class SandboxHandle:
         except Error:
             raise
         except Exception as exc:
-            mark_sandbox_failure(self.state, self.lease, exc, phase="background_job")
-            kind = sandbox_failure_kind(exc)
+            kind = mark_sandbox_failure(
+                self.state, self.lease, exc, phase="background_job"
+            )
             if kind is not None:
                 raise SandboxError(
                     f"Sandbox {self.lease.id} failed during background job ({kind}): {exc}"
@@ -489,8 +494,7 @@ async def run_sandbox_command(
         except Error:
             raise
         except Exception as exc:
-            mark_sandbox_failure(state, lease, exc, phase="command")
-            kind = sandbox_failure_kind(exc)
+            kind = mark_sandbox_failure(state, lease, exc, phase="command")
             if kind is not None:
                 raise SandboxError(
                     f"Sandbox {lease.id} failed during command ({kind}): {exc}"

--- a/verifiers/v1/utils/sandbox_utils.py
+++ b/verifiers/v1/utils/sandbox_utils.py
@@ -45,14 +45,14 @@ T = TypeVar("T")
 logger = logging.getLogger(__name__)
 
 
+class SandboxRecord(Protocol):
+    id: object
+
+
 class RetryLogger(Protocol):
     def log(
         self, level: int, msg: str, /, *args: object, **kwargs: object
     ) -> object: ...
-
-
-class SandboxRecord(Protocol):
-    id: object
 
 
 class SandboxCommandResult(Protocol):
@@ -127,6 +127,7 @@ class SandboxClient(Protocol):
         timeout: int | None = None,
         working_dir: str | None = None,
         env: dict[str, str] | None = None,
+        poll_interval: int = 3,
     ) -> SandboxCommandResult: ...
 
 
@@ -136,16 +137,12 @@ async def with_sandbox_retry(operation: Callable[[], Awaitable[T]]) -> T:
         stop=tc.stop_after_attempt(SANDBOX_RETRY_ATTEMPTS),
         wait=tc.wait_exponential_jitter(initial=0.5, max=30, jitter=1e-3),
         before_sleep=tc.before_sleep_log(retry_logger, logging.WARNING),
-        sleep=sandbox_retry_sleep,
+        sleep=asyncio.sleep,
         reraise=True,
     ):
         with attempt:
             return await operation()
     raise AssertionError("sandbox retry loop exited without running")
-
-
-async def sandbox_retry_sleep(seconds: float) -> None:
-    await asyncio.sleep(seconds)
 
 
 async def close_sandbox_client(client: SandboxClient) -> None:
@@ -156,6 +153,44 @@ async def close_sandbox_client(client: SandboxClient) -> None:
     aclose = getattr(client, "aclose", None)
     if callable(aclose):
         await aclose()
+
+
+def sandbox_failure_kind(exc: BaseException) -> str | None:
+    if isinstance(exc, TimeoutError):
+        return "timeout"
+    name = type(exc).__name__
+    text = str(exc)
+    if name == "SandboxOOMError" or "OOM" in text or "OOM_KILLED" in text:
+        return "oom"
+    if name in {"SandboxTimeoutError", "CommandTimeoutError"} or "timed out" in text:
+        return "timeout"
+    return None
+
+
+def mark_sandbox_failure(
+    state: State,
+    lease: "SandboxLease | None",
+    exc: BaseException,
+    *,
+    phase: str | None = None,
+) -> None:
+    kind = sandbox_failure_kind(exc)
+    if kind == "oom":
+        state["sandbox_oom"] = True
+    elif kind == "timeout":
+        state["sandbox_timeout"] = True
+    if kind is not None:
+        failure: ConfigData = {
+            "kind": kind,
+            "type": type(exc).__name__,
+            "message": str(exc),
+        }
+        if phase is not None:
+            failure["phase"] = phase
+        if lease is not None:
+            failure["sandbox_id"] = lease.id
+            failure["scope"] = lease.scope
+        state.setdefault("sandbox_failures", []).append(failure)
 
 
 class SandboxLease:
@@ -176,6 +211,7 @@ class SandboxLease:
         self.scope_key: str | None = None
         self.deleted = False
         self.lock = asyncio.Lock()
+        self.delete_lock = asyncio.Lock()
 
     async def execute(
         self,
@@ -240,12 +276,14 @@ class SandboxLease:
         timeout: int | None = None,
         working_dir: str | None = None,
         env: dict[str, str] | None = None,
+        poll_interval: int = 3,
     ) -> SandboxCommandResult:
         call_args: ConfigData = {
             "sandbox_id": self.id,
             "command": command,
             "working_dir": working_dir,
             "env": env,
+            "poll_interval": poll_interval,
         }
         if timeout is not None:
             call_args["timeout"] = timeout
@@ -255,12 +293,11 @@ class SandboxLease:
         )
 
     async def delete(self) -> None:
-        if self.deleted:
-            return
-        self.deleted = True
-        try:
+        async with self.delete_lock:
+            if self.deleted:
+                return
             await with_sandbox_retry(lambda: self.client.delete(self.id))
-        finally:
+            self.deleted = True
             if self.owns_client:
                 await close_sandbox_client(self.client)
 
@@ -281,12 +318,23 @@ class SandboxHandle:
         working_dir: str | None = None,
         env: dict[str, str] | None = None,
     ) -> SandboxCommandResult:
-        result = await self.lease.execute(
-            command=command,
-            timeout=timeout,
-            working_dir=working_dir,
-            env=env,
-        )
+        try:
+            result = await self.lease.execute(
+                command=command,
+                timeout=timeout,
+                working_dir=working_dir,
+                env=env,
+            )
+        except Error:
+            raise
+        except Exception as exc:
+            mark_sandbox_failure(self.state, self.lease, exc, phase="execute")
+            kind = sandbox_failure_kind(exc)
+            if kind is not None:
+                raise SandboxError(
+                    f"Sandbox {self.lease.id} failed during execute ({kind}): {exc}"
+                ) from exc
+            raise
         record_tool_sandbox_command(self.state, self.lease, command, result)
         return result
 
@@ -314,13 +362,26 @@ class SandboxHandle:
         timeout: int | None = None,
         working_dir: str | None = None,
         env: dict[str, str] | None = None,
-    ) -> object:
-        result = await self.lease.run_background_job(
-            command=command,
-            timeout=timeout,
-            working_dir=working_dir,
-            env=env,
-        )
+        poll_interval: int = 3,
+    ) -> SandboxCommandResult:
+        try:
+            result = await self.lease.run_background_job(
+                command=command,
+                timeout=timeout,
+                working_dir=working_dir,
+                env=env,
+                poll_interval=poll_interval,
+            )
+        except Error:
+            raise
+        except Exception as exc:
+            mark_sandbox_failure(self.state, self.lease, exc, phase="background_job")
+            kind = sandbox_failure_kind(exc)
+            if kind is not None:
+                raise SandboxError(
+                    f"Sandbox {self.lease.id} failed during background job ({kind}): {exc}"
+                ) from exc
+            raise
         record_tool_sandbox_command(self.state, self.lease, command, result)
         return result
 
@@ -328,14 +389,10 @@ class SandboxHandle:
         await self.lease.delete()
 
 
-async def create_tool_sandbox_lease(
-    toolset: "Toolset", client: SandboxClient | None = None
-) -> SandboxLease:
-    return await create_scoped_sandbox_lease(toolset, tool_sandbox_key(toolset), client)
-
-
 async def create_sandbox_lease(
-    sandbox_config: SandboxConfig, key: str, client: SandboxClient | None = None
+    sandbox_config: SandboxConfig,
+    key: str,
+    client: SandboxClient | None = None,
 ) -> SandboxLease:
     sandbox_data = sandbox_config.data()
     owns_client = client is None
@@ -343,19 +400,14 @@ async def create_sandbox_lease(
         from verifiers.utils.threaded_sandbox_client import ThreadedAsyncSandboxClient
 
         client = cast(SandboxClient, ThreadedAsyncSandboxClient())
-    try:
-        sandbox_id = await create_sandbox(client, sandbox_data)
-    except BaseException:
-        if owns_client:
-            await close_sandbox_client(client)
-        raise
+    sandbox_id = await create_sandbox(client, sandbox_data, owns_client=owns_client)
     lease = SandboxLease(
         client, sandbox_id, sandbox_config.scope, key, owns_client=owns_client
     )
     try:
         await setup_sandbox(lease, sandbox_data)
     except BaseException:
-        await lease.delete()
+        await asyncio.shield(lease.delete())
         raise
     return lease
 
@@ -380,7 +432,11 @@ async def run_sandbox_command(
 ) -> State:
     validate_program_bindings(program)
     sandbox_data = sandbox_config.data()
-    lease = await runtime.resolve_program_sandbox(sandbox_config, task, state)
+    try:
+        lease = await runtime.resolve_program_sandbox(sandbox_config, task, state)
+    except Exception as exc:
+        mark_sandbox_failure(state, None, exc, phase="create")
+        raise
     async with lease.lock:
         state["sandbox_id"] = lease.id
         runtime_state = state.runtime_state()
@@ -396,17 +452,21 @@ async def run_sandbox_command(
         use_sandbox_python_path = bool(
             python_package_list(sandbox_data.get("packages"))
         )
-        await runtime.setup_rollout(
-            task,
-            state,
-            setup_handlers=program_setup_handlers(
-                lease,
-                program,
-                runtime,
-                use_sandbox_python_path=use_sandbox_python_path,
-            ),
-            sandbox=handle,
-        )
+        try:
+            await runtime.setup_rollout(
+                task,
+                state,
+                setup_handlers=program_setup_handlers(
+                    lease,
+                    program,
+                    runtime,
+                    use_sandbox_python_path=use_sandbox_python_path,
+                ),
+                sandbox=handle,
+            )
+        except Exception as exc:
+            mark_sandbox_failure(state, lease, exc, phase="setup")
+            raise
         workdir = sandbox_config.workdir
         if workdir:
             await lease.client.execute_command(
@@ -418,12 +478,24 @@ async def run_sandbox_command(
         if use_sandbox_python_path or "mcp" in program_channels(program):
             command = sandbox_python_path_command(command)
         command_timeout = sandbox_config.command_timeout
-        result = await lease.run_background_job(
-            command,
-            timeout=command_timeout,
-            working_dir=workdir,
-            env=env,
-        )
+        try:
+            result = await lease.run_background_job(
+                command,
+                timeout=command_timeout,
+                working_dir=workdir,
+                env=env,
+                poll_interval=int_config(sandbox_data, "poll_interval", 3),
+            )
+        except Error:
+            raise
+        except Exception as exc:
+            mark_sandbox_failure(state, lease, exc, phase="command")
+            kind = sandbox_failure_kind(exc)
+            if kind is not None:
+                raise SandboxError(
+                    f"Sandbox {lease.id} failed during command ({kind}): {exc}"
+                ) from exc
+            raise
         state["command"] = {
             "argv": argv,
             "returncode": result.exit_code,
@@ -563,10 +635,19 @@ def _program_channel_setup_handler(
     return setup_handler(handler, priority=priority)
 
 
-async def create_sandbox(client: SandboxClient, sandbox_config: ConfigData) -> str:
+async def create_sandbox(
+    client: SandboxClient,
+    sandbox_config: ConfigData,
+    *,
+    owns_client: bool = False,
+) -> str:
     from prime_sandboxes import CreateSandboxRequest
 
     labels = sandbox_config.get("labels")
+    gpu_count = int_config(sandbox_config, "gpu_count", 0)
+    vm = sandbox_config.get("vm")
+    environment_vars = sandbox_config.get("environment_vars")
+    secrets = sandbox_config.get("secrets")
     request = CreateSandboxRequest(
         name=f"vf-v1-{uuid.uuid4().hex[:8]}",
         docker_image=str(sandbox_config.get("image") or "python:3.11-slim"),
@@ -574,30 +655,108 @@ async def create_sandbox(client: SandboxClient, sandbox_config: ConfigData) -> s
         cpu_cores=float_config(sandbox_config, "cpu_cores", 1.0),
         memory_gb=float_config(sandbox_config, "memory_gb", 2.0),
         disk_size_gb=float_config(sandbox_config, "disk_size_gb", 5.0),
-        gpu_count=int_config(sandbox_config, "gpu_count", 0),
+        gpu_count=gpu_count,
+        gpu_type=str(sandbox_config["gpu_type"])
+        if sandbox_config.get("gpu_type") is not None
+        else None,
+        vm=bool(vm) if vm is not None else gpu_count > 0,
         network_access=bool(sandbox_config.get("network_access", True)),
         timeout_minutes=int_config(sandbox_config, "timeout_minutes", 60),
         labels=[str(label) for label in labels] if isinstance(labels, list) else [],
+        environment_vars={
+            str(key): str(value) for key, value in environment_vars.items()
+        }
+        if isinstance(environment_vars, dict) and environment_vars
+        else None,
+        secrets={str(key): str(value) for key, value in secrets.items()}
+        if isinstance(secrets, dict) and secrets
+        else None,
+        team_id=str(sandbox_config["team_id"])
+        if sandbox_config.get("team_id") is not None
+        else None,
+        region=str(sandbox_config["region"])
+        if sandbox_config.get("region") is not None
+        else None,
+        registry_credentials_id=str(sandbox_config["registry_credentials_id"])
+        if sandbox_config.get("registry_credentials_id") is not None
+        else None,
+        guaranteed=bool(sandbox_config.get("guaranteed", False)),
     )
-    sandbox = await with_sandbox_retry(lambda: client.create(request))
+    create_task = asyncio.create_task(
+        with_sandbox_retry(lambda: client.create(request))
+    )
+    try:
+        create_waiter = asyncio.shield(create_task)
+        if sandbox_config.get("create_timeout") is not None:
+            sandbox = await asyncio.wait_for(
+                create_waiter, int_config(sandbox_config, "create_timeout", 0)
+            )
+        else:
+            sandbox = await create_waiter
+    except (asyncio.CancelledError, TimeoutError):
+        try:
+            sandbox = cast(SandboxRecord, await asyncio.shield(create_task))
+        except BaseException:
+            if owns_client:
+                await close_sandbox_client(client)
+            raise
+        await asyncio.shield(
+            delete_sandbox_id(
+                client,
+                str(sandbox.id),
+                close_client=owns_client,
+                reason="cancelled creation",
+            )
+        )
+        raise
+    except BaseException:
+        if owns_client:
+            await close_sandbox_client(client)
+        raise
     sandbox_id = str(sandbox.id)
     try:
-        await client.wait_for_creation(
+        wait = client.wait_for_creation(
             sandbox_id,
             max_attempts=SANDBOX_WAIT_FOR_CREATION_ATTEMPTS,
         )
+        if sandbox_config.get("wait_timeout") is not None:
+            await asyncio.wait_for(wait, int_config(sandbox_config, "wait_timeout", 0))
+        else:
+            await wait
     except BaseException:
-        try:
-            await with_sandbox_retry(lambda: client.delete(sandbox_id))
-        except Exception as cleanup_exc:
-            logger.warning(
-                "Failed to delete sandbox %s after creation failure: %s",
+        delete_task = asyncio.create_task(
+            delete_sandbox_id(
+                client,
                 sandbox_id,
-                cleanup_exc,
-                exc_info=True,
+                close_client=owns_client,
+                reason="creation failure",
             )
+        )
+        await asyncio.shield(delete_task)
         raise
     return sandbox_id
+
+
+async def delete_sandbox_id(
+    client: SandboxClient,
+    sandbox_id: str,
+    *,
+    close_client: bool,
+    reason: str,
+) -> None:
+    try:
+        await with_sandbox_retry(lambda: client.delete(sandbox_id))
+    except Exception as cleanup_exc:
+        logger.warning(
+            "Failed to delete sandbox %s after %s: %s",
+            sandbox_id,
+            reason,
+            cleanup_exc,
+            exc_info=True,
+        )
+    finally:
+        if close_client:
+            await close_sandbox_client(client)
 
 
 async def setup_sandbox(handle: SandboxLease, sandbox_config: ConfigData) -> None:
@@ -639,9 +798,7 @@ async def setup_sandbox(handle: SandboxLease, sandbox_config: ConfigData) -> Non
 
 
 def attach_sandbox_ref(state: State, lease: SandboxLease) -> None:
-    sandboxes = state.runtime_state().setdefault("sandboxes", {})
-    if not isinstance(sandboxes, dict):
-        raise TypeError("state.runtime.sandboxes must be a mapping.")
+    sandboxes = cast(ConfigData, state.runtime_state().setdefault("sandboxes", {}))
     sandboxes[lease.key] = {"id": lease.id, "scope": lease.scope}
 
 
@@ -654,21 +811,15 @@ def record_tool_sandbox_command(
         "stdout": result.stdout or "",
         "stderr": result.stderr or "",
     }
-    commands = state.setdefault("sandbox_commands", [])
-    if not isinstance(commands, list):
-        raise TypeError("state.sandbox_commands must be a list.")
-    commands = cast(list[ConfigData], commands)
+    commands = cast(list[ConfigData], state.setdefault("sandbox_commands", []))
     commands.append(command_record)
-    sandboxes = state.runtime_state().setdefault("sandboxes", {})
-    if isinstance(sandboxes, dict):
-        tool_state = sandboxes.setdefault(
-            lease.key, {"id": lease.id, "scope": lease.scope}
-        )
-        if isinstance(tool_state, dict):
-            tool_commands = tool_state.setdefault("commands", [])
-            if isinstance(tool_commands, list):
-                tool_commands = cast(list[ConfigData], tool_commands)
-                tool_commands.append(command_record)
+    sandboxes = cast(ConfigData, state.runtime_state().setdefault("sandboxes", {}))
+    tool_state = cast(
+        ConfigData,
+        sandboxes.setdefault(lease.key, {"id": lease.id, "scope": lease.scope}),
+    )
+    tool_commands = cast(list[ConfigData], tool_state.setdefault("commands", []))
+    tool_commands.append(command_record)
 
 
 def tool_sandbox_key(toolset: "Toolset") -> str:
@@ -741,50 +892,45 @@ async def upload_program_dirs(
         )
         if local_source is None:
             continue
-        await upload_program_dir(client, sandbox_id, path, local_source)
-
-
-async def upload_program_dir(
-    client: SandboxClient, sandbox_id: str, remote_path: str, local_source: object
-) -> None:
-    if isinstance(local_source, str):
-        local_source = Path(local_source)
-    if not isinstance(local_source, (Path, Traversable)):
-        raise TypeError("program.dirs values must resolve to paths.")
-    remote_tar = f"/tmp/_vf_upload_{remote_path.strip('/').replace('/', '_')}.tar.gz"
-    tmp_path = await asyncio.to_thread(build_dir_archive, local_source, remote_path)
-    try:
+        if isinstance(local_source, str):
+            local_source = Path(local_source)
+        if not isinstance(local_source, (Path, Traversable)):
+            raise TypeError("program.dirs values must resolve to paths.")
+        remote_tar = f"/tmp/_vf_upload_{path.strip('/').replace('/', '_')}.tar.gz"
+        archive_path = await runtime.cached_upload_archive(local_source, path)
         await maybe_call_with_named_args(
             client.upload_file,
             sandbox_id=sandbox_id,
             file_path=remote_tar,
-            local_file_path=str(tmp_path),
+            local_file_path=str(archive_path),
         )
         result = await maybe_call_with_named_args(
             client.execute_command,
             sandbox_id=sandbox_id,
             command=(
-                f"mkdir -p {shlex.quote(str(Path(remote_path).parent))} && "
+                f"mkdir -p {shlex.quote(str(Path(path).parent))} && "
                 f"tar -xzf {shlex.quote(remote_tar)} -C / && "
                 f"rm -f {shlex.quote(remote_tar)}"
             ),
         )
         if result.exit_code:
             raise SandboxError(f"Program dir upload failed: {result.stderr}")
-    finally:
-        tmp_path.unlink(missing_ok=True)
 
 
 def build_dir_archive(local_source: Path | Traversable, remote_path: str) -> Path:
     with tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False) as tmp_file:
         tar_path = Path(tmp_file.name)
     arcname = remote_path.lstrip("/")
-    with tarfile.open(tar_path, "w:gz") as tar:
-        if isinstance(local_source, Path):
-            tar.add(local_source, arcname=arcname, filter=upload_tar_filter)
-        else:
-            with resources.as_file(local_source) as local_path:
-                tar.add(local_path, arcname=arcname, filter=upload_tar_filter)
+    try:
+        with tarfile.open(tar_path, "w:gz") as tar:
+            if isinstance(local_source, Path):
+                tar.add(local_source, arcname=arcname, filter=upload_tar_filter)
+            else:
+                with resources.as_file(local_source) as local_path:
+                    tar.add(local_path, arcname=arcname, filter=upload_tar_filter)
+    except BaseException:
+        tar_path.unlink(missing_ok=True)
+        raise
     return tar_path
 
 


### PR DESCRIPTION
## Summary

This PR reworks the V1 sandbox runtime lifecycle so high-fanout sandbox workloads can scale without serializing unrelated sandbox creation behind one runtime lock. It also adds a runtime-level harness upload cache and hardens sandbox cancellation cleanup so cancelled creates do not orphan provider sandboxes.

## Architecture changes

At a high level, sandbox ownership is now centered around a single runtime lease cache instead of several overlapping cleanup paths. `Runtime.resolve_sandbox_lease()` coalesces creations by lease key, awaits the shared creation task through `asyncio.shield()`, and writes the completed lease into `sandbox_leases` once. The old active-id cleanup registry remains removed; successful sandboxes are owned by leases, and failed create/wait/setup paths clean up in the creation helper.

Sandbox creation no longer holds the runtime lock across provider create/wait/setup work. The lock is only used to read/write the lease/task maps, while actual provider work runs outside the lock and is bounded by harness-level create concurrency. This preserves reuse for group/global leases while allowing unrelated rollout sandboxes to provision concurrently. Delete paths are also bounded by delete concurrency/rate controls.

Cancelled awaiters no longer detach shared creation tasks. If a caller awaiting `resolve_sandbox_lease()` is cancelled, the creation task stays in `sandbox_creation_tasks` unless the creation task itself was cancelled. Scope cleanup and runtime teardown now gather tracked creation tasks and close any completed-but-unclaimed `SandboxLease` result, preventing late successful creates from becoming invisible to cleanup.

Provider create cancellation is also handled synchronously enough for teardown safety. `create_sandbox()` shields the provider `client.create()` call, and when cancellation or create timeout happens it waits for the late provider result and deletes the sandbox id before the creation task completes. This prevents runtime teardown from closing the shared sandbox client before the late-create cleanup has a chance to delete the sandbox.

`SandboxLease.delete()` now marks a lease deleted only after the remote delete succeeds, guarded by a delete lock. If deletion exhausts retries or is cancelled, the lease remains retryable instead of becoming a local no-op while the remote sandbox may still exist.

The public sandbox scaling controls now live on `SandboxConfig`: `create_concurrency`, `create_rate_per_second`, `delete_concurrency`, and `delete_rate_per_second`.

`SandboxConfig` now threads additional provider request fields through `CreateSandboxRequest`, including GPU type, VM placement, environment vars, secrets, team/region, registry credentials, guaranteed placement, create/wait timeouts, and background-job polling interval. Group-scoped model clients are retained through group cleanup so late group scoring cannot hit a closed client.

## Harness upload cache

Harness/program directory uploads now share a runtime archive cache. The cache stores an `asyncio.Task[Path]` keyed by `(remote_path, resolved_source, source_fingerprint)`, so concurrent uploads of the same unchanged directory coalesce into one tarball build. Each sandbox still uploads and extracts the archive independently, but the expensive local tar creation is reused across samples in the same runtime.

The fingerprint is based on relative path, file type, mtime, and size for the source tree, while pruning ignored heavy directories such as `.git`, `.venv`, caches, and `node_modules`. That keeps the cache cheap on large harnesses and prevents stale archives when a source directory changes within the same runtime. Runtime teardown awaits cached build tasks and unlinks completed archive files, including when the original archive awaiter was cancelled.

## Test cleanup

The V1 runtime lifecycle test file now has 81 focused tests after removing low-signal coverage and adding cancellation/cleanup regressions. The remaining tests cover sandbox creation retry/cleanup, cancelled provider create/wait cleanup, cancelled shared creation awaiters, teardown/release cleanup of unclaimed leases, retryable failed deletes, owned-client retryability after delete failure, request field threading, bounded concurrent creation, group/global ownership, OOM markers, and upload cache reuse/invalidation/cancel cleanup.

## Verification

- `uv run ruff format && uv run ruff check --fix .`
- `uv run --python 3.13 ty check verifiers packages/tasksets/tasksets packages/harnesses/harnesses`
- `uv run pytest tests/test_v1_runtime_lifecycle.py` (`81 passed`)
- `uv run pytest tests/test_v1_runtime_lifecycle.py tests/test_v1_config_extension.py` (`245 passed`)
- `uv run pytest tests/` (`1632 passed, 32 skipped, 2 failed`; failures are `tests/test_envs.py::test_env[toxicity_explanation]` and `tests/test_envs.py::test_env[wiki_search]`, both due to missing OpenAI API/admin key configuration)

Note: local commit/push hooks run through `uv` and repeatedly dirty `uv.lock`; the lockfile is intentionally restored and not included in this PR per repo instructions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core runtime teardown, lease deletion semantics, and provider sandbox create/cancel paths where bugs can orphan remote sandboxes or leak resources under load.
> 
> **Overview**
> Reworks the **V1 sandbox runtime** so high-fanout workloads can provision sandboxes **concurrently** instead of serializing all provider work behind one lock. **`Runtime.resolve_sandbox_lease()`** coalesces in-flight creates per lease key (shared `asyncio` task + `shield`), applies harness **`SandboxConfig`** **create/delete concurrency and rate limits**, and hardens **teardown/cancellation** so late provider creates and unclaimed leases still get deleted. **`SandboxConfig`** gains provider fields (GPU/VM, env/secrets, team/region, timeouts, **`poll_interval`**) plus **`create_*` / `delete_*`** throttling knobs; nested config tests reject unknown top-level harness keys like `sandbox_create_concurrency`.
> 
> **`create_sandbox()`** maps those fields into provider requests, handles cancel/timeout during create/wait with cleanup deletes, and **`SandboxLease.delete()`** only marks deleted after a successful remote delete (retryable on failure). Failures record **OOM/timeout** metadata on state; program dir uploads use a **runtime tarball cache** (`cached_upload_archive`) with fingerprint invalidation and teardown cleanup. **Group cleanup** keeps owned model clients alive until group release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 315ca8814d0764723ddfbfca43da5540204d7121. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scale V1 sandbox runtime lifecycle with concurrency limits, rate limiting, and coalesced creation
> - Adds `AsyncRateLimiter` and semaphore-based concurrency controls to sandbox create/delete operations, configured via new `SandboxConfig` fields (`create_concurrency`, `create_rate_per_second`, `delete_concurrency`, `delete_rate_per_second`).
> - Introduces `resolve_sandbox_lease` in [runtime.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1520/files#diff-7c2c1b88c61b8a75e00bb82f7ece60290f886d4a3ed87e97a5e1cbf86b26973d) to coalesce concurrent requests for the same sandbox into a single creation, preventing duplicate sandboxes under load.
> - Extends `create_sandbox` in [sandbox_utils.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1520/files#diff-b1154f3be7f28191532de46fbe23a973a5f93e1450a71beb9c93910e358fda13) to support additional config fields (`gpu_type`, `vm`, `environment_vars`, `secrets`, `team_id`, `region`, `guaranteed`), optional create/wait timeouts, and cancellation-safe cleanup.
> - Adds `cached_upload_archive` to deduplicate archive builds across concurrent uploads, with SHA-256-based cache invalidation on directory content changes and cleanup on teardown.
> - Adds structured sandbox failure recording (`mark_sandbox_failure`, `sandbox_failure_kind`) so OOM and timeout failures are classified and surfaced in state with phase metadata.
> - Extends teardown to cancel in-flight creations, delete any resulting sandboxes, throttle lease closures, and remove temporary upload archives.
> - Risk: `SandboxLease.delete` now serializes concurrent deletes via a lock and only marks the lease deleted after a successful call; callers that previously assumed immediate deletion may observe different timing.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1520 opened
>
> - Added validation logic to `Runtime.resolve_sandbox_lease` to reject lease resolution when the lease is marked as deleted or when the creation task was cancelled before resolution, and modified `SandboxLease.delete` to set the `deleted` flag before attempting client deletion and revert it on failure, enabling detection of in-flight deletion attempts [8a13d10]
> - Modified `Runtime.clear_sandbox_creation_tasks` to claim and cancel only the creation tasks it successfully removes from `sandbox_creation_tasks`, await their cancellation, and when closing a successfully created `SandboxLease` fails, re-add the lease to `sandbox_leases` if it was not deleted, then log a warning and optionally record a cleanup error [8a13d10]
> - Modified `Runtime.cleanup_upload_archives` to skip non-`Path` results, wrap `Path.unlink` calls in try/except blocks, and log warnings with `exc_info=True` when unlink fails [8a13d10]
> - Modified `mark_sandbox_failure` to return the computed failure kind string or `None`, and updated `SandboxHandle.execute`, `SandboxHandle.run_background_job`, and `run_sandbox_command` to use the returned kind value instead of calling `sandbox_failure_kind` separately [8a13d10]
> - Consolidated duplicated sandbox lease initialization logic in runtime [afbf112]
> - Modified `Runtime.teardown` to track failed sandbox deletions and defer cleanup operations [315ca88]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4f0448a.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->





