### PR TITLE
feat: add textarena taskset with a framework-driven user simulator

### DIFF
--- a/configs/terminal-bench-2.toml
+++ b/configs/terminal-bench-2.toml
@@ -1,0 +1,13 @@
+# terminal-bench-2-v1 — the harbor taskset pinned to Terminal-Bench 2. Needs the `harbor`
+# CLI (`uv tool install harbor`) and docker; enable_bash gives the agent the shell tool.
+#
+#   uv run eval @ configs/terminal-bench-2.toml
+num_tasks = 10
+
+[taskset]
+id = "terminal-bench-2-v1"
+
+[harness]
+id = "default"
+runtime = { type = "docker" }
+enable_bash = true

--- a/configs/textarena.toml
+++ b/configs/textarena.toml
@@ -1,15 +1,17 @@
-# textarena-v1 (Wordle-v0) — a multi-turn word game driven by a user simulator.
-# The framework's interception server plays the game (a vf.User registered on the taskset);
-# the harness/program never see it. The user sim runs colocated, so use the subprocess runtime.
+# textarena-v1 — single-player TextArena games driven by a user simulator (vf.User).
+# Supported (--taskset.game): Wordle-v0, Wordle-v0-long, Hangman-v0, WordLadder-v0,
+# WordSearch-v0. The framework's interception server plays the game; the harness never sees
+# it. The user sim runs colocated, so use the subprocess runtime.
 #
 #   uv run eval @ configs/textarena.toml --model <small-instruct-model>
 num_tasks = 5
 num_rollouts = 2
-max_turns = 8
+max_turns = 15
 
 [taskset]
 id = "textarena-v1"
 game = "Wordle-v0"
+num_tasks = 50  # pool of seeded episodes to draw the eval's tasks from
 
 [harness]
 id = "default"

--- a/configs/textarena.toml
+++ b/configs/textarena.toml
@@ -1,0 +1,17 @@
+# textarena-v1 (Wordle-v0) — a multi-turn word game driven by a user simulator.
+# The framework's interception server plays the game (a vf.User registered on the taskset);
+# the harness/program never see it. The user sim runs colocated, so use the subprocess runtime.
+#
+#   uv run eval @ configs/textarena.toml --model <small-instruct-model>
+num_tasks = 5
+num_rollouts = 2
+max_turns = 8
+
+[taskset]
+id = "textarena-v1"
+game = "Wordle-v0"
+
+[harness]
+id = "default"
+enable_bash = false
+runtime = { type = "subprocess" }

--- a/configs/wordle.toml
+++ b/configs/wordle.toml
@@ -1,0 +1,15 @@
+# wordle-v1 — the textarena taskset pinned to Wordle, driven by a user simulator.
+#
+#   uv run eval @ configs/wordle.toml --model <small-instruct-model>
+num_tasks = 5
+num_rollouts = 2
+max_turns = 8
+
+[taskset]
+id = "wordle-v1"
+num_tasks = 50  # pool of seeded episodes to draw the eval's tasks from
+
+[harness]
+id = "default"
+enable_bash = false
+runtime = { type = "subprocess" }

--- a/examples/tasksets/deepwiki_v1/deepwiki_v1.py
+++ b/examples/tasksets/deepwiki_v1/deepwiki_v1.py
@@ -43,8 +43,8 @@ class DeepWikiTaskset(vf.Taskset[DeepWikiTask, vf.TasksetConfig]):
             for i, (repo, language) in enumerate(TASKS)
         ]
 
-    def tool_servers(self, task: DeepWikiTask) -> list[vf.ToolServer]:
-        return [vf.ToolServer(name="deepwiki", url=DEEPWIKI_URL)]
+    def tool_servers(self, task: DeepWikiTask) -> list[vf.Tools]:
+        return [vf.Tools(name="deepwiki", url=DEEPWIKI_URL)]
 
     @vf.reward(weight=1.0)
     async def answered(

--- a/examples/tasksets/deepwiki_v1/deepwiki_v1.py
+++ b/examples/tasksets/deepwiki_v1/deepwiki_v1.py
@@ -43,7 +43,7 @@ class DeepWikiTaskset(vf.Taskset[DeepWikiTask, vf.TasksetConfig]):
             for i, (repo, language) in enumerate(TASKS)
         ]
 
-    def tool_servers(self, task: DeepWikiTask) -> list[vf.Tools]:
+    def tools(self, task: DeepWikiTask) -> list[vf.Tools]:
         return [vf.Tools(name="deepwiki", url=DEEPWIKI_URL)]
 
     @vf.reward(weight=1.0)

--- a/examples/tasksets/glossary_v1/glossary_v1.py
+++ b/examples/tasksets/glossary_v1/glossary_v1.py
@@ -1,7 +1,7 @@
 """glossary: a custom COLOCATED tool server.
 
 Each task asks the model to look up an entity. The taskset ships a tiny tool server
-(`server.py`, a single-file uv script) and declares it via `tool_servers`, passing the
+(`server.py`, a single-file uv script) and declares it via `tools`, passing the
 facts in through an env var; the harness surfaces its `lookup` tool as `facts_lookup`, and
 the reward checks the looked-up fact reached the answer.
 
@@ -42,7 +42,7 @@ class GlossaryTaskset(vf.Taskset[GlossaryTask, vf.TasksetConfig]):
             for i, (entity, fact) in enumerate(FACTS.items())
         ]
 
-    def tool_servers(self, task: GlossaryTask) -> list[vf.Tools]:
+    def tools(self, task: GlossaryTask) -> list[vf.Tools]:
         return [
             vf.Tools(name="facts", script=SERVER, env={"FACTS_JSON": json.dumps(FACTS)})
         ]

--- a/examples/tasksets/glossary_v1/glossary_v1.py
+++ b/examples/tasksets/glossary_v1/glossary_v1.py
@@ -42,11 +42,9 @@ class GlossaryTaskset(vf.Taskset[GlossaryTask, vf.TasksetConfig]):
             for i, (entity, fact) in enumerate(FACTS.items())
         ]
 
-    def tool_servers(self, task: GlossaryTask) -> list[vf.ToolServer]:
+    def tool_servers(self, task: GlossaryTask) -> list[vf.Tools]:
         return [
-            vf.ToolServer(
-                name="facts", script=SERVER, env={"FACTS_JSON": json.dumps(FACTS)}
-            )
+            vf.Tools(name="facts", script=SERVER, env={"FACTS_JSON": json.dumps(FACTS)})
         ]
 
     @vf.reward(weight=1.0)

--- a/examples/tasksets/terminal_bench_2_v1/pyproject.toml
+++ b/examples/tasksets/terminal_bench_2_v1/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "terminal-bench-2-v1"
+version = "0.1.0"
+description = "Terminal-Bench 2 — the harbor taskset pinned to terminal-bench/terminal-bench-2."
+requires-python = ">=3.10"
+dependencies = ["tasksets"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["terminal_bench_2_v1"]

--- a/examples/tasksets/terminal_bench_2_v1/terminal_bench_2_v1/__init__.py
+++ b/examples/tasksets/terminal_bench_2_v1/terminal_bench_2_v1/__init__.py
@@ -1,0 +1,19 @@
+"""terminal-bench-2-v1 — the harbor taskset pinned to Terminal-Bench 2 (example env).
+
+A thin wrapper over `harbor`: pins `dataset` to "terminal-bench/terminal-bench-2". Needs the
+`harbor` CLI (`uv tool install harbor`) and a container runtime (docker/prime), like harbor.
+"""
+
+from typing import Literal
+
+from harbor import HarborConfig, HarborTaskset
+
+
+class TerminalBench2Config(HarborConfig):
+    dataset: Literal["terminal-bench/terminal-bench-2"] = (
+        "terminal-bench/terminal-bench-2"
+    )
+
+
+def load_taskset(config: TerminalBench2Config) -> HarborTaskset:
+    return HarborTaskset(config)

--- a/examples/tasksets/wiki_search_v1/wiki_search_v1/__init__.py
+++ b/examples/tasksets/wiki_search_v1/wiki_search_v1/__init__.py
@@ -78,9 +78,9 @@ class WikiSearchTaskset(vf.Taskset[TriviaTask, WikiSearchConfig]):
             for i, row in enumerate(rows.select(range(min(NUM_QUESTIONS, len(rows)))))
         ]
 
-    def tool_servers(self, task: TriviaTask) -> list[vf.ToolServer]:
+    def tool_servers(self, task: TriviaTask) -> list[vf.Tools]:
         return [
-            vf.ToolServer(
+            vf.Tools(
                 name="wiki", command=[sys.executable, "-m", "wiki_search_v1.server"]
             )
         ]

--- a/examples/tasksets/wiki_search_v1/wiki_search_v1/__init__.py
+++ b/examples/tasksets/wiki_search_v1/wiki_search_v1/__init__.py
@@ -78,7 +78,7 @@ class WikiSearchTaskset(vf.Taskset[TriviaTask, WikiSearchConfig]):
             for i, row in enumerate(rows.select(range(min(NUM_QUESTIONS, len(rows)))))
         ]
 
-    def tool_servers(self, task: TriviaTask) -> list[vf.Tools]:
+    def tools(self, task: TriviaTask) -> list[vf.Tools]:
         return [
             vf.Tools(
                 name="wiki", command=[sys.executable, "-m", "wiki_search_v1.server"]

--- a/examples/tasksets/wikispeedia_v1/wikispeedia_v1/__init__.py
+++ b/examples/tasksets/wikispeedia_v1/wikispeedia_v1/__init__.py
@@ -101,9 +101,9 @@ class WikispeediaTaskset(vf.Taskset[WikiTask, WikispeediaConfig]):
             for i, (source, target, dist) in enumerate(pairs)
         ]
 
-    def tool_servers(self, task: WikiTask) -> list[vf.ToolServer]:
+    def tool_servers(self, task: WikiTask) -> list[vf.Tools]:
         return [
-            vf.ToolServer(
+            vf.Tools(
                 name="wiki",
                 command=[sys.executable, "-m", "wikispeedia_v1.server"],
                 env={

--- a/examples/tasksets/wikispeedia_v1/wikispeedia_v1/__init__.py
+++ b/examples/tasksets/wikispeedia_v1/wikispeedia_v1/__init__.py
@@ -101,7 +101,7 @@ class WikispeediaTaskset(vf.Taskset[WikiTask, WikispeediaConfig]):
             for i, (source, target, dist) in enumerate(pairs)
         ]
 
-    def tool_servers(self, task: WikiTask) -> list[vf.Tools]:
+    def tools(self, task: WikiTask) -> list[vf.Tools]:
         return [
             vf.Tools(
                 name="wiki",

--- a/examples/tasksets/wordle_v1/pyproject.toml
+++ b/examples/tasksets/wordle_v1/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "wordle-v1"
+version = "0.1.0"
+description = "Wordle — the textarena taskset pinned to Wordle-v0."
+requires-python = ">=3.10"
+dependencies = ["tasksets[textarena]"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["wordle_v1"]

--- a/examples/tasksets/wordle_v1/wordle_v1/__init__.py
+++ b/examples/tasksets/wordle_v1/wordle_v1/__init__.py
@@ -1,0 +1,18 @@
+"""wordle-v1 — the textarena taskset pinned to Wordle (example env).
+
+A thin wrapper over `textarena_v1`: pins `game` to "Wordle-v0", so `wordle-v1` is a
+zero-config Wordle env. Everything else — the user simulator, seed-based task generation,
+and game-authoritative scoring — is inherited unchanged.
+"""
+
+from typing import Literal
+
+from textarena_v1 import TextArenaConfig, TextArenaTaskset
+
+
+class WordleConfig(TextArenaConfig):
+    game: Literal["Wordle-v0"] = "Wordle-v0"
+
+
+def load_taskset(config: WordleConfig) -> TextArenaTaskset:
+    return TextArenaTaskset(config)

--- a/packages/tasksets/pyproject.toml
+++ b/packages/tasksets/pyproject.toml
@@ -5,9 +5,14 @@ description = "Shipped v1 tasksets (resolved by id via `import <id>`), vendored 
 requires-python = ">=3.10"
 dependencies = []
 
+[project.optional-dependencies]
+# textarena_v1 (the TextArena taskset) needs the game engine; kept optional so the other
+# shipped tasksets install without it.
+textarena = ["textarena==0.7.4", "nltk>=3.9.2"]
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["harbor"]
+packages = ["harbor", "textarena_v1"]

--- a/packages/tasksets/textarena_v1/__init__.py
+++ b/packages/tasksets/textarena_v1/__init__.py
@@ -117,7 +117,7 @@ class TextArenaTaskset(vf.Taskset[TextArenaTask, TextArenaConfig]):
             for i, word in enumerate(_word_list(template))
         ]
 
-    def user_server(self, task: TextArenaTask) -> vf.User:
+    def user(self, task: TextArenaTask) -> vf.User:
         return vf.User(
             name="user",
             command=[sys.executable, "-m", "textarena_v1.server"],

--- a/packages/tasksets/textarena_v1/__init__.py
+++ b/packages/tasksets/textarena_v1/__init__.py
@@ -13,6 +13,7 @@ Scoring is a pure function of the trace: the model wins by guessing the secret w
 import re
 import sys
 from collections.abc import Sequence
+from typing import Literal
 
 import verifiers.v1 as vf
 
@@ -37,8 +38,14 @@ _MOVE = re.compile(r"\[(\w+)\]")
 
 
 class TextArenaConfig(vf.TasksetConfig):
-    game: str
-    """The TextArena game id (required; the working example is "Wordle-v0")."""
+    game: Literal[
+        "Wordle-v0", "Wordle-v0-hardcore", "Wordle-v0-long", "Wordle-v0-long-hardcore"
+    ]
+    """The TextArena game (required). Restricted to the Wordle family — the games tested to
+    work with this taskset's assumptions: the answer is a single secret word (seeded via the
+    `secret_word` game-state key) scored by an exact-match `[word]` guess. The working
+    example is "Wordle-v0"; the others vary word length (long = 7) and dictionary size
+    (hardcore = full English word list)."""
 
 
 class TextArenaTask(vf.Task):
@@ -100,11 +107,15 @@ def _wordle_marks(guess: str, answer: str) -> tuple[int, int]:
 class TextArenaTaskset(vf.Taskset[TextArenaTask, TextArenaConfig]):
     def load_tasks(self) -> list[TextArenaTask]:
         # One task per word in the game's list; the eval (num_tasks / shuffle) selects.
+        # Keep only lowercase words: the hardcore lists include capitalized proper nouns,
+        # and TextArena lowercases the guess but not the stored secret, so a capitalized
+        # answer can never be matched (an unwinnable task).
         nltk.download("words", quiet=True)
         nltk.download("averaged_perceptron_tagger_eng", quiet=True)
         template = ta.make(env_id=self.config.game)
         template.reset(num_players=1)
         _, instruction = template.get_observation()
+        words = [w for w in _word_list(template) if w.isalpha() and w == w.lower()]
         return [
             TextArenaTask(
                 idx=i,
@@ -114,7 +125,7 @@ class TextArenaTaskset(vf.Taskset[TextArenaTask, TextArenaConfig]):
                 answer=word,
                 game=self.config.game,
             )
-            for i, word in enumerate(_word_list(template))
+            for i, word in enumerate(words)
         ]
 
     def user(self, task: TextArenaTask) -> vf.User:

--- a/packages/tasksets/textarena_v1/__init__.py
+++ b/packages/tasksets/textarena_v1/__init__.py
@@ -9,13 +9,15 @@ for the subprocess/docker runtimes), so this taskset uses the subprocess runtime
 
 Scoring is game-authoritative: when the episode ends the user simulator writes the game's
 own outcome (`env.state.rewards`) to `OUTCOME_FILE` in the runtime, and the reward reads it
-back — so the taskset needs no per-game guess parsing. Everything the simulator needs to set
-up a game is carried in the task's `info` dict (game id + the secret word to seed).
+back — so the taskset needs no per-game guess parsing. Each task is reproduced from an RNG
+seed (carried in `info`): the taskset seeds the game to build the instruction and the
+simulator re-seeds to the same episode, so no per-game word-list or state-key knowledge is
+needed and any single-player TextArena game fits.
 """
 
 import json
