### PR TITLE
refactor: clean up rlm config

### DIFF
--- a/.semgrep/verifiers.yml
+++ b/.semgrep/verifiers.yml
@@ -95,7 +95,6 @@ rules:
         - /environments/dspy_rlm/dspy_rlm.py
         - /environments/hello_group_reward_v1/hello_group_reward_v1.py
         - /environments/hello_parallel_sandbox_v1/hello_parallel_sandbox_v1.py
-        - /environments/hello_rlm_v1/hello_rlm_v1.py
         - /environments/hello_self_judge_v1/hello_self_judge_v1.py
         - /environments/hello_subagent_v1/hello_subagent_v1.py
         - /environments/langchain_deep_agents_wikispeedia/langchain_deep_agents_wikispeedia.py

--- a/.semgrep/verifiers.yml
+++ b/.semgrep/verifiers.yml
@@ -95,6 +95,7 @@ rules:
         - /environments/dspy_rlm/dspy_rlm.py
         - /environments/hello_group_reward_v1/hello_group_reward_v1.py
         - /environments/hello_parallel_sandbox_v1/hello_parallel_sandbox_v1.py
+        - /environments/hello_rlm_v1/hello_rlm_v1.py
         - /environments/hello_self_judge_v1/hello_self_judge_v1.py
         - /environments/hello_subagent_v1/hello_subagent_v1.py
         - /environments/langchain_deep_agents_wikispeedia/langchain_deep_agents_wikispeedia.py

--- a/environments/hello_rlm_v1/hello_rlm_v1.py
+++ b/environments/hello_rlm_v1/hello_rlm_v1.py
@@ -28,7 +28,7 @@ class HelloRLMTaskset(vf.Taskset[HelloRLMTasksetConfig]):
         return [tasks[i] for i in wanted]
 
     @vf.reward(weight=1.0)
-    async def exact_answer(task, state) -> float:
+    async def exact_answer(self, task, state) -> float:
         stdout = str(state.get("command", {}).get("stdout") or "")
         return float(str(task["answer"]).lower() in stdout.lower())
 

--- a/environments/hello_rlm_v1/hello_rlm_v1.py
+++ b/environments/hello_rlm_v1/hello_rlm_v1.py
@@ -8,59 +8,63 @@ async def exact_answer(task, state) -> float:
     return float(str(task["answer"]).lower() in stdout.lower())
 
 
+# Each task exercises a distinct RLM capability end-to-end. Indices are stable
+# so callers can pin a subset via `task_idx` on the taskset config.
+TASKS: list[dict[str, str]] = [
+    # 0: plain text echo — no tools needed.
+    {
+        "question": "Reply with exactly 'hello rlm'.",
+        "answer": "hello rlm",
+    },
+    # 1: ipython tool — model must run Python in the persistent REPL to print
+    # the answer rather than answering inline.
+    {
+        "question": (
+            "Use your ipython tool to print exactly the string 'hello rlm' "
+            "(no quotes, no extra text). Do not answer in plain text."
+        ),
+        "answer": "hello rlm",
+    },
+    # 2: ipython shell escape — exercise the `!cmd` shell passthrough.
+    {
+        "question": (
+            "Inside an ipython cell, use the `!` shell escape to run "
+            "`echo hello rlm` so the shell prints the literal string."
+        ),
+        "answer": "hello rlm",
+    },
+    # 3: ipython arithmetic — answer requires actual computation, not echo.
+    {
+        "question": (
+            "Use the ipython tool to compute 7! (the factorial of 7) and "
+            "report the result as a single integer."
+        ),
+        "answer": "5040",
+    },
+]
+
+
 def load_tasks(split: vf.TaskSplit = "train"):
     _ = split
-    return [
-        {
-            "question": "Reply with exactly hello rlm.",
-            "answer": "hello rlm",
-        },
-        {
-            "question": "Reply with exactly taskset harness.",
-            "answer": "taskset harness",
-        },
-        {
-            "question": "Reply with exactly runtime boundary.",
-            "answer": "runtime boundary",
-        },
-        {
-            "question": "Reply with exactly sandbox lease.",
-            "answer": "sandbox lease",
-        },
-        {
-            "question": "Reply with exactly toolset scope.",
-            "answer": "toolset scope",
-        },
-        {
-            "question": "Reply with exactly group reward.",
-            "answer": "group reward",
-        },
-        {
-            "question": "Reply with exactly endpoint proxy.",
-            "answer": "endpoint proxy",
-        },
-        {
-            "question": "Reply with exactly cleanup signal.",
-            "answer": "cleanup signal",
-        },
-        {
-            "question": "Reply with exactly harbor task.",
-            "answer": "harbor task",
-        },
-        {
-            "question": "Reply with exactly recursive model.",
-            "answer": "recursive model",
-        },
-    ]
+    return list(TASKS)
 
 
 class HelloRLMTasksetConfig(vf.TasksetConfig):
     rewards: list[str] = ["exact_answer"]
+    task_idx: int | list[int] | None = None
+    """Restrict the taskset to a subset of `TASKS` by index. Useful for dev
+    runs that only want to exercise one capability (e.g. `task_idx=1` for the
+    ipython-tool test). `None` means run all tasks."""
 
 
 class HelloRLMTaskset(vf.Taskset[HelloRLMTasksetConfig]):
     def load_tasks(self, split: vf.TaskSplit = "train") -> vf.Tasks:
-        return load_tasks(split)
+        tasks = load_tasks(split)
+        idx = self.config.task_idx
+        if idx is None:
+            return tasks
+        wanted = [idx] if isinstance(idx, int) else list(idx)
+        return [tasks[i] for i in wanted]
 
 
 def load_taskset(config: HelloRLMTasksetConfig) -> HelloRLMTaskset:

--- a/environments/hello_rlm_v1/hello_rlm_v1.py
+++ b/environments/hello_rlm_v1/hello_rlm_v1.py
@@ -32,10 +32,6 @@ class HelloRLMTaskset(vf.Taskset[HelloRLMTasksetConfig]):
         stdout = str(state.get("command", {}).get("stdout") or "")
         return float(str(task["answer"]).lower() in stdout.lower())
 
-    @vf.stop
-    async def max_turns_reached(self, state) -> bool:
-        return len(state.get("trajectory", [])) >= 1
-
 
 def load_taskset(config: HelloRLMTasksetConfig) -> HelloRLMTaskset:
     return HelloRLMTaskset(config=config)

--- a/environments/hello_rlm_v1/hello_rlm_v1.py
+++ b/environments/hello_rlm_v1/hello_rlm_v1.py
@@ -1,56 +1,17 @@
 import verifiers as vf
 from harnesses import RLM, RLMConfig
 
-
-@vf.reward(weight=1.0)
-async def exact_answer(task, state) -> float:
-    stdout = str(state.get("command", {}).get("stdout") or "")
-    return float(str(task["answer"]).lower() in stdout.lower())
-
-
-# Each task exercises a distinct RLM capability end-to-end. Indices are stable
-# so callers can pin a subset via `task_idx` on the taskset config.
 TASKS: list[dict[str, str]] = [
-    # 0: plain text echo — no tools needed.
-    {
-        "question": "Reply with exactly 'hello rlm'.",
-        "answer": "hello rlm",
-    },
-    # 1: ipython tool — model must run Python in the persistent REPL to print
-    # the answer rather than answering inline.
-    {
-        "question": (
-            "Use your ipython tool to print exactly the string 'hello rlm' "
-            "(no quotes, no extra text). Do not answer in plain text."
-        ),
-        "answer": "hello rlm",
-    },
-    # 2: ipython shell escape — exercise the `!cmd` shell passthrough.
-    {
-        "question": (
-            "Inside an ipython cell, use the `!` shell escape to run "
-            "`echo hello rlm` so the shell prints the literal string."
-        ),
-        "answer": "hello rlm",
-    },
-    # 3: ipython arithmetic — answer requires actual computation, not echo.
-    {
-        "question": (
-            "Use the ipython tool to compute 7! (the factorial of 7) and "
-            "report the result as a single integer."
-        ),
-        "answer": "5040",
-    },
+    # 0: plain text
+    {"question": "Say 'hello rlm'.", "answer": "hello rlm"},
+    # 1: python
+    {"question": "Use ipython to print 'hello rlm'.", "answer": "hello rlm"},
+    # 2: bash
+    {"question": "Use `!echo hello rlm` in ipython.", "answer": "hello rlm"},
 ]
 
 
-def load_tasks(split: vf.TaskSplit = "train"):
-    _ = split
-    return list(TASKS)
-
-
 class HelloRLMTasksetConfig(vf.TasksetConfig):
