### PR TITLE
fix: build a chat-completions client for v0 eval in the legacy bridge

### DIFF
--- a/verifiers/v1/legacy.py
+++ b/verifiers/v1/legacy.py
@@ -298,32 +298,38 @@ class LegacyEnvServer(EnvServer):
         return contextlib.nullcontext()
 
     def _v0_client(self, client_config: ClientConfig, model: str):
-        """Translate the v1 renderer ``ClientConfig`` into a v0 renderer client (cached;
-        a renderer builds the tokenizer pool on first use). The tokenizer is pinned to
+        """Translate a v1 ``ClientConfig`` into a v0 client (cached). A renderer config
+        (token-in/out, training) builds a v0 renderer client whose tokenizer is pinned to
         ``renderer_model_name`` (the base model) so a LoRA adapter name — served only for
-        sampling — never drives tokenizer loading; the per-request ``model`` still selects
-        the sampling target in ``run_rollout``."""
-        if not isinstance(client_config, RendererClientConfig):
-            raise ValueError(
-                "the v0 legacy bridge trains through a renderer (token-in/out) client, "
-                f"got client type {client_config.type!r}; MITO (chat-completions) "
-                "training of v0 envs is not supported"
-            )
-        renderer_model = client_config.renderer_model_name or model
+        sampling — never drives tokenizer loading. An OpenAI config (chat-completions, eval)
+        builds a v0 chat-completions client. The per-request ``model`` selects the sampling
+        target in ``run_rollout``."""
+        is_renderer = isinstance(client_config, RendererClientConfig)
+        renderer_model = (
+            client_config.renderer_model_name if is_renderer else None
+        ) or model
         key = (client_config.model_dump_json(), renderer_model)
         if key not in self._clients:
             from verifiers.clients import resolve_client
             from verifiers.types import ClientConfig as V0ClientConfig
 
-            v0_config = V0ClientConfig(
-                client_type="renderer",
-                renderer_config=client_config.renderer,
-                renderer_model_name=renderer_model,
-                renderer_pool_size=client_config.pool_size,
-                api_base_url=client_config.base_url,
-                api_key_var=client_config.api_key_var,
-                extra_headers=dict(client_config.headers or {}),
-            )
+            if is_renderer:
+                v0_config = V0ClientConfig(
+                    client_type="renderer",
+                    renderer_config=client_config.renderer,
+                    renderer_model_name=renderer_model,
+                    renderer_pool_size=client_config.pool_size,
+                    api_base_url=client_config.base_url,
+                    api_key_var=client_config.api_key_var,
+                    extra_headers=dict(client_config.headers or {}),
+                )
+            else:
+                v0_config = V0ClientConfig(
+                    client_type="openai_chat_completions",
+                    api_base_url=client_config.base_url,
+                    api_key_var=client_config.api_key_var,
+                    extra_headers=dict(client_config.headers or {}),
+                )
             self._clients[key] = resolve_client(v0_config)
         return self._clients[key]
 


### PR DESCRIPTION
## Summary

Fixes v0 env **eval** crashing in the legacy bridge.

The orchestrator drives both training *and* eval rollouts of a v0 env through the same `LegacyEnvServer` (`run_rollout` / `run_group` → `_run_v0` → `_v0_client`). Training uses a renderer (token-in/out) client; **eval uses an OpenAI chat-completions client** (`pool.get_eval_client()`). The guard added in #1613 raised on any non-renderer config:

```
ValueError: the v0 legacy bridge trains through a renderer (token-in/out) client,
got client type 'openai'; MITO (chat-completions) training of v0 envs is not supported
```

so it broke v0 eval.

`_v0_client` now **dispatches on the config type** instead of raising:
- `RendererClientConfig` (`type="renderers"`, training) → v0 renderer client (unchanged).
- `OpenAIClientConfig` (`type="openai"`, eval) → v0 chat-completions client.

## Verification

- `ruff check --isolated` / `ruff format --isolated --check` clean.
- `_v0_client(OpenAIClientConfig(), model)` builds an `OpenAIChatCompletionsClient` (no longer raises); a `RendererClientConfig` builds the renderer client as before.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Support OpenAI chat-completions client config in `LegacyEnvServer._v0_client`
> Previously, `_v0_client` in [legacy.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1615/files#diff-96c5091f7d2968ddfbe984f433163f21cab745ea95174158e924984d55abbfed) raised a `ValueError` for any non-renderer client config. It now accepts OpenAI chat-completions configs and builds a `V0ClientConfig` with `client_type="openai_chat_completions"`, omitting renderer-specific fields. Renderer configs continue to pin the tokenizer to `renderer_model_name` as before.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 06b45e2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow adapter change in the legacy bridge; renderer training path is unchanged and eval now mirrors existing `_eval_client` behavior.
> 
> **Overview**
> **Fixes v0 environment eval** when rollouts go through `LegacyEnvServer` (orchestrator eval uses `OpenAIClientConfig`, not the renderer used for training).
> 
> `LegacyEnvServer._v0_client` no longer raises on non-renderer v1 configs. It **branches on config type**: `RendererClientConfig` still maps to a v0 renderer client (tokenizer pinned via `renderer_model_name`); any other config (eval’s OpenAI chat-completions) maps to v0 `openai_chat_completions` with base URL, API key var, and headers only. Client caching is unchanged.
> 
> Training-only rejection of chat-completions for v0 MITO is removed in favor of supporting eval while keeping the renderer path for training.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06b45e202e7adabf3ff6eeaa2c44e04c4d15c11a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->