### PR TITLE
fix: import Traversable from importlib.resources.abc on Python >=3.14

### DIFF
--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,5 +1,6 @@
 """Tests for the base Environment class."""
 
+import importlib
 import json
 from typing import cast
 from unittest.mock import AsyncMock, Mock, patch
@@ -20,6 +21,23 @@ from verifiers.types import (
     ToolCall,
 )
 from verifiers.utils.save_utils import make_dataset as build_dataset
+
+
+def test_importlib_traversable_modules_import():
+    """Import modules that use the version-tolerant Traversable import."""
+    module_names = (
+        "verifiers.v1.runtime",
+        "verifiers.v1.taskset",
+        "verifiers.v1.utils.sandbox_utils",
+        "verifiers.v1.utils.taskset_utils",
+        "verifiers.envs.experimental.composable.composable_env",
+        "verifiers.envs.experimental.composable.harness",
+        "verifiers.envs.experimental.composable.task",
+        "verifiers.envs.experimental.composable.harnesses.rlm",
+    )
+
+    for module_name in module_names:
+        assert importlib.import_module(module_name)
 
 
 # Create a concrete implementation for testing the abstract base class

--- a/verifiers/envs/experimental/composable/composable_env.py
+++ b/verifiers/envs/experimental/composable/composable_env.py
@@ -42,11 +42,16 @@ import shlex
 import tarfile
 import tempfile
 import time
-from importlib.abc import Traversable
 from pathlib import Path
 from typing import Any
 
+try:
+    from importlib.resources.abc import Traversable
+except ImportError:  # Python < 3.14
+    from importlib.abc import Traversable
+
 import verifiers as vf
+
 from verifiers.envs.experimental.cli_agent_env import CliAgentEnv
 from verifiers.envs.experimental.composable.harness import Harness
 from verifiers.envs.experimental.composable.task import TaskSet

