### PR TITLE
feat: add modal runtime

### DIFF
--- a/packages/tasksets/harbor/__init__.py
+++ b/packages/tasksets/harbor/__init__.py
@@ -110,13 +110,12 @@ def resolve_image(task_dir: Path, config: dict, require_image: bool) -> str | No
 
 
 def parse_resources(env: dict) -> Resources:
-    """Map a task.toml [environment] block to Resources (0 gpus -> unset). Modal units
-    (MB, GPU spec string) line up with harbor's `memory_mb` / `storage_mb` directly."""
+    """Map a task.toml [environment] block to Resources (0 gpus -> unset)."""
     return Resources(
         cpu=env.get("cpus"),
-        memory=int(env["memory_mb"]) if env.get("memory_mb") else None,
+        memory=env["memory_mb"] / 1024 if env.get("memory_mb") else None,
         gpu=str(env["gpus"]) if env.get("gpus") else None,
-        disk=int(env["storage_mb"]) if env.get("storage_mb") else None,
+        disk=env["storage_mb"] / 1024 if env.get("storage_mb") else None,
     )
 
 

--- a/packages/tasksets/harbor/__init__.py
+++ b/packages/tasksets/harbor/__init__.py
@@ -110,12 +110,13 @@ def resolve_image(task_dir: Path, config: dict, require_image: bool) -> str | No
 
 
 def parse_resources(env: dict) -> Resources:
-    """Map a task.toml [environment] block to Resources (0 gpus -> unset)."""
+    """Map a task.toml [environment] block to Resources (0 gpus -> unset). Modal units
+    (MB, GPU spec string) line up with harbor's `memory_mb` / `storage_mb` directly."""
     return Resources(
-        cpu_cores=env.get("cpus"),
-        memory_gb=env["memory_mb"] / 1024 if env.get("memory_mb") else None,
-        gpu_count=env.get("gpus") or None,
-        disk_gb=env["storage_mb"] / 1024 if env.get("storage_mb") else None,
+        cpu=env.get("cpus"),
+        memory=int(env["memory_mb"]) if env.get("memory_mb") else None,
+        gpu=str(env["gpus"]) if env.get("gpus") else None,
+        disk=int(env["storage_mb"]) if env.get("storage_mb") else None,
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "nest-asyncio>=1.6.0", # for jupyter notebooks
     "openai>=1.108.1",
     "openai-agents>=0.0.7",
+    "modal>=1.4.0",
     "prime-tunnel>=0.1.8",
     "prime-sandboxes>=0.2.27",
     "pydantic>=2.11.9",

--- a/uv.lock
+++ b/uv.lock
@@ -1469,6 +1469,19 @@ wheels = [
 ]
 
 [[package]]
+name = "grpclib"
+version = "0.4.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h2" },
+    { name = "multidict" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/28/5a2c299ec82a876a252c5919aa895a6f1d1d35c96417c5ce4a4660dc3a80/grpclib-0.4.9.tar.gz", hash = "sha256:cc589c330fa81004c6400a52a566407574498cb5b055fa927013361e21466c46", size = 84798, upload-time = "2025-12-14T22:23:14.349Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/90/b0cbbd9efcc82816c58f31a34963071aa19fb792a212a5d9caf8e0fc3097/grpclib-0.4.9-py3-none-any.whl", hash = "sha256:7762ec1c8ed94dfad597475152dd35cbd11aecaaca2f243e29702435ca24cf0e", size = 77063, upload-time = "2025-12-14T22:23:13.224Z" },
+]
+
+[[package]]
 name = "gsm8k-v1"
 version = "0.1.0"
 source = { editable = "examples/tasksets/gsm8k_v1" }
@@ -1486,6 +1499,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "h2"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hpack" },
+    { name = "hyperframe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
 ]
 
 [[package]]
@@ -1529,6 +1555,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/e5/0b56d723a76ca67abadbf7fb71609fb0ea7e6926e94fcca6c65a85b36a0e/hjson-3.1.0.tar.gz", hash = "sha256:55af475a27cf83a7969c808399d7bccdec8fb836a07ddbd574587593b9cdcf75", size = 40541, upload-time = "2022-08-13T02:53:01.919Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/7f/13cd798d180af4bf4c0ceddeefba2b864a63c71645abc0308b768d67bb81/hjson-3.1.0-py3-none-any.whl", hash = "sha256:65713cdcf13214fb554eb8b4ef803419733f4f5e551047c9b711098ab7186b89", size = 54018, upload-time = "2022-08-13T02:52:59.899Z" },
+]
+
+[[package]]
+name = "hpack"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca", size = 51276, upload-time = "2025-01-22T21:44:58.347Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496", size = 34357, upload-time = "2025-01-22T21:44:56.92Z" },
 ]
 
 [[package]]
@@ -1615,6 +1650,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/56/52/1b54cb569509c725a32c1315261ac9fd0e6b91bbbf74d86fca10d3376164/huggingface_hub-1.12.0.tar.gz", hash = "sha256:7c3fe85e24b652334e5d456d7a812cd9a071e75630fac4365d9165ab5e4a34b6", size = 763091, upload-time = "2026-04-24T13:32:08.674Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/2b/ef03ddb96bd1123503c2bd6932001020292deea649e9bf4caa2cb65a85bf/huggingface_hub-1.12.0-py3-none-any.whl", hash = "sha256:d74939969585ee35748bd66de09baf84099d461bda7287cd9043bfb99b0e424d", size = 646806, upload-time = "2026-04-24T13:32:06.717Z" },
+]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
 ]
 
 [[package]]
@@ -2468,6 +2512,30 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4b/f9/dc3787ee5c813cc27fe79f45ad4500d9b5437f23a7402435cc34e07c7718/mmh3-5.2.1-cp313-cp313-win32.whl", hash = "sha256:54b64fb2433bc71488e7a449603bf8bd31fbcf9cb56fbe1eb6d459e90b86c37b", size = 40769, upload-time = "2026-03-05T15:55:05.277Z" },
     { url = "https://files.pythonhosted.org/packages/43/67/850e0b5a1e97799822ebfc4ca0e8c6ece3ed8baf7dcdf64de817dfdda2ca/mmh3-5.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:cae6383181f1e345317742d2ddd88f9e7d2682fa4c9432e3a74e47d92dce0229", size = 41563, upload-time = "2026-03-05T15:55:06.283Z" },
     { url = "https://files.pythonhosted.org/packages/c0/cc/98c90b28e1da5458e19fbfaf4adb5289208d3bfccd45dd14eab216a2f0bb/mmh3-5.2.1-cp313-cp313-win_arm64.whl", hash = "sha256:022aa1a528604e6c83d0a7705fdef0b5355d897a9e0fa3a8d26709ceaa06965d", size = 39310, upload-time = "2026-03-05T15:55:07.323Z" },
