### PR TITLE
fix: v0 legacy bridge — group scoring + MITO client

### DIFF
--- a/examples/tasksets/color_codeword_v1/color_codeword_v1/__init__.py
+++ b/examples/tasksets/color_codeword_v1/color_codeword_v1/__init__.py
@@ -1,0 +1,128 @@
+"""color-codeword-v1 — decode a codeword from colored squares shown as images over turns.
+
+The v1 port of the multimodal `color-codeword` env. Each color maps to a letter
+(Red=A … Black=I); over several turns the model is shown colored squares (as images) and
+outputs the accumulated codeword, giving the full sequence on the final turn.
+
+The squares are delivered turn by turn by a colocated `vf.User` (see `user.py`) — the
+default harness carries only a text instruction, so the images ride the user-simulator path
+(which now preserves multimodal content). The whole episode is one native-v1 multimodal
+rollout, exercising image input end to end (renderer → `TurnTokens.multi_modal_data`).
+"""
+
+import json
+import random
+import re
+import sys
+
+import verifiers.v1 as vf
+
+# Color → letter mapping (9 visually distinct colors). RGB lives in the user simulator,
+# which is the only side that renders the squares to images.
+COLOR_MAP = {
+    "red": "A",
+    "green": "B",
+    "blue": "C",
+    "yellow": "D",
+    "purple": "E",
+    "cyan": "F",
+    "orange": "G",
+    "white": "H",
+    "black": "I",
+}
+
+SYSTEM_PROMPT = """You will be shown colored squares across multiple turns. Each color maps to a letter:
+
+Red=A, Green=B, Blue=C, Yellow=D, Purple=E, Cyan=F, Orange=G, White=H, Black=I
+
+After each turn, output your accumulated codeword so far. Output ONLY the letters with NO spaces."""
+
+INSTRUCTION = (
+    "I'll show you colored squares over the next few turns. After each, reply with the "
+    "accumulated codeword so far (letters only, no spaces). Reply 'ready' to begin."
+)
+
+
+def extract_codeword(text: str) -> str:
+    """The decoded codeword in `text`: the longest standalone A–I run, else all A–I chars."""
+    text = (text or "").upper()
+    matches = re.findall(r"\b[A-I]+\b", text)
+    return (
+        max(matches, key=len)
+        if matches
+        else "".join(c for c in text if c in "ABCDEFGHI")
+    )
+
+
+class ColorCodewordConfig(vf.TasksetConfig):
+    num_examples: int = 1000
+    """Number of episodes (random codewords) to generate."""
+    images_per_turn: int = 1
+    """Colored squares shown per turn."""
+    max_turns: int = 3
+    """Turns of squares; codeword length is `images_per_turn * max_turns`."""
+    seed: int = 42
+
+
+class ColorCodewordTask(vf.Task):
+    answer: str
+    """The full codeword (one letter per square, in order)."""
+    info: dict
+    """`colors_per_turn` (the squares the user simulator reveals) and `num_turns`."""
+
+
+class ColorCodewordTaskset(vf.Taskset[ColorCodewordTask, ColorCodewordConfig]):
+    def load_tasks(self) -> list[ColorCodewordTask]:
+        c = self.config
+        assert c.images_per_turn >= 1 and c.max_turns >= 1
+        rng = random.Random(c.seed)
+        colors = list(COLOR_MAP)
+        length = c.images_per_turn * c.max_turns
+        tasks: list[ColorCodewordTask] = []
+        for _ in range(c.num_examples):
+            sequence = [rng.choice(colors) for _ in range(length)]
+            colors_per_turn = [
+                sequence[t * c.images_per_turn : (t + 1) * c.images_per_turn]
+                for t in range(c.max_turns)
+            ]
+            tasks.append(
+                ColorCodewordTask(
+                    idx=len(tasks),
+                    system_prompt=SYSTEM_PROMPT,
+                    instruction=INSTRUCTION,
+                    answer="".join(COLOR_MAP[x] for x in sequence),
+                    info={"colors_per_turn": colors_per_turn, "num_turns": c.max_turns},
+                )
+            )
+        return tasks
+
+    def user(self, task: ColorCodewordTask) -> vf.User:
+        info = {
+            "colors_per_turn": task.info["colors_per_turn"],
+            "num_turns": task.info["num_turns"],
+        }
+        return vf.User(
+            name="user",
+            command=[sys.executable, "-m", "color_codeword_v1.user"],
+            env={"COLOR_CODEWORD_INFO": json.dumps(info)},
+        )
+
+    @vf.reward(weight=1.0)
+    async def codeword_exact(self, task: ColorCodewordTask, trace: vf.Trace) -> float:
+        responses = [m.content or "" for m in trace.assistant_messages]
+        final = responses[-1] if responses else ""
+        return 1.0 if extract_codeword(final) == task.answer else 0.0
+
+    @vf.metric
+    async def partial_match(self, task: ColorCodewordTask, trace: vf.Trace) -> float:
+        if not task.answer:
+            return 0.0
+        responses = [m.content or "" for m in trace.assistant_messages]
+        extracted = extract_codeword(responses[-1] if responses else "")
+        return sum(1 for a, b in zip(task.answer, extracted) if a == b) / len(
+            task.answer
+        )
+
+
+def load_taskset(config: ColorCodewordConfig) -> ColorCodewordTaskset:
+    return ColorCodewordTaskset(config)