--- a/verifiers/envs/experimental/composable/harness.py
+++ b/verifiers/envs/experimental/composable/harness.py
@@ -15,9 +15,13 @@ connects them.
 """
 
 from dataclasses import dataclass
-from importlib.abc import Traversable
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable
+
+try:
+    from importlib.resources.abc import Traversable
+except ImportError:  # Python < 3.14
+    from importlib.abc import Traversable
 
 if TYPE_CHECKING:
     from verifiers.envs.experimental.composable.task import SandboxSpec

--- a/verifiers/envs/experimental/composable/harnesses/rlm.py
+++ b/verifiers/envs/experimental/composable/harnesses/rlm.py
@@ -3,9 +3,13 @@
 import hashlib
 import random
 import shlex
-from importlib.abc import Traversable
 from pathlib import Path
 from typing import Callable
+
+try:
+    from importlib.resources.abc import Traversable
+except ImportError:  # Python < 3.14
+    from importlib.abc import Traversable
 
 from verifiers.envs.experimental.composable import Harness
 from verifiers.envs.experimental.utils.git_checkout_cache import (

--- a/verifiers/envs/experimental/composable/task.py
+++ b/verifiers/envs/experimental/composable/task.py
@@ -27,9 +27,13 @@ A **SandboxSpec** describes sandbox requirements (image, CPU, memory, etc.).
 import importlib
 import importlib.resources as resources
 from dataclasses import dataclass
-from importlib.abc import Traversable
 from pathlib import Path
 from typing import Any, Callable
+
+try:
+    from importlib.resources.abc import Traversable
+except ImportError:  # Python < 3.14
+    from importlib.abc import Traversable
 
 from verifiers.envs.experimental.composable._filter import _resolve_filter_fn
 from verifiers.types import DatasetBuilder, Messages, State

--- a/verifiers/v1/runtime.py
+++ b/verifiers/v1/runtime.py
@@ -8,7 +8,6 @@ import uuid
 from collections.abc import Awaitable, Callable, Iterable, Sequence
 from contextlib import AsyncExitStack
 from dataclasses import dataclass, field
-from importlib.abc import Traversable
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -19,6 +18,11 @@ from typing import (
     get_args,
     runtime_checkable,
 )
+
+try:
+    from importlib.resources.abc import Traversable
+except ImportError:  # Python < 3.14
+    from importlib.abc import Traversable
 
 from verifiers.clients import Client, resolve_client
 from verifiers.types import Messages, Response, Tool

--- a/verifiers/v1/taskset.py
+++ b/verifiers/v1/taskset.py
@@ -1,6 +1,10 @@
-from importlib.abc import Traversable
 from pathlib import Path
 from typing import Generic, TypeVar, cast, final
+
+try:
+    from importlib.resources.abc import Traversable
+except ImportError:  # Python < 3.14
+    from importlib.abc import Traversable
 
 from datasets import Dataset
 from pydantic import AliasChoices, Field

--- a/verifiers/v1/utils/sandbox_utils.py
+++ b/verifiers/v1/utils/sandbox_utils.py
@@ -8,9 +8,13 @@ import tarfile
 import tempfile
 import uuid
 from collections.abc import Awaitable, Callable
-from importlib.abc import Traversable
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, Protocol, TypeVar, cast
+
+try:
+    from importlib.resources.abc import Traversable
+except ImportError:  # Python < 3.14
+    from importlib.abc import Traversable
 
 import tenacity as tc
 

--- a/verifiers/v1/utils/taskset_utils.py
+++ b/verifiers/v1/utils/taskset_utils.py
@@ -5,9 +5,13 @@ import uuid
 from collections.abc import Iterable
 from contextlib import suppress
 from copy import deepcopy
-from importlib.abc import Traversable
 from pathlib import Path
 from typing import cast
+
+try:
+    from importlib.resources.abc import Traversable
+except ImportError:  # Python < 3.14
+    from importlib.abc import Traversable
 
 from datasets import Dataset
 from verifiers.types import task_payload_from_info


### PR DESCRIPTION
## Summary

Makes the `Traversable` import tolerant of Python 3.14, where `prime eval` currently crashes on import because the symbol moved namespaces.

## Why

On Python 3.14+, `from importlib.abc import Traversable` raises `ImportError` because `Traversable` moved to `importlib.resources.abc`. Issue #1521 reports that `prime eval` therefore crashes at import time on a fresh 3.14 install, before any command runs, so the package is unusable on the latest Python.

## Description

Fixes #1521. On Python 3.14+, `from importlib.abc import Traversable` raises `ImportError` because `Traversable` moved to `importlib.resources.abc`, so `prime eval` crashes on import with a fresh 3.14 install. The import is replaced with a version-tolerant guard (try `importlib.resources.abc`, fall back to `importlib.abc` on Python < 3.14) across the eight affected modules in `verifiers/v1/` and `verifiers/envs/experimental/composable/`. The `requires-python` pin is left unchanged; this PR is scoped to the import.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
- [x] All existing tests pass when running `uv run pytest` locally.
- [x] New tests have been added to cover the changes

`tests/test_environment.py` gains `test_importlib_traversable_modules_import`, which imports all eight touched modules so a regression on either Python branch fails fast. The fallback branch keeps behavior byte-identical on 3.10 through 3.13.

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

`Traversable` resolves to the same runtime type on both branches, so downstream `isinstance` checks and type hints are unaffected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow import-shim change with fallback preserving prior behavior on supported Python versions; risk is low aside from missing a `Traversable` import site.
> 
> **Overview**
> Fixes **import-time crashes on Python 3.14+** where `Traversable` no longer lives in `importlib.abc` (it moved to `importlib.resources.abc`), which broke commands like `prime eval` before any user code ran.
> 
> Each affected module now **tries `importlib.resources.abc` first** and **falls back to `importlib.abc` on older Python**, with no intended behavior change on 3.10–3.13. Updates span **v1 runtime/taskset/sandbox and taskset utils** plus **experimental composable env, harness, task, and RLM harness**.
> 
> Adds **`test_importlib_traversable_modules_import`** in `tests/test_environment.py` to import all eight touched modules so either import branch regressions fail fast in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ece2383d8e76e5ea291d0dfb1342d56aef539be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `Traversable` import to use `importlib.resources.abc` on Python >=3.14
> In Python 3.14, `Traversable` was removed from `importlib.abc` and moved to `importlib.resources.abc`. Eight modules across `verifiers/` are updated to use a `try/except` that imports from `importlib.resources.abc` first, falling back to `importlib.abc` for older Python versions. A new test in `tests/test_environment.py` verifies all affected modules import successfully.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2ece238.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->