### PR TITLE
fix: configure logging in spawned env-server workers

### DIFF
--- a/verifiers/v1/cli/runner.py
+++ b/verifiers/v1/cli/runner.py
@@ -77,7 +77,9 @@ async def run_eval_server(config: EvalConfig) -> list[Trace]:
     `EnvClient` — the same path prime-rl trains through, so it exercises the
     router + workers end-to-end. Output matches `run_eval` (config.toml + results.jsonl)."""
     import multiprocessing as mp
+    from functools import partial
 
+    from verifiers.v1.cli.log import setup_logging
     from verifiers.v1.serve import EnvClient, env_config_data, serve_env
 
     legacy = config.is_legacy
@@ -90,6 +92,9 @@ async def run_eval_server(config: EvalConfig) -> list[Trace]:
         if legacy
         else {"config_data": env_config_data(config)}  # picklable across the spawn
     )
+    # The pool broker + workers are spawned (fresh interpreters, no logging) — hand them
+    # the same loguru setup the main process uses so their rollout logs come back.
+    level = "DEBUG" if config.verbose else "INFO"
     mpctx = mp.get_context("spawn")
     address_queue: mp.Queue = mpctx.Queue()
     proc = mpctx.Process(
@@ -99,6 +104,7 @@ async def run_eval_server(config: EvalConfig) -> list[Trace]:
             legacy=legacy,
             address="tcp://127.0.0.1:0",
             address_queue=address_queue,
+            log_setup=partial(setup_logging, level),
             **server_kwargs,
         ),
         daemon=False,

--- a/verifiers/v1/cli/serve.py
+++ b/verifiers/v1/cli/serve.py
@@ -7,6 +7,7 @@ rollouts on request by task idx.
 """
 
 import sys
+from functools import partial
 
 from pydantic_config import cli
 
@@ -52,10 +53,13 @@ def main(argv: list[str] | None = None) -> None:
     if config.dry_run:
         print(config.model_dump_json(indent=2, exclude_none=True))
         return
-    setup_logging("DEBUG" if config.verbose else "INFO")
+    level = "DEBUG" if config.verbose else "INFO"
+    setup_logging(level)
 
     # A single in-process server (num_workers=1) or a router + worker pool (>1); the
     # frontend speaks the same protocol either way. serve_env owns the SIGTERM teardown.