--- a/examples/tasksets/color_codeword_v1/color_codeword_v1/user.py
+++ b/examples/tasksets/color_codeword_v1/color_codeword_v1/user.py
@@ -1,0 +1,79 @@
+"""color-codeword-v1 user simulator: reveals the colored squares one turn at a time.
+
+Launched per-rollout as a `vf.User` subprocess. It holds the episode's per-turn colors
+(from `COLOR_CODEWORD_INFO`) and serves a single `respond` tool: after each assistant turn
+it renders that turn's squares to PNG images and injects them as a multimodal user message
+(OpenAI `image_url` parts), until all turns are done. This is where the images enter the
+rollout — the renderer turns them into `multi_modal_data` for training.
+"""
+
+import base64
+import json
+import os
+from io import BytesIO
+
+from mcp.server.fastmcp import FastMCP
+from PIL import Image
+
+import verifiers.v1 as vf
+
+COLOR_RGB = {
+    "red": (255, 0, 0),
+    "green": (0, 255, 0),
+    "blue": (0, 0, 255),
+    "yellow": (255, 255, 0),
+    "purple": (128, 0, 128),
+    "cyan": (0, 255, 255),
+    "orange": (255, 165, 0),
+    "white": (255, 255, 255),
+    "black": (0, 0, 0),
+}
+
+INFO = json.loads(os.environ["COLOR_CODEWORD_INFO"])
+COLORS_PER_TURN = INFO["colors_per_turn"]
+NUM_TURNS = INFO["num_turns"]
+
+
+def _data_url(color: str) -> str:
+    img = Image.new("RGB", (100, 100), COLOR_RGB[color])
+    buf = BytesIO()
+    img.save(buf, format="PNG")
+    return f"data:image/png;base64,{base64.b64encode(buf.getvalue()).decode()}"
+
+
+def _image_message(colors: list[str], text: str) -> dict:
+    content = [
+        {"type": "image_url", "image_url": {"url": _data_url(c)}} for c in colors
+    ]
+    content.append({"type": "text", "text": text})
+    return {"role": "user", "content": content}
+
+
+mcp = FastMCP("user")
+
+_turn = 0  # squares-turns delivered so far (one `respond` per assistant turn)
+
+
+@mcp.tool()
+def respond(message: str) -> str:
+    """Reveal the next turn's squares, or end the episode once all turns are shown."""
+    global _turn
+    if _turn >= NUM_TURNS:
+        return json.dumps({"messages": [], "done": True})
+    colors = COLORS_PER_TURN[_turn]
+    _turn += 1
+    total = sum(len(COLORS_PER_TURN[i]) for i in range(_turn))
+    if _turn == NUM_TURNS:
+        text = (
+            f"Here {'is' if len(colors) == 1 else 'are'} {len(colors)} more square(s). "
+            f"Now output the full {total}-letter codeword (letters only, no spaces)."
+        )
+    else:
+        text = (
+            f"Here {'is' if len(colors) == 1 else 'are'} {len(colors)} square(s). "
+            "Output the accumulated codeword so far (letters only)."
+        )
+    return json.dumps({"messages": [_image_message(colors, text)], "done": False})
+
+
+vf.run_mcp_server(mcp)

