### PR TITLE
feat: per-rollout token limits (max_input/output/total_tokens)

### DIFF
--- a/verifiers/v1/configs/eval.py
+++ b/verifiers/v1/configs/eval.py
@@ -12,7 +12,7 @@ from verifiers.v1.types import SamplingConfig
 
 class EvalConfig(EnvConfig):
     """The eval run plus its environment: inherits the env's fields (`taskset`, `harness`,
-    `max_turns`, timeouts) so they're top-level flags (`--taskset.id`, `--harness.id`,
+    `max_turns`, token limits, timeouts) so they're top-level flags (`--taskset.id`, `--harness.id`,
     `--harness.runtime.*`, …) with no `--env.` prefix, and adds the run knobs (model,
     sampling, counts, …)."""
 

--- a/verifiers/v1/configs/serve.py
+++ b/verifiers/v1/configs/serve.py
@@ -1,6 +1,6 @@
 """The `EnvServerConfig`: the config the env-server CLI parses.
 
-Inherits `EnvConfig` (taskset + harness + timeouts + max_turns) so the swappable
+Inherits `EnvConfig` (taskset + harness + timeouts + turn/token limits) so the swappable
 harness/runtime knobs are the same flags as the eval CLI (`--taskset.id`, `--harness.id`,
 `--harness.runtime.type`, `--taskset.*`), and adds only the serving knobs (bind address).
 This is the type the orchestrator embeds to drive the server.

--- a/verifiers/v1/env.py
+++ b/verifiers/v1/env.py
@@ -21,6 +21,7 @@ from verifiers.v1.harness import HarnessConfig
 from verifiers.v1.clients import RolloutContext
 from verifiers.v1.decorators import discover_decorated
 from verifiers.v1.episode import Episode
+from verifiers.v1.interception import RolloutLimits
 from verifiers.v1.retries import RetryConfig
 from verifiers.v1.rollout import Rollout
 from verifiers.v1.runtimes import (
@@ -58,6 +59,15 @@ class EnvConfig(BaseConfig):
     """Max model turns per rollout (None = no limit). Enforced by the framework (the
     interception server refuses turns past it), so it applies to any harness — turn
     capping is a framework concern, never an harness or task field."""
+    max_input_tokens: int | None = None
+    """Max input (prompt) tokens per rollout (None = no limit). Caps the trace's
+    `prompt_len`; framework-enforced between turns, like `max_turns`."""
+    max_output_tokens: int | None = None
+    """Max output (completion) tokens per rollout (None = no limit). Caps the trace's
+    `completion_len`; framework-enforced between turns, like `max_turns`."""
+    max_total_tokens: int | None = None
+    """Max total (prompt + completion) tokens per rollout (None = no limit). Caps the
+    trace's `total_tokens`; framework-enforced between turns, like `max_turns`."""
 
     @model_validator(mode="before")
     @classmethod
@@ -92,7 +102,12 @@ class Environment:
         self.harness = load_harness(config.harness)
         self.harness_timeout = config.timeout.rollout
         self.scoring_timeout = config.timeout.scoring
-        self.max_turns = config.max_turns
+        self.limits = RolloutLimits(
+            max_turns=config.max_turns,
+            max_input_tokens=config.max_input_tokens,
+            max_output_tokens=config.max_output_tokens,
+            max_total_tokens=config.max_total_tokens,
+        )
         self._warned_resources: set[tuple[str, str]] = set()
 
     def runtime_for(self, task: Task) -> RuntimeConfig:
@@ -160,7 +175,7 @@ class Environment:
                 runtime_config=runtime_config,
                 harness_timeout=harness_timeout,
                 scoring_timeout=scoring_timeout,
-                max_turns=self.max_turns,
+                limits=self.limits,
             )
             for _ in range(n)
         ]

--- a/verifiers/v1/env.py
+++ b/verifiers/v1/env.py
@@ -61,13 +61,13 @@ class EnvConfig(BaseConfig):
     capping is a framework concern, never an harness or task field."""
     max_input_tokens: int | None = None
     """Max input (prompt) tokens per rollout (None = no limit). Caps the trace's
-    `prompt_len`; framework-enforced between turns, like `max_turns`."""
+    `prompt_len`; framework-enforced between turns."""
     max_output_tokens: int | None = None
     """Max output (completion) tokens per rollout (None = no limit). Caps the trace's
-    `completion_len`; framework-enforced between turns, like `max_turns`."""
+    `completion_len`; framework-enforced between turns."""
     max_total_tokens: int | None = None
     """Max total (prompt + completion) tokens per rollout (None = no limit). Caps the
