### PR TITLE
feat: configurable creation-rate limiter for modal + prime runtimes

### DIFF
--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -88,7 +88,11 @@ class CreationLimiter:
     """An async leaky bucket shared across processes via a lock file: each `async with`
     reserves the next `1/per_sec`-spaced slot (advancing the on-disk cursor under an exclusive
     flock) and sleeps until it, so the aggregate creation rate across all host processes stays
-    at `per_sec`. The reservation runs off the event loop; the wait does not hold the lock."""
+    at `per_sec`. The reservation runs off the event loop; the wait does not hold the lock.
+
+    Machinery overhead — a thread hop + the flock + a ~20-byte file write — is ~0.15ms
+    per acquire (~0.2-0.4ms amortized under heavy concurrency), negligible against the
+    seconds a sandbox/tunnel start takes. (The pacing sleep itself is the rate limit.)"""
 
     def __init__(self, name: str, per_sec: float) -> None:
         self._interval = 1 / per_sec

--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -8,15 +8,18 @@ depend only on this contract, so they stay runtime-agnostic.
 import asyncio
 import atexit
 import contextlib
+import fcntl
 import hashlib
 import logging
+import os
 import shlex
+import tempfile
+import time
 import uuid
 import weakref
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 
-from aiolimiter import AsyncLimiter
 from tenacity import (
     AsyncRetrying,
     RetryCallState,
@@ -72,32 +75,73 @@ def parse_gpu(gpu: str | None) -> tuple[str | None, int]:
     return head, 1
 
 
-# Process-wide leaky buckets pacing a remote runtime's resource creation (Modal sandboxes,
-# Prime tunnels) under the provider's per-account rate limit — shared across all concurrent
-# rollouts, keyed by rate. Capacity 1 (1 permit every `1/per_sec`s) keeps issuing evenly
-# paced rather than firing a full bucket at once, which would burst over the limit.
-_creation_limiters: dict[float, AsyncLimiter] = {}
+# Host-global leaky buckets pacing a remote runtime's resource creation (Modal sandboxes,
+# Prime tunnels) under the provider's per-account rate limit. Backed by a lock file so the
+# rate holds across EVERY process on the host — the single-process eval and all the elastic
+# env-server worker processes alike — not just within one process, so the configured rate is
+# the actual account-wide rate (assuming one env-server host). Keyed by name: one bucket file
+# per name, shared by every process (and every run) on the host that opens it.
+_LIMITER_DIR = os.path.join(tempfile.gettempdir(), "vf-rate-limiters")
 
 
-def creation_limiter(per_sec: float | None) -> AsyncLimiter | None:
-    """A shared limiter pacing resource creation to `per_sec` per second (None/<= 0 disables).
+class CreationLimiter:
+    """An async leaky bucket shared across processes via a lock file: each `async with`
+    reserves the next `1/per_sec`-spaced slot (advancing the on-disk cursor under an exclusive
+    flock) and sleeps until it, so the aggregate creation rate across all host processes stays
+    at `per_sec`. The reservation runs off the event loop; the wait does not hold the lock."""
 
