### PR TITLE
feat: elastic env-server pool (static/elastic pool config)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -4609,7 +4609,7 @@ wheels = [
 
 [[package]]
 name = "renderers"
-version = "0.1.8.dev28"
+version = "0.1.8.dev43"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastokens" },
@@ -4621,9 +4621,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "transformers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ea/73/44de1aaf8e2e1f891d7773760cf6fb9049009aee9f70904ccb4505210762/renderers-0.1.8.dev28.tar.gz", hash = "sha256:0dd6c74173d78f181411250815f3eeac85c1e9edee5c9d9ad2648842460b903f", size = 293084, upload-time = "2026-05-25T23:51:49.913Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/ab/3c55e9476064554931c6faa890353dbb497210f744631390e44deb3f9f70/renderers-0.1.8.dev43.tar.gz", hash = "sha256:2961647fc36f7497275c4e64538f044038a86c079384515afe7bbfa2e8062b22", size = 316761, upload-time = "2026-06-10T00:04:09.869Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4f/e7/a15449f2e9b223867c9d628b662b93f88f719ea1cc532ea16f7728d9b513/renderers-0.1.8.dev28-py3-none-any.whl", hash = "sha256:53574dfb3ee71c4589153fb693343d032f44f08b11ea693167ff1b3e3a254329", size = 153774, upload-time = "2026-05-25T23:51:48.541Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/17/38e64015955d20ef26147ed3667eb5aa9e613a133ff0274ab072bbcbb796/renderers-0.1.8.dev43-py3-none-any.whl", hash = "sha256:ffef914ebddd0691cba33997ef46f2340a2981b5bad0090aa4d6f788c5e7fde7", size = 170410, upload-time = "2026-06-10T00:04:08.318Z" },
 ]
 
 [[package]]
