### PR TITLE
Make env server retries idempotent

### DIFF
--- a/tests/test_env_server.py
+++ b/tests/test_env_server.py
@@ -417,6 +417,31 @@ class TestIdempotentRetries:
         finally:
             await router.close()
 
+    @pytest.mark.asyncio
+    async def test_start_worker_does_not_duplicate_ipc_paths(self):
+        """Worker IPC paths are deterministic, so restarts should not re-add them."""
+        router = EnvRouter(env_id="test")
+        process = MagicMock()
+        process.pid = 123
+        ctx = MagicMock()
+        ctx.Process.return_value = process
+
+        try:
+            with (
+                patch(
+                    "verifiers.serve.server.env_router.mp.get_context",
+                    return_value=ctx,
+                ),
+                patch.object(router.ctx, "socket", return_value=MagicMock()),
+            ):
+                router.start_worker(0)
+                router.start_worker(0)
+
+            worker_path = router.get_worker_address(0).replace("ipc://", "")
+            assert router.ipc_paths.count(worker_path) == 1
+        finally:
+            await router.close()
+
 
 class TestSendCancelErrorHandling:
     """Tests that ``send_cancel`` swallows transport errors but not

--- a/tests/test_env_server.py
+++ b/tests/test_env_server.py
@@ -12,11 +12,13 @@ import contextlib
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import msgpack
 import pytest
 
 from verifiers.types import ClientConfig, RolloutInput, UserMessage
 from verifiers.utils.serve_utils import get_free_port
 from verifiers.serve import (
+    EnvRouter,
     HealthRequest,
     HealthResponse,
     PendingRequest,
@@ -324,6 +326,96 @@ class TestRetryOnServerError:
             assert attempt_count == 1
 
             await client.close()
+
+
+class TestIdempotentRetries:
+    """Tests for request idempotency across retry and response replay paths."""
+
+    @pytest.mark.asyncio
+    async def test_receive_loop_acks_pending_response(self):
+        """Completed responses are acked only when a pending future receives them."""
+        client = make_client()
+        pending, future = make_pending_request(request_id="req_1")
+        async with client.pending_lock:
+            client.pending_requests[pending.request_id] = pending
+
+        response_bytes = msgpack.packb(
+            HealthResponse(success=True).model_dump(), use_bin_type=True
+        )
+        client.socket.recv_multipart = AsyncMock(
+            side_effect=[[b"req_1", response_bytes], asyncio.CancelledError()]
+        )
+        client.send_ack = AsyncMock()
+
+        try:
+            await client.receive_loop()
+            client.send_ack.assert_awaited_once_with("req_1")
+            assert future.result()["success"] is True
+            assert client.pending_requests == {}
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_receive_loop_does_not_ack_stale_response(self):
+        """Late responses for cleared pending state must remain replayable."""
+        client = make_client()
+        client.socket.recv_multipart = AsyncMock(
+            side_effect=[[b"missing_req", b"payload"], asyncio.CancelledError()]
+        )
+        client.send_ack = AsyncMock()
+
+        try:
+            await client.receive_loop()
+            client.send_ack.assert_not_awaited()
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_send_request_uses_full_uuid_hex(self):
+        """Request ids keep full UUID entropy because caches are keyed by id."""
+        client = make_client()
+        sent_request_ids: list[str] = []
+        full_uuid_hex = "a" * 32
+
+        async def mock_send(frames, **kwargs):
+            if len(frames) == 2 and frames[1] in {b"", b"ack"}:
+                return
+            request_id = frames[0].decode()
+            sent_request_ids.append(request_id)
+            pending = client.pending_requests[request_id]
+            pending.future.set_result(HealthResponse(success=True).model_dump())
+
+        with (
+            patch("verifiers.serve.client.zmq_env_client.uuid.uuid4") as mock_uuid4,
+            patch_client_socket(client, send_side_effect=mock_send),
+        ):
+            mock_uuid4.return_value.hex = full_uuid_hex
+            try:
+                await client.send_request(HealthRequest(), HealthResponse, timeout=1.0)
+            finally:
+                await client.close()
+
+        assert sent_request_ids == [full_uuid_hex]
+
+    @pytest.mark.asyncio
+    async def test_completed_response_cache_prunes_expired_and_excess_entries(self):
+        """Abandoned completed responses are bounded without waiting for acks."""
+        router = EnvRouter(env_id="test")
+        now = time.time()
+
+        try:
+            router.completed_responses[b"expired"] = (now - 1, b"old")
+            router.completed_responses[b"fresh"] = (now + 60, b"fresh")
+            router.prune_completed_responses(now)
+            assert list(router.completed_responses) == [b"fresh"]
+
+            router.max_completed_responses = 2
+            router.completed_responses[b"one"] = (now + 60, b"one")
+            router.completed_responses[b"two"] = (now + 60, b"two")
+            router.prune_completed_responses(now)
+            assert list(router.completed_responses) == [b"one", b"two"]
+        finally:
+            await router.close()
 
 
 class TestSendCancelErrorHandling:

--- a/verifiers/serve/client/zmq_env_client.py
+++ b/verifiers/serve/client/zmq_env_client.py
@@ -213,28 +213,26 @@ class ZMQEnvClient(EnvClient):
 
                 request_id_bytes, response_data = msg[0], msg[1]
                 request_id = request_id_bytes.decode()
-                await self.send_ack(request_id)
 
                 # Pop pending request atomically
                 async with self.pending_lock:
                     pending_req = self.pending_requests.pop(request_id, None)
 
-                if pending_req is not None and not pending_req.future.done():
-                    try:
-                        response = msgpack.unpackb(response_data, raw=False)
-                        pending_req.future.set_result(response)
-                    except Exception as unpack_error:
-                        # Unpacking failed - fail the specific future
-                        self.logger.error(
-                            f"Request {request_id[:7]} failed to unpack response from env server {self.name} ({unpack_error})"
-                        )
-                        pending_req.future.set_exception(
-                            RuntimeError(
-                                f"Failed to deserialize response: {unpack_error}"
-                            )
-                        )
-                elif pending_req is None:
-                    pass  # ignore responses for requests we already popped (e.g. timed out)
+                if pending_req is None or pending_req.future.done():
+                    continue
+
+                await self.send_ack(request_id)
+                try:
+                    response = msgpack.unpackb(response_data, raw=False)
+                    pending_req.future.set_result(response)
+                except Exception as unpack_error:
+                    # Unpacking failed - fail the specific future
+                    self.logger.error(
+                        f"Request {request_id[:7]} failed to unpack response from env server {self.name} ({unpack_error})"
+                    )
+                    pending_req.future.set_exception(
+                        RuntimeError(f"Failed to deserialize response: {unpack_error}")
+                    )
 
             except asyncio.CancelledError:
                 break
@@ -288,7 +286,7 @@ class ZMQEnvClient(EnvClient):
                 use_bin_type=True,
             ),
         )
-        request_id = uuid.uuid4().hex[:8]
+        request_id = uuid.uuid4().hex
 
         while True:
             # Create future and pending request atomically

--- a/verifiers/serve/client/zmq_env_client.py
+++ b/verifiers/serve/client/zmq_env_client.py
@@ -152,10 +152,18 @@ class ZMQEnvClient(EnvClient):
             # propagate (they are not `Exception` subclasses).
             pass
 
+    async def send_ack(self, request_id: str) -> None:
+        """Acknowledge receipt so the server can drop cached responses."""
+        try:
+            await self.socket.send_multipart([request_id.encode(), b"ack"])
+        except Exception:
+            pass
+
     async def cancel_all_pending(
         self,
         reason: str = "Request cancelled",
         use_cancelled: bool = False,
+        notify_server: bool = True,
     ) -> list[PendingRequest]:
         """Cancel all pending requests and return their metadata.
 
