### PR TITLE
[codex] Bridge tool image outputs for OpenAI chat

### DIFF
--- a/tests/test_client_multimodal_types.py
+++ b/tests/test_client_multimodal_types.py
@@ -53,6 +53,43 @@ async def test_openai_to_native_prompt_with_typed_multimodal_content_parts():
 
 
 @pytest.mark.asyncio
+async def test_openai_tool_image_outputs_are_bridged_through_user_message():
+    client = OpenAIChatCompletionsClient(object())
+    messages = [
+        AssistantMessage(
+            content=None,
+            tool_calls=[
+                ToolCall(id="call_1", name="browser_screenshot", arguments="{}")
+            ],
+        ),
+        ToolMessage(
+            tool_call_id="call_1",
+            content=[
+                TextContentPart(text='{"ok": true, "action": "screenshot"}'),
+                ImageUrlContentPart(
+                    image_url=ImageUrlSource(url="data:image/png;base64,abc123")
+                ),
+            ],
+        ),
+    ]
+
+    prompt, kwargs = await client.to_native_prompt(messages)
+
+    assert kwargs == {}
+    assert len(prompt) == 3
+    assert prompt[1]["role"] == "tool"
+    assert prompt[1]["content"] == '{"ok": true, "action": "screenshot"}'
+    assert prompt[2]["role"] == "user"
+    assert prompt[2]["content"] == [
+        {"type": "text", "text": '{"ok": true, "action": "screenshot"}'},
+        {
+            "type": "image_url",
+            "image_url": {"url": "data:image/png;base64,abc123"},
+        },
+    ]
+
+
+@pytest.mark.asyncio
 async def test_anthropic_to_native_prompt_with_typed_multimodal_content_parts():
     pytest.importorskip("anthropic")
     from verifiers.clients.anthropic_messages_client import AnthropicMessagesClient

--- a/verifiers/clients/openai_chat_completions_client.py
+++ b/verifiers/clients/openai_chat_completions_client.py
@@ -1,4 +1,5 @@
 import functools
+import json
 from collections.abc import Iterable, Mapping
 from typing import Any, TypeAlias, cast
 