+import random
 import sys
-from collections.abc import Sequence
 from typing import Literal
 
 import verifiers.v1 as vf
@@ -40,64 +42,53 @@ SYSTEM_PROMPT = (
 OUTCOME_FILE = "textarena_outcome.json"
 
 
-def _word_list(env: object) -> list[str]:
-    """The game's word list, flattened (some games expose a dict of difficulty -> words)."""
-    words = getattr(env, "word_list", None)
-    if isinstance(words, dict):
-        words = [
-            w
-            for values in words.values()
-            for w in (values if isinstance(values, (list, tuple)) else [values])
-        ]
-    if not isinstance(words, Sequence) or isinstance(words, (str, bytes)):
-        raise ValueError(
-            f"TextArena game {getattr(env, 'env_id', '?')} exposes no word_list"
-        )
-    return [str(w) for w in words]
-
-
 class TextArenaConfig(vf.TasksetConfig):
     game: Literal[
         "Wordle-v0",
-        "Wordle-v0-hardcore",
         "Wordle-v0-long",
-        "Wordle-v0-long-hardcore",
         "Hangman-v0",
-        "Hangman-v0-hardcore",
+        "WordLadder-v0",
+        "WordSearch-v0",
     ]
-    """The TextArena game (required). Restricted to the tested single-secret-word games (the
-    Wordle and Hangman families): the secret is one word drawn from the game's `word_list`,
-    and the game reports its own win/partial outcome. The working example is "Wordle-v0";
-    variants vary word length (Wordle long = 7) and dictionary size (hardcore = full English
-    word list)."""
+    """The TextArena game (required). The tested single-player games: Wordle / Wordle-long
+    and Hangman (guess a hidden word), WordLadder (change one letter at a time to reach a
+    target), and WordSearch (find words in a grid)."""
+    num_tasks: int = 1000
+    """How many seeded episodes to generate; the eval/orchestrator selects from these."""
 
 
 class TextArenaTask(vf.Task):
     info: dict
-    """Everything the user simulator needs to set up the game: the `game` id and the secret
-    `answer` to seed."""
+    """What the user simulator needs to set up the game: the `game` id and the RNG `seed`
+    that reproduces the exact episode this task's instruction was built from."""
 
 
 class TextArenaTaskset(vf.Taskset[TextArenaTask, TextArenaConfig]):
     def load_tasks(self) -> list[TextArenaTask]:
-        # One task per (lowercase) word; the eval (num_tasks / shuffle) selects. Capitalized
-        # proper nouns in the hardcore lists are unwinnable (TextArena lowercases the guess
-        # but not the stored secret), so drop them.
+        # One task per RNG seed; the simulator re-seeds to reproduce the same episode. Games
+        # that embed the per-episode setup in the prompt (WordLadder's start/target,
+        # WordSearch's grid) need the instruction built under each seed; games whose prompt
+        # is seed-invariant (Wordle, Hangman) build it once.
         nltk.download("words", quiet=True)
         nltk.download("averaged_perceptron_tagger_eng", quiet=True)
-        template = ta.make(env_id=self.config.game)
-        template.reset(num_players=1)
-        _, instruction = template.get_observation()
-        words = [w for w in _word_list(template) if w.isalpha() and w == w.lower()]
+
+        def observation(seed: int) -> str:
+            random.seed(seed)
+            env = ta.make(env_id=self.config.game)
+            env.reset(num_players=1)
+            return str(env.get_observation()[1])
+
+        first = observation(0)
+        seed_specific = observation(1) != first
         return [
             TextArenaTask(
                 idx=i,
                 name=f"{self.config.game}#{i}",
-                instruction=str(instruction),
+                instruction=observation(i) if seed_specific else first,
                 system_prompt=SYSTEM_PROMPT,
-                info={"game": self.config.game, "answer": word},
+                info={"game": self.config.game, "seed": i},
             )
-            for i, word in enumerate(words)
+            for i in range(self.config.num_tasks)
         ]
 
     def user(self, task: TextArenaTask) -> vf.User:

--- a/packages/tasksets/textarena_v1/__init__.py
+++ b/packages/tasksets/textarena_v1/__init__.py
@@ -1,16 +1,19 @@
 """textarena_v1 — TextArena games as a v1 taskset, driven by a user simulator.
 
 Each task is one episode of a TextArena game (the working example is Wordle). The model
-plays by emitting guesses; the framework's interception server drives a `vf.User` (the game
+plays by emitting moves; the framework's interception server drives a `vf.User` (the game
 engine, see `server.py`) that replies with the game's feedback as a user turn — so a whole
 game is one rollout of alternating assistant/user turns, and the harness/program never see
 the simulator. The user simulator runs colocated in the harness's runtime (host-reachable
 for the subprocess/docker runtimes), so this taskset uses the subprocess runtime.
 
-Scoring is a pure function of the trace: the model wins by guessing the secret word.
+Scoring is game-authoritative: when the episode ends the user simulator writes the game's
+own outcome (`env.state.rewards`) to `OUTCOME_FILE` in the runtime, and the reward reads it
+back — so the taskset needs no per-game guess parsing. Everything the simulator needs to set
+up a game is carried in the task's `info` dict (game id + the secret word to seed).
 """
 
-import re
+import json
 import sys
 from collections.abc import Sequence
 from typing import Literal
@@ -27,31 +30,14 @@ except ImportError as e:
 
 SYSTEM_PROMPT = (
     "You are a competitive game player. Read the game instructions carefully and always "
-    "use the exact answer format the game requires. Think step-by-step first, then give "
-    "your move as the only square-bracketed word in your reply (e.g. [crane]) — the game "
-    "reads the first bracketed word, so don't put other words in brackets."
+    "use the exact move format the game requires. Think step-by-step first, then give your "
+    "move as the only square-bracketed token in your reply — the game reads the first "
+    "bracketed token, so don't put other words in brackets."
 )
 
-# TextArena parses the move as the FIRST bracketed token, via re.search(r"\[(\w+)\]") (see
-# Wordle/env.py) — match that exactly so the reward scores the same word the game acted on.
-_MOVE = re.compile(r"\[(\w+)\]")
-
-
-class TextArenaConfig(vf.TasksetConfig):
-    game: Literal[
-        "Wordle-v0", "Wordle-v0-hardcore", "Wordle-v0-long", "Wordle-v0-long-hardcore"
-    ]
-    """The TextArena game (required). Restricted to the Wordle family — the games tested to
-    work with this taskset's assumptions: the answer is a single secret word (seeded via the
-    `secret_word` game-state key) scored by an exact-match `[word]` guess. The working
-    example is "Wordle-v0"; the others vary word length (long = 7) and dictionary size
-    (hardcore = full English word list)."""
-
-
-class TextArenaTask(vf.Task):
-    answer: str
-    """The secret word for this episode; the user simulator's game is seeded with it."""
-    game: str
+# The user simulator writes the game's outcome here (in the runtime workspace) and the
+# reward reads it back; shared with `server.py`.
+OUTCOME_FILE = "textarena_outcome.json"
 
 
 def _word_list(env: object) -> list[str]:
@@ -70,46 +56,33 @@ def _word_list(env: object) -> list[str]:
     return [str(w) for w in words]
 
 
-def _normalize(word: str) -> str:
-    return word.strip().lower()
+class TextArenaConfig(vf.TasksetConfig):
+    game: Literal[
+        "Wordle-v0",
+        "Wordle-v0-hardcore",
+        "Wordle-v0-long",
+        "Wordle-v0-long-hardcore",
+        "Hangman-v0",
+        "Hangman-v0-hardcore",
+    ]
+    """The TextArena game (required). Restricted to the tested single-secret-word games (the
+    Wordle and Hangman families): the secret is one word drawn from the game's `word_list`,
+    and the game reports its own win/partial outcome. The working example is "Wordle-v0";
+    variants vary word length (Wordle long = 7) and dictionary size (hardcore = full English
+    word list)."""
 
 
-def _extract_guess(content: str) -> str | None:
-    """The word TextArena acts on: the first bracketed token in the message (or None)."""
-    match = _MOVE.search(content)
-    return match.group(1) if match else None
-
-
-def _guesses(trace: vf.Trace) -> list[str]:
-    """The move per assistant turn that made one, in order."""
-    moves = (_extract_guess(m.content or "") for m in trace.assistant_messages)
-    return [g for g in moves if g]
-
-
-def _wordle_marks(guess: str, answer: str) -> tuple[int, int]:
-    """(#greens, #yellows) for a guess vs the answer — standard, letter-count-aware Wordle."""
-    n = len(answer)
-    g = _normalize(guess).ljust(n)[:n]
-    a = answer.lower()
-    greens = sum(1 for i in range(n) if g[i] == a[i])
-    counts: dict[str, int] = {}
-    for i in range(n):
-        if g[i] != a[i]:
-            counts[a[i]] = counts.get(a[i], 0) + 1
-    yellows = 0
-    for i in range(n):
-        if g[i] != a[i] and counts.get(g[i], 0) > 0:
-            counts[g[i]] -= 1
-            yellows += 1
-    return greens, yellows
+class TextArenaTask(vf.Task):
+    info: dict
+    """Everything the user simulator needs to set up the game: the `game` id and the secret
+    `answer` to seed."""
 
 
 class TextArenaTaskset(vf.Taskset[TextArenaTask, TextArenaConfig]):
     def load_tasks(self) -> list[TextArenaTask]:
-        # One task per word in the game's list; the eval (num_tasks / shuffle) selects.
-        # Keep only lowercase words: the hardcore lists include capitalized proper nouns,
-        # and TextArena lowercases the guess but not the stored secret, so a capitalized
-        # answer can never be matched (an unwinnable task).
+        # One task per (lowercase) word; the eval (num_tasks / shuffle) selects. Capitalized
+        # proper nouns in the hardcore lists are unwinnable (TextArena lowercases the guess
+        # but not the stored secret), so drop them.
         nltk.download("words", quiet=True)
         nltk.download("averaged_perceptron_tagger_eng", quiet=True)
         template = ta.make(env_id=self.config.game)
@@ -122,8 +95,7 @@ class TextArenaTaskset(vf.Taskset[TextArenaTask, TextArenaConfig]):
                 name=f"{self.config.game}#{i}",
                 instruction=str(instruction),
                 system_prompt=SYSTEM_PROMPT,
-                answer=word,
-                game=self.config.game,
+                info={"game": self.config.game, "answer": word},
             )
             for i, word in enumerate(words)
         ]