-    trace's `total_tokens`; framework-enforced between turns, like `max_turns`."""
+    trace's `total_tokens`; framework-enforced between turns."""
 
     @model_validator(mode="before")
     @classmethod

--- a/verifiers/v1/interception.py
+++ b/verifiers/v1/interception.py
@@ -188,8 +188,7 @@ class InterceptionServer:
             return web.json_response({"error": "unauthorized"}, status=401)
         turn = len(self.trace.trajectory) + 1  # 1-based: the turn being handled
         # A framework limit (turns or a token budget) refuses the turn before it's served,
-        # halting any harness — the same mechanism as a @stop. Capping turns/tokens is the
-        # framework's job, not the harness's.
+        # halting any harness — the same mechanism as a @stop.
         if (limit := self.limits.reached(self.trace)) is not None:
             self.trace.stop(limit)
             logger.debug("limit %r reached: id=%s turn=%d", limit, self.trace.id, turn)

--- a/verifiers/v1/interception.py
+++ b/verifiers/v1/interception.py
@@ -11,6 +11,7 @@ and the user simulator are handled out-of-band for now).
 import logging
 import secrets
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 
 from aiohttp import web
 
@@ -115,6 +116,39 @@ def serialize_completion(response: Response, model: str) -> dict:
 _MAX_REQUEST_BODY = 1024**3  # 1 GiB (aiohttp's default is 1 MiB)
 
 
+@dataclass(frozen=True)
+class RolloutLimits:
+    """Per-rollout framework limits (None = no cap), checked before each turn is served.
+    The first limit reached refuses the turn — halting any harness, the same mechanism as
+    a @stop — and becomes the trace's stop condition. Each caps a trace computed property:
+    `max_turns` -> num_turns, `max_input_tokens` -> prompt_len, `max_output_tokens` ->
+    completion_len, `max_total_tokens` -> total_tokens. Token caps are soft by one turn:
+    they're checked between turns, so the turn that crosses a cap still completes."""
+
+    max_turns: int | None = None
+    max_input_tokens: int | None = None
+    max_output_tokens: int | None = None
+    max_total_tokens: int | None = None
+
+    def reached(self, trace: Trace) -> str | None:
+        """The name of the first limit `trace` has reached, or None if within all caps."""
+        if self.max_turns is not None and trace.num_turns >= self.max_turns:
+            return "max_turns"
+        if self.max_input_tokens is not None and trace.prompt_len >= self.max_input_tokens:
+            return "max_input_tokens"
+        if (
+            self.max_output_tokens is not None
+            and trace.completion_len >= self.max_output_tokens
+        ):
+            return "max_output_tokens"
+        if (
+            self.max_total_tokens is not None
+            and trace.total_tokens >= self.max_total_tokens
+        ):
+            return "max_total_tokens"
+        return None
+
+
 class InterceptionServer:
     """A localhost server that proxies one rollout's chat-completions calls."""
 
@@ -123,12 +157,12 @@ class InterceptionServer:
         ctx: RolloutContext,
         trace: Trace,
         stops: list[Callable[[Trace], Awaitable[bool]]] | None = None,
-        max_turns: int | None = None,
+        limits: RolloutLimits | None = None,
     ) -> None:
         self.ctx = ctx
         self.trace = trace
         self.stops = stops or []
-        self.max_turns = max_turns
+        self.limits = limits or RolloutLimits()
         self.secret = secrets.token_urlsafe(16)
         self.port = 0
         self.runner: web.AppRunner | None = None
@@ -153,13 +187,14 @@ class InterceptionServer:
             logger.warning("interception: unauthorized request id=%s", self.trace.id)
             return web.json_response({"error": "unauthorized"}, status=401)
         turn = len(self.trace.trajectory) + 1  # 1-based: the turn being handled
