### PR TITLE
Handle QUEST judge structured parse errors

### DIFF
--- a/tests/test_quest_taskset.py
+++ b/tests/test_quest_taskset.py
@@ -1,0 +1,46 @@
+import pytest
+import verifiers as vf
+from pydantic import BaseModel, ValidationError
+
+from verifiers.envs.experimental.composable.tasksets.search.quest.taskset import (
+    QuestOpenAIClient,
+)
+
+
+class _BinaryResult(BaseModel):
+    reasoning: str
+    result: bool
+
+
+class _FakeStructuredCompletions:
+    async def parse(self, **kwargs):
+        response_format = kwargs["response_format"]
+        return response_format.model_validate_json(
+            r'{"reasoning": "bad \q escape", "result": true}'
+        )
+
+
+class _FakeChat:
+    completions = _FakeStructuredCompletions()
+
+
+class _FakeBeta:
+    chat = _FakeChat()
+
+
+class _FakeOpenAIClient:
+    beta = _FakeBeta()
+
+
+@pytest.mark.asyncio
+async def test_quest_structured_parse_error_becomes_invalid_model_response():
+    client = QuestOpenAIClient(client=_FakeOpenAIClient(), model="judge-model")
+
+    with pytest.raises(vf.InvalidModelResponseError) as exc_info:
+        await client.async_response(
+            messages=[{"role": "user", "content": "judge this"}],
+            response_format=_BinaryResult,
+        )
+
+    assert "QUEST judge returned invalid structured response" in str(exc_info.value)
+    assert isinstance(exc_info.value.__cause__, ValidationError)

--- a/verifiers/envs/experimental/composable/tasksets/search/quest/taskset.py
+++ b/verifiers/envs/experimental/composable/tasksets/search/quest/taskset.py
@@ -34,7 +34,7 @@ from openai import (
     RateLimitError,
     UnprocessableEntityError,
 )
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 from verifiers.envs.experimental.composable import SandboxSpec, SandboxTaskSet
 from verifiers.types import ClientConfig
 from verifiers.utils.client_utils import setup_openai_client
@@ -188,6 +188,10 @@ class QuestOpenAIClient:
                 )
             except _QUEST_JUDGE_ERROR_TYPES as exc:
                 _raise_quest_judge_error(exc, model=model)
+            except ValidationError as exc:
+                raise vf.InvalidModelResponseError(
+                    f"QUEST judge returned invalid structured response for {model}: {exc}"
+                ) from exc
             choice = _single_choice(response, context="structured")
             parsed = choice.message.parsed
             if parsed is None:


### PR DESCRIPTION
## Summary
- Wrap pydantic structured-output parse failures from the QUEST judge as `vf.InvalidModelResponseError`
- Add a regression test for malformed judge JSON so one bad structured response does not crash the full eval

## Test
- `uv run pytest tests/test_quest_taskset.py`
- `uv run ruff check verifiers/envs/experimental/composable/tasksets/search/quest/taskset.py tests/test_quest_taskset.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow error-handling change on the QUEST judge client path with a focused unit test; no auth, data, or API contract changes.
> 
> **Overview**
> **QUEST judge structured outputs** now treat Pydantic validation failures as first-class model errors instead of bubbling raw `ValidationError`.
> 
> In `QuestOpenAIClient.async_response`, when `beta.chat.completions.parse` succeeds at the HTTP/SDK layer but structured parsing fails (`ValidationError`), the code raises `vf.InvalidModelResponseError` with a clear message and chains the original exception—aligned with other judge response failures (empty parsed, SDK validation, etc.).
> 
> A new async test uses a fake OpenAI client that returns malformed JSON for a `BaseModel` response format and asserts the raised error is `InvalidModelResponseError` with `ValidationError` as `__cause__`, guarding against a single bad judge response taking down a full eval.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef2f00d59d9b4f03f80a2fcdf1f8486a02ee4c2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Convert Pydantic `ValidationError` to `InvalidModelResponseError` in `QuestOpenAIClient.async_response`
> When the QUEST judge's structured response branch calls `_client.beta.chat.completions.parse(...)` and Pydantic raises a `ValidationError`, `async_response` now catches it and re-raises it as `vf.InvalidModelResponseError`, preserving the original error as `__cause__`. A new async test in [test_quest_taskset.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1620/files#diff-b1d7d001b973f99169bbcd0c5ccc6801350645f644f7d33ad64ef7bfad3c3444) verifies this behavior using a fake OpenAI client that returns invalid JSON.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ef2f00d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->