### PR TITLE
fix(v1,serve): evict rollout trajectories, discard delivered intercepts, trim worker arenas

### DIFF
--- a/verifiers/serve/server/env_worker.py
+++ b/verifiers/serve/server/env_worker.py
@@ -248,8 +248,17 @@ class EnvWorker:
 
     async def stats_loop(self, interval: float = 10.0) -> None:
         """Loop to push worker stats to the router."""
+        try:
+            import ctypes
+
+            libc = ctypes.CDLL("libc.so.6")
+        except OSError:
+            libc = None
         while True:
             await asyncio.sleep(interval)
+
+            if libc is not None:
+                libc.malloc_trim(0)
 
             stats = EnvWorkerStats(
                 worker_id=self.worker_id,

--- a/verifiers/v1/runtime.py
+++ b/verifiers/v1/runtime.py
@@ -1052,6 +1052,7 @@ class Runtime:
         key = str(state["trajectory_id"])
         self._model_request_locks.pop(key, None)
         self._inflight_visible_model_requests.pop(key, None)
+        self.trajectories.pop(key, None)
         self.release_tool_handles(state)
 
     async def cleanup_group(self, tasks: list[Task], states: list[State]) -> None:

--- a/verifiers/v1/utils/endpoint_utils.py
+++ b/verifiers/v1/utils/endpoint_utils.py
@@ -240,6 +240,10 @@ class Endpoint:
     def get_request(self, request_id: str) -> EndpointInterceptData:
         return cast(EndpointInterceptData, self.server.intercepts[request_id])
 
+    def discard_request(self, request_id: str) -> None:
+        """Drop a delivered intercept from the server's per-request store."""
+        self.server.intercepts.pop(request_id, None)
+
     def request_context(
         self, request_id: str, request: EndpointInterceptData
     ) -> ModelRequestContext:
@@ -513,14 +517,17 @@ async def forward_request(
             state._set_error(e)
         raise
     finally:
-        if bool(request.get("stream")):
-            if request.get("protocol") != "openai_chat_completions":
-                raise NotImplementedError(
-                    "Streaming interception is currently supported for OpenAI Chat Completions."
-                )
-            await synthesize_stream(request, response, error)
-        else:
-            deliver_response(request, response, error)
+        try:
+            if bool(request.get("stream")):
+                if request.get("protocol") != "openai_chat_completions":
+                    raise NotImplementedError(
+                        "Streaming interception is currently supported for OpenAI Chat Completions."
+                    )
+                await synthesize_stream(request, response, error)
+            else:
+                deliver_response(request, response, error)
+        finally:
+            endpoint.discard_request(request_id)
 
 
 def normalize_endpoint_prompt(request: EndpointInterceptData) -> Messages:


### PR DESCRIPTION
Three env-worker memory fixes for long multi-turn rollouts, ports to `main` of fixes production-validated on `feat/ephemeral-mm-pixels` (#1608, #1610) against worldsims browser-env training runs.

## 1. Evict completed rollouts from `Runtime.trajectories` (leak)

`prepare_state → resolve_trajectory → register_trajectory` stores **every** rollout's live trajectory list in `Runtime.trajectories` so handle-borrowing sub-runtime states (e.g. in-sandbox program model calls resolving the owning rollout's trajectory) can look it up — but nothing ever removed the entry, and the Runtime lives for the env-worker process lifetime. Every *completed* rollout's full trajectory (per-step prompt copies + full-prefix token arrays) stayed referenced forever: ~50–400MB leaked per rollout on long browser envs, OOM-killing env pods within a handful of training steps. Now popped in `cleanup_rollout` alongside the existing per-trajectory dict evictions (`_model_request_locks`, `_inflight_visible_model_requests`); `cleanup_rollout` runs in the harness `finally`, so error paths evict too. Borrowers' lifetimes are bounded by the owning rollout, so nothing can resolve the entry after cleanup. (`list` doesn't support weakrefs, so the `WeakValueDictionary` pattern used by the runtime registry wasn't available here — manual eviction is required.)

## 2. Discard delivered intercepts (dominant term: −74% worker peak RSS)

`InterceptionServer.intercepts` retained every request's **raw body — the full message history, including base64 images on multimodal envs — until rollout unregister**, so a long rollout held every turn's request simultaneously (renderer-side image offload rewrites a normalized *copy*, so the intercept's base64 never left). `forward_request` now discards the intercept after delivery via `Endpoint.discard_request`: the HTTP handler keeps its own local reference so delivery is unaffected, discard is idempotent, and rollout-unregister still sweeps undelivered entries (matching the manual per-request pop the opencode envs already do).

## 3. `malloc_trim(0)` at the worker stats cadence (resting RSS ÷3)

Env workers never returned freed arena pages to the OS, so RSS ratcheted to ~3× the live set under rollout churn. Trim every 10s in the existing stats loop via ctypes (the call releases the GIL — it cannot stall the event loop). `gc.collect` is deliberately avoided here: full collections on large heaps block past the worker heartbeat timeout and get healthy workers killed.

## Measurement

Churn simulation (4 concurrent 45-turn browser rollouts per worker, real subprocess RSS, glibc/pymalloc):

| scenario | worker peak | worker resting |
|---|---:|---:|
| baseline | 1053 MB | 943–988 MB |
| + intercept discard | 275 MB | 179–218 MB |
| + worker trim | **275 MB** | **119–155 MB** |

Production lineage (worldsims env pin): without fix 1 the env pod OOMed at training step ~5 (~115GB); with fix 1 alone it climbed to ~90GB and still failed; with all of the above the pod holds flat. `py_compile` + `ruff check` clean; discard behavior unit-checked (local reference intact post-discard; idempotent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rollout cleanup and endpoint request lifecycle timing; low logic risk but affects memory-sensitive training paths where regressions would show as missing trajectories or failed intercept lookups if cleanup ran too early (mitigated by discarding only after delivery).
> 
> **Overview**
> Addresses **env-worker memory growth** during long, concurrent multi-turn rollouts with three targeted changes.
> 
> **Runtime:** `cleanup_rollout` now **`pop`s the rollout’s entry from `Runtime.trajectories`**, alongside existing per-trajectory lock/inflight cleanup, so completed rollouts no longer keep full trajectory lists alive for the worker process lifetime.
> 
> **Endpoint interception:** Adds **`Endpoint.discard_request`** and calls it from **`forward_request`** after stream/non-stream delivery, so **`InterceptionServer.intercepts` no longer retains raw request bodies** (e.g. multimodal base64) for every turn until rollout unregister.
> 
> **Env worker:** The **10s stats loop** optionally invokes **`malloc_trim(0)`** via `libc.so.6` (skipped if unavailable) to **return freed glibc arena pages** and reduce resting RSS under rollout churn.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2449c2112d0e98fe2a263fa1b6ea9c14d25b2ed0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix memory leaks by evicting rollout trajectories, discarding delivered intercepts, and trimming worker heap
> - [`Runtime.cleanup_rollout`](https://github.com/PrimeIntellect-ai/verifiers/pull/1611/files#diff-7c2c1b88c61b8a75e00bb82f7ece60290f886d4a3ed87e97a5e1cbf86b26973d) now removes the trajectory entry from `self.trajectories` when a rollout is cleaned up, preventing unbounded trajectory accumulation.
> - [`forward_request`](https://github.com/PrimeIntellect-ai/verifiers/pull/1611/files#diff-a70063758e2336829655d3b4801af8a67bd77ded23d6e95bc1beb922a56c4ca8) unconditionally removes the intercept from `Endpoint.server.intercepts` after forwarding, even if response delivery raises.
> - [`EnvWorker.stats_loop`](https://github.com/PrimeIntellect-ai/verifiers/pull/1611/files#diff-18d86019aa63101f5547c71c2bbfbcf226c40775c5a4fc07b9232ed6830755d6) calls `libc.malloc_trim(0)` on glibc-based systems each stats interval to release free heap memory back to the OS.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 2449c21. 3 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->