@@ -5837,8 +5837,8 @@ requires-dist = [
     { name = "pyzmq", specifier = ">=27.1.0" },
     { name = "reasoning-gym", marker = "extra == 'rg'" },
     { name = "regex", specifier = "<2026.4.4" },
-    { name = "renderers", specifier = ">=0.1.8.dev28" },
-    { name = "renderers", marker = "extra == 'renderers'", specifier = ">=0.1.8.dev28" },
+    { name = "renderers", specifier = ">=0.1.8.dev40" },
+    { name = "renderers", marker = "extra == 'renderers'", specifier = ">=0.1.8.dev40" },
     { name = "requests" },
     { name = "requests", marker = "extra == 'rl'" },
     { name = "rich" },

--- a/verifiers/v1/__init__.py
+++ b/verifiers/v1/__init__.py
@@ -23,6 +23,7 @@ from verifiers.v1.env import (
     Environment,
     StaticPoolConfig,
     TimeoutConfig,
+    pool_serve_kwargs,
 )
 from verifiers.v1.episode import Episode
 from verifiers.v1.errors import ModelError, ProgramError, RolloutError, ToolError
@@ -147,6 +148,7 @@ __all__ = [
     "EnvServerConfig",
     "StaticPoolConfig",
     "ElasticPoolConfig",
+    "pool_serve_kwargs",
     "RetryConfig",
     "TimeoutConfig",
     "Episode",

--- a/verifiers/v1/__init__.py
+++ b/verifiers/v1/__init__.py
@@ -16,7 +16,14 @@ from verifiers.v1.clients import (
     resolve_client,
 )
 from verifiers.v1.decorators import group_reward, metric, reward, stop
-from verifiers.v1.env import EnvConfig, Environment, TimeoutConfig
+from verifiers.v1.env import (
+    ElasticPoolConfig,
+    EnvConfig,
+    EnvServerConfig,
+    Environment,
+    StaticPoolConfig,
+    TimeoutConfig,
+)
 from verifiers.v1.episode import Episode
 from verifiers.v1.errors import ModelError, ProgramError, RolloutError, ToolError
 from verifiers.v1.harness import Harness, HarnessConfig
@@ -137,6 +144,9 @@ __all__ = [
     "PrimeConfig",
     "Environment",
     "EnvConfig",
+    "EnvServerConfig",
+    "StaticPoolConfig",
+    "ElasticPoolConfig",
     "RetryConfig",
     "TimeoutConfig",
     "Episode",

--- a/verifiers/v1/cli/eval.py
+++ b/verifiers/v1/cli/eval.py
@@ -61,31 +61,27 @@ def main(argv: list[str] | None = None) -> None:
     if config.dry_run:  # resolved + validated; dump it and skip the run
         print(config.model_dump_json(indent=2, exclude_none=True))
         return
-    # Drive rollouts through the env server unless num_workers is 0 (run in-process here).
-    # None = unbounded pool; >0 = up to that many workers.
-    server_backed = config.num_workers != 0
-    # The --rich dashboard reads live v1 Rollout state, so it's off for a legacy or
-    # server-backed (worker-pool) run — neither runs rollouts in this process.
-    rich = config.rich and not config.is_legacy and not server_backed
+    # The --rich dashboard reads live v1 Rollout state, so it needs the in-process path; a
+    # plain (non-rich) v1 run goes through the env server using `pool` (the path prime-rl
+    # trains through). Legacy always runs in-process via the bridge.
+    rich = config.rich and not config.is_legacy
     # --rich owns the screen, so quiet the per-rollout INFO logs it would replace.
     setup_logging("DEBUG" if config.verbose else "WARNING" if rich else "INFO")
     # Make SIGTERM behave like Ctrl-C (SIGINT) so a killed/timed-out eval still runs each
     # rollout's `finally` (tears down containers/sandboxes) and any worker pool it spawned.
     signal.signal(signal.SIGTERM, lambda *_: (_ for _ in ()).throw(KeyboardInterrupt()))
 
-    if server_backed:  # a worker pool runs rollouts (v1 or legacy)
-        from verifiers.v1.cli.runner import run_eval_server
-
-        traces = asyncio.run(run_eval_server(config))
-    elif (
-        config.is_legacy
-    ):  # v0 backwards-compat: run the classic env, bridged to Traces
+    if config.is_legacy:  # v0 backwards-compat: run the classic env, bridged to Traces
         from verifiers.v1.legacy import run_legacy_eval
 
         traces = asyncio.run(run_legacy_eval(config))
-    else:
+    elif rich:  # in-process for the live dashboard
         env = vf.Environment(config)
         traces = asyncio.run(run_eval(env, config))
+    else:  # drive rollouts through the env server's worker pool
+        from verifiers.v1.cli.runner import run_eval_server
+
+        traces = asyncio.run(run_eval_server(config))
     if not rich:  # --rich is the whole output; otherwise dump each trace as JSON
         for trace in traces:
             print(trace.model_dump_json(indent=2, exclude_none=True))

--- a/verifiers/v1/cli/eval.py
+++ b/verifiers/v1/cli/eval.py
@@ -61,18 +61,19 @@ def main(argv: list[str] | None = None) -> None:
     if config.dry_run:  # resolved + validated; dump it and skip the run
         print(config.model_dump_json(indent=2, exclude_none=True))
         return
+    # Drive rollouts through the env server unless num_workers is 0 (run in-process here).
+    # None = unbounded pool; >0 = up to that many workers.
+    server_backed = config.num_workers != 0
     # The --rich dashboard reads live v1 Rollout state, so it's off for a legacy or
     # server-backed (worker-pool) run — neither runs rollouts in this process.
-    rich = config.rich and not config.is_legacy and not config.num_workers
+    rich = config.rich and not config.is_legacy and not server_backed
     # --rich owns the screen, so quiet the per-rollout INFO logs it would replace.
     setup_logging("DEBUG" if config.verbose else "WARNING" if rich else "INFO")
     # Make SIGTERM behave like Ctrl-C (SIGINT) so a killed/timed-out eval still runs each
     # rollout's `finally` (tears down containers/sandboxes) and any worker pool it spawned.
     signal.signal(signal.SIGTERM, lambda *_: (_ for _ in ()).throw(KeyboardInterrupt()))
 
-    if (
-        config.num_workers > 0
-    ):  # server-backed: a worker pool runs rollouts (v1 or legacy)
+    if server_backed:  # a worker pool runs rollouts (v1 or legacy)
         from verifiers.v1.cli.runner import run_eval_server
 
         traces = asyncio.run(run_eval_server(config))

--- a/verifiers/v1/cli/runner.py
+++ b/verifiers/v1/cli/runner.py
@@ -80,6 +80,7 @@ async def run_eval_server(config: EvalConfig) -> list[Trace]:
     from functools import partial
 
     from verifiers.v1.cli.log import setup_logging
+    from verifiers.v1.env import pool_serve_kwargs
     from verifiers.v1.serve import EnvClient, env_config_data, serve_env
 
     legacy = config.is_legacy
@@ -100,13 +101,11 @@ async def run_eval_server(config: EvalConfig) -> list[Trace]:
     proc = mpctx.Process(
         target=serve_env,
         kwargs=dict(
-            max_workers=config.num_workers,
+            **pool_serve_kwargs(config.pool),
             legacy=legacy,
             address="tcp://127.0.0.1:0",
             address_queue=address_queue,
             log_setup=partial(setup_logging, level),
-            worker_multiplex=config.worker_multiplex,
-            elastic=config.elastic,
             **server_kwargs,
         ),
         daemon=False,
@@ -123,10 +122,10 @@ async def run_eval_server(config: EvalConfig) -> list[Trace]:
         if config.num_tasks is not None:
             idxs = idxs[: config.num_tasks]
         logger.info(
-            "running %dx%d rollouts via the env-server pool (max_workers=%s) on %s",
+            "running %dx%d rollouts via the env-server %s pool on %s",
             len(idxs),
             config.num_rollouts,
-            "inf" if config.num_workers is None else config.num_workers,
+            config.pool.type,
             config.model,
         )
         out = output_path(config)

--- a/verifiers/v1/cli/runner.py
+++ b/verifiers/v1/cli/runner.py
@@ -100,12 +100,13 @@ async def run_eval_server(config: EvalConfig) -> list[Trace]:
     proc = mpctx.Process(
         target=serve_env,
         kwargs=dict(
-            num_workers=config.num_workers,
+            max_workers=config.num_workers,
             legacy=legacy,
             address="tcp://127.0.0.1:0",
             address_queue=address_queue,
             log_setup=partial(setup_logging, level),
-            multiplex=config.multiplex,
+            worker_multiplex=config.worker_multiplex,
+            elastic=config.elastic,
             **server_kwargs,
         ),
         daemon=False,
@@ -122,10 +123,10 @@ async def run_eval_server(config: EvalConfig) -> list[Trace]:
         if config.num_tasks is not None:
             idxs = idxs[: config.num_tasks]
         logger.info(
-            "running %dx%d rollouts via a %d-worker pool on %s",
+            "running %dx%d rollouts via the env-server pool (max_workers=%s) on %s",
             len(idxs),
             config.num_rollouts,
-            config.num_workers,
+            "inf" if config.num_workers is None else config.num_workers,
             config.model,
         )
         out = output_path(config)

--- a/verifiers/v1/cli/runner.py
+++ b/verifiers/v1/cli/runner.py
@@ -105,6 +105,7 @@ async def run_eval_server(config: EvalConfig) -> list[Trace]:
             address="tcp://127.0.0.1:0",
             address_queue=address_queue,
             log_setup=partial(setup_logging, level),
+            multiplex=config.multiplex,
             **server_kwargs,
         ),
         daemon=False,

--- a/verifiers/v1/cli/serve.py
+++ b/verifiers/v1/cli/serve.py
@@ -74,5 +74,6 @@ def main(argv: list[str] | None = None) -> None:
         legacy=config.is_legacy,
         address=config.address,
         log_setup=partial(setup_logging, level),
+        multiplex=config.multiplex,
         **server_kwargs,
     )

--- a/verifiers/v1/cli/serve.py
+++ b/verifiers/v1/cli/serve.py
@@ -56,10 +56,10 @@ def main(argv: list[str] | None = None) -> None:
     level = "DEBUG" if config.verbose else "INFO"
     setup_logging(level)
 
-    # A single in-process server (num_workers=1) or a router + worker pool (>1); the
-    # frontend speaks the same protocol either way. serve_env owns the SIGTERM teardown.
-    # Pool workers are spawned with no logging, so hand serve_env the same setup to apply
-    # in each one.
+    # A single in-process server (num_workers<=1) or a router + worker pool (>1, or None for
+    # unbounded); the frontend speaks the same protocol either way. serve_env owns the
+    # SIGTERM teardown. Pool workers are spawned with no logging, so hand serve_env the same
+    # setup to apply in each one.
     server_kwargs = (
         {
             "env_id": config.id,
@@ -70,10 +70,11 @@ def main(argv: list[str] | None = None) -> None:
         else {"config": config}
     )
     serve_env(
-        num_workers=config.num_workers,
+        max_workers=config.num_workers,
         legacy=config.is_legacy,
         address=config.address,
         log_setup=partial(setup_logging, level),
-        multiplex=config.multiplex,
+        worker_multiplex=config.worker_multiplex,
+        elastic=config.elastic,
         **server_kwargs,
     )

--- a/verifiers/v1/cli/serve.py
+++ b/verifiers/v1/cli/serve.py
@@ -19,7 +19,8 @@ from verifiers.v1.cli.resolve import (
     references_config_file,
     with_positional_taskset,
 )
-from verifiers.v1.configs.serve import EnvServerConfig
+from verifiers.v1.configs.serve import ServeConfig
+from verifiers.v1.env import pool_serve_kwargs
 from verifiers.v1.serve import serve_env
 
 USAGE = "usage: uv run serve [<taskset-id>] [--harness.id <id>] [--id <env-id> (legacy)] [options] [@ file.toml]"
@@ -35,7 +36,7 @@ def main(argv: list[str] | None = None) -> None:
             if local:
                 print(f"example {kind}:", ", ".join(local))
         sys.argv = [sys.argv[0], "--help"]
-        cli(narrow_config(EnvServerConfig, argv))
+        cli(narrow_config(ServeConfig, argv))
         return
     legacy_id = any(a == "--id" or a.startswith("--id=") for a in argv)  # v0 env id
     if (
@@ -47,7 +48,7 @@ def main(argv: list[str] | None = None) -> None:
             USAGE
         )  # need a --taskset.id (v1), a legacy --id (v0), or @ file.toml
 
-    config_type = narrow_config(EnvServerConfig, argv)
+    config_type = narrow_config(ServeConfig, argv)
     sys.argv = [sys.argv[0], *argv]
     config = cli(config_type)
     if config.dry_run:
@@ -56,10 +57,10 @@ def main(argv: list[str] | None = None) -> None:
     level = "DEBUG" if config.verbose else "INFO"
     setup_logging(level)
 
-    # A single in-process server (num_workers<=1) or a router + worker pool (>1, or None for
-    # unbounded); the frontend speaks the same protocol either way. serve_env owns the
-    # SIGTERM teardown. Pool workers are spawned with no logging, so hand serve_env the same
-    # setup to apply in each one.
+    # The pool config decides in-process vs router + worker pool (static or elastic); the
+    # frontend speaks the same protocol either way. serve_env owns the SIGTERM teardown.
+    # Pool workers are spawned with no logging, so hand serve_env the same setup to apply
+    # in each one.
     server_kwargs = (
         {
             "env_id": config.id,
@@ -70,11 +71,9 @@ def main(argv: list[str] | None = None) -> None:
         else {"config": config}
     )
     serve_env(
-        max_workers=config.num_workers,
+        **pool_serve_kwargs(config.pool),
         legacy=config.is_legacy,
         address=config.address,
         log_setup=partial(setup_logging, level),
-        worker_multiplex=config.worker_multiplex,
-        elastic=config.elastic,
         **server_kwargs,
     )

--- a/verifiers/v1/configs/__init__.py
+++ b/verifiers/v1/configs/__init__.py
@@ -1,6 +1,6 @@
 """Config schemas for the v1 entrypoints — the objects the CLIs parse."""
 
 from verifiers.v1.configs.eval import EvalConfig
-from verifiers.v1.configs.serve import EnvServerConfig
+from verifiers.v1.configs.serve import ServeConfig
 
-__all__ = ["EvalConfig", "EnvServerConfig"]
+__all__ = ["EvalConfig", "ServeConfig"]

--- a/verifiers/v1/configs/eval.py
+++ b/verifiers/v1/configs/eval.py
@@ -44,9 +44,13 @@ class EvalConfig(EnvConfig):
     )
     """Max rollouts in flight at once."""
     num_workers: int = Field(0, validation_alias=AliasChoices("num_workers", "w"))
-    """Run the eval through an env-server worker pool of this many processes (0 = off,
+    """Run the eval through an env-server worker pool of up to this many processes (0 = off,
     in-process). >0 spawns the router + workers and drives rollouts over ZMQ — the same
-    path prime-rl trains through, so it exercises the pool e2e for v1 and legacy v0 envs."""
+    path prime-rl trains through, so it exercises the pool e2e for v1 and legacy v0 envs.
+    The pool starts at one worker and scales up to this cap on demand."""
+    multiplex: int = 128
+    """Per-worker capacity for the pool's scale-up trigger: it spawns the next worker once
+    in-flight rollouts reach 90% of `workers * multiplex` (until `num_workers` is hit)."""
     verbose: bool = Field(False, validation_alias=AliasChoices("verbose", "v"))
     """Log at debug level instead of the default info."""
     dry_run: bool = False

--- a/verifiers/v1/configs/eval.py
+++ b/verifiers/v1/configs/eval.py
@@ -6,15 +6,16 @@ from uuid import uuid4
 from pydantic import AliasChoices, Field
 
 from verifiers.v1.clients import ClientConfig, OpenAIClientConfig
-from verifiers.v1.env import EnvConfig
+from verifiers.v1.env import EnvServerConfig
 from verifiers.v1.types import SamplingConfig
 
 
-class EvalConfig(EnvConfig):
+class EvalConfig(EnvServerConfig):
     """The eval run plus its environment: inherits the env's fields (`taskset`, `harness`,
-    `max_turns`, token limits, timeouts) so they're top-level flags (`--taskset.id`, `--harness.id`,
-    `--harness.runtime.*`, …) with no `--env.` prefix, and adds the run knobs (model,
-    sampling, counts, …)."""
+    `max_turns`, token limits, timeouts) and the worker `pool` so they're top-level flags
+    (`--taskset.id`, `--harness.id`, `--harness.runtime.*`, `--pool.*`, …) with no `--env.`
+    prefix, and adds the run knobs (model, sampling, counts, …). A non-`--rich` run drives
+    rollouts through the env server using `pool`; `--rich` runs them in-process."""
 
     uuid: str = Field(default_factory=lambda: str(uuid4()), exclude=True)
     """Auto-generated run id — the leaf of the output dir, so runs never overwrite.
@@ -43,13 +44,6 @@ class EvalConfig(EnvConfig):
         128, validation_alias=AliasChoices("max_concurrent", "c")
     )
     """Max rollouts in flight at once."""
-    num_workers: int | None = Field(
-        0, validation_alias=AliasChoices("num_workers", "w")
-    )
-    """Drive the eval through an env server: 0 = off (run in-process); 1 = a single server
-    over ZMQ; >1 = a worker pool capped here; None = an unbounded pool. >0 exercises the
-    same path prime-rl trains through (v1 and legacy v0). With `elastic` (default) the pool
-    starts at one worker and scales up to this cap as load grows (see `worker_multiplex`)."""
     verbose: bool = Field(False, validation_alias=AliasChoices("verbose", "v"))
     """Log at debug level instead of the default info."""
     dry_run: bool = False

--- a/verifiers/v1/configs/eval.py
+++ b/verifiers/v1/configs/eval.py
@@ -43,14 +43,13 @@ class EvalConfig(EnvConfig):
         128, validation_alias=AliasChoices("max_concurrent", "c")
     )
     """Max rollouts in flight at once."""
-    num_workers: int = Field(0, validation_alias=AliasChoices("num_workers", "w"))
-    """Run the eval through an env-server worker pool of up to this many processes (0 = off,
-    in-process). >0 spawns the router + workers and drives rollouts over ZMQ — the same
-    path prime-rl trains through, so it exercises the pool e2e for v1 and legacy v0 envs.
-    The pool starts at one worker and scales up to this cap on demand."""
-    multiplex: int = 128
-    """Per-worker capacity for the pool's scale-up trigger: it spawns the next worker once
-    in-flight rollouts reach 90% of `workers * multiplex` (until `num_workers` is hit)."""
+    num_workers: int | None = Field(
+        0, validation_alias=AliasChoices("num_workers", "w")
+    )
+    """Drive the eval through an env server: 0 = off (run in-process); 1 = a single server
+    over ZMQ; >1 = a worker pool capped here; None = an unbounded pool. >0 exercises the
+    same path prime-rl trains through (v1 and legacy v0). With `elastic` (default) the pool
+    starts at one worker and scales up to this cap as load grows (see `worker_multiplex`)."""
     verbose: bool = Field(False, validation_alias=AliasChoices("verbose", "v"))
     """Log at debug level instead of the default info."""
     dry_run: bool = False

--- a/verifiers/v1/configs/serve.py
+++ b/verifiers/v1/configs/serve.py
@@ -16,12 +16,12 @@ class EnvServerConfig(EnvConfig):
         "tcp://127.0.0.1:5000", validation_alias=AliasChoices("address", "a")
     )
     """ZMQ address the ROUTER binds (and clients connect to)."""
