### PR TITLE
fix: reap the whole subprocess tree when a runtime run is cancelled

### DIFF
--- a/verifiers/v1/runtimes/subprocess.py
+++ b/verifiers/v1/runtimes/subprocess.py
@@ -25,14 +25,6 @@ from verifiers.v1.runtimes.base import ProgramResult, Runtime
 # allow-by-default model is subprocess-only.
 
 
-def _killpg(proc: asyncio.subprocess.Process, sig: int) -> None:
-    """Signal the process's whole group, reaping any children it spawned (the `sh -> uv ->
-    python` tree a uv script becomes). The process is started with its own session
-    (`start_new_session`), so its pgid is its pid. Best-effort — the group may already be gone."""
-    with contextlib.suppress(ProcessLookupError, PermissionError):
-        os.killpg(os.getpgid(proc.pid), sig)
-
-
 class SubprocessConfig(BaseConfig):
     type: Literal["subprocess"] = "subprocess"
 
@@ -70,10 +62,12 @@ class SubprocessRuntime(Runtime):
         finally:
             # If the await didn't finish, the caller cancelled it (e.g. the rollout's
             # scoring_timeout / harness_timeout fired): communicate() leaves the process
-            # running, so SIGKILL the whole group — otherwise a hung child (a wedged uv/sympy
-            # verify) outlives the rollout and leaks CPU. A no-op once it has exited on its own.
+            # running, so SIGKILL its whole group (start_new_session => pgid == pid) — otherwise
+            # a hung child (a wedged uv/sympy verify) outlives the rollout and leaks CPU. A
+            # no-op once it has exited on its own.
             if proc.returncode is None:
-                _killpg(proc, signal.SIGKILL)
+                with contextlib.suppress(ProcessLookupError, PermissionError):
+                    os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
         return ProgramResult(
             exit_code=proc.returncode or 0,
             stdout=stdout.decode(errors="replace"),
@@ -111,7 +105,10 @@ class SubprocessRuntime(Runtime):
 
     def cleanup(self) -> None:
         for proc in self._background:
-            _killpg(proc, signal.SIGTERM)
+            # Kill the whole group (start_new_session => pgid == pid), not just proc.pid, so a
+            # background server's children (sh -> uv -> python) are reaped too.
+            with contextlib.suppress(ProcessLookupError, PermissionError):
+                os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
         self._background = []
         if self.workdir is not None:
             shutil.rmtree(self.workdir, ignore_errors=True)

--- a/verifiers/v1/runtimes/subprocess.py
+++ b/verifiers/v1/runtimes/subprocess.py
@@ -25,6 +25,14 @@ from verifiers.v1.runtimes.base import ProgramResult, Runtime
 # allow-by-default model is subprocess-only.
 
 
+def _killpg(proc: asyncio.subprocess.Process, sig: int) -> None:
+    """Signal the process's whole group, reaping any children it spawned (the `sh -> uv ->
+    python` tree a uv script becomes). The process is started with its own session
+    (`start_new_session`), so its pgid is its pid. Best-effort — the group may already be gone."""
+    with contextlib.suppress(ProcessLookupError, PermissionError):
+        os.killpg(os.getpgid(proc.pid), sig)
+
+
 class SubprocessConfig(BaseConfig):
     type: Literal["subprocess"] = "subprocess"
 
@@ -55,8 +63,17 @@ class SubprocessRuntime(Runtime):
             cwd=self.workdir,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            start_new_session=True,  # own process group, so we can reap the whole tree
         )
