### PR TITLE
fix: tee eval logs to output dir; keep them off the rich dashboard

### DIFF
--- a/verifiers/v1/cli/eval.py
+++ b/verifiers/v1/cli/eval.py
@@ -19,6 +19,7 @@ from pydantic_config import cli
 
 import verifiers.v1 as vf
 from verifiers.v1.cli.log import setup_logging
+from verifiers.v1.cli.output import output_path
 from verifiers.v1.cli.resolve import (
     extract_id,
     local_examples,
@@ -66,13 +67,17 @@ def main(argv: list[str] | None = None) -> None:
     # plain (non-rich) v1 run goes through the env server using `pool` (the path prime-rl
     # trains through). Legacy always runs in-process via the bridge.
     rich = config.rich and not config.is_legacy
-    # --rich owns the screen, so quiet the per-rollout INFO logs it would replace.
-    setup_logging("DEBUG" if config.verbose else "WARNING" if rich else "INFO")
-    if rich and not config.verbose:
-        # The Live dashboard owns the screen — gag WARNING-and-below from every logger
-        # (library + third-party, which `setup_logging` doesn't route) so stray log lines
-        # don't flash over it. Errors still print; pass --verbose to see everything.
-        logging.disable(logging.WARNING)
+    # Always tee the run's logs to a file under the output dir (in-process and server mode).
+    log_file = str(output_path(config) / "eval.log")
+    level = "DEBUG" if config.verbose else "INFO"
+    if rich:
+        # The Live dashboard owns the terminal: keep logs off it entirely (regardless of
+        # verbosity) while still writing them to the file. `lastResort = None` drops any
+        # third-party stdlib records that bypass loguru, so nothing flashes over the UI.
+        setup_logging(level, log_file=log_file, console=False)
+        logging.lastResort = None
+    else:
+        setup_logging(level, log_file=log_file, console=True)
     # Make SIGTERM behave like Ctrl-C (SIGINT) so a killed/timed-out eval still runs each
     # rollout's `finally` (tears down containers/sandboxes) and any worker pool it spawned.
     signal.signal(signal.SIGTERM, lambda *_: (_ for _ in ()).throw(KeyboardInterrupt()))

--- a/verifiers/v1/cli/eval.py
+++ b/verifiers/v1/cli/eval.py
@@ -71,11 +71,8 @@ def main(argv: list[str] | None = None) -> None:
     log_file = str(output_path(config) / "eval.log")
     level = "DEBUG" if config.verbose else "INFO"
     if rich:
-        # The Live dashboard owns the terminal: keep logs off it entirely (regardless of
-        # verbosity) while still writing them to the file. `lastResort = None` drops any
-        # third-party stdlib records that bypass loguru, so nothing flashes over the UI.
         setup_logging(level, log_file=log_file, console=False)
-        logging.lastResort = None
+        logging.lastResort = None  # drop stray stdlib records (else they print over the UI)
     else:
         setup_logging(level, log_file=log_file, console=True)
     # Make SIGTERM behave like Ctrl-C (SIGINT) so a killed/timed-out eval still runs each

--- a/verifiers/v1/cli/eval.py
+++ b/verifiers/v1/cli/eval.py
@@ -11,6 +11,7 @@ pydantic-config help — narrowed to whatever `--taskset.id` / `--harness.id` ar
 """
 
 import asyncio
+import logging
 import signal
 import sys
 
@@ -67,6 +68,11 @@ def main(argv: list[str] | None = None) -> None:
     rich = config.rich and not config.is_legacy
     # --rich owns the screen, so quiet the per-rollout INFO logs it would replace.
     setup_logging("DEBUG" if config.verbose else "WARNING" if rich else "INFO")
+    if rich and not config.verbose:
+        # The Live dashboard owns the screen — gag WARNING-and-below from every logger
+        # (library + third-party, which `setup_logging` doesn't route) so stray log lines
+        # don't flash over it. Errors still print; pass --verbose to see everything.
+        logging.disable(logging.WARNING)
     # Make SIGTERM behave like Ctrl-C (SIGINT) so a killed/timed-out eval still runs each
     # rollout's `finally` (tears down containers/sandboxes) and any worker pool it spawned.
     signal.signal(signal.SIGTERM, lambda *_: (_ for _ in ()).throw(KeyboardInterrupt()))

--- a/verifiers/v1/cli/log.py
+++ b/verifiers/v1/cli/log.py
@@ -9,6 +9,7 @@ loguru. Mirrors prime-rl's `intercept_vf_logging`.
 
 import logging
 import sys
+from pathlib import Path
 
 from loguru import logger
 
@@ -35,12 +36,21 @@ class InterceptHandler(logging.Handler):
         )
 
 
-def setup_logging(level: str = "INFO") -> None:
-    """Send loguru to stderr and route the library's stdlib logs into it."""
+def setup_logging(
+    level: str = "INFO", log_file: str | None = None, console: bool = True
+) -> None:
+    """Route the library's stdlib logs through loguru, to stderr (when `console`) and/or a
+    `log_file`. `console=False` (used under the `--rich` dashboard, which owns the screen)
+    keeps logs off the terminal while still writing them to `log_file`."""
+    lvl = level.upper()
     logger.remove()
-    logger.add(sys.stderr, level=level.upper(), format=FORMAT)
+    if console:
+        logger.add(sys.stderr, level=lvl, format=FORMAT)
+    if log_file is not None:
+        Path(log_file).parent.mkdir(parents=True, exist_ok=True)
+        logger.add(log_file, level=lvl, format=FORMAT)
     library = logging.getLogger(LIBRARY_LOGGER)
     library.handlers.clear()  # drop the opt-in NullHandler
     library.addHandler(InterceptHandler())
-    library.setLevel(level.upper())
+    library.setLevel(lvl)
     library.propagate = False

--- a/verifiers/v1/cli/runner.py
+++ b/verifiers/v1/cli/runner.py
@@ -94,8 +94,10 @@ async def run_eval_server(config: EvalConfig) -> list[Trace]:
         else {"config_data": env_config_data(config)}  # picklable across the spawn
     )
     # The pool broker + workers are spawned (fresh interpreters, no logging) — hand them
