### PR TITLE
fix(parsers): select the last answer in XMLParser.parse_answer for chat messages

### DIFF
--- a/tests/test_xml_parser.py
+++ b/tests/test_xml_parser.py
@@ -101,6 +101,16 @@ class TestXMLParser:
             result == "45"
         )  # Should return just the last answer, not a full parse() namespace
 
+    def test_parse_answer_last_answer_within_single_message(self, xml_parser):
+        content = (
+            "<reasoning>first attempt</reasoning><answer>44</answer>"
+            "<reasoning>actually, reconsider</reasoning><answer>45</answer>"
+        )
+        assert xml_parser.parse_answer(content) == "45"
+        assert (
+            xml_parser.parse_answer([{"role": "assistant", "content": content}]) == "45"
+        )
+
     def test_parse_answer_no_answer_field(self, xml_parser):
         """Test parse_answer when no answer field is found."""
         completion = [

--- a/verifiers/parsers/xml_parser.py
+++ b/verifiers/parsers/xml_parser.py
@@ -103,7 +103,7 @@ class XMLParser(Parser):
                     if isinstance(msg, dict)
                     else (msg.content or "")
                 )
-                parsed = self.parse(content)
+                parsed = self.parse(content, last=True)
                 if (
                     parsed
                     and hasattr(parsed, self.answer_field)


### PR DESCRIPTION
## Description
`XMLParser.parse_answer` is documented to "Extract the last answer from a completion." The string-input branch calls `self.parse(completion, last=True)`, but the chat-message branch called `self.parse(content)` without `last=True`. As a result, a single assistant message containing multiple `<answer>` tags (e.g. a draft answer followed by a self-corrected final answer) returned the **first** answer instead of the last — contradicting the docstring, the string branch, and downstream callers that rely on the final answer (`MathRubric`, `JudgeRubric`, wordle, reverse_text, mmmu, ...). The fix passes `last=True` in the chat-message branch so string and chat-message inputs behave identically.

This completes a follow-up that was explicitly deferred in #196 ("Fix `XMLParser.parse_answer`'s handling of str completions"), which introduced the `last` parameter and applied it to the string branch only. 

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [x]  New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One-line behavioral fix in answer extraction; aligns rubrics/scoring with existing string behavior and docstring, with no auth or data-path changes.
> 
> **Overview**
> Fixes **`XMLParser.parse_answer`** so chat-style completions match the documented “last answer” behavior when a **single** assistant message contains multiple `<answer>` tags (e.g. draft then self-correction).
> 
> The chat-message path now calls **`parse(content, last=True)`**, same as the string branch, instead of returning the first `<answer>` in that message.
> 
> Adds tests covering both raw string and assistant-message list inputs for multiple answers in one message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ecba822d83fe22c6275320431f749397f164122. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `XMLParser.parse_answer` to select the last `<answer>` within a single chat message
> When `parse_answer` receives a list of messages, it previously extracted the first `<answer>` occurrence within an assistant message's content. It now passes `last=True` to the inner `parse` call in [xml_parser.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1575/files#diff-9d84a37e6e2c7b967b5444646178bb9003b4f2354a4ab7eb40dee867b7b51006), returning the last `<answer>` value instead. Behavioral Change: callers passing multi-turn message lists will now receive the last answer in a message rather than the first when a message contains multiple `<answer>` blocks.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4ecba82.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->