### PR TITLE
feat: run v0 environments on the eval CLI (legacy bridge)

### DIFF
--- a/verifiers/v1/cli/eval.py
+++ b/verifiers/v1/cli/eval.py
@@ -28,7 +28,7 @@ from verifiers.v1.cli.resolve import (
 from verifiers.v1.cli.runner import run_eval
 from verifiers.v1.configs.eval import EvalConfig
 
-USAGE = "usage: uv run eval [<taskset-id>] [--harness.id <id>] [--id <v0-env-id>] [options] [@ file.toml]"
+USAGE = "usage: uv run eval [<taskset-id>] [--harness.id <id>] [--id <env-id> (legacy)] [options] [@ file.toml]"
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/verifiers/v1/cli/eval.py
+++ b/verifiers/v1/cli/eval.py
@@ -28,7 +28,7 @@ from verifiers.v1.cli.resolve import (
 from verifiers.v1.cli.runner import run_eval
 from verifiers.v1.configs.eval import EvalConfig
 
-USAGE = "usage: uv run eval [<taskset-id>] [--harness.id <id>] [options] [@ file.toml]"
+USAGE = "usage: uv run eval [<taskset-id>] [--harness.id <id>] [--legacy.id <v0-env-id>] [options] [@ file.toml]"
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -45,10 +45,14 @@ def main(argv: list[str] | None = None) -> None:
             narrow_config(EvalConfig, argv)
         )  # full option help, narrowed to the given ids
         return
-    if not extract_id(argv, "taskset") and not references_config_file(argv):
+    if (
+        not extract_id(argv, "taskset")
+        and not extract_id(argv, "legacy")
+        and not references_config_file(argv)
+    ):
         raise SystemExit(
             USAGE
-        )  # need a taskset: a positional / --taskset.id, or one in @ file.toml
+        )  # need a taskset (positional / --taskset.id), a --legacy.id, or a @ file.toml
 
     config_type = narrow_config(EvalConfig, argv)
     sys.argv = [sys.argv[0], *argv]  # let prime-pydantic-config render help/errors
@@ -56,14 +60,23 @@ def main(argv: list[str] | None = None) -> None:
     if config.dry_run:  # resolved + validated; dump it and skip the run
         print(config.model_dump_json(indent=2, exclude_none=True))
         return
+    # The --rich dashboard reads live v1 Rollout state, so it's off for a legacy run.
+    rich = config.rich and not config.legacy.id
     # --rich owns the screen, so quiet the per-rollout INFO logs it would replace.
-    setup_logging("DEBUG" if config.verbose else "WARNING" if config.rich else "INFO")
+    setup_logging("DEBUG" if config.verbose else "WARNING" if rich else "INFO")
 
-    env = vf.Environment(config)
-    # Make SIGTERM behave like Ctrl-C (SIGINT) so a killed/timed-out eval still runs
-    # each rollout's `finally` — i.e. tears down its docker container / prime sandbox.
-    signal.signal(signal.SIGTERM, lambda *_: (_ for _ in ()).throw(KeyboardInterrupt()))
-    traces = asyncio.run(run_eval(env, config))
-    if not config.rich:  # --rich is the whole output; otherwise dump each trace as JSON
+    if config.legacy.id:  # v0 backwards-compat: run the classic env, bridged to Traces
+        from verifiers.v1.legacy import run_legacy_eval
+
+        traces = asyncio.run(run_legacy_eval(config))
+    else:
+        env = vf.Environment(config)
+        # Make SIGTERM behave like Ctrl-C (SIGINT) so a killed/timed-out eval still runs
+        # each rollout's `finally` — i.e. tears down its docker container / prime sandbox.
+        signal.signal(
+            signal.SIGTERM, lambda *_: (_ for _ in ()).throw(KeyboardInterrupt())
+        )
+        traces = asyncio.run(run_eval(env, config))
+    if not rich:  # --rich is the whole output; otherwise dump each trace as JSON
         for trace in traces:
             print(trace.model_dump_json(indent=2, exclude_none=True))

--- a/verifiers/v1/cli/eval.py
+++ b/verifiers/v1/cli/eval.py
@@ -28,7 +28,7 @@ from verifiers.v1.cli.resolve import (
 from verifiers.v1.cli.runner import run_eval
 from verifiers.v1.configs.eval import EvalConfig
 
-USAGE = "usage: uv run eval [<taskset-id>] [--harness.id <id>] [--legacy.id <v0-env-id>] [options] [@ file.toml]"
+USAGE = "usage: uv run eval [<taskset-id>] [--harness.id <id>] [--id <v0-env-id>] [options] [@ file.toml]"
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -45,14 +45,15 @@ def main(argv: list[str] | None = None) -> None:
             narrow_config(EvalConfig, argv)
         )  # full option help, narrowed to the given ids
         return
