### PR TITLE
feat(v1): add swelego-v1 taskset (SWE-Lego on rlm harness / prime runtime)

### DIFF
--- a/examples/tasksets/swelego_v1/pyproject.toml
+++ b/examples/tasksets/swelego_v1/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "swelego-v1"
+version = "0.1.0"
+description = "swelego-v1 — SWE-Lego real-data issue-resolving tasks (agentic; sandbox pytest reward)."
+requires-python = ">=3.10"
+dependencies = ["datasets"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build]
+include = ["swelego_v1.py", "pyproject.toml"]

--- a/examples/tasksets/swelego_v1/swelego_v1.py
+++ b/examples/tasksets/swelego_v1/swelego_v1.py
@@ -1,0 +1,254 @@
+"""swelego-v1 — SWE-Lego-Real-Data (PrimeIntellect/SWE-Lego-Real-Data) as a v1 taskset.
+
+Each row is a real GitHub issue with a public Docker image (`jierun/sweb.eval.x86_64.*`)
+carrying the repo at `/testbed` and a conda `testbed` env. `setup` links that env onto
+`/root/.venv`, pre-installs a static ripgrep (the images' apt is ~150s slow and the rlm
+harness installs `rg` via apt when missing), and applies the row's `test_patch` so the
+agent can read the failing tests from t=0. The `solved` reward canonicalizes the test
+files (revert agent edits from `base_commit`, re-apply `test_patch` — the SWE-bench
+anti-tamper dance), runs the row's `test_cmd` verbatim (whole test FILES plus the flags
+upstream's eval uses — module-scoped fixtures and `--cov-fail-under` thresholds break
+when you cherry-pick ids), and scores 1.0 iff every FAIL_TO_PASS and PASS_TO_PASS id is
+PASSED in the pytest `-rA` short summary. Scoring parsed outcomes (not pytest's exit
+code) avoids false negatives where a repo-wide coverage threshold makes pytest exit
+non-zero even though every scored test passed. A v1 port of the v0 ComposableEnv
+`SWELegoTaskSet`.
+"""
+
+import re
+from textwrap import dedent
+
+import verifiers.v1 as vf
+
+DATASET = "PrimeIntellect/SWE-Lego-Real-Data"
+# A filtered fork of SWE-Lego/SWE-Lego-Real-Data that drops rows with truncated pytest
+# parametrize test ids; `resolved` carries the rows whose gold patch validates.
+SPLIT = "resolved"
+
+REPO_PATH = "/testbed"
+
+# The testbed conda env (with the project + pytest installed) and quiet, non-interactive
+# tooling — exported for every command the taskset runs in the sandbox.
+ENV = {
+    "PATH": (
+        "/opt/miniconda3/envs/testbed/bin:/opt/miniconda3/bin:"
+        "/opt/conda/envs/testbed/bin:/opt/conda/bin:"
+        "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+    ),
+    "PAGER": "cat",
+    "MANPAGER": "cat",
+    "LESS": "-R",
+    "PIP_PROGRESS_BAR": "off",
+    "TQDM_DISABLE": "1",
+}
+
+# Symlink the testbed conda env onto /root/.venv (checks both common conda roots;
+# `ln -sfn` alone returns 0 even when the target is missing, so test `-d` explicitly).
+LINK_VENV = (
+    "for d in /opt/miniconda3/envs/testbed /opt/conda/envs/testbed; do "
+    '[ -d "$d" ] && ln -sfn "$d" /root/.venv && break; done; true'
+)
+
+# Pre-install a static musl ripgrep. The jierun SWE-bench eval images have slow apt
+# sources (`apt-get update` ~150s) and the rlm harness apt-installs rg when missing —
+# the direct binary download skips that. Failure is non-fatal (the harness falls back).
+INSTALL_RG = (
+    "command -v rg >/dev/null 2>&1 || { "
+    "V=14.1.1; "
+    "curl -sSL --max-time 100 "
+    "https://github.com/BurntSushi/ripgrep/releases/download/"
+    "${V}/ripgrep-${V}-x86_64-unknown-linux-musl.tar.gz "
+    "| tar xz -C /tmp "
+    "&& install -m 755 /tmp/ripgrep-${V}-x86_64-unknown-linux-musl/rg /usr/local/bin/rg; "
+    "}"
+)
+
+# Canonical SWE-bench grading dance, step 1: wipe agent edits to every file `$patch`
+# (the row's test_patch) touches — `git checkout "$base" -- <path>` for files that
+# existed at the base commit, `rm -f` for files the patch added. Reverts from `$base`
+# (not HEAD): an agent that ran `git add && git commit` mid-rollout moved HEAD to its
+# own — potentially weakened — test version. Step 2 (re-apply test_patch cleanly) runs
+# right after, via `_apply_patch`. Agent *source* edits survive untouched.
+REVERT_TEST_FILES = r"""
+git apply --numstat "$patch" | cut -f3- | while IFS= read -r path; do
+  path=${path#\"}; path=${path%\"}
+  if git cat-file -e "$base:$path" 2>/dev/null; then
+    git checkout "$base" -- "$path" 2>/dev/null || true
+  else
+    rm -f -- "$path"
+  fi
+done
+"""
+
+# Parametrized pytest ids can contain spaces (e.g.
+# ``test_foo[TypeMismatch, List var assigned to String]``), so the id capture group is
+# non-greedy up to an optional ``\s+-\s+<reason>`` tail that FAILED / ERROR / XFAIL
+# emit. Plain `\S+` would truncate such ids at the first inner whitespace and silently
+# fail to match F2P/P2P entries.
+OUTCOME_LINE_RE = re.compile(
+    r"^(PASSED|FAILED|ERROR|XFAIL|XPASS)\s+(.+?)(?:\s+-\s+.*)?$"
+)
+
+
+def parse_outcomes(output: str) -> dict[str, str]:
+    """Parse pytest ``-rA`` short-summary lines into ``{test_id: outcome}``.
+
+    Pytest with ``-rA`` prints one ``OUTCOME test_id`` line per test in the
+    short-summary block (e.g. ``PASSED tests/foo.py::Cls::test``); if pytest re-runs
+    anything, later lines win. ``SKIPPED`` is intentionally not parsed: pytest prints
+    it as ``SKIPPED [N] <file>:<line>: <reason>`` without a usable test id, so it can't
+    be matched against FAIL_TO_PASS / PASS_TO_PASS regardless — a skipped F2P/P2P test
+    correctly scores 0 via "no PASSED entry".
+    """
+    outcomes: dict[str, str] = {}
+    for line in output.splitlines():
+        m = OUTCOME_LINE_RE.match(line)
+        if m:
+            # Non-greedy capture can leave trailing whitespace — strip before storing
+            # so dict lookups against F2P/P2P entries match exactly.
+            outcomes[m.group(2).rstrip()] = m.group(1)
+    return outcomes
+
+
+def calculate_reward(test_output: str, required: list[str]) -> float:
+    """1.0 iff every required (FAIL_TO_PASS + PASS_TO_PASS) test id is PASSED.
+
+    No parsed outcomes at all usually means the row's ``test_cmd`` doesn't emit
+    ``-rA`` short-summary lines — that scores 0, like any missing id.
+    """
+    outcomes = parse_outcomes(test_output)
+    if not outcomes or not required:
+        return 0.0
+    return 1.0 if all(outcomes.get(t) == "PASSED" for t in required) else 0.0
+
+
+def build_eval_script(test_cmd: str) -> str:
+    """Wrap the row's canonical ``test_cmd`` (whole test-file paths plus the flags the
+    repo's config expects: ``LANG=C.UTF-8``, ``-p no:cacheprovider``, sometimes
+    ``--cov=pkg``) in conda activation. Exits 0 regardless of the pytest outcome —
+    scoring reads the ``-rA`` summary, so a non-zero exit from here means infra, not a
+    failing test."""
+    return dedent(
+        f"""\
+        #!/bin/bash
+        set -uo pipefail
+
+        cd {REPO_PATH}
+
+        set +u
+        if [ -f /opt/miniconda3/bin/activate ]; then
+            source /opt/miniconda3/bin/activate
+        elif [ -f /opt/conda/bin/activate ]; then
+            source /opt/conda/bin/activate
+        fi
+        conda activate testbed 2>/dev/null || true
+        set -u
+
+        set +e
+        {test_cmd}
+        PYTEST_EXIT=$?
+        set -e
+
+        echo ""
+        echo "SWELEGO_PYTEST_EXIT=$PYTEST_EXIT"
+        exit 0
+        """
+    )
+
+
+class SWELegoTask(vf.Task):
+    test_cmd: str
+    """Canonical pytest invocation for scoring — run verbatim, outcomes parsed via `-rA`."""
+    test_patch: str = ""
+    """Patch adding the failing tests; applied in `setup`, re-canonicalized before scoring."""
+    base_commit: str = ""
+    """Commit test files are reverted to before `test_patch` is re-applied at scoring."""
+    fail_to_pass: list[str] = []
+    pass_to_pass: list[str] = []
+    gold_patch: str = ""
+    """Gold source patch (for validation/dummy rollouts)."""
+
+
+class SWELegoTaskset(vf.Taskset[SWELegoTask, vf.TasksetConfig]):
+    NEEDS_CONTAINER = True
+
+    def load_tasks(self) -> list[SWELegoTask]:
+        from datasets import load_dataset
+
+        rows = load_dataset(DATASET, split=SPLIT)
+        return [
+            SWELegoTask(
+                idx=i,
+                name=row.get("instance_id") or f"swelego-{i}",
+                instruction=row["problem_statement"],
+                image=row["image_name"],
+                workdir=REPO_PATH,
+                resources=vf.Resources(cpu=4, memory=4, disk=10),
+                test_cmd=row.get("test_cmd") or "",
+                test_patch=row.get("test_patch") or "",
+                base_commit=row.get("base_commit") or "",
+                fail_to_pass=list(row.get("FAIL_TO_PASS") or []),
+                pass_to_pass=list(row.get("PASS_TO_PASS") or []),
+                gold_patch=row.get("patch") or "",
+            )
+            for i, row in enumerate(rows)
+        ]
+
+    async def setup(self, task: SWELegoTask, runtime: vf.Runtime) -> None:
+        await runtime.run(["sh", "-c", LINK_VENV], ENV)
+        await runtime.run(["sh", "-c", INSTALL_RG], ENV)
+        # The failing tests live in a separate test_patch — apply it before the agent
+        # runs so it can read them (and so gold-patch validation scores against them).
+        if task.test_patch.strip():
+            await self._apply_patch(runtime, task.test_patch, "test_patch")
+
+    @vf.reward(weight=1.0)
+    async def solved(self, task: SWELegoTask, runtime: vf.Runtime) -> float:
+        required = task.fail_to_pass + task.pass_to_pass
+        if not required or not task.test_cmd.strip():
+            return 0.0
+        if task.test_patch.strip() and task.base_commit:
+            # Re-write the patch from the task (the agent could have tampered with the
+            # copy in /tmp), revert its files to base, and re-apply it cleanly.
+            await runtime.write("/tmp/test_patch.patch", task.test_patch.encode())
+            await runtime.run(
+                ["sh", "-c", REVERT_TEST_FILES],
+                {**ENV, "patch": "/tmp/test_patch.patch", "base": task.base_commit},
+            )
+            try:
+                await self._apply_patch(runtime, task.test_patch, "test_patch")
+            except vf.ProgramError:
+                # The agent broke the tree badly enough that the canonical tests can't
+                # come back — that's a failed task, not an infra error.
+                return 0.0
+        result = await runtime.run(
+            ["bash", "-c", build_eval_script(task.test_cmd)], ENV
+        )
+        return calculate_reward(result.stdout or "", required)
+
+    async def apply_gold_patch(self, task: SWELegoTask, runtime: vf.Runtime) -> None:
+        """Apply the gold source patch (for validation/dummy rollouts); `setup` already
+        applied `test_patch`, so the F2P tests are in place."""
+        if not task.gold_patch.strip():
+            raise vf.ProgramError(f"empty gold patch for {task.name}")
+        await self._apply_patch(runtime, task.gold_patch, "gold")
+
+    async def _apply_patch(self, runtime: vf.Runtime, patch: str, label: str) -> None:
+        # Strict apply first, then a fuzzy `patch` fallback for slightly-stale hunks
+        # (mirrors the v0 taskset's two-strategy apply).
+        path = f"/tmp/{label}.patch"
+        await runtime.write(path, patch.encode())
+        for cmd in (
+            f"git apply --whitespace=fix {path}",
+            f"patch --batch --fuzz=5 -p1 -i {path}",
+        ):
+            result = await runtime.run(["sh", "-c", cmd], ENV)
+            if result.exit_code == 0:
+                return
+        raise vf.ProgramError(
+            f"{label} apply failed: exit={result.exit_code} {result.stderr.strip()[-500:]}"
+        )
+
+
+def load_taskset(config: vf.TasksetConfig) -> SWELegoTaskset:
+    return SWELegoTaskset(config)


### PR DESCRIPTION
Stacked on #1576 (`feat/nano-as-v1`).

Port of the v0 ComposableEnv `SWELegoTaskSet` to a v1 taskset, following the `r2e_gym_v1` / `scaleswe_v1` pattern.

## What it does

- Loads `PrimeIntellect/SWE-Lego-Real-Data` (`resolved` split, 4432 tasks; public `jierun/sweb.eval.x86_64.*` images, repo at `/testbed`).
- `setup`: links the testbed conda env onto `/root/.venv`, pre-installs a static ripgrep (the images' apt is ~150s slow and the rlm harness apt-installs `rg` when missing), applies the row's `test_patch` so the agent can read the failing tests from t=0.
- `solved`: runs the row's `test_cmd` **verbatim** (whole test FILES + the flags upstream's eval uses — module-scoped fixtures and `--cov-fail-under` thresholds break if you cherry-pick ids) and scores 1.0 iff every FAIL_TO_PASS + PASS_TO_PASS id is PASSED in the pytest `-rA` short summary. Parsing outcomes (not pytest's exit code) avoids false negatives from repo-wide coverage thresholds.
- Anti-tamper: before scoring, agent edits to every file `test_patch` touches are reverted from `base_commit` (not HEAD — a mid-rollout `git commit` would otherwise restore weakened tests) and `test_patch` is re-applied. Ported from the v0 Python diff-header parser to ~8 lines of shell (`git apply --numstat` + `git cat-file -e "$base:$path"`), with the patch re-written from the host-side task so sandbox tampering can't survive.
- `apply_gold_patch` for validation/dummy rollouts.

## Validation

**Gold/base scoring parity (prime sandboxes, no model)** — `resolved` is defined by v0's gold validation, so gold→1.0 is a direct v0-parity probe:

| instance | base | gold |
|---|---|---|
| googleapis__python-bigquery-644 | 0.0 | 1.0 |
| pydata__xarray-2625 | 0.0 | 1.0 |
| pytorch__ignite-1155 | 0.0 | 0.0* |

\* Chased to ground: on the **same gold-patched sandbox**, a byte-equivalent v0-style scoring run (`/eval.sh` + `export` prefix + file capture) and v1 `solved()` both return 0.0 with the identical single failure — `test_distrib_cpu` (a P2P id) binds TCP port 2222 for torch.distributed's TCPStore, and prime sandboxes already occupy 2222 (errno 98). Environment limitation affecting v0 equally, not a port regression. Rows whose P2P set includes a distributed test binding 2222 are unwinnable on prime runtimes.

**Live smoke** — `openai/gpt-5-mini` via Prime Inference, rlm harness, prime runtime, 4 shuffled tasks × 2 rollouts: 8/8 rollouts completed with zero infra errors, mean reward 0.375 (textual-3432 2/2 solved, vermin-237 1/2, apispec-716 + pgmpy-973 0/2) — non-degenerate reward signal with within-task variance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New sandbox grading path runs arbitrary dataset `test_cmd` and shell/git patch logic in containers; scoring correctness affects training rewards but does not change core auth or production services.
> 
> **Overview**
> Adds a new **swelego-v1** example taskset that ports the v0 `SWELegoTaskSet` to the v1 `vf.Taskset` API for real GitHub issue repair on SWE-bench-style Docker images.
> 
> Tasks load from `PrimeIntellect/SWE-Lego-Real-Data` (`resolved` split) with per-row images, problem text, `test_cmd`, `test_patch`, F2P/P2P ids, and gold patches. **Setup** symlinks the testbed conda env, optionally installs static `ripgrep`, and applies `test_patch`. **`solved`** reverts agent tampering on test files from `base_commit`, re-applies `test_patch`, runs the dataset’s `test_cmd` in conda, and scores **1.0** only when every required pytest id shows **PASSED** in `-rA` output (not pytest exit code). **`apply_gold_patch`** supports validation rollouts. Includes hatch `pyproject.toml` packaging the module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be76ecc6b33e1f704f37119f8f920318e7095c09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add swelego-v1 taskset for running SWE-Lego tasks on the prime runtime
> - Adds a new taskset module at [examples/tasksets/swelego_v1/swelego_v1.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1642/files#diff-b36d9c77ba67cff7a65b928402dbd6720e7215ec5dee27bda58bce5faca21327) that loads SWE-Lego-Real-Data from HuggingFace datasets and maps rows to `SWELegoTask` instances.
> - Container setup symlinks the testbed conda env, installs ripgrep if missing, and applies any `test_patch` before the agent runs.
> - Scoring re-canonicalizes tests by reverting and reapplying the test patch, runs pytest via a generated eval script, and parses pytest `-rA` short-summary output to return 1.0 only if all required tests pass.
> - Patch application tries `git apply --whitespace=fix` first, then falls back to `patch --batch --fuzz=5 -p1`, raising `ProgramError` if both fail.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized be76ecc. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->