-    num_workers: int = Field(1, validation_alias=AliasChoices("num_workers", "w"))
-    """Max worker processes in the pool (1 = a single in-process server, no pool). The pool
-    starts at one worker and scales up to this cap on demand."""
-    multiplex: int = 128
-    """Per-worker capacity for the pool's scale-up trigger: it spawns the next worker once
-    in-flight rollouts reach 90% of `workers * multiplex` (until `num_workers` is hit)."""
+    num_workers: int | None = Field(
+        1, validation_alias=AliasChoices("num_workers", "w")
+    )
+    """Max worker processes in the pool (1 = a single in-process server, no pool; None =
+    unbounded). With `elastic` (default) the pool starts at one worker and scales up to this
+    cap as load grows (see `worker_multiplex`); set `--no-elastic` to pre-spawn the pool."""
     verbose: bool = Field(False, validation_alias=AliasChoices("verbose", "v"))
     """Log at debug level instead of info."""
     dry_run: bool = False

--- a/verifiers/v1/configs/serve.py
+++ b/verifiers/v1/configs/serve.py
@@ -1,27 +1,21 @@
-"""The `EnvServerConfig`: the config the env-server CLI parses.
+"""The `ServeConfig`: the config the env-server CLI parses.
 
-Inherits `EnvConfig` (taskset + harness + timeouts + turn/token limits) so the swappable
-harness/runtime knobs are the same flags as the eval CLI (`--taskset.id`, `--harness.id`,
-`--harness.runtime.type`, `--taskset.*`), and adds only the serving knobs (bind address).
-This is the type the orchestrator embeds to drive the server.
+Inherits `EnvServerConfig` (taskset + harness + timeouts + turn/token limits + the worker
+`pool`), so the swappable harness/runtime knobs are the same flags as the eval CLI
+(`--taskset.id`, `--harness.id`, `--harness.runtime.type`, `--taskset.*`, `--pool.*`), and
+adds only the CLI-specific serving knobs (bind address, verbose, dry-run).
 """
 
 from pydantic import AliasChoices, Field
 
-from verifiers.v1.env import EnvConfig
+from verifiers.v1.env import EnvServerConfig
 
 
-class EnvServerConfig(EnvConfig):
+class ServeConfig(EnvServerConfig):
     address: str = Field(
         "tcp://127.0.0.1:5000", validation_alias=AliasChoices("address", "a")
     )
     """ZMQ address the ROUTER binds (and clients connect to)."""
-    num_workers: int | None = Field(
-        1, validation_alias=AliasChoices("num_workers", "w")
-    )
-    """Max worker processes in the pool (1 = a single in-process server, no pool; None =
-    unbounded). With `elastic` (default) the pool starts at one worker and scales up to this
-    cap as load grows (see `worker_multiplex`); set `--no-elastic` to pre-spawn the pool."""
     verbose: bool = Field(False, validation_alias=AliasChoices("verbose", "v"))
     """Log at debug level instead of info."""
     dry_run: bool = False

--- a/verifiers/v1/configs/serve.py
+++ b/verifiers/v1/configs/serve.py
@@ -17,7 +17,11 @@ class EnvServerConfig(EnvConfig):
     )
     """ZMQ address the ROUTER binds (and clients connect to)."""
     num_workers: int = Field(1, validation_alias=AliasChoices("num_workers", "w"))
-    """Worker processes in the pool (1 = a single in-process server, no pool)."""
+    """Max worker processes in the pool (1 = a single in-process server, no pool). The pool
+    starts at one worker and scales up to this cap on demand."""
+    multiplex: int = 128
+    """Per-worker capacity for the pool's scale-up trigger: it spawns the next worker once
+    in-flight rollouts reach 90% of `workers * multiplex` (until `num_workers` is hit)."""
     verbose: bool = Field(False, validation_alias=AliasChoices("verbose", "v"))
     """Log at debug level instead of info."""
     dry_run: bool = False

--- a/verifiers/v1/env.py
+++ b/verifiers/v1/env.py
@@ -13,6 +13,7 @@ compare a task's rollouts.
 
 import contextlib
 import logging
+from typing import Annotated, Literal
 
 from pydantic import Field, SerializeAsAny, model_validator
 from pydantic_config import BaseConfig
@@ -41,6 +42,42 @@ class TimeoutConfig(BaseConfig):
     """Max wall-clock for the rollout (the harness run)."""
     scoring: float | None = None
     """Max wall-clock for scoring — verify + rewards/metrics."""
+
+
+class StaticPoolConfig(BaseConfig):
+    """Fixed env-server pool: pre-spawn `num_workers` workers up front."""
+
+    type: Literal["static"] = "static"
+    num_workers: int = Field(4, ge=1)
+    """Worker processes to pre-spawn (1 = a single in-process server, no pool)."""
+
+
+class ElasticPoolConfig(BaseConfig):
+    """Elastic env-server pool: start at one worker and scale up on demand."""
+
+    type: Literal["elastic"] = "elastic"
+    max_workers: int | None = None
+    """Upper bound on workers (None = unbounded)."""
+    multiplex: int = Field(128, ge=1)
+    """Rollouts per worker for the scale-up trigger: add a worker once in-flight rollouts
+    reach 90% of `workers * multiplex`."""
+
+
+# Discriminated on `type` so the CLI selects with `--pool.type static|elastic`.
+PoolConfig = Annotated[
+    StaticPoolConfig | ElasticPoolConfig, Field(discriminator="type")
+]
+
+
+def pool_serve_kwargs(pool: StaticPoolConfig | ElasticPoolConfig) -> dict:
+    """Unpack a pool config into `serve_env` kwargs (`max_workers` / `multiplex` / `elastic`)."""
+    if isinstance(pool, ElasticPoolConfig):
+        return {
+            "max_workers": pool.max_workers,
+            "multiplex": pool.multiplex,
+            "elastic": True,
+        }
+    return {"max_workers": pool.num_workers, "elastic": False}
 
 
 class EnvConfig(BaseConfig):
@@ -73,16 +110,6 @@ class EnvConfig(BaseConfig):
     """Rollouts that share one interception server (and, behind a remote runtime, one
     tunnel). N concurrent rollouts use ~N/multiplex servers + tunnels instead of one each —
     key past the per-token tunnel cap. 1 = a server (+ tunnel) per rollout."""
-    elastic: bool = True
-    """Scale the env-server worker pool up on demand instead of pre-spawning it: start at
-    one worker and add another whenever in-flight rollouts reach 90% of
-    `workers * worker_multiplex`, up to the pool's worker cap. False pre-spawns the whole
-    pool. Only relevant when the env is served through a pool (`num_workers`/`max_workers`
-    > 1, or unbounded)."""
-    worker_multiplex: int = Field(128, ge=1)
-    """Rollouts per worker for the elastic scale-up trigger (distinct from `multiplex`,
-    which shares interception servers *within* a worker): the pool adds a worker once
-    in-flight rollouts reach 90% of `workers * worker_multiplex`."""
     # --- legacy (v0) backwards-compat -----------------------------------------
     # Run a classic `verifiers.load_environment(id, **args)` env, bridged to v1 Traces (see
     # `verifiers.v1.legacy`), instead of a v1 taskset/harness. Set `id` (leave `taskset`
@@ -130,6 +157,16 @@ class EnvConfig(BaseConfig):
             if ident:
                 data[field] = resolve(ident).model_validate({**raw, "id": ident})
         return data
+
+
+class EnvServerConfig(EnvConfig):
+    """An env plus how it's *served*: the env definition (`EnvConfig`) and the worker-pool
+    sizing. Shared by the `serve` CLI, server-backed eval, and prime-rl's orchestrator, so
+    they all configure the pool the same way (`--pool.type elastic|static`)."""
+
+    pool: PoolConfig = ElasticPoolConfig()
+    """Worker-pool sizing for the env server. `elastic` (default) starts at one worker and
+    scales up on demand; `static` pre-spawns a fixed `num_workers`."""
 
 
 logger = logging.getLogger(__name__)

--- a/verifiers/v1/env.py
+++ b/verifiers/v1/env.py
@@ -73,6 +73,16 @@ class EnvConfig(BaseConfig):
     """Rollouts that share one interception server (and, behind a remote runtime, one
     tunnel). N concurrent rollouts use ~N/multiplex servers + tunnels instead of one each —
     key past the per-token tunnel cap. 1 = a server (+ tunnel) per rollout."""
+    elastic: bool = True
+    """Scale the env-server worker pool up on demand instead of pre-spawning it: start at
+    one worker and add another whenever in-flight rollouts reach 90% of
+    `workers * worker_multiplex`, up to the pool's worker cap. False pre-spawns the whole
+    pool. Only relevant when the env is served through a pool (`num_workers`/`max_workers`
+    > 1, or unbounded)."""
+    worker_multiplex: int = Field(128, ge=1)
+    """Rollouts per worker for the elastic scale-up trigger (distinct from `multiplex`,
+    which shares interception servers *within* a worker): the pool adds a worker once
+    in-flight rollouts reach 90% of `workers * worker_multiplex`."""
     # --- legacy (v0) backwards-compat -----------------------------------------
     # Run a classic `verifiers.load_environment(id, **args)` env, bridged to v1 Traces (see
     # `verifiers.v1.legacy`), instead of a v1 taskset/harness. Set `id` (leave `taskset`

--- a/verifiers/v1/serve/pool.py
+++ b/verifiers/v1/serve/pool.py
@@ -14,7 +14,7 @@ the broker holds the real client identity in `pending` and routes the reply back
 worker.
 
 Scaling is elastic but upscale-only: a new worker is spawned when in-flight requests
-reach 90% of current capacity (`workers * multiplex`). Workers are spawned `spawn`-style
+reach 90% of current capacity (`workers * worker_multiplex`). Workers are spawned `spawn`-style
 (own env, own loop) and monitor a death pipe so an orphaned worker self-exits if the
 broker dies. TODO: downscale idle workers, per-worker restart-on-death, stats/lag
 monitors (v0 had them; omitted here — rollout errors are returned as data, not crashes,
@@ -81,23 +81,27 @@ def _worker_entry(
 class EnvServerPool:
     """ROUTER broker that elastically scales worker processes (least-busy dispatch).
 
