### PR TITLE
Collect sandbox artifacts under lease

### DIFF
--- a/verifiers/v1/harness.py
+++ b/verifiers/v1/harness.py
@@ -255,7 +255,8 @@ class Harness(RuntimeOwnerMixin[ConfigT], Generic[ConfigT]):
                     state = await self.run_program(task, state)
                     await self.runtime.is_completed(task, state)
                 state._set_stop_condition("program_completed")
-                await self.runtime.collect_artifacts(task, state)
+                if not state.runtime_state().pop("artifacts_collected", False):
+                    await self.runtime.collect_artifacts(task, state)
             except Error as e:
                 self.record_error(state, e)
             await self.runtime.update_rollout(task, state)

--- a/verifiers/v1/runtime.py
+++ b/verifiers/v1/runtime.py
@@ -1069,7 +1069,13 @@ class Runtime:
             self.release_scoped_tools("group", state)
             await self.release_model_client(state, group=True)
 
-    async def collect_artifacts(self, task: Task, state: State) -> None:
+    async def collect_artifacts(
+        self,
+        task: Task,
+        state: State,
+        *,
+        sandbox_lease: "SandboxLease | None" = None,
+    ) -> None:
         artifacts = self.runtime_artifacts(task, state)
         if not artifacts:
             return
@@ -1081,7 +1087,9 @@ class Runtime:
                 raise ValueError(f"Artifact {name!r} is already present on state.")
         values = await asyncio.gather(
             *(
-                self.collect_runtime_artifact(artifact, task, state)
+                self.collect_runtime_artifact(
+                    artifact, task, state, sandbox_lease=sandbox_lease
+                )
                 for artifact in artifacts.values()
             )
         )
@@ -2210,9 +2218,16 @@ class Runtime:
             return spec.parse(f.read())
 
     async def collect_runtime_artifact(
-        self, artifact: RuntimeArtifact, task: Task, state: State
+        self,
+        artifact: RuntimeArtifact,
+        task: Task,
+        state: State,
+        *,
+        sandbox_lease: "SandboxLease | None" = None,
     ) -> object:
-        sandbox_lease = self.active_artifact_sandbox_lease(artifact.owner, state)
+        sandbox_lease = self.active_artifact_sandbox_lease(
+            artifact.owner, state, program_sandbox_lease=sandbox_lease
+        )
         owner_requires_sandbox = (
             isinstance(artifact.owner, Toolset | User)
             and artifact.owner.sandbox is not None
@@ -2231,21 +2246,25 @@ class Runtime:
         )
 
     def active_artifact_sandbox_lease(
-        self, owner: ArtifactOwner, state: State
+        self,
+        owner: ArtifactOwner,
+        state: State,
+        *,
+        program_sandbox_lease: "SandboxLease | None" = None,
     ) -> "SandboxLease | None":
         if not isinstance(owner, Toolset | User):
-            return self.active_program_sandbox_lease(state)
+            return program_sandbox_lease or self.active_program_sandbox_lease(state)
         from .utils.sandbox_utils import sandbox_owner_key, tool_sandbox_key
 
         sandbox = owner.sandbox
         if sandbox is None:
-            return self.active_program_sandbox_lease(state)
+            return program_sandbox_lease or self.active_program_sandbox_lease(state)
         if sandbox == "program":
-            return self.active_program_sandbox_lease(state)
+            return program_sandbox_lease or self.active_program_sandbox_lease(state)
         if not isinstance(sandbox, SandboxConfig):
             raise TypeError("Owner sandbox must be SandboxConfig or 'program'.")
         if sandbox.prefer == "program":
-            lease = self.active_program_sandbox_lease(state)
+            lease = program_sandbox_lease or self.active_program_sandbox_lease(state)
             if lease is not None:
                 return lease
         scope = sandbox.scope

--- a/verifiers/v1/utils/sandbox_program_utils.py
+++ b/verifiers/v1/utils/sandbox_program_utils.py
@@ -89,24 +89,31 @@ async def run_sandbox_python_program(
         tool_defs=runtime.tool_defs(state),
     )
     command_record = state.get("command")
