### PR TITLE
fix(v1,serve): env-worker memory — step slimming, registry eviction, intercept discard, worker trim

### DIFF
--- a/verifiers/v1/runtime.py
+++ b/verifiers/v1/runtime.py
@@ -989,6 +989,12 @@ class Runtime:
         await self.close_mcp_tools(state)
         self.release_scoped_tools("rollout", state)
         await self.release_model_client(state)
+        # The live-trajectory registry (register_trajectory) is only read by
+        # resolve_trajectory for handle-borrowing sub-runtime states, whose
+        # lifetime is within the owning rollout — without this pop the
+        # long-lived Runtime retains every completed rollout's full
+        # trajectory and the env worker leaks ~50-400MB per rollout.
+        self.trajectories.pop(str(state["trajectory_id"]), None)
         self.release_tool_handles(state)
 
     async def cleanup_group(self, tasks: list[Task], states: list[State]) -> None:

--- a/verifiers/v1/runtime.py
+++ b/verifiers/v1/runtime.py
@@ -875,10 +875,21 @@ class Runtime:
         is_truncated = response.message.is_truncated or (
             tokens is not None and bool(tokens.get("is_truncated"))
         )
+        # Identity/usage only: the full Response dump would re-store the
+        # message content (= ``completion``) and ``message.tokens``
+        # (= ``tokens``, incl. per-token attribution), doubling every
+        # trajectory step in worker memory, on the wire, and in the
+        # orchestrator's group buffers. v1 step readers that want the
+        # heavy fields isinstance-check the live ``Response``, which a
+        # serialized dict never passes; usage is recorded on state at
+        # this call site via ``record_response_usage``.
+        response_meta = serializable(response)
+        if isinstance(response_meta, dict):
+            response_meta.pop("message", None)
         step = {
             "prompt": serializable(prompt),
             "completion": serializable(completion),
-            "response": serializable(response),
+            "response": response_meta,
             "tokens": serializable(tokens),
             "reward": None,
             "advantage": None,


### PR DESCRIPTION
Four env-worker memory fixes for the v1 trajectory/endpoint path, found and production-validated incrementally on worldsims browser runs (each predicted/confirmed by a measurement harness; details below):

## 1. Drop the response message dump from trajectory steps
Each step stored `serializable(response)` wholesale — its `message` restates the step's `completion` and its `tokens` (full-prefix ids/mask **plus per-token `prompt_attribution`**), doubling every step in worker memory, on the wire, and in prime-rl's group buffers. Steps now keep identity/usage only. No v1-path consumer reads the dropped fields (all step-level readers `isinstance(…, Response)`-check, which serialized dicts fail).

## 2. Evict completed rollouts from `Runtime.trajectories` (true leak)
`prepare_state → register_trajectory` stores every rollout's live trajectory for handle-borrowing sub-runtime states, and nothing ever removed it — the process-lifetime Runtime retained every completed rollout's full trajectory (~50–400MB each; OOM-killed env pods by training step ~5). Popped in `cleanup_rollout` (runs in the harness `finally`).

## 3. Discard delivered intercepts (dominant term: −74% worker peak)
`InterceptionServer.intercepts` retained every request's **raw body — the full message history including in-sandbox base64 screenshots** — until rollout unregister, so a long rollout held every turn's request simultaneously. (The renderer's image offload rewrites a normalized *copy*; the intercept's base64 never left.) `forward_request` now discards after delivery; the HTTP handler keeps its local reference, discard is idempotent, unregister still sweeps undelivered entries.

## 4. `malloc_trim` at the worker stats cadence (resting RSS ÷3)
Workers had no trim anywhere (the per-batch trim is orchestrator-only); freed arena pages ratcheted RSS to ~3× the live set. Trim every 10s via ctypes (GIL released). Deliberately **not** `gc.collect` — full collections on fat heaps are what caused the worker heartbeat-timeout kills.

## Measurement (churn simulation, 4 concurrent 45-turn rollouts/worker, real subprocess RSS)
| scenario | worker peak | worker resting |
|---|---:|---:|
| fixes 1+2 only | 1053 MB | 943–988 MB |
| + intercept discard | 275 MB | 179–218 MB |
| + worker trim (all four) | **275 MB** | **119–155 MB** |

Production lineage on the worldsims env pin (`worldsims/ephemeral-mm-pixels-vf-model`): no-fixes OOMed at step 5 (~115GB env pod); fixes 1+2 still climbed to ~90GB and failed; all four shipped as `e522d36e` — run `oh7jsedjxix7rbk23sdvsujd` training on it now.

Commits 1–2 are ports refitted to this branch's runtime structure; 3–4 cherry-picked clean. `py_compile` + `ruff` clean. Structural successor for 1–2: #1606's delta-native message graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)