@@ -184,9 +192,9 @@ class ZMQEnvClient(EnvClient):
             # Clear tracking dict
             self.pending_requests.clear()
 
-        # Best-effort: notify server to cancel these requests
-        for pending_req in cancelled_requests:
-            await self.send_cancel(pending_req.request_id)
+        if notify_server:
+            for pending_req in cancelled_requests:
+                await self.send_cancel(pending_req.request_id)
 
         return cancelled_requests
 
@@ -205,6 +213,7 @@ class ZMQEnvClient(EnvClient):
 
                 request_id_bytes, response_data = msg[0], msg[1]
                 request_id = request_id_bytes.decode()
+                await self.send_ack(request_id)
 
                 # Pop pending request atomically
                 async with self.pending_lock:
@@ -279,10 +288,9 @@ class ZMQEnvClient(EnvClient):
                 use_bin_type=True,
             ),
         )
+        request_id = uuid.uuid4().hex[:8]
 
         while True:
-            request_id = uuid.uuid4().hex
-
             # Create future and pending request atomically
             future: Future = asyncio.Future()
             pending_req = PendingRequest(
@@ -422,5 +430,5 @@ class ZMQEnvClient(EnvClient):
         self.server_state = ServerState.UNHEALTHY
         self.healthy_event.clear()
         msg = f"Env server {self.name} became unhealthy ({failed_checks} consecutive health check failures)"
-        asyncio.ensure_future(self.cancel_all_pending(msg))
+        asyncio.ensure_future(self.cancel_all_pending(msg, notify_server=False))
         self.logger.warning(msg)

--- a/verifiers/serve/server/env_router.py
+++ b/verifiers/serve/server/env_router.py
@@ -14,6 +14,7 @@ import multiprocessing as mp
 import os
 import time
 import uuid
+from collections import OrderedDict
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from multiprocessing.connection import Connection
@@ -143,7 +144,11 @@ class EnvRouter:
         # setup state
         self.workers: dict[int, WorkerHandle] = {}
         self.request_to_worker: dict[bytes, int] = {}  # request_id → worker_id
-        self.completed_responses: dict[bytes, bytes] = {}
+        self.max_completed_responses = 10_000
+        self.completed_response_ttl = 300.0
+        self.completed_responses: OrderedDict[bytes, tuple[float, bytes]] = (
+            OrderedDict()
+        )
         self.on_response: OnResponseCallback | None = None
         self.lag_monitor = EventLoopLagMonitor()
 
@@ -279,7 +284,12 @@ class EnvRouter:
                         info = self.complete_request(request_id)
                         if info is not None:
                             client_id = info.client_id
-                        self.completed_responses[request_id] = response_bytes
+                        self.completed_responses[request_id] = (
+                            time.time() + self.completed_response_ttl,
+                            response_bytes,
+                        )
+                        self.completed_responses.move_to_end(request_id)
+                        self.prune_completed_responses()
                         await on_response(client_id, request_id, response_bytes)
 
                 # ── worker stats ───────────────────────────────────
@@ -298,6 +308,7 @@ class EnvRouter:
                     last_stats_log = now
                 if now - last_heartbeat_check >= 5.0:
                     await self.check_workers()
+                    self.prune_completed_responses(now)
                     last_heartbeat_check = now
 
         except asyncio.CancelledError:
@@ -351,9 +362,11 @@ class EnvRouter:
         self, client_id: bytes, request_id: bytes, payload: bytes
     ) -> None:
         """Send a request to the least-busy worker."""