-    await run_sandbox_command(runner_program, sandbox_config, task, state, runtime)
-    lease = runtime.active_program_sandbox_lease(state)
-    if lease is None:
-        raise RuntimeError("Sandbox Python program has no active sandbox lease.")
-    output = json.loads(
-        await read_sandbox_artifact(lease.client, lease.id, STATE_OUTPUT_PATH)
+
+    async def apply_state_output(lease, _result) -> None:
+        output = json.loads(
+            await read_sandbox_artifact(lease.client, lease.id, STATE_OUTPUT_PATH)
+        )
+        if not isinstance(output, dict):
+            raise RuntimeError("Sandbox Python program did not return state.")
+        patch = dict(cast(ConfigData, output))
+        apply_internal_state_patch(state, patch, mode=mode)
+        patch_artifacts = patch.pop("artifacts", None)
+        if isinstance(patch_artifacts, dict):
+            state.setdefault("artifacts", {})
+            state["artifacts"].update(dict(patch_artifacts))
+        state.update(patch)
+        if command_record is not None:
+            state["command"] = command_record
+
+    await run_sandbox_command(
+        runner_program,
+        sandbox_config,
+        task,
+        state,
+        runtime,
+        after_command=apply_state_output,
     )
-    if not isinstance(output, dict):
-        raise RuntimeError("Sandbox Python program did not return state.")
-    patch = dict(cast(ConfigData, output))
-    apply_internal_state_patch(state, patch, mode=mode)
-    patch_artifacts = patch.pop("artifacts", None)
-    if isinstance(patch_artifacts, dict):
-        state.setdefault("artifacts", {})
-        state["artifacts"].update(dict(patch_artifacts))
-    state.update(patch)
-    if command_record is not None:
-        state["command"] = command_record
     return state
 
 

--- a/verifiers/v1/utils/sandbox_utils.py
+++ b/verifiers/v1/utils/sandbox_utils.py
@@ -473,6 +473,8 @@ async def run_sandbox_command(
     task: Task,
     state: State,
     runtime: Runtime,
+    after_command: Callable[[SandboxLease, SandboxCommandResult], Awaitable[None]]
+    | None = None,
 ) -> State:
     validate_program_bindings(program)
     sandbox_data = sandbox_config.data()
@@ -553,6 +555,10 @@ async def run_sandbox_command(
                 f"Sandbox command exited with {result.exit_code}: {result.stderr}"
             )
         state._set_stop_condition("command_completed")
+        if after_command is not None:
+            await after_command(lease, result)
+        await runtime.collect_artifacts(task, state, sandbox_lease=lease)
+        runtime_state["artifacts_collected"] = True
         return state
 
 


### PR DESCRIPTION
Independent PR targeting `main`.

This PR does not depend on #1564, #1565, or #1566. The three changes were originally opened as a stack, but they touch separate subsystems and can be reviewed and merged independently.

### Summary
This keeps sandbox program state output and artifact collection inside the existing sandbox lease lock so shared sandboxes cannot be reused before those files are read.

### Changes
- add an after-command hook while the sandbox lease is still locked
- read sandbox Python state output in that hook
- collect runtime artifacts with the already-held program lease
- skip later artifact collection when command execution already collected them

### Verification
- uv run --frozen pytest tests/test_path_utils.py tests/test_save_utils.py tests/test_env_server.py -q
- uv run --frozen pytest tests/test_v1_runtime_lifecycle.py -q -k 'not test_real_sandbox_base_program_calls_host_callable_tool'
- uv run --frozen ruff format --check && uv run --frozen ruff check .

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rollout timing for sandbox command programs (artifacts and state output now depend on lease lifetime); race fixes for shared sandboxes but behavior shift if cleanup assumed post-harness collection.
> 
> **Overview**
> Keeps **sandbox program state reads and runtime artifact collection** inside the existing program sandbox **lease lock**, so a shared sandbox is not released or reused before output files are consumed.
> 
> `run_sandbox_command` gains an optional **`after_command`** hook (still under the lock). Sandbox Python programs use it to read `/tmp/vf_state_out.json` and merge state immediately after the command succeeds, instead of doing that after `run_sandbox_command` returns.
> 
> **Artifact collection** now runs at the end of `run_sandbox_command` via `runtime.collect_artifacts(..., sandbox_lease=lease)`, with `Runtime` / `active_artifact_sandbox_lease` updated to prefer that held lease for program-scoped artifacts. **`Harness.run`** skips a second `collect_artifacts` when `runtime_state["artifacts_collected"]` is already set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b795676c58341ce3fe56d6a77d702bd94f206c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Collect sandbox artifacts under lease immediately after sandbox command execution
> - `run_sandbox_command` in [sandbox_utils.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1566/files#diff-b1154f3be7f28191532de46fbe23a973a5f93e1450a71beb9c93910e358fda13) now collects artifacts via `runtime.collect_artifacts` with the active sandbox lease after each command completes, then sets `runtime_state["artifacts_collected"] = True`.
> - An optional `after_command` callback is added to `run_sandbox_command`, invoked before artifact collection; `run_sandbox_python_program` uses this to apply state output immediately after the command finishes.
> - `Runtime.collect_artifacts` and `Runtime.collect_runtime_artifact` accept an optional `sandbox_lease` parameter, forwarding it through to `active_artifact_sandbox_lease` so the correct sandbox context is used.
> - The `Harness` rollout method skips artifact collection if `artifacts_collected` is already set in `runtime_state`, preventing duplicate collection.
> - Behavioral Change: artifact collection now happens inside `run_sandbox_command` rather than afterward, and state output from sandboxed Python programs is applied via callback rather than post-hoc.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2b79567.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->