### PR TITLE
fix: exclude timing.setup.duration from Trace.to_wire

### DIFF
--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -354,6 +354,7 @@ class Trace(StrictBaseModel, Generic[TaskT]):
         gets written to disk."""
         exclude: dict = {field: True for field in type(self).model_computed_fields}
         exclude["timing"] = {
+            "setup": {"duration": True},
             "generation": {"duration": True},
             "scoring": {"duration": True},
         }


### PR DESCRIPTION
## Summary

`Trace.to_wire()` drops the computed `duration` of each timing span (a strict `Trace` can't accept computed fields as input, and the consumer recomputes them). #1631 added `Timing.setup` but didn't add it to the exclude map, so `setup.duration` leaked into the wire dump.

Over the **env-server (serve) path** — now the default — the trace round-trips through `to_wire()`, and `RunRolloutResponse` validation then rejects `timing.setup.duration` with `extra_forbidden`, **failing every rollout** on the worker/elastic path. (In-process eval doesn't serialize, so it slipped past #1631's verification.)

Fix: exclude `timing.setup.duration` alongside `generation`/`scoring`.

## Verification

`t.to_wire()` no longer emits `timing.setup.duration`, and `Trace.model_validate(t.to_wire())` (what `RunRolloutResponse` does) round-trips without error. Confirmed end-to-end: gsm8k-v1 rollouts over the serve path complete cleanly with the fix (they failed `extra_forbidden` without it). ruff clean.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Exclude `timing.setup.duration` from `Trace.to_wire` serialization
> Adds `timing.setup.duration` to the exclude map in [trace.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1634/files#diff-834820c3aa80d87ee1c1c57fb54c74f09c66ac727036d964e6005c8613c00b5e), matching the existing omissions of `timing.generation.duration` and `timing.scoring.duration`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0eec77c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->