### PR TITLE
Use full checkout for uv CI jobs

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
@@ -46,6 +48,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
@@ -82,6 +84,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Detect changed environments
         id: changed-envs
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
## Summary
- fetch full git history for uv-dependent CI jobs
- keep local path package resolution compatible with git-derived Verifiers dev versions

## Test
- ruby YAML parse for style/test workflows
- previously verified on #1544 with raised harnesses Verifiers floor

Split out from #1544.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change to checkout depth; no application code or secrets handling changes.
> 
> **Overview**
> CI jobs that run **`uv sync`** now check out the **full git history** (`fetch-depth: 0`) instead of the default shallow clone.
> 
> This applies to **Ty** and **Semgrep** in `style.yml`, and to the main **Verifiers** test matrix and **Environments** job in `test.yml`. The goal is to keep **local path / workspace package resolution** working when **Verifiers dev versions** are derived from git (e.g. harnesses floors tied to repo state). The **Ruff** job is unchanged and still uses submodule checkout only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 288639f308bc81281821c2d95554c65d375e6993. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use full git history checkout for uv CI jobs
> Sets `fetch-depth: 0` on `actions/checkout@v4` in the `ty` and `semgrep` jobs in [style.yml](https://github.com/PrimeIntellect-ai/verifiers/pull/1553/files#diff-0c9224ae51df3f33b61bd0e4b0e0b7a2c8ea7c90efd43221a0b61577c8cd0c4c), and in the main test matrix and environment-testing jobs in [test.yml](https://github.com/PrimeIntellect-ai/verifiers/pull/1553/files#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88). This makes the full git history available to all steps in these jobs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 288639f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->