### PR TITLE
feat: parse vLLM token ids + logprobs in the chat client

### DIFF
--- a/verifiers/v1/clients/openai.py
+++ b/verifiers/v1/clients/openai.py
@@ -1,9 +1,11 @@
 """OpenAI-compatible chat-completions client.
 
 Distilled from v1's 545-line client: message<->wire translation, tool schemas,
-best-effort reasoning_content. Token-id/logprob/routed-experts/audio handling is
-dropped (training-only). This is the one place raw provider dicts cross into our
-typed `Response`.
+best-effort reasoning_content. Sampling args pass straight through; when the
+response carries vLLM's token ids + sampling logprobs (the caller asked for
+`logprobs` and `return_token_ids`), we parse them into the response's `tokens`
+so MITO training needs no renderer. Routed-experts/audio handling stays dropped.
+This is the one place raw provider dicts cross into our typed `Response`.
 """
 
 from openai import AsyncOpenAI, OpenAIError
@@ -19,6 +21,7 @@ from verifiers.v1.types import (
     SamplingConfig,
     Tool,
     ToolCall,
+    TurnTokens,
     Usage,
 )
 
@@ -58,6 +61,25 @@ def tool_to_wire(tool: Tool) -> dict:
     return {"type": "function", "function": function}
 
 
+def tokens_from_wire(completion, choice) -> TurnTokens | None:
+    """Parse vLLM's token ids + sampling logprobs into `TurnTokens`, for training.
+
+    vLLM surfaces the completion ids on the choice (`return_token_ids`), the prompt
+    ids on the completion, and the sampled logprobs as one `logprobs.content` entry
+    per generated token (`logprobs=True`). All are absent on providers that don't
+    return them, so this is best-effort: no completion ids means no `tokens`.
+    """
+    completion_ids = getattr(choice, "token_ids", None)
+    if not completion_ids:
+        return None
+    content = choice.logprobs.content if choice.logprobs else None
+    return TurnTokens(
+        prompt_ids=list(getattr(completion, "prompt_token_ids", None) or []),
+        completion_ids=list(completion_ids),
+        completion_logprobs=[lp.logprob for lp in content] if content else [],
+    )
+
+
 def response_from_wire(completion) -> Response:
     choice = completion.choices[0]
     message = choice.message
@@ -87,6 +109,7 @@ def response_from_wire(completion) -> Response:
         ),
         finish_reason=finish,
         usage=usage,
+        tokens=tokens_from_wire(completion, choice),
     )
 
 

--- a/verifiers/v1/types.py
+++ b/verifiers/v1/types.py
@@ -97,8 +97,9 @@ class Usage(StrictBaseModel):
 
 
 class TurnTokens(StrictBaseModel):
-    """Token ids + sampling logprobs for one response, for training. Populated only
-    by the renderer client (which tokenizes client-side); None otherwise."""
+    """Token ids + sampling logprobs for one response, for training. Populated by the
+    renderer client (client-side tokenization) or the chat client (parsed from vLLM's
+    token ids); None when the provider returns neither."""
 
     prompt_ids: list[int] = Field(default_factory=list)
     completion_ids: list[int] = Field(default_factory=list)
@@ -115,7 +116,7 @@ class Response(StrictBaseModel):
     finish_reason: FinishReason
     usage: Usage | None = None
     tokens: TurnTokens | None = None
-    """Client-side token ids + logprobs (renderer client only)."""
+    """Token ids + logprobs for training (renderer client, or chat client via vLLM)."""
 
 
 # --- sampling -----------------------------------------------------------------


### PR DESCRIPTION
## Summary

- The `openai_chat_completions` client now best-effort parses the prompt/completion token ids and sampling logprobs that vLLM returns (`return_token_ids` + `logprobs`) into `Response.tokens`.
- This lets **MITO training (no renderer)** train on real on-policy tokens instead of re-tokenizing messages downstream — the chat client now carries `TurnTokens` just like the renderer client does.
- New `tokens_from_wire(completion, choice)`: reads `choice.token_ids` (completion ids), `completion.prompt_token_ids` (prompt ids), and one `logprobs.content[i].logprob` per generated token.
- Pure pass-through on the request side: sampling args are forwarded unchanged (the caller, e.g. prime-rl, opts in by sending `logprobs` + `return_token_ids`). `tokens` stays `None` when the provider returns neither (eval, non-vLLM providers).
- Doc fixes on `TurnTokens` / `Response.tokens` to reflect that the chat client can populate them too.

Base is the `feat/nano-as-v1` vf branch.

## Verification

Confirmed end-to-end against a running vLLM server:
- Dummy chat request with prime-rl's training sampling args (`temperature`, `top_p=1.0`, `logprobs=True`) + `return_token_ids=True`: `prompt_token_ids` (== `usage.prompt_tokens`), `choice.token_ids` (== `usage.completion_tokens`, ends in `<|im_end|>`), and one logprob per completion token — all aligned and accessible via the OpenAI SDK objects.
- 20-step `reverse-text-v1` RL run in **MITO mode with the orchestrator-side backfill disabled**, so tokens could *only* come from this parser: Trainable 128/128 (100%) every step, **0** "No trainable samples" warnings, reward 0.16 → 0.78, 0% errors. A saved rollout's `response.tokens` decoded back to the correct prompt and a real reversed-text answer.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Parse vLLM token ids and logprobs into `Response.tokens` in the OpenAI chat client
> Adds a `tokens_from_wire` helper in [openai.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1585/files#diff-d83c59263a4ca33d6ff77e8ee865785d2b1d0cce2b5c7a516d12790ab16ba123) that extracts `choice.token_ids`, `completion.prompt_token_ids`, and `choice.logprobs` from a vLLM completion response and constructs a `TurnTokens` object. `response_from_wire` now calls this helper to populate `Response.tokens` when the provider returns token ids; previously `tokens` was always `None` in this client. Returns `None` when token ids are absent, so non-vLLM providers are unaffected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 89368c8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, best-effort parsing on the response path only; providers without token ids behave as before with `tokens=None`.
> 
> **Overview**
> The OpenAI chat-completions client now **best-effort fills `Response.tokens`** from vLLM when the caller enables `logprobs` and `return_token_ids`, so MITO training can use on-policy token ids and sampling logprobs without a renderer client.
> 
> A new **`tokens_from_wire`** helper reads `choice.token_ids`, `completion.prompt_token_ids`, and per-token logprobs from `choice.logprobs.content`; **`response_from_wire`** attaches the result to every response. If completion token ids are missing (eval or non-vLLM providers), **`tokens` stays `None`**—request forwarding is unchanged.
> 
> Docstrings on **`TurnTokens`** and **`Response.tokens`** now state the chat client can populate them via vLLM, not only the renderer path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89368c899f65b5842775a8612ebf5da0602daf6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->