### PR TITLE
fix(v1,serve): discard delivered intercepts; trim worker arenas at heartbeat cadence

### DIFF
--- a/verifiers/serve/server/env_worker.py
+++ b/verifiers/serve/server/env_worker.py
@@ -257,8 +257,25 @@ class EnvWorker:
 
     async def stats_loop(self, interval: float = 10.0) -> None:
         """Loop to push worker stats to the router."""
+        libc = None
+        try:
+            import ctypes
+
+            libc = ctypes.CDLL("libc.so.6")
+        except OSError:
+            pass
         while True:
             await asyncio.sleep(interval)
+
+            # Return freed arena pages to the OS at the heartbeat cadence.
+            # Long multimodal rollouts churn hundreds of MB of boxed objects
+            # per rollout; without trim the worker's RSS ratchets to its
+            # high-water mark (~3x the live set, measured). ctypes calls
+            # release the GIL, so this never stalls the loop — unlike
+            # gc.collect(), which must NOT be called here (full collections
+            # on fat heaps are what caused worker heartbeat timeouts).
+            if libc is not None:
+                libc.malloc_trim(0)
 
             stats = EnvWorkerStats(
                 worker_id=self.worker_id,

--- a/verifiers/v1/utils/endpoint_utils.py
+++ b/verifiers/v1/utils/endpoint_utils.py
@@ -224,6 +224,18 @@ class Endpoint:
     def get_request(self, request_id: str) -> ConfigData:
         return cast(ConfigData, self.server.intercepts[request_id])
 
+    def discard_request(self, request_id: str) -> None:
+        """Drop a delivered intercept from the server's per-request store.
+
+        Each intercept retains the raw request body — the full message
+        history including in-sandbox base64 screenshots — and the server
+        only sweeps them at rollout unregister, so without per-delivery
+        discard a long browser rollout holds every turn's request body
+        simultaneously (~74% of env-worker memory measured). The HTTP
+        handler keeps its own local reference, so delivery is unaffected.
+        """
+        self.server.intercepts.pop(request_id, None)
+
     def request_context(
         self, request_id: str, request: ConfigData
     ) -> ModelRequestContext:
@@ -450,14 +462,17 @@ async def forward_request(
             state._set_error(error_info(e))
         raise
     finally:
-        if bool(request.get("stream")):
-            if request.get("protocol") != "openai_chat_completions":
-                raise NotImplementedError(
-                    "Streaming interception is currently supported for OpenAI Chat Completions."
-                )
-            await synthesize_stream(request, response, error)
-        else:
-            deliver_response(request, response, error)
+        try:
+            if bool(request.get("stream")):
+                if request.get("protocol") != "openai_chat_completions":
+                    raise NotImplementedError(
+                        "Streaming interception is currently supported for OpenAI Chat Completions."
+                    )
+                await synthesize_stream(request, response, error)
+            else:
+                deliver_response(request, response, error)
+        finally:
+            endpoint.discard_request(request_id)
 
 
 def normalize_endpoint_prompt(request: ConfigData) -> Messages:


### PR DESCRIPTION
Completes the env-worker memory series: #1608 merged the first two fixes (step slimming + registry eviction) just before the commit carrying these last two was pushed to its branch — this PR is that stranded delta, cherry-picked onto the current base.

## 3. Discard delivered intercepts (dominant term: −74% worker peak)

`InterceptionServer.intercepts` retained every request's **raw body — the full message history including in-sandbox base64 screenshots — until rollout unregister**, so a long browser rollout held every turn's request simultaneously. (The renderer's image offload rewrites a normalized *copy*; the intercept's base64 never left.) `forward_request` now discards the intercept after delivery via a new `Endpoint.discard_request`: the HTTP handler keeps its own local reference so delivery is unaffected, discard is idempotent, and rollout-unregister still sweeps undelivered entries.

## 4. `malloc_trim(0)` at the worker stats cadence (resting RSS ÷3)

Env workers had no trim anywhere (the per-batch trim added on prime-rl's side is orchestrator-only); freed arena pages ratcheted worker RSS to ~3× the live set. Trim every 10s in the existing stats loop via ctypes (releases the GIL — never stalls the loop). Deliberately **not** `gc.collect`: full collections on fat heaps are what caused the worker heartbeat-timeout kills.

## Measurement (churn simulation: 4 concurrent 45-turn browser rollouts/worker, real subprocess RSS)

| scenario | worker peak | worker resting |
|---|---:|---:|
| #1608 fixes only | 1053 MB | 943–988 MB |
| + intercept discard | 275 MB | 179–218 MB |
| + worker trim (both) | **275 MB** | **119–155 MB** |

Production: without these two, the worldsims perplexity env pod climbed to ~90GB and failed even with #1608's fixes; with all four (worldsims pin `e522d36e`), run `oh7jsedjxix7rbk23sdvsujd` is training now. `py_compile` + `ruff` clean; discard behavior unit-checked (local ref intact post-discard, idempotent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches request-forwarding lifecycle and periodic native memory calls in serve workers; behavior is localized but affects long-running rollout memory and timing under load.
> 
> **Overview**
> **Env-worker memory:** The stats heartbeat loop now calls **`malloc_trim(0)`** on Linux (via `ctypes` + `libc.so.6`) so freed allocator pages are returned to the OS on the same ~10s cadence as worker stats. The change deliberately avoids **`gc.collect()`** in that loop to prevent heartbeat stalls on large heaps.
> 
> **Intercept retention:** **`Endpoint.discard_request`** removes each delivered intercept from **`InterceptionServer.intercepts`** after streaming or non-streaming delivery in **`forward_request`**. Raw request bodies (including full multimodal histories) no longer accumulate for every turn until rollout unregister; the handler’s local `request` reference still covers delivery, and rollout unregister continues to sweep anything undelivered.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 868124c01305828667c7f00371fcb5d89277c397. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Discard delivered intercepts and trim worker heap memory at heartbeat cadence
> - Adds `Endpoint.discard_request` in [`endpoint_utils.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1610/files#diff-a70063758e2336829655d3b4801af8a67bd77ded23d6e95bc1beb922a56c4ca8) to delete completed intercept entries from `server.intercepts`, reducing retained memory after request delivery.
> - Wraps the response delivery block in `forward_request` with `try/finally` so `discard_request` is always called, including on error paths.
> - Adds a `malloc_trim(0)` call via `ctypes` in [`EnvWorker.stats_loop`](https://github.com/PrimeIntellect-ai/verifiers/pull/1610/files#diff-18d86019aa63101f5547c71c2bbfbcf226c40775c5a4fc07b9232ed6830755d6) to return freed heap pages to the OS on each stats interval when libc is available.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 868124c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->