### PR TITLE
chore: bump modal creates_per_sec default 5 -> 40

### DIFF
--- a/verifiers/v1/runtimes/modal.py
+++ b/verifiers/v1/runtimes/modal.py
@@ -51,8 +51,7 @@ class ModalConfig(BaseConfig):
     declare it without a warning) but not enforced."""
     creates_per_sec: float | None = 40.0
     """Pace sandbox creation to this many per second, enforced host-wide across every
-    env-server worker process (None/<= 0 disables it) — kept under Modal's per-workspace
-    sandbox-creation rate limit."""
+    env-server worker process (None/<= 0 disables it)."""
 
 
 class ModalRuntime(Runtime):

--- a/verifiers/v1/runtimes/modal.py
+++ b/verifiers/v1/runtimes/modal.py
@@ -49,9 +49,10 @@ class ModalConfig(BaseConfig):
     disk: float = 5.0
     """Disk in GB. Modal sandboxes have no disk knob, so this is accepted (so a task can
     declare it without a warning) but not enforced."""
-    creates_per_sec: float | None = 5.0
+    creates_per_sec: float | None = 40.0
     """Pace sandbox creation to this many per second, enforced host-wide across every
-    env-server worker process (None/<= 0 disables it) — Modal's per-workspace limit is 5/s."""
+    env-server worker process (None/<= 0 disables it) — kept under Modal's per-workspace
+    sandbox-creation rate limit."""
 
 
 class ModalRuntime(Runtime):


### PR DESCRIPTION
## Summary

- Bump `ModalConfig.creates_per_sec` default **5.0 → 40.0**. The account's Modal sandbox-creation rate limit is higher than the original 5/s, so the host-global creation limiter can pace at 40/s instead of throttling to 5/s.
- Same mechanism, just more headroom: a 512-sandbox burst ramps up in ~13s (512 ÷ 40) instead of ~100s, while the limiter still keeps the host-wide creation rate under the account ceiling. Override per provider config as before (`--harness.runtime.creates_per_sec`).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump `ModalConfig.creates_per_sec` default from 5 to 40
> Updates the default sandbox creation rate in [modal.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1646/files#diff-a6217d92f043d6050e8609d4341d62b5d097d5db796f6197cd604e09d81683c0) from 5.0 to 40.0 per second. Also removes the outdated docstring note about a 5/s per-workspace limit.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f153bf9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single default config value and comment change; limiter behavior is unchanged and still overridable.
> 
> **Overview**
> Raises the default **Modal** host-wide sandbox creation pace from **5/s to 40/s** via `ModalConfig.creates_per_sec`, so large bursts ramp faster while the same `creation_limiter` still caps creation across env-server workers.
> 
> The field docstring no longer cites a 5/s Modal workspace limit; overrides remain available (e.g. `--harness.runtime.creates_per_sec`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f153bf9fc49c23b9af78aba9666678bcb54c29b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->