### PR TITLE
feat: enable labels for prime sandboxes + tunnels

### DIFF
--- a/verifiers/v1/cli/runner.py
+++ b/verifiers/v1/cli/runner.py
@@ -47,6 +47,13 @@ async def run_eval(env: Environment, config: EvalConfig) -> list[Trace]:
     # append, safe to call from concurrent rollouts in the one event loop.
     out = output_path(config)
     save_config(config, out)
+    # Default the runtime's labels to the run uuid (after saving, so re-running `@ config.toml`
+    # gets a fresh uuid rather than reusing the saved one). Shared by every sandbox and tunnel
+    # the run creates, so they can be found/cleaned up together. Only label-aware runtimes
+    # (prime) carry the field; others are left untouched.
+    runtime = env.harness.config.runtime
+    if hasattr(runtime, "labels") and not runtime.labels:
+        runtime.labels = [config.uuid]
     logger.info("results: %s", out)
 
     def on_complete(trace: Trace) -> None:

--- a/verifiers/v1/cli/runner.py
+++ b/verifiers/v1/cli/runner.py
@@ -47,13 +47,6 @@ async def run_eval(env: Environment, config: EvalConfig) -> list[Trace]:
     # append, safe to call from concurrent rollouts in the one event loop.
     out = output_path(config)
     save_config(config, out)
-    # Default the runtime's labels to the run uuid (after saving, so re-running `@ config.toml`
-    # gets a fresh uuid rather than reusing the saved one). Shared by every sandbox and tunnel
-    # the run creates, so they can be found/cleaned up together. Only label-aware runtimes
-    # (prime) carry the field; others are left untouched.
-    runtime = env.harness.config.runtime
-    if hasattr(runtime, "labels") and not runtime.labels:
-        runtime.labels = [config.uuid]
     logger.info("results: %s", out)
 
     def on_complete(trace: Trace) -> None:

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -30,6 +30,9 @@ class PrimeConfig(BaseConfig):
     """Request guaranteed (vs best-effort) capacity."""
     region: str | None = None
     """Region to provision in (None = provider-chosen)."""
+    labels: list[str] = []
+    """Labels attached to the sandbox and its tunnels — e.g. to group every resource a run
+    creates. When unset, the eval defaults them to the run's uuid (see `run_eval`)."""
     timeout: int | Literal["auto"] = 21600
     """Max sandbox lifetime in seconds (default 6h; or "auto" = the highest prime
     supports). A hard backstop: the sandbox self-terminates even if local cleanup is
@@ -85,6 +88,7 @@ class PrimeRuntime(Runtime):
             sandbox = await self._client.create(
                 CreateSandboxRequest(
                     name=self.name,
+                    labels=self.config.labels,
                     docker_image=self.config.image,
                     network_access=self.config.network_access,
                     vm=self.config.vm,
@@ -109,7 +113,7 @@ class PrimeRuntime(Runtime):
         # The sandbox is remote, so reach a host port via a tunnel (one per port).
         from prime_tunnel import Tunnel
 
-        tunnel = Tunnel(local_port=port)
+        tunnel = Tunnel(local_port=port, labels=self.config.labels or None)
         try:
             url = str(await tunnel.start()).rstrip("/")
         except Exception as e:


### PR DESCRIPTION
## Summary

- Add `PrimeConfig.labels: list[str]` (settable via `--harness.runtime.labels`), passed to `CreateSandboxRequest` **and** to every `Tunnel`. A run's prime sandboxes and tunnels can then share a label so they're findable / cleanable together.

## Verification (e2e against prime)

`uv run eval gsm8k-v1 -n 2 -r 2 --harness.id default --harness.runtime.type prime`:

- Mid-run, `SandboxClient.list(labels=[label])` returned the run's sandboxes, each carrying the label (with `name` still the per-rollout trace id).
- All 4 rollouts completed **reward=1.0** through the prime sandbox + tunnel; **no sandboxes leaked** after (`list(exclude_terminated=True)` → 0).
- Tunnel labeling confirmed via a live `Tunnel(labels=[…])` → `TunnelClient.list_tunnels(labels=[…])` round-trip (`status=connected, labels=[…]`).

Note: auto-defaulting the labels to the eval run uuid was dropped for now — set them explicitly via `--harness.runtime.labels`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive config wiring to Prime sandbox/tunnel APIs with no changes to auth, exec, or teardown logic.
> 
> **Overview**
> Adds **`PrimeConfig.labels`** so Prime eval runs can tag every sandbox and tunnel with the same strings (via **`--harness.runtime.labels`**), making resources listable and cleanable as a group.
> 
> On **sandbox create**, labels are forwarded to **`CreateSandboxRequest`**. On **`expose`**, the same list is passed into **`Tunnel`** (empty config becomes `None` for the tunnel API). Labels are opt-in; there is no automatic run-uuid default in this change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 774861689209201baea2a487aff7508390ecdb5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add labels support to prime sandbox and tunnel creation in `PrimeRuntime`
> Adds a `labels: list[str]` field to `PrimeConfig` in [prime.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1604/files#diff-d22d61279ff7587a2b14c72ab1a0fc9d3f805a735338a70f8efc7fe19aaa8502). Labels are forwarded to `CreateSandboxRequest` on sandbox start and to tunnel construction in the `expose` method (passed as `None` when the list is empty).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7748616.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->