### PR TITLE
fix: preserve rollout meta in the v0 -> v1 legacy bridge

### DIFF
--- a/verifiers/v1/legacy.py
+++ b/verifiers/v1/legacy.py
@@ -43,8 +43,18 @@ from verifiers.v1.types import (
 
 logger = logging.getLogger(__name__)
 
+_FINISH_REASONS = frozenset({"stop", "length", "tool_calls"})
+
 
 # --- v0 RolloutOutput -> v1 Trace mapping -----------------------------------
+
+
+def _as_dict(obj: Any) -> Any:
+    """v0 rollout objects are pydantic models in-process (messages, ``Response``); coerce
+    to plain dicts so the mapping reads them whether they arrive as objects or dicts."""
+    if hasattr(obj, "model_dump"):
+        return obj.model_dump()
+    return obj
 
 
 def _text(content: Any) -> str:
@@ -63,6 +73,7 @@ def _tool_calls(raw: Any) -> list[ToolCall] | None:
         return None
     calls: list[ToolCall] = []
     for tc in raw:
+        tc = _as_dict(tc)
         if not isinstance(tc, dict):
             continue
         fn = tc.get("function", tc)  # OpenAI shape: {id, function: {name, arguments}}
@@ -79,6 +90,7 @@ def _tool_calls(raw: Any) -> list[ToolCall] | None:
 def _to_v1_messages(msgs: Any) -> list:
     out: list = []
     for m in msgs or []:
+        m = _as_dict(m)
         if not isinstance(m, dict):
             continue
         role = m.get("role")
@@ -104,16 +116,20 @@ def _to_v1_messages(msgs: Any) -> list:
     return out
 
 
-def _to_v1_response(raw: Any, model: str) -> Response:
-    raw = raw or {}
-    msg = raw.get("message", {}) if isinstance(raw, dict) else {}
-    usage_raw = raw.get("usage") if isinstance(raw, dict) else None
+def _to_v1_response(raw: Any, model: str, tokens: TurnTokens | None = None) -> Response:
+    raw = _as_dict(raw)
+    raw = raw if isinstance(raw, dict) else {}
+    msg = _as_dict(raw.get("message"))
+    msg = msg if isinstance(msg, dict) else {}
+    usage_raw = raw.get("usage")
     usage = None
     if isinstance(usage_raw, dict) and "prompt_tokens" in usage_raw:
         usage = Usage(
             prompt_tokens=int(usage_raw.get("prompt_tokens") or 0),
             completion_tokens=int(usage_raw.get("completion_tokens") or 0),
         )
+    # v0 records finish_reason on the response message; v1 puts it on the response.
+    finish = msg.get("finish_reason") or raw.get("finish_reason")
     return Response(
         id=str(raw.get("id") or ""),
         created=int(raw.get("created") or 0),
@@ -123,8 +139,9 @@ def _to_v1_response(raw: Any, model: str) -> Response:
             reasoning_content=msg.get("reasoning_content"),
             tool_calls=_tool_calls(msg.get("tool_calls")),
         ),
-        finish_reason=raw.get("finish_reason"),
+        finish_reason=finish if finish in _FINISH_REASONS else None,
         usage=usage,
+        tokens=tokens,
     )
 
 
@@ -161,18 +178,26 @@ def _timing(raw: Any) -> Timing:
 
 
 def rollout_output_to_trace(out: dict, task_idx: int) -> Trace:
