### PR TITLE
feat: per-call model + runtime retries

### DIFF
--- a/verifiers/v1/README.md
+++ b/verifiers/v1/README.md
@@ -42,7 +42,8 @@ wall-clock timeouts — are all CLI flags (or TOML):
 ```bash
 uv run eval gsm8k-v1 -n 5 -r 3 \
   --max-turns 8 --max-total-tokens 8192 \        # per-rollout budgets (also --max-{input,output}-tokens)
-  --retry.attempts 3 --retry.include ProgramError \  # retry a failed rollout, by exception type
+  --retries.model.max-attempts 3 --retries.runtime.max-attempts 3 \  # retry a single model/runtime call
+  --retries.rollout.max-attempts 3 --retries.rollout.include ProgramError \  # retry a whole rollout, by exception type
   --timeout.rollout 600 --timeout.scoring 120        # wall-clock caps, in seconds
 ```
 
@@ -176,13 +177,15 @@ renderer required.)
 ### Limits & retries
 
 Framework-enforced budgets, applied between turns (so they hold for any harness), plus
-native whole-rollout retries:
+retries at two granularities: per-call (model + runtime, default 3 attempts — reruns just
+the failed call, keeping the rollout's progress) and whole-rollout (default off):
 
 ```bash
 uv run eval gsm8k-v1 -n 1 --max-turns 8                  # cap model turns
 uv run eval gsm8k-v1 -n 1 --max-total-tokens 8192        # cap prompt+completion tokens
                                                           # (also --max-input-tokens / --max-output-tokens)
-uv run eval gsm8k-v1 -n 1 --retry.attempts 3 --retry.include ProgramError  # retry by exception type
+uv run eval gsm8k-v1 -n 1 --retries.model.max-attempts 5 --retries.runtime.max-attempts 5  # per-call retries
+uv run eval gsm8k-v1 -n 1 --retries.rollout.max-attempts 3 --retries.rollout.include ProgramError  # whole-rollout, by exception type
 ```
 
 ### First-class Harbor support

--- a/verifiers/v1/README.md
+++ b/verifiers/v1/README.md
@@ -42,8 +42,8 @@ wall-clock timeouts — are all CLI flags (or TOML):
 ```bash
 uv run eval gsm8k-v1 -n 5 -r 3 \
   --max-turns 8 --max-total-tokens 8192 \        # per-rollout budgets (also --max-{input,output}-tokens)
-  --retries.model.max-attempts 3 --retries.runtime.max-attempts 3 \  # retry a single model/runtime call
-  --retries.rollout.max-attempts 3 --retries.rollout.include ProgramError \  # retry a whole rollout, by exception type
+  --retries.model.max-retries 3 --retries.runtime.max-retries 3 \  # retry a single model/runtime call
+  --retries.rollout.max-retries 3 --retries.rollout.include ProgramError \  # retry a whole rollout, by exception type
   --timeout.rollout 600 --timeout.scoring 120        # wall-clock caps, in seconds
 ```
 
@@ -177,15 +177,16 @@ renderer required.)
 ### Limits & retries
 
 Framework-enforced budgets, applied between turns (so they hold for any harness), plus
