### PR TITLE
feat(v1): add Harness.transform_prompt hook

### DIFF
--- a/docs/byo-harness.md
+++ b/docs/byo-harness.md
@@ -429,6 +429,21 @@ class PythonHarnessConfig(vf.HarnessConfig):
 Put sandbox overrides on tasks only when the taskset owns per-task images,
 files, resource sizing, or setup.
 
+### Prompt Preparation Hook
+
+Harnesses can reshape the prompt right before each model request using `prepare_prompt(prompt, state)`. The default implementation is identity; override it to compact context, redact content, or inject reminders. The prepared messages are what the runtime sends to the model and records in the trajectory, and the base-program loop uses the prepared prompt on subsequent turns.
+
+```python
+class MyHarness(vf.Harness[MyHarnessConfig]):
+    def prepare_prompt(self, prompt: vf.Messages, state: vf.State) -> vf.Messages:
+        # Example: prepend a brief reminder to the first system message
+        messages = vf.normalize_messages(prompt)
+        if messages and messages[0].role == "system":
+            content = str(messages[0].content or "")
+            messages[0].content = "Answer concisely. " + content
+        return messages
+```
+
 ## Lifecycle And Scoring
 
 Lifecycle decorators attach behavior to the owning class:

--- a/verifiers/v1/harness.py
+++ b/verifiers/v1/harness.py
@@ -220,8 +220,8 @@ class Harness(RuntimeOwnerMixin[ConfigT], Generic[ConfigT]):
     def load_system_prompt(self, config: ConfigT) -> SystemPrompt:
         return config.system_prompt
 
-    def transform_prompt(self, prompt: Messages, state: State) -> Messages:
-        """Hook to transform the prompt before each model request.
+    def prepare_prompt(self, prompt: Messages, state: State) -> Messages:
+        """Hook to prepare the prompt before each model request.
 
         Default identity — vf applies no transform of its own. Override in a
         subclass to return a modified prompt. Applied at the single point every
@@ -531,6 +531,20 @@ class Harness(RuntimeOwnerMixin[ConfigT], Generic[ConfigT]):
                 tool_defs=self.runtime.tool_defs(state),
             )
             turn += 1
+            # Align the local host-loop thread with the exact prompt sent to the model
+            # (which may have been modified by the harness's prepare_prompt hook).
+            trajectory = state.get("trajectory")
+            if isinstance(trajectory, list) and trajectory:
+                last_step = trajectory[-1]
+                if isinstance(last_step, dict):
+                    used_prompt = last_step.get("prompt")
+                    if isinstance(used_prompt, list):
+                        messages = normalize_messages(
+                            cast(Messages, used_prompt), field_name="used_prompt"
+                        )
+                        prompt_messages = [
+                            m.model_dump(exclude_none=True) for m in messages
+                        ]
             messages.extend(await parse_response_message(response))
             rendered_messages = sync_completion()
             tool_calls = list(response.message.tool_calls or [])

--- a/verifiers/v1/harness.py
+++ b/verifiers/v1/harness.py
@@ -220,6 +220,18 @@ class Harness(RuntimeOwnerMixin[ConfigT], Generic[ConfigT]):
     def load_system_prompt(self, config: ConfigT) -> SystemPrompt:
         return config.system_prompt
 
+    def transform_prompt(self, prompt: Messages, state: State) -> Messages:
+        """Hook to transform the prompt before each model request.
+
+        Default identity — vf applies no transform of its own. Override in a
+        subclass to return a modified prompt. Applied at the single point every
+        model request passes through (``Runtime.submit_model_request``), so it
+        covers base-program, fn-mode, and host-loop rollouts uniformly. May be
+        sync or async. The returned messages are what the host tokenizes, sends
+        to the model, and records as the trajectory step.
+        """
+        return prompt
+
     def load_program_config(self, config: ConfigT) -> ProgramConfig:
         return config.program.resolve()
 

--- a/verifiers/v1/runtime.py
+++ b/verifiers/v1/runtime.py
@@ -883,6 +883,7 @@ class Runtime:
             return self._completed_model_response(state)
         released = False
         try:
