### PR TITLE
add dataset shuffle to `vf-eval`

### DIFF
--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -232,8 +232,12 @@ client translate them for the selected provider.
 |------|-------|---------|-------------|
 | `--num-examples` | `-n` | 5 | Number of dataset examples to evaluate |
 | `--rollouts-per-example` | `-r` | 3 | Rollouts per example (for pass@k, variance) |
+| `--shuffle` | — | false | Shuffle the evaluation dataset before selecting examples |
+| `--shuffle-seed` | — | 0 when shuffled | Seed used with `--shuffle` |
 
 Multiple rollouts per example enable metrics like pass@k and help measure variance. The total number of rollouts is `num_examples × rollouts_per_example`.
+
+When `--shuffle` is enabled, Verifiers shuffles the full evaluation dataset first, then selects `--num-examples`, then repeats each selected example according to `--rollouts-per-example`. This applies to standard environments, composable tasksets, and v1 Taskset/Harness environments because it happens in the shared evaluation input-selection layer.
 
 ### Concurrency
 
@@ -300,7 +304,7 @@ With `-s` (save results) enabled, partial results are written to disk after each
 prime eval run my-env -n 1000 -s --resume ./environments/my_env/outputs/evals/my-env--openai--gpt-4.1-mini/abc12345
 ```
 
-When a resume path is provided, it must point to a valid evaluation results directory containing both `results.jsonl` and `metadata.json`. With `--resume` and no path, verifiers scans the environment/model output directory and picks the most recent incomplete run matching `env_id`, `model`, and `rollouts_per_example` where saved `num_examples` is less than or equal to the current run. When resuming:
+When a resume path is provided, it must point to a valid evaluation results directory containing both `results.jsonl` and `metadata.json`. With `--resume` and no path, verifiers scans the environment/model output directory and picks the most recent incomplete run matching `env_id`, `model`, `rollouts_per_example`, `shuffle`, and `shuffle_seed` where saved `num_examples` is less than or equal to the current run. When resuming:
 
 1. Existing completed rollouts are loaded from the checkpoint
 2. Remaining rollouts are computed based on the example ids and group size
@@ -311,7 +315,7 @@ If all rollouts are already complete, the evaluation returns immediately with th
 
 **Configuration compatibility:**
 
-When resuming, the current run configuration should match the original run. Mismatches in parameters like `--model`, `--env-args`, or `--rollouts-per-example` can lead to undefined behavior. For reliable results, resume with the same configuration used to create the checkpoint, only increasing `--num-examples` if you need additional rollouts beyond the original target.
+When resuming, the current run configuration should match the original run. Mismatches in parameters like `--model`, `--env-args`, `--rollouts-per-example`, `--shuffle`, or `--shuffle-seed` can lead to undefined behavior. For reliable results, resume with the same configuration used to create the checkpoint, only increasing `--num-examples` if you need additional rollouts beyond the original target.
 
 **Example workflow:**
 
@@ -411,6 +415,8 @@ other fields are optional:
 | `harness` | table | v1 harness config passed through `EnvConfig.harness` |
 | `num_examples` | integer | Number of dataset examples to evaluate |
 | `rollouts_per_example` | integer | Rollouts per example |
+| `shuffle` | boolean | Shuffle the evaluation dataset before selecting examples |
+| `shuffle_seed` | integer | Seed used when `shuffle = true` |
 | `extra_env_kwargs` | table | Arguments passed to environment constructor |
 | `model` | string | Model to evaluate |
 | `endpoint_id` | string | Endpoint registry id (requires TOML `endpoints_path`) |

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -323,6 +323,8 @@ class GenerateMetadata(TypedDict):
     base_url: str
     num_examples: int
     rollouts_per_example: int
+    shuffle: NotRequired[bool]
+    shuffle_seed: NotRequired[int | None]
     sampling_args: SamplingArgs
     date: str
     time_ms: float
@@ -340,6 +342,8 @@ class GenerateMetadata(TypedDict):
 ```
 
 `base_url` is always serialized as a string. For multi-endpoint runs (e.g., using `ClientConfig.endpoint_configs`), it is stored as a comma-separated list of URLs.
+
+`shuffle` records whether evaluation inputs were shuffled before selecting examples. `shuffle_seed` records the seed used for that shuffle; when shuffle is enabled without an explicit seed, the saved value is `0`.
 
 `version_info` captures the verifiers framework version/commit and the environment package version/commit at generation time. Populated automatically by `GenerateOutputsBuilder`.
 
@@ -1129,6 +1133,8 @@ class EvalConfig(BaseModel):
     sampling_args: SamplingArgs
     num_examples: int
     rollouts_per_example: int
+    shuffle: bool = False
+    shuffle_seed: int | None = None
     max_concurrent: int
     independent_scoring: bool = False
     extra_env_kwargs: dict = {}

--- a/skills/evaluate-environments/SKILL.md
+++ b/skills/evaluate-environments/SKILL.md
@@ -25,11 +25,12 @@ prime eval run owner/my-env -m openai/gpt-4.1-mini -n 5
 ```
 3. Scale only after smoke pass:
 ```bash
-prime eval run owner/my-env -m openai/gpt-4.1-mini -n 200 -r 3 -s
+prime eval run owner/my-env -m openai/gpt-4.1-mini -n 200 -r 3 --shuffle -s
 ```
-4. Treat ownerless env ids as local-first. If not found locally, rely on Prime resolution for your remote env where applicable.
-5. When the user asks for a "real" or "base" eval, do not substitute a tiny smoke run. Use the requested model/env and make the run size explicit before interpreting results.
-6. If the user says the defaults are fine or asks for no flags, use the shortest canonical command and rely on global config:
+4. Use `--shuffle` for representative dataset sampling once smoke tests pass. Set `--shuffle-seed` explicitly for reproducible reports; if omitted, the default seed is `0`.
+5. Treat ownerless env ids as local-first. If not found locally, rely on Prime resolution for your remote env where applicable.
+6. When the user asks for a "real" or "base" eval, do not substitute a tiny smoke run. Use the requested model/env and make the run size explicit before interpreting results.
+7. If the user says the defaults are fine or asks for no flags, use the shortest canonical command and rely on global config:
 ```bash
 prime eval run my-env
 prime eval run my-env -m openai/gpt-4.1-mini
