### PR TITLE
fix: treat overlong prompts as clean truncated rollouts

### DIFF
--- a/verifiers/v1/clients/openai.py
+++ b/verifiers/v1/clients/openai.py
@@ -11,7 +11,7 @@ This is the one place raw provider dicts cross into our typed `Response`.
 from openai import AsyncOpenAI, OpenAIError
 
 from verifiers.v1.clients.client import Client
-from verifiers.v1.errors import ModelError
+from verifiers.v1.errors import ModelError, OverlongPromptError
 from verifiers.v1.types import (
     AssistantMessage,
     FinishReason,
@@ -26,6 +26,33 @@ from verifiers.v1.types import (
 )
 
 FINISH_REASONS = frozenset({"stop", "length", "tool_calls"})
+
+# Case-folded substrings that mark a provider rejecting a prompt for exceeding the model's
+# context window — vLLM, OpenAI and friends each phrase it differently. An overlong prompt
+# is a budget limit, not a crash, so we surface it as a distinct `OverlongPromptError` that
+# the interception server turns into a clean, truncated rollout (see
+# `verifiers.v1.interception.server.handle_chat`).
+_CONTEXT_LENGTH_PHRASES = (
+    "this model's maximum context length is",
+    "is longer than the model's context length",
+    "is longer than the maximum model length",
+    "exceeds the model's context length",
+    "exceed the configured limit",
+    "exceeds the configured limit",
+    "exceeded model",
+    "prompt_too_long",
+    "context length",
+    "maximum model length",
+)
+
+
+def model_error(e: OpenAIError) -> ModelError:
+    """Map a provider client error to our error type, distinguishing an overlong prompt
+    from any other model-call failure (auth, rate limit, a genuine bad request, ...)."""
+    text = str(e).casefold()
+    if any(phrase in text for phrase in _CONTEXT_LENGTH_PHRASES):
+        return OverlongPromptError(str(e))
+    return ModelError(str(e))
 
 
 def _content_to_wire(content):
@@ -142,7 +169,7 @@ class OpenAIChatCompletionsClient(Client):
         try:
             completion = await self.openai.chat.completions.create(**body)
         except OpenAIError as e:
-            raise ModelError(str(e)) from e
+            raise model_error(e) from e
         return response_from_wire(completion)
 
     async def close(self) -> None:

--- a/verifiers/v1/clients/openai.py
+++ b/verifiers/v1/clients/openai.py
@@ -27,11 +27,6 @@ from verifiers.v1.types import (
 
 FINISH_REASONS = frozenset({"stop", "length", "tool_calls"})
 
-# Case-folded substrings that mark a provider rejecting a prompt for exceeding the model's
-# context window — vLLM, OpenAI and friends each phrase it differently. An overlong prompt
-# is a budget limit, not a crash, so we surface it as a distinct `OverlongPromptError` that
-# the interception server turns into a clean, truncated rollout (see
-# `verifiers.v1.interception.server.handle_chat`).
 _CONTEXT_LENGTH_PHRASES = (
     "this model's maximum context length is",
     "is longer than the model's context length",

--- a/verifiers/v1/clients/renderer.py
+++ b/verifiers/v1/clients/renderer.py
@@ -11,13 +11,14 @@ needs a running vLLM engine.
 import json
 
 from openai import AsyncOpenAI, OpenAIError
+from renderers import OverlongPromptError as RendererOverlongPromptError
 from renderers import RendererConfig
 
 from verifiers.v1.clients.client import Client
-from verifiers.v1.clients.openai import FINISH_REASONS
+from verifiers.v1.clients.openai import FINISH_REASONS, model_error
 from verifiers.v1.clients.openai import message_to_wire as chat_message_to_wire
 from verifiers.v1.clients.openai import tool_to_wire
-from verifiers.v1.errors import ModelError
+from verifiers.v1.errors import OverlongPromptError
 from verifiers.v1.types import (
     AssistantMessage,
     FinishReason,
@@ -135,8 +136,14 @@ class RendererClient(Client):
                 tools=[tool_to_wire(t) for t in tools] if tools else None,
                 sampling_params=sampling_args.model_dump(exclude_none=True),
             )
+        except RendererOverlongPromptError as e:
+            # The renderer tokenizes client-side and checks the prompt against the engine's
+            # context window (from `GET /v1/models`), so an overlong prompt is rejected here
+            # before the engine sees it — rebadge to our error so the interception server
+            # ends the rollout as a clean truncation, same as the engine-4xx path below.
+            raise OverlongPromptError(str(e)) from e
         except OpenAIError as e:
-            raise ModelError(str(e)) from e
+            raise model_error(e) from e
         return response_from_generate(result, model)
 
     async def close(self) -> None:

--- a/verifiers/v1/clients/renderer.py
+++ b/verifiers/v1/clients/renderer.py
@@ -137,10 +137,6 @@ class RendererClient(Client):
                 sampling_params=sampling_args.model_dump(exclude_none=True),
             )
         except RendererOverlongPromptError as e:
-            # The renderer tokenizes client-side and checks the prompt against the engine's
-            # context window (from `GET /v1/models`), so an overlong prompt is rejected here
-            # before the engine sees it — rebadge to our error so the interception server
-            # ends the rollout as a clean truncation, same as the engine-4xx path below.
             raise OverlongPromptError(str(e)) from e
         except OpenAIError as e:
             raise model_error(e) from e

--- a/verifiers/v1/errors.py
+++ b/verifiers/v1/errors.py
@@ -12,7 +12,13 @@ class RolloutError(Exception):
 
 
 class ModelError(RolloutError):
-    """A model/provider call failed (bad request, auth, overlong prompt, ...)."""
+    """A model/provider call failed (bad request, auth, ...)."""
+
+
+class OverlongPromptError(ModelError):
+    """The prompt (plus the requested completion) exceeded the model's context window.
+    A budget limit, not a crash: the interception server ends the rollout as a clean,
+    truncated trajectory rather than recording it as an error."""
 
 
 class ToolError(RolloutError):

--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -276,11 +276,9 @@ class InterceptionServer:
                     prompt, session.ctx.model, session.ctx.sampling, tools
                 )
             except OverlongPromptError:
-                # The prompt outgrew the model's context window — a budget limit, not a
-                # crash. End the rollout cleanly as a truncated trajectory: return the last
-                # turn if a simulated conversation already produced one, else refuse the call
-                # to halt the harness (its model call errors out; Harness.run treats an exit
-                # after a stop condition as expected) — same shape as `refused` above.
+                # An overlong prompt is a budget limit, not a crash: end the rollout cleanly
+                # as a truncation — return the last turn if there is one, else refuse to halt
+                # the harness (same shape as `refused` above).
                 session.trace.stop("context_length")
                 logger.debug("prompt too long: id=%s", session.trace.id)
                 if last is None:

--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -27,6 +27,7 @@ from aiohttp import web
 
 from verifiers.v1.clients import RolloutContext
 from verifiers.v1 import graph
+from verifiers.v1.errors import OverlongPromptError
 from verifiers.v1.trace import Trace
 from verifiers.v1.types import (
     AssistantMessage,
@@ -274,6 +275,19 @@ class InterceptionServer:
                 response = await session.ctx.client.get_response(
                     prompt, session.ctx.model, session.ctx.sampling, tools
                 )
+            except OverlongPromptError:
+                # The prompt outgrew the model's context window — a budget limit, not a
+                # crash. End the rollout cleanly as a truncated trajectory: return the last
+                # turn if a simulated conversation already produced one, else refuse the call
+                # to halt the harness (its model call errors out; Harness.run treats an exit
+                # after a stop condition as expected) — same shape as `refused` above.
+                session.trace.stop("context_length")
+                logger.debug("prompt too long: id=%s", session.trace.id)
+                if last is None:
+                    return web.json_response(
+                        {"error": "rollout stopped: context_length"}, status=400
+                    )
+                return web.json_response(serialize_completion(last, session.ctx.model))
             except Exception as e:  # surface to the program as an API error
                 logger.warning("model call failed: id=%s %s", session.trace.id, e)
                 return web.json_response({"error": str(e)}, status=502)

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -255,13 +255,15 @@ class Trace(StrictBaseModel, Generic[TaskT]):
     def is_truncated(self) -> bool:
         """Whether the rollout was cut off by a budget/limit rather than ending on its
         own terms: the framework halted it (`max_turns`, a token budget, or
-        `harness_timeout`), or the final turn hit the token cap (`finish_reason ==
+        `harness_timeout`), the prompt outgrew the model's context window
+        (`context_length`), or the final turn hit the token cap (`finish_reason ==
         "length"`)."""
         if self.stop_condition in (
             "max_turns",
             "max_input_tokens",
             "max_output_tokens",
             "max_total_tokens",
+            "context_length",
             "harness_timeout",
         ):
             return True


### PR DESCRIPTION
## Summary

Overlong prompts (the prompt + requested completion exceeding the model's context window) are a budget limit, not a crash. Previously the model call failed, the interception server returned a 502, and the rollout was recorded as an **error**. This makes them produce a **clean, truncated rollout** instead — so a conversation that simply grows past the context window is preserved as data, not lost to an error.

Detection lives in the clients; the truncation policy lives in the interception server.

- **`v1/errors.py`** — add `OverlongPromptError(ModelError)`.
- **`v1/clients/openai.py`** — `model_error(e)` maps a provider 4xx whose message matches a context-length phrase to `OverlongPromptError` (any other failure stays a `ModelError`).
- **`v1/clients/renderer.py`** — rebadge the **renderers-native** client-side `OverlongPromptError` (raised pre-flight from `GET /v1/models`, so it is *not* an `OpenAIError`) **and** the engine 4xx. Without this the renderer path's overlong would slip through uncaught.
- **`v1/interception/server.py`** — `handle_chat` catches `OverlongPromptError`, sets a `context_length` truncation stop, and mirrors the existing `refused` path: it returns the last good turn when a simulated conversation already produced one, else refuses the call to halt the harness cleanly (`Harness.run` treats an exit after a stop condition as expected).
- **`v1/trace.py`** — `Trace.is_truncated` counts `context_length`.

Mirrors the v0 path (`@handle_openai_overlong_prompt` + `renderer_client`'s `RendererOverlongPromptError` rebadge).

## Verification

Ran a multi-turn echo rollout (`echo-multi-v1`, user-simulator driven, with a long `phrases` override) against a local vLLM served with `--max-model-len 1024`, so the conversation grows until the prompt overflows the context window.

**Before** (the overlong turn surfaces as a hard failure):

```
openai.InternalServerError: Error code: 502 - "The prompt is 1025 tokens, which exceeds
the model's maximum context length of 1024 tokens" → ProgramError: harness exited 1
```

**After** — for **both** the `openai` and `renderers` clients, and **both** branches:

| client | scenario | result |
|---|---|---|
| openai | multi-turn overflow (`last is not None`) | `has_error=False`, `stop_condition=context_length`, `is_truncated=True`, 5 turns preserved |
| renderers | multi-turn overflow | `has_error=False`, `stop_condition=context_length`, `is_truncated=True`, 5 turns preserved |
| openai | first-turn overflow (`last is None`, harness halted via 400) | `has_error=False`, `stop_condition=context_length`, `is_truncated=True`, 0 turns |
| renderers | first-turn overflow | same |


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Treat overlong prompts as clean truncated rollouts in the interception server
> - Introduces `OverlongPromptError` in [errors.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1625/files#diff-5621d6869aa43b8c83352b3f958fe94b199952c4ae37c042fe2a25106962cb5b) as a `ModelError` subclass for context-length failures, distinct from generic model errors.
> - Updates [openai.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1625/files#diff-d83c59263a4ca33d6ff77e8ee865785d2b1d0cce2b5c7a516d12790ab16ba123) and [renderer.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1625/files#diff-7feb5238c01baf26c722dd6fbe294cf5c653e9b030bf790d597209847c2d22a8) to raise `OverlongPromptError` instead of `ModelError` when the underlying error text indicates a context-length overflow.
> - Updates the `InterceptionServer.handle_chat` handler in [server.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1625/files#diff-84e2f8d027d609e8760ef6d533535ec9d99dfc6384d5ddb6111b4001b2010f35) to catch `OverlongPromptError`, stop the trace with reason `"context_length"`, and return the last assistant turn as a normal completion (or a 400 if no prior turn exists) instead of a 502.
> - Marks traces stopped due to `"context_length"` as truncated via `Trace.is_truncated` in [trace.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1625/files#diff-834820c3aa80d87ee1c1c57fb54c74f09c66ac727036d964e6005c8613c00b5e).
> - Behavioral Change: overlong-prompt failures that previously produced 502 errors now produce either a valid completion response or a 400, and the trace is flagged as truncated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 36d1455.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rollout completion semantics for a common failure mode (context overflow); incorrect phrase matching could misclassify other API errors as truncation.
> 
> **Overview**
> **Context-window overflows are treated as clean truncations instead of rollout failures.**
> 
> Adds `OverlongPromptError` and maps provider/renderer context-length failures to it via `model_error()` (OpenAI client) and renderer pre-flight rebadging. The interception server catches this like other budget stops: sets `stop_condition` to `context_length`, returns the last good assistant turn when one exists, or a 400 `rollout stopped: context_length` on the first turn. `Trace.is_truncated` now includes `context_length`.
> 
> Rollouts that grow past the model limit keep prior turns as data (`has_error=False`) rather than ending in a 502 and `ProgramError`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36d1455c1cf637265e5f9d29e33b2f5225aa33e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->