+            prompt = await self._transform_prompt(prompt, state)
             client = self.model_client(state)
             request_start = time.time()
             response = await client.get_response(
@@ -924,6 +925,21 @@ class Runtime:
         finally:
             if not released:
                 self._release_model_request(state, context)
+
+    async def _transform_prompt(self, prompt: Messages, state: State) -> Messages:
+        """Apply the harness ``transform_prompt`` hook (default identity).
+
+        The single point every model request passes through, so a subclass's
+        prompt transform applies uniformly across base-program, fn-mode, and
+        host-loop rollouts. Tolerates sync or async hooks.
+        """
+        harness = self.harness
+        if harness is None:
+            return prompt
+        result = harness.transform_prompt(prompt, state)
+        if inspect.isawaitable(result):
+            result = await result
+        return result if result is not None else prompt
 
     async def _reserve_model_request(
         self, task: Task, state: State, context: ModelRequestContext

--- a/verifiers/v1/runtime.py
+++ b/verifiers/v1/runtime.py
@@ -883,7 +883,7 @@ class Runtime:
             return self._completed_model_response(state)
         released = False
         try:
-            prompt = await self._transform_prompt(prompt, state)
+            prompt = await self._prepare_prompt(prompt, state)
             client = self.model_client(state)
             request_start = time.time()
             response = await client.get_response(
@@ -926,17 +926,17 @@ class Runtime:
             if not released:
                 self._release_model_request(state, context)
 
-    async def _transform_prompt(self, prompt: Messages, state: State) -> Messages:
-        """Apply the harness ``transform_prompt`` hook (default identity).
+    async def _prepare_prompt(self, prompt: Messages, state: State) -> Messages:
+        """Apply the harness ``prepare_prompt`` hook (default identity).
 
         The single point every model request passes through, so a subclass's
-        prompt transform applies uniformly across base-program, fn-mode, and
+        prompt preparation applies uniformly across base-program, fn-mode, and
         host-loop rollouts. Tolerates sync or async hooks.
         """
         harness = self.harness
         if harness is None:
             return prompt
-        result = harness.transform_prompt(prompt, state)
+        result = harness.prepare_prompt(prompt, state)
         if inspect.isawaitable(result):
             result = await result
         return result if result is not None else prompt

--- a/verifiers/v1/runtime.py
+++ b/verifiers/v1/runtime.py
@@ -938,7 +938,7 @@ class Runtime:
             return prompt
         result = harness.prepare_prompt(prompt, state)
         if inspect.isawaitable(result):
-            result = await result
+            result = await cast(Awaitable[Messages], result)
         return result if result is not None else prompt
 
     async def _reserve_model_request(


### PR DESCRIPTION
Adds a default-identity `Harness.transform_prompt(prompt, state)` hook, applied in `Runtime.submit_model_request` right before the model call — the single point every model request passes through (base-program, fn-mode, host-loop).

Subclasses override it to reshape the prompt before each request (e.g. context compaction, redaction, reminders); the returned messages are what the host tokenizes, sends, and records as the trajectory step. Default is identity, so existing harnesses are unaffected. Sync and async both supported.

2 files, 28 insertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the single code path for all model requests and trajectory prompts; default is identity, but overrides change model input and recorded trajectories.
> 
> **Overview**
> Adds **`Harness.prepare_prompt(prompt, state)`**, an overridable hook (default identity) so harnesses can reshape messages immediately before each model call.
> 
> **`Runtime.submit_model_request`** now runs **`_prepare_prompt`** first; sync and async overrides are supported. The prepared messages are sent to the model and stored on the trajectory step.
> 
> The **base-program host loop** re-reads the last trajectory step’s **`prompt`** after each request so local **`messages`** stay aligned with what **`prepare_prompt`** actually sent on the next turn.
> 
> **`docs/byo-harness.md`** documents the hook with a subclass example.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b411a1f18a99422964abc946baa0b24938d7746. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `Harness.transform_prompt` hook to transform prompts before each model request
> - Adds a `prepare_prompt(prompt, state)` method to [`Harness`](https://github.com/PrimeIntellect-ai/verifiers/pull/1561/files#diff-05e981bb3680a934fbc6865d9dff3b25fc692d0c9970684bf8d41f4aea7ee384) with a no-op default; subclasses may override to mutate messages before each model call.
> - [`Runtime.submit_model_request`](https://github.com/PrimeIntellect-ai/verifiers/pull/1561/files#diff-7c2c1b88c61b8a75e00bb82f7ece60290f886d4a3ed87e97a5e1cbf86b26973d) now passes prompts through a new `_prepare_prompt` helper that invokes the hook, supporting both sync and async overrides.
> - The host-loop in [`harness.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1561/files#diff-05e981bb3680a934fbc6865d9dff3b25fc692d0c9970684bf8d41f4aea7ee384) syncs its local `messages` variable from the recorded trajectory prompt after each turn, so subsequent turns use the hook-modified prompt.
> - Behavioral Change: all model requests now go through `prepare_prompt`; the default is identity, but any harness subclass that overrides it will affect every turn's prompt and trajectory recording.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5b411a1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->