### PR TITLE
Decouple composable harnesses from harness packages

### DIFF
--- a/tests/test_composable_env.py
+++ b/tests/test_composable_env.py
@@ -193,25 +193,23 @@ def test_taskset_repr():
     assert "3" in repr(ts)
 
 
-def test_composable_mini_swe_agent_unversioned_package_uses_unpinned_requirement():
-    setup = build_mini_swe_agent_install_script(package="  mini-swe-agent  ")
+def test_composable_mini_swe_agent_install_script_owns_wheel_download():
+    setup = build_mini_swe_agent_install_script()
 
-    assert (
-        "vf_python_install --target /opt/mini-swe-agent/prefix/site-packages mini-swe-agent"
-        in setup
-    )
-    assert "mini-swe-agent==mini-swe-agent" not in setup
+    assert "mini_swe_agent-2.2.8-py3-none-any.whl" in setup
+    assert "sha256sum -c -" in setup
+    assert "694df4de1337e665e3cd82e99f93374f573bf52b8e7c362ac5d8045ad9f7c37c" in setup
 
 
-def test_composable_opencode_unversioned_release_uses_latest_download_url():
+def test_composable_opencode_install_script_owns_release_download():
     setup = build_opencode_install_script(
-        release="  PrimeIntellect-ai/opencode  ",
         install_ripgrep=False,
     )
 
     assert "OPENCODE_RELEASE_REPO=PrimeIntellect-ai/opencode" in setup
-    assert "OPENCODE_RELEASE_PATH=releases/latest/download" in setup
-    assert "releases/download/vPrimeIntellect-ai/opencode" not in setup
+    assert "OPENCODE_RELEASE_VERSION=1.1.63-rl2" in setup
+    assert "releases/download/v$OPENCODE_RELEASE_TAG" in setup
+    assert "47f4102796da50769e27d2c9ea6a9cf7941f76898390cb497278cab39c4b6ed4" in setup
 
 
 @pytest.mark.asyncio

--- a/tests/test_composable_env.py
+++ b/tests/test_composable_env.py
@@ -193,12 +193,11 @@ def test_taskset_repr():
     assert "3" in repr(ts)
 
 
-def test_composable_mini_swe_agent_install_script_owns_wheel_download():
+def test_composable_mini_swe_agent_install_script_uses_pip_requirement():
     setup = build_mini_swe_agent_install_script()
 
-    assert "mini_swe_agent-2.2.8-py3-none-any.whl" in setup
-    assert "sha256sum -c -" in setup
-    assert "694df4de1337e665e3cd82e99f93374f573bf52b8e7c362ac5d8045ad9f7c37c" in setup
+    assert "mini-swe-agent==2.2.8" in setup
+    assert "files.pythonhosted.org" not in setup
 
 
 def test_composable_opencode_install_script_owns_release_download():
@@ -209,15 +208,7 @@ def test_composable_opencode_install_script_owns_release_download():
     assert "OPENCODE_RELEASE_REPO=PrimeIntellect-ai/opencode" in setup
     assert "OPENCODE_RELEASE_VERSION=1.1.63-rl2" in setup
     assert "releases/download/v$OPENCODE_RELEASE_TAG" in setup
-    assert (
-        "x64) OPENCODE_RELEASE_SHA256="
-        "47f4102796da50769e27d2c9ea6a9cf7941f76898390cb497278cab39c4b6ed4 ;;" in setup
-    )
-    assert "No SHA256 configured for OpenCode" in setup
-    assert (
-        'echo "$OPENCODE_RELEASE_SHA256  /tmp/opencode.tar.gz" | sha256sum -c -'
-        in setup
-    )
+    assert "tar -xzf /tmp/opencode.tar.gz" in setup
 
 
 @pytest.mark.asyncio

--- a/tests/test_composable_env.py
+++ b/tests/test_composable_env.py
@@ -209,7 +209,15 @@ def test_composable_opencode_install_script_owns_release_download():
     assert "OPENCODE_RELEASE_REPO=PrimeIntellect-ai/opencode" in setup
     assert "OPENCODE_RELEASE_VERSION=1.1.63-rl2" in setup
     assert "releases/download/v$OPENCODE_RELEASE_TAG" in setup
