### PR TITLE
perf: occasional malloc_trim to bound v1 worker RSS

### DIFF
--- a/verifiers/v1/episode.py
+++ b/verifiers/v1/episode.py
@@ -67,7 +67,8 @@ class Episode:
             if not group_scored:  # reward already final → don't wait for the group
                 rollout.phase = Phase.DONE
                 on_complete(trace)
-            trim_memory_periodically()  # hand freed per-turn request bodies back to the OS
+            # hand freed per-turn request bodies (base64 images) back to the OS
+            await trim_memory_periodically()
             return trace
 
         traces = await asyncio.gather(*(run_one(r) for r in self.rollouts))

--- a/verifiers/v1/episode.py
+++ b/verifiers/v1/episode.py
@@ -27,6 +27,7 @@ from verifiers.v1.retries import run_with_retry
 from verifiers.v1.rollout import Phase, Rollout
 from verifiers.v1.taskset import Taskset
 from verifiers.v1.trace import Trace
+from verifiers.v1.utils import trim_memory_periodically
 
 if TYPE_CHECKING:
     from verifiers.v1.interception import InterceptionPool
@@ -66,6 +67,7 @@ class Episode:
             if not group_scored:  # reward already final → don't wait for the group
                 rollout.phase = Phase.DONE
                 on_complete(trace)
+            trim_memory_periodically()  # hand freed per-turn request bodies back to the OS
             return trace
 
         traces = await asyncio.gather(*(run_one(r) for r in self.rollouts))

--- a/verifiers/v1/utils.py
+++ b/verifiers/v1/utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import ctypes
 from typing import TYPE_CHECKING
 
@@ -22,7 +23,9 @@ _rollouts_since_trim = 0
 
 def trim_memory() -> None:
     """Best-effort `malloc_trim(0)` — return glibc's freed arenas to the OS. A no-op off
-    glibc (musl, macOS), resolved once and then cached."""
+    glibc (musl, macOS), resolved once and then cached. Walks every arena's free lists, so it
+    can block for tens of ms on a large heap — call it off the event loop (see
+    `trim_memory_periodically`)."""
     global _malloc_trim
     if _malloc_trim is None:
         try:
@@ -33,14 +36,16 @@ def trim_memory() -> None:
         _malloc_trim(0)
 
 
-def trim_memory_periodically() -> None:
+async def trim_memory_periodically() -> None:
     """Call `trim_memory` once every `_TRIM_EVERY_ROLLOUTS` invocations. Invoked per finished
-    rollout so a worker's resting RSS is bounded without trimming on every single one."""
+    rollout so a worker's resting RSS is bounded without trimming on every single one. The
+    trim runs in a worker thread — `ctypes` releases the GIL during the call, so the heap walk
+    doesn't block the event loop (and every other in-flight rollout with it)."""
     global _rollouts_since_trim
     _rollouts_since_trim += 1
     if _rollouts_since_trim >= _TRIM_EVERY_ROLLOUTS:
         _rollouts_since_trim = 0
-        trim_memory()
+        await asyncio.to_thread(trim_memory)
 
 
 def format_time(seconds: float) -> str:

--- a/verifiers/v1/utils.py
+++ b/verifiers/v1/utils.py
@@ -2,10 +2,45 @@
 
 from __future__ import annotations
 
+import ctypes
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from verifiers.v1.trace import Trace
+
+
+# Resolved once on first use: glibc's malloc_trim, or False where it isn't available.
+_malloc_trim: object = None
+
+# A rollout parses large request bodies (base64 images) per turn and frees them, but glibc
+# keeps the freed arenas, so a long-lived worker's resting RSS climbs and never drops. An
+# occasional malloc_trim hands those arenas back to the OS; trimming every Nth rollout (not
+# every one) keeps the per-trim arena walk off the hot path.
+_TRIM_EVERY_ROLLOUTS = 16
+_rollouts_since_trim = 0
+
+
+def trim_memory() -> None:
+    """Best-effort `malloc_trim(0)` — return glibc's freed arenas to the OS. A no-op off
+    glibc (musl, macOS), resolved once and then cached."""
+    global _malloc_trim
+    if _malloc_trim is None:
+        try:
+            _malloc_trim = ctypes.CDLL("libc.so.6").malloc_trim
+        except (OSError, AttributeError):
+            _malloc_trim = False
+    if _malloc_trim:
+        _malloc_trim(0)
+
+
+def trim_memory_periodically() -> None:
+    """Call `trim_memory` once every `_TRIM_EVERY_ROLLOUTS` invocations. Invoked per finished
+    rollout so a worker's resting RSS is bounded without trimming on every single one."""
+    global _rollouts_since_trim
+    _rollouts_since_trim += 1
+    if _rollouts_since_trim >= _TRIM_EVERY_ROLLOUTS:
+        _rollouts_since_trim = 0
+        trim_memory()
 
 
 def format_time(seconds: float) -> str:


### PR DESCRIPTION
## Summary

- A v1 rollout parses large base64 request bodies (e.g. screenshots) per turn via the interception server and frees them, but glibc keeps the freed arenas — so a long-lived eval / env-server worker's *resting* RSS climbs and never drops back.
- Add a best-effort `trim_memory()` (`malloc_trim(0)` via `ctypes`) in `verifiers/v1/utils.py`, resolved once and cached; a no-op off glibc (musl, macOS).
- Call it occasionally — once every `_TRIM_EVERY_ROLLOUTS` (16) finished rollouts, gated in `Episode.run` — so freed arenas go back to the OS without putting the arena walk on the hot path. Both the eval runner and the env-server training worker drive rollouts through `Episode.run`, so both are covered.
- **Run the trim off the event loop**: `malloc_trim(0)` walks every arena's free lists and can block for tens of ms on exactly the large/fragmented heaps this targets. Inline that would stall the whole event loop — and under the multiplexed env server, every concurrent rollout with it. `trim_memory_periodically()` offloads via `asyncio.to_thread`; `ctypes` releases the GIL during the call, so the heap walk runs concurrently with the loop.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Operational memory tuning only; best-effort no-op on non-glibc platforms and runs off the hot path in a background thread.
> 
> **Overview**
> Adds **periodic glibc heap trimming** so long-lived v1 workers (eval runner and env-server) don’t keep climbing **resting RSS** after rollouts free large per-turn bodies (e.g. base64 screenshots) that glibc still holds in arenas.
> 
> New helpers in `verifiers/v1/utils.py`: **`trim_memory()`** resolves and caches `malloc_trim(0)` via `ctypes` (no-op off glibc), and **`trim_memory_periodically()`** runs it every **16** finished rollouts on a **worker thread** via `asyncio.to_thread` so the arena walk doesn’t block the event loop.
> 
> **`Episode.run`** awaits `trim_memory_periodically()` after each rollout completes, so every path that drives rollouts through episodes gets the behavior without per-caller wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8700a46f44f72119049fa2adf4f09e70c3abc042. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Call `malloc_trim` periodically in v1 workers to bound RSS growth
> - Adds `trim_memory_periodically()` in [utils.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1621/files#diff-b7a40f7f76929d82f9e0f511eb8c7a88cb2dfa86b03d6f5f8bc64142f80577b2) that calls glibc's `malloc_trim(0)` every 16 rollouts via `asyncio.to_thread`, returning freed per-turn request body memory to the OS.
> - On non-glibc platforms, `trim_memory` resolves to a no-op after the first failed `ctypes` lookup.
> - [episode.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1621/files#diff-ea3591865e4c7653852776e680f3abbf509a3f3a406d518c8dce528669aa0abf) awaits `trim_memory_periodically()` after each rollout completes.
> - Risk: introduces a worker-thread dispatch every 16 rollouts; negligible on glibc, no-op elsewhere.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8700a46.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->