### PR TITLE
Fix hosted eval append-only result streaming

### DIFF
--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,5 +1,6 @@
 """Tests for the base Environment class."""
 
+import asyncio
 import json
 from typing import cast
 from unittest.mock import AsyncMock, Mock, patch
@@ -75,6 +76,21 @@ class SimpleEnvironment(Environment):
             state["error"] = e
 
         return state
+
+
+class DelayedEnvironment(SimpleEnvironment):
+    """Simple environment that completes lower example IDs later."""
+
+    async def rollout(
+        self,
+        input: RolloutInput,
+        client,
+        model: str,
+        sampling_args: SamplingArgs | None = None,
+    ):
+        if input["example_id"] == 0:
+            await asyncio.sleep(0.05)
+        return await super().rollout(input, client, model, sampling_args)
 
 
 class TestEnvironmentBase:
@@ -466,6 +482,40 @@ class TestEnvironmentBase:
         assert "reward" in dataset.column_names
         assert "example_id" in dataset.column_names
         assert "foo" in dataset.column_names  # custom field from make_output fixture
+
+    @pytest.mark.asyncio
+    async def test_generate_does_not_rewrite_incremental_results_file(
+        self, mock_client, sample_dataset, make_input, tmp_path
+    ):
+        """Final result sorting should not rewrite append-streamed JSONL rows."""
+
+        def reward_func(completion):
+            _ = completion
+            return 1.0
+
+        env = DelayedEnvironment(
+            dataset=sample_dataset,
+            parser=Parser(),
+            rubric=Rubric(funcs=[reward_func]),
+        )
+        inputs = [make_input(example_id=0), make_input(example_id=1)]
+
+        results = await env.generate(
+            inputs,
+            client=mock_client,
+            model="test-model",
+            max_concurrent=2,
+            results_path=tmp_path,
+            save_results=True,
+            independent_scoring=True,
+        )
+
+        assert [output["example_id"] for output in results["outputs"]] == [0, 1]
+        saved_rows = [
+            json.loads(line)
+            for line in (tmp_path / "results.jsonl").read_text().splitlines()
+        ]
+        assert [row["example_id"] for row in saved_rows] == [1, 0]
 
     @pytest.mark.asyncio
     async def test_generate_updates_metadata(self, mock_client):

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -1025,6 +1025,7 @@ class Environment(ABC):
                 on_log(f"Saving results to {builder.results_path}")
 
             tasks: dict[asyncio.Task, int] = {}
+            wrote_incremental_results = False
             try:
                 # create tasks based on mode
                 if independent_scoring:
@@ -1088,6 +1089,7 @@ class Environment(ABC):
                         await asyncio.to_thread(
                             save_new_outputs, new_outputs, builder.results_path
                         )
+                        wrote_incremental_results = True
                         await asyncio.to_thread(
                             save_metadata, metadata, builder.results_path
                         )
@@ -1104,9 +1106,10 @@ class Environment(ABC):
 
             # save if requested
             if save_results:
-                await asyncio.to_thread(
-                    save_outputs, results["outputs"], builder.results_path
-                )
+                if not wrote_incremental_results:
+                    await asyncio.to_thread(
+                        save_outputs, results["outputs"], builder.results_path
+                    )
                 await asyncio.to_thread(
                     save_metadata, results["metadata"], builder.results_path
                 )


### PR DESCRIPTION
## Summary
- Keep `results.jsonl` append-only after incremental eval saves.
- Still return sorted in-memory results and update final metadata.
- Add a regression test for out-of-order rollout completion.

## Root cause
Hosted eval partially streams `results.jsonl` while verifiers appends completed rollouts. At the end of `Environment.generate`, verifiers rewrote `results.jsonl` in sorted example order, so the hosted partial uploader detected a non-append-only file change and failed after successful rollouts.

## Validation
- `uv run ruff check verifiers/envs/environment.py tests/test_environment.py`
- `uv run pytest tests/test_environment.py -q`
- `uv run pre-commit run --files verifiers/envs/environment.py tests/test_environment.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to eval result persistence when incremental saves are enabled; non-incremental paths still use the final full write.
> 
> **Overview**
> **`Environment.generate`** no longer rewrites **`results.jsonl`** after incremental streaming saves. A **`wrote_incremental_results`** flag is set whenever rollouts are appended via **`save_new_outputs`**; the end-of-run **`save_outputs`** (full-file write in sorted **`example_id`** order) runs only when nothing was streamed incrementally.
> 
> Returned results are still built with **`sort_by_example_id=True`**, and final **`metadata.json`** is still written. This keeps hosted eval partial uploaders happy (append-only JSONL) while preserving deterministic in-memory ordering.
> 
> A regression test uses **`DelayedEnvironment`** so example 0 finishes after example 1: on-disk rows stay in completion order **`[1, 0]`**, while **`results["outputs"]`** remains **`[0, 1]`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fb21ca34043e3b64aa466ec6498d749057f06c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `Environment.generate` to preserve append-order when saving incremental results
> - When `save_results=True` and incremental results have been written during generation, the final step now skips rewriting the outputs file, preserving the append-order (e.g. completion order) in `results.jsonl`.
> - Only metadata is saved at finalization; in-memory results returned to the caller remain sorted by `example_id`.
> - A new `DelayedEnvironment` test subclass creates deterministic out-of-order completions to verify the file retains append order `[1, 0]` while the returned list is ordered `[0, 1]`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9fb21ca.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->