### PR TITLE
feat: native rollout retries (EnvConfig.retry)

### DIFF
--- a/verifiers/v1/__init__.py
+++ b/verifiers/v1/__init__.py
@@ -18,6 +18,7 @@ from verifiers.v1.clients import (
 from verifiers.v1.clients import RolloutContext
 from verifiers.v1.decorators import group_reward, metric, reward, stop
 from verifiers.v1.env import EnvConfig, Environment, TimeoutConfig
+from verifiers.v1.retries import RetryConfig
 from verifiers.v1.episode import Episode
 from verifiers.v1.rollout import Rollout
 from verifiers.v1.errors import ModelError, ProgramError, RolloutError, ToolError
@@ -121,6 +122,7 @@ __all__ = [
     "PrimeConfig",
     "Environment",
     "EnvConfig",
+    "RetryConfig",
     "TimeoutConfig",
     "Episode",
     "Rollout",

--- a/verifiers/v1/env.py
+++ b/verifiers/v1/env.py
@@ -21,6 +21,7 @@ from verifiers.v1.harness import HarnessConfig
 from verifiers.v1.clients import RolloutContext
 from verifiers.v1.decorators import discover_decorated
 from verifiers.v1.episode import Episode
+from verifiers.v1.retries import RetryConfig
 from verifiers.v1.rollout import Rollout
 from verifiers.v1.runtimes import (
     RuntimeConfig,
@@ -52,6 +53,7 @@ class EnvConfig(BaseConfig):
     taskset: SerializeAsAny[TasksetConfig] = TasksetConfig()
     harness: SerializeAsAny[HarnessConfig] = HarnessConfig(id="default")
     timeout: TimeoutConfig = TimeoutConfig()
+    retry: RetryConfig = RetryConfig()
     max_turns: int | None = None
     """Max model turns per rollout (None = no limit). Enforced by the framework (the
     interception server refuses turns past it), so it applies to any harness — turn
@@ -162,7 +164,7 @@ class Environment:
             )
             for _ in range(n)
         ]
-        return Episode(rollouts, self.taskset)
+        return Episode(rollouts, self.taskset, retry=self.config.retry)
 
     @contextlib.asynccontextmanager
     async def shared_tools(self, tasks: list[Task]):

--- a/verifiers/v1/episode.py
+++ b/verifiers/v1/episode.py
@@ -15,20 +15,30 @@ Each Rollout tears its own runtime down (see rollout.py), so the Episode owns no
 runtimes — only the rollouts and the scoring across them.
 """
 
+from __future__ import annotations
+
 import asyncio
 from collections.abc import Callable
 from contextlib import nullcontext
+from typing import TYPE_CHECKING
 
 from verifiers.v1.decorators import discover_decorated
+from verifiers.v1.retries import run_with_retry
 from verifiers.v1.rollout import Phase, Rollout
 from verifiers.v1.taskset import Taskset
 from verifiers.v1.trace import Trace
 
+if TYPE_CHECKING:
+    from verifiers.v1.retries import RetryConfig
+
 
 class Episode:
-    def __init__(self, rollouts: list[Rollout], taskset: Taskset) -> None:
+    def __init__(
+        self, rollouts: list[Rollout], taskset: Taskset, retry: RetryConfig
+    ) -> None:
         self.rollouts = rollouts
         self.taskset = taskset
+        self.retry = retry
 
     async def run(
         self,
@@ -48,7 +58,7 @@ class Episode:
 
         async def run_one(rollout: Rollout) -> Trace:
             async with semaphore or nullcontext():
-                trace = await rollout.run(shared_urls)
+                trace = await run_with_retry(rollout, shared_urls, self.retry)
             if not group_scored:  # reward already final → don't wait for the group
                 rollout.phase = Phase.DONE
                 on_complete(trace)

--- a/verifiers/v1/legacy.py
+++ b/verifiers/v1/legacy.py
@@ -218,7 +218,7 @@ def rollout_output_to_trace(out: dict, task_idx: int) -> Trace:
         metrics={k: float(v) for k, v in (out.get("metrics") or {}).items()},
         is_completed=bool(out.get("is_completed", True)),
         stop_condition=out.get("stop_condition"),
-        error=error,
+        errors=[error] if error else [],
         timing=_timing(out.get("timing")),
     )
     return trace

--- a/verifiers/v1/retries.py
+++ b/verifiers/v1/retries.py
@@ -1,0 +1,78 @@
+"""Rollout-level retries: rerun a whole rollout while it ends with a retryable error.
+
+Parity with v0's rollout retries. `RetryConfig` lives on `EnvConfig.retry`; `run_with_retry`
+wraps a `Rollout` with tenacity, retrying on the trace's captured error (matched by exception
+type name against include/exclude) and accumulating each failed attempt's error onto the
+returned trace's `errors`, so the final trace shows the whole retry history.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pydantic_config import BaseConfig
+from tenacity import (
+    AsyncRetrying,
+    RetryCallState,
+    retry_if_result,
+    stop_after_attempt,
+)
+
+if TYPE_CHECKING:
+    from verifiers.v1.rollout import Rollout
+    from verifiers.v1.trace import Trace
+
+
+class RetryConfig(BaseConfig):
+    """Retry a whole rollout when it ends with a captured error (parity with v0's
+    rollout-level retries). Matching is by the error's exception type name, so
+    `include`/`exclude` name exception classes (e.g. ``ModelError``, ``ProgramError``)."""
+
+    attempts: int = 3
+    """Total rollout attempts (1 = no retry)."""
+    include: list[str] = []
+    """Only retry errors whose type is listed. Empty = retry anything not excluded."""
+    exclude: list[str] = []
+    """Never retry errors whose type is listed (wins over `include`)."""
+
+
+def should_retry(trace: Trace, retry: RetryConfig) -> bool:
+    """Whether a finished rollout should be retried: it ended with an error whose
+    exception type is included (and not excluded)."""
+    error = trace.error
+    if error is None:
+        return False
+    if error.type in retry.exclude:
+        return False
+    if retry.include:
+        return error.type in retry.include
+    return True
+
+
+async def run_with_retry(
+    rollout: Rollout, shared_urls: dict[str, str] | None, retry: RetryConfig
+) -> Trace:
+    """Run the whole rollout, retrying it while its trace ends with a retryable error.
+    Each retry-causing attempt's error is collected onto the returned trace's `errors`,
+    so the final trace shows the full history; the last attempt's trace is returned
+    as-is once attempts run out (or the rollout succeeds / hits a non-retryable error)."""
+    if retry.attempts <= 1:
+        return await rollout.run(shared_urls)
+
+    history: list = []
+
+    def record(state: RetryCallState) -> None:
+        # before_sleep fires only between attempts (a retry is imminent), so this
+        # collects exactly the errors that caused a retry — never the final attempt's.
+        history.extend(state.outcome.result().errors)
+
+    retrying = AsyncRetrying(
+        stop=stop_after_attempt(retry.attempts),
+        retry=retry_if_result(lambda trace: should_retry(trace, retry)),
+        before_sleep=record,
+        retry_error_callback=lambda state: state.outcome.result(),
+    )
+    trace = await retrying(rollout.run, shared_urls)
+    if trace.errors:  # final attempt errored too → prepend the earlier attempts'
+        trace.errors = history + trace.errors
+    return trace

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -136,7 +136,9 @@ class Trace(StrictBaseModel, Generic[TaskT]):
 
     is_completed: bool = False
     stop_condition: str | None = None
-    error: Error | None = None
+    errors: list[Error] = Field(default_factory=list)
+    """Every error captured across attempts, oldest first (more than one only when the
+    rollout was retried). `error` exposes the most recent."""
     timing: Timing = Field(default_factory=Timing)
 
     _branch_cache: dict[int, list[list[int]]] = PrivateAttr(default_factory=dict)
@@ -148,9 +150,15 @@ class Trace(StrictBaseModel, Generic[TaskT]):
     def reward(self) -> float:
         return sum(self.rewards.values())
 
+    @computed_field
+    @property
+    def error(self) -> Error | None:
+        """The most recent captured error (the rest are earlier retry attempts)."""
+        return self.errors[-1] if self.errors else None
+
     @property
     def has_error(self) -> bool:
-        return self.error is not None
+        return bool(self.errors)
 
     @property
     def last_turn(self) -> Turn | None:
@@ -273,10 +281,12 @@ class Trace(StrictBaseModel, Generic[TaskT]):
 
     def capture_error(self, error: Exception) -> None:
         """Record a caught error (with traceback) and stop the rollout."""
-        self.error = Error(
-            type=type(error).__name__,
-            message=str(error),
-            traceback=traceback.format_exc(),
+        self.errors.append(
+            Error(
+                type=type(error).__name__,
+                message=str(error),
+                traceback=traceback.format_exc(),
+            )
         )
         self.stop("error")
 


### PR DESCRIPTION
## Summary

Native, rollout-level retries in v1 — parity with v0's whole-rollout retries.

- New `RetryConfig` (in `verifiers/v1/retries.py`) on `EnvConfig.retry`:
  - `attempts: int = 3` — total rollout attempts (1 = no retry)
  - `include: list[str]` — only retry errors whose **exception type name** is listed (empty = retry anything not excluded)
  - `exclude: list[str]` — never retry these types (wins over `include`)
- `run_with_retry` reruns the whole `Rollout` with **tenacity** while its trace ends with a retryable captured error. Matching is by **exception type name only**.
- `EvalConfig` inherits `EnvConfig`, and the env server runs through `Environment.episode`, so retries apply to **both eval and training** with no extra plumbing. Flags: `--retry.attempts`, `--retry.include`, `--retry.exclude`.

### Retries are first-class on the Trace

- `Trace.errors: list[Error]` — every captured error across attempts, oldest first (more than one only when retried).
- `Trace.error` is now a **computed field** returning the most recent error (`errors[-1]`), so existing readers keep working and a retried-then-failed trace shows the full history of what led to each retry.
- `to_wire` drops the computed `error` and carries `errors`; the consumer recomputes `error`. The v0 legacy bridge now builds `errors=[...]`.

## Verification (eval, unknown model → `ProgramError`)

`uv run eval reverse-text-v1 -m this-model/does-not-exist --harness.runtime.type subprocess ...`:

| flags | attempts | `trace.errors` | `error` |
|---|---|---|---|
| `--retry.attempts 3 --retry.include ProgramError` | 3 | `[ProgramError ×3]` | ProgramError |
| `--retry.attempts 3 --retry.exclude ProgramError` | 1 | `[ProgramError]` | ProgramError |
| `--retry.attempts 3 --retry.include ModelError` (no type match) | 1 | `[ProgramError]` | ProgramError |
| `--retry.attempts 2` (default include) | 2 | `[ProgramError ×2]` | ProgramError |

prime-rl needs no change to use this — it sets `EnvConfig.retry` and the env server picks it up natively.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add native rollout retries via `EnvConfig.retry` and `RetryConfig`
> - Introduces [`RetryConfig`](https://github.com/PrimeIntellect-ai/verifiers/pull/1588/files#diff-dd324cbc3488c3521fea600c7be4001a3f62becf8988cb8290ccbf4c9a487106) with `attempts` (default 3), `include`, and `exclude` fields to control which error types trigger retries.
> - Adds a `retry` field to [`EnvConfig`](https://github.com/PrimeIntellect-ai/verifiers/pull/1588/files#diff-69be10bd5960e88d88f219d4f261d0bdd16586857f9126451b04d05bac4c2cbb) so retry behavior is configured at the environment level and passed through to each `Episode`.
> - Replaces direct `rollout.run()` calls in [`Episode._run_rollout`](https://github.com/PrimeIntellect-ai/verifiers/pull/1588/files#diff-ea3591865e4c7653852776e680f3abbf509a3f3a406d518c8dce528669aa0abf) with `run_with_retry`, which uses `tenacity.AsyncRetrying` and accumulates errors across attempts.
> - Changes [`Trace`](https://github.com/PrimeIntellect-ai/verifiers/pull/1588/files#diff-834820c3aa80d87ee1c1c57fb54c74f09c66ac727036d964e6005c8613c00b5e) to store `errors: list[Error]` instead of a single `error` field; the `error` property now returns the last error, and `has_error` checks if the list is non-empty.
> - Behavioral Change: `Trace.errors` now accumulates all errors across retry attempts; code reading `Trace.error` directly still works via the computed property, but code expecting a single `error` field will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bc613e6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes trace serialization (`errors` list) and can multiply rollout work per task when retries fire; `trace.error` readers stay compatible via a computed property.
> 
> **Overview**
> Adds **native rollout-level retries** in v1 (v0 parity) via new `RetryConfig` on `EnvConfig.retry` (`attempts`, `include`/`exclude` by exception **type name**).
> 
> `Environment.episode` passes retry settings into `Episode`, which runs each rollout through **`run_with_retry`** (tenacity) instead of a single `rollout.run()`. Failed retryable attempts accumulate on the returned trace.
> 
> **`Trace`** now stores **`errors: list[Error]`** (oldest first); **`error`** is a computed “latest” field and **`capture_error`** appends. Wire/legacy mapping emit `errors` (computed `error` dropped on wire). Public export: **`RetryConfig`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc613e61b36ca48a8ce296c3278cd066200b0536. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->