@@ -175,15 +176,47 @@ class OpenAIChatCompletionsClient(
                 return [normalize_content_part(p) for p in content]
             return content
 
-        def from_chat_message(message: Message) -> OpenAIChatMessage:
+        def split_tool_content_for_chat_completions(
+            content: Any,
+        ) -> tuple[Any, list[dict[str, Any]] | None]:
+            """Keep tool messages provider-legal and bridge images via user role."""
+
+            normalized = normalize_content(content)
+            if not isinstance(normalized, list):
+                return normalized, None
+
+            tool_text_parts: list[str] = []
+            bridged_parts: list[dict[str, Any]] = []
+            for part in normalized:
+                part_type = part.get("type") if isinstance(part, Mapping) else None
+                if part_type == "image_url":
+                    bridged_parts.append(dict(part))
+                    continue
+                if part_type == "text":
+                    text = part.get("text")
+                    if isinstance(text, str) and text:
+                        tool_text_parts.append(text)
+                        bridged_parts.append({"type": "text", "text": text})
+                    continue
+                tool_text_parts.append(json.dumps(part, ensure_ascii=False))
+
+            if not bridged_parts:
+                return normalized, None
+            return "\n".join(tool_text_parts) or "[tool image output]", bridged_parts
+
+        def from_chat_message(message: Message) -> list[OpenAIChatMessage]:
             if isinstance(message, SystemMessage):
-                return ChatCompletionSystemMessageParam(
-                    role="system", content=normalize_content(message.content)
-                )
+                return [
+                    ChatCompletionSystemMessageParam(
+                        role="system", content=normalize_content(message.content)
+                    )
+                ]
             elif isinstance(message, UserMessage):
-                return ChatCompletionUserMessageParam(
-                    role="user", content=normalize_content(message.content)
-                )
+                return [
+                    ChatCompletionUserMessageParam(
+                        role="user", content=normalize_content(message.content)
+                    )
+                ]
             elif isinstance(message, AssistantMessage):
                 if message.tool_calls is not None:
                     oai_tool_calls: (
@@ -201,26 +234,44 @@ class OpenAIChatCompletionsClient(
                     ]
                 else:
                     oai_tool_calls = None
-                return ChatCompletionAssistantMessageParam(
-                    role="assistant",
-                    content=cast(Any, normalize_content(message.content)),
-                    tool_calls=cast(Any, oai_tool_calls),
-                    reasoning_content=message.reasoning_content,  # type: ignore[arg-type]
-                )
+                return [
+                    ChatCompletionAssistantMessageParam(
+                        role="assistant",
+                        content=cast(Any, normalize_content(message.content)),
+                        tool_calls=cast(Any, oai_tool_calls),
+                        reasoning_content=message.reasoning_content,  # type: ignore[arg-type]
+                    )
+                ]
             elif isinstance(message, ToolMessage):
-                return ChatCompletionToolMessageParam(
-                    role="tool",
-                    tool_call_id=message.tool_call_id,
-                    content=cast(Any, normalize_content(message.content)),
+                tool_content, bridged_parts = split_tool_content_for_chat_completions(
+                    message.content
                 )
+                messages: list[OpenAIChatMessage] = [
+                    ChatCompletionToolMessageParam(
+                        role="tool",
+                        tool_call_id=message.tool_call_id,
+                        content=cast(Any, tool_content),
+                    )
+                ]
+                if bridged_parts is not None:
+                    messages.append(
+                        ChatCompletionUserMessageParam(
+                            role="user",
+                            content=cast(Any, bridged_parts),
+                        )
+                    )
+                return messages
             elif isinstance(message, TextMessage):
-                return ChatCompletionUserMessageParam(
-                    role="user", content=message.content
-                )
+                return [
+                    ChatCompletionUserMessageParam(role="user", content=message.content)
+                ]
             else:
                 raise ValueError(f"Invalid chat message: {message}")
 
-        return [from_chat_message(message) for message in messages], {}
+        native_messages: OpenAIChatMessages = []
+        for message in messages:
+            native_messages.extend(from_chat_message(message))
+        return native_messages, {}
 
     async def to_native_tool(self, tool: Tool) -> OpenAITool:
         if tool.strict is None:


### PR DESCRIPTION
## Summary
- keep OpenAI chat tool messages provider-legal by converting image-bearing tool outputs into text-only tool messages plus a user-role image observation
- preserve model-visible image content for the next assistant turn without violating chat-completions role constraints
- add a multimodal client regression for screenshot-style tool outputs

## Validation
- uv run --with pytest python -m pytest tests/test_client_multimodal_types.py -q
- uv run --with pytest python -m pytest tests/test_openai_chat_completions_token_client.py tests/test_renderer_client.py tests/test_tool_env.py tests/test_client_multimodal_types.py -q
- uv run --with ruff ruff check verifiers/clients/openai_chat_completions_client.py tests/test_client_multimodal_types.py
- pre-commit hooks on commit and push

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bridge tool image outputs into a user message for OpenAI chat completions
> - OpenAI's chat completions API does not support `image_url` content parts in tool messages, so `OpenAIChatCompletionsClient.to_native_prompt` now splits multimodal tool content: text parts stay in the `tool` role message as a string, and image parts are emitted as a follow-up `user` role message.
> - A new inner helper `split_tool_content_for_chat_completions` in [openai_chat_completions_client.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1539/files#diff-025b956ea9171f7b691b13e0e1ce59d1b1ec6d71bbbde418bf55dc53c2daf7fd) handles the normalization: it JSON-serializes non-text parts, joins text parts, and falls back to the placeholder `'[tool image output]'` when only images are present.
> - `to_native_prompt` now returns a flattened list that may contain more messages than the input, changing the length and structure of the resulting prompt.
> - Behavioral Change: prompts containing tool messages with image content will now produce an extra `user` message in the native prompt output.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e4fcf47.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->