+    legacy_id = any(a == "--id" or a.startswith("--id=") for a in argv)  # v0 env id
     if (
         not extract_id(argv, "taskset")
-        and not extract_id(argv, "legacy")
+        and not legacy_id
         and not references_config_file(argv)
     ):
         raise SystemExit(
             USAGE
-        )  # need a taskset (positional / --taskset.id), a --legacy.id, or a @ file.toml
+        )  # need a taskset (positional / --taskset.id), a legacy --id, or a @ file.toml
 
     config_type = narrow_config(EvalConfig, argv)
     sys.argv = [sys.argv[0], *argv]  # let prime-pydantic-config render help/errors
@@ -61,11 +62,11 @@ def main(argv: list[str] | None = None) -> None:
         print(config.model_dump_json(indent=2, exclude_none=True))
         return
     # The --rich dashboard reads live v1 Rollout state, so it's off for a legacy run.
-    rich = config.rich and not config.legacy.id
+    rich = config.rich and not config.is_legacy
     # --rich owns the screen, so quiet the per-rollout INFO logs it would replace.
     setup_logging("DEBUG" if config.verbose else "WARNING" if rich else "INFO")
 
-    if config.legacy.id:  # v0 backwards-compat: run the classic env, bridged to Traces
+    if config.is_legacy:  # v0 backwards-compat: run the classic env, bridged to Traces
         from verifiers.v1.legacy import run_legacy_eval
 
         traces = asyncio.run(run_legacy_eval(config))

--- a/verifiers/v1/configs/eval.py
+++ b/verifiers/v1/configs/eval.py
@@ -4,10 +4,20 @@ from pathlib import Path
 from uuid import uuid4
 
 from pydantic import AliasChoices, Field
+from pydantic_config import BaseConfig
 
 from verifiers.v1.clients import ClientConfig, OpenAIClientConfig
 from verifiers.v1.env import EnvConfig
 from verifiers.v1.types import SamplingConfig
+
+
+class LegacyConfig(BaseConfig):
+    """Opt-in v0 backwards-compat. When `id` is set, the eval runs a classic
+    `verifiers.load_environment(id, **args)` env in-process and bridges its rollouts to v1
+    `Trace`s (all in `verifiers.v1.legacy`), ignoring `taskset`/`harness`/runtime."""
+
+    id: str | None = None
+    args: dict = {}
 
 
 class EvalConfig(EnvConfig):
@@ -54,3 +64,5 @@ class EvalConfig(EnvConfig):
     )
     """Where to write the run (config.toml + results.jsonl). None = a fresh per-run dir
     under `outputs/<env>--<model>--<harness>/<uuid>` (so runs never overwrite each other)."""
+    legacy: LegacyConfig = LegacyConfig()
+    """Run a classic v0 env instead: `--legacy.id <env-id> [--legacy.args '{...}']`."""

--- a/verifiers/v1/configs/eval.py
+++ b/verifiers/v1/configs/eval.py
@@ -4,20 +4,10 @@ from pathlib import Path
 from uuid import uuid4
 
 from pydantic import AliasChoices, Field
-from pydantic_config import BaseConfig
 
 from verifiers.v1.clients import ClientConfig, OpenAIClientConfig
 from verifiers.v1.env import EnvConfig
 from verifiers.v1.types import SamplingConfig
-
-
-class LegacyConfig(BaseConfig):
-    """Opt-in v0 backwards-compat. When `id` is set, the eval runs a classic
-    `verifiers.load_environment(id, **args)` env in-process and bridges its rollouts to v1
-    `Trace`s (all in `verifiers.v1.legacy`), ignoring `taskset`/`harness`/runtime."""
-
-    id: str | None = None
-    args: dict = {}
 
 
 class EvalConfig(EnvConfig):
@@ -64,5 +54,3 @@ class EvalConfig(EnvConfig):
     )
     """Where to write the run (config.toml + results.jsonl). None = a fresh per-run dir
     under `outputs/<env>--<model>--<harness>/<uuid>` (so runs never overwrite each other)."""