-    # the same loguru setup the main process uses so their rollout logs come back.
+    # the same loguru setup the main process uses (stderr + the run's log file) so their
+    # rollout logs come back and land in the output dir.
     level = "DEBUG" if config.verbose else "INFO"
+    log_file = str(output_path(config) / "eval.log")
     mpctx = mp.get_context("spawn")
     address_queue: mp.Queue = mpctx.Queue()
     proc = mpctx.Process(
@@ -105,7 +107,7 @@ async def run_eval_server(config: EvalConfig) -> list[Trace]:
             legacy=legacy,
             address="tcp://127.0.0.1:0",
             address_queue=address_queue,
-            log_setup=partial(setup_logging, level),
+            log_setup=partial(setup_logging, level, log_file),
             **server_kwargs,
         ),
         daemon=False,


### PR DESCRIPTION
## Summary

In `--rich` eval mode the Live dashboard owns the terminal, but logs still printed to stderr and **flashed over it**. Make rich mode **turn off console logging while keeping logs in a file**, and always tee the run's logs to the output dir (in-process *and* server mode).

- **`setup_logging(level, log_file=None, console=True)`** — loguru sink to stderr (when `console`) and/or to `log_file`.
- **eval CLI** — always writes the run's logs to `<output_dir>/eval.log`. Under `--rich`: `console=False` (no stderr sink) + drop the stdlib `lastResort` handler, so nothing flashes over the dashboard **regardless of `--verbose`**; the file still gets everything (`verifiers.v1` at the chosen level). Non-rich logs to console **and** file.
- **`run_eval_server`** — the spawned broker/workers also tee to `<output_dir>/eval.log`, so server-mode logs land in the output dir too.

Supersedes the earlier rich-mode `logging.disable(WARNING)` gag (which couldn't keep the logs in a file).

## Verification

- **rich**: `eval.log` has the rollout logs, **0 log lines leak to the terminal** (also with `--verbose`).
- **non-rich / server**: logs appear on the console and in `eval.log` (incl. the `EnvServerPool up` line).

`ruff` clean.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Tee eval logs to output directory and suppress them from the rich dashboard
> - [`setup_logging`](https://github.com/PrimeIntellect-ai/verifiers/pull/1635/files#diff-ce6f56dd3e08d612b002258656311a0e77adf9da73b12af1b13b6805f0d99e60) gains `log_file` and `console` parameters, creating parent directories as needed and routing loguru sinks accordingly.
> - In `--rich` mode, console logging is disabled and `logging.lastResort` is set to `None` to suppress stray stdlib logs from printing over the UI; file logging at INFO/DEBUG continues.
> - In non-rich mode, logs are teed to both console and the file.
> - [`run_eval_server`](https://github.com/PrimeIntellect-ai/verifiers/pull/1635/files#diff-3d708e6dbc4cd4b549bfca1be17b1385b52b7cd03992bf82522e225f4aaaadbf) passes the same `eval.log` path into spawned broker/worker processes so their logs are captured to the run's output directory.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c1d6729.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI logging routing only; no changes to eval execution, auth, or data paths beyond writing eval.log.
> 
> **Overview**
> Eval runs now **always tee logs to** `<output_dir>/eval.log` in both in-process and env-server modes. **`setup_logging`** accepts optional **`log_file`** and **`console`** flags so loguru can write to stderr, a file, or both (parent dirs are created for the file sink).
> 
> In **`--rich`** mode, logging goes **only to the file** (`console=False`) and **`logging.lastResort`** is cleared so stray stdlib logs do not flash over the dashboard. Rich mode no longer forces **WARNING** on the console; it uses **INFO** (or **DEBUG** with `--verbose**) in the file like non-rich runs. Non-rich mode keeps stderr **and** the same log file.
> 
> Spawned env-server workers receive the same **`log_file`** via **`partial(setup_logging, level, log_file)`** so pool rollout logs land in the output directory too.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1d6729faad602459e7bcc563bea7ce77083269b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->