### PR TITLE
Use registry images for Scale-SWE

### DIFF
--- a/verifiers/envs/experimental/composable/tasksets/swe/scale_swe/taskset.py
+++ b/verifiers/envs/experimental/composable/tasksets/swe/scale_swe/taskset.py
@@ -34,6 +34,7 @@ from verifiers.envs.experimental.composable import SandboxSpec, SandboxTaskSet
 logger = logging.getLogger(__name__)
 
 DATASET_NAME = "AweAI-Team/Scale-SWE"
+REGISTRY_PREFIX = "us-central1-docker.pkg.dev/prime-intellect-platform/prod-sandbox"
 
 ENV_VARS_SCALE_SWE = {
     "PATH": (
@@ -68,6 +69,13 @@ if __name__ == "__main__":
     ret = pytest.main(args)
     print("<pytest>true</pytest>" if ret == 0 else "<pytest>false</pytest>")
 """
+
+
+def _build_docker_image(info: dict) -> str:
+    image = info["image_url"]
+    if image.startswith(REGISTRY_PREFIX):
+        return image
+    return f"{REGISTRY_PREFIX}/{image}"
 
 
 class ScaleSWERubric(vf.Rubric):
@@ -155,7 +163,7 @@ class ScaleSWETaskSet(SandboxTaskSet):
 
     def get_sandbox_spec(self, info: dict) -> SandboxSpec:
         return SandboxSpec(
-            image=info["image_url"],
+            image=_build_docker_image(info),
             timeout_minutes=self.timeout_minutes,
         )
 


### PR DESCRIPTION
## Summary
- add Scale-SWE registry image mapping using the existing Prime sandbox registry prefix
- preserve already-prefixed Scale-SWE image refs to avoid double-prefixing

## Verification
- `uv run python - <<'PY' ...` checked raw and already-prefixed ScaleSWE image refs both resolve to the registry ref
- `uv run pre-commit run --files verifiers/envs/experimental/composable/tasksets/swe/scale_swe/taskset.py`
- pre-push hook: `ty (ci parity)`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small image-resolution change aligned with other SWE tasksets; no auth, scoring, or test logic changes.
> 
> **Overview**
> Scale-SWE sandboxes now resolve task Docker images through the **Prime prod-sandbox registry** instead of using raw `image_url` values from the dataset.
> 
> A shared `REGISTRY_PREFIX` and `_build_docker_image()` helper prefix `info["image_url"]` with that registry path when it is not already fully qualified, matching the pattern used for Multi-SWE. `get_sandbox_spec()` passes the resolved ref into `SandboxSpec.image`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95d6db95d06fc93dedeb9e25917ee103056d8360. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use registry-qualified images for Scale-SWE sandbox specs
> Adds a `_build_docker_image` helper in [taskset.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1531/files#diff-23125490be4e237e9c65e271e04b455ad8dc137bf887da4fada5749137f04d33) that prefixes `info['image_url']` with the `us-central1-docker.pkg.dev/prime-intellect-platform/prod-sandbox/` registry path unless the URL already starts with that prefix. `ScaleSWETaskSet.get_sandbox_spec` now uses this helper instead of passing `info['image_url']` directly to `SandboxSpec`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 95d6db9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->