### PR TITLE
fix: blank elapsed for queued rollouts in the rich dashboard

### DIFF
--- a/verifiers/v1/cli/dashboard.py
+++ b/verifiers/v1/cli/dashboard.py
@@ -137,6 +137,7 @@ def _rows(groups: list[list[Rollout]], now: float, runtime_type: str) -> Table:
             )
             runtime = f"{runtime_type}({descriptor})" if descriptor else runtime_type
             turns = t.num_turns
+            start = t.timing.generation.start
             end = t.timing.scoring.end or t.timing.generation.end or now
             left = [
                 f"task {label}",
@@ -146,7 +147,8 @@ def _rows(groups: list[list[Rollout]], now: float, runtime_type: str) -> Table:
                 _tokens(t),
                 stop,  # stop condition (agent_completed / max_turns / harness_timeout), once done
             ]
-            elapsed = format_time(end - t.timing.generation.start)
+            # No start time yet (queued, not generating) → blank, not `now - 0` (~56 years).
+            elapsed = format_time(end - start) if start else ""
             rows.append((_brace(i, len(group)), state, left, result, elapsed))
     grid = Table.grid(expand=True, padding=(0, 1))
     grid.add_column(


### PR DESCRIPTION
## Summary

The `--rich` eval dashboard rendered **queued (not-yet-started) rollouts** with a ~56-year elapsed time (`20615d 20h`). A queued rollout's `trace.timing.generation.start` is `0` (it's only set when generation begins), and `end` falls back to `now`, so `format_time(end - start)` became `format_time(now)`. Guard on `start` — blank until the rollout starts generating. Running/done rows are unchanged.

```python
# verifiers/v1/cli/dashboard.py
start = t.timing.generation.start
end = t.timing.scoring.end or t.timing.generation.end or now
elapsed = format_time(end - start) if start else ""   # was: format_time(end - t.timing.generation.start)
```

## Verification

```
format_time(time.time())  -> 20615d 20h     # matches the reported value (elapsed = now - 0)
queued Trace .generation.start -> 0.0
OLD elapsed -> 20615d 20h
NEW elapsed -> ''                            # blank for queued; running/done unaffected
```

`ruff` clean.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix blank elapsed time for queued rollouts in the rich dashboard
> In [dashboard.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1633/files#diff-c60769cf42a5e4975c5dc5a0f893c697282abd7d848c02c6229b8b5cc42b2bad), the `_rows` helper now leaves the elapsed field blank when no generation start time is present, rather than computing a large spurious duration from a zero timestamp.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0b77bf3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change in dashboard row formatting with no effect on eval execution or scoring.
> 
> **Overview**
> Fixes a display bug in the **`--rich` eval dashboard** where rollouts that are **queued** (not yet generating) showed a bogus elapsed time on the order of **~56 years** (`20615d 20h`).
> 
> In `_rows`, elapsed time is now computed only when `trace.timing.generation.start` is set. Queued traces still have `generation.start == 0` while `end` falls back to `now`, so the old `format_time(end - start)` effectively formatted **now** as a duration. **Running and finished rows are unchanged** once generation has started.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b77bf3eb23d3a070e5064e3fb054923444222d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->