-    """Map a v0 ``RolloutOutput`` into a v1 ``Trace``. The three training-critical token
-    fields (prompt_ids / completion_ids / completion_logprobs) map 1:1; ``is_truncated`` is
-    a computed v1 field, so we rely on the final turn's ``finish_reason`` / stop condition."""
-    trajectory = [
-        Turn(
-            prompt=_to_v1_messages(step.get("prompt")),
-            response=_to_v1_response(step.get("response"), str(out.get("model") or "")),
-            tokens=_to_v1_tokens(step.get("tokens")),
+    """Map a v0 ``RolloutOutput`` into a v1 ``Trace``, preserving the meta a native v1
+    trace carries: per-turn prompt messages, the response message (content / reasoning /
+    tool calls), ``finish_reason`` and ``usage``, the token ids/logprobs, and the task's
+    system prompt / instruction / answer. ``is_truncated`` is a computed v1 field derived
+    from the final turn's ``finish_reason`` and the stop condition."""
+    model = str(out.get("model") or "")
+    trajectory: list[Turn] = []
+    for step in out.get("trajectory") or []:
+        if not isinstance(step, dict):
+            continue
+        # The renderer records tokens on both the turn (training reads these) and the
+        # response, mirroring the native v1 client; keep both so the trace is identical.
+        tokens = _to_v1_tokens(step.get("tokens"))
+        trajectory.append(
+            Turn(
+                prompt=_to_v1_messages(step.get("prompt")),
+                response=_to_v1_response(step.get("response"), model, tokens),
+                tokens=tokens,
+            )
         )
-        for step in (out.get("trajectory") or [])
-        if isinstance(step, dict)
-    ]
 
     error = None
     raw_error = out.get("error")
@@ -187,7 +212,7 @@ def rollout_output_to_trace(out: dict, task_idx: int) -> Trace:
             error = Error(type="Error", message=str(raw_error), traceback=None)
 
     trace: Trace = Trace[WireTask](
-        task=WireTask(idx=task_idx, instruction=_prompt_text(out.get("prompt"))),
+        task=_to_wire_task(task_idx, out.get("prompt"), out.get("answer")),
         trajectory=trajectory,
         rewards={"reward": float(out.get("reward") or 0.0)},
         metrics={k: float(v) for k, v in (out.get("metrics") or {}).items()},
@@ -199,9 +224,26 @@ def rollout_output_to_trace(out: dict, task_idx: int) -> Trace:
     return trace
 
 
-def _prompt_text(prompt: Any) -> str:
-    return "\n\n".join(
-        _text(m.get("content")) for m in (prompt or []) if isinstance(m, dict)
+def _to_wire_task(task_idx: int, prompt: Any, answer: Any) -> WireTask:
+    """Carry the v0 prompt's meta onto the v1 task: the system message becomes
+    ``system_prompt``, the user message(s) become ``instruction``, and the reference
+    ``answer`` rides along as a taskset-extra field (``WireTask`` allows extras)."""
+    system_prompt: str | None = None
+    user_texts: list[str] = []
+    for m in prompt or []:
+        m = _as_dict(m)
+        if not isinstance(m, dict):
+            continue
+        if m.get("role") == "system" and system_prompt is None:
+            system_prompt = _text(m.get("content"))
+        elif m.get("role") == "user":
+            user_texts.append(_text(m.get("content")))
+    extra = {"answer": answer} if answer else {}
+    return WireTask(
+        idx=task_idx,
+        instruction="\n\n".join(user_texts),
+        system_prompt=system_prompt,
+        **extra,
     )
 
 


### PR DESCRIPTION
## Summary

The v0 → v1 legacy bridge (`rollout_output_to_trace`) was producing a near-empty `Turn.response`: it kept only the token ids and dropped almost everything else a native v1 trace carries.

**Root cause:** a v0 `RolloutOutput` nests its data as **pydantic objects** in-process (`SystemMessage`/`UserMessage`/`AssistantMessage`, `Response`), and records `finish_reason` on `response.message` (not the response). The bridge's helpers only handled plain `dict`s (`if not isinstance(m, dict): continue`) and read `finish_reason` off the response top-level — so the message lists were silently skipped and the response fields came back null.

**Fix:**
- `_as_dict()` coerces v0 pydantic objects to dicts before mapping, so the helpers read them whether they arrive as objects or dicts.
- `_to_v1_response` now reads `finish_reason` from `response.message` (its v0 location), keeps `usage`, and mirrors the token ids onto `response.tokens` (as the native v1 client does).
- New `_to_wire_task` carries the prompt's **system message → `system_prompt`**, **user message(s) → `instruction`**, and the reference **`answer`** (as a `WireTask` extra) onto the task.

A v0-bridged `Trace` now matches the native v1 schema.

## Discrepancies fixed (v0-bridge vs native v1, reverse-text step 0)

Before, the bridge dropped: `turn.prompt` (empty), `response.message.content` / `reasoning_content` (null), `finish_reason` (null), `usage` (null), `response.tokens` (null), `task.instruction` (empty), `task.system_prompt` (null), `task.answer` (missing). `is_truncated` also stayed wrong because it's computed from `finish_reason`.

After, the only remaining schema differences are benign and **not** lost information:
- **rewards/metrics naming**: v0 names its aggregate `rewards.reward` + `metrics.lcs_reward_func`; v1 names it `rewards.lcs`. The value is preserved and `trace.reward` resolves identically — an env-level naming difference the bridge shouldn't rewrite.
- **`message.content` `str` vs `null|str`**: sampling artifact; the field is nullable in both.

## Verification

Captured real v0 `RolloutOutput`s through the legacy path against a live vLLM server and diffed the resulting traces against native v1 reverse-text rollouts: prompt messages, response content/reasoning, `finish_reason`, `usage`, tokens (turn + response), and `task.system_prompt`/`instruction`/`answer` all now present and matching. `finish_reason="length"` correctly drives the computed `is_truncated`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only the legacy adapter path but affect training-visible trace shape (tokens, finish_reason, task fields); incorrect mapping could still skew truncation or RL reads if edge cases remain.
> 
> **Overview**
> The v0→v1 legacy bridge in `rollout_output_to_trace` was dropping most trace metadata because mapping helpers only accepted plain dicts while in-process v0 rollouts use Pydantic models, and `finish_reason` was read from the wrong level.
> 
> **`_as_dict()`** normalizes v0 objects via `model_dump()` before `_to_v1_messages`, `_tool_calls`, and `_to_v1_response` run, so prompts, assistant content/reasoning/tool calls, and usage populate correctly instead of being skipped.
> 
> **`_to_v1_response`** now resolves `finish_reason` from `response.message` (v0) with a fallback to the response root, restricts values to `stop` / `length` / `tool_calls`, and attaches the same **turn tokens** on `response.tokens` to match native v1 clients.
> 
> **`_to_wire_task`** replaces flattening the whole prompt into `instruction`: system → `system_prompt`, user text → `instruction`, and optional reference **`answer`** as a `WireTask` extra.
> 
> Together, bridged traces align with native v1 for training-critical fields; **`is_truncated`** can compute correctly once `finish_reason="length"` is preserved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdf82e891791f4015765c67ae891f77a8f5ef70c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix rollout metadata preservation in the v0 to v1 legacy bridge
> - Adds `_as_dict` helper in [legacy.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1586/files#diff-96c5091f7d2968ddfbe984f433163f21cab745ea95174158e924984d55abbfed) to coerce pydantic-like v0 objects to dicts before mapping, fixing dropped messages and tool calls.
> - `_to_v1_response` now populates `Response.tokens` and sets `finish_reason` only when it is one of `stop`, `length`, or `tool_calls`; otherwise `None`.
> - `rollout_output_to_trace` now sets `system_prompt` from the first system message, builds `instruction` from user messages only, and carries `answer` in task extras.
> - `Response.tokens` is now populated per turn by passing computed `TurnTokens` through `_to_v1_response`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fdf82e8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->