### PR TITLE
Cache Hugging Face tokenizers in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,9 @@ on:
       - "packages/**"
       - ".github/workflows/test.yml"
 
+env:
+  HF_HOME: ${{ github.workspace }}/.cache/huggingface
+
 jobs:
   test:
     name: Verifiers
@@ -23,6 +26,7 @@ jobs:
     env:
       PRIME_API_KEY: ${{ secrets.PRIME_API_KEY }}
       PRIME_TEAM_ID: ${{ secrets.PRIME_TEAM_ID }}
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
     strategy:
       fail-fast: false
       matrix:
@@ -38,6 +42,14 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+
+      - name: Cache Hugging Face tokenizers
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.HF_HOME }}
+          key: hf-tokenizers-${{ runner.os }}-${{ hashFiles('uv.lock', 'tests/test_renderer_client.py', 'tests/test_renderer_e2e.py') }}
+          restore-keys: |
+            hf-tokenizers-${{ runner.os }}-
 
       - name: Install dependencies
         run: uv sync


### PR DESCRIPTION
## Summary
- add a Hugging Face cache directory for the Test workflow
- restore/save that cache in the existing Python test matrix
- pass HF_TOKEN through to the main Verifiers test job to reduce public Hub rate-limit pressure

## Context
This is the smaller follow-up for the Hugging Face 429 flake observed on #1529. It keeps the existing Test workflow topology and avoids the separate cache-warm job.

## Validation
- ruby YAML parse for .github/workflows/test.yml
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only changes (cache path, secrets env, cache step) with no application runtime or auth logic changes.
> 
> **Overview**
> The **Test** workflow now pins Hugging Face artifacts under a workspace-local **`HF_HOME`** and restores/saves that directory with **`actions/cache`**, keyed off **`uv.lock`** and the renderer test files that drive tokenizer downloads.
> 
> The main **Verifiers** matrix job also receives **`HF_TOKEN`** from repo secrets so Hub access is less likely to hit public rate limits (addressing CI 429 flakes on tokenizer loads).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1811e61f2f96ed7572fa57583d548e302d22132a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cache Hugging Face tokenizers in CI to speed up test runs
> Adds a caching step in [test.yml](.github/workflows/test.yml) that stores and restores the Hugging Face tokenizer directory (`HF_HOME`) across CI runs. The cache key is derived from the OS and hashes of `uv.lock` and the relevant test files, with a fallback restore key. `HF_TOKEN` is also now exposed to the job via repository secrets.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1811e61.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->