### PR TITLE
fix: drop every timing span's computed duration from Trace.to_wire

### DIFF
--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -353,9 +353,12 @@ class Trace(StrictBaseModel, Generic[TaskT]):
         trajectory on every reply. The full `model_dump` (with derived fields) is what
         gets written to disk."""
         exclude: dict = {field: True for field in type(self).model_computed_fields}
+        # Drop each timing span's computed `duration` — derived per `TimeSpan` field of
+        # `Timing` (setup/generation/scoring, and any future span) so none leaks to the wire.
         exclude["timing"] = {
-            "generation": {"duration": True},
-            "scoring": {"duration": True},
+            name: {f: True for f in TimeSpan.model_computed_fields}
+            for name, info in Timing.model_fields.items()
+            if info.annotation is TimeSpan
         }
         return self.model_dump(mode="json", exclude=exclude)
 


### PR DESCRIPTION
## Summary

Server-mode rollouts (the env-server path — `eval --no-rich`, and prime-rl training) failed with:

```
RunRolloutResponse: trace.timing.setup.duration — Extra inputs are not permitted
```

`Trace.to_wire()` excludes each timing span's computed `duration` before sending, but the list was hardcoded to `generation`/`scoring` and missed the newer `setup` span. So `setup.duration` leaked into the wire and the strict (`extra_forbidden`) receiving model rejected it — **breaking every server-mode rollout**. Derive the exclude from `Timing`'s `TimeSpan` fields so all spans (and any future one) are stripped.

## Verification

- Round-trip: `Trace.to_wire()` emits `setup`/`generation`/`scoring` with only `start`/`end`; `Trace.model_validate(wire)` no longer raises.
- e2e: `eval gsm8k-v1 --no-rich` (server/pool path) now completes — **rc=0, 3/3 rollouts, 0 `extra_forbidden`** (was rc=1, crash on the first reply).

`ruff` clean.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Drop computed `duration` fields from all `Timing` spans in `Trace.to_wire`
> Previously, `Trace.to_wire` in [trace.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1636/files#diff-834820c3aa80d87ee1c1c57fb54c74f09c66ac727036d964e6005c8613c00b5e) only excluded `duration` from `generation` and `scoring` spans. It now iterates over all `Timing.model_fields`, and for every field typed as `TimeSpan`, excludes that span's computed fields dynamically using `TimeSpan.model_computed_fields`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cd8a995.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single serialization-path change in `to_wire` with no auth or data-model behavior changes beyond omitting derived timing fields on the wire.
> 
> **Overview**
> **Fixes server-mode rollout failures** where strict `Trace` validation rejected wire payloads because `timing.setup.duration` was still sent.
> 
> `Trace.to_wire()` already stripped computed `duration` from `generation` and `scoring`, but not from the newer **`setup`** span. The exclude list is now built by scanning `Timing.model_fields` and, for every field typed as `TimeSpan`, excluding that span’s `TimeSpan.model_computed_fields` (so `setup` is covered and future timing spans are handled the same way).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd8a995880271588636ac7b268305cb9731feb21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->