### PR TITLE
Default OpenSeeker full dataset and use filter_fn row filters

### DIFF
--- a/verifiers/envs/experimental/composable/tasksets/search/README.md
+++ b/verifiers/envs/experimental/composable/tasksets/search/README.md
@@ -19,7 +19,10 @@ from verifiers.envs.experimental.composable.tasksets.search import make_search_t
 
 taskset = make_search_taskset(backend="openseeker")
 taskset = make_search_taskset(backend="quest", category="objective")
-redsearcher = make_search_taskset(backend="redsearcher", difficulty="easy")
+redsearcher = make_search_taskset(
+    backend="redsearcher",
+    filter_fn="lambda x: x['info']['difficulty'] == 'easy'",
+)
 ```
 
 `make_search_taskset()` dispatches by backend name. Unknown backends raise `ValueError` with the available backend list.

--- a/verifiers/envs/experimental/composable/tasksets/search/openseeker/README.md
+++ b/verifiers/envs/experimental/composable/tasksets/search/openseeker/README.md
@@ -4,6 +4,10 @@ Composable search taskset for [`PolarSeeker/OpenSeeker-v1-Data`](https://hugging
 
 OpenSeeker v1 data contains synthesized deep-search QA pairs plus trajectories generated with `search` and `visit` tools. The public OpenSeeker evaluator scores only the final answer: it sends the question, gold answer, and model response to an LLM judge and expects `A` for correct or `B` for incorrect. This backend preserves that binary semantic answer-judge contract.
 
+By default, the taskset uses the full dataset. The `trajectory_correctness`
+argument filters the quality label of the stored OpenSeeker source trajectory,
+not the validity of the question or gold answer.
+
 ## Usage
 
 ```python
@@ -18,7 +22,7 @@ taskset = make_search_taskset(backend="openseeker")
 |---|---:|---|
 | `dataset_name` | `PolarSeeker/OpenSeeker-v1-Data` | Hugging Face dataset name. |
 | `split` | `train` | Dataset split. |
-| `trajectory_correctness` | `Correct` | Keep rows with this trajectory label. Use `None` or `all` for all rows. |
+| `trajectory_correctness` | `None` | Keep rows with this source trajectory label. Use `None` or `all` for all rows. |
 | `min_tool_calls` | `None` | Optional lower bound for `number of tool calls`. |
 | `max_tool_calls` | `None` | Optional upper bound for `number of tool calls`. |
 | `include_trajectory` | `False` | Include the large source trajectory in task metadata. |

