### PR TITLE
Clean rollout error diagnostics

### DIFF
--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -673,8 +673,8 @@ class TestMaybeRetry:
         rollout_outputs = outputs["outputs"]
         assert env.call_counts[0] == 1  # No retries for non-retryable error
         assert rollout_outputs[0].get("error") is not None
-        error_info = rollout_outputs[0]["error"]
-        assert "ToolError" == error_info["error"]
+        error_data = rollout_outputs[0]["error"]
+        assert "ToolError" == error_data["error"]
 
     @pytest.mark.asyncio
     async def test_error_in_state_after_max_retries_exhausted(
@@ -694,8 +694,8 @@ class TestMaybeRetry:
         rollout_outputs = outputs["outputs"]
         assert env.call_counts[0] == 3  # 1 initial + 2 retries
         assert rollout_outputs[0].get("error") is not None
-        error_info = rollout_outputs[0]["error"]
-        assert "InfraError" == error_info["error"]
+        error_data = rollout_outputs[0]["error"]
+        assert "InfraError" == error_data["error"]
 
 
 class TestEmptyModelResponseErrors:

--- a/tests/test_environment_extra.py
+++ b/tests/test_environment_extra.py
@@ -412,7 +412,7 @@ async def test_generate_preserves_rollout_scoring_error_when_cleanup_fails(
         )
 
     assert "cleanup exploded" in "\n".join(getattr(exc_info.value, "__notes__", []))
-    assert rubric.cleaned_states[0]["cleanup_errors"][0]["message"] == (
+    assert rubric.cleaned_states[0]["cleanup_errors"][0]["error"]["message"] == (
         "cleanup exploded"
     )
 
@@ -505,7 +505,8 @@ async def test_generate_preserves_group_scoring_error_when_cleanup_fails(
         getattr(exc_info.value, "__notes__", [])
     )
     assert [
-        state["cleanup_errors"][0]["message"] for state in rubric.cleaned_states
+        state["cleanup_errors"][0]["error"]["message"]
+        for state in rubric.cleaned_states
     ] == ["group cleanup exploded", "group cleanup exploded"]
 
 

--- a/tests/test_v1_config_extension.py
+++ b/tests/test_v1_config_extension.py
@@ -1156,12 +1156,13 @@ def test_lifecycle_fields_are_framework_managed() -> None:
     task = Task({"prompt": [{"role": "user", "content": "hi"}]}).freeze()
     state = vf.State.for_task(task)
     assert state.uses_v1_contract is True
+    error = vf.Error("boom")
 
     for key, value in {
         "is_completed": True,
         "stop_condition": "done",
         "is_truncated": True,
-        "error": {"message": "boom"},
+        "error": error,
     }.items():
         assert State({key: value})[key] == value
         with pytest.raises(RuntimeError, match="framework-managed"):
@@ -1188,12 +1189,14 @@ def test_lifecycle_fields_are_framework_managed() -> None:
     state._set_completed(True)
     state._set_stop_condition("done")
     state._set_truncated(True)
-    state._set_error({"message": "boom"})
+    with pytest.raises(TypeError, match="vf.Error"):
+        state._set_error(cast(Any, {"message": "boom"}))
+    state._set_error(error)
 
     assert state["is_completed"] is True
     assert state["stop_condition"] == "done"
     assert state["is_truncated"] is True
-    assert state["error"] == {"message": "boom"}
+    assert state["error"] is error
 
 
 def test_toolsets_config_accepts_addressable_map_and_fn_tables() -> None:

--- a/tests/test_v1_runtime_lifecycle.py
+++ b/tests/test_v1_runtime_lifecycle.py
@@ -1005,7 +1005,7 @@ async def test_v1_harness_preserves_rollout_scoring_error_when_cleanup_fails() -
         await harness.run(task, state)
 
     assert state["cleanup_ran"] is True
-    assert state["cleanup_errors"][0]["stage"] == "cleanup_rollout"
+    assert state["cleanup_errors"][0]["phase"] == "cleanup_rollout"
     assert "v1 cleanup exploded" in "\n".join(getattr(exc_info.value, "__notes__", []))
 
 
@@ -1128,7 +1128,7 @@ async def test_v1_group_surfaces_cancelled_sibling_cleanup_errors(
     notes = "\n".join(getattr(exc_info.value, "__notes__", []))
     assert "cancelled group sibling" in notes
     assert "cancelled cleanup exploded" in notes
-    assert created_states[0]["cleanup_errors"][0]["message"] == (
+    assert created_states[0]["cleanup_errors"][0]["error"]["message"] == (
         "cancelled cleanup exploded"
     )
     assert any(
@@ -1697,14 +1697,19 @@ def test_sandbox_program_patch_cannot_set_lifecycle_fields() -> None:
     patch = {
         "stop_condition": "no_tools",
         "is_truncated": True,
-        "error": {"message": "handled"},
+        "error": vf.ErrorData(
+            error="SandboxError",
+            message="handled",
+            error_chain_repr="SandboxError('handled')",
+            error_chain_str="SandboxError",
+        ),
     }
     apply_internal_state_patch(state, patch, mode="base")
 
     assert patch == {}
     assert state["stop_condition"] == "no_tools"
     assert state["is_truncated"] is True
-    assert state["error"] == {"message": "handled"}
+    assert isinstance(state["error"], vf.SandboxError)
 
 
 def test_program_channels_mcp_injects_proxy_into_sandbox_program() -> None:
@@ -1945,6 +1950,9 @@ async def test_sandbox_command_marks_oom_failures(
     assert state["sandbox_failures"][0]["kind"] == "oom"
     assert state["sandbox_failures"][0]["phase"] == "command"
     assert state["error"]["error"] == "SandboxError"
+    state["example_id"] = 0
+    output = state_to_output(state)
+    assert output["sandbox_failures"] == state["sandbox_failures"]
 
 
 @pytest.mark.asyncio
@@ -3428,8 +3436,8 @@ async def test_failed_sandbox_program_preserves_primary_error_and_artifact_error
     state = await harness.run(task)
 
     assert state["error"]["error"] == "SandboxError"
-    assert state["artifact_errors"][0]["error"] == "FileNotFoundError"
-    assert state["artifact_errors"][0]["stage"] == "artifact_collection"
+    assert state["artifact_errors"][0]["error"]["error"] == "FileNotFoundError"
+    assert state["artifact_errors"][0]["phase"] == "artifact_collection"
     assert state["stop_condition"] == "has_error"
     output = state_to_output(state)
     assert output["artifact_errors"] == state["artifact_errors"]

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -71,7 +71,11 @@ from verifiers.utils.async_utils import (
     maybe_semaphore,
     with_sem,
 )
-from verifiers.utils.error_utils import ErrorChain, error_info, note_secondary_error
+from verifiers.utils.error_utils import (
+    ErrorChain,
+    diagnostic_error_data,
+    note_secondary_error,
+)
 from verifiers.utils.message_utils import normalize_messages
 from verifiers.utils.save_utils import (
     GenerateOutputsBuilder,
@@ -693,13 +697,9 @@ class Environment(ABC):
                 if primary_error is None:
                     raise
                 state.setdefault("cleanup_errors", []).append(
-                    error_info(
-                        cleanup_error,
-                        stage="cleanup",
-                        details={"example_id": state.get("example_id")},
-                    )
+                    diagnostic_error_data(cleanup_error, phase="cleanup")
                 )
-                note_secondary_error(primary_error, cleanup_error, stage="cleanup")
+                note_secondary_error(primary_error, cleanup_error, phase="cleanup")
                 self.logger.exception("Cleanup failed after rollout error")
         return state
 
@@ -739,13 +739,9 @@ class Environment(ABC):
                     await self.rubric.cleanup(state)
                 except Exception as cleanup_error:
                     state.setdefault("cleanup_errors", []).append(
-                        error_info(
-                            cleanup_error,
-                            stage="cleanup",
-                            details={"example_id": state.get("example_id")},
-                        )
+                        diagnostic_error_data(cleanup_error, phase="cleanup")
                     )
-                    note_secondary_error(primary_error, cleanup_error, stage="cleanup")
+                    note_secondary_error(primary_error, cleanup_error, phase="cleanup")
                     self.logger.exception("Cleanup failed after group rollout error")
             raise
 
@@ -772,13 +768,9 @@ class Environment(ABC):
                     if primary_error is None:
                         raise
                     state.setdefault("cleanup_errors", []).append(
-                        error_info(
-                            cleanup_error,
-                            stage="cleanup",
-                            details={"example_id": state.get("example_id")},
-                        )
+                        diagnostic_error_data(cleanup_error, phase="cleanup")
                     )
-                    note_secondary_error(primary_error, cleanup_error, stage="cleanup")
+                    note_secondary_error(primary_error, cleanup_error, phase="cleanup")
                     self.logger.exception("Cleanup failed after group scoring error")
 
         return group_states

--- a/verifiers/envs/experimental/cli_agent_env.py
+++ b/verifiers/envs/experimental/cli_agent_env.py
@@ -717,7 +717,7 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
         num_turns = len(state.get("trajectory", []))
         stop_condition = state.get("stop_condition", "unknown")
         error = state.get("error")
-        error_info = (
+        error_summary = (
             f"{type(error).__name__}: {truncate(str(error), 80)}" if error else None
         )
         exit_code = state.get("agent_exit_code")
@@ -741,8 +741,8 @@ class CliAgentEnv(SandboxMixin, vf.MultiTurnEnv):
         ]
         if timed_out:
             parts.append("timed_out=True")
-        if error_info:
-            parts.append(f"error={error_info}")
+        if error_summary:
+            parts.append(f"error={error_summary}")
         self.logger.info(" | ".join(parts))
 
     @vf.cleanup

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -26,6 +26,8 @@ from pydantic import (
     field_validator,
 )
 
+from verifiers.errors import Error
+
 if TYPE_CHECKING:
     from anthropic.types import RedactedThinkingBlock
     from anthropic.types import ThinkingBlock as AnthropicThinkingBlock
@@ -33,7 +35,6 @@ if TYPE_CHECKING:
     from renderers import RendererConfig
 
     from verifiers.clients import Client
-    from verifiers.errors import Error
 else:
     RedactedThinkingBlock = Any
     AnthropicThinkingBlock = Any
@@ -388,13 +389,45 @@ class RolloutTiming(CustomBaseModel):
         )
 
 
-class ErrorInfo(TypedDict):
+class ErrorData(TypedDict):
     error: str
     message: str
-    stage: str | None
-    details: dict[str, Any]
     error_chain_repr: str
     error_chain_str: str
+
+
+DiagnosticErrorPhase: TypeAlias = Literal[
+    "artifact_collection",
+    "cleanup",
+    "cleanup_rollout",
+    "cleanup_group",
+    "sandbox_cleanup",
+]
+
+
+class DiagnosticErrorData(TypedDict):
+    phase: DiagnosticErrorPhase
+    error: ErrorData
+    scope: NotRequired[str]
+
+
+SandboxFailureKind: TypeAlias = Literal["oom", "timeout"]
+SandboxFailurePhase: TypeAlias = Literal[
+    "background_job",
+    "create",
+    "setup",
+    "execute",
+    "command",
+]
+
+
+class SandboxFailureData(TypedDict):
+    kind: SandboxFailureKind
+    type: str
+    message: str
+    phase: NotRequired[SandboxFailurePhase]
+    sandbox_id: NotRequired[str]
+    scope: NotRequired[str]
 
 
 class RolloutOutput(dict):
@@ -423,7 +456,10 @@ class RolloutOutput(dict):
     # Optional fields
     answer: str
     info: Info
-    error: ErrorInfo | None
+    error: ErrorData | None
+    artifact_errors: list[DiagnosticErrorData]
+    cleanup_errors: list[DiagnosticErrorData]
+    sandbox_failures: list[SandboxFailureData]
     stop_condition: str | None
     trajectory: list["TrajectoryStep"]
     tool_defs: list[Tool]
@@ -492,7 +528,7 @@ class State(dict):
     advantage: float | None
     metrics: dict[str, float] | None
     timing: RolloutTiming | None
-    error: "Error | ErrorInfo | None"
+    error: "Error | None"
     usage: TokenUsage | None
     usage_tracker: object
     _vf_state_contract: Literal["legacy", "v1"]
@@ -592,7 +628,9 @@ class State(dict):
     def _set_completed(self, value: bool = True) -> None:
         self._set_internal("is_completed", value)
 
-    def _set_error(self, value: Any) -> None:
+    def _set_error(self, value: Error | None) -> None:
+        if value is not None and not isinstance(value, Error):
+            raise TypeError("state.error must be a vf.Error or None.")
         self._set_internal("error", value)
 
     def _set_stop_condition(
@@ -851,8 +889,16 @@ class State(dict):
 
     def finalize(self) -> "State":
         self.strip_runtime_handles()
+        self.serialize_error()
         self.assert_serializable()
         return self
+
+    def serialize_error(self) -> None:
+        error = self.get("error")
+        if isinstance(error, Error):
+            from verifiers.utils.error_utils import error_data
+
+            self._set_internal("error", error_data(error))
 
     @classmethod
     def _legacy_for_task(cls, task: Mapping[str, Any]) -> "State":

--- a/verifiers/utils/async_utils.py
+++ b/verifiers/utils/async_utils.py
@@ -2,7 +2,6 @@ import asyncio
 import inspect
 import logging
 from collections import deque
-from collections.abc import Mapping
 from collections.abc import Coroutine
 from time import perf_counter
 from typing import Any, AsyncContextManager, Callable, Optional, TypeVar
@@ -13,7 +12,7 @@ from pydantic import BaseModel
 
 import verifiers as vf
 from verifiers.utils.error_utils import ErrorChain
-from verifiers.utils.error_utils import error_info_to_exception
+from verifiers.utils.error_utils import error_data_to_exception, is_error_data
 from verifiers.utils.logging_utils import print_time
 
 logger = logging.getLogger(__name__)
@@ -167,8 +166,8 @@ def maybe_retry(
             err = result.get("error")
             if err and any(isinstance(err, err_type) for err_type in error_types):
                 raise err
-            if isinstance(err, Mapping):
-                retry_error = error_info_to_exception(err, error_types)
+            if is_error_data(err):
+                retry_error = error_data_to_exception(err, error_types)
                 if retry_error is not None:
                     raise retry_error
         elif isinstance(result, list):
@@ -176,8 +175,8 @@ def maybe_retry(
                 err = state.get("error")
                 if err and any(isinstance(err, err_type) for err_type in error_types):
                     raise err
-                if isinstance(err, Mapping):
-                    retry_error = error_info_to_exception(err, error_types)
+                if is_error_data(err):
+                    retry_error = error_data_to_exception(err, error_types)
                     if retry_error is not None:
                         raise retry_error
 

--- a/verifiers/utils/error_utils.py
+++ b/verifiers/utils/error_utils.py
@@ -1,8 +1,11 @@
-from collections.abc import Mapping
-from typing import Callable, cast
+from typing import Callable, TypeGuard, cast
 
 import verifiers as vf
-from verifiers.types import ErrorInfo
+from verifiers.types import (
+    DiagnosticErrorData,
+    DiagnosticErrorPhase,
+    ErrorData,
+)
 
 
 def get_error_chain(
@@ -56,32 +59,99 @@ class ErrorChain:
         return " -> ".join([repr(e) for e in self.chain])
 
 
-def error_info(
-    error: BaseException,
-    *,
-    stage: str | None = None,
-    details: Mapping[str, object] | None = None,
-) -> ErrorInfo:
+def error_data(error: BaseException) -> ErrorData:
     error_chain = ErrorChain(error)
-    info = ErrorInfo(
+    return ErrorData(
         error=type(error).__name__,
         message=str(error) or type(error).__name__,
-        stage=stage,
-        details=dict(details or {}),
         error_chain_repr=repr(error_chain),
         error_chain_str=str(error_chain),
     )
-    return info
+
+
+def is_error_data(value: object) -> TypeGuard[ErrorData]:
+    expected = {"error", "message", "error_chain_repr", "error_chain_str"}
+    if not isinstance(value, dict):
+        return False
+    match value:
+        case {
+            "error": str(),
+            "message": str(),
+            "error_chain_repr": str(),
+            "error_chain_str": str(),
+        }:
+            return set(value) == expected
+    return False
+
+
+def validate_error_data(value: object) -> ErrorData:
+    if not is_error_data(value):
+        raise TypeError(
+            "ErrorData must contain string error, message, error_chain_repr, "
+            "and error_chain_str fields."
+        )
+    return value
+
+
+def diagnostic_error_data(
+    error: BaseException,
+    *,
+    phase: DiagnosticErrorPhase,
+    scope: str | None = None,
+) -> DiagnosticErrorData:
+    diagnostic = DiagnosticErrorData(phase=phase, error=error_data(error))
+    if scope is not None:
+        diagnostic["scope"] = scope
+    return diagnostic
+
+
+def is_diagnostic_error_data(value: object) -> TypeGuard[DiagnosticErrorData]:
+    if not isinstance(value, dict):
+        return False
+    match value:
+        case {"phase": str() as phase, "error": error}:
+            if set(value) == {"phase", "error"}:
+                scope_valid = True
+            elif set(value) == {"phase", "error", "scope"}:
+                match value:
+                    case {"scope": str()}:
+                        scope_valid = True
+                    case _:
+                        scope_valid = False
+            else:
+                scope_valid = False
+        case _:
+            return False
+    if phase not in {
+        "artifact_collection",
+        "cleanup",
+        "cleanup_rollout",
+        "cleanup_group",
+        "sandbox_cleanup",
+    }:
+        return False
+    if not is_error_data(error):
+        return False
+    return scope_valid
+
+
+def validate_diagnostic_error_data(value: object) -> DiagnosticErrorData:
+    if not is_diagnostic_error_data(value):
+        raise TypeError(
+            "DiagnosticErrorData must contain phase and error fields, "
+            "with optional string scope."
+        )
+    return value
 
 
 def note_secondary_error(
     primary_error: BaseException,
     secondary_error: BaseException,
     *,
-    stage: str,
+    phase: DiagnosticErrorPhase,
 ) -> None:
     note = (
-        f"{stage} failed while handling {type(primary_error).__name__}: "
+        f"{phase} failed while handling {type(primary_error).__name__}: "
         f"{repr(ErrorChain(secondary_error))}"
     )
     add_note = getattr(primary_error, "add_note", None)
@@ -95,13 +165,38 @@ def note_secondary_error(
     setattr(primary_error, "__notes__", notes)
 
 
-def error_info_to_exception(
-    error: Mapping[str, object],
+def error_data_to_exception(
+    error: ErrorData,
     error_types: tuple[type[Exception], ...],
 ) -> Exception | None:
-    chain = str(error.get("error_chain_str") or error.get("error") or "")
-    detail = str(error.get("error_chain_repr") or error.get("error") or "")
+    chain = error["error_chain_str"] or error["error"]
+    detail = error["error_chain_repr"] or error["error"]
     for error_type in error_types:
         if error_type.__name__ in chain:
             return error_type(detail)
     return None
+
+
+def error_from_data(error: ErrorData) -> vf.Error:
+    exception = error_data_to_exception(error, vf_error_types())
+    if isinstance(exception, vf.Error):
+        return exception
+    detail = error["error_chain_repr"] or error["error"]
+    return vf.Error(detail)
+
+
+def vf_error_types() -> tuple[type[vf.Error], ...]:
+    return (
+        vf.BrowserSandboxError,
+        vf.SandboxError,
+        vf.TunnelError,
+        vf.InfraError,
+        vf.EmptyModelResponseError,
+        vf.InvalidModelResponseError,
+        vf.ModelError,
+        vf.ToolParseError,
+        vf.ToolCallError,
+        vf.ToolError,
+        vf.OverlongPromptError,
+        vf.Error,
+    )

--- a/verifiers/utils/logging_utils.py
+++ b/verifiers/utils/logging_utils.py
@@ -10,7 +10,7 @@ from rich.table import Table
 from rich.text import Text
 
 from verifiers.errors import Error
-from verifiers.types import ErrorInfo, Messages
+from verifiers.types import ErrorData, Messages
 from verifiers.utils.error_utils import ErrorChain
 
 LOGGER_NAME = "verifiers"
@@ -156,7 +156,7 @@ def quiet_verifiers():
 def print_prompt_completions_sample(
     prompts: list[Messages],
     completions: list[Messages],
-    errors: list[Error | ErrorInfo | None],
+    errors: list[Error | ErrorData | None],
     rewards: list[float],
     step: int,
     num_samples: int = 1,

--- a/verifiers/utils/save_utils.py
+++ b/verifiers/utils/save_utils.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping
 from datetime import date, datetime
 from pathlib import Path
 from typing import Any, cast
+from typing import TypeGuard
 
 from datasets import Dataset
 from openai import AsyncOpenAI
@@ -13,17 +14,22 @@ from pydantic import BaseModel
 
 from verifiers.types import (
     ClientConfig,
-    ErrorInfo,
+    DiagnosticErrorData,
     GenerateMetadata,
     GenerateOutputs,
     Response,
     RolloutOutput,
+    SandboxFailureData,
     SamplingArgs,
     State,
     TokenUsage,
     Tool,
 )
-from verifiers.utils.error_utils import ErrorChain
+from verifiers.utils.error_utils import (
+    error_data,
+    validate_diagnostic_error_data,
+    validate_error_data,
+)
 from verifiers.utils.message_utils import (
     sanitize_tool_calls,
     serialize_messages_for_output,
@@ -46,6 +52,62 @@ from verifiers.utils.usage_utils import (
 from verifiers.utils.version_utils import get_version_info
 
 logger = logging.getLogger(__name__)
+
+
+def diagnostic_errors(value: object, field_name: str) -> list[DiagnosticErrorData]:
+    if not isinstance(value, list):
+        raise TypeError(f"state.{field_name} must be a list.")
+    return [validate_diagnostic_error_data(item) for item in value]
+
+
+def is_sandbox_failure_data(value: object) -> TypeGuard[SandboxFailureData]:
+    if not isinstance(value, dict):
+        return False
+    data = cast(dict[str, object], value)
+    expected = {"kind", "type", "message"}
+    optional = {"phase", "sandbox_id", "scope"}
+    if not expected <= set(data) <= expected | optional:
+        return False
+    match data:
+        case {
+            "kind": str() as kind,
+            "type": str(),
+            "message": str(),
+        }:
+            pass
+        case _:
+            return False
+    if kind not in {"oom", "timeout"}:
+        return False
+    if "phase" in data:
+        phase = data["phase"]
+        if not isinstance(phase, str) or phase not in {
+            "background_job",
+            "create",
+            "setup",
+            "execute",
+            "command",
+        }:
+            return False
+    for field in ("sandbox_id", "scope"):
+        if field in data and not isinstance(data[field], str):
+            return False
+    return True
+
+
+def validate_sandbox_failure_data(value: object) -> SandboxFailureData:
+    if not is_sandbox_failure_data(value):
+        raise TypeError(
+            "SandboxFailureData must contain string kind, type, and message "
+            "fields, with optional phase, sandbox_id, and scope strings."
+        )
+    return value
+
+
+def sandbox_failures(value: object, field_name: str) -> list[SandboxFailureData]:
+    if not isinstance(value, list):
+        raise TypeError(f"state.{field_name} must be a list.")
+    return [validate_sandbox_failure_data(item) for item in value]
 
 
 def is_json_serializable(value: object) -> bool:
@@ -280,34 +342,12 @@ def state_to_output(
             serialize_messages_for_output(completion)
         )
         output["completion"] = output_completion
-    # use repr for error
     error = state.get("error")
     if error is not None:
-        if isinstance(error, Mapping) and {
-            "error",
-            "error_chain_repr",
-            "error_chain_str",
-        } <= set(error):
-            stage = error.get("stage")
-            details = error.get("details")
-            output["error"] = ErrorInfo(
-                error=str(error["error"]),
-                message=str(error.get("message") or error["error"]),
-                stage=None if stage is None else str(stage),
-                details=dict(details) if isinstance(details, Mapping) else {},
-                error_chain_repr=str(error["error_chain_repr"]),
-                error_chain_str=str(error["error_chain_str"]),
-            )
+        if isinstance(error, BaseException):
+            output["error"] = error_data(error)
         else:
-            error_chain = ErrorChain(cast(BaseException, error))
-            output["error"] = ErrorInfo(
-                error=type(error).__name__,
-                message=str(error) or type(error).__name__,
-                stage=None,
-                details={},
-                error_chain_repr=repr(error_chain),
-                error_chain_str=str(error_chain),
-            )
+            output["error"] = validate_error_data(error)
         output["error_chain"] = output["error"]["error_chain_repr"]
         output["long_error_chain"] = output["error"]["error_chain_str"]
     # only include optional fields if non-empty
@@ -315,9 +355,13 @@ def state_to_output(
         output.pop("answer")
     if "info" in output and not output["info"]:
         output.pop("info")
-    for key in ("sandbox_failures", "artifact_errors", "cleanup_errors"):
+    for key in ("artifact_errors", "cleanup_errors"):
         if key in state:
-            output[key] = state[key]
+            output[key] = diagnostic_errors(state[key], key)
+    if "sandbox_failures" in state:
+        output["sandbox_failures"] = sandbox_failures(
+            state["sandbox_failures"], "sandbox_failures"
+        )
     # flatten metrics to top-level keys (backwards compatibility)
     state_metrics = state.get("metrics") or {}
     for k, v in state_metrics.items():

--- a/verifiers/v1/env.py
+++ b/verifiers/v1/env.py
@@ -6,7 +6,11 @@ import verifiers as vf
 from verifiers.clients import Client
 from verifiers.types import ClientConfig
 from verifiers.types import RolloutInput, SamplingArgs
-from verifiers.utils.error_utils import error_info, note_secondary_error
+from verifiers.utils.error_utils import (
+    diagnostic_error_data,
+    note_secondary_error,
+    validate_diagnostic_error_data,
+)
 
 from .config import Config
 from .harness import Harness, HarnessConfig
@@ -195,14 +199,14 @@ class Env(vf.Environment):
                         secondary_notes.append(f"cancelled group sibling: {note}")
                 for _, state in pending_state_pairs:
                     for cleanup_error in state.get("cleanup_errors", []):
-                        if not isinstance(cleanup_error, dict):
+                        try:
+                            diagnostic = validate_diagnostic_error_data(cleanup_error)
+                        except TypeError:
                             continue
-                        stage = cleanup_error.get("stage") or "cleanup"
-                        message = cleanup_error.get("message") or cleanup_error.get(
-                            "error"
-                        )
                         secondary_notes.append(
-                            f"cancelled group sibling {stage} failed: {message}"
+                            "cancelled group sibling "
+                            f"{diagnostic['phase']} failed: "
+                            f"{diagnostic['error']['message']}"
                         )
                 for secondary_note in dict.fromkeys(secondary_notes):
                     add_note = getattr(primary_error, "add_note", None)
@@ -223,9 +227,9 @@ class Env(vf.Environment):
             except Exception as cleanup_error:
                 for state in states:
                     state.setdefault("cleanup_errors", []).append(
-                        error_info(cleanup_error, stage="cleanup")
+                        diagnostic_error_data(cleanup_error, phase="cleanup")
                     )
-                note_secondary_error(primary_error, cleanup_error, stage="cleanup")
+                note_secondary_error(primary_error, cleanup_error, phase="cleanup")
                 self.logger.exception("Cleanup failed after v1 group rollout error")
             for state in states:
                 state.strip_runtime_handles()
@@ -245,9 +249,9 @@ class Env(vf.Environment):
                     raise
                 for state in states:
                     state.setdefault("cleanup_errors", []).append(
-                        error_info(cleanup_error, stage="cleanup")
+                        diagnostic_error_data(cleanup_error, phase="cleanup")
                     )
-                note_secondary_error(primary_error, cleanup_error, stage="cleanup")
+                note_secondary_error(primary_error, cleanup_error, phase="cleanup")
                 self.logger.exception("Cleanup failed after v1 group scoring error")
         for state in states:
             state.strip_runtime_handles()

--- a/verifiers/v1/harness.py
+++ b/verifiers/v1/harness.py
@@ -15,7 +15,7 @@ from verifiers.types import (
     ToolMessage,
 )
 from verifiers.utils.async_utils import maybe_call_with_named_args
-from verifiers.utils.error_utils import error_info, note_secondary_error
+from verifiers.utils.error_utils import diagnostic_error_data, note_secondary_error
 from verifiers.utils.message_utils import normalize_messages
 from verifiers.utils.response_utils import parse_response_message
 from verifiers.utils.tool_utils import is_valid_tool_content_parts
@@ -261,7 +261,7 @@ class Harness(RuntimeOwnerMixin[ConfigT], Generic[ConfigT]):
                 if not rollout_failed:
                     raise
                 state.setdefault("artifact_errors", []).append(
-                    error_info(e, stage="artifact_collection")
+                    diagnostic_error_data(e, phase="artifact_collection")
                 )
             await self.runtime.update_rollout(task, state)
             state.record_generation_timing()
@@ -282,10 +282,10 @@ class Harness(RuntimeOwnerMixin[ConfigT], Generic[ConfigT]):
                 if primary_error is None:
                     raise
                 state.setdefault("cleanup_errors", []).append(
-                    error_info(cleanup_error, stage="cleanup_rollout")
+                    diagnostic_error_data(cleanup_error, phase="cleanup_rollout")
                 )
                 note_secondary_error(
-                    primary_error, cleanup_error, stage="cleanup_rollout"
+                    primary_error, cleanup_error, phase="cleanup_rollout"
                 )
             if "group_key" not in state.runtime_state():
                 try:
@@ -294,16 +294,17 @@ class Harness(RuntimeOwnerMixin[ConfigT], Generic[ConfigT]):
                     if primary_error is None:
                         raise
                     state.setdefault("cleanup_errors", []).append(
-                        error_info(cleanup_error, stage="cleanup_group")
+                        diagnostic_error_data(cleanup_error, phase="cleanup_group")
                     )
                     note_secondary_error(
-                        primary_error, cleanup_error, stage="cleanup_group"
+                        primary_error, cleanup_error, phase="cleanup_group"
                     )
                 if completed:
                     state.finalize()
                 else:
                     state.strip_runtime_handles()
             elif completed:
+                state.serialize_error()
                 state.assert_serializable()
         return state
 
@@ -313,7 +314,7 @@ class Harness(RuntimeOwnerMixin[ConfigT], Generic[ConfigT]):
             state._set_truncated(True)
             state._set_stop_condition("prompt_too_long", overwrite=True)
             return
-        state._set_error(error_info(error))
+        state._set_error(error)
         state._set_stop_condition("has_error", overwrite=True)
 
     async def score_group(self, tasks: list[Task], states: list[State]) -> list[State]:

--- a/verifiers/v1/runtime.py
+++ b/verifiers/v1/runtime.py
@@ -21,10 +21,11 @@ from typing import (
 )
 
 from verifiers.clients import Client, resolve_client
-from verifiers.types import Messages, Response, Tool
+from verifiers.types import DiagnosticErrorData, Messages, Response, Tool
 from verifiers.types import ClientConfig, ClientType, SamplingArgs
 from verifiers.utils.async_utils import maybe_call_with_named_args
 from verifiers.utils.client_utils import resolve_client_config
+from verifiers.utils.error_utils import diagnostic_error_data
 from verifiers.utils.message_utils import normalize_messages
 from verifiers.utils.response_utils import parse_response_message, parse_response_tokens
 from verifiers.utils.tool_utils import convert_func_to_tool_def
@@ -1217,14 +1218,11 @@ class Runtime:
                 )
                 if state is not None and scope is not None:
                     cleanup_errors = cast(
-                        list[ConfigData], state.setdefault("cleanup_errors", [])
+                        list[DiagnosticErrorData],
+                        state.setdefault("cleanup_errors", []),
                     )
                     cleanup_errors.append(
-                        {
-                            "type": type(exc).__name__,
-                            "message": str(exc),
-                            "scope": scope,
-                        }
+                        diagnostic_error_data(exc, phase="sandbox_cleanup", scope=scope)
                     )
 
     async def resolve_sandbox_lease(
@@ -2438,14 +2436,10 @@ class Runtime:
                     exc_info=True,
                 )
                 cleanup_errors = cast(
-                    list[ConfigData], state.setdefault("cleanup_errors", [])
+                    list[DiagnosticErrorData], state.setdefault("cleanup_errors", [])
                 )
                 cleanup_errors.append(
-                    {
-                        "type": type(exc).__name__,
-                        "message": str(exc),
-                        "scope": scope,
-                    }
+                    diagnostic_error_data(exc, phase="sandbox_cleanup", scope=scope)
                 )
             else:
                 async with self.sandbox_lock:

--- a/verifiers/v1/utils/endpoint_utils.py
+++ b/verifiers/v1/utils/endpoint_utils.py
@@ -23,7 +23,6 @@ from verifiers.types import (
     ToolMessage,
     UserMessage,
 )
-from verifiers.utils.error_utils import error_info
 from verifiers.utils.interception_utils import (
     InterceptionServer,
     deliver_response,
@@ -447,7 +446,7 @@ async def forward_request(
     except BaseException as e:
         error = e
         if isinstance(e, Error):
-            state._set_error(error_info(e))
+            state._set_error(e)
         raise
     finally:
         if bool(request.get("stream")):

--- a/verifiers/v1/utils/sandbox_program_utils.py
+++ b/verifiers/v1/utils/sandbox_program_utils.py
@@ -8,6 +8,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import cast
 
+from verifiers.errors import Error
+from verifiers.utils.error_utils import error_from_data, validate_error_data
 from verifiers.utils.interception_utils import serialize_tool_defs
 
 from ..runtime import Runtime
@@ -119,11 +121,17 @@ def apply_internal_state_patch(state: State, patch: ConfigData, *, mode: str) ->
         elif key == "is_truncated":
             state._set_truncated(bool(value), overwrite=True)
         elif key == "error":
-            state._set_error(value)
+            state._set_error(state_error(value))
         else:
             raise RuntimeError(
                 f"Sandbox Python program cannot set framework-managed state key {key!r}."
             )
+
+
+def state_error(value: object) -> Error | None:
+    if value is None:
+        return None
+    return error_from_data(validate_error_data(value))
 
 
 def sandbox_runner_program(

--- a/verifiers/v1/utils/sandbox_utils.py
+++ b/verifiers/v1/utils/sandbox_utils.py
@@ -16,6 +16,7 @@ import tenacity as tc
 
 from verifiers.decorators import setup as setup_handler
 from verifiers.errors import Error, SandboxError
+from verifiers.types import SandboxFailureData, SandboxFailureKind, SandboxFailurePhase
 from verifiers.utils.async_utils import maybe_call_with_named_args
 
 from .program_utils import command_argv, command_env, float_config, int_config
@@ -155,7 +156,7 @@ async def close_sandbox_client(client: SandboxClient) -> None:
         await aclose()
 
 
-def sandbox_failure_kind(exc: BaseException) -> str | None:
+def sandbox_failure_kind(exc: BaseException) -> SandboxFailureKind | None:
     if isinstance(exc, TimeoutError):
         return "timeout"
     name = type(exc).__name__
@@ -172,19 +173,19 @@ def mark_sandbox_failure(
     lease: "SandboxLease | None",
     exc: BaseException,
     *,
-    phase: str | None = None,
-) -> str | None:
+    phase: SandboxFailurePhase | None = None,
+) -> SandboxFailureKind | None:
     kind = sandbox_failure_kind(exc)
     if kind == "oom":
         state["sandbox_oom"] = True
     elif kind == "timeout":
         state["sandbox_timeout"] = True
     if kind is not None:
-        failure: ConfigData = {
-            "kind": kind,
-            "type": type(exc).__name__,
-            "message": str(exc),
-        }
+        failure = SandboxFailureData(
+            kind=kind,
+            type=type(exc).__name__,
+            message=str(exc),
+        )
         if phase is not None:
             failure["phase"] = phase
         if lease is not None:


### PR DESCRIPTION
## Summary
- rename rollout exception serialization from ErrorInfo to ErrorData and make primary rollout output errors exact serialized vf.Error records
- separate secondary artifact/cleanup/sandbox cleanup failures into DiagnosticErrorData with explicit phases
- keep live State.error as vf.Error only, validating sandbox patches and retry handling against exact ErrorData instead of loose mappings

## Checks
- uv run ruff check .
- uv run ty check verifiers
- uv run pytest tests/test_v1_runtime_lifecycle.py tests/test_environment_extra.py tests/test_environment.py tests/test_error_chain.py -q

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes serialized error schemas and state.error typing across legacy and v1 rollout paths; consumers of cleanup_errors/artifact_errors must follow the nested structure.
> 
> **Overview**
> Standardizes rollout error shapes by replacing **`ErrorInfo`** with **`ErrorData`** for primary serialized errors and introducing **`DiagnosticErrorData`** (with **`phase`** instead of **`stage`**) for secondary artifact/cleanup/sandbox failures. **`SandboxFailureData`** is now validated when building outputs.
> 
> **Runtime `state.error`** is **`vf.Error` only** (`_set_error` rejects dicts); **`State.finalize()`** / **`serialize_error()`** convert it to **`ErrorData`** for **`RolloutOutput`**. Harness and endpoint code store exceptions directly instead of pre-serializing. **`save_utils.state_to_output`** validates diagnostic and sandbox failure lists rather than copying raw state blobs.
> 
> **Breaking for readers of secondary errors:** use `cleanup_errors[i]['error']['message']` and `['phase']` instead of top-level `message` / `stage`. Retry logic uses **`is_error_data`** / **`error_data_to_exception`** on exact **`ErrorData`** shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9dd793a4238f0fab166bf23ab3aac3ea52e3acf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace flat error diagnostics with structured `DiagnosticErrorData` schema across rollout lifecycle
> - Introduces `ErrorData` and `DiagnosticErrorData` typed structures in [error_utils.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1550/files#diff-88b8a23523c98c1e849b18fb8734eaa13b5e7a68196c34f9022355926ee043f0), replacing the old `ErrorInfo`/`error_info` pattern with `error_data` and `diagnostic_error_data` helpers that include a `phase` field instead of `stage`.
> - `State.error` in [types.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1550/files#diff-8bc45ba080ed8ff01ee6adbafb54c0346181c6f292928e53c2a94dd9ed5156c3) now holds a `vf.Error` object at runtime; `finalize()` serializes it to `ErrorData` via `serialize_error()`, and `_set_error()` raises `TypeError` for non-`Error` values.
> - Cleanup, artifact, and sandbox diagnostic errors throughout [environment.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1550/files#diff-066aa9922fcaf4d3d3fc471b078fbfa64512119dbb81392b7feba435fc92c0aa), [harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1550/files#diff-05e981bb3680a934fbc6865d9dff3b25fc692d0c9970684bf8d41f4aea7ee384), [runtime.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1550/files#diff-7c2c1b88c61b8a75e00bb82f7ece60290f886d4a3ed87e97a5e1cbf86b26973d), and [env.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1550/files#diff-69be10bd5960e88d88f219d4f261d0bdd16586857f9126451b04d05bac4c2cbb) are now recorded as nested `DiagnosticErrorData` with explicit `phase` values.
> - [save_utils.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1550/files#diff-e4491159a12a733bc8861a33ba9d2d09b27942f04c4baa1629f0806efa07547d) `state_to_output` now strictly validates `error`, `cleanup_errors`, `artifact_errors`, and `sandbox_failures` against defined schemas, raising `TypeError`/`ValueError` on violations.
> - Behavioral Change: `cleanup_errors` entries now nest error details under an `error` key (e.g. `cleanup_errors[0]['error']['message']`), and the `stage` field is replaced by `phase` — callers reading raw state output must update their access paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c9dd793.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->