--- a/examples/tasksets/color_codeword_v1/pyproject.toml
+++ b/examples/tasksets/color_codeword_v1/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "color-codeword-v1"
+version = "0.1.0"
+description = "color-codeword-v1 — decode a codeword from colored squares shown as images over multiple turns (native v1 multimodal), driven by a colocated user simulator."
+requires-python = ">=3.10"
+dependencies = ["pillow"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["color_codeword_v1"]

--- a/tests/test_trace_delta_wire.py
+++ b/tests/test_trace_delta_wire.py
@@ -1,0 +1,132 @@
+"""Wire delta-encoding for `Trace.to_wire()` (see `verifiers/v1/trace.py`).
+
+Consecutive turns in a branch restate the whole conversation, so `prompt_ids` (and
+cumulative multimodal `mm_items`) are stored as per-turn deltas on the wire and restored
+by `Trace`'s `mode="before"` validator. These tests pin the round-trip and the size win.
+"""
+
+import copy
+
+import verifiers.v1 as vf
+
+
+def _turn(prompt_ids, completion_ids, mm=None):
+    return vf.Turn(
+        prompt=[vf.UserMessage(content="x")],
+        response=vf.Response(
+            id="r",
+            created=0,
+            model="m",
+            message=vf.AssistantMessage(content="y"),
+            finish_reason="stop",
+        ),
+        tokens=vf.TurnTokens(
+            prompt_ids=prompt_ids,
+            completion_ids=completion_ids,
+            completion_logprobs=[0.0] * len(completion_ids),
+            multi_modal_data=mm,
+        ),
+    )
+
+
+def _trace(turns):
+    return vf.Trace[vf.Task](task=vf.Task(idx=0, instruction="go"), trajectory=turns)
+
+
+def _linear_turns(n_turns):
+    """A linear conversation: each turn's prompt is the prior (prompt+completion) plus
+    new context tokens — i.e. the cumulative form the renderer emits."""
+    full, turns = [], []
+    for t in range(n_turns):
+        full = full + list(range(t * 10, t * 10 + 10))
+        completion = list(range(900 + t * 5, 900 + t * 5 + 5))
+        turns.append(_turn(list(full), completion))
+        full = full + completion
+    return turns
+
+
+def test_prompt_ids_delta_is_smaller_and_round_trips():
+    turns = _linear_turns(4)
+    wire = _trace(turns).to_wire()
+
+    full = sum(len(t.tokens.prompt_ids) for t in turns)
+    delta = sum(len(t["tokens"]["prompt_ids"]) for t in wire["trajectory"])
+    assert delta < full  # quadratic full -> linear delta
+    assert [t["tokens"]["pk"] for t in wire["trajectory"]] == [0, 15, 30, 45]
+
+    back = vf.Trace[vf.Task].model_validate(copy.deepcopy(wire))
+    for b, o in zip(back.trajectory, turns):
+        assert list(b.tokens.prompt_ids) == list(o.tokens.prompt_ids)
+        assert list(b.tokens.completion_ids) == list(o.tokens.completion_ids)
+    # markers are wire-only — they must not survive validation onto the strict model
+    assert all(
+        "pk" not in b.tokens.model_dump() and "mk" not in b.tokens.model_dump()
+        for b in back.trajectory
+    )
+
+
+def test_fork_turn_stores_full_prompt():
+    """A turn whose prompt doesn't extend the running sequence (a branch/fork) has no
+    shared prefix, so it stores the full tail (pk == 0) and still round-trips."""
+    turns = _linear_turns(2) + [_turn([7, 7, 7], [1, 1])]
+    wire = _trace(turns).to_wire()
+    assert wire["trajectory"][-1]["tokens"]["pk"] == 0
+
+    back = vf.Trace[vf.Task].model_validate(copy.deepcopy(wire))
+    assert [list(t.tokens.prompt_ids) for t in back.trajectory] == [
+        list(t.tokens.prompt_ids) for t in turns
+    ]
+
+
+def test_multimodal_items_delta_round_trips_with_repeats():
+    """Cumulative mm_items collapse to the new image(s) per turn; a repeated image (same
+    hash, here red appearing twice) keeps a distinct slot, matched by position."""
+
+    def wt():
+        return vf.WireTensor(dtype="float32", shape=[1], data="AA==")
+
+    def mm(hashes):
+        return vf.MMData(
+            mm_items={"image": [{"pixel_values": wt()} for _ in hashes]},
+            mm_hashes={"image": list(hashes)},
+        )
+
+    turns = [
+        _turn([0, 1], [9], mm(["hR"])),
+        _turn([0, 1, 9, 2, 3], [8], mm(["hR", "hG"])),
+        _turn([0, 1, 9, 2, 3, 8, 4, 5], [7], mm(["hR", "hG", "hR"])),
+    ]
+    wire = _trace(turns).to_wire()
+    assert [t["tokens"]["mk"]["image"] for t in wire["trajectory"]] == [0, 1, 2]
+    assert [
+        t["tokens"]["multi_modal_data"]["mm_hashes"]["image"]
+        for t in wire["trajectory"]
+    ] == [
+        ["hR"],
+        ["hG"],
+        ["hR"],
+    ]
+
+    back = vf.Trace[vf.Task].model_validate(copy.deepcopy(wire))
+    for b, o in zip(back.trajectory, turns):
+        assert (
+            b.tokens.multi_modal_data.mm_hashes["image"]
+            == o.tokens.multi_modal_data.mm_hashes["image"]
+        )
+        assert len(b.tokens.multi_modal_data.mm_items["image"]) == len(
+            o.tokens.multi_modal_data.mm_items["image"]
+        )
+
+
+def test_decode_without_markers_is_noop():
+    """Expanding a trace dict that carries no delta markers (full prompt_ids, e.g. a
+    non-wire input) leaves it untouched — so validation never corrupts plain traces."""
+    from verifiers.v1.trace import _delta_decode_turns
+
+    turns = [
+        {"tokens": {"prompt_ids": [1, 2, 3], "completion_ids": [4]}},
+        {"tokens": {"prompt_ids": [1, 2, 3, 4, 5], "completion_ids": [6]}},
+    ]
+    snapshot = copy.deepcopy(turns)
+    _delta_decode_turns(turns)
+    assert turns == snapshot

--- a/verifiers/v1/__init__.py
+++ b/verifiers/v1/__init__.py
@@ -54,6 +54,8 @@ from verifiers.v1.trace import (
 )
 from verifiers.v1.types import (
     AssistantMessage,
+    ImagePart,
+    ImageUrl,
     Message,
     Messages,
     MMData,
@@ -61,6 +63,7 @@ from verifiers.v1.types import (
     SamplingConfig,
     StrictBaseModel,
     SystemMessage,
+    TextPart,
     Tool,
     ToolCall,
     ToolMessage,
@@ -77,6 +80,9 @@ __all__ = [
     "env_name",
     "MMData",
     "WireTensor",
+    "TextPart",
+    "ImagePart",
+    "ImageUrl",
     "AssistantMessage",
     "Message",
     "Messages",

--- a/verifiers/v1/__init__.py
+++ b/verifiers/v1/__init__.py
@@ -56,6 +56,7 @@ from verifiers.v1.types import (
     AssistantMessage,
     Message,
     Messages,
+    MMData,
     Response,
     SamplingConfig,
     StrictBaseModel,
@@ -65,6 +66,7 @@ from verifiers.v1.types import (
     ToolMessage,
     Usage,
     UserMessage,
+    WireTensor,
 )
 from verifiers.v1.user import User
 
@@ -73,6 +75,8 @@ __all__ = [
     "EnvId",
     "ensure_installed",
     "env_name",
+    "MMData",
+    "WireTensor",
     "AssistantMessage",
     "Message",
     "Messages",

--- a/verifiers/v1/clients/openai.py
+++ b/verifiers/v1/clients/openai.py
@@ -47,7 +47,10 @@ def message_to_wire(message: Message) -> dict:
             "tool_call_id": message.tool_call_id,
             "content": message.content,
         }
-    return {"role": message.role, "content": message.content}
+    content = message.content
+    if isinstance(content, list):  # multimodal parts -> plain OpenAI dicts
+        content = [part.model_dump() for part in content]
+    return {"role": message.role, "content": content}
 
 
 def tool_to_wire(tool: Tool) -> dict:

--- a/verifiers/v1/clients/renderer.py
+++ b/verifiers/v1/clients/renderer.py
@@ -23,6 +23,7 @@ from verifiers.v1.types import (
     FinishReason,
     Message,
     Messages,
+    MMData,
     Response,
     SamplingConfig,
     Tool,
@@ -79,6 +80,7 @@ def response_from_generate(result: dict, model: str) -> Response:
             prompt_ids=prompt_ids,
             completion_ids=completion_ids,
             completion_logprobs=result.get("completion_logprobs") or [],
+            multi_modal_data=MMData.from_renderer(result.get("multi_modal_data")),
         ),
     )
 

--- a/verifiers/v1/interception.py
+++ b/verifiers/v1/interception.py
@@ -43,7 +43,9 @@ def parse_message(raw: dict) -> Message:
     """An OpenAI request message dict -> a typed Message."""
     role = raw.get("role")
     content = raw.get("content")
-    if isinstance(content, list):  # multimodal parts -> joined text
+    if role == "user":  # may carry multimodal content parts (text + images); keep them
+        return UserMessage(content=content if content is not None else "")
+    if isinstance(content, list):  # other roles are text-only -> flatten parts
         content = "".join(p.get("text", "") for p in content if isinstance(p, dict))
     content = content or ""
     if role == "system":

--- a/verifiers/v1/legacy.py
+++ b/verifiers/v1/legacy.py
@@ -147,6 +147,9 @@ def _to_v1_response(raw: Any, model: str, tokens: TurnTokens | None = None) -> R
 
 
 def _to_v1_tokens(raw: Any) -> TurnTokens | None:
+    # NOTE: only ids + sampling logprobs are bridged. Multimodal inputs (`mm_kwargs`) and
+    # MoE router-replay (`routed_experts`) are not yet carried through `TurnTokens`, so a v0
+    # VLM or router-replay run is not supported via the bridge yet.
     if not isinstance(raw, dict):
         return None
     if not raw.get("completion_ids") and not raw.get("prompt_ids"):
@@ -279,7 +282,10 @@ class LegacyEnvServer(EnvServer):
         # The formatted dataset rows are RolloutInputs (prompt + example_id); index by task_idx.
         self.dataset = self.env.get_dataset()
         self.tasks = self.dataset  # `len(self.tasks)` drives the `info` response
-        self.requires_group_scoring = False
+        # Reflect the v0 env's rubric: an env with group-level reward funcs must be scored
+        # as a group (`run_group` → `score_group`), else per-rollout `score_rollout` asserts
+        # there are no group funcs and every rollout errors.
+        self.requires_group_scoring = self.env.requires_group_rollouts
         self._clients: dict[tuple[str, str], Any] = {}
 
         self.ctx = zmq.asyncio.Context()
@@ -292,26 +298,36 @@ class LegacyEnvServer(EnvServer):
         self.address = self.frontend.getsockopt_string(zmq.LAST_ENDPOINT)
 
     def _v0_client(self, client_config: ClientConfig, model: str):
-        """Translate the v1 renderer ``ClientConfig`` into a v0 renderer client (cached;
-        a renderer builds the tokenizer pool on first use). The tokenizer is pinned to
-        ``renderer_model_name`` (the base model) so a LoRA adapter name — served only for
-        sampling — never drives tokenizer loading; the per-request ``model`` still selects
-        the sampling target in ``run_rollout``."""
+        """Build the v0 client matching the v1 client type (cached):
+          - renderer (TITO): client-side tokenization. The tokenizer is pinned to
+            ``renderer_model_name`` (the base model) so a LoRA adapter name — served only
+            for sampling — never drives tokenizer loading.
+          - chat (MITO, `type="openai"`): tokens come from vLLM via `return_token_ids`,
+            so the v0 chat-completions client is used instead of building a renderer pool.
+        The per-request ``model`` still selects the sampling target in ``run_rollout``."""
         renderer_model = getattr(client_config, "renderer_model_name", None) or model
         key = (client_config.model_dump_json(), renderer_model)
         if key not in self._clients:
             from verifiers.clients import resolve_client
             from verifiers.types import ClientConfig as V0ClientConfig
 
-            v0_config = V0ClientConfig(
-                client_type="renderer",
-                renderer_config=getattr(client_config, "renderer", None),
-                renderer_model_name=renderer_model,
-                renderer_pool_size=getattr(client_config, "pool_size", None),
-                api_base_url=client_config.base_url,
-                api_key_var=client_config.api_key_var,
-                extra_headers=dict(client_config.headers or {}),
-            )
+            if client_config.type == "renderers":
+                v0_config = V0ClientConfig(
+                    client_type="renderer",
+                    renderer_config=getattr(client_config, "renderer", None),
+                    renderer_model_name=renderer_model,
+                    renderer_pool_size=getattr(client_config, "pool_size", None),
+                    api_base_url=client_config.base_url,
+                    api_key_var=client_config.api_key_var,
+                    extra_headers=dict(client_config.headers or {}),
+                )
+            else:  # MITO: chat-completions, tokens parsed from vLLM (return_token_ids)
+                v0_config = V0ClientConfig(
+                    client_type="openai_chat_completions",
+                    api_base_url=client_config.base_url,
+                    api_key_var=client_config.api_key_var,
+                    extra_headers=dict(client_config.headers or {}),
+                )
             self._clients[key] = resolve_client(v0_config)
         return self._clients[key]
 
@@ -338,11 +354,22 @@ class LegacyEnvServer(EnvServer):
         )
 
     async def _run_group(self, req: RunGroupRequest) -> RunGroupResponse:
-        traces = []
-        for _ in range(req.n):
-            out = await self._run_v0(req.task_idx, req.client, req.model, req.sampling)
-            traces.append(rollout_output_to_trace(out, req.task_idx).to_wire())
-        return RunGroupResponse(traces=traces)
+        # One group through the v0 env so `score_group` runs (group/preference rewards over
+        # all rollouts at once) — not N independent `run_rollout`s, which only per-rollout
+        # score and would drop the cross-rollout rewards.
+        client = self._v0_client(req.client, req.model)
+        outputs = await self.env.run_group(
+            [dict(self.dataset[req.task_idx]) for _ in range(req.n)],
+            client=client,
+            model=req.model,
+            sampling_args=req.sampling.model_dump(exclude_none=True),
+            state_columns=["trajectory"],
+        )
+        return RunGroupResponse(
+            traces=[
+                rollout_output_to_trace(out, req.task_idx).to_wire() for out in outputs
+            ]
+        )
 
 
 # --- in-process v0 eval (the `eval` CLI's `--legacy.id` path) ------------------

--- a/verifiers/v1/legacy.py
+++ b/verifiers/v1/legacy.py
@@ -32,6 +32,7 @@ from verifiers.v1.task import WireTask
 from verifiers.v1.trace import Error, TimeSpan, Timing, Trace, Turn
 from verifiers.v1.types import (
     AssistantMessage,
+    MMData,
     Response,
     SamplingConfig,
     SystemMessage,
@@ -147,9 +148,8 @@ def _to_v1_response(raw: Any, model: str, tokens: TurnTokens | None = None) -> R
 
 
 def _to_v1_tokens(raw: Any) -> TurnTokens | None:
-    # NOTE: only ids + sampling logprobs are bridged. Multimodal inputs (`mm_kwargs`) and
-    # MoE router-replay (`routed_experts`) are not yet carried through `TurnTokens`, so a v0
-    # VLM or router-replay run is not supported via the bridge yet.
+    # Bridges ids + sampling logprobs + multimodal inputs (the v0 renderer's
+    # `multi_modal_data`). NOTE: MoE router-replay (`routed_experts`) is not yet carried.
     if not isinstance(raw, dict):
         return None
     if not raw.get("completion_ids") and not raw.get("prompt_ids"):
@@ -158,6 +158,7 @@ def _to_v1_tokens(raw: Any) -> TurnTokens | None:
         prompt_ids=list(raw.get("prompt_ids") or []),
         completion_ids=list(raw.get("completion_ids") or []),
         completion_logprobs=list(raw.get("completion_logprobs") or []),
+        multi_modal_data=MMData.from_renderer(raw.get("multi_modal_data")),
     )
 
 

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -15,7 +15,7 @@ import uuid
 from collections.abc import Mapping
 from typing import Generic, TypeVar
 
-from pydantic import Field, PrivateAttr, computed_field
+from pydantic import Field, PrivateAttr, computed_field, model_validator
 
 from verifiers.v1 import branching
 from verifiers.v1.task import TaskT
@@ -119,6 +119,87 @@ class Branch(StrictBaseModel):
         return [*last.prompt, last.response.message]
 
 
+def _lcp_len(a: list, b: list) -> int:
+    """Length of the longest common prefix of two sequences."""
+    n = 0
+    for x, y in zip(a, b):
+        if x != y:
+            break
+        n += 1
+    return n
+
+
+def _delta_encode_turns(turns: list[dict]) -> None:
+    """Compress `prompt_ids` and cumulative multimodal `mm_items` to per-turn deltas, in
+    place. Consecutive turns in a branch share a growing prefix — the prompt restates the
+    whole conversation each turn — so a turn stores only the tail beyond the running
+    sequence and records the kept-prefix length in `pk` (prompt) / `mk` (per-modality mm).
+    Avoids the quadratic blow-up of re-sending the full prompt every turn.
+    `_delta_decode_turns` inverts this. The kept length is the actual longest common
+    prefix, so forks (no shared prefix) just store the full tail — always lossless."""
+    run_ids: list[int] = []
+    run_hashes: dict[str, list[str]] = {}
+    for turn in turns:
+        tok = turn.get("tokens")
+        if not isinstance(tok, dict):
+            run_ids, run_hashes = [], {}
+            continue
+        pid = tok.get("prompt_ids") or []
+        keep = _lcp_len(run_ids, pid)
+        tok["prompt_ids"] = pid[keep:]
+        tok["pk"] = keep
+        run_ids = pid + (tok.get("completion_ids") or [])
+
+        mm = tok.get("multi_modal_data")
+        if isinstance(mm, dict) and mm.get("mm_items"):
+            mk: dict[str, int] = {}
+            hashes_map = mm.get("mm_hashes") or {}
+            for modality, items in list(mm["mm_items"].items()):
+                hashes = hashes_map.get(modality) or []
+                mkeep = _lcp_len(run_hashes.get(modality, []), hashes) if hashes else 0
+                mm["mm_items"][modality] = items[mkeep:]
+                if modality in hashes_map:
+                    hashes_map[modality] = hashes[mkeep:]
+                mk[modality] = mkeep
+                run_hashes[modality] = hashes
+            tok["mk"] = mk
+
+
+def _delta_decode_turns(turns: list[dict]) -> None:
+    """Inverse of `_delta_encode_turns`: rebuild full `prompt_ids` / cumulative `mm_items`
+    from the per-turn deltas and drop the `pk`/`mk` markers. A no-op on inputs without
+    markers (full, uncompressed dicts), so it's safe to run on any trace input."""
+    run_ids: list[int] = []
+    run_items: dict[str, list] = {}
+    run_hashes: dict[str, list] = {}
+    for turn in turns:
+        if not isinstance(turn, dict):
+            run_ids, run_items, run_hashes = [], {}, {}
+            continue
+        tok = turn.get("tokens")
+        if not isinstance(tok, dict):
+            run_ids, run_items, run_hashes = [], {}, {}
+            continue
+        if "pk" in tok:
+            keep = tok.pop("pk")
+            tok["prompt_ids"] = run_ids[:keep] + (tok.get("prompt_ids") or [])
+            run_ids = tok["prompt_ids"] + (tok.get("completion_ids") or [])
+        mk = tok.pop("mk", None)
+        mm = tok.get("multi_modal_data")
+        if mk is not None and isinstance(mm, dict):
+            hashes_map = mm.get("mm_hashes")
+            for modality, mkeep in mk.items():
+                items = run_items.get(modality, [])[:mkeep] + (
+                    mm["mm_items"].get(modality) or []
+                )
+                mm["mm_items"][modality] = items
+                run_items[modality] = items
+                if isinstance(hashes_map, dict) and modality in hashes_map:
+                    h = run_hashes.get(modality, [])[:mkeep] + hashes_map[modality]
+                    hashes_map[modality] = h
+                    run_hashes[modality] = h
+
+
 class Trace(StrictBaseModel, Generic[TaskT]):
     """The full record of one rollout. Subclass to add typed fields."""
 
@@ -144,6 +225,15 @@ class Trace(StrictBaseModel, Generic[TaskT]):
     _branch_cache: dict[int, list[list[int]]] = PrivateAttr(default_factory=dict)
     """Branch segmentation (index-groups, no turn copies) cached by trajectory length —
     the trajectory only grows, so its length is a sufficient invalidation key."""
+
+    @model_validator(mode="before")
+    @classmethod
+    def _expand_wire_delta(cls, data):
+        """Restore delta-compressed `to_wire` payloads (see `_delta_encode_turns`) before
+        strict field validation; a no-op on normal/full inputs."""
+        if isinstance(data, dict) and isinstance(data.get("trajectory"), list):
+            _delta_decode_turns(data["trajectory"])
+        return data
 
     @computed_field
     @property
@@ -303,13 +393,20 @@ class Trace(StrictBaseModel, Generic[TaskT]):
         timing durations. A strict `Trace` can't round-trip them as input, and the
         consumer recomputes them, so we avoid re-running branching + duplicating the
         trajectory on every reply. The full `model_dump` (with derived fields) is what
-        gets written to disk."""
+        gets written to disk.
+
+        Within a branch, consecutive turns share a growing prefix, so `prompt_ids` (and
+        cumulative multimodal `mm_items`) are delta-encoded against the running sequence —
+        `_expand_wire_delta` restores them on the way back in. This is what keeps the wire
+        from growing quadratically with turn count."""
         exclude: dict = {field: True for field in type(self).model_computed_fields}
         exclude["timing"] = {
             "generation": {"duration": True},
             "scoring": {"duration": True},
         }
-        return self.model_dump(mode="json", exclude=exclude)
+        dump = self.model_dump(mode="json", exclude=exclude)
+        _delta_encode_turns(dump.get("trajectory") or [])
+        return dump
 
 
 TraceT = TypeVar("TraceT", bound=Trace)  # type: ignore[type-arg]

--- a/verifiers/v1/types.py
+++ b/verifiers/v1/types.py
@@ -20,6 +20,30 @@ class StrictBaseModel(BaseModel):
 # --- messages -----------------------------------------------------------------
 
 
+class TextPart(StrictBaseModel):
+    """A text content part (OpenAI shape)."""
+
+    type: Literal["text"] = "text"
+    text: str
+
+
+class ImageUrl(StrictBaseModel):
+    url: str
+    """An http(s) URL or a `data:image/...;base64,...` data URI."""
+
+
+class ImagePart(StrictBaseModel):
+    """An image content part (OpenAI shape) — carries a VLM image into the prompt."""
+
+    type: Literal["image_url"] = "image_url"
+    image_url: ImageUrl
+
+
+ContentPart = Annotated[TextPart | ImagePart, Field(discriminator="type")]
+Content = str | list[ContentPart]
+"""A message body: plain text, or OpenAI-style content parts (text + images)."""
+
+
 class SystemMessage(StrictBaseModel):
     """A system instruction message."""
 
@@ -28,10 +52,10 @@ class SystemMessage(StrictBaseModel):
 
 
 class UserMessage(StrictBaseModel):
-    """A user message."""
+    """A user message — text, or content parts (e.g. images) for a VLM."""
 
     role: Literal["user"] = "user"
-    content: str
+    content: Content
 
 
 class ToolCall(StrictBaseModel):

--- a/verifiers/v1/types.py
+++ b/verifiers/v1/types.py
@@ -96,6 +96,69 @@ class Usage(StrictBaseModel):
         return self.prompt_tokens + self.completion_tokens
 
 
+class WireTensor(StrictBaseModel):
+    """A tensor on the wire: dtype + shape + base64 of the raw buffer. JSON-native, so it
+    survives `model_dump(mode="json")` + msgpack (a raw tensor would not)."""
+
+    dtype: str
+    shape: list[int]
+    data: str  # base64 of arr.tobytes()
+
+
+def _encode_wire_tensor(val: Any) -> WireTensor:
+    """Encode a torch tensor / numpy array / already-encoded `{dtype,shape,data:bytes}`
+    dict into a `WireTensor` (base64). Torch/numpy imported lazily — text-only callers
+    never hit this."""
+    import base64
+
+    if isinstance(val, dict) and "data" in val and "dtype" in val:  # v0-wire encoded
+        return WireTensor(
+            dtype=str(val["dtype"]),
+            shape=list(val["shape"]),
+            data=base64.b64encode(bytes(val["data"])).decode(),
+        )
+    import numpy as np
+
+    if hasattr(val, "detach"):  # torch tensor
+        val = val.detach().cpu().contiguous().numpy()
+    arr = np.ascontiguousarray(val)
+    return WireTensor(
+        dtype=str(arr.dtype),
+        shape=list(arr.shape),
+        data=base64.b64encode(arr.tobytes()).decode(),
+    )
+
+
+class MMData(StrictBaseModel):
+    """Per-turn multimodal sidecar — the JSON-native mirror of `renderers.MultiModalData`.
+    `mm_items[modality][i]` is the HF processor's per-image dict (e.g. `pixel_values`,
+    `image_grid_thw`) with each tensor encoded as a `WireTensor`."""
+
+    mm_items: dict[str, list[dict[str, WireTensor]]] = Field(default_factory=dict)
+    mm_hashes: dict[str, list[str]] = Field(default_factory=dict)
+
+    @classmethod
+    def from_renderer(cls, mm: Any) -> "MMData | None":
+        """Encode a `renderers.MultiModalData` (or an already-encoded dict) into a
+        JSON-native `MMData`; None when there's no image/video payload."""
+        if mm is None:
+            return None
+        items = getattr(mm, "mm_items", None)
+        hashes = getattr(mm, "mm_hashes", None)
+        if items is None and isinstance(mm, dict):
+            items, hashes = mm.get("mm_items"), mm.get("mm_hashes")
+        if not items:
+            return None
+        wire = {
+            modality: [
+                {key: _encode_wire_tensor(val) for key, val in item.items()}
+                for item in per_modality
+            ]
+            for modality, per_modality in items.items()
+        }
+        return cls(mm_items=wire, mm_hashes=hashes or {})
+
+
 class TurnTokens(StrictBaseModel):
     """Token ids + sampling logprobs for one response, for training. Populated by the
     renderer client (client-side tokenization) or the chat client (parsed from vLLM's
@@ -104,6 +167,8 @@ class TurnTokens(StrictBaseModel):
     prompt_ids: list[int] = Field(default_factory=list)
     completion_ids: list[int] = Field(default_factory=list)
     completion_logprobs: list[float] = Field(default_factory=list)
+    multi_modal_data: MMData | None = None
+    """Per-turn image/video inputs (VLM training); None for text-only turns."""
 
 
 class Response(StrictBaseModel):


### PR DESCRIPTION
## Summary

Correctness fixes + native multimodal for v0 (classic verifiers) and native v1 environments.

- **Group scoring (was broken).** `LegacyEnvServer.requires_group_scoring` was hardcoded `False`, so a v0 env with group/preference reward funcs hit `rubric.score_rollout`'s `len(group_reward_funcs)==0` assert and errored every rollout. Now reflects the env's rubric (`env.requires_group_rollouts`), and `_run_group` runs `env.run_group(...)` once (so `score_group` applies cross-rollout rewards) instead of looping per-rollout `score_rollout`.
- **MITO client.** `_v0_client` hardcoded the renderer client; it now builds a chat-completions client for MITO (`type="openai"`) and the renderer client for `type="renderers"`.
- **Native multimodal — output.** First-class JSON-native mm types on the v1 trace: `WireTensor` + `MMData` (mirror `renderers.MultiModalData`, base64 tensors so they survive the `model_dump(json)`+msgpack wire) and a `TurnTokens.multi_modal_data` field. The **v1 renderer client emits it natively** (`response_from_generate`); the **legacy bridge populates it** from the v0 renderer output.
- **Native multimodal — input.** A v1 message can now carry OpenAI-style content parts (`TextPart`/`ImagePart` on `UserMessage.content`), preserved through `interception.parse_message` and the clients (`message_to_wire` emits list content as dicts) so the renderer processes images into `multi_modal_data`. Text + system/tool messages are unchanged.
- **Wire delta-encoding (footprint).** Consecutive turns in a branch restate the whole conversation, so each turn's `prompt_ids` (and cumulative `multi_modal_data` mm_items) repeated the entire prefix — `to_wire()` payloads grew **quadratically** with turn count. `to_wire()` now stores only the tail beyond the running sequence (longest-common-prefix length recorded per turn: `pk` for prompt ids, `mk` per mm modality); a `mode="before"` validator on `Trace` restores the full ids/items before strict validation. Wire-only, lossless, transparent to every consumer (forks with no shared prefix store the full tail; markers are stripped on the way in). A repeated image keeps its own slot (matched by position, not deduped).
- **Example.** `color-codeword-v1` (examples/tasksets) — a native v1 multimodal env whose colocated `vf.User` reveals colored squares as images each turn; the v1 analogue of the v0 `color-codeword` env.

## Not yet supported

MoE router-replay (`routed_experts`) is still not carried through `TurnTokens`.

## Verification (with the prime-rl consumer PR #2751)

- v0 + v1 reverse-text (text) train cleanly.
- **v0 multimodal** (color-codeword via the bridge, Qwen3-VL-4B): trace carries `multi_modal_data` and the trainer completes the M-RoPE path (`Training finished!`) — vs. before, 0 mm and silent training on placeholder tokens.
- **v1 multimodal** (color-codeword-v1, native): images flow User-sim → interception → renderer → trace; rollouts reward ~0.8 (the VLM reads the squares) and the Qwen3-VL trainer completes (`Training finished!`).
- **Wire codec**: `tests/test_trace_delta_wire.py` pins the `to_wire()`→`model_validate` round-trip for prompt ids, forks, and cumulative multimodal items (with repeats); existing env-server / renderer / trajectory tests stay green.
