### PR TITLE
chore: guard the v0 legacy bridge against non-renderer training clients

### DIFF
--- a/verifiers/v1/legacy.py
+++ b/verifiers/v1/legacy.py
@@ -21,7 +21,7 @@ from typing import Any
 import zmq
 import zmq.asyncio
 
-from verifiers.v1.clients.config import ClientConfig
+from verifiers.v1.clients.config import ClientConfig, RendererClientConfig
 from verifiers.v1.serve.server import EnvServer
 from verifiers.v1.serve.types import (
     RunGroupRequest,
@@ -299,7 +299,13 @@ class LegacyEnvServer(EnvServer):
         ``renderer_model_name`` (the base model) so a LoRA adapter name — served only for
         sampling — never drives tokenizer loading; the per-request ``model`` still selects
         the sampling target in ``run_rollout``."""
-        renderer_model = getattr(client_config, "renderer_model_name", None) or model
+        if not isinstance(client_config, RendererClientConfig):
+            raise ValueError(
+                "the v0 legacy bridge trains through a renderer (token-in/out) client, "
+                f"got client type {client_config.type!r}; MITO (chat-completions) "
+                "training of v0 envs is not supported"
+            )
+        renderer_model = client_config.renderer_model_name or model
         key = (client_config.model_dump_json(), renderer_model)
         if key not in self._clients:
             from verifiers.clients import resolve_client
@@ -307,9 +313,9 @@ class LegacyEnvServer(EnvServer):
 
             v0_config = V0ClientConfig(
                 client_type="renderer",
-                renderer_config=getattr(client_config, "renderer", None),
+                renderer_config=client_config.renderer,
                 renderer_model_name=renderer_model,
-                renderer_pool_size=getattr(client_config, "pool_size", None),
+                renderer_pool_size=client_config.pool_size,
                 api_base_url=client_config.base_url,
                 api_key_var=client_config.api_key_var,
                 extra_headers=dict(client_config.headers or {}),


### PR DESCRIPTION
## Summary

Hardens the v0 legacy bridge's training client builder (`LegacyEnvServer._v0_client`).

- `_v0_client` hardcoded a v0 **renderer** (token-in/out) client. That's correct today — prime-rl trains renderer-only (the orchestrator's student and teacher pools both pin `train_client_type="renderer"`, and it isn't a user-config knob).
- But the v1 `ClientConfig` is a discriminated union (`type="renderers"` vs `type="openai"`/MITO). A MITO config reaching this path would have *silently* built a renderer client from an `OpenAIClientConfig` (its missing `renderer`/`renderer_model_name` fall back via `getattr`), doing **TITO instead of the requested MITO** rather than failing.

Now:

- Raise a clear `ValueError` if `_v0_client` gets a non-renderer config — MITO (chat-completions) training of v0 envs isn't supported, so fail loudly instead of running the wrong inference mode.
- With the renderer type now guaranteed, read `renderer` / `renderer_model_name` / `pool_size` directly instead of via defensive `getattr`.

This is the natural seam at which to add real `type="openai"` dispatch if MITO training of v0 envs is ever enabled.

## Verification

- `ruff check --isolated` / `ruff format --isolated --check` clean.
- `_v0_client` raises `ValueError` on an `OpenAIClientConfig`; a `RendererClientConfig` flows through unchanged.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Guard `LegacyEnvServer._v0_client` against non-renderer training clients
> Adds a strict `isinstance` check in `_v0_client` that raises `ValueError` when `client_config` is not a `RendererClientConfig`. Also replaces `getattr`-based access with direct attribute reads for `renderer_model_name`, `renderer`, and `pool_size`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aef8445.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow guard in the legacy training path; renderer configs behave as before, with clearer failure for unsupported MITO training.
> 
> **Overview**
> **`LegacyEnvServer._v0_client`** now **requires** a **`RendererClientConfig`**. If training passes an **`OpenAIClientConfig`** (MITO / chat-completions), it raises a **`ValueError`** instead of silently building a renderer client with missing fields and running token-in/token-out training.
> 
> After the type check, **`renderer`**, **`renderer_model_name`**, and **`pool_size`** are read directly on the config (no **`getattr`** fallbacks).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aef84454856e2d1b96ae783b8f53873283d65896. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->