### PR TITLE
fix: serve the eval split for eval-only v0 envs in the legacy bridge

### DIFF
--- a/verifiers/v1/legacy.py
+++ b/verifiers/v1/legacy.py
@@ -417,7 +417,7 @@ async def run_legacy_eval(config) -> list[Trace]:
     env = load_environment(ensure_installed(config.id), **(config.args or {}))
     if config.extra_env_kwargs:  # post-load knobs (max_total_completion_tokens, …)
         env.set_kwargs(**config.extra_env_kwargs)
-    dataset = env.get_dataset()
+    dataset = env.get_eval_dataset()  # the eval split (falls back to train when unset)
     idxs = list(range(len(dataset)))
     if config.shuffle:
         random.Random(0).shuffle(idxs)  # fixed seed: same sample every run

--- a/verifiers/v1/legacy.py
+++ b/verifiers/v1/legacy.py
@@ -275,7 +275,11 @@ class LegacyEnvServer(EnvServer):
         if extra_env_kwargs:  # post-load knobs applied via the v0 env's setters
             self.env.set_kwargs(**extra_env_kwargs)
         # The formatted dataset rows are RolloutInputs (prompt + example_id); index by task_idx.
-        self.dataset = self.env.get_dataset()
+        # Eval-only v0 envs (e.g. aime2024) define no train split; serve the eval split instead.
+        try:
+            self.dataset = self.env.get_dataset()
+        except ValueError:
+            self.dataset = self.env.get_eval_dataset()
         self.tasks = self.dataset  # `len(self.tasks)` drives the `info` response
         self.requires_group_scoring = self.env.requires_group_rollouts
         self._clients: dict[tuple[str, str], Any] = {}


### PR DESCRIPTION
## Summary

Fixes the v0 legacy bridge crashing / serving the wrong split for eval-only and dual-split v0 envs. Two v0 paths, both of which called `env.get_dataset()` (the train split):

- **`LegacyEnvServer.__init__`** (the ZMQ server the orchestrator spawns) — crashed on an eval-only env (e.g. `aime2024`, which defines only an eval split) with `ValueError: dataset is not set`. Now falls back to `env.get_eval_dataset()` when there's no train split.
- **`run_legacy_eval`** (the `eval` CLI's `--legacy.id` path) — the eval entrypoint, but it loaded the *train* split: it crashed on eval-only envs and ran on the train split for envs that define both. Now uses `env.get_eval_dataset()` directly (it's unambiguously eval).

`get_eval_dataset()` itself falls back to the train split when no eval split is set, so train-only envs are unaffected. Local to the bridge — **no prime-rl wiring**.

## Note — eval env that also has a train set

The two paths differ on a v0 env that defines **both** splits:

- `run_legacy_eval` is unambiguously eval, so it correctly serves the **eval** split.
- `LegacyEnvServer` cannot tell train from eval from inside the bridge (that intent lives in the launcher), so `get_dataset()` succeeds and it serves the **train** split. Serving the eval split here would require threading an explicit `is_eval` from the launcher (prime-rl wiring), which this PR deliberately avoids. For genuinely eval-only envs (the crashing case) it's correct either way.

## Verification

- `ruff check --isolated` / `ruff format --isolated --check` clean.
- Eval-only env: `get_dataset()` raises → `get_eval_dataset()` returns the eval split. Train-only / dual-split via the server: `get_dataset()` succeeds, behavior unchanged. Eval CLI: always the eval split (train fallback when unset).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized dataset-selection logic in the v0 legacy bridge; train-only behavior is preserved via existing `get_eval_dataset()` fallback.
> 
> **Overview**
> **Fixes eval-only v0 envs** (e.g. `aime2024`) that only define an eval split: the legacy bridge no longer crashes on `ValueError: dataset is not set` when loading tasks.
> 
> In **`LegacyEnvServer`**, dataset loading now tries `get_dataset()` (train) and **falls back to `get_eval_dataset()`** when train is unset. In **`run_legacy_eval`** (the `eval` CLI `--legacy.id` path), the task list is loaded from **`get_eval_dataset()`** instead of the train split so eval runs on the eval set. `get_eval_dataset()` already falls back to train when there is no eval split, so train-only envs stay the same.
> 
> For v0 envs with **both** splits, the ZMQ server still serves train when `get_dataset()` succeeds (eval intent is not threaded from the launcher in this change); the eval CLI always uses the eval split.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9b8e0239cbe50ca70577833b13938b6fda60a80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix legacy bridge to serve eval dataset for eval-only v0 envs
> - In [`LegacyEnvServer.__init__`](https://github.com/PrimeIntellect-ai/verifiers/pull/1614/files#diff-96c5091f7d2968ddfbe984f433163f21cab745ea95174158e924984d55abbfed), wraps `env.get_dataset()` in a try/except so that a `ValueError` falls back to `env.get_eval_dataset()`, supporting envs that only expose an eval split.
> - In `run_legacy_eval`, switches from `env.get_dataset()` to `env.get_eval_dataset()` so in-process eval always runs over the eval split rather than the train split.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d9b8e02.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->