### PR TITLE
fix: default rollout max_retries to 3

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1131,7 +1131,7 @@ class EvalConfig(BaseModel):
     max_concurrent: int
     independent_scoring: bool = False
     extra_env_kwargs: dict = {}
-    max_retries: int = 0
+    max_retries: int = 3
     verbose: bool = False
     state_columns: list[str] | None = None
     save_results: bool = False

--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -594,8 +594,8 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--max-retries",
         type=int,
-        default=0,
-        help="Max retries for transient infrastructure errors (default: 0)",
+        default=3,
+        help="Max retries for transient infrastructure errors (default: 3)",
     )
     parser.add_argument(
         "--disable-env-server",
@@ -958,7 +958,7 @@ def main(argv: list[str] | None = None):
             num_examples=num_examples,
             rollouts_per_example=rollouts_per_example,
             max_concurrent=raw.get("max_concurrent", DEFAULT_MAX_CONCURRENT),
-            max_retries=raw.get("max_retries", 0),
+            max_retries=raw.get("max_retries", 3),
             num_workers=raw.get("num_workers", "auto"),
             disable_env_server=raw.get("disable_env_server", False),
             verbose=raw.get("verbose", False),

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -1329,7 +1329,7 @@ class EvalConfig(BaseModel):
     num_workers: int | str = "auto"
     independent_scoring: bool = False
     extra_env_kwargs: dict = {}
-    max_retries: int = 0
+    max_retries: int = 3
     disable_env_server: bool = False
     # logging
     verbose: bool = False


### PR DESCRIPTION
## Summary
- Default the eval rollout retry count for transient infrastructure errors to `3` instead of `0`.
- Updated `EvalConfig.max_retries`, the `vf-eval --max-retries` CLI flag (default + help text), and the eval config ingestion fallback.
- Updated the `EvalConfig` reference docs to match.

## Breaking
- `vf-eval` / eval configs now retry transient infra errors up to 3 times by default. To restore the previous behavior, pass `--max-retries 0` (or set `max_retries = 0` in the eval config).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Default-only behavior change for eval retries; no auth or data paths. Slightly longer runs on flaky infra unless callers opt out with max_retries=0.
> 
> **Overview**
> Changes the **default rollout retry count** for transient infrastructure errors from **0** to **3** across eval configuration.
> 
> **`EvalConfig.max_retries`**, **`vf-eval --max-retries`** (default and help text), and the eval config builder fallback when `max_retries` is omitted now use **3**. Reference docs for **`EvalConfig`** match.
> 
> **Breaking:** Evals retry failed rollouts up to three times by default (via `maybe_retry` around rollout/group execution). Use **`--max-retries 0`** or **`max_retries = 0`** in config to keep the old no-retry behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cbdeba979b9e4880d6daf1b3fc0845849287953. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default `max_retries` to 3 in rollout eval configuration
> Changes the default value of `max_retries` from `0` to `3` in [`EvalConfig`](https://github.com/PrimeIntellect-ai/verifiers/pull/1533/files#diff-8bc45ba080ed8ff01ee6adbafb54c0346181c6f292928e53c2a94dd9ed5156c3), the CLI argument parser, and the TOML config loader in [`eval.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1533/files#diff-6b37997f6eb279df06f6c885920ff82ac5940e25ca859a9dd445bdc4028277b6). Documentation in [`docs/reference.md`](https://github.com/PrimeIntellect-ai/verifiers/pull/1533/files#diff-e210870c197f23a0840de87fbe37e0803aaa4c48ac5108fb14e2bcee8855199b) is updated to match. Behavioral Change: any eval run that previously relied on the default of `0` retries will now retry up to 3 times automatically.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4cbdeba.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->