-    rewards: list[str] = ["exact_answer"]
     task_idx: int | list[int] | None = None
     """Restrict the taskset to a subset of `TASKS` by index. Useful for dev
     runs that only want to exercise one capability (e.g. `task_idx=1` for the
@@ -59,12 +20,21 @@ class HelloRLMTasksetConfig(vf.TasksetConfig):
 
 class HelloRLMTaskset(vf.Taskset[HelloRLMTasksetConfig]):
     def load_tasks(self, split: vf.TaskSplit = "train") -> vf.Tasks:
-        tasks = load_tasks(split)
+        tasks = list(TASKS)
         idx = self.config.task_idx
         if idx is None:
             return tasks
         wanted = [idx] if isinstance(idx, int) else list(idx)
         return [tasks[i] for i in wanted]
+
+    @vf.reward(weight=1.0)
+    async def exact_answer(task, state) -> float:
+        stdout = str(state.get("command", {}).get("stdout") or "")
+        return float(str(task["answer"]).lower() in stdout.lower())
+
+    @vf.stop
+    async def max_turns_reached(self, state) -> bool:
+        return len(state.get("trajectory", [])) >= 1
 
 
 def load_taskset(config: HelloRLMTasksetConfig) -> HelloRLMTaskset:
@@ -75,8 +45,13 @@ def load_harness(config: RLMConfig) -> RLM:
     return RLM(config=config)
 
 
-def load_environment(config: vf.EnvConfig) -> vf.Env:
+class HelloRLMEnvConfig(vf.EnvConfig):
+    taskset: HelloRLMTasksetConfig = HelloRLMTasksetConfig()
+    harness: RLMConfig = RLMConfig()
+
+
+def load_environment(config: HelloRLMEnvConfig) -> vf.Env:
     return vf.Env(
-        taskset=vf.load_taskset(config=config.taskset),
-        harness=vf.load_harness(config=config.harness),
+        taskset=load_taskset(config=config.taskset),
+        harness=load_harness(config=config.harness),
     )

--- a/environments/hello_rlm_v1/hello_rlm_v1.py
+++ b/environments/hello_rlm_v1/hello_rlm_v1.py
@@ -1,7 +1,7 @@
 import verifiers as vf
 from harnesses import RLM, RLMConfig
 
-TASKS: list[dict[str, str]] = [
+TASKS = [
     # 0: plain text
     {"question": "Say 'hello rlm'.", "answer": "hello rlm"},
     # 1: python

--- a/environments/hello_rlm_v1/hello_rlm_v1.py
+++ b/environments/hello_rlm_v1/hello_rlm_v1.py
@@ -41,13 +41,8 @@ def load_harness(config: RLMConfig) -> RLM:
     return RLM(config=config)
 
 
-class HelloRLMEnvConfig(vf.EnvConfig):
-    taskset: HelloRLMTasksetConfig = HelloRLMTasksetConfig()
-    harness: RLMConfig = RLMConfig()
-
-
-def load_environment(config: HelloRLMEnvConfig) -> vf.Env:
+def load_environment(config: vf.EnvConfig) -> vf.Env:
     return vf.Env(
-        taskset=load_taskset(config=config.taskset),
-        harness=load_harness(config=config.harness),
+        taskset=vf.load_taskset(config=config.taskset),
+        harness=vf.load_harness(config=config.harness),
     )

--- a/environments/rlm_swe_v1/README.md
+++ b/environments/rlm_swe_v1/README.md
@@ -21,8 +21,8 @@ env = load_environment(
         taskset=RlmSweTasksetConfig(timeout_minutes=90),
         harness=RLMConfig(
             program=RLMProgramConfig(
-                local_checkout="/path/to/checkout",
-                rlm_tools=["bash", "edit"],
+                repo_path="/path/to/checkout",
+                tools=["bash", "edit"],
             )
         ),
     )

--- a/environments/rlm_swe_v1/rlm_swe_v1.py
+++ b/environments/rlm_swe_v1/rlm_swe_v1.py
@@ -492,7 +492,6 @@ def load_taskset(
 
 
 class RlmSweProgramConfig(RLMProgramConfig):
-    workdir: str = DEFAULT_REPO_PATH
     tools: list[str] = list(DEFAULT_RLM_TOOLS)
 
 

--- a/environments/rlm_swe_v1/rlm_swe_v1.py
+++ b/environments/rlm_swe_v1/rlm_swe_v1.py
@@ -17,14 +17,33 @@ REGISTRY_PREFIX = "us-central1-docker.pkg.dev/prime-intellect-platform/prod-sand
 
 class RlmSweTasksetConfig(vf.TasksetConfig):
     taskset_id: str = "swe/r2e"
+    """Identifier surfaced to the runtime and stamped on each task row."""
+
     dataset_name: str = "R2E-Gym/R2E-Gym-Subset"
+    """HuggingFace dataset to load SWE instances from."""
+
     repo_path: str = "/testbed"
+    """In-sandbox path to the checked-out repo. Also exported as
+    `AGENT_WORKDIR` and used as the sandbox `workdir`."""
+
     filter_repos: list[str] | None = None
-    ds_num_proc: int | None = None
-    ds_keep_in_memory: bool = True
+    """Optional `repo_name` allow-out list; rows whose `repo_name` is in this
+    set are dropped before task rows are built."""
+
     timeout_minutes: int | None = None
+    """Per-task sandbox timeout in minutes. None leaves the sandbox default
+    (60). Also drives `test_timeout` (`timeout_minutes * 60`)."""
+
     hide_tests_from_agent: bool = True
+    """When True, `/r2e_tests` is archived off the sandbox during setup and
+    restored just before scoring so the agent can't read or modify the test
+    suite. When False, `/r2e_tests` is moved into `repo_path/r2e_tests` and
+    left visible."""
+
     env: vf.ConfigData | None = None
+    """Extra environment variables to merge on top of the SWE baseline
+    (`PATH`, `PAGER`, etc.). Exported into both the agent program env and
+    the test-run env."""
 
 
 def sandbox_config(
@@ -76,16 +95,9 @@ class R2ESWETaskset(vf.Taskset[RlmSweTasksetConfig]):
     def load_tasks(self, split: vf.TaskSplit = "train") -> vf.Tasks:
         repo_path = self.config.repo_path
         task_env = dict(self.config.env or {})
-        dataset_kwargs = dict(
-            num_proc=self.config.ds_num_proc,
-            keep_in_memory=self.config.ds_keep_in_memory,
-            load_from_cache_file=False,
-        )
+        dataset_kwargs = dict(keep_in_memory=True, load_from_cache_file=False)
         dataset = load_dataset(
-            self.config.dataset_name,
-            split="train",
-            keep_in_memory=self.config.ds_keep_in_memory,
-            num_proc=self.config.ds_num_proc,
+            self.config.dataset_name, split="train", keep_in_memory=True
         )
         if self.config.filter_repos:
             filter_set = frozenset(self.config.filter_repos)

--- a/environments/rlm_swe_v1/rlm_swe_v1.py
+++ b/environments/rlm_swe_v1/rlm_swe_v1.py
@@ -4,124 +4,27 @@ import re
 import shlex
 from collections.abc import Mapping
 from pathlib import Path
-from typing import Protocol, cast
+from typing import cast
 
 from datasets import load_dataset
 import verifiers as vf
-from harnesses import RLM, RLMConfig, RLMProgramConfig
+from harnesses import RLM, RLMConfig
 
 logger = logging.getLogger(__name__)
 
 REGISTRY_PREFIX = "us-central1-docker.pkg.dev/prime-intellect-platform/prod-sandbox"
-DEFAULT_DATASET_NAME = "R2E-Gym/R2E-Gym-Subset"
-DEFAULT_REPO_PATH = "/testbed"
-DEFAULT_ALT_PATH = "/root"
-DEFAULT_RLM_TOOLS = ("bash", "edit")
 
 
 class RlmSweTasksetConfig(vf.TasksetConfig):
     taskset_id: str = "swe/r2e"
-    dataset_name: str = DEFAULT_DATASET_NAME
-    repo_path: str = DEFAULT_REPO_PATH
-    alt_path: str = DEFAULT_ALT_PATH
+    dataset_name: str = "R2E-Gym/R2E-Gym-Subset"
+    repo_path: str = "/testbed"
     filter_repos: list[str] | None = None
     ds_num_proc: int | None = None
     ds_keep_in_memory: bool = True
     timeout_minutes: int | None = None
     hide_tests_from_agent: bool = True
     env: vf.ConfigData | None = None
-
-
-class SandboxCommandResult(Protocol):
-    exit_code: int
-    stdout: str | None
-    stderr: str | None
-
-
-class R2ESandbox(Protocol):
-    id: str
-
-    async def execute(
-        self,
-        command: str,
-        working_dir: str | None = None,
-        timeout: int = 90,
-    ) -> SandboxCommandResult: ...
-
-    async def download_file(
-        self, remote_path: str, local_path: str, timeout: int = 300
-    ) -> None: ...
-
-    async def upload_file(
-        self, remote_path: str, local_path: str, timeout: int = 300
-    ) -> None: ...
-
-    async def upload_bytes(self, remote_path: str, data: bytes, name: str) -> None: ...
-
-    async def run_background_job(
-        self, command: str, timeout: int, working_dir: str
-    ) -> SandboxCommandResult: ...
-
-
-def load_tasks(
-    dataset_name: str = DEFAULT_DATASET_NAME,
-    repo_path: str = DEFAULT_REPO_PATH,
-    filter_repos: list[str] | None = None,
-    ds_num_proc: int | None = None,
-    ds_keep_in_memory: bool = True,
-    timeout_minutes: int | None = None,
-    env: vf.ConfigData | None = None,
-) -> list[vf.JsonData]:
-    dataset_kwargs = dict(
-        num_proc=ds_num_proc,
-        keep_in_memory=ds_keep_in_memory,
-        load_from_cache_file=False,
-    )
-    dataset = load_dataset(
-        dataset_name,
-        split="train",
-        keep_in_memory=ds_keep_in_memory,
-        num_proc=ds_num_proc,
-    )
-    if filter_repos:
-        filter_set = frozenset(filter_repos)
-        dataset = dataset.filter(
-            lambda row: row.get("repo_name") not in filter_set,
-            **dataset_kwargs,
-        )
-    dataset = dataset.map(
-        process_r2e_example,
-        remove_columns=dataset.column_names,
-        **dataset_kwargs,
-    )
-    task_env = dict(env or {})
-    rows: list[vf.JsonData] = []
-    for index, row in enumerate(dataset):
-        row = dict(row)
-        info = dict(row["info"])
-        instruction = str(info["problem_statement"])
-        program_env = env_vars(repo_path=repo_path, env=task_env)
-        agent_path = program_env.pop("PATH", None)
-        if agent_path is not None:
-            program_env.setdefault("AGENT_PATH", agent_path)
-        program_env.setdefault("AGENT_WORKDIR", repo_path)
-        task_row: vf.JsonData = {
-            "example_id": index,
-            "task_id": info.get("instance_id") or index,
-            "question": row.get("question", instruction),
-            "instruction": instruction,
-            "prompt": [{"role": "user", "content": instruction}],
-            "answer": row.get("answer", ""),
-            "info": info,
-            "sandbox": sandbox_config(
-                info=info,
-                repo_path=repo_path,
-                timeout_minutes=timeout_minutes,
-            ),
-            "program": {"env": program_env},
-        }
-        rows.append(task_row)
-    return rows
 
 
 def sandbox_config(
@@ -171,21 +74,64 @@ class R2ESWETaskset(vf.Taskset[RlmSweTasksetConfig]):
         )
 
     def load_tasks(self, split: vf.TaskSplit = "train") -> vf.Tasks:
-        return load_tasks(
-            dataset_name=self.config.dataset_name,
-            repo_path=self.config.repo_path,
-            filter_repos=self.config.filter_repos,
-            ds_num_proc=self.config.ds_num_proc,
-            ds_keep_in_memory=self.config.ds_keep_in_memory,
-            timeout_minutes=self.config.timeout_minutes,
-            env=dict(self.config.env or {}),
+        repo_path = self.config.repo_path
+        task_env = dict(self.config.env or {})
+        dataset_kwargs = dict(
+            num_proc=self.config.ds_num_proc,
+            keep_in_memory=self.config.ds_keep_in_memory,
+            load_from_cache_file=False,
         )
+        dataset = load_dataset(
+            self.config.dataset_name,
+            split="train",
+            keep_in_memory=self.config.ds_keep_in_memory,
+            num_proc=self.config.ds_num_proc,
+        )
+        if self.config.filter_repos:
+            filter_set = frozenset(self.config.filter_repos)
+            dataset = dataset.filter(
+                lambda row: row.get("repo_name") not in filter_set,
+                **dataset_kwargs,
+            )
+        dataset = dataset.map(
+            process_r2e_example,
+            remove_columns=dataset.column_names,
+            **dataset_kwargs,
+        )
+        rows: list[vf.JsonData] = []
+        for index, row in enumerate(dataset):
+            row = dict(row)
+            info = dict(row["info"])
+            instruction = str(info["problem_statement"])
+            program_env = env_vars(repo_path=repo_path, env=task_env)
+            agent_path = program_env.pop("PATH", None)
+            if agent_path is not None:
+                program_env.setdefault("AGENT_PATH", agent_path)
+            program_env.setdefault("AGENT_WORKDIR", repo_path)
+            rows.append(
+                {
+                    "example_id": index,
+                    "task_id": info.get("instance_id") or index,
+                    "question": row.get("question", instruction),
+                    "instruction": instruction,
+                    "prompt": [{"role": "user", "content": instruction}],
+                    "answer": row.get("answer", ""),
+                    "info": info,
+                    "sandbox": sandbox_config(
+                        info=info,
+                        repo_path=repo_path,
+                        timeout_minutes=self.config.timeout_minutes,
+                    ),
+                    "program": {"env": program_env},
+                }
+            )
+        return rows
 
     @vf.setup(priority=250)
     async def setup_r2e_sandbox(self, task, state, sandbox=None) -> None:
         if sandbox is None:
             raise RuntimeError("R2E SWE setup requires the active program sandbox.")
-        state["_rlm_swe_sandbox"] = sandbox
+        state["sandbox"] = sandbox
         state["sandbox_id"] = getattr(sandbox, "id", state.get("sandbox_id"))
         sandbox_config = task.get("sandbox")
         if isinstance(sandbox_config, Mapping):
@@ -193,7 +139,7 @@ class R2ESWETaskset(vf.Taskset[RlmSweTasksetConfig]):
             state.setdefault("test_timeout", timeout_minutes * 60)
         await self.setup_sandbox(sandbox, state)
 
-    async def setup_sandbox(self, sandbox: R2ESandbox, state: vf.State) -> None:
+    async def setup_sandbox(self, sandbox, state: vf.State) -> None:
         async def exec_checked(
             command: str, working_dir: str | None = None, timeout: int = 90
         ):
@@ -205,15 +151,6 @@ class R2ESWETaskset(vf.Taskset[RlmSweTasksetConfig]):
                     f"Setup command failed: {command} exit_code={result.exit_code}"
                 )
             return result
-
-        link_commands = [
-            f"ln -s {self.config.repo_path}/.venv {self.config.alt_path}/.venv",
-            f"ln -s {self.config.repo_path}/.venv/bin/python {self.config.alt_path}/.local/bin/python",
-            f"ln -s {self.config.repo_path}/.venv/bin/python {self.config.alt_path}/.local/bin/python3",
-            f"find {self.config.repo_path}/.venv/bin -type f -executable -exec ln -sfn {{}} {self.config.alt_path}/.local/bin/ \\;",
-        ]
-        for command in link_commands:
-            await exec_checked(command)
 
         try:
             cleanup_commands = [
@@ -257,7 +194,7 @@ class R2ESWETaskset(vf.Taskset[RlmSweTasksetConfig]):
     async def solved(self, task, state) -> float:
         if state.get("error") is not None:
             return 0.0
-        sandbox = state.get("_rlm_swe_sandbox")
+        sandbox = state.get("sandbox")
         if sandbox is None:
             return 0.0
         try:
@@ -275,7 +212,7 @@ class R2ESWETaskset(vf.Taskset[RlmSweTasksetConfig]):
 
     async def run_tests(
         self,
-        sandbox: R2ESandbox,
+        sandbox,
         state: vf.State,
         test_timeout: int,
     ) -> str:
@@ -334,7 +271,7 @@ class R2ESWETaskset(vf.Taskset[RlmSweTasksetConfig]):
                 return 0.0
         return 1.0
 
-    async def apply_gold_patch(self, sandbox: R2ESandbox, state: vf.State) -> None:
+    async def apply_gold_patch(self, sandbox, state: vf.State) -> None:
         info = cast(vf.JsonData, state["info"])
         assert isinstance(info, Mapping)
         patch = extract_gold_patch(
@@ -360,7 +297,7 @@ class R2ESWETaskset(vf.Taskset[RlmSweTasksetConfig]):
             )
 
     async def validate_instance(self, state: vf.State) -> bool:
-        sandbox = cast(R2ESandbox, state["_rlm_swe_sandbox"])
+        sandbox = state["sandbox"]
         await self.apply_gold_patch(sandbox, state)
         test_timeout = state.get("test_timeout", 900)
         assert isinstance(test_timeout, int)
@@ -379,7 +316,7 @@ class R2ESWETaskset(vf.Taskset[RlmSweTasksetConfig]):
         archive = state.pop("r2e_tests_archive_local_path", None)
         if isinstance(archive, str):
             Path(archive).unlink(missing_ok=True)
-        state.pop("_rlm_swe_sandbox", None)
+        state.pop("sandbox", None)
 
 
 def process_r2e_example(row: vf.JsonData) -> vf.JsonData:
@@ -485,30 +422,16 @@ def extract_gold_patch(
     return patch
 
 
-def load_taskset(
-    config: RlmSweTasksetConfig,
-) -> R2ESWETaskset:
+def load_taskset(config: RlmSweTasksetConfig) -> R2ESWETaskset:
     return R2ESWETaskset(config=config)
 
 
-class RlmSweProgramConfig(RLMProgramConfig):
-    tools: list[str] = list(DEFAULT_RLM_TOOLS)
-
-
-class RlmSweHarnessConfig(RLMConfig):
-    program: RlmSweProgramConfig = RlmSweProgramConfig()
-
-
-def load_harness(config: RlmSweHarnessConfig) -> RLM:
+def load_harness(config: RLMConfig) -> RLM:
     return RLM(config=config)
 
 
-class RlmSweEnvConfig(vf.EnvConfig):
-    taskset: RlmSweTasksetConfig = RlmSweTasksetConfig()
-    harness: RlmSweHarnessConfig = RlmSweHarnessConfig()
-
-
-def load_environment(config: RlmSweEnvConfig) -> vf.Env:
-    taskset = load_taskset(config=config.taskset)
-    harness = load_harness(config=config.harness)
-    return vf.Env(taskset=taskset, harness=harness)
+def load_environment(config: vf.EnvConfig) -> vf.Env:
+    return vf.Env(
+        taskset=vf.load_taskset(config=config.taskset),
+        harness=vf.load_harness(config=config.harness),
+    )

--- a/environments/rlm_swe_v1/rlm_swe_v1.py
+++ b/environments/rlm_swe_v1/rlm_swe_v1.py
@@ -493,7 +493,7 @@ def load_taskset(
 
 class RlmSweProgramConfig(RLMProgramConfig):
     workdir: str = DEFAULT_REPO_PATH
-    rlm_tools: list[str] = list(DEFAULT_RLM_TOOLS)
+    tools: list[str] = list(DEFAULT_RLM_TOOLS)
 
 
 class RlmSweHarnessConfig(RLMConfig):

--- a/environments/rlm_swe_v1/rlm_swe_v1.py
+++ b/environments/rlm_swe_v1/rlm_swe_v1.py
@@ -13,26 +13,16 @@ from harnesses import RLM, RLMConfig
 logger = logging.getLogger(__name__)
 
 REGISTRY_PREFIX = "us-central1-docker.pkg.dev/prime-intellect-platform/prod-sandbox"
+REPO_PATH = "/testbed"
 
 
 class RlmSweTasksetConfig(vf.TasksetConfig):
-    taskset_id: str = "swe/r2e"
-    """Identifier surfaced to the runtime and stamped on each task row."""
-
     dataset_name: str = "R2E-Gym/R2E-Gym-Subset"
     """HuggingFace dataset to load SWE instances from."""
-
-    repo_path: str = "/testbed"
-    """In-sandbox path to the checked-out repo. Also exported as
-    `AGENT_WORKDIR` and used as the sandbox `workdir`."""
 
     filter_repos: list[str] | None = None
     """Optional `repo_name` allow-out list; rows whose `repo_name` is in this
     set are dropped before task rows are built."""
-
-    timeout_minutes: int | None = None
-    """Per-task sandbox timeout in minutes. None leaves the sandbox default
-    (60). Also drives `test_timeout` (`timeout_minutes * 60`)."""
 
     hide_tests_from_agent: bool = True
     """When True, `/r2e_tests` is archived off the sandbox during setup and
