### PR TITLE
Match REDSearcher released judge prompt

### DIFF
--- a/verifiers/envs/experimental/composable/tasksets/search/redsearcher/README.md
+++ b/verifiers/envs/experimental/composable/tasksets/search/redsearcher/README.md
@@ -19,7 +19,7 @@ The paired `rlm_search` environment prompts RLM to write this file and provides 
 
 ## Scoring
 
-`RedSearcherRubric` compares the final response against the released `answer` label. It first applies a strict normalized exact-answer shortcut for unambiguous matches. Otherwise it uses an OpenAI-compatible LLM-as-judge prompt that follows the answer-matching convention in REDSearcher's DeepTraceHub evaluation code: judge whether the predicted final answer is equivalent to the ground truth and return binary accuracy.
+`RedSearcherRubric` compares the final response against the released `answer` label. It first applies a strict normalized exact-answer shortcut for unambiguous matches. Otherwise it uses an OpenAI-compatible LLM-as-judge prompt that matches REDSearcher's released DeepTraceHub BROWSECOMP evaluator prompt and returns binary accuracy.
 
 A reward of `1.0` means the final response matched the ground-truth answer; `0.0` means it did not, or no final answer was produced. Judge provider failures are preserved as `vf.Error` values on `state["error"]`.
 

--- a/verifiers/envs/experimental/composable/tasksets/search/redsearcher/taskset.py
+++ b/verifiers/envs/experimental/composable/tasksets/search/redsearcher/taskset.py
@@ -47,28 +47,75 @@ DEFAULT_JUDGE_API_KEY_VAR = "PRIME_API_KEY"
 DEFAULT_JUDGE_MODEL = "openai/gpt-5.4-mini"
 DEFAULT_SANDBOX_IMAGE = "python:3.11-slim"
 