@@ -132,35 +104,20 @@ class TextArenaTaskset(vf.Taskset[TextArenaTask, TextArenaConfig]):
         return vf.User(
             name="user",
             command=[sys.executable, "-m", "textarena_v1.server"],
-            env={
-                "TEXTARENA_GAME": task.game,
-                "TEXTARENA_ANSWER": task.answer,
-            },
+            env={"TEXTARENA_INFO": json.dumps(task.info)},
         )
 
     @vf.reward(weight=1.0)
-    async def correct(self, task: TextArenaTask, trace: vf.Trace) -> float:
-        answer = _normalize(task.answer)
-        return float(any(_normalize(g) == answer for g in _guesses(trace)))
-
-    @vf.reward(weight=0.2)
-    async def partial(self, task: TextArenaTask, trace: vf.Trace) -> float:
-        # Best-guess shaping (green/yellow letters), recomputed from the trace; skipped once
-        # solved (the win already scores 1.0 via `correct`).
-        guesses = _guesses(trace)
-        answer = _normalize(task.answer)
-        n = len(task.answer)
-        if not guesses or not n or any(_normalize(g) == answer for g in guesses):
+    async def game_reward(
+        self, task: TextArenaTask, trace: vf.Trace, runtime: vf.Runtime
+    ) -> float:
+        # The simulator wrote the game's own outcome to the runtime when the episode ended;
+        # a missing file means the game never finished (e.g. every move was invalid).
+        try:
+            data = await runtime.read(OUTCOME_FILE)
+        except (FileNotFoundError, OSError):
             return 0.0
-        scores = (
-            (greens + 0.5 * yellows) / n
-            for greens, yellows in (_wordle_marks(g, task.answer) for g in guesses)
-        )
-        return max(scores, default=0.0)
-
-    @vf.metric
-    async def num_guesses(self, trace: vf.Trace) -> float:
-        return float(len(_guesses(trace)))
+        return float(json.loads(data)["reward"])
 
 
 def load_taskset(config: TextArenaConfig) -> TextArenaTaskset:

--- a/packages/tasksets/textarena_v1/__init__.py
+++ b/packages/tasksets/textarena_v1/__init__.py
@@ -1,0 +1,168 @@
+"""textarena_v1 — TextArena games as a v1 taskset, driven by a user simulator.
+
+Each task is one episode of a TextArena game (the working example is Wordle). The model
+plays by emitting guesses; the framework's interception server drives a `vf.User` (the game
+engine, see `server.py`) that replies with the game's feedback as a user turn — so a whole
+game is one rollout of alternating assistant/user turns, and the harness/program never see
+the simulator. The user simulator runs colocated in the harness's runtime (host-reachable
+for the subprocess/docker runtimes), so this taskset uses the subprocess runtime.
+
+Scoring is a pure function of the trace: the model wins by guessing the secret word.
+"""
+
+import random
+import re
+import sys
+from collections.abc import Sequence
+
+import verifiers.v1 as vf
+
+try:
+    import nltk
+    import textarena as ta
+except ImportError as e:
+    raise ImportError(
+        "textarena_v1 requires nltk and textarena. Install with: uv add 'tasksets[textarena]'"
+    ) from e
+
+SYSTEM_PROMPT = (
+    "You are a competitive game player. Read the game instructions carefully and always "
+    "use the exact answer format the game requires. Think step-by-step first, then give "
+    "your move as the only square-bracketed word in your reply (e.g. [crane]) — the game "
+    "reads the first bracketed word, so don't put other words in brackets."
+)
+
+# TextArena parses the move as the FIRST bracketed token, via re.search(r"\[(\w+)\]") (see
+# Wordle/env.py) — match that exactly so the reward scores the same word the game acted on.
+_MOVE = re.compile(r"\[(\w+)\]")
+
+
+class TextArenaConfig(vf.TasksetConfig):
+    game: str = "Wordle-v0"
+    """The TextArena game id (the working example is "Wordle-v0")."""
+    num_tasks: int = 20
+    seed: int = 0
+    max_turns: int = 8
+    answer_state_key: str = "secret_word"
+    """The `game_state` key the secret answer is written to (Wordle: "secret_word")."""
+
+
+class TextArenaTask(vf.Task):
+    answer: str
+    """The secret word for this episode; the user simulator's game is seeded with it."""
+    game: str
+    answer_state_key: str
+
+
+def _word_list(env: object) -> list[str]:
+    """The game's word list, flattened (some games expose a dict of difficulty -> words)."""
+    words = getattr(env, "word_list", None)
+    if isinstance(words, dict):
+        words = [
+            w
+            for values in words.values()
+            for w in (values if isinstance(values, (list, tuple)) else [values])
+        ]
+    if not isinstance(words, Sequence) or isinstance(words, (str, bytes)):
+        raise ValueError(
+            f"TextArena game {getattr(env, 'env_id', '?')} exposes no word_list"
+        )
+    return [str(w) for w in words]
+
+
+def _normalize(word: str) -> str:
+    return word.strip().lower()
+
+
+def _extract_guess(content: str) -> str | None:
+    """The word TextArena acts on: the first bracketed token in the message (or None)."""
+    match = _MOVE.search(content)
+    return match.group(1) if match else None
+
+
+def _guesses(trace: vf.Trace) -> list[str]:
+    """The move per assistant turn that made one, in order."""
+    moves = (_extract_guess(m.content or "") for m in trace.assistant_messages)
+    return [g for g in moves if g]
+
+
+def _wordle_marks(guess: str, answer: str) -> tuple[int, int]:
+    """(#greens, #yellows) for a guess vs the answer — standard, letter-count-aware Wordle."""
+    n = len(answer)
+    g = _normalize(guess).ljust(n)[:n]
+    a = answer.lower()
+    greens = sum(1 for i in range(n) if g[i] == a[i])
+    counts: dict[str, int] = {}
+    for i in range(n):
+        if g[i] != a[i]:
+            counts[a[i]] = counts.get(a[i], 0) + 1
+    yellows = 0
+    for i in range(n):
+        if g[i] != a[i] and counts.get(g[i], 0) > 0:
+            counts[g[i]] -= 1
+            yellows += 1
+    return greens, yellows
+
+
+class TextArenaTaskset(vf.Taskset[TextArenaTask, TextArenaConfig]):
+    def load_tasks(self) -> list[TextArenaTask]:
+        nltk.download("words", quiet=True)
+        nltk.download("averaged_perceptron_tagger_eng", quiet=True)
+        template = ta.make(env_id=self.config.game)
+        template.reset(num_players=1)
+        _, instruction = template.get_observation()
+        words = _word_list(template)
+        rng = random.Random(self.config.seed)
+        return [
+            TextArenaTask(
+                idx=i,
+                name=f"{self.config.game}#{i}",
+                instruction=str(instruction),
+                system_prompt=SYSTEM_PROMPT,
+                answer=rng.choice(words),
+                game=self.config.game,
+                answer_state_key=self.config.answer_state_key,
+            )
+            for i in range(self.config.num_tasks)
+        ]
+
+    def user_server(self, task: TextArenaTask) -> vf.User:
+        # A colocated user simulator (the game engine) reachable from the host interception
+        # server; the secret word is injected via env, set before the first observation.
+        return vf.User(
+            name="user",
+            command=[sys.executable, "-m", "textarena_v1.server"],
+            env={
+                "TEXTARENA_GAME": task.game,
+                "TEXTARENA_ANSWER": task.answer,
+                "TEXTARENA_ANSWER_KEY": task.answer_state_key,
+            },
+        )
+
+    @vf.reward(weight=1.0)
+    async def correct(self, task: TextArenaTask, trace: vf.Trace) -> float:
+        answer = _normalize(task.answer)
+        return float(any(_normalize(g) == answer for g in _guesses(trace)))
+
+    @vf.reward(weight=0.2)
+    async def partial(self, task: TextArenaTask, trace: vf.Trace) -> float:
+        # Best-guess shaping (green/yellow letters), recomputed from the trace; skipped once
+        # solved (the win already scores 1.0 via `correct`).
+        guesses = _guesses(trace)
+        answer = _normalize(task.answer)
+        n = len(task.answer)
+        if not guesses or not n or any(_normalize(g) == answer for g in guesses):
+            return 0.0
+        scores = (
+            (greens + 0.5 * yellows) / n
+            for greens, yellows in (_wordle_marks(g, task.answer) for g in guesses)
+        )
+        return max(scores, default=0.0)
+
+    @vf.metric
+    async def num_guesses(self, trace: vf.Trace) -> float:
+        return float(len(_guesses(trace)))
+
+
+def load_taskset(config: TextArenaConfig) -> TextArenaTaskset:
+    return TextArenaTaskset(config)

