### PR TITLE
fix: feed resolved system prompt into RLM agent

### DIFF
--- a/packages/harnesses/harnesses/rlm.py
+++ b/packages/harnesses/harnesses/rlm.py
@@ -42,7 +42,10 @@ class RLMProgramConfig(vf.ProgramConfig):
                 "fn": "verifiers.v1.utils.prompt_utils:task_text",
                 "keys": ["instruction", "question"],
             },
-            RLM_DEFAULT_APPEND_TO_SYSTEM_PROMPT_PATH: self.append_to_system_prompt,
+            RLM_DEFAULT_APPEND_TO_SYSTEM_PROMPT_PATH: {
+                "fn": "harnesses.utils.rlm_utils:rlm_append_to_system_prompt",
+                "append": self.append_to_system_prompt,
+            },
             DEFAULT_RLM_TOOL_SKILLS_ARCHIVE_PATH: {
                 "fn": "harnesses.utils.rlm_utils:rlm_tool_skills_archive"
             },

--- a/packages/harnesses/harnesses/utils/rlm_utils.py
+++ b/packages/harnesses/harnesses/utils/rlm_utils.py
@@ -17,7 +17,9 @@ from verifiers.envs.experimental.utils.git_checkout_cache import (
 )
 from verifiers.v1.runtime import Runtime
 from verifiers.v1.state import State
+from verifiers.v1.task import Task
 from verifiers.v1.types import ConfigData
+from verifiers.v1.utils.prompt_utils import state_system_prompt_text
 
 DEFAULT_RLM_CHECKOUT_PATH = "/tmp/rlm-checkout"
 DEFAULT_RLM_SKILLS_PATH = "/task/rlm-skills"
@@ -28,6 +30,21 @@ DEFAULT_RLM_LOCAL_CHECKOUT_CACHE_ROOT = (
     Path.home() / ".cache" / "verifiers" / "rlm-checkouts"
 )
 REQUIRED_RLM_CHECKOUT_FILES = ("install.sh", "pyproject.toml")