+# Matches DeepTraceHub's released BROWSECOMP judge prompt, the closest public
+# reference for REDSearcher's RL reward while the RL trainer remains unreleased.
 _JUDGE_PROMPT = """\
-You are grading a deep-search question answering response.
+Based on the given question, standard answer, and model-predicted answer, evaluate whether the model's response is correct. Your task is to classify the result as: [CORRECT] or [INCORRECT].
 
-Decide whether the predicted response gives the same final answer as the
-ground-truth answer. Ignore citations, formatting, capitalization, and extra
-explanation unless they contradict the final answer. For numeric answers,
-allow insignificant formatting differences but not a different value. If the
-response gives multiple incompatible answers, is evasive, or merely repeats
-the question, mark it incorrect.
+First, we'll list examples for each category, then you'll evaluate a new question's predicted answer.
+Here are examples of [CORRECT] responses:
+```
+Question: What are the names of Barack Obama's children?
+Standard Answer: Malia Obama and Sasha Obama
+Model Prediction 1: Malia Obama and Sasha Obama
+Model Prediction 2: Malia and Sasha
+Model Prediction 3: Most would say Malia and Sasha, but I'm not sure, I should verify
+Model Prediction 4: Barack Obama has two daughters, Malia Ann and Natasha Marian, commonly known as Malia Obama and Sasha Obama.
+```
+These responses are all [CORRECT] because they:
+    - Fully include the important information from the standard answer.
+    - Don't contain any information that contradicts the standard answer.
+    - Focus only on semantic content; language, capitalization, punctuation, grammar, and order aren't important.
+    - Vague statements or guesses are acceptable as long as they include the standard answer and don't contain incorrect information or contradictions.
 
-Question:
-{question}
+Here are examples of [INCORRECT] responses:
+```
+Question: What are the names of Barack Obama's children?
+Standard Answer: Malia Obama and Sasha Obama
+Model Prediction 1: Malia
+Model Prediction 2: Malia, Sasha and Susan or Sasha Obama or Malia Obama, or Natasha Marian, or Einstein
+Model Prediction 3: While I don't know their exact names, I can tell you Barack Obama has two children.
+Model Prediction 4: You might be thinking of Betsy and Olivia. But you should verify the details with the latest references. Is that the correct answer?
+Model Prediction 5: Barack Obama's children
+```
+These responses are all [INCORRECT] because they:
+    - Contain factual statements that contradict the standard answer.
+    - Are empty or merely repeat the question.
+    - Enumerate multiple answers or repeat the answer.
 
-Ground-truth answer:
-{answer}
+Pay special attention to the following:
+- The standard answer may contain responses to multiple aspects of the question, and within the same aspect, there might be different descriptions, all of which are correct and are given in the same bracket, connected by commas. For example, for the question "What is the name of ByteDance's AI model?", the standard answer is "[[Doubao, Skylark]]":
+    - Predicted answers "Doubao", "Doubao, Skylark", "Skylark", etc. are all [CORRECT].
+- For standard answers containing responses to different aspects, the model needs to provide answers to all aspects to be considered correct; otherwise, it's directly judged as [INCORRECT]. There is no [PARTIALLY CORRECT] output option. These answers will be given in different brackets. For example, for the question "Who are the members of TFBOYS?", the standard answer is "[[Wang Junkai][Wang Yuan][Yi Yangqianxi]]":
+    - Predicted answers like "Wang Junkai, Wang Yuan, Yi Yangqianxi" that include all answers are [CORRECT].
+    - Predicted answers like "Wang Junkai, Yi Yangqianxi" that don't include all answers are [INCORRECT].
 
-Predicted response:
-{response}
+Also note the following points:
+- For questions with numerical standard answers, the predicted answer should match the standard answer. For example, for the question "What is the total length in meters of the Huangpu River Bridge on the Jinshan Railway?", the standard answer is "3518.17":
+    - Predicted answers "3518", "3518.1", "3518.17" are all [CORRECT].
+    - Predicted answers "3520" and "3600" are [INCORRECT].
+- If the model prediction doesn't directly answer the question, attempts to circumvent or fails to directly provide the standard answer, it's considered an [INCORRECT] answer.
+    - For example, for the question "Who is JJ Lin's wife?", with the standard answer "Ding Wenqi", model predictions like "JJ Lin's wife", "JJ Lin's wife should be excellent", "JJ Lin's wife might be a public figure" are all [INCORRECT].
+- If the standard answer contains more information than the question asks for, the predicted answer only needs to include the information mentioned in the question.
+    - For example, for the question "What is the main chemical component of magnesite?", with the standard answer "Magnesium carbonate (MgCO3)", "Magnesium carbonate" or "MgCO3" are both considered [CORRECT] answers.
+- If information omitted in the predicted answer can be clearly inferred from the question, it's considered correct.
+    - For example, for the question "The Nuragic ruins of Barumini were listed as a World Cultural Heritage by UNESCO in 1997, so where is this site located?", with the standard answer "Sardinia, Italy", the predicted answer "Sardinia" is considered [CORRECT].
+- If it's clear that different translations of a name refer to the same person, it's considered correct.
+    - For example, if the standard answer is "Robinson", answers like "Lubinson" or "Lubinsun" are both correct.
+- You should focus more on the match between the standard answer and the model prediction, rather than whether the standard answer itself is correct.
 
-Return only one letter:
-A. CORRECT
-B. INCORRECT
+Below is a new question example. Please reply with only [CORRECT] or [INCORRECT], without apologies or corrections to your own errors, just evaluate the answer.
+```
+Question: {question}
+Standard Answer: {correct_answer}
+Predicted Answer: {response}
+```
+
+Evaluate this new question's predicted answer as one of the following:
+A. [CORRECT]
+B. [INCORRECT]
+
+Return only the option representing [CORRECT] or [INCORRECT], i.e. just return A or B, without adding any other text.
 """
 
 _CONTEXT_LENGTH_ERROR_PHRASES = (
@@ -475,7 +522,7 @@ class RedSearcherRubric(vf.Rubric):
         prompt = _JUDGE_PROMPT.format(
             question=question,
             response=response,
-            answer=answer,
+            correct_answer=answer,
         )
         client = self._get_client()
         request_kwargs = dict(self.judge_sampling_args)


### PR DESCRIPTION
## Summary
- replace the REDSearcher rubric judge prompt with the released DeepTraceHub BROWSECOMP evaluator prompt
- format the judge prompt with the upstream `correct_answer` placeholder
- update the REDSearcher taskset README to describe the released evaluator prompt match

## Rationale
The REDSearcher RL trainer is still unreleased, but the paper says RL uses binary LLM-as-judge rewards and DeepTraceHub is the public evaluator implementation. This makes the Verifiers port match the closest public prompt reference without claiming access to the private trainer.

Upstream reference: https://github.com/RedSearchAgent/DeepTraceHub/blob/a5bafdd1a4a256d93732d09762e5a89ebc368764/prompt/system_prompt.py#L102-L169

## Validation
- `uv run ruff check verifiers/envs/experimental/composable/tasksets/search/redsearcher/taskset.py verifiers/envs/experimental/composable/tasksets/search/redsearcher/README.md`
- `uv run ruff format --check verifiers/envs/experimental/composable/tasksets/search/redsearcher/taskset.py`
- prompt smoke check for formatting and A/B parser outputs
- equality check against DeepTraceHub `LLM_AS_JUDGE_BROWSECOMP_TONGYI_EN_PROMPT`
- commit/push hooks: ruff, Semgrep, ty

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes LLM judge instructions for binary rewards, which can shift scores versus the old prompt even though parsing and infra paths are unchanged.
> 
> **Overview**
> Aligns **REDSearcher** LLM-as-judge scoring with the **public DeepTraceHub BROWSECOMP** evaluator instead of a short custom prompt.
> 
> In `taskset.py`, `_JUDGE_PROMPT` is replaced with the released BROWSECOMP template (few-shot [CORRECT]/[INCORRECT] rules, multi-aspect and numeric guidance) and `_judge_answer` now fills `{correct_answer}` rather than `{answer}`. The README scoring section states the rubric uses that released prompt; exact-match shortcut and A/B parsing are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d455a35587ef17678a9bf80b3c791c2a3b19707. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Match `_JUDGE_PROMPT` in REDSearcher to DeepTraceHub's released BROWSECOMP evaluator prompt
> - Replaces the concise grading prompt in [taskset.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1581/files#diff-5596c82525b54a78fd198cddee238cba2e3c76446481b112ba9e657b27693e5a) with an expanded BROWSECOMP-aligned prompt that includes example CORRECT/INCORRECT cases, multi-aspect and alternative-answer rules, and numeric tolerance handling.
> - Changes the expected judge response format from a text label to a single letter `A` (CORRECT) or `B` (INCORRECT).
> - Fixes a `KeyError` in `RedSearcherRubric.answer_reward` by renaming the format kwarg from `answer=` to `correct_answer=` to match the new `{correct_answer}` placeholder.
> - Behavioral Change: judgement outcomes may differ from the prior prompt due to the new prompt's stricter semantic matching rules and changed response format.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2d455a3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->