### PR TITLE
fix: free runtime resources on exit/interrupt

### DIFF
--- a/verifiers/v1/runtimes/__init__.py
+++ b/verifiers/v1/runtimes/__init__.py
@@ -11,7 +11,7 @@ from typing import Annotated
 
 from pydantic import Field
 
-from verifiers.v1.runtimes.base import ProgramResult, Runtime
+from verifiers.v1.runtimes.base import ProgramResult, Runtime, _register
 from verifiers.v1.runtimes.docker import DockerConfig, DockerRuntime
 from verifiers.v1.runtimes.prime import PrimeConfig, PrimeRuntime
 from verifiers.v1.runtimes.subprocess import SubprocessConfig, SubprocessRuntime
@@ -23,10 +23,13 @@ RuntimeConfig = Annotated[
 
 def make_runtime(config: RuntimeConfig) -> Runtime:
     if isinstance(config, PrimeConfig):
-        return PrimeRuntime(config)
-    if isinstance(config, DockerConfig):
-        return DockerRuntime(config)
-    return SubprocessRuntime(config)
+        runtime: Runtime = PrimeRuntime(config)
+    elif isinstance(config, DockerConfig):
+        runtime = DockerRuntime(config)
+    else:
+        runtime = SubprocessRuntime(config)
+    _register(runtime)  # track for the atexit teardown backstop
+    return runtime
 
 
 __all__ = [

--- a/verifiers/v1/runtimes/__init__.py
+++ b/verifiers/v1/runtimes/__init__.py
@@ -11,7 +11,7 @@ from typing import Annotated
 
 from pydantic import Field
 
-from verifiers.v1.runtimes.base import ProgramResult, Runtime, _register
+from verifiers.v1.runtimes.base import ProgramResult, Runtime, register
 from verifiers.v1.runtimes.docker import DockerConfig, DockerRuntime
 from verifiers.v1.runtimes.prime import PrimeConfig, PrimeRuntime
 from verifiers.v1.runtimes.subprocess import SubprocessConfig, SubprocessRuntime
@@ -28,7 +28,7 @@ def make_runtime(config: RuntimeConfig) -> Runtime:
         runtime = DockerRuntime(config)
     else:
         runtime = SubprocessRuntime(config)
-    _register(runtime)  # track for the atexit teardown backstop
+    register(runtime)
     return runtime
 
 

--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -46,29 +46,25 @@ class ProgramResult:
     stderr: str
 
 
-# A runtime provisions an external resource (a /tmp workspace, a container, a remote
-# sandbox). `stop()` frees it on the normal path — it runs from the rollout's `finally`,
-# so it covers success, error, and cancellation. A catchable exit (Ctrl-C / SIGTERM) can
-# cancel that `finally` mid-teardown, so every runtime is tracked in `_LIVE` (weakly, by
-# `make_runtime`) and freed by an `atexit` hook. That hook is *synchronous*: at interpreter
-# shutdown the event loop and its thread-pool are gone, so async teardown ("cannot schedule
-# new futures") fails — hence `cleanup` is sync. A SIGKILL runs none of this; prime
-# sandboxes self-terminate via a server-side max-lifetime, a local runtime leaves a workdir.
+# `stop()` frees a runtime's external resource on the normal path (the rollout's `finally`).
+# A Ctrl-C / SIGTERM can cancel that `finally` mid-teardown, so runtimes are tracked in
+# `_LIVE` and freed by a *synchronous* `atexit` hook (`cleanup`) — sync because the event
+# loop is gone at interpreter shutdown. SIGKILL runs none of this.
 _LIVE: "weakref.WeakSet[Runtime]" = weakref.WeakSet()
 _atexit_armed = False
 
 
-def _register(runtime: "Runtime") -> None:
+def register(runtime: "Runtime") -> None:
     """Track a runtime so the atexit hook can free it if a signal cuts its `finally` short.
     Weak, so a finished rollout's runtime drops out on its own; arms the hook once."""
     global _atexit_armed
     _LIVE.add(runtime)
     if not _atexit_armed:
         _atexit_armed = True
-        atexit.register(_cleanup_live_at_exit)
+        atexit.register(cleanup_at_exit)
 
 
-def _cleanup_live_at_exit() -> None:
+def cleanup_at_exit() -> None:
     """Synchronously free any runtime still live at interpreter shutdown — a Ctrl-C /
     SIGTERM cancelled its `finally` mid-teardown. Sync on purpose (the event loop is gone);
     best-effort and idempotent (a clean `stop` already ran it)."""

--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -5,9 +5,13 @@ server. Concrete runtimes live alongside this base; harnesses and the Environmen
 depend only on this contract, so they stay runtime-agnostic.
 """
 
+import asyncio
+import atexit
+import contextlib
 import hashlib
 import shlex
 import uuid
+import weakref
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 
@@ -42,11 +46,52 @@ class ProgramResult:
     stderr: str
 
 
+# A runtime provisions an external resource (a /tmp workspace, a container, a remote
+# sandbox). `stop()` frees it on the normal path — it runs from the rollout's `finally`,
+# so it covers success, error, and cancellation. A catchable exit (Ctrl-C / SIGTERM) can
+# cancel that `finally` mid-teardown, so every runtime is tracked in `_LIVE` (weakly, by
+# `make_runtime`) and freed by an `atexit` hook. That hook is *synchronous*: at interpreter
+# shutdown the event loop and its thread-pool are gone, so async teardown ("cannot schedule
+# new futures") fails — hence `cleanup` is sync. A SIGKILL runs none of this; prime
+# sandboxes self-terminate via a server-side max-lifetime, a local runtime leaves a workdir.
+_LIVE: "weakref.WeakSet[Runtime]" = weakref.WeakSet()
+_atexit_armed = False
+
+
+def _register(runtime: "Runtime") -> None:
+    """Track a runtime so the atexit hook can free it if a signal cuts its `finally` short.
+    Weak, so a finished rollout's runtime drops out on its own; arms the hook once."""
+    global _atexit_armed
+    _LIVE.add(runtime)
+    if not _atexit_armed:
+        _atexit_armed = True
+        atexit.register(_cleanup_live_at_exit)
+
+
+def _cleanup_live_at_exit() -> None:
+    """Synchronously free any runtime still live at interpreter shutdown — a Ctrl-C /
+    SIGTERM cancelled its `finally` mid-teardown. Sync on purpose (the event loop is gone);
+    best-effort and idempotent (a clean `stop` already ran it)."""
+    for runtime in list(_LIVE):
+        with contextlib.suppress(Exception):
+            runtime.cleanup()
+
+
 class Runtime(ABC):
     @abstractmethod
     async def start(self) -> None:
         """Provision execution (workspace / container / sandbox). Use `expose` to turn a
         host port into a URL the program can reach."""
+
+    def cleanup(self) -> None:
+        """Synchronously free the provisioned resource — best-effort and idempotent. The
+        source of truth for teardown: usable from the atexit backstop where async machinery
+        is dead, and run off the event loop by `stop` on the normal path. Default no-op."""
+
+    async def stop(self) -> None:
+        """Free the provisioned resource on the normal path, off the event loop. Override
+        only for teardown that must be async (e.g. a remote API call)."""
+        await asyncio.to_thread(self.cleanup)
 
     async def expose(self, port: int) -> str:
         """A base URL the program (inside this runtime) can use to reach a host service
@@ -55,9 +100,6 @@ class Runtime(ABC):
         network (subprocess, docker --network host). Remote runtimes (prime) override to
         tunnel the port."""
         return f"http://127.0.0.1:{port}"
-
-    async def stop(self) -> None:
-        """Tear down any provisioned resources. Default no-op."""
 
     @abstractmethod
     async def run(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
@@ -117,7 +159,7 @@ class Runtime(ABC):
         number of distinct scripts. Published via a unique temp + atomic `mv`, so
         concurrent rollouts writing the same content never race a half-written read."""
         data = script.encode() if isinstance(script, str) else script
-        path = f"/tmp/v1-scripts/{hashlib.sha256(data).hexdigest()}.py"
+        path = f"/tmp/vf-scripts/{hashlib.sha256(data).hexdigest()}.py"
         tmp = f"{path}.{uuid.uuid4().hex}.tmp"
         await self.write(tmp, data)
         await self.run(

--- a/verifiers/v1/runtimes/docker.py
+++ b/verifiers/v1/runtimes/docker.py
@@ -191,7 +191,6 @@ class DockerRuntime(Runtime):
             True  # idempotency guard; keep `_container` so the name still shows
         )
         logger.debug("docker: removing container %s", self._container)
-        # blocking `docker rm` — no event loop needed (works from the atexit backstop)
         with contextlib.suppress(Exception):
             subprocess.run(
                 ["docker", "rm", "--force", self._container],

--- a/verifiers/v1/runtimes/docker.py
+++ b/verifiers/v1/runtimes/docker.py
@@ -191,7 +191,8 @@ class DockerRuntime(Runtime):
             True  # idempotency guard; keep `_container` so the name still shows
         )
         logger.debug("docker: removing container %s", self._container)
-        with contextlib.suppress(Exception):  # blocking `docker rm` → no event loop needed
+        # blocking `docker rm` — no event loop needed (works from the atexit backstop)
+        with contextlib.suppress(Exception):
             subprocess.run(
                 ["docker", "rm", "--force", self._container],
                 stdout=subprocess.DEVNULL,

--- a/verifiers/v1/runtimes/docker.py
+++ b/verifiers/v1/runtimes/docker.py
@@ -8,6 +8,7 @@ import asyncio
 import contextlib
 import logging
 import shlex
+import subprocess
 import uuid
 from pathlib import PurePosixPath
 from typing import Literal
@@ -84,7 +85,7 @@ class DockerRuntime(Runtime):
             raise RuntimeError(
                 f"docker runtime selected but the Docker daemon is not reachable: {detail}{hint}"
             )
-        self._container = f"v1-{uuid.uuid4().hex[:12]}"
+        self._container = f"vf-{uuid.uuid4().hex[:12]}"
         limits: list[str] = []
         if self.config.cpu_cores is not None:
             limits += ["--cpus", str(self.config.cpu_cores)]
@@ -183,12 +184,17 @@ class DockerRuntime(Runtime):
                 f"write {path!r}: {stderr.decode(errors='replace').strip()}"
             )
 
-    async def stop(self) -> None:
+    def cleanup(self) -> None:
         if self._container is None or self._stopped:
             return
         self._stopped = (
             True  # idempotency guard; keep `_container` so the name still shows
         )
         logger.debug("docker: removing container %s", self._container)
-        with contextlib.suppress(Exception):
-            await docker("rm", "--force", self._container)
+        with contextlib.suppress(Exception):  # blocking `docker rm` → no event loop needed
+            subprocess.run(
+                ["docker", "rm", "--force", self._container],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=30,
+            )

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -81,7 +81,7 @@ class PrimeRuntime(Runtime):
         try:
             sandbox = await self._client.create(
                 CreateSandboxRequest(
-                    name="v1-program",
+                    name="vf-program",
                     docker_image=self.config.image,
                     network_access=self.config.network_access,
                     vm=self.config.vm,
@@ -187,6 +187,16 @@ class PrimeRuntime(Runtime):
             )
         except Exception as e:
             raise ProgramError(f"write {path!r}: {e}") from e
+
+    def cleanup(self) -> None:
+        # Synchronous atexit backstop: stop the (already sync) tunnels. The sandbox is
+        # deleted by the async `stop` on the normal path; if shutdown cut the rollout's
+        # `finally` short and we only reach here, the sandbox self-terminates via its
+        # server-side max-lifetime — a sync delete isn't possible through the async client.
+        for tunnel in self._tunnels:
+            with contextlib.suppress(Exception):
+                tunnel.sync_stop()
+        self._tunnels = []
 
     async def stop(self) -> None:
         # Best-effort, idempotent teardown: each step is independent so one failure

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -189,14 +189,20 @@ class PrimeRuntime(Runtime):
             raise ProgramError(f"write {path!r}: {e}") from e
 
     def cleanup(self) -> None:
-        # Synchronous atexit backstop: stop the (already sync) tunnels. The sandbox is
-        # deleted by the async `stop` on the normal path; if shutdown cut the rollout's
-        # `finally` short and we only reach here, the sandbox self-terminates via its
-        # server-side max-lifetime — a sync delete isn't possible through the async client.
+        # Synchronous atexit backstop (the async client can't run once the loop is gone):
+        # stop the already-sync tunnels and delete the sandbox via the sync client, so the
+        # costly resource isn't left to its max-lifetime. Idempotent — the async `stop`
+        # deletes it on the normal path, and a second delete just 404s (suppressed).
         for tunnel in self._tunnels:
             with contextlib.suppress(Exception):
                 tunnel.sync_stop()
         self._tunnels = []
+        if self._sandbox_id is not None:
+            from prime_sandboxes import SandboxClient
+            from prime_sandboxes.core import APIClient
+
+            with contextlib.suppress(Exception):
+                SandboxClient(APIClient()).delete(self._sandbox_id)
 
     async def stop(self) -> None:
         # Best-effort, idempotent teardown: each step is independent so one failure

--- a/verifiers/v1/runtimes/subprocess.py
+++ b/verifiers/v1/runtimes/subprocess.py
@@ -1,17 +1,15 @@
 """Local subprocess runtime: run the program on the host; server on localhost.
 
-Each rollout gets a fresh, unique `/tmp/v1-<pid>-*` workspace (created on `start`,
-removed on `stop`) used as the program's cwd, so concurrent local rollouts are
-isolated and trivially cleaned up. Relative `read`/`write` paths resolve against it.
-`stop()` removes it; a startup sweep reclaims any left behind by a process that was
-killed before it could (the pid in the name says whose workspace it was).
+Each rollout gets a fresh, unique `/tmp/vf-*` workspace (created on `start`, removed on
+`stop`/`cleanup`) used as the program's cwd, so concurrent local rollouts are isolated
+and trivially cleaned up. Relative `read`/`write` paths resolve against it.
 """
 
 import asyncio
 import contextlib
-import glob
 import os
 import shutil
+import signal
 import tempfile
 from pathlib import Path
 from typing import Literal
@@ -19,25 +17,6 @@ from typing import Literal
 from pydantic_config import BaseConfig
 
 from verifiers.v1.runtimes.base import ProgramResult, Runtime
-
-_WORKDIR_PREFIX = f"v1-{os.getpid()}-"
-_swept_orphans = False
-
-
-def _sweep_orphan_workdirs() -> None:
-    """Remove `/tmp/v1-<pid>-*` workspaces whose owning process is gone — leftovers from
-    a rollout killed before `stop()` ran. PID-keyed, so a concurrent live process's
-    workspaces are never touched; best-effort, so a racing peer's `rmtree` can't fail us."""
-    for path in glob.glob("/tmp/v1-*-*"):
-        pid = os.path.basename(path).split("-")[1]
-        if not pid.isdigit():
-            continue
-        try:
-            os.kill(int(pid), 0)
-        except ProcessLookupError:  # owner is gone → orphan
-            shutil.rmtree(path, ignore_errors=True)
-        except OSError:  # alive (or not ours to signal) → keep
-            pass
 
 # A local subprocess inherits the host environment EXCEPT any var whose name
 # contains "API_KEY" — so it can never reach a real provider with the host's API
@@ -64,11 +43,7 @@ class SubprocessRuntime(Runtime):
         return self.workdir.name if self.workdir else None
 
     async def start(self) -> None:
-        global _swept_orphans
-        if not _swept_orphans:  # once per process: reclaim dead processes' leftovers
-            _swept_orphans = True
-            await asyncio.to_thread(_sweep_orphan_workdirs)
-        self.workdir = Path(tempfile.mkdtemp(prefix=_WORKDIR_PREFIX, dir="/tmp"))
+        self.workdir = Path(tempfile.mkdtemp(prefix="vf-", dir="/tmp"))
 
     async def run(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
         full_env = {k: v for k, v in os.environ.items() if "API_KEY" not in k.upper()}
@@ -115,10 +90,10 @@ class SubprocessRuntime(Runtime):
         target.parent.mkdir(parents=True, exist_ok=True)
         await asyncio.to_thread(target.write_bytes, data)
 
-    async def stop(self) -> None:
-        for proc in self._background:
-            with contextlib.suppress(ProcessLookupError):
-                proc.terminate()
+    def cleanup(self) -> None:
+        for proc in self._background:  # os.kill (not proc.terminate) → no event loop needed
+            with contextlib.suppress(ProcessLookupError, OSError):
+                os.kill(proc.pid, signal.SIGTERM)
         self._background = []
         if self.workdir is not None:
-            await asyncio.to_thread(shutil.rmtree, self.workdir, True)
+            shutil.rmtree(self.workdir, ignore_errors=True)

--- a/verifiers/v1/runtimes/subprocess.py
+++ b/verifiers/v1/runtimes/subprocess.py
@@ -91,7 +91,8 @@ class SubprocessRuntime(Runtime):
         await asyncio.to_thread(target.write_bytes, data)
 
     def cleanup(self) -> None:
-        for proc in self._background:  # os.kill (not proc.terminate) → no event loop needed
+        # os.kill (not proc.terminate) so it works without an event loop (atexit backstop)
+        for proc in self._background:
             with contextlib.suppress(ProcessLookupError, OSError):
                 os.kill(proc.pid, signal.SIGTERM)
         self._background = []

--- a/verifiers/v1/runtimes/subprocess.py
+++ b/verifiers/v1/runtimes/subprocess.py
@@ -91,7 +91,6 @@ class SubprocessRuntime(Runtime):
         await asyncio.to_thread(target.write_bytes, data)
 
     def cleanup(self) -> None:
-        # os.kill (not proc.terminate) so it works without an event loop (atexit backstop)
         for proc in self._background:
             with contextlib.suppress(ProcessLookupError, OSError):
                 os.kill(proc.pid, signal.SIGTERM)

--- a/verifiers/v1/runtimes/subprocess.py
+++ b/verifiers/v1/runtimes/subprocess.py
@@ -1,12 +1,15 @@
 """Local subprocess runtime: run the program on the host; server on localhost.
 
-Each rollout gets a fresh, unique `/tmp/v1-*` workspace (created on `start`,
+Each rollout gets a fresh, unique `/tmp/v1-<pid>-*` workspace (created on `start`,
 removed on `stop`) used as the program's cwd, so concurrent local rollouts are
 isolated and trivially cleaned up. Relative `read`/`write` paths resolve against it.
+`stop()` removes it; a startup sweep reclaims any left behind by a process that was
+killed before it could (the pid in the name says whose workspace it was).
 """
 
 import asyncio
 import contextlib
+import glob
 import os
 import shutil
 import tempfile
@@ -16,6 +19,25 @@ from typing import Literal
 from pydantic_config import BaseConfig
 
 from verifiers.v1.runtimes.base import ProgramResult, Runtime
+
+_WORKDIR_PREFIX = f"v1-{os.getpid()}-"
+_swept_orphans = False
+
+
+def _sweep_orphan_workdirs() -> None:
+    """Remove `/tmp/v1-<pid>-*` workspaces whose owning process is gone — leftovers from
+    a rollout killed before `stop()` ran. PID-keyed, so a concurrent live process's
+    workspaces are never touched; best-effort, so a racing peer's `rmtree` can't fail us."""
+    for path in glob.glob("/tmp/v1-*-*"):
+        pid = os.path.basename(path).split("-")[1]
+        if not pid.isdigit():
+            continue
+        try:
+            os.kill(int(pid), 0)
+        except ProcessLookupError:  # owner is gone → orphan
+            shutil.rmtree(path, ignore_errors=True)
+        except OSError:  # alive (or not ours to signal) → keep
+            pass
 
 # A local subprocess inherits the host environment EXCEPT any var whose name
 # contains "API_KEY" — so it can never reach a real provider with the host's API
@@ -42,7 +64,11 @@ class SubprocessRuntime(Runtime):
         return self.workdir.name if self.workdir else None
 
     async def start(self) -> None:
-        self.workdir = Path(tempfile.mkdtemp(prefix="v1-", dir="/tmp"))
+        global _swept_orphans
+        if not _swept_orphans:  # once per process: reclaim dead processes' leftovers
+            _swept_orphans = True
+            await asyncio.to_thread(_sweep_orphan_workdirs)
+        self.workdir = Path(tempfile.mkdtemp(prefix=_WORKDIR_PREFIX, dir="/tmp"))
 
     async def run(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
         full_env = {k: v for k, v in os.environ.items() if "API_KEY" not in k.upper()}


### PR DESCRIPTION
## Summary

A runtime provisions an external resource (a `/tmp` workspace, a docker container, a remote sandbox). `stop()` frees it on the normal path (it runs from the rollout's `finally`, covering success / error / cancellation), but a **catchable exit (Ctrl-C / SIGTERM)** can cancel that `finally` mid-teardown — and for an async teardown (a sandbox HTTP-delete, `docker rm`) the cancellation can cut it off, leaking the resource. Repeated leaks fill `/tmp` (`No space left on device`) or pile up sandboxes/containers.

**General, backend-agnostic fix** in `Runtime`:
- `cleanup()` — **synchronous** teardown, the source of truth (it must work from the atexit hook, where the event loop and its thread-pool are gone, so async teardown raises `cannot schedule new futures`).
- `stop()` — public **async**, the happy path. Defaults to running `cleanup()` off the event loop; prime overrides it for the async sandbox delete + client `aclose`.
- `make_runtime` registers each runtime in a `WeakSet` and arms a single **sync `atexit` hook** that calls `cleanup()` on anything still live. So a signal that cuts the `finally` short still frees the workspace / container / sandbox — reusing each backend's own cleanup, no per-backend signal code.

Per-backend `cleanup()` is plain blocking work: `shutil.rmtree` (subprocess), `subprocess.run(["docker","rm","-f"])` (docker), tunnel stop **+ a sync `SandboxClient(...).delete()`** (prime — so the sandbox, the costly resource, is deleted at exit too, not left to its TTL).

Also renames the `v1-` resource prefix to `vf-`.

### SIGKILL is intentionally out of scope

`SIGKILL`/OOM can't be caught — no signal handler, `atexit`, or `finally` runs — so the dying process can't release anything external. Reclaiming those needs a mechanism *outside* the process (a startup reaper, a supervisor, or a server-side TTL). Prime sandboxes still self-terminate via their `max_lifetime` as the final net; a `SIGKILL`ed subprocess/docker leaves its workspace/container, which is left out of scope here rather than carrying a PID-tagged reaper.

## Verification

Ran `gsm8k-v1` (real model `arcee-ai/trinity-mini` via Prime Inference) on **all three runtimes**, for the happy path and a mid-flight Ctrl-C, checking that **no runtime resource is left behind before or after** each run:

| runtime | resource checked | happy path | Ctrl-C (interrupted mid-flight) |
|---|---|---|---|
| subprocess | `/tmp/vf-*` workdirs | 0 → 2 rollouts, reward 1.0 → **0** | 4 workdirs in flight → **0** |
| docker | `vf-*` containers | 0 → container created & removed, reward 1.0 → **0** | 2 containers in flight → **0** |
| prime | `vf-program` sandboxes | 0 → sandbox created & deleted, reward 1.0 → **0** | 2 sandboxes in flight → **0** |

The prime Ctrl-C row is the important one: the two in-flight sandboxes were **deleted on interrupt** (via `stop()` / the sync `cleanup()` at atexit), not left to their `max_lifetime`.

Mechanism checks: confirmed the *async* teardown fails at interpreter shutdown (`cannot schedule new futures`) while the sync `cleanup()` succeeds (why the atexit path is sync), and that the prime sync `SandboxClient(APIClient()).delete(...)` path reaches the API.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches teardown for all runtimes including Prime API deletes and Docker container removal; behavior change on interrupt paths but idempotent and best-effort.
> 
> **Overview**
> Adds a **sync teardown path** so runtimes still free workspaces, Docker containers, and Prime sandboxes when Ctrl-C/SIGTERM cancels the rollout `finally` before async `stop()` finishes.
> 
> The `Runtime` contract gains **`cleanup()`** as the idempotent, blocking teardown API; default **`stop()`** delegates to it via `asyncio.to_thread`. **`make_runtime`** registers each instance in a **`WeakSet`** and arms a one-time **`atexit`** hook that calls **`cleanup()`** on anything still live. Subprocess, Docker, and Prime each implement **`cleanup()`** (e.g. `shutil.rmtree`, sync `docker rm`, sync sandbox delete + tunnel stop); Prime keeps async **`stop()`** for the normal API delete path.
> 
> Also renames runtime resource prefixes from **`v1-`** to **`vf-`** (workdirs, containers, sandboxes, script cache paths).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44edc4bf2c3e55d360f1fd0b12443a2a88d80c1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Free runtime resources on process exit via synchronous `cleanup()` and `atexit` registration
> - Adds a synchronous `cleanup()` method to the `Runtime` base class and overrides it in `DockerRuntime`, `PrimeRuntime`, and `SubprocessRuntime` to tear down containers, sandboxes, and processes without requiring an event loop.
> - Introduces a `WeakSet`-based registry in [base.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1590/files#diff-0811c040a163eb5a3212208f1e3a6c6388d7690fcc4780c081cc7754036232b9) that lazily registers an `atexit` hook; all runtimes created via `make_runtime` are registered automatically.
> - The default async `stop()` now delegates to `cleanup()` via `asyncio.to_thread`, unifying teardown through the sync path.
> - Renames resource prefixes from `v1-` to `vf-` across Docker containers, Prime sandboxes, subprocess workspaces, and script paths under `/tmp`.
> - Behavioral Change: existing resources created with `v1-` prefixes will not be matched or cleaned up by the new code; script paths under `/tmp` also change, invalidating uv cache keys.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 44edc4b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->