### PR TITLE
Tighten loose verifier runtime types

### DIFF
--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -673,8 +673,8 @@ class TestMaybeRetry:
         rollout_outputs = outputs["outputs"]
         assert env.call_counts[0] == 1  # No retries for non-retryable error
         assert rollout_outputs[0].get("error") is not None
-        error_info = rollout_outputs[0]["error"]
-        assert "ToolError" == error_info["error"]
+        error_data = rollout_outputs[0]["error"]
+        assert "ToolError" == error_data["error"]
 
     @pytest.mark.asyncio
     async def test_error_in_state_after_max_retries_exhausted(
@@ -694,8 +694,8 @@ class TestMaybeRetry:
         rollout_outputs = outputs["outputs"]
         assert env.call_counts[0] == 3  # 1 initial + 2 retries
         assert rollout_outputs[0].get("error") is not None
-        error_info = rollout_outputs[0]["error"]
-        assert "InfraError" == error_info["error"]
+        error_data = rollout_outputs[0]["error"]
+        assert "InfraError" == error_data["error"]
 
 
 class TestEmptyModelResponseErrors:

--- a/tests/test_v1_config_extension.py
+++ b/tests/test_v1_config_extension.py
@@ -1156,12 +1156,13 @@ def test_lifecycle_fields_are_framework_managed() -> None:
     task = Task({"prompt": [{"role": "user", "content": "hi"}]}).freeze()
     state = vf.State.for_task(task)
     assert state.uses_v1_contract is True
+    error = vf.Error("boom")
 
     for key, value in {
         "is_completed": True,
         "stop_condition": "done",
         "is_truncated": True,
-        "error": {"message": "boom"},
+        "error": error,
     }.items():
         assert State({key: value})[key] == value
         with pytest.raises(RuntimeError, match="framework-managed"):
@@ -1188,12 +1189,14 @@ def test_lifecycle_fields_are_framework_managed() -> None:
     state._set_completed(True)
     state._set_stop_condition("done")
     state._set_truncated(True)
-    state._set_error({"message": "boom"})
+    with pytest.raises(TypeError, match="vf.Error"):
+        state._set_error(cast(Any, {"message": "boom"}))
+    state._set_error(error)
 
     assert state["is_completed"] is True
     assert state["stop_condition"] == "done"
     assert state["is_truncated"] is True
-    assert state["error"] == {"message": "boom"}
+    assert state["error"] is error
 
 
 def test_toolsets_config_accepts_addressable_map_and_fn_tables() -> None:

--- a/tests/test_v1_runtime_lifecycle.py
+++ b/tests/test_v1_runtime_lifecycle.py
@@ -1646,14 +1646,19 @@ def test_sandbox_program_patch_cannot_set_lifecycle_fields() -> None:
     patch = {
         "stop_condition": "no_tools",
         "is_truncated": True,
-        "error": {"message": "handled"},
+        "error": vf.ErrorData(
+            error="SandboxError",
+            message="handled",
+            error_chain_repr="SandboxError('handled')",
+            error_chain_str="SandboxError",
+        ),
     }
     apply_internal_state_patch(state, patch, mode="base")
 
     assert patch == {}
     assert state["stop_condition"] == "no_tools"
     assert state["is_truncated"] is True
-    assert state["error"] == {"message": "handled"}
+    assert isinstance(state["error"], vf.SandboxError)
 
 
 def test_program_channels_mcp_injects_proxy_into_sandbox_program() -> None:

--- a/verifiers/envs/experimental/cli_agent_env.py
+++ b/verifiers/envs/experimental/cli_agent_env.py
@@ -717,7 +717,7 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
         num_turns = len(state.get("trajectory", []))
         stop_condition = state.get("stop_condition", "unknown")
         error = state.get("error")
-        error_info = (
+        error_summary = (
             f"{type(error).__name__}: {truncate(str(error), 80)}" if error else None
         )
         exit_code = state.get("agent_exit_code")
@@ -741,8 +741,8 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
         ]
         if timed_out:
             parts.append("timed_out=True")
-        if error_info:
-            parts.append(f"error={error_info}")
+        if error_summary:
+            parts.append(f"error={error_summary}")
         self.logger.info(" | ".join(parts))
 
     @vf.cleanup

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -17,6 +17,8 @@ from typing import (
     cast,
 )
 
+from anthropic import Anthropic, AsyncAnthropic
+from openai import AsyncOpenAI, OpenAI
 from pydantic import (
     AliasChoices,
     BaseModel,
@@ -26,6 +28,8 @@ from pydantic import (
     field_validator,
 )
 
+from verifiers.errors import Error
+
 if TYPE_CHECKING:
     from anthropic.types import RedactedThinkingBlock
     from anthropic.types import ThinkingBlock as AnthropicThinkingBlock
@@ -33,7 +37,6 @@ if TYPE_CHECKING:
     from renderers import RendererConfig
 
     from verifiers.clients import Client
-    from verifiers.errors import Error
 else:
     RedactedThinkingBlock = Any
     AnthropicThinkingBlock = Any
@@ -72,6 +75,7 @@ EndpointApi = Literal[
     "openai_responses",
     "anthropic_messages",
 ]
+EndpointClient: TypeAlias = AsyncOpenAI | OpenAI | AsyncAnthropic | Anthropic
 MessageType = Literal["chat", "completion"]  # deprecated
 
 
@@ -388,8 +392,9 @@ class RolloutTiming(CustomBaseModel):
         )
 
 
-class ErrorInfo(TypedDict):
+class ErrorData(TypedDict):
     error: str
+    message: str
     error_chain_repr: str
     error_chain_str: str
 
@@ -420,7 +425,7 @@ class RolloutOutput(dict):
     # Optional fields
     answer: str
     info: Info
-    error: ErrorInfo | None
+    error: ErrorData | None
     stop_condition: str | None
     trajectory: list["TrajectoryStep"]
     tool_defs: list[Tool]
@@ -489,7 +494,7 @@ class State(dict):
     advantage: float | None
     metrics: dict[str, float] | None
     timing: RolloutTiming | None
-    error: "Error | ErrorInfo | None"
+    error: Error | None
     usage: TokenUsage | None
     usage_tracker: object
     _vf_state_contract: Literal["legacy", "v1"]
@@ -589,7 +594,9 @@ class State(dict):
     def _set_completed(self, value: bool = True) -> None:
         self._set_internal("is_completed", value)
 
-    def _set_error(self, value: Any) -> None:
+    def _set_error(self, value: Error | None) -> None:
+        if value is not None and not isinstance(value, Error):
+            raise TypeError("state.error must be a vf.Error or None.")
         self._set_internal("error", value)
 
     def _set_stop_condition(
@@ -656,7 +663,7 @@ class State(dict):
         api: EndpointApi | ClientType = "chat_completions",
         *,
         sync: bool = False,
-    ) -> object:
+    ) -> EndpointClient:
         from verifiers.v1.utils.endpoint_utils import client_from_state
 
         return client_from_state(self, api, sync=sync)
