### PR TITLE
Fix InterceptionServer re-binding a stale port across restarts

### DIFF
--- a/verifiers/utils/interception_utils.py
+++ b/verifiers/utils/interception_utils.py
@@ -69,6 +69,7 @@ class InterceptionServer:
     """
 
     def __init__(self, port: int, secret: str | None = None):
+        self._initial_port = port  # requested port (0 = OS-assigned); see stop()
         self.port = port
         self.secret = secret or secrets.token_urlsafe(32)
         self._app: Any = None
@@ -158,6 +159,9 @@ class InterceptionServer:
                     self._runner = None
                     self._site = None
                     self._app = None
+                    # Reset to the requested port so the next start() re-resolves
+                    # a fresh OS port instead of re-binding the stale cached one.
+                    self.port = self._initial_port
 
     def _set_rollout_error(self, rollout_id: str, error: BaseException) -> None:
         """Attach `error` to the rollout's state if one is registered and


### PR DESCRIPTION
stop() cleared _app/_runner/_site but left self.port at the OS-assigned value from the first start(), so a later start() re-bound that exact port (the getsockname() readback only runs when self.port == 0). If something else took that port in the meantime, the restart failed and stayed stuck on the dead port.

Capture the originally-requested port as self._initial_port and reset self.port to it in stop(), so an OS-assigned server (initial port 0) re-resolves a fresh port on restart while an explicit-port server keeps its port.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small lifecycle fix in the HTTP interception server; no auth, data, or API contract changes.
> 
> **Overview**
> Fixes **InterceptionServer** lifecycle so **stop/start** cycles do not keep reusing a stale OS-assigned listen port.
> 
> On first **start** with `port=0`, the resolved port was written to `self.port`, but **stop** only tore down aiohttp without resetting that value. A later **start** then tried to bind that exact port (because `getsockname()` refresh only runs when `port == 0`), which could fail if the port was taken elsewhere.
> 
> The change stores the originally requested port as `_initial_port` and resets `self.port` to it in **stop**, so port `0` gets a fresh assignment on restart while an explicit port is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 887db3aef3cce6dc6322fdd2a40fcf3a06fc67b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `InterceptionServer` re-binding a stale port after restart
> When `InterceptionServer` restarts, `self.port` could retain the previously bound port rather than the originally requested one. This fix stores the initially requested port in `_initial_port` at construction and resets `self.port` to it at the end of `stop()`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 887db3a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->