### PR TITLE
feat(v1): record sampled provenance on MessageNode

### DIFF
--- a/tests/v1/test_graph.py
+++ b/tests/v1/test_graph.py
@@ -64,3 +64,27 @@ def test_reasoning_content_participates_in_graph_prefix_matching():
         if isinstance(node.message, vf.AssistantMessage) and node.message.tool_calls
     ]
     assert len(tool_call_nodes) == 2
+
+
+def test_prompt_supplied_assistant_messages_are_not_sampled_turns():
+    task = vf.Task(idx=0, instruction="few-shot")
+    trace = vf.Trace(task=task)
+    fabricated = vf.AssistantMessage(
+        content=None,
+        tool_calls=[vf.ToolCall(id="call_0", name="lookup", arguments="{}")],
+    )
+    response = vf.AssistantMessage(content="real answer")
+
+    graph.add_turn(
+        trace,
+        [
+            vf.UserMessage(content="question"),
+            fabricated,
+            vf.ToolMessage(content="fabricated result", tool_call_id="call_0"),
+        ],
+        _response(response),
+    )
+
+    assert [n.sampled for n in trace.nodes] == [False, False, False, True]
+    assert trace.num_turns == 1
+    assert trace.assistant_messages == [response]

--- a/verifiers/v1/graph.py
+++ b/verifiers/v1/graph.py
@@ -47,6 +47,10 @@ class MessageNode(StrictBaseModel):
     """Index into `Trace.nodes` of the predecessor message; None for a root."""
     message: Message
     """The message this node carries (system / user / assistant / tool)."""
+    sampled: bool = False
+    """True iff a model call produced this message (the response in `add_turn`); False for
+    every prompt-supplied message — including assistant/tool messages fabricated as context
+    the model never generated, which role alone can't tell apart from real turns."""
     token_ids: list[int] = Field(default_factory=list)
     """This message's delta contribution to the cumulative token sequence: its leading
     template scaffold + its own tokens — for an assistant, the generation-prompt scaffold
@@ -223,6 +227,7 @@ def add_turn(trace: "Trace", prompt: "list[Message]", response: Response) -> Non
         MessageNode(
             parent=parent,
             message=response.message,
+            sampled=True,
             token_ids=[*gen_prompt, *comp_ids],
             mask=[False] * len(gen_prompt) + [True] * len(comp_ids),
             logprobs=list(tokens.completion_logprobs) if tokens else [],

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -77,8 +77,9 @@ class Branch(StrictBaseModel):
     @computed_field
     @property
     def num_turns(self) -> int:
-        """Model turns (assistant messages) in this branch."""
-        return sum(1 for n in self.nodes if isinstance(n.message, AssistantMessage))
+        """Model turns (sampled responses) in this branch — prompt-supplied assistant
+        messages don't count."""
+        return sum(1 for n in self.nodes if n.sampled)
 
     @property
     def messages(self) -> Messages:
@@ -209,15 +210,9 @@ class Trace(StrictBaseModel, Generic[TaskT]):
         return bool(self.errors)
 
     def _last_assistant(self) -> "MessageNode | None":
-        """The most recent assistant node, or None for a trace with no responses."""
-        return next(
-            (
-                n
-                for n in reversed(self.nodes)
-                if isinstance(n.message, AssistantMessage)
-            ),
-            None,
-        )
+        """The most recent sampled (model-produced) node, or None for a trace with no
+        responses."""
+        return next((n for n in reversed(self.nodes) if n.sampled), None)
 
     @property
     def prompt_len(self) -> int:
@@ -266,8 +261,9 @@ class Trace(StrictBaseModel, Generic[TaskT]):
 
     @property
     def num_turns(self) -> int:
-        """Total model turns (assistant nodes) across all branches."""
-        return sum(1 for n in self.nodes if isinstance(n.message, AssistantMessage))
+        """Total model turns (sampled responses) across all branches — prompt-supplied
+        assistant messages don't count."""
+        return sum(1 for n in self.nodes if n.sampled)
 
     @computed_field
     @property