-    Per-process: under the multi-worker env-server pool each worker gets its own bucket, so
-    the effective global rate is `per_sec` times the worker count."""
+    def __init__(self, name: str, per_sec: float) -> None:
+        self._interval = 1 / per_sec
+        self._path = os.path.join(_LIMITER_DIR, f"{name}.bucket")
+
+    def _reserve(self) -> float:
+        os.makedirs(_LIMITER_DIR, exist_ok=True)
+        # monotonic is host-wide on Linux, so the cursor is comparable across processes.
+        with open(self._path, "a+") as f:
+            fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+            try:
+                f.seek(0)
+                data = f.read().strip()
+                now = time.monotonic()
+                slot = max(now, float(data) if data else 0.0)
+                f.seek(0)
+                f.truncate()
+                f.write(repr(slot + self._interval))
+                f.flush()
+                return slot - now
+            finally:
+                fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+
+    async def __aenter__(self) -> "CreationLimiter":
+        wait = await asyncio.to_thread(self._reserve)
+        if wait > 0:
+            await asyncio.sleep(wait)
+        return self
+
+    async def __aexit__(self, *exc) -> bool:
+        return False
+
+
+_creation_limiters: dict[str, CreationLimiter] = {}
+
+
+def creation_limiter(per_sec: float | None, name: str) -> CreationLimiter | None:
+    """A host-global limiter pacing `name`'s creation to `per_sec`/s (None/<= 0 disables).
+
+    All callers (and processes) sharing a `name` share one bucket, so use one rate per name."""
     if not per_sec or per_sec <= 0:
         return None
-    limiter = _creation_limiters.get(per_sec)
+    limiter = _creation_limiters.get(name)
     if limiter is None:
-        limiter = _creation_limiters[per_sec] = AsyncLimiter(1, 1 / per_sec)
+        limiter = _creation_limiters[name] = CreationLimiter(name, per_sec)
     return limiter
 
 
 # The prime_tunnel service caps tunnel starts at 512/min per API token — a property of the
-# tunnel service, shared by every runtime that opens a prime_tunnel (prime AND modal), so
-# it's a fixed process-wide limiter rather than a per-runtime config knob. (Same per-process
-# caveat as above: N env-server workers => N x this rate globally.)
+# tunnel service, shared by every runtime that opens a prime_tunnel (prime AND modal). One
+# host-global limiter, not a per-runtime config knob.
 _TUNNELS_PER_MIN = 512
-_TUNNEL_LIMITER = creation_limiter(_TUNNELS_PER_MIN / 60)
+_TUNNEL_LIMITER = creation_limiter(_TUNNELS_PER_MIN / 60, "prime-tunnel")
 
 
 # `stop()` frees a runtime's external resource on the normal path (the rollout's `finally`).

--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -16,6 +16,7 @@ import weakref
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 
+from aiolimiter import AsyncLimiter
 from tenacity import (
     AsyncRetrying,
     RetryCallState,
@@ -69,6 +70,23 @@ def parse_gpu(gpu: str | None) -> tuple[str | None, int]:
     if head.isdigit():
         return None, int(head)
     return head, 1
+
+
+# Process-wide leaky buckets pacing a remote runtime's resource creation (Modal sandboxes,
+# Prime tunnels) under the provider's per-account rate limit — shared across all concurrent
+# rollouts, keyed by rate. Capacity 1 (1 permit every `1/per_sec`s) keeps issuing evenly
+# paced rather than firing a full bucket at once, which would burst over the limit.
+_creation_limiters: dict[float, AsyncLimiter] = {}
+
+
+def creation_limiter(per_sec: float) -> AsyncLimiter | None:
+    """A shared limiter pacing resource creation to `per_sec` per second (<= 0 disables)."""
+    if per_sec <= 0:
+        return None
+    limiter = _creation_limiters.get(per_sec)
+    if limiter is None:
+        limiter = _creation_limiters[per_sec] = AsyncLimiter(1, 1 / per_sec)
+    return limiter
 
 
 # `stop()` frees a runtime's external resource on the normal path (the rollout's `finally`).

--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -8,13 +8,9 @@ depend only on this contract, so they stay runtime-agnostic.
 import asyncio
 import atexit
 import contextlib
-import fcntl
 import hashlib
 import logging
-import os
 import shlex
-import tempfile
-import time
 import uuid
 import weakref
 from abc import ABC, abstractmethod
@@ -73,79 +69,6 @@ def parse_gpu(gpu: str | None) -> tuple[str | None, int]:
     if head.isdigit():
         return None, int(head)
     return head, 1
-
-
-# Host-global leaky buckets pacing a remote runtime's resource creation (Modal sandboxes,
-# Prime tunnels) under the provider's per-account rate limit. Backed by a lock file so the
-# rate holds across EVERY process on the host — the single-process eval and all the elastic
-# env-server worker processes alike — not just within one process, so the configured rate is
-# the actual account-wide rate (assuming one env-server host). Keyed by name: one bucket file
-# per name, shared by every process (and every run) on the host that opens it.
-_LIMITER_DIR = os.path.join(tempfile.gettempdir(), "vf-rate-limiters")
-
-
-class CreationLimiter:
-    """An async leaky bucket shared across processes via a lock file: each `async with`
-    reserves the next `1/per_sec`-spaced slot (advancing the on-disk cursor under an exclusive
-    flock) and sleeps until it, so the aggregate creation rate across all host processes stays
-    at `per_sec`. The reservation runs off the event loop; the wait does not hold the lock.
-
-    Machinery overhead — a thread hop + the flock + a ~20-byte file write — is ~0.15ms
-    per acquire (~0.2-0.4ms amortized under heavy concurrency), negligible against the
-    seconds a sandbox/tunnel start takes. (The pacing sleep itself is the rate limit.)"""
-
-    def __init__(self, name: str, per_sec: float) -> None:
-        self._interval = 1 / per_sec
-        self._path = os.path.join(_LIMITER_DIR, f"{name}.bucket")
-
-    def _reserve(self) -> float:
-        os.makedirs(_LIMITER_DIR, exist_ok=True)
-        # monotonic is host-wide on Linux, so the cursor is comparable across processes.
-        with open(self._path, "a+") as f:
-            fcntl.flock(f.fileno(), fcntl.LOCK_EX)
-            try:
-                f.seek(0)
-                data = f.read().strip()
-                now = time.monotonic()
-                slot = max(now, float(data) if data else 0.0)
-                f.seek(0)
-                f.truncate()
-                f.write(repr(slot + self._interval))
-                f.flush()
-                return slot - now
-            finally:
-                fcntl.flock(f.fileno(), fcntl.LOCK_UN)
-
-    async def __aenter__(self) -> "CreationLimiter":
-        wait = await asyncio.to_thread(self._reserve)
-        if wait > 0:
-            await asyncio.sleep(wait)
-        return self
-
-    async def __aexit__(self, *exc) -> bool:
-        return False
-
-
-_creation_limiters: dict[str, CreationLimiter] = {}
-
-
-def creation_limiter(per_sec: float | None, name: str) -> CreationLimiter | None:
-    """A host-global limiter pacing `name`'s creation to `per_sec`/s (None/<= 0 disables).
-
-    All callers (and processes) sharing a `name` share one bucket, so use one rate per name."""
-    if not per_sec or per_sec <= 0:
-        return None
-    limiter = _creation_limiters.get(name)
-    if limiter is None:
-        limiter = _creation_limiters[name] = CreationLimiter(name, per_sec)
-    return limiter
-
-
-# The prime_tunnel service caps tunnel starts at 512/min per API token — a property of the
-# tunnel service, shared by every runtime that opens a prime_tunnel (prime AND modal). One
-# host-global limiter, not a per-runtime config knob.
-_TUNNELS_PER_MIN = 512
-_TUNNEL_LIMITER = creation_limiter(_TUNNELS_PER_MIN / 60, "prime-tunnel")
 
 
 # `stop()` frees a runtime's external resource on the normal path (the rollout's `finally`).

--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -79,14 +79,25 @@ def parse_gpu(gpu: str | None) -> tuple[str | None, int]:
 _creation_limiters: dict[float, AsyncLimiter] = {}
 
 
-def creation_limiter(per_sec: float) -> AsyncLimiter | None:
-    """A shared limiter pacing resource creation to `per_sec` per second (<= 0 disables)."""
-    if per_sec <= 0:
+def creation_limiter(per_sec: float | None) -> AsyncLimiter | None:
+    """A shared limiter pacing resource creation to `per_sec` per second (None/<= 0 disables).
+
+    Per-process: under the multi-worker env-server pool each worker gets its own bucket, so
+    the effective global rate is `per_sec` times the worker count."""
+    if not per_sec or per_sec <= 0:
         return None
     limiter = _creation_limiters.get(per_sec)
     if limiter is None:
         limiter = _creation_limiters[per_sec] = AsyncLimiter(1, 1 / per_sec)
     return limiter
+
+
+# The prime_tunnel service caps tunnel starts at 512/min per API token — a property of the
+# tunnel service, shared by every runtime that opens a prime_tunnel (prime AND modal), so
+# it's a fixed process-wide limiter rather than a per-runtime config knob. (Same per-process
+# caveat as above: N env-server workers => N x this rate globally.)
+_TUNNELS_PER_MIN = 512
+_TUNNEL_LIMITER = creation_limiter(_TUNNELS_PER_MIN / 60)
 
 
 # `stop()` frees a runtime's external resource on the normal path (the rollout's `finally`).

--- a/verifiers/v1/runtimes/limiters.py
+++ b/verifiers/v1/runtimes/limiters.py
@@ -1,0 +1,76 @@
+"""Host-global creation-rate limiters for the remote runtimes.
+
+A leaky bucket backed by a lock file, so a provider's per-account creation rate (Modal
+sandboxes, Prime tunnels) is enforced across EVERY process on the host — the single-process
+eval and all the elastically-spawned env-server worker processes alike — not just within one
+process. So the configured rate is the actual account-wide rate (assuming one env-server
+host). Keyed by name: one bucket file per name, shared by every process (and run) on the host.
+"""
+
+import asyncio
+import fcntl
+import os
+import tempfile
+import time
+
+_LIMITER_DIR = os.path.join(tempfile.gettempdir(), "vf-rate-limiters")
+
+
+class CreationLimiter:
+    """An async leaky bucket shared across processes via a lock file: each `async with`
+    reserves the next `1/per_sec`-spaced slot (advancing the on-disk cursor under an exclusive
+    flock) and sleeps until it, so the aggregate creation rate across all host processes stays
+    at `per_sec`. The reservation runs off the event loop; the wait does not hold the lock."""
+
+    def __init__(self, name: str, per_sec: float) -> None:
+        self._interval = 1 / per_sec
+        self._path = os.path.join(_LIMITER_DIR, f"{name}.bucket")
+
+    def _reserve(self) -> float:
+        os.makedirs(_LIMITER_DIR, exist_ok=True)
+        # monotonic is host-wide on Linux, so the cursor is comparable across processes.
+        with open(self._path, "a+") as f:
+            fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+            try:
+                f.seek(0)
+                data = f.read().strip()
+                now = time.monotonic()
+                slot = max(now, float(data) if data else 0.0)
+                f.seek(0)
+                f.truncate()
+                f.write(repr(slot + self._interval))
+                f.flush()
+                return slot - now
+            finally:
+                fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+
+    async def __aenter__(self) -> "CreationLimiter":
+        wait = await asyncio.to_thread(self._reserve)
+        if wait > 0:
+            await asyncio.sleep(wait)
+        return self
+
+    async def __aexit__(self, *exc) -> bool:
+        return False
+
+
+_creation_limiters: dict[str, CreationLimiter] = {}
+
+
+def creation_limiter(per_sec: float | None, name: str) -> CreationLimiter | None:
+    """A host-global limiter pacing `name`'s creation to `per_sec`/s (None/<= 0 disables).
+
+    All callers (and processes) sharing a `name` share one bucket, so use one rate per name."""
+    if not per_sec or per_sec <= 0:
+        return None
+    limiter = _creation_limiters.get(name)
+    if limiter is None:
+        limiter = _creation_limiters[name] = CreationLimiter(name, per_sec)
+    return limiter
+
+
+# The prime_tunnel service caps tunnel starts at 512/min per API token — a property of the
+# tunnel service, shared by every runtime that opens a prime_tunnel (prime AND modal). One
+# host-global limiter, not a per-runtime config knob.
+_TUNNELS_PER_MIN = 512
+_TUNNEL_LIMITER = creation_limiter(_TUNNELS_PER_MIN / 60, "prime-tunnel")

--- a/verifiers/v1/runtimes/modal.py
+++ b/verifiers/v1/runtimes/modal.py
@@ -15,7 +15,7 @@ from typing import Literal
 from pydantic_config import BaseConfig
 
 from verifiers.v1.errors import ProgramError
-from verifiers.v1.runtimes.base import ProgramResult, Runtime
+from verifiers.v1.runtimes.base import ProgramResult, Runtime, creation_limiter
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +48,10 @@ class ModalConfig(BaseConfig):
     disk: float = 5.0
     """Disk in GB. Modal sandboxes have no disk knob, so this is accepted (so a task can
     declare it without a warning) but not enforced."""
+    sandbox_creates_per_sec: float = 5.0
+    """Pace sandbox creation to stay under Modal's per-workspace creation rate limit (5/s on
+    a new account; raising it needs Modal support). A process-wide limiter shared across all
+    concurrent rollouts; <= 0 disables it."""
 
 
 class ModalRuntime(Runtime):
@@ -74,20 +78,23 @@ class ModalRuntime(Runtime):
         )
         try:
             app = await modal.App.lookup.aio(_APP_NAME, create_if_missing=True)
-            self._sandbox = await modal.Sandbox.create.aio(
-                "sleep",
-                "infinity",  # keep-alive entrypoint; the harness runs via `exec`
-                app=app,
-                name=self.name,
-                image=modal.Image.from_registry(self.config.image),
-                workdir=self.config.workdir,
-                cpu=self.config.cpu,
-                memory=int(self.config.memory * 1024),  # Modal memory is MB
-                gpu=self.config.gpu,
-                region=self.config.region,
-                block_network=not self.config.network_access,
-                timeout=timeout,
-            )
+            async with creation_limiter(
+                self.config.sandbox_creates_per_sec
+            ) or contextlib.nullcontext():
+                self._sandbox = await modal.Sandbox.create.aio(
+                    "sleep",
+                    "infinity",  # keep-alive entrypoint; the harness runs via `exec`
+                    app=app,
+                    name=self.name,
+                    image=modal.Image.from_registry(self.config.image),
+                    workdir=self.config.workdir,
+                    cpu=self.config.cpu,
+                    memory=int(self.config.memory * 1024),  # Modal memory is MB
+                    gpu=self.config.gpu,
+                    region=self.config.region,
+                    block_network=not self.config.network_access,
+                    timeout=timeout,
+                )
             self._sandbox_id = self._sandbox.object_id
             logger.info(
                 "modal: sandbox %s up (image=%s)", self._sandbox_id, self.config.image

--- a/verifiers/v1/runtimes/modal.py
+++ b/verifiers/v1/runtimes/modal.py
@@ -15,12 +15,8 @@ from typing import Literal
 from pydantic_config import BaseConfig
 
 from verifiers.v1.errors import ProgramError
-from verifiers.v1.runtimes.base import (
-    _TUNNEL_LIMITER,
-    ProgramResult,
-    Runtime,
-    creation_limiter,
-)
+from verifiers.v1.runtimes.base import ProgramResult, Runtime
+from verifiers.v1.runtimes.limiters import _TUNNEL_LIMITER, creation_limiter
 
 logger = logging.getLogger(__name__)
 

--- a/verifiers/v1/runtimes/modal.py
+++ b/verifiers/v1/runtimes/modal.py
@@ -54,9 +54,8 @@ class ModalConfig(BaseConfig):
     """Disk in GB. Modal sandboxes have no disk knob, so this is accepted (so a task can
     declare it without a warning) but not enforced."""
     creates_per_sec: float | None = 5.0
-    """Pace sandbox creation to this many per second, shared across concurrent rollouts in
-    this process (None/<= 0 disables it) — Modal's per-workspace limit is 5/s. Per-process,
-    so under the multi-worker env-server pool the global rate is this times the worker count."""
+    """Pace sandbox creation to this many per second, enforced host-wide across every
+    env-server worker process (None/<= 0 disables it) — Modal's per-workspace limit is 5/s."""
 
 
 class ModalRuntime(Runtime):