+]
+
+[[package]]
+name = "modal"
+version = "1.4.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "cbor2" },
+    { name = "certifi" },
+    { name = "click" },
+    { name = "grpclib" },
+    { name = "protobuf" },
+    { name = "rich" },
+    { name = "synchronicity" },
+    { name = "toml" },
+    { name = "types-certifi" },
+    { name = "types-toml" },
+    { name = "typing-extensions" },
+    { name = "watchfiles" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/7d/4126d0fe879ef3e86002ca821a34cb68a2588ea2e8ccb2bfe421d0f42ffe/modal-1.4.3.tar.gz", hash = "sha256:35b2fc840f759b512e12527afb538e1ea4cc232b84cfbfcef3f5d96d5a66abaa", size = 720488, upload-time = "2026-05-18T22:34:45.842Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/54/400262056c144ceee5edab40efa2541ae8928ae5f244fd9025f3ad26c909/modal-1.4.3-py3-none-any.whl", hash = "sha256:802917181f576458a0cb833322157dab09c4f367326426c5a732661a0c519577", size = 826232, upload-time = "2026-05-18T22:34:43.335Z" },
 ]
 
 [[package]]
@@ -5066,6 +5134,18 @@ wheels = [
 ]
 
 [[package]]
+name = "synchronicity"
+version = "0.12.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/d5/e96e6082790c92480380f28aa53e111844cdac7b0f75846f4772cb535a43/synchronicity-0.12.3.tar.gz", hash = "sha256:0d4228b85eaf2805f23b4615b2039a9d24ea811646e2d9f8d0c033094eb85841", size = 60261, upload-time = "2026-05-28T12:33:50.206Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/ea/531a6ea751cbd989da386144810b1b8f529b0aae8c1a9beda8b40966c9c2/synchronicity-0.12.3-py3-none-any.whl", hash = "sha256:e476818cd14102136f41622c619de548f0000c024485fc18521c8fe908ea7574", size = 40982, upload-time = "2026-05-28T12:33:49.125Z" },
+]
+
+[[package]]
 name = "tabulate"
 version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5210,6 +5290,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/18/a545c4ea42af3df6effd7d13d250ba77a0a86fb20393143bbb9a92e434d4/tokenizers-0.22.2-cp39-abi3-win32.whl", hash = "sha256:a6bf3f88c554a2b653af81f3204491c818ae2ac6fbc09e76ef4773351292bc92", size = 2502363, upload-time = "2026-01-05T10:45:20.593Z" },
     { url = "https://files.pythonhosted.org/packages/65/71/0670843133a43d43070abeb1949abfdef12a86d490bea9cd9e18e37c5ff7/tokenizers-0.22.2-cp39-abi3-win_amd64.whl", hash = "sha256:c9ea31edff2968b44a88f97d784c2f16dc0729b8b143ed004699ebca91f05c48", size = 2747786, upload-time = "2026-01-05T10:45:18.411Z" },
     { url = "https://files.pythonhosted.org/packages/72/f4/0de46cfa12cdcbcd464cc59fde36912af405696f687e53a091fb432f694c/tokenizers-0.22.2-cp39-abi3-win_arm64.whl", hash = "sha256:9ce725d22864a1e965217204946f830c37876eee3b2ba6fc6255e8e903d5fcbc", size = 2612133, upload-time = "2026-01-05T10:45:17.232Z" },
+]
+
+[[package]]
+name = "toml"
+version = "0.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253, upload-time = "2020-11-01T01:40:22.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588, upload-time = "2020-11-01T01:40:20.672Z" },
 ]
 
 [[package]]
@@ -5470,6 +5559,15 @@ wheels = [
 ]
 
 [[package]]
+name = "types-certifi"
+version = "2021.10.8.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/68/943c3aeaf14624712a0357c4a67814dba5cea36d194f5c764dad7959a00c/types-certifi-2021.10.8.3.tar.gz", hash = "sha256:72cf7798d165bc0b76e1c10dd1ea3097c7063c42c21d664523b928e88b554a4f", size = 2095, upload-time = "2022-06-09T15:19:05.244Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/63/2463d89481e811f007b0e1cd0a91e52e141b47f9de724d20db7b861dcfec/types_certifi-2021.10.8.3-py3-none-any.whl", hash = "sha256:b2d1e325e69f71f7c78e5943d410e650b4707bb0ef32e4ddf3da37f54176e88a", size = 2136, upload-time = "2022-06-09T15:19:03.127Z" },
+]
+
+[[package]]
 name = "types-requests"
 version = "2.33.0.20260408"
 source = { registry = "https://pypi.org/simple" }
@@ -5479,6 +5577,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/69/6a/749dc53a54a3f35842c1f8197b3ca6b54af6d7458a1bfc75f6629b6da666/types_requests-2.33.0.20260408.tar.gz", hash = "sha256:95b9a86376807a216b2fb412b47617b202091c3ea7c078f47cc358d5528ccb7b", size = 23882, upload-time = "2026-04-08T04:34:49.33Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/90/b8/78fd6c037de4788c040fdd323b3369804400351b7827473920f6c1d03c10/types_requests-2.33.0.20260408-py3-none-any.whl", hash = "sha256:81f31d5ea4acb39f03be7bc8bed569ba6d5a9c5d97e89f45ac43d819b68ca50f", size = 20739, upload-time = "2026-04-08T04:34:48.325Z" },
+]
+
+[[package]]
+name = "types-toml"
+version = "0.10.8.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/11/6ece999e91f2ccb848ab4420f3f4816e78ac0541f739e6864affdaaa5737/types_toml-0.10.8.20260518.tar.gz", hash = "sha256:80e10facd24fdeda9d5c672187d72be3ac284843788d67f5aae59e3e016db6fe", size = 9419, upload-time = "2026-05-18T06:02:16.719Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/25/489751806bf5c95e4007f8e17409199c54d31e49ffbea07c5729b1286c8e/types_toml-0.10.8.20260518-py3-none-any.whl", hash = "sha256:0e564ab05f6fde62a315b3b5a9b6624fda569399795d30a37e64705a70459303", size = 9669, upload-time = "2026-05-18T06:02:15.86Z" },
 ]
 
 [[package]]