-        stdout, stderr = await proc.communicate()
+        try:
+            stdout, stderr = await proc.communicate()
+        finally:
+            # If the await didn't finish, the caller cancelled it (e.g. the rollout's
+            # scoring_timeout / harness_timeout fired): communicate() leaves the process
+            # running, so SIGKILL the whole group — otherwise a hung child (a wedged uv/sympy
+            # verify) outlives the rollout and leaks CPU. A no-op once it has exited on its own.
+            if proc.returncode is None:
+                _killpg(proc, signal.SIGKILL)
         return ProgramResult(
             exit_code=proc.returncode or 0,
             stdout=stdout.decode(errors="replace"),
@@ -78,6 +95,7 @@ class SubprocessRuntime(Runtime):
                 cwd=self.workdir,
                 stdout=f,
                 stderr=asyncio.subprocess.STDOUT,
+                start_new_session=True,  # own process group, so cleanup() reaps the whole tree
             )
         self._background.append(
             proc
@@ -93,8 +111,7 @@ class SubprocessRuntime(Runtime):
 
     def cleanup(self) -> None:
         for proc in self._background:
-            with contextlib.suppress(ProcessLookupError, OSError):
-                os.kill(proc.pid, signal.SIGTERM)
+            _killpg(proc, signal.SIGTERM)
         self._background = []
         if self.workdir is not None:
             shutil.rmtree(self.workdir, ignore_errors=True)


### PR DESCRIPTION
## Summary

When a rollout's `scoring_timeout` (or `harness_timeout`) fires, `asyncio.wait_for` cancels the `SubprocessRuntime.run()` that's awaiting `proc.communicate()` — which releases the rollout's permit, but **left the subprocess running**. `cleanup()` only signalled `proc.pid`, never the `sh → uv → python` tree a uv script becomes. So a hung child — e.g. a wedged `uv`/`math-verify` scoring process whose own signal-based (`SIGALRM`) timeout was defeated by a non-yielding C call — **outlived its rollout and kept burning CPU**. Enough of these accumulate and stall the run (the sudden math-env step-time spikes / "grind to a halt").

This makes the subprocess runtime reap whole process trees:
- Spawn every child in its own session (`start_new_session=True`) so its process group is reapable.
- `run()`: on cancel/incomplete exit, `os.killpg(SIGKILL)` the group (a no-op once the program exited on its own).
- `cleanup()`: `os.killpg(SIGTERM)` the background servers' groups instead of just `proc.pid`.

Net effect: a bounded `scoring_timeout`/`harness_timeout` now releases the permit **and** the CPU. Pair it with setting `timeout.scoring` (≈ 2–3× `math_verify_timeout`) — the timeout provides the bound, this change makes the bound actually reap the work.

Only the subprocess runtime is affected: docker/prime already tear down the in-container process tree when the per-rollout container/sandbox is removed; subprocess children run on the host and outlive the cancel.

## Verification

Isolation test: 12 concurrent "rollouts" whose scorer hangs (real `SubprocessRuntime.run_uv_script`), measuring orphaned process trees left behind.

| | scoring_timeout=None (outer cancel) | scoring_timeout=5s |
|---|---|---|
| before | 24 orphaned trees | 24 orphaned trees |
| after | **0** | **0** (rollouts release in 5s) |


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Kill the entire subprocess tree when a runtime run is cancelled
> - Foreground subprocesses in `SubprocessRuntime.run` now start in their own session/process group (`start_new_session=True`). If the task is cancelled before the child exits, `SIGKILL` is sent to the entire process group, preventing orphaned descendants.
> - Background subprocesses in `run_background` also start with `start_new_session=True` so they form their own process group.
> - `cleanup()` now resolves the child's process group ID and sends `SIGTERM` to the whole group instead of only the direct child PID.
> - Both signal calls suppress `ProcessLookupError` and `PermissionError` for already-exited processes.
> - Risk: processes that previously survived cancellation will now be forcibly killed; any cleanup logic inside those child processes will not run.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 064f710.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes process lifecycle and signal handling on the host subprocess path; mis-grouping could affect unrelated processes, though `start_new_session` limits scope to each spawned tree.
> 
> **Overview**
> Fixes **orphaned host subprocess trees** when rollouts are cancelled by `scoring_timeout` / `harness_timeout`: cancelling `SubprocessRuntime.run()` during `communicate()` used to drop the await but leave children (e.g. `sh → uv → python`) running and leaking CPU.
> 
> **`SubprocessRuntime`** now spawns with `start_new_session=True` so each run has its own process group. **`run()`** wraps `communicate()` in `try/finally` and **`SIGKILL`s the whole group** via `os.killpg` if the process is still alive when the await ends (including cancellation). **`run_background()`** uses the same session flag, and **`cleanup()`** signals **`SIGTERM` to the process group** instead of only the top-level PID.
> 
> Scope is **subprocess runtime only**; container/docker runtimes already tear down trees with the sandbox.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 064f71082e9105e0199194a5d6a3def9e7fc6edc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->