@@ -84,7 +83,7 @@ class ModalRuntime(Runtime):
         try:
             app = await modal.App.lookup.aio(_APP_NAME, create_if_missing=True)
             async with (
-                creation_limiter(self.config.creates_per_sec)
+                creation_limiter(self.config.creates_per_sec, "modal-sandbox")
                 or contextlib.nullcontext()
             ):
                 self._sandbox = await modal.Sandbox.create.aio(

--- a/verifiers/v1/runtimes/modal.py
+++ b/verifiers/v1/runtimes/modal.py
@@ -15,7 +15,12 @@ from typing import Literal
 from pydantic_config import BaseConfig
 
 from verifiers.v1.errors import ProgramError
-from verifiers.v1.runtimes.base import ProgramResult, Runtime, creation_limiter
+from verifiers.v1.runtimes.base import (
+    _TUNNEL_LIMITER,
+    ProgramResult,
+    Runtime,
+    creation_limiter,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -48,10 +53,10 @@ class ModalConfig(BaseConfig):
     disk: float = 5.0
     """Disk in GB. Modal sandboxes have no disk knob, so this is accepted (so a task can
     declare it without a warning) but not enforced."""
-    sandbox_creates_per_sec: float = 5.0
-    """Pace sandbox creation to stay under Modal's per-workspace creation rate limit (5/s on
-    a new account; raising it needs Modal support). A process-wide limiter shared across all
-    concurrent rollouts; <= 0 disables it."""
+    creates_per_sec: float | None = 5.0
+    """Pace sandbox creation to this many per second, shared across concurrent rollouts in
+    this process (None/<= 0 disables it) — Modal's per-workspace limit is 5/s. Per-process,
+    so under the multi-worker env-server pool the global rate is this times the worker count."""
 
 
 class ModalRuntime(Runtime):
@@ -78,9 +83,10 @@ class ModalRuntime(Runtime):
         )
         try:
             app = await modal.App.lookup.aio(_APP_NAME, create_if_missing=True)
-            async with creation_limiter(
-                self.config.sandbox_creates_per_sec
-            ) or contextlib.nullcontext():
+            async with (
+                creation_limiter(self.config.creates_per_sec)
+                or contextlib.nullcontext()
+            ):
                 self._sandbox = await modal.Sandbox.create.aio(
                     "sleep",
                     "infinity",  # keep-alive entrypoint; the harness runs via `exec`
@@ -113,7 +119,10 @@ class ModalRuntime(Runtime):
 
         tunnel = Tunnel(local_port=port)
         try:
-            url = str(await tunnel.start()).rstrip("/")
+            async with (
+                _TUNNEL_LIMITER
+            ):  # shared prime_tunnel rate (512/min, runtime-independent)
+                url = str(await tunnel.start()).rstrip("/")
         except Exception as e:
             raise ProgramError(f"modal tunnel failed (host port {port}): {e}") from e
         self._tunnels.append(tunnel)

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -54,10 +54,9 @@ class PrimeConfig(BaseConfig):
     disk: float = 5.0
     """Disk in GB."""
     creates_per_min: int | None = None
-    """Pace sandbox creation to this many per minute, shared across concurrent rollouts in
-    this process (None/<= 0 disables it). Per-process, so under the multi-worker env-server
-    pool the global rate is this times the worker count. (Tunnel creation is limited
-    separately and globally — see base._TUNNEL_LIMITER.)"""
+    """Pace sandbox creation to this many per minute, enforced host-wide across every
+    env-server worker process (None/<= 0 disables it). (Tunnel creation is limited separately
+    and globally — see base._TUNNEL_LIMITER.)"""
 
 
 class PrimeRuntime(Runtime):
@@ -97,7 +96,9 @@ class PrimeRuntime(Runtime):
         }
         try:
             async with (
-                creation_limiter((self.config.creates_per_min or 0) / 60)
+                creation_limiter(
+                    (self.config.creates_per_min or 0) / 60, "prime-sandbox"
+                )
                 or contextlib.nullcontext()
             ):
                 sandbox = await self._client.create(

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -11,6 +11,7 @@ from pydantic_config import BaseConfig
 
 from verifiers.v1.errors import ProgramError
 from verifiers.v1.runtimes.base import (
+    _TUNNEL_LIMITER,
     ProgramResult,
     Runtime,
     creation_limiter,
@@ -52,10 +53,11 @@ class PrimeConfig(BaseConfig):
     """GPU spec, e.g. "A100" or "A100:2" (a bare count = provider-chosen type)."""
     disk: float = 5.0
     """Disk in GB."""
-    tunnel_creates_per_min: int = 512
-    """Pace tunnel creation to stay under Prime's per-token tunnel rate limit (512/min); past
-    it `tunnel.start()` returns 429. A process-wide limiter shared across all concurrent
-    rollouts, evenly paced; <= 0 disables it."""
+    creates_per_min: int | None = None
+    """Pace sandbox creation to this many per minute, shared across concurrent rollouts in
+    this process (None/<= 0 disables it). Per-process, so under the multi-worker env-server
+    pool the global rate is this times the worker count. (Tunnel creation is limited
+    separately and globally — see base._TUNNEL_LIMITER.)"""
 
 
 class PrimeRuntime(Runtime):
@@ -94,17 +96,21 @@ class PrimeRuntime(Runtime):
             "region": self.config.region,
         }
         try:
-            sandbox = await self._client.create(
-                CreateSandboxRequest(
-                    name=self.name,
-                    labels=self.config.labels,
-                    docker_image=self.config.image,
-                    network_access=self.config.network_access,
-                    vm=self.config.vm,
-                    guaranteed=self.config.guaranteed,
-                    **{k: v for k, v in options.items() if v is not None},
+            async with (
+                creation_limiter((self.config.creates_per_min or 0) / 60)
+                or contextlib.nullcontext()
+            ):
+                sandbox = await self._client.create(
+                    CreateSandboxRequest(
+                        name=self.name,
+                        labels=self.config.labels,
+                        docker_image=self.config.image,
+                        network_access=self.config.network_access,
+                        vm=self.config.vm,
+                        guaranteed=self.config.guaranteed,
+                        **{k: v for k, v in options.items() if v is not None},
+                    )
                 )
-            )
             self._sandbox_id = sandbox.id
             await self._client.wait_for_creation(self._sandbox_id)
             logger.info(
@@ -124,9 +130,9 @@ class PrimeRuntime(Runtime):
 
         tunnel = Tunnel(local_port=port, labels=self.config.labels or None)
         try:
-            async with creation_limiter(
-                self.config.tunnel_creates_per_min / 60
-            ) or contextlib.nullcontext():
+            async with (
+                _TUNNEL_LIMITER
+            ):  # shared prime_tunnel rate (512/min, runtime-independent)
                 url = str(await tunnel.start()).rstrip("/")
         except Exception as e:
             raise ProgramError(f"prime tunnel failed (host port {port}): {e}") from e

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -7,26 +7,21 @@ import shlex
 from pathlib import PurePosixPath
 from typing import Literal
 
-from aiolimiter import AsyncLimiter
 from pydantic_config import BaseConfig
 
 from verifiers.v1.errors import ProgramError
-from verifiers.v1.runtimes.base import ProgramResult, Runtime, parse_gpu
+from verifiers.v1.runtimes.base import (
+    ProgramResult,
+    Runtime,
+    creation_limiter,
+    parse_gpu,
+)
 
 logger = logging.getLogger(__name__)
 
 
 # "auto" timeout requests the max prime allows (24h).
 _MAX_TIMEOUT_SECONDS = 24 * 60 * 60
-
-# Prime caps tunnel creation at 512/min per API token; past that `tunnel.start()`
-# returns 429 (per-token limit) and the rollout dies. One process-wide leaky bucket
-# paces tunnel issuing across all concurrent rollouts to stay under it. Phrased as
-# 1-every-(60/rate)s (capacity 1) rather than (rate, 60) on purpose: a full rate-capacity
-# bucket would let `rate` tunnels fire at once and then refill, ~doubling within the first
-# minute and still tripping the limit — capacity 1 keeps issuing evenly paced.
-_TUNNELS_PER_MIN = 512
-_TUNNEL_LIMITER = AsyncLimiter(1, 60 / _TUNNELS_PER_MIN)
 
 
 class PrimeConfig(BaseConfig):
@@ -57,6 +52,10 @@ class PrimeConfig(BaseConfig):
     """GPU spec, e.g. "A100" or "A100:2" (a bare count = provider-chosen type)."""
     disk: float = 5.0
     """Disk in GB."""
+    tunnel_creates_per_min: int = 512
+    """Pace tunnel creation to stay under Prime's per-token tunnel rate limit (512/min); past
+    it `tunnel.start()` returns 429. A process-wide limiter shared across all concurrent
+    rollouts, evenly paced; <= 0 disables it."""
 
 
 class PrimeRuntime(Runtime):
@@ -125,7 +124,9 @@ class PrimeRuntime(Runtime):
 
         tunnel = Tunnel(local_port=port, labels=self.config.labels or None)
         try:
-            async with _TUNNEL_LIMITER:  # stay under prime's per-token tunnel rate
+            async with creation_limiter(
+                self.config.tunnel_creates_per_min / 60
+            ) or contextlib.nullcontext():
                 url = str(await tunnel.start()).rstrip("/")
         except Exception as e:
             raise ProgramError(f"prime tunnel failed (host port {port}): {e}") from e

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -10,13 +10,8 @@ from typing import Literal
 from pydantic_config import BaseConfig
 
 from verifiers.v1.errors import ProgramError
-from verifiers.v1.runtimes.base import (
-    _TUNNEL_LIMITER,
-    ProgramResult,
-    Runtime,
-    creation_limiter,
-    parse_gpu,
-)
+from verifiers.v1.runtimes.base import ProgramResult, Runtime, parse_gpu
+from verifiers.v1.runtimes.limiters import _TUNNEL_LIMITER, creation_limiter
 
 logger = logging.getLogger(__name__)
 
@@ -56,7 +51,7 @@ class PrimeConfig(BaseConfig):
     creates_per_min: int | None = None
     """Pace sandbox creation to this many per minute, enforced host-wide across every
     env-server worker process (None/<= 0 disables it). (Tunnel creation is limited separately
-    and globally — see base._TUNNEL_LIMITER.)"""
+    and globally — see limiters._TUNNEL_LIMITER.)"""
 
 
 class PrimeRuntime(Runtime):


### PR DESCRIPTION
## Summary

A shared, configurable, **host-global** rate limiter for the remote runtimes, so launching many rollouts doesn't trip the provider's per-account creation limits — and the configured rate is easy to reason about (it's the actual account-wide rate, not per-process).

All the limiter code lives in **`verifiers/v1/runtimes/limiters.py`**; `base.py` is back to just the runtime contract, and `modal.py`/`prime.py` import from `limiters`.

- `limiters.CreationLimiter` — an async leaky bucket backed by a **lock file**: each `async with` reserves the next `1/rate`-spaced slot by advancing an on-disk cursor under an exclusive `flock`, then sleeps until it (reservation runs off the event loop; the wait doesn't hold the lock). Because the bucket is a file, the rate is enforced across **every process on the host** — the single-process eval *and* all the elastically-spawned env-server worker processes (`serve/pool.py` spawns workers via `mp` on one host). `creation_limiter(per_sec, name)` returns one per name (`None`/`<=0` disables).
- **Sandbox creation** (configurable per provider): `ModalConfig.creates_per_sec` (default **5.0** — Modal's per-workspace limit, `RESOURCE_EXHAUSTED: "Sandbox creation rate limit (5/s) exceeded"`); `PrimeConfig.creates_per_min` (default **None** — off).
- **Tunnel creation**: one global bucket (`limiters._TUNNEL_LIMITER`, 512/min, name `prime-tunnel`). The `prime_tunnel` per-token limit is a property of the tunnel service, not a runtime, and **both prime and modal open prime_tunnels** (modal previously didn't pace tunnel creation) — so they share it.

Surfaced in the provider config: `--harness.runtime.creates_per_sec` (modal) / `--harness.runtime.creates_per_min` (prime).

## Why host-global (vs per-process)

The env-server worker pool spawns N worker *processes* elastically, so an in-process limiter would enforce `rate × workers` globally — unpredictable. The lock-file bucket is shared by all host processes, so the configured rate is the real rate. (Scope is the host; for a single env-server host — the norm — that equals the account-wide rate. Multiple env-server *hosts* would each get the rate, i.e. a distributed bucket would be needed; noted as a follow-up.)

## Overhead

Negligible. The limiter only wraps a sandbox/tunnel **creation** (which takes *seconds*), and per acquire its machinery is a thread hop + the `flock` + a small file write — a tiny fraction of a create. (The pacing *sleep* is the rate limit itself, not overhead.)

## Verification

- Cross-process: two processes sharing one bucket at 5/s paced their acquisitions **globally** (~1.8s span), not independently (~0.8s). `creation_limiter(None, …)` → `None`.
- Both runtimes share the same `_TUNNEL_LIMITER`. ruff clean.
- Empirically confirmed the account's Modal limit at 5/s (512 unbounded → `RESOURCE_EXHAUSTED`); with this limiter, paced creation stays under it across processes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rollout startup timing and cross-process coordination around provider APIs; misconfiguration could slow evals or still hit limits on multi-host deployments.
> 
> **Overview**
> Adds **`verifiers/v1/runtimes/limiters.py`**, a **host-global** async leaky bucket (`fcntl` lock file under temp) so sandbox and tunnel creation rates apply across **all processes** on one host (eval + env-server workers), not per-process.
> 
> **Modal** gains `creates_per_sec` (default **5/s**) around `Sandbox.create`; **Prime** gains optional `creates_per_min` around sandbox create. **Tunnel** pacing moves out of Prime’s in-process `AsyncLimiter` into shared `_TUNNEL_LIMITER` (512/min, `prime-tunnel`), and **Modal `expose`** now uses that same limiter (previously unpaced).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 936950a489761c686deaa0d3c0f2a6667c985336. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add configurable host-global creation-rate limiters to modal and prime runtimes
> - Adds [limiters.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1639/files#diff-4dacc0bd72504a23b9dbad2571674f250b9d051f4ff1c34dad326bcb94828b9c) with a cross-process leaky-bucket `CreationLimiter` using fcntl file locks and an on-disk cursor to coordinate rate limiting across all processes on the same host.
> - `ModalConfig` gains a `creates_per_sec` field (default 5.0) and `PrimeConfig` gains `creates_per_min`; sandbox creation in both runtimes is now paced by the host-global limiter.
> - Replaces the process-local `aiolimiter.AsyncLimiter` in `PrimeRuntime.expose` with a shared host-global 512/min tunnel limiter (`_TUNNEL_LIMITER`) also applied to `ModalRuntime.expose`.
> - Behavioral Change: sandbox creation and tunnel starts in both runtimes may now block asynchronously until their rate-limited slot is available, affecting concurrency under load.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 936950a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->