### PR TITLE
[codex] Preserve command exit codes

### DIFF
--- a/verifiers/v1/utils/program_utils.py
+++ b/verifiers/v1/utils/program_utils.py
@@ -3,7 +3,6 @@ import os
 import shlex
 from typing import TypeAlias, cast
 
-from verifiers.errors import InfraError
 from verifiers.utils.async_utils import maybe_call_with_named_args
 
 from .config_utils import resolve_config_object, string_mapping
@@ -76,10 +75,6 @@ async def run_local_command(
     state["completion"] = [
         {"role": "assistant", "content": state["command"]["stdout"].strip()}
     ]
-    if proc.returncode:
-        raise InfraError(
-            f"Command exited with {proc.returncode}: {state['command']['stderr']}"
-        )
     state._set_stop_condition("command_completed")
     return state
 

--- a/verifiers/v1/utils/sandbox_utils.py
+++ b/verifiers/v1/utils/sandbox_utils.py
@@ -547,10 +547,6 @@ async def run_sandbox_command(
         state["completion"] = [
             {"role": "assistant", "content": state["command"]["stdout"].strip()}
         ]
-        if result.exit_code:
-            raise SandboxError(
-                f"Sandbox command exited with {result.exit_code}: {result.stderr}"
-            )
         state._set_stop_condition("command_completed")
         return state
 


### PR DESCRIPTION
## Summary

Treat completed command processes as normal program results even when they exit nonzero.

## Root cause

Both local and sandbox command runners populated `state["command"]`, then promoted every nonzero exit code into an infrastructure error. This conflated agent-authored command failures, such as command-not-found or test failures, with actual sandbox creation, transport, or execution failures.

## Impact

Completed commands now retain their `returncode`, `stdout`, and `stderr` and finish with `command_completed`. Exceptions raised while creating, setting up, or communicating with the sandbox remain infrastructure errors.

## Validation

- `uv run pytest tests/test_v1_runtime_lifecycle.py -q`
- relevant Ruff, Semgrep, and CI parity checks passed before the split

This PR intentionally contains only the shared command-runner behavior change.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve command exit codes in `run_local_command` and `run_sandbox_command`
> Previously, both functions raised an exception (`InfraError` or `SandboxError`) when a subprocess returned a non-zero exit code, stopping execution. Now both functions always set the stop condition to `command_completed` and return the full state (including return code, stdout, and stderr) regardless of exit code.
>
> - [program_utils.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1649/files#diff-5d8102f08cbe8a87ba9c63416d3037ad6f39d86e4cdf6c41448e8ece703446e9): removes the `InfraError` raise on non-zero return codes and the now-unused `InfraError` import
> - [sandbox_utils.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1649/files#diff-b1154f3be7f28191532de46fbe23a973a5f93e1450a71beb9c93910e358fda13): removes the `SandboxError` raise on non-zero sandbox exit codes
> - Behavioral Change: callers that previously relied on exceptions to detect command failure must now inspect `state['command']` for the return code
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5217073.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->