@@ -40,61 +30,23 @@ class RlmSweTasksetConfig(vf.TasksetConfig):
     suite. When False, `/r2e_tests` is moved into `repo_path/r2e_tests` and
     left visible."""
 
-    env: vf.ConfigData | None = None
-    """Extra environment variables to merge on top of the SWE baseline
-    (`PATH`, `PAGER`, etc.). Exported into both the agent program env and
-    the test-run env."""
 
-
-def sandbox_config(
-    *, info: vf.JsonData, repo_path: str, timeout_minutes: int | None
-) -> vf.JsonData:
-    config: vf.JsonData = {
-        "image": f"{REGISTRY_PREFIX}/{info['docker_image']}",
-        "cpu_cores": 4,
-        "memory_gb": 4,
-        "disk_size_gb": 10,
-        "gpu_count": 0,
-        "workdir": repo_path,
-        "scope": "rollout",
-    }
-    if timeout_minutes is not None:
-        config["timeout_minutes"] = timeout_minutes
-    return config
-
-
-def env_vars(*, repo_path: str, env: vf.ConfigData) -> dict[str, str]:
-    return {
-        "PATH": (
-            f"/opt/miniconda3/bin:{repo_path}/.venv/bin:/root/.local/bin:"
-            "/root/.cargo/bin:/go/bin:/usr/local/go/bin:/usr/local/cargo:"
-            "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-        ),
-        "PAGER": "cat",
-        "MANPAGER": "cat",
-        "LESS": "-R",
-        "PIP_PROGRESS_BAR": "off",
-        "TQDM_DISABLE": "1",
-        **{str(key): str(value) for key, value in env.items()},
-    }
+SANDBOX_PATH = (
+    f"/opt/miniconda3/bin:{REPO_PATH}/.venv/bin:/root/.local/bin:"
+    "/root/.cargo/bin:/go/bin:/usr/local/go/bin:/usr/local/cargo:"
+    "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+)
+SANDBOX_ENV = {
+    "PAGER": "cat",
+    "MANPAGER": "cat",
+    "LESS": "-R",
+    "PIP_PROGRESS_BAR": "off",
+    "TQDM_DISABLE": "1",
+}
 
 
 class R2ESWETaskset(vf.Taskset[RlmSweTasksetConfig]):
-    def sandbox_config(self, info: vf.JsonData) -> vf.JsonData:
-        return sandbox_config(
-            info=info,
-            repo_path=self.config.repo_path,
-            timeout_minutes=self.config.timeout_minutes,
-        )
-
-    def get_env_vars(self) -> dict[str, str]:
-        return env_vars(
-            repo_path=self.config.repo_path, env=dict(self.config.env or {})
-        )
-
     def load_tasks(self, split: vf.TaskSplit = "train") -> vf.Tasks:
-        repo_path = self.config.repo_path
-        task_env = dict(self.config.env or {})
         dataset_kwargs = dict(keep_in_memory=True, load_from_cache_file=False)
         dataset = load_dataset(
             self.config.dataset_name, split="train", keep_in_memory=True
@@ -115,11 +67,6 @@ class R2ESWETaskset(vf.Taskset[RlmSweTasksetConfig]):
             row = dict(row)
             info = dict(row["info"])
             instruction = str(info["problem_statement"])
-            program_env = env_vars(repo_path=repo_path, env=task_env)
-            agent_path = program_env.pop("PATH", None)
-            if agent_path is not None:
-                program_env.setdefault("AGENT_PATH", agent_path)
-            program_env.setdefault("AGENT_WORKDIR", repo_path)
             rows.append(
                 {
                     "example_id": index,
@@ -129,12 +76,22 @@ class R2ESWETaskset(vf.Taskset[RlmSweTasksetConfig]):
                     "prompt": [{"role": "user", "content": instruction}],
                     "answer": row.get("answer", ""),
                     "info": info,
-                    "sandbox": sandbox_config(
-                        info=info,
-                        repo_path=repo_path,
-                        timeout_minutes=self.config.timeout_minutes,
-                    ),
-                    "program": {"env": program_env},
+                    "sandbox": {
+                        "image": f"{REGISTRY_PREFIX}/{info['docker_image']}",
+                        "cpu_cores": 4,
+                        "memory_gb": 4,
+                        "disk_size_gb": 10,
+                        "gpu_count": 0,
+                        "workdir": REPO_PATH,
+                        "scope": "rollout",
+                    },
+                    "program": {
+                        "env": {
+                            **SANDBOX_ENV,
+                            "AGENT_PATH": SANDBOX_PATH,
+                            "AGENT_WORKDIR": REPO_PATH,
+                        }
+                    },
                 }
             )
         return rows
@@ -168,11 +125,11 @@ class R2ESWETaskset(vf.Taskset[RlmSweTasksetConfig]):
             cleanup_commands = [
                 (
                     "timeout 30 bash -c 'shopt -s globstar; rm -rf **/*.pyc **/__pycache__' 2>/dev/null || timeout 30 find . -name '*.pyc' -delete || true",
-                    self.config.repo_path,
+                    REPO_PATH,
                 ),
                 (
                     "timeout 30 bash -c 'shopt -s globstar; rm -rf **/__pycache__' 2>/dev/null || timeout 30 find . -name '__pycache__' -exec rm -rf {} + || true",
-                    self.config.repo_path,
+                    REPO_PATH,
                 ),
                 (
                     "timeout 30 bash -c 'shopt -s globstar; rm -rf /r2e_tests/**/*.pyc /r2e_tests/**/__pycache__' 2>/dev/null || timeout 30 find /r2e_tests -name '*.pyc' -delete || true",
@@ -189,9 +146,7 @@ class R2ESWETaskset(vf.Taskset[RlmSweTasksetConfig]):
             logger.warning("Continuing without deleting pycache: %r", exc)
 
         if not self.config.hide_tests_from_agent:
-            await exec_checked(
-                f"mv /r2e_tests {self.config.repo_path}/r2e_tests", timeout=60
-            )
+            await exec_checked(f"mv /r2e_tests {REPO_PATH}/r2e_tests", timeout=60)
             return
 
         remote_archive = "/tmp/r2e_tests.tar.gz"
@@ -235,7 +190,7 @@ class R2ESWETaskset(vf.Taskset[RlmSweTasksetConfig]):
                 remote_archive, str(local_archive_path), timeout=300
             )
             result = await sandbox.execute(
-                f"tar -C {self.config.repo_path} -xzf {remote_archive}",
+                f"tar -C {REPO_PATH} -xzf {remote_archive}",
                 timeout=300,
             )
             if result.exit_code != 0:
@@ -251,17 +206,15 @@ class R2ESWETaskset(vf.Taskset[RlmSweTasksetConfig]):
 
         env_str = " ".join(
             f"{shlex.quote(key)}={shlex.quote(value)}"
-            for key, value in self.get_env_vars().items()
+            for key, value in {**SANDBOX_ENV, "PATH": SANDBOX_PATH}.items()
         )
         command = f"export {env_str}; /bin/bash run_tests.sh > test_output.txt 2>&1"
         result = await sandbox.run_background_job(
-            command, timeout=test_timeout, working_dir=self.config.repo_path
+            command, timeout=test_timeout, working_dir=REPO_PATH
         )
         if result.exit_code > 1:
             raise RuntimeError(f"Error running tests: exit_code={result.exit_code}")
-        result = await sandbox.execute(
-            f"cat {self.config.repo_path}/test_output.txt", timeout=300
-        )
+        result = await sandbox.execute(f"cat {REPO_PATH}/test_output.txt", timeout=300)
         return result.stdout or ""
 
     def calculate_reward(self, test_output: str, info: vf.JsonData) -> float:
@@ -299,7 +252,7 @@ class R2ESWETaskset(vf.Taskset[RlmSweTasksetConfig]):
         await sandbox.upload_bytes("/tmp/gold.patch", patch.encode(), "gold.patch")
         result = await sandbox.execute(
             "git apply --whitespace=fix /tmp/gold.patch",
-            working_dir=self.config.repo_path,
+            working_dir=REPO_PATH,
             timeout=30,
         )
         if result.exit_code != 0:

--- a/packages/harnesses/harnesses/rlm.py
+++ b/packages/harnesses/harnesses/rlm.py
@@ -22,78 +22,57 @@ class RLMProgramConfig(vf.ProgramConfig):
     how the `rlm` CLI is invoked at run time.
     """
 
-    sandbox: vf.SandboxConfig | None = Field(
-        default=None,
-        description=(
-            "Sandbox override. When None, RLM provisions a python:3.11-slim "
-            "baseline; when set, the provided fields are merged on top "
-            "(workdir and command_timeout are always forced by RLM)."
-        ),
-    )
-    workdir: str = Field(
-        default="/workspace",
-        description="In-sandbox working directory the `rlm` CLI cd's into; must be absolute.",
-    )
-    instruction_path: str = Field(
-        default="/rlm/instruction.txt",
-        description="In-sandbox path to the rendered task instruction file; must be absolute.",
-    )
-    repo_url: str = Field(
-        default="github.com/PrimeIntellect-ai/rlm-harness.git",
-        description="Git URL of the RLM harness checkout (ignored if `repo_path` is set).",
-    )
-    repo_ref: str = Field(
-        default="main",
-        description="Git ref to check out from `repo_url`.",
-    )
-    max_depth: int = Field(
-        default=0,
-        description="Max RLM recursion depth; 0 disables sub-LLM calls.",
-    )
-    summarize_at_tokens: int | None = Field(
-        default=None,
-        description="Trigger RLM context summarization when the token count exceeds this.",
-    )
-    append_to_system_prompt: str = Field(
-        default="",
-        description="Extra text appended to the RLM system prompt.",
-    )
-    repo_path: str | None = Field(
-        default=None,
-        description=(
-            "Local path to an existing RLM checkout. If set, takes precedence "
-            "over `repo_url` / `repo_ref` (no clone is performed)."
-        ),
-    )
-    gh_token_var: str | None = Field(
-        default="GH_TOKEN",
-        description="Env var holding the GitHub token used to fetch `repo_url`.",
-    )
-    tools: list[str] = Field(
-        default=["ipython"],
-        description="RLM tool plugins to load (passed as `RLM_TOOLS`).",
-    )
-    env_vars: dict[str, str] = Field(
-        default={},
-        description="Extra env vars exported into the sandbox.",
-    )
-    skills: str | None = Field(
-        default=None,
-        description="Override path to a skills directory; defaults to the taskset's `skills` upload dir.",
-    )
+    sandbox: vf.SandboxConfig | None = None
+    """Sandbox override. When None, RLM provisions a python:3.11-slim baseline;
+    when set, the provided fields are merged on top (workdir and
+    command_timeout are always forced by RLM)."""
+
+    workdir: str = "/workspace"
+    """In-sandbox working directory the `rlm` CLI cd's into; must be absolute."""
+
+    instruction_path: str = "/rlm/instruction.txt"
+    """In-sandbox path to the rendered task instruction file; must be absolute."""
+
+    repo_url: str = "github.com/PrimeIntellect-ai/rlm-harness.git"
+    """Git URL of the RLM harness checkout (ignored if `repo_path` is set)."""
+
+    repo_ref: str = "main"
+    """Git ref to check out from `repo_url`."""
+
+    repo_path: str | None = None
+    """Local path to an existing RLM checkout. If set, takes precedence over
+    `repo_url` / `repo_ref` (no clone is performed)."""
+
+    gh_token_var: str | None = "GH_TOKEN"
+    """Env var holding the GitHub token used to fetch `repo_url`."""
+
+    max_depth: int = Field(default=0, ge=0)
+    """Max RLM recursion depth; 0 disables sub-LLM calls."""
+
+    summarize_at_tokens: int | None = Field(default=None, gt=0)
+    """Trigger RLM context summarization when the token count exceeds this."""
+
+    append_to_system_prompt: str = ""
+    """Extra text appended to the RLM system prompt."""
+
+    tools: list[str] = ["ipython"]
+    """RLM tool plugins to load (passed as `RLM_TOOLS`)."""
+
+    env_vars: dict[str, str] = {}
+    """Extra env vars exported into the sandbox."""
+
+    skills: str | None = None
+    """Override path to a skills directory; defaults to the taskset's `skills`
+    upload dir."""
 
     @model_validator(mode="after")
-    def _check(self) -> "RLMProgramConfig":
+    def _check_absolute_paths(self) -> "RLMProgramConfig":
         if not self.workdir.startswith("/"):
             raise ValueError(f"workdir must be absolute, got {self.workdir!r}")
         if not self.instruction_path.startswith("/"):
             raise ValueError(
                 f"instruction_path must be absolute, got {self.instruction_path!r}"
             )
