### PR TITLE
Bump harnesses verifiers minimum

### DIFF
--- a/environments/hello_rlm_v1/pyproject.toml
+++ b/environments/hello_rlm_v1/pyproject.toml
@@ -7,7 +7,7 @@ description = "Minimal v1 environment that runs the RLM CLI through a sandboxed 
 requires-python = ">=3.11"
 dependencies = [
     "verifiers>=0.1.13.dev0",
-    "harnesses>=0.1.1",
+    "harnesses>=0.1.2",
 ]
 
 [build-system]

--- a/environments/opencode_harbor/pyproject.toml
+++ b/environments/opencode_harbor/pyproject.toml
@@ -7,7 +7,7 @@ version = "0.1.2"
 requires-python = ">=3.10"
 dependencies = [
     "verifiers>=0.1.10.dev4",
-    "harnesses>=0.1.1",
+    "harnesses>=0.1.2",
     "tasksets>=0.1.1",
     "prime-sandboxes>=0.2.10",
     "tomli>=2.3.0",

--- a/environments/rlm_swe_v1/README.md
+++ b/environments/rlm_swe_v1/README.md
@@ -22,7 +22,7 @@ env = load_environment(
         harness=RLMConfig(
             program=RLMProgramConfig(
                 local_checkout="/path/to/checkout",
-                rlm_tools=["bash", "edit"],
+                tools=["bash", "edit"],
             )
         ),
     )

--- a/environments/rlm_swe_v1/pyproject.toml
+++ b/environments/rlm_swe_v1/pyproject.toml
@@ -7,7 +7,7 @@ tags = ["v1", "rlm", "swe", "cli-agent"]
 requires-python = ">=3.11"
 dependencies = [
     "datasets",
-    "harnesses>=0.1.1",
+    "harnesses>=0.1.2",
     "pydantic",
     "verifiers",
 ]

--- a/environments/rlm_swe_v1/rlm_swe_v1.py
+++ b/environments/rlm_swe_v1/rlm_swe_v1.py
@@ -493,7 +493,7 @@ def load_taskset(
 
 class RlmSweProgramConfig(RLMProgramConfig):
     workdir: str = DEFAULT_REPO_PATH
-    rlm_tools: list[str] = list(DEFAULT_RLM_TOOLS)
+    tools: list[str] = list(DEFAULT_RLM_TOOLS)
 
 
 class RlmSweHarnessConfig(RLMConfig):

--- a/packages/harnesses/README.md
+++ b/packages/harnesses/README.md
@@ -66,10 +66,13 @@ Command agents use `name@version` specs where their installer supports a
 versioned package or release. Use `@latest` for a moving latest install:
 
 ```toml
-[eval.harness.program]
-# OpenCode
-release = "PrimeIntellect-ai/opencode@latest"
+[eval.harness]
+id = "harnesses.opencode"
+version = "PrimeIntellect-ai/opencode@latest"
+```
 
-# MiniSWEAgent or Pi
-package = "mini-swe-agent@2.2.8"
+```toml
+[eval.harness]
+id = "harnesses.mini_swe_agent"
+version = "mini-swe-agent@2.2.8"
 ```

--- a/packages/harnesses/harnesses/__init__.py
+++ b/packages/harnesses/harnesses/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 from .mini_swe_agent import MiniSWEAgent, MiniSWEAgentConfig, MiniSWEAgentProgramConfig
 from .opencode import OpenCode, OpenCodeConfig, OpenCodeProgramConfig

--- a/packages/harnesses/harnesses/mini_swe_agent.py
+++ b/packages/harnesses/harnesses/mini_swe_agent.py
@@ -16,38 +16,37 @@ MINI_SWE_AGENT_DEFAULT_INSTRUCTION_PATH = "/mini-swe-agent/prompt.txt"
 MINI_SWE_AGENT_DEFAULT_SYSTEM_PROMPT_PATH = "/mini-swe-agent/system.txt"
 MINI_SWE_AGENT_DEFAULT_LOG_PATH = "/logs/agent/mini-swe-agent.log"
 MINI_SWE_AGENT_DEFAULT_TRAJECTORY_PATH = "/logs/agent/mini-swe-agent.traj.json"
-MINI_SWE_AGENT_DEFAULT_PACKAGE = "mini-swe-agent@2.2.8"
+MINI_SWE_AGENT_DEFAULT_VERSION = "mini-swe-agent@2.2.8"
 MINI_SWE_AGENT_DEFAULT_CONFIG_SPEC = "mini"
 MINI_SWE_AGENT_DEFAULT_MODEL_CLASS = "litellm"
 MINI_SWE_AGENT_DEFAULT_ENVIRONMENT_TIMEOUT = 120
 
 
 def build_mini_swe_agent_install_script(
-    package: str = MINI_SWE_AGENT_DEFAULT_PACKAGE,
+    version: str = MINI_SWE_AGENT_DEFAULT_VERSION,
     prefix_dir: str = DEFAULT_PREFIX_DIR,
 ) -> str:
-    install_dir = str(PurePosixPath(prefix_dir).parent)
-    site_packages_dir = f"{prefix_dir.rstrip('/')}/site-packages"
-    setup_prefix_dir = shlex.quote(prefix_dir)
-    setup_site_packages_dir = shlex.quote(site_packages_dir)
-    package_name, package_version = split_versioned_agent_spec(package)
-    package_requirement = package_name
-    if package_version and package_version != "latest":
-        package_requirement = f"{package_name}=={package_version}"
+    root = shlex.quote(str(PurePosixPath(prefix_dir).parent))
+    prefix = shlex.quote(prefix_dir)
+    site_packages = shlex.quote(f"{prefix_dir.rstrip('/')}/site-packages")
+    name, parsed_version = split_versioned_agent_spec(version)
+    requirement = name
+    if parsed_version and parsed_version != "latest":
+        requirement = f"{name}=={parsed_version}"
     return f"""\
 set -e
 {python_runtime_setup_command()}
-rm -rf {setup_prefix_dir}
-mkdir -p {shlex.quote(install_dir)} {setup_prefix_dir}/bin {setup_site_packages_dir} {shlex.quote(DEFAULT_LOG_DIR)} /mini-swe-agent
-vf_python_install --target {setup_site_packages_dir} {shlex.quote(package_requirement)}
-echo "$VF_PYTHON" > {setup_prefix_dir}/python
-cat > {setup_prefix_dir}/bin/mini <<'EOF'
+rm -rf {prefix}
+mkdir -p {root} {prefix}/bin {site_packages} {shlex.quote(DEFAULT_LOG_DIR)} /mini-swe-agent
+vf_python_install --target {site_packages} {shlex.quote(requirement)}
+echo "$VF_PYTHON" > {prefix}/python
+cat > {prefix}/bin/mini <<'EOF'
 #!/usr/bin/env sh
-export PYTHONPATH={setup_site_packages_dir}:${{PYTHONPATH:-}}
-exec "$(cat {setup_prefix_dir}/python)" -m minisweagent.run.mini "$@"
+export PYTHONPATH={site_packages}:${{PYTHONPATH:-}}
+exec "$(cat {prefix}/python)" -m minisweagent.run.mini "$@"
 EOF
-chmod +x {setup_prefix_dir}/bin/mini
-test -x {setup_prefix_dir}/bin/mini
+chmod +x {prefix}/bin/mini
+test -x {prefix}/bin/mini
 """
 
 
@@ -57,7 +56,6 @@ class MiniSWEAgentProgramConfig(vf.ProgramConfig):
     system_prompt_path: str = MINI_SWE_AGENT_DEFAULT_SYSTEM_PROMPT_PATH
     log_path: str = MINI_SWE_AGENT_DEFAULT_LOG_PATH
     trajectory_path: str = MINI_SWE_AGENT_DEFAULT_TRAJECTORY_PATH
-    package: str = MINI_SWE_AGENT_DEFAULT_PACKAGE
     config_spec: str = MINI_SWE_AGENT_DEFAULT_CONFIG_SPEC
     model_class: str = MINI_SWE_AGENT_DEFAULT_MODEL_CLASS
     environment_timeout: int = MINI_SWE_AGENT_DEFAULT_ENVIRONMENT_TIMEOUT
@@ -65,7 +63,9 @@ class MiniSWEAgentProgramConfig(vf.ProgramConfig):
     extra_config_specs: list[str] | None = None
     sandbox: vf.SandboxConfig | None = vf.SandboxConfig()
 
-    def resolve(self) -> vf.ProgramConfig:
+    def resolve(
+        self, version: str = MINI_SWE_AGENT_DEFAULT_VERSION
+    ) -> vf.ProgramConfig:
         files: dict[str, vf.ProgramValue] = {
             self.instruction_path: {"fn": "verifiers.v1.utils.prompt_utils:task_text"},
             self.system_prompt_path: {
@@ -87,13 +87,11 @@ class MiniSWEAgentProgramConfig(vf.ProgramConfig):
             }
         )
         if self.agent_workdir == MINI_SWE_AGENT_DEFAULT_AGENT_WORKDIR:
-            workdir_assignment = (
+            workdir_line = (
                 f"MINI_SWE_AGENT_WORKDIR={MINI_SWE_AGENT_DEFAULT_AGENT_WORKDIR}"
             )
         else:
-            workdir_assignment = (
-                f"MINI_SWE_AGENT_WORKDIR={shlex.quote(self.agent_workdir)}"
-            )
+            workdir_line = f"MINI_SWE_AGENT_WORKDIR={shlex.quote(self.agent_workdir)}"
 
         config_args = [
             "-c",
@@ -115,11 +113,11 @@ class MiniSWEAgentProgramConfig(vf.ProgramConfig):
             config_args.extend(["-c", shlex.quote(spec)])
 
         setup = build_mini_swe_agent_install_script(
-            package=self.package,
+            version=version,
         )
         log_dir = str(PurePosixPath(self.log_path).parent)
         trajectory_dir = str(PurePosixPath(self.trajectory_path).parent)
-        system_prompt_path = shlex.quote(self.system_prompt_path)
+        system_prompt_file = shlex.quote(self.system_prompt_path)
         script = f"""\
 set -eo pipefail
 export PATH={shlex.quote(DEFAULT_PREFIX_DIR)}/bin:"$PATH"
@@ -129,14 +127,14 @@ export MSWEA_SILENT_STARTUP=true
 export MSWEA_GLOBAL_CONFIG_DIR=/tmp/mini-swe-agent-config
 export OPENAI_API_KEY="${{OPENAI_API_KEY:-intercepted}}"
 
-{workdir_assignment}
+{workdir_line}
 mkdir -p {shlex.quote(log_dir)} {shlex.quote(trajectory_dir)} "$MINI_SWE_AGENT_WORKDIR" "$MSWEA_GLOBAL_CONFIG_DIR"
 
 MINI_SWE_AGENT_TASK="$(cat {shlex.quote(self.instruction_path)})"
 CONFIG_ARGS=({" ".join(config_args)})
 CONFIG_ARGS+=(-c "environment.cwd=$MINI_SWE_AGENT_WORKDIR")
-if [ -s {system_prompt_path} ]; then
-  CONFIG_ARGS+=(-c "agent.system_template=$(cat {system_prompt_path})")
+if [ -s {system_prompt_file} ]; then
+  CONFIG_ARGS+=(-c "agent.system_template=$(cat {system_prompt_file})")
 fi
 cd "$MINI_SWE_AGENT_WORKDIR"
 timeout --kill-after=30s "${{AGENT_TIMEOUT_SECONDS:-3600}}" {shlex.quote(DEFAULT_MINI_BINARY)} \\
@@ -158,12 +156,16 @@ timeout --kill-after=30s "${{AGENT_TIMEOUT_SECONDS:-3600}}" {shlex.quote(DEFAULT
 
 
 class MiniSWEAgentConfig(vf.HarnessConfig):
+    version: str = MINI_SWE_AGENT_DEFAULT_VERSION
     program: MiniSWEAgentProgramConfig = MiniSWEAgentProgramConfig()
     max_turns: int = 4
 
 
 class MiniSWEAgent(vf.Harness[MiniSWEAgentConfig]):
     config: MiniSWEAgentConfig
+
+    def load_program_config(self, config: MiniSWEAgentConfig) -> vf.ProgramConfig:
+        return config.program.resolve(version=config.version)
 
 
 def load_harness(config: MiniSWEAgentConfig) -> MiniSWEAgent:

--- a/packages/harnesses/harnesses/opencode.py
+++ b/packages/harnesses/harnesses/opencode.py
@@ -7,7 +7,7 @@ from verifiers.v1.utils.mcp_proxy_utils import proxy_command
 
 from .utils import split_versioned_agent_spec
 
-OPENCODE_DEFAULT_RELEASE = "PrimeIntellect-ai/opencode@1.1.63-rl2"
+OPENCODE_DEFAULT_VERSION = "PrimeIntellect-ai/opencode@1.1.63-rl2"
 OPENCODE_DEFAULT_AGENT_WORKDIR = "/app"
 OPENCODE_DEFAULT_INSTRUCTION_PATH = "/opencode/instruction.txt"
 OPENCODE_DEFAULT_SYSTEM_PROMPT_PATH = "/opencode/system.txt"
@@ -50,11 +50,10 @@ class OpenCodeProgramConfig(vf.ProgramConfig):
     disabled_tools: list[str] = OPENCODE_DEFAULT_DISABLED_TOOLS
     allow_git: bool = False
     disable_compaction: bool = True
-    release: str = OPENCODE_DEFAULT_RELEASE
     install_ripgrep: bool = True
     provider_timeout_ms: int = 3_600_000
 
-    def resolve(self) -> vf.ProgramConfig:
+    def resolve(self, version: str = OPENCODE_DEFAULT_VERSION) -> vf.ProgramConfig:
         files: dict[str, vf.ProgramValue] = {
             self.instruction_path: {"fn": "verifiers.v1.utils.prompt_utils:task_text"},
             self.system_prompt_path: {
@@ -70,29 +69,29 @@ class OpenCodeProgramConfig(vf.ProgramConfig):
                 }
             }
         )
-        rg_install = (
+        ripgrep_install = (
             "apt-get -o Acquire::Retries=3 install -y -qq ripgrep > /dev/null 2>&1 || true"
             if self.install_ripgrep
             else ""
         )
-        release_repo, release_version = split_versioned_agent_spec(self.release)
-        release_path = "releases/latest/download"
-        if release_version and release_version != "latest":
-            release_tag = (
-                release_version
-                if release_version.startswith("v")
-                else f"v{release_version}"
+        repo, parsed_version = split_versioned_agent_spec(version)
+        path = "releases/latest/download"
+        if parsed_version and parsed_version != "latest":
+            tag = (
+                parsed_version
+                if parsed_version.startswith("v")
+                else f"v{parsed_version}"
             )
-            release_path = f"releases/download/{release_tag}"
+            path = f"releases/download/{tag}"
         # Acquire::Retries=3 mitigates transient archive.ubuntu.com CDN sync
         # mismatches that fail fresh-sandbox apt-get calls mid-rollout.
         setup = f"""\
 set -e
 apt-get -o Acquire::Retries=3 update -qq && apt-get -o Acquire::Retries=3 install -y -qq curl tar ca-certificates > /dev/null 2>&1
-{rg_install}
+{ripgrep_install}
 
-OPENCODE_RELEASE_REPO={shlex.quote(release_repo)}
-OPENCODE_RELEASE_PATH={shlex.quote(release_path)}
+OPENCODE_RELEASE_REPO={shlex.quote(repo)}
+OPENCODE_RELEASE_PATH={shlex.quote(path)}
 
 case "$(uname -m)" in
   x86_64) OPENCODE_ARCH=x64 ;;
@@ -201,12 +200,16 @@ class OpenCodeConfig(vf.HarnessConfig):
     system_prompt: vf.PromptInput | vf.SystemPromptConfig | None = (
         OPENCODE_DEFAULT_SYSTEM_PROMPT
     )
+    version: str = OPENCODE_DEFAULT_VERSION
     program: OpenCodeProgramConfig = OpenCodeProgramConfig()
     max_turns: int = 4
 
 
 class OpenCode(vf.Harness[OpenCodeConfig]):
     config: OpenCodeConfig
+
+    def load_program_config(self, config: OpenCodeConfig) -> vf.ProgramConfig:
+        return config.program.resolve(version=config.version)
 
 
 def load_harness(config: OpenCodeConfig) -> OpenCode:

--- a/packages/harnesses/harnesses/pi.py
+++ b/packages/harnesses/harnesses/pi.py
@@ -5,7 +5,7 @@ from pathlib import PurePosixPath
 import verifiers as vf
 from verifiers.v1.utils.mcp_proxy_utils import proxy_command
 
-PI_DEFAULT_PACKAGE = "@earendil-works/pi-coding-agent@latest"
+PI_DEFAULT_VERSION = "@earendil-works/pi-coding-agent@latest"
 PI_DEFAULT_WORKDIR = "/app"
 PI_DEFAULT_INSTRUCTION_PATH = "/pi/instruction.txt"
 PI_DEFAULT_SYSTEM_PROMPT_PATH = "/pi/system.txt"
@@ -18,11 +18,10 @@ class PiProgramConfig(vf.ProgramConfig):
     instruction_path: str = PI_DEFAULT_INSTRUCTION_PATH
     system_prompt_path: str = PI_DEFAULT_SYSTEM_PROMPT_PATH
     log_path: str = PI_DEFAULT_LOG_PATH
-    package: str = PI_DEFAULT_PACKAGE
     install_mcp_adapter: bool = True
     sandbox: vf.SandboxConfig | None = vf.SandboxConfig()
 
-    def resolve(self) -> vf.ProgramConfig:
+    def resolve(self, version: str = PI_DEFAULT_VERSION) -> vf.ProgramConfig:
         files: dict[str, vf.ProgramValue] = {
             self.instruction_path: {"fn": "verifiers.v1.utils.prompt_utils:task_text"},
             self.system_prompt_path: {
@@ -82,7 +81,7 @@ apt-get -o Acquire::Retries=3 update -qq && apt-get -o Acquire::Retries=3 instal
 npm install -g --ignore-scripts n
 n 22.19.0
 hash -r
-npm install -g --ignore-scripts {shlex.quote(self.package)}
+npm install -g --ignore-scripts {shlex.quote(version)}
 """
         artifacts = vf.ArtifactsConfig.model_validate(
             {
@@ -127,12 +126,16 @@ class PiConfig(vf.HarnessConfig):
     system_prompt: vf.PromptInput | vf.SystemPromptConfig | None = (
         PI_DEFAULT_SYSTEM_PROMPT
     )
+    version: str = PI_DEFAULT_VERSION
     program: PiProgramConfig = PiProgramConfig()
     max_turns: int = 4
 
 
 class Pi(vf.Harness[PiConfig]):
     config: PiConfig
+
+    def load_program_config(self, config: PiConfig) -> vf.ProgramConfig:
+        return config.program.resolve(version=config.version)
 
 
 def load_harness(config: PiConfig) -> Pi:

--- a/packages/harnesses/harnesses/rlm.py
+++ b/packages/harnesses/harnesses/rlm.py
@@ -11,7 +11,7 @@ from .utils.rlm_utils import (
 )
 
 RLM_DEFAULT_REPO_URL = "github.com/PrimeIntellect-ai/rlm-harness.git"
-RLM_DEFAULT_REPO_REF = "main"
+RLM_DEFAULT_REF = "main"
 RLM_DEFAULT_EXEC_TIMEOUT = 300
 RLM_DEFAULT_MAX_DEPTH = 0
 RLM_DEFAULT_INSTRUCTION_PATH = "/rlm/instruction.txt"
@@ -24,15 +24,15 @@ class RLMProgramConfig(vf.ProgramConfig):
     sandbox: vf.SandboxConfig | None = None
     workdir: str = RLM_DEFAULT_WORKDIR
     instruction_path: str = RLM_DEFAULT_INSTRUCTION_PATH
-    rlm_repo_url: str = RLM_DEFAULT_REPO_URL
-    rlm_repo_ref: str = RLM_DEFAULT_REPO_REF
-    rlm_exec_timeout: int = RLM_DEFAULT_EXEC_TIMEOUT
-    rlm_max_depth: int = RLM_DEFAULT_MAX_DEPTH
+    repo_url: str = RLM_DEFAULT_REPO_URL
+    ref: str = RLM_DEFAULT_REF
+    exec_timeout: int = RLM_DEFAULT_EXEC_TIMEOUT
+    max_depth: int = RLM_DEFAULT_MAX_DEPTH
     summarize_at_tokens: int | None = None
     append_to_system_prompt: str = ""
     local_checkout: str | None = None
     gh_token_var: str | None = "GH_TOKEN"
-    rlm_tools: list[str] = RLM_DEFAULT_TOOLS
+    tools: list[str] = RLM_DEFAULT_TOOLS
     env_vars: dict[str, str] = {}
     skills: str | None = None
 
@@ -55,8 +55,8 @@ class RLMProgramConfig(vf.ProgramConfig):
                     if self.local_checkout
                     else {}
                 ),
-                "rlm_repo_url": self.rlm_repo_url,
-                "rlm_repo_ref": self.rlm_repo_ref,
+                "repo_url": self.repo_url,
+                "ref": self.ref,
                 **({"gh_token_var": self.gh_token_var} if self.gh_token_var else {}),
             }
         }
@@ -71,9 +71,9 @@ class RLMProgramConfig(vf.ProgramConfig):
             "PATH": "/root/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
             "OPENAI_MODEL": "runtime.model",
             "RLM_MODEL": "runtime.model",
-            "RLM_TOOLS": ",".join(self.rlm_tools),
-            "RLM_EXEC_TIMEOUT": str(self.rlm_exec_timeout),
-            "RLM_MAX_DEPTH": str(self.rlm_max_depth),
+            "RLM_TOOLS": ",".join(self.tools),
+            "RLM_EXEC_TIMEOUT": str(self.exec_timeout),
+            "RLM_MAX_DEPTH": str(self.max_depth),
             **self.env_vars,
         }
         if self.summarize_at_tokens is not None:
@@ -90,7 +90,7 @@ class RLMProgramConfig(vf.ProgramConfig):
                 }
             }
         )
-        command_timeout = max(self.rlm_exec_timeout + 120, 600)
+        command_timeout = max(self.exec_timeout + 120, 600)
         setup_timeout = command_timeout
         if self.sandbox is not None and "setup_timeout" in self.sandbox.data(
             fill_defaults=False

--- a/packages/harnesses/harnesses/terminus_2.py
+++ b/packages/harnesses/harnesses/terminus_2.py
@@ -8,7 +8,7 @@ TERMINUS_2_DEFAULT_AGENT_WORKDIR = "/app"
 TERMINUS_2_DEFAULT_INSTRUCTION_PATH = "/terminus_2/instruction.md"
 TERMINUS_2_DEFAULT_SYSTEM_PROMPT_PATH = "/terminus_2/system_prompt.txt"
 TERMINUS_2_DEFAULT_LOG_PATH = "/logs/agent/terminus_2.log"
-TERMINUS_2_DEFAULT_HARBOR_PACKAGE = "harbor==0.6.6"
+TERMINUS_2_DEFAULT_VERSION = "harbor==0.6.6"
 TERMINUS_2_DEFAULT_PYTHON_VERSION = "3.12"
 TERMINUS_2_DEFAULT_MODEL_NAME = "openai/gpt-4.1-mini"
 TERMINUS_2_DEFAULT_API_BASE_URL = "https://api.pinference.ai/api/v1"
@@ -19,14 +19,13 @@ class Terminus2ProgramConfig(vf.ProgramConfig):
     instruction_path: str = TERMINUS_2_DEFAULT_INSTRUCTION_PATH
     system_prompt_path: str = TERMINUS_2_DEFAULT_SYSTEM_PROMPT_PATH
     log_path: str = TERMINUS_2_DEFAULT_LOG_PATH
-    harbor_package: str = TERMINUS_2_DEFAULT_HARBOR_PACKAGE
     python_version: str = TERMINUS_2_DEFAULT_PYTHON_VERSION
     model_name: str = TERMINUS_2_DEFAULT_MODEL_NAME
     api_base_url: str = TERMINUS_2_DEFAULT_API_BASE_URL
     sandbox: vf.SandboxConfig | None = vf.SandboxConfig()
     max_turns: int = 4
 
-    def resolve(self) -> vf.ProgramConfig:
+    def resolve(self, version: str = TERMINUS_2_DEFAULT_VERSION) -> vf.ProgramConfig:
         files: dict[str, vf.ProgramValue] = {
             self.instruction_path: {"fn": "verifiers.v1.utils.prompt_utils:task_text"},
             self.system_prompt_path: {
@@ -171,7 +170,7 @@ mkdir -p {shlex.quote(log_dir)} "$TERMINUS_2_WORKDIR"
 cd "$TERMINUS_2_WORKDIR"
 uv --no-config run --no-project --quiet \
   --python {shlex.quote(self.python_version)} \
-  --with {shlex.quote(self.harbor_package)} \
+  --with {shlex.quote(version)} \
   python - <<'PY' 2>&1 | tee -a {shlex.quote(self.log_path)}
 {agent_script}
 PY
@@ -186,11 +185,15 @@ PY
 
 
 class Terminus2Config(vf.HarnessConfig):
+    version: str = TERMINUS_2_DEFAULT_VERSION
     program: Terminus2ProgramConfig = Terminus2ProgramConfig()
 
 
 class Terminus2(vf.Harness[Terminus2Config]):
     config: Terminus2Config
+
+    def load_program_config(self, config: Terminus2Config) -> vf.ProgramConfig:
+        return config.program.resolve(version=config.version)
 
 
 def load_harness(config: Terminus2Config) -> Terminus2:

--- a/packages/harnesses/harnesses/utils/rlm_utils.py
+++ b/packages/harnesses/harnesses/utils/rlm_utils.py
@@ -31,23 +31,23 @@ REQUIRED_RLM_CHECKOUT_FILES = ("install.sh", "pyproject.toml")
 
 
 def rlm_checkout_path(
-    rlm_repo_url: str,
-    rlm_repo_ref: str,
+    repo_url: str,
+    ref: str,
     local_checkout: str | None = None,
     gh_token_var: str | None = "GH_TOKEN",
 ) -> Path:
     return rlm_checkout_loader(
         local_checkout=local_checkout,
-        rlm_repo_url=rlm_repo_url,
-        rlm_repo_ref=rlm_repo_ref,
+        repo_url=repo_url,
+        ref=ref,
         gh_token_var=gh_token_var,
     )()
 
 
 def rlm_checkout_loader(
     local_checkout: str | Path | None,
-    rlm_repo_url: str,
-    rlm_repo_ref: str,
+    repo_url: str,
+    ref: str,
     gh_token_var: str | None,
 ) -> Callable[[], Path]:
     checkout: Path | None = None
@@ -63,8 +63,8 @@ def rlm_checkout_loader(
             )
         else:
             checkout = resolve_git_checkout(
-                repo_url=rlm_repo_url,
-                ref=rlm_repo_ref,
+                repo_url=repo_url,
+                ref=ref,
                 cache_root=DEFAULT_RLM_LOCAL_CHECKOUT_CACHE_ROOT,
                 gh_token=os.environ.get(gh_token_var) if gh_token_var else None,
                 required_files=REQUIRED_RLM_CHECKOUT_FILES,

--- a/packages/harnesses/pyproject.toml
+++ b/packages/harnesses/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 license = "MIT"
 requires-python = ">=3.10,<3.14"
 dependencies = [
-    "verifiers>=0.1.15.dev158",
+    "verifiers>=0.1.15.dev11",
 ]
 
 [project.optional-dependencies]

--- a/packages/harnesses/pyproject.toml
+++ b/packages/harnesses/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 license = "MIT"
 requires-python = ">=3.10,<3.14"
 dependencies = [
-    "verifiers>=0.1.15.dev11",
+    "verifiers>=0.1.15.dev158",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,10 +92,10 @@ tasksets = [
     "tasksets[openenv,openreward,ta]>=0.1.1",
 ]
 harnesses = [
-    "harnesses>=0.1.1",
+    "harnesses>=0.1.2",
 ]
 packages = [
-    "harnesses>=0.1.1",
+    "harnesses>=0.1.2",
     "tasksets[openenv,openreward,ta]>=0.1.1",
 ]
 browser = [

--- a/tests/test_composable_env.py
+++ b/tests/test_composable_env.py
@@ -22,6 +22,7 @@ from verifiers.envs.experimental.composable.harnesses.mini_swe_agent import (
 )
 from verifiers.envs.experimental.composable.harnesses.opencode import (
     build_install_script as build_opencode_install_script,
+    opencode_harness,
 )
 
 
@@ -212,6 +213,20 @@ def test_composable_opencode_unversioned_version_uses_latest_download_url():
     assert "OPENCODE_RELEASE_REPO=PrimeIntellect-ai/opencode" in setup
     assert "OPENCODE_RELEASE_PATH=releases/latest/download" in setup
     assert "releases/download/vPrimeIntellect-ai/opencode" not in setup
+
+
+def test_composable_opencode_accepts_opencode_swe_release_kwargs():
+    harness = opencode_harness(
+        system_prompt=None,
+        release_repo="PrimeIntellect-ai/opencode",
+        release_version="1.1.63-rl1",
+        release_sha256="17104d601b8bf6fd03dd46a6de055b422414b9ada524fe085b09683f455ccac1",
+    )
+
+    assert "OPENCODE_RELEASE_REPO=PrimeIntellect-ai/opencode" in harness.install_script
+    assert (
+        "OPENCODE_RELEASE_PATH=releases/download/v1.1.63-rl1" in harness.install_script
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_composable_env.py
+++ b/tests/test_composable_env.py
@@ -193,8 +193,8 @@ def test_taskset_repr():
     assert "3" in repr(ts)
 
 
-def test_composable_mini_swe_agent_unversioned_package_uses_unpinned_requirement():
-    setup = build_mini_swe_agent_install_script(package="  mini-swe-agent  ")
+def test_composable_mini_swe_agent_unversioned_version_uses_unpinned_requirement():
+    setup = build_mini_swe_agent_install_script(version="  mini-swe-agent  ")
 
     assert (
         "vf_python_install --target /opt/mini-swe-agent/prefix/site-packages mini-swe-agent"
@@ -203,9 +203,9 @@ def test_composable_mini_swe_agent_unversioned_package_uses_unpinned_requirement
     assert "mini-swe-agent==mini-swe-agent" not in setup
 
 
-def test_composable_opencode_unversioned_release_uses_latest_download_url():
+def test_composable_opencode_unversioned_version_uses_latest_download_url():
     setup = build_opencode_install_script(
-        release="  PrimeIntellect-ai/opencode  ",
+        version="  PrimeIntellect-ai/opencode  ",
         install_ripgrep=False,
     )
 

--- a/tests/test_rlm_composable_env.py
+++ b/tests/test_rlm_composable_env.py
@@ -227,8 +227,8 @@ def test_resolve_local_checkout_materializes_host_cache_for_named_ref(
     )
 
     resolved = resolve_local_checkout(
-        rlm_repo_url=str(source_checkout),
-        rlm_ref="main",
+        repo_url=str(source_checkout),
+        ref="main",
     )
 
     assert resolved.name == source_commit
@@ -250,8 +250,8 @@ def test_rlm_harness_uses_default_host_cache_when_local_checkout_unspecified(
     )
 
     harness = rlm_harness(
-        rlm_repo_url=str(source_checkout),
-        rlm_ref="main",
+        repo_url=str(source_checkout),
+        ref="main",
     )
 
     assert harness.get_upload_dirs is not None
@@ -272,8 +272,8 @@ def test_rlm_harness_memoizes_resolved_checkout_per_instance(tmp_path, monkeypat
     )
 
     harness = rlm_harness(
-        rlm_repo_url=str(source_checkout),
-        rlm_ref="main",
+        repo_url=str(source_checkout),
+        ref="main",
     )
     first_upload_checkout = harness.get_upload_dirs()["rlm_checkout"]
 
@@ -302,8 +302,8 @@ def test_rlm_harness_preserves_prior_checkout_while_leased(tmp_path, monkeypatch
     )
 
     first_harness = rlm_harness(
-        rlm_repo_url=str(source_checkout),
-        rlm_ref="main",
+        repo_url=str(source_checkout),
+        ref="main",
     )
     first_checkout = first_harness.get_upload_dirs()["rlm_checkout"]
     assert isinstance(first_checkout, Path)
@@ -312,8 +312,8 @@ def test_rlm_harness_preserves_prior_checkout_while_leased(tmp_path, monkeypatch
     second_commit = _commit_file(source_checkout, "README.md", "updated\n")
 
     second_harness = rlm_harness(
-        rlm_repo_url=str(source_checkout),
-        rlm_ref="main",
+        repo_url=str(source_checkout),
+        ref="main",
     )
     second_checkout = second_harness.get_upload_dirs()["rlm_checkout"]
     assert isinstance(second_checkout, Path)
@@ -333,15 +333,15 @@ def test_rlm_harness_prunes_stale_checkout_after_lease_released(tmp_path, monkey
     )
 
     first_checkout = rlm_harness(
-        rlm_repo_url=str(source_checkout),
-        rlm_ref="main",
+        repo_url=str(source_checkout),
+        ref="main",
     ).get_upload_dirs()["rlm_checkout"]
     _commit_file(source_checkout, "README.md", "updated\n")
     git_checkout_cache_module._release_all_in_use_locks()
 
     second_checkout = rlm_harness(
-        rlm_repo_url=str(source_checkout),
-        rlm_ref="main",
+        repo_url=str(source_checkout),
+        ref="main",
     ).get_upload_dirs()["rlm_checkout"]
     assert second_checkout != first_checkout
     assert not first_checkout.exists()
@@ -364,8 +364,8 @@ def test_rlm_harness_skips_pruning_externally_locked_stale_checkout(
     )
 
     first_harness = rlm_harness(
-        rlm_repo_url=str(source_checkout),
-        rlm_ref="main",
+        repo_url=str(source_checkout),
+        ref="main",
     )
     first_checkout = first_harness.get_upload_dirs()["rlm_checkout"]
     assert first_checkout.name == first_commit
@@ -375,16 +375,16 @@ def test_rlm_harness_skips_pruning_externally_locked_stale_checkout(
 
     with shared_path_lock(first_checkout, suffix=".in-use.lock"):
         second_checkout = rlm_harness(
-            rlm_repo_url=str(source_checkout),
-            rlm_ref="main",
+            repo_url=str(source_checkout),
+            ref="main",
         ).get_upload_dirs()["rlm_checkout"]
         assert second_checkout.name == second_commit
         assert first_checkout.exists()
 
     git_checkout_cache_module._release_all_in_use_locks()
     third_checkout = rlm_harness(
-        rlm_repo_url=str(source_checkout),
-        rlm_ref="main",
+        repo_url=str(source_checkout),
+        ref="main",
     ).get_upload_dirs()["rlm_checkout"]
     assert third_checkout == second_checkout
     assert not first_checkout.exists()
@@ -415,8 +415,8 @@ def test_resolve_local_checkout_redacts_gh_token_on_clone_failure(
 
     with pytest.raises(RuntimeError) as exc_info:
         resolve_local_checkout(
-            rlm_repo_url="github.com/PrimeIntellect-ai/rlm.git",
-            rlm_ref="main",
+            repo_url="github.com/PrimeIntellect-ai/rlm.git",
+            ref="main",
             gh_token=token,
         )
 
@@ -437,8 +437,8 @@ def test_resolve_local_checkout_materializes_host_cache_for_exact_commit(
     )
 
     resolved = resolve_local_checkout(
-        rlm_repo_url=str(source_checkout),
-        rlm_ref=second_commit,
+        repo_url=str(source_checkout),
+        ref=second_commit,
     )
 
     assert resolved.name == second_commit

--- a/tests/test_v1_harbor_cli.py
+++ b/tests/test_v1_harbor_cli.py
@@ -25,10 +25,10 @@ from harnesses import (
     Terminus2Config,
     Terminus2ProgramConfig,
 )
-from harnesses.pi import PI_DEFAULT_PACKAGE
+from harnesses.pi import PI_DEFAULT_VERSION
 from harnesses.terminus_2 import (
     TERMINUS_2_DEFAULT_API_BASE_URL,
-    TERMINUS_2_DEFAULT_HARBOR_PACKAGE,
+    TERMINUS_2_DEFAULT_VERSION,
     TERMINUS_2_DEFAULT_MODEL_NAME,
     Terminus2,
 )
@@ -268,7 +268,7 @@ def test_opencode_config_owns_opencode_harness_fields() -> None:
             max_turns=2,
         )
     )
-    program = cast(dict[str, object], harness.config.program.data())
+    program = cast(dict[str, object], harness.program_config.data())
     command = cast(list[object], program["command"])
     mcp_setup = cast(dict[str, object], program["channels"])["mcp"]
     setup = cast(str, program["setup"])
@@ -287,33 +287,34 @@ def test_opencode_config_owns_opencode_harness_fields() -> None:
 
 
 @pytest.mark.parametrize(
-    "release", ["PrimeIntellect-ai/opencode@latest", "  PrimeIntellect-ai/opencode  "]
+    "version",
+    ["PrimeIntellect-ai/opencode@latest", "  PrimeIntellect-ai/opencode  "],
 )
-def test_opencode_latest_release_uses_latest_download_url(release: str) -> None:
+def test_opencode_latest_version_uses_latest_download_url(
+    version: str,
+) -> None:
     harness = OpenCode(
         config=OpenCodeConfig(
+            version=version,
             program=OpenCodeProgramConfig(
-                release=release,
                 install_ripgrep=False,
-            )
+            ),
         )
     )
-    program = cast(dict[str, object], harness.config.program.data())
+    program = cast(dict[str, object], harness.program_config.data())
     setup = cast(str, program["setup"])
 
     assert "OPENCODE_RELEASE_REPO=PrimeIntellect-ai/opencode" in setup
     assert "OPENCODE_RELEASE_PATH=releases/latest/download" in setup
 
 
-def test_opencode_custom_release_uses_versioned_spec() -> None:
+def test_opencode_custom_version_uses_versioned_release() -> None:
     harness = OpenCode(
         config=OpenCodeConfig(
-            program=OpenCodeProgramConfig(
-                release="Example/open-code@v2.0.0",
-            )
+            version="Example/open-code@v2.0.0",
         )
     )
-    program = cast(dict[str, object], harness.config.program.data())
+    program = cast(dict[str, object], harness.program_config.data())
     setup = cast(str, program["setup"])
 
     assert "OPENCODE_RELEASE_REPO=Example/open-code" in setup
@@ -339,7 +340,7 @@ def test_packaged_command_harnesses_defer_partial_program_overrides(
         "args": ["--caller"],
     }
     harness = harness_cls(config=config_cls(program=override))
-    program = cast(dict[str, object], harness.config.program.data())
+    program = cast(dict[str, object], harness.program_config.data())
     env = cast(dict[str, object], program["env"])
     setup = cast(list[object], program["setup"])
     args = cast(list[object], program["args"])
@@ -363,7 +364,7 @@ def test_packaged_command_harness_config_program_patch_precedence() -> None:
             program=MiniSWEAgentProgramConfig(env={"OPENAI_MODEL": "caller-model"})
         )
     )
-    program = cast(dict[str, object], harness.config.program.data())
+    program = cast(dict[str, object], harness.program_config.data())
     env = cast(dict[str, object], program["env"])
 
     assert env["OPENAI_MODEL"] == "caller-model"
@@ -385,16 +386,16 @@ def test_packaged_command_harness_config_program_rejects_owned_keys(
 
 def test_pi_harness_writes_intercepted_model_and_mcp_config() -> None:
     harness = Pi()
-    program = cast(dict[str, object], harness.config.program.data())
+    program = cast(dict[str, object], harness.program_config.data())
     setup = cast(str, program["setup"])
     channels = cast(dict[str, object], program["channels"])
     mcp_setup = cast(str, channels["mcp"])
 
     assert "apt-get -o Acquire::Retries=3 update" in setup
     assert "apt-get -o Acquire::Retries=3 install" in setup
-    assert harness.config.program.package == PI_DEFAULT_PACKAGE
-    assert PI_DEFAULT_PACKAGE == "@earendil-works/pi-coding-agent@latest"
-    assert f"npm install -g --ignore-scripts {PI_DEFAULT_PACKAGE}" in setup
+    assert harness.config.version == PI_DEFAULT_VERSION
+    assert PI_DEFAULT_VERSION == "@earendil-works/pi-coding-agent@latest"
+    assert f"npm install -g --ignore-scripts {PI_DEFAULT_VERSION}" in setup
     assert "mariozechner" not in setup
     assert '"baseUrl": "${OPENAI_BASE_URL}"' in mcp_setup
     assert '"api": "openai-completions"' in mcp_setup
@@ -404,13 +405,9 @@ def test_pi_harness_writes_intercepted_model_and_mcp_config() -> None:
     assert f'"command": "{SANDBOX_PYTHON}"' in mcp_setup
 
 
-def test_pi_harness_preserves_scoped_npm_package_versions() -> None:
-    harness = Pi(
-        config=PiConfig(
-            program=PiProgramConfig(package="@anthropic-ai/claude-code@1.2.3")
-        )
-    )
-    program = cast(dict[str, object], harness.config.program.data())
+def test_pi_harness_preserves_scoped_npm_versions() -> None:
+    harness = Pi(config=PiConfig(version="@anthropic-ai/claude-code@1.2.3"))
+    program = cast(dict[str, object], harness.program_config.data())
     setup = cast(str, program["setup"])
 
     assert "npm install -g --ignore-scripts @anthropic-ai/claude-code@1.2.3" in setup
@@ -445,7 +442,7 @@ def test_terminus_2_harness_builds_sandbox_program() -> None:
 
     run_script = cast(str, command[2])
     assert "TERMINUS_2_WORKDIR=/workspace" in run_script
-    assert f"--with {TERMINUS_2_DEFAULT_HARBOR_PACKAGE}" in run_script
+    assert f"--with {TERMINUS_2_DEFAULT_VERSION}" in run_script
     assert "git+https://github.com" not in run_script
     assert "max_turns=7" in run_script
 

--- a/tests/test_v1_mini_swe_agent.py
+++ b/tests/test_v1_mini_swe_agent.py
@@ -68,7 +68,7 @@ def test_mini_swe_agent_builds_sandbox_program():
             ),
         )
     )
-    program = cast(dict[str, Any], harness.config.program.data())
+    program = cast(dict[str, Any], harness.program_config.data())
     command = cast(list[str], program["command"])
     script = command[-1]
 
@@ -86,12 +86,12 @@ def test_mini_swe_agent_builds_sandbox_program():
     assert "mini_swe_agent_log" in cast(dict[str, object], program["artifacts"])
 
 
-@pytest.mark.parametrize("package", ["mini-swe-agent@latest", "  mini-swe-agent  "])
-def test_mini_swe_agent_latest_package_uses_unpinned_pip_requirement(package: str):
-    harness = MiniSWEAgent(
-        config=MiniSWEAgentConfig(program=MiniSWEAgentProgramConfig(package=package))
-    )
-    program = cast(dict[str, Any], harness.config.program.data())
+@pytest.mark.parametrize("version", ["mini-swe-agent@latest", "  mini-swe-agent  "])
+def test_mini_swe_agent_latest_version_uses_unpinned_pip_requirement(
+    version: str,
+):
+    harness = MiniSWEAgent(config=MiniSWEAgentConfig(version=version))
+    program = cast(dict[str, Any], harness.program_config.data())
     setup = cast(str, program["setup"])
 
     assert (
@@ -100,13 +100,9 @@ def test_mini_swe_agent_latest_package_uses_unpinned_pip_requirement(package: st
     )
 
 
-def test_mini_swe_agent_pinned_package_uses_pip_requirement():
-    harness = MiniSWEAgent(
-        config=MiniSWEAgentConfig(
-            program=MiniSWEAgentProgramConfig(package="mini-swe-agent@2.2.7")
-        )
-    )
-    program = cast(dict[str, Any], harness.config.program.data())
+def test_mini_swe_agent_pinned_version_uses_pip_requirement():
+    harness = MiniSWEAgent(config=MiniSWEAgentConfig(version="mini-swe-agent@2.2.7"))
+    program = cast(dict[str, Any], harness.program_config.data())
     setup = cast(str, program["setup"])
 
     assert "mini-swe-agent==2.2.7" in setup

--- a/tests/test_v1_rlm_swe.py
+++ b/tests/test_v1_rlm_swe.py
@@ -81,8 +81,8 @@ def test_rlm_harness_accepts_typed_config_surface():
         config=RLMConfig(
             program=RLMProgramConfig(
                 local_checkout="/tmp/checkout",
-                rlm_tools=["bash", "edit"],
-                rlm_exec_timeout=11,
+                tools=["bash", "edit"],
+                exec_timeout=11,
                 env_vars={"CUSTOM": "1"},
             )
         )
@@ -90,7 +90,7 @@ def test_rlm_harness_accepts_typed_config_surface():
     program = as_dict(harness.config.program)
     program_env = as_dict(program["env"])
 
-    assert harness.config.program.rlm_tools == ["bash", "edit"]
+    assert harness.config.program.tools == ["bash", "edit"]
     assert program_env["RLM_TOOLS"] == "bash,edit"
     assert program_env["RLM_EXEC_TIMEOUT"] == "11"
     assert program_env["CUSTOM"] == "1"

--- a/verifiers/envs/experimental/composable/harnesses/__init__.py
+++ b/verifiers/envs/experimental/composable/harnesses/__init__.py
@@ -9,7 +9,7 @@ from verifiers.envs.experimental.composable.harnesses.rlm import (
 )
 from verifiers.envs.experimental.composable.harnesses.opencode import (
     DEFAULT_DISABLED_TOOLS,
-    DEFAULT_RELEASE,
+    DEFAULT_VERSION as OPENCODE_DEFAULT_VERSION,
     DEFAULT_SYSTEM_PROMPT,
     OPENCODE_INSTALL_SCRIPT,
     build_install_script as build_opencode_install_script,
@@ -39,7 +39,7 @@ __all__ = [
     "build_opencode_run_command",
     "OPENCODE_INSTALL_SCRIPT",
     "DEFAULT_DISABLED_TOOLS",
-    "DEFAULT_RELEASE",
+    "OPENCODE_DEFAULT_VERSION",
     "DEFAULT_SYSTEM_PROMPT",
     "mini_swe_agent_harness",
     "build_mini_swe_agent_install_script",

--- a/verifiers/envs/experimental/composable/harnesses/mini_swe_agent.py
+++ b/verifiers/envs/experimental/composable/harnesses/mini_swe_agent.py
@@ -4,8 +4,8 @@ from pathlib import PurePosixPath
 import shlex
 
 from harnesses.mini_swe_agent import (
-    MINI_SWE_AGENT_DEFAULT_PACKAGE,
-    build_mini_swe_agent_install_script as build_packaged_mini_swe_agent_install_script,
+    MINI_SWE_AGENT_DEFAULT_VERSION,
+    build_mini_swe_agent_install_script as build_packaged_install_script,
 )
 
 DEFAULT_INSTALL_DIR = "/opt/mini-swe-agent"
@@ -14,7 +14,7 @@ DEFAULT_SITE_PACKAGES_DIR = f"{DEFAULT_PREFIX_DIR}/site-packages"
 DEFAULT_MINI_BINARY = f"{DEFAULT_PREFIX_DIR}/bin/mini"
 MINI_SWE_AGENT_CLI_PACKAGE = "mini-swe-agent"
 MINI_SWE_AGENT_CLI_VERSION = "2.2.8"
-DEFAULT_PACKAGE = MINI_SWE_AGENT_DEFAULT_PACKAGE
+DEFAULT_VERSION = MINI_SWE_AGENT_DEFAULT_VERSION
 DEFAULT_INSTRUCTION_PATH = "/mini-swe-agent/prompt.txt"
 DEFAULT_SYSTEM_PROMPT_PATH = "/mini-swe-agent/system.txt"
 DEFAULT_LOG_DIR = "/logs/agent"
@@ -27,12 +27,12 @@ DEFAULT_ENVIRONMENT_TIMEOUT = 120
 
 
 def build_mini_swe_agent_install_script(
-    package: str = DEFAULT_PACKAGE,
+    version: str = DEFAULT_VERSION,
     prefix_dir: str = DEFAULT_PREFIX_DIR,
 ) -> str:
     """Build the shell script that installs mini-SWE-agent."""
-    return build_packaged_mini_swe_agent_install_script(
-        package=package,
+    return build_packaged_install_script(
+        version=version,
         prefix_dir=prefix_dir,
     )
 
@@ -59,9 +59,9 @@ def build_mini_swe_agent_run_command(
     # Keep the default workdir shell-expanded for env-level overrides, mirroring
     # the other harnesses.
     if agent_workdir == DEFAULT_AGENT_WORKDIR:
-        workdir_assignment = f"MINI_SWE_AGENT_WORKDIR={DEFAULT_AGENT_WORKDIR}"
+        workdir_line = f"MINI_SWE_AGENT_WORKDIR={DEFAULT_AGENT_WORKDIR}"
     else:
-        workdir_assignment = f"MINI_SWE_AGENT_WORKDIR={shlex.quote(agent_workdir)}"
+        workdir_line = f"MINI_SWE_AGENT_WORKDIR={shlex.quote(agent_workdir)}"
 
     config_args = [
         "-c",
@@ -95,7 +95,7 @@ export MSWEA_SILENT_STARTUP=true
 export MSWEA_GLOBAL_CONFIG_DIR=/tmp/mini-swe-agent-config
 export OPENAI_API_KEY="${{OPENAI_API_KEY:-intercepted}}"
 
-{workdir_assignment}
+{workdir_line}
 mkdir -p {shlex.quote(log_dir)} {shlex.quote(trajectory_dir)} "$MINI_SWE_AGENT_WORKDIR" "$MSWEA_GLOBAL_CONFIG_DIR"
 
 MINI_SWE_AGENT_TASK="$(cat {shlex.quote(instruction_path)})"
@@ -133,7 +133,7 @@ def mini_swe_agent_harness(
     system_prompt_path: str = DEFAULT_SYSTEM_PROMPT_PATH,
     log_path: str = DEFAULT_LOG_PATH,
     trajectory_path: str = DEFAULT_TRAJECTORY_PATH,
-    package: str = DEFAULT_PACKAGE,
+    version: str = DEFAULT_VERSION,
     config_spec: str = DEFAULT_CONFIG_SPEC,
     model_class: str = DEFAULT_MODEL_CLASS,
     environment_timeout: int = DEFAULT_ENVIRONMENT_TIMEOUT,
@@ -153,7 +153,7 @@ def mini_swe_agent_harness(
     # into mini's agent.system_template at runtime.
     return Harness(
         install_script=build_mini_swe_agent_install_script(
-            package=package,
+            version=version,
         ),
         run_command=build_mini_swe_agent_run_command(
             agent_workdir=agent_workdir,

--- a/verifiers/envs/experimental/composable/harnesses/opencode.py
+++ b/verifiers/envs/experimental/composable/harnesses/opencode.py
@@ -245,6 +245,9 @@ def opencode_harness(
     allow_git: bool = False,
     disable_compaction: bool = True,
     version: str = DEFAULT_VERSION,
+    release_repo: str | None = None,
+    release_version: str | None = None,
+    release_sha256: str | None = None,
     instruction_path: str = "/opencode/prompt.txt",
     system_prompt_path: str = "/opencode/system.txt",
     log_path: str = "/opencode/logs.txt",
@@ -269,6 +272,8 @@ def opencode_harness(
             system_prompt = system_prompt + "\n" + task_system_prompt
         else:
             system_prompt = task_system_prompt
+    if release_repo is not None:
+        version = f"{release_repo}@{release_version or 'latest'}"
 
     return Harness(
         install_script=build_install_script(

--- a/verifiers/envs/experimental/composable/harnesses/opencode.py
+++ b/verifiers/envs/experimental/composable/harnesses/opencode.py
@@ -17,7 +17,7 @@ from harnesses.utils import split_versioned_agent_spec
 
 # ── Defaults ─────────────────────────────────────────────────────────────
 
-DEFAULT_RELEASE = "PrimeIntellect-ai/opencode@1.1.63-rl2"
+DEFAULT_VERSION = "PrimeIntellect-ai/opencode@1.1.63-rl2"
 DEFAULT_SYSTEM_PROMPT = (Path(__file__).parent / "prompt.txt").read_text()
 
 DEFAULT_DISABLED_TOOLS = [
@@ -47,34 +47,30 @@ DEFAULT_DISABLED_TOOLS = [
 
 
 def build_install_script(
-    release: str = DEFAULT_RELEASE,
+    version: str = DEFAULT_VERSION,
     install_ripgrep: bool = True,
 ) -> str:
     """Build the shell script that installs OpenCode in a sandbox."""
-    rg_install = (
+    ripgrep_install = (
         "apt-get -o Acquire::Retries=3 install -y -qq ripgrep > /dev/null 2>&1 || true"
         if install_ripgrep
         else ""
     )
-    release_repo, release_version = split_versioned_agent_spec(release)
-    release_path = "releases/latest/download"
-    if release_version and release_version != "latest":
-        release_tag = (
-            release_version
-            if release_version.startswith("v")
-            else f"v{release_version}"
-        )
-        release_path = f"releases/download/{release_tag}"
+    repo, parsed_version = split_versioned_agent_spec(version)
+    path = "releases/latest/download"
+    if parsed_version and parsed_version != "latest":
+        tag = parsed_version if parsed_version.startswith("v") else f"v{parsed_version}"
+        path = f"releases/download/{tag}"
     # Acquire::Retries=3 mitigates transient archive.ubuntu.com CDN sync mismatches
     # (e.g. "File has unexpected size ... Mirror sync in progress?"). See launchpad
     # bug #1876035. apt's default retries is 0, so one bad fetch fails the rollout.
     return f"""\
 set -e
 apt-get -o Acquire::Retries=3 update -qq && apt-get -o Acquire::Retries=3 install -y -qq curl tar > /dev/null 2>&1
-{rg_install}
+{ripgrep_install}
 
-OPENCODE_RELEASE_REPO={shlex.quote(release_repo)}
-OPENCODE_RELEASE_PATH={shlex.quote(release_path)}
+OPENCODE_RELEASE_REPO={shlex.quote(repo)}
+OPENCODE_RELEASE_PATH={shlex.quote(path)}
 
 case "$(uname -m)" in
   x86_64) OPENCODE_ARCH=x64 ;;
@@ -248,7 +244,7 @@ def opencode_harness(
     agent_workdir: str = "/app",
     allow_git: bool = False,
     disable_compaction: bool = True,
-    release: str = DEFAULT_RELEASE,
+    version: str = DEFAULT_VERSION,
     instruction_path: str = "/opencode/prompt.txt",
     system_prompt_path: str = "/opencode/system.txt",
     log_path: str = "/opencode/logs.txt",
@@ -276,7 +272,7 @@ def opencode_harness(
 
     return Harness(
         install_script=build_install_script(
-            release=release,
+            version=version,
         ),
         run_command=build_opencode_run_command(
             agent_workdir=agent_workdir,

--- a/verifiers/envs/experimental/composable/harnesses/rlm.py
+++ b/verifiers/envs/experimental/composable/harnesses/rlm.py
@@ -79,8 +79,8 @@ def render_rlm_completion(state: State) -> None:
 def resolve_local_checkout(
     local_checkout: str | Path | None = None,
     *,
-    rlm_repo_url: str = DEFAULT_RLM_REPO_URL,
-    rlm_ref: str = DEFAULT_RLM_REF,
+    repo_url: str = DEFAULT_RLM_REPO_URL,
+    ref: str = DEFAULT_RLM_REF,
     gh_token: str | None = None,
 ) -> Path:
     if local_checkout is not None:
@@ -89,8 +89,8 @@ def resolve_local_checkout(
             required_files=_REQUIRED_CHECKOUT_FILES,
         )
     return resolve_git_checkout(
-        repo_url=rlm_repo_url,
-        ref=rlm_ref,
+        repo_url=repo_url,
+        ref=ref,
         cache_root=DEFAULT_RLM_LOCAL_CHECKOUT_CACHE_ROOT,
         gh_token=gh_token,
         required_files=_REQUIRED_CHECKOUT_FILES,
@@ -127,17 +127,17 @@ rlm "$(cat {instruction_path})"
 def rlm_harness(
     workdir: str = "/testbed",
     instruction_path: str = "/task/instruction.md",
-    rlm_repo_url: str = DEFAULT_RLM_REPO_URL,
-    rlm_ref: str = DEFAULT_RLM_REF,
-    rlm_max_turns: int = DEFAULT_RLM_MAX_TURNS,
-    rlm_exec_timeout: int = DEFAULT_RLM_EXEC_TIMEOUT,
-    rlm_max_depth: int = DEFAULT_RLM_MAX_DEPTH,
+    repo_url: str = DEFAULT_RLM_REPO_URL,
+    ref: str = DEFAULT_RLM_REF,
+    max_turns: int = DEFAULT_RLM_MAX_TURNS,
+    exec_timeout: int = DEFAULT_RLM_EXEC_TIMEOUT,
+    max_depth: int = DEFAULT_RLM_MAX_DEPTH,
     summarize_at_tokens: int | tuple[int, int] | list[int] | None = None,
     include_sub_rlm_trajectories: bool = False,
     append_to_system_prompt: str | None = None,
     local_checkout: str | Path | None = None,
     gh_token: str | None = None,
-    rlm_tools: list[str] | None = None,
+    tools: list[str] | None = None,
 ) -> Harness:
     """Build an RLM harness.
 
@@ -146,11 +146,11 @@ def rlm_harness(
     to ``Harness.environment_vars`` and merged into the sandbox by
     ``ComposableEnv`` (harness-wins):
 
-    - ``rlm_tools`` → ``RLM_TOOLS`` (also drives ``Harness.tool_names`` so
+    - ``tools`` → ``RLM_TOOLS`` (also drives ``Harness.tool_names`` so
       ``ToolMonitorRubric`` tracks exactly the active tools)
-    - ``rlm_max_turns`` → ``RLM_MAX_TURNS``
-    - ``rlm_exec_timeout`` → ``RLM_EXEC_TIMEOUT``
-    - ``rlm_max_depth`` → ``RLM_MAX_DEPTH``: deepest sub-agent level
+    - ``max_turns`` → ``RLM_MAX_TURNS``
+    - ``exec_timeout`` → ``RLM_EXEC_TIMEOUT``
+    - ``max_depth`` → ``RLM_MAX_DEPTH``: deepest sub-agent level
       allowed. ``0`` (default) disables ``rlm()`` recursion from inside
       ipython entirely; ``1`` lets the parent spawn sub-agents but
       blocks them from spawning their own; etc.
@@ -200,15 +200,15 @@ def rlm_harness(
         upload_dirs: dict[str, Traversable | Path] = {
             DEFAULT_RLM_CHECKOUT_UPLOAD_NAME: resolve_local_checkout(
                 local_checkout,
-                rlm_repo_url=rlm_repo_url,
-                rlm_ref=rlm_ref,
+                repo_url=repo_url,
+                ref=ref,
                 gh_token=gh_token,
             ),
         }
         resolved_upload_dirs = upload_dirs
         return resolved_upload_dirs
 
-    tool_names = list(rlm_tools) if rlm_tools is not None else ["ipython"]
+    tool_names = list(tools) if tools is not None else ["ipython"]
 
     # Validate summarize_at_tokens shape eagerly so configuration errors
     # surface at harness-build time, not per-rollout inside the closure.
@@ -216,9 +216,9 @@ def rlm_harness(
 
     static_env_vars = {
         "RLM_TOOLS": ",".join(tool_names),
-        "RLM_MAX_TURNS": str(rlm_max_turns),
-        "RLM_EXEC_TIMEOUT": str(rlm_exec_timeout),
-        "RLM_MAX_DEPTH": str(rlm_max_depth),
+        "RLM_MAX_TURNS": str(max_turns),
+        "RLM_EXEC_TIMEOUT": str(exec_timeout),
+        "RLM_MAX_DEPTH": str(max_depth),
     }
 
     def env_vars_for_rollout(state: State) -> dict[str, str]:

--- a/verifiers/v1/harness.py
+++ b/verifiers/v1/harness.py
@@ -106,6 +106,7 @@ class HarnessConfig(LifecycleConfig):
     )
     program: ProgramConfig = ProgramConfig()
     model: ModelConfig = ModelConfig()
+    version: str | None = None
     system_prompt: SystemPrompt = None
     system_prompt_strategy: SystemPromptStrategy = "HT"
     sandbox: SandboxConfig | None = None
@@ -189,7 +190,7 @@ class Harness(RuntimeOwnerMixin[ConfigT], Generic[ConfigT]):
             ):
                 raise TypeError("harness_id must be a string.")
             self.harness_id = resolved_harness_id or type(self).__name__
-            self.program_config = self.config.program.resolve()
+            self.program_config = self.load_program_config(self.config)
             system_prompt_value = self.load_system_prompt(self.config)
             self.system_prompt = normalize_system_prompt(
                 system_prompt_value, field_name="harness.system_prompt"
@@ -219,6 +220,9 @@ class Harness(RuntimeOwnerMixin[ConfigT], Generic[ConfigT]):
 
     def load_system_prompt(self, config: ConfigT) -> SystemPrompt:
         return config.system_prompt
+
+    def load_program_config(self, config: ConfigT) -> ProgramConfig:
+        return config.program.resolve()
 
     def load_sandbox(self, config: SandboxConfig | None) -> SandboxConfig | None:
         sandbox = self.program_config.sandbox


### PR DESCRIPTION
Stacked on #1544, but targeted at `main` so it can be reviewed as a mainline PR.

This bumps the standalone `harnesses` package dependency from `verifiers>=0.1.15.dev11` to `verifiers>=0.1.15.dev158`, so `harnesses==0.1.2` only installs with a `verifiers` build that includes the `Harness.load_program_config` hook used by the versioned harness config changes.

Addresses https://github.com/PrimeIntellect-ai/verifiers/pull/1544#discussion_r3358663829.

Verification:
- `UV_FROZEN=1 uv build --out-dir /tmp/harnesses-verifiers-dev158-dist packages/harnesses`
- Confirmed wheel metadata contains `Requires-Dist: verifiers>=0.1.15.dev158`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump harnesses version to 0.1.2 with version-based program resolution and renamed config fields
> - Replaces `package`/`release` fields in all harness program configs (`MiniSWEAgent`, `OpenCode`, `Pi`, `Terminus2`) with a unified `version` field; adds `load_program_config` override to each harness class to pass the version into `resolve`.
> - Renames RLM config fields: `rlm_repo_url`→`repo_url`, `rlm_repo_ref`→`ref`, `rlm_tools`→`tools`, `rlm_exec_timeout`→`exec_timeout`, `rlm_max_depth`→`max_depth` in both [rlm.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1545/files#diff-0f9ff970b858120ce10a63abd11ccc74b91c4666d3988dd257e7aa71f5044570) and [rlm_utils.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1545/files#diff-fe3f0ade3ce9da9168fdf63cb7303119f8a64f7553fdf2269ffeec258f8c997e).
> - Adds an optional `version` field to the base `HarnessConfig` model and refactors `Harness.__init__` to delegate program resolution to an overridable `load_program_config` method.
> - Bumps `verifiers` minimum in harnesses from `>=0.1.15.dev11` to `>=0.1.15.dev158`, and bumps the `harnesses` minimum across environments and the root workspace from `>=0.1.1` to `>=0.1.2`.
> - Risk: all callers of harness factories and config classes must use the renamed fields; the old `package`, `release`, and `rlm_`-prefixed parameter names are removed.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 0a5b15c. 20 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->