+
+
+def rlm_append_to_system_prompt(task: Task, state: State, append: str = "") -> str:
+    """Text appended to the RLM agent's built-in system prompt.
+
+    The ``rlm`` tool builds its own coding-agent system prompt and tacks
+    ``RLM_APPEND_TO_SYSTEM_PROMPT`` on after it, so the agent reads the
+    harness prompt first and the task instructions second. We feed that env
+    var the resolved ``state["system_prompt"]`` (harness + taskset/task,
+    ordered by the harness ``system_prompt_strategy``) joined with the
+    program's static ``append_to_system_prompt`` — otherwise a taskset's
+    ``load_system_prompt`` is silently dropped under the RLM harness.
+    """
+    resolved = state_system_prompt_text(task, state)
+    return "\n\n".join(part for part in (resolved, append) if part)
 
 
 def rlm_checkout_path(

--- a/packages/harnesses/harnesses/utils/rlm_utils.py
+++ b/packages/harnesses/harnesses/utils/rlm_utils.py
@@ -33,16 +33,9 @@ REQUIRED_RLM_CHECKOUT_FILES = ("install.sh", "pyproject.toml")
 
 
 def rlm_append_to_system_prompt(task: Task, state: State, append: str = "") -> str:
-    """Text appended to the RLM agent's built-in system prompt.
-
-    The ``rlm`` tool builds its own coding-agent system prompt and tacks
-    ``RLM_APPEND_TO_SYSTEM_PROMPT`` on after it, so the agent reads the
-    harness prompt first and the task instructions second. We feed that env
-    var the resolved ``state["system_prompt"]`` (harness + taskset/task,
-    ordered by the harness ``system_prompt_strategy``) joined with the
-    program's static ``append_to_system_prompt`` — otherwise a taskset's
-    ``load_system_prompt`` is silently dropped under the RLM harness.
-    """
+    """Resolved ``state["system_prompt"]`` joined with the static ``append``,
+    fed to ``RLM_APPEND_TO_SYSTEM_PROMPT`` so the rlm tool tacks the task
+    system prompt onto its built-in coding-agent prompt."""
     resolved = state_system_prompt_text(task, state)
     return "\n\n".join(part for part in (resolved, append) if part)
 

--- a/tests/test_v1_rlm_swe.py
+++ b/tests/test_v1_rlm_swe.py
@@ -19,10 +19,8 @@ from harnesses.rlm import (
     DEFAULT_RLM_TOOL_SKILL_MARKER,
     DEFAULT_RLM_TOOL_SKILLS_ARCHIVE_PATH,
     DEFAULT_RLM_TOOL_SKILLS_MANIFEST_NAME,
-    RLM_DEFAULT_APPEND_TO_SYSTEM_PROMPT_PATH,
 )
 from harnesses.utils.rlm_utils import rlm_tool_skills_archive
-from harnesses.utils.rlm_utils import rlm_append_to_system_prompt
 from harnesses.utils.rlm_utils import rlm_skills_dir
 from verifiers.v1.utils.program_utils import merge_task_program, merge_task_sandbox
 
@@ -96,44 +94,6 @@ def test_rlm_harness_accepts_typed_config_surface():
     assert program_env["RLM_TOOLS"] == "bash,edit"
     assert program_env["RLM_EXEC_TIMEOUT"] == "11"
     assert program_env["CUSTOM"] == "1"
-
-
-def test_rlm_harness_append_file_resolves_system_prompt():
-    harness = RLM(
-        config=RLMConfig(
-            program=RLMProgramConfig(
-                local_checkout="/tmp/checkout",
-                append_to_system_prompt="Extra note.",
-            )
-        )
-    )
-    program = as_dict(harness.config.program)
-    files = as_dict(program["files"])
-
-    assert files[RLM_DEFAULT_APPEND_TO_SYSTEM_PROMPT_PATH] == {
-        "fn": "harnesses.utils.rlm_utils:rlm_append_to_system_prompt",
-        "append": "Extra note.",
-    }
-
-
-def test_rlm_append_to_system_prompt_includes_taskset_prompt():
-    task = vf.Task({"prompt": []}).freeze()
-    state = vf.State.for_task(task)
-    state["system_prompt"] = [{"role": "system", "content": "Game rules."}]
-
-    # Taskset/task system prompt flows through on its own.
-    assert rlm_append_to_system_prompt(task, state) == "Game rules."
-    # Static append is tacked on after the resolved prompt.
-    assert (
-        rlm_append_to_system_prompt(task, state, append="Extra note.")
-        == "Game rules.\n\nExtra note."
-    )
-    # With no resolved system prompt, only the static append remains.
-    state["system_prompt"] = []
-    assert (
-        rlm_append_to_system_prompt(task, state, append="Extra note.") == "Extra note."
-    )
-    assert rlm_append_to_system_prompt(task, state) == ""
 
 
 def test_rlm_endpoint_hides_nested_depth_requests():

--- a/tests/test_v1_rlm_swe.py
+++ b/tests/test_v1_rlm_swe.py
@@ -19,8 +19,10 @@ from harnesses.rlm import (
     DEFAULT_RLM_TOOL_SKILL_MARKER,
     DEFAULT_RLM_TOOL_SKILLS_ARCHIVE_PATH,
     DEFAULT_RLM_TOOL_SKILLS_MANIFEST_NAME,
+    RLM_DEFAULT_APPEND_TO_SYSTEM_PROMPT_PATH,
 )
 from harnesses.utils.rlm_utils import rlm_tool_skills_archive
+from harnesses.utils.rlm_utils import rlm_append_to_system_prompt
 from harnesses.utils.rlm_utils import rlm_skills_dir
 from verifiers.v1.utils.program_utils import merge_task_program, merge_task_sandbox
 
@@ -94,6 +96,44 @@ def test_rlm_harness_accepts_typed_config_surface():
     assert program_env["RLM_TOOLS"] == "bash,edit"
     assert program_env["RLM_EXEC_TIMEOUT"] == "11"
     assert program_env["CUSTOM"] == "1"
+
+
+def test_rlm_harness_append_file_resolves_system_prompt():
+    harness = RLM(
+        config=RLMConfig(
+            program=RLMProgramConfig(
+                local_checkout="/tmp/checkout",
+                append_to_system_prompt="Extra note.",
+            )
+        )
+    )
+    program = as_dict(harness.config.program)
+    files = as_dict(program["files"])
+
+    assert files[RLM_DEFAULT_APPEND_TO_SYSTEM_PROMPT_PATH] == {
+        "fn": "harnesses.utils.rlm_utils:rlm_append_to_system_prompt",
+        "append": "Extra note.",
+    }
+
+
+def test_rlm_append_to_system_prompt_includes_taskset_prompt():
+    task = vf.Task({"prompt": []}).freeze()
+    state = vf.State.for_task(task)
+    state["system_prompt"] = [{"role": "system", "content": "Game rules."}]
+
+    # Taskset/task system prompt flows through on its own.
+    assert rlm_append_to_system_prompt(task, state) == "Game rules."
+    # Static append is tacked on after the resolved prompt.
+    assert (
+        rlm_append_to_system_prompt(task, state, append="Extra note.")
+        == "Game rules.\n\nExtra note."
+    )
+    # With no resolved system prompt, only the static append remains.
+    state["system_prompt"] = []
+    assert (
+        rlm_append_to_system_prompt(task, state, append="Extra note.") == "Extra note."
+    )
+    assert rlm_append_to_system_prompt(task, state) == ""
 
 
 def test_rlm_endpoint_hides_nested_depth_requests():


### PR DESCRIPTION
## Summary

- The RLM harness runs `rlm` as a command program and never consumed `state["system_prompt"]`, so a taskset's `load_system_prompt` was silently dropped under `harnesses.rlm`. Every other coding-agent harness (`pi`, `mini_swe_agent`, `opencode`, `terminus_2`) already writes `state_system_prompt_text` into its agent's system prompt; RLM was the outlier.
- Add a `rlm_append_to_system_prompt` helper that joins the resolved system prompt (harness + taskset/task, ordered by `system_prompt_strategy`) with the program's static `append_to_system_prompt`, and feed it into `RLM_APPEND_TO_SYSTEM_PROMPT`.
- The `rlm` tool appends this after its built-in coding-agent prompt, so the agent reads the **harness prompt first, then the task system prompt** — the requested ordering.

## Verification

Before (e.g. `wikispeedia` under `harnesses.rlm`), the agent only saw the generic "You are a coding agent…" prompt; the game rules were missing. After, running:

```
uv run vf-eval wikispeedia -n1 -r1 -d -v -a '{"config": {"harness": {"id": "harnesses.rlm"}}}' -s
```

the agent's system prompt ends with:

```
... Call at most one built-in tool per turn.

This game is easy and fun:

You are given two Wikipedia articles. Starting from the first article, your goal is to reach the second one ... Use the `click_link` tool to navigate to one. Use `go_back` to undo your last click.
...
```

Added unit tests cover the wiring (`files[...]` resolves to the helper with the static `append` passed through) and the join behavior (resolved-only, resolved + static, static-only, empty).

Envs that already stuff their prompt into `append_to_system_prompt` (rlm_oolong, rlm_swe, …) define no taskset `load_system_prompt`, so their resolved prompt is empty and behavior is unchanged.

Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix RLM agent to receive the resolved system prompt at runtime
> - Previously, `RLMProgramConfig.resolve` mapped `RLM_DEFAULT_APPEND_TO_SYSTEM_PROMPT_PATH` to the static `append_to_system_prompt` string directly, so the task/state system prompt was never included.
> - Now the mapping uses a dynamic resolver dict that calls the new `rlm_append_to_system_prompt` utility in [rlm_utils.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1532/files#diff-fe3f0ade3ce9da9168fdf63cb7303119f8a64f7553fdf2269ffeec258f8c997e), which combines the resolved system prompt from `state_system_prompt_text(task, state)` with the static append string, separated by a blank line.
> - Behavioral Change: the file written to `RLM_DEFAULT_APPEND_TO_SYSTEM_PROMPT_PATH` now contains the full resolved system prompt in addition to any static append text, where before it contained only the static append text.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 04912d7. (Automatic summaries will resume when PR exits draft mode or review begins).</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->