### PR TITLE
fix: retry the user-sim connect at high concurrency (capture failures as ProgramError)

### DIFF
--- a/verifiers/v1/user.py
+++ b/verifiers/v1/user.py
@@ -21,7 +21,7 @@ import logging
 from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass
 
-from verifiers.v1.errors import ProgramError
+from verifiers.v1.errors import ProgramError, RolloutError
 from verifiers.v1.runtimes import Runtime, RuntimeConfig, make_runtime
 from verifiers.v1.tools import Tools, serve_tools
 from verifiers.v1.types import Messages
@@ -47,57 +47,64 @@ class User(Tools):
 Respond = Callable[[str], Awaitable[tuple[Messages, bool]]]
 
 
-async def _await_user_ready(url: str) -> None:
-    """Poll the user server until it accepts a connection (any HTTP response — an MCP server
-    406s a bare GET — means up). Retries a transient refusal (the colocated server can be slow
-    to accept under high concurrency), and on exhaustion raises `ProgramError` — a captured,
-    retryable rollout error — so the failure flows through the rollout's error handling instead
-    of escaping as a raw transport exception that would crash the batch."""
-    import httpx
-
-    last_exc: Exception | None = None
-    async with httpx.AsyncClient(timeout=2.0) as client:
-        for attempt in range(_USER_CONNECT_ATTEMPTS):
-            try:
-                await client.get(url)
-                return
-            except Exception as e:  # connection refused / timeout: retry
-                last_exc = e
-                await asyncio.sleep(
-                    min(_USER_CONNECT_BACKOFF * 2**attempt, _USER_CONNECT_MAX_BACKOFF)
-                )
-    raise ProgramError(
-        f"user server at {url} unreachable after {_USER_CONNECT_ATTEMPTS} attempts: {last_exc!r}"
-    )
-
-
 @contextlib.asynccontextmanager
 async def connect_user(url: str) -> AsyncIterator[Respond]:
     """Open an MCP client session to a user server at `url` and yield an async
     `respond(message)` that calls its `respond` tool, parsing the JSON it returns
-    (`{"messages": [...], "done": bool}`) into typed `(messages, done)`. Waits (with retry) for
-    the server to accept connections first, so a transient refusal under load is recovered."""
+    (`{"messages": [...], "done": bool}`) into typed `(messages, done)`.
+
+    Retries the connect — under high concurrency the colocated user server can be slow to
+    accept (or briefly refuse) a connection. A server that stays unreachable raises
+    `ProgramError` (a captured, retryable rollout error), so a transport failure never escapes
+    as a raw `ExceptionGroup`/`ConnectError` that would bypass rollout error handling and crash
+    the batch. The connect is entered and exited in this one frame so anyio's cancel scopes stay
+    correctly nested."""
     from mcp import ClientSession
     from mcp.client.streamable_http import streamable_http_client
 
     from verifiers.v1.interception import parse_message
 
-    await _await_user_ready(url)
-    async with contextlib.AsyncExitStack() as stack:
-        read, write, *_ = await stack.enter_async_context(streamable_http_client(url))
-        session = await stack.enter_async_context(ClientSession(read, write))
-        await session.initialize()
+    last_exc: Exception | None = None
+    for attempt in range(_USER_CONNECT_ATTEMPTS):
+        connected = False
+        try:
+            async with (
+                streamable_http_client(url) as (read, write, *_),
+                ClientSession(read, write) as session,
+            ):
+                await session.initialize()
+                connected = True
 
-        async def respond(message: str) -> tuple[Messages, bool]:
-            result = await session.call_tool("respond", {"message": message})
-            texts = [
-                b.text for b in result.content if getattr(b, "type", None) == "text"
-            ]
-            data = json.loads("\n".join(texts))
-            messages = [parse_message(m) for m in data["messages"]]
-            return messages, bool(data["done"])
+                async def respond(message: str) -> tuple[Messages, bool]:
+                    result = await session.call_tool("respond", {"message": message})
+                    texts = [
+                        b.text
+                        for b in result.content
+                        if getattr(b, "type", None) == "text"
+                    ]
+                    data = json.loads("\n".join(texts))
+                    messages = [parse_message(m) for m in data["messages"]]
+                    return messages, bool(data["done"])
 
-        yield respond
+                yield respond
+            return
+        except RolloutError:
+            raise  # a real rollout error surfaced after connecting: propagate as-is
+        except Exception as e:
+            if connected:
+                # the user-sim connection broke mid-rollout/teardown (e.g. the colocated server
+                # was killed under memory pressure): capture it as a retryable rollout error
+                # instead of letting the raw transport ExceptionGroup escape and crash the batch
+                raise ProgramError(
+                    f"user server at {url} connection lost: {e!r}"
+                ) from e
+            last_exc = e  # the connect itself failed: back off and retry
+            await asyncio.sleep(
+                min(_USER_CONNECT_BACKOFF * 2**attempt, _USER_CONNECT_MAX_BACKOFF)
+            )
+    raise ProgramError(
+        f"user server at {url} unreachable after {_USER_CONNECT_ATTEMPTS} attempts: {last_exc!r}"
+    )
 
 
 @contextlib.asynccontextmanager

--- a/verifiers/v1/user.py
+++ b/verifiers/v1/user.py
@@ -14,17 +14,26 @@ side. `respond(message)` takes the model's last assistant text and returns the n
 messages plus whether the conversation is done.
 """
 
+import asyncio
 import contextlib
 import json
 import logging
 from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass
 
+from verifiers.v1.errors import ProgramError
 from verifiers.v1.runtimes import Runtime, RuntimeConfig, make_runtime
 from verifiers.v1.tools import Tools, serve_tools
 from verifiers.v1.types import Messages
 
 logger = logging.getLogger(__name__)
+
+# The colocated user server is up once its in-runtime probe passes, but under high concurrency
+# it can still momentarily refuse a host connection. Retry the connect before giving up so a
+# transient refusal doesn't fail the rollout.
+_USER_CONNECT_ATTEMPTS = 12
+_USER_CONNECT_BACKOFF = 0.2  # seconds, exponential up to the cap
+_USER_CONNECT_MAX_BACKOFF = 2.0
 
 
 @dataclass(frozen=True)
@@ -38,16 +47,42 @@ class User(Tools):
 Respond = Callable[[str], Awaitable[tuple[Messages, bool]]]
 
 
+async def _await_user_ready(url: str) -> None:
+    """Poll the user server until it accepts a connection (any HTTP response — an MCP server
+    406s a bare GET — means up). Retries a transient refusal (the colocated server can be slow
+    to accept under high concurrency), and on exhaustion raises `ProgramError` — a captured,
+    retryable rollout error — so the failure flows through the rollout's error handling instead
+    of escaping as a raw transport exception that would crash the batch."""
+    import httpx
+
+    last_exc: Exception | None = None
+    async with httpx.AsyncClient(timeout=2.0) as client:
+        for attempt in range(_USER_CONNECT_ATTEMPTS):
+            try:
+                await client.get(url)
+                return
+            except Exception as e:  # connection refused / timeout: retry
+                last_exc = e
+                await asyncio.sleep(
+                    min(_USER_CONNECT_BACKOFF * 2**attempt, _USER_CONNECT_MAX_BACKOFF)
+                )
+    raise ProgramError(
+        f"user server at {url} unreachable after {_USER_CONNECT_ATTEMPTS} attempts: {last_exc!r}"
+    )
+
+
 @contextlib.asynccontextmanager
 async def connect_user(url: str) -> AsyncIterator[Respond]:
     """Open an MCP client session to a user server at `url` and yield an async
     `respond(message)` that calls its `respond` tool, parsing the JSON it returns
-    (`{"messages": [...], "done": bool}`) into typed `(messages, done)`."""
+    (`{"messages": [...], "done": bool}`) into typed `(messages, done)`. Waits (with retry) for
+    the server to accept connections first, so a transient refusal under load is recovered."""
     from mcp import ClientSession
     from mcp.client.streamable_http import streamable_http_client
 
     from verifiers.v1.interception import parse_message
 
+    await _await_user_ready(url)
     async with contextlib.AsyncExitStack() as stack:
         read, write, *_ = await stack.enter_async_context(streamable_http_client(url))
         session = await stack.enter_async_context(ClientSession(read, write))


### PR DESCRIPTION
## Summary

At high concurrency (e.g. `eval alphabet-sort-v1 --no-rich -c 512` on the subprocess runtime), the colocated user simulator (`vf.User` — one MCP server per rollout) can transiently refuse / be slow to accept a host connection. The raw `httpx.ConnectError` (wrapped in an anyio `ExceptionGroup`) **escaped `rollout.run`'s `except RolloutError`**, so it bypassed rollout-level retry and propagated as a *fatal* exception. Through `run_eval_server`'s `gather(return_exceptions=False)` that single failure cancelled all in-flight rollouts, crashed the run, and **orphaned** the cancelled rollouts' user subprocesses (own session — `atexit` doesn't run on SIGTERM): ~260–500 leaked `python -m …user` procs holding ~50 GB.

Fix is at the source, in `connect_user`:
- It **retries the real MCP connect** (`streamable_http_client` + `ClientSession.initialize`) — the connection is entered *and* exited in one frame so anyio's cancel scopes stay correctly nested.
- Any **transport failure is converted to `ProgramError`** (a `RolloutError`): a connect that never succeeds after the retries, or a connection that breaks mid-rollout / at teardown. Genuine `RolloutError`s (a real harness/model error) still propagate unchanged.

So a transient refusal is **recovered by retry**, and a persistent one is **captured** into the trace (caught by `rollout.run`'s `except RolloutError`) → recorded as an errored trace (and retried at the rollout level) — **never escaping to crash the batch**.

`run_eval_server`'s `gather` is intentionally left at `return_exceptions=False` (genuine bugs still surface); the user-sim failure is contained at its origin instead.

## Why this layer

The exception bubbled origin → crash through two gaps; this PR closes the first (the root):

| Where | Before |
|-------|--------|
| `user.py` `connect_user` | single connect, no retry; transient `httpx.ConnectError` raised |
| **`rollout.py:227` `except RolloutError`** | **🔑 not a `RolloutError` → escapes capture + retry** |
| `episode.py` `run_with_retry` | `retry_if_result` only retries *returned* error-traces, not raised exceptions → re-raises |
| `serve/server.py` `_handle` → `serve/client.py:93` | worker returns an error response; client re-raises as `RuntimeError` |
| `runner.py:213` `gather(return_exceptions=False)` | one error cancels all in-flight → crash → orphaned user procs |

By making the user-sim failure a captured `RolloutError`, it now flows through the existing error-recording (and retry) machinery rather than escaping.

## Verification

End-to-end, subprocess runtime, `deepseek-v4-flash`:

| `eval alphabet-sort-v1 --no-rich -c 512 -n 1024` | before | after |
|---|---|---|
| exit | crash (rc=1) | **rc=0 (completed all)** |
| rollouts completed | ~10–180 then crash | **1024 / 1024** |
| errored traces | — | **0** (all transient connects recovered by retry) |
| crash tracebacks | 4 | **0** |
| orphaned user processes | ~260–500 (~50 GB) | **0** |

Also:
- Unit: `connect_user` against a dead port → retries → raises `ProgramError` (a `RolloutError`), clean asyncio shutdown (an earlier handoff design failed with anyio's `exit cancel scope in a different task` — hence the single-frame retry).
- Minimal repro (`serve_user` driven directly, no model): N = 32 / 128 / 256 / 512 all succeed, 0 orphans.
- `ruff check` + `ruff format --check` clean.

## Notes

- **Orphaned user processes:** the storm was a *consequence* of the crash (mass-cancellation + workers SIGTERM'd, skipping the `atexit` reap). With the failure contained, rollouts tear down normally and reap their user subprocess — the e2e leaves 0. Hardening the reap for legitimate kills (Ctrl-C / worker SIGTERM) is a possible follow-up.
- **Remote runtimes (prime/modal):** by design they run the colocated user *inside the remote sandbox*, not as a local subprocess, so they avoid the local subprocess explosion + localhost connect pressure entirely (analysis; not separately measured).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rollout error boundaries for all user-simulator connections; misclassification could hide real bugs or over-retry, but scope is limited to MCP client connect/teardown in `connect_user`.
> 
> **Overview**
> **Hardens `connect_user`** so colocated user-simulator MCP connections survive high concurrency instead of crashing whole eval batches.
> 
> `connect_user` now **retries** `streamable_http_client` + `ClientSession.initialize` up to 12 times with capped exponential backoff when the host connect is refused or slow. The client session is opened and torn down in a **single async frame** (replacing `AsyncExitStack`) so anyio cancel scopes stay valid across retries.
> 
> **Transport failures are wrapped as `ProgramError`** (`RolloutError`): persistent unreachable servers after retries, or connection loss after a successful connect (including teardown). Genuine `RolloutError`s from the harness still propagate unchanged, so `rollout.run` can record/retry errors instead of letting raw `ConnectError`/`ExceptionGroup` cancel all in-flight rollouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c50d9b304e750692b4d13fd25945f1870b8534c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Retry user-sim connection with exponential backoff and wrap failures as `ProgramError`
> - [`connect_user`](https://github.com/PrimeIntellect-ai/verifiers/pull/1641/files#diff-dad41b3a55e161581fffa081fe002cf51ee4c2c02a3b42a47e805b24bdda547e) now retries the user server connection up to `_USER_CONNECT_ATTEMPTS` times with exponential backoff (capped at `_USER_CONNECT_MAX_BACKOFF`) to handle failures at high concurrency.
> - On mid-session connection loss (after a successful `session.initialize`), raises `ProgramError` indicating the connection was lost; after exhausting all retries, raises `ProgramError` indicating the server is unreachable.
> - `RolloutError` continues to propagate unchanged.
> - Behavioral Change: raw transport exceptions are no longer surfaced directly; they are now wrapped in `ProgramError` unless they are `RolloutError`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4c50d9b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->