@@ -98,6 +99,7 @@ prime eval run configs/eval/my-benchmark.toml
 ```
 3. Make config files the default for benchmark sweeps, multi-model comparisons, and recurring reports.
 4. Use `name` on individual `[[eval]]` entries when the same environment appears multiple times. `id` selects the environment to load; `name` labels the run in displays, summaries, metadata, and saved result paths.
+5. Put `shuffle = true` and, for reproducibility, `shuffle_seed = <int>` in each `[[eval]]` entry that should sample from a shuffled dataset before selecting `num_examples`.
 
 ## Common Evaluation Patterns
 1. For single-environment v1 smoke runs, override typed taskset and harness config with dotted flags:
@@ -131,15 +133,29 @@ prime eval run my-env -s -C "judge_response,parsed_answer"
 ```bash
 prime eval run my-env -n 1000 -s --resume
 ```
-7. Save results to a custom output directory:
+Resume matching includes `--shuffle` and `--shuffle-seed`. Use the same shuffle settings as the interrupted run; only increase `-n/--num-examples` when extending a saved run.
+7. Shuffle examples before selecting the evaluation subset:
+```bash
+prime eval run my-env -n 200 -r 3 --shuffle --shuffle-seed 123 -s
+```
+8. Configure shuffle in TOML:
+```toml
+[[eval]]
+id = "my-env"
+num_examples = 200
+rollouts_per_example = 3
+shuffle = true
+shuffle_seed = 123
+```
+9. Save results to a custom output directory:
 ```bash
 prime eval run my-env -s -o /path/to/output
 ```
-8. Run multi-environment TOML suites:
+10. Run multi-environment TOML suites:
 ```bash
 prime eval run configs/eval/my-benchmark.toml
 ```
-9. Run the same environment more than once with different args by giving each entry a `name`:
+11. Run the same environment more than once with different args by giving each entry a `name`:
 ```toml
 [[eval]]
 id = "reverse-text"
@@ -155,7 +171,7 @@ name = "reverse-text-long"
 [eval.args]
 max_length = 256
 ```
-9. Put generation parameters in TOML sampling sections:
+12. Put generation parameters in TOML sampling sections:
 ```toml
 [sampling]
 max_tokens = 1024
@@ -167,18 +183,18 @@ enable_thinking = true
 env_id = "my-env"
 ```
 Use `[eval.sampling]` for per-eval overrides. `[sampling]` is shorthand for `sampling_args`; `reasoning_effort` and `enable_thinking` stay top-level and are mirrored into `extra_body.chat_template_kwargs`.
-10. Pass extra HTTP headers via CLI (repeatable):
+13. Pass extra HTTP headers via CLI (repeatable):
 ```bash
 prime eval run my-env -m my-proxy --header "X-Custom-Header: value"
 ```
-11. Set headers in `[[eval]]` TOML configs as a table or list (merge order: registry row < `headers` table < `header` list / `--header`):
+14. Set headers in `[[eval]]` TOML configs as a table or list (merge order: registry row < `headers` table < `header` list / `--header`):
 ```toml
 [[eval]]
 env_id = "my-env"
 headers = { "X-Custom-Header" = "value" }
 header = ["X-Another: val"]
 ```
-12. Run ablation sweeps using `[[ablation]]` blocks in TOML configs:
+15. Run ablation sweeps using `[[ablation]]` blocks in TOML configs:
 ```toml
 [[ablation]]
 env_id = "my-env"

--- a/tests/test_composable_env.py
+++ b/tests/test_composable_env.py
@@ -187,6 +187,28 @@ def test_taskset_take():
     assert isinstance(taken, MockSandboxTaskSet)
 
 
+def test_composable_env_eval_inputs_can_shuffle_taskset_dataset():
+    taskset = MockTaskSet(dataset=_make_dataset(6), name="math")
+    env = ComposableEnv(
+        taskset=taskset,
+        harness=Harness(run_command="true"),
+    )
+
+    inputs = env._get_eval_inputs(
+        num_examples=3,
+        rollouts_per_example=2,
+        shuffle=True,
+        shuffle_seed=11,
+    )
+    expected = (
+        env.get_eval_dataset().shuffle(seed=11).select(range(3)).repeat(2).to_list()
+    )
+
+    assert [row["example_id"] for row in inputs] == [
+        row["example_id"] for row in expected
+    ]
+
+
 def test_taskset_repr():
     ts = MockTaskSet(dataset=_make_dataset(), name="mytest")
     assert "mytest" in repr(ts)