@@ -5594,6 +5701,7 @@ dependencies = [
     { name = "loguru" },
     { name = "math-verify" },
     { name = "mcp" },
+    { name = "modal" },
     { name = "msgpack" },
     { name = "nest-asyncio" },
     { name = "numpy" },
@@ -5705,6 +5813,7 @@ requires-dist = [
     { name = "loguru", specifier = ">=0.7.0" },
     { name = "math-verify", specifier = ">=0.8.0" },
     { name = "mcp", specifier = ">=1.14.1" },
+    { name = "modal", specifier = ">=1.4.0" },
     { name = "msgpack", specifier = ">=1.1.2" },
     { name = "nest-asyncio", specifier = ">=1.6.0" },
     { name = "nltk", marker = "extra == 'ta'" },

--- a/verifiers/v1/runtimes/__init__.py
+++ b/verifiers/v1/runtimes/__init__.py
@@ -1,8 +1,8 @@
 """Execution runtimes for harnesses.
 
 Each runtime decides WHERE the program runs and HOW it reaches the host
-interception server: subprocess (local), docker (local container), or prime
-(remote sandbox). They share the `Runtime` contract, so the Environment is
+interception server: subprocess (local), docker (local container), or prime /
+modal (remote sandbox). They share the `Runtime` contract, so the Environment is
 runtime-agnostic. `RuntimeConfig` is the discriminated config union and
 `make_runtime` builds the runtime matching a config.
 """
@@ -13,17 +13,21 @@ from pydantic import Field
 
 from verifiers.v1.runtimes.base import ProgramResult, Runtime, register
 from verifiers.v1.runtimes.docker import DockerConfig, DockerRuntime
+from verifiers.v1.runtimes.modal import ModalConfig, ModalRuntime
 from verifiers.v1.runtimes.prime import PrimeConfig, PrimeRuntime
 from verifiers.v1.runtimes.subprocess import SubprocessConfig, SubprocessRuntime
 
 RuntimeConfig = Annotated[
-    SubprocessConfig | DockerConfig | PrimeConfig, Field(discriminator="type")
+    SubprocessConfig | DockerConfig | PrimeConfig | ModalConfig,
+    Field(discriminator="type"),
 ]
 
 
 def make_runtime(config: RuntimeConfig) -> Runtime:
     if isinstance(config, PrimeConfig):
         runtime: Runtime = PrimeRuntime(config)
+    elif isinstance(config, ModalConfig):
+        runtime = ModalRuntime(config)
     elif isinstance(config, DockerConfig):
         runtime = DockerRuntime(config)
     else:
@@ -43,4 +47,6 @@ __all__ = [
     "DockerRuntime",
     "PrimeConfig",
     "PrimeRuntime",
+    "ModalConfig",
+    "ModalRuntime",
 ]

--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -46,6 +46,20 @@ class ProgramResult:
     stderr: str
 
 
+def parse_gpu(gpu: str | None) -> tuple[str | None, int]:
+    """A Modal-style GPU spec -> (type, count) for providers that want them split:
+    "A100" -> ("A100", 1), "A100:2" -> ("A100", 2), "2" -> (None, 2) (count only,
+    provider-chosen type), None/"" -> (None, 0)."""
+    if not gpu:
+        return None, 0
+    head, _, tail = gpu.partition(":")
+    if tail:
+        return head, int(tail)
+    if head.isdigit():
+        return None, int(head)
+    return head, 1
+
+
 # `stop()` frees a runtime's external resource on the normal path (the rollout's `finally`).
 # A Ctrl-C / SIGTERM can cancel that `finally` mid-teardown, so runtimes are tracked in
 # `_LIVE` and freed by a *synchronous* `atexit` hook (`cleanup`) — sync because the event

--- a/verifiers/v1/runtimes/docker.py
+++ b/verifiers/v1/runtimes/docker.py
@@ -16,7 +16,7 @@ from typing import Literal
 from pydantic_config import BaseConfig
 
 from verifiers.v1.errors import ProgramError
-from verifiers.v1.runtimes.base import ProgramResult, Runtime
+from verifiers.v1.runtimes.base import ProgramResult, Runtime, parse_gpu
 
 logger = logging.getLogger(__name__)
 
@@ -25,16 +25,17 @@ class DockerConfig(BaseConfig):
     type: Literal["docker"] = "docker"
     image: str = "python:3.11-slim"
     workdir: str = "/app"
-    cpu_cores: float | None = None
-    """Pin the container to this many CPUs (docker `--cpus`). None = unlimited."""
-    memory_gb: float | None = None
-    """Hard memory limit in GB (docker `--memory`). None = unlimited."""
-    gpu_count: int | None = None
-    """Expose this many GPUs (docker `--gpus`; needs the nvidia container toolkit).
-    None/0 = none."""
-    disk_gb: float | None = None
-    """Advisory disk request. Docker has no portable per-container size limit, so this
-    is accepted (so a task can declare it without a warning) but not enforced."""
+    # Resources in Modal's units (also settable per-task via Task.resources).
+    cpu: float | None = None
+    """Pin the container to this many CPU cores (docker `--cpus`). None = unlimited."""
+    memory: int | None = None
+    """Hard memory limit in MB (docker `--memory`). None = unlimited."""
+    gpu: str | None = None
+    """GPU spec, e.g. "A100" or "2" (docker `--gpus` uses the count; needs the nvidia
+    container toolkit). None = none."""
+    disk: int | None = None
+    """Advisory disk request in MB. Docker has no portable per-container size limit, so
+    this is accepted (so a task can declare it without a warning) but not enforced."""
 
 
 async def docker(*args: str) -> ProgramResult:
@@ -87,12 +88,13 @@ class DockerRuntime(Runtime):
             )
         self._container = f"vf-{uuid.uuid4().hex[:12]}"
         limits: list[str] = []
-        if self.config.cpu_cores is not None:
-            limits += ["--cpus", str(self.config.cpu_cores)]
-        if self.config.memory_gb is not None:
-            limits += ["--memory", f"{self.config.memory_gb}g"]
-        if self.config.gpu_count:
-            limits += ["--gpus", str(self.config.gpu_count)]
+        if self.config.cpu is not None:
+            limits += ["--cpus", str(self.config.cpu)]
+        if self.config.memory is not None:
+            limits += ["--memory", f"{self.config.memory}m"]
+        _, gpu_count = parse_gpu(self.config.gpu)
+        if gpu_count:
+            limits += ["--gpus", str(gpu_count)]
         run = await docker(
             "run",
             "--detach",

--- a/verifiers/v1/runtimes/docker.py
+++ b/verifiers/v1/runtimes/docker.py
@@ -28,13 +28,13 @@ class DockerConfig(BaseConfig):
     # Resources in Modal's units (also settable per-task via Task.resources).
     cpu: float | None = None
     """Pin the container to this many CPU cores (docker `--cpus`). None = unlimited."""
-    memory: int | None = None
-    """Hard memory limit in MB (docker `--memory`). None = unlimited."""
+    memory: float | None = None
+    """Hard memory limit in GB (docker `--memory`). None = unlimited."""
     gpu: str | None = None
     """GPU spec, e.g. "A100" or "2" (docker `--gpus` uses the count; needs the nvidia
     container toolkit). None = none."""
-    disk: int | None = None
-    """Advisory disk request in MB. Docker has no portable per-container size limit, so
+    disk: float | None = None
+    """Advisory disk request in GB. Docker has no portable per-container size limit, so
     this is accepted (so a task can declare it without a warning) but not enforced."""
 
 
@@ -91,7 +91,7 @@ class DockerRuntime(Runtime):
         if self.config.cpu is not None:
             limits += ["--cpus", str(self.config.cpu)]
         if self.config.memory is not None:
-            limits += ["--memory", f"{self.config.memory}m"]
+            limits += ["--memory", f"{self.config.memory}g"]
         _, gpu_count = parse_gpu(self.config.gpu)
         if gpu_count:
             limits += ["--gpus", str(gpu_count)]

--- a/verifiers/v1/runtimes/modal.py
+++ b/verifiers/v1/runtimes/modal.py
@@ -41,12 +41,12 @@ class ModalConfig(BaseConfig):
     # precedence cli/toml > task > this default).
     cpu: float = 1.0
     """CPU cores."""
-    memory: int = 2048
-    """Memory in MB."""
+    memory: float = 2.0
+    """Memory in GB."""
     gpu: str | None = None
     """GPU spec, e.g. "A100" or "A100:2"."""
-    disk: int = 5120
-    """Disk in MB. Modal sandboxes have no disk knob, so this is accepted (so a task can
+    disk: float = 5.0
+    """Disk in GB. Modal sandboxes have no disk knob, so this is accepted (so a task can
     declare it without a warning) but not enforced."""
 
 
@@ -81,7 +81,7 @@ class ModalRuntime(Runtime):
                 image=modal.Image.from_registry(self.config.image),
                 workdir=self.config.workdir,
                 cpu=self.config.cpu,
-                memory=self.config.memory,
+                memory=int(self.config.memory * 1024),  # Modal memory is MB
                 gpu=self.config.gpu,
                 region=self.config.region,
                 block_network=not self.config.network_access,

--- a/verifiers/v1/runtimes/modal.py
+++ b/verifiers/v1/runtimes/modal.py
@@ -20,9 +20,9 @@ from verifiers.v1.runtimes.base import ProgramResult, Runtime
 logger = logging.getLogger(__name__)
 
 
-# Modal's max sandbox lifetime (24h); "auto" timeout requests it. Sandboxes are created
-# with a `sleep infinity` entrypoint so they stay alive for `exec` until we terminate them.
-_MAX_TIMEOUT_MINUTES = 24 * 60
+# Modal's max sandbox lifetime (24h in seconds); "auto" timeout requests it. Sandboxes are
+# created with a `sleep infinity` entrypoint so they stay alive for `exec` until terminated.
+_MAX_TIMEOUT_SECONDS = 24 * 60 * 60
 # Shared Modal app every rollout's sandbox attaches to (created on first lookup).
 _APP_NAME = "verifiers-v1"
 
@@ -34,19 +34,20 @@ class ModalConfig(BaseConfig):
     network_access: bool = True
     region: str | None = None
     """Region to provision in (None = provider-chosen)."""
-    gpu_type: str | None = None
-    """GPU model when gpu_count > 0 (Modal requires a type, e.g. "A100", "H100")."""
-    timeout: int | Literal["auto"] = 360
-    """Max sandbox lifetime in minutes (default 6h; or "auto" = the highest Modal supports,
+    timeout: int | Literal["auto"] = 21600
+    """Max sandbox lifetime in seconds (default 6h; or "auto" = the highest Modal supports,
     24h). A hard backstop: the sandbox self-terminates even if local cleanup is skipped."""
-    # Resources, mirroring the provider defaults (also settable per-task via
-    # Task.resources, with precedence cli/toml > task > this default).
-    cpu_cores: float = 1.0
-    memory_gb: float = 2.0
-    gpu_count: int = 0
-    disk_gb: float = 5.0
-    """Advisory disk request. Modal sandboxes have no per-sandbox size knob, so this is
-    accepted (so a task can declare it without a warning) but not enforced."""
+    # Resources, in Modal's native units (also settable per-task via Task.resources, with
+    # precedence cli/toml > task > this default).
+    cpu: float = 1.0
+    """CPU cores."""
+    memory: int = 2048
+    """Memory in MB."""
+    gpu: str | None = None
+    """GPU spec, e.g. "A100" or "A100:2"."""
+    disk: int = 5120
+    """Disk in MB. Modal sandboxes have no disk knob, so this is accepted (so a task can
+    declare it without a warning) but not enforced."""
 
 
 class ModalRuntime(Runtime):
@@ -62,21 +63,11 @@ class ModalRuntime(Runtime):
     def descriptor(self) -> str | None:
         return self._sandbox_id
 
-    def _gpu(self) -> str | None:
-        """Modal's `gpu` string (e.g. "A100:2"), or None for CPU-only."""
-        if self.config.gpu_count <= 0:
-            return None
-        if not self.config.gpu_type:
-            raise ProgramError(
-                "modal gpu_count > 0 requires gpu_type (e.g. 'A100', 'H100')"
-            )
-        return f"{self.config.gpu_type}:{self.config.gpu_count}"
-
     async def start(self) -> None:
         import modal
 
         timeout = (
-            _MAX_TIMEOUT_MINUTES
+            _MAX_TIMEOUT_SECONDS
             if self.config.timeout == "auto"
             else self.config.timeout
         )
@@ -89,12 +80,12 @@ class ModalRuntime(Runtime):
                 name="v1-program",
                 image=modal.Image.from_registry(self.config.image),
                 workdir=self.config.workdir,
-                cpu=self.config.cpu_cores,
-                memory=int(self.config.memory_gb * 1024),  # Modal memory is MB
-                gpu=self._gpu(),
+                cpu=self.config.cpu,
+                memory=self.config.memory,
+                gpu=self.config.gpu,
                 region=self.config.region,
                 block_network=not self.config.network_access,
-                timeout=timeout * 60,  # Modal timeout is seconds
+                timeout=timeout,
             )
             self._sandbox_id = self._sandbox.object_id
             logger.info(

--- a/verifiers/v1/runtimes/modal.py
+++ b/verifiers/v1/runtimes/modal.py
@@ -1,0 +1,209 @@
+"""Remote Modal sandbox runtime: run the program in a Modal sandbox, server via tunnel.
+
+The program runs in a remote sandbox and reaches the host interception server over a
+tunnel — the host-side `prime_tunnel`, since Modal's own port forwarding goes the other
+way (it publishes a sandbox port, not a host one).
+"""
+
+import asyncio
+import contextlib
+import logging
+import shlex
+from pathlib import PurePosixPath
+from typing import Literal
+
+from pydantic_config import BaseConfig
+
+from verifiers.v1.errors import ProgramError
+from verifiers.v1.runtimes.base import ProgramResult, Runtime
+
+logger = logging.getLogger(__name__)
+
+
+# Modal's max sandbox lifetime (24h); "auto" timeout requests it. Sandboxes are created
+# with a `sleep infinity` entrypoint so they stay alive for `exec` until we terminate them.
+_MAX_TIMEOUT_MINUTES = 24 * 60
+# Shared Modal app every rollout's sandbox attaches to (created on first lookup).
+_APP_NAME = "verifiers-v1"
+
+
+class ModalConfig(BaseConfig):
+    type: Literal["modal"] = "modal"
+    image: str = "python:3.11-slim"
+    workdir: str = "/app"
+    network_access: bool = True
+    region: str | None = None
+    """Region to provision in (None = provider-chosen)."""
+    gpu_type: str | None = None
+    """GPU model when gpu_count > 0 (Modal requires a type, e.g. "A100", "H100")."""
+    timeout: int | Literal["auto"] = 360
+    """Max sandbox lifetime in minutes (default 6h; or "auto" = the highest Modal supports,
+    24h). A hard backstop: the sandbox self-terminates even if local cleanup is skipped."""
+    # Resources, mirroring the provider defaults (also settable per-task via
+    # Task.resources, with precedence cli/toml > task > this default).
+    cpu_cores: float = 1.0
+    memory_gb: float = 2.0
+    gpu_count: int = 0
+    disk_gb: float = 5.0
+    """Advisory disk request. Modal sandboxes have no per-sandbox size knob, so this is
+    accepted (so a task can declare it without a warning) but not enforced."""
+
+
+class ModalRuntime(Runtime):
+    """Runs the program in a Modal sandbox; the server is reached via a tunnel."""
+
+    def __init__(self, config: ModalConfig) -> None:
+        self.config = config
+        self._sandbox = None
+        self._sandbox_id: str | None = None
+        self._tunnels: list = []
+
+    @property
+    def descriptor(self) -> str | None:
+        return self._sandbox_id
+
+    def _gpu(self) -> str | None:
+        """Modal's `gpu` string (e.g. "A100:2"), or None for CPU-only."""
+        if self.config.gpu_count <= 0:
+            return None
+        if not self.config.gpu_type:
+            raise ProgramError(
+                "modal gpu_count > 0 requires gpu_type (e.g. 'A100', 'H100')"
+            )
+        return f"{self.config.gpu_type}:{self.config.gpu_count}"
+
+    async def start(self) -> None:
+        import modal
+
+        timeout = (
+            _MAX_TIMEOUT_MINUTES
+            if self.config.timeout == "auto"
+            else self.config.timeout
+        )
+        try:
+            app = await modal.App.lookup.aio(_APP_NAME, create_if_missing=True)
+            self._sandbox = await modal.Sandbox.create.aio(
+                "sleep",
+                "infinity",  # keep-alive entrypoint; the harness runs via `exec`
+                app=app,
+                name="v1-program",
+                image=modal.Image.from_registry(self.config.image),
+                workdir=self.config.workdir,
+                cpu=self.config.cpu_cores,
+                memory=int(self.config.memory_gb * 1024),  # Modal memory is MB
+                gpu=self._gpu(),
+                region=self.config.region,
+                block_network=not self.config.network_access,
+                timeout=timeout * 60,  # Modal timeout is seconds
+            )
+            self._sandbox_id = self._sandbox.object_id
+            logger.info(
+                "modal: sandbox %s up (image=%s)", self._sandbox_id, self.config.image
+            )
+            await self._sandbox.filesystem.make_directory.aio(self.config.workdir)
+        except (
+            Exception
+        ) as e:  # provisioning failure is one rollout's problem, not the eval's
+            raise ProgramError(f"modal sandbox provisioning failed: {e}") from e
+
+    async def expose(self, port: int) -> str:
+        # The sandbox is remote, so reach a host port via a tunnel (one per port). Modal's
+        # own forwarding publishes a sandbox port, not a host one, so use the host-side
+        # `prime_tunnel` here.
+        from prime_tunnel import Tunnel
+
+        tunnel = Tunnel(local_port=port)
+        try:
+            url = str(await tunnel.start()).rstrip("/")
+        except Exception as e:
+            raise ProgramError(f"modal tunnel failed (host port {port}): {e}") from e
+        self._tunnels.append(tunnel)
+        logger.info("modal: tunnel up at %s (host port %d)", url, port)
+        return url
+
+    async def run(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
+        try:
+            proc = await self._sandbox.exec.aio(
+                *argv, workdir=self.config.workdir, env=env
+            )
+            # Drain both pipes concurrently so a large stderr can't deadlock stdout.
+            stdout, stderr = await asyncio.gather(
+                proc.stdout.read.aio(), proc.stderr.read.aio()
+            )
+            await proc.wait.aio()
+        except (
+            Exception
+        ) as e:  # a sandbox/API failure is one rollout's problem, not the eval's
+            raise ProgramError(f"modal exec failed: {e}") from e
+        return ProgramResult(
+            exit_code=proc.returncode or 0,
+            stdout=stdout or "",
+            stderr=stderr or "",
+        )
+
+    async def run_background(
+        self, argv: list[str], env: dict[str, str], log: str
+    ) -> None:
+        # `&` backgrounds inside the sandbox; the job returns immediately, the process
+        # lives until the sandbox is terminated in stop().
+        inner = f"nohup {shlex.join(argv)} > {shlex.quote(log)} 2>&1 &"
+        result = await self.run(["sh", "-c", inner], env)
+        if result.exit_code != 0:
+            raise ProgramError(
+                f"modal background launch failed: {result.stderr.strip()}"
+            )
+
+    async def read(self, path: str) -> bytes:
+        try:
+            return await self._sandbox.filesystem.read_bytes.aio(path)
+        except Exception as e:
+            raise ProgramError(f"read {path!r}: {e}") from e
+
+    async def write(self, path: str, data: bytes) -> None:
+        # Resolve a relative path against the workdir and create its parent first (Modal's
+        # write does not mkdir).
+        target = (
+            path
+            if path.startswith("/")
+            else f"{self.config.workdir.rstrip('/')}/{path}"
+        )
+        try:
+            await self._sandbox.filesystem.make_directory.aio(
+                str(PurePosixPath(target).parent)
+            )
+            await self._sandbox.filesystem.write_bytes.aio(data, target)
+        except Exception as e:
+            raise ProgramError(f"write {path!r}: {e}") from e
+
+    def cleanup(self) -> None:
+        # Synchronous atexit backstop (the async API can't run once the loop is gone): stop
+        # the already-sync tunnels and terminate the sandbox via Modal's sync API, so the
+        # costly resource isn't left to its max-lifetime. Idempotent — the async `stop`
+        # handles the normal path, and a second terminate is a no-op.
+        for tunnel in self._tunnels:
+            with contextlib.suppress(Exception):
+                tunnel.sync_stop()
+        self._tunnels = []
+        sandbox, self._sandbox = self._sandbox, None
+        if sandbox is not None:  # `_sandbox_id` kept so descriptor survives teardown
+            with contextlib.suppress(Exception):
+                sandbox.terminate()
+
+    async def stop(self) -> None:
+        # Best-effort, idempotent teardown on the normal path: tunnels first, then the
+        # sandbox (the costly resource) via the async API. Runs from the rollout's
+        # `finally`, so it fires on success, error, and cancellation; `_sandbox` is nulled
+        # as the idempotency guard (the atexit `cleanup` then no-ops).
+        for tunnel in self._tunnels:
+            with contextlib.suppress(Exception):
+                tunnel.sync_stop()
+        self._tunnels = []
+        sandbox, self._sandbox = self._sandbox, None
+        if sandbox is None:
+            return
+        try:
+            await sandbox.terminate.aio()
+        except Exception as e:
+            logger.warning(
+                "modal: failed to terminate sandbox %s: %s", self._sandbox_id, e
+            )

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -38,12 +38,12 @@ class PrimeConfig(BaseConfig):
     # precedence cli/toml > task > this default). Mapped to prime's API in `start`.
     cpu: float = 1.0
     """CPU cores."""
-    memory: int = 2048
-    """Memory in MB."""
+    memory: float = 2.0
+    """Memory in GB."""
     gpu: str | None = None
     """GPU spec, e.g. "A100" or "A100:2" (a bare count = provider-chosen type)."""
-    disk: int = 5120
-    """Disk in MB."""
+    disk: float = 5.0
+    """Disk in GB."""
 
 
 class PrimeRuntime(Runtime):
@@ -68,13 +68,13 @@ class PrimeRuntime(Runtime):
             if self.config.timeout == "auto"
             else self.config.timeout
         )
-        # Map the Modal-unit resources onto prime's API (GB, minutes, split GPU).
-        # gpu_type/region are only sent when set (else provider-chosen).
+        # Map the resources onto prime's API (minutes, split GPU; memory/disk are already
+        # GB). gpu_type/region are only sent when set (else provider-chosen).
         gpu_type, gpu_count = parse_gpu(self.config.gpu)
         options = {
             "cpu_cores": self.config.cpu,
-            "memory_gb": self.config.memory / 1024,
-            "disk_size_gb": self.config.disk / 1024,
+            "memory_gb": self.config.memory,
+            "disk_size_gb": self.config.disk,
             "gpu_count": gpu_count,
             "timeout_minutes": timeout // 60,
             "gpu_type": gpu_type,

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -10,14 +10,13 @@ from typing import Literal
 from pydantic_config import BaseConfig
 
 from verifiers.v1.errors import ProgramError
-from verifiers.v1.runtimes.base import ProgramResult, Runtime
+from verifiers.v1.runtimes.base import ProgramResult, Runtime, parse_gpu
 
 logger = logging.getLogger(__name__)
 
 
-# Prime sandbox defaults, mirrored here so our behavior is stable even if the
-# provider's defaults change. "auto" timeout requests the max prime allows.
-_MAX_TIMEOUT_MINUTES = 24 * 60
+# "auto" timeout requests the max prime allows (24h).
+_MAX_TIMEOUT_SECONDS = 24 * 60 * 60
 
 
 class PrimeConfig(BaseConfig):
@@ -31,18 +30,20 @@ class PrimeConfig(BaseConfig):
     """Request guaranteed (vs best-effort) capacity."""
     region: str | None = None
     """Region to provision in (None = provider-chosen)."""
-    gpu_type: str | None = None
-    """GPU model when gpu_count > 0 (None = provider-chosen)."""
-    timeout: int | Literal["auto"] = 360
-    """Max sandbox lifetime in minutes (default 6h; or "auto" = the highest prime
+    timeout: int | Literal["auto"] = 21600
+    """Max sandbox lifetime in seconds (default 6h; or "auto" = the highest prime
     supports). A hard backstop: the sandbox self-terminates even if local cleanup is
     skipped."""
-    # Resources, mirroring the provider defaults (also settable per-task via
-    # Task.resources, with precedence cli/toml > task > this default).
-    cpu_cores: float = 1.0
-    memory_gb: float = 2.0
-    gpu_count: int = 0
-    disk_gb: float = 5.0
+    # Resources, in Modal's units (also settable per-task via Task.resources, with
+    # precedence cli/toml > task > this default). Mapped to prime's API in `start`.
+    cpu: float = 1.0
+    """CPU cores."""
+    memory: int = 2048
+    """Memory in MB."""
+    gpu: str | None = None
+    """GPU spec, e.g. "A100" or "A100:2" (a bare count = provider-chosen type)."""
+    disk: int = 5120
+    """Disk in MB."""
 
 
 class PrimeRuntime(Runtime):
@@ -63,19 +64,20 @@ class PrimeRuntime(Runtime):
 
         self._client = AsyncSandboxClient()
         timeout = (
-            _MAX_TIMEOUT_MINUTES
+            _MAX_TIMEOUT_SECONDS
             if self.config.timeout == "auto"
             else self.config.timeout
         )
-        # We always send the mirrored resource defaults (so behavior is stable);
+        # Map the Modal-unit resources onto prime's API (GB, minutes, split GPU).
         # gpu_type/region are only sent when set (else provider-chosen).
+        gpu_type, gpu_count = parse_gpu(self.config.gpu)
         options = {
-            "cpu_cores": self.config.cpu_cores,
-            "memory_gb": self.config.memory_gb,
-            "disk_size_gb": self.config.disk_gb,
-            "gpu_count": self.config.gpu_count,
-            "timeout_minutes": timeout,
-            "gpu_type": self.config.gpu_type,
+            "cpu_cores": self.config.cpu,
+            "memory_gb": self.config.memory / 1024,
+            "disk_size_gb": self.config.disk / 1024,
+            "gpu_count": gpu_count,
+            "timeout_minutes": timeout // 60,
+            "gpu_type": gpu_type,
             "region": self.config.region,
         }
         try:

--- a/verifiers/v1/task.py
+++ b/verifiers/v1/task.py
@@ -14,17 +14,21 @@ from verifiers.v1.types import StrictBaseModel
 
 
 class Resources(StrictBaseModel):
-    """Runtime resources a task requests (all optional). Applied to the runtime
-    config where the field exists (e.g. `cpu_cores` on prime); a field the runtime
-    doesn't support is warned about and ignored. Precedence: cli/toml > task > the
-    runtime default (`None` here = use the runtime/provider default)."""
+    """Runtime resources a task requests (all optional), in Modal's units. Applied to the
+    runtime config where the field exists; a field the runtime doesn't support is warned
+    about and ignored. Precedence: cli/toml > task > the runtime default (`None` here =
+    use the runtime/provider default)."""
 
     model_config = ConfigDict(frozen=True)
 
-    cpu_cores: float | None = None
-    memory_gb: float | None = None
-    gpu_count: int | None = None
-    disk_gb: float | None = None
+    cpu: float | None = None
+    """CPU cores."""
+    memory: int | None = None
+    """Memory in MB."""
+    gpu: str | None = None
+    """GPU spec, e.g. "A100" or "A100:2" (type[:count])."""
+    disk: int | None = None
+    """Disk in MB (enforced by prime; advisory on docker/modal)."""
 
 
 class Task(StrictBaseModel):

--- a/verifiers/v1/task.py
+++ b/verifiers/v1/task.py
@@ -23,12 +23,12 @@ class Resources(StrictBaseModel):
 
     cpu: float | None = None
     """CPU cores."""
-    memory: int | None = None
-    """Memory in MB."""
+    memory: float | None = None
+    """Memory in GB."""
     gpu: str | None = None
     """GPU spec, e.g. "A100" or "A100:2" (type[:count])."""
-    disk: int | None = None
-    """Disk in MB (enforced by prime; advisory on docker/modal)."""
+    disk: float | None = None
+    """Disk in GB (enforced by prime; advisory on docker/modal)."""
 
 
 class Task(StrictBaseModel):


### PR DESCRIPTION
## Summary

- Adds a **Modal** cloud runtime (`--harness.runtime.type modal`) alongside `prime`. The program runs in a [Modal Sandbox](https://modal.com/docs/guide/sandbox); like prime it reaches the host interception server over the host-side `prime_tunnel` (Modal's own forwarding publishes a *sandbox* port, not a host one). Wired into the runtime union, `make_runtime`, and the `register()` cleanup backstop. Adds `modal>=1.4.0`.
- **Unifies the resource convention across all runtimes** (Modal's cleaner naming), on `Task.resources` and every runtime config: `cpu` (cores), `memory` (GB), `gpu` (spec string), `disk` (GB), `timeout` (seconds). Each runtime maps these to its own API.

## Resource convention (shared by `Task.resources` + all runtime configs)

| field | unit | modal | prime | docker |
|---|---|---|---|---|
| `cpu` | cores | `cpu` | `cpu_cores` | `--cpus` |
| `memory` | GB | `memory` (×1024 → MB) | `memory_gb` | `--memory <n>g` |
| `gpu` | spec str `"A100:2"` | `gpu` | `gpu_type`+`gpu_count` (split) | `--gpus <count>` |
| `disk` | GB | — (advisory) | `disk_size_gb` | — (advisory) |
| `timeout` | seconds | `timeout` | `timeout_minutes` (÷60) | — |

A shared `parse_gpu()` splits the GPU spec: `"A100"→("A100",1)`, `"A100:2"→("A100",2)`, `None→(None,0)`. Prime requires `gpu_type` whenever `gpu_count>0` (its model validator) — the typed specs satisfy this; a bare count is unsupported on both prime and modal. `disk` is enforced only by prime; Modal sandboxes have no disk knob (the SDK hardcodes `ephemeral_disk=None` for sandboxes — Functions-only) and docker has no portable per-container size limit, so both accept-but-ignore it.

## Breaking

Runtime resource fields are renamed (and `timeout` re-unitted) on `Task.resources`, `PrimeConfig`, `DockerConfig` (and the new `ModalConfig`). Migration:

| old | new |
|---|---|
| `cpu_cores` | `cpu` |
| `memory_gb` | `memory` (still GB) |
| `gpu_count: 2` + `gpu_type: "A100"` | `gpu: "A100:2"` |
| `disk_gb` | `disk` (still GB) |
| `timeout: 360` (prime, minutes) | `timeout: 21600` (seconds) |

Defaults are unchanged in real terms (prime still 1 cpu / 2 GB mem / 5 GB disk / 6 h). CLI/TOML setting `--harness.runtime.cpu_cores`/`memory_gb`/`gpu_count`/`gpu_type`/`disk_gb` or per-task `resources` must move to the new names.

## Cleanup

Mirrors prime's two-path teardown: async `stop()` terminates the sandbox on the normal path; sync `cleanup()` is the `atexit` backstop (Modal's sync `terminate()`) for a signal-cut `stop()`. Both stop tunnels first, null `_sandbox` as an idempotency guard, suppressed.

## Verification

- `ruff check`/`format` clean; `modal` imports (1.4.3).
- API checked against the installed SDK (`.aio` on `Sandbox.create`/`exec`/`terminate`/`App.lookup`/`filesystem.read_bytes`/`write_bytes`; `ContainerProcess.returncode`); resource params + GPU validator confirmed against the real `CreateSandboxRequest` / `Sandbox.create` signatures.
- `parse_gpu` cases; defaults map to prior real values (prime → `cpu_cores=1.0`, `memory_gb=2.0`, `disk_size_gb=5.0`, `timeout_minutes=360`); modal maps `memory` GB→MB (2.0→2048); `Resources` strict-validates; modal resolves in the union via `--dry-run`.
- **Live, post-refactor**: `subprocess` and `prime` debug rollouts both complete cleanly (reward 1.0); prime accepts the new fields live (`--harness.runtime.cpu 2 --harness.runtime.memory 4` → sandbox provisioned).

## Live Modal rollout (verified)

End-to-end `--harness.runtime.type modal` rollout against `gsm8k-v1`:

```
$ uv run eval gsm8k-v1 --harness.id default --harness.enable_bash false \
    --harness.runtime.type modal --num_tasks 1 --num_rollouts 1 --rich false

INFO rollout start: id=2b177d36... task=0 harness=default runtime=modal
INFO modal: sandbox sb-F1AcvXNPe5zI4a3e9uFXMI up (image=python:3.11-slim)
INFO modal: tunnel up at https://t-0-58a6b8a168392964.tunnel.pinfra.io (host port 42765)
INFO rollout done: id=2b177d36... reward=1.000 turns=1 stop=agent_completed     # ~29s
```

Sandbox provisions, the host tunnel comes up, and the rollout completes cleanly (`reward=1.0`, `turns=1`, `stop=agent_completed`, no errors). **Cleanup confirmed** after the run:

```
>>> modal.Sandbox.from_id("sb-F1AcvXNPe5zI4a3e9uFXMI").poll()   # 137  -> terminated
>>> len(modal.Sandbox.list())                                    # 0    -> no leak
```

## Notes / follow-ups

- `public_url()` is not implemented for modal (inherits base `None`): Modal port self-publishing needs `encrypted_ports` declared at sandbox-create time, which doesn't fit the post-create `expose` flow. Colocated tool servers on `tools.runtime = modal` would fall back; a follow-up can add it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking config renames and Prime timeout unit change affect existing TOML/CLI; new remote Modal path provisions sandboxes and tunnels with cleanup backstops.
> 
> **Overview**
> Adds a **Modal** cloud runtime (`--harness.runtime.type modal`) so rollouts run in Modal Sandboxes and reach the host interception server via `prime_tunnel`, with async `stop()` and sync `cleanup()` teardown like Prime.
> 
> **Breaking:** `Task.resources` and `PrimeConfig` / `DockerConfig` (and Harbor `parse_resources`) now use a shared resource shape: `cpu`, `memory` (GB), `gpu` (spec string, e.g. `"A100:2"`), `disk` (GB), and `timeout` in **seconds** on Prime/Modal. Old names (`cpu_cores`, `memory_gb`, `gpu_count` + `gpu_type`, `disk_gb`, Prime timeout in minutes) must be migrated. Shared `parse_gpu()` splits the GPU string for Prime and Docker `--gpus`.
> 
> Adds `modal>=1.4.0` to project dependencies and registers `ModalConfig` / `ModalRuntime` in the runtime union and `make_runtime`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8c49d4c0c28ee1f81086f7a0cfaa5cb1689dba0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Modal sandbox runtime to verifier runtime system
> - Adds `ModalRuntime` and `ModalConfig` in [modal.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1594/files#diff-a6217d92f043d6050e8609d4341d62b5d097d5db796f6197cd604e09d81683c0), backed by Modal sandboxes with support for foreground/background execution, port tunneling, and sandbox file I/O.
> - Registers `ModalRuntime` in [runtimes/__init__.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1594/files#diff-2277d8028e645feaa9a55aa5c89b8db0545b9f8cbbe492472d904040718b52f4) so `make_runtime` dispatches on `type="modal"`.
> - Unifies resource field naming across all runtimes and configs (`cpu`, `memory`, `gpu` as string spec, `disk`) to match Modal-native conventions; introduces `parse_gpu` in [base.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1594/files#diff-0811c040a163eb5a3212208f1e3a6c6388d7690fcc4780c081cc7754036232b9) to convert string GPU specs (e.g. `"A100:2"`) to `(type, count)` tuples.
> - `PrimeConfig` and `DockerConfig` are updated to use the new field names; Prime provisioning now converts the second-based timeout to minutes for its API.
> - Risk: renaming resource fields (`cpu_cores`→`cpu`, `memory_gb`→`memory`, etc.) is a breaking schema change for any existing configs or callers using the old field names.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a8c49d4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->