-        if self.max_depth < 0:
-            raise ValueError("max_depth must be >= 0")
-        if self.summarize_at_tokens is not None and self.summarize_at_tokens <= 0:
-            raise ValueError("summarize_at_tokens must be > 0")
         return self
 
     def resolve(self) -> vf.ProgramConfig:

--- a/packages/harnesses/harnesses/rlm.py
+++ b/packages/harnesses/harnesses/rlm.py
@@ -14,11 +14,6 @@ from .utils.rlm_utils import (
 
 
 class RLMProgramConfig(vf.ProgramConfig):
-    sandbox: vf.SandboxConfig | None = None
-    """Sandbox override. When None, RLM provisions a python:3.11-slim baseline;
-    when set, the provided fields are merged on top (workdir and
-    command_timeout are always forced by RLM)."""
-
     workdir: str = "/workspace"
     """In-sandbox working directory the `rlm` CLI cd's into; must be absolute."""
 

--- a/packages/harnesses/harnesses/rlm.py
+++ b/packages/harnesses/harnesses/rlm.py
@@ -113,14 +113,17 @@ class RLMProgramConfig(vf.ProgramConfig):
                 }
             }
         )
+        sandbox_override = (
+            self.sandbox if isinstance(self.sandbox, vf.SandboxConfig) else None
+        )
         command_timeout = 600
         setup_timeout = command_timeout
-        if self.sandbox is not None and "setup_timeout" in self.sandbox.data(
+        if sandbox_override is not None and "setup_timeout" in sandbox_override.data(
             fill_defaults=False
         ):
-            setup_timeout = self.sandbox.setup_timeout
+            setup_timeout = sandbox_override.setup_timeout
 
-        if self.sandbox is None:
+        if sandbox_override is None:
             sandbox = vf.SandboxConfig(
                 image="python:3.11-slim",
                 workdir=self.workdir,
@@ -137,7 +140,7 @@ class RLMProgramConfig(vf.ProgramConfig):
                 {
                     "workdir": self.workdir,
                     "command_timeout": command_timeout,
-                    **self.sandbox.data(),
+                    **sandbox_override.data(),
                     "setup_timeout": setup_timeout,
                 }
             )

--- a/packages/harnesses/harnesses/rlm.py
+++ b/packages/harnesses/harnesses/rlm.py
@@ -1,5 +1,7 @@
 import shlex
 
+from pydantic import Field, model_validator
+
 import verifiers as vf
 
 from .utils.rlm_utils import (
@@ -10,31 +12,89 @@ from .utils.rlm_utils import (
     DEFAULT_RLM_TOOL_SKILLS_MANIFEST_NAME,
 )
 
-RLM_DEFAULT_REPO_URL = "github.com/PrimeIntellect-ai/rlm-harness.git"
-RLM_DEFAULT_REPO_REF = "main"
-RLM_DEFAULT_EXEC_TIMEOUT = 300
-RLM_DEFAULT_MAX_DEPTH = 0
-RLM_DEFAULT_INSTRUCTION_PATH = "/rlm/instruction.txt"
-RLM_DEFAULT_APPEND_TO_SYSTEM_PROMPT_PATH = "/rlm/append_to_system_prompt.txt"
-RLM_DEFAULT_WORKDIR = "/workspace"
-RLM_DEFAULT_TOOLS = ["ipython"]
+_APPEND_TO_SYSTEM_PROMPT_PATH = "/rlm/append_to_system_prompt.txt"
 
 
 class RLMProgramConfig(vf.ProgramConfig):
-    sandbox: vf.SandboxConfig | None = None
-    workdir: str = RLM_DEFAULT_WORKDIR
-    instruction_path: str = RLM_DEFAULT_INSTRUCTION_PATH
-    rlm_repo_url: str = RLM_DEFAULT_REPO_URL
-    rlm_repo_ref: str = RLM_DEFAULT_REPO_REF
-    rlm_exec_timeout: int = RLM_DEFAULT_EXEC_TIMEOUT
-    rlm_max_depth: int = RLM_DEFAULT_MAX_DEPTH
-    summarize_at_tokens: int | None = None
-    append_to_system_prompt: str = ""
-    local_checkout: str | None = None
-    gh_token_var: str | None = "GH_TOKEN"
-    rlm_tools: list[str] = RLM_DEFAULT_TOOLS
-    env_vars: dict[str, str] = {}
-    skills: str | None = None
+    """Program config for the RLM harness.
+
+    Drives how the RLM repo is fetched, what gets staged into the sandbox, and
+    how the `rlm` CLI is invoked at run time.
+    """
+
+    sandbox: vf.SandboxConfig | None = Field(
+        default=None,
+        description=(
+            "Sandbox override. When None, RLM provisions a python:3.11-slim "
+            "baseline; when set, the provided fields are merged on top "
+            "(workdir and command_timeout are always forced by RLM)."
+        ),
+    )
+    workdir: str = Field(
+        default="/workspace",
+        description="In-sandbox working directory the `rlm` CLI cd's into; must be absolute.",
+    )
+    instruction_path: str = Field(
+        default="/rlm/instruction.txt",
+        description="In-sandbox path to the rendered task instruction file; must be absolute.",
+    )
+    repo_url: str = Field(
+        default="github.com/PrimeIntellect-ai/rlm-harness.git",
+        description="Git URL of the RLM harness checkout (ignored if `repo_path` is set).",
+    )
+    repo_ref: str = Field(
+        default="main",
+        description="Git ref to check out from `repo_url`.",
+    )
+    max_depth: int = Field(
+        default=0,
+        description="Max RLM recursion depth; 0 disables sub-LLM calls.",
+    )
+    summarize_at_tokens: int | None = Field(
+        default=None,
+        description="Trigger RLM context summarization when the token count exceeds this.",
+    )
+    append_to_system_prompt: str = Field(
+        default="",
+        description="Extra text appended to the RLM system prompt.",
+    )
+    repo_path: str | None = Field(
+        default=None,
+        description=(
+            "Local path to an existing RLM checkout. If set, takes precedence "
+            "over `repo_url` / `repo_ref` (no clone is performed)."
+        ),
+    )
+    gh_token_var: str | None = Field(
+        default="GH_TOKEN",
+        description="Env var holding the GitHub token used to fetch `repo_url`.",
+    )
+    tools: list[str] = Field(
+        default=["ipython"],
+        description="RLM tool plugins to load (passed as `RLM_TOOLS`).",
+    )
+    env_vars: dict[str, str] = Field(
+        default={},
+        description="Extra env vars exported into the sandbox.",
+    )
+    skills: str | None = Field(
+        default=None,
+        description="Override path to a skills directory; defaults to the taskset's `skills` upload dir.",
+    )
+
+    @model_validator(mode="after")
+    def _check(self) -> "RLMProgramConfig":
+        if not self.workdir.startswith("/"):
+            raise ValueError(f"workdir must be absolute, got {self.workdir!r}")
+        if not self.instruction_path.startswith("/"):
+            raise ValueError(
+                f"instruction_path must be absolute, got {self.instruction_path!r}"
+            )
+        if self.max_depth < 0:
+            raise ValueError("max_depth must be >= 0")
+        if self.summarize_at_tokens is not None and self.summarize_at_tokens <= 0:
+            raise ValueError("summarize_at_tokens must be > 0")
+        return self
 
     def resolve(self) -> vf.ProgramConfig:
         files: dict[str, vf.ProgramValue] = {
@@ -42,7 +102,7 @@ class RLMProgramConfig(vf.ProgramConfig):
                 "fn": "verifiers.v1.utils.prompt_utils:task_text",
                 "keys": ["instruction", "question"],
             },
-            RLM_DEFAULT_APPEND_TO_SYSTEM_PROMPT_PATH: self.append_to_system_prompt,
+            _APPEND_TO_SYSTEM_PROMPT_PATH: self.append_to_system_prompt,
             DEFAULT_RLM_TOOL_SKILLS_ARCHIVE_PATH: {
                 "fn": "harnesses.utils.rlm_utils:rlm_tool_skills_archive"
             },
@@ -50,13 +110,9 @@ class RLMProgramConfig(vf.ProgramConfig):
         dirs: dict[str, vf.ProgramValue] = {
             DEFAULT_RLM_CHECKOUT_PATH: {
                 "fn": "harnesses.utils.rlm_utils:rlm_checkout_path",
-                **(
-                    {"local_checkout": self.local_checkout}
-                    if self.local_checkout
-                    else {}
-                ),
-                "rlm_repo_url": self.rlm_repo_url,
-                "rlm_repo_ref": self.rlm_repo_ref,
+                **({"repo_path": self.repo_path} if self.repo_path else {}),
+                "repo_url": self.repo_url,
+                "repo_ref": self.repo_ref,
                 **({"gh_token_var": self.gh_token_var} if self.gh_token_var else {}),
             }
         }
@@ -71,13 +127,11 @@ class RLMProgramConfig(vf.ProgramConfig):
             "PATH": "/root/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
             "OPENAI_MODEL": "runtime.model",
             "RLM_MODEL": "runtime.model",
-            "RLM_TOOLS": ",".join(self.rlm_tools),
-            "RLM_EXEC_TIMEOUT": str(self.rlm_exec_timeout),
-            "RLM_MAX_DEPTH": str(self.rlm_max_depth),
+            "RLM_TOOLS": ",".join(self.tools),
+            "RLM_MAX_DEPTH": str(self.max_depth),
             **self.env_vars,
         }
         if self.summarize_at_tokens is not None:
-            assert self.summarize_at_tokens > 0
             env["RLM_SUMMARIZE_AT_TOKENS"] = str(self.summarize_at_tokens)
 
         artifacts = vf.ArtifactsConfig.model_validate(
@@ -90,7 +144,7 @@ class RLMProgramConfig(vf.ProgramConfig):
                 }
             }
         )
-        command_timeout = max(self.rlm_exec_timeout + 120, 600)
+        command_timeout = 600
         setup_timeout = command_timeout
         if self.sandbox is not None and "setup_timeout" in self.sandbox.data(
             fill_defaults=False
@@ -155,7 +209,7 @@ set -eo pipefail
 export PATH="$HOME/.local/bin:${{AGENT_PATH:-$PATH}}"
 export RLM_MODEL="${{RLM_MODEL:-$OPENAI_MODEL}}"
 export OPENAI_API_KEY="${{OPENAI_API_KEY:-intercepted}}"
-export RLM_APPEND_TO_SYSTEM_PROMPT="$(cat {shlex.quote(RLM_DEFAULT_APPEND_TO_SYSTEM_PROMPT_PATH)} 2>/dev/null || true)"
+export RLM_APPEND_TO_SYSTEM_PROMPT="$(cat {shlex.quote(_APPEND_TO_SYSTEM_PROMPT_PATH)} 2>/dev/null || true)"
 cd "${{AGENT_WORKDIR:-{self.workdir}}}"
 rlm "$(cat {shlex.quote(self.instruction_path)})"
 """

--- a/packages/harnesses/harnesses/rlm.py
+++ b/packages/harnesses/harnesses/rlm.py
@@ -1,6 +1,6 @@
 import shlex
 
-from pydantic import Field, model_validator
+from pydantic import Field
 
 import verifiers as vf
 
@@ -12,14 +12,12 @@ from .utils.rlm_utils import (
     DEFAULT_RLM_TOOL_SKILLS_MANIFEST_NAME,
 )
 
+RLM_WORKDIR = "/workspace"
+RLM_INSTRUCTION_PATH = "/rlm/instruction.txt"
+RLM_APPEND_TO_SYSTEM_PROMPT_PATH = "/rlm/append_to_system_prompt.txt"
+
 
 class RLMProgramConfig(vf.ProgramConfig):
-    workdir: str = "/workspace"
-    """In-sandbox working directory the `rlm` CLI cd's into; must be absolute."""
-
-    instruction_path: str = "/rlm/instruction.txt"
-    """In-sandbox path to the rendered task instruction file; must be absolute."""
-
     repo_url: str = "github.com/PrimeIntellect-ai/rlm-harness.git"
     """Git URL of the RLM harness checkout (ignored if `repo_path` is set)."""
 
@@ -30,6 +28,9 @@ class RLMProgramConfig(vf.ProgramConfig):
     """Local path to an existing RLM checkout. If set, takes precedence over
     `repo_url` / `repo_ref` (no clone is performed)."""
 
+    tools: list[str] = ["ipython"]
+    """RLM tool plugins to load (passed as `RLM_TOOLS`)."""
+
     max_depth: int = Field(default=0, ge=0)
     """Max RLM recursion depth; 0 disables sub-LLM calls."""
 
@@ -39,38 +40,16 @@ class RLMProgramConfig(vf.ProgramConfig):
     append_to_system_prompt: str = ""
     """Extra text appended to the RLM system prompt."""
 
-    tools: list[str] = ["ipython"]
-    """RLM tool plugins to load (passed as `RLM_TOOLS`)."""
-
     allow_git: bool = False
     """Disable RLM's restricted git-history guard (sets `RLM_ALLOW_GIT=1`)."""
 
-    env_vars: dict[str, str] = {}
-    """Extra env vars exported into the sandbox."""
-
-    skills: str | None = None
-    """Override path to a skills directory; defaults to the taskset's `skills`
-    upload dir."""
-
-    @model_validator(mode="after")
-    def _check_absolute_paths(self) -> "RLMProgramConfig":
-        if not self.workdir.startswith("/"):
-            raise ValueError(f"workdir must be absolute, got {self.workdir!r}")
-        if not self.instruction_path.startswith("/"):
-            raise ValueError(
-                f"instruction_path must be absolute, got {self.instruction_path!r}"
-            )
-        return self
-
     def resolve(self) -> vf.ProgramConfig:
-        append_to_system_prompt_path = "/rlm/append_to_system_prompt.txt"
-
         files: dict[str, vf.ProgramValue] = {
-            self.instruction_path: {
+            RLM_INSTRUCTION_PATH: {
                 "fn": "verifiers.v1.utils.prompt_utils:task_text",
                 "keys": ["instruction", "question"],
             },
-            append_to_system_prompt_path: self.append_to_system_prompt,
+            RLM_APPEND_TO_SYSTEM_PROMPT_PATH: self.append_to_system_prompt,
             DEFAULT_RLM_TOOL_SKILLS_ARCHIVE_PATH: {
                 "fn": "harnesses.utils.rlm_utils:rlm_tool_skills_archive"
             },
@@ -81,14 +60,9 @@ class RLMProgramConfig(vf.ProgramConfig):
                 **({"repo_path": self.repo_path} if self.repo_path else {}),
                 "repo_url": self.repo_url,
                 "repo_ref": self.repo_ref,
-            }
+            },
+            DEFAULT_RLM_SKILLS_PATH: {"fn": "harnesses.utils.rlm_utils:rlm_skills_dir"},
         }