--- a/packages/tasksets/textarena_v1/__init__.py
+++ b/packages/tasksets/textarena_v1/__init__.py
@@ -10,7 +10,6 @@ for the subprocess/docker runtimes), so this taskset uses the subprocess runtime
 Scoring is a pure function of the trace: the model wins by guessing the secret word.
 """
 
-import random
 import re
 import sys
 from collections.abc import Sequence
@@ -38,20 +37,14 @@ _MOVE = re.compile(r"\[(\w+)\]")
 
 
 class TextArenaConfig(vf.TasksetConfig):
-    game: str = "Wordle-v0"
-    """The TextArena game id (the working example is "Wordle-v0")."""
-    num_tasks: int = 20
-    seed: int = 0
-    max_turns: int = 8
-    answer_state_key: str = "secret_word"
-    """The `game_state` key the secret answer is written to (Wordle: "secret_word")."""
+    game: str
+    """The TextArena game id (required; the working example is "Wordle-v0")."""
 
 
 class TextArenaTask(vf.Task):
     answer: str
     """The secret word for this episode; the user simulator's game is seeded with it."""
     game: str
-    answer_state_key: str
 
 
 def _word_list(env: object) -> list[str]:
@@ -106,36 +99,31 @@ def _wordle_marks(guess: str, answer: str) -> tuple[int, int]:
 
 class TextArenaTaskset(vf.Taskset[TextArenaTask, TextArenaConfig]):
     def load_tasks(self) -> list[TextArenaTask]:
+        # One task per word in the game's list; the eval (num_tasks / shuffle) selects.
         nltk.download("words", quiet=True)
         nltk.download("averaged_perceptron_tagger_eng", quiet=True)
         template = ta.make(env_id=self.config.game)
         template.reset(num_players=1)
         _, instruction = template.get_observation()
-        words = _word_list(template)
-        rng = random.Random(self.config.seed)
         return [
             TextArenaTask(
                 idx=i,
                 name=f"{self.config.game}#{i}",
                 instruction=str(instruction),
                 system_prompt=SYSTEM_PROMPT,
-                answer=rng.choice(words),
+                answer=word,
                 game=self.config.game,
-                answer_state_key=self.config.answer_state_key,
             )
-            for i in range(self.config.num_tasks)
+            for i, word in enumerate(_word_list(template))
         ]
 
     def user_server(self, task: TextArenaTask) -> vf.User:
-        # A colocated user simulator (the game engine) reachable from the host interception
-        # server; the secret word is injected via env, set before the first observation.
         return vf.User(
             name="user",
             command=[sys.executable, "-m", "textarena_v1.server"],
             env={
                 "TEXTARENA_GAME": task.game,
                 "TEXTARENA_ANSWER": task.answer,
-                "TEXTARENA_ANSWER_KEY": task.answer_state_key,
             },
         )
 

--- a/packages/tasksets/textarena_v1/server.py
+++ b/packages/tasksets/textarena_v1/server.py
@@ -1,0 +1,75 @@
+"""TextArena user simulator: the game engine as a framework-driven conversation partner.
+
+Launched by the framework as a host subprocess per rollout (a `vf.User`, structurally a
+tool server). It holds one TextArena game in memory, seeded with the rollout's secret word
+from the env the taskset injects, and serves a single `respond` tool: given the model's
+last message (a guess), it steps the game and returns the game's feedback as the next user
+message, plus whether the game is over. The interception server drives it — the harness and
+its program never see it.
+
+Feedback is trimmed to the latest block (the text after `Feedback:` in the last `[GAME]`
+message) so each injected user turn stays small and doesn't duplicate the running history.
+"""
+
+import json
+import os
+import re
+
+from mcp.server.fastmcp import FastMCP
+
+import verifiers.v1 as vf
+
+import nltk
+
+# textarena pulls nltk corpora on import; keep it quiet and ensure they're present first.
+_orig_download = nltk.download
+nltk.download = lambda *a, **k: _orig_download(*a, **{**k, "quiet": True})  # type: ignore[assignment]
+nltk.download("words")
+nltk.download("averaged_perceptron_tagger_eng")
+
+import textarena as ta  # noqa: E402
+
+GAME = os.environ["TEXTARENA_GAME"]
+ANSWER = os.environ["TEXTARENA_ANSWER"]
+ANSWER_KEY = os.environ.get("TEXTARENA_ANSWER_KEY", "secret_word")
+
+env = ta.make(env_id=GAME)
+env.reset(num_players=1)
+env.state.game_state[ANSWER_KEY] = ANSWER
+
+mcp = FastMCP("user")
+
+
+def parse_guess(message: str) -> str:
+    """The model's latest `<guess>...</guess>` (else the whole message), passed to the game
+    verbatim — TextArena owns its own action format (Wordle expects a bracketed `[word]`)."""
+    matches = re.findall(r"<guess>(.*?)</guess>", message, re.DOTALL | re.IGNORECASE)
+    return matches[-1].strip() if matches else message.strip()
+
+
+def latest_feedback(observation: str) -> str:
+    latest = observation.split("[GAME]")[-1].strip()
+    return latest.split("Feedback:")[-1].strip() if "Feedback:" in latest else latest
+
+
+@mcp.tool()
+def respond(message: str) -> str:
+    """Step the game with the model's latest guess; return the next user message + done."""
+    env.step(parse_guess(message))
+    if env.state.done:
+        reason = str(env.state.game_info[0]["reason"])
+        return json.dumps(
+            {"messages": [{"role": "user", "content": reason}], "done": True}
+        )
+    _, observation = env.get_observation()
+    return json.dumps(
+        {
+            "messages": [
+                {"role": "user", "content": latest_feedback(str(observation))}
+            ],
+            "done": False,
+        }
+    )
+
+
+vf.run_mcp_server(mcp)

--- a/packages/tasksets/textarena_v1/server.py
+++ b/packages/tasksets/textarena_v1/server.py
@@ -1,11 +1,12 @@
 """TextArena user simulator: the game engine as a framework-driven conversation partner.
 
-Launched by the framework as a host subprocess per rollout (a `vf.User`, structurally a
-tool server). It holds one TextArena game in memory, seeded with the rollout's secret word
-from the env the taskset injects, and serves a single `respond` tool: given the model's
-last message (a guess), it steps the game and returns the game's feedback as the next user
-message, plus whether the game is over. The interception server drives it — the harness and
-its program never see it.
+Launched by the framework as a host subprocess per rollout (a `vf.User`). It holds one
+TextArena game in memory, set up from the `TEXTARENA_INFO` the taskset injects (game id +
+the secret word to seed), and serves a single `respond` tool: given the model's last
+message it steps the game and returns the next observation as a user message, plus whether
+the episode is over. When the game ends it writes the game's own outcome
+(`env.state.rewards`) to `OUTCOME_FILE` in the runtime workspace, where the taskset's reward
+reads it back.
 
 Feedback is trimmed to the latest block (the text after `Feedback:` in the last `[GAME]`
 message) so each injected user turn stays small and doesn't duplicate the running history.
@@ -13,11 +14,13 @@ message) so each injected user turn stays small and doesn't duplicate the runnin
 
 import json
 import os
-import re
+import random
 
 from mcp.server.fastmcp import FastMCP
 
 import verifiers.v1 as vf
+
+from textarena_v1 import OUTCOME_FILE
 
 import nltk
 
@@ -29,21 +32,22 @@ nltk.download("averaged_perceptron_tagger_eng")
 
 import textarena as ta  # noqa: E402
 
-GAME = os.environ["TEXTARENA_GAME"]
-ANSWER = os.environ["TEXTARENA_ANSWER"]
+INFO = json.loads(os.environ["TEXTARENA_INFO"])
 
-env = ta.make(env_id=GAME)
-env.reset(num_players=1)
-env.state.game_state["secret_word"] = ANSWER
+env = ta.make(env_id=INFO["game"])
+# Seed the secret generically: intercept the word pick during reset so the game itself
+# selects our answer and derives all of its own state (Wordle's secret_word, Hangman's
+# board, ...), without us needing to know each game's state keys.
+_orig_choice = random.choice
+random.choice = lambda seq: (
+    INFO["answer"] if seq is env.word_list else _orig_choice(seq)
+)
+try:
+    env.reset(num_players=1)
+finally:
+    random.choice = _orig_choice
 
 mcp = FastMCP("user")
-
-
-def parse_guess(message: str) -> str:
-    """The model's latest `<guess>...</guess>` (else the whole message), passed to the game
-    verbatim — TextArena owns its own action format (Wordle expects a bracketed `[word]`)."""
-    matches = re.findall(r"<guess>(.*?)</guess>", message, re.DOTALL | re.IGNORECASE)
-    return matches[-1].strip() if matches else message.strip()
 
 
 def latest_feedback(observation: str) -> str:
@@ -53,10 +57,13 @@ def latest_feedback(observation: str) -> str:
 
 @mcp.tool()
 def respond(message: str) -> str:
-    """Step the game with the model's latest guess; return the next user message + done."""
-    env.step(parse_guess(message))
+    """Step the game with the model's move; return the next user message + done."""
+    env.step(message)  # TextArena parses the bracketed move out of the message itself
     if env.state.done:
+        reward = float((env.state.rewards or {}).get(0, 0.0))
         reason = str(env.state.game_info[0]["reason"])
+        with open(OUTCOME_FILE, "w") as f:
+            json.dump({"reward": reward, "reason": reason}, f)
         return json.dumps(
             {"messages": [{"role": "user", "content": reason}], "done": True}
         )

--- a/packages/tasksets/textarena_v1/server.py
+++ b/packages/tasksets/textarena_v1/server.py
@@ -2,7 +2,7 @@
 
 Launched by the framework as a host subprocess per rollout (a `vf.User`). It holds one
 TextArena game in memory, set up from the `TEXTARENA_INFO` the taskset injects (game id +
-the secret word to seed), and serves a single `respond` tool: given the model's last
+RNG seed), and serves a single `respond` tool: given the model's last
 message it steps the game and returns the next observation as a user message, plus whether
 the episode is over. When the game ends it writes the game's own outcome
 (`env.state.rewards`) to `OUTCOME_FILE` in the runtime workspace, where the taskset's reward
@@ -34,18 +34,11 @@ import textarena as ta  # noqa: E402
 
 INFO = json.loads(os.environ["TEXTARENA_INFO"])
 
+# Generic seed: the game derives its whole setup from the global RNG at reset, so seeding it
+# reproduces the exact episode the taskset built the instruction from — no per-game keys.
 env = ta.make(env_id=INFO["game"])
-# Seed the secret generically: intercept the word pick during reset so the game itself
-# selects our answer and derives all of its own state (Wordle's secret_word, Hangman's
-# board, ...), without us needing to know each game's state keys.
-_orig_choice = random.choice
-random.choice = lambda seq: (
-    INFO["answer"] if seq is env.word_list else _orig_choice(seq)
-)
-try:
-    env.reset(num_players=1)
-finally:
-    random.choice = _orig_choice
+random.seed(INFO["seed"])
+env.reset(num_players=1)
 
 mcp = FastMCP("user")
 

--- a/packages/tasksets/textarena_v1/server.py
+++ b/packages/tasksets/textarena_v1/server.py
@@ -31,11 +31,10 @@ import textarena as ta  # noqa: E402
 
 GAME = os.environ["TEXTARENA_GAME"]
 ANSWER = os.environ["TEXTARENA_ANSWER"]
-ANSWER_KEY = os.environ.get("TEXTARENA_ANSWER_KEY", "secret_word")
 
 env = ta.make(env_id=GAME)
 env.reset(num_players=1)
-env.state.game_state[ANSWER_KEY] = ANSWER
+env.state.game_state["secret_word"] = ANSWER
 
 mcp = FastMCP("user")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ examples = [
     "compact",
     "gsm8k-v1", "wikispeedia-v1", "glossary-v1", "deepwiki-v1", "wiki-search-v1", "code-golf-v1",
     "reverse-text-v1", "hello-rlm-v1", "math-env-v1", "aime24-v1",
+    "wordle-v1", "terminal-bench-2-v1",
 ]
 
 [project.optional-dependencies]
@@ -147,6 +148,8 @@ wiki-search-v1 = { path = "examples/tasksets/wiki_search_v1", editable = true }
 gsm8k-v1 = { path = "examples/tasksets/gsm8k_v1", editable = true }
 code-golf-v1 = { path = "examples/tasksets/code_golf_v1", editable = true }
 reverse-text-v1 = { path = "examples/tasksets/reverse_text_v1", editable = true }
+wordle-v1 = { path = "examples/tasksets/wordle_v1", editable = true }
+terminal-bench-2-v1 = { path = "examples/tasksets/terminal_bench_2_v1", editable = true }
 math-env-v1 = { path = "examples/tasksets/math_env_v1", editable = true }
 aime24-v1 = { path = "examples/tasksets/aime24_v1", editable = true }
 

--- a/uv.lock
+++ b/uv.lock
@@ -5079,6 +5079,12 @@ name = "tasksets"
 version = "0.1.0"
 source = { editable = "packages/tasksets" }
 
+[package.optional-dependencies]
+textarena = [
+    { name = "nltk" },
+    { name = "textarena" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "nltk", marker = "extra == 'textarena'", specifier = ">=3.9.2" },
@@ -5094,6 +5100,17 @@ sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
 ]
+
+[[package]]
+name = "terminal-bench-2-v1"
+version = "0.1.0"
+source = { editable = "examples/tasksets/terminal_bench_2_v1" }
+dependencies = [
+    { name = "tasksets" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "tasksets" }]
 
 [[package]]
 name = "textarena"