--- a/verifiers/envs/experimental/composable/tasksets/search/openseeker/README.md
+++ b/verifiers/envs/experimental/composable/tasksets/search/openseeker/README.md
@@ -4,9 +4,10 @@ Composable search taskset for [`PolarSeeker/OpenSeeker-v1-Data`](https://hugging
 
 OpenSeeker v1 data contains synthesized deep-search QA pairs plus trajectories generated with `search` and `visit` tools. The public OpenSeeker evaluator scores only the final answer: it sends the question, gold answer, and model response to an LLM judge and expects `A` for correct or `B` for incorrect. This backend preserves that binary semantic answer-judge contract.
 
-By default, the taskset uses the full dataset. The `trajectory_correctness`
-argument filters the quality label of the stored OpenSeeker source trajectory,
-not the validity of the question or gold answer.
+By default, the taskset uses the full dataset. Use the shared `filter_fn`
+argument for row subsets such as source trajectory quality or tool-call count.
+The `trajectory_correctness` metadata describes the stored OpenSeeker source
+trajectory, not the validity of the question or gold answer.
 
 ## Usage
 
@@ -14,6 +15,16 @@ not the validity of the question or gold answer.
 from verifiers.envs.experimental.composable.tasksets.search import make_search_taskset
 
 taskset = make_search_taskset(backend="openseeker")
+
+correct_source_trajectories = make_search_taskset(
+    backend="openseeker",
+    filter_fn="lambda x: x['info']['trajectory_correctness'] == 'Correct'",
+)
+
+shorter_source_trajectories = make_search_taskset(
+    backend="openseeker",
+    filter_fn="lambda x: (x['info']['number_of_tool_calls'] or 0) <= 20",
+)
 ```
 
 ## Arguments
@@ -22,9 +33,7 @@ taskset = make_search_taskset(backend="openseeker")
 |---|---:|---|
 | `dataset_name` | `PolarSeeker/OpenSeeker-v1-Data` | Hugging Face dataset name. |
 | `split` | `train` | Dataset split. |
-| `trajectory_correctness` | `None` | Keep rows with this source trajectory label. Use `None` or `all` for all rows. |
-| `min_tool_calls` | `None` | Optional lower bound for `number of tool calls`. |
-| `max_tool_calls` | `None` | Optional upper bound for `number of tool calls`. |
+| `filter_fn` | `None` | Optional composable taskset filter over normalized rows. |
 | `include_trajectory` | `False` | Include the large source trajectory in task metadata. |
 | `answer_file` | `/task/answer.txt` | Final answer path in the sandbox. |
 | `judge_model` | `openai/gpt-5.4-mini` | OpenAI-compatible model used for binary answer judging. |

--- a/verifiers/envs/experimental/composable/tasksets/search/openseeker/taskset.py
+++ b/verifiers/envs/experimental/composable/tasksets/search/openseeker/taskset.py
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_DATASET_NAME = "PolarSeeker/OpenSeeker-v1-Data"
 DEFAULT_SPLIT = "train"
-DEFAULT_TRAJECTORY_CORRECTNESS = "Correct"
+DEFAULT_TRAJECTORY_CORRECTNESS = None
 DEFAULT_ANSWER_FILE = "/task/answer.txt"
 DEFAULT_WORKDIR = "/workspace"
 DEFAULT_JUDGE_BASE_URL = "https://api.pinference.ai/api/v1"

--- a/verifiers/envs/experimental/composable/tasksets/search/openseeker/taskset.py
+++ b/verifiers/envs/experimental/composable/tasksets/search/openseeker/taskset.py
@@ -40,7 +40,6 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_DATASET_NAME = "PolarSeeker/OpenSeeker-v1-Data"
 DEFAULT_SPLIT = "train"
-DEFAULT_TRAJECTORY_CORRECTNESS = None
 DEFAULT_ANSWER_FILE = "/task/answer.txt"
 DEFAULT_WORKDIR = "/workspace"
 DEFAULT_JUDGE_BASE_URL = "https://api.pinference.ai/api/v1"
@@ -281,9 +280,6 @@ class OpenSeekerTaskSet(SandboxTaskSet):
         self,
         dataset_name: str = DEFAULT_DATASET_NAME,
         split: str = DEFAULT_SPLIT,
-        trajectory_correctness: str | None = DEFAULT_TRAJECTORY_CORRECTNESS,
-        min_tool_calls: int | None = None,
-        max_tool_calls: int | None = None,
         include_trajectory: bool = False,
         filter_fn: str | None = None,
         ds_keep_in_memory: bool | None = False,
@@ -299,27 +295,8 @@ class OpenSeekerTaskSet(SandboxTaskSet):
         judge_api_key_var: str = DEFAULT_JUDGE_API_KEY_VAR,
         judge_sampling_args: dict[str, Any] | None = None,
     ) -> None:
-        if trajectory_correctness == "all":
-            trajectory_correctness = None
-        if trajectory_correctness not in {"Correct", "Incorrect", None}:
-            raise ValueError(
-                "trajectory_correctness must be 'Correct', 'Incorrect', 'all', or None"
-            )
-        if min_tool_calls is not None and min_tool_calls < 0:
-            raise ValueError("min_tool_calls must be non-negative")
-        if max_tool_calls is not None and max_tool_calls < 0:
-            raise ValueError("max_tool_calls must be non-negative")
-        if (
-            min_tool_calls is not None
-            and max_tool_calls is not None
-            and min_tool_calls > max_tool_calls
-        ):
-            raise ValueError("min_tool_calls cannot exceed max_tool_calls")
         self.dataset_name = dataset_name
         self.split = split
-        self.trajectory_correctness = trajectory_correctness
-        self.min_tool_calls = min_tool_calls
-        self.max_tool_calls = max_tool_calls
         self.include_trajectory = include_trajectory
         self.ds_keep_in_memory = ds_keep_in_memory
         self.ds_num_proc = ds_num_proc
@@ -335,12 +312,9 @@ class OpenSeekerTaskSet(SandboxTaskSet):
         self._judge_base_url = judge_base_url
         self._judge_api_key_var = judge_api_key_var
         self._judge_sampling_args = dict(judge_sampling_args or {})
-        name_parts = ["search", "openseeker"]
-        if trajectory_correctness is not None:
-            name_parts.append(trajectory_correctness.lower())
         super().__init__(
             dataset=self._build_dataset,
-            name="/".join(name_parts),
+            name="search/openseeker",
             filter_fn=filter_fn,
         )
 
@@ -364,22 +338,9 @@ class OpenSeekerTaskSet(SandboxTaskSet):
         rows: list[dict[str, Any]] = []
         for row_index, row in enumerate(raw):
             correctness = row.get("trajectory correctness")
-            if (
-                self.trajectory_correctness is not None
-                and correctness != self.trajectory_correctness
-            ):
-                continue
             tool_calls = row.get("number of tool calls")
             if not isinstance(tool_calls, int):
                 tool_calls = None
-            if self.min_tool_calls is not None and (
-                tool_calls is None or tool_calls < self.min_tool_calls
-            ):
-                continue
-            if self.max_tool_calls is not None and (
-                tool_calls is None or tool_calls > self.max_tool_calls
-            ):
-                continue
             question = str(row.get("question") or "").strip()
             answer = str(row.get("answer") or "").strip()
             if not question or not answer:

--- a/verifiers/envs/experimental/composable/tasksets/search/redsearcher/README.md
+++ b/verifiers/envs/experimental/composable/tasksets/search/redsearcher/README.md
@@ -29,7 +29,7 @@ A reward of `1.0` means the final response matched the ground-truth answer; `0.0
 |---|---:|---|
 | `dataset_name` | `Zchu/REDSearcher_RL_1K` | Hugging Face dataset name. |
 | `split` | `train` | Dataset split. |
-| `difficulty` | `None` | Optional difficulty filter: `easy`, `medium`, `hard`, or `all`. |
+| `filter_fn` | `None` | Optional composable taskset filter over normalized rows, for example `lambda x: x['info']['difficulty'] == 'easy'`. |
 | `answer_file` | `/task/answer.txt` | Final answer path in the sandbox. |
 | `judge_model` | `openai/gpt-5.4-mini` | OpenAI-compatible model for answer-match judging. |
 | `judge_base_url` | `https://api.pinference.ai/api/v1` | Judge API base URL. |

--- a/verifiers/envs/experimental/composable/tasksets/search/redsearcher/taskset.py
+++ b/verifiers/envs/experimental/composable/tasksets/search/redsearcher/taskset.py
@@ -225,7 +225,6 @@ class RedSearcherTaskSet(SandboxTaskSet):
         self,
         dataset_name: str = DEFAULT_DATASET_NAME,
         split: str = DEFAULT_SPLIT,
-        difficulty: str | None = None,
         filter_fn: str | None = None,
         ds_keep_in_memory: bool | None = True,
         ds_num_proc: int | None = None,
@@ -242,13 +241,8 @@ class RedSearcherTaskSet(SandboxTaskSet):
         judge_max_retries: int = 5,
         use_exact_match_shortcut: bool = True,
     ) -> None:
-        if difficulty not in {None, "all", "easy", "medium", "hard"}:
-            raise ValueError(
-                "difficulty must be one of None, 'all', 'easy', 'medium', or 'hard'"
-            )
         self.dataset_name = dataset_name
         self.split = split
-        self.difficulty = difficulty
         self.ds_keep_in_memory = ds_keep_in_memory
         self.ds_num_proc = ds_num_proc
         self.answer_file = answer_file
@@ -265,10 +259,9 @@ class RedSearcherTaskSet(SandboxTaskSet):
         self._judge_sampling_args = dict(judge_sampling_args or {})
         self._judge_max_retries = judge_max_retries
         self._use_exact_match_shortcut = use_exact_match_shortcut
-        label = difficulty or "all"
         super().__init__(
             dataset=self._build_dataset,
-            name=f"search/redsearcher/{label}",
+            name="search/redsearcher",
             filter_fn=filter_fn,
         )
 
@@ -282,8 +275,6 @@ class RedSearcherTaskSet(SandboxTaskSet):
         rows: list[dict[str, Any]] = []
         for idx, row in enumerate(raw):
             difficulty = str(row.get("difficulty") or "")
-            if self.difficulty not in {None, "all"} and difficulty != self.difficulty:
-                continue
             question = str(row.get("problem") or "").strip()
             answer = str(row.get("answer") or "").strip()
             if not question or not answer:


### PR DESCRIPTION
## Summary
- default OpenSeeker to the full `PolarSeeker/OpenSeeker-v1-Data` dataset
- remove OpenSeeker row-filter kwargs (`trajectory_correctness`, `min_tool_calls`, `max_tool_calls`) in favor of the shared composable `filter_fn`
- remove REDSearcher `difficulty` as a constructor filter and document the equivalent `filter_fn` usage
- keep OpenSeeker trajectory quality/tool-call metadata and REDSearcher difficulty in `info` so filters remain expressible

## Validation
- `uv run python - <<'PY' ...` in the verifiers worktree: OpenSeeker full dataset `11677`, OpenSeeker Correct filter `4949`, OpenSeeker `<=20` tool-call filter `3442`, REDSearcher full dataset `1000`, REDSearcher easy filter `168`
- `uv run ruff check verifiers/envs/experimental/composable/tasksets/search/openseeker/taskset.py verifiers/envs/experimental/composable/tasksets/search/redsearcher/taskset.py`
- commit/push hooks passed: `ruff check`, `ruff format`, Semgrep v1 policy, and `ty` during push

## Companion PR
- `rlm_search` wrapper cleanup: https://github.com/PrimeIntellect-ai/research-environments/pull/507

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default OpenSeeker and RedSearcher tasksets to full datasets and replace built-in filters with `filter_fn`
> - Removes `trajectory_correctness`, `min_tool_calls`, and `max_tool_calls` from `OpenSeekerTaskSet` and `difficulty` from `RedSearcherTaskSet`; both tasksets now load all rows by default.
> - Replaces built-in filtering with a shared `filter_fn` argument passed through to the base `SandboxTaskSet`, letting callers supply a predicate (e.g. `lambda row: row['info']['difficulty'] == 'hard'`).
> - Taskset names no longer include a correctness or difficulty suffix — both are always named `search/openseeker` and `search/redsearcher`.
> - READMEs are updated with `filter_fn` usage examples.
> - Risk: passing the removed arguments (`trajectory_correctness`, `min_tool_calls`, `max_tool_calls`, `difficulty`) to the constructors will now raise an error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ceb6306.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->