+    # Pool workers are spawned with no logging, so hand serve_env the same setup to apply
+    # in each one.
     server_kwargs = (
         {
             "env_id": config.id,
@@ -69,5 +73,6 @@ def main(argv: list[str] | None = None) -> None:
         num_workers=config.num_workers,
         legacy=config.is_legacy,
         address=config.address,
+        log_setup=partial(setup_logging, level),
         **server_kwargs,
     )

--- a/verifiers/v1/serve/pool.py
+++ b/verifiers/v1/serve/pool.py
@@ -26,6 +26,7 @@ import os
 import signal
 import threading
 import uuid
+from collections.abc import Callable
 
 import msgpack
 import zmq
@@ -54,14 +55,17 @@ def _monitor_parent(conn) -> None:
 
 
 def _worker_entry(
-    *, server_kwargs: dict, address: str, death_pipe, legacy: bool
+    *, server_kwargs: dict, address: str, death_pipe, legacy: bool, log_setup=None
 ) -> None:
     """Spawned worker: an ordinary EnvServer/LegacyEnvServer bound to `address` (ipc).
     A native config arrives as a dict (`config_data`): the eval/serve CLI's narrowed
     config type is dynamic and unpicklable, so we rebuild it here via EnvConfig's
-    id-resolving validator."""
+    id-resolving validator. `log_setup` (if given) configures this fresh process's
+    logging so per-rollout logs surface — a spawned worker inherits no handlers."""
     from verifiers.v1.legacy import LegacyEnvServer
 
+    if log_setup is not None:
+        log_setup()
     _monitor_parent(death_pipe)
     if "config_data" in server_kwargs:
         server_kwargs = {
@@ -80,10 +84,12 @@ class EnvServerPool:
         num_workers: int,
         address: str,
         legacy: bool,
+        log_setup: Callable[[], None] | None = None,
     ) -> None:
         self.server_kwargs = server_kwargs
         self.num_workers = num_workers
         self.legacy = legacy
+        self.log_setup = log_setup
         self.session = uuid.uuid4().hex[:12]
         self.workers: list[dict] = []
 
@@ -111,6 +117,7 @@ class EnvServerPool:
                     address=address,
                     death_pipe=child_conn,
                     legacy=self.legacy,
+                    log_setup=self.log_setup,
                 ),
                 daemon=False,
             )
@@ -207,6 +214,7 @@ def serve_env(
     legacy: bool = False,
     address: str = "tcp://127.0.0.1:5000",
     address_queue=None,
+    log_setup: Callable[[], None] | None = None,
     **server_kwargs,
 ) -> None:
     """Serve one env over ZMQ: a single in-process `EnvServer` when `num_workers <= 1`,
@@ -217,16 +225,22 @@ def serve_env(
     A native env config may be passed as `config` (an object) or `config_data` (the
     picklable dict from `env_config_data`, for callers that spawn this function and so
     can't pickle a dynamically-narrowed config type); legacy passes `env_id`/`env_args`/
-    `extra_env_kwargs`."""
+    `extra_env_kwargs`.
+
+    `log_setup` (a picklable callable) configures logging for this process and every
+    spawned worker — without it a spawned server inherits no handlers and its INFO logs
+    (rollout start/done, the pool line) are silently dropped."""
     # SIGTERM -> KeyboardInterrupt so a killed server runs its teardown (pool: kill the
     # workers; single: close clients).
     signal.signal(signal.SIGTERM, lambda *_: (_ for _ in ()).throw(KeyboardInterrupt()))
+    if log_setup is not None:
+        log_setup()
     if num_workers > 1:
         if (
             "config" in server_kwargs
         ):  # dict-ify for the workers (config_data is picklable)
             server_kwargs = {"config_data": env_config_data(server_kwargs["config"])}
-        pool = EnvServerPool(server_kwargs, num_workers, address, legacy)
+        pool = EnvServerPool(server_kwargs, num_workers, address, legacy, log_setup)
         if address_queue is not None:
             address_queue.put(pool.address)
         asyncio.run(pool.run())


### PR DESCRIPTION
## Summary

Restores per-rollout logging in the env-server worker pool. Pool worker processes — and the eval CLI's spawned broker — start as fresh `spawn` interpreters with **no logging handlers**, so their `INFO` logs were silently dropped even though rollouts ran fine. The lost lines are the ones we lean on for debugging: `rollout start` / `rollout done: reward=… turns=… stop=…`, the `ProgramError`/context-exceed warnings, and `EnvServer`/`EnvServerPool up`.

- **`serve/pool.py`** — `serve_env` takes an optional picklable `log_setup` callable, applies it in its own process (the broker / in-process server) and threads it to every worker (`EnvServerPool` → `_worker_entry`, called before `run_server`). Default `None` keeps the library silent-by-default.
- **`cli/runner.py` / `cli/serve.py`** — the eval and serve CLIs pass `partial(setup_logging, level)`, so the spawned broker + workers get the same loguru setup the main process uses.

A worker inherits the broker's `stdout`/`stderr`, so its logs land wherever the broker's already go (terminal for the CLIs; the env log file for prime-rl, see the companion PR) — no new file paths or per-worker files.

## Verification

`eval gsm8k-v1 --num_workers 2 --rich false --num_rollouts 4` (subprocess runtime) — the previously-dropped worker logs now surface:

```
INFO EnvServerPool up: address=tcp://127.0.0.1:42355 workers=2
INFO EnvServer up: taskset=gsm8k-v1 address=ipc:///tmp/vf-pool-...-0 tasks=1319 group_scoring=False
INFO EnvServer up: taskset=gsm8k-v1 address=ipc:///tmp/vf-pool-...-1 tasks=1319 group_scoring=False
INFO rollout start: id=44d2... task=0 harness=default runtime=subprocess
... (4 starts)
INFO rollout done: id=7769... task=0 reward=1.000 turns=1 stop=agent_completed
... (4 dones)
```

`ruff` clean.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Configure logging in spawned env-server worker processes
> Spawned worker processes previously inherited no logging configuration, so their logs were silently dropped. A `log_setup` callable (built via `functools.partial` from `setup_logging`) is now passed through `serve_env` → `EnvServerPool` → `_worker_entry`, where it is invoked at process start. Both the [runner](https://github.com/PrimeIntellect-ai/verifiers/pull/1626/files#diff-3d708e6dbc4cd4b549bfca1be17b1385b52b7cd03992bf82522e225f4aaaadbf) and [serve CLI](https://github.com/PrimeIntellect-ai/verifiers/pull/1626/files#diff-7e6a6940db5ce75a0def6f6ecb54bc3c73d5f14e051adbe257114e0217bdb107) construct this callable from the configured verbosity level, so all workers log at the same level as the main process.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3df34ba.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change with optional default; no rollout, routing, or protocol behavior changes.
> 
> **Overview**
> Adds optional **`log_setup`** plumbing so **spawned env-server broker and worker processes** configure logging the same way as the main CLI process.
> 
> `serve_env` accepts a picklable `log_setup` callable, invokes it in the broker/single-server process, and passes it into **`EnvServerPool`** and **`_worker_entry`** so each fresh `spawn` worker runs it before `run_server`. Default **`None`** preserves silent-by-default library behavior.
> 
> The **eval** (`run_eval_server`) and **serve** CLIs pass **`partial(setup_logging, level)`** (from `--verbose`), restoring previously dropped worker **`INFO`** lines such as pool startup, `EnvServer up`, and per-rollout start/done.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3df34ba5e1921eca3237b61ac42448071f6ecf79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->