### PR TITLE
fix: run alphabet-sort user simulator on the host (colocated=False)

### DIFF
--- a/examples/tasksets/alphabet_sort_v1/alphabet_sort_v1/__init__.py
+++ b/examples/tasksets/alphabet_sort_v1/alphabet_sort_v1/__init__.py
@@ -6,28 +6,28 @@ on each follow-up turn re-sorts the cumulative list — tagging the newly added 
 `<combined_alphabetical_sorted>` tags. The reward is the per-turn sequence similarity to the
 ground truth, power-scaled.
 
-The follow-up turns are colocated with the agent as a `vf.User` (see `user.py`): the
-interception server drives the simulator after every assistant turn and injects the next
-follow-up as a user message, so the whole episode is one rollout the harness only ever sees as
-a single exchange. The episodes are pre-generated in `load_tasks`; the simulator replays them.
+The follow-up turns are supplied by a `vf.User` simulator (see `user.py`): the interception
+server drives the simulator after every assistant turn and injects the next follow-up as a
+user message, so the whole episode is one rollout the harness only ever sees as a single
+exchange. The simulator runs on the host (not colocated in the agent's runtime), so the
+host-driven loop reaches it on every runtime. The episodes are pre-generated in `load_tasks`;
+the simulator replays them.
 """
 
 import difflib
 import json
 import random
 import re
-from pathlib import Path
+import sys
 from typing import Literal
 
 from datasets import load_dataset
 
 import verifiers.v1 as vf
+from verifiers.v1.taskset import UserConfig
 
 DATASET = "kalomaze/alphabetic-arxiv-authors-it1"
 SEED = 1337420
-# The user simulator is shipped as a self-contained uv script so it runs in any runtime
-# (host, or a docker/prime/modal sandbox), not just the host's subprocess.
-USER_SCRIPT = (Path(__file__).parent / "user.py").read_bytes()
 
 
 class AlphabetSortConfig(vf.TasksetConfig):
@@ -45,6 +45,11 @@ class AlphabetSortConfig(vf.TasksetConfig):
     """Power-scale each turn then average (True), or average raw similarities then power once (False)."""
     split: Literal["train"] = "train"
     """Split of the source author-names dataset to build the episodes from."""
+    user: UserConfig = UserConfig(colocated=False)
+    """Run the user simulator on the host (its own subprocess runtime), not colocated in the
+    agent's runtime. The framework drives the simulator from the host, and a remote agent
+    runtime (prime/modal) can't publish a colocated server's port back to the host — so
+    running it host-side keeps it reachable on every runtime."""
 
 
 class AlphabetSortTask(vf.Task):
@@ -147,7 +152,7 @@ class AlphabetSortTaskset(vf.Taskset[AlphabetSortTask, AlphabetSortConfig]):
         }
         return vf.User(
             name="user",
-            script=USER_SCRIPT,
+            command=[sys.executable, "-m", "alphabet_sort_v1.user"],
             env={"ALPHABET_SORT_INFO": json.dumps(info)},
         )
 

--- a/examples/tasksets/alphabet_sort_v1/alphabet_sort_v1/__init__.py
+++ b/examples/tasksets/alphabet_sort_v1/alphabet_sort_v1/__init__.py
@@ -16,7 +16,7 @@ import difflib
 import json
 import random
 import re
-import sys
+from pathlib import Path
 from typing import Literal
 
 from datasets import load_dataset
@@ -25,6 +25,9 @@ import verifiers.v1 as vf
 
 DATASET = "kalomaze/alphabetic-arxiv-authors-it1"
 SEED = 1337420
+# The user simulator is shipped as a self-contained uv script so it runs in any runtime
+# (host, or a docker/prime/modal sandbox), not just the host's subprocess.
+USER_SCRIPT = (Path(__file__).parent / "user.py").read_bytes()
 
 
 class AlphabetSortConfig(vf.TasksetConfig):
@@ -144,7 +147,7 @@ class AlphabetSortTaskset(vf.Taskset[AlphabetSortTask, AlphabetSortConfig]):
         }
         return vf.User(
             name="user",
-            command=[sys.executable, "-m", "alphabet_sort_v1.user"],
+            script=USER_SCRIPT,
             env={"ALPHABET_SORT_INFO": json.dumps(info)},
         )
 

--- a/examples/tasksets/alphabet_sort_v1/alphabet_sort_v1/user.py
+++ b/examples/tasksets/alphabet_sort_v1/alphabet_sort_v1/user.py
@@ -1,22 +1,18 @@
-# /// script
-# requires-python = ">=3.10"
-# dependencies = ["mcp", "uvicorn"]
-# ///
 """alphabet-sort-v1 user simulator: replays the episode's pre-generated follow-up turns.
 
-A self-contained uv script (the taskset ships it as a `vf.User.script`), so the framework
-runs it via `uv run` in whatever runtime the rollout uses — host, or a docker/prime/modal
-sandbox — resolving its inline deps there. It holds the task's follow-up prompts and turn
-count (from `ALPHABET_SORT_INFO`) and serves a single `respond` tool: after each assistant
-turn it injects the next follow-up as a user message, until all turns are done. This
-colocates v0's `MultiTurnEnv.env_response` with the agent — the harness drives it, never the
-model.
+Launched by the framework as a per-rollout subprocess (a `vf.User`). It holds the task's
+follow-up prompts and turn count (from `ALPHABET_SORT_INFO`) and serves a single `respond`
+tool: after each assistant turn it injects the next follow-up as a user message, until all
+turns are done. This colocates v0's `MultiTurnEnv.env_response` with the agent — the harness
+drives it, never the model.
 """
 
 import json
 import os
 
 from mcp.server.fastmcp import FastMCP
+
+import verifiers.v1 as vf
 
 INFO = json.loads(os.environ["ALPHABET_SORT_INFO"])
 FOLLOW_UPS = INFO["follow_ups"]
@@ -43,12 +39,4 @@ def respond(message: str) -> str:
     )
 
 
-if __name__ == "__main__":
-    import uvicorn
-
-    port = int(os.environ["MCP_PORT"])
-    uvicorn.Server(
-        uvicorn.Config(
-            mcp.streamable_http_app(), host="127.0.0.1", port=port, log_level="critical"
-        )
-    ).run()
+vf.run_mcp_server(mcp)

--- a/examples/tasksets/alphabet_sort_v1/alphabet_sort_v1/user.py
+++ b/examples/tasksets/alphabet_sort_v1/alphabet_sort_v1/user.py
@@ -1,18 +1,22 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["mcp", "uvicorn"]
+# ///
 """alphabet-sort-v1 user simulator: replays the episode's pre-generated follow-up turns.
 
-Launched by the framework as a per-rollout subprocess (a `vf.User`). It holds the task's
-follow-up prompts and turn count (from `ALPHABET_SORT_INFO`) and serves a single `respond`
-tool: after each assistant turn it injects the next follow-up as a user message, until all
-turns are done. This colocates v0's `MultiTurnEnv.env_response` with the agent — the harness
-drives it, never the model.
+A self-contained uv script (the taskset ships it as a `vf.User.script`), so the framework
+runs it via `uv run` in whatever runtime the rollout uses — host, or a docker/prime/modal
+sandbox — resolving its inline deps there. It holds the task's follow-up prompts and turn
+count (from `ALPHABET_SORT_INFO`) and serves a single `respond` tool: after each assistant
+turn it injects the next follow-up as a user message, until all turns are done. This
+colocates v0's `MultiTurnEnv.env_response` with the agent — the harness drives it, never the
+model.
 """
 
 import json
 import os
 
 from mcp.server.fastmcp import FastMCP
-
-import verifiers.v1 as vf
 
 INFO = json.loads(os.environ["ALPHABET_SORT_INFO"])
 FOLLOW_UPS = INFO["follow_ups"]
@@ -39,4 +43,12 @@ def respond(message: str) -> str:
     )
 
 
-vf.run_mcp_server(mcp)
+if __name__ == "__main__":
+    import uvicorn
+
+    port = int(os.environ["MCP_PORT"])
+    uvicorn.Server(
+        uvicorn.Config(
+            mcp.streamable_http_app(), host="127.0.0.1", port=port, log_level="critical"
+        )
+    ).run()


### PR DESCRIPTION
## Summary

alphabet-sort-v1's user simulator (a `vf.User`) is **driven by the framework from the host** — after each assistant turn the interception server calls its `respond` and injects the next follow-up. It was configured to run **colocated in the agent's runtime**, which only works when the host can reach a port *inside* that runtime: fine for subprocess and docker (host network), but a prime/modal sandbox can't publish the colocated port back to the host (prime exposes ports only in the default region; modal has no `public_url`). So on prime/modal every rollout errored at turn 0 (`tool server 'user' not serving`).

Fix: default the taskset's user sim to **`UserConfig(colocated=False)`**, so it runs in its own subprocess (host) runtime. Since the framework drives it from the host anyway, running it host-side makes it reachable on every agent runtime — no port-publishing needed.

One-line change in spirit: `AlphabetSortConfig.user = UserConfig(colocated=False)` (+ a docstring tidy). No framework changes.

## Verification

`alphabet-sort-v1`, 1 task × 2 rollouts, `deepseek-v4-flash`, default config:

| runtime | before | after |
|---|---|---|
| subprocess | ✅ reward [1.0, 1.0] | ✅ reward [1.0, 0.869] |
| docker | ❌ ProgramError @ turn 0 | ✅ reward [1.0, 1.0], 4 turns |
| prime | ❌ ProgramError @ turn 0 | ✅ reward [0.61, 1.0], 4 turns |
| modal | ❌ ProgramError @ turn 0 | ✅ reward [0.61, 1.0], 4 turns |

All four: 0 errors, full 4-turn episodes.

## Note

The other colocated-server example tasksets (`color-codeword-v1`, `wiki-search-v1`, `wikispeedia-v1`) have the same colocated-user/tool pattern and would hit this on remote runtimes; left as a follow-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example taskset config and docstrings only; behavior change is intentional to fix remote runtime connectivity without touching core framework code.
> 
> **Overview**
> **alphabet-sort-v1** now defaults the `vf.User` follow-up simulator to **`UserConfig(colocated=False)`**, so it runs in a host subprocess instead of inside the agent runtime.
> 
> The module docstring is updated to match: the interception server still drives the simulator from the host, but the sim is explicitly described as host-reachable on all agent runtimes (subprocess, docker, prime, modal). Previously, colocated user servers failed on remote sandboxes that cannot expose in-runtime ports to the host (`tool server 'user' not serving` at turn 0).
> 
> No framework changes—only `AlphabetSortConfig` and documentation in `alphabet_sort_v1/__init__.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b98c00b86bf6c22fc0b6fb4c6c913037505fd2f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Run `AlphabetSortConfig` user simulator on the host with `colocated=False`
> Adds a `user` field to `AlphabetSortConfig` defaulting to `UserConfig(colocated=False)`, so the user simulator runs on the host rather than colocated with the agent runtime. Also imports `UserConfig` from `verifiers.v1.taskset` in [__init__.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1645/files#diff-4acd1f2383eeb2307c9fd843f38891bf7edb8da1c1085cbe3ccf00a043e65138).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b98c00b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->