-    legacy: LegacyConfig = LegacyConfig()
-    """Run a classic v0 env instead: `--legacy.id <env-id> [--legacy.args '{...}']`."""

--- a/verifiers/v1/env.py
+++ b/verifiers/v1/env.py
@@ -68,12 +68,20 @@ class EnvConfig(BaseConfig):
     max_total_tokens: int | None = None
     """Max total (prompt + completion) tokens per rollout (None = no limit). Caps the
     trace's `total_tokens`; framework-enforced between turns."""
+    # --- legacy (v0) backwards-compat -----------------------------------------
+    # Run a classic `verifiers.load_environment(id, **args)` env, bridged to v1 Traces (see
+    # `verifiers.v1.legacy`), instead of a v1 taskset/harness. Set `id` (leave `taskset`
+    # unset) to opt in; native v1 envs leave these untouched. Mirrors prime-rl's EnvConfig
+    # so it inherits these (a v0 env is driven the same way in eval and the env server).
     id: str | None = None
     """Classic (v0) env id, loaded via `verifiers.load_environment(id, **args)` and run
-    through the legacy bridge (`verifiers.v1.legacy`). Set this *instead of* `taskset` to
-    run a legacy v0 environment."""
+    through the legacy bridge. Set this *instead of* `taskset` to run a v0 environment."""
     args: dict = {}
-    """Kwargs forwarded to the v0 env's `load_environment` (only used when `id` is set)."""
+    """Construction kwargs forwarded to `load_environment(id, **args)`."""
+    extra_env_kwargs: dict = {}
+    """Post-load kwargs applied to the v0 env via `env.set_kwargs(**extra_env_kwargs)` (e.g.
+    `max_total_completion_tokens`, `max_seq_len`, `timeout_seconds`) — typically
+    auto-populated by the orchestrator, distinct from the `args` passed at construction."""
 
     @property
     def is_legacy(self) -> bool:
@@ -84,6 +92,8 @@ class EnvConfig(BaseConfig):
     def env_id(self) -> str:
         """The env identifier — the v1 taskset id, else the legacy v0 env id."""
         return self.taskset.id or self.id or ""
+
+    # --- end legacy -----------------------------------------------------------
 
     @model_validator(mode="before")
     @classmethod

--- a/verifiers/v1/env.py
+++ b/verifiers/v1/env.py
@@ -68,6 +68,22 @@ class EnvConfig(BaseConfig):
     max_total_tokens: int | None = None
     """Max total (prompt + completion) tokens per rollout (None = no limit). Caps the
     trace's `total_tokens`; framework-enforced between turns."""
+    id: str | None = None
+    """Classic (v0) env id, loaded via `verifiers.load_environment(id, **args)` and run
+    through the legacy bridge (`verifiers.v1.legacy`). Set this *instead of* `taskset` to
+    run a legacy v0 environment."""
+    args: dict = {}
+    """Kwargs forwarded to the v0 env's `load_environment` (only used when `id` is set)."""
+
+    @property
+    def is_legacy(self) -> bool:
+        """A v0/legacy env (run via the bridge): a legacy `id` is set and no v1 `taskset`."""
+        return self.id is not None and not self.taskset.id
+
+    @property
+    def env_id(self) -> str:
+        """The env identifier — the v1 taskset id, else the legacy v0 env id."""
+        return self.taskset.id or self.id or ""
 
     @model_validator(mode="before")
     @classmethod

--- a/verifiers/v1/legacy.py
+++ b/verifiers/v1/legacy.py
@@ -263,12 +263,15 @@ class LegacyEnvServer(EnvServer):
         env_id: str,
         env_args: dict | None = None,
         address: str = "tcp://127.0.0.1:5000",
+        extra_env_kwargs: dict | None = None,
     ) -> None:
         from verifiers import load_environment
 
         self.address = address
         self.taskset_id = env_id
         self.env = load_environment(env_id, **(env_args or {}))
+        if extra_env_kwargs:  # post-load knobs applied via the v0 env's setters
+            self.env.set_kwargs(**extra_env_kwargs)
         # The formatted dataset rows are RolloutInputs (prompt + example_id); index by task_idx.
         self.dataset = self.env.get_dataset()
         self.tasks = self.dataset  # `len(self.tasks)` drives the `info` response
@@ -385,6 +388,8 @@ async def run_legacy_eval(config) -> list[Trace]:
     from verifiers.v1.cli.output import append_trace, save_config
 
     env = load_environment(config.id, **(config.args or {}))
