### PR TITLE
NaN metrics affect reward (even with weight=0.0)

### DIFF
--- a/tests/test_rubric.py
+++ b/tests/test_rubric.py
@@ -1,5 +1,6 @@
 """Tests for the Rubric class."""
 
+import math
 from typing import cast
 
 import pytest
@@ -172,6 +173,42 @@ class TestRubric:
         assert state["metrics"]["func1"] == 1.0  # completion == answer
         assert state["metrics"]["func2"] == 0.4  # len("test") * 0.1
         assert state["reward"] == 1.0 * 1.0 + 0.4 * 0.5  # Weighted sum
+
+    @pytest.mark.asyncio
+    async def test_score_rollout_zero_weight_metric_nan_does_not_poison_reward(self):
+        """A weight-0 metric returning NaN must not poison the reward.
+
+        Zero-weight terms are skipped in the reward sum; otherwise 0.0 * nan = nan
+        would make the whole reward (and any downstream advantage/loss) NaN.
+        """
+
+        def reward_func(completion, answer, **kwargs):
+            return 1.0 if completion == answer else 0.0
+
+        def nan_metric(completion, **kwargs):
+            return float("nan")
+
+        rubric = Rubric()
+        rubric.add_reward_func(reward_func, weight=1.0)
+        rubric.add_metric(nan_metric)  # default weight 0.0
+
+        state = State(
+            input=RolloutInput(
+                prompt="test prompt",
+                answer="test",
+                example_id=0,
+            )
+        )
+        state["completion"] = "test"
+        state["trajectory"] = []
+        state["timing"] = RolloutTiming()
+
+        await rubric.score_rollout(state)
+
+        # The metric is still recorded (as NaN) but excluded from the reward sum.
+        assert math.isnan(state["metrics"]["nan_metric"])
+        assert math.isfinite(state["reward"])
+        assert state["reward"] == 1.0
 
     @pytest.mark.asyncio
     async def test_score_rollout_with_list_completion(self):

--- a/verifiers/rubrics/rubric.py
+++ b/verifiers/rubrics/rubric.py
@@ -347,6 +347,9 @@ class Rubric:
                             if not self._is_group_func(func)
                         ],
                     )
+                    # Skip zero-weight terms (metrics) so a non-finite metric
+                    # score cannot poison the reward via 0.0 * nan = nan.
+                    if weight != 0.0
                 ]
             ),
         )


### PR DESCRIPTION
## Description

  `Rubric.add_metric()` registers a function with weight `0.0` so it is logged but
  should not contribute to the reward. However, `score_rollout()` computes the
  per-rollout reward as `sum(score_i * weight_i)` over **all** individual (non-group)
  funcs — including weight-0 metrics. Because `0.0 * nan == nan` (and
  `sum([..., nan]) == nan`), a metric that returns a non-finite value silently
  poisons the entire reward, and therefore any downstream advantage/loss, even
  though it was meant to contribute nothing.

  This is easy to hit in practice: a metric that reports `float("nan")` for
  malformed/unscored rollouts (a natural "skip me in the mean" sentinel) turns the
  reward into `nan` for those rollouts and NaNs the training loss.

  Fix: skip zero-weight terms when summing the reward, so a metric cannot affect the
  reward regardless of what it returns. Metrics are still evaluated and recorded in
  `state["metrics"]` exactly as before — only the reward summation changes.

  ## Type of Change
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Documentation update
  - [ ] Test improvement

  ## Testing
  - [ ] All existing tests pass when running `uv run pytest` locally.
  - [x] New tests have been added to cover the changes

  Added `test_score_rollout_zero_weight_metric_nan_does_not_poison_reward` in
  `tests/test_rubric.py`: a rubric with a weight-1 reward func and a weight-0 metric
  returning `nan`. It asserts the metric is still recorded as `nan` while the reward
  stays finite. The test **fails on `main`** (`reward == nan`) and **passes with this
  fix**. `tests/test_rubric.py` (all cases) passes, and `ruff format --check` /
  `ruff check` are clean.

  ## Checklist
  - [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
  - [x] I have performed a self-review of my own code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] Any dependent changes have been merged and published

  ## Additional Notes

  Minimal reproduction:

  ```python
  import math
  from verifiers import Rubric

  r = Rubric()
  r.add_reward_func(lambda **kw: 1.0, weight=1.0)
  r.add_metric(lambda **kw: float("nan"))  # weight 0.0
  # before: reward == nan ; after: reward == 1.0 (metric still logged as nan)

  Scope: only the individual-rollout reward sum in score_rollout is changed. The
  group-scoring path is untouched. A metric given a non-zero weight that returns
  a non-finite value will still propagate (intentionally — if you weight it into the
  reward, its NaN should surface).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to individual rollout reward aggregation with a focused regression test; group scoring is untouched.
> 
> **Overview**
> Fixes a bug where **weight-0 metrics** (via `add_metric`) could still corrupt `state["reward"]` during `score_rollout`. The reward sum previously included `score * weight` for every individual func, so a metric returning `NaN` produced `0.0 * nan == nan` and poisoned training rewards/advantages even though metrics are meant to be logged only.
> 
> **`Rubric.score_rollout`** now **omits zero-weight terms** from the reward sum while still evaluating them and recording values in `state["metrics"]`. A regression test asserts a `NaN` metric stays in metrics but the reward stays finite.
> 
> Group scoring (`score_group`) is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 577887aaa3cd72b976b005d126bfe590d78ca7f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix NaN metric values poisoning reward in `Rubric.score_rollout` when weight is 0.0
> In the reward aggregation step, `0.0 * NaN` evaluates to `NaN`, causing zero-weight metrics with non-finite values to corrupt `state['reward']`. The fix filters out zero-weight terms from the list comprehension in [`rubric.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1546/files#diff-93524b7f0aef49ccda32abbb52371781199c6551aed59a94957e5f432d6e7145) before multiplication, so only metrics with non-zero weights contribute to the final reward.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 577887a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->