@@ -5658,8 +5675,10 @@ examples = [
     { name = "hello-rlm-v1" },
     { name = "math-env-v1" },
     { name = "reverse-text-v1" },
+    { name = "terminal-bench-2-v1" },
     { name = "wiki-search-v1" },
     { name = "wikispeedia-v1" },
+    { name = "wordle-v1" },
 ]
 harnesses = [
     { name = "harnesses" },
@@ -5752,8 +5771,10 @@ examples = [
     { name = "hello-rlm-v1", editable = "examples/tasksets/hello_rlm_v1" },
     { name = "math-env-v1", editable = "examples/tasksets/math_env_v1" },
     { name = "reverse-text-v1", editable = "examples/tasksets/reverse_text_v1" },
+    { name = "terminal-bench-2-v1", editable = "examples/tasksets/terminal_bench_2_v1" },
     { name = "wiki-search-v1", editable = "examples/tasksets/wiki_search_v1" },
     { name = "wikispeedia-v1", editable = "examples/tasksets/wikispeedia_v1" },
+    { name = "wordle-v1", editable = "examples/tasksets/wordle_v1" },
 ]
 harnesses = [{ name = "harnesses", editable = "packages/harnesses" }]
 tasksets = [{ name = "tasksets", editable = "packages/tasksets" }]
@@ -6030,6 +6051,17 @@ sdist = { url = "https://files.pythonhosted.org/packages/b3/8f/705086c9d734d3b66
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/07/c6fe3ad3e685340704d314d765b7912993bcb8dc198f0e7a89382d37974b/win32_setctime-1.2.0-py3-none-any.whl", hash = "sha256:95d644c4e708aba81dc3704a116d8cbc974d70b3bdb8be1d150e36be6e9d1390", size = 4083, upload-time = "2024-12-07T15:28:26.465Z" },
 ]
+
+[[package]]
+name = "wordle-v1"
+version = "0.1.0"
+source = { editable = "examples/tasksets/wordle_v1" }
+dependencies = [
+    { name = "tasksets", extra = ["textarena"] },
+]
+
+[package.metadata]
+requires-dist = [{ name = "tasksets", extras = ["textarena"] }]
 
 [[package]]
 name = "xformers"

--- a/uv.lock
+++ b/uv.lock
@@ -5079,6 +5079,13 @@ name = "tasksets"
 version = "0.1.0"
 source = { editable = "packages/tasksets" }
 
+[package.metadata]
+requires-dist = [
+    { name = "nltk", marker = "extra == 'textarena'", specifier = ">=3.9.2" },
+    { name = "textarena", marker = "extra == 'textarena'", specifier = "==0.7.4" },
+]
+provides-extras = ["textarena"]
+
 [[package]]
 name = "tenacity"
 version = "9.1.4"

--- a/verifiers/v1/__init__.py
+++ b/verifiers/v1/__init__.py
@@ -32,6 +32,7 @@ from verifiers.v1.loaders import (
     taskset_config_type,
 )
 from verifiers.v1.tools import ToolServer, run_mcp_server
+from verifiers.v1.user import User
 from verifiers.v1.runtimes import (
     DockerConfig,
     PrimeConfig,
@@ -137,6 +138,8 @@ __all__ = [
     # mcp
     "ToolServer",
     "run_mcp_server",
+    # user simulator
+    "User",
 ]
 
 # The library logs via stdlib logging (per-module `getLogger(__name__)`), but is

--- a/verifiers/v1/__init__.py
+++ b/verifiers/v1/__init__.py
@@ -31,7 +31,7 @@ from verifiers.v1.loaders import (
     task_type,
     taskset_config_type,
 )
-from verifiers.v1.tools import ToolServer, run_mcp_server
+from verifiers.v1.tools import Tools, run_mcp_server
 from verifiers.v1.user import User
 from verifiers.v1.runtimes import (
     DockerConfig,
@@ -136,7 +136,7 @@ __all__ = [
     "taskset_config_type",
     "harness_config_type",
     # mcp
-    "ToolServer",
+    "Tools",
     "run_mcp_server",
     # user simulator
     "User",

--- a/verifiers/v1/env.py
+++ b/verifiers/v1/env.py
@@ -191,7 +191,5 @@ class Environment:
         if not (tools.shared and tasks):
             yield {}
             return
-        async with serve_shared(
-            self.taskset.tool_servers(tasks[0]), tools.runtime
-        ) as urls:
+        async with serve_shared(self.taskset.tools(tasks[0]), tools.runtime) as urls:
             yield urls

--- a/verifiers/v1/interception.py
+++ b/verifiers/v1/interception.py
@@ -4,14 +4,18 @@ Every rollout runs an harness program whose OpenAI-style calls are caught here:
 this small localhost server routes each `POST /v1/chat/completions` to our
 `Client`, records a `Turn`, and returns the result in OpenAI shape. We inject
 `OPENAI_BASE_URL`/`OPENAI_API_KEY` so the program's SDK talks to us. Chat
-completions only, no streaming — only the model endpoint is intercepted (tools
-and the user simulator are handled out-of-band for now).
+completions only, no streaming. When the rollout sets a user simulator (see
+`verifiers.v1.user`), this server also drives it: after each model turn it injects
+the simulator's reply as a user turn and re-prompts the model, so a multi-turn
+exchange plays out within one program request, transparently to the harness. Tools
+are handled out-of-band (run by the harness).
 """
 
 import logging
 import secrets
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from aiohttp import web
 
@@ -28,6 +32,9 @@ from verifiers.v1.types import (
     ToolMessage,
     UserMessage,
 )
+
+if TYPE_CHECKING:
+    from verifiers.v1.user import Respond
 
 logger = logging.getLogger(__name__)
 
@@ -169,6 +176,11 @@ class InterceptionServer:
         self.secret = secrets.token_urlsafe(16)
         self.port = 0
         self.runner: web.AppRunner | None = None
+        self.user: "Respond | None" = None
+        """A user simulator the rollout sets before the harness runs (see
+        `verifiers.v1.user`). When set, each model turn with no tool call is followed by
+        the simulator's reply, injected as a user turn, and the model is re-prompted —
+        all within one program request, transparently to the harness."""
 
     async def __aenter__(self) -> "InterceptionServer":
         app = web.Application(client_max_size=_MAX_REQUEST_BODY)
@@ -185,55 +197,60 @@ class InterceptionServer:
         if self.runner is not None:
             await self.runner.cleanup()
 
+    async def _refused(self) -> str | None:
+        """The framework's limits (turns / token budget) and `@stop` checks, run before each
+        model call. Sets the stop condition and returns its name, else None. A refused first
+        call halts the harness (its model call errors out); Harness.run treats it as clean."""
+        if (limit := self.limits.reached(self.trace)) is not None:
+            self.trace.stop(limit)
+            logger.debug("limit %r reached: id=%s", limit, self.trace.id)
+            return limit
+        for stop in self.stops:
+            if await stop(self.trace):
+                self.trace.stop(stop.__name__)
+                logger.debug("stop %r fired: id=%s", stop.__name__, self.trace.id)
+                return stop.__name__
+        return None
+
     async def handle_chat(self, request: web.Request) -> web.Response:
         if request.headers.get("Authorization") != f"Bearer {self.secret}":
             logger.warning("interception: unauthorized request id=%s", self.trace.id)
             return web.json_response({"error": "unauthorized"}, status=401)
-        turn = len(self.trace.trajectory) + 1  # 1-based: the turn being handled
-        # A framework limit (turns or a token budget) refuses the turn before it's served,
-        # halting any harness — the same mechanism as a @stop.
-        if (limit := self.limits.reached(self.trace)) is not None:
-            self.trace.stop(limit)
-            logger.debug("limit %r reached: id=%s turn=%d", limit, self.trace.id, turn)
-            return web.json_response({"error": f"rollout stopped: {limit}"}, status=400)
-        # A @stop firing here refuses the turn before it is served, which halts the
-        # harness (its model call errors out); Harness.run treats that exit as clean.
-        for stop in self.stops:
-            if await stop(self.trace):
-                self.trace.stop(stop.__name__)
-                logger.debug(
-                    "stop %r fired: id=%s turn=%d", stop.__name__, self.trace.id, turn
-                )
-                return web.json_response(
-                    {"error": f"rollout stopped: {stop.__name__}"}, status=400
-                )
         body = await request.json()
         prompt: Messages = [parse_message(m) for m in body.get("messages", [])]
         tools = parse_tools(body.get("tools"))
-        logger.debug(
-            "chat request: id=%s turn=%d model=%s messages=%d tools=%d",
-            self.trace.id,
-            turn,
-            self.ctx.model,
-            len(prompt),
-            len(tools or []),
-        )
-        try:
-            response = await self.ctx.client.get_response(
-                prompt, self.ctx.model, self.ctx.sampling, tools
-            )
-        except Exception as e:  # surface to the program as an API error
-            logger.warning("model call failed: id=%s %s", self.trace.id, e)
-            return web.json_response({"error": str(e)}, status=502)
-        completion_tokens = response.usage.completion_tokens if response.usage else None
-        logger.debug(
-            "chat response: id=%s finish=%s tool_calls=%d completion_tokens=%s",
-            self.trace.id,
-            response.finish_reason,
-            len(response.message.tool_calls or []),
-            completion_tokens,
-        )
-        self.trace.trajectory.append(
-            Turn(prompt=prompt, response=response, tokens=response.tokens)
-        )  # branches are derived from the trajectory (see Trace.branches)
-        return web.json_response(serialize_completion(response, self.ctx.model))
+        # A user simulator turns one program request into a multi-turn exchange: after each
+        # model turn the simulator's reply is injected as a user turn and the model is
+        # re-prompted, so a whole game plays out here and only the final assistant message
+        # returns to the (simulator-unaware) program. Without a simulator the loop runs once.
+        last: Response | None = None
+        while True:
+            refused = await self._refused()
+            if refused is not None:
+                # Refuse the first model call to halt the harness; once a simulated
+                # conversation is under way, just end it and return the last turn cleanly.
+                if last is None:
+                    return web.json_response(
+                        {"error": f"rollout stopped: {refused}"}, status=400
+                    )
+                return web.json_response(serialize_completion(last, self.ctx.model))
+            try:
+                response = await self.ctx.client.get_response(
+                    prompt, self.ctx.model, self.ctx.sampling, tools
+                )
+            except Exception as e:  # surface to the program as an API error
+                logger.warning("model call failed: id=%s %s", self.trace.id, e)
+                return web.json_response({"error": str(e)}, status=502)
+            self.trace.trajectory.append(
+                Turn(prompt=prompt, response=response, tokens=response.tokens)
+            )  # branches are derived from the trajectory (see Trace.branches)
+            last = response
+            # Hand back to the program when the model wants a tool (the program runs it) or
+            # when there's no user simulator to keep the conversation going.
+            if response.message.tool_calls or self.user is None:
+                return web.json_response(serialize_completion(response, self.ctx.model))
+            user_messages, done = await self.user(response.message.content or "")
+            if done:
+                self.trace.stop("user_completed")
+                return web.json_response(serialize_completion(response, self.ctx.model))
+            prompt = [*prompt, response.message, *user_messages]

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -23,7 +23,7 @@ from verifiers.v1.interception import InterceptionServer, RolloutLimits
 from verifiers.v1.runtimes import Runtime, RuntimeConfig, make_runtime
 from verifiers.v1.task import Task
 from verifiers.v1.taskset import Taskset
-from verifiers.v1.tools import serve_mcp
+from verifiers.v1.tools import serve_tools
 from verifiers.v1.trace import Trace
 from verifiers.v1.user import serve_user
 
@@ -100,7 +100,7 @@ class Rollout:
                 tool_servers = self.taskset.tool_servers(self.task)
                 tools = self.taskset.config.tools
                 async with (
-                    serve_mcp(
+                    serve_tools(
                         tool_servers,
                         runtime,
                         colocated=tools.colocated,

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -97,7 +97,7 @@ class Rollout:
             ) as server:
                 await runtime.start()
                 endpoint = f"{await runtime.expose(server.port)}/v1"
-                tool_servers = self.taskset.tool_servers(self.task)
+                tool_servers = self.taskset.tools(self.task)
                 tools = self.taskset.config.tools
                 async with (
                     serve_tools(
@@ -107,11 +107,8 @@ class Rollout:
                         tool_runtime_config=tools.runtime,
                         shared_urls=shared_urls,
                     ) as urls,
-                    serve_user(self.taskset.user_server(self.task), runtime) as respond,
+                    serve_user(self.taskset.user(self.task), runtime) as server.user,
                 ):
-                    # The interception server drives the user simulator (if any); the
-                    # harness/program stays unaware. None when the taskset has no user sim.
-                    server.user = respond
                     self.phase = (
                         Phase.RUNNING
                     )  # setup done — the harness is now driving

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -25,6 +25,7 @@ from verifiers.v1.task import Task
 from verifiers.v1.taskset import Taskset
 from verifiers.v1.tools import serve_mcp
 from verifiers.v1.trace import Trace
+from verifiers.v1.user import serve_user
 
 logger = logging.getLogger(__name__)
 
@@ -98,13 +99,19 @@ class Rollout:
                 endpoint = f"{await runtime.expose(server.port)}/v1"
                 tool_servers = self.taskset.tool_servers(self.task)
                 tools = self.taskset.config.tools
-                async with serve_mcp(
-                    tool_servers,
-                    runtime,
-                    colocated=tools.colocated,
-                    tool_runtime_config=tools.runtime,
-                    shared_urls=shared_urls,
-                ) as urls:
+                async with (
+                    serve_mcp(
+                        tool_servers,
+                        runtime,
+                        colocated=tools.colocated,
+                        tool_runtime_config=tools.runtime,
+                        shared_urls=shared_urls,
+                    ) as urls,
+                    serve_user(self.taskset.user_server(self.task), runtime) as respond,
+                ):
+                    # The interception server drives the user simulator (if any); the
+                    # harness/program stays unaware. None when the taskset has no user sim.
+                    server.user = respond
                     self.phase = (
                         Phase.RUNNING
                     )  # setup done — the harness is now driving

--- a/verifiers/v1/taskset.py
+++ b/verifiers/v1/taskset.py
@@ -23,7 +23,7 @@ from pydantic import model_validator
 from pydantic_config import BaseConfig
 
 from verifiers.v1.decorators import discover_decorated, invoke
-from verifiers.v1.tools import ToolServer
+from verifiers.v1.tools import Tools
 from verifiers.v1.runtimes import Runtime, RuntimeConfig, SubprocessConfig
 from verifiers.v1.task import TaskT
 from verifiers.v1.trace import Trace
@@ -79,7 +79,7 @@ class Taskset(Generic[TaskT, ConfigT]):
     def load_tasks(self) -> list[TaskT]:
         raise NotImplementedError
 
-    def tool_servers(self, task: TaskT) -> list[ToolServer]:
+    def tool_servers(self, task: TaskT) -> list[Tools]:
         """MCP servers exposing this task's tools, launched in the runtime by the
         harness. Empty by default; override to give a task tools."""
         return []

--- a/verifiers/v1/taskset.py
+++ b/verifiers/v1/taskset.py
@@ -17,7 +17,7 @@ For a heterogeneous taskset (different verification per task), have a single
 
 import asyncio
 from collections.abc import Mapping
-from typing import Generic, TypeVar
+from typing import TYPE_CHECKING, Generic, TypeVar
 
 from pydantic import model_validator
 from pydantic_config import BaseConfig
@@ -27,6 +27,9 @@ from verifiers.v1.tools import ToolServer
 from verifiers.v1.runtimes import Runtime, RuntimeConfig, SubprocessConfig
 from verifiers.v1.task import TaskT
 from verifiers.v1.trace import Trace
+
+if TYPE_CHECKING:
+    from verifiers.v1.user import User
 
 
 class ToolsConfig(BaseConfig):
@@ -80,6 +83,14 @@ class Taskset(Generic[TaskT, ConfigT]):
         """MCP servers exposing this task's tools, launched in the runtime by the
         harness. Empty by default; override to give a task tools."""
         return []
+
+    def user_server(self, task: TaskT) -> "User | None":
+        """A user simulator for this task — structurally a tool server (an MCP server
+        with a runtime), but driven by the framework, not exposed to the model. After
+        each model turn the interception server calls its `respond` tool and injects the
+        reply as a user turn. None by default; override to make a task a simulated
+        multi-turn conversation (e.g. a TextArena game)."""
+        return None
 
     async def score(self, trace: Trace, runtime: Runtime) -> None:
         """Score one rollout: run all `@metric` then `@reward` over its trace,

--- a/verifiers/v1/taskset.py
+++ b/verifiers/v1/taskset.py
@@ -1,7 +1,7 @@
 """The taskset: produces typed tasks and owns scoring.
 
 A `Taskset` is the data + judgement half of an environment. It yields typed
-`Task`s, may expose tools via `tool_servers`, and defines rewards/metrics as
+`Task`s, may expose tools via `tools`, and defines rewards/metrics as
 decorated methods. All task framing lives in each task's user prompt (baked in by
 `load_tasks`); the harness drives control flow.
 
@@ -17,23 +17,21 @@ For a heterogeneous taskset (different verification per task), have a single
 
 import asyncio
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Generic, TypeVar
+from typing import Generic, TypeVar
 
 from pydantic import model_validator
 from pydantic_config import BaseConfig
 
 from verifiers.v1.decorators import discover_decorated, invoke
 from verifiers.v1.tools import Tools
+from verifiers.v1.user import User
 from verifiers.v1.runtimes import Runtime, RuntimeConfig, SubprocessConfig
 from verifiers.v1.task import TaskT
 from verifiers.v1.trace import Trace
 
-if TYPE_CHECKING:
-    from verifiers.v1.user import User
-
 
 class ToolsConfig(BaseConfig):
-    """How a taskset's `tool_servers` are run (`colocated` and `shared` are mutually
+    """How a taskset's `tools` are run (`colocated` and `shared` are mutually
     exclusive; reachability — localhost vs tunnel — is then inferred):
       - colocated: in the harness's runtime, per rollout (localhost; `runtime` ignored).
       - shared:    one instance for the whole eval, in its own `runtime`.
@@ -79,12 +77,12 @@ class Taskset(Generic[TaskT, ConfigT]):
     def load_tasks(self) -> list[TaskT]:
         raise NotImplementedError
 
-    def tool_servers(self, task: TaskT) -> list[Tools]:
+    def tools(self, task: TaskT) -> list[Tools]:
         """MCP servers exposing this task's tools, launched in the runtime by the
         harness. Empty by default; override to give a task tools."""
         return []
 
-    def user_server(self, task: TaskT) -> "User | None":
+    def user(self, task: TaskT) -> User | None:
         """A user simulator for this task — structurally a tool server (an MCP server
         with a runtime), but driven by the framework, not exposed to the model. After
         each model turn the interception server calls its `respond` tool and injects the

--- a/verifiers/v1/tools.py
+++ b/verifiers/v1/tools.py
@@ -1,6 +1,6 @@
 """Tools: how a task gives the harness tools, via tool servers it declares.
 
-A taskset returns `Tools`s from `Taskset.tool_servers`. A server is either a
+A taskset returns `Tools`s from `Taskset.tools`. A server is either a
 single-file uv script the harness runs (`script` — its only runtime dep is `uv`, which
 resolves the script's PEP 723 inline deps, so it runs in any runtime: host, the harness's
 runtime when colocated, or its own) or an already-running remote endpoint (`url`, e.g.
@@ -127,7 +127,7 @@ async def _resolve_url(tool_runtime: Runtime, agent_runtime: Runtime, port: int)
 
 
 @contextlib.asynccontextmanager
-async def serve_shared(servers: list[Tools], tool_runtime_config: RuntimeConfig):
+async def serve_shared(tools: list[Tools], tool_runtime_config: RuntimeConfig):
     """Start shared tool servers ONCE for a whole eval (each in its own `tools.runtime`)
     and yield `{name: url}` reachable by every rollout's harness — a prime tool runtime
     publishes its port (works for any harness), a host one is reached at localhost (works
@@ -136,7 +136,7 @@ async def serve_shared(servers: list[Tools], tool_runtime_config: RuntimeConfig)
     tool_runtimes: list[Runtime] = []
     urls: dict[str, str] = {}
     try:
-        for server in servers:
+        for server in tools:
             if server.url:
                 urls[server.name] = server.url
                 continue
@@ -157,7 +157,7 @@ async def serve_shared(servers: list[Tools], tool_runtime_config: RuntimeConfig)
 
 @contextlib.asynccontextmanager
 async def serve_tools(
-    servers: list[Tools],
+    tools: list[Tools],
     agent_runtime: Runtime,
     colocated: bool = False,
     tool_runtime_config: RuntimeConfig | None = None,
@@ -168,7 +168,7 @@ async def serve_tools(
     tool_runtimes: list[Runtime] = []  # per-rollout tool runtimes to tear down
     urls: dict[str, str] = {}
     try:
-        for server in servers:
+        for server in tools:
             if server.url:  # already running remotely
                 urls[server.name] = server.url
                 logger.info("tool server '%s' (remote): %s", server.name, server.url)

--- a/verifiers/v1/tools.py
+++ b/verifiers/v1/tools.py
@@ -1,12 +1,12 @@
 """Tools: how a task gives the harness tools, via tool servers it declares.
 
-A taskset returns `ToolServer`s from `Taskset.tool_servers`. A server is either a
+A taskset returns `Tools`s from `Taskset.tool_servers`. A server is either a
 single-file uv script the harness runs (`script` — its only runtime dep is `uv`, which
 resolves the script's PEP 723 inline deps, so it runs in any runtime: host, the harness's
 runtime when colocated, or its own) or an already-running remote endpoint (`url`, e.g.
 deepwiki). The server binds the port passed via `MCP_PORT`.
 
-`serve_mcp` brings a task's servers up for a rollout — colocated in the harness's runtime
+`serve_tools` brings a task's servers up for a rollout — colocated in the harness's runtime
 (reached via localhost) or in their own `tools.runtime` (reached via that runtime's
 `public_url`, or the harness runtime's `expose` for a tunnel) — and yields `{name: url}`;
 `serve_shared` brings up shared ones once per eval. `run_mcp_server` is the server-side
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
-class ToolServer:
+class Tools:
     """A tool server exposing tools to the model (as `<name>_<tool>`). Set exactly one
     of `script` (a single-file uv script we run) or `url` (already-running remote)."""
 
@@ -94,7 +94,7 @@ def _free_port() -> int:
     raise ProgramError("could not find a free port in [3000, 9000)")
 
 
-async def serve_in_runtime(server: ToolServer, runtime: Runtime, port: int) -> None:
+async def serve_in_runtime(server: Tools, runtime: Runtime, port: int) -> None:
     """Run `server` inside `runtime` on `port` (background) and wait until it serves.
     A `script` runs via uv (its deps come from the script); a `command` must already be
     runnable in the runtime."""
@@ -127,7 +127,7 @@ async def _resolve_url(tool_runtime: Runtime, agent_runtime: Runtime, port: int)
 
 
 @contextlib.asynccontextmanager
-async def serve_shared(servers: list[ToolServer], tool_runtime_config: RuntimeConfig):
+async def serve_shared(servers: list[Tools], tool_runtime_config: RuntimeConfig):
     """Start shared tool servers ONCE for a whole eval (each in its own `tools.runtime`)
     and yield `{name: url}` reachable by every rollout's harness — a prime tool runtime
     publishes its port (works for any harness), a host one is reached at localhost (works
@@ -156,8 +156,8 @@ async def serve_shared(servers: list[ToolServer], tool_runtime_config: RuntimeCo
 
 
 @contextlib.asynccontextmanager
-async def serve_mcp(
-    servers: list[ToolServer],
+async def serve_tools(
+    servers: list[Tools],
     agent_runtime: Runtime,
     colocated: bool = False,
     tool_runtime_config: RuntimeConfig | None = None,

--- a/verifiers/v1/user.py
+++ b/verifiers/v1/user.py
@@ -1,0 +1,81 @@
+"""The user simulator: a first-class conversation partner, served like a tool server.
+
+A taskset registers a `User` via `Taskset.user_server` — structurally a `ToolServer`
+(an MCP server with a runtime), exposing a single `respond` tool. Unlike a tool server,
+the user simulator is never handed to the model: the framework drives it. After each model
+turn the interception server calls `respond` with the model's last message, appends the
+simulated user message(s) to the conversation, and re-prompts the model — so a multi-turn
+game (e.g. TextArena) plays out as alternating assistant/user turns recorded in the trace,
+with the harness and its program none the wiser.
+
+`serve_user` brings the user server up for a rollout (colocated, like a tool server) and
+yields the async `respond` the interception server drives; `connect_user` is the MCP client
+side. `respond(message)` takes the model's last assistant text and returns the next user
+messages plus whether the conversation is done.
+"""
+
+import contextlib
+import json
+import logging
+from collections.abc import AsyncIterator, Awaitable, Callable
+from dataclasses import dataclass
+
+from verifiers.v1.runtimes import Runtime
+from verifiers.v1.tools import ToolServer, serve_mcp
+from verifiers.v1.types import Messages
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class User(ToolServer):
+    """A user simulator — structurally a tool server (an MCP server with a runtime), but
+    consumed by the framework, not the model. Its single `respond` tool maps the model's
+    last message to the next user message(s) and a done flag."""
+
+
+# The model's last assistant text in; the next user messages + a done flag out.
+Respond = Callable[[str], Awaitable[tuple[Messages, bool]]]
+
+
+@contextlib.asynccontextmanager
+async def connect_user(url: str) -> AsyncIterator[Respond]:
+    """Open an MCP client session to a user server at `url` and yield an async
+    `respond(message)` that calls its `respond` tool, parsing the JSON it returns
+    (`{"messages": [...], "done": bool}`) into typed `(messages, done)`."""
+    from mcp import ClientSession
+    from mcp.client.streamable_http import streamable_http_client
+
+    from verifiers.v1.interception import parse_message
+
+    async with contextlib.AsyncExitStack() as stack:
+        read, write, *_ = await stack.enter_async_context(streamable_http_client(url))
+        session = await stack.enter_async_context(ClientSession(read, write))
+        await session.initialize()
+
+        async def respond(message: str) -> tuple[Messages, bool]:
+            result = await session.call_tool("respond", {"message": message})
+            texts = [
+                b.text for b in result.content if getattr(b, "type", None) == "text"
+            ]
+            data = json.loads("\n".join(texts))
+            messages = [parse_message(m) for m in data["messages"]]
+            return messages, bool(data["done"])
+
+        yield respond
+
+
+@contextlib.asynccontextmanager
+async def serve_user(
+    user: ToolServer | None, runtime: Runtime
+) -> AsyncIterator[Respond | None]:
+    """Bring a rollout's user server up (colocated in the harness's runtime, like a tool
+    server) and yield the async `respond` for the interception server to drive — or `None`
+    when the taskset has no user server. Colocated keeps it reachable from the host (where
+    the interception server runs) for the subprocess/docker runtimes."""
+    if user is None:
+        yield None
+        return
+    async with serve_mcp([user], runtime, colocated=True) as urls:
+        async with connect_user(next(iter(urls.values()))) as respond:
+            yield respond

--- a/verifiers/v1/user.py
+++ b/verifiers/v1/user.py
@@ -1,6 +1,6 @@
 """The user simulator: a first-class conversation partner, served like a tool server.
 
-A taskset registers a `User` via `Taskset.user_server` — structurally a `ToolServer`
+A taskset registers a `User` via `Taskset.user_server` — structurally a `Tools`
 (an MCP server with a runtime), exposing a single `respond` tool. Unlike a tool server,
 the user simulator is never handed to the model: the framework drives it. After each model
 turn the interception server calls `respond` with the model's last message, appends the
@@ -21,14 +21,14 @@ from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass
 
 from verifiers.v1.runtimes import Runtime
-from verifiers.v1.tools import ToolServer, serve_mcp
+from verifiers.v1.tools import Tools, serve_tools
 from verifiers.v1.types import Messages
 
 logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
-class User(ToolServer):
+class User(Tools):
     """A user simulator — structurally a tool server (an MCP server with a runtime), but
     consumed by the framework, not the model. Its single `respond` tool maps the model's
     last message to the next user message(s) and a done flag."""
@@ -67,7 +67,7 @@ async def connect_user(url: str) -> AsyncIterator[Respond]:
 
 @contextlib.asynccontextmanager
 async def serve_user(
-    user: ToolServer | None, runtime: Runtime
+    user: Tools | None, runtime: Runtime
 ) -> AsyncIterator[Respond | None]:
     """Bring a rollout's user server up (colocated in the harness's runtime, like a tool
     server) and yield the async `respond` for the interception server to drive — or `None`
@@ -76,6 +76,6 @@ async def serve_user(
     if user is None:
         yield None
         return
-    async with serve_mcp([user], runtime, colocated=True) as urls:
+    async with serve_tools([user], runtime, colocated=True) as urls:
         async with connect_user(next(iter(urls.values()))) as respond:
             yield respond

--- a/verifiers/v1/user.py
+++ b/verifiers/v1/user.py
@@ -1,6 +1,6 @@
 """The user simulator: a first-class conversation partner, served like a tool server.
 
-A taskset registers a `User` via `Taskset.user_server` — structurally a `Tools`
+A taskset registers a `User` via `Taskset.user` — structurally a `Tools`
 (an MCP server with a runtime), exposing a single `respond` tool. Unlike a tool server,
 the user simulator is never handed to the model: the framework drives it. After each model
 turn the interception server calls `respond` with the model's last message, appends the


### PR DESCRIPTION
## Summary

- Add `vf.User` — a first-class user simulator that is structurally a tool server (`vf.Tools`: an MCP server with a runtime), registered on a taskset via the new `Taskset.user(task)` hook (parallel to `Taskset.tools`).
- Drive the user simulator from the framework. The per-rollout interception server, after each model turn with no tool call, calls the simulator's `respond` tool, injects its reply as a user turn, and re-prompts the model — so a whole multi-turn game plays out within a single program request, transparently to the harness and its `program.py` (both unchanged; they never see the simulator). With no user simulator the interception loop runs exactly once, as before.
- Ship `textarena-v1` in the `tasksets` package: single-player TextArena games via a generic, seed-based `ta.Env → tasks` conversion. `game` is a `Literal` of the verified games: `Wordle-v0`, `Wordle-v0-long`, `Hangman-v0`, `WordLadder-v0`, `WordSearch-v0`.
- **Game-authoritative scoring**: when the episode ends, the simulator writes the game's own outcome (`env.state.rewards`) to a file in the runtime, and one generic `@reward` reads it back — no per-game guess parsing. (Win = 1.0; many games also report partial credit.)
- **Generic conversion**: each task is an RNG seed (carried in the task's `info` dict). `load_tasks` seeds the game to build the instruction (per-seed for games whose prompt embeds the setup — WordLadder's start/target, WordSearch's grid) and the simulator re-seeds to the same episode. No per-game word-list or state-key knowledge, so any single-player TextArena game fits. A `num_tasks` config sets how many seeds to generate.
- Add two pinned example tasksets (each a ~10-line subclass that fixes one field and reuses everything else, showing how to pin a built-in taskset): **`wordle-v1`** (`textarena_v1` with `game` pinned to `Wordle-v0`) and **`terminal-bench-2-v1`** (`harbor` with `dataset` pinned to `terminal-bench/terminal-bench-2`).
- Rename the tool surface (see **Breaking**). `textarena` + `nltk` are an optional `textarena` extra on the `tasksets` package.

## Breaking

- `verifiers.v1.ToolServer` → **`verifiers.v1.Tools`** (`vf.ToolServer(...)` → `vf.Tools(...)`); shipped example tasksets migrated.
- `verifiers.v1.tools.serve_mcp` → **`serve_tools`**.
- `Taskset.tool_servers(task)` → **`Taskset.tools(task)`**; new sibling **`Taskset.user(task)`** returns the optional user simulator.

## How the user simulator works

`vf.User` is consumed by `verifiers/v1/interception.py`, not the harness:

- `Rollout` serves the user server (colocated, like a tool server) and hands the interception server an async `respond(message) -> (messages, done)` (`verifiers/v1/user.py`).
- `InterceptionServer.handle_chat` loops: model turn → record a `Turn` → if the model made a tool call or there is no simulator, return to the program; otherwise call `respond`, append the user message(s) to the prompt, and re-prompt. The loop respects the framework's `RolloutLimits` (turns / token budget) and `@stop`s; `done` ends it.
- The game's final outcome travels out-of-band via the runtime file, so it survives even though the terminal user turn isn't a model call.

## Verification

`uv run eval @ configs/textarena.toml` (subprocess runtime, `deepseek/deepseek-v4-flash`), on this branch rebased onto `feat/nano-as-v1`:

- `Wordle-v0`, `Wordle-v0-long`, `Hangman-v0`, `WordLadder-v0` reward 1.0; `WordSearch-v0` solves within the turn budget (harder; longer episodes). Hangman shows both a win (1.0) and a loss (0.0), confirming game-authoritative scoring reads wins and losses. `err 0.00`, `stop=user_completed`.
- Non-regression: `gsm8k-v1` (no user simulator) runs unchanged.
- The `Tools`/`serve_tools` rename is smoke-verified across every tool-server placement (each reward 1.0): `glossary-v1` (colocated), `wikispeedia-v1` (own runtime), `wiki-search-v1` (shared), `deepwiki-v1` (remote URL).
- `ruff check` + `ruff format --check` clean repo-wide; `uv run pytest -k "v1 or interception"` passes.

## Notes

- The user simulator runs colocated (host-reachable for the subprocess/docker runtimes), so the example pins the subprocess runtime; a prime colocated simulator would need a public URL.
- `game` is gated to the tested set. Out of scope: `WordChains` (needs 2 players), games with no `word_list` (`GuessTheNumber`, `Crosswords`), or LLM-gamemaster games (`TwentyQuestions`, `Taboo`, …).
- The Wordle/Hangman `-hardcore` variants are intentionally excluded: their lists include capitalized proper nouns that are unwinnable under random seeding (TextArena lowercases the guess, not the stored secret).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking public v1 API renames affect all tasksets using tools; interception’s new multi-turn loop changes rollout behavior for user-simulator tasksets but leaves non-simulator paths as a single iteration.
> 
> **Overview**
> Introduces **`vf.User`** and **`Taskset.user(task)`** so tasksets can register an MCP-backed user simulator the framework drives (not the model). **`InterceptionServer.handle_chat`** now loops: after each assistant turn without tool calls, it calls the simulator’s `respond`, injects user messages, and re-prompts until `done` or limits/`@stop` fire—so multi-turn games run inside one harness chat completion while the trace still records full assistant/user turns.
> 
> **Breaking renames:** `ToolServer` → **`Tools`**, `serve_mcp` → **`serve_tools`**, `Taskset.tool_servers` → **`Taskset.tools`**; example tasksets updated.
> 
> Ships **`textarena-v1`**: seed-based TextArena episodes via a colocated user server (`textarena_v1/server.py`), with rewards read from a runtime outcome file written when the game ends. Optional **`tasksets[textarena]`** extra pins `textarena`/`nltk`. Adds thin **`wordle-v1`** and **`terminal-bench-2-v1`** example plugins plus eval configs (`configs/textarena.toml`, `wordle.toml`, `terminal-bench-2.toml`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff76d317fabb0efba430630a72cd06e97d714f70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add TextArena taskset with a framework-driven user simulator for multi-turn game rollouts
> - Adds [`textarena_v1`](https://github.com/PrimeIntellect-ai/verifiers/pull/1592/files#diff-ea154515affd3adda31f68505c301f49751662a2412402151b35fbdd0b91c7aa) taskset that runs TextArena games (e.g. Wordle-v0) as seeded episodes, scoring via game outcomes written by a colocated user simulator.
> - Adds [`textarena_v1/server.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1592/files#diff-51efdbbbe27002ad5d1ceb44656f435454022668d66b8bdcc5a55c73eea05262), a FastMCP server exposing a `respond` tool that steps the game and signals completion via an outcome file.
> - Extends [`InterceptionServer`](https://github.com/PrimeIntellect-ai/verifiers/pull/1592/files#diff-fa4511bfb817d69f882d91dd89f39b454b0473a234ad00d00e4e40d99fd7e7e3) to support multi-turn conversations: it loops model calls and invokes the user simulator until done or the model requests tools.
> - Adds [`verifiers/v1/user.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1592/files#diff-dad41b3a55e161581fffa081fe002cf51ee4c2c02a3b42a47e805b24bdda547e) with `User`, `Respond`, `connect_user`, and `serve_user` — first-class MCP-based user simulator support in the rollout framework.
> - Renames `ToolServer` → `Tools`, `tool_servers()` → `tools()`, and `serve_mcp()` → `serve_tools()` across the public API; adds optional `user()` hook to the `Taskset` base class.
> - Risk: `ToolServer` is no longer exported from `verifiers.v1`; any external taskset importing it will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ff76d31.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->