### PR TITLE
build: add fallback-version for no-VCS editable builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -225,6 +225,11 @@ vf-vllm = "verifiers.scripts.vllm:main"
 # hatchling configuration
 [tool.hatch.version]
 source = "vcs"
+# Resolve a version when building without VCS metadata (e.g. the prime-rl
+# Docker build copies the source but not a usable .git for the submodule).
+# Mirrors renderers; without it hatch-vcs raises LookupError and the editable
+# build fails.
+fallback-version = "0.0.0"
 
 [tool.hatch.version.raw-options]
 local_scheme = "no-local-version"


### PR DESCRIPTION
Cherry-picked from c33261b9 (Eli Gottlieb) on the worldsims/ephemeral-mm-pixels branch.

- prime-rl Docker build does `COPY deps/verifiers/` without a usable `.git`, so hatch-vcs fails with `LookupError: unable to detect version`
- adds `fallback-version = "0.0.0"` so no-VCS builds resolve; tagged releases unchanged
- unblocks hosted-rl image build (currently red)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only change with no runtime behavior impact; version resolution still uses Git when available.
> 
> **Overview**
> Adds **`fallback-version = "0.0.0"`** under `[tool.hatch.version]` so **hatch-vcs** can resolve a version when the package is built **without usable Git metadata** (e.g. prime-rl Docker `COPY` of `deps/verifiers/`).
> 
> Without this, editable installs fail with **`LookupError: unable to detect version`**. **Tagged releases with a real `.git` are unchanged**; the fallback only applies in no-VCS builds, matching the pattern used for **renderers**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78c1b3c545a7df1f9cce99f72894883548c99212. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `fallback-version` to hatch-vcs config to prevent editable build failures
> Sets `fallback-version = "0.0.0"` in [pyproject.toml](https://github.com/PrimeIntellect-ai/verifiers/pull/1650/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711) under `[tool.hatch.version]`. Without this, `hatch-vcs` raises a `LookupError` when VCS metadata is unavailable (e.g. in editable installs from a source archive), causing the build to fail.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 78c1b3c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->