-retries at two granularities: per-call (model + runtime, default 3 attempts — reruns just
-the failed call, keeping the rollout's progress) and whole-rollout (default off):
+retries at two granularities: per-call (model + runtime, default 3 retries — reruns just
+the failed call, keeping the rollout's progress) and whole-rollout (default 1 retry). A
+retry count of 0 turns a layer off.
 
 ```bash
 uv run eval gsm8k-v1 -n 1 --max-turns 8                  # cap model turns
 uv run eval gsm8k-v1 -n 1 --max-total-tokens 8192        # cap prompt+completion tokens
                                                           # (also --max-input-tokens / --max-output-tokens)
-uv run eval gsm8k-v1 -n 1 --retries.model.max-attempts 5 --retries.runtime.max-attempts 5  # per-call retries
-uv run eval gsm8k-v1 -n 1 --retries.rollout.max-attempts 3 --retries.rollout.include ProgramError  # whole-rollout, by exception type
+uv run eval gsm8k-v1 -n 1 --retries.model.max-retries 5 --retries.runtime.max-retries 5  # per-call retries
+uv run eval gsm8k-v1 -n 1 --retries.rollout.max-retries 3 --retries.rollout.include ProgramError  # whole-rollout, by exception type
 ```
 
 ### First-class Harbor support

--- a/verifiers/v1/__init__.py
+++ b/verifiers/v1/__init__.py
@@ -38,7 +38,7 @@ from verifiers.v1.loaders import (
     task_type,
     taskset_config_type,
 )
-from verifiers.v1.retries import RetryConfig
+from verifiers.v1.retries import CallRetryConfig, RetryConfig, RolloutRetryConfig
 from verifiers.v1.rollout import Rollout
 from verifiers.v1.runtimes import (
     DockerConfig,
@@ -149,7 +149,9 @@ __all__ = [
     "StaticPoolConfig",
     "ElasticPoolConfig",
     "pool_serve_kwargs",
+    "CallRetryConfig",
     "RetryConfig",
+    "RolloutRetryConfig",
     "TimeoutConfig",
     "Episode",
     "Rollout",

--- a/verifiers/v1/clients/__init__.py
+++ b/verifiers/v1/clients/__init__.py
@@ -1,6 +1,6 @@
 """The client abstraction and its OpenAI-compatible + renderer implementations."""
 
-from verifiers.v1.clients.client import Client, RolloutContext
+from verifiers.v1.clients.client import Client, RetryingClient, RolloutContext
 from verifiers.v1.clients.config import (
     BaseClientConfig,
     ClientConfig,
@@ -13,6 +13,7 @@ from verifiers.v1.clients.renderer import RendererClient
 
 __all__ = [
     "Client",
+    "RetryingClient",
     "RolloutContext",
     "BaseClientConfig",
     "ClientConfig",

--- a/verifiers/v1/clients/client.py
+++ b/verifiers/v1/clients/client.py
@@ -7,6 +7,14 @@ abstract method. Each concrete client owns its own wire translation internally.
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 
+from tenacity import (
+    AsyncRetrying,
+    retry_if_exception_type,
+    retry_if_not_exception_type,
+    stop_after_attempt,
+)
+
+from verifiers.v1.errors import ModelError, OverlongPromptError
 from verifiers.v1.types import Messages, Response, SamplingConfig, Tool
 
 
@@ -23,6 +31,36 @@ class Client(ABC):
 
     async def close(self) -> None:
         """Release any underlying resources. Default no-op."""
+
+
+class RetryingClient(Client):
+    """Wraps a client to retry each completion on a transient `ModelError` (tenacity,
+    `max_attempts` total). An `OverlongPromptError` is never retried — it's a budget
+    limit the interception server turns into a clean truncation, not a transient fault."""
+
+    def __init__(self, inner: Client, max_attempts: int) -> None:
+        self.inner = inner
+        self.max_attempts = max_attempts
+
+    async def get_response(
+        self,
+        prompt: Messages,
+        model: str,
+        sampling_args: SamplingConfig,
+        tools: list[Tool] | None = None,
+    ) -> Response:
+        retrying = AsyncRetrying(
+            stop=stop_after_attempt(self.max_attempts),
+            retry=retry_if_exception_type(ModelError)
+            & retry_if_not_exception_type(OverlongPromptError),
+            reraise=True,
+        )
+        return await retrying(
+            self.inner.get_response, prompt, model, sampling_args, tools
+        )
+
+    async def close(self) -> None:
+        await self.inner.close()
 
 
 @dataclass(frozen=True)

--- a/verifiers/v1/clients/client.py
+++ b/verifiers/v1/clients/client.py
@@ -4,11 +4,13 @@ Collapsed from v1's 4-typevar generic ABC with five conversion hooks to a single
 abstract method. Each concrete client owns its own wire translation internally.
 """
 
+import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 
 from tenacity import (
     AsyncRetrying,
+    RetryCallState,
     retry_if_exception_type,
     retry_if_not_exception_type,
     stop_after_attempt,
@@ -16,6 +18,8 @@ from tenacity import (
 
 from verifiers.v1.errors import ModelError, OverlongPromptError
 from verifiers.v1.types import Messages, Response, SamplingConfig, Tool
+
+logger = logging.getLogger(__name__)
 
 
 class Client(ABC):
@@ -34,19 +38,29 @@ class Client(ABC):
 
 
 class RetryingClient(Client):
-    """Wraps a client to retry each completion on a transient `ModelError` (tenacity,
-    `max_attempts` total). An `OverlongPromptError` is never retried — it's a budget
-    limit the interception server turns into a clean truncation, not a transient fault."""
+    """Wraps a client to retry each completion on a transient `ModelError` (tenacity, up to
+    `max_retries` retries). An `OverlongPromptError` is never retried — it's a budget limit
+    the interception server turns into a clean truncation, not a transient fault."""
 
-    def __init__(self, inner: Client, max_attempts: int) -> None:
+    def __init__(self, inner: Client, max_retries: int) -> None:
         self.inner = inner
+        self.max_retries = max_retries
         # One Retrying, reused across (and concurrent within) calls: the control flow runs
         # off a per-call RetryCallState, so only its bookkeeping `.statistics` is shared.
         self._retrying = AsyncRetrying(
-            stop=stop_after_attempt(max_attempts),
+            stop=stop_after_attempt(max_retries + 1),
             retry=retry_if_exception_type(ModelError)
             & retry_if_not_exception_type(OverlongPromptError),
+            before_sleep=self._log_retry,
             reraise=True,
+        )
+
+    def _log_retry(self, state: RetryCallState) -> None:
+        logger.warning(
+            "retrying model call (attempt %d/%d) after error: %s",
+            state.attempt_number,
+            self.max_retries + 1,
+            state.outcome.exception(),
         )
 
     async def get_response(

--- a/verifiers/v1/clients/client.py
+++ b/verifiers/v1/clients/client.py
@@ -40,7 +40,14 @@ class RetryingClient(Client):
 
     def __init__(self, inner: Client, max_attempts: int) -> None:
         self.inner = inner
-        self.max_attempts = max_attempts
+        # One Retrying, reused across (and concurrent within) calls: the control flow runs
+        # off a per-call RetryCallState, so only its bookkeeping `.statistics` is shared.
+        self._retrying = AsyncRetrying(
+            stop=stop_after_attempt(max_attempts),
+            retry=retry_if_exception_type(ModelError)
+            & retry_if_not_exception_type(OverlongPromptError),
+            reraise=True,
+        )
 
     async def get_response(
         self,
@@ -49,13 +56,7 @@ class RetryingClient(Client):
         sampling_args: SamplingConfig,
         tools: list[Tool] | None = None,
     ) -> Response:
-        retrying = AsyncRetrying(
-            stop=stop_after_attempt(self.max_attempts),
-            retry=retry_if_exception_type(ModelError)
-            & retry_if_not_exception_type(OverlongPromptError),
-            reraise=True,
-        )
-        return await retrying(
+        return await self._retrying(
             self.inner.get_response, prompt, model, sampling_args, tools
         )
 

--- a/verifiers/v1/env.py
+++ b/verifiers/v1/env.py
@@ -92,7 +92,7 @@ class EnvConfig(BaseConfig):
     taskset: SerializeAsAny[TasksetConfig] = TasksetConfig()
     harness: SerializeAsAny[HarnessConfig] = HarnessConfig(id="default")
     timeout: TimeoutConfig = TimeoutConfig()
-    retry: RetryConfig = RetryConfig()
+    retries: RetryConfig = RetryConfig()
     max_turns: int | None = None
     """Max model turns per rollout (None = no limit). Enforced by the framework (the
     interception server refuses turns past it), so it applies to any harness — turn
@@ -270,6 +270,7 @@ class Environment:
             if self.scoring_timeout is not None
             else task.scoring_timeout
         )
+        retries = self.config.retries
         rollouts = [
             Rollout(
                 task=task,
@@ -280,10 +281,12 @@ class Environment:
                 harness_timeout=harness_timeout,
                 scoring_timeout=scoring_timeout,
                 limits=self.limits,
+                model_retries=retries.model.max_attempts,
+                runtime_retries=retries.runtime.max_attempts,
             )
             for _ in range(n)
         ]
-        return Episode(rollouts, self.taskset, retry=self.config.retry)
+        return Episode(rollouts, self.taskset, retry=retries.rollout)
 
     def interception_pool(self) -> InterceptionPool:
         """The shared interception pool for this env's rollouts — one server (+ tunnel

--- a/verifiers/v1/env.py
+++ b/verifiers/v1/env.py
@@ -281,8 +281,8 @@ class Environment:
                 harness_timeout=harness_timeout,
                 scoring_timeout=scoring_timeout,
                 limits=self.limits,
-                model_retries=retries.model.max_attempts,
-                runtime_retries=retries.runtime.max_attempts,
+                model_retries=retries.model.max_retries,
+                runtime_retries=retries.runtime.max_retries,
             )
             for _ in range(n)
         ]

--- a/verifiers/v1/episode.py
+++ b/verifiers/v1/episode.py
@@ -31,12 +31,12 @@ from verifiers.v1.utils import trim_memory_periodically
 
 if TYPE_CHECKING:
     from verifiers.v1.interception import InterceptionPool
-    from verifiers.v1.retries import RetryConfig
+    from verifiers.v1.retries import RolloutRetryConfig
 
 
 class Episode:
     def __init__(
-        self, rollouts: list[Rollout], taskset: Taskset, retry: RetryConfig
+        self, rollouts: list[Rollout], taskset: Taskset, retry: RolloutRetryConfig
     ) -> None:
         self.rollouts = rollouts
         self.taskset = taskset

--- a/verifiers/v1/retries.py
+++ b/verifiers/v1/retries.py
@@ -11,6 +11,7 @@ superseded by the finer per-call retries).
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 from pydantic import Field
@@ -27,13 +28,15 @@ if TYPE_CHECKING:
     from verifiers.v1.rollout import Rollout
     from verifiers.v1.trace import Trace
 
+logger = logging.getLogger(__name__)
+
 
 class CallRetryConfig(BaseConfig):
     """Retries around a single model or runtime call (tenacity). Reruns just the failed
     call, so the rest of the rollout's progress survives a transient failure."""
 
-    max_attempts: int = Field(3, ge=0)
-    """Total attempts for one call (0 or 1 = no retry)."""
+    max_retries: int = Field(3, ge=0)
+    """Retries for one call beyond the first attempt (0 = no retry, N = up to N retries)."""
 
 
 class RolloutRetryConfig(BaseConfig):
@@ -41,8 +44,8 @@ class RolloutRetryConfig(BaseConfig):
     rollout-level retries). Matching is by the error's exception type name, so
     `include`/`exclude` name exception classes (e.g. ``ModelError``, ``ProgramError``)."""
 
-    max_attempts: int = Field(1, ge=0)
-    """Total rollout attempts (0 or 1 = no retry)."""
+    max_retries: int = Field(1, ge=0)
+    """Whole-rollout retries beyond the first attempt (0 = no retry, N = up to N retries)."""
     include: list[str] = []
     """Only retry errors whose type is listed. Empty = retry anything not excluded."""
     exclude: list[str] = []
@@ -84,7 +87,7 @@ async def run_with_retry(
     Each retry-causing attempt's error is collected onto the returned trace's `errors`,
     so the final trace shows the full history; the last attempt's trace is returned
     as-is once attempts run out (or the rollout succeeds / hits a non-retryable error)."""
-    if retry.max_attempts <= 1:
+    if retry.max_retries < 1:
         return await rollout.run(shared_urls, interception)
 
     history: list = []
@@ -92,10 +95,18 @@ async def run_with_retry(
     def record(state: RetryCallState) -> None:
         # before_sleep fires only between attempts (a retry is imminent), so this
         # collects exactly the errors that caused a retry — never the final attempt's.
-        history.extend(state.outcome.result().errors)
+        trace = state.outcome.result()
+        logger.warning(
+            "retrying rollout %s (attempt %d/%d) after error: %s",
+            trace.id,
+            state.attempt_number,
+            retry.max_retries + 1,
+            trace.error.type if trace.error else "?",
+        )
+        history.extend(trace.errors)
 
     retrying = AsyncRetrying(
-        stop=stop_after_attempt(retry.max_attempts),
+        stop=stop_after_attempt(retry.max_retries + 1),
         retry=retry_if_result(lambda trace: should_retry(trace, retry)),
         before_sleep=record,
         retry_error_callback=lambda state: state.outcome.result(),

--- a/verifiers/v1/retries.py
+++ b/verifiers/v1/retries.py
@@ -32,8 +32,8 @@ class CallRetryConfig(BaseConfig):
     """Retries around a single model or runtime call (tenacity). Reruns just the failed
     call, so the rest of the rollout's progress survives a transient failure."""
 
-    max_attempts: int = Field(3, ge=1)
-    """Total attempts for one call (1 = no retry)."""
+    max_attempts: int = Field(3, ge=0)
+    """Total attempts for one call (0 or 1 = no retry)."""
 
 
 class RolloutRetryConfig(BaseConfig):
@@ -41,8 +41,8 @@ class RolloutRetryConfig(BaseConfig):
     rollout-level retries). Matching is by the error's exception type name, so
     `include`/`exclude` name exception classes (e.g. ``ModelError``, ``ProgramError``)."""
 
-    max_attempts: int = Field(1, ge=1)
-    """Total rollout attempts (1 = no retry)."""
+    max_attempts: int = Field(1, ge=0)
+    """Total rollout attempts (0 or 1 = no retry)."""
     include: list[str] = []
     """Only retry errors whose type is listed. Empty = retry anything not excluded."""
     exclude: list[str] = []

--- a/verifiers/v1/retries.py
+++ b/verifiers/v1/retries.py
@@ -1,15 +1,19 @@
-"""Rollout-level retries: rerun a whole rollout while it ends with a retryable error.
+"""Retries at two granularities: per-call (model, runtime) and whole-rollout.
 
-Parity with v0's rollout retries. `RetryConfig` lives on `EnvConfig.retry`; `run_with_retry`
-wraps a `Rollout` with tenacity, retrying on the trace's captured error (matched by exception
-type name against include/exclude) and accumulating each failed attempt's error onto the
-returned trace's `errors`, so the final trace shows the whole retry history.
+`RetryConfig` lives on `EnvConfig.retries`. Per-call retries wrap a single model or
+runtime call (`RetryingClient` / `RetryingRuntime`), rerunning just the failed call so
+the rest of the rollout's progress is kept — the cheap, default-on layer. Whole-rollout
+retries (`run_with_retry`) rerun an entire trajectory when its trace ends with a retryable
+error (matched by exception type name against include/exclude), accumulating each failed
+attempt's error onto the returned trace's `errors`; off by default (parity with v0, but
+superseded by the finer per-call retries).
 """
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from pydantic import Field
 from pydantic_config import BaseConfig
 from tenacity import (
     AsyncRetrying,
@@ -24,12 +28,20 @@ if TYPE_CHECKING:
     from verifiers.v1.trace import Trace
 
 
-class RetryConfig(BaseConfig):
+class CallRetryConfig(BaseConfig):
+    """Retries around a single model or runtime call (tenacity). Reruns just the failed
+    call, so the rest of the rollout's progress survives a transient failure."""
+
+    max_attempts: int = Field(3, ge=1)
+    """Total attempts for one call (1 = no retry)."""
+
+
+class RolloutRetryConfig(BaseConfig):
     """Retry a whole rollout when it ends with a captured error (parity with v0's
     rollout-level retries). Matching is by the error's exception type name, so
     `include`/`exclude` name exception classes (e.g. ``ModelError``, ``ProgramError``)."""
 
-    attempts: int = 3
+    max_attempts: int = Field(1, ge=1)
     """Total rollout attempts (1 = no retry)."""
     include: list[str] = []
     """Only retry errors whose type is listed. Empty = retry anything not excluded."""
@@ -37,7 +49,19 @@ class RetryConfig(BaseConfig):
     """Never retry errors whose type is listed (wins over `include`)."""
 
 
-def should_retry(trace: Trace, retry: RetryConfig) -> bool:
+class RetryConfig(BaseConfig):
+    """All of a rollout's retries: per-call `model` + `runtime` (rerun a single failed
+    call) and whole-`rollout` (rerun the whole trajectory on a captured error)."""
+
+    model: CallRetryConfig = CallRetryConfig()
+    """Retries around each model/provider call (the interception server's completion)."""
+    runtime: CallRetryConfig = CallRetryConfig()
+    """Retries around each runtime call (provision, exec, file read/write)."""
+    rollout: RolloutRetryConfig = RolloutRetryConfig()
+    """Retries of the whole rollout, on a captured retryable error."""
+
+
+def should_retry(trace: Trace, retry: RolloutRetryConfig) -> bool:
     """Whether a finished rollout should be retried: it ended with an error whose
     exception type is included (and not excluded)."""
     error = trace.error
@@ -54,13 +78,13 @@ async def run_with_retry(
     rollout: Rollout,
     shared_urls: dict[str, str] | None,
     interception: InterceptionPool | None,
-    retry: RetryConfig,
+    retry: RolloutRetryConfig,
 ) -> Trace:
     """Run the whole rollout, retrying it while its trace ends with a retryable error.
     Each retry-causing attempt's error is collected onto the returned trace's `errors`,
     so the final trace shows the full history; the last attempt's trace is returned
     as-is once attempts run out (or the rollout succeeds / hits a non-retryable error)."""
-    if retry.attempts <= 1:
+    if retry.max_attempts <= 1:
         return await rollout.run(shared_urls, interception)
 
     history: list = []
@@ -71,7 +95,7 @@ async def run_with_retry(
         history.extend(state.outcome.result().errors)
 
     retrying = AsyncRetrying(
-        stop=stop_after_attempt(retry.attempts),
+        stop=stop_after_attempt(retry.max_attempts),
         retry=retry_if_result(lambda trace: should_retry(trace, retry)),
         before_sleep=record,
         retry_error_callback=lambda state: state.outcome.result(),

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -75,9 +75,7 @@ class Rollout:
         self.scoring_timeout = scoring_timeout
         self.limits = limits or RolloutLimits()
         self.model_retries = model_retries
-        """Retries per model call (0 = no retry); wraps the client in `run()`."""
         self.runtime_retries = runtime_retries
-        """Retries per runtime call (0 = no retry); wraps the runtime in `run()`."""
         self.phase = Phase.SETUP
         """Lifecycle phase for display (see `Phase`); advanced through the rollout, and
         set to DONE by the Episode once group scoring has run."""

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -63,8 +63,8 @@ class Rollout:
         harness_timeout: float | None = None,
         scoring_timeout: float | None = None,
         limits: RolloutLimits | None = None,
-        model_retries: int = 1,
-        runtime_retries: int = 1,
+        model_retries: int = 0,
+        runtime_retries: int = 0,
     ) -> None:
         self.task = task
         self.taskset = taskset
@@ -75,9 +75,9 @@ class Rollout:
         self.scoring_timeout = scoring_timeout
         self.limits = limits or RolloutLimits()
         self.model_retries = model_retries
-        """Total attempts per model call (1 = no retry); wraps the client in `run()`."""
+        """Retries per model call (0 = no retry); wraps the client in `run()`."""
         self.runtime_retries = runtime_retries
-        """Total attempts per runtime call (1 = no retry); wraps the runtime in `run()`."""
+        """Retries per runtime call (0 = no retry); wraps the runtime in `run()`."""
         self.phase = Phase.SETUP
         """Lifecycle phase for display (see `Phase`); advanced through the rollout, and
         set to DONE by the Episode once group scoring has run."""
@@ -123,11 +123,11 @@ class Rollout:
         self.runtime = make_runtime(
             self.runtime_config, name=trace.id
         )  # ref set first → always tearable-down; named after the rollout for traceability
-        if self.runtime_retries > 1:
+        if self.runtime_retries > 0:
             self.runtime = RetryingRuntime(self.runtime, self.runtime_retries)
         runtime = self.runtime
         ctx = self.ctx
-        if self.model_retries > 1:
+        if self.model_retries > 0:
             ctx = replace(ctx, client=RetryingClient(ctx.client, self.model_retries))
         stops = discover_decorated(self.taskset, "stop")
         logger.info(

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -15,15 +15,21 @@ import asyncio
 import logging
 import time
 from contextlib import asynccontextmanager
+from dataclasses import replace
 from enum import StrEnum
 from typing import TYPE_CHECKING
 
 from verifiers.v1.harness import Harness
-from verifiers.v1.clients import RolloutContext
+from verifiers.v1.clients import RetryingClient, RolloutContext
 from verifiers.v1.decorators import discover_decorated
 from verifiers.v1.errors import ProgramError, RolloutError
 from verifiers.v1.interception import InterceptionServer, RolloutLimits, RolloutSession
-from verifiers.v1.runtimes import Runtime, RuntimeConfig, make_runtime
+from verifiers.v1.runtimes import (
+    RetryingRuntime,
+    Runtime,
+    RuntimeConfig,
+    make_runtime,
+)
 from verifiers.v1.task import Task
 from verifiers.v1.taskset import Taskset
 from verifiers.v1.tools import serve_tools
@@ -57,6 +63,8 @@ class Rollout:
         harness_timeout: float | None = None,
         scoring_timeout: float | None = None,
         limits: RolloutLimits | None = None,
+        model_retries: int = 1,
+        runtime_retries: int = 1,
     ) -> None:
         self.task = task
         self.taskset = taskset
@@ -66,6 +74,10 @@ class Rollout:
         self.harness_timeout = harness_timeout
         self.scoring_timeout = scoring_timeout
         self.limits = limits or RolloutLimits()
+        self.model_retries = model_retries
+        """Total attempts per model call (1 = no retry); wraps the client in `run()`."""
+        self.runtime_retries = runtime_retries
+        """Total attempts per runtime call (1 = no retry); wraps the runtime in `run()`."""
         self.phase = Phase.SETUP
         """Lifecycle phase for display (see `Phase`); advanced through the rollout, and
         set to DONE by the Episode once group scoring has run."""
@@ -111,7 +123,12 @@ class Rollout:
         self.runtime = make_runtime(
             self.runtime_config, name=trace.id
         )  # ref set first → always tearable-down; named after the rollout for traceability
+        if self.runtime_retries > 1:
+            self.runtime = RetryingRuntime(self.runtime, self.runtime_retries)
         runtime = self.runtime
+        ctx = self.ctx
+        if self.model_retries > 1:
+            ctx = replace(ctx, client=RetryingClient(ctx.client, self.model_retries))
         stops = discover_decorated(self.taskset, "stop")
         logger.info(
             "rollout start: id=%s task=%s harness=%s runtime=%s",
@@ -121,7 +138,7 @@ class Rollout:
             self.runtime_config.type,
         )
         try:
-            session = RolloutSession(self.ctx, trace, stops, self.limits)
+            session = RolloutSession(ctx, trace, stops, self.limits)
             await runtime.start()
             await self.taskset.setup(self.task, runtime)
             async with self._serve_interception(interception, runtime, session) as (
@@ -151,7 +168,7 @@ class Rollout:
                     try:
                         await asyncio.wait_for(
                             self.harness.run(
-                                self.ctx, trace, runtime, endpoint, secret, urls
+                                ctx, trace, runtime, endpoint, secret, urls
                             ),
                             self.harness_timeout,
                         )

--- a/verifiers/v1/runtimes/__init__.py
+++ b/verifiers/v1/runtimes/__init__.py
@@ -11,7 +11,12 @@ from typing import Annotated
 
 from pydantic import Field
 
-from verifiers.v1.runtimes.base import ProgramResult, Runtime, register
+from verifiers.v1.runtimes.base import (
+    ProgramResult,
+    RetryingRuntime,
+    Runtime,
+    register,
+)
 from verifiers.v1.runtimes.docker import DockerConfig, DockerRuntime
 from verifiers.v1.runtimes.modal import ModalConfig, ModalRuntime
 from verifiers.v1.runtimes.prime import PrimeConfig, PrimeRuntime
@@ -38,6 +43,7 @@ def make_runtime(config: RuntimeConfig, name: str | None = None) -> Runtime:
 
 __all__ = [
     "ProgramResult",
+    "RetryingRuntime",
     "Runtime",
     "RuntimeConfig",
     "make_runtime",

--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -15,6 +15,13 @@ import weakref
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 
+from tenacity import (
+    AsyncRetrying,
+    retry_if_exception_type,
+    retry_if_not_exception_type,
+    stop_after_attempt,
+)
+
 # Ensure `uv` is available to run our PEP 723 scripts (the harness + tool servers): use it
 # if present, else bootstrap it — via pip; else via the standalone installer (curl/wget),
 # first installing curl + CA certs from the distro package manager when the image has no
@@ -184,3 +191,60 @@ class Runtime(ABC):
         )
         command = f'{_ENSURE_UV}; exec uv run {shlex.quote(path)} "$@"'
         return await self.run(["sh", "-c", command, path, *(args or [])], env or {})
+
+
+class RetryingRuntime(Runtime):
+    """Wraps a runtime to retry each call on a transient error (tenacity, `max_attempts`
+    total). A program's own failure surfaces as a `ProgramResult` (non-zero exit), not an
+    exception, so retries fire only on infra/transport faults — provisioning, exec
+    transport, file I/O across the runtime boundary. `CancelledError` (a `BaseException`)
+    and `NotImplementedError` (an unsupported op) are never retried. Sync teardown
+    (`cleanup`) and display (`descriptor`) delegate straight through; `run_uv_script` is
+    inherited, so it runs over the retrying `write`/`run`."""
+
+    def __init__(self, inner: Runtime, max_attempts: int) -> None:
+        super().__init__(inner.name)
+        self.inner = inner
+        self.max_attempts = max_attempts
+
+    async def _retry(self, fn, *args):
+        retrying = AsyncRetrying(
+            stop=stop_after_attempt(self.max_attempts),
+            retry=retry_if_exception_type(Exception)
+            & retry_if_not_exception_type(NotImplementedError),
+            reraise=True,
+        )
+        return await retrying(fn, *args)
+
+    async def start(self) -> None:
+        await self._retry(self.inner.start)
+
+    async def stop(self) -> None:
+        await self._retry(self.inner.stop)
+
+    def cleanup(self) -> None:
+        self.inner.cleanup()
+
+    async def expose(self, port: int) -> str:
+        return await self._retry(self.inner.expose, port)
+
+    async def run(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
+        return await self._retry(self.inner.run, argv, env)
+
+    async def run_background(
+        self, argv: list[str], env: dict[str, str], log: str
+    ) -> None:
+        await self._retry(self.inner.run_background, argv, env, log)
+
+    @property
+    def descriptor(self) -> str | None:
+        return self.inner.descriptor
+
+    async def public_url(self, port: int) -> str | None:
+        return await self._retry(self.inner.public_url, port)
+
+    async def read(self, path: str) -> bytes:
+        return await self._retry(self.inner.read, path)
+
+    async def write(self, path: str, data: bytes) -> None:
+        await self._retry(self.inner.write, path, data)

--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -205,16 +205,17 @@ class RetryingRuntime(Runtime):
     def __init__(self, inner: Runtime, max_attempts: int) -> None:
         super().__init__(inner.name)
         self.inner = inner
-        self.max_attempts = max_attempts
-
-    async def _retry(self, fn, *args):
-        retrying = AsyncRetrying(
-            stop=stop_after_attempt(self.max_attempts),
+        # One Retrying, reused across (and concurrent within) calls: the control flow runs
+        # off a per-call RetryCallState, so only its bookkeeping `.statistics` is shared.
+        self._retrying = AsyncRetrying(
+            stop=stop_after_attempt(max_attempts),
             retry=retry_if_exception_type(Exception)
             & retry_if_not_exception_type(NotImplementedError),
             reraise=True,
         )
-        return await retrying(fn, *args)
+
+    async def _retry(self, fn, *args):
+        return await self._retrying(fn, *args)
 
     async def start(self) -> None:
         await self._retry(self.inner.start)

--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -9,6 +9,7 @@ import asyncio
 import atexit
 import contextlib
 import hashlib
+import logging
 import shlex
 import uuid
 import weakref
@@ -17,10 +18,13 @@ from dataclasses import dataclass
 
 from tenacity import (
     AsyncRetrying,
+    RetryCallState,
     retry_if_exception_type,
     retry_if_not_exception_type,
     stop_after_attempt,
 )
+
+logger = logging.getLogger(__name__)
 
 # Ensure `uv` is available to run our PEP 723 scripts (the harness + tool servers): use it
 # if present, else bootstrap it — via pip; else via the standalone installer (curl/wget),
@@ -194,24 +198,35 @@ class Runtime(ABC):
 
 
 class RetryingRuntime(Runtime):
-    """Wraps a runtime to retry each call on a transient error (tenacity, `max_attempts`
-    total). A program's own failure surfaces as a `ProgramResult` (non-zero exit), not an
-    exception, so retries fire only on infra/transport faults — provisioning, exec
-    transport, file I/O across the runtime boundary. `CancelledError` (a `BaseException`)
-    and `NotImplementedError` (an unsupported op) are never retried. Sync teardown
-    (`cleanup`) and display (`descriptor`) delegate straight through; `run_uv_script` is
-    inherited, so it runs over the retrying `write`/`run`."""
+    """Wraps a runtime to retry each call on a transient error (tenacity, up to
+    `max_retries` retries). A program's own failure surfaces as a `ProgramResult` (non-zero
+    exit), not an exception, so retries fire only on infra/transport faults — provisioning,
+    exec transport, file I/O across the runtime boundary. `CancelledError` (a
+    `BaseException`) and `NotImplementedError` (an unsupported op) are never retried. Sync
+    teardown (`cleanup`) and display (`descriptor`) delegate straight through;
+    `run_uv_script` is inherited, so it runs over the retrying `write`/`run`."""
 
-    def __init__(self, inner: Runtime, max_attempts: int) -> None:
+    def __init__(self, inner: Runtime, max_retries: int) -> None:
         super().__init__(inner.name)
         self.inner = inner
+        self.max_retries = max_retries
         # One Retrying, reused across (and concurrent within) calls: the control flow runs
         # off a per-call RetryCallState, so only its bookkeeping `.statistics` is shared.
         self._retrying = AsyncRetrying(
-            stop=stop_after_attempt(max_attempts),
+            stop=stop_after_attempt(max_retries + 1),
             retry=retry_if_exception_type(Exception)
             & retry_if_not_exception_type(NotImplementedError),
+            before_sleep=self._log_retry,
             reraise=True,
+        )
+
+    def _log_retry(self, state: RetryCallState) -> None:
+        logger.warning(
+            "retrying runtime.%s (attempt %d/%d) after error: %s",
+            getattr(state.fn, "__name__", "call"),
+            state.attempt_number,
+            self.max_retries + 1,
+            state.outcome.exception(),
         )
 
     async def _retry(self, fn, *args):


### PR DESCRIPTION
## Summary

- Add tenacity-backed **per-call retries** around a single model call and a single runtime call, configurable on `EnvConfig.retries`. A per-call retry reruns just the failed call (keeping the rollout's progress), so a transient model/infra fault no longer costs a whole trajectory.
- `retries.model.max_retries` (default **3**) — `RetryingClient` wraps the client's `get_response`. Retries `ModelError`, but **never** `OverlongPromptError` (a budget limit the interception server turns into a clean truncation, not a transient fault).
- `retries.runtime.max_retries` (default **3**) — `RetryingRuntime` wraps the rollout runtime (`start`/`stop`/`run`/`read`/`write`/`expose`/`public_url`/`run_background`; `run_uv_script` is inherited so it drives the agent through the retrying `write`/`run`). Retries transport/infra faults; `CancelledError` (a `BaseException`) and `NotImplementedError` are never retried. A program's own failure surfaces as a non-zero `ProgramResult`, not an exception, so it is never retried.
- The whole-rollout retry (parity with v0) moves under `retries.rollout` (default **1**), alongside its existing `include`/`exclude`.
- Each retry logs a `warning` (tenacity `before_sleep`) naming the failed call, the attempt number, and the error.
- Both per-call wrappers are applied per-rollout in `Rollout.run`, and only when their `max_retries > 0` — mirroring how the per-rollout timeouts flow `EnvConfig` → `Environment` → `Rollout`. A single `AsyncRetrying` is built per wrapper and reused (tenacity drives control flow off a per-call `RetryCallState`, so concurrent reuse is safe).

**Semantics:** `max_retries` counts retries *beyond* the first attempt — `0` = no retry, `1` = retry at most once (2 attempts), `N` = up to N retries (`N+1` attempts). `0` turns a layer off.

```bash
uv run eval gsm8k-v1 -n 1 \
  --retries.model.max-retries 3 --retries.runtime.max-retries 3 \
  --retries.rollout.max-retries 0   # turn the whole-rollout retry off
```

## Breaking

- `EnvConfig.retry` → **`EnvConfig.retries`**.
- `RetryConfig.attempts` → **`RetryConfig.rollout.max_retries`** (now counts retries, not attempts; default stays `1`, i.e. one whole-rollout retry).
- `RetryConfig.{include,exclude}` → `RetryConfig.rollout.{include,exclude}`.
- CLI: `--retry.attempts` / `--retry.include` → `--retries.rollout.max-retries` / `--retries.rollout.include`. New: `--retries.model.max-retries`, `--retries.runtime.max-retries`.

No migration needed in prime-rl: its orchestrator `EnvConfig` inherits `vf.EnvConfig`, and no checked-in config or source references the old `retry` field.

## Verification

Ran against this branch (no network needed):

- Config: defaults `model=3, runtime=3, rollout=1`; nested CLI/TOML overrides resolve; `max_retries` floors at `ge=0`.
- `max_retries` arithmetic: `2` → 3 attempts; `1` → 2 attempts (retry once); `0` → 1 attempt (no retry).
- `RetryingClient`: retries `ModelError` and exhausts after `max_retries`; never retries `OverlongPromptError` (1 call).
- `RetryingRuntime`: retries generic `Exception`; never retries `CancelledError` / `NotImplementedError` (1 call); delegates `name`/`descriptor`; `run_uv_script` recovers from a transient `run` failure through the wrapped methods; one shared instance handles concurrent calls with independent per-call retry counting.
- Each retry emits a `warning` (e.g. `retrying model call (attempt 1/3) after error: …`).
- End-to-end: `Environment.episode()` threads `retries.{model,runtime}.max_retries` onto each `Rollout` and `retries.rollout` onto the `Episode`.
- `eval … --dry-run` confirms `--retries.{model,runtime,rollout}.max-retries` parse onto the nested `RetryConfig`.
- `ruff check` / `ruff format` clean on changed files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core rollout execution and changes env/CLI retry field names; behavior changes (more automatic retries) can mask persistent failures or increase eval runtime/cost on flaky infra.
> 
> **Overview**
> Introduces **tenacity-backed per-call retries** for model and runtime operations, so transient failures rerun only the failed call instead of discarding rollout progress.
> 
> **Config/API (breaking):** `EnvConfig.retry` becomes **`retries`** with nested `model`, `runtime`, and `rollout` settings. Whole-rollout retry moves to `retries.rollout` (`max_retries` replaces `attempts`; `include`/`exclude` unchanged in meaning). Defaults: **3** per-call retries for model and runtime, **1** whole-rollout retry. `max_retries` is retries after the first attempt (`0` disables that layer).
> 
> **Implementation:** `RetryingClient` wraps completions and retries `ModelError` but not `OverlongPromptError`. `RetryingRuntime` wraps infra calls (`start`, `run`, I/O, etc.) and retries generic `Exception` except `NotImplementedError`. `Rollout.run` applies both wrappers when counts are &gt; 0; `Environment.episode()` threads limits from config. Whole-rollout `run_with_retry` gains warning logs and uses `max_retries + 1` attempts.
> 
> Docs and public exports updated for `--retries.{model,runtime,rollout}.*` CLI flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cdc4f2716583ec1ff4491cfe42911fc85b821b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->