### PR TITLE
fix(v1): record final/context token usage at write time

### DIFF
--- a/tests/test_v1_runtime_lifecycle.py
+++ b/tests/test_v1_runtime_lifecycle.py
@@ -722,7 +722,12 @@ async def test_v1_records_default_metrics_usage_and_timing() -> None:
     state = await harness.run(task)
 
     assert state["metrics"]["num_turns"] == 1.0
-    assert state["token_usage"] == {"input_tokens": 11.0, "output_tokens": 7.0}
+    assert state["token_usage"] == {
+        "input_tokens": 11.0,
+        "output_tokens": 7.0,
+        "final_output_tokens": 7.0,
+        "final_input_tokens": 11.0,
+    }
     assert state["usage"] == state["token_usage"]
     assert state["timing"]["total"] > 0.0
     assert state["timing"]["generation"]["duration"] > 0.0

--- a/verifiers/utils/save_utils.py
+++ b/verifiers/utils/save_utils.py
@@ -248,13 +248,19 @@ def state_to_output(
         # responses are plain dicts), so prefer them when present. Classic envs
         # keep live Response objects in the trajectory, so recompute there.
         raw_usage = state.get("token_usage")
-        if isinstance(raw_usage, Mapping) and "final_output_tokens" in raw_usage:
-            token_usage["final_output_tokens"] = float(
-                raw_usage.get("final_output_tokens", 0.0)
-            )
-            token_usage["final_input_tokens"] = float(
-                raw_usage.get("final_input_tokens", 0.0)
-            )
+        final_output = (
+            raw_usage.get("final_output_tokens")
+            if isinstance(raw_usage, Mapping)
+            else None
+        )
+        final_input = (
+            raw_usage.get("final_input_tokens")
+            if isinstance(raw_usage, Mapping)
+            else None
+        )
+        if final_output is not None and final_input is not None:
+            token_usage["final_output_tokens"] = float(final_output)
+            token_usage["final_input_tokens"] = float(final_input)
         else:
             trajectory = state.get("trajectory", [])
             if isinstance(trajectory, list):

--- a/verifiers/utils/save_utils.py
+++ b/verifiers/utils/save_utils.py
@@ -243,12 +243,24 @@ def state_to_output(
             "input_tokens": usage.get("input_tokens", 0.0),
             "output_tokens": usage.get("output_tokens", 0.0),
         }
-        # Add context token metrics from trajectory
-        trajectory = state.get("trajectory", [])
-        if isinstance(trajectory, list):
-            from verifiers.utils.usage_utils import compute_context_token_metrics
+        # Context ("final") token metrics. v1 records these at write time from
+        # the live Response (the serialized trajectory can't be re-derived since
+        # responses are plain dicts), so prefer them when present. Classic envs
+        # keep live Response objects in the trajectory, so recompute there.
+        raw_usage = state.get("token_usage")
+        if isinstance(raw_usage, Mapping) and "final_output_tokens" in raw_usage:
+            token_usage["final_output_tokens"] = float(
+                raw_usage.get("final_output_tokens", 0.0)
+            )
+            token_usage["final_input_tokens"] = float(
+                raw_usage.get("final_input_tokens", 0.0)
+            )
+        else:
+            trajectory = state.get("trajectory", [])
+            if isinstance(trajectory, list):
+                from verifiers.utils.usage_utils import compute_context_token_metrics
 
-            token_usage.update(compute_context_token_metrics(trajectory))
+                token_usage.update(compute_context_token_metrics(trajectory))
         output["token_usage"] = token_usage
 
     # sanitize messages (handle None for error cases)

--- a/verifiers/v1/utils/usage_utils.py
+++ b/verifiers/v1/utils/usage_utils.py
@@ -18,4 +18,17 @@ def record_response_usage(state: State, response: Response) -> None:
     usage["output_tokens"] = float(usage.get("output_tokens", 0.0)) + float(
         output_tokens
     )
+    # Context ("final") token metrics, accumulated at write time from the live
+    # Response. v1 serializes trajectory responses to plain dicts, so they can't
+    # be recomputed from the trajectory afterward (the isinstance(Response) gate
+    # in compute_context_token_metrics fails). Mirror that helper's formula for a
+    # linear rollout: final_output is the running sum of completions; final_input
+    # is the latest step's full context minus that sum.
+    usage["final_output_tokens"] = float(usage.get("final_output_tokens", 0.0)) + float(
+        output_tokens
+    )
+    last_step_total = float(input_tokens) + float(output_tokens)
+    usage["final_input_tokens"] = max(
+        0.0, last_step_total - usage["final_output_tokens"]
+    )
     state["usage"] = usage


### PR DESCRIPTION
## Problem

For **v1** environments, `token_usage.final_input_tokens` / `final_output_tokens` are always `0`. Downstream, this zeroes prime-rl's wandb `seq_len/*` and `progress/tokens` metrics (they're derived from `final_input + final_output`), even though rollouts clearly generate tokens.

