### PR TITLE
fix(v1): align message graph hashing with renderer prefixes

### DIFF
--- a/tests/v1/test_graph.py
+++ b/tests/v1/test_graph.py
@@ -1,0 +1,66 @@
+import verifiers.v1 as vf
+from verifiers.v1 import graph
+
+
+def _response(message: vf.AssistantMessage) -> vf.Response:
+    return vf.Response(
+        id="",
+        created=0,
+        model="test",
+        message=message,
+        finish_reason="stop",
+    )
+
+
+def test_tool_call_hash_matches_v0_content_and_arguments_normalization():
+    left = vf.AssistantMessage(
+        content=None,
+        tool_calls=[
+            vf.ToolCall(id="call_0", name="lookup", arguments='{"b": 2, "a": 1}')
+        ],
+    )
+    right = vf.AssistantMessage(
+        content="",
+        tool_calls=[vf.ToolCall(id="call_0", name="lookup", arguments='{"a":1,"b":2}')],
+    )
+
+    assert graph.message_hash(left) == graph.message_hash(right)
+
+
+def test_reasoning_content_participates_in_graph_prefix_matching():
+    task = vf.Task(idx=0, instruction="use a tool")
+    trace = vf.Trace(task=task)
+    user = vf.UserMessage(content="use a tool")
+    call = vf.ToolCall(id="call_0", name="lookup", arguments="{}")
+
+    graph.add_turn(
+        trace,
+        [user],
+        _response(
+            vf.AssistantMessage(
+                content=None,
+                reasoning_content="plan A",
+                tool_calls=[call],
+            )
+        ),
+    )
+    graph.add_turn(
+        trace,
+        [
+            user,
+            vf.AssistantMessage(
+                content=None,
+                reasoning_content="plan B",
+                tool_calls=[call],
+            ),
+            vf.ToolMessage(content="result", tool_call_id="call_0"),
+        ],
+        _response(vf.AssistantMessage(content="done")),
+    )
+
+    tool_call_nodes = [
+        node
+        for node in trace.nodes
+        if isinstance(node.message, vf.AssistantMessage) and node.message.tool_calls
+    ]
+    assert len(tool_call_nodes) == 2

--- a/verifiers/v1/graph.py
+++ b/verifiers/v1/graph.py
@@ -18,6 +18,7 @@ the exact `prompt_ids + completion_ids` the model saw.
 from __future__ import annotations
 
 import hashlib
+import json
 from typing import TYPE_CHECKING
 
 from pydantic import Field
@@ -60,16 +61,25 @@ class MessageNode(StrictBaseModel):
     """The response's finish reason (assistant nodes only) — kept for truncation detection."""
 
 
+def _canonical_tool_arguments(arguments: str) -> str:
+    try:
+        return json.dumps(json.loads(arguments), sort_keys=True, separators=(",", ":"))
+    except (json.JSONDecodeError, ValueError):
+        return arguments
+
+
 def message_hash(message: Message) -> str:
     """Stable content hash on the fields that round-trip through a prompt — role, content
-    (None and "" equal), assistant tool calls, tool call id; `reasoning_content` ignored.
-    Two messages hash equal iff they're the same conversational message, so a re-stated
-    prefix message dedups to one node. The dedup key for sharing a prefix across
+    (None and "" equal), assistant reasoning content when present, assistant tool calls,
+    tool call id. Two messages hash equal iff they're the same conversational message, so a
+    re-stated prefix message dedups to one node. The dedup key for sharing a prefix across
     turns/branches; salt-free so it is identical across processes and after deserialization."""
     parts: list[str] = [type(message).__name__, message.content or ""]
     if isinstance(message, AssistantMessage):
+        if message.reasoning_content is not None:
+            parts += ["reasoning_content", message.reasoning_content]
         for tc in message.tool_calls or []:
-            parts += [tc.id, tc.name, tc.arguments]
+            parts += [tc.id, tc.name, _canonical_tool_arguments(tc.arguments)]
     elif isinstance(message, ToolMessage):
         parts.append(message.tool_call_id)
     return hashlib.blake2b("\x00".join(parts).encode(), digest_size=16).hexdigest()


### PR DESCRIPTION
## Summary

- Canonicalize assistant tool-call arguments before v1 message graph hashing so JSON formatting drift does not split prefixes.
- Include assistant `reasoning_content` in the graph hash when present, matching renderer prefix comparison behavior.
- Add focused graph tests for v0 parity around tool-call content/arguments and reasoning-aware prefix matching.

## Validation

- `uv run --active ruff format verifiers/v1/graph.py tests/v1/test_graph.py`
- `uv run --active ruff check verifiers/v1/graph.py tests/v1/test_graph.py`
- `uv run --active pytest tests/v1/test_graph.py`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `message_hash` to normalize tool call arguments and include `reasoning_content` in graph prefix matching
> - [`message_hash`](https://github.com/PrimeIntellect-ai/verifiers/pull/1617/files#diff-64c9d635eb215902a512c9e8ab316fd9b9967c36db03d4049aacc812cdfbd740) now canonicalizes `ToolCall.arguments` (sorts keys, strips whitespace) via a new `_canonical_tool_arguments` helper, so JSON-equivalent argument strings produce the same hash.
> - `message_hash` also now includes `reasoning_content` when present on `AssistantMessage`, so messages with differing reasoning are treated as distinct nodes in the trace graph.
> - Tests in [`tests/v1/test_graph.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1617/files#diff-a69f45493b76a68b88ea3c1a7a460b2584b2f9cef28f60f14c06e133cfd0adb5) validate both behaviors.
> - Behavioral Change: previously, JSON arguments with different formatting/key order hashed differently, and `reasoning_content` was ignored during hashing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bbe87df.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dedup keys for trace graph nodes, which can alter branch structure and prefix reuse for rollouts with reasoning or differently formatted tool JSON; scope is limited to `message_hash`/`add_turn`, not auth or I/O.
> 
> **Overview**
> **Aligns v1 trace-graph deduplication** with renderer-style prefix identity by tightening `message_hash` in `verifiers/v1/graph.py`.
> 
> **Tool calls:** assistant `ToolCall.arguments` are passed through a new `_canonical_tool_arguments` helper (parse JSON, `sort_keys`, compact separators) before hashing, so equivalent payloads no longer split the shared prefix when whitespace or key order differs. Non-JSON argument strings are left unchanged.
> 
> **Reasoning:** when `AssistantMessage.reasoning_content` is set, it is now part of the hash (previously ignored), so different reasoning on otherwise similar tool-call turns create separate graph nodes instead of incorrectly reusing one node.
> 
> **Tests:** `tests/v1/test_graph.py` covers JSON/`content` None vs `""` parity for tool-call hashing and asserts two turns differing only in `reasoning_content` yield two tool-call nodes after `add_turn`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbe87dff30ba7bb67eac17205bc2cadb4057f5cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->