### PR TITLE
fix: honor group scoring in the v0 legacy env server

### DIFF
--- a/verifiers/v1/legacy.py
+++ b/verifiers/v1/legacy.py
@@ -277,7 +277,7 @@ class LegacyEnvServer(EnvServer):
         # The formatted dataset rows are RolloutInputs (prompt + example_id); index by task_idx.
         self.dataset = self.env.get_dataset()
         self.tasks = self.dataset  # `len(self.tasks)` drives the `info` response
-        self.requires_group_scoring = False
+        self.requires_group_scoring = self.env.requires_group_rollouts
         self._clients: dict[tuple[str, str], Any] = {}
 
         self.ctx = zmq.asyncio.Context()
@@ -340,10 +340,16 @@ class LegacyEnvServer(EnvServer):
         )
 
     async def _run_group(self, req: RunGroupRequest) -> RunGroupResponse:
-        traces = []
-        for _ in range(req.n):
-            out = await self._run_v0(req.task_idx, req.client, req.model, req.sampling)
-            traces.append(rollout_output_to_trace(out, req.task_idx).to_wire())
+        client = self._v0_client(req.client, req.model)
+        # run_group scores the rollouts together so group/preference reward funcs apply.
+        outs = await self.env.run_group(
+            group_inputs=[dict(self.dataset[req.task_idx]) for _ in range(req.n)],
+            client=client,
+            model=req.model,
+            sampling_args=req.sampling.model_dump(exclude_none=True),
+            state_columns=["trajectory"],
+        )
+        traces = [rollout_output_to_trace(out, req.task_idx).to_wire() for out in outs]
         return RunGroupResponse(traces=traces)
 
 


### PR DESCRIPTION
## Summary

Fixes group scoring in the v0 legacy env server (`LegacyEnvServer`).

- `requires_group_scoring` was hardcoded `False`, so a v0 env whose rubric defines group/preference reward funcs was advertised (via the `info` response) as single-rollout, and the orchestrator routed it down the per-rollout path.
- `_run_group` looped `env.run_rollout` (→ `rubric.score_rollout`) `n` times. `score_rollout` asserts there are no group-level reward funcs, so **every rollout of such an env errored**.

Now:

- `requires_group_scoring = self.env.requires_group_rollouts` — reflects the env's actual rubric (`rubric.has_group_rewards`). A non-group env still reports `False` and keeps the single-rollout path.
- `_run_group` calls `env.run_group(...)` once, so the rubric scores the rollouts together (`score_group`) and cross-rollout (group/preference) rewards apply. `score_group` also handles individual-level reward funcs, so it's correct whether or not the env defines group rewards.

## Verification

- `ruff check --isolated` / `ruff format --isolated --check` clean.
- `LegacyEnvServer` imports and the new `_run_group` / `requires_group_scoring` resolve against the v0 `Environment.run_group` / `requires_group_rollouts` API.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes orchestration routing and the group rollout scoring path for legacy v0 envs; behavior fix but affects reward computation for group-rubric environments.
> 
> **Overview**
> **Fixes group scoring for v0 environments served through `LegacyEnvServer`.**
> 
> `requires_group_scoring` now comes from `self.env.requires_group_rollouts` instead of always being `False`, so the server `info` response and orchestrator correctly use the group rollout path when the rubric has group/preference rewards.
> 
> `_run_group` no longer runs `n` independent `run_rollout` calls (which hit `score_rollout` and fail on group-level reward funcs). It calls `env.run_group` once with `n` copies of the task input, so scoring goes through `score_group` and cross-rollout rewards apply.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31121583a1e6eb8d7d9e9a7294b0696ab3bca274. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix group scoring in `LegacyEnvServer` to delegate to the v0 env's `run_group` API
> - `LegacyEnvServer.__init__` now reads `requires_group_scoring` from the v0 env's `requires_group_rollouts` flag instead of hardcoding `False`.
> - `LegacyEnvServer._run_group` replaces n independent `_run_v0` calls with a single `self.env.run_group` call, passing duplicated dataset row inputs for the task.
> - Behavioral Change: group rollouts are now executed as a true group rather than as independent single rollouts, which may affect scoring for environments that depend on cross-rollout group context.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3112158.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->