### PR TITLE
feat: record per-rollout setup timing as a distinct phase

### DIFF
--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -107,7 +107,7 @@ class Rollout:
         is the eval-level shared interception pool (None = a server per rollout)."""
         trace: Trace = Trace(task=self.task)
         self.trace = trace  # expose for the --rich dashboard
-        trace.timing.generation.start = time.time()
+        trace.timing.setup.start = time.time()
         self.runtime = make_runtime(
             self.runtime_config, name=trace.id
         )  # ref set first → always tearable-down; named after the rollout for traceability
@@ -145,9 +145,11 @@ class Rollout:
                         colocated=self.taskset.config.user.colocated,
                     ) as session.user,
                 ):
-                    self.phase = (
-                        Phase.RUNNING
-                    )  # setup done — the harness is now driving
+                    # setup done — the harness is now driving
+                    now = time.time()
+                    trace.timing.setup.end = now
+                    trace.timing.generation.start = now
+                    self.phase = Phase.RUNNING
                     try:
                         await asyncio.wait_for(
                             self.harness.run(
@@ -184,8 +186,11 @@ class Rollout:
             trace.capture_error(e)
         finally:
             trace.is_completed = True
-            if not trace.timing.generation.end:  # error path: harness didn't finish
-                trace.timing.generation.end = time.time()
+            now = time.time()
+            if not trace.timing.setup.end:  # error during setup: close the setup span
+                trace.timing.setup.end = now
+            if trace.timing.generation.start and not trace.timing.generation.end:
+                trace.timing.generation.end = now  # error mid-run: close generation
             # Tear down here — group rewards (later) need only the trace, not a live
             # runtime. `runtime` is always set: make_runtime() ran before the `try`.
             try:

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -44,9 +44,11 @@ class TimeSpan(StrictBaseModel):
 
 
 class Timing(StrictBaseModel):
-    """Wall-clock timing for the phases of a rollout."""
+    """Wall-clock timing for the phases of a rollout: provisioning the runtime + serving
+    (`setup`), the harness driving the conversation (`generation`), then scoring."""
 
     start: float = Field(default_factory=time.time)
+    setup: TimeSpan = Field(default_factory=TimeSpan)
     generation: TimeSpan = Field(default_factory=TimeSpan)
     scoring: TimeSpan = Field(default_factory=TimeSpan)
 


### PR DESCRIPTION
## Summary

Record per-rollout **setup** timing (runtime provisioning + serving) as a distinct phase, alongside `generation` and `scoring`.

- `trace.py` — new `Timing.setup: TimeSpan`.
- `rollout.py` — `setup.start` is stamped up front; at the "setup done → harness driving" point, `setup.end` and `generation.start` share the same instant, so the phases are contiguous and non-overlapping (`setup → generation → scoring`). The `finally` closes whichever span was open on the error paths (error during setup closes `setup` and leaves `generation` unset; error mid-run closes `generation`).

Motivation: a per-rollout/per-runtime view that separates **provisioning overhead** (negligible for subprocess, seconds for docker/prime) from generation — e.g. for the runtime benchmark.

## Breaking

`generation.duration` now **excludes** setup (it previously folded in runtime provisioning + serving). Negligible for subprocess (~1ms), but seconds for docker/prime — now attributed to the new `setup` span. Any consumer of `generation.duration` (dashboard, training logs) will see the narrower number.

## Verification

One real gsm8k rollout (hosted model, subprocess runtime): `setup` dur=0.001s, `generation` dur=7.164s, `scoring` dur=0.262s, `setup.end == generation.start` ✓ (contiguous), reward 1.0. `ruff --isolated` clean.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Record per-rollout setup timing as a distinct phase in `Rollout.run`
> - Adds a `setup` span (`timing.setup.start`/`timing.setup.end`) to the [`Timing` model](https://github.com/PrimeIntellect-ai/verifiers/pull/1631/files#diff-834820c3aa80d87ee1c1c57fb54c74f09c66ac727036d964e6005c8613c00b5e) alongside the existing `generation` and `scoring` spans.
> - In [`Rollout.run`](https://github.com/PrimeIntellect-ai/verifiers/pull/1631/files#diff-f886b7f4717cf8fce9270bd4ff4790f3182aa1016abb9efb7f6e57efe18d1bf2), `timing.generation.start` is now set at the moment setup completes (right before the harness drives) rather than at the start of the rollout.
> - Error paths in the `finally` block now close whichever spans are open: `timing.setup.end` if setup failed, and `timing.generation.end` if generation started but did not complete.
> - Behavioral Change: traces that previously had `timing.generation.start` anchored to the beginning of the rollout will now see it shifted to after setup finishes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 48e770f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> `generation.duration` and anything keyed on `generation.start` change meaning for docker/prime runtimes; trace schema gains a new field but error-path timing is more accurate.
> 
> **Overview**
> Introduces a dedicated **`setup`** timing span on each trace so runtime provisioning and tool/user serving are measured separately from harness-driven work.
> 
> **`Timing`** gains `setup: TimeSpan`, documented as sitting before **`generation`** and **`scoring`**. In **`Rollout.run`**, `setup.start` is recorded at rollout entry (replacing the old behavior where `generation.start` was stamped there). When setup finishes—runtime started, task setup, interception, tools, and user are ready—a single timestamp closes **`setup`** and opens **`generation`**, so the phases are contiguous. The **`finally`** block now closes **`setup`** if setup failed before completion, and closes **`generation`** only when it had started but did not finish (instead of always patching **`generation.end`** on any incomplete run).
> 
> **Behavioral change:** **`generation.duration`** no longer includes provisioning/serving overhead (small for subprocess, often seconds for docker/prime); that time moves to **`setup.duration`**. Consumers that treated **`generation`** as “wall time since rollout began” (e.g. dashboard sort/elapsed keyed on **`generation.start`**) now see harness-only timing unless they add **`setup`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48e770fdc21e1e61a79ee2dd490b3578972d6bb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->