-        response_bytes = self.completed_responses.get(request_id)
-        if response_bytes is not None:
+        self.prune_completed_responses()
+        cached_response = self.completed_responses.get(request_id)
+        if cached_response is not None:
             if self.on_response is not None:
+                _, response_bytes = cached_response
                 await self.on_response(client_id, request_id, response_bytes)
             return
 
@@ -400,6 +413,17 @@ class EnvRouter:
     def ack_request(self, request_id: bytes) -> None:
         """Forget a completed response once the client confirms receipt."""
         self.completed_responses.pop(request_id, None)
+
+    def prune_completed_responses(self, now: float | None = None) -> None:
+        """Drop expired or excess completed-response cache entries."""
+        now = time.time() if now is None else now
+        while self.completed_responses:
+            expires_at, _ = next(iter(self.completed_responses.values()))
+            within_ttl = expires_at > now
+            within_size = len(self.completed_responses) <= self.max_completed_responses
+            if within_ttl and within_size:
+                break
+            self.completed_responses.popitem(last=False)
 
     def is_current_worker(self, worker_id: int, incarnation: str) -> bool:
         """Check whether a worker message came from the current process."""

--- a/verifiers/serve/server/env_router.py
+++ b/verifiers/serve/server/env_router.py
@@ -45,6 +45,7 @@ class ActiveRequestInfo:
 @dataclass
 class WorkerHandle:
     worker_id: int
