### PR TITLE
Add v1 tunnel labels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "nest-asyncio>=1.6.0", # for jupyter notebooks
     "openai>=1.108.1",
     "openai-agents>=0.0.7",
-    "prime-tunnel>=0.1.6",
+    "prime-tunnel>=0.1.8",
     "prime-sandboxes>=0.2.25",
     "pydantic>=2.11.9",
     "requests",

--- a/uv.lock
+++ b/uv.lock
@@ -5155,16 +5155,16 @@ wheels = [
 
 [[package]]
 name = "prime-tunnel"
-version = "0.1.6"
+version = "0.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
     { name = "tenacity" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/e8/fec186cfbcc670deed94a7b5ace67688feed38b114b1c602d35a8f8d7564/prime_tunnel-0.1.6.tar.gz", hash = "sha256:5e371bc3557d8a5257a43ef1aeea1f8918da966a8565dacd33a647b6c82a0eaa", size = 13019, upload-time = "2026-04-13T15:13:17.24Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/e7/557c7623bd8c9a7a9127d880dce2a3d8612d3a7df02bdde6f01c958a20b8/prime_tunnel-0.1.8.tar.gz", hash = "sha256:07803d5d5c6ec83c260bbef0ecd340f4f6acab0f6a254d5d34a4c6ddfc777c0b", size = 14576, upload-time = "2026-06-02T06:39:36.56Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/35/adfac88e5880418f095758729b73e395c81be869d0be786fcd4b31938b2f/prime_tunnel-0.1.6-py3-none-any.whl", hash = "sha256:bc096bca509621379f671e2401253ab2ebe6c8c143d797b6ef85d8290c462e0d", size = 14914, upload-time = "2026-04-13T15:13:16.08Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/5f/181fe0ca1ca8507c0a373e55363b411bdeab9ad904c68edec7d7b1bdea74/prime_tunnel-0.1.8-py3-none-any.whl", hash = "sha256:fab081f566e0887ce50c7b5872169e9f356fc3263d5f0493cfabb3150eb73b0a", size = 15843, upload-time = "2026-06-02T06:39:34.043Z" },
 ]
 
 [[package]]
@@ -8007,7 +8007,7 @@ requires-dist = [
     { name = "pillow" },
     { name = "prime-pydantic-config", extras = ["toml"] },
     { name = "prime-sandboxes", specifier = ">=0.2.25" },
-    { name = "prime-tunnel", specifier = ">=0.1.6" },
+    { name = "prime-tunnel", specifier = ">=0.1.8" },
     { name = "pydantic", specifier = ">=2.11.9" },
     { name = "pymupdf" },
     { name = "python-dotenv", marker = "extra == 'browser'", specifier = ">=1.0.0" },

--- a/verifiers/v1/harness.py
+++ b/verifiers/v1/harness.py
@@ -236,8 +236,10 @@ class Harness(RuntimeOwnerMixin[ConfigT], Generic[ConfigT]):
         return config
 
     def load_endpoint(self) -> Endpoint:
+        sandbox_config = self.program_sandbox_config(self.program_config)
         return Endpoint(
-            use_tunnel=self.program_sandbox_config(self.program_config) is not None
+            use_tunnel=sandbox_config is not None,
+            tunnel_labels=sandbox_config.labels if sandbox_config is not None else None,
         )
 
     def rebuild_runtime(self) -> None:

--- a/verifiers/v1/utils/endpoint_utils.py
+++ b/verifiers/v1/utils/endpoint_utils.py
@@ -146,6 +146,7 @@ class Endpoint:
         secret: str | None = None,
         use_tunnel: bool = False,
         logger: logging.Logger | None = None,
+        tunnel_labels: list[str] | None = None,
     ):
         self.use_tunnel = use_tunnel
         self.logger = logger or logging.getLogger(__name__)
@@ -154,6 +155,7 @@ class Endpoint:
             secret=secret or os.environ.get("ENDPOINT_SECRET"),
         )
         self.secret = self.server.secret