+    if config.extra_env_kwargs:  # post-load knobs (max_total_completion_tokens, …)
+        env.set_kwargs(**config.extra_env_kwargs)
     dataset = env.get_dataset()
     idxs = list(range(len(dataset)))
     if config.shuffle:

--- a/verifiers/v1/legacy.py
+++ b/verifiers/v1/legacy.py
@@ -14,6 +14,7 @@ v1 stays importable without the v0 package present.
 """
 
 import logging
+from pathlib import Path
 from typing import Any
 
 import zmq
@@ -335,3 +336,94 @@ class LegacyEnvServer(EnvServer):
             out = await self._run_v0(req.task_idx, req.client, req.model, req.sampling)
             traces.append(rollout_output_to_trace(out, req.task_idx).to_wire())
         return RunGroupResponse(traces=traces)
+
+
+# --- in-process v0 eval (the `eval` CLI's `--legacy.id` path) ------------------
+
+
+def _eval_client(client_config: ClientConfig, model: str):
+    """A v0 chat-completions client built from the v1 eval `ClientConfig` (base url + api
+    key var + headers). Eval needs no token ids, so this skips the renderer pool the
+    training bridge (`_v0_client`) builds."""
+    from verifiers.clients import resolve_client
+    from verifiers.types import ClientConfig as V0ClientConfig
+
+    return resolve_client(
+        V0ClientConfig(
+            client_type="openai_chat_completions",
+            api_base_url=client_config.base_url,
+            api_key_var=client_config.api_key_var,
+            extra_headers=dict(getattr(client_config, "headers", None) or {}),
+        )
+    )
+
+
+def _legacy_output_dir(config) -> Path:
+    """The legacy run's output dir, mirroring the native `output_path` shape but keyed by
+    the v0 env id (`outputs/<id>--<model>--legacy/<uuid>`); honors `--output-dir`."""
+    if config.output_dir is not None:
+        return config.output_dir
+    name = f"{config.legacy.id}--{config.model.replace('/', '--')}--legacy"
+    return Path("outputs") / name / config.uuid
+
+
+async def run_legacy_eval(config) -> list[Trace]:
+    """In-process v0 eval used by the `eval` CLI when `config.legacy.id` is set.
+
+    Loads the v0 env, runs `num_rollouts` per task with bounded concurrency, maps each v0
+    `RolloutOutput` to a v1 `Trace` (`rollout_output_to_trace`), persists results as they
+    land (the same `results.jsonl` / `config.toml` a native run writes), and returns the
+    traces. The v0 env is run directly (`env.run_rollout`, no env server), so this needs no
+    runtime / interception server. All v0 specifics live here; the CLI only branches on
+    `config.legacy.id`."""
+    import asyncio
+    import random
+
+    from verifiers import load_environment
+
+    from verifiers.v1.cli.output import append_trace, save_config
+
+    env = load_environment(config.legacy.id, **(config.legacy.args or {}))
+    dataset = env.get_dataset()
+    idxs = list(range(len(dataset)))
+    if config.shuffle:
+        random.Random(0).shuffle(idxs)  # fixed seed: same sample every run
+    if config.num_tasks is not None:
+        idxs = idxs[: config.num_tasks]
+
+    client = _eval_client(config.client, config.model)
+    sampling_args = config.sampling.model_dump(exclude_none=True)
+    out_dir = _legacy_output_dir(config)
+    save_config(config, out_dir)
+    logger.info("results: %s", out_dir)
+    logger.info(
+        "running %dx%d v0 rollouts on %s (legacy: %s)",
+        len(idxs),
+        config.num_rollouts,
+        config.model,
+        config.legacy.id,
+    )
+
+    sem = asyncio.Semaphore(config.max_concurrent) if config.max_concurrent else None
+
+    async def run_one(task_idx: int) -> Trace:
+        async def go() -> Trace:
+            out = await env.run_rollout(
+                input=dict(dataset[task_idx]),
+                client=client,
+                model=config.model,
+                sampling_args=sampling_args,
+                state_columns=["trajectory"],
+            )
+            trace = rollout_output_to_trace(out, task_idx)
+            append_trace(out_dir, trace)
+            return trace
+
+        if sem is None:
+            return await go()
+        async with sem:
+            return await go()
+
+    # `num_rollouts` rollouts per selected task, all bounded by the one semaphore.
+    coros = [run_one(i) for i in idxs for _ in range(config.num_rollouts)]
+    return list(await asyncio.gather(*coros))

--- a/verifiers/v1/legacy.py
+++ b/verifiers/v1/legacy.py
@@ -363,19 +363,20 @@ def _legacy_output_dir(config) -> Path:
     the v0 env id (`outputs/<id>--<model>--legacy/<uuid>`); honors `--output-dir`."""
     if config.output_dir is not None:
         return config.output_dir