+    incarnation: str
     process: BaseProcess
     address: str
     socket: zmq.asyncio.Socket
@@ -142,6 +143,8 @@ class EnvRouter:
         # setup state
         self.workers: dict[int, WorkerHandle] = {}
         self.request_to_worker: dict[bytes, int] = {}  # request_id → worker_id
+        self.completed_responses: dict[bytes, bytes] = {}
+        self.on_response: OnResponseCallback | None = None
         self.lag_monitor = EventLoopLagMonitor()
 
         self.ipc_paths: list[str] = [
@@ -173,6 +176,7 @@ class EnvRouter:
 
         worker_name = self.get_worker_name(worker_id)
         worker_addr = self.get_worker_address(worker_id)
+        incarnation = uuid.uuid4().hex[:8]
         self.ipc_paths.append(worker_addr.replace("ipc://", ""))
 
         ctx = mp.get_context("spawn")
@@ -189,6 +193,7 @@ class EnvRouter:
             ),
             kwargs=dict(
                 worker_id=worker_id,
+                incarnation=incarnation,
                 worker_name=worker_name,
                 request_address=worker_addr,
                 response_address=self.response_address,
@@ -206,11 +211,12 @@ class EnvRouter:
         socket.connect(worker_addr)
 
         self.logger.info(
-            f"Started worker (id={worker_id}, name={worker_name}, address={worker_addr}, pid={process.pid})"
+            f"Started worker (id={worker_id}, incarnation={incarnation}, name={worker_name}, address={worker_addr}, pid={process.pid})"
         )
 
         return WorkerHandle(
             worker_id=worker_id,
+            incarnation=incarnation,
             process=process,
             socket=socket,
             address=worker_addr,
@@ -235,6 +241,7 @@ class EnvRouter:
             stop_event: Set to signal shutdown.
         """
         self.start_workers()
+        self.on_response = on_response
 
         poller = zmq.asyncio.Poller()
         poller.register(self.response_pull, zmq.POLLIN)
@@ -256,10 +263,23 @@ class EnvRouter:
                             )
                         except zmq.Again:
                             break
-                        if len(frames) != 3:
+                        if len(frames) != 5:
                             continue
-                        client_id, request_id, response_bytes = frames
-                        self.complete_request(request_id)
+                        (
+                            worker_id_bytes,
+                            incarnation_bytes,
+                            client_id,
+                            request_id,
+                            response_bytes,
+                        ) = frames
+                        worker_id = int(worker_id_bytes.decode())
+                        incarnation = incarnation_bytes.decode()
+                        if not self.is_current_worker(worker_id, incarnation):
+                            continue
+                        info = self.complete_request(request_id)
+                        if info is not None:
+                            client_id = info.client_id
+                        self.completed_responses[request_id] = response_bytes
                         await on_response(client_id, request_id, response_bytes)
 
                 # ── worker stats ───────────────────────────────────
@@ -283,6 +303,7 @@ class EnvRouter:
         except asyncio.CancelledError:
             pass
         finally:
+            self.on_response = None
             poller.unregister(self.response_pull)
             poller.unregister(self.stats_pull)
 
@@ -330,6 +351,19 @@ class EnvRouter:
         self, client_id: bytes, request_id: bytes, payload: bytes
     ) -> None:
         """Send a request to the least-busy worker."""
+        response_bytes = self.completed_responses.get(request_id)
+        if response_bytes is not None:
+            if self.on_response is not None:
+                await self.on_response(client_id, request_id, response_bytes)
+            return
+
+        active_worker_id = self.request_to_worker.get(request_id)
+        if active_worker_id is not None:
+            worker = self.workers.get(active_worker_id)
+            if worker is not None and request_id in worker.active_requests:
+                worker.active_requests[request_id].client_id = client_id
+                return
+
         worker_id = self.select_worker()
         worker = self.workers[worker_id]
         await worker.socket.send_multipart([client_id, request_id, payload])
@@ -363,13 +397,22 @@ class EnvRouter:
             return worker.active_requests.pop(request_id, None)
         return None
 
+    def ack_request(self, request_id: bytes) -> None:
+        """Forget a completed response once the client confirms receipt."""
+        self.completed_responses.pop(request_id, None)
+
+    def is_current_worker(self, worker_id: int, incarnation: str) -> bool:
+        """Check whether a worker message came from the current process."""
+        worker = self.workers.get(worker_id)
+        return worker is not None and worker.incarnation == incarnation
+
     def handle_stats_message(self, data: bytes) -> None:
         """Parse a stats message and update the worker handle."""
         try:
             raw = msgpack.unpackb(data, raw=False)
             stats = EnvWorkerStats.model_validate(raw)
             worker = self.workers.get(stats.worker_id)
-            if worker is not None:
+            if worker is not None and worker.incarnation == stats.incarnation:
                 worker.stats = stats
                 worker.last_heartbeat = stats.timestamp
         except Exception:
@@ -414,6 +457,7 @@ class EnvRouter:
 
         self.workers.clear()
         self.request_to_worker.clear()
+        self.completed_responses.clear()
 
         self.response_pull.close()
         self.stats_pull.close()

--- a/verifiers/serve/server/env_router.py
+++ b/verifiers/serve/server/env_router.py
@@ -182,7 +182,9 @@ class EnvRouter:
         worker_name = self.get_worker_name(worker_id)
         worker_addr = self.get_worker_address(worker_id)
         incarnation = uuid.uuid4().hex[:8]
-        self.ipc_paths.append(worker_addr.replace("ipc://", ""))
+        ipc_path = worker_addr.replace("ipc://", "")
+        if ipc_path not in self.ipc_paths:
+            self.ipc_paths.append(ipc_path)
 
         ctx = mp.get_context("spawn")
         process = ctx.Process(

--- a/verifiers/serve/server/env_worker.py
+++ b/verifiers/serve/server/env_worker.py
@@ -38,6 +38,7 @@ from verifiers.utils.serve_utils import msgpack_encoder
 
 class EnvWorkerStats(BaseModel):
     worker_id: int
+    incarnation: str
     timestamp: float
     active_tasks: int
     lag: EventLoopLagStats = EventLoopLagStats()
@@ -63,6 +64,7 @@ class EnvWorker:
         json_logging: bool = False,
         *,
         worker_id: int,
+        incarnation: str,
         worker_name: str,
         request_address: str,
         response_address: str,
@@ -73,6 +75,7 @@ class EnvWorker:
         self.death_pipe = death_pipe
         self.env_id = env_id
         self.worker_id = worker_id
+        self.incarnation = incarnation
         self.worker_name = worker_name
 
         # setup logging — each worker gets its own log file
@@ -184,7 +187,13 @@ class EnvWorker:
                     ),
                 )
                 await self.response_socket.send_multipart(
-                    [client_id, request_id.encode(), response_bytes]
+                    [
+                        str(self.worker_id).encode(),
+                        self.incarnation.encode(),
+                        client_id,
+                        request_id_bytes,
+                        response_bytes,
+                    ]
                 )
             except Exception:
                 pass
@@ -192,7 +201,6 @@ class EnvWorker:
         try:
             raw = await asyncio.to_thread(msgpack.unpackb, payload_bytes, raw=False)
             request_type = raw.get("request_type")
-            request_id = raw.get("request_id", request_id)
 
             if request_type == "run_rollout":
                 request = await asyncio.to_thread(RunRolloutRequest.model_validate, raw)
@@ -241,7 +249,13 @@ class EnvWorker:
 
         try:
             await self.response_socket.send_multipart(
-                [client_id, request_id.encode(), response_bytes]
+                [
+                    str(self.worker_id).encode(),
+                    self.incarnation.encode(),
+                    client_id,
+                    request_id_bytes,
+                    response_bytes,
+                ]
             )
         except zmq.ZMQError as e:
             self.logger.warning(f"Failed to send response for {request_id[:7]}: {e}")
@@ -253,6 +267,7 @@ class EnvWorker:
 
             stats = EnvWorkerStats(
                 worker_id=self.worker_id,
+                incarnation=self.incarnation,
                 timestamp=time.time(),
                 active_tasks=len(self.active_tasks),
                 lag=EventLoopLagStats.from_monitor(self.lag_monitor),

--- a/verifiers/serve/server/zmq_env_server.py
+++ b/verifiers/serve/server/zmq_env_server.py
@@ -22,6 +22,7 @@ _HEALTH_RESPONSE = msgpack.packb({"success": True, "error": None}, use_bin_type=
 
 # Sentinel payload used by health-check probes.
 _HEALTH_PING = b"ping"
+_ACK = b"ack"
 
 
 class ZMQEnvServer(EnvServer):
@@ -93,6 +94,8 @@ class ZMQEnvServer(EnvServer):
                                 )
                             except zmq.ZMQError:
                                 pass  # peer disconnected between ping and pong
+                        elif payload == _ACK:
+                            self.router.ack_request(request_id)
                         elif not payload:
                             await self.router.forward_cancel(request_id, client_id)
                         else:


### PR DESCRIPTION
Independent PR targeting `main`.

This PR does not depend on #1564, #1565, or #1566. The three changes were originally opened as a stack, but they touch separate subsystems and can be reviewed and merged independently.

### Summary
This makes ZMQ env-server retries reuse one logical request ID and prevents duplicate retry dispatch from executing the same rollout twice.

### Changes
- reuse the same short request ID across retry attempts
- acknowledge completed responses so the server can drop its response cache
- replay completed duplicate requests and reroute active duplicate requests
- fence stale worker responses and stats with worker incarnation IDs

### Verification
- uv run --frozen pytest tests/test_path_utils.py tests/test_save_utils.py tests/test_env_server.py -q
- uv run --frozen pytest tests/test_v1_runtime_lifecycle.py -q -k 'not test_real_sandbox_base_program_calls_host_callable_tool'
- uv run --frozen ruff format --check && uv run --frozen ruff check .

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rollout dispatch and retry semantics on the critical client–router–worker path; incorrect idempotency could skip work or double-execute, though incarnation fencing and cache replay are designed to prevent that.
> 
> **Overview**
> Makes ZMQ env-server **retries idempotent** so the same logical rollout is not executed twice after transport failures or duplicate sends.
> 
> **Client (`ZMQEnvClient`)** keeps one **full UUID hex request ID** for the whole `send_request` retry loop (no new ID per attempt). After a response is matched to a pending future, it sends an **`ack`** frame so the server can drop cached data; late responses with no pending entry are ignored **without** acking (so the server can still replay). `cancel_all_pending` gains **`notify_server=False`** for unhealthy transitions so local futures fail without spamming cancel frames.
> 
> **Router (`EnvRouter`)** adds a **TTL- and size-bounded** completed-response cache. Duplicate dispatches with the same ID **replay from cache** or **re-bind `client_id`** on an in-flight request instead of re-queuing work. Workers tag responses/stats with a per-process **`incarnation`**; stale messages from restarted workers are dropped. Worker IPC paths are only registered once on restart.
> 
> **Wire format**: worker→router responses are now **5 frames** (worker id, incarnation, client id, request id, payload). **`ZMQEnvServer`** handles client **`ack`** payloads via `router.ack_request()`.
> 
> New **`TestIdempotentRetries`** covers ack behavior, stable request IDs, cache pruning, and IPC path deduplication.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1e39c5fa97f02836a3c4da2098c765938a33920. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make env server retries idempotent by caching completed responses and acknowledging delivery
> - `EnvRouter` now maintains a bounded, TTL-based cache (max 10,000 entries, 300s TTL) of completed responses keyed by request ID, enabling cached replay on retry instead of re-executing work.
> - `EnvRouter.dispatch_request` coalesces duplicate in-flight requests by updating the destination client ID rather than dispatching again, and replays cached responses immediately for already-completed requests.
> - `ZMQEnvClient.send_request` now generates a single UUID outside the retry loop so all retries share the same request ID, enabling the server to recognize and replay cached results.
> - `ZMQEnvClient.receive_loop` sends an `ack` frame to the server after receiving a valid response; the server forwards this to `EnvRouter.ack_request` to evict the entry from the cache.
> - Workers now include a unique `incarnation` token in all response and stats frames; the router ignores messages from stale worker incarnations to prevent misrouted responses after restarts.
> - Behavioral Change: `on_became_unhealthy` no longer sends cancel notifications to the server for each pending request (`notify_server=False`).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a1e39c5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->