### PR TITLE
Remove mini-SWE shell timeout wrapper

### DIFF
--- a/packages/harnesses/harnesses/__init__.py
+++ b/packages/harnesses/harnesses/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 
 from .mini_swe_agent import MiniSWEAgent, MiniSWEAgentConfig, MiniSWEAgentProgramConfig
 from .opencode import OpenCode, OpenCodeConfig, OpenCodeProgramConfig

--- a/packages/harnesses/harnesses/mini_swe_agent.py
+++ b/packages/harnesses/harnesses/mini_swe_agent.py
@@ -141,7 +141,7 @@ if [ -s {system_prompt_file} ]; then
   CONFIG_ARGS+=(-c "agent.system_template=$(cat {system_prompt_file})")
 fi
 cd "$MINI_SWE_AGENT_WORKDIR"
-timeout --kill-after=30s "${{AGENT_TIMEOUT_SECONDS:-3600}}" {shlex.quote(DEFAULT_MINI_BINARY)} \\
+{shlex.quote(DEFAULT_MINI_BINARY)} \\
   --model "$OPENAI_MODEL" \\
   --task "$MINI_SWE_AGENT_TASK" \\
   --output {shlex.quote(self.trajectory_path)} \\


### PR DESCRIPTION
## Summary

- Remove the shell-level `timeout` wrapper from the packaged mini-SWE-agent command.
- Bump the `harnesses` package version to `0.1.3` so the fix can be published.

## Root cause

The wrapper used GNU-specific `timeout --kill-after=30s`. BusyBox-based task images reject that option before mini-SWE-agent starts.

## Impact

The sandbox API remains responsible for enforcing the command deadline through `command_timeout`, so mini-SWE-agent no longer depends on a particular `timeout` binary being installed in the task image. Publishing `harnesses==0.1.3` propagates the fix.

## Validation

- `uv run pytest tests/test_v1_mini_swe_agent.py -q`
- direct import check confirmed `harnesses.__version__ == "0.1.3"`
- Ruff, formatting, Semgrep, and `ty` pre-push checks passed

This PR intentionally contains only the mini-SWE harness fix and package version bump.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small harness launch-script change with timeout enforcement still handled by the sandbox API; version bump only.
> 
> **Overview**
> Removes the GNU `timeout --kill-after=30s` wrapper around the packaged **mini-SWE-agent** launch script so agent startup works on BusyBox-based task images that reject that flag.
> 
> The harness now invokes `mini` directly; execution limits stay with the sandbox **`command_timeout`** path rather than a host-specific `timeout` binary. **`harnesses`** is bumped to **`0.1.3`** for release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a368438c696ae7631b284e0e0da9b5f904e0f2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove GNU `timeout` wrapper from `MiniSWEAgent` command construction
> Removes the `timeout --kill-after=30s ${AGENT_TIMEOUT_SECONDS:-3600}` wrapper from the bash script built in [mini_swe_agent.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1648/files#diff-7d7a34284596b8cbbfdca5f06547bac8257c81891fa7e66a0eb11c1a3b3015a8). The binary now runs directly without an external timeout.
>
> - Behavioral Change: `AGENT_TIMEOUT_SECONDS` no longer has any effect; the agent process will not be forcibly killed after a timeout period.
> - Bumps the harness package version from `0.1.2` to `0.1.3`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3a36843.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->