-        # The framework's max_turns cap refuses turns past it, halting any harness (same
-        # mechanism as a @stop) — a turn limit is the framework's job, not the harness's.
-        if self.max_turns is not None and len(self.trace.trajectory) >= self.max_turns:
-            self.trace.stop("max_turns")
-            logger.debug("max_turns %d reached: id=%s", self.max_turns, self.trace.id)
+        # A framework limit (turns or a token budget) refuses the turn before it's served,
+        # halting any harness — the same mechanism as a @stop. Capping turns/tokens is the
+        # framework's job, not the harness's.
+        if (limit := self.limits.reached(self.trace)) is not None:
+            self.trace.stop(limit)
+            logger.debug("limit %r reached: id=%s turn=%d", limit, self.trace.id, turn)
             return web.json_response(
-                {"error": "rollout stopped: max_turns"}, status=400
+                {"error": f"rollout stopped: {limit}"}, status=400
             )
         # A @stop firing here refuses the turn before it is served, which halts the
         # harness (its model call errors out); Harness.run treats that exit as clean.

--- a/verifiers/v1/interception.py
+++ b/verifiers/v1/interception.py
@@ -134,7 +134,10 @@ class RolloutLimits:
         """The name of the first limit `trace` has reached, or None if within all caps."""
         if self.max_turns is not None and trace.num_turns >= self.max_turns:
             return "max_turns"
-        if self.max_input_tokens is not None and trace.prompt_len >= self.max_input_tokens:
+        if (
+            self.max_input_tokens is not None
+            and trace.prompt_len >= self.max_input_tokens
+        ):
             return "max_input_tokens"
         if (
             self.max_output_tokens is not None
@@ -192,9 +195,7 @@ class InterceptionServer:
         if (limit := self.limits.reached(self.trace)) is not None:
             self.trace.stop(limit)
             logger.debug("limit %r reached: id=%s turn=%d", limit, self.trace.id, turn)
-            return web.json_response(
-                {"error": f"rollout stopped: {limit}"}, status=400
-            )
+            return web.json_response({"error": f"rollout stopped: {limit}"}, status=400)
         # A @stop firing here refuses the turn before it is served, which halts the
         # harness (its model call errors out); Harness.run treats that exit as clean.
         for stop in self.stops:

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -19,7 +19,7 @@ from verifiers.v1.harness import Harness
 from verifiers.v1.clients import RolloutContext
 from verifiers.v1.decorators import discover_decorated
 from verifiers.v1.errors import ProgramError, RolloutError
-from verifiers.v1.interception import InterceptionServer
+from verifiers.v1.interception import InterceptionServer, RolloutLimits
 from verifiers.v1.runtimes import Runtime, RuntimeConfig, make_runtime
 from verifiers.v1.task import Task
 from verifiers.v1.taskset import Taskset
@@ -49,7 +49,7 @@ class Rollout:
         runtime_config: RuntimeConfig,
         harness_timeout: float | None = None,
         scoring_timeout: float | None = None,
-        max_turns: int | None = None,
+        limits: RolloutLimits | None = None,
     ) -> None:
         self.task = task
         self.taskset = taskset
@@ -58,7 +58,7 @@ class Rollout:
         self.runtime_config = runtime_config
         self.harness_timeout = harness_timeout
         self.scoring_timeout = scoring_timeout
-        self.max_turns = max_turns
+        self.limits = limits or RolloutLimits()
         self.phase = Phase.SETUP
         """Lifecycle phase for display (see `Phase`); advanced through the rollout, and
         set to DONE by the Episode once group scoring has run."""
