### PR TITLE
Revert top-level v1 env config shorthand

### DIFF
--- a/tests/test_v1_config_extension.py
+++ b/tests/test_v1_config_extension.py
@@ -2738,68 +2738,6 @@ def test_load_environment_validates_typed_env_config_arg(
     }
 
 
-def test_load_environment_accepts_top_level_taskset_harness_shorthand(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    module_name = "typed_env_config_shorthand"
-    module = types.ModuleType(module_name)
-    seen: dict[str, object] = {}
-
-    def load_environment(split: str = "train", *, config: EnvConfig) -> Env:
-        seen["split"] = split
-        seen["config"] = config
-        return Env(
-            taskset=make_taskset(config=config.taskset),
-            harness=make_harness(config=config.harness),
-        )
-
-    module.load_environment = load_environment
-    monkeypatch.setitem(sys.modules, module_name, module)
-
-    env = vf.load_environment(
-        "typed-env-config-shorthand",
-        split="test",
-        taskset={"taskset_id": "top-level"},
-        harness={"model": {"name": "top-level-model"}},
-    )
-
-    assert seen["split"] == "test"
-    config = seen["config"]
-    assert isinstance(config, EnvConfig)
-    assert config.taskset.taskset_id == "top-level"
-    assert config.harness.model.name == "top-level-model"
-    assert env.taskset.config.taskset_id == "top-level"
-    assert env.harness.config.model.name == "top-level-model"
-    assert env.env_args == {
-        "split": "test",
-        "taskset": {"taskset_id": "top-level"},
-        "harness": {"model": {"name": "top-level-model"}},
-    }
-
-
-def test_load_environment_rejects_duplicate_top_level_config_shorthand(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    module_name = "typed_env_config_duplicate_shorthand"
-    module = types.ModuleType(module_name)
-
-    def load_environment(config: EnvConfig) -> Env:
-        return Env(
-            taskset=make_taskset(config=config.taskset),
-            harness=make_harness(config=config.harness),
-        )
-
-    module.load_environment = load_environment
-    monkeypatch.setitem(sys.modules, module_name, module)
-
-    with pytest.raises(RuntimeError, match="not both"):
-        vf.load_environment(
-            "typed-env-config-duplicate-shorthand",
-            config={"taskset": {"taskset_id": "nested"}},
-            taskset={"taskset_id": "top-level"},
-        )
-
-
 def test_load_environment_validates_env_config_subclass_sections(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -3159,36 +3097,6 @@ def test_load_environment_composes_component_package_without_root_loader(
     assert env.taskset.get_dataset()[0]["answer"] == "train:composed"
     assert type(env.harness) is Harness
     assert env.harness.config.max_turns == 3
-
-
-def test_load_environment_component_package_accepts_top_level_config_shorthand(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    module_name = "component_only_taskset_shorthand"
-    module = types.ModuleType(module_name)
-
-    class LocalTasksetConfig(TasksetConfig):
-        answer: str = "configured"
-
-    class LocalTaskset(Taskset[LocalTasksetConfig]):
-        def load_tasks(self, split: vf.TaskSplit = "train") -> vf.Tasks:
-            return [{"prompt": [], "answer": f"{split}:{self.config.answer}"}]
-
-    def load_taskset(config: LocalTasksetConfig) -> LocalTaskset:
-        return LocalTaskset(config=config)
-
-    module.load_taskset = load_taskset
-    monkeypatch.setitem(sys.modules, module_name, module)
-
-    env = vf.load_environment(
-        "component-only-taskset-shorthand",
-        taskset={"answer": "top-level"},
-        harness={"max_turns": 2},
-    )
-
-    assert env.taskset.get_dataset()[0]["answer"] == "train:top-level"
-    assert type(env.harness) is Harness
-    assert env.harness.config.max_turns == 2
 
 
 def test_load_environment_delegates_missing_child_loaders_by_config_id(

--- a/verifiers/utils/env_utils.py
+++ b/verifiers/utils/env_utils.py
@@ -14,8 +14,6 @@ from verifiers.v1.harness import Harness, HarnessConfig
 from verifiers.v1.taskset import Taskset, TasksetConfig
 from verifiers.v1.utils.config_utils import coerce_config, explicit_config_data
 
-ENV_CONFIG_SHORTHAND_FIELDS = ("taskset", "harness")
-
 
 def load_environment(env_id: str, **env_args) -> Environment:
     logger = logging.getLogger("verifiers.utils.env_utils")
@@ -205,7 +203,11 @@ def prepare_typed_env_config(
     if config_type is None:
         return env_args
 
-    config, call_env_args = normalize_env_config_args(env_args, config_type)
+    config = env_args.get("config", {})
+    if config is None:
+        raise TypeError("load_environment config must be a concrete EnvConfig object.")
+
+    call_env_args = dict(env_args)
     call_env_args["config"] = load_env_config(module, config_type, config)
     return call_env_args
 
@@ -214,60 +216,17 @@ def load_environment_from_components(
     module: ModuleType,
     env_args: dict,
 ) -> Env:
-    config, call_env_args = normalize_env_config_args(env_args, EnvConfig)
-    extra_args = set(call_env_args)
+    extra_args = set(env_args) - {"config"}
     if extra_args:
         raise TypeError(
             "Default Taskset/Harness environment loading only accepts config; "
             f"got {sorted(extra_args)}."
         )
-    config = load_env_config(module, EnvConfig, config)
+    config = load_env_config(module, EnvConfig, env_args.get("config", {}))
     return Env(
         taskset=load_taskset_from_module(module, config=config.taskset),
         harness=load_harness_from_module(module, config=config.harness),
     )
-
-
-def normalize_env_config_args(
-    env_args: Mapping[str, object],
-    config_type: type[EnvConfig],
-) -> tuple[object, dict[str, object]]:
-    call_env_args = dict(env_args)
-    config = call_env_args.pop("config", {})
-    if config is None:
-        raise TypeError("load_environment config must be a concrete EnvConfig object.")
-
-    shorthand = {
-        field_name: call_env_args.pop(field_name)
-        for field_name in ENV_CONFIG_SHORTHAND_FIELDS
-        if field_name in call_env_args
-    }
-    if not shorthand:
-        return config, call_env_args
-
-    config_data: dict[str, object]
-    if isinstance(config, config_type):
-        config_data = dict(explicit_config_data(config))
-    elif isinstance(config, BaseModel):
-        raise TypeError(
-            f"load_environment config must be {config_type.__name__}; "
-            f"got {type(config).__name__}."
-        )
-    elif isinstance(config, Mapping):
-        config_data = dict(explicit_config_data(config))
-    else:
-        raise TypeError("load_environment config must be a mapping or EnvConfig.")
-
-    duplicate_fields = sorted(set(config_data) & set(shorthand))
-    if duplicate_fields:
-        raise TypeError(
-            "Specify load_environment taskset/harness settings either under config "
-            f"or at top level, not both: {duplicate_fields}."
-        )
-
-    for field_name, value in shorthand.items():
-        config_data[field_name] = value
-    return config_data, call_env_args
 
 
 def env_config_annotation(


### PR DESCRIPTION
## Summary
- Remove the `taskset` / `harness` top-level shorthand added to `vf.load_environment(...)`.
- Keep the narrow v1 contract: component config still flows through `config`, with CLI/TOML normalization handling sibling sections.
- Drop the tests that exercised the extra spelling.

## Testing
- `uv run pytest tests/test_v1_config_extension.py -q`
- `uv run ruff check verifiers/utils/env_utils.py tests/test_v1_config_extension.py`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> API narrowing that removes an alternate call style; primary `config` mapping path is unchanged and still tested.
> 
> **Overview**
> Reverts the alternate spelling for `vf.load_environment(...)` where `taskset` and `harness` could be passed as **top-level** kwargs alongside or instead of nesting them under `config`.
> 
> **`verifiers/utils/env_utils.py`** now only accepts component settings through the `config` argument: `prepare_typed_env_config` reads `env_args["config"]` directly (still rejecting `config=None`), and default component loading treats any kwargs other than `config` as an error. The merge helper that lifted top-level `taskset`/`harness` into `EnvConfig` and blocked duplicates with nested `config` is removed.
> 
> Three tests in `tests/test_v1_config_extension.py` that covered top-level shorthand and duplicate-config rejection are deleted; loading via `config={"taskset": ..., "harness": ...}` remains covered by existing tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0529b33d1038f87046c28a7de8005ee2ec46af29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Revert top-level `taskset`/`harness` shorthand support in v1 env config
> - Removes `normalize_env_config_args` and the `ENV_CONFIG_SHORTHAND_FIELDS` constant from [`env_utils.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1548/files#diff-55b6352da7741e80b93a7b4d9f45b50934a57a258cf7025977566a375daa8f60); top-level `taskset`/`harness` keys are no longer merged into `config`.
> - `load_environment_from_components` now raises `TypeError` for any top-level key other than `config`.
> - `prepare_typed_env_config` now raises `TypeError` if `config=None` is passed explicitly.
> - Removes three tests covering the shorthand behavior from [`test_v1_config_extension.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1548/files#diff-7876c3101e79e79a50ea913fb8894193904a3f57c67e867c33bda2af29fc2741).
> - Behavioral Change: callers passing `taskset` or `harness` at the top level of env args will now receive a `TypeError` instead of having those values silently merged into the config.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0529b33.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->