-    name = f"{config.legacy.id}--{config.model.replace('/', '--')}--legacy"
+    name = f"{config.env_id}--{config.model.replace('/', '--')}--legacy"
     return Path("outputs") / name / config.uuid
 
 
 async def run_legacy_eval(config) -> list[Trace]:
-    """In-process v0 eval used by the `eval` CLI when `config.legacy.id` is set.
+    """In-process v0 eval used by the `eval` CLI when `config.is_legacy` (a legacy `id` is
+    set, no v1 `taskset`).
 
     Loads the v0 env, runs `num_rollouts` per task with bounded concurrency, maps each v0
     `RolloutOutput` to a v1 `Trace` (`rollout_output_to_trace`), persists results as they
     land (the same `results.jsonl` / `config.toml` a native run writes), and returns the
     traces. The v0 env is run directly (`env.run_rollout`, no env server), so this needs no
     runtime / interception server. All v0 specifics live here; the CLI only branches on
-    `config.legacy.id`."""
+    `config.is_legacy`."""
     import asyncio
     import random
 
@@ -383,7 +384,7 @@ async def run_legacy_eval(config) -> list[Trace]:
 
     from verifiers.v1.cli.output import append_trace, save_config
 
-    env = load_environment(config.legacy.id, **(config.legacy.args or {}))
+    env = load_environment(config.id, **(config.args or {}))
     dataset = env.get_dataset()
     idxs = list(range(len(dataset)))
     if config.shuffle:
@@ -401,7 +402,7 @@ async def run_legacy_eval(config) -> list[Trace]:
         len(idxs),
         config.num_rollouts,
         config.model,
-        config.legacy.id,
+        config.id,
     )
 
     sem = asyncio.Semaphore(config.max_concurrent) if config.max_concurrent else None


### PR DESCRIPTION
## Summary

- Backwards-compat: the v1 `uv run eval` entrypoint can now evaluate a **classic v0 environment** via `--id <env-id>`, bridged to v1 `Trace`s — same mechanism the orchestrator uses (`rollout_output_to_trace`), run **in-process** for eval (no env server).
- **All v0 glue stays in `verifiers/v1/legacy.py`** (`run_legacy_eval`, reusing `rollout_output_to_trace`): loads the v0 env, runs `num_rollouts` per task with bounded concurrency via `env.run_rollout`, maps each `RolloutOutput` → `Trace`, writes the same `results.jsonl` / `config.toml` a native run does.
- **Selector lives on `vf.EnvConfig`**, grouped under an explicit *legacy (v0)* separator, matching prime-rl's shape so `EvalConfig` / `EnvServerConfig` inherit it:
  - `id` — v0 env id (`load_environment(id, **args)`)
  - `args` — construction kwargs
  - `extra_env_kwargs` — post-load knobs applied via `env.set_kwargs(**…)` (e.g. `max_total_completion_tokens`, `max_seq_len`, `timeout_seconds`)
  - `is_legacy` (`id set, no taskset`) / `env_id` properties
- The eval CLI branches on `config.is_legacy`; `--rich` (v1 `Rollout` state) is auto-off for legacy runs.

## Alignment with prime-rl

Mirrors prime-rl's legacy wiring: prime-rl's `EnvConfig(vf.EnvConfig)` exposes `id`/`args`/`extra_env_kwargs`/`is_legacy`/`env_id`, and its env server does `if env.is_legacy: LegacyEnvServer(env_id, env_args, extra_env_kwargs)`. **`extra_env_kwargs` is on prime-rl *main* but missing from `feat/nano-as-v1`** — adding it to the base `vf.EnvConfig` fills that gap and lets prime-rl drop its duplicates and inherit. Both legacy entry points (`run_legacy_eval` + `LegacyEnvServer`) apply it via the v0 `env.set_kwargs`.

## Usage

```bash
uv run eval --id reverse-text --num_tasks 2
uv run eval --id wordle --args.use_think true -m <model>
uv run eval --id reverse-text --extra_env_kwargs.max_total_completion_tokens 256
```