-    assert "47f4102796da50769e27d2c9ea6a9cf7941f76898390cb497278cab39c4b6ed4" in setup
+    assert (
+        "x64) OPENCODE_RELEASE_SHA256="
+        "47f4102796da50769e27d2c9ea6a9cf7941f76898390cb497278cab39c4b6ed4 ;;" in setup
+    )
+    assert "No SHA256 configured for OpenCode" in setup
+    assert (
+        'echo "$OPENCODE_RELEASE_SHA256  /tmp/opencode.tar.gz" | sha256sum -c -'
+        in setup
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_composable_env.py
+++ b/tests/test_composable_env.py
@@ -200,15 +200,31 @@ def test_composable_mini_swe_agent_install_script_uses_pip_requirement():
     assert "files.pythonhosted.org" not in setup
 
 
+def test_composable_mini_swe_agent_latest_uses_unpinned_requirement():
+    setup = build_mini_swe_agent_install_script(package_version="latest")
+
+    assert "mini-swe-agent==latest" not in setup
+    assert "target /opt/mini-swe-agent/prefix/site-packages mini-swe-agent" in setup
+
+
 def test_composable_opencode_install_script_owns_release_download():
     setup = build_opencode_install_script(
         install_ripgrep=False,
     )
 
     assert "OPENCODE_RELEASE_REPO=PrimeIntellect-ai/opencode" in setup
-    assert "OPENCODE_RELEASE_VERSION=1.1.63-rl2" in setup
-    assert "releases/download/v$OPENCODE_RELEASE_TAG" in setup
+    assert "OPENCODE_RELEASE_PATH=releases/download/v1.1.63-rl2" in setup
     assert "tar -xzf /tmp/opencode.tar.gz" in setup
+
+
+def test_composable_opencode_latest_uses_latest_download_url():
+    setup = build_opencode_install_script(
+        release_version="latest",
+        install_ripgrep=False,
+    )
+
+    assert "OPENCODE_RELEASE_PATH=releases/latest/download" in setup
+    assert "releases/download/vlatest" not in setup
 
 
 @pytest.mark.asyncio

--- a/tests/test_composable_env.py
+++ b/tests/test_composable_env.py
@@ -200,31 +200,13 @@ def test_composable_mini_swe_agent_install_script_uses_pip_requirement():
     assert "files.pythonhosted.org" not in setup
 
 
-def test_composable_mini_swe_agent_latest_uses_unpinned_requirement():
-    setup = build_mini_swe_agent_install_script(package_version="latest")
-
-    assert "mini-swe-agent==latest" not in setup
-    assert "target /opt/mini-swe-agent/prefix/site-packages mini-swe-agent" in setup
-
-
 def test_composable_opencode_install_script_owns_release_download():
     setup = build_opencode_install_script(
         install_ripgrep=False,
     )
 
-    assert "OPENCODE_RELEASE_REPO=PrimeIntellect-ai/opencode" in setup
-    assert "OPENCODE_RELEASE_PATH=releases/download/v1.1.63-rl2" in setup
+    assert "PrimeIntellect-ai/opencode/releases/download/v1.1.63-rl2" in setup
     assert "tar -xzf /tmp/opencode.tar.gz" in setup
-
-
-def test_composable_opencode_latest_uses_latest_download_url():
-    setup = build_opencode_install_script(
-        release_version="latest",
-        install_ripgrep=False,
-    )
-
-    assert "OPENCODE_RELEASE_PATH=releases/latest/download" in setup
-    assert "releases/download/vlatest" not in setup
 
 
 @pytest.mark.asyncio

--- a/verifiers/envs/experimental/composable/harnesses/__init__.py
+++ b/verifiers/envs/experimental/composable/harnesses/__init__.py
@@ -9,7 +9,9 @@ from verifiers.envs.experimental.composable.harnesses.rlm import (
 )
 from verifiers.envs.experimental.composable.harnesses.opencode import (
     DEFAULT_DISABLED_TOOLS,
-    DEFAULT_RELEASE,
+    DEFAULT_RELEASE_REPO,
+    DEFAULT_RELEASE_SHA256,
+    DEFAULT_RELEASE_VERSION,
     DEFAULT_SYSTEM_PROMPT,
     OPENCODE_INSTALL_SCRIPT,
     build_install_script as build_opencode_install_script,
@@ -39,7 +41,9 @@ __all__ = [
     "build_opencode_run_command",
     "OPENCODE_INSTALL_SCRIPT",
     "DEFAULT_DISABLED_TOOLS",
-    "DEFAULT_RELEASE",
+    "DEFAULT_RELEASE_REPO",
+    "DEFAULT_RELEASE_VERSION",
+    "DEFAULT_RELEASE_SHA256",
     "DEFAULT_SYSTEM_PROMPT",
     "mini_swe_agent_harness",
     "build_mini_swe_agent_install_script",

--- a/verifiers/envs/experimental/composable/harnesses/__init__.py
+++ b/verifiers/envs/experimental/composable/harnesses/__init__.py
@@ -10,7 +10,6 @@ from verifiers.envs.experimental.composable.harnesses.rlm import (
 from verifiers.envs.experimental.composable.harnesses.opencode import (
     DEFAULT_DISABLED_TOOLS,
     DEFAULT_RELEASE_REPO,
-    DEFAULT_RELEASE_SHA256,
     DEFAULT_RELEASE_VERSION,
     DEFAULT_SYSTEM_PROMPT,
     OPENCODE_INSTALL_SCRIPT,
@@ -43,7 +42,6 @@ __all__ = [
     "DEFAULT_DISABLED_TOOLS",
     "DEFAULT_RELEASE_REPO",
     "DEFAULT_RELEASE_VERSION",
-    "DEFAULT_RELEASE_SHA256",
     "DEFAULT_SYSTEM_PROMPT",
     "mini_swe_agent_harness",
     "build_mini_swe_agent_install_script",

--- a/verifiers/envs/experimental/composable/harnesses/mini_swe_agent.py
+++ b/verifiers/envs/experimental/composable/harnesses/mini_swe_agent.py
@@ -12,7 +12,6 @@ MINI_SWE_AGENT_CLI_PACKAGE = "mini-swe-agent"
 MINI_SWE_AGENT_CLI_VERSION = "2.2.8"
 MINI_SWE_AGENT_PYTHON_VERSION = "3.11"
 UV_PACKAGE_VERSION = "0.11.7"
-DEFAULT_PACKAGE_VERSION = MINI_SWE_AGENT_CLI_VERSION
 DEFAULT_INSTRUCTION_PATH = "/mini-swe-agent/prompt.txt"
 DEFAULT_SYSTEM_PROMPT_PATH = "/mini-swe-agent/system.txt"
 DEFAULT_LOG_DIR = "/logs/agent"
@@ -25,7 +24,6 @@ DEFAULT_ENVIRONMENT_TIMEOUT = 120
 
 
 def build_mini_swe_agent_install_script(
-    package_version: str = DEFAULT_PACKAGE_VERSION,
     prefix_dir: str = DEFAULT_PREFIX_DIR,
     install_python: bool = True,
 ) -> str:
@@ -44,9 +42,7 @@ fi
 
     quoted_prefix_dir = shlex.quote(prefix_dir)
     site_packages_dir = f"{prefix_dir}/site-packages"
-    package_requirement = MINI_SWE_AGENT_CLI_PACKAGE
-    if package_version != "latest":
-        package_requirement = f"{MINI_SWE_AGENT_CLI_PACKAGE}=={package_version}"
+    package_requirement = f"{MINI_SWE_AGENT_CLI_PACKAGE}=={MINI_SWE_AGENT_CLI_VERSION}"
     quoted_site_packages_dir = shlex.quote(site_packages_dir)
     quoted_install_dir = shlex.quote(DEFAULT_INSTALL_DIR)
     quoted_uv_site_packages_dir = shlex.quote(DEFAULT_UV_SITE_PACKAGES_DIR)
@@ -179,7 +175,6 @@ def mini_swe_agent_harness(
     system_prompt_path: str = DEFAULT_SYSTEM_PROMPT_PATH,
     log_path: str = DEFAULT_LOG_PATH,
     trajectory_path: str = DEFAULT_TRAJECTORY_PATH,
-    package_version: str = DEFAULT_PACKAGE_VERSION,
     config_spec: str = DEFAULT_CONFIG_SPEC,
     model_class: str = DEFAULT_MODEL_CLASS,
     environment_timeout: int = DEFAULT_ENVIRONMENT_TIMEOUT,
@@ -198,9 +193,7 @@ def mini_swe_agent_harness(
     # The system prompt is passed through ComposableEnv as a file and injected
     # into mini's agent.system_template at runtime.
     return Harness(
-        install_script=build_mini_swe_agent_install_script(
-            package_version=package_version,
-        ),
+        install_script=build_mini_swe_agent_install_script(),
         run_command=build_mini_swe_agent_run_command(
             agent_workdir=agent_workdir,
             instruction_path=instruction_path,

--- a/verifiers/envs/experimental/composable/harnesses/mini_swe_agent.py
+++ b/verifiers/envs/experimental/composable/harnesses/mini_swe_agent.py
@@ -44,7 +44,9 @@ fi
 
     quoted_prefix_dir = shlex.quote(prefix_dir)
     site_packages_dir = f"{prefix_dir}/site-packages"
-    package_requirement = f"{MINI_SWE_AGENT_CLI_PACKAGE}=={package_version}"
+    package_requirement = MINI_SWE_AGENT_CLI_PACKAGE
+    if package_version != "latest":
+        package_requirement = f"{MINI_SWE_AGENT_CLI_PACKAGE}=={package_version}"
     quoted_site_packages_dir = shlex.quote(site_packages_dir)
     quoted_install_dir = shlex.quote(DEFAULT_INSTALL_DIR)
     quoted_uv_site_packages_dir = shlex.quote(DEFAULT_UV_SITE_PACKAGES_DIR)

--- a/verifiers/envs/experimental/composable/harnesses/mini_swe_agent.py
+++ b/verifiers/envs/experimental/composable/harnesses/mini_swe_agent.py
@@ -10,13 +10,9 @@ DEFAULT_UV_SITE_PACKAGES_DIR = f"{DEFAULT_INSTALL_DIR}/uv-site-packages"
 DEFAULT_MINI_BINARY = f"{DEFAULT_PREFIX_DIR}/bin/mini"
 MINI_SWE_AGENT_CLI_PACKAGE = "mini-swe-agent"
 MINI_SWE_AGENT_CLI_VERSION = "2.2.8"
-MINI_SWE_AGENT_CLI_SHA256 = (
-    "694df4de1337e665e3cd82e99f93374f573bf52b8e7c362ac5d8045ad9f7c37c"
-)
 MINI_SWE_AGENT_PYTHON_VERSION = "3.11"
 UV_PACKAGE_VERSION = "0.11.7"
 DEFAULT_PACKAGE_VERSION = MINI_SWE_AGENT_CLI_VERSION
-DEFAULT_PACKAGE_SHA256 = MINI_SWE_AGENT_CLI_SHA256
 DEFAULT_INSTRUCTION_PATH = "/mini-swe-agent/prompt.txt"
 DEFAULT_SYSTEM_PROMPT_PATH = "/mini-swe-agent/system.txt"
 DEFAULT_LOG_DIR = "/logs/agent"
@@ -30,7 +26,6 @@ DEFAULT_ENVIRONMENT_TIMEOUT = 120
 
 def build_mini_swe_agent_install_script(
     package_version: str = DEFAULT_PACKAGE_VERSION,
-    package_sha256: str = DEFAULT_PACKAGE_SHA256,
     prefix_dir: str = DEFAULT_PREFIX_DIR,
     install_python: bool = True,
 ) -> str:
@@ -49,13 +44,11 @@ fi
 
     quoted_prefix_dir = shlex.quote(prefix_dir)
     site_packages_dir = f"{prefix_dir}/site-packages"
-    wheel_filename = f"mini_swe_agent-{package_version}-py3-none-any.whl"
-    wheel_url = (
-        f"https://files.pythonhosted.org/packages/py3/m/mini-swe-agent/{wheel_filename}"
-    )
+    package_requirement = f"{MINI_SWE_AGENT_CLI_PACKAGE}=={package_version}"
     quoted_site_packages_dir = shlex.quote(site_packages_dir)
     quoted_install_dir = shlex.quote(DEFAULT_INSTALL_DIR)
     quoted_uv_site_packages_dir = shlex.quote(DEFAULT_UV_SITE_PACKAGES_DIR)
+    quoted_package_requirement = shlex.quote(package_requirement)
     return f"""\
 set -e
 {install_tools}
@@ -72,17 +65,10 @@ if ! "$PYTHON_BIN" -c 'import sys; raise SystemExit(sys.version_info < (3, 10))'
   env PYTHONPATH={quoted_uv_site_packages_dir} "$PYTHON_BIN" -m uv python install {MINI_SWE_AGENT_PYTHON_VERSION}
   MINI_SWE_AGENT_PYTHON="$(env PYTHONPATH={quoted_uv_site_packages_dir} "$PYTHON_BIN" -m uv python find {MINI_SWE_AGENT_PYTHON_VERSION})"
 fi
-MINI_SWE_AGENT_WHEEL_DIR="$(mktemp -d)"
-trap 'rm -rf "$MINI_SWE_AGENT_WHEEL_DIR"' EXIT
-MINI_SWE_AGENT_WHEEL="$MINI_SWE_AGENT_WHEEL_DIR/{wheel_filename}"
-MINI_SWE_AGENT_WHEEL_URL={shlex.quote(wheel_url)}
-export MINI_SWE_AGENT_WHEEL MINI_SWE_AGENT_WHEEL_URL
-"$PYTHON_BIN" -c 'import os, urllib.request; urllib.request.urlretrieve(os.environ["MINI_SWE_AGENT_WHEEL_URL"], os.environ["MINI_SWE_AGENT_WHEEL"])'
-echo "{package_sha256}  $MINI_SWE_AGENT_WHEEL" | sha256sum -c -
 if [ "$MINI_SWE_AGENT_PYTHON" = "$PYTHON_BIN" ]; then
-  "$PYTHON_BIN" -m pip install --quiet --target {quoted_site_packages_dir} "$MINI_SWE_AGENT_WHEEL"
+  "$PYTHON_BIN" -m pip install --quiet --target {quoted_site_packages_dir} {quoted_package_requirement}
 else
-  env PYTHONPATH={quoted_uv_site_packages_dir} "$PYTHON_BIN" -m uv pip install --python "$MINI_SWE_AGENT_PYTHON" --target {quoted_site_packages_dir} "$MINI_SWE_AGENT_WHEEL"
+  env PYTHONPATH={quoted_uv_site_packages_dir} "$PYTHON_BIN" -m uv pip install --python "$MINI_SWE_AGENT_PYTHON" --target {quoted_site_packages_dir} {quoted_package_requirement}
 fi
 echo "$MINI_SWE_AGENT_PYTHON" > {quoted_prefix_dir}/python
 cat > {quoted_prefix_dir}/bin/mini <<'EOF'
@@ -180,7 +166,6 @@ MINI_SWE_AGENT_CONFIG = {
     "install_script": MINI_SWE_AGENT_INSTALL_SCRIPT,
     "cli_package": MINI_SWE_AGENT_CLI_PACKAGE,
     "cli_version": MINI_SWE_AGENT_CLI_VERSION,
-    "cli_sha256": MINI_SWE_AGENT_CLI_SHA256,
 }
 
 
@@ -193,7 +178,6 @@ def mini_swe_agent_harness(
     log_path: str = DEFAULT_LOG_PATH,
     trajectory_path: str = DEFAULT_TRAJECTORY_PATH,
     package_version: str = DEFAULT_PACKAGE_VERSION,
-    package_sha256: str = DEFAULT_PACKAGE_SHA256,
     config_spec: str = DEFAULT_CONFIG_SPEC,
     model_class: str = DEFAULT_MODEL_CLASS,
     environment_timeout: int = DEFAULT_ENVIRONMENT_TIMEOUT,
@@ -214,7 +198,6 @@ def mini_swe_agent_harness(
     return Harness(
         install_script=build_mini_swe_agent_install_script(
             package_version=package_version,
-            package_sha256=package_sha256,
         ),
         run_command=build_mini_swe_agent_run_command(
             agent_workdir=agent_workdir,

--- a/verifiers/envs/experimental/composable/harnesses/mini_swe_agent.py
+++ b/verifiers/envs/experimental/composable/harnesses/mini_swe_agent.py
@@ -3,18 +3,20 @@
 from pathlib import PurePosixPath
 import shlex
 
-from harnesses.mini_swe_agent import (
-    MINI_SWE_AGENT_DEFAULT_PACKAGE,
-    build_mini_swe_agent_install_script as build_packaged_mini_swe_agent_install_script,
-)
-
 DEFAULT_INSTALL_DIR = "/opt/mini-swe-agent"
 DEFAULT_PREFIX_DIR = f"{DEFAULT_INSTALL_DIR}/prefix"
 DEFAULT_SITE_PACKAGES_DIR = f"{DEFAULT_PREFIX_DIR}/site-packages"
+DEFAULT_UV_SITE_PACKAGES_DIR = f"{DEFAULT_INSTALL_DIR}/uv-site-packages"
 DEFAULT_MINI_BINARY = f"{DEFAULT_PREFIX_DIR}/bin/mini"
 MINI_SWE_AGENT_CLI_PACKAGE = "mini-swe-agent"
 MINI_SWE_AGENT_CLI_VERSION = "2.2.8"
-DEFAULT_PACKAGE = MINI_SWE_AGENT_DEFAULT_PACKAGE
+MINI_SWE_AGENT_CLI_SHA256 = (
+    "694df4de1337e665e3cd82e99f93374f573bf52b8e7c362ac5d8045ad9f7c37c"
+)
+MINI_SWE_AGENT_PYTHON_VERSION = "3.11"
+UV_PACKAGE_VERSION = "0.11.7"
+DEFAULT_PACKAGE_VERSION = MINI_SWE_AGENT_CLI_VERSION
+DEFAULT_PACKAGE_SHA256 = MINI_SWE_AGENT_CLI_SHA256
 DEFAULT_INSTRUCTION_PATH = "/mini-swe-agent/prompt.txt"
 DEFAULT_SYSTEM_PROMPT_PATH = "/mini-swe-agent/system.txt"
 DEFAULT_LOG_DIR = "/logs/agent"
@@ -27,14 +29,70 @@ DEFAULT_ENVIRONMENT_TIMEOUT = 120
 
 
 def build_mini_swe_agent_install_script(
-    package: str = DEFAULT_PACKAGE,
+    package_version: str = DEFAULT_PACKAGE_VERSION,
+    package_sha256: str = DEFAULT_PACKAGE_SHA256,
     prefix_dir: str = DEFAULT_PREFIX_DIR,
+    install_python: bool = True,
 ) -> str:
     """Build the shell script that installs mini-SWE-agent."""
-    return build_packaged_mini_swe_agent_install_script(
-        package=package,
-        prefix_dir=prefix_dir,
+    install_tools = ""
+    if install_python:
+        # Acquire::Retries=3 mitigates transient archive.ubuntu.com CDN sync
+        # mismatches that fail fresh-sandbox apt-get update mid-rollout.
+        install_tools = """\
+export DEBIAN_FRONTEND=noninteractive
+if ! command -v python3 >/dev/null 2>&1 || ! python3 -m pip --version >/dev/null 2>&1; then
+  apt-get -o Acquire::Retries=3 update -qq
+  apt-get -o Acquire::Retries=3 install -y -qq python3 python3-pip ca-certificates
+fi
+"""
+
+    quoted_prefix_dir = shlex.quote(prefix_dir)
+    site_packages_dir = f"{prefix_dir}/site-packages"
+    wheel_filename = f"mini_swe_agent-{package_version}-py3-none-any.whl"
+    wheel_url = (
+        f"https://files.pythonhosted.org/packages/py3/m/mini-swe-agent/{wheel_filename}"
     )
+    quoted_site_packages_dir = shlex.quote(site_packages_dir)
+    quoted_install_dir = shlex.quote(DEFAULT_INSTALL_DIR)
+    quoted_uv_site_packages_dir = shlex.quote(DEFAULT_UV_SITE_PACKAGES_DIR)
+    return f"""\
+set -e
+{install_tools}
+rm -rf {quoted_prefix_dir}
+mkdir -p {quoted_install_dir} {quoted_prefix_dir}/bin {quoted_site_packages_dir} {quoted_uv_site_packages_dir} {shlex.quote(DEFAULT_LOG_DIR)} /mini-swe-agent
+export PIP_CONFIG_FILE=/dev/null
+export PIP_INDEX_URL=https://pypi.org/simple
+export PIP_BREAK_SYSTEM_PACKAGES=1
+unset PIP_EXTRA_INDEX_URL
+PYTHON_BIN="$(command -v python3)"
+MINI_SWE_AGENT_PYTHON="$PYTHON_BIN"
+if ! "$PYTHON_BIN" -c 'import sys; raise SystemExit(sys.version_info < (3, 10))'; then
+  "$PYTHON_BIN" -m pip install --quiet --target {quoted_uv_site_packages_dir} uv=={UV_PACKAGE_VERSION}
+  env PYTHONPATH={quoted_uv_site_packages_dir} "$PYTHON_BIN" -m uv python install {MINI_SWE_AGENT_PYTHON_VERSION}
+  MINI_SWE_AGENT_PYTHON="$(env PYTHONPATH={quoted_uv_site_packages_dir} "$PYTHON_BIN" -m uv python find {MINI_SWE_AGENT_PYTHON_VERSION})"
+fi
+MINI_SWE_AGENT_WHEEL_DIR="$(mktemp -d)"
+trap 'rm -rf "$MINI_SWE_AGENT_WHEEL_DIR"' EXIT
+MINI_SWE_AGENT_WHEEL="$MINI_SWE_AGENT_WHEEL_DIR/{wheel_filename}"
+MINI_SWE_AGENT_WHEEL_URL={shlex.quote(wheel_url)}
+export MINI_SWE_AGENT_WHEEL MINI_SWE_AGENT_WHEEL_URL
+"$PYTHON_BIN" -c 'import os, urllib.request; urllib.request.urlretrieve(os.environ["MINI_SWE_AGENT_WHEEL_URL"], os.environ["MINI_SWE_AGENT_WHEEL"])'
+echo "{package_sha256}  $MINI_SWE_AGENT_WHEEL" | sha256sum -c -
+if [ "$MINI_SWE_AGENT_PYTHON" = "$PYTHON_BIN" ]; then
+  "$PYTHON_BIN" -m pip install --quiet --target {quoted_site_packages_dir} "$MINI_SWE_AGENT_WHEEL"
+else
+  env PYTHONPATH={quoted_uv_site_packages_dir} "$PYTHON_BIN" -m uv pip install --python "$MINI_SWE_AGENT_PYTHON" --target {quoted_site_packages_dir} "$MINI_SWE_AGENT_WHEEL"
+fi
+echo "$MINI_SWE_AGENT_PYTHON" > {quoted_prefix_dir}/python
+cat > {quoted_prefix_dir}/bin/mini <<'EOF'
+#!/usr/bin/env sh
+export PYTHONPATH={shlex.quote(site_packages_dir)}:${{PYTHONPATH:-}}
+exec "$(cat {quoted_prefix_dir}/python)" -m minisweagent.run.mini "$@"
+EOF
+chmod +x {quoted_prefix_dir}/bin/mini
+test -x {quoted_prefix_dir}/bin/mini
+"""
 
 
 def build_mini_swe_agent_run_command(
@@ -122,6 +180,7 @@ MINI_SWE_AGENT_CONFIG = {
     "install_script": MINI_SWE_AGENT_INSTALL_SCRIPT,
     "cli_package": MINI_SWE_AGENT_CLI_PACKAGE,
     "cli_version": MINI_SWE_AGENT_CLI_VERSION,
+    "cli_sha256": MINI_SWE_AGENT_CLI_SHA256,
 }
 
 
@@ -133,7 +192,8 @@ def mini_swe_agent_harness(
     system_prompt_path: str = DEFAULT_SYSTEM_PROMPT_PATH,
     log_path: str = DEFAULT_LOG_PATH,
     trajectory_path: str = DEFAULT_TRAJECTORY_PATH,
-    package: str = DEFAULT_PACKAGE,
+    package_version: str = DEFAULT_PACKAGE_VERSION,
+    package_sha256: str = DEFAULT_PACKAGE_SHA256,
     config_spec: str = DEFAULT_CONFIG_SPEC,
     model_class: str = DEFAULT_MODEL_CLASS,
     environment_timeout: int = DEFAULT_ENVIRONMENT_TIMEOUT,
@@ -153,7 +213,8 @@ def mini_swe_agent_harness(
     # into mini's agent.system_template at runtime.
     return Harness(
         install_script=build_mini_swe_agent_install_script(
-            package=package,
+            package_version=package_version,
+            package_sha256=package_sha256,
         ),
         run_command=build_mini_swe_agent_run_command(
             agent_workdir=agent_workdir,

--- a/verifiers/envs/experimental/composable/harnesses/opencode.py
+++ b/verifiers/envs/experimental/composable/harnesses/opencode.py
@@ -17,9 +17,6 @@ from pathlib import Path, PurePosixPath
 
 DEFAULT_RELEASE_REPO = "PrimeIntellect-ai/opencode"
 DEFAULT_RELEASE_VERSION = "1.1.63-rl2"
-DEFAULT_RELEASE_SHA256 = {
-    "x64": "47f4102796da50769e27d2c9ea6a9cf7941f76898390cb497278cab39c4b6ed4",
-}
 DEFAULT_SYSTEM_PROMPT = (Path(__file__).parent / "prompt.txt").read_text()
 
 DEFAULT_DISABLED_TOOLS = [
@@ -51,19 +48,13 @@ DEFAULT_DISABLED_TOOLS = [
 def build_install_script(
     release_repo: str = DEFAULT_RELEASE_REPO,
     release_version: str = DEFAULT_RELEASE_VERSION,
-    release_sha256: dict[str, str] | None = None,
     install_ripgrep: bool = True,
 ) -> str:
     """Build the shell script that installs OpenCode in a sandbox."""
-    release_sha256 = release_sha256 or DEFAULT_RELEASE_SHA256
     rg_install = (
         "apt-get -o Acquire::Retries=3 install -y -qq ripgrep > /dev/null 2>&1 || true"
         if install_ripgrep
         else ""
-    )
-    sha256_cases = "\n".join(
-        f"  {shlex.quote(arch)}) OPENCODE_RELEASE_SHA256={shlex.quote(sha256)} ;;"
-        for arch, sha256 in release_sha256.items()
     )
     # Acquire::Retries=3 mitigates transient archive.ubuntu.com CDN sync mismatches
     # (e.g. "File has unexpected size ... Mirror sync in progress?"). See launchpad
@@ -86,17 +77,11 @@ OPENCODE_ASSET="opencode-linux-$OPENCODE_ARCH.tar.gz"
 OPENCODE_RELEASE_TAG="${{OPENCODE_RELEASE_VERSION#v}}"
 OPENCODE_RELEASE_URL="https://github.com/$OPENCODE_RELEASE_REPO/releases/download/v$OPENCODE_RELEASE_TAG/$OPENCODE_ASSET"
 
-case "$OPENCODE_ARCH" in
-{sha256_cases}
-  *) echo "No SHA256 configured for OpenCode $OPENCODE_RELEASE_VERSION on $OPENCODE_ARCH"; exit 1 ;;
-esac
-
 mkdir -p "$HOME/.opencode/bin"
 if [ -x "$HOME/.opencode/bin/opencode" ]; then
   echo "OpenCode already installed, skipping download"
 else
   curl -fsSL "$OPENCODE_RELEASE_URL" -o /tmp/opencode.tar.gz
-  echo "$OPENCODE_RELEASE_SHA256  /tmp/opencode.tar.gz" | sha256sum -c -
   tar -xzf /tmp/opencode.tar.gz -C /tmp
   install -m 755 /tmp/opencode "$HOME/.opencode/bin/opencode"
   rm -f /tmp/opencode.tar.gz /tmp/opencode
@@ -257,7 +242,6 @@ def opencode_harness(
     disable_compaction: bool = True,
     release_repo: str = DEFAULT_RELEASE_REPO,
     release_version: str = DEFAULT_RELEASE_VERSION,
-    release_sha256: dict[str, str] | None = None,
     instruction_path: str = "/opencode/prompt.txt",
     system_prompt_path: str = "/opencode/system.txt",
     log_path: str = "/opencode/logs.txt",
@@ -287,7 +271,6 @@ def opencode_harness(
         install_script=build_install_script(
             release_repo=release_repo,
             release_version=release_version,
-            release_sha256=release_sha256,
         ),
         run_command=build_opencode_run_command(
             agent_workdir=agent_workdir,

--- a/verifiers/envs/experimental/composable/harnesses/opencode.py
+++ b/verifiers/envs/experimental/composable/harnesses/opencode.py
@@ -51,6 +51,14 @@ def build_install_script(
     install_ripgrep: bool = True,
 ) -> str:
     """Build the shell script that installs OpenCode in a sandbox."""
+    release_path = "releases/latest/download"
+    if release_version != "latest":
+        release_tag = (
+            release_version
+            if release_version.startswith("v")
+            else f"v{release_version}"
+        )
+        release_path = f"releases/download/{release_tag}"
     rg_install = (
         "apt-get -o Acquire::Retries=3 install -y -qq ripgrep > /dev/null 2>&1 || true"
         if install_ripgrep
@@ -65,7 +73,7 @@ apt-get -o Acquire::Retries=3 update -qq && apt-get -o Acquire::Retries=3 instal
 {rg_install}
 
 OPENCODE_RELEASE_REPO={shlex.quote(release_repo)}
-OPENCODE_RELEASE_VERSION={shlex.quote(release_version)}
+OPENCODE_RELEASE_PATH={shlex.quote(release_path)}
 
 case "$(uname -m)" in
   x86_64) OPENCODE_ARCH=x64 ;;
@@ -74,8 +82,7 @@ case "$(uname -m)" in
 esac
 
 OPENCODE_ASSET="opencode-linux-$OPENCODE_ARCH.tar.gz"
-OPENCODE_RELEASE_TAG="${{OPENCODE_RELEASE_VERSION#v}}"
-OPENCODE_RELEASE_URL="https://github.com/$OPENCODE_RELEASE_REPO/releases/download/v$OPENCODE_RELEASE_TAG/$OPENCODE_ASSET"
+OPENCODE_RELEASE_URL="https://github.com/$OPENCODE_RELEASE_REPO/$OPENCODE_RELEASE_PATH/$OPENCODE_ASSET"
 
 mkdir -p "$HOME/.opencode/bin"
 if [ -x "$HOME/.opencode/bin/opencode" ]; then

--- a/verifiers/envs/experimental/composable/harnesses/opencode.py
+++ b/verifiers/envs/experimental/composable/harnesses/opencode.py
@@ -17,9 +17,9 @@ from pathlib import Path, PurePosixPath
 
 DEFAULT_RELEASE_REPO = "PrimeIntellect-ai/opencode"
 DEFAULT_RELEASE_VERSION = "1.1.63-rl2"
-DEFAULT_RELEASE_SHA256 = (
-    "47f4102796da50769e27d2c9ea6a9cf7941f76898390cb497278cab39c4b6ed4"
-)
+DEFAULT_RELEASE_SHA256 = {
+    "x64": "47f4102796da50769e27d2c9ea6a9cf7941f76898390cb497278cab39c4b6ed4",
+}
 DEFAULT_SYSTEM_PROMPT = (Path(__file__).parent / "prompt.txt").read_text()
 
 DEFAULT_DISABLED_TOOLS = [
@@ -51,16 +51,20 @@ DEFAULT_DISABLED_TOOLS = [
 def build_install_script(
     release_repo: str = DEFAULT_RELEASE_REPO,
     release_version: str = DEFAULT_RELEASE_VERSION,
-    release_sha256: str = DEFAULT_RELEASE_SHA256,
+    release_sha256: dict[str, str] | None = None,
     install_ripgrep: bool = True,
 ) -> str:
     """Build the shell script that installs OpenCode in a sandbox."""
+    release_sha256 = release_sha256 or DEFAULT_RELEASE_SHA256
     rg_install = (
         "apt-get -o Acquire::Retries=3 install -y -qq ripgrep > /dev/null 2>&1 || true"
         if install_ripgrep
         else ""
     )
-    sha256_check = f'echo "{release_sha256}  /tmp/opencode.tar.gz" | sha256sum -c -'
+    sha256_cases = "\n".join(
+        f"  {shlex.quote(arch)}) OPENCODE_RELEASE_SHA256={shlex.quote(sha256)} ;;"
+        for arch, sha256 in release_sha256.items()
+    )
     # Acquire::Retries=3 mitigates transient archive.ubuntu.com CDN sync mismatches
     # (e.g. "File has unexpected size ... Mirror sync in progress?"). See launchpad
     # bug #1876035. apt's default retries is 0, so one bad fetch fails the rollout.
@@ -82,12 +86,17 @@ OPENCODE_ASSET="opencode-linux-$OPENCODE_ARCH.tar.gz"
 OPENCODE_RELEASE_TAG="${{OPENCODE_RELEASE_VERSION#v}}"
 OPENCODE_RELEASE_URL="https://github.com/$OPENCODE_RELEASE_REPO/releases/download/v$OPENCODE_RELEASE_TAG/$OPENCODE_ASSET"
 
+case "$OPENCODE_ARCH" in
+{sha256_cases}
+  *) echo "No SHA256 configured for OpenCode $OPENCODE_RELEASE_VERSION on $OPENCODE_ARCH"; exit 1 ;;
+esac
+
 mkdir -p "$HOME/.opencode/bin"
 if [ -x "$HOME/.opencode/bin/opencode" ]; then
   echo "OpenCode already installed, skipping download"
 else
   curl -fsSL "$OPENCODE_RELEASE_URL" -o /tmp/opencode.tar.gz
-  {sha256_check}
+  echo "$OPENCODE_RELEASE_SHA256  /tmp/opencode.tar.gz" | sha256sum -c -
   tar -xzf /tmp/opencode.tar.gz -C /tmp
   install -m 755 /tmp/opencode "$HOME/.opencode/bin/opencode"
   rm -f /tmp/opencode.tar.gz /tmp/opencode
@@ -248,7 +257,7 @@ def opencode_harness(
     disable_compaction: bool = True,
     release_repo: str = DEFAULT_RELEASE_REPO,
     release_version: str = DEFAULT_RELEASE_VERSION,
-    release_sha256: str = DEFAULT_RELEASE_SHA256,
+    release_sha256: dict[str, str] | None = None,
     instruction_path: str = "/opencode/prompt.txt",
     system_prompt_path: str = "/opencode/system.txt",
     log_path: str = "/opencode/logs.txt",

--- a/verifiers/envs/experimental/composable/harnesses/opencode.py
+++ b/verifiers/envs/experimental/composable/harnesses/opencode.py
@@ -13,11 +13,13 @@ import json
 import shlex
 from pathlib import Path, PurePosixPath
 
-from harnesses.utils import split_versioned_agent_spec
-
 # ── Defaults ─────────────────────────────────────────────────────────────
 
-DEFAULT_RELEASE = "PrimeIntellect-ai/opencode@1.1.63-rl2"
+DEFAULT_RELEASE_REPO = "PrimeIntellect-ai/opencode"
+DEFAULT_RELEASE_VERSION = "1.1.63-rl2"
+DEFAULT_RELEASE_SHA256 = (
+    "47f4102796da50769e27d2c9ea6a9cf7941f76898390cb497278cab39c4b6ed4"
+)
 DEFAULT_SYSTEM_PROMPT = (Path(__file__).parent / "prompt.txt").read_text()
 
 DEFAULT_DISABLED_TOOLS = [
@@ -47,7 +49,9 @@ DEFAULT_DISABLED_TOOLS = [
 
 
 def build_install_script(
-    release: str = DEFAULT_RELEASE,
+    release_repo: str = DEFAULT_RELEASE_REPO,
+    release_version: str = DEFAULT_RELEASE_VERSION,
+    release_sha256: str = DEFAULT_RELEASE_SHA256,
     install_ripgrep: bool = True,
 ) -> str:
     """Build the shell script that installs OpenCode in a sandbox."""
@@ -56,15 +60,7 @@ def build_install_script(
         if install_ripgrep
         else ""
     )
-    release_repo, release_version = split_versioned_agent_spec(release)
-    release_path = "releases/latest/download"
-    if release_version and release_version != "latest":
-        release_tag = (
-            release_version
-            if release_version.startswith("v")
-            else f"v{release_version}"
-        )
-        release_path = f"releases/download/{release_tag}"
+    sha256_check = f'echo "{release_sha256}  /tmp/opencode.tar.gz" | sha256sum -c -'
     # Acquire::Retries=3 mitigates transient archive.ubuntu.com CDN sync mismatches
     # (e.g. "File has unexpected size ... Mirror sync in progress?"). See launchpad
     # bug #1876035. apt's default retries is 0, so one bad fetch fails the rollout.
@@ -74,7 +70,7 @@ apt-get -o Acquire::Retries=3 update -qq && apt-get -o Acquire::Retries=3 instal
 {rg_install}
 
 OPENCODE_RELEASE_REPO={shlex.quote(release_repo)}
-OPENCODE_RELEASE_PATH={shlex.quote(release_path)}
+OPENCODE_RELEASE_VERSION={shlex.quote(release_version)}
 
 case "$(uname -m)" in
   x86_64) OPENCODE_ARCH=x64 ;;
@@ -83,13 +79,15 @@ case "$(uname -m)" in
 esac
 
 OPENCODE_ASSET="opencode-linux-$OPENCODE_ARCH.tar.gz"
-OPENCODE_RELEASE_URL="https://github.com/$OPENCODE_RELEASE_REPO/$OPENCODE_RELEASE_PATH/$OPENCODE_ASSET"
+OPENCODE_RELEASE_TAG="${{OPENCODE_RELEASE_VERSION#v}}"
+OPENCODE_RELEASE_URL="https://github.com/$OPENCODE_RELEASE_REPO/releases/download/v$OPENCODE_RELEASE_TAG/$OPENCODE_ASSET"
 
 mkdir -p "$HOME/.opencode/bin"
 if [ -x "$HOME/.opencode/bin/opencode" ]; then
   echo "OpenCode already installed, skipping download"
 else
   curl -fsSL "$OPENCODE_RELEASE_URL" -o /tmp/opencode.tar.gz
+  {sha256_check}
   tar -xzf /tmp/opencode.tar.gz -C /tmp
   install -m 755 /tmp/opencode "$HOME/.opencode/bin/opencode"
   rm -f /tmp/opencode.tar.gz /tmp/opencode
@@ -248,7 +246,9 @@ def opencode_harness(
     agent_workdir: str = "/app",
     allow_git: bool = False,
     disable_compaction: bool = True,
-    release: str = DEFAULT_RELEASE,
+    release_repo: str = DEFAULT_RELEASE_REPO,
+    release_version: str = DEFAULT_RELEASE_VERSION,
+    release_sha256: str = DEFAULT_RELEASE_SHA256,
     instruction_path: str = "/opencode/prompt.txt",
     system_prompt_path: str = "/opencode/system.txt",
     log_path: str = "/opencode/logs.txt",
@@ -276,7 +276,9 @@ def opencode_harness(
 
     return Harness(
         install_script=build_install_script(
-            release=release,
+            release_repo=release_repo,
+            release_version=release_version,
+            release_sha256=release_sha256,
         ),
         run_command=build_opencode_run_command(
             agent_workdir=agent_workdir,

--- a/verifiers/envs/experimental/composable/harnesses/opencode.py
+++ b/verifiers/envs/experimental/composable/harnesses/opencode.py
@@ -46,19 +46,9 @@ DEFAULT_DISABLED_TOOLS = [
 
 
 def build_install_script(
-    release_repo: str = DEFAULT_RELEASE_REPO,
-    release_version: str = DEFAULT_RELEASE_VERSION,
     install_ripgrep: bool = True,
 ) -> str:
     """Build the shell script that installs OpenCode in a sandbox."""
-    release_path = "releases/latest/download"
-    if release_version != "latest":
-        release_tag = (
-            release_version
-            if release_version.startswith("v")
-            else f"v{release_version}"
-        )
-        release_path = f"releases/download/{release_tag}"
     rg_install = (
         "apt-get -o Acquire::Retries=3 install -y -qq ripgrep > /dev/null 2>&1 || true"
         if install_ripgrep
@@ -72,9 +62,6 @@ set -e
 apt-get -o Acquire::Retries=3 update -qq && apt-get -o Acquire::Retries=3 install -y -qq curl tar > /dev/null 2>&1
 {rg_install}
 
-OPENCODE_RELEASE_REPO={shlex.quote(release_repo)}
-OPENCODE_RELEASE_PATH={shlex.quote(release_path)}
-
 case "$(uname -m)" in
   x86_64) OPENCODE_ARCH=x64 ;;
   aarch64|arm64) OPENCODE_ARCH=arm64 ;;
@@ -82,7 +69,7 @@ case "$(uname -m)" in
 esac
 
 OPENCODE_ASSET="opencode-linux-$OPENCODE_ARCH.tar.gz"
-OPENCODE_RELEASE_URL="https://github.com/$OPENCODE_RELEASE_REPO/$OPENCODE_RELEASE_PATH/$OPENCODE_ASSET"
+OPENCODE_RELEASE_URL="https://github.com/{DEFAULT_RELEASE_REPO}/releases/download/v{DEFAULT_RELEASE_VERSION}/$OPENCODE_ASSET"
 
 mkdir -p "$HOME/.opencode/bin"
 if [ -x "$HOME/.opencode/bin/opencode" ]; then
@@ -247,8 +234,6 @@ def opencode_harness(
     agent_workdir: str = "/app",
     allow_git: bool = False,
     disable_compaction: bool = True,
-    release_repo: str = DEFAULT_RELEASE_REPO,
-    release_version: str = DEFAULT_RELEASE_VERSION,
     instruction_path: str = "/opencode/prompt.txt",
     system_prompt_path: str = "/opencode/system.txt",
     log_path: str = "/opencode/logs.txt",
@@ -275,10 +260,7 @@ def opencode_harness(
             system_prompt = task_system_prompt
 
     return Harness(
-        install_script=build_install_script(
-            release_repo=release_repo,
-            release_version=release_version,
-        ),
+        install_script=build_install_script(),
         run_command=build_opencode_run_command(
             agent_workdir=agent_workdir,
             prompt_path=instruction_path,


### PR DESCRIPTION
## Summary
- restore self-contained mini-SWE-agent installer logic in legacy ComposableEnv
- restore self-contained OpenCode release/version/checksum handling
- update composable tests to assert local installer ownership

## Tests
- uv run ruff format
- uv run ruff check --fix
- uv run pytest tests/test_composable_env.py tests/test_rlm_composable_env.py
- uv run pytest tests/test_imports.py

Note: local git hooks were skipped for commit/push after manual checks because the hook's uv invocation rewrote uv.lock due the repo exclude-newer environment; uv.lock is intentionally not changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sandbox rollout install paths and removes `release`/`package` knobs on composable harness factories, which can break callers that relied on custom versions or `latest` downloads.
> 
> **Overview**
> **Inlines composable sandbox installers** so legacy `ComposableEnv` harnesses no longer delegate to the separate `harnesses` package or `split_versioned_agent_spec` helpers.
> 
> For **mini-SWE-agent**, `build_mini_swe_agent_install_script` is rewritten to emit a full shell bootstrap (optional apt `python3`/`pip`, pinned PyPI `mini-swe-agent==2.2.8`, optional `uv` + Python 3.11 when the sandbox interpreter is too old, and a `mini` launcher shim). The **`package`** argument is removed from the install builder and `mini_swe_agent_harness`.
> 
> For **OpenCode**, release selection is fixed to **`PrimeIntellect-ai/opencode` @ `v1.1.63-rl2`** via a hardcoded GitHub download URL (replacing dynamic `latest` / version parsing). **`DEFAULT_RELEASE`** becomes **`DEFAULT_RELEASE_REPO`** and **`DEFAULT_RELEASE_VERSION`**, and the **`release`** parameter is dropped from `build_install_script` and `opencode_harness`.
> 
> Tests now assert the pinned pip requirement and the concrete OpenCode tarball URL instead of unversioned / `latest` install behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50481a27b3b0649610d8396c19e4d69b354ce100. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Decouple composable harnesses from harness packages by pinning versions internally
> - [`mini_swe_agent.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1551/files#diff-91314aaa0a9d6bc048a9e15505ed9454e015e6fd2e8499f68db212d103444a89) rewrites `build_mini_swe_agent_install_script` to generate an inline shell script that pins `mini-swe-agent==2.2.8`, installs via pip or uv, provisions Python 3.11 when the system Python is <3.10, and writes a `bin/mini` launcher with an isolated `PYTHONPATH`.
> - [`opencode.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1551/files#diff-646213d37dd034b98063b1fc1fd3d0a4f7cb1925d6cb6f8c9a7658d836ba0980) replaces `DEFAULT_RELEASE` with `DEFAULT_RELEASE_REPO` and `DEFAULT_RELEASE_VERSION` and removes all 'latest'/arbitrary repo logic, always downloading `v1.1.63-rl2` from `PrimeIntellect-ai/opencode`.
> - Both `mini_swe_agent_harness` and `opencode_harness` factory functions drop their `package`/`release` parameters; callers can no longer override the installed version.
> - Risk: existing code that passes a custom `package` or `release` argument to either harness factory will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 50481a2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->