--- a/tests/test_environment_extra.py
+++ b/tests/test_environment_extra.py
@@ -324,7 +324,6 @@ def test_get_eval_inputs_shuffles_before_take_and_repeat(mock_client, make_dummy
     assert [row["example_id"] for row in inputs] == [
         row["example_id"] for row in expected
     ]
-    assert env.get_eval_dataset()["example_id"] == list(range(6))
 
 
 @pytest.mark.asyncio

--- a/tests/test_environment_extra.py
+++ b/tests/test_environment_extra.py
@@ -302,6 +302,31 @@ def test_evaluate_fallback_and_repeat(mock_client, make_dummy_env, make_input):
     assert len(states) == 2 * 2
 
 
+def test_get_eval_inputs_shuffles_before_take_and_repeat(mock_client, make_dummy_env):
+    ds = Dataset.from_dict(
+        {
+            "question": [f"q{i}" for i in range(6)],
+            "answer": [f"a{i}" for i in range(6)],
+        }
+    )
+    env = make_dummy_env(mock_client, dataset=ds)
+
+    inputs = env._get_eval_inputs(
+        num_examples=3,
+        rollouts_per_example=2,
+        shuffle=True,
+        shuffle_seed=123,
+    )
+    expected = (
+        env.get_eval_dataset().shuffle(seed=123).select(range(3)).repeat(2).to_list()
+    )
+
+    assert [row["example_id"] for row in inputs] == [
+        row["example_id"] for row in expected
+    ]
+    assert env.get_eval_dataset()["example_id"] == list(range(6))
+
+
 @pytest.mark.asyncio
 async def test_generate_inside_running_loop(mock_client, make_dummy_env, make_input):
     env = make_dummy_env(mock_client)

--- a/tests/test_eval_cli.py
+++ b/tests/test_eval_cli.py
@@ -179,13 +179,6 @@ def test_parse_args_rejects_unknown_eval_flags():
         vf_eval.parse_args(["env1", "--unknown-flag", "value"])
 
 
-def test_parse_args_accepts_shuffle_flags():
-    args = vf_eval.parse_args(["env1", "--shuffle", "--shuffle-seed", "123"])
-
-    assert args.shuffle is True
-    assert args.shuffle_seed == 123
-
-
 def test_cli_shuffle_defaults_seed_when_enabled(monkeypatch, run_cli):
     captured = run_cli(
         monkeypatch,
@@ -1213,18 +1206,11 @@ def test_cli_toml_per_env_rollouts_per_example(monkeypatch, run_cli):
 
 def test_cli_toml_per_env_shuffle(monkeypatch, run_cli):
     with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
-        f.write(
-            '[[eval]]\nenv_id = "env1"\nshuffle = true\nshuffle_seed = 321\n\n'
-            '[[eval]]\nenv_id = "env2"\n'
-        )
+        f.write('[[eval]]\nenv_id = "env1"\nshuffle = true\nshuffle_seed = 321\n')
         f.flush()
         captured = run_cli(monkeypatch, {"env_id_or_config": f.name})
 
-    configs = captured["configs"]
-    assert configs[0].shuffle is True
-    assert configs[0].shuffle_seed == 321
-    assert configs[1].shuffle is False
-    assert configs[1].shuffle_seed is None
+    assert captured["configs"][0].shuffle_seed == 321
 
 
 def test_cli_toml_per_eval_settings_used(monkeypatch, run_cli):

--- a/tests/test_eval_cli.py
+++ b/tests/test_eval_cli.py
@@ -72,6 +72,8 @@ def run_cli(make_metadata, make_state, make_input):
             "headers_from_state": None,
             "num_examples": 1,
             "rollouts_per_example": 1,
+            "shuffle": False,
+            "shuffle_seed": None,
             "max_concurrent": 1,
             "independent_scoring": False,
             "max_tokens": 42,
@@ -175,6 +177,27 @@ def test_parse_args_accepts_v1_env_config_overrides():
 def test_parse_args_rejects_unknown_eval_flags():
     with pytest.raises(SystemExit):
         vf_eval.parse_args(["env1", "--unknown-flag", "value"])
+
+
+def test_parse_args_accepts_shuffle_flags():
+    args = vf_eval.parse_args(["env1", "--shuffle", "--shuffle-seed", "123"])
+
+    assert args.shuffle is True
+    assert args.shuffle_seed == 123
+
+
+def test_cli_shuffle_defaults_seed_when_enabled(monkeypatch, run_cli):
+    captured = run_cli(
+        monkeypatch,
+        {
+            "shuffle": True,
+            "shuffle_seed": None,
+        },
+    )
+
+    config = captured["configs"][0]
+    assert config.shuffle is True
+    assert config.shuffle_seed == 0
 
 
 def test_cli_v1_env_config_overrides_preserve_env_args_config(
@@ -1186,6 +1209,22 @@ def test_cli_toml_per_env_rollouts_per_example(monkeypatch, run_cli):
     assert len(configs) == 2
     assert configs[0].rollouts_per_example == 3
     assert configs[1].rollouts_per_example == 5
+
+
+def test_cli_toml_per_env_shuffle(monkeypatch, run_cli):
+    with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
+        f.write(
+            '[[eval]]\nenv_id = "env1"\nshuffle = true\nshuffle_seed = 321\n\n'
+            '[[eval]]\nenv_id = "env2"\n'
+        )
+        f.flush()
+        captured = run_cli(monkeypatch, {"env_id_or_config": f.name})
+
+    configs = captured["configs"]
+    assert configs[0].shuffle is True
+    assert configs[0].shuffle_seed == 321
+    assert configs[1].shuffle is False
+    assert configs[1].shuffle_seed is None
 
 
 def test_cli_toml_per_eval_settings_used(monkeypatch, run_cli):

--- a/tests/test_path_utils.py
+++ b/tests/test_path_utils.py
@@ -114,8 +114,7 @@ def test_find_latest_incomplete_eval_results_path_matches_shuffle_metadata(
         env_dir_path=str(tmp_path / "environments"),
     )
 
-    assert result is not None
-    assert result.resolve() == matching_run.resolve()
+    assert result.resolve() == matching_run
 
 
 def test_get_eval_runs_dir_uses_name_as_result_label(tmp_path: Path):

--- a/tests/test_path_utils.py
+++ b/tests/test_path_utils.py
@@ -70,6 +70,54 @@ def test_find_latest_incomplete_eval_results_path_returns_none_when_no_match(
     assert result is None
 
 
+def test_find_latest_incomplete_eval_results_path_matches_shuffle_metadata(
+    tmp_path: Path, monkeypatch
+):
+    env_id = "dummy-env"
+    model = "openai/gpt-4.1-mini"
+    runs_dir = tmp_path / "outputs" / "evals" / f"{env_id}--{model.replace('/', '--')}"
+
+    matching_run = runs_dir / "matching"
+    wrong_seed_run = runs_dir / "wrong-seed"
+    for run in [matching_run, wrong_seed_run]:
+        run.mkdir(parents=True)
+        (run / "results.jsonl").write_text('{"example_id":0}\n', encoding="utf-8")
+
+    matching_run.joinpath("metadata.json").write_text(
+        (
+            '{"env_id":"dummy-env","model":"openai/gpt-4.1-mini",'
+            '"num_examples":4,"rollouts_per_example":1,'
+            '"shuffle":true,"shuffle_seed":123}'
+        ),
+        encoding="utf-8",
+    )
+    wrong_seed_run.joinpath("metadata.json").write_text(
+        (
+            '{"env_id":"dummy-env","model":"openai/gpt-4.1-mini",'
+            '"num_examples":4,"rollouts_per_example":1,'
+            '"shuffle":true,"shuffle_seed":456}'
+        ),
+        encoding="utf-8",
+    )
+
+    os.utime(matching_run, (1, 1))
+    os.utime(wrong_seed_run, (2, 2))
+    monkeypatch.chdir(tmp_path)
+
+    result = find_latest_incomplete_eval_results_path(
+        env_id=env_id,
+        model=model,
+        num_examples=4,
+        rollouts_per_example=1,
+        shuffle=True,
+        shuffle_seed=123,
+        env_dir_path=str(tmp_path / "environments"),
+    )
+
+    assert result is not None
+    assert result.resolve() == matching_run.resolve()
+
+
 def test_get_eval_runs_dir_uses_name_as_result_label(tmp_path: Path):
     runs_dir = get_eval_runs_dir(
         env_id="dummy-env",

--- a/tests/test_save_utils.py
+++ b/tests/test_save_utils.py
@@ -221,6 +221,25 @@ class TestSavingMetadata:
         assert metadata["shuffle"] is True
         assert metadata["shuffle_seed"] == 123
 
+    def test_generate_outputs_builder_records_default_shuffle_seed(self):
+        builder = GenerateOutputsBuilder(
+            env_id="test-env",
+            env_args={},
+            model="test-model",
+            client=ClientConfig(api_base_url="http://localhost:8000/v1"),
+            num_examples=1,
+            rollouts_per_example=1,
+            state_columns=[],
+            sampling_args={},
+            results_path=Path("/tmp/test-results"),
+            shuffle=True,
+        )
+
+        metadata = builder.build_metadata()
+
+        assert metadata["shuffle"] is True
+        assert metadata["shuffle_seed"] == 0
+
 
 class TestSavingResults:
     def test_response_usage_tokens_prompt_completion(self):
@@ -590,6 +609,38 @@ class TestResumeMetadataValidation:
             model="test-model",
             num_examples=5,
             rollouts_per_example=2,
+        )
+
+    def test_validate_resume_metadata_accepts_default_shuffle_seed_saved_by_builder(
+        self, tmp_path: Path
+    ):
+        results_path = tmp_path / "results"
+        results_path.mkdir()
+        builder = GenerateOutputsBuilder(
+            env_id="math-env",
+            env_args={},
+            model="test-model",
+            client=ClientConfig(api_base_url="http://localhost:8000/v1"),
+            num_examples=3,
+            rollouts_per_example=2,
+            state_columns=[],
+            sampling_args={},
+            results_path=results_path,
+            shuffle=True,
+        )
+        metadata_path = results_path / "metadata.json"
+        metadata_path.write_text(
+            json.dumps(builder.build_metadata(), default=make_serializable),
+            encoding="utf-8",
+        )
+
+        validate_resume_metadata(
+            results_path=results_path,
+            env_id="math-env",
+            model="test-model",
+            num_examples=3,
+            rollouts_per_example=2,
+            shuffle=True,
         )
 
     def test_validate_resume_metadata_raises_on_mismatch(self, tmp_path: Path):

--- a/tests/test_save_utils.py
+++ b/tests/test_save_utils.py
@@ -31,6 +31,7 @@ from verifiers.utils.save_utils import (
     load_outputs,
     make_serializable,
     save_new_outputs,
+    save_metadata,
     states_to_outputs,
     truncate_malformed_trailing_line,
     validate_resume_metadata,
@@ -198,47 +199,37 @@ class TestSavingMetadata:
         assert (
             metadata["base_url"] == "http://localhost:8000/v1,http://localhost:8001/v1"
         )
-        assert metadata["shuffle"] is False
-        assert metadata["shuffle_seed"] is None
 
-    def test_generate_outputs_builder_records_shuffle_metadata(self):
+    def test_save_metadata_records_default_shuffle_seed_for_resume(
+        self, tmp_path: Path
+    ):
+        results_path = tmp_path / "results"
         builder = GenerateOutputsBuilder(
-            env_id="test-env",
+            env_id="math-env",
             env_args={},
             model="test-model",
             client=ClientConfig(api_base_url="http://localhost:8000/v1"),
-            num_examples=1,
-            rollouts_per_example=1,
+            num_examples=3,
+            rollouts_per_example=2,
             state_columns=[],
             sampling_args={},
-            results_path=Path("/tmp/test-results"),
+            results_path=results_path,
             shuffle=True,
-            shuffle_seed=123,
         )
+        save_metadata(builder.build_metadata(), results_path)
 
-        metadata = builder.build_metadata()
-
-        assert metadata["shuffle"] is True
-        assert metadata["shuffle_seed"] == 123
-
-    def test_generate_outputs_builder_records_default_shuffle_seed(self):
-        builder = GenerateOutputsBuilder(
-            env_id="test-env",
-            env_args={},
+        assert (
+            json.loads((results_path / "metadata.json").read_text())["shuffle_seed"]
+            == 0
+        )
+        validate_resume_metadata(
+            results_path=results_path,
+            env_id="math-env",
             model="test-model",
-            client=ClientConfig(api_base_url="http://localhost:8000/v1"),
-            num_examples=1,
-            rollouts_per_example=1,
-            state_columns=[],
-            sampling_args={},
-            results_path=Path("/tmp/test-results"),
+            num_examples=3,
+            rollouts_per_example=2,
             shuffle=True,
         )
-
-        metadata = builder.build_metadata()
-
-        assert metadata["shuffle"] is True
-        assert metadata["shuffle_seed"] == 0
 
 
 class TestSavingResults:
@@ -609,38 +600,6 @@ class TestResumeMetadataValidation:
             model="test-model",
             num_examples=5,
             rollouts_per_example=2,
-        )
-
-    def test_validate_resume_metadata_accepts_default_shuffle_seed_saved_by_builder(
-        self, tmp_path: Path
-    ):
-        results_path = tmp_path / "results"
-        results_path.mkdir()
-        builder = GenerateOutputsBuilder(
-            env_id="math-env",
-            env_args={},
-            model="test-model",
-            client=ClientConfig(api_base_url="http://localhost:8000/v1"),
-            num_examples=3,
-            rollouts_per_example=2,
-            state_columns=[],
-            sampling_args={},
-            results_path=results_path,
-            shuffle=True,
-        )
-        metadata_path = results_path / "metadata.json"
-        metadata_path.write_text(
-            json.dumps(builder.build_metadata(), default=make_serializable),
-            encoding="utf-8",
-        )
-
-        validate_resume_metadata(
-            results_path=results_path,
-            env_id="math-env",
-            model="test-model",
-            num_examples=3,
-            rollouts_per_example=2,
-            shuffle=True,
         )
 
     def test_validate_resume_metadata_raises_on_mismatch(self, tmp_path: Path):

--- a/tests/test_save_utils.py
+++ b/tests/test_save_utils.py
@@ -198,6 +198,28 @@ class TestSavingMetadata:
         assert (
             metadata["base_url"] == "http://localhost:8000/v1,http://localhost:8001/v1"
         )
+        assert metadata["shuffle"] is False
+        assert metadata["shuffle_seed"] is None
+
+    def test_generate_outputs_builder_records_shuffle_metadata(self):
+        builder = GenerateOutputsBuilder(
+            env_id="test-env",
+            env_args={},
+            model="test-model",
+            client=ClientConfig(api_base_url="http://localhost:8000/v1"),
+            num_examples=1,
+            rollouts_per_example=1,
+            state_columns=[],
+            sampling_args={},
+            results_path=Path("/tmp/test-results"),
+            shuffle=True,
+            shuffle_seed=123,
+        )
+
+        metadata = builder.build_metadata()
+
+        assert metadata["shuffle"] is True
+        assert metadata["shuffle_seed"] == 123
 
 
 class TestSavingResults:
@@ -593,6 +615,35 @@ class TestResumeMetadataValidation:
                 model="test-model",
                 num_examples=3,
                 rollouts_per_example=2,
+            )
+
+    def test_validate_resume_metadata_rejects_shuffle_mismatch(self, tmp_path: Path):
+        results_path = tmp_path / "results"
+        results_path.mkdir()
+        metadata_path = results_path / "metadata.json"
+        metadata_path.write_text(
+            json.dumps(
+                {
+                    "env_id": "math-env",
+                    "model": "test-model",
+                    "num_examples": 3,
+                    "rollouts_per_example": 2,
+                    "shuffle": True,
+                    "shuffle_seed": 123,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with pytest.raises(ValueError, match="shuffle_seed"):
+            validate_resume_metadata(
+                results_path=results_path,
+                env_id="math-env",
+                model="test-model",
+                num_examples=3,
+                rollouts_per_example=2,
+                shuffle=True,
+                shuffle_seed=456,
             )
 
 

--- a/tests/test_v1_taskset_utils.py
+++ b/tests/test_v1_taskset_utils.py
@@ -4,7 +4,7 @@ import types
 
 from datasets import Dataset
 
-from verifiers.v1 import Taskset
+from verifiers.v1 import Env, Taskset
 from verifiers.v1.utils.taskset_utils import dataset_from_result, discover_sibling_dir
 
 
@@ -118,3 +118,25 @@ def test_taskset_skips_empty_skills_dir(tmp_path, monkeypatch) -> None:
 
     assert taskset.get_skills_dir() == skills_dir
     assert taskset.get_upload_dirs() == {"skills": skills_dir}
+
+
+def test_v1_env_eval_inputs_can_shuffle_taskset_dataset() -> None:
+    class DemoTaskset(Taskset):
+        def load_tasks(self, split: str = "train"):
+            return [{"question": f"Reverse {i}.", "answer": str(i)} for i in range(6)]
+
+    env = Env(taskset=DemoTaskset())
+
+    inputs = env._get_eval_inputs(
+        num_examples=3,
+        rollouts_per_example=2,
+        shuffle=True,
+        shuffle_seed=7,
+    )
+    expected = (
+        env.get_eval_dataset().shuffle(seed=7).select(range(3)).repeat(2).to_list()
+    )
+
+    assert [row["example_id"] for row in inputs] == [
+        row["example_id"] for row in expected
+    ]

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -938,6 +938,9 @@ class Environment(ABC):
         total_rollouts = len(raw_inputs)
         num_examples = len(set([i["example_id"] for i in raw_inputs]))
         rollouts_per_example = total_rollouts // num_examples if num_examples > 0 else 0
+        resolved_shuffle_seed = (
+            (0 if shuffle_seed is None else shuffle_seed) if shuffle else None
+        )
         builder = GenerateOutputsBuilder(
             env_id=self.env_id,
             env_args=self.env_args,
@@ -950,7 +953,7 @@ class Environment(ABC):
             results_path=results_path,
             pass_threshold=self.pass_threshold,
             shuffle=shuffle,
-            shuffle_seed=shuffle_seed if shuffle else None,
+            shuffle_seed=resolved_shuffle_seed,
         )
 
         single_client: Client | None = None
@@ -996,7 +999,7 @@ class Environment(ABC):
                     num_examples=num_examples,
                     rollouts_per_example=rollouts_per_example,
                     shuffle=shuffle,
-                    shuffle_seed=shuffle_seed if shuffle else None,
+                    shuffle_seed=resolved_shuffle_seed,
                 )
                 on_log(f"Resuming evaluation from {results_path}")
                 outputs = load_outputs(results_path)

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -400,12 +400,13 @@ class Environment(ABC):
         self.build_dataset()
         if self.dataset is None:
             raise ValueError("dataset is not set")
+        dataset = self.dataset
         if seed is not None:
-            self.dataset = self.dataset.shuffle(seed=seed)
+            dataset = dataset.shuffle(seed=seed)
         if n > 0:
-            n = min(n, len(self.dataset))
-            return self.dataset.select(range(n))
-        return self.dataset
+            n = min(n, len(dataset))
+            return dataset.select(range(n))
+        return dataset
 
     @final
     def get_eval_dataset(self, n: int = -1, seed: int | None = None) -> "Dataset":
@@ -415,12 +416,13 @@ class Environment(ABC):
                 "eval_dataset is not set, falling back to train dataset"
             )
             return self.get_dataset(n, seed)
+        eval_dataset = self.eval_dataset
         if seed is not None:
-            self.eval_dataset = self.eval_dataset.shuffle(seed=seed)
+            eval_dataset = eval_dataset.shuffle(seed=seed)
         if n > 0:
-            n = min(n, len(self.eval_dataset))
-            return self.eval_dataset.select(range(n))
-        return self.eval_dataset
+            n = min(n, len(eval_dataset))
+            return eval_dataset.select(range(n))
+        return eval_dataset
 
     @final
     def _get_usage_tracker(
@@ -831,6 +833,8 @@ class Environment(ABC):
         hf_hub_dataset_name: str | None = None,
         independent_scoring: bool = False,
         max_retries: int = 0,
+        shuffle: bool = False,
+        shuffle_seed: int | None = None,
         on_start: StartCallback | None = None,
         on_progress: ProgressCallback | list[ProgressCallback] | None = None,
         on_log: LogCallback | None = None,
@@ -945,6 +949,8 @@ class Environment(ABC):
             sampling_args=sampling_args,
             results_path=results_path,
             pass_threshold=self.pass_threshold,
+            shuffle=shuffle,
+            shuffle_seed=shuffle_seed if shuffle else None,
         )
 
         single_client: Client | None = None
@@ -989,6 +995,8 @@ class Environment(ABC):
                     model=model,
                     num_examples=num_examples,
                     rollouts_per_example=rollouts_per_example,
+                    shuffle=shuffle,
+                    shuffle_seed=shuffle_seed if shuffle else None,
                 )
                 on_log(f"Resuming evaluation from {results_path}")
                 outputs = load_outputs(results_path)
@@ -1152,11 +1160,20 @@ class Environment(ABC):
 
     # evaluation
     def _get_eval_inputs(
-        self, num_examples: int = -1, rollouts_per_example: int = 1
+        self,
+        num_examples: int = -1,
+        rollouts_per_example: int = 1,
+        shuffle: bool = False,
+        shuffle_seed: int | None = None,
     ) -> List[RolloutInput]:
         # get_eval_dataset handles fallback to train dataset if no eval source exists
-        inputs = self.get_eval_dataset(n=num_examples)
+        inputs = self.get_eval_dataset()
         assert inputs is not None, "No dataset found"
+        if shuffle:
+            inputs = inputs.shuffle(seed=0 if shuffle_seed is None else shuffle_seed)
+        if num_examples > 0:
+            num_examples = min(num_examples, len(inputs))
+            inputs = inputs.select(range(num_examples))
         if rollouts_per_example > 1:
             inputs = inputs.repeat(rollouts_per_example)
         return inputs.to_list()
@@ -1176,6 +1193,8 @@ class Environment(ABC):
         hf_hub_dataset_name: str | None = None,
         independent_scoring: bool = False,
         max_retries: int = 0,
+        shuffle: bool = False,
+        shuffle_seed: int | None = None,
         on_start: StartCallback | None = None,
         on_progress: ProgressCallback | list[ProgressCallback] | None = None,
         on_log: LogCallback | None = None,
@@ -1189,7 +1208,13 @@ class Environment(ABC):
                 A single callback replaces the default. A list of callbacks runs
                 alongside the default.
         """
-        inputs = self._get_eval_inputs(num_examples, rollouts_per_example)
+        resolved_shuffle_seed = 0 if shuffle and shuffle_seed is None else shuffle_seed
+        inputs = self._get_eval_inputs(
+            num_examples,
+            rollouts_per_example,
+            shuffle=shuffle,
+            shuffle_seed=resolved_shuffle_seed,
+        )
         return await self.generate(
             inputs,
             client=client,
@@ -1203,6 +1228,8 @@ class Environment(ABC):
             hf_hub_dataset_name=hf_hub_dataset_name,
             independent_scoring=independent_scoring,
             max_retries=max_retries,
+            shuffle=shuffle,
+            shuffle_seed=resolved_shuffle_seed,
             on_start=on_start,
             on_progress=on_progress,
             on_log=on_log,
@@ -1224,11 +1251,19 @@ class Environment(ABC):
         hf_hub_dataset_name: str | None = None,
         independent_scoring: bool = False,
         max_retries: int = 0,
+        shuffle: bool = False,
+        shuffle_seed: int | None = None,
     ) -> GenerateOutputs:
         """
         Evaluate model on the Environment evaluation dataset synchronously.
         """
-        inputs = self._get_eval_inputs(num_examples, rollouts_per_example)
+        resolved_shuffle_seed = 0 if shuffle and shuffle_seed is None else shuffle_seed
+        inputs = self._get_eval_inputs(
+            num_examples,
+            rollouts_per_example,
+            shuffle=shuffle,
+            shuffle_seed=resolved_shuffle_seed,
+        )
         return self.generate_sync(
             inputs,
             client=client,
@@ -1242,6 +1277,8 @@ class Environment(ABC):
             hf_hub_dataset_name=hf_hub_dataset_name,
             independent_scoring=independent_scoring,
             max_retries=max_retries,
+            shuffle=shuffle,
+            shuffle_seed=resolved_shuffle_seed,
         )
 
     # setters for use by trainers

--- a/verifiers/scripts/eval.py
+++ b/verifiers/scripts/eval.py
@@ -474,6 +474,18 @@ def build_parser() -> argparse.ArgumentParser:
         help="Number of rollouts per example",
     )
     parser.add_argument(
+        "--shuffle",
+        default=False,
+        action="store_true",
+        help="Shuffle the evaluation dataset before selecting examples",
+    )
+    parser.add_argument(
+        "--shuffle-seed",
+        type=int,
+        default=None,
+        help="Seed for --shuffle. Defaults to 0 when --shuffle is enabled.",
+    )
+    parser.add_argument(
         "--max-concurrent",
         "-c",
         type=int,
@@ -712,6 +724,12 @@ def main(argv: list[str] | None = None):
             logger.debug(
                 f"Using rollouts_per_example={rollouts_per_example} from {source}"
             )
+        shuffle = bool(raw.get("shuffle", False))
+        shuffle_seed = raw.get("shuffle_seed")
+        if shuffle and shuffle_seed is None:
+            shuffle_seed = 0
+        if not shuffle:
+            shuffle_seed = None
 
         raw_endpoint_id = raw.get("endpoint_id")
         raw_model_field = raw.get("model")
@@ -918,6 +936,8 @@ def main(argv: list[str] | None = None):
                 model=model,
                 num_examples=num_examples,
                 rollouts_per_example=rollouts_per_example,
+                shuffle=shuffle,
+                shuffle_seed=shuffle_seed,
                 env_dir_path=raw.get("env_dir_path", DEFAULT_ENV_DIR_PATH),
                 output_dir=raw.get("output_dir"),
                 name=name,
@@ -957,6 +977,8 @@ def main(argv: list[str] | None = None):
             sampling_args=merged_sampling_args,
             num_examples=num_examples,
             rollouts_per_example=rollouts_per_example,
+            shuffle=shuffle,
+            shuffle_seed=shuffle_seed,
             max_concurrent=raw.get("max_concurrent", DEFAULT_MAX_CONCURRENT),
             max_retries=raw.get("max_retries", 3),
             num_workers=raw.get("num_workers", "auto"),

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -1137,6 +1137,8 @@ class GenerateMetadata(TypedDict):
     base_url: str
     num_examples: int
     rollouts_per_example: int
+    shuffle: NotRequired[bool]
+    shuffle_seed: NotRequired[int | None]
     sampling_args: SamplingArgs
     date: str
     time: float  # whole-eval wall-clock seconds
@@ -1325,6 +1327,8 @@ class EvalConfig(BaseModel):
     sampling_args: SamplingArgs
     num_examples: int
     rollouts_per_example: int
+    shuffle: bool = False
+    shuffle_seed: int | None = None
     max_concurrent: int
     num_workers: int | str = "auto"
     independent_scoring: bool = False

--- a/verifiers/utils/eval_utils.py
+++ b/verifiers/utils/eval_utils.py
@@ -658,6 +658,8 @@ def load_toml_config(
         # evaluation
         "num_examples",
         "rollouts_per_example",
+        "shuffle",
+        "shuffle_seed",
         "max_concurrent",
         "independent_scoring",
         "max_retries",
@@ -1102,7 +1104,7 @@ async def run_evaluation(
 
         logger.debug(f"Starting evaluation with model: {config.model}")
         logger.debug(
-            f"Configuration: num_examples={config.num_examples}, rollouts_per_example={config.rollouts_per_example}, max_concurrent={config.max_concurrent}"
+            f"Configuration: num_examples={config.num_examples}, rollouts_per_example={config.rollouts_per_example}, shuffle={config.shuffle}, shuffle_seed={config.shuffle_seed}, max_concurrent={config.max_concurrent}"
         )
 
         effective_group_max_concurrent = config.max_concurrent
@@ -1127,6 +1129,8 @@ async def run_evaluation(
             sampling_args=config.sampling_args,
             num_examples=config.num_examples,
             rollouts_per_example=config.rollouts_per_example,
+            shuffle=config.shuffle,
+            shuffle_seed=config.shuffle_seed,
             max_concurrent=effective_group_max_concurrent,
             results_path=results_path,
             state_columns=config.state_columns,

--- a/verifiers/utils/path_utils.py
+++ b/verifiers/utils/path_utils.py
@@ -107,6 +107,8 @@ def find_latest_incomplete_eval_results_path(
     model: str,
     num_examples: int,
     rollouts_per_example: int,
+    shuffle: bool = False,
+    shuffle_seed: int | None = None,
     env_dir_path: str = "./environments",
     output_dir: str | None = None,
     name: str | None = None,
@@ -147,6 +149,12 @@ def find_latest_incomplete_eval_results_path(
             continue
         if metadata.get("rollouts_per_example") != rollouts_per_example:
             continue
+        if bool(metadata.get("shuffle", False)) != shuffle:
+            continue
+        if shuffle:
+            expected_shuffle_seed = 0 if shuffle_seed is None else shuffle_seed
+            if metadata.get("shuffle_seed") != expected_shuffle_seed:
+                continue
 
         saved_num_examples = metadata.get("num_examples")
         if not isinstance(saved_num_examples, int) or saved_num_examples > num_examples:

--- a/verifiers/utils/save_utils.py
+++ b/verifiers/utils/save_utils.py
@@ -575,7 +575,9 @@ class GenerateOutputsBuilder:
         self.num_examples = num_examples
         self.rollouts_per_example = rollouts_per_example
         self.shuffle = shuffle
-        self.shuffle_seed = shuffle_seed if shuffle else None
+        self.shuffle_seed = (
+            (0 if shuffle_seed is None else shuffle_seed) if shuffle else None
+        )
         self.state_columns = state_columns or []
         self.sampling_args = sampling_args
         self.results_path = results_path or get_results_path(env_id, model)

--- a/verifiers/utils/save_utils.py
+++ b/verifiers/utils/save_utils.py
@@ -565,6 +565,8 @@ class GenerateOutputsBuilder:
         sampling_args: SamplingArgs,
         results_path: Path | None,
         pass_threshold: float = 0.5,
+        shuffle: bool = False,
+        shuffle_seed: int | None = None,
     ):
         self.env_id = env_id
         self.env_args = env_args
@@ -572,6 +574,8 @@ class GenerateOutputsBuilder:
         self.client = client
         self.num_examples = num_examples
         self.rollouts_per_example = rollouts_per_example
+        self.shuffle = shuffle
+        self.shuffle_seed = shuffle_seed if shuffle else None
         self.state_columns = state_columns or []
         self.sampling_args = sampling_args
         self.results_path = results_path or get_results_path(env_id, model)
@@ -674,6 +678,8 @@ class GenerateOutputsBuilder:
             base_url=self.base_url,
             num_examples=self.num_examples,
             rollouts_per_example=self.rollouts_per_example,
+            shuffle=self.shuffle,
+            shuffle_seed=self.shuffle_seed,
             sampling_args=self.sampling_args,
             date=datetime.now().isoformat(),
             time=time.time() - self.start_time,
@@ -748,6 +754,8 @@ def validate_resume_metadata(
     model: str,
     num_examples: int,
     rollouts_per_example: int,
+    shuffle: bool = False,
+    shuffle_seed: int | None = None,
 ) -> None:
     """Validate saved metadata matches the current resume configuration.
 
@@ -792,6 +800,17 @@ def validate_resume_metadata(
         mismatches.append(
             f"num_examples: saved={saved_num_examples!r}, current={num_examples!r} (current must be >= saved)"
         )
+
+    saved_shuffle = bool(saved_metadata.get("shuffle", False))
+    if saved_shuffle != shuffle:
+        mismatches.append(f"shuffle: saved={saved_shuffle!r}, current={shuffle!r}")
+    if shuffle:
+        expected_shuffle_seed = 0 if shuffle_seed is None else shuffle_seed
+        saved_shuffle_seed = saved_metadata.get("shuffle_seed", "<missing>")
+        if saved_shuffle_seed != expected_shuffle_seed:
+            mismatches.append(
+                f"shuffle_seed: saved={saved_shuffle_seed!r}, current={expected_shuffle_seed!r}"
+            )
 
     if mismatches:
         mismatch_text = "; ".join(mismatches)


### PR DESCRIPTION
## Summary
- Add `--shuffle` and `--shuffle-seed` to `vf-eval` and TOML eval configs.
- Apply shuffling in the shared evaluation input-selection path before `num_examples` selection and rollout repetition.
- Record shuffle settings in eval metadata and require matching shuffle settings for explicit and auto resume.
- Add coverage for standard envs, composable tasksets, and v1 Taskset/Harness environments.

## Validation
- `uv run ruff check verifiers/envs/environment.py verifiers/scripts/eval.py verifiers/utils/eval_utils.py verifiers/utils/path_utils.py verifiers/utils/save_utils.py verifiers/types.py tests/test_eval_cli.py tests/test_environment_extra.py tests/test_composable_env.py tests/test_path_utils.py tests/test_save_utils.py tests/test_v1_taskset_utils.py`
- `uv run pytest tests/test_eval_cli.py tests/test_environment_extra.py tests/test_composable_env.py tests/test_path_utils.py tests/test_save_utils.py tests/test_v1_taskset_utils.py`
- `uv run ty check verifiers/envs/environment.py verifiers/scripts/eval.py verifiers/utils/eval_utils.py verifiers/utils/path_utils.py verifiers/utils/save_utils.py verifiers/types.py`
- commit hook: ruff check, ruff format, Semgrep v1 policy, generated AGENTS/CLAUDE check
- pre-push hook: ruff check, ruff format, Semgrep v1 policy, generated AGENTS/CLAUDE check, ty ci parity

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which examples are evaluated and resume compatibility; wrong shuffle settings on resume could mix checkpoint data with a different example order.
> 
> **Overview**
> Adds **`--shuffle`** and **`--shuffle-seed`** to `prime eval` / `vf-eval` and to per-`[[eval]]` TOML configs. When shuffle is on without an explicit seed, the run uses seed **`0`**.
> 
> Evaluation example selection now **shuffles the full eval dataset, then takes `num_examples`, then repeats for rollouts** in the shared `_get_eval_inputs` path (standard envs, composable tasksets, and v1 `Env`). **`get_dataset` / `get_eval_dataset`** no longer mutate cached datasets when applying a shuffle seed.
> 
> Shuffle settings are written to **`metadata.json`** and must match for **explicit and auto `--resume`** (`find_latest_incomplete_eval_results_path` and `validate_resume_metadata`). Docs and the evaluate-environments skill describe the new flags and resume behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9445adc6f130487f70e00768bb191355b904aeff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `--shuffle` and `--shuffle-seed` flags to `vf-eval`
> - Adds `--shuffle` (bool) and `--shuffle-seed` (int) CLI flags to [eval.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1556/files#diff-6b37997f6eb279df06f6c885920ff82ac5940e25ca859a9dd445bdc4028277b6); when shuffle is enabled without an explicit seed, `shuffle_seed` defaults to `0`.
> - Shuffle is applied before `num_examples` selection and `rollouts_per_example` repetition in `Environment.get_eval_dataset` and `get_dataset`, which no longer mutate `self.dataset`/`self.eval_dataset`.
> - Auto-resume via `find_latest_incomplete_eval_results_path` now only matches incomplete runs with identical `shuffle` and `shuffle_seed` settings.
> - Saved metadata and resume validation in [save_utils.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1556/files#diff-e4491159a12a733bc8861a33ba9d2d09b27942f04c4baa1629f0806efa07547d) include the new fields; mismatched shuffle settings on resume raise `ValueError`.
> - TOML configs can also specify `shuffle` and `shuffle_seed` per environment.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9445adc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->