@@ -92,7 +92,7 @@ class Rollout:
         )
         try:
             async with InterceptionServer(
-                self.ctx, trace, stops, self.max_turns
+                self.ctx, trace, stops, self.limits
             ) as server:
                 await runtime.start()
                 endpoint = f"{await runtime.expose(server.port)}/v1"

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -227,9 +227,16 @@ class Trace(StrictBaseModel, Generic[TaskT]):
     @property
     def is_truncated(self) -> bool:
         """Whether the rollout was cut off by a budget/limit rather than ending on its
-        own terms: the framework halted it (`max_turns` / `harness_timeout`), or the
-        final turn hit the token cap (`finish_reason == "length"`)."""
-        if self.stop_condition in ("max_turns", "harness_timeout"):
+        own terms: the framework halted it (`max_turns`, a token budget, or
+        `harness_timeout`), or the final turn hit the token cap (`finish_reason ==
+        "length"`)."""
+        if self.stop_condition in (
+            "max_turns",
+            "max_input_tokens",
+            "max_output_tokens",
+            "max_total_tokens",
+            "harness_timeout",
+        ):
             return True
         last = self.last_turn
         return bool(last and last.response.finish_reason == "length")


### PR DESCRIPTION
## Summary

- Add framework-enforced **per-rollout token budgets** to `EnvConfig`, alongside the existing `max_turns`:
  - `max_input_tokens` — caps the trace's `prompt_len`
  - `max_output_tokens` — caps the trace's `completion_len`
  - `max_total_tokens` — caps the trace's `total_tokens`
- Introduce `RolloutLimits` (a small frozen bundle in `interception.py`) that holds all framework limits — turns + the three token budgets — and exposes `reached(trace)`, returning the name of the first limit reached (or `None`). This subsumes the old standalone `max_turns` check so all framework limits go through one place and thread as a single object (`Environment` → `Rollout` → `InterceptionServer`).
- The interception server checks `limits.reached(trace)` before serving each turn (same mechanism as a `@stop`): the first limit reached refuses the turn, halting any harness, and is recorded as the trace's `stop_condition`.
- `Trace.is_truncated` now treats the token-limit stop conditions (`max_input_tokens` / `max_output_tokens` / `max_total_tokens`) as truncation, like `max_turns` / `harness_timeout`.

The checks read the trace's existing computed properties (`prompt_len` / `completion_len` / `total_tokens`), so they apply uniformly to any harness. Token caps are **soft by one turn**: they're checked between turns, so the turn that crosses a cap still completes.

## Breaking

- `InterceptionServer(...)` and `Rollout(...)` no longer take a `max_turns` keyword — they take `limits: RolloutLimits | None` instead. `Environment.max_turns` is replaced by `Environment.limits`. These are internal constructors (only `Environment.episode` / `Rollout.run` call them); the public `EnvConfig.max_turns` config field and its CLI flag are unchanged.

## Verification

- `ruff check --isolated` clean on all changed files.
- Smoke-tested `RolloutLimits.reached`: `>=` boundary semantics, the input/output/total → `prompt_len`/`completion_len`/`total_tokens` mapping, and limit priority (turns before tokens when both are reached). Imports of `env` / `rollout` / `trace` / `interception` confirmed (no circular import from the new `env` → `interception` edge).

Follow-up (separate PR, prime-rl side): surface these fields on the orchestrator's env config so they can be set from training TOMLs.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-rollout token limits (max_input/output/total_tokens) to rollout execution
> - Introduces a `RolloutLimits` frozen dataclass in [interception.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1591/files#diff-fa4511bfb817d69f882d91dd89f39b454b0473a234ad00d00e4e40d99fd7e7e3) that holds optional caps for turns, input tokens, output tokens, and total tokens, with a `reached()` method that checks a `Trace` against all limits.
> - Adds `max_input_tokens`, `max_output_tokens`, and `max_total_tokens` fields to `EnvConfig` in [env.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1591/files#diff-69be10bd5960e88d88f219d4f261d0bdd16586857f9126451b04d05bac4c2cbb), which are aggregated into a `RolloutLimits` object and passed down to each `Rollout`.
> - The `InterceptionServer` now calls `limits.reached()` before serving each turn; if any limit is hit, it returns HTTP 400 with `rollout stopped: {limit}` and sets the trace stop condition to the limit name.
> - `Trace.is_truncated` in [trace.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1591/files#diff-834820c3aa80d87ee1c1c57fb54c74f09c66ac727036d964e6005c8613c00b5e) now returns `True` for the three new token-limit stop conditions in addition to `max_turns` and `harness_timeout`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5ae2372.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rollout halt behavior and internal Rollout/InterceptionServer APIs; misconfigured limits could truncate eval rollouts unexpectedly, but enforcement mirrors existing max_turns.
> 
> **Overview**
> Adds **framework-enforced per-rollout token budgets** on `EnvConfig` (`max_input_tokens`, `max_output_tokens`, `max_total_tokens`) alongside existing `max_turns`, exposed as top-level eval/serve CLI flags like other env limits.
> 
> Introduces **`RolloutLimits`** with `reached(trace)` so turn and token caps are checked in one place before each intercepted chat turn (same halt path as `@stop`). `Environment` builds limits from config and passes them through `Rollout` to `InterceptionServer` instead of a standalone `max_turns` argument.
> 
> **`Trace.is_truncated`** now treats token-limit stop conditions (`max_input_tokens`, `max_output_tokens`, `max_total_tokens`) as truncation, consistent with `max_turns` and `harness_timeout`. Token caps are evaluated between turns (soft by one turn).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ae237257f88b435843afcc152aee72756ee8dd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->