`--id` (no `taskset`) makes `is_legacy` true; `taskset`/`harness`/runtime are ignored. Dict fields use dotted CLI syntax (`--args.<k> <v>`, `--extra_env_kwargs.<k> <v>`) or a `@ config.toml`.

## Verification

```
$ uv run eval --id reverse-text --extra_env_kwargs.max_total_completion_tokens 256 --num_tasks 2 --rich false
INFO running 2x1 v0 rollouts on deepseek/deepseek-v4-flash (legacy: reverse-text)
# results.jsonl -> 2 traces: reward 0.92 / 1.0, turns=1, stop=max_turns_reached, errors=0
```

`EvalConfig(id='reverse-text')` → `is_legacy=True`, `env_id='reverse-text'`; native (`taskset`) → `is_legacy=False`. `set_kwargs` applies cleanly. Native v1 path unchanged (`gsm8k-v1` subprocess → reward 1.0). `ruff check`/`format` clean.

## Notes

- Legacy runner uses a plain v0 `openai_chat_completions` client (eval needs no token ids), unlike the training bridge's renderer client.
- `--id org/name[@version]` installs the v0 env from the Environments Hub on demand (via #1597's `ensure_installed`); a local `--id <name>` must already be importable (`uv pip install -e environments/<name>`).
- **Follow-up (prime-rl):** drop the now-duplicated `id`/`args`/`extra_env_kwargs`/`is_legacy`/`env_id` from prime-rl's `EnvConfig` and inherit from `vf.EnvConfig`; pass `extra_env_kwargs` to `LegacyEnvServer` in `env_server.py` (+ port main's auto-populate of `max_total_completion_tokens` / `timeout_seconds` / `max_seq_len`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a parallel eval execution path and shared legacy config on `EnvConfig`, but native v1 eval is unchanged when a taskset is used; risk is mainly misconfiguration (legacy vs v1) and dependency on lazy v0 imports.
> 
> **Overview**
> Adds **backwards-compatible v0 environment evaluation** on the v1 `uv run eval` CLI via **`--id <env-id>`** (no taskset), aligned with prime-rl’s legacy env shape.
> 
> **`EnvConfig`** gains legacy fields: `id`, `args`, `extra_env_kwargs`, plus **`is_legacy`** / **`env_id`** so eval and env-server configs can select a classic `load_environment` env instead of a v1 taskset/harness.
> 
> The **eval CLI** treats `--id` as a valid entry (alongside taskset or `@ file.toml`), branches on **`config.is_legacy`** to call **`run_legacy_eval`** instead of the native v1 path, and **disables `--rich`** for legacy runs (v1 rollout dashboard doesn’t apply).
> 
> **`verifiers/v1/legacy.py`** wires **`extra_env_kwargs`** through **`LegacyEnvServer`** via `env.set_kwargs`, and adds **`run_legacy_eval`**: in-process v0 rollouts with bounded concurrency, **`RolloutOutput` → `Trace`** mapping, and the same **`results.jsonl` / `config.toml`** output layout as native eval (no env server / interception).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adbcf956e1d5bb091741be223f2cc588b32f6d16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add legacy v0 environment support to the eval CLI via `--id` flag
> - Adds `--id <env-id>` flag to the eval CLI ([eval.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1598/files#diff-8f7a00d66bef28d392db358253b7b52ede6a6a89ac219bfe315c7b9bf8a234eb)) that triggers a legacy v0 evaluation path, bypassing the v1 taskset/harness and suppressing the rich dashboard.
> - Implements `run_legacy_eval` in [legacy.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1598/files#diff-96c5091f7d2968ddfbe984f433163f21cab745ea95174158e924984d55abbfed) to run v0 environments in-process: loads the env, samples tasks with optional deterministic shuffle and concurrency limits, runs rollouts, and persists results as v1 `Trace` objects to `outputs/<env>--<model>--legacy/<uuid>/results.jsonl`.
> - Extends `EnvConfig` in [env.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1598/files#diff-69be10bd5960e88d88f219d4f261d0bdd16586857f9126451b04d05bac4c2cbb) with `id`, `args`, `extra_env_kwargs` fields and `is_legacy`/`env_id` properties to represent v0 environments alongside v1 taskset configs.
> - Behavioral Change: when `--id` is passed, SIGTERM handling and the v1 environment setup are skipped entirely.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized adbcf95.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->