### PR TITLE
fix(serve): bump worker heartbeat timeout 30s -> 60s

### DIFF
--- a/verifiers/serve/server/env_router.py
+++ b/verifiers/serve/server/env_router.py
@@ -102,7 +102,7 @@ class EnvRouter:
         json_logging: bool = False,
         *,
         num_workers: int = 1,
-        worker_heartbeat_timeout: float = 30.0,
+        worker_heartbeat_timeout: float = 60.0,
         stats_log_interval: float = 10.0,
         death_pipe: Connection | None = None,
     ):

--- a/verifiers/serve/server/env_server.py
+++ b/verifiers/serve/server/env_server.py
@@ -37,7 +37,7 @@ class EnvServer(ABC):
         json_logging: bool = False,
         *,
         num_workers: int = 1,
-        worker_heartbeat_timeout: float = 30.0,
+        worker_heartbeat_timeout: float = 60.0,
         stats_log_interval: float = 10.0,
         death_pipe: Connection | None = None,
     ):


### PR DESCRIPTION
Single-commit PR: doubles the env-server worker heartbeat timeout default from 30s to 60s (router check + `EnvServer` constructor default).

## Why

Env workers under heavy multimodal rollout load (browser envs: image offload, large tool responses, prompt compaction) can legitimately stall their stats heartbeat past 30s. The router then declares the worker dead, kills and restarts it, and re-dispatches its pending rollouts — we've seen this kill loaded-but-healthy workers mid-rollout on hosted worldsims browser-env training runs.

## What

- `verifiers/serve/server/env_router.py`: `worker_heartbeat_timeout: float = 30.0` → `60.0`
- `verifiers/serve/server/env_server.py`: same default on the constructor

No behavior change other than the threshold; workers that are actually dead still get reaped, just 30s later.

Already running in production via the worldsims env pin (`worldsims/ephemeral-mm-pixels-vf-model` @ f2ac064d, gflights-booking-env 0.1.74).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single default threshold change in serve infrastructure; no auth or data-path changes, and dead workers are still reaped after the longer window.
> 
> **Overview**
> Raises the default **worker heartbeat timeout** from **30s to 60s** on `EnvRouter` and `EnvServer`, so the router waits longer before treating a worker as dead when stats heartbeats stall.
> 
> This only changes the default constructor parameter; `check_workers()` still restarts workers on timeout or process death, and callers can override the value explicitly. The intent is to avoid killing healthy workers under heavy load (e.g. multimodal browser rollouts) that pause heartbeats longer than 30s while still in progress.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ca6ac86417dc763a8c8ff374cc9cc757a80d83b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump worker heartbeat timeout default from 30s to 60s in `EnvRouter` and `EnvServer`
> Increases the default `worker_heartbeat_timeout` from `30.0` to `60.0` seconds in both [env_router.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1599/files#diff-5f42e5c44b82aeddf6020de01b59c5480cac9144a3f6ffc79c3ee01683ad92ec) and [env_server.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1599/files#diff-ffbf52ba825710b29c0d7a94da599c570033ecd2b7ce2a0704491af1f07a14cc). Only affects instances constructed without an explicit timeout value. Behavioral Change: workers now have twice as long to send a heartbeat before being considered dead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3ca6ac8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->