@@ -848,8 +855,16 @@ class State(dict):
 
     def finalize(self) -> "State":
         self.strip_runtime_handles()
+        self.serialize_error()
         self.assert_serializable()
         return self
+
+    def serialize_error(self) -> None:
+        error = self.get("error")
+        if isinstance(error, Error):
+            from verifiers.utils.error_utils import error_data
+
+            self._set_internal("error", error_data(error))
 
     @classmethod
     def _legacy_for_task(cls, task: Mapping[str, Any]) -> "State":

--- a/verifiers/utils/async_utils.py
+++ b/verifiers/utils/async_utils.py
@@ -13,7 +13,7 @@ from pydantic import BaseModel
 
 import verifiers as vf
 from verifiers.utils.error_utils import ErrorChain
-from verifiers.utils.error_utils import error_info_to_exception
+from verifiers.utils.error_utils import error_data_to_exception
 from verifiers.utils.logging_utils import print_time
 
 logger = logging.getLogger(__name__)
@@ -168,7 +168,7 @@ def maybe_retry(
             if err and any(isinstance(err, err_type) for err_type in error_types):
                 raise err
             if isinstance(err, Mapping):
-                retry_error = error_info_to_exception(err, error_types)
+                retry_error = error_data_to_exception(err, error_types)
                 if retry_error is not None:
                     raise retry_error
         elif isinstance(result, list):
@@ -177,7 +177,7 @@ def maybe_retry(
                 if err and any(isinstance(err, err_type) for err_type in error_types):
                     raise err
                 if isinstance(err, Mapping):
-                    retry_error = error_info_to_exception(err, error_types)
+                    retry_error = error_data_to_exception(err, error_types)
                     if retry_error is not None:
                         raise retry_error
 

--- a/verifiers/utils/env_utils.py
+++ b/verifiers/utils/env_utils.py
@@ -4,7 +4,15 @@ import logging
 import sys
 from collections.abc import Mapping
 from types import ModuleType, UnionType
-from typing import Callable, Union, cast, get_args, get_origin, get_type_hints
+from typing import (
+    Callable,
+    TypeAlias,
+    Union,
+    cast,
+    get_args,
+    get_origin,
+    get_type_hints,
+)
 
 from pydantic import BaseModel
 from verifiers.envs.environment import Environment
@@ -12,7 +20,12 @@ from verifiers.utils.config_utils import MissingKeyError
 from verifiers.v1.env import Env, EnvConfig
 from verifiers.v1.harness import Harness, HarnessConfig
 from verifiers.v1.taskset import Taskset, TasksetConfig
+from verifiers.v1.types import ConfigData, ConfigValue
 from verifiers.v1.utils.config_utils import coerce_config, explicit_config_data
+
+EnvConfigLoadData: TypeAlias = dict[str, ConfigValue | BaseModel]
+EnvConfigChildInput: TypeAlias = ConfigData | EnvConfigLoadData
+EnvConfigInput: TypeAlias = EnvConfig | ConfigData
 
 
 def load_environment(env_id: str, **env_args) -> Environment:
@@ -127,7 +140,7 @@ def caller_module() -> ModuleType:
 def load_taskset(
     env_id: str | None = None,
     *,
-    config: TasksetConfig | Mapping[str, object] | None = None,
+    config: TasksetConfig | ConfigData | None = None,
 ) -> Taskset:
     module = caller_module() if env_id is None else import_env_module(env_id)
     return load_taskset_from_module(module, config=config)
@@ -136,7 +149,7 @@ def load_taskset(
 def load_harness(
     env_id: str | None = None,
     *,
-    config: HarnessConfig | Mapping[str, object] | None = None,
+    config: HarnessConfig | ConfigData | None = None,
 ) -> Harness:
     module = caller_module() if env_id is None else import_env_module(env_id)
     return load_harness_from_module(module, config=config)
@@ -145,7 +158,7 @@ def load_harness(
 def load_taskset_from_module(
     module: ModuleType,
     *,
-    config: TasksetConfig | Mapping[str, object] | None = None,
+    config: TasksetConfig | ConfigData | None = None,
 ) -> Taskset:
     factory = getattr(module, "load_taskset", None)
     if factory is None:
@@ -170,7 +183,7 @@ def load_taskset_from_module(
 def load_harness_from_module(
     module: ModuleType,
     *,
-    config: HarnessConfig | Mapping[str, object] | None = None,
+    config: HarnessConfig | ConfigData | None = None,
 ) -> Harness:
     factory = getattr(module, "load_harness", None)
     if factory is None:
@@ -260,11 +273,11 @@ def env_config_type(annotation: object) -> type[EnvConfig] | None:
 def load_env_config(
     module: ModuleType,
     config_type: type[EnvConfig],
-    value: object,
+    value: EnvConfigInput,
     *,
     child_types: Mapping[str, type[BaseModel]] | None = None,
 ) -> EnvConfig:
-    data: dict[str, object]
+    data: EnvConfigLoadData
     if isinstance(value, config_type):
         data = dict(explicit_config_data(value))
     elif isinstance(value, BaseModel):
@@ -275,7 +288,7 @@ def load_env_config(
     elif not isinstance(value, Mapping):
         raise TypeError("load_environment config must be a mapping or EnvConfig.")
     else:
-        data = dict(explicit_config_data(value))
+        data = dict(value)
     resolved_child_types = (
         env_config_child_types(module, config_type, data)
         if child_types is None
@@ -293,6 +306,8 @@ def load_env_config(
             continue
         if child is None:
             raise TypeError(f"config.{field_name} cannot be None.")
+        if not isinstance(child, BaseModel | dict):
+            raise TypeError(f"config.{field_name} must be a mapping or config object.")
         data[field_name] = child_type.model_validate(explicit_config_data(child))
     config = config_type.model_validate(data)
     for field_name, child_type in resolved_child_types.items():
@@ -308,7 +323,7 @@ def load_env_config(
 def env_config_child_types(
     module: ModuleType,
     config_type: type[EnvConfig],
-    value: Mapping[str, object] | None = None,
+    value: EnvConfigChildInput | None = None,
 ) -> dict[str, type[BaseModel]]:
     child_types: dict[str, type[BaseModel]] = {}
     for field_name, id_field, factory_name, base_type in (

--- a/verifiers/utils/error_utils.py
+++ b/verifiers/utils/error_utils.py
@@ -1,8 +1,7 @@
-from collections.abc import Mapping
-from typing import Callable, cast
+from typing import Callable, TypeGuard, cast
 
 import verifiers as vf
-from verifiers.types import ErrorInfo
+from verifiers.types import ErrorData
 
 
 def get_error_chain(
@@ -56,22 +55,72 @@ class ErrorChain:
         return " -> ".join([repr(e) for e in self.chain])
 
 
-def error_info(error: BaseException) -> ErrorInfo:
+def error_data(error: BaseException) -> ErrorData:
     error_chain = ErrorChain(error)
-    return ErrorInfo(
+    return ErrorData(
         error=type(error).__name__,
+        message=str(error) or type(error).__name__,
         error_chain_repr=repr(error_chain),
         error_chain_str=str(error_chain),
     )
 
 
-def error_info_to_exception(
-    error: Mapping[str, object],
+def is_error_data(value: object) -> TypeGuard[ErrorData]:
+    expected = {"error", "message", "error_chain_repr", "error_chain_str"}
+    if not isinstance(value, dict):
+        return False
+    match value:
+        case {
+            "error": str(),
+            "message": str(),
+            "error_chain_repr": str(),
+            "error_chain_str": str(),
+        }:
+            return set(value) == expected
+    return False
+
+
+def validate_error_data(value: object) -> ErrorData:
+    if not is_error_data(value):
+        raise TypeError(
+            "ErrorData must contain string error, message, error_chain_repr, "
+            "and error_chain_str fields."
+        )
+    return value
+
+
+def error_data_to_exception(
+    error: ErrorData,
     error_types: tuple[type[Exception], ...],
 ) -> Exception | None:
-    chain = str(error.get("error_chain_str") or error.get("error") or "")
-    detail = str(error.get("error_chain_repr") or error.get("error") or "")
+    chain = error["error_chain_str"] or error["error"]
+    detail = error["error_chain_repr"] or error["error"]
     for error_type in error_types:
         if error_type.__name__ in chain:
             return error_type(detail)
     return None
+
+
+def error_from_data(error: ErrorData) -> vf.Error:
+    exception = error_data_to_exception(error, vf_error_types())
+    if isinstance(exception, vf.Error):
+        return exception
+    detail = error["error_chain_repr"] or error["error"]
+    return vf.Error(detail)
+
+
+def vf_error_types() -> tuple[type[vf.Error], ...]:
+    return (
+        vf.BrowserSandboxError,
+        vf.SandboxError,
+        vf.TunnelError,
+        vf.InfraError,
+        vf.EmptyModelResponseError,
+        vf.InvalidModelResponseError,
+        vf.ModelError,
+        vf.ToolParseError,
+        vf.ToolCallError,
+        vf.ToolError,
+        vf.OverlongPromptError,
+        vf.Error,
+    )

--- a/verifiers/utils/logging_utils.py
+++ b/verifiers/utils/logging_utils.py
@@ -10,7 +10,7 @@ from rich.table import Table
 from rich.text import Text
 
 from verifiers.errors import Error
-from verifiers.types import ErrorInfo, Messages
+from verifiers.types import ErrorData, Messages
 from verifiers.utils.error_utils import ErrorChain
 
 LOGGER_NAME = "verifiers"
@@ -156,7 +156,7 @@ def quiet_verifiers():
 def print_prompt_completions_sample(
     prompts: list[Messages],
     completions: list[Messages],
-    errors: list[Error | ErrorInfo | None],
+    errors: list[Error | ErrorData | None],
     rewards: list[float],
     step: int,
     num_samples: int = 1,

--- a/verifiers/utils/save_utils.py
+++ b/verifiers/utils/save_utils.py
@@ -13,7 +13,6 @@ from pydantic import BaseModel
 
 from verifiers.types import (
     ClientConfig,
-    ErrorInfo,
     GenerateMetadata,
     GenerateOutputs,
     Response,
@@ -23,7 +22,7 @@ from verifiers.types import (
     TokenUsage,
     Tool,
 )
-from verifiers.utils.error_utils import ErrorChain
+from verifiers.utils.error_utils import error_data, validate_error_data
 from verifiers.utils.message_utils import (
     sanitize_tool_calls,
     serialize_messages_for_output,
@@ -280,26 +279,12 @@ def state_to_output(
             serialize_messages_for_output(completion)
         )
         output["completion"] = output_completion
-    # use repr for error
     error = state.get("error")
     if error is not None:
-        if isinstance(error, Mapping) and {
-            "error",
-            "error_chain_repr",
-            "error_chain_str",
-        } <= set(error):
-            output["error"] = ErrorInfo(
-                error=str(error["error"]),
-                error_chain_repr=str(error["error_chain_repr"]),
-                error_chain_str=str(error["error_chain_str"]),
-            )
+        if isinstance(error, BaseException):
+            output["error"] = error_data(error)
         else:
-            error_chain = ErrorChain(cast(BaseException, error))
-            output["error"] = ErrorInfo(
-                error=type(error).__name__,
-                error_chain_repr=repr(error_chain),
-                error_chain_str=str(error_chain),
-            )
+            output["error"] = validate_error_data(error)
         output["error_chain"] = output["error"]["error_chain_repr"]
         output["long_error_chain"] = output["error"]["error_chain_str"]
     # only include optional fields if non-empty

--- a/verifiers/v1/harness.py
+++ b/verifiers/v1/harness.py
@@ -15,7 +15,6 @@ from verifiers.types import (
     ToolMessage,
 )
 from verifiers.utils.async_utils import maybe_call_with_named_args
-from verifiers.utils.error_utils import error_info
 from verifiers.utils.message_utils import normalize_messages
 from verifiers.utils.response_utils import parse_response_message
 from verifiers.utils.tool_utils import is_valid_tool_content_parts
@@ -273,6 +272,7 @@ class Harness(RuntimeOwnerMixin[ConfigT], Generic[ConfigT]):
                 else:
                     state.strip_runtime_handles()
             elif completed:
+                state.serialize_error()
                 state.assert_serializable()
             log_rollout_finish(state)
         return state
@@ -283,7 +283,7 @@ class Harness(RuntimeOwnerMixin[ConfigT], Generic[ConfigT]):
             state._set_truncated(True)
             state._set_stop_condition("prompt_too_long", overwrite=True)
             return
-        state._set_error(error_info(error))
+        state._set_error(error)
         state._set_stop_condition("has_error", overwrite=True)
 
     async def score_group(self, tasks: list[Task], states: list[State]) -> list[State]:

--- a/verifiers/v1/model.py
+++ b/verifiers/v1/model.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, TypeAlias, cast
 
 from verifiers.types import ClientConfig, SamplingArgs
 
@@ -28,7 +28,10 @@ class ModelConfig(Config):
         raise TypeError("model.client must resolve to a Client or ClientConfig.")
 
 
-def model_config_from_value(value: object = None) -> ModelConfig:
+ModelConfigSource: TypeAlias = ModelConfig | str | ConfigData | None
+
+
+def model_config_from_value(value: ModelConfigSource = None) -> ModelConfig:
     if isinstance(value, ModelConfig):
         return value
     if isinstance(value, str):
@@ -40,7 +43,7 @@ def model_config_from_value(value: object = None) -> ModelConfig:
     raise TypeError("model must be a string or mapping.")
 
 
-def model_config_data(value: object = None) -> ConfigData:
+def model_config_data(value: ModelConfigSource = None) -> ConfigData:
     return cast(
         ConfigData, model_config_from_value(value).model_dump(exclude_none=True)
     )

--- a/verifiers/v1/program.py
+++ b/verifiers/v1/program.py
@@ -277,8 +277,6 @@ def program_list_items(
         return []
     if isinstance(value, list):
         return cast(list[ProgramValue], list(value))
-    if isinstance(value, tuple):
-        return cast(list[ProgramValue], list(value))
     if isinstance(value, str) or isinstance(value, dict):
         return [cast(ProgramValue, value)]
     raise TypeError(f"{field_name} must be a string, mapping, or list.")

--- a/verifiers/v1/runtime.py
+++ b/verifiers/v1/runtime.py
@@ -1730,7 +1730,7 @@ class Runtime:
                 source_root = binding_source_root(source)
                 validate_binding_source(source, f"User binding {name!r}")
                 if source_root == "objects":
-                    object_name = binding_object_name(source)
+                    object_name = binding_object_name(cast(str, source))
                     if object_name not in user.objects:
                         raise KeyError(
                             f"User binding {name!r} references unknown User object "
@@ -1778,7 +1778,7 @@ class Runtime:
             )
             source_root = binding_source_root(source)
             if source_root == "objects":
-                object_name = binding_object_name(source)
+                object_name = binding_object_name(cast(str, source))
                 if object_name not in owner.objects:
                     raise KeyError(
                         f"Binding {binding_key!r} references unknown object "
@@ -1818,7 +1818,7 @@ class Runtime:
                     "for callable tools owned by the same Toolset."
                 )
             if source_root == "objects":
-                object_name = binding_object_name(source)
+                object_name = binding_object_name(cast(str, source))
                 if object_name not in toolset.objects:
                     raise KeyError(
                         f"Binding {binding_key!r} references unknown Toolset object "

--- a/verifiers/v1/utils/binding_utils.py
+++ b/verifiers/v1/utils/binding_utils.py
@@ -190,8 +190,12 @@ def validate_binding_source(
     root = binding_source_root(source)
     validate_binding_source_root(root, context, allow_objects=allow_objects)
     if root == "objects":
+        if not isinstance(source, str):
+            raise TypeError(f"{context} must be a string source.")
         binding_object_name(source)
     if root in {"taskset", "harness"}:
+        if not isinstance(source, str):
+            raise TypeError(f"{context} must be a string source.")
         owner_object_name(source)
     if isinstance(source, dict):
         validate_callable_source(cast(ConfigData, source), context)
@@ -212,7 +216,7 @@ def function_name(fn: Handler) -> str:
     return name
 
 
-def binding_key_parts(key: object) -> tuple[str, str]:
+def binding_key_parts(key: str) -> tuple[str, str]:
     if not isinstance(key, str):
         raise TypeError("Binding keys must be strings.")
     target, separator, arg_name = key.partition(".")
@@ -242,7 +246,7 @@ def validate_binding_source_root(
         raise ValueError(f"{context} cannot use objects.* sources.")
 
 
-def binding_object_name(source: object) -> str:
+def binding_object_name(source: str) -> str:
     if not isinstance(source, str):
         raise TypeError("Object binding source must be a string.")
     root, separator, tail = source.partition(".")
@@ -254,7 +258,7 @@ def binding_object_name(source: object) -> str:
     return name
 
 
-def owner_object_name(source: object) -> str:
+def owner_object_name(source: str) -> str:
     if not isinstance(source, str):
         raise TypeError("Owner object binding source must be a string.")
     root, separator, tail = source.partition(".")

--- a/verifiers/v1/utils/config_utils.py
+++ b/verifiers/v1/utils/config_utils.py
@@ -31,7 +31,7 @@ _CONFIG_REF_MODULE: ContextVar[str | None] = ContextVar(
 
 
 def explicit_config_data(
-    value: object, target: type[BaseModel] | None = None
+    value: BaseModel | ConfigData | None, target: type[BaseModel] | None = None
 ) -> ConfigData:
     if value is None:
         data: ConfigData = {}
@@ -48,7 +48,9 @@ def explicit_config_data(
     return data
 
 
-def coerce_config(config_cls: type[ConfigT], value: object = None) -> ConfigT:
+def coerce_config(
+    config_cls: type[ConfigT], value: BaseModel | ConfigData | None = None
+) -> ConfigT:
     if value is None:
         return config_cls()
     if isinstance(value, config_cls):
@@ -168,7 +170,7 @@ def resolve_config_annotation(owner_type: ConfigOwner, annotation: object) -> ob
 
 
 def resolved_config_data(
-    value: object, target: type[BaseModel] | None = None
+    value: BaseModel | ConfigData | None, target: type[BaseModel] | None = None
 ) -> ConfigData:
     if value is None:
         data: ConfigData = {}
@@ -248,7 +250,7 @@ def config_ref_parts(ref: str) -> tuple[str, str]:
 
 
 @contextmanager
-def config_ref_context(config: object) -> Iterator[None]:
+def config_ref_context(config: BaseModel | ConfigData | None) -> Iterator[None]:
     module_name = config_ref_module(config)
     if module_name is None:
         yield
@@ -260,7 +262,7 @@ def config_ref_context(config: object) -> Iterator[None]:
         _CONFIG_REF_MODULE.reset(token)
 
 
-def config_ref_module(config: object) -> str | None:
+def config_ref_module(config: BaseModel | ConfigData | None) -> str | None:
     if isinstance(config, BaseModel):
         module_name = type(config).__module__
         if module_name not in FRAMEWORK_CONFIG_MODULES:

--- a/verifiers/v1/utils/endpoint_utils.py
+++ b/verifiers/v1/utils/endpoint_utils.py
@@ -5,7 +5,7 @@ import os
 import time
 import uuid
 from collections.abc import Awaitable, Callable
-from typing import Literal, Protocol, cast
+from typing import Literal, Protocol, TypeAlias, cast
 
 from anthropic import Anthropic, AsyncAnthropic
 from openai import AsyncOpenAI, OpenAI
@@ -15,6 +15,7 @@ from verifiers.types import (
     AssistantMessage,
     ClientType,
     EndpointApi,
+    EndpointClient,
     EndpointConfig,
     Messages,
     SystemMessage,
@@ -23,7 +24,6 @@ from verifiers.types import (
     ToolMessage,
     UserMessage,
 )
-from verifiers.utils.error_utils import error_info
 from verifiers.utils.interception_utils import (
     InterceptionServer,
     deliver_response,
@@ -34,21 +34,27 @@ from verifiers.utils.message_utils import normalize_messages
 from ..runtime import ModelRequestContext, Runtime, TrajectoryVisibility
 from ..state import State
 from ..task import Task
-from ..types import ConfigData, PromptMessage, ToolParameters
+from ..types import ConfigData, JsonData, PromptMessage, ToolParameters
 
 VF_TRAJECTORY_VISIBILITY_HEADER = "x-verifiers-trajectory"
 VF_ENDPOINT_API_KEY_VAR = "VF_ENDPOINT_API_KEY"
+NormalizedEndpointApi: TypeAlias = Literal[
+    "chat_completions",
+    "completions",
+    "responses",
+    "messages",
+]
 
 
 class TunnelHandle(Protocol):
     is_running: bool
-    url: object
+    url: str | None
 
-    async def start(self) -> object: ...
+    async def start(self) -> str: ...
 
     async def check_registered(self) -> bool: ...
 
-    def sync_stop(self) -> object: ...
+    def sync_stop(self) -> None: ...
 
 
 def client_from_state(
@@ -56,7 +62,7 @@ def client_from_state(
     api: EndpointApi | ClientType = "chat_completions",
     *,
     sync: bool = False,
-) -> object:
+) -> EndpointClient:
     endpoint = endpoint_from_state(state)
     return endpoint.client(state, api=api, sync=sync)
 
@@ -81,7 +87,7 @@ def endpoint_from_state(state: State) -> "Endpoint":
 
 
 def endpoint_api_client_type(
-    api: Literal["chat_completions", "completions", "responses", "messages"],
+    api: NormalizedEndpointApi,
 ) -> Literal[
     "openai_chat_completions",
     "openai_completions",
@@ -99,7 +105,7 @@ def endpoint_api_client_type(
 
 def normalize_endpoint_api(
     api: EndpointApi | ClientType,
-) -> Literal["chat_completions", "completions", "responses", "messages"]:
+) -> NormalizedEndpointApi:
     if api in {
         "chat_completions",
         "openai_chat_completions",
@@ -154,7 +160,7 @@ class Endpoint:
         self,
         state: State,
         tool_handler: object | None = None,
-        tool_defs: object | None = None,
+        tool_defs: list[Tool] | None = None,
         user_handler: object | None = None,
         stop_handler: object | None = None,
     ) -> str:
@@ -183,7 +189,7 @@ class Endpoint:
         api: EndpointApi | ClientType = "chat_completions",
         *,
         sync: bool = False,
-    ) -> AsyncOpenAI | OpenAI | AsyncAnthropic | Anthropic:
+    ) -> EndpointClient:
         api = normalize_endpoint_api(api)
         api_key = self.secret or "intercepted"
         if api == "messages":
@@ -312,14 +318,14 @@ async def run_intercepted_program(
     runtime: Runtime,
     task: Task,
     state: State,
-) -> object:
+) -> State | ConfigData | None:
     async def call_tool(name: str, arguments: ConfigData) -> object:
         return await runtime.call_tool(name, task, state, **dict(arguments))
 
-    async def call_user(transcript: list[PromptMessage]) -> object:
+    async def call_user(transcript: list[PromptMessage]) -> list[JsonData]:
         return await runtime.user_messages(task, state, transcript=transcript)
 
-    async def check_stop() -> object:
+    async def check_stop() -> ConfigData:
         return {
             "done": await runtime.is_completed(task, state),
             "stop_condition": state.get("stop_condition"),
@@ -414,7 +420,9 @@ async def cancel_forwarders(pending: set[asyncio.Task[None]]) -> None:
         await asyncio.gather(*pending, return_exceptions=True)
 
 
-async def raise_execution_error(execution: asyncio.Task[object]) -> None:
+async def raise_execution_error(
+    execution: asyncio.Task[State | ConfigData | None],
+) -> None:
     if execution.cancelled():
         await execution
     error = execution.exception()
@@ -447,7 +455,7 @@ async def forward_request(
     except BaseException as e:
         error = e
         if isinstance(e, Error):
-            state._set_error(error_info(e))
+            state._set_error(e)
         raise
     finally:
         if bool(request.get("stream")):

--- a/verifiers/v1/utils/logging_utils.py
+++ b/verifiers/v1/utils/logging_utils.py
@@ -2,6 +2,7 @@ import logging
 from collections import Counter
 
 from verifiers.utils.display_utils import format_numeric, format_timing_plain
+from verifiers.utils.error_utils import ErrorChain, is_error_data
 from verifiers.utils.logging_utils import truncate
 
 from ..state import State
@@ -50,8 +51,11 @@ def log_rollout_finish(state: State) -> None:
         f"reward={format_numeric(state.get('reward') or 0.0)}",
         "metrics={" + metric_summary + "}",
     ]
-    if state.get("error"):
-        parts.append(f"error={truncate(state['error']['error_chain_str'], 200)}")
+    error = state.get("error")
+    if isinstance(error, BaseException):
+        parts.append(f"error={truncate(str(ErrorChain(error)), 200)}")
+    elif is_error_data(error):
+        parts.append(f"error={truncate(error['error_chain_str'], 200)}")
     if state.get("is_truncated"):
         parts.append("truncated=True")
     logger.info(" | ".join(parts))

--- a/verifiers/v1/utils/program_utils.py
+++ b/verifiers/v1/utils/program_utils.py
@@ -1,8 +1,7 @@
 import asyncio
 import os
 import shlex
-from collections.abc import Sequence
-from typing import cast
+from typing import TypeAlias, cast
 
 from verifiers.errors import InfraError
 from verifiers.utils.async_utils import maybe_call_with_named_args
@@ -24,6 +23,9 @@ from ..artifact import ArtifactsConfig
 from ..program import ProgramChannel, ProgramValue
 from ..sandbox import SandboxConfig
 from ..types import ConfigData, Handler, RuntimeData
+
+ProgramMappingInput: TypeAlias = dict[str, ProgramValue] | None
+ProgramListInput: TypeAlias = ProgramValue | None
 
 PROGRAM_KIND_KEYS = {"base", "fn", "command"}
 PROGRAM_OPTION_KEYS = {
@@ -88,9 +90,13 @@ async def command_argv(
     command = program.get("command")
     if isinstance(command, str):
         argv = shlex.split(command)
-    elif isinstance(command, Sequence):
+    elif isinstance(command, list):
         argv = [
-            str(await resolve_program_value(part, task, state, runtime, program))
+            str(
+                await resolve_program_value(
+                    cast(ProgramValue, part), task, state, runtime, program
+                )
+            )
             for part in command
         ]
     else:
@@ -100,7 +106,11 @@ async def command_argv(
         raise TypeError("program.args must be a list.")
     for arg in args:
         argv.append(
-            str(await resolve_program_value(arg, task, state, runtime, program))
+            str(
+                await resolve_program_value(
+                    cast(ProgramValue, arg), task, state, runtime, program
+                )
+            )
         )
     if not argv:
         raise ValueError("program.command cannot be empty.")
@@ -137,13 +147,15 @@ async def command_env(
         if not isinstance(key, str):
             raise TypeError("program.env keys must be strings.")
         env[key] = str(
-            await resolve_program_value(value, task, state, runtime, program)
+            await resolve_program_value(
+                cast(ProgramValue, value), task, state, runtime, program
+            )
         )
     return env
 
 
 async def resolve_program_value(
-    value: object,
+    value: ProgramValue,
     task: Task,
     state: State,
     runtime: Runtime,
@@ -155,7 +167,7 @@ async def resolve_program_value(
         kwargs = await program_binding_kwargs(fn, program, task, state, runtime)
         for key, item in configured_kwargs.items():
             kwargs[key] = await resolve_program_value(
-                item, task, state, runtime, program
+                cast(ProgramValue, item), task, state, runtime, program
             )
         return await maybe_call_with_named_args(
             fn, task=task, state=state, runtime=runtime, **kwargs
@@ -182,7 +194,7 @@ async def resolve_program_value(
     return value
 
 
-def program_value_callable(value: object) -> tuple[Handler, ConfigData] | None:
+def program_value_callable(value: ProgramValue) -> tuple[Handler, ConfigData] | None:
     if isinstance(value, dict) and "fn" in value:
         spec = cast(ConfigData, value)
         validate_program_callable_source(spec)
@@ -265,7 +277,7 @@ def program_binding_targets(
     targets: dict[str, Handler] = {}
 
     def add(value: object) -> None:
-        callable_spec = program_value_callable(value)
+        callable_spec = program_value_callable(cast(ProgramValue, value))
         if callable_spec is None:
             return
         fn, _ = callable_spec
@@ -283,7 +295,7 @@ def program_binding_targets(
             add(value)
 
     command = program.get("command")
-    if isinstance(command, Sequence) and not isinstance(command, str):
+    if isinstance(command, list):
         for item in command:
             add(item)
     add_items(program.get("args"))
@@ -302,7 +314,7 @@ def program_setup_callable_names(program: ConfigData) -> set[str]:
     setup = program.get("setup")
     items = setup if isinstance(setup, list) else [setup]
     for item in items:
-        callable_spec = program_value_callable(item)
+        callable_spec = program_value_callable(cast(ProgramValue, item))
         if callable_spec is not None:
             fn, _ = callable_spec
             names.add(function_name(fn))
@@ -407,19 +419,30 @@ def merge_task_program(program: ConfigData, task: Task, *, kind: str) -> ConfigD
     merged = dict(program)
     for key in ("files", "dirs", "env", "artifacts"):
         merged[key] = merge_program_mapping_option(
-            program.get(key), task_program.get(key), key
+            cast(ProgramMappingInput, program.get(key)),
+            cast(ProgramMappingInput, task_program.get(key)),
+            key,
         )
     merged["bindings"] = merge_program_bindings(
-        program.get("bindings"), task_program.get("bindings")
+        cast(ProgramMappingInput, program.get("bindings")),
+        cast(ProgramMappingInput, task_program.get("bindings")),
     )
     merged["setup"] = [
-        *program_list_items(program.get("setup"), "program.setup"),
-        *program_list_items(task_program.get("setup"), "task.program.setup"),
+        *program_list_items(
+            cast(ProgramListInput, program.get("setup")), "program.setup"
+        ),
+        *program_list_items(
+            cast(ProgramListInput, task_program.get("setup")), "task.program.setup"
+        ),
     ]
     if kind == "command":
         merged["args"] = [
-            *program_list_items(program.get("args"), "program.args"),
-            *program_list_items(task_program.get("args"), "task.program.args"),
+            *program_list_items(
+                cast(ProgramListInput, program.get("args")), "program.args"
+            ),
+            *program_list_items(
+                cast(ProgramListInput, task_program.get("args")), "task.program.args"
+            ),
         ]
     return merged
 
@@ -437,7 +460,7 @@ def merge_task_sandbox(sandbox_config: SandboxConfig, task: Task) -> SandboxConf
 
 
 def merge_program_mapping_option(
-    program_value: object, task_value: object, key: str
+    program_value: ProgramMappingInput, task_value: ProgramMappingInput, key: str
 ) -> ConfigData:
     if key == "artifacts":
         program_mapping = ArtifactsConfig.model_validate(program_value or {}).data(
@@ -457,7 +480,9 @@ def merge_program_mapping_option(
     return {**program_mapping, **task_mapping}
 
 
-def merge_program_bindings(program_value: object, task_value: object) -> ConfigData:
+def merge_program_bindings(
+    program_value: ProgramMappingInput, task_value: ProgramMappingInput
+) -> ConfigData:
     program_bindings = BindingsConfig.model_validate(program_value or {}).entries(
         "program.bindings", allow_objects=False
     )
@@ -473,23 +498,27 @@ def merge_program_bindings(program_value: object, task_value: object) -> ConfigD
     return string_mapping({**program_bindings, **task_bindings})
 
 
-def program_option_mapping(value: object, field_name: str) -> ConfigData:
+def program_option_mapping(
+    value: ProgramMappingInput, field_name: str
+) -> dict[str, ProgramValue]:
     if value is None:
         return {}
     if not isinstance(value, dict):
         raise TypeError(f"{field_name} must be a mapping.")
     try:
-        return string_mapping(value)
+        return cast(dict[str, ProgramValue], string_mapping(value))
     except TypeError as exc:
         raise TypeError(f"{field_name} keys must be strings.") from exc
 
 
-def program_list_items(value: object, field_name: str) -> list[ProgramValue]:
+def program_list_items(value: ProgramListInput, field_name: str) -> list[ProgramValue]:
     if value is None:
         return []
     if isinstance(value, str):
         return [value]
-    if not isinstance(value, Sequence):
+    if isinstance(value, tuple):
+        raise TypeError(f"{field_name} must be a string, mapping, or list.")
+    if not isinstance(value, list):
         return [cast(ProgramValue, value)]
     return [cast(ProgramValue, item) for item in value]
 

--- a/verifiers/v1/utils/runtime_owner_utils.py
+++ b/verifiers/v1/utils/runtime_owner_utils.py
@@ -1,9 +1,15 @@
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Callable, Generic, TypeVar
 
-from ..config import LifecycleConfig
+from ..config import LifecycleConfig, ToolsetCollectionData
 from ..artifact import Artifacts, ArtifactsConfig
-from ..toolset import Toolset, Toolsets, collect_toolsets, normalize_toolset_collection
+from ..toolset import (
+    Toolset,
+    ToolsetCollection,
+    Toolsets,
+    collect_toolsets,
+    normalize_toolset_collection,
+)
 from ..types import Handler, Objects
 from ..user import User, UserConfig, user_from_config
 from .binding_utils import BindingSources, ObjectsConfig
@@ -66,7 +72,9 @@ class RuntimeOwnerMixin(Generic[ConfigT]):
     def initialize_runtime_user(self, user: UserConfig | None) -> None:
         self.user = None if user is None else self.load_user(user)
 
-    def initialize_runtime_toolsets(self, config: ConfigT, toolsets: object) -> None:
+    def initialize_runtime_toolsets(
+        self, config: ConfigT, toolsets: ToolsetCollectionData
+    ) -> None:
         self.toolsets, self.named_toolsets = collect_toolsets(
             self.load_toolsets(config), toolsets
         )
@@ -101,7 +109,7 @@ class RuntimeOwnerMixin(Generic[ConfigT]):
         self.advantages.append(fn)
         self.refresh_runtime()
 
-    def add_toolset(self, toolset: object) -> None:
+    def add_toolset(self, toolset: ToolsetCollection) -> None:
         toolsets, named_toolsets = normalize_toolset_collection(toolset)
         duplicate = set(self.named_toolsets) & set(named_toolsets)
         if duplicate:

--- a/verifiers/v1/utils/sandbox_program_utils.py
+++ b/verifiers/v1/utils/sandbox_program_utils.py
@@ -8,6 +8,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import cast
 
+from verifiers.errors import Error
+from verifiers.utils.error_utils import error_from_data, validate_error_data
 from verifiers.utils.interception_utils import serialize_tool_defs
 
 from ..runtime import Runtime
@@ -26,7 +28,12 @@ from .sandbox_python_utils import (
     python_runtime_command,
     python_runtime_setup_command,
 )
-from .program_utils import program_list_items, program_option_mapping
+from .program_utils import (
+    ProgramListInput,
+    ProgramMappingInput,
+    program_list_items,
+    program_option_mapping,
+)
 from ..types import ConfigData
 
 TASK_PATH = "/tmp/vf_task.json"
@@ -119,11 +126,19 @@ def apply_internal_state_patch(state: State, patch: ConfigData, *, mode: str) ->
         elif key == "is_truncated":
             state._set_truncated(bool(value), overwrite=True)
         elif key == "error":
-            state._set_error(value)
+            state._set_error(state_error(value))
         else:
             raise RuntimeError(
                 f"Sandbox Python program cannot set framework-managed state key {key!r}."
             )
+
+
+def state_error(value: object) -> Error | None:
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise TypeError("Sandbox Python program error patch must be a mapping or None.")
+    return error_from_data(validate_error_data(value))
 
 
 def sandbox_runner_program(
@@ -138,7 +153,9 @@ def sandbox_runner_program(
     package = sandbox_program_package(mode=mode, fn_ref=fn_ref)
     if package is not None:
         program = sandbox_program_with_package(program, package)
-    files = program_option_mapping(program.get("files"), "program.files")
+    files = program_option_mapping(
+        cast(ProgramMappingInput, program.get("files")), "program.files"
+    )
     files[TASK_PATH] = json.dumps(task)
     files[TOOL_DEFS_PATH] = json.dumps(
         serializable(serialize_tool_defs(tool_defs or [], "openai_chat_completions"))
@@ -165,11 +182,15 @@ def sandbox_runner_program(
         **dict(program),
         "files": files,
         "command": command,
-        "env": program_option_mapping(program.get("env"), "program.env"),
+        "env": program_option_mapping(
+            cast(ProgramMappingInput, program.get("env")), "program.env"
+        ),
         "setup": [
             python_runtime_setup_command(),
             *package_setup,
-            *program_list_items(program.get("setup"), "program.setup"),
+            *program_list_items(
+                cast(ProgramListInput, program.get("setup")), "program.setup"
+            ),
         ],
         VF_STATE_INPUT_PATH_KEY: STATE_INPUT_PATH,
     }
@@ -209,7 +230,9 @@ def sandbox_program_with_package(
     program: ConfigData, package: SandboxPackage
 ) -> ConfigData:
     merged = dict(program)
-    dirs = program_option_mapping(merged.get("dirs"), "program.dirs")
+    dirs = program_option_mapping(
+        cast(ProgramMappingInput, merged.get("dirs")), "program.dirs"
+    )
     if package.remote_root in dirs:
         raise ValueError(
             f"program.dirs already defines internal package path {package.remote_root!r}."

--- a/verifiers/v1/utils/sandbox_utils.py
+++ b/verifiers/v1/utils/sandbox_utils.py
@@ -20,7 +20,11 @@ from verifiers.utils.async_utils import maybe_call_with_named_args
 
 from .program_utils import command_argv, command_env, float_config, int_config
 from .program_utils import program_channels
-from .program_utils import program_option_mapping, program_channel_setup
+from .program_utils import (
+    ProgramMappingInput,
+    program_option_mapping,
+    program_channel_setup,
+)
 from .program_utils import resolve_program_value
 from .program_utils import validate_program_bindings
 from .sandbox_python_utils import (
@@ -862,7 +866,9 @@ async def upload_program_files(
 ) -> None:
     from prime_sandboxes import APIError, UploadTimeoutError
 
-    files = program_option_mapping(program.get("files"), "program.files")
+    files = program_option_mapping(
+        cast(ProgramMappingInput, program.get("files")), "program.files"
+    )
     for path, source in files.items():
         content = await resolve_program_value(source, task, state, runtime, program)
         if not isinstance(content, str):
@@ -889,7 +895,9 @@ async def upload_program_dirs(
     state: State,
     runtime: Runtime,
 ) -> None:
-    dirs = program_option_mapping(program.get("dirs"), "program.dirs")
+    dirs = program_option_mapping(
+        cast(ProgramMappingInput, program.get("dirs")), "program.dirs"
+    )
     for path, source in dirs.items():
         local_source = await resolve_program_value(
             source, task, state, runtime, program

--- a/verifiers/v1/utils/toolset_utils.py
+++ b/verifiers/v1/utils/toolset_utils.py
@@ -177,7 +177,7 @@ def tool_item(value: object) -> "ToolEntry":
         )
     if isinstance(value, dict):
         if "command" in value:
-            config = coerce_config(MCPToolConfig, value)
+            config = coerce_config(MCPToolConfig, cast(ConfigData, value))
             return MCPTool(
                 command=config.command,
                 args=config.args,
@@ -192,7 +192,7 @@ def tool_item(value: object) -> "ToolEntry":
     return cast(Handler, value)
 
 
-def toolset_config_mapping(config: object | None) -> ConfigData:
+def toolset_config_mapping(config: BaseModel | ConfigData | None) -> ConfigData:
     from ..toolset import ToolsetConfig
 
     if config is None:


### PR DESCRIPTION
## Summary
- tighten broad arg/return types across v1 runtime, config, program, sandbox, and endpoint helpers
- rename serialized rollout errors from ErrorInfo to ErrorData and keep live state errors as vf.Error instances until finalization
- validate sandbox-returned ErrorData exactly before rehydrating it to vf.Error

## Validation
- uv run ruff check .
- uv run ty check verifiers
- uv run pytest tests/test_v1_runtime_lifecycle.py tests/test_v1_endpoint_protocols.py tests/test_v1_config_extension.py tests/test_environment.py tests/test_tool_env.py tests/test_stateful_tool_env.py tests/test_singleturn_env.py tests/test_interception_utils.py tests/test_error_chain.py -q
- pre-commit hooks on commit and pre-push hooks on push

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Tighten verifier runtime types so `State.error` holds `Error` instances until serialization
> - `State.error` now holds a `vf.Error` instance (or `None`) at runtime; `_set_error` raises `TypeError` for any other type. `finalize()` calls the new `serialize_error()` to convert the `Error` to `ErrorData` before serialization checks.
> - `ErrorData` gains a mandatory `message` field; `error_data()`, `is_error_data()`, and `validate_error_data()` in [error_utils.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1549/files#diff-88b8a23523c98c1e849b18fb8734eaa13b5e7a68196c34f9022355926ee043f0) enforce this shape. New `error_from_data()` enables round-trip reconstruction of `vf.Error` from serialized data.
> - `Harness.record_error` now stores the raw `Error` on state instead of serializing to a dict early; serialization is deferred to finalize/grouped-completion paths.
> - Sandbox state patches validate error payloads as `ErrorData` and convert them back to `vf.Error` via `state_error()` in [sandbox_program_utils.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1549/files#diff-650fad1707ec4b94d785f84962c51b4c8e27ffb169b46c1f15dc145b72913cde).
> - Risk: callers that previously passed arbitrary dicts to `state._set_error` or `validate_error_data` will now raise `TypeError` at runtime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ac0436f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the contract for `state.error` and serialized rollout errors (breaking for callers passing error dicts or tuples in program list fields), but behavior is covered by updated lifecycle tests and affects a well-defined finalize/sandbox boundary.
> 
> **Overview**
> This PR **tightens v1 runtime typing** and **changes how rollout errors are represented** end to end.
> 
> **Errors:** `ErrorInfo` becomes **`ErrorData`** with a required **`message`** field. While a rollout runs, **`state["error"]` is a `vf.Error` instance** (or `None`); `_set_error` no longer accepts ad-hoc dicts. **`State.finalize()`** (and incomplete group rollouts) call **`serialize_error()`** to convert exceptions to `ErrorData` before serializability checks. New helpers **`error_data`**, **`validate_error_data`**, **`error_from_data`**, and **`is_error_data`** replace the old `error_info` / `error_info_to_exception` flow; retries and save paths use **`error_data_to_exception`**.
> 
> **Harness / interception:** `record_error` and model forward paths store the **`Error` object** directly instead of pre-serializing. Sandbox patches go through **`state_error()`**, which validates **`ErrorData`** shape then rehydrates to **`vf.Error`**.
> 
> **Other typing:** Config loaders and utils narrow **`object`** to **`ConfigData` / `BaseModel`**; **`EndpointClient`** types **`get_client()`**; binding helpers require **string** sources where appropriate; program merge/list helpers use explicit **`ProgramValue`** aliases and **`program_list_items` rejects tuples** (lists or single values only).
> 
> Tests are updated to expect **`vf.Error`** on live state and full **`ErrorData`** in internal patches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8569e8c4bce6eb61b71db3fcff1db19d9564fabf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->