@@ -291,9 +287,12 @@ class Trace(StrictBaseModel, Generic[TaskT]):
 
     @property
     def assistant_messages(self) -> list[AssistantMessage]:
-        """Every model response, in order — one per turn, branch-independent."""
+        """Every model response, in order — one per turn, branch-independent. Excludes
+        prompt-supplied assistant messages (`sampled` is the provenance signal)."""
         return [
-            n.message for n in self.nodes if isinstance(n.message, AssistantMessage)
+            n.message
+            for n in self.nodes
+            if n.sampled and isinstance(n.message, AssistantMessage)
         ]
 
     @property


### PR DESCRIPTION
## Problem

A prompt can restate assistant/tool messages the model never actually generated — few-shot history, fabricated back-and-forth exchanges, simulated tool results. The graph stores these correctly at the token level (`mask=False`, no logprobs, so training is unaffected), but the message-level views inferred "model turn" from message **role**, conflating fabricated assistant messages with real sampled responses:

- `Trace.num_turns` / `Branch.num_turns` overcounted turns — and `max_turns` enforcement in the interception server goes through `num_turns`, so fabricated history burned down the turn budget
- `Trace.assistant_messages` ("every model response") included messages the model never produced
- `_last_assistant` (feeding `has_response` and `is_truncated`) could pick a fabricated node

This provenance is not recoverable from existing data: token masks are empty for endpoints that return no token ids, `finish_reason` can legitimately be `None`, and `usage` is transient (dropped on wire/disk).

## Change

Record provenance at the single point where it is known: `graph.add_turn` marks the response node `sampled=True`. Every `MessageNode` gains a `sampled: bool = False` field; all prompt-supplied messages keep the default, regardless of role.

The role-based views now consult it:
- `Trace.num_turns`, `Branch.num_turns` count sampled nodes
- `Trace.assistant_messages`, `_last_assistant` filter on `sampled`

`MessageNode` is constructed only in `add_turn` (the v0 legacy bridge funnels through it too), so this covers every producer. Prefix dedup keeps it correct for free: a restated real response reuses its `sampled=True` node, and old serialized traces parse with the conservative default (`False`).

Adds one test: a prompt carrying a fabricated assistant + tool exchange yields `sampled` only on the real response, `num_turns == 1`, and `assistant_messages` containing only the real response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Record sampled provenance on `MessageNode` to exclude prompt-supplied assistant messages from turn counts
> - Adds a `sampled` boolean field (default `False`) to `MessageNode` in [graph.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1643/files#diff-64c9d635eb215902a512c9e8ab316fd9b9967c36db03d4049aacc812cdfbd740); `add_turn` sets `sampled=True` on the assistant response node it creates.
> - Updates `Branch.num_turns`, `Trace.num_turns`, `Trace._last_assistant`, and `Trace.assistant_messages` in [trace.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1643/files#diff-834820c3aa80d87ee1c1c57fb54c74f09c66ac727036d964e6005c8613c00b5e) to use `node.sampled` instead of `isinstance(message, AssistantMessage)`.
> - Behavioral Change: `num_turns` and `assistant_messages` now exclude fabricated/prompt-supplied assistant messages; only model-produced responses are counted or returned.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 78d46a4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how turn limits and truncation/response detection are computed; behavior shifts for prompts with fabricated assistant history, but training token masks are unchanged.
> 
> **Overview**
> Adds a **`sampled`** flag on `MessageNode` (default `False`) and sets **`sampled=True`** only on the assistant node created in **`graph.add_turn`** for the model response.
> 
> **Turn and response views** no longer treat every assistant-role message as a model turn: **`Trace.num_turns`**, **`Branch.num_turns`**, **`assistant_messages`**, and **`_last_assistant`** (used by **`has_response`** / **`is_truncated`**) now key off **`node.sampled`**, so few-shot or fabricated assistant/tool history in the prompt does not inflate turn counts or **`max_turns`** checks in the interception server.
> 
> A regression test asserts that prompt-supplied assistant/tool nodes stay **`sampled=False`** while only the real response counts as a turn.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78d46a4de512ebec083d6f505bb27f953cb4d8a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->