### PR TITLE
fix(v1): fall back to provider usage for dashboard token counts

### DIFF
--- a/verifiers/v1/cli/dashboard.py
+++ b/verifiers/v1/cli/dashboard.py
@@ -79,12 +79,19 @@ def _tokens(trace: Trace) -> str:
     """Input/output tokens for the main branch: output is every assistant (completion)
     token generated across the branch's turns; input is the last turn's prompt — the full
     final context the model saw. (Output can exceed the final context — reasoning tokens
-    count toward completions but aren't re-fed — so it's not derived by subtraction.)"""
+    count toward completions but aren't re-fed — so it's not derived by subtraction.)
+
+    Prefers the token-id counts; falls back to provider-reported usage when the endpoint
+    returns no token ids (e.g. plain OpenAI completions), so the counts aren't shown as 0/0."""
     branches = trace.branches
     if not branches or not branches[0].nodes:
         return ""
     b = branches[0]
-    return f"{format_count(b.prompt_len)}/{format_count(b.completion_len)} tokens"
+    prompt = b.prompt_len or b.num_prompt_tokens
+    completion = b.completion_len or b.num_completion_tokens
+    if not prompt and not completion:
+        return ""
+    return f"{format_count(prompt)}/{format_count(completion)} tokens"
 
 
 def _groups(rollouts: list[Rollout]) -> list[list[Rollout]]:

--- a/verifiers/v1/graph.py
+++ b/verifiers/v1/graph.py
@@ -31,6 +31,7 @@ from verifiers.v1.types import (
     Response,
     StrictBaseModel,
     ToolMessage,
+    Usage,
 )
 
 if TYPE_CHECKING:
@@ -63,6 +64,10 @@ class MessageNode(StrictBaseModel):
     multi_modal_data: MultiModalData | None = Field(default=None, exclude=True)
     """The renderer items for the images this message's content introduces. Transient
     (excluded from wire/disk); `Branch.multi_modal_data` concatenates them along the path."""
+    usage: Usage | None = Field(default=None, exclude=True)
+    """Provider-reported token usage for this message's response (assistant nodes). Transient
+    (excluded from wire/disk); lets the live dashboard show token counts even when the endpoint
+    returns no token ids (so `token_ids` is empty)."""
 
     model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
 
@@ -222,6 +227,7 @@ def add_turn(trace: "Trace", prompt: "list[Message]", response: Response) -> Non
             mask=[False] * len(gen_prompt) + [True] * len(comp_ids),
             logprobs=list(tokens.completion_logprobs) if tokens else [],
             finish_reason=response.finish_reason,
+            usage=response.usage,
         )
     )
     # Register the assistant so the next turn's prompt (which restates it) reuses this node.

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -145,6 +145,21 @@ class Branch(StrictBaseModel):
         )
         return self.total_tokens - last_completion
 
+    @property
+    def num_prompt_tokens(self) -> int:
+        """Final-turn input tokens from provider-reported usage — a fallback for display when
+        the endpoint returns no token ids (so `prompt_len` is 0); 0 if no usage was reported."""
+        last = next(
+            (n.usage for n in reversed(self.nodes) if n.usage is not None), None
+        )
+        return last.prompt_tokens if last else 0
+
+    @property
+    def num_completion_tokens(self) -> int:
+        """All completion tokens across the branch from provider-reported usage — a fallback for
+        display when the endpoint returns no token ids; 0 if no usage was reported."""
+        return sum(n.usage.completion_tokens for n in self.nodes if n.usage is not None)
+
 
 class Trace(StrictBaseModel, Generic[TaskT]):
     """The full record of one rollout. Subclass to add typed fields."""


### PR DESCRIPTION
## Summary

- The `--rich` eval dashboard showed `0/0 tokens` per rollout for endpoints that don't return token ids (e.g. plain OpenAI completions through an inference gateway): `_tokens` derived its counts from the branch's token-id lengths, which are empty there.
- Carry the response's `usage` onto the assistant `MessageNode` as a transient (`exclude=True`) sidecar — same pattern as the multimodal sidecar, never written to wire / `results.jsonl`.
- Add `Branch.num_prompt_tokens` / `num_completion_tokens` (usage-based) and have `_tokens` fall back to them when token ids are absent. Semantics preserved: input = the final turn's prompt tokens (full final context), output = the sum of completion tokens across every turn.
- The renderer path (token ids present) is unchanged — token-id counts take precedence; usage is only the fallback.
- Regression from #1606 (delta-native message graph), which switched `_tokens` off `response.usage` onto token-id lengths.

## Verification

Synthetic OpenAI-style trace (usage reported, `response.tokens=None`) driven through the real `add_turn` → `_tokens`:

- Before: `0/0 tokens`
- After: `100/20 tokens` — input = final turn's `usage.prompt_tokens`, output = summed `usage.completion_tokens`

`ruff check` and `ruff format --check` pass on the three changed files.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fall back to provider usage for token counts in dashboard when token IDs are unavailable
> - Adds a `usage` field to `MessageNode` in [graph.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1627/files#diff-64c9d635eb215902a512c9e8ab316fd9b9967c36db03d4049aacc812cdfbd740) to store provider-reported token usage for assistant responses (excluded from serialization); populates it in `add_turn`.
> - Adds `num_prompt_tokens` and `num_completion_tokens` properties to `Branch` in [trace.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1627/files#diff-834820c3aa80d87ee1c1c57fb54c74f09c66ac727036d964e6005c8613c00b5e) that derive counts from provider usage when token IDs are absent.
> - Updates the `_tokens` helper in [dashboard.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1627/files#diff-c60769cf42a5e4975c5dc5a0f893c697282abd7d848c02c6229b8b5cc42b2bad) to prefer token-ID-derived counts but fall back to provider usage, returning an empty string when both are missing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 76d9e9c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only fallback in the live dashboard; usage is excluded from persistence and token-id counts still win when present.
> 
> **Overview**
> Fixes the **`--rich` eval dashboard** showing **`0/0 tokens`** when the inference endpoint returns provider **`usage`** but no token ids (e.g. plain OpenAI completions).
> 
> **`MessageNode`** now keeps a transient **`usage`** sidecar (same pattern as multimodal data, **`exclude=True`**), set in **`add_turn`** from **`response.usage`**. **`Branch`** adds **`num_prompt_tokens`** (last assistant turn’s reported prompt) and **`num_completion_tokens`** (sum across turns). **`_tokens`** prefers existing token-id-based **`prompt_len`** / **`completion_len`**, falls back to those usage properties, and omits the token column when both are zero.
> 
> The renderer path with token ids is unchanged; usage is display-only and not persisted to wire / **`results.jsonl`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76d9e9c7e670ab1f30b6666fd9badc09cce6ea3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->