### PR TITLE
fix(v1): replace unreachable sandboxes

### DIFF
--- a/verifiers/utils/threaded_sandbox_client.py
+++ b/verifiers/utils/threaded_sandbox_client.py
@@ -5,7 +5,14 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Callable
 
-from prime_sandboxes import AsyncSandboxClient, CommandTimeoutError
+from prime_sandboxes import (
+    AsyncSandboxClient,
+    CommandTimeoutError,
+    SandboxImagePullError,
+    SandboxNotRunningError,
+    SandboxOOMError,
+    SandboxTimeoutError,
+)
 
 from verifiers.utils.thread_utils import (
     get_or_create_thread_attr,
@@ -22,6 +29,7 @@ class ThreadedAsyncSandboxClient:
     """
 
     DEFAULT_MAX_WORKERS = 50
+    READINESS_FAILURE_ATTEMPTS = 5
 
     def __init__(
         self,
@@ -74,6 +82,72 @@ class ThreadedAsyncSandboxClient:
             return await loop.run_in_executor(self.executor, run_in_thread)
 
         return wrapper
+
+    async def wait_for_creation_resilient(
+        self,
+        sandbox_id: str,
+        max_attempts: int = 60,
+        stability_checks: int = 1,
+    ) -> None:
+        """Wait for readiness without occupying one worker for the entire poll loop."""
+        consecutive_successes = 0
+        readiness_failures = 0
+        last_readiness_error: Exception | None = None
+        for attempt in range(max_attempts):
+            sandbox = await self.get(sandbox_id)
+            if sandbox.status == "RUNNING":
+                try:
+                    await self.execute_command(
+                        sandbox_id,
+                        "echo 'sandbox ready'",
+                        timeout=10,
+                    )
+                except Exception as exc:
+                    consecutive_successes = 0
+                    readiness_failures += 1
+                    last_readiness_error = exc
+                    if readiness_failures >= self.READINESS_FAILURE_ATTEMPTS:
+                        raise SandboxNotRunningError(
+                            sandbox_id,
+                            status="RUNNING",
+                            message=(
+                                f"Sandbox {sandbox_id} stayed unreachable after "
+                                f"{readiness_failures} readiness checks: {exc}"
+                            ),
+                        ) from exc
+                else:
+                    readiness_failures = 0
+                    consecutive_successes += 1
+                    if consecutive_successes >= stability_checks:
+                        return
+                    await asyncio.sleep(0.5)
+                    continue
+            elif sandbox.status in {"ERROR", "TERMINATED", "TIMEOUT"}:
+                error_type = sandbox.error_type
+                error_class = {
+                    "OOM_KILLED": SandboxOOMError,
+                    "TIMEOUT": SandboxTimeoutError,
+                    "IMAGE_PULL_FAILED": SandboxImagePullError,
+                }.get(error_type, SandboxNotRunningError)
+                message = (
+                    f"Sandbox {sandbox_id} failed ({error_type}): "
+                    f"{sandbox.error_message}"
+                    if sandbox.error_message
+                    else None
+                )
+                raise error_class(
+                    sandbox_id,
+                    status=sandbox.status,
+                    error_type=error_type,
+                    message=message,
+                )
+
+            await asyncio.sleep(1 if attempt < 5 else 2)
+
+        message = "Timeout during sandbox creation"
+        if last_readiness_error is not None:
+            message += f": {last_readiness_error}"
+        raise SandboxNotRunningError(sandbox_id, status=message)
 
     async def run_background_job(
         self,

--- a/verifiers/v1/utils/sandbox_utils.py
+++ b/verifiers/v1/utils/sandbox_utils.py
@@ -725,59 +725,82 @@ async def create_sandbox(
         else None,
         guaranteed=bool(sandbox_config.get("guaranteed", False)),
     )
-    create_task = asyncio.create_task(
-        with_sandbox_retry(lambda: client.create(request))
-    )
-    try:
-        create_waiter = asyncio.shield(create_task)
-        if sandbox_config.get("create_timeout") is not None:
-            sandbox = await asyncio.wait_for(
-                create_waiter, int_config(sandbox_config, "create_timeout", 0)
-            )
-        else:
-            sandbox = await create_waiter
-    except (asyncio.CancelledError, TimeoutError):
+    for readiness_attempt in range(SANDBOX_RETRY_ATTEMPTS):
+        create_task = asyncio.create_task(
+            with_sandbox_retry(lambda: client.create(request))
+        )
         try:
-            sandbox = cast(SandboxRecord, await asyncio.shield(create_task))
+            create_waiter = asyncio.shield(create_task)
+            if sandbox_config.get("create_timeout") is not None:
+                sandbox = await asyncio.wait_for(
+                    create_waiter, int_config(sandbox_config, "create_timeout", 0)
+                )
+            else:
+                sandbox = await create_waiter
+        except (asyncio.CancelledError, TimeoutError):
+            try:
+                sandbox = cast(SandboxRecord, await asyncio.shield(create_task))
+            except BaseException:
+                if owns_client:
+                    await close_sandbox_client(client)
+                raise
+            await asyncio.shield(
+                delete_sandbox_id(
+                    client,
+                    str(sandbox.id),
+                    close_client=owns_client,
+                    reason="cancelled creation",
+                )
+            )
+            raise
         except BaseException:
             if owns_client:
                 await close_sandbox_client(client)
             raise
-        await asyncio.shield(
-            delete_sandbox_id(
+        sandbox_id = str(sandbox.id)
+        try:
+            wait_for_creation = getattr(
                 client,
-                str(sandbox.id),
-                close_client=owns_client,
-                reason="cancelled creation",
+                "wait_for_creation_resilient",
+                client.wait_for_creation,
             )
-        )
-        raise
-    except BaseException:
-        if owns_client:
-            await close_sandbox_client(client)
-        raise
-    sandbox_id = str(sandbox.id)
-    try:
-        wait = client.wait_for_creation(
-            sandbox_id,
-            max_attempts=SANDBOX_WAIT_FOR_CREATION_ATTEMPTS,
-        )
-        if sandbox_config.get("wait_timeout") is not None:
-            await asyncio.wait_for(wait, int_config(sandbox_config, "wait_timeout", 0))
-        else:
-            await wait
-    except BaseException:
-        delete_task = asyncio.create_task(
-            delete_sandbox_id(
-                client,
+            wait = wait_for_creation(
                 sandbox_id,
-                close_client=owns_client,
-                reason="creation failure",
+                max_attempts=SANDBOX_WAIT_FOR_CREATION_ATTEMPTS,
             )
-        )
-        await asyncio.shield(delete_task)
-        raise
-    return sandbox_id
+            if sandbox_config.get("wait_timeout") is not None:
+                await asyncio.wait_for(
+                    wait, int_config(sandbox_config, "wait_timeout", 0)
+                )
+            else:
+                await wait
+        except BaseException as exc:
+            replace_sandbox = (
+                type(exc).__name__ == "SandboxNotRunningError"
+                and getattr(exc, "status", None) == "RUNNING"
+            )
+            final_attempt = readiness_attempt == SANDBOX_RETRY_ATTEMPTS - 1
+            await asyncio.shield(
+                delete_sandbox_id(
+                    client,
+                    sandbox_id,
+                    close_client=owns_client and (final_attempt or not replace_sandbox),
+                    reason="readiness failure",
+                )
+            )
+            if final_attempt or not replace_sandbox:
+                raise
+            logger.warning(
+                "Replacing unreachable sandbox %s after readiness failure: %s "
+                "(attempt %s/%s)",
+                sandbox_id,
+                exc,
+                readiness_attempt + 1,
+                SANDBOX_RETRY_ATTEMPTS,
+            )
+            continue
+        return sandbox_id
+    raise AssertionError("sandbox readiness retry loop exited without running")
 
 
 async def delete_sandbox_id(


### PR DESCRIPTION
## Summary
- add a V1-only readiness loop that does not hold a sandbox worker while polling
- preserve the underlying gateway error after repeated readiness failures
- delete and replace sandboxes that report `RUNNING` but remain unreachable
- leave the legacy sandbox wait path unchanged

## Why
V1 reuses one `ThreadedAsyncSandboxClient` per runtime. At eval concurrency 32, that client has four workers, while the SDK `wait_for_creation()` call occupies one worker for its entire poll loop. A sandbox with broken gateway routing can therefore pin 25% of the pool for 37-110 minutes.

The observed failures were control-plane `RUNNING` instances whose gateway exec path returned `503 upstream connect error`, `404 Process discovery failed`, or timed out. Increasing readiness attempts only extended the failure.

## Validation
- `ruff check` and `ruff format --check`
- `pytest -q tests/test_v1_runtime_lifecycle.py`
- `pytest -q tests/test_sandbox_mixin.py tests/test_cli_agent_env.py tests/test_sandbox_env.py`
- synthetic unreachable-sandbox replacement and error-preservation checks
- live `python:3.11-slim` sandbox creation/readiness/exec/delete smoke test

No docs or tests changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sandbox create/readiness and retry behavior on a shared threaded client; misclassification of readiness errors could delete healthy sandboxes or mask failures, but legacy wait paths are unchanged.
> 
> **Overview**
> Adds **`wait_for_creation_resilient`** on `ThreadedAsyncSandboxClient` so V1 readiness polling uses short `get` / `execute_command` calls on the asyncio side instead of blocking a thread-pool worker for the whole SDK `wait_for_creation` loop. While status is `RUNNING`, it probes with `echo 'sandbox ready'`, maps `ERROR` / `TERMINATED` / `TIMEOUT` to the appropriate `prime_sandboxes` errors, and after repeated exec failures raises **`SandboxNotRunningError` with `status="RUNNING"`** while keeping the underlying gateway error in the message.
> 
> **`create_sandbox`** in V1 now wraps create + wait in up to **`SANDBOX_RETRY_ATTEMPTS`** iterations: it prefers `wait_for_creation_resilient` when present (legacy clients still use `wait_for_creation`). On that “RUNNING but unreachable” error it deletes the bad sandbox, logs a warning, and creates a replacement; other readiness failures still delete and re-raise on the last attempt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad7f1fd6ec3e91ebc45bf092e771b944f7a75f12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Retry sandbox creation on unreachable sandboxes in `create_sandbox`
> - Adds a `wait_for_creation_resilient` method to [`ThreadedAsyncSandboxClient`](https://github.com/PrimeIntellect-ai/verifiers/pull/1578/files#diff-77ad5a110ce18dd8ece1ae9dd05c80ea7f2ade8393efb1806b0f94bc7d0e6154) that polls sandbox status and runs in-sandbox readiness checks, tracking consecutive successes and tolerating transient failures up to `READINESS_FAILURE_ATTEMPTS = 5`.
> - Reworks [`create_sandbox`](https://github.com/PrimeIntellect-ai/verifiers/pull/1578/files#diff-b1154f3be7f28191532de46fbe23a973a5f93e1450a71beb9c93910e358fda13) to retry provisioning up to `SANDBOX_RETRY_ATTEMPTS` times, preferring `wait_for_creation_resilient` when available.
> - When a sandbox reaches `RUNNING` status but fails readiness checks (`SandboxNotRunningError` with status `RUNNING`), it is deleted and replaced unless it is the final attempt.
> - Terminal sandbox failures (OOM, timeout, image pull errors) are mapped to specific exceptions and re-raised immediately without retrying.
> - Risk: `create_sandbox` may now raise different, more specific exceptions than before depending on how the sandbox fails.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized ad7f1fd. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->