### PR TITLE
feat: finalize hook + per-stage timeouts

### DIFF
--- a/verifiers/v1/README.md
+++ b/verifiers/v1/README.md
@@ -44,7 +44,7 @@ uv run eval gsm8k-v1 -n 5 -r 3 \
   --max-turns 8 --max-total-tokens 8192 \        # per-rollout budgets (also --max-{input,output}-tokens)
   --retries.model.max-retries 3 --retries.runtime.max-retries 3 \  # retry a single model/runtime call
   --retries.rollout.max-retries 3 --retries.rollout.include ProgramError \  # retry a whole rollout, by exception type
-  --timeout.rollout 600 --timeout.scoring 120        # wall-clock caps, in seconds
+  --timeout.setup 120 --timeout.rollout 600 --timeout.finalize 120 --timeout.scoring 120  # per-stage wall-clock caps, in seconds
 ```
 
 Common knobs have short aliases:

--- a/verifiers/v1/cli/dashboard.py
+++ b/verifiers/v1/cli/dashboard.py
@@ -1,8 +1,8 @@
 """The `--rich` live dashboard: a config overview, a progress bar, and one line per rollout.
 
 Reads each `Rollout.trace`/`phase` every tick — no extra plumbing. Rows are colored by
-phase/outcome: setup (yellow ○), running (cyan ●), scoring (blue ◐), success (green ✓),
-error (red ✗) — the reward shows only once a rollout is fully scored (phase DONE), so it
+phase/outcome: setup (yellow ○), running (cyan ●), finalize (magenta ◑), scoring (blue ◐),
+success (green ✓), error (red ✗) — the reward shows only once a rollout is fully scored (phase DONE), so it
 never flips as scoring lands. A task's rollouts are grouped adjacently and joined by a
 left brace (╭│╰), so an episode (a task's n rollouts) reads as a unit. Every started
 rollout stays on screen (finished ones keep their result); the overview + progress sit on
@@ -29,11 +29,19 @@ from verifiers.v1.utils import format_count, format_reward, format_time
 _STYLE = {
     "setup": "yellow",
     "running": "cyan",
+    "finalize": "magenta",
     "scoring": "blue",
     "success": "green",
     "error": "red",
 }
-_MARK = {"setup": "○", "running": "●", "scoring": "◐", "success": "✓", "error": "✗"}
+_MARK = {
+    "setup": "○",
+    "running": "●",
+    "finalize": "◑",
+    "scoring": "◐",
+    "success": "✓",
+    "error": "✗",
+}
 
 
 def _config(config: EvalConfig) -> Table:
@@ -138,7 +146,12 @@ def _rows(groups: list[list[Rollout]], now: float, runtime_type: str) -> Table:
             runtime = f"{runtime_type}({descriptor})" if descriptor else runtime_type
             turns = t.num_turns
             start = t.timing.generation.start
-            end = t.timing.scoring.end or t.timing.generation.end or now
+            end = (
+                t.timing.scoring.end
+                or t.timing.finalize.end
+                or t.timing.generation.end
+                or now
+            )
             left = [
                 f"task {label}",
                 t.id[:8],

--- a/verifiers/v1/env.py
+++ b/verifiers/v1/env.py
@@ -36,10 +36,16 @@ from verifiers.v1.tools import serve_shared
 
 
 class TimeoutConfig(BaseConfig):
-    """Framework-enforced wall-clock timeouts, in seconds (None = no limit)."""
+    """Framework-enforced wall-clock timeouts per rollout stage, in seconds (None = no
+    limit). Each bounds one stage of `Rollout.run`: the taskset's `setup` hook, the harness
+    run, the taskset's `finalize` hook, then scoring."""
 
+    setup: float | None = None
+    """Max wall-clock for the taskset's `setup` hook (per-task runtime prep)."""
     rollout: float | None = None
     """Max wall-clock for the rollout (the harness run)."""
+    finalize: float | None = None
+    """Max wall-clock for the taskset's `finalize` hook (post-run work, before scoring)."""
     scoring: float | None = None
     """Max wall-clock for scoring — verify + rewards/metrics."""
 
@@ -197,7 +203,9 @@ class Environment:
                 "(NEEDS_CONTAINER), but the harness runs on the subprocess runtime; "
                 "use --harness.runtime.type docker or prime."
             )
+        self.setup_timeout = config.timeout.setup
         self.harness_timeout = config.timeout.rollout
+        self.finalize_timeout = config.timeout.finalize
         self.scoring_timeout = config.timeout.scoring
         self.limits = RolloutLimits(
             max_turns=config.max_turns,
@@ -260,10 +268,18 @@ class Environment:
                 f"need >=2; got n={n} (pass -r/--num-rollouts >= 2)"
             )
         runtime_config = self.runtime_for(task)
+        setup_timeout = (
+            self.setup_timeout if self.setup_timeout is not None else task.setup_timeout
+        )
         harness_timeout = (
             self.harness_timeout
             if self.harness_timeout is not None
             else task.harness_timeout
+        )
+        finalize_timeout = (
+            self.finalize_timeout
+            if self.finalize_timeout is not None
+            else task.finalize_timeout
         )
         scoring_timeout = (
             self.scoring_timeout
@@ -278,7 +294,9 @@ class Environment:
                 harness=self.harness,
                 ctx=ctx,
                 runtime_config=runtime_config,
+                setup_timeout=setup_timeout,
                 harness_timeout=harness_timeout,
+                finalize_timeout=finalize_timeout,
                 scoring_timeout=scoring_timeout,
                 limits=self.limits,
                 model_retries=retries.model.max_retries,

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -2,10 +2,11 @@
 
 A Rollout owns a single trajectory end-to-end, including its runtime's lifecycle. It
 makes and starts the runtime, gets an interception endpoint (a slot on the shared pool if
-one is given, else a per-rollout server exposed via its own runtime), runs the harness
-against it under `harness_timeout`, runs the per-rollout `@reward`/`@metric` signals under
-`scoring_timeout` while the runtime is still live, then tears the runtime down in a
-`finally`. Cross-rollout `@group_reward`s run afterwards (in the Episode) over the traces
+one is given, else a per-rollout server exposed via its own runtime), then drives the
+staged lifecycle while the runtime is live — the taskset's `setup`, the harness, the
+taskset's `finalize`, and the per-rollout `@reward`/`@metric` scoring — each under its own
+stage timeout (`setup_timeout`/`harness_timeout`/`finalize_timeout`/`scoring_timeout`),
+then tears the runtime down in a `finally`. Cross-rollout `@group_reward`s run afterwards (in the Episode) over the traces
 alone — they never need a live runtime — so a runtime is never kept up past its own
 rollout. The runtime ref is set the instant it's created, so it's always tearable-down
 even if `run()` crashes.
@@ -44,10 +45,11 @@ logger = logging.getLogger(__name__)
 
 class Phase(StrEnum):
     """A rollout's lifecycle phase (for display): provisioning, the harness driving,
-    per-rollout + group scoring, then fully scored."""
+    post-run finalize, per-rollout + group scoring, then fully scored."""
 
     SETUP = "setup"
     RUNNING = "running"
+    FINALIZE = "finalize"
     SCORING = "scoring"
     DONE = "done"
 
@@ -60,7 +62,9 @@ class Rollout:
         harness: Harness,
         ctx: RolloutContext,
         runtime_config: RuntimeConfig,
+        setup_timeout: float | None = None,
         harness_timeout: float | None = None,
+        finalize_timeout: float | None = None,
         scoring_timeout: float | None = None,
         limits: RolloutLimits | None = None,
         model_retries: int = 0,
@@ -71,7 +75,9 @@ class Rollout:
         self.harness = harness
         self.ctx = ctx
         self.runtime_config = runtime_config
+        self.setup_timeout = setup_timeout
         self.harness_timeout = harness_timeout
+        self.finalize_timeout = finalize_timeout
         self.scoring_timeout = scoring_timeout
         self.limits = limits or RolloutLimits()
         self.model_retries = model_retries
@@ -138,7 +144,14 @@ class Rollout:
         try:
             session = RolloutSession(ctx, trace, stops, self.limits)
             await runtime.start()
-            await self.taskset.setup(self.task, runtime)
+            try:
+                await asyncio.wait_for(
+                    self.taskset.setup(self.task, runtime), self.setup_timeout
+                )
+            except TimeoutError:
+                raise ProgramError(
+                    f"setup exceeded setup_timeout of {self.setup_timeout}s"
+                ) from None
             async with self._serve_interception(interception, runtime, session) as (
                 endpoint,
                 secret,
@@ -177,11 +190,25 @@ class Rollout:
                         # harness produced (like max_turns), don't error out. `is_truncated`
                         # is computed from this stop condition.
                         trace.stop("harness_timeout")
-            trace.timing.generation.end = time.time()
+            now = time.time()
+            trace.timing.generation.end = now
+            trace.timing.finalize.start = now
+            self.phase = Phase.FINALIZE  # post-run taskset work, before scoring
+            try:
+                await asyncio.wait_for(
+                    self.taskset.finalize(self.task, trace, runtime),
+                    self.finalize_timeout,
+                )
+            except TimeoutError:
+                raise ProgramError(
+                    f"finalize exceeded finalize_timeout of {self.finalize_timeout}s"
+                ) from None
+            now = time.time()
+            trace.timing.finalize.end = now
             self.phase = (
                 Phase.SCORING
             )  # per-rollout scoring; the Episode marks DONE after group scoring
-            trace.timing.scoring.start = time.time()
+            trace.timing.scoring.start = now
             try:
                 # Per-rollout scoring: taskset + harness, concurrently, both with the live
                 # runtime. (Cross-rollout `@group_reward`s run later, in the Episode.)
@@ -206,6 +233,8 @@ class Rollout:
                 trace.timing.setup.end = now
             if trace.timing.generation.start and not trace.timing.generation.end:
                 trace.timing.generation.end = now  # error mid-run: close generation
+            if trace.timing.finalize.start and not trace.timing.finalize.end:
+                trace.timing.finalize.end = now  # error mid-finalize: close finalize
             # Tear down here — group rewards (later) need only the trace, not a live
             # runtime. `runtime` is always set: make_runtime() ran before the `try`.
             try:

--- a/verifiers/v1/task.py
+++ b/verifiers/v1/task.py
@@ -59,9 +59,15 @@ class Task(StrictBaseModel):
     the runtime config's `workdir` (where the runtime supports one). For a containerized
     task whose image puts the working tree at a non-default path (e.g. a SWE row's
     `/workspace/<repo>`)."""
+    setup_timeout: float | None = None
+    """Optional per-task setup timeout (seconds). Merges with the eval's
+    `setup_timeout`: cli/toml > this > default (no limit)."""
     harness_timeout: float | None = None
     """Optional per-task harness timeout (seconds). Merges with the eval's
     `harness_timeout`: cli/toml > this > default (no limit)."""
+    finalize_timeout: float | None = None
+    """Optional per-task finalize timeout (seconds). Merges with the eval's
+    `finalize_timeout`: cli/toml > this > default (no limit)."""
     scoring_timeout: float | None = None
     """Optional per-task scoring timeout (seconds). Merges with the eval's
     `scoring_timeout`: cli/toml > this > default (no limit)."""

--- a/verifiers/v1/taskset.py
+++ b/verifiers/v1/taskset.py
@@ -125,6 +125,14 @@ class Taskset(Generic[TaskT, ConfigT]):
         a SWE row checking out its base commit). Errors propagate and fail the rollout."""
         return None
 
+    async def finalize(self, task: TaskT, trace: Trace, runtime: Runtime) -> None:
+        """Post-process the live runtime after the harness finishes, before scoring. No-op
+        by default; override to do per-rollout work the rewards depend on — apply/commit the
+        agent's diff, run a build, snapshot state, pull artifacts into the trace. Runs while
+        the runtime is still live (after generation, before `@reward`/`@metric`); the
+        symmetric counterpart to `setup`. Errors propagate and fail the rollout."""
+        return None
+
     async def score(self, trace: Trace, runtime: Runtime) -> None:
         """Score one rollout: run all `@metric` then `@reward` over its trace,
         concurrently within each phase. Each metric is recorded in `trace.metrics`

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -45,11 +45,13 @@ class TimeSpan(StrictBaseModel):
 
 class Timing(StrictBaseModel):
     """Wall-clock timing for the phases of a rollout: provisioning the runtime + serving
-    (`setup`), the harness driving the conversation (`generation`), then scoring."""
+    (`setup`), the harness driving the conversation (`generation`), post-run work before
+    scoring (`finalize`), then scoring."""
 
     start: float = Field(default_factory=time.time)
     setup: TimeSpan = Field(default_factory=TimeSpan)
     generation: TimeSpan = Field(default_factory=TimeSpan)
+    finalize: TimeSpan = Field(default_factory=TimeSpan)
     scoring: TimeSpan = Field(default_factory=TimeSpan)
 
 


### PR DESCRIPTION
## Summary

- **`finalize` taskset hook** — the symmetric counterpart to `setup`, run after the harness finishes and **before scoring**, while the runtime is still live. Override it for per-rollout runtime work the rewards depend on: apply/commit the agent's diff, run a build, snapshot state, pull artifacts into the trace. No-op by default; errors fail the rollout.

  ```
  setup → (harness runs) → finalize → @reward / @metric scoring
  ```

- **Per-stage timeouts.** `TimeoutConfig` goes from two timeouts to one per rollout stage — `setup`, `rollout` (the harness run), `finalize`, `scoring`. Each bounds its stage's `await`. `setup`/`finalize` time out as a `ProgramError` (captured onto the trace, like scoring); the harness `rollout` timeout keeps its graceful `harness_timeout` stop. Per-task fallbacks (`Task.setup_timeout` / `Task.finalize_timeout`) and the `cli/toml > task > default` precedence mirror the existing harness/scoring timeouts.

  ```bash
  uv run eval gsm8k-v1 -n 1 \
    --timeout.setup 120 --timeout.rollout 600 --timeout.finalize 120 --timeout.scoring 120
  ```

- **Observability.** A `finalize` span on `Trace.timing` (chronological: `setup → generation → finalize → scoring`; its computed `duration` is dropped from the wire like the others), a `Phase.FINALIZE`, and dashboard styling (magenta `◑`).

This is **additive / non-breaking**: `TimeoutConfig` keeps `rollout` and `scoring`; `setup`/`finalize` are new optional fields, the `finalize` hook is a no-op by default, and nothing is renamed or removed.

## Verification

Driven against this branch, offline (real `SubprocessRuntime` + fake harness/taskset):

- `finalize` is invoked **exactly once, between generation and scoring** (`generation.end == finalize.start == ... == finalize.end == scoring.start`, no gaps), with the runtime still live.
- `--timeout.finalize` exceeded → `ProgramError("finalize exceeded finalize_timeout …")` captured on the trace; the span is closed in the `finally`.
- `--timeout.setup` exceeded → `ProgramError`, and `finalize`/scoring never run.
- `episode()` resolves each stage timeout `cli/toml > task > default` and threads it onto the `Rollout`.
- `Timing` carries the `finalize` span; `to_wire` drops its `duration`; dashboard `_STYLE`/`_MARK` have `finalize` (no `KeyError`).
- `eval … --timeout.setup 30 --timeout.finalize 45 --dry-run` resolves `[timeout] setup=30.0, finalize=45.0`.
- `ruff check` / `ruff format` clean.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `finalize` hook and per-stage timeouts to the verifier rollout lifecycle
> - Adds a `finalize` async hook to `Taskset` that runs post-generation work before scoring, with its own `finalize_timeout` enforced separately from setup, rollout, and scoring timeouts.
> - Extends `TimeoutConfig`, `Task`, `Rollout`, and `Environment` to accept and expose `setup_timeout` and `finalize_timeout` alongside existing per-stage timeouts.
> - Records a `finalize` `TimeSpan` in `Timing` and adds a `FINALIZE` phase to the `Phase` enum in [rollout.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1640/files#diff-f886b7f4717cf8fce9270bd4ff4790f3182aa1016abb9efb7f6e57efe18d1bf2).
> - Updates the dashboard in [dashboard.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1640/files#diff-c60769cf42a5e4975c5dc5a0f893c697282abd7d848c02c6229b8b5cc42b2bad) to display the finalize phase with a magenta `◑` marker and account for finalize timing in elapsed-time calculations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d6bc758.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core rollout lifecycle ordering and timeout behavior; additive defaults (no-op finalize, optional timeouts) limit breakage but tasksets that override finalize or set tight setup caps affect scoring and failure modes.
> 
> **Overview**
> Adds a **`finalize`** taskset hook that runs after the harness and before scoring while the runtime is still live (symmetric to `setup`), for post-run work rewards depend on.
> 
> **Per-stage timeouts** expand `TimeoutConfig` with `setup` and `finalize` alongside existing `rollout` and `scoring`; `setup`/`finalize` enforce `asyncio.wait_for` and surface timeouts as `ProgramError`, while harness `rollout` still ends gracefully with `harness_timeout`. Resolution follows **cli/toml > task > default** via new `Task.setup_timeout` / `Task.finalize_timeout` and `Environment.episode` wiring into `Rollout`.
> 
> **Observability:** `Trace.timing.finalize`, `Phase.FINALIZE`, and the rich dashboard (magenta `◑`, elapsed time includes finalize) document the new stage. Docs show `--timeout.setup` / `--timeout.finalize` flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6bc7584047596f224b3a584b8fd8f786bd9bffe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->