+        self.tunnel_labels = list(tunnel_labels) if tunnel_labels else []
         self._tunnel: TunnelHandle | None = None
         self._tunnel_lock = asyncio.Lock()
         self._tunnel_last_checked = 0.0
@@ -295,7 +297,10 @@ class Endpoint:
                         self._tunnel = None
 
             if self._tunnel is None:
-                tunnel = cast(TunnelHandle, Tunnel(local_port=self.server.port))
+                tunnel = cast(
+                    TunnelHandle,
+                    Tunnel(local_port=self.server.port, labels=self.tunnel_labels),
+                )
                 url = await tunnel.start()
                 self._tunnel = tunnel
                 self._tunnel_last_checked = time.time()


### PR DESCRIPTION
## Summary
- add a `tunnel_labels` arg to the v1 `Endpoint`, forwarded to `prime_tunnel.Tunnel(labels=...)`
- `Harness.load_endpoint` threads the program's resolved `SandboxConfig.labels` into the `Endpoint`, so a harness tunnel inherits the same labels as the sandbox it bridges
- bump `prime-tunnel>=0.1.8` (the version that added the `labels` arg)

## Why
#1476 made sandboxes taggable + bulk-stoppable by label (`SandboxConfig.labels` -> `CreateSandboxRequest`). The tunnel each sandboxed rollout opens went out unlabeled, so long-lived or orphaned tunnels can't be filtered or bulk-deleted by run (`prime_tunnel` supports `bulk_delete_tunnels(labels=...)`). The tunnel exists only to bridge the sandboxed program back to the host, so it inherits the sandbox's labels — the natural mirror of #1476, with no new config surface.

## Mirror of #1476
| sandbox (#1476) | tunnel (this PR) |
| --- | --- |
| `SandboxConfig.labels` | reused — tunnel inherits it |
| `create_sandbox` reads `sandbox_config.get("labels")` -> `CreateSandboxRequest(labels=...)` | `load_endpoint` reads `sandbox_config.labels` -> `Endpoint(tunnel_labels=...)` -> `Tunnel(labels=...)` |

Backward compatible: default is `[]`, so behavior is unchanged when unset.

## Dependency bump
`labels` landed in `prime_tunnel` 0.1.8 (absent in 0.1.6/0.1.7), so the floor moves `>=0.1.6` -> `>=0.1.8`. Compatible: 0.1.8 keeps `Requires-Python >=3.10` and the same `httpx`/`pydantic`/`tenacity` floors as 0.1.6, adds no new deps, and nothing in the ecosystem caps prime-tunnel (prime / prime-rl pin `>=0.1.6`).

## Checks
- `ruff check` / `ruff format --check` on the touched files — clean
- `ty check verifiers` — passes
- existing endpoint tests still pass (`pytest tests/test_v1_endpoint_protocols.py`)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add tunnel labels support to v1 `Endpoint`
> - Adds an optional `tunnel_labels` parameter to [`Endpoint.__init__`](https://github.com/PrimeIntellect-ai/verifiers/pull/1584/files#diff-a70063758e2336829655d3b4801af8a67bd77ded23d6e95bc1beb922a56c4ca8), storing the labels as a list on the instance.
> - Passes `labels=self.tunnel_labels` when creating a `Tunnel` in `Endpoint.register_rollout`.
> - Updates [`Harness.load_endpoint`](https://github.com/PrimeIntellect-ai/verifiers/pull/1584/files#diff-05e981bb3680a934fbc6865d9dff3b25fc692d0c9970684bf8d41f4aea7ee384) to extract labels from `sandbox_config.labels` and forward them to `Endpoint`.
> - Bumps the `prime-tunnel` dependency constraint from `>=0.1.6` to `>=0.1.8` to support the new labels argument.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f22bc9b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->