### PR TITLE
feat: name runtime resources after the rollout id

### DIFF
--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -80,8 +80,8 @@ class Rollout:
         self.trace = trace  # expose for the --rich dashboard
         trace.timing.generation.start = time.time()
         self.runtime = make_runtime(
-            self.runtime_config
-        )  # ref set first → always tearable-down
+            self.runtime_config, name=trace.id
+        )  # ref set first → always tearable-down; named after the rollout for traceability
         runtime = self.runtime
         stops = discover_decorated(self.taskset, "stop")
         logger.info(

--- a/verifiers/v1/runtimes/__init__.py
+++ b/verifiers/v1/runtimes/__init__.py
@@ -21,13 +21,13 @@ RuntimeConfig = Annotated[
 ]
 
 
-def make_runtime(config: RuntimeConfig) -> Runtime:
+def make_runtime(config: RuntimeConfig, name: str | None = None) -> Runtime:
     if isinstance(config, PrimeConfig):
-        runtime: Runtime = PrimeRuntime(config)
+        runtime: Runtime = PrimeRuntime(config, name)
     elif isinstance(config, DockerConfig):
-        runtime = DockerRuntime(config)
+        runtime = DockerRuntime(config, name)
     else:
-        runtime = SubprocessRuntime(config)
+        runtime = SubprocessRuntime(config, name)
     register(runtime)
     return runtime
 

--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -74,6 +74,13 @@ def cleanup_at_exit() -> None:
 
 
 class Runtime(ABC):
+    def __init__(self, name: str | None = None) -> None:
+        self.name = name or f"vf-{uuid.uuid4().hex[:12]}"
+        """Resource name — the subprocess workdir, docker `--name`, prime sandbox name.
+        The rollout passes its trace id, so the provisioned resource is greppable back to
+        the rollout it serves; falls back to a unique `vf-` name (standalone / tool
+        runtimes, where there's no single owning rollout)."""
+
     @abstractmethod
     async def start(self) -> None:
         """Provision execution (workspace / container / sandbox). Use `expose` to turn a

--- a/verifiers/v1/runtimes/docker.py
+++ b/verifiers/v1/runtimes/docker.py
@@ -9,7 +9,6 @@ import contextlib
 import logging
 import shlex
 import subprocess
-import uuid
 from pathlib import PurePosixPath
 from typing import Literal
 
@@ -56,7 +55,8 @@ async def docker(*args: str) -> ProgramResult:
 class DockerRuntime(Runtime):
     """Runs the program in a local Docker container reachable over the host network."""
 
-    def __init__(self, config: DockerConfig) -> None:
+    def __init__(self, config: DockerConfig, name: str | None = None) -> None:
+        super().__init__(name)
         self.config = config
         self._container: str | None = None  # our `--name` (used for exec/rm)
         self._container_id: str | None = None  # docker's short id (for display)
@@ -85,7 +85,7 @@ class DockerRuntime(Runtime):
             raise RuntimeError(
                 f"docker runtime selected but the Docker daemon is not reachable: {detail}{hint}"
             )
-        self._container = f"vf-{uuid.uuid4().hex[:12]}"
+        self._container = self.name
         limits: list[str] = []
         if self.config.cpu_cores is not None:
             limits += ["--cpus", str(self.config.cpu_cores)]

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -48,7 +48,8 @@ class PrimeConfig(BaseConfig):
 class PrimeRuntime(Runtime):
     """Runs the program in a Prime sandbox; the server is reached via a tunnel."""
 
-    def __init__(self, config: PrimeConfig) -> None:
+    def __init__(self, config: PrimeConfig, name: str | None = None) -> None:
+        super().__init__(name)
         self.config = config
         self._client = None
         self._sandbox_id: str | None = None
@@ -81,7 +82,7 @@ class PrimeRuntime(Runtime):
         try:
             sandbox = await self._client.create(
                 CreateSandboxRequest(
-                    name="vf-program",
+                    name=self.name,
                     docker_image=self.config.image,
                     network_access=self.config.network_access,
                     vm=self.config.vm,

--- a/verifiers/v1/runtimes/subprocess.py
+++ b/verifiers/v1/runtimes/subprocess.py
@@ -1,6 +1,6 @@
 """Local subprocess runtime: run the program on the host; server on localhost.
 
-Each rollout gets a fresh, unique `/tmp/vf-*` workspace (created on `start`, removed on
+Each rollout gets a fresh `/tmp/<name>` workspace (created on `start`, removed on
 `stop`/`cleanup`) used as the program's cwd, so concurrent local rollouts are isolated
 and trivially cleaned up. Relative `read`/`write` paths resolve against it.
 """
@@ -10,7 +10,6 @@ import contextlib
 import os
 import shutil
 import signal
-import tempfile
 from pathlib import Path
 from typing import Literal
 
@@ -33,7 +32,8 @@ class SubprocessConfig(BaseConfig):
 class SubprocessRuntime(Runtime):
     """Runs the program as a local subprocess in a unique /tmp workspace."""
 
-    def __init__(self, config: SubprocessConfig) -> None:
+    def __init__(self, config: SubprocessConfig, name: str | None = None) -> None:
+        super().__init__(name)
         self.config = config
         self.workdir: Path | None = None
         self._background: list[asyncio.subprocess.Process] = []
@@ -43,7 +43,8 @@ class SubprocessRuntime(Runtime):
         return self.workdir.name if self.workdir else None
 
     async def start(self) -> None:
-        self.workdir = Path(tempfile.mkdtemp(prefix="vf-", dir="/tmp"))
+        self.workdir = Path("/tmp") / self.name
+        self.workdir.mkdir()
 
     async def run(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
         full_env = {k: v for k, v in os.environ.items() if "API_KEY" not in k.upper()}


### PR DESCRIPTION
## Summary

- The **subprocess workdir** (`/tmp/<id>`), **docker `--name`**, and **prime sandbox name** now equal the rollout's auto-generated trace id, so every provisioned resource is greppable back to the rollout it serves.
- `make_runtime(config, name=...)` threads the name through to each runtime; `Rollout.run()` passes `name=trace.id`.
- The `Runtime` base holds `self.name`, falling back to a unique `vf-<uuid>` when no name is given (standalone / tool runtimes, where there's no single owning rollout).

Previously the three were independent and un-correlatable: a random `mkdtemp` `/tmp/vf-*` workdir, a `vf-<uuid>` container, and a static `vf-program` sandbox name (every prime sandbox shared one name).

## Verification

Debug rollout (`eval gsm8k-v1 -n 1 --harness.runtime.type <rt>`) against all three runtimes, capturing the live resource and matching it to the trace id, with a no-leak check before/after:

| runtime | resource | trace id == resource name | cleaned up |
|---|---|---|---|
| subprocess | `/tmp/<id>` workdir | ✓ (full 32-hex match, captured live) | ✓ workdir removed, 0 leftover |
| docker | container `--name` | ✓ (full 32-hex match, captured live) | ✓ container removed (count 1→1) |
| prime | sandbox name | ✓ (seen live in sandbox list) | ✓ sandbox `TERMINATED` after rollout |

All three rollouts completed with `exit=0`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Name runtime resources after the rollout trace ID
> - Runtimes now accept an optional `name` parameter, defaulting to a generated `vf-<12 hex>` identifier in the base [Runtime](https://github.com/PrimeIntellect-ai/verifiers/pull/1596/files#diff-0811c040a163eb5a3212208f1e3a6c6388d7690fcc4780c081cc7754036232b9) class.
> - Docker containers, Prime sandboxes, and subprocess workspaces all use this name for their underlying resources instead of randomly generated values.
> - [Rollout.run](https://github.com/PrimeIntellect-ai/verifiers/pull/1596/files#diff-f886b7f4717cf8fce9270bd4ff4790f3182aa1016abb9efb7f6e57efe18d1bf2) passes the rollout trace ID as the runtime name, making provisioned resource names deterministic and traceable.
> - Behavioral Change: `SubprocessRuntime` now creates a fixed `/tmp/<name>` directory via `mkdir()` instead of using `tempfile.mkdtemp()`; the directory is no longer guaranteed unique if a run is retried with the same trace ID.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 231513d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Subprocess isolation now uses a fixed `/tmp/<name>` path with plain `mkdir()`, which can collide on retry with the same trace id; Docker/Prime naming changes are mostly operational traceability.
> 
> **Overview**
> **Runtime resources are now named from the rollout trace id** so subprocess workdirs, Docker containers, and Prime sandboxes can be correlated with a specific rollout in logs and on the host.
> 
> `make_runtime` accepts an optional `name`, stored on the base `Runtime` (default `vf-<12 hex>` when omitted, e.g. tool servers). `Rollout.run` passes `trace.id` into that parameter. **Docker** uses it for `--name`; **Prime** for sandbox `name` (replacing the shared `vf-program` label); **Subprocess** provisions `/tmp/<name>` via `mkdir()` instead of `tempfile.mkdtemp()` with a random `vf-*` prefix.
> 
> **Note:** subprocess workspaces are no longer guaranteed unique if provisioning runs again with the same name before cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 231513d2c5cb6fb0690abc47df1c07b1710c8dc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->