-        if self.skills is not None:
-            dirs[DEFAULT_RLM_SKILLS_PATH] = self.skills
-        else:
-            dirs[DEFAULT_RLM_SKILLS_PATH] = {
-                "fn": "harnesses.utils.rlm_utils:rlm_skills_dir"
-            }
 
         env: dict[str, vf.ProgramValue] = {
             "PATH": "/root/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
@@ -96,7 +70,6 @@ class RLMProgramConfig(vf.ProgramConfig):
             "RLM_MODEL": "runtime.model",
             "RLM_TOOLS": ",".join(self.tools),
             "RLM_MAX_DEPTH": str(self.max_depth),
-            **self.env_vars,
         }
         if self.summarize_at_tokens is not None:
             env["RLM_SUMMARIZE_AT_TOKENS"] = str(self.summarize_at_tokens)
@@ -106,7 +79,7 @@ class RLMProgramConfig(vf.ProgramConfig):
         artifacts = vf.ArtifactsConfig.model_validate(
             {
                 "rlm_metrics": {
-                    "path": f"{self.workdir}/.rlm/sessions/*/meta.json",
+                    "path": f"{RLM_WORKDIR}/.rlm/sessions/*/meta.json",
                     "format": "json",
                     "key": "metrics",
                     "optional": True,
@@ -126,7 +99,7 @@ class RLMProgramConfig(vf.ProgramConfig):
         if sandbox_override is None:
             sandbox = vf.SandboxConfig(
                 image="python:3.11-slim",
-                workdir=self.workdir,
+                workdir=RLM_WORKDIR,
                 cpu_cores=1,
                 memory_gb=2,
                 disk_size_gb=5,
@@ -138,7 +111,7 @@ class RLMProgramConfig(vf.ProgramConfig):
         else:
             sandbox = vf.SandboxConfig.model_validate(
                 {
-                    "workdir": self.workdir,
+                    "workdir": RLM_WORKDIR,
                     "command_timeout": command_timeout,
                     **sandbox_override.data(),
                     "setup_timeout": setup_timeout,
@@ -181,9 +154,9 @@ set -eo pipefail
 export PATH="$HOME/.local/bin:${{AGENT_PATH:-$PATH}}"
 export RLM_MODEL="${{RLM_MODEL:-$OPENAI_MODEL}}"
 export OPENAI_API_KEY="${{OPENAI_API_KEY:-intercepted}}"
-export RLM_APPEND_TO_SYSTEM_PROMPT="$(cat {shlex.quote(append_to_system_prompt_path)} 2>/dev/null || true)"
-cd "${{AGENT_WORKDIR:-{self.workdir}}}"
-rlm "$(cat {shlex.quote(self.instruction_path)})"
+export RLM_APPEND_TO_SYSTEM_PROMPT="$(cat {shlex.quote(RLM_APPEND_TO_SYSTEM_PROMPT_PATH)} 2>/dev/null || true)"
+cd "${{AGENT_WORKDIR:-{RLM_WORKDIR}}}"
+rlm "$(cat {shlex.quote(RLM_INSTRUCTION_PATH)})"
 """
         return self.resolve_command(
             command=["bash", "-lc", run_script],

--- a/packages/harnesses/harnesses/rlm.py
+++ b/packages/harnesses/harnesses/rlm.py
@@ -12,16 +12,8 @@ from .utils.rlm_utils import (
     DEFAULT_RLM_TOOL_SKILLS_MANIFEST_NAME,
 )
 
-_APPEND_TO_SYSTEM_PROMPT_PATH = "/rlm/append_to_system_prompt.txt"
-
 
 class RLMProgramConfig(vf.ProgramConfig):
-    """Program config for the RLM harness.
-
-    Drives how the RLM repo is fetched, what gets staged into the sandbox, and
-    how the `rlm` CLI is invoked at run time.
-    """
-
     sandbox: vf.SandboxConfig | None = None
     """Sandbox override. When None, RLM provisions a python:3.11-slim baseline;
     when set, the provided fields are merged on top (workdir and
@@ -43,9 +35,6 @@ class RLMProgramConfig(vf.ProgramConfig):
     """Local path to an existing RLM checkout. If set, takes precedence over
     `repo_url` / `repo_ref` (no clone is performed)."""
 
-    gh_token_var: str | None = "GH_TOKEN"
-    """Env var holding the GitHub token used to fetch `repo_url`."""
-
     max_depth: int = Field(default=0, ge=0)
     """Max RLM recursion depth; 0 disables sub-LLM calls."""
 
@@ -57,6 +46,9 @@ class RLMProgramConfig(vf.ProgramConfig):
 
     tools: list[str] = ["ipython"]
     """RLM tool plugins to load (passed as `RLM_TOOLS`)."""
+
+    allow_git: bool = False
+    """Disable RLM's restricted git-history guard (sets `RLM_ALLOW_GIT=1`)."""
 
     env_vars: dict[str, str] = {}
     """Extra env vars exported into the sandbox."""
@@ -76,12 +68,14 @@ class RLMProgramConfig(vf.ProgramConfig):
         return self
 
     def resolve(self) -> vf.ProgramConfig:
+        append_to_system_prompt_path = "/rlm/append_to_system_prompt.txt"
+
         files: dict[str, vf.ProgramValue] = {
             self.instruction_path: {
                 "fn": "verifiers.v1.utils.prompt_utils:task_text",
                 "keys": ["instruction", "question"],
             },
-            _APPEND_TO_SYSTEM_PROMPT_PATH: self.append_to_system_prompt,
+            append_to_system_prompt_path: self.append_to_system_prompt,
             DEFAULT_RLM_TOOL_SKILLS_ARCHIVE_PATH: {
                 "fn": "harnesses.utils.rlm_utils:rlm_tool_skills_archive"
             },
@@ -92,7 +86,6 @@ class RLMProgramConfig(vf.ProgramConfig):
                 **({"repo_path": self.repo_path} if self.repo_path else {}),
                 "repo_url": self.repo_url,
                 "repo_ref": self.repo_ref,
-                **({"gh_token_var": self.gh_token_var} if self.gh_token_var else {}),
             }
         }
         if self.skills is not None:
@@ -112,6 +105,8 @@ class RLMProgramConfig(vf.ProgramConfig):
         }
         if self.summarize_at_tokens is not None:
             env["RLM_SUMMARIZE_AT_TOKENS"] = str(self.summarize_at_tokens)
+        if self.allow_git:
+            env["RLM_ALLOW_GIT"] = "1"
 
         artifacts = vf.ArtifactsConfig.model_validate(
             {
@@ -188,7 +183,7 @@ set -eo pipefail
 export PATH="$HOME/.local/bin:${{AGENT_PATH:-$PATH}}"
 export RLM_MODEL="${{RLM_MODEL:-$OPENAI_MODEL}}"
 export OPENAI_API_KEY="${{OPENAI_API_KEY:-intercepted}}"
-export RLM_APPEND_TO_SYSTEM_PROMPT="$(cat {shlex.quote(_APPEND_TO_SYSTEM_PROMPT_PATH)} 2>/dev/null || true)"
+export RLM_APPEND_TO_SYSTEM_PROMPT="$(cat {shlex.quote(append_to_system_prompt_path)} 2>/dev/null || true)"
 cd "${{AGENT_WORKDIR:-{self.workdir}}}"
 rlm "$(cat {shlex.quote(self.instruction_path)})"
 """

--- a/packages/harnesses/harnesses/rlm.py
+++ b/packages/harnesses/harnesses/rlm.py
@@ -15,6 +15,7 @@ from .utils.rlm_utils import (
 RLM_WORKDIR = "/workspace"
 RLM_INSTRUCTION_PATH = "/rlm/instruction.txt"
 RLM_APPEND_TO_SYSTEM_PROMPT_PATH = "/rlm/append_to_system_prompt.txt"
+RLM_HOME = "/rlm"
 
 
 class RLMProgramConfig(vf.ProgramConfig):
@@ -70,6 +71,7 @@ class RLMProgramConfig(vf.ProgramConfig):
             "RLM_MODEL": "runtime.model",
             "RLM_TOOLS": ",".join(self.tools),
             "RLM_MAX_DEPTH": str(self.max_depth),
+            "RLM_HOME": RLM_HOME,
         }
         if self.summarize_at_tokens is not None:
             env["RLM_SUMMARIZE_AT_TOKENS"] = str(self.summarize_at_tokens)
@@ -79,7 +81,7 @@ class RLMProgramConfig(vf.ProgramConfig):
         artifacts = vf.ArtifactsConfig.model_validate(
             {
                 "rlm_metrics": {
-                    "path": f"{RLM_WORKDIR}/.rlm/sessions/*/meta.json",
+                    "path": f"{RLM_HOME}/sessions/*/meta.json",
                     "format": "json",
                     "key": "metrics",
                     "optional": True,

--- a/packages/harnesses/harnesses/utils/rlm_utils.py
+++ b/packages/harnesses/harnesses/utils/rlm_utils.py
@@ -5,7 +5,6 @@ import keyword
 import re
 import tarfile
 import textwrap
-from collections.abc import Callable
 from importlib.abc import Traversable
 from pathlib import Path
 from typing import cast
@@ -34,39 +33,18 @@ def rlm_checkout_path(
     repo_ref: str,
     repo_path: str | None = None,
 ) -> Path:
-    return rlm_checkout_loader(
-        repo_path=repo_path,
+    """Return a local path to an RLM checkout — `repo_path` if given, else a cached clone of `repo_url`@`repo_ref`."""
+    if repo_path is not None:
+        return validate_git_checkout(
+            Path(repo_path),
+            required_files=REQUIRED_RLM_CHECKOUT_FILES,
+        )
+    return resolve_git_checkout(
         repo_url=repo_url,
-        repo_ref=repo_ref,
-    )()
-
-
-def rlm_checkout_loader(
-    repo_path: str | Path | None,
-    repo_url: str,
-    repo_ref: str,
-) -> Callable[[], Path]:
-    checkout: Path | None = None
-
-    def load() -> Path:
-        nonlocal checkout
-        if checkout is not None:
-            return checkout
-        if repo_path is not None:
-            checkout = validate_git_checkout(
-                Path(repo_path),
-                required_files=REQUIRED_RLM_CHECKOUT_FILES,
-            )
-        else:
-            checkout = resolve_git_checkout(
-                repo_url=repo_url,
-                ref=repo_ref,
-                cache_root=DEFAULT_RLM_LOCAL_CHECKOUT_CACHE_ROOT,
-                required_files=REQUIRED_RLM_CHECKOUT_FILES,
-            )
-        return checkout
-
-    return load
+        ref=repo_ref,
+        cache_root=DEFAULT_RLM_LOCAL_CHECKOUT_CACHE_ROOT,
+        required_files=REQUIRED_RLM_CHECKOUT_FILES,
+    )
 
 
 def rlm_tool_skills_archive(state: State, runtime: Runtime) -> str:

--- a/packages/harnesses/harnesses/utils/rlm_utils.py
+++ b/packages/harnesses/harnesses/utils/rlm_utils.py
@@ -43,6 +43,7 @@ def rlm_checkout_path(
 
 
 def rlm_tool_skills_archive(state: State, runtime: Runtime) -> str:
+    """Package the runtime's verifier tools as RLM skills and return them as a base64-encoded tar.gz."""
     tool_defs = runtime.tool_defs(state) or []
     if not tool_defs:
         return ""
@@ -255,6 +256,7 @@ Tool schema:
 
 
 def rlm_skills_dir(state: State, runtime: Runtime) -> Path | Traversable | None:
+    """Resolve the skills directory for the RLM run: `program.skills` if set, else the taskset's `skills` upload dir."""
     from harnesses.rlm import RLM
 
     harness = runtime.harness

--- a/packages/harnesses/harnesses/utils/rlm_utils.py
+++ b/packages/harnesses/harnesses/utils/rlm_utils.py
@@ -31,23 +31,23 @@ REQUIRED_RLM_CHECKOUT_FILES = ("install.sh", "pyproject.toml")
 
 
 def rlm_checkout_path(
-    rlm_repo_url: str,
-    rlm_repo_ref: str,
-    local_checkout: str | None = None,
+    repo_url: str,
+    repo_ref: str,
+    repo_path: str | None = None,
     gh_token_var: str | None = "GH_TOKEN",
 ) -> Path:
     return rlm_checkout_loader(
-        local_checkout=local_checkout,
-        rlm_repo_url=rlm_repo_url,
-        rlm_repo_ref=rlm_repo_ref,
+        repo_path=repo_path,
+        repo_url=repo_url,
+        repo_ref=repo_ref,
         gh_token_var=gh_token_var,
     )()
 
 
 def rlm_checkout_loader(
-    local_checkout: str | Path | None,
-    rlm_repo_url: str,
-    rlm_repo_ref: str,
+    repo_path: str | Path | None,
+    repo_url: str,
+    repo_ref: str,
     gh_token_var: str | None,
 ) -> Callable[[], Path]:
     checkout: Path | None = None
@@ -56,15 +56,15 @@ def rlm_checkout_loader(
         nonlocal checkout
         if checkout is not None:
             return checkout
-        if local_checkout is not None:
+        if repo_path is not None:
             checkout = validate_git_checkout(
-                Path(local_checkout),
+                Path(repo_path),
                 required_files=REQUIRED_RLM_CHECKOUT_FILES,
             )
         else:
             checkout = resolve_git_checkout(
-                repo_url=rlm_repo_url,
-                ref=rlm_repo_ref,
+                repo_url=repo_url,
+                ref=repo_ref,
                 cache_root=DEFAULT_RLM_LOCAL_CHECKOUT_CACHE_ROOT,
                 gh_token=os.environ.get(gh_token_var) if gh_token_var else None,
                 required_files=REQUIRED_RLM_CHECKOUT_FILES,

--- a/packages/harnesses/harnesses/utils/rlm_utils.py
+++ b/packages/harnesses/harnesses/utils/rlm_utils.py
@@ -11,7 +11,6 @@ from typing import cast
 
 from verifiers.envs.experimental.utils.git_checkout_cache import (
     resolve_git_checkout,
-    validate_git_checkout,
 )
 from verifiers.v1.runtime import Runtime
 from verifiers.v1.state import State
@@ -34,15 +33,11 @@ def rlm_checkout_path(
     repo_path: str | None = None,
 ) -> Path:
     """Return a local path to an RLM checkout — `repo_path` if given, else a cached clone of `repo_url`@`repo_ref`."""
-    if repo_path is not None:
-        return validate_git_checkout(
-            Path(repo_path),
-            required_files=REQUIRED_RLM_CHECKOUT_FILES,
-        )
     return resolve_git_checkout(
         repo_url=repo_url,
         ref=repo_ref,
         cache_root=DEFAULT_RLM_LOCAL_CHECKOUT_CACHE_ROOT,
+        local_checkout=repo_path,
         required_files=REQUIRED_RLM_CHECKOUT_FILES,
     )
 

--- a/packages/harnesses/harnesses/utils/rlm_utils.py
+++ b/packages/harnesses/harnesses/utils/rlm_utils.py
@@ -256,21 +256,11 @@ Tool schema:
 
 
 def rlm_skills_dir(state: State, runtime: Runtime) -> Path | Traversable | None:
-    """Resolve the skills directory for the RLM run: `program.skills` if set, else the taskset's `skills` upload dir."""
-    from harnesses.rlm import RLM
-
-    harness = runtime.harness
-    if not isinstance(harness, RLM):
-        raise TypeError("rlm_skills_dir requires an RLM harness runtime.")
-    if harness.config.program.skills is not None:
-        return Path(harness.config.program.skills)
+    """Return the taskset's `skills` upload directory, or None if none is provided."""
+    _ = state
     taskset = runtime.taskset
     if taskset is None:
         return None
-    upload_dirs = taskset.get_upload_dirs()
-    assert isinstance(upload_dirs, dict)
-    skills_dir = upload_dirs.get("skills")
-    if skills_dir is None:
-        return None
-    assert isinstance(skills_dir, (Path, Traversable))
+    skills_dir = taskset.get_upload_dirs().get("skills")
+    assert skills_dir is None or isinstance(skills_dir, (Path, Traversable))
     return skills_dir

--- a/packages/harnesses/harnesses/utils/rlm_utils.py
+++ b/packages/harnesses/harnesses/utils/rlm_utils.py
@@ -2,7 +2,6 @@ import base64
 import io
 import json
 import keyword
-import os
 import re
 import tarfile
 import textwrap
@@ -34,13 +33,11 @@ def rlm_checkout_path(
     repo_url: str,
     repo_ref: str,
     repo_path: str | None = None,
-    gh_token_var: str | None = "GH_TOKEN",
 ) -> Path:
     return rlm_checkout_loader(
         repo_path=repo_path,
         repo_url=repo_url,
         repo_ref=repo_ref,
-        gh_token_var=gh_token_var,
     )()
 
 
@@ -48,7 +45,6 @@ def rlm_checkout_loader(
     repo_path: str | Path | None,
     repo_url: str,
     repo_ref: str,
-    gh_token_var: str | None,
 ) -> Callable[[], Path]:
     checkout: Path | None = None
 
@@ -66,7 +62,6 @@ def rlm_checkout_loader(
                 repo_url=repo_url,
                 ref=repo_ref,
                 cache_root=DEFAULT_RLM_LOCAL_CHECKOUT_CACHE_ROOT,
-                gh_token=os.environ.get(gh_token_var) if gh_token_var else None,
                 required_files=REQUIRED_RLM_CHECKOUT_FILES,
             )
         return checkout

--- a/tests/test_v1_rlm_swe.py
+++ b/tests/test_v1_rlm_swe.py
@@ -59,7 +59,7 @@ def tool_skills_archive(harness: vf.Harness, state: vf.State) -> bytes:
 def test_rlm_harness_builds_sandbox_program_without_eager_checkout():
     harness = RLM(
         config=RLMConfig(
-            program=RLMProgramConfig(local_checkout="/tmp/does-not-need-to-exist-yet")
+            program=RLMProgramConfig(repo_path="/tmp/does-not-need-to-exist-yet")
         )
     )
     program = as_dict(harness.config.program)
@@ -80,9 +80,8 @@ def test_rlm_harness_accepts_typed_config_surface():
     harness = RLM(
         config=RLMConfig(
             program=RLMProgramConfig(
-                local_checkout="/tmp/checkout",
-                rlm_tools=["bash", "edit"],
-                rlm_exec_timeout=11,
+                repo_path="/tmp/checkout",
+                tools=["bash", "edit"],
                 env_vars={"CUSTOM": "1"},
             )
         )
@@ -90,16 +89,13 @@ def test_rlm_harness_accepts_typed_config_surface():
     program = as_dict(harness.config.program)
     program_env = as_dict(program["env"])
 
-    assert harness.config.program.rlm_tools == ["bash", "edit"]
+    assert harness.config.program.tools == ["bash", "edit"]
     assert program_env["RLM_TOOLS"] == "bash,edit"
-    assert program_env["RLM_EXEC_TIMEOUT"] == "11"
     assert program_env["CUSTOM"] == "1"
 
 
 def test_rlm_endpoint_hides_nested_depth_requests():
-    harness = RLM(
-        config=RLMConfig(program=RLMProgramConfig(local_checkout="/tmp/checkout"))
-    )
+    harness = RLM(config=RLMConfig(program=RLMProgramConfig(repo_path="/tmp/checkout")))
 
     assert harness.endpoint.trajectory_visibility({"x-rlm-depth": "0"}) == "append"
     assert harness.endpoint.trajectory_visibility({"x-rlm-depth": "1"}) == "hidden"
@@ -115,7 +111,7 @@ def test_rlm_harness_preserves_program_setup_timeout_override():
     harness = RLM(
         config=RLMConfig(
             program=RLMProgramConfig(
-                local_checkout="/tmp/checkout",
+                repo_path="/tmp/checkout",
                 setup_timeout=123,
             ),
         )
@@ -129,7 +125,7 @@ def test_rlm_harness_uses_sandbox_setup_timeout_default():
     harness = RLM(
         config=RLMConfig(
             program=RLMProgramConfig(
-                local_checkout="/tmp/checkout",
+                repo_path="/tmp/checkout",
                 sandbox=vf.SandboxConfig(setup_timeout=777),
             ),
         )
@@ -143,7 +139,7 @@ def test_rlm_harness_keeps_minimum_setup_timeout_for_default_sandbox_config():
     harness = RLM(
         config=RLMConfig(
             program=RLMProgramConfig(
-                local_checkout="/tmp/checkout",
+                repo_path="/tmp/checkout",
                 sandbox=vf.SandboxConfig(),
             ),
         )
@@ -162,7 +158,7 @@ def test_rlm_harness_can_upload_skills(tmp_path: Path):
 
     harness = RLM(
         config=RLMConfig(
-            program=RLMProgramConfig(local_checkout="/tmp/checkout", skills=str(skills))
+            program=RLMProgramConfig(repo_path="/tmp/checkout", skills=str(skills))
         )
     )
     program = as_dict(harness.config.program)
@@ -194,7 +190,7 @@ def test_rlm_harness_uploads_taskset_skills_by_default(tmp_path: Path):
     env = vf.Env(
         taskset=SkillTaskset(config=vf.TasksetConfig()),
         harness=RLM(
-            config=RLMConfig(program=RLMProgramConfig(local_checkout="/tmp/checkout"))
+            config=RLMConfig(program=RLMProgramConfig(repo_path="/tmp/checkout"))
         ),
     )
     program = as_dict(env.harness.config.program)
@@ -223,9 +219,7 @@ def test_rlm_harness_recomputes_taskset_skills(tmp_path: Path):
         def get_upload_dirs(self):
             return {}
 
-    harness = RLM(
-        config=RLMConfig(program=RLMProgramConfig(local_checkout="/tmp/checkout"))
-    )
+    harness = RLM(config=RLMConfig(program=RLMProgramConfig(repo_path="/tmp/checkout")))
     vf.Env(
         taskset=SkillTaskset(config=SkillTasksetConfig(skills_path=str(first_skills))),
         harness=harness,
@@ -258,7 +252,7 @@ async def test_rlm_harness_generates_skills_for_v1_tools():
     env = vf.Env(
         taskset=taskset,
         harness=RLM(
-            config=RLMConfig(program=RLMProgramConfig(local_checkout="/tmp/checkout"))
+            config=RLMConfig(program=RLMProgramConfig(repo_path="/tmp/checkout"))
         ),
     )
     task = next(iter(env.taskset))
@@ -298,7 +292,7 @@ async def test_vf_tool_skill_falls_back_for_runtime_bound_tools():
     env = vf.Env(
         taskset=taskset,
         harness=RLM(
-            config=RLMConfig(program=RLMProgramConfig(local_checkout="/tmp/checkout"))
+            config=RLMConfig(program=RLMProgramConfig(repo_path="/tmp/checkout"))
         ),
     )
     task = next(iter(env.taskset))
@@ -323,7 +317,7 @@ def test_rlm_tool_skills_archive_avoids_base_skill_name_collisions(tmp_path: Pat
     (skills / "lookup_order").mkdir(parents=True)
     harness = RLM(
         config=RLMConfig(
-            program=RLMProgramConfig(local_checkout="/tmp/checkout", skills=str(skills))
+            program=RLMProgramConfig(repo_path="/tmp/checkout", skills=str(skills))
         )
     )
     tool_def = Tool(
@@ -349,9 +343,7 @@ def test_rlm_tool_skills_archive_avoids_base_skill_name_collisions(tmp_path: Pat
 
 
 def test_vf_tool_skill_uses_arguments_dict_for_tool_parameters():
-    harness = RLM(
-        config=RLMConfig(program=RLMProgramConfig(local_checkout="/tmp/checkout"))
-    )
+    harness = RLM(config=RLMConfig(program=RLMProgramConfig(repo_path="/tmp/checkout")))
     tool_def = Tool(
         name="reserved_param",
         description="Reserved parameter.",
@@ -385,9 +377,7 @@ def test_vf_tool_skill_uses_arguments_dict_for_tool_parameters():
 async def test_vf_tool_skill_filters_extra_kwargs_for_closed_schemas(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    harness = RLM(
-        config=RLMConfig(program=RLMProgramConfig(local_checkout="/tmp/checkout"))
-    )
+    harness = RLM(config=RLMConfig(program=RLMProgramConfig(repo_path="/tmp/checkout")))
     tool_def = Tool(
         name="list_events",
         description="List calendar events.",
@@ -441,9 +431,7 @@ async def test_vf_tool_skill_filters_extra_kwargs_for_closed_schemas(
 async def test_vf_tool_skill_omits_unset_optional_arguments(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    harness = RLM(
-        config=RLMConfig(program=RLMProgramConfig(local_checkout="/tmp/checkout"))
-    )
+    harness = RLM(config=RLMConfig(program=RLMProgramConfig(repo_path="/tmp/checkout")))
     tool_def = Tool(
         name="search",
         description="Search documents.",
@@ -500,9 +488,7 @@ async def test_vf_tool_skill_omits_unset_optional_arguments(
 async def test_vf_tool_skill_surfaces_verifier_tool_errors(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    harness = RLM(
-        config=RLMConfig(program=RLMProgramConfig(local_checkout="/tmp/checkout"))
-    )
+    harness = RLM(config=RLMConfig(program=RLMProgramConfig(repo_path="/tmp/checkout")))
     tool_def = Tool(
         name="list_events",
         description="List calendar events.",
@@ -584,7 +570,7 @@ def test_rlm_harness_explicit_skills_override_taskset_skills(tmp_path: Path):
         harness=RLM(
             config=RLMConfig(
                 program=RLMProgramConfig(
-                    local_checkout="/tmp/checkout",
+                    repo_path="/tmp/checkout",
                     skills=str(explicit_skills),
                 )
             )
@@ -616,7 +602,7 @@ def test_rlm_swe_environment_uses_v1_r2e_taskset(monkeypatch):
             ),
             harness=rlm_swe_v1.RlmSweHarnessConfig(
                 program=rlm_swe_v1.RlmSweProgramConfig(
-                    local_checkout="/tmp/checkout",
+                    repo_path="/tmp/checkout",
                     env_vars={"CALLER": "1"},
                 )
             ),

--- a/tests/test_v1_rlm_swe.py
+++ b/tests/test_v1_rlm_swe.py
@@ -556,17 +556,15 @@ def test_rlm_swe_environment_uses_v1_r2e_taskset(monkeypatch):
     monkeypatch.setattr(rlm_swe_v1, "load_dataset", fake_load_dataset)
 
     env = rlm_swe_v1.load_environment(
-        config=rlm_swe_v1.RlmSweEnvConfig(
+        config=vf.EnvConfig(
             taskset=rlm_swe_v1.RlmSweTasksetConfig(
                 dataset_name="fake-r2e",
                 repo_path="/workspace/repo",
                 timeout_minutes=30,
                 env={"CUSTOM": "1"},
             ),
-            harness=rlm_swe_v1.RlmSweHarnessConfig(
-                program=rlm_swe_v1.RlmSweProgramConfig(
-                    repo_path="/tmp/checkout",
-                )
+            harness=RLMConfig(
+                program=RLMProgramConfig(repo_path="/tmp/checkout"),
             ),
         ),
     )
@@ -595,7 +593,7 @@ def test_rlm_swe_environment_uses_v1_r2e_taskset(monkeypatch):
     assert task_program_env["PAGER"] == "cat"
     assert task_program_env["CUSTOM"] == "1"
     assert "CUSTOM" not in program_env
-    assert program_env["RLM_TOOLS"] == "bash,edit"
+    assert program_env["RLM_TOOLS"] == "ipython"
     assert merged_sandbox["workdir"] == "/workspace/repo"
     assert merged_env["AGENT_WORKDIR"] == "/workspace/repo"
     assert "/workspace/repo/.venv/bin" in merged_env["AGENT_PATH"]

--- a/tests/test_v1_rlm_swe.py
+++ b/tests/test_v1_rlm_swe.py
@@ -82,7 +82,6 @@ def test_rlm_harness_accepts_typed_config_surface():
             program=RLMProgramConfig(
                 repo_path="/tmp/checkout",
                 tools=["bash", "edit"],
-                env_vars={"CUSTOM": "1"},
             )
         )
     )
@@ -91,7 +90,6 @@ def test_rlm_harness_accepts_typed_config_surface():
 
     assert harness.config.program.tools == ["bash", "edit"]
     assert program_env["RLM_TOOLS"] == "bash,edit"
-    assert program_env["CUSTOM"] == "1"
 
 
 def test_rlm_endpoint_hides_nested_depth_requests():
@@ -151,22 +149,12 @@ def test_rlm_harness_keeps_minimum_setup_timeout_for_default_sandbox_config():
     assert sandbox["setup_timeout"] == 600
 
 
-def test_rlm_harness_can_upload_skills(tmp_path: Path):
-    skills = tmp_path / "skills"
-    (skills / "edit").mkdir(parents=True)
-    (skills / "edit" / "SKILL.md").write_text("---\nname: edit\n---\n")
-
-    harness = RLM(
-        config=RLMConfig(
-            program=RLMProgramConfig(repo_path="/tmp/checkout", skills=str(skills))
-        )
-    )
+def test_rlm_harness_installs_tool_skills_archive():
+    harness = RLM(config=RLMConfig(program=RLMProgramConfig(repo_path="/tmp/checkout")))
     program = as_dict(harness.config.program)
-    dirs = as_dict(program["dirs"])
     files = as_dict(program["files"])
     setup = cast(list[str], program["setup"])
 
-    assert dirs["/task/rlm-skills"] == str(skills)
     assert files[DEFAULT_RLM_TOOL_SKILLS_ARCHIVE_PATH] == {
         "fn": "harnesses.utils.rlm_utils:rlm_tool_skills_archive"
     }
@@ -315,11 +303,13 @@ async def test_vf_tool_skill_falls_back_for_runtime_bound_tools():
 def test_rlm_tool_skills_archive_avoids_base_skill_name_collisions(tmp_path: Path):
     skills = tmp_path / "skills"
     (skills / "lookup_order").mkdir(parents=True)
-    harness = RLM(
-        config=RLMConfig(
-            program=RLMProgramConfig(repo_path="/tmp/checkout", skills=str(skills))
-        )
-    )
+
+    class SkillTaskset(vf.Taskset):
+        def get_upload_dirs(self):
+            return {"skills": skills}
+
+    harness = RLM(config=RLMConfig(program=RLMProgramConfig(repo_path="/tmp/checkout")))
+    vf.Env(taskset=SkillTaskset(config=vf.TasksetConfig()), harness=harness)
     tool_def = Tool(
         name="lookup_order",
         description="Look up an order.",
@@ -555,33 +545,6 @@ def test_taskset_discovers_sibling_skills_dir_by_default(
     assert taskset.get_upload_dirs() == {"skills": skills}
 
 
-def test_rlm_harness_explicit_skills_override_taskset_skills(tmp_path: Path):
-    taskset_skills = tmp_path / "taskset-skills"
-    explicit_skills = tmp_path / "explicit-skills"
-    taskset_skills.mkdir()
-    explicit_skills.mkdir()
-
-    class SkillTaskset(vf.Taskset):
-        def get_upload_dirs(self):
-            return {"skills": taskset_skills}
-
-    env = vf.Env(
-        taskset=SkillTaskset(config=vf.TasksetConfig()),
-        harness=RLM(
-            config=RLMConfig(
-                program=RLMProgramConfig(
-                    repo_path="/tmp/checkout",
-                    skills=str(explicit_skills),
-                )
-            )
-        ),
-    )
-    program = as_dict(env.harness.config.program)
-    dirs = as_dict(program["dirs"])
-
-    assert dirs["/task/rlm-skills"] == str(explicit_skills)
-
-
 def test_rlm_swe_environment_uses_v1_r2e_taskset(monkeypatch):
     calls: dict[str, object] = {}
 
@@ -603,7 +566,6 @@ def test_rlm_swe_environment_uses_v1_r2e_taskset(monkeypatch):
             harness=rlm_swe_v1.RlmSweHarnessConfig(
                 program=rlm_swe_v1.RlmSweProgramConfig(
                     repo_path="/tmp/checkout",
-                    env_vars={"CALLER": "1"},
                 )
             ),
         ),
@@ -633,14 +595,12 @@ def test_rlm_swe_environment_uses_v1_r2e_taskset(monkeypatch):
     assert task_program_env["PAGER"] == "cat"
     assert task_program_env["CUSTOM"] == "1"
     assert "CUSTOM" not in program_env
-    assert program_env["CALLER"] == "1"
     assert program_env["RLM_TOOLS"] == "bash,edit"
     assert merged_sandbox["workdir"] == "/workspace/repo"
     assert merged_env["AGENT_WORKDIR"] == "/workspace/repo"
     assert "/workspace/repo/.venv/bin" in merged_env["AGENT_PATH"]
     assert merged_env["PAGER"] == "cat"
     assert merged_env["CUSTOM"] == "1"
-    assert merged_env["CALLER"] == "1"
 
 
 def test_rlm_swe_taskset_hooks_are_registered_with_runtime():

--- a/tests/test_v1_rlm_swe.py
+++ b/tests/test_v1_rlm_swe.py
@@ -557,12 +557,7 @@ def test_rlm_swe_environment_uses_v1_r2e_taskset(monkeypatch):
 
     env = rlm_swe_v1.load_environment(
         config=vf.EnvConfig(
-            taskset=rlm_swe_v1.RlmSweTasksetConfig(
-                dataset_name="fake-r2e",
-                repo_path="/workspace/repo",
-                timeout_minutes=30,
-                env={"CUSTOM": "1"},
-            ),
+            taskset=rlm_swe_v1.RlmSweTasksetConfig(dataset_name="fake-r2e"),
             harness=RLMConfig(
                 program=RLMProgramConfig(repo_path="/tmp/checkout"),
             ),
@@ -580,25 +575,20 @@ def test_rlm_swe_environment_uses_v1_r2e_taskset(monkeypatch):
     assert isinstance(env.taskset, rlm_swe_v1.R2ESWETaskset)
     assert isinstance(env.harness, RLM)
     assert calls["dataset_name"] == "fake-r2e"
-    assert task["taskset_id"] == "swe/r2e"
     assert task["instruction"] == "Fix repo-0."
     assert task["sandbox"]["image"] == (
         f"{rlm_swe_v1.REGISTRY_PREFIX}/r2e/image:latest"
     )
-    assert task["sandbox"]["workdir"] == "/workspace/repo"
-    assert task["sandbox"]["timeout_minutes"] == 30
+    assert task["sandbox"]["workdir"] == rlm_swe_v1.REPO_PATH
     task_program_env = as_dict(as_dict(task["program"])["env"])
-    assert task_program_env["AGENT_WORKDIR"] == "/workspace/repo"
-    assert "/workspace/repo/.venv/bin" in task_program_env["AGENT_PATH"]
+    assert task_program_env["AGENT_WORKDIR"] == rlm_swe_v1.REPO_PATH
+    assert f"{rlm_swe_v1.REPO_PATH}/.venv/bin" in task_program_env["AGENT_PATH"]
     assert task_program_env["PAGER"] == "cat"
-    assert task_program_env["CUSTOM"] == "1"
-    assert "CUSTOM" not in program_env
     assert program_env["RLM_TOOLS"] == "ipython"
-    assert merged_sandbox["workdir"] == "/workspace/repo"
-    assert merged_env["AGENT_WORKDIR"] == "/workspace/repo"
-    assert "/workspace/repo/.venv/bin" in merged_env["AGENT_PATH"]
+    assert merged_sandbox["workdir"] == rlm_swe_v1.REPO_PATH
+    assert merged_env["AGENT_WORKDIR"] == rlm_swe_v1.REPO_PATH
+    assert f"{rlm_swe_v1.REPO_PATH}/.venv/bin" in merged_env["AGENT_PATH"]
     assert merged_env["PAGER"] == "cat"
-    assert merged_env["CUSTOM"] == "1"
 
 
 def test_rlm_swe_taskset_hooks_are_registered_with_runtime():
@@ -621,9 +611,7 @@ async def test_rlm_swe_taskset_setup_and_reward(monkeypatch):
     monkeypatch.setattr(
         rlm_swe_v1, "load_dataset", lambda *args, **kwargs: fake_r2e_dataset()
     )
-    taskset = rlm_swe_v1.load_taskset(
-        config=rlm_swe_v1.RlmSweTasksetConfig(timeout_minutes=30)
-    )
+    taskset = rlm_swe_v1.load_taskset(config=rlm_swe_v1.RlmSweTasksetConfig())
     task = next(iter(taskset))
     state = vf.State.for_task(task)
     sandbox = FakeSandbox()
@@ -653,21 +641,18 @@ PASSED tests/test_example.py::test_fix
 
     assert calls["setup_sandbox"] is sandbox
     assert calls["setup_state"] is state
-    assert calls["run_tests"] == (sandbox, state, 1800)
+    assert calls["run_tests"] == (sandbox, state, 3600)
     assert state["sandbox_id"] == "sandbox-1"
-    assert state["test_timeout"] == 1800
+    assert state["test_timeout"] == 3600
     assert reward == 1.0
     assert "sandbox_client" not in state
-    assert "_rlm_swe_sandbox" not in state
+    assert "sandbox" not in state
 
 
 @pytest.mark.asyncio
 async def test_rlm_swe_run_tests_quotes_env_values():
     taskset = rlm_swe_v1.load_taskset(
-        config=rlm_swe_v1.RlmSweTasksetConfig(
-            hide_tests_from_agent=False,
-            env={"SAFE": "two words; $(echo nope)", "QUOTE": "it's ok"},
-        )
+        config=rlm_swe_v1.RlmSweTasksetConfig(hide_tests_from_agent=False)
     )
     sandbox = RecordingSandbox()
 
@@ -676,20 +661,9 @@ async def test_rlm_swe_run_tests_quotes_env_values():
     assert output == "test output"
     assert len(sandbox.background_jobs) == 1
     command = sandbox.background_jobs[0]["command"]
-    assert "SAFE='two words; $(echo nope)'" in command
-    assert "QUOTE='it'\"'\"'s ok'" in command
+    # PATH includes the venv on the hardcoded repo path
+    assert f"{rlm_swe_v1.REPO_PATH}/.venv/bin" in command
     assert command.endswith("/bin/bash run_tests.sh > test_output.txt 2>&1")
-
-
-def test_rlm_swe_get_env_vars_uses_configured_repo_path():
-    taskset = rlm_swe_v1.load_taskset(
-        config=rlm_swe_v1.RlmSweTasksetConfig(repo_path="/workspace/repo")
-    )
-
-    path = taskset.get_env_vars()["PATH"]
-
-    assert "/workspace/repo/.venv/bin" in path
-    assert "/testbed/.venv/bin" not in path
 
 
 def test_rlm_swe_reward_rejects_pytest_summary_without_nodeid():

--- a/verifiers/v1/utils/sandbox_utils.py
+++ b/verifiers/v1/utils/sandbox_utils.py
@@ -6,6 +6,7 @@ import logging
 import shlex
 import tarfile
 import tempfile
+import time
 import uuid
 from collections.abc import Awaitable, Callable
 from importlib.abc import Traversable
@@ -17,6 +18,7 @@ import tenacity as tc
 from verifiers.decorators import setup as setup_handler
 from verifiers.errors import Error, SandboxError
 from verifiers.utils.async_utils import maybe_call_with_named_args
+from verifiers.utils.logging_utils import print_size, print_time
 
 from .program_utils import command_argv, command_env, float_config, int_config
 from .program_utils import program_channels
@@ -686,6 +688,14 @@ async def create_sandbox(
         else None,
         guaranteed=bool(sandbox_config.get("guaranteed", False)),
     )
+    started = time.monotonic()
+    logger.info(
+        "Creating sandbox (image=%s, cpu=%s, mem=%sGB, gpu=%d)",
+        request.docker_image,
+        request.cpu_cores,
+        request.memory_gb,
+        gpu_count,
+    )
     create_task = asyncio.create_task(
         with_sandbox_retry(lambda: client.create(request))
     )
@@ -738,6 +748,11 @@ async def create_sandbox(
         )
         await asyncio.shield(delete_task)
         raise
+    logger.info(
+        "[sandbox %s] ready in %s",
+        sandbox_id,
+        print_time(time.monotonic() - started),
+    )
     return sandbox_id
 
 
@@ -863,7 +878,12 @@ async def upload_program_files(
     from prime_sandboxes import APIError, UploadTimeoutError
 
     files = program_option_mapping(program.get("files"), "program.files")
+    if not files:
+        return
+    started = time.monotonic()
+    logger.info("[sandbox %s] uploading %d program file(s)", sandbox_id, len(files))
     for path, source in files.items():
+        file_started = time.monotonic()
         content = await resolve_program_value(source, task, state, runtime, program)
         if not isinstance(content, str):
             content = str(content)
@@ -879,6 +899,19 @@ async def upload_program_files(
             raise SandboxError(
                 f"Program file upload failed for {path!r} in sandbox {sandbox_id}: {exc}"
             ) from exc
+        logger.debug(
+            "[sandbox %s] uploaded %s (%s) in %s",
+            sandbox_id,
+            path,
+            print_size(len(content.encode())),
+            print_time(time.monotonic() - file_started),
+        )
+    logger.info(
+        "[sandbox %s] uploaded %d program file(s) in %s",
+        sandbox_id,
+        len(files),
+        print_time(time.monotonic() - started),
+    )
 
 
 async def upload_program_dirs(
@@ -890,11 +923,18 @@ async def upload_program_dirs(
     runtime: Runtime,
 ) -> None:
     dirs = program_option_mapping(program.get("dirs"), "program.dirs")
+    if not dirs:
+        return
+    started = time.monotonic()
+    logger.info("[sandbox %s] uploading %d program dir(s)", sandbox_id, len(dirs))
+    uploaded = 0
     for path, source in dirs.items():
+        dir_started = time.monotonic()
         local_source = await resolve_program_value(
             source, task, state, runtime, program
         )
         if local_source is None:
+            logger.debug("[sandbox %s] skipped dir %s (no source)", sandbox_id, path)
             continue
         if isinstance(local_source, str):
             local_source = Path(local_source)
@@ -902,6 +942,7 @@ async def upload_program_dirs(
             raise TypeError("program.dirs values must resolve to paths.")
         remote_tar = f"/tmp/_vf_upload_{path.strip('/').replace('/', '_')}.tar.gz"
         archive_path = await runtime.cached_upload_archive(local_source, path)
+        archive_size = Path(archive_path).stat().st_size
         await maybe_call_with_named_args(
             client.upload_file,
             sandbox_id=sandbox_id,
@@ -919,6 +960,20 @@ async def upload_program_dirs(
         )
         if result.exit_code:
             raise SandboxError(f"Program dir upload failed: {result.stderr}")
+        uploaded += 1
+        logger.debug(
+            "[sandbox %s] uploaded dir %s (%s archive) in %s",
+            sandbox_id,
+            path,
+            print_size(archive_size),
+            print_time(time.monotonic() - dir_started),
+        )
+    logger.info(
+        "[sandbox %s] uploaded %d program dir(s) in %s",
+        sandbox_id,
+        uploaded,
+        print_time(time.monotonic() - started),
+    )
 
 
 def build_dir_archive(local_source: Path | Traversable, remote_path: str) -> Path:
@@ -1043,7 +1098,17 @@ async def run_program_items(
 ) -> None:
     env = await command_env(program, task, state, runtime, include_base=False)
     timeout = int_config(program, "setup_timeout", 300)
-    for command in items:
+    if not items:
+        return
+    started = time.monotonic()
+    logger.info(
+        "[sandbox %s] running %d %s command(s)",
+        sandbox_id,
+        len(items),
+        error_prefix.lower().split()[0],
+    )
+    for index, command in enumerate(items, start=1):
+        command_started = time.monotonic()
         command = await resolve_program_value(command, task, state, runtime, program)
         command = str(command)
         if use_sandbox_python_path:
@@ -1057,6 +1122,21 @@ async def run_program_items(
         )
         if result.exit_code:
             raise SandboxError(f"{error_prefix}: {result.stderr}")
+        logger.debug(
+            "[sandbox %s] %s command %d/%d done in %s",
+            sandbox_id,
+            error_prefix.lower().split()[0],
+            index,
+            len(items),
+            print_time(time.monotonic() - command_started),
+        )
+    logger.info(
+        "[sandbox %s] ran %d %s command(s) in %s",
+        sandbox_id,
+        len(items),
+        error_prefix.lower().split()[0],
+        print_time(time.monotonic() - started),
+    )
 
 
 async def read_sandbox_artifact(

--- a/verifiers/v1/utils/sandbox_utils.py
+++ b/verifiers/v1/utils/sandbox_utils.py
@@ -689,7 +689,7 @@ async def create_sandbox(
         guaranteed=bool(sandbox_config.get("guaranteed", False)),
     )
     started = time.monotonic()
-    logger.info(
+    logger.debug(
         "Creating sandbox (image=%s, cpu=%s, mem=%sGB, gpu=%d)",
         request.docker_image,
         request.cpu_cores,
@@ -748,7 +748,7 @@ async def create_sandbox(
         )
         await asyncio.shield(delete_task)
         raise
-    logger.info(
+    logger.debug(
         "[sandbox %s] ready in %s",
         sandbox_id,
         print_time(time.monotonic() - started),
@@ -881,7 +881,7 @@ async def upload_program_files(
     if not files:
         return
     started = time.monotonic()
-    logger.info("[sandbox %s] uploading %d program file(s)", sandbox_id, len(files))
+    logger.debug("[sandbox %s] uploading %d program file(s)", sandbox_id, len(files))
     for path, source in files.items():
         file_started = time.monotonic()
         content = await resolve_program_value(source, task, state, runtime, program)
@@ -906,7 +906,7 @@ async def upload_program_files(
             print_size(len(content.encode())),
             print_time(time.monotonic() - file_started),
         )
-    logger.info(
+    logger.debug(
         "[sandbox %s] uploaded %d program file(s) in %s",
         sandbox_id,
         len(files),
@@ -926,7 +926,7 @@ async def upload_program_dirs(
     if not dirs:
         return
     started = time.monotonic()
-    logger.info("[sandbox %s] uploading %d program dir(s)", sandbox_id, len(dirs))
+    logger.debug("[sandbox %s] uploading %d program dir(s)", sandbox_id, len(dirs))
     uploaded = 0
     for path, source in dirs.items():
         dir_started = time.monotonic()
@@ -968,7 +968,7 @@ async def upload_program_dirs(
             print_size(archive_size),
             print_time(time.monotonic() - dir_started),
         )
-    logger.info(
+    logger.debug(
         "[sandbox %s] uploaded %d program dir(s) in %s",
         sandbox_id,
         uploaded,
@@ -1101,7 +1101,7 @@ async def run_program_items(
     if not items:
         return
     started = time.monotonic()
-    logger.info(
+    logger.debug(
         "[sandbox %s] running %d %s command(s)",
         sandbox_id,
         len(items),
@@ -1130,7 +1130,7 @@ async def run_program_items(
             len(items),
             print_time(time.monotonic() - command_started),
         )
-    logger.info(
+    logger.debug(
         "[sandbox %s] ran %d %s command(s) in %s",
         sandbox_id,
         len(items),


### PR DESCRIPTION
## Summary

- Drop single-use `RLM_DEFAULT_*` globals; `RLMProgramConfig` is the source of truth.
- Attribute-docstring style on every field; reserve `Field(...)` for real constraints (`ge`, `gt`).
- Drop the `rlm_` prefix from config fields where the class itself already names the harness:
  - `rlm_repo_url` → `repo_url`
  - `rlm_repo_ref` → `repo_ref`
  - `rlm_max_depth` → `max_depth`
  - `rlm_tools` → `tools`
- Rename `local_checkout` → `repo_path`; docstring notes it takes precedence over `repo_url` / `repo_ref`.
- Drop `gh_token_var` from the config and from `rlm_checkout_path` / `rlm_checkout_loader`; the default RLM repo is public.
- Drop `rlm_exec_timeout` from the config; `RLM_EXEC_TIMEOUT` can still be set via `env_vars` and `command_timeout` via `sandbox=SandboxConfig(command_timeout=...)`. Default `command_timeout` is a flat 600s.
- Drop `workdir`, `instruction_path`, `skills`, `env_vars` fields. Internal sandbox paths become module-level globals (`RLM_WORKDIR`, `RLM_INSTRUCTION_PATH`, `RLM_APPEND_TO_SYSTEM_PROMPT_PATH`, `RLM_HOME`).
- `resolve()` always emits the skills-dir fn-ref; the static-skills branch is gone. `rlm_skills_dir` simplifies to a taskset-only lookup (drops the RLM type narrowing and the program.skills branch).
- Add `allow_git: bool = False` → exports `RLM_ALLOW_GIT=1`.
- Decouple RLM session storage from the agent workdir: pin `RLM_HOME=/rlm` and use the same path for the `rlm_metrics` artifact glob.
- Inline `rlm_checkout_loader` into `rlm_checkout_path` (single caller, dead memoization) and delegate the `local_checkout` branch to `resolve_git_checkout`.
- Sandbox-lifecycle timing logs at DEBUG (create_sandbox, upload_files / dirs, run_setup) via `print_size` / `print_time`.
- Rework `environments/hello_rlm_v1`:
  - Three capability-distinct tasks (echo, ipython tool, ipython shell escape).
  - `HelloRLMTasksetConfig.task_idx: int | list[int] | None` to pin a subset for dev runs.
  - `exact_answer` reward moved onto the Taskset class.
  - `load_environment` reverted to the canonical semgrep-enforced shim.

## Verification

Bug fix in 06729c39: SWE rollouts (any taskset that sets `AGENT_WORKDIR` and/or `sandbox.workdir` away from `/workspace`) had empty `rlm_metrics` because the artifact glob was hardcoded to `/workspace/.rlm/sessions/*/meta.json` but the rlm CLI wrote sessions under `{cwd}/.rlm/sessions/...` (cwd-relative `RLM_HOME` default).

**Before** (per `git show 06729c39~1`):
```python
"path": f"{RLM_WORKDIR}/.rlm/sessions/*/meta.json",   # always /workspace/.rlm/...
# env had no RLM_HOME → rlm CLI used its relative default ".rlm" under cwd
```

**After** (this PR):
```
=== where rlm session writes ===
RLM_HOME (env): /rlm
=== where harness collects from ===
rlm_metrics path: /rlm/sessions/*/meta.json
=== agent workdir (independent) ===
sandbox.workdir: /testbed
```

Repro:
```python
config = RLMConfig(
    program=RLMProgramConfig(
        repo_path="/tmp/checkout",
        sandbox=vf.SandboxConfig(workdir="/testbed"),
    )
)
harness = RLM(config=config)
program = harness.config.program.data()
# program["env"]["RLM_HOME"] == "/rlm"
# program["artifacts"]["rlm_metrics"]["path"] == "/rlm/sessions/*/meta.json"
# harness.sandbox.workdir == "/testbed"
```

Session dir and agent workdir are decoupled: agent is free to `cd` anywhere (`/testbed`, `/workspace/repo`, etc.) while rlm sessions consistently land at `/rlm/sessions/...` and the artifact glob matches.

## Breaking

`RLMProgramConfig` field renames / removals (no aliases kept):

| Before | After |
| --- | --- |
| `rlm_repo_url` | `repo_url` |
| `rlm_repo_ref` | `repo_ref` |
| `rlm_max_depth` | `max_depth` |
| `rlm_tools` | `tools` |
| `local_checkout` | `repo_path` |
| `gh_token_var` | removed (public repo) |
| `rlm_exec_timeout` | removed — pass `env_vars={"RLM_EXEC_TIMEOUT": "..."}` and/or `sandbox=SandboxConfig(command_timeout=...)` |
| `workdir` | removed — pin via `sandbox=SandboxConfig(workdir=...)` |
| `instruction_path` | removed — module-level constant |
| `skills` | removed — sourced from `taskset.get_upload_dirs()["skills"]` |
| `env_vars` | removed — extend via `sandbox.env_vars` or task-level `program.env` |

`harnesses.utils.rlm_utils:rlm_checkout_path` kwargs follow suit: `rlm_repo_url`/`rlm_repo_ref`/`local_checkout`/`gh_token_var` → `repo_url`/`repo_ref`/`repo_path` (the last two dropped). `rlm_checkout_loader` is gone. The separate `verifiers.envs.experimental.composable.harnesses.rlm` API is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking `RLMProgramConfig` API and SWE env config removals affect callers; fixed 600s command timeout and removed `env_vars` may change rollout behavior for long jobs or custom env injection.
> 
> **Overview**
> **RLM harness config** is flattened and renamed: `local_checkout` → `repo_path`, `rlm_tools` → `tools`, and similar drops of the `rlm_` prefix. Several knobs are removed (`rlm_exec_timeout`, `env_vars`, `workdir`, `instruction_path`, program-level `skills`, `gh_token_var`); checkout resolution goes through `resolve_git_checkout` only. **`RLM_HOME` is pinned to `/rlm`** so `rlm_metrics` collects from `/rlm/sessions/*/meta.json` regardless of agent `workdir` (fixes empty metrics on SWE-style `/testbed` sandboxes). Default **`command_timeout` is 600s** with no automatic `RLM_EXEC_TIMEOUT` env. Skills uploads always use a taskset fn-ref; **`allow_git`** maps to `RLM_ALLOW_GIT=1`.
> 
> **`rlm_swe_v1`** drops bespoke `RlmSweHarnessConfig` / env wrappers in favor of generic `vf.EnvConfig` + `RLMConfig`, hardcodes repo layout at `/testbed`, inlines dataset→task building, and stores the active sandbox under `state["sandbox"]` instead of `_rlm_swe_sandbox`. SWE-specific config surface shrinks (no per-task `repo_path`, `timeout_minutes` on taskset config, `env` injection, or `/root` venv symlinks).
> 
> **`hello_rlm_v1`** becomes three capability-focused tasks with optional **`task_idx`** filtering; the exact-answer reward lives on the taskset class.
> 
> **Sandbox utils** add DEBUG timing/size logs for create, file/dir upload, and setup commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d4f7a473f46398c013f8a977cd3475e678f50a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refactor RLM config to standardize field names, defaults, and task filtering
> - Renames `RLMProgramConfig` fields: `local_checkout`→`repo_path`, `rlm_tools`→`tools`, `rlm_repo_url/ref`→`repo_url/repo_ref`; removes `rlm_exec_timeout` and `env_vars`; fixes command timeout to 600s and workdir to `/workspace`.
> - Simplifies `RlmSweTasksetConfig` by removing path/timeout/env override fields; sandbox workdir is now fixed to `/testbed` and test timeout defaults to 3600s.
> - Reduces `hello_rlm_v1` tasks from 10 static QA pairs to 3 (plain text, IPython, bash); adds `task_idx` config field for selecting a subset.
> - Moves `exact_answer` reward from module scope into `HelloRLMTaskset` as an async method.
> - Adds short-circuit guards and debug timing/size logs to sandbox utility functions in [`sandbox_utils.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1535/files#diff-b1154f3be7f28191532de46fbe23a973a5f93e1450a71beb9c93910e358fda13).
> - Risk: Behavioral change — existing configs using old field names (`local_checkout`, `rlm_tools`, `env_vars`, `timeout_minutes`) will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4d4f7a4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->