### PR TITLE
feat: add --resume for evals (re-run a previous run's missing/errored rollouts)

### DIFF
--- a/verifiers/v1/cli/eval.py
+++ b/verifiers/v1/cli/eval.py
@@ -19,7 +19,7 @@ from pydantic_config import cli
 
 import verifiers.v1 as vf
 from verifiers.v1.cli.log import setup_logging
-from verifiers.v1.cli.output import output_path
+from verifiers.v1.cli.output import output_path, write_config
 from verifiers.v1.cli.resolve import (
     extract_id,
     local_examples,
@@ -30,6 +30,8 @@ from verifiers.v1.cli.resolve import (
 from verifiers.v1.cli.resume import load_resume_config, split_resume
 from verifiers.v1.cli.runner import run_eval
 from verifiers.v1.configs.eval import EvalConfig
+
+logger = logging.getLogger(__name__)
 
 USAGE = (
     "usage: uv run eval [<taskset-id>] [--harness.id <id>] [--id <env-id> (legacy)] [options] [@ file.toml]\n"
@@ -52,7 +54,8 @@ def main(argv: list[str] | None = None) -> None:
         )  # full option help, narrowed to the given ids
         return
     resume_dir, rest = split_resume(argv)
-    if resume_dir is not None:  # re-run a previous run's missing/errored rollouts, in place
+    # re-run a previous run's missing/errored rollouts, in place
+    if resume_dir is not None:
         if rest:
             raise SystemExit(
                 f"{USAGE}\n--resume re-runs a saved config verbatim and takes no other arguments"
@@ -72,8 +75,9 @@ def main(argv: list[str] | None = None) -> None:
         config_type = narrow_config(EvalConfig, argv)
         sys.argv = [sys.argv[0], *argv]  # let prime-pydantic-config render help/errors
         config = cli(config_type)
-        if config.dry_run:  # resolved + validated; dump it and skip the run
-            print(config.model_dump_json(indent=2, exclude_none=True))
+        if config.dry_run:  # resolved + validated; write it to the output dir and exit
+            setup_logging("DEBUG" if config.verbose else "INFO")
+            logger.info("wrote config to %s", write_config(config, output_path(config)))
             return
     if config.is_legacy and config.resume is not None:
         raise SystemExit("--resume is not supported for legacy (v0) evals")
@@ -86,7 +90,8 @@ def main(argv: list[str] | None = None) -> None:
     level = "DEBUG" if config.verbose else "INFO"
     if rich:
         setup_logging(level, log_file=log_file, console=False)
-        logging.lastResort = None  # drop stray stdlib records (else they print over the UI)
+        # drop stray stdlib records that bypass loguru (else they print over the UI)
+        logging.lastResort = None
     else:
         setup_logging(level, log_file=log_file, console=True)
     # Make SIGTERM behave like Ctrl-C (SIGINT) so a killed/timed-out eval still runs each

--- a/verifiers/v1/cli/eval.py
+++ b/verifiers/v1/cli/eval.py
@@ -27,10 +27,14 @@ from verifiers.v1.cli.resolve import (
     references_config_file,
     with_positional_taskset,
 )
+from verifiers.v1.cli.resume import load_resume_config, split_resume
 from verifiers.v1.cli.runner import run_eval
 from verifiers.v1.configs.eval import EvalConfig
 
-USAGE = "usage: uv run eval [<taskset-id>] [--harness.id <id>] [--id <env-id> (legacy)] [options] [@ file.toml]"
+USAGE = (
+    "usage: uv run eval [<taskset-id>] [--harness.id <id>] [--id <env-id> (legacy)] [options] [@ file.toml]\n"
+    "       uv run eval --resume <output-dir>   (re-run a previous run's missing/errored rollouts)"
+)
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -47,22 +51,32 @@ def main(argv: list[str] | None = None) -> None:
             narrow_config(EvalConfig, argv)
         )  # full option help, narrowed to the given ids
         return
-    legacy_id = any(a == "--id" or a.startswith("--id=") for a in argv)  # v0 env id
-    if (
-        not extract_id(argv, "taskset")
-        and not legacy_id
-        and not references_config_file(argv)
-    ):
-        raise SystemExit(
-            USAGE
-        )  # need a taskset (positional / --taskset.id), a legacy --id, or a @ file.toml
+    resume_dir, rest = split_resume(argv)
+    if resume_dir is not None:  # re-run a previous run's missing/errored rollouts, in place
+        if rest:
+            raise SystemExit(
+                f"{USAGE}\n--resume re-runs a saved config verbatim and takes no other arguments"
+            )
+        config = load_resume_config(resume_dir)
+    else:
+        legacy_id = any(a == "--id" or a.startswith("--id=") for a in argv)  # v0 env id
+        if (
+            not extract_id(argv, "taskset")
+            and not legacy_id
+            and not references_config_file(argv)
+        ):
+            raise SystemExit(
+                USAGE
+            )  # need a taskset (positional / --taskset.id), a legacy --id, or a @ file.toml
 
-    config_type = narrow_config(EvalConfig, argv)
-    sys.argv = [sys.argv[0], *argv]  # let prime-pydantic-config render help/errors
-    config = cli(config_type)
-    if config.dry_run:  # resolved + validated; dump it and skip the run
-        print(config.model_dump_json(indent=2, exclude_none=True))
-        return
+        config_type = narrow_config(EvalConfig, argv)
+        sys.argv = [sys.argv[0], *argv]  # let prime-pydantic-config render help/errors
+        config = cli(config_type)
+        if config.dry_run:  # resolved + validated; dump it and skip the run
+            print(config.model_dump_json(indent=2, exclude_none=True))
+            return
+    if config.is_legacy and config.resume is not None:
+        raise SystemExit("--resume is not supported for legacy (v0) evals")
     # The --rich dashboard reads live v1 Rollout state, so it needs the in-process path; a
     # plain (non-rich) v1 run goes through the env server using `pool` (the path prime-rl
     # trains through). Legacy always runs in-process via the bridge.

--- a/verifiers/v1/cli/output.py
+++ b/verifiers/v1/cli/output.py
@@ -28,14 +28,21 @@ def output_path(config: EvalConfig) -> Path:
     return Path("outputs") / name / config.uuid
 
 
+def write_config(config: EvalConfig, results_dir: Path) -> Path:
+    """Write the run's resolved `config.toml` (re-readable via `@ config.toml`); return its
+    path. mode="json" makes values TOML-friendly (Path -> str, etc.); exclude_none drops the
+    nulls TOML can't represent."""
+    results_dir.mkdir(parents=True, exist_ok=True)
+    toml = tomli_w.dumps(config.model_dump(mode="json", exclude_none=True))
+    config_path = results_dir / "config.toml"
+    config_path.write_text(toml)
+    return config_path
+
+
 def save_config(config: EvalConfig, results_dir: Path) -> None:
     """Set up the run's output dir: write `config.toml` and start a fresh (empty)
     `results.jsonl`. Call once up front, before traces start landing."""
-    results_dir.mkdir(parents=True, exist_ok=True)
-    # mode="json" makes values TOML-friendly (Path -> str, etc.); exclude_none drops the
-    # nulls TOML can't represent.
-    toml = tomli_w.dumps(config.model_dump(mode="json", exclude_none=True))
-    (results_dir / "config.toml").write_text(toml)
+    write_config(config, results_dir)
     (results_dir / "results.jsonl").write_text(
         ""
     )  # fresh; appended to as traces complete

--- a/verifiers/v1/cli/resume.py
+++ b/verifiers/v1/cli/resume.py
@@ -22,7 +22,9 @@ def split_resume(argv: list[str]) -> tuple[Path | None, list[str]]:
     for i, arg in enumerate(argv):
         if arg == "--resume":
             if i + 1 >= len(argv):
-                raise SystemExit("--resume needs an output dir: uv run eval --resume <dir>")
+                raise SystemExit(
+                    "--resume needs an output dir: uv run eval --resume <dir>"
+                )
             return Path(argv[i + 1]), argv[:i] + argv[i + 2 :]
         if arg.startswith("--resume="):
             return Path(arg.split("=", 1)[1]), argv[:i] + argv[i + 1 :]

--- a/verifiers/v1/cli/resume.py
+++ b/verifiers/v1/cli/resume.py
@@ -94,9 +94,10 @@ def rewrite_results(resume_dir: Path, keep: list[dict]) -> None:
     tmp.replace(path)
 
 
-def nothing_to_resume(resume_dir: Path, num_tasks: int, num_rollouts: int) -> SystemExit:
-    """The error raised when every selected rollout already completed without error."""
-    return SystemExit(
+def nothing_to_resume_msg(resume_dir: Path, num_tasks: int, num_rollouts: int) -> str:
+    """The message shown (and then exit 0 - the run is already complete) when every selected
+    rollout already completed without error."""
+    return (
         f"nothing to resume in {resume_dir}: all {num_tasks}x{num_rollouts} rollouts "
         f"already completed without error"
     )

--- a/verifiers/v1/cli/resume.py
+++ b/verifiers/v1/cli/resume.py
@@ -1,0 +1,102 @@
+"""Resume an interrupted eval: re-run only the rollouts a previous run didn't finish.
+
+A run writes `config.toml` + `results.jsonl` into its output dir. `--resume <dir>` reloads
+that config verbatim (so it takes no other flags) and writes back into the same dir, running
+only the rollouts still owed: the *missing* ones (never written — the run was interrupted) and
+the *errored* ones (written with an error). Good rollouts are kept; errored ones are dropped
+and redone. A group-scored taskset is resumed a whole task at a time (its rollouts are scored
+together), so any task that isn't fully complete is redone from scratch.
+"""
+
+import json
+import tomllib
+from collections import defaultdict
+from pathlib import Path
+
+from verifiers.v1.configs.eval import EvalConfig
+
+
+def split_resume(argv: list[str]) -> tuple[Path | None, list[str]]:
+    """Pull `--resume <dir>` / `--resume=<dir>` out of argv, returning (dir, the other args).
+    The caller rejects any leftover args, since resume re-runs the saved config verbatim."""
+    for i, arg in enumerate(argv):
+        if arg == "--resume":
+            if i + 1 >= len(argv):
+                raise SystemExit("--resume needs an output dir: uv run eval --resume <dir>")
+            return Path(argv[i + 1]), argv[:i] + argv[i + 2 :]
+        if arg.startswith("--resume="):
+            return Path(arg.split("=", 1)[1]), argv[:i] + argv[i + 1 :]
+    return None, argv
+
+
+def load_resume_config(resume_dir: Path) -> EvalConfig:
+    """Rebuild the run's `EvalConfig` from its saved `config.toml`, pointed back at its own
+    output dir so the resumed rollouts append to the same `results.jsonl`."""
+    config_path = resume_dir / "config.toml"
+    if not config_path.exists():
+        raise SystemExit(
+            f"--resume: no config.toml in {resume_dir} - not an eval output dir"
+        )
+    config = EvalConfig.model_validate(tomllib.loads(config_path.read_text()))
+    config.resume = resume_dir
+    config.output_dir = resume_dir
+    return config
+
+
+def _read_results(results_path: Path) -> list[dict]:
+    """The previous run's traces as raw dicts. The on-disk dump carries computed fields a
+    strict `Trace` can't re-validate, so we read the JSON directly — resume only needs each
+    trace's `task.idx` and whether it `errors`ed."""
+    if not results_path.exists():
+        return []
+    return [
+        json.loads(line)
+        for line in results_path.read_text().splitlines()
+        if line.strip()
+    ]
+
+
+def plan(
+    resume_dir: Path, selected_idxs: list[int], num_rollouts: int, group: bool
+) -> tuple[list[dict], dict[int, int]]:
+    """Diff the saved results against the run's target (`num_rollouts` per selected task).
+    Returns (rows to keep in `results.jsonl`, rollouts owed per task idx). An errored trace is
+    dropped and re-run; a group-scored task is kept only if fully complete, else its whole
+    group is redone."""
+    by_idx: dict[int, list[dict]] = defaultdict(list)
+    for row in _read_results(resume_dir / "results.jsonl"):
+        by_idx[row["task"]["idx"]].append(row)
+    keep: list[dict] = []
+    owed: dict[int, int] = {}
+    for idx in selected_idxs:
+        good = [row for row in by_idx.get(idx, []) if not row.get("errors")]
+        if group:
+            if len(good) >= num_rollouts:
+                keep.extend(good[:num_rollouts])
+            else:
+                owed[idx] = num_rollouts  # re-run the whole group; keep none of it
+        else:
+            keep.extend(good[:num_rollouts])
+            missing = num_rollouts - min(len(good), num_rollouts)
+            if missing:
+                owed[idx] = missing
+    return keep, owed
+
+
+def rewrite_results(resume_dir: Path, keep: list[dict]) -> None:
+    """Replace `results.jsonl` with just the kept (good) traces; resumed rollouts append. Via a
+    temp file + atomic rename, so an interrupted resume can't corrupt the prior good results."""
+    path = resume_dir / "results.jsonl"
+    tmp = path.with_suffix(".jsonl.tmp")
+    with tmp.open("w") as f:
+        for row in keep:
+            f.write(json.dumps(row) + "\n")
+    tmp.replace(path)
+
+
+def nothing_to_resume(resume_dir: Path, num_tasks: int, num_rollouts: int) -> SystemExit:
+    """The error raised when every selected rollout already completed without error."""
+    return SystemExit(
+        f"nothing to resume in {resume_dir}: all {num_tasks}x{num_rollouts} rollouts "
+        f"already completed without error"
+    )

--- a/verifiers/v1/cli/runner.py
+++ b/verifiers/v1/cli/runner.py
@@ -43,8 +43,9 @@ async def run_eval(env: Environment, config: EvalConfig) -> list[Trace]:
     if config.resume is not None:
         group = bool(discover_decorated(env.taskset, "group_reward"))
         keep, owed = resume_.plan(out, [t.idx for t in tasks], config.num_rollouts, group)
-        if not owed:
-            raise resume_.nothing_to_resume(out, len(tasks), config.num_rollouts)
+        if not owed:  # already complete - report it and exit successfully
+            print(resume_.nothing_to_resume_msg(out, len(tasks), config.num_rollouts))
+            raise SystemExit(0)
         tasks = [task for task in tasks if owed.get(task.idx)]
         episodes = [env.episode(task, ctx, n=owed[task.idx]) for task in tasks]
         resume_.rewrite_results(out, keep)
@@ -149,8 +150,9 @@ async def run_eval_server(config: EvalConfig) -> list[Trace]:
             keep, owed = resume_.plan(
                 out, idxs, config.num_rollouts, info.requires_group_scoring
             )
-            if not owed:
-                raise resume_.nothing_to_resume(out, len(idxs), config.num_rollouts)
+            if not owed:  # already complete - report it and exit successfully
+                print(resume_.nothing_to_resume_msg(out, len(idxs), config.num_rollouts))
+                raise SystemExit(0)
             resume_.rewrite_results(out, keep)
             idxs = [idx for idx in idxs if owed.get(idx)]
             logger.info(

--- a/verifiers/v1/cli/runner.py
+++ b/verifiers/v1/cli/runner.py
@@ -8,7 +8,7 @@ import time
 
 from verifiers.v1.clients import RolloutContext, resolve_client
 from verifiers.v1.configs.eval import EvalConfig
-from verifiers.v1.cli import resume as resume_
+from verifiers.v1.cli import resume
 from verifiers.v1.cli.dashboard import dashboard
 from verifiers.v1.cli.output import append_trace, output_path, save_config
 from verifiers.v1.decorators import discover_decorated
@@ -42,13 +42,15 @@ async def run_eval(env: Environment, config: EvalConfig) -> list[Trace]:
     # concurrent rollouts in the one event loop.
     if config.resume is not None:
         group = bool(discover_decorated(env.taskset, "group_reward"))
-        keep, owed = resume_.plan(out, [t.idx for t in tasks], config.num_rollouts, group)
+        keep, owed = resume.plan(
+            out, [t.idx for t in tasks], config.num_rollouts, group
+        )
         if not owed:  # already complete - report it and exit successfully
-            print(resume_.nothing_to_resume_msg(out, len(tasks), config.num_rollouts))
+            print(resume.nothing_to_resume_msg(out, len(tasks), config.num_rollouts))
             raise SystemExit(0)
         tasks = [task for task in tasks if owed.get(task.idx)]
         episodes = [env.episode(task, ctx, n=owed[task.idx]) for task in tasks]
-        resume_.rewrite_results(out, keep)
+        resume.rewrite_results(out, keep)
         logger.info(
             "resuming %s: %d task(s), %d rollout(s) owed",
             out,
@@ -147,16 +149,19 @@ async def run_eval_server(config: EvalConfig) -> list[Trace]:
             idxs = idxs[: config.num_tasks]
         out = output_path(config)
         if config.resume is not None:
-            keep, owed = resume_.plan(
+            keep, owed = resume.plan(
                 out, idxs, config.num_rollouts, info.requires_group_scoring
             )
             if not owed:  # already complete - report it and exit successfully
-                print(resume_.nothing_to_resume_msg(out, len(idxs), config.num_rollouts))
+                print(resume.nothing_to_resume_msg(out, len(idxs), config.num_rollouts))
                 raise SystemExit(0)
-            resume_.rewrite_results(out, keep)
+            resume.rewrite_results(out, keep)
             idxs = [idx for idx in idxs if owed.get(idx)]
             logger.info(
-                "resuming %s: %d task(s), %d rollout(s) owed", out, len(idxs), sum(owed.values())
+                "resuming %s: %d task(s), %d rollout(s) owed",
+                out,
+                len(idxs),
+                sum(owed.values()),
             )
         else:
             owed = {idx: config.num_rollouts for idx in idxs}

--- a/verifiers/v1/cli/runner.py
+++ b/verifiers/v1/cli/runner.py
@@ -8,8 +8,10 @@ import time
 
 from verifiers.v1.clients import RolloutContext, resolve_client
 from verifiers.v1.configs.eval import EvalConfig
+from verifiers.v1.cli import resume as resume_
 from verifiers.v1.cli.dashboard import dashboard
 from verifiers.v1.cli.output import append_trace, output_path, save_config
+from verifiers.v1.decorators import discover_decorated
 from verifiers.v1.env import Environment
 from verifiers.v1.trace import Trace
 
@@ -33,20 +35,39 @@ async def run_eval(env: Environment, config: EvalConfig) -> list[Trace]:
     semaphore = (
         asyncio.Semaphore(config.max_concurrent) if config.max_concurrent else None
     )
-    episodes = [env.episode(task, ctx, n=config.num_rollouts) for task in tasks]
-    logger.info(
-        "running %dx%d rollouts on %s", len(tasks), config.num_rollouts, config.model
-    )
+    out = output_path(config)
+    # Write config.toml up front, then persist each trace as it completes (so the results are
+    # durable mid-run, not only at the end). On resume, keep the saved config + good traces and
+    # run only the owed rollouts. `append_trace` is a sync single-line append, safe to call from
+    # concurrent rollouts in the one event loop.
+    if config.resume is not None:
+        group = bool(discover_decorated(env.taskset, "group_reward"))
+        keep, owed = resume_.plan(out, [t.idx for t in tasks], config.num_rollouts, group)
+        if not owed:
+            raise resume_.nothing_to_resume(out, len(tasks), config.num_rollouts)
+        tasks = [task for task in tasks if owed.get(task.idx)]
+        episodes = [env.episode(task, ctx, n=owed[task.idx]) for task in tasks]
+        resume_.rewrite_results(out, keep)
+        logger.info(
+            "resuming %s: %d task(s), %d rollout(s) owed",
+            out,
+            len(tasks),
+            sum(owed.values()),
+        )
+    else:
+        episodes = [env.episode(task, ctx, n=config.num_rollouts) for task in tasks]
+        save_config(config, out)
+        logger.info(
+            "running %dx%d rollouts on %s",
+            len(tasks),
+            config.num_rollouts,
+            config.model,
+        )
     start = time.time()
     rollouts = [rollout for episode in episodes for rollout in episode.rollouts]
     display = (
         dashboard(rollouts, config, start) if config.rich else contextlib.nullcontext()
     )
-    # Write config.toml up front, then persist each trace as it completes (so the results
-    # are durable mid-run, not only at the end). `append_trace` is a sync single-line
-    # append, safe to call from concurrent rollouts in the one event loop.
-    out = output_path(config)
-    save_config(config, out)
     logger.info("results: %s", out)
 
     def on_complete(trace: Trace) -> None:
@@ -123,15 +144,28 @@ async def run_eval_server(config: EvalConfig) -> list[Trace]:
             random.Random(_SHUFFLE_SEED).shuffle(idxs)
         if config.num_tasks is not None:
             idxs = idxs[: config.num_tasks]
-        logger.info(
-            "running %dx%d rollouts via the env-server %s pool on %s",
-            len(idxs),
-            config.num_rollouts,
-            config.pool.type,
-            config.model,
-        )
         out = output_path(config)
-        save_config(config, out)
+        if config.resume is not None:
+            keep, owed = resume_.plan(
+                out, idxs, config.num_rollouts, info.requires_group_scoring
+            )
+            if not owed:
+                raise resume_.nothing_to_resume(out, len(idxs), config.num_rollouts)
+            resume_.rewrite_results(out, keep)
+            idxs = [idx for idx in idxs if owed.get(idx)]
+            logger.info(
+                "resuming %s: %d task(s), %d rollout(s) owed", out, len(idxs), sum(owed.values())
+            )
+        else:
+            owed = {idx: config.num_rollouts for idx in idxs}
+            save_config(config, out)
+            logger.info(
+                "running %dx%d rollouts via the env-server %s pool on %s",
+                len(idxs),
+                config.num_rollouts,
+                config.pool.type,
+                config.model,
+            )
         logger.info("results: %s", out)
         semaphore = (
             asyncio.Semaphore(config.max_concurrent) if config.max_concurrent else None
@@ -168,9 +202,7 @@ async def run_eval_server(config: EvalConfig) -> list[Trace]:
         if info.requires_group_scoring:
             units = [run_group_unit(i) for i in idxs]
         else:
-            units = [
-                run_rollout_unit(i) for i in idxs for _ in range(config.num_rollouts)
-            ]
+            units = [run_rollout_unit(i) for i in idxs for _ in range(owed[i])]
         results = await asyncio.gather(*units)
         await client.close()
         return [trace for unit_traces in results for trace in unit_traces]

--- a/verifiers/v1/configs/eval.py
+++ b/verifiers/v1/configs/eval.py
@@ -55,3 +55,7 @@ class EvalConfig(EnvServerConfig):
     )
     """Where to write the run (config.toml + results.jsonl). None = a fresh per-run dir
     under `outputs/<env>--<model>--<harness>/<uuid>` (so runs never overwrite each other)."""
+    resume: Path | None = Field(None, exclude=True)
+    """Set by `--resume <dir>`: re-run only the rollouts a previous run left missing or
+    errored, appending to that run's own results. The run's saved config is loaded verbatim,
+    so `--resume` takes no other arguments. Excluded from the saved config."""


### PR DESCRIPTION
## Summary

- Add `--resume <output-dir>` to the v1 `uv run eval` CLI: re-run only the rollouts a previous run didn't finish — the **missing** ones (interrupted before they were written) and the **errored** ones — appending to that run's own `results.jsonl`.
- The run's saved `config.toml` is loaded **verbatim**, so `--resume` takes no other arguments (combining it with anything else is rejected with a usage error).
- Good rollouts are kept; errored ones are dropped and redone. Resume works **per `-r`**: a task interrupted at e.g. 1/4 rollouts is topped back up to 4. A **group-scored** taskset is resumed a whole task at a time (its rollouts are scored together), so any task that isn't fully complete is redone from scratch. `results.jsonl` is rewritten via a temp file + atomic rename, so an interrupted resume can't corrupt the prior good results.
- When the run is **already complete** (every selected rollout finished without error), prints a message and **exits 0** — a finished eval is a success, not a failure. A dir that isn't an eval output dir is still a usage error.
- Works for **both** eval execution paths: in-process (`--rich`) and the env-server worker pool (`--no-rich`, the path prime-rl trains through).
- Usage banner + `-h` updated.

Also in this PR (same eval dispatch code):
- `--dry-run` now **writes the resolved config to `<output_dir>/config.toml`** (via a new `write_config` helper that `save_config` reuses) and logs `wrote config to <path>`, instead of printing the JSON blob to stdout — mirrors prime-rl. `serve` is unchanged.

## Verification

Interrupted a `gsm8k-v1` eval mid-run (SIGINT), then resumed, then resumed again:

| Scenario | After interrupt | After resume | Resume again (complete) |
|----------|-----------------|--------------|-------------------------|
| `-n 12 -r 1`, server (`--no-rich`) | 3/12 good | **12/12 good, 12 distinct idx** (9 owed) | `rc=0` — `nothing to resume … already completed without error` |
| `-n 12 -r 1`, in-process (`--rich`) | 3/12 good | **12/12 good, 12 distinct idx** | `rc=0` — same |
| `-n 3 -r 4` (per-`-r` top-up) | `{idx0: 4, idx1: 1}` | **`{idx0: 4, idx1: 4, idx2: 4}`** (owed 7: 3+4) | — |

No duplicate task idxs; exactly the missing rollouts re-scheduled.

`--dry-run -o <dir>` → `rc=0`, logs `wrote config to <dir>/config.toml`, writes only `config.toml` (no `results.jsonl`).

Usage hints / guards:
- `uv run eval` (no args) and `-h` show the `--resume <output-dir>` line.
- `--resume` with no dir → `--resume needs an output dir`.
- `--resume <dir> -n 4` → `--resume re-runs a saved config verbatim and takes no other arguments`.
- `--resume <nonexistent>` → `no config.toml in <dir> - not an eval output dir`.

Unit-checked the scheduling diff (`resume.plan()`): missing → owed; errored → dropped + owed; group incomplete → whole group redone; all complete → nothing owed.

## Notes

- The existing `--resume` section in `docs/evaluation.md` documents the **v0** `prime eval run` CLI (different layout: `outputs/evals/.../metadata.json`, auto-detect, must-match-config). This change is for the separate **v1** `uv run eval` CLI (`config.toml` + `results.jsonl`); v1 eval-CLI docs are out of scope here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches both eval execution paths and mutates on-disk results via atomic rewrite; behavior is bounded by saved config and explicit resume guards, but incorrect planning could drop or duplicate traces.
> 
> **Overview**
> Adds **`--resume <output-dir>`** to the v1 `uv run eval` CLI so interrupted or partially failed runs can finish in place without re-running successful rollouts.
> 
> **Resume flow:** The CLI loads the saved **`config.toml`** from that directory (no other flags allowed), sets `output_dir`/`resume` on `EvalConfig`, and rejects resume for legacy v0 evals. **`resume.plan()`** compares `results.jsonl` to the target task list: keeps good traces, drops errored ones, schedules missing rollouts per task (or **whole tasks** for group-scored tasksets). **`rewrite_results()`** atomically rewrites `results.jsonl` with kept rows before new traces append.
> 
> **Runner integration:** Both **in-process** (`run_eval`) and **env-server pool** (`run_eval_server`) branches call the same planning logic; owed rollout counts drive episode/`run_rollout` scheduling (independent rollouts use `owed[i]`). If nothing is owed, the CLI prints a completion message and **exits 0**.
> 
> **Other:** `write_config()` is extracted for reuse; **`--dry-run`** now writes `config.toml` under the output path instead of printing JSON to stdout. Usage/help documents the new subcommand.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8084aa2937aea45fb74b0a32f848501b0295bc1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `--resume` flag to eval CLI to re-run missing or errored rollouts from a prior run
> - A new `--resume <output-dir>` flag reads `config.toml` from a prior run's output directory, determines which rollouts are missing or errored, and schedules only those, appending results to the existing `results.jsonl`.
> - Resume logic lives in the new [resume.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1638/files#diff-610bd9ffa7e243b153cd2e7637ae155056c9453b37236e6d4a706f0064f157c1) module, which handles config loading, result parsing, work planning (respecting group-scored vs. independent tasks), and atomic rewrite of `results.jsonl` before new rollouts run.
> - Both in-process ([runner.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1638/files#diff-3d708e6dbc4cd4b549bfca1be17b1385b52b7cd03992bf82522e225f4aaaadbf) `run_eval`) and server-mode (`run_eval_server`) eval paths support resuming; if all rollouts are already complete, the process exits with a completion message.
> - In dry-run mode, the resolved config is now written to `config.toml` under the output directory instead of printed as JSON to stdout.
> - `--resume` cannot be combined with other CLI args or used with legacy (v0) evals; both cases exit with an error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8084aa2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->