## Root cause

`final_*` are derived by `compute_context_token_metrics(trajectory)` (`utils/usage_utils.py`), called from `state_to_output`. That helper gates every step on `isinstance(response, Response)`.

The v1 runtime stores `"response": serializable(response)` — a plain **dict** (state must be JSON-serializable; the harness even enforces `state.assert_serializable()`). So `isinstance(dict, Response)` is `False`, the loop finds nothing, and it returns `{final_*: 0}`. Classic `MultiTurnEnv` keeps live `Response` objects in the trajectory, so it's unaffected.

`input_tokens` / `output_tokens` stay correct because they're accumulated live in `record_response_usage` before serialization — only the trajectory-rederived `final_*` break.

## Fix (in the spirit of v1)

v1 already tracks usage at write time from the live `Response`, with `state` as the serializable source of truth. So compute the context-token metrics there too, instead of re-parsing the serialized trajectory:

- `record_response_usage` now accumulates `final_output_tokens` (running sum of completions) and `final_input_tokens` (latest step's full context − completions), mirroring `compute_context_token_metrics`'s formula for a linear rollout.
- `state_to_output` prefers these write-time values when present, and only falls back to recomputing from the trajectory for classic envs (live `Response` objects). Additive — classic path unchanged.

## Verification

- `tests/test_context_token_metrics.py`, `tests/test_save_utils.py` pass; updated `test_v1_runtime_lifecycle::test_v1_records_default_metrics_usage_and_timing` to assert the new keys.
- ruff check/format + `ty` clean.
- Ran `prime-rl`'s `configs/debug/reverse_text_v1.toml` end-to-end on GPU: `seq_len/all/mean` went `0 → 167.96` (≈ prefill 51.75 + decode 116.2), `progress/tokens` `0 → 21499`.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Record `final_output_tokens` and `final_input_tokens` in token usage at write time
> - [`record_response_usage`](https://github.com/PrimeIntellect-ai/verifiers/pull/1525/files#diff-ed5e732c8e230f9c998aff9a5bb8f4a1b8b3e21ebaa4bc7a08c3497f801cafa5) now accumulates `final_output_tokens` and `final_input_tokens` into `state['token_usage']` on each response, using a running max-offset calculation for input tokens.
> - [`state_to_output`](https://github.com/PrimeIntellect-ai/verifiers/pull/1525/files#diff-e4491159a12a733bc8861a33ba9d2d09b27942f04c4baa1629f0806efa07547d) prefers these pre-recorded values when serializing `RolloutOutput['token_usage']`, falling back to computing context metrics from the trajectory when absent.
> - Behavioral Change: rollouts using the v1 runtime will now populate `final_output_tokens` and `final_input_tokens` from accumulated state rather than post-hoc trajectory computation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 747e8f2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metrics-only change with a classic-env fallback; no auth or data-path changes, though multi-turn v1 rollouts depend on the same linear-rollout formula as the existing helper.
> 
> **Overview**
> **v1 rollouts** were exporting **`final_input_tokens` / `final_output_tokens` as zero** because `state_to_output` recomputed them from the trajectory via `compute_context_token_metrics`, which only counts live `Response` objects—v1 stores serialized dicts in the trajectory.
> 
> **`record_response_usage`** now accumulates **`final_output_tokens`** (running completion sum) and **`final_input_tokens`** (latest step total context minus that sum) on each model response, using the same linear-rollout logic as the shared helper.
> 
> **`state_to_output`** copies those fields from `state["token_usage"]` when both are present; otherwise it still recomputes from the trajectory for classic envs. Lifecycle test expectations were updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 747e8f21a70ca2b15aa0dfb0218b86cdfee9b123. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->