-    Starts with a single worker and spawns another whenever in-flight requests reach
-    90% of current capacity (`workers * multiplex`), up to `max_workers`. Upscale-only
-    for now — workers are never reclaimed. The broker forwards opaque request frames, so
-    workers can be `EnvServer` (v1) or `LegacyEnvServer` (v0) without the broker caring."""
+    With `elastic=True` (default) it starts with a single worker and spawns another
+    whenever in-flight requests reach 90% of current capacity (`workers * worker_multiplex`), up
+    to `max_workers`. Upscale-only for now — workers are never reclaimed. `elastic=False`
+    pre-spawns all `max_workers` upfront (the old fixed-pool behavior). The broker forwards
+    opaque request frames, so workers can be `EnvServer` (v1) or `LegacyEnvServer` (v0)
+    without the broker caring."""
 
     def __init__(
         self,
         server_kwargs: dict,
-        max_workers: int,
+        max_workers: int | None,
         address: str,
         legacy: bool,
         log_setup: Callable[[], None] | None = None,
-        multiplex: int = 128,
+        worker_multiplex: int = 128,
+        elastic: bool = True,
     ) -> None:
         self.server_kwargs = server_kwargs
         self.max_workers = max_workers
-        self.multiplex = multiplex
+        self.worker_multiplex = worker_multiplex
+        self.elastic = elastic
         self.legacy = legacy
         self.log_setup = log_setup
         self.session = uuid.uuid4().hex[:12]
@@ -154,28 +158,37 @@ class EnvServerPool:
 
         A new worker starts at `active=0`, so least-busy dispatch funnels the backlog to
         it as it comes online (a few seconds to load the env) — fine, since we only scale
-        up once already saturated."""
-        if len(self.workers) >= self.max_workers:
+        up once already saturated. `max_workers=None` scales without a cap."""
+        if self.max_workers is not None and len(self.workers) >= self.max_workers:
             return
-        if in_flight >= 0.9 * len(self.workers) * self.multiplex:
+        if in_flight >= 0.9 * len(self.workers) * self.worker_multiplex:
             self._spawn_worker()
             logger.info(
-                "EnvServerPool scaled up to %d/%d workers (in_flight=%d)",
+                "EnvServerPool scaled up to %d/%s workers (in_flight=%d)",
                 len(self.workers),
-                self.max_workers,
+                self._cap_str,
                 in_flight,
             )
+
+    @property
+    def _cap_str(self) -> str:
+        return "inf" if self.max_workers is None else str(self.max_workers)
 
     async def run(self) -> None:
         self._poller = zmq.asyncio.Poller()
         self._poller.register(self.frontend, zmq.POLLIN)
-        self._spawn_worker()  # start with one; scale up on demand
+        # Elastic: start with one and scale up on demand. Otherwise pre-spawn the lot
+        # (`max_workers` is a concrete count when elastic is off).
+        for _ in range(1 if self.elastic else (self.max_workers or 1)):
+            self._spawn_worker()
         pending: dict[bytes, dict] = {}  # request_id -> {client_id, worker}
         logger.info(
-            "EnvServerPool up: address=%s multiplex=%d max_workers=%d",
+            "EnvServerPool up: address=%s workers=%d/%s worker_multiplex=%d elastic=%s",
             self.address,
-            self.multiplex,
-            self.max_workers,
+            len(self.workers),
+            self._cap_str,
+            self.worker_multiplex,
+            self.elastic,
         )
         try:
             while True:
@@ -200,7 +213,8 @@ class EnvServerPool:
                         await worker["dealer"].send_multipart(
                             [request_id, method, payload]
                         )
-                        self._maybe_scale_up(len(pending))
+                        if self.elastic:
+                            self._maybe_scale_up(len(pending))
                 for w in self.workers:
                     if w["dealer"] in events:
                         request_id, data = await w["dealer"].recv_multipart()
@@ -248,21 +262,25 @@ def env_config_data(config) -> dict:
 
 def serve_env(
     *,
-    num_workers: int,
+    max_workers: int | None,
     legacy: bool = False,
     address: str = "tcp://127.0.0.1:5000",
     address_queue=None,
     log_setup: Callable[[], None] | None = None,
-    multiplex: int = 128,
+    worker_multiplex: int = 128,
+    elastic: bool = True,
     **server_kwargs,
 ) -> None:
-    """Serve one env over ZMQ: a single in-process `EnvServer` when `num_workers <= 1`,
-    else an `EnvServerPool` broker that scales from one worker up to `num_workers`. The
-    frontend speaks the same protocol either way, so the client is identical. Reports the
-    bound address on `address_queue` (for a spawner that passed an OS-assigned `:0`).
+    """Serve one env over ZMQ: a single in-process `EnvServer` when `max_workers <= 1`,
+    else an `EnvServerPool` broker over up to `max_workers` worker processes (`None` =
+    unbounded). The frontend speaks the same protocol either way, so the client is
+    identical. Reports the bound address on `address_queue` (for a spawner that passed an
+    OS-assigned `:0`).
 
-    `multiplex` is the per-worker capacity used by the pool's scale-up trigger (it spawns
-    the next worker at 90% of `workers * multiplex` in-flight).
+    `elastic` (default True) starts the pool at one worker and scales up to `max_workers`
+    as load grows; `worker_multiplex` is the per-worker capacity for the scale-up trigger (spawn
+    the next worker at 90% of `workers * worker_multiplex` in-flight). `elastic=False` pre-spawns
+    all `max_workers`.
 
     A native env config may be passed as `config` (an object) or `config_data` (the
     picklable dict from `env_config_data`, for callers that spawn this function and so
@@ -281,7 +299,7 @@ def serve_env(
     if log_setup is not None:
         log_setup()
     try:
-        if num_workers > 1:
+        if max_workers is None or max_workers > 1:
             if (
                 "config" in server_kwargs
             ):  # dict-ify for the workers (config_data is picklable)
@@ -289,7 +307,13 @@ def serve_env(
                     "config_data": env_config_data(server_kwargs["config"])
                 }
             pool = EnvServerPool(
-                server_kwargs, num_workers, address, legacy, log_setup, multiplex
+                server_kwargs,
+                max_workers,
+                address,
+                legacy,
+                log_setup,
+                worker_multiplex,
+                elastic,
             )
             if address_queue is not None:
                 address_queue.put(pool.address)

--- a/verifiers/v1/serve/pool.py
+++ b/verifiers/v1/serve/pool.py
@@ -14,7 +14,7 @@ the broker holds the real client identity in `pending` and routes the reply back
 worker.
 
 Scaling is elastic but upscale-only: a new worker is spawned when in-flight requests
-reach 90% of current capacity (`workers * worker_multiplex`). Workers are spawned `spawn`-style
+reach 90% of current capacity (`workers * multiplex`). Workers are spawned `spawn`-style
 (own env, own loop) and monitor a death pipe so an orphaned worker self-exits if the
 broker dies. TODO: downscale idle workers, per-worker restart-on-death, stats/lag
 monitors (v0 had them; omitted here — rollout errors are returned as data, not crashes,
@@ -82,7 +82,7 @@ class EnvServerPool:
     """ROUTER broker that elastically scales worker processes (least-busy dispatch).
 
     With `elastic=True` (default) it starts with a single worker and spawns another
-    whenever in-flight requests reach 90% of current capacity (`workers * worker_multiplex`), up
+    whenever in-flight requests reach 90% of current capacity (`workers * multiplex`), up
     to `max_workers`. Upscale-only for now — workers are never reclaimed. `elastic=False`
     pre-spawns all `max_workers` upfront (the old fixed-pool behavior). The broker forwards
     opaque request frames, so workers can be `EnvServer` (v1) or `LegacyEnvServer` (v0)
@@ -95,12 +95,12 @@ class EnvServerPool:
         address: str,
         legacy: bool,
         log_setup: Callable[[], None] | None = None,
-        worker_multiplex: int = 128,
+        multiplex: int = 128,
         elastic: bool = True,
     ) -> None:
         self.server_kwargs = server_kwargs
         self.max_workers = max_workers
-        self.worker_multiplex = worker_multiplex
+        self.multiplex = multiplex
         self.elastic = elastic
         self.legacy = legacy
         self.log_setup = log_setup
@@ -161,7 +161,7 @@ class EnvServerPool:
         up once already saturated. `max_workers=None` scales without a cap."""
         if self.max_workers is not None and len(self.workers) >= self.max_workers:
             return
-        if in_flight >= 0.9 * len(self.workers) * self.worker_multiplex:
+        if in_flight >= 0.9 * len(self.workers) * self.multiplex:
             self._spawn_worker()
             logger.info(
                 "EnvServerPool scaled up to %d/%s workers (in_flight=%d)",
@@ -183,11 +183,11 @@ class EnvServerPool:
             self._spawn_worker()
         pending: dict[bytes, dict] = {}  # request_id -> {client_id, worker}
         logger.info(
-            "EnvServerPool up: address=%s workers=%d/%s worker_multiplex=%d elastic=%s",
+            "EnvServerPool up: address=%s workers=%d/%s multiplex=%d elastic=%s",
             self.address,
             len(self.workers),
             self._cap_str,
-            self.worker_multiplex,
+            self.multiplex,
             self.elastic,
         )
         try:
@@ -267,7 +267,7 @@ def serve_env(
     address: str = "tcp://127.0.0.1:5000",
     address_queue=None,
     log_setup: Callable[[], None] | None = None,
-    worker_multiplex: int = 128,
+    multiplex: int = 128,
     elastic: bool = True,
     **server_kwargs,
 ) -> None:
@@ -278,8 +278,8 @@ def serve_env(
     OS-assigned `:0`).
 
     `elastic` (default True) starts the pool at one worker and scales up to `max_workers`
-    as load grows; `worker_multiplex` is the per-worker capacity for the scale-up trigger (spawn
-    the next worker at 90% of `workers * worker_multiplex` in-flight). `elastic=False` pre-spawns
+    as load grows; `multiplex` is the per-worker capacity for the scale-up trigger (spawn
+    the next worker at 90% of `workers * multiplex` in-flight). `elastic=False` pre-spawns
     all `max_workers`.
 
     A native env config may be passed as `config` (an object) or `config_data` (the
@@ -312,7 +312,7 @@ def serve_env(
                 address,
                 legacy,
                 log_setup,
-                worker_multiplex,
+                multiplex,
                 elastic,
             )
             if address_queue is not None:

--- a/verifiers/v1/serve/pool.py
+++ b/verifiers/v1/serve/pool.py
@@ -5,17 +5,20 @@ CPU-bound work (renderer tokenization, scoring) competes for that loop. v0 relie
 this with a router + worker pool; this reinstates it for v1.
 
 A broker binds the client-facing ROUTER (the *same* wire protocol as a lone
-`EnvServer`, so `EnvClient` is unchanged), spawns `num_workers` worker processes —
-each an ordinary `EnvServer` / `LegacyEnvServer` bound to its own ipc address — and
-load-balances requests to the least-busy worker over a `DEALER` per worker. The
-worker's `client_id` (its reply identity) is the broker's DEALER identity; the broker
-holds the real client identity in `pending` and routes the reply back by `request_id`.
-`health` is answered inline (no worker needed); everything else goes to a worker.
+`EnvServer`, so `EnvClient` is unchanged), starts one worker process and scales up to
+`max_workers` on demand — each an ordinary `EnvServer` / `LegacyEnvServer` bound to its
+own ipc address — load-balancing requests to the least-busy worker over a `DEALER` per
+worker. The worker's `client_id` (its reply identity) is the broker's DEALER identity;
+the broker holds the real client identity in `pending` and routes the reply back by
+`request_id`. `health` is answered inline (no worker needed); everything else goes to a
+worker.
 
-Workers are spawned `spawn`-style (own env, own loop) and monitor a death pipe so an
-orphaned worker self-exits if the broker dies. TODO: per-worker restart-on-death and
-stats/lag monitors (v0 had them; omitted here — rollout errors are returned as data,
-not crashes, so worker death is rare).
+Scaling is elastic but upscale-only: a new worker is spawned when in-flight requests
+reach 90% of current capacity (`workers * multiplex`). Workers are spawned `spawn`-style
+(own env, own loop) and monitor a death pipe so an orphaned worker self-exits if the
+broker dies. TODO: downscale idle workers, per-worker restart-on-death, stats/lag
+monitors (v0 had them; omitted here — rollout errors are returned as data, not crashes,
+so worker death is rare).
 """
 
 import asyncio
@@ -76,22 +79,31 @@ def _worker_entry(
 
 
 class EnvServerPool:
-    """ROUTER broker over `num_workers` worker processes (least-busy dispatch)."""
+    """ROUTER broker that elastically scales worker processes (least-busy dispatch).
+
+    Starts with a single worker and spawns another whenever in-flight requests reach
+    90% of current capacity (`workers * multiplex`), up to `max_workers`. Upscale-only
+    for now — workers are never reclaimed. The broker forwards opaque request frames, so
+    workers can be `EnvServer` (v1) or `LegacyEnvServer` (v0) without the broker caring."""
 
     def __init__(
         self,
         server_kwargs: dict,
-        num_workers: int,
+        max_workers: int,
         address: str,
         legacy: bool,
         log_setup: Callable[[], None] | None = None,
+        multiplex: int = 128,
     ) -> None:
         self.server_kwargs = server_kwargs
-        self.num_workers = num_workers
+        self.max_workers = max_workers
+        self.multiplex = multiplex
         self.legacy = legacy
         self.log_setup = log_setup
         self.session = uuid.uuid4().hex[:12]
         self.workers: list[dict] = []
+        self._mpctx = mp.get_context("spawn")
+        self._poller: zmq.asyncio.Poller | None = None
 
         self.ctx = zmq.asyncio.Context()
         self.frontend = self.ctx.socket(zmq.ROUTER)
@@ -105,44 +117,69 @@ class EnvServerPool:
     def _worker_path(self, i: int) -> str:
         return f"/tmp/vf-pool-{self.session}-{i}"
 
-    def _start_workers(self) -> None:
-        mpctx = mp.get_context("spawn")
-        for i in range(self.num_workers):
-            address = f"ipc://{self._worker_path(i)}"
-            parent_conn, child_conn = mpctx.Pipe()
-            proc = mpctx.Process(
-                target=_worker_entry,
-                kwargs=dict(
-                    server_kwargs=self.server_kwargs,
-                    address=address,
-                    death_pipe=child_conn,
-                    legacy=self.legacy,
-                    log_setup=self.log_setup,
-                ),
-                daemon=False,
-            )
-            proc.start()
-            child_conn.close()  # parent keeps the write end (its close signals death)
-            dealer = self.ctx.socket(zmq.DEALER)
-            dealer.setsockopt(zmq.LINGER, 0)
-            dealer.connect(address)  # connect before bind is fine — ZMQ queues
-            self.workers.append(
-                {"process": proc, "dealer": dealer, "pipe": parent_conn, "active": 0}
+    def _spawn_worker(self) -> None:
+        i = len(self.workers)  # upscale-only, so the next index is the current count
+        address = f"ipc://{self._worker_path(i)}"
+        parent_conn, child_conn = self._mpctx.Pipe()
+        proc = self._mpctx.Process(
+            target=_worker_entry,
+            kwargs=dict(
+                server_kwargs=self.server_kwargs,
+                address=address,
+                death_pipe=child_conn,
+                legacy=self.legacy,
+                log_setup=self.log_setup,
+            ),
+            daemon=False,
+        )
+        proc.start()
+        child_conn.close()  # parent keeps the write end (its close signals death)
+        dealer = self.ctx.socket(zmq.DEALER)
+        dealer.setsockopt(zmq.LINGER, 0)
+        dealer.connect(address)  # connect before bind is fine — ZMQ queues
+        self.workers.append(
+            {
+                "process": proc,
+                "dealer": dealer,
+                "pipe": parent_conn,
+                "active": 0,
+                "index": i,
+            }
+        )
+        if self._poller is not None:
+            self._poller.register(dealer, zmq.POLLIN)
+
+    def _maybe_scale_up(self, in_flight: int) -> None:
+        """Spawn one more worker when in-flight requests reach 90% of current capacity.
+
+        A new worker starts at `active=0`, so least-busy dispatch funnels the backlog to
+        it as it comes online (a few seconds to load the env) — fine, since we only scale
+        up once already saturated."""
+        if len(self.workers) >= self.max_workers:
+            return
+        if in_flight >= 0.9 * len(self.workers) * self.multiplex:
+            self._spawn_worker()
+            logger.info(
+                "EnvServerPool scaled up to %d/%d workers (in_flight=%d)",
+                len(self.workers),
+                self.max_workers,
+                in_flight,
             )
 
     async def run(self) -> None:
-        self._start_workers()
-        poller = zmq.asyncio.Poller()
-        poller.register(self.frontend, zmq.POLLIN)
-        for w in self.workers:
-            poller.register(w["dealer"], zmq.POLLIN)
+        self._poller = zmq.asyncio.Poller()
+        self._poller.register(self.frontend, zmq.POLLIN)
+        self._spawn_worker()  # start with one; scale up on demand
         pending: dict[bytes, dict] = {}  # request_id -> {client_id, worker}
         logger.info(
-            "EnvServerPool up: address=%s workers=%d", self.address, self.num_workers
+            "EnvServerPool up: address=%s multiplex=%d max_workers=%d",
+            self.address,
+            self.multiplex,
+            self.max_workers,
         )
         try:
             while True:
-                events = dict(await poller.poll())
+                events = dict(await self._poller.poll())
                 if self.frontend in events:
                     (
                         client_id,
@@ -163,6 +200,7 @@ class EnvServerPool:
                         await worker["dealer"].send_multipart(
                             [request_id, method, payload]
                         )
+                        self._maybe_scale_up(len(pending))
                 for w in self.workers:
                     if w["dealer"] in events:
                         request_id, data = await w["dealer"].recv_multipart()
@@ -185,7 +223,7 @@ class EnvServerPool:
                 w["pipe"].close()
             with contextlib.suppress(Exception):
                 w["process"].terminate()
-        for i, w in enumerate(self.workers):
+        for w in self.workers:
             with contextlib.suppress(Exception):
                 w["process"].join(timeout=10)
             if w["process"].is_alive():
@@ -194,7 +232,7 @@ class EnvServerPool:
             with contextlib.suppress(Exception):
                 w["dealer"].close()
             with contextlib.suppress(OSError):
-                os.unlink(self._worker_path(i))
+                os.unlink(self._worker_path(w["index"]))
         self.frontend.close()
         self.ctx.term()
         logger.info("EnvServerPool down")
@@ -215,12 +253,16 @@ def serve_env(
     address: str = "tcp://127.0.0.1:5000",
     address_queue=None,
     log_setup: Callable[[], None] | None = None,
+    multiplex: int = 128,
     **server_kwargs,
 ) -> None:
     """Serve one env over ZMQ: a single in-process `EnvServer` when `num_workers <= 1`,
-    else an `EnvServerPool` broker over `num_workers` worker processes. The frontend
-    speaks the same protocol either way, so the client is identical. Reports the bound
-    address on `address_queue` (for a spawner that passed an OS-assigned `:0`).
+    else an `EnvServerPool` broker that scales from one worker up to `num_workers`. The
+    frontend speaks the same protocol either way, so the client is identical. Reports the
+    bound address on `address_queue` (for a spawner that passed an OS-assigned `:0`).
+
+    `multiplex` is the per-worker capacity used by the pool's scale-up trigger (it spawns
+    the next worker at 90% of `workers * multiplex` in-flight).
 
     A native env config may be passed as `config` (an object) or `config_data` (the
     picklable dict from `env_config_data`, for callers that spawn this function and so
@@ -246,7 +288,9 @@ def serve_env(
                 server_kwargs = {
                     "config_data": env_config_data(server_kwargs["config"])
                 }
-            pool = EnvServerPool(server_kwargs, num_workers, address, legacy, log_setup)
+            pool = EnvServerPool(
+                server_kwargs, num_workers, address, legacy, log_setup, multiplex
+            )
             if address_queue is not None:
                 address_queue.put(pool.address)
             asyncio.run(pool.run())


### PR DESCRIPTION
## Summary

Makes the env-server worker pool **elastic (upscale-only)**, configured by a `pool` **discriminated union** on a new shared `EnvServerConfig(EnvConfig)` base.

- **`serve/pool.py`** — `EnvServerPool` starts at **one** worker and spawns the next when in-flight requests reach **90% of `workers * multiplex`**, capped at `max_workers` (**`None` = unbounded**). New workers register their DEALER in the live poller; least-busy dispatch funnels backlog to them as they warm up. `elastic=False` pre-spawns all `max_workers` (the old fixed pool). The broker forwards opaque frames, so v1 `EnvServer` and v0 `LegacyEnvServer` workers both work.
- **Config (`env.py`)** — `pool: StaticConfig{num_workers=4} | ElasticConfig{max_workers=None, multiplex=128}`, **default elastic**, on a shared `EnvServerConfig(EnvConfig)`. The serve CLI (`ServeConfig`), `EvalConfig`, and prime-rl's `EnvConfig` all extend it, so pool sizing lives in one place — separate from the env definition. `multiplex` is namespaced under the elastic config, so it no longer collides with `EnvConfig.multiplex` (interception-server sharing, 32).
- **`serve_env`** unpacks the pool via `pool_serve_kwargs` (`max_workers`/`multiplex`/`elastic`). The eval CLI runs rollouts through the pool on a non-`--rich` run; `--rich` keeps the in-process dashboard.

## Verification

`eval gsm8k-v1 --rich false --pool.type elastic --pool.max-workers 8 --pool.multiplex 128 -n1 -r512 -c512` (subprocess, deepseek-v4-flash): ramps **1→5** at in-flight **116 / 231 / 346 / 461** (= `0.9·n·128`), 512/512 rollouts, **reward 0.855, 0 errors**. Cap-vs-unbounded unit check: `max_workers=None, mux=64 → 9 workers`; `cap 8, mux 64 → 8 (capped)`; `cap 8, mux 128 → 5 (load-driven)`. Interception `multiplex` stays 32. `ruff` clean.

## Breaking

- The serve-CLI config `EnvServerConfig` is **renamed `ServeConfig`** (the name `EnvServerConfig` now denotes the shared base with `pool`).
- The flat `num_workers` (eval `-w`) is replaced by `--pool.*` (`--pool.type elastic|static`, `--pool.max-workers`, `--pool.multiplex`, `--pool.num-workers`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default eval execution path and worker-pool scaling behavior; breaking CLI/config renames may break scripts using num_workers or the old EnvServerConfig name.
> 
> **Overview**
> Introduces an **elastic (upscale-only) env-server worker pool** and centralizes sizing on a shared **`EnvServerConfig`** with a discriminated **`pool`** (`static` vs `elastic`, default elastic).
> 
> **`EnvServerPool`** now starts with one worker and spawns more when in-flight requests hit **90% of `workers × multiplex`**, up to `max_workers` (`None` = unbounded). `elastic=False` keeps the old behavior of pre-spawning a fixed worker count. **`pool_serve_kwargs`** maps pool config into `serve_env` (`max_workers`, `multiplex`, `elastic`).
> 
> **Eval routing** changes: non-`--rich` v1 evals always drive rollouts through the env-server pool (prime-rl path); `--rich` stays in-process for the dashboard. The flat **`num_workers` / `-w`** flag is removed in favor of **`--pool.*`**.
> 
> **Breaking:** the serve CLI type **`EnvServerConfig` → `ServeConfig`**; **`EnvServerConfig`** is now the shared base that includes `pool`. Lockfile bumps **`renderers`** (`0.1.8.dev28` → `dev43`) and tightens the minimum specifier to `>=0.1.8.dev40`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0c5bc98bf9f8d741058716f01f2f52f57d8fefe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->