### PR TITLE
[codex] fix Harbor agent timeout mapping

### DIFF
--- a/packages/tasksets/tasksets/harbor_v1/__init__.py
+++ b/packages/tasksets/tasksets/harbor_v1/__init__.py
@@ -133,7 +133,7 @@ def parse_task(task_dir: Path, idx: int, require_image: bool) -> HarborTask:
         description=task.get("description"),
         instruction=(task_dir / "instruction.md").read_text().strip(),
         image=resolve_image(task_dir, config, require_image),
-        harness_timeout=config.get("harness", {}).get("timeout_sec"),
+        harness_timeout=config.get("agent", {}).get("timeout_sec"),
         scoring_timeout=config.get("verifier", {}).get("timeout_sec"),
         resources=parse_resources(config.get("environment", {})),
         keywords=task.get("keywords", []),


### PR DESCRIPTION
## Summary

Read Harbor's canonical `[agent].timeout_sec` field when populating `HarborTask.harness_timeout`.

## Root cause

The parser looked under `[harness]`, which Harbor task configs do not use, so agent timeouts were silently ignored.

## Impact

Harbor tasks now pass their configured agent timeout into the v1 rollout harness, allowing framework-level timeout handling to occur before the sandbox hard runtime limit.

## Validation

- `uv run ruff check packages/tasksets/tasksets/harbor_v1/__init__.py`
- `uv run ruff format --check packages/tasksets/tasksets/harbor_v1/__init__.py`
- Parser smoke test confirming `[agent].timeout_sec = 1800` maps to `harness_timeout = 1800`
- Pre-commit and pre-push hooks

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Harbor agent timeout mapping to read from `agent.timeout_sec` config key
> In [`harbor_v1/__init__.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1647/files#diff-faf796cc512bd64c548f888039bfa8538845722c7967bcf2b7279d044d916710), `HarborTask.harness_timeout` was incorrectly populated from `config['harness']['timeout_sec']` instead of `config['agent']['timeout_sec']`. This fix corrects the config key lookup in `parse_task`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dc2e717.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single config-key correction in Harbor task parsing with no auth, data, or broad behavioral surface beyond restoring intended timeout propagation.
> 
> **Overview**
> **`parse_task`** now sets **`HarborTask.harness_timeout`** from **`[agent].timeout_sec`** in `task.toml` instead of **`[harness].timeout_sec`**.
> 
> Harbor task configs use the **`agent`** section for agent timeouts; reading **`harness`** left **`harness_timeout`** unset so the v1 rollout harness could not apply task-configured limits before the sandbox hard runtime cap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc2e717026258be5c9000472942e57f5b58a529d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->