### PR TITLE
fix(v1): isolate sandbox client failures

### DIFF
--- a/verifiers/v1/utils/sandbox_utils.py
+++ b/verifiers/v1/utils/sandbox_utils.py
@@ -203,6 +203,8 @@ def sandbox_failure_kind(exc: BaseException) -> str | None:
         return "oom"
     if name in {"SandboxTimeoutError", "CommandTimeoutError"} or "timed out" in text:
         return "timeout"
+    if name == "SandboxNotRunningError":
+        return "not_running"
     return None
 
 
@@ -373,11 +375,10 @@ class SandboxHandle:
             raise
         except Exception as exc:
             kind = mark_sandbox_failure(self.state, self.lease, exc, phase="execute")
-            if kind is not None:
-                raise SandboxError(
-                    f"Sandbox {self.lease.id} failed during execute ({kind}): {exc}"
-                ) from exc
-            raise
+            failure = f" ({kind})" if kind is not None else ""
+            raise SandboxError(
+                f"Sandbox {self.lease.id} failed during execute{failure}: {exc}"
+            ) from exc
         record_tool_sandbox_command(self.state, self.lease, command, result)
         return result
 
@@ -421,11 +422,10 @@ class SandboxHandle:
             kind = mark_sandbox_failure(
                 self.state, self.lease, exc, phase="background_job"
             )
-            if kind is not None:
-                raise SandboxError(
-                    f"Sandbox {self.lease.id} failed during background job ({kind}): {exc}"
-                ) from exc
-            raise
+            failure = f" ({kind})" if kind is not None else ""
+            raise SandboxError(
+                f"Sandbox {self.lease.id} failed during background job{failure}: {exc}"
+            ) from exc
         record_tool_sandbox_command(self.state, self.lease, command, result)
         return result
 
@@ -534,11 +534,10 @@ async def run_sandbox_command(
             raise
         except Exception as exc:
             kind = mark_sandbox_failure(state, lease, exc, phase="command")
-            if kind is not None:
-                raise SandboxError(
-                    f"Sandbox {lease.id} failed during command ({kind}): {exc}"
-                ) from exc
-            raise
+            failure = f" ({kind})" if kind is not None else ""
+            raise SandboxError(
+                f"Sandbox {lease.id} failed during command{failure}: {exc}"
+            ) from exc
         state["command"] = {
             "argv": argv,
             "returncode": result.exit_code,


### PR DESCRIPTION
## Summary

- wrap sandbox client exceptions from command execution as `vf.SandboxError`
- classify `SandboxNotRunningError` as `not_running` in sandbox failure metadata
- keep a failed sandbox rollout from escaping `Harness.run()` and cancelling concurrent evaluation work

## Context

Hosted eval `m19r1p2d6f1t2zxu8bwnoxy5` failed when a sandbox entered `status=ERROR` while Verifiers polled its background job. The raw `SandboxNotRunningError` bypassed per-rollout `vf.Error` handling, failed the environment-server request, and cancelled the other active rollouts.

## Testing

- `uv run pytest tests/test_v1_runtime_lifecycle.py -k sandbox_command_marks_oom_failures`
- `UV_FROZEN=1 uv run pre-commit run --files verifiers/v1/utils/sandbox_utils.py`
- pre-push `ty (ci parity)`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes error propagation on the sandbox execution path; mis-wrapping could mask bugs, but scope is limited to v1 sandbox utils and aligns failures with existing vf.Error handling.
> 
> **Overview**
> **Sandbox client failures are always surfaced as `SandboxError`** during execute, background job polling, and program command runs. Previously, only exceptions with a recognized failure *kind* (OOM, timeout, etc.) were wrapped; others (e.g. `SandboxNotRunningError`) could escape and break hosted eval rollouts.
> 
> `sandbox_failure_kind` now maps **`SandboxNotRunningError`** to **`not_running`** for `sandbox_failures` metadata. Wrapped errors still record the kind in the message when known, but wrapping no longer depends on classification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e5a83d94d7f2ddc9d38553b8a4a40782cde11ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Wrap all sandbox client failures as `SandboxError` in sandbox utilities
> - `SandboxHandle.execute`, `SandboxHandle.background_job`, and `run_sandbox_command` in [sandbox_utils.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1622/files#diff-b1154f3be7f28191532de46fbe23a973a5f93e1450a71beb9c93910e358fda13) now always raise `SandboxError` for non-`Error` exceptions, regardless of whether a failure kind is classified.
> - `sandbox_failure_kind` now recognizes `SandboxNotRunningError` and returns `'not_running'`.
> - Behavioral Change: Previously, unclassified exceptions propagated as their original types; callers that caught specific exception types from these functions will no longer receive them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7e5a83d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->