### PR TITLE
feat(v1): dialect-routed interception — byte relay on matching protocols, typed translate otherwise

### DIFF
--- a/examples/harnesses/compact/compact/harness.py
+++ b/examples/harnesses/compact/compact/harness.py
@@ -39,7 +39,7 @@ class CompactingHarness(Harness[CompactingHarnessConfig]):
         mcp_urls: dict[str, str],
     ) -> ProgramResult:
         env = {
-            "OPENAI_BASE_URL": endpoint,
+            "OPENAI_BASE_URL": f"{endpoint}/v1",
             "OPENAI_API_KEY": secret,
             "OPENAI_MODEL": ctx.model,
         }

--- a/packages/harnesses/harnesses/default/harness.py
+++ b/packages/harnesses/harnesses/default/harness.py
@@ -53,10 +53,15 @@ class DefaultHarness(Harness[DefaultHarnessConfig]):
             system_prompt = "\n\n".join(
                 p for p in (BASH_SYSTEM_PROMPT, system_prompt) if p
             )
+        # The program owns its request bodies (the interception server relays them as-is),
+        # so the eval's sampling rides along as env and the program merges it per call.
+        sampling = ctx.sampling.model_dump(exclude_none=True)
+        sampling.pop("stream", None)  # the program's chat loop never streams
         env = {
-            "OPENAI_BASE_URL": endpoint,
+            "OPENAI_BASE_URL": f"{endpoint}/v1",
             "OPENAI_API_KEY": secret,
             "OPENAI_MODEL": ctx.model,
+            "OPENAI_SAMPLING": json.dumps(sampling),
             "ENABLE_BASH": "1" if self.config.enable_bash else "0",
             "APPEND_SYSTEM_PROMPT": system_prompt or "",
         }

--- a/packages/harnesses/harnesses/default/program.py
+++ b/packages/harnesses/harnesses/default/program.py
@@ -42,6 +42,10 @@ BASH_TOOL = {
 # base_url + api_key come from OPENAI_BASE_URL / OPENAI_API_KEY.
 client = AsyncOpenAI()
 
+# The eval's sampling args, merged into every request body (the interception server
+# relays our requests verbatim, so the program carries them itself).
+SAMPLING = json.loads(os.environ.get("OPENAI_SAMPLING", "{}"))
+
 
 def run_bash(command: str) -> str:
     try:
@@ -55,7 +59,10 @@ def run_bash(command: str) -> str:
 
 async def chat(messages: list[dict], tools: list[dict]):
     completion = await client.chat.completions.create(
-        model=os.environ["OPENAI_MODEL"], messages=messages, tools=tools or None
+        model=os.environ["OPENAI_MODEL"],
+        messages=messages,
+        tools=tools or None,
+        extra_body=SAMPLING,  # extra_body: sampling keys go on the wire untyped
     )
     return completion.choices[0].message
 

--- a/packages/harnesses/harnesses/rlm/__init__.py
+++ b/packages/harnesses/harnesses/rlm/__init__.py
@@ -51,7 +51,7 @@ class RLMHarness(Harness[RLMHarnessConfig]):
         # rlm reaches the interception server via OPENAI_BASE_URL/API_KEY (its
         # provider precedence falls back to OPENAI_*), and reads RLM_* for itself.
         env = {
-            "OPENAI_BASE_URL": endpoint,
+            "OPENAI_BASE_URL": f"{endpoint}/v1",
             "OPENAI_API_KEY": secret,
             "RLM_MODEL": ctx.model,
             "RLM_MAX_DEPTH": str(self.config.max_depth),

--- a/tests/v1/test_clients.py
+++ b/tests/v1/test_clients.py
@@ -36,7 +36,7 @@ from verifiers.v1.clients.openai_responses import message_to_wire as responses_m
 from verifiers.v1.clients.openai_responses import (
     response_from_wire as responses_response,
 )
-from verifiers.v1.interception.server import parse_message, serialize_completion
+from verifiers.v1.dialects import parse_message, serialize_completion
 from verifiers.v1.types import content_to_parts
 
 

--- a/tests/v1/test_dialects.py
+++ b/tests/v1/test_dialects.py
@@ -1,0 +1,496 @@
+"""The wire dialects and the interception server's relay/translate arms.
+
+Codec tests round-trip each dialect's serializers through its own parsers (and validate
+the serialized shapes against the provider SDK models, so a program's real SDK would
+accept them). Server tests run a live `InterceptionServer` with stub clients: a typed
+stub exercises the translate arm (any ingress dialect -> typed client -> native shape
+back), a relay stub asserts byte-verbatim pass-through (JSON and SSE) on the matching
+dialect.
+"""
+
+import json
+
+import aiohttp
+import verifiers.v1 as vf
+from anthropic.types import Message as AnthropicSDKMessage
+from openai.types.responses import Response as OpenAISDKResponse
+
+from verifiers.v1.clients import RolloutContext
+from verifiers.v1.clients.client import Client, RelayReply
+from verifiers.v1.dialects import AnthropicDialect, ChatDialect, ResponsesDialect, sse
+from verifiers.v1.interception import InterceptionServer, RolloutSession
+from verifiers.v1.trace import Trace
+
+CHAT = ChatDialect()
+ANTHROPIC = AnthropicDialect()
+RESPONSES = ResponsesDialect()
+
+
+def make_response(**overrides) -> vf.Response:
+    fields = {
+        "id": "resp_1",
+        "created": 1,
+        "model": "test-model",
+        "message": vf.AssistantMessage(content="Hello!"),
+        "finish_reason": "stop",
+        "usage": vf.Usage(prompt_tokens=10, completion_tokens=5),
+        **overrides,
+    }
+    return vf.Response(**fields)
+
+
+TOOLED = make_response(
+    message=vf.AssistantMessage(
+        content="Using a tool.",
+        reasoning_content="Let me check the weather.",
+        tool_calls=[
+            vf.ToolCall(id="call_1", name="weather", arguments='{"city":"Berlin"}')
+        ],
+    ),
+    finish_reason="tool_calls",
+)
+
+
+# --- anthropic codec ------------------------------------------------------------
+
+
+def test_anthropic_parse_request():
+    body = {
+        "model": "claude-x",
+        "system": "Be terse.",
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Look at this:"},
+                    {
+                        "type": "image",
+                        "source": {
+                            "type": "base64",
+                            "media_type": "image/png",
+                            "data": "aW1hZ2U=",
+                        },
+                    },
+                ],
+            },
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "Hmm.", "signature": "sig"},
+                    {"type": "text", "text": "Checking."},
+                    {
+                        "type": "tool_use",
+                        "id": "tu_1",
+                        "name": "look",
+                        "input": {"x": 1},
+                    },
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "tu_1",
+                        "content": "a red square",
+                    }
+                ],
+            },
+        ],
+        "tools": [
+            {"name": "look", "description": "Look.", "input_schema": {"type": "object"}}
+        ],
+    }
+    prompt, tools = ANTHROPIC.parse_request(body)
+    system, user, assistant, tool = prompt
+    assert isinstance(system, vf.SystemMessage) and system.content == "Be terse."
+    assert isinstance(user, vf.UserMessage)
+    assert user.content[1].image_url.url == "data:image/png;base64,aW1hZ2U="
+    assert isinstance(assistant, vf.AssistantMessage)
+    assert assistant.content == "Checking."
+    assert assistant.reasoning_content == "Hmm."
+    assert assistant.tool_calls[0].name == "look"
+    assert json.loads(assistant.tool_calls[0].arguments) == {"x": 1}
+    assert isinstance(tool, vf.ToolMessage) and tool.tool_call_id == "tu_1"
+    assert tools[0].name == "look" and tools[0].parameters == {"type": "object"}
+
+
+def test_anthropic_serialize_validates_and_reasoning_round_trips():
+    wire = ANTHROPIC.serialize_response(TOOLED, "test-model")
+    AnthropicSDKMessage.model_validate(wire)  # a real Anthropic SDK would accept it
+    assert wire["stop_reason"] == "tool_use"
+    # The program echoes our message back; parse_request must recover the reasoning
+    # (the passback some models require) and the tool call.
+    prompt, _ = ANTHROPIC.parse_request(
+        {"messages": [{"role": "assistant", "content": wire["content"]}]}
+    )
+    (echoed,) = prompt
+    assert echoed.reasoning_content == "Let me check the weather."
+    assert echoed.content == "Using a tool."
+    assert echoed.tool_calls[0].id == "call_1"
+
+
+def test_anthropic_stream_round_trip():
+    raw = ANTHROPIC.serialize_stream(TOOLED, "test-model")
+    response = ANTHROPIC.parse_stream(raw)
+    assert response.message.content == "Using a tool."
+    assert response.message.reasoning_content == "Let me check the weather."
+    assert response.message.tool_calls[0].arguments == '{"city": "Berlin"}'
+    assert response.finish_reason == "tool_calls"
+    assert response.usage.completion_tokens == 5
+
+
+def test_anthropic_secret_carriers():
+    assert ANTHROPIC.secret({"x-api-key": "s1"}) == "s1"
+    assert ANTHROPIC.secret({"Authorization": "Bearer s2"}) == "s2"
+
+
+def test_anthropic_count_tokens_estimate():
+    estimate = ANTHROPIC.handle_aux(
+        "/v1/messages/count_tokens",
+        {"messages": [{"role": "user", "content": "word " * 100}]},
+    )
+    assert estimate["input_tokens"] > 50
+
+
+# --- responses codec ------------------------------------------------------------
+
+
+def test_responses_parse_request_groups_assistant_run():
+    body = {
+        "model": "gpt-x",
+        "instructions": "Be terse.",
+        "input": [
+            {"role": "user", "content": [{"type": "input_text", "text": "Weather?"}]},
+            {
+                "type": "reasoning",
+                "id": "rs_1",
+                "summary": [{"type": "summary_text", "text": "Hmm."}],
+            },
+            {
+                "type": "function_call",
+                "call_id": "call_1",
+                "name": "weather",
+                "arguments": "{}",
+            },
+            {"type": "function_call_output", "call_id": "call_1", "output": "sunny"},
+        ],
+        "tools": [
+            {"type": "function", "name": "weather", "parameters": {}, "strict": True}
+        ],
+    }
+    prompt, tools = RESPONSES.parse_request(body)
+    system, user, assistant, tool = prompt
+    assert isinstance(system, vf.SystemMessage) and system.content == "Be terse."
+    assert isinstance(user, vf.UserMessage)
+    assert isinstance(assistant, vf.AssistantMessage)
+    assert assistant.reasoning_content == "Hmm."
+    assert assistant.tool_calls[0].id == "call_1"
+    assert (
+        assistant.provider_state[0]["type"] == "reasoning"
+    )  # native continuation state
+    assert isinstance(tool, vf.ToolMessage) and tool.content == "sunny"
+    assert tools[0].strict is True
+
+
+def test_responses_parse_request_string_input():
+    prompt, tools = RESPONSES.parse_request({"input": "hi"})
+    assert isinstance(prompt[0], vf.UserMessage) and prompt[0].content == "hi"
+    assert tools is None
+
+
+def test_responses_serialize_validates_and_round_trips():
+    wire = RESPONSES.serialize_response(TOOLED, "test-model")
+    OpenAISDKResponse.model_validate(wire)  # a real OpenAI SDK would accept it
+    kinds = [item["type"] for item in wire["output"]]
+    assert kinds == ["reasoning", "message", "function_call"]
+    response = RESPONSES.parse_response(wire)
+    assert response.message.content == "Using a tool."
+    assert response.message.tool_calls[0].name == "weather"
+    assert response.finish_reason == "tool_calls"
+
+
+def test_responses_stream_round_trip():
+    raw = RESPONSES.serialize_stream(make_response(), "test-model")
+    response = RESPONSES.parse_stream(raw)
+    assert response.message.content == "Hello!"
+    assert response.finish_reason == "stop"
+
+
+# --- chat codec (stream paths; the JSON paths are covered in test_clients) -------
+
+
+def test_chat_stream_round_trip():
+    raw = CHAT.serialize_stream(TOOLED, "test-model")
+    response = CHAT.parse_stream(raw)
+    assert response.message.content == "Using a tool."
+    assert response.message.reasoning_content == "Let me check the weather."
+    assert response.message.tool_calls[0].arguments == '{"city":"Berlin"}'
+    assert response.usage.completion_tokens == 5
+
+
+def test_chat_parse_stream_accumulates_deltas():
+    chunks = [
+        {
+            "id": "c1",
+            "object": "chat.completion.chunk",
+            "created": 1,
+            "model": "m",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"role": "assistant", "content": "Hel"},
+                    "finish_reason": None,
+                }
+            ],
+        },
+        {
+            "id": "c1",
+            "object": "chat.completion.chunk",
+            "created": 1,
+            "model": "m",
+            "choices": [
+                {"index": 0, "delta": {"content": "lo"}, "finish_reason": "stop"}
+            ],
+        },
+    ]
+    raw = b"".join(sse(c) for c in chunks) + b"data: [DONE]\n\n"
+    response = CHAT.parse_stream(raw)
+    assert response.message.content == "Hello"
+    assert response.finish_reason == "stop"
+
+
+# --- the server's two arms --------------------------------------------------------
+
+
+class TypedStub(Client):
+    """Translate-arm client: no native dialect, returns a canned typed response."""
+
+    def __init__(self, response: vf.Response) -> None:
+        self.response = response
+        self.seen_prompt = None
+
+    async def get_response(self, prompt, model, sampling_args, tools=None):
+        self.seen_prompt = prompt
+        return self.response
+
+
+class RelayStub(Client):
+    """Relay-arm client: returns canned bytes, records what was relayed."""
+
+    def __init__(self, payload: bytes, content_type: str = "application/json") -> None:
+        self.payload = payload
+        self.content_type = content_type
+        self.relayed: tuple[bytes, str] | None = None
+
+    async def get_response(self, prompt, model, sampling_args, tools=None):
+        raise AssertionError("relay arm must not translate")
+
+    async def relay(self, body: bytes, route: str) -> RelayReply:
+        self.relayed = (body, route)
+
+        async def chunks():
+            yield self.payload
+
+        return RelayReply(self.content_type, chunks())
+
+
+class ChatRelayStub(RelayStub):
+    dialect = "chat"
+
+
+class AnthropicRelayStub(RelayStub):
+    dialect = "anthropic"
+
+
+def make_session(client: Client) -> RolloutSession:
+    return RolloutSession(
+        ctx=RolloutContext(
+            client=client, model="test-model", sampling=vf.SamplingConfig()
+        ),
+        trace=Trace(task=vf.Task(idx=0, instruction="test")),
+    )
+
+
+async def serve(session: RolloutSession):
+    server = InterceptionServer()
+    await server.__aenter__()
+    secret = server.register(session)
+    return server, secret, f"http://127.0.0.1:{server.port}"
+
+
+async def test_server_translates_anthropic_ingress():
+    """An anthropic-dialect program against a non-anthropic client: typed translate,
+    response handed back in anthropic shape, turn recorded."""
+    client = TypedStub(make_response())
+    session = make_session(client)
+    server, secret, base = await serve(session)
+    try:
+        async with aiohttp.ClientSession() as http:
+            resp = await http.post(
+                f"{base}/v1/messages",
+                json={
+                    "model": "x",
+                    "max_tokens": 16,
+                    "messages": [{"role": "user", "content": "hi"}],
+                },
+                headers={"x-api-key": secret},
+            )
+            body = await resp.json()
+        assert resp.status == 200
+        assert body["type"] == "message"
+        assert body["content"] == [{"type": "text", "text": "Hello!"}]
+        assert isinstance(client.seen_prompt[0], vf.UserMessage)
+        assert session.trace.num_turns == 1
+    finally:
+        await server.__aexit__(None, None, None)
+
+
+async def test_server_relays_matching_dialect_bytes():
+    """A chat-dialect program with a chat client: the request bytes reach the client
+    verbatim, the canned upstream bytes come back verbatim, the turn is recorded."""
+    upstream = json.dumps(
+        CHAT.serialize_response(make_response(), "test-model")
+    ).encode()
+    client = ChatRelayStub(upstream)
+    session = make_session(client)
+    server, secret, base = await serve(session)
+    request_body = json.dumps(
+        {
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "seed": 7,
+        }
+    ).encode()
+    try:
+        async with aiohttp.ClientSession() as http:
+            resp = await http.post(
+                f"{base}/v1/chat/completions",
+                data=request_body,
+                headers={
+                    "Authorization": f"Bearer {secret}",
+                    "Content-Type": "application/json",
+                },
+            )
+            returned = await resp.read()
+        assert resp.status == 200
+        assert returned == upstream  # bytes out, untouched
+        relayed_body, relayed_route = client.relayed
+        assert (
+            relayed_body == request_body
+        )  # bytes in, untouched (incl. unknown `seed`)
+        assert relayed_route == "/v1/chat/completions"
+        assert session.trace.num_turns == 1
+    finally:
+        await server.__aexit__(None, None, None)
+
+
+async def test_server_relays_stream_and_records_turn():
+    """A streaming relay: SSE bytes pass through verbatim and the assembled final
+    message lands on the trace."""
+    payload = ANTHROPIC.serialize_stream(make_response(), "test-model")
+    client = AnthropicRelayStub(payload, content_type="text/event-stream")
+    session = make_session(client)
+    server, secret, base = await serve(session)
+    try:
+        async with aiohttp.ClientSession() as http:
+            resp = await http.post(
+                f"{base}/v1/messages",
+                json={
+                    "model": "x",
+                    "max_tokens": 16,
+                    "stream": True,
+                    "messages": [{"role": "user", "content": "hi"}],
+                },
+                headers={"x-api-key": secret},
+            )
+            returned = await resp.read()
+        assert returned == payload
+        assert session.trace.num_turns == 1
+        assert session.trace.assistant_messages[0].content == "Hello!"
+    finally:
+        await server.__aexit__(None, None, None)
+
+
+async def test_server_translate_streams_fake_sse():
+    """A streaming program against a non-matching client: the typed response goes back
+    as a minimal valid SSE stream in the program's dialect."""
+    client = TypedStub(make_response())
+    session = make_session(client)
+    server, secret, base = await serve(session)
+    try:
+        async with aiohttp.ClientSession() as http:
+            resp = await http.post(
+                f"{base}/v1/messages",
+                json={
+                    "model": "x",
+                    "max_tokens": 16,
+                    "stream": True,
+                    "messages": [{"role": "user", "content": "hi"}],
+                },
+                headers={"x-api-key": secret},
+            )
+            raw = await resp.read()
+        assert resp.headers["Content-Type"].startswith("text/event-stream")
+        assert ANTHROPIC.parse_stream(raw).message.content == "Hello!"
+        assert session.trace.num_turns == 1
+    finally:
+        await server.__aexit__(None, None, None)
+
+
+async def test_server_aux_route_estimates_or_relays():
+    """count_tokens: estimated locally on the translate arm, relayed on the relay arm."""
+    session = make_session(TypedStub(make_response()))
+    server, secret, base = await serve(session)
+    try:
+        async with aiohttp.ClientSession() as http:
+            resp = await http.post(
+                f"{base}/v1/messages/count_tokens",
+                json={"messages": [{"role": "user", "content": "word " * 50}]},
+                headers={"x-api-key": secret},
+            )
+            assert (await resp.json())["input_tokens"] > 20
+    finally:
+        await server.__aexit__(None, None, None)
+
+    relay = AnthropicRelayStub(b'{"input_tokens": 123}')
+    session = make_session(relay)
+    server, secret, base = await serve(session)
+    try:
+        async with aiohttp.ClientSession() as http:
+            resp = await http.post(
+                f"{base}/v1/messages/count_tokens",
+                json={"messages": []},
+                headers={"x-api-key": secret},
+            )
+            assert (await resp.json())["input_tokens"] == 123
+        assert relay.relayed[1] == "/v1/messages/count_tokens"
+        assert session.trace.num_turns == 0  # aux calls are not model turns
+    finally:
+        await server.__aexit__(None, None, None)
+
+
+async def test_server_refusal_uses_dialect_error_shape():
+    """A turn-limit refusal halts an anthropic program with an Anthropic-shaped error."""
+    from verifiers.v1.interception import RolloutLimits
+
+    session = make_session(TypedStub(make_response()))
+    session.limits = RolloutLimits(max_turns=0)
+    server, secret, base = await serve(session)
+    try:
+        async with aiohttp.ClientSession() as http:
+            resp = await http.post(
+                f"{base}/v1/messages",
+                json={
+                    "model": "x",
+                    "max_tokens": 16,
+                    "messages": [{"role": "user", "content": "hi"}],
+                },
+                headers={"x-api-key": secret},
+            )
+            body = await resp.json()
+        assert resp.status == 400
+        assert body["type"] == "error"
+        assert "max_turns" in body["error"]["message"]
+    finally:
+        await server.__aexit__(None, None, None)

--- a/verifiers/v1/clients/anthropic.py
+++ b/verifiers/v1/clients/anthropic.py
@@ -4,6 +4,7 @@ import json
 import time
 from typing import Any, cast
 
+import httpx
 from anthropic import AnthropicError, AsyncAnthropic
 from anthropic.types import (
     Base64ImageSourceParam,
@@ -22,7 +23,7 @@ from anthropic.types import (
     URLImageSourceParam,
 )
 
-from verifiers.v1.clients.client import Client
+from verifiers.v1.clients.client import Client, RelayReply, relay_headers, relay_post
 from verifiers.v1.errors import ModelError
 from verifiers.v1.types import (
     AssistantMessage,
@@ -190,8 +191,19 @@ def response_from_wire(response: AnthropicMessage) -> Response:
 
 
 class AnthropicMessagesClient(Client):
+    dialect = "anthropic"
+
     def __init__(self, anthropic: AsyncAnthropic) -> None:
         self.anthropic = anthropic
+        self._http: httpx.AsyncClient | None = None
+
+    async def relay(self, body: bytes, route: str) -> RelayReply:
+        # Anthropic base URLs are roots (the SDK appends /v1/...), so the ingress
+        # route maps on unchanged — including the count_tokens aux route.
+        if self._http is None:
+            self._http = httpx.AsyncClient(timeout=None)
+        url = str(self.anthropic.base_url).rstrip("/") + route
+        return await relay_post(self._http, url, relay_headers(self.anthropic), body)
 
     async def get_response(
         self,
@@ -235,3 +247,5 @@ class AnthropicMessagesClient(Client):
 
     async def close(self) -> None:
         await self.anthropic.close()
+        if self._http is not None:
+            await self._http.aclose()

--- a/verifiers/v1/clients/client.py
+++ b/verifiers/v1/clients/client.py
@@ -2,12 +2,21 @@
 
 Collapsed from v1's 4-typevar generic ABC with five conversion hooks to a single
 abstract method. Each concrete client owns its own wire translation internally.
+
+A client whose endpoint natively speaks a registered dialect also declares it
+(`dialect`) and supports `relay`: forwarding a program's request *bytes* verbatim to
+its endpoint, the interception server's no-translation fast path. Clients without a
+matching ingress dialect (renderer, google) leave `dialect = None` and are only ever
+reached through the typed `get_response`.
 """
 
 import logging
 from abc import ABC, abstractmethod
+from collections.abc import AsyncIterator, Mapping
 from dataclasses import dataclass
+from typing import ClassVar
 
+import httpx
 from tenacity import (
     AsyncRetrying,
     RetryCallState,
@@ -16,13 +25,65 @@ from tenacity import (
     stop_after_attempt,
 )
 
-from verifiers.v1.errors import ModelError, OverlongPromptError
+from verifiers.v1.errors import ModelError, OverlongPromptError, classify_model_error
 from verifiers.v1.types import Messages, Response, SamplingConfig, Tool
 
 logger = logging.getLogger(__name__)
 
 
+@dataclass
+class RelayReply:
+    """A relayed upstream response: its content type and body chunks (one chunk for a
+    JSON body, many for SSE). The connection closes when `chunks` is exhausted."""
+
+    content_type: str
+    chunks: AsyncIterator[bytes]
+
+
+async def relay_post(
+    http: httpx.AsyncClient, url: str, headers: Mapping[str, str], body: bytes
+) -> RelayReply:
+    """POST `body` verbatim and stream the response back. An error status is read fully
+    and raised as a `ModelError` (an overlong prompt as `OverlongPromptError`), so the
+    retry and truncation machinery treat relayed calls exactly like typed ones."""
+    # Lowercase keys so e.g. an SDK "Content-Type" and ours can't both go on the wire
+    # (duplicate content-type headers make providers reject the body).
+    normalized = {k.lower(): v for k, v in headers.items()}
+    normalized.setdefault("content-type", "application/json")
+    request = http.build_request("POST", url, content=body, headers=normalized)
+    response = await http.send(request, stream=True)
+    if response.status_code >= 400:
+        text = (await response.aread()).decode("utf-8", errors="replace")
+        await response.aclose()
+        raise classify_model_error(f"upstream {response.status_code}: {text}")
+
+    async def chunks() -> AsyncIterator[bytes]:
+        try:
+            async for chunk in response.aiter_bytes():
+                yield chunk
+        finally:
+            await response.aclose()
+
+    return RelayReply(
+        content_type=response.headers.get("content-type", "application/json"),
+        chunks=chunks(),
+    )
+
+
+def relay_headers(sdk) -> dict[str, str]:
+    """An SDK client's headers (defaults + auth, minus its Omit sentinels) — what a
+    byte relay sends upstream. `auth_headers` is merged explicitly because newer SDK
+    versions no longer fold auth into `default_headers`."""
+    merged: Mapping[str, object] = {**sdk.default_headers, **sdk.auth_headers}
+    return {k: v for k, v in merged.items() if isinstance(v, str)}
+
+
 class Client(ABC):
+    dialect: ClassVar[str | None] = None
+    """The registered ingress dialect this client's endpoint natively speaks (see
+    `verifiers.v1.dialects`). When a program's request arrives in this dialect, the
+    interception server relays its bytes via `relay` instead of translating."""
+
     @abstractmethod
     async def get_response(
         self,
@@ -32,6 +93,12 @@ class Client(ABC):
         tools: list[Tool] | None = None,
     ) -> Response:
         """Run one completion, translating to/from this client's wire format."""
+
+    async def relay(self, body: bytes, route: str) -> RelayReply:
+        """Forward a program's request bytes verbatim to this client's endpoint.
+        `route` is the ingress route the request arrived on (e.g. `/v1/messages`);
+        the client maps it onto its own base URL."""
+        raise NotImplementedError(f"{type(self).__name__} does not relay")
 
     async def close(self) -> None:
         """Release any underlying resources. Default no-op."""
@@ -55,6 +122,10 @@ class RetryingClient(Client):
             reraise=True,
         )
 
+    @property
+    def dialect(self) -> str | None:  # type: ignore[override]
+        return self.inner.dialect
+
     def _log_retry(self, state: RetryCallState) -> None:
         logger.warning(
             "retrying model call (attempt %d/%d) after error: %s",
@@ -73,6 +144,11 @@ class RetryingClient(Client):
         return await self._retrying(
             self.inner.get_response, prompt, model, sampling_args, tools
         )
+
+    async def relay(self, body: bytes, route: str) -> RelayReply:
+        # Safe to retry: a relay raises (and is retried) before any response byte has
+        # been handed back; once a `RelayReply` is returned, streaming is underway.
+        return await self._retrying(self.inner.relay, body, route)
 
     async def close(self) -> None:
         await self.inner.close()

--- a/verifiers/v1/clients/openai.py
+++ b/verifiers/v1/clients/openai.py
@@ -20,8 +20,10 @@ from openai.types.chat import (
 from openai.types.chat.chat_completion import Choice
 from openai.types.shared_params import FunctionDefinition
 
-from verifiers.v1.clients.client import Client
-from verifiers.v1.errors import ModelError, OverlongPromptError
+import httpx
+
+from verifiers.v1.clients.client import Client, RelayReply, relay_headers, relay_post
+from verifiers.v1.errors import ModelError, classify_model_error
 from verifiers.v1.types import (
     AssistantMessage,
     FinishReason,
@@ -39,27 +41,11 @@ from verifiers.v1.types import (
     UserMessage,
 )
 
-_CONTEXT_LENGTH_PHRASES = (
-    "this model's maximum context length is",
-    "is longer than the model's context length",
-    "is longer than the maximum model length",
-    "exceeds the model's context length",
-    "exceed the configured limit",
-    "exceeds the configured limit",
-    "exceeded model",
-    "prompt_too_long",
-    "context length",
-    "maximum model length",
-)
-
 
 def model_error(e: OpenAIError) -> ModelError:
     """Map a provider client error to our error type, distinguishing an overlong prompt
     from any other model-call failure (auth, rate limit, a genuine bad request, ...)."""
-    text = str(e).casefold()
-    if any(phrase in text for phrase in _CONTEXT_LENGTH_PHRASES):
-        return OverlongPromptError(str(e))
-    return ModelError(str(e))
+    return classify_model_error(str(e))
 
 
 def content_to_wire(content) -> str | list[ChatCompletionContentPartParam]:
@@ -201,8 +187,19 @@ def response_from_wire(completion: ChatCompletion) -> Response:
 
 
 class OpenAIChatCompletionsClient(Client):
+    dialect = "chat"
+
     def __init__(self, openai: AsyncOpenAI) -> None:
         self.openai = openai
+        self._http: httpx.AsyncClient | None = None
+
+    async def relay(self, body: bytes, route: str) -> RelayReply:
+        # The SDK's base_url already carries `/v1` (the OpenAI convention), so the
+        # ingress route maps onto it with the prefix stripped.
+        if self._http is None:
+            self._http = httpx.AsyncClient(timeout=None)
+        url = str(self.openai.base_url).rstrip("/") + route.removeprefix("/v1")
+        return await relay_post(self._http, url, relay_headers(self.openai), body)
 
     async def get_response(
         self,
@@ -238,3 +235,5 @@ class OpenAIChatCompletionsClient(Client):
 
     async def close(self) -> None:
         await self.openai.close()
+        if self._http is not None:
+            await self._http.aclose()

--- a/verifiers/v1/clients/openai_responses.py
+++ b/verifiers/v1/clients/openai_responses.py
@@ -2,6 +2,7 @@
 
 from typing import Any, cast
 
+import httpx
 from openai import AsyncOpenAI, OpenAIError
 from openai.types.responses import (
     EasyInputMessageParam,
@@ -19,7 +20,7 @@ from openai.types.responses import (
 )
 from openai.types.responses.response_input_param import FunctionCallOutput
 
-from verifiers.v1.clients.client import Client
+from verifiers.v1.clients.client import Client, RelayReply, relay_headers, relay_post
 from verifiers.v1.clients.openai import model_error
 from verifiers.v1.errors import ModelError
 from verifiers.v1.types import (
@@ -151,8 +152,18 @@ def response_from_wire(response: OpenAIResponse) -> Response:
 
 
 class OpenAIResponsesClient(Client):
+    dialect = "responses"
+
     def __init__(self, openai: AsyncOpenAI) -> None:
         self.openai = openai
+        self._http: httpx.AsyncClient | None = None
+
+    async def relay(self, body: bytes, route: str) -> RelayReply:
+        # The SDK's base_url already carries `/v1` (the OpenAI convention).
+        if self._http is None:
+            self._http = httpx.AsyncClient(timeout=None)
+        url = str(self.openai.base_url).rstrip("/") + route.removeprefix("/v1")
+        return await relay_post(self._http, url, relay_headers(self.openai), body)
 
     async def get_response(
         self,
@@ -209,3 +220,5 @@ class OpenAIResponsesClient(Client):
 
     async def close(self) -> None:
         await self.openai.close()
+        if self._http is not None:
+            await self._http.aclose()

--- a/verifiers/v1/dialects/__init__.py
+++ b/verifiers/v1/dialects/__init__.py
@@ -1,0 +1,33 @@
+"""Wire dialects: the native API formats the interception server understands.
+
+One `Dialect` per native format, each owning its route, auth carrier, and wire <-> vf
+codec. The interception server serves every registered dialect's routes, so a request's
+format is resolved from the endpoint the program's SDK posts to — the harness declares
+nothing, and a program may mix formats within one rollout.
+"""
+
+from verifiers.v1.dialects.anthropic import AnthropicDialect
+from verifiers.v1.dialects.base import Dialect, iter_sse, sse
+from verifiers.v1.dialects.chat import (
+    ChatDialect,
+    parse_message,
+    parse_tools,
+    serialize_completion,
+)
+from verifiers.v1.dialects.responses import ResponsesDialect
+
+DIALECTS: tuple[Dialect, ...] = (ChatDialect(), AnthropicDialect(), ResponsesDialect())
+"""The registered dialects, all served simultaneously by the interception server."""
+
+__all__ = [
+    "Dialect",
+    "DIALECTS",
+    "ChatDialect",
+    "AnthropicDialect",
+    "ResponsesDialect",
+    "iter_sse",
+    "sse",
+    "parse_message",
+    "parse_tools",
+    "serialize_completion",
+]

--- a/verifiers/v1/dialects/anthropic.py
+++ b/verifiers/v1/dialects/anthropic.py
@@ -1,0 +1,288 @@
+"""The Anthropic Messages dialect (claude-code and friends).
+
+Request parsing maps Anthropic content blocks onto the typed messages; responses are
+parsed with the Anthropic client's `response_from_wire`. The serializers (translate
+path) hand a typed `Response` back in Anthropic shape — reasoning is emitted as a
+thinking block so the program displays it and echoes it back, where `parse_request`
+recovers it into `reasoning_content` (the passback some reasoning models require).
+"""
+
+import json
+from collections.abc import Mapping
+
+from anthropic.types import Message as AnthropicMessage
+
+from verifiers.v1.clients.anthropic import response_from_wire
+from verifiers.v1.dialects.base import Dialect, iter_sse, sse
+from verifiers.v1.types import (
+    AssistantMessage,
+    ContentPart,
+    ImageUrlContentPart,
+    ImageUrlSource,
+    Messages,
+    Response,
+    SystemMessage,
+    TextContentPart,
+    Tool,
+    ToolCall,
+    ToolMessage,
+    UserMessage,
+)
+
+STOP_REASONS = {"stop": "end_turn", "length": "max_tokens", "tool_calls": "tool_use"}
+
+
+def parse_content(content) -> str | list[ContentPart]:
+    """Anthropic user-side content (text + image blocks) -> typed content parts."""
+    if isinstance(content, str):
+        return content
+    parts: list[ContentPart] = []
+    for block in content:
+        if block.get("type") == "text":
+            parts.append(TextContentPart(text=block.get("text", "")))
+        elif block.get("type") == "image":
+            source = block.get("source") or {}
+            if source.get("type") == "url":
+                url = source.get("url", "")
+            else:
+                url = f"data:{source.get('media_type', '')};base64,{source.get('data', '')}"
+            parts.append(ImageUrlContentPart(image_url=ImageUrlSource(url=url)))
+    return parts
+
+
+def block_text(content) -> str:
+    """Flatten a tool_result's content (a string or text blocks) to text."""
+    if isinstance(content, str):
+        return content
+    return "".join(b.get("text", "") for b in content or [] if b.get("type") == "text")
+
+
+def parse_messages(body: dict) -> Messages:
+    """The request's `system` + `messages` -> typed messages. Assistant turns fold their
+    blocks into one message (thinking -> reasoning, tool_use -> tool calls); a user turn's
+    tool_result blocks become individual tool messages, its rest one user message."""
+    prompt: Messages = []
+    if system := body.get("system"):
+        prompt.append(SystemMessage(content=parse_content(system)))
+    for message in body.get("messages", []):
+        content = message.get("content")
+        if message.get("role") == "assistant":
+            blocks = (
+                [{"type": "text", "text": content}]
+                if isinstance(content, str)
+                else content or []
+            )
+            text = "".join(b.get("text", "") for b in blocks if b.get("type") == "text")
+            reasoning = "".join(
+                b.get("thinking", "") for b in blocks if b.get("type") == "thinking"
+            )
+            calls = [
+                ToolCall(
+                    id=b.get("id", ""),
+                    name=b.get("name", ""),
+                    arguments=json.dumps(b.get("input") or {}),
+                )
+                for b in blocks
+                if b.get("type") == "tool_use"
+            ]
+            prompt.append(
+                AssistantMessage(
+                    content=text or None,
+                    reasoning_content=reasoning or None,
+                    tool_calls=calls or None,
+                )
+            )
+            continue
+        rest = []
+        for block in [] if isinstance(content, str) else content or []:
+            if block.get("type") == "tool_result":
+                prompt.append(
+                    ToolMessage(
+                        tool_call_id=block.get("tool_use_id", ""),
+                        content=block_text(block.get("content")),
+                    )
+                )
+            else:
+                rest.append(block)
+        if isinstance(content, str) or rest:
+            prompt.append(
+                UserMessage(
+                    content=content if isinstance(content, str) else parse_content(rest)
+                )
+            )
+    return prompt
+
+
+class AnthropicDialect(Dialect):
+    name = "anthropic"
+    route = "/v1/messages"
+    aux_routes = ("/v1/messages/count_tokens",)
+
+    def secret(self, headers: Mapping[str, str]) -> str:
+        # The SDK sends the key as `x-api-key`; an ANTHROPIC_AUTH_TOKEN arrives as Bearer.
+        return headers.get("x-api-key") or super().secret(headers)
+
+    def error_body(self, message: str) -> dict:
+        return {
+            "type": "error",
+            "error": {"type": "invalid_request_error", "message": message},
+        }
+
+    def parse_request(self, body: dict) -> tuple[Messages, list[Tool] | None]:
+        tools = [
+            Tool(
+                name=t["name"],
+                description=t.get("description", ""),
+                parameters=t.get("input_schema", {}),
+            )
+            for t in body.get("tools") or []
+            if "input_schema" in t  # skip server tools (web_search etc.)
+        ] or None
+        return parse_messages(body), tools
+
+    def parse_response(self, raw: dict) -> Response:
+        return response_from_wire(AnthropicMessage.model_validate(raw))
+
+    def parse_stream(self, raw: bytes) -> Response:
+        """Assemble message_start / content_block_* / message_delta events into the
+        complete message, then parse it."""
+        message: dict = {}
+        blocks: dict[int, dict] = {}
+        partial_json: dict[int, str] = {}
+        for event in iter_sse(raw):
+            kind = event.get("type")
+            if kind == "message_start":
+                message = event.get("message") or {}
+            elif kind == "content_block_start":
+                blocks[event["index"]] = dict(event.get("content_block") or {})
+            elif kind == "content_block_delta":
+                block = blocks.setdefault(event["index"], {"type": "text", "text": ""})
+                delta = event.get("delta") or {}
+                if delta.get("type") == "text_delta":
+                    block["text"] = block.get("text", "") + delta.get("text", "")
+                elif delta.get("type") == "thinking_delta":
+                    block["thinking"] = block.get("thinking", "") + delta.get(
+                        "thinking", ""
+                    )
+                elif delta.get("type") == "signature_delta":
+                    block["signature"] = block.get("signature", "") + delta.get(
+                        "signature", ""
+                    )
+                elif delta.get("type") == "input_json_delta":
+                    partial_json[event["index"]] = partial_json.get(
+                        event["index"], ""
+                    ) + delta.get("partial_json", "")
+            elif kind == "message_delta":
+                message.update(
+                    {
+                        k: v
+                        for k, v in (event.get("delta") or {}).items()
+                        if v is not None
+                    }
+                )
+                usage = {**(message.get("usage") or {}), **(event.get("usage") or {})}
+                message["usage"] = usage
+        for index, partial in partial_json.items():
+            blocks[index]["input"] = json.loads(partial or "{}")
+        message["content"] = [blocks[i] for i in sorted(blocks)]
+        return self.parse_response(message)
+
+    def serialize_response(self, response: Response, model: str) -> dict:
+        message = response.message
+        content: list[dict] = []
+        if message.reasoning_content:
+            # Emitted so the program shows reasoning and echoes it back next turn,
+            # where parse_request recovers it (required passback for some models).
+            content.append(
+                {
+                    "type": "thinking",
+                    "thinking": message.reasoning_content,
+                    "signature": "",
+                }
+            )
+        if message.content:
+            content.append({"type": "text", "text": message.content})
+        for call in message.tool_calls or []:
+            content.append(
+                {
+                    "type": "tool_use",
+                    "id": call.id,
+                    "name": call.name,
+                    "input": json.loads(call.arguments or "{}"),
+                }
+            )
+        return {
+            "id": response.id or "vf-intercept",
+            "type": "message",
+            "role": "assistant",
+            "model": response.model or model,
+            "content": content,
+            "stop_reason": STOP_REASONS.get(response.finish_reason or "", "end_turn"),
+            "stop_sequence": None,
+            "usage": {
+                "input_tokens": response.usage.prompt_tokens if response.usage else 0,
+                "output_tokens": response.usage.completion_tokens
+                if response.usage
+                else 0,
+            },
+        }
+
+    def serialize_stream(self, response: Response, model: str) -> bytes:
+        """The completed response as a minimal valid Anthropic event stream: each content
+        block as start + one delta + stop, framed by message_start/delta/stop."""
+        full = self.serialize_response(response, model)
+        deltas = {
+            "text": lambda b: {"type": "text_delta", "text": b["text"]},
+            "thinking": lambda b: {"type": "thinking_delta", "thinking": b["thinking"]},
+            "tool_use": lambda b: {
+                "type": "input_json_delta",
+                "partial_json": json.dumps(b["input"]),
+            },
+        }
+        out = sse(
+            {
+                "type": "message_start",
+                "message": {**full, "content": [], "stop_reason": None},
+            },
+            "message_start",
+        )
+        for index, block in enumerate(full["content"]):
+            start = dict(block)
+            if block["type"] == "text":
+                start["text"] = ""
+            elif block["type"] == "thinking":
+                start["thinking"] = ""
+            else:
+                start["input"] = {}
+            out += sse(
+                {"type": "content_block_start", "index": index, "content_block": start},
+                "content_block_start",
+            )
+            out += sse(
+                {
+                    "type": "content_block_delta",
+                    "index": index,
+                    "delta": deltas[block["type"]](block),
+                },
+                "content_block_delta",
+            )
+            out += sse(
+                {"type": "content_block_stop", "index": index}, "content_block_stop"
+            )
+        out += sse(
+            {
+                "type": "message_delta",
+                "delta": {"stop_reason": full["stop_reason"], "stop_sequence": None},
+                "usage": {"output_tokens": full["usage"]["output_tokens"]},
+            },
+            "message_delta",
+        )
+        return out + sse({"type": "message_stop"}, "message_stop")
+
+    def handle_aux(self, path: str, body: dict) -> dict:
+        """count_tokens, estimated (translate path only — relayed verbatim otherwise):
+        ~4 chars per token over the request's text."""
+        chars = len(json.dumps(body.get("messages", []))) + len(
+            json.dumps(body.get("system", ""))
+        )
+        return {"input_tokens": max(1, chars // 4)}

--- a/verifiers/v1/dialects/base.py
+++ b/verifiers/v1/dialects/base.py
@@ -1,0 +1,115 @@
+"""The `Dialect` abstraction: one native wire format, translated both ways.
+
+A `Dialect` is one native API's wire format (OpenAI chat completions, Anthropic
+Messages, OpenAI Responses). The interception server serves every registered
+dialect's `route` (see `dialects.DIALECTS`), so a request's format is resolved from
+the endpoint the program's SDK posts to — the harness declares nothing.
+
+Each dialect owns the full codec for its format:
+
+- wire -> vf (`parse_request` / `parse_response` / `parse_stream`): always used, to
+  build the trace and drive limits/stops/user-sim.
+- vf -> wire (`serialize_response` / `serialize_stream`): used only on the translate
+  path, when the rollout's client speaks a *different* protocol (e.g. training via
+  the renderer) and the typed `Response` must be handed back to the program in its
+  native format.
+
+When the client natively speaks the dialect (`Client.dialect == Dialect.name`) the
+server relays the request bytes verbatim instead — no vf -> wire reconstruction
+touches the load-bearing bytes (see `interception.server`).
+"""
+
+import json
+from abc import ABC, abstractmethod
+from collections.abc import Mapping
+from typing import ClassVar
+
+from verifiers.v1.types import Messages, Response, Tool
+
+
+def iter_sse(raw: bytes) -> list[dict]:
+    """Parse a complete SSE byte stream into its JSON data payloads, in order.
+    Skips non-JSON sentinels (OpenAI's `data: [DONE]`). Shared by the dialects'
+    `parse_stream` implementations."""
+    events: list[dict] = []
+    for block in raw.decode("utf-8", errors="replace").split("\n\n"):
+        data = "\n".join(
+            line.removeprefix("data:").strip()
+            for line in block.splitlines()
+            if line.startswith("data:")
+        )
+        if not data or data == "[DONE]":
+            continue
+        events.append(json.loads(data))
+    return events
+
+
+def sse(payload: dict, event: str | None = None) -> bytes:
+    """One SSE frame for `payload` (with an `event:` name when the format uses one)."""
+    head = f"event: {event}\n" if event else ""
+    return f"{head}data: {json.dumps(payload)}\n\n".encode()
+
+
+class Dialect(ABC):
+    """One native API's wire format: routes, auth carrier, and the wire <-> vf codec."""
+
+    name: ClassVar[str]
+    """The protocol id, matched against `Client.dialect` to pick relay vs translate."""
+    route: ClassVar[str]
+    """The path a program's SDK posts model turns to (e.g. `/v1/chat/completions`)."""
+    aux_routes: ClassVar[tuple[str, ...]] = ()
+    """Side endpoints the SDK may call that are not model turns (e.g. Anthropic's
+    `count_tokens`): relayed verbatim when the client speaks this dialect, answered
+    with `handle_aux` otherwise. Never recorded on the trace."""
+
+    def secret(self, headers: Mapping[str, str]) -> str:
+        """The per-rollout secret from the request, read from this format's auth carrier
+        (default: an `Authorization: Bearer` token)."""
+        return headers.get("Authorization", "").removeprefix("Bearer ")
+
+    def streaming(self, body: dict) -> bool:
+        """Whether the request asks for a streamed (SSE) response."""
+        return bool(body.get("stream"))
+
+    def error_body(self, message: str) -> dict:
+        """An error payload in this format's error shape."""
+        return {"error": {"message": message, "type": "invalid_request_error"}}
+
+    @abstractmethod
+    def parse_request(self, body: dict) -> tuple[Messages, list[Tool] | None]:
+        """The native request -> the typed prompt + tools (for the trace and the
+        translate path)."""
+
+    @abstractmethod
+    def parse_response(self, raw: dict) -> Response:
+        """A native (non-streamed) response -> the typed `Response`."""
+
+    @abstractmethod
+    def parse_stream(self, raw: bytes) -> Response:
+        """A complete native SSE byte stream -> the typed `Response` (assembles the
+        final message from the events; used to record a relayed stream on the trace)."""
+
+    @abstractmethod
+    def serialize_response(self, response: Response, model: str) -> dict:
+        """The typed `Response` -> this format's response payload (translate path)."""
+
+    @abstractmethod
+    def serialize_stream(self, response: Response, model: str) -> bytes:
+        """The typed `Response` -> a minimal valid SSE byte stream in this format
+        (translate path, for a program that requested streaming)."""
+
+    def handle_aux(self, path: str, body: dict) -> dict:
+        """Answer an aux route locally (translate path only — when the client speaks the
+        dialect, aux requests are relayed verbatim instead). Default: no aux routes."""
+        raise NotImplementedError
+
+    def extend_request(
+        self, body: dict, completion: dict, user_messages: Messages
+    ) -> dict:
+        """Extend a relayed request body with the last completion's assistant message and
+        a user simulator's injected turn(s). Only the chat dialect implements this — the
+        only harness contract with a user simulator speaks chat; on other dialects a
+        simulator works via the translate path."""
+        raise NotImplementedError(
+            f"user simulator over the relay path is not supported for {self.name}"
+        )

--- a/verifiers/v1/dialects/chat.py
+++ b/verifiers/v1/dialects/chat.py
@@ -1,0 +1,223 @@
+"""The OpenAI chat-completions dialect (the lingua franca every aggregator speaks).
+
+wire -> vf request parsing moved here from the interception server; response parsing
+reuses the chat client's `response_from_wire`. The serializers produce the
+`chat.completion` (and chunked SSE) shapes the program's OpenAI SDK expects.
+"""
+
+import time
+
+from openai.types.chat import ChatCompletion
+
+from verifiers.v1.clients.openai import response_from_wire
+from verifiers.v1.dialects.base import Dialect, iter_sse, sse
+from verifiers.v1.types import (
+    AssistantMessage,
+    Message,
+    Messages,
+    Response,
+    SystemMessage,
+    Tool,
+    ToolCall,
+    ToolMessage,
+    UserMessage,
+    content_to_parts,
+)
+
+
+def content_text(content) -> str:
+    """Flatten content to text — for roles that never carry images (assistant, tool)."""
+    if isinstance(content, list):
+        return "".join(p.get("text", "") for p in content if isinstance(p, dict))
+    return content or ""
+
+
+def parse_message(raw: dict) -> Message:
+    """An OpenAI request message dict -> a typed Message. User/system bodies keep their
+    image parts (multimodal ingress); assistant/tool bodies flatten to text."""
+    role = raw.get("role")
+    content = raw.get("content")
+    if role == "system":
+        return SystemMessage(content=content_to_parts(content))
+    if role == "tool":
+        return ToolMessage(
+            tool_call_id=raw.get("tool_call_id", ""), content=content_text(content)
+        )
+    if role == "assistant":
+        calls = [
+            ToolCall(
+                id=c["id"],
+                name=c["function"]["name"],
+                arguments=c["function"]["arguments"],
+            )
+            for c in (raw.get("tool_calls") or [])
+        ] or None
+        return AssistantMessage(
+            content=content_text(content) or None,
+            reasoning_content=raw.get("reasoning_content") or raw.get("reasoning"),
+            tool_calls=calls,
+            provider_state=raw.get("reasoning_details") or raw.get("provider_state"),
+        )
+    return UserMessage(content=content_to_parts(content))
+
+
+def parse_tools(raw: list[dict] | None) -> list[Tool] | None:
+    if not raw:
+        return None
+    return [
+        Tool(
+            name=t["function"]["name"],
+            description=t["function"].get("description", ""),
+            parameters=t["function"].get("parameters", {}),
+            strict=t["function"].get("strict"),
+        )
+        for t in raw
+        if t.get("type", "function") == "function"
+    ]
+
+
+def serialize_completion(response: Response, model: str) -> dict:
+    """A `Response` -> an OpenAI chat.completion dict the program's SDK expects."""
+    message: dict = {"role": "assistant", "content": response.message.content}
+    if response.message.reasoning_content is not None:
+        message["reasoning_content"] = response.message.reasoning_content
+    if response.message.provider_state is not None:
+        message["reasoning_details"] = response.message.provider_state
+    if response.message.tool_calls:
+        message["tool_calls"] = [
+            {
+                "id": c.id,
+                "type": "function",
+                "function": {"name": c.name, "arguments": c.arguments},
+            }
+            for c in response.message.tool_calls
+        ]
+    usage = (
+        {
+            "prompt_tokens": response.usage.prompt_tokens,
+            "completion_tokens": response.usage.completion_tokens,
+            "total_tokens": response.usage.total_tokens,
+        }
+        if response.usage
+        else None
+    )
+    return {
+        "id": response.id or "vf-intercept",
+        "object": "chat.completion",
+        "created": response.created,
+        "model": response.model or model,
+        "choices": [
+            {
+                "index": 0,
+                "message": message,
+                "finish_reason": response.finish_reason or "stop",
+            }
+        ],
+        "usage": usage,
+    }
+
+
+class ChatDialect(Dialect):
+    name = "chat"
+    route = "/v1/chat/completions"
+
+    def parse_request(self, body: dict) -> tuple[Messages, list[Tool] | None]:
+        return (
+            [parse_message(m) for m in body.get("messages", [])],
+            parse_tools(body.get("tools")),
+        )
+
+    def parse_response(self, raw: dict) -> Response:
+        return response_from_wire(ChatCompletion.model_validate(raw))
+
+    def parse_stream(self, raw: bytes) -> Response:
+        """Assemble `chat.completion.chunk` deltas into one completion, then parse it."""
+        chunks = iter_sse(raw)
+        message: dict = {"role": "assistant", "content": None}
+        tool_calls: dict[int, dict] = {}
+        finish_reason = None
+        usage = None
+        for chunk in chunks:
+            usage = chunk.get("usage") or usage
+            for choice in chunk.get("choices") or []:
+                if choice.get("index", 0) != 0:
+                    continue
+                finish_reason = choice.get("finish_reason") or finish_reason
+                delta = choice.get("delta") or {}
+                for key in ("content", "reasoning_content", "reasoning"):
+                    if delta.get(key) is not None:
+                        message[key] = (message.get(key) or "") + delta[key]
+                for tc in delta.get("tool_calls") or []:
+                    slot = tool_calls.setdefault(
+                        tc.get("index", 0),
+                        {"type": "function", "function": {"name": "", "arguments": ""}},
+                    )
+                    slot["id"] = tc.get("id") or slot.get("id", "")
+                    fn = tc.get("function") or {}
+                    if fn.get("name"):
+                        slot["function"]["name"] = fn["name"]
+                    slot["function"]["arguments"] += fn.get("arguments") or ""
+        if tool_calls:
+            message["tool_calls"] = [tool_calls[i] for i in sorted(tool_calls)]
+        head = chunks[0] if chunks else {}
+        return self.parse_response(
+            {
+                "id": head.get("id", "vf-intercept"),
+                "object": "chat.completion",
+                "created": head.get("created", int(time.time())),
+                "model": head.get("model", ""),
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": message,
+                        "finish_reason": finish_reason or "stop",
+                    }
+                ],
+                "usage": usage,
+            }
+        )
+
+    def serialize_response(self, response: Response, model: str) -> dict:
+        return serialize_completion(response, model)
+
+    def extend_request(
+        self, body: dict, completion: dict, user_messages: Messages
+    ) -> dict:
+        """Extend a relayed request with the last completion's verbatim assistant
+        message plus the user simulator's injected turn(s) — the framework-authored
+        continuation request the relay path re-sends."""
+        from verifiers.v1.clients.openai import message_to_wire
+
+        return {
+            **body,
+            "messages": [
+                *body.get("messages", []),
+                completion["choices"][0]["message"],
+                *(message_to_wire(m) for m in user_messages),
+            ],
+        }
+
+    def serialize_stream(self, response: Response, model: str) -> bytes:
+        """The completed response as a minimal valid chunk stream: one delta carrying
+        the whole message, a usage chunk, then `[DONE]`."""
+        completion = serialize_completion(response, model)
+        delta = completion["choices"][0]["message"]
+        if "tool_calls" in delta:
+            delta["tool_calls"] = [
+                {**tc, "index": i} for i, tc in enumerate(delta["tool_calls"])
+            ]
+        chunk = {
+            "id": completion["id"],
+            "object": "chat.completion.chunk",
+            "created": completion["created"],
+            "model": completion["model"],
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": delta,
+                    "finish_reason": completion["choices"][0]["finish_reason"],
+                }
+            ],
+            "usage": completion["usage"],
+        }
+        return sse(chunk) + b"data: [DONE]\n\n"

--- a/verifiers/v1/dialects/responses.py
+++ b/verifiers/v1/dialects/responses.py
@@ -1,0 +1,239 @@
+"""The OpenAI Responses dialect (codex and friends).
+
+Request parsing walks the `input` items, grouping each run of assistant-side items
+(reasoning / assistant message / function_call) into one typed assistant message whose
+`provider_state` carries the raw items (the same continuation state the Responses
+egress client replays verbatim). Server-side statefulness (`previous_response_id`)
+is not emulated: the relay path's endpoint owns it, the translate path rejects it.
+"""
+
+import json
+import time
+
+from openai.types.responses import Response as OpenAIResponse
+
+from verifiers.v1.clients.openai_responses import response_from_wire
+from verifiers.v1.dialects.base import Dialect, iter_sse, sse
+from verifiers.v1.types import (
+    AssistantMessage,
+    ContentPart,
+    ImageUrlContentPart,
+    ImageUrlSource,
+    Messages,
+    Response,
+    SystemMessage,
+    TextContentPart,
+    Tool,
+    ToolCall,
+    ToolMessage,
+    UserMessage,
+)
+
+FINAL_EVENTS = ("response.completed", "response.incomplete", "response.failed")
+ASSISTANT_ITEMS = ("reasoning", "function_call")
+
+
+def parse_content(content) -> str | list[ContentPart]:
+    if isinstance(content, str):
+        return content
+    parts: list[ContentPart] = []
+    for part in content:
+        kind = part.get("type")
+        if kind in ("input_text", "output_text"):
+            parts.append(TextContentPart(text=part.get("text", "")))
+        elif kind == "input_image":
+            parts.append(
+                ImageUrlContentPart(
+                    image_url=ImageUrlSource(
+                        url=part.get("image_url", ""),
+                        detail=part.get("detail")
+                        if part.get("detail") != "auto"
+                        else None,
+                    )
+                )
+            )
+    return parts
+
+
+def fold_assistant(items: list[dict]) -> AssistantMessage:
+    """One run of assistant-side items -> one typed assistant message, raw items kept
+    as `provider_state` (the Responses egress client replays them verbatim)."""
+    content = ""
+    reasoning: list[str] = []
+    calls: list[ToolCall] = []
+    for item in items:
+        if item.get("type") == "reasoning":
+            reasoning += [s.get("text", "") for s in item.get("summary") or []]
+            reasoning += [c.get("text", "") for c in item.get("content") or []]
+        elif item.get("type") == "function_call":
+            calls.append(
+                ToolCall(
+                    id=item.get("call_id", ""),
+                    name=item.get("name", ""),
+                    arguments=item.get("arguments", ""),
+                )
+            )
+        else:  # an assistant message item
+            content += (
+                item["content"]
+                if isinstance(item.get("content"), str)
+                else "".join(
+                    p.get("text", "")
+                    for p in item.get("content") or []
+                    if p.get("type") in ("input_text", "output_text")
+                )
+            )
+    return AssistantMessage(
+        content=content or None,
+        reasoning_content="\n".join(r for r in reasoning if r) or None,
+        tool_calls=calls or None,
+        provider_state=items,
+    )
+
+
+class ResponsesDialect(Dialect):
+    name = "responses"
+    route = "/v1/responses"
+
+    def parse_request(self, body: dict) -> tuple[Messages, list[Tool] | None]:
+        prompt: Messages = []
+        if instructions := body.get("instructions"):
+            prompt.append(SystemMessage(content=instructions))
+        raw = body.get("input")
+        items = (
+            [{"role": "user", "content": raw}] if isinstance(raw, str) else raw or []
+        )
+        run: list[dict] = []  # the current run of assistant-side items
+        for item in items:
+            assistant = item.get("type") in ASSISTANT_ITEMS or (
+                item.get("role") == "assistant"
+            )
+            if run and not assistant:
+                prompt.append(fold_assistant(run))
+                run = []
+            if assistant:
+                run.append(item)
+            elif item.get("type") == "function_call_output":
+                prompt.append(
+                    ToolMessage(
+                        tool_call_id=item.get("call_id", ""),
+                        content=item.get("output", "")
+                        if isinstance(item.get("output"), str)
+                        else json.dumps(item.get("output")),
+                    )
+                )
+            elif item.get("role") in ("system", "developer"):
+                prompt.append(SystemMessage(content=parse_content(item.get("content"))))
+            else:
+                prompt.append(UserMessage(content=parse_content(item.get("content"))))
+        if run:
+            prompt.append(fold_assistant(run))
+        tools = [
+            Tool(
+                name=t["name"],
+                description=t.get("description") or "",
+                parameters=t.get("parameters") or {},
+                strict=t.get("strict"),
+            )
+            for t in body.get("tools") or []
+            if t.get("type") == "function"
+        ] or None
+        return prompt, tools
+
+    def parse_response(self, raw: dict) -> Response:
+        return response_from_wire(OpenAIResponse.model_validate(raw))
+
+    def parse_stream(self, raw: bytes) -> Response:
+        """The terminal event (`response.completed` / `.incomplete` / `.failed`)
+        carries the full response object — parse that."""
+        for event in reversed(iter_sse(raw)):
+            if event.get("type") in FINAL_EVENTS:
+                return self.parse_response(event["response"])
+        raise ValueError("Responses stream ended without a terminal event")
+
+    def serialize_response(self, response: Response, model: str) -> dict:
+        message = response.message
+        output: list[dict] = []
+        if message.reasoning_content:
+            output.append(
+                {
+                    "type": "reasoning",
+                    "id": "rs_vf-intercept",
+                    "summary": [
+                        {"type": "summary_text", "text": message.reasoning_content}
+                    ],
+                }
+            )
+        if message.content is not None:
+            output.append(
+                {
+                    "type": "message",
+                    "id": "msg_vf-intercept",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": message.content,
+                            "annotations": [],
+                        }
+                    ],
+                }
+            )
+        for index, call in enumerate(message.tool_calls or []):
+            output.append(
+                {
+                    "type": "function_call",
+                    "id": f"fc_vf-intercept-{index}",
+                    "call_id": call.id,
+                    "name": call.name,
+                    "arguments": call.arguments,
+                    "status": "completed",
+                }
+            )
+        incomplete = response.finish_reason == "length"
+        return {
+            "id": response.id or "resp_vf-intercept",
+            "object": "response",
+            "created_at": response.created or int(time.time()),
+            "model": response.model or model,
+            "status": "incomplete" if incomplete else "completed",
+            "incomplete_details": {"reason": "max_output_tokens"}
+            if incomplete
+            else None,
+            "output": output,
+            "parallel_tool_calls": True,
+            "tool_choice": "auto",
+            "tools": [],
+            "error": None,
+            "usage": {
+                "input_tokens": response.usage.prompt_tokens,
+                "output_tokens": response.usage.completion_tokens,
+                "total_tokens": response.usage.total_tokens,
+                "input_tokens_details": {"cached_tokens": 0},
+                "output_tokens_details": {"reasoning_tokens": 0},
+            }
+            if response.usage
+            else None,
+        }
+
+    def serialize_stream(self, response: Response, model: str) -> bytes:
+        """A minimal valid Responses event stream: `response.created`, then the
+        terminal event carrying the full response."""
+        full = self.serialize_response(response, model)
+        created = sse(
+            {
+                "type": "response.created",
+                "sequence_number": 0,
+                "response": {**full, "status": "in_progress", "output": []},
+            },
+            "response.created",
+        )
+        final = (
+            "response.incomplete"
+            if full["status"] == "incomplete"
+            else ("response.completed")
+        )
+        return created + sse(
+            {"type": final, "sequence_number": 1, "response": full}, final
+        )

--- a/verifiers/v1/errors.py
+++ b/verifiers/v1/errors.py
@@ -21,6 +21,33 @@ class OverlongPromptError(ModelError):
     truncated trajectory rather than recording it as an error."""
 
 
+# Phrases providers use to say "your prompt exceeded the context window" (OpenAI, vLLM,
+# SGLang, DeepSeek, Anthropic, ...). Substrings of the error text, casefolded.
+_CONTEXT_LENGTH_PHRASES = (
+    "this model's maximum context length is",
+    "is longer than the model's context length",
+    "is longer than the maximum model length",
+    "exceeds the model's context length",
+    "exceed the configured limit",
+    "exceeds the configured limit",
+    "exceeded model",
+    "prompt_too_long",
+    "prompt is too long",
+    "context length",
+    "maximum model length",
+)
+
+
+def classify_model_error(text: str) -> ModelError:
+    """Map a provider error message to our error type, distinguishing an overlong prompt
+    (a budget limit the interception server turns into a clean truncation) from any other
+    model-call failure (auth, rate limit, a genuine bad request, ...)."""
+    lowered = text.casefold()
+    if any(phrase in lowered for phrase in _CONTEXT_LENGTH_PHRASES):
+        return OverlongPromptError(text)
+    return ModelError(text)
+
+
 class ToolError(RolloutError):
     """A tool invocation failed."""
 

--- a/verifiers/v1/harness.py
+++ b/verifiers/v1/harness.py
@@ -142,7 +142,10 @@ class Harness(ABC, Generic[ConfigT]):
     ) -> ProgramResult:
         """Run the harness program in `runtime` to completion and return its result. The
         task is `trace.task`; model calls should reach the interception server at
-        `endpoint` (bearer token `secret`); `mcp_urls` are the task's tool servers
+        `endpoint` — the server's *root*, serving every registered dialect's routes, so
+        each harness appends what its program's SDK expects (`{endpoint}/v1` for an
+        OpenAI base URL, `endpoint` itself for an Anthropic one) and authenticates with
+        `secret` (bearer token / api key); `mcp_urls` are the task's tool servers
         (name -> URL) to wire in. Each harness owns the env its program needs — read
         `ctx.model` for the model id (the default/compact harnesses set OPENAI_*; rlm sets
         RLM_* too). The uv-script harnesses just `runtime.run_uv_script(...)`."""

--- a/verifiers/v1/interception/__init__.py
+++ b/verifiers/v1/interception/__init__.py
@@ -1,8 +1,9 @@
 """The interception layer.
 
-`server` catches an harness's chat-completions and proxies them to the model, multiplexing
-many rollouts on one server keyed by their secret; `pool` shares those servers (one tunnel
-each, behind a remote runtime) across all of an eval's or env-server's rollouts.
+`server` catches an harness program's model calls (any registered dialect, resolved by
+route) and relays or translates them to the model, multiplexing many rollouts on one
+server keyed by their secret; `pool` shares those servers (one tunnel each, behind a
+remote runtime) across all of an eval's or env-server's rollouts.
 """
 
 from verifiers.v1.interception.pool import InterceptionPool, PooledServer
@@ -10,9 +11,6 @@ from verifiers.v1.interception.server import (
     InterceptionServer,
     RolloutLimits,
     RolloutSession,
-    parse_message,
-    parse_tools,
-    serialize_completion,
 )
 
 __all__ = [
@@ -21,7 +19,4 @@ __all__ = [
     "InterceptionServer",
     "RolloutLimits",
     "RolloutSession",
-    "parse_message",
-    "parse_tools",
-    "serialize_completion",
 ]

--- a/verifiers/v1/interception/pool.py
+++ b/verifiers/v1/interception/pool.py
@@ -66,7 +66,8 @@ class InterceptionPool:
         exposer = make_runtime(
             self.runtime_config, name=f"interception-{len(self._servers)}"
         )
-        endpoint = f"{await exposer.expose(server.port)}/v1"
+        # The root endpoint — each harness appends what its program's SDK expects.
+        endpoint = await exposer.expose(server.port)
         entry = PooledServer(server, exposer, endpoint)
         self._servers.append(entry)
         logger.info(

--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -1,22 +1,31 @@
-"""The interception server: harness chat-completions, caught and proxied.
+"""The interception server: a polyglot proxy for the harness program's model calls.
 
-Every rollout runs an harness program whose OpenAI-style calls are caught here: a small
-localhost server routes each `POST /v1/chat/completions` to our `Client`, records the turn
-into the trace's message graph, and returns the result in OpenAI shape. We inject
-`OPENAI_BASE_URL`/`OPENAI_API_KEY` so the program's SDK talks to us. Chat completions only,
-no streaming.
+Every rollout runs an harness program whose model calls are caught here. The server
+serves every registered dialect's routes (see `verifiers.v1.dialects`), so a request's
+wire format is resolved from the endpoint the program's SDK posts to — the harness
+declares nothing, and one rollout's processes may mix formats.
+
+Each request takes one of two arms:
+
+- **relay** — when the rollout's client natively speaks the request's dialect
+  (`Client.dialect == Dialect.name`), the request *bytes* are forwarded verbatim and the
+  response (JSON or SSE) is relayed back untouched; the dialect parses a copy only to
+  record the turn. No field is lost to a typed round-trip.
+- **translate** — otherwise (training via the renderer, or a cross-protocol pairing),
+  the request is parsed into typed messages, the client runs it in its own wire format,
+  and the typed `Response` is serialized back in the dialect the program spoke.
 
 One server multiplexes many rollouts: each rollout registers a `RolloutSession` under its
-own secret (the bearer token the harness already sends), and the server routes by that
-secret to the right session. So N rollouts need one server (and, behind a remote runtime,
-one tunnel) per pool member rather than one each — see `interception.pool`.
+own secret (read from the dialect's auth carrier), and the server routes by that secret.
+So N rollouts need one server (and, behind a remote runtime, one tunnel) per pool member
+rather than one each — see `interception.pool`.
 
 When a rollout sets a user simulator (see `verifiers.v1.user`), the session also drives it:
 after each model turn it injects the simulator's reply as a user turn and re-prompts the
 model, so a multi-turn exchange plays out within one program request, transparently to the
-harness. Tools are handled out-of-band (run by the harness).
-"""
+harness. Tools are handled out-of-band (run by the harness)."""
 
+import json
 import logging
 import secrets
 from collections.abc import Awaitable, Callable
@@ -27,117 +36,15 @@ from aiohttp import web
 
 from verifiers.v1.clients import RolloutContext
 from verifiers.v1 import graph
+from verifiers.v1.dialects import DIALECTS, Dialect
 from verifiers.v1.errors import OverlongPromptError
 from verifiers.v1.trace import Trace
-from verifiers.v1.types import (
-    AssistantMessage,
-    Message,
-    Messages,
-    Response,
-    SystemMessage,
-    Tool,
-    ToolCall,
-    ToolMessage,
-    UserMessage,
-    content_to_parts,
-)
+from verifiers.v1.types import Messages
 
 if TYPE_CHECKING:
     from verifiers.v1.user import Respond
 
 logger = logging.getLogger(__name__)
-
-
-def _content_text(content) -> str:
-    """Flatten content to text — for roles that never carry images (assistant, tool)."""
-    if isinstance(content, list):
-        return "".join(p.get("text", "") for p in content if isinstance(p, dict))
-    return content or ""
-
-
-def parse_message(raw: dict) -> Message:
-    """An OpenAI request message dict -> a typed Message. User/system bodies keep their
-    image parts (multimodal ingress); assistant/tool bodies flatten to text."""
-    role = raw.get("role")
-    content = raw.get("content")
-    if role == "system":
-        return SystemMessage(content=content_to_parts(content))
-    if role == "tool":
-        return ToolMessage(
-            tool_call_id=raw.get("tool_call_id", ""), content=_content_text(content)
-        )
-    if role == "assistant":
-        calls = [
-            ToolCall(
-                id=c["id"],
-                name=c["function"]["name"],
-                arguments=c["function"]["arguments"],
-            )
-            for c in (raw.get("tool_calls") or [])
-        ] or None
-        return AssistantMessage(
-            content=_content_text(content) or None,
-            reasoning_content=raw.get("reasoning_content") or raw.get("reasoning"),
-            tool_calls=calls,
-            provider_state=raw.get("reasoning_details") or raw.get("provider_state"),
-        )
-    return UserMessage(content=content_to_parts(content))
-
-
-def parse_tools(raw: list[dict] | None) -> list[Tool] | None:
-    if not raw:
-        return None
-    return [
-        Tool(
-            name=t["function"]["name"],
-            description=t["function"].get("description", ""),
-            parameters=t["function"].get("parameters", {}),
-            strict=t["function"].get("strict"),
-        )
-        for t in raw
-        if t.get("type", "function") == "function"
-    ]
-
-
-def serialize_completion(response: Response, model: str) -> dict:
-    """A `Response` -> an OpenAI chat.completion dict the program's SDK expects."""
-    message: dict = {"role": "assistant", "content": response.message.content}
-    if response.message.reasoning_content is not None:
-        message["reasoning_content"] = response.message.reasoning_content
-    if response.message.provider_state is not None:
-        message["reasoning_details"] = response.message.provider_state
-    if response.message.tool_calls:
-        message["tool_calls"] = [
-            {
-                "id": c.id,
-                "type": "function",
-                "function": {"name": c.name, "arguments": c.arguments},
-            }
-            for c in response.message.tool_calls
-        ]
-    usage = (
-        {
-            "prompt_tokens": response.usage.prompt_tokens,
-            "completion_tokens": response.usage.completion_tokens,
-            "total_tokens": response.usage.total_tokens,
-        }
-        if response.usage
-        else None
-    )
-    return {
-        "id": response.id or "vf-intercept",
-        "object": "chat.completion",
-        "created": response.created,
-        "model": response.model or model,
-        "choices": [
-            {
-                "index": 0,
-                "message": message,
-                "finish_reason": response.finish_reason or "stop",
-            }
-        ],
-        "usage": usage,
-    }
 
 
 # Each session proxies one rollout's own harness requests, so aiohttp's default 1 MiB body
@@ -218,11 +125,12 @@ class RolloutSession:
 
 
 class InterceptionServer:
-    """A localhost server that proxies chat-completions for one or more rollouts. Each
-    rollout `register`s a `RolloutSession` and gets back a secret; `handle_chat` routes every
-    request to the session whose secret matches the request's bearer token. A single server
-    can multiplex many rollouts (the basis for `interception.pool`); used 1:1 it's just a
-    server with one session."""
+    """A localhost server that proxies model calls for one or more rollouts. It serves
+    every registered dialect's routes, so a request's wire format is resolved from the
+    endpoint it arrived on. Each rollout `register`s a `RolloutSession` and gets back a
+    secret; every request routes to the session whose secret matches its auth. A single
+    server can multiplex many rollouts (the basis for `interception.pool`); used 1:1 it's
+    just a server with one session."""
 
     def __init__(self) -> None:
         self.sessions: dict[str, RolloutSession] = {}
@@ -230,8 +138,8 @@ class InterceptionServer:
         self.runner: web.AppRunner | None = None
 
     def register(self, session: RolloutSession) -> str:
-        """Add a session under a fresh secret (the bearer token the harness must send) and
-        return it."""
+        """Add a session under a fresh secret (the bearer token / api key the harness must
+        send) and return it."""
         secret = secrets.token_urlsafe(16)
         self.sessions[secret] = session
         return secret
@@ -239,9 +147,24 @@ class InterceptionServer:
     def unregister(self, secret: str) -> None:
         self.sessions.pop(secret, None)
 
+    def _bind_model(self, dialect: Dialect):
+        async def handler(request: web.Request) -> web.StreamResponse:
+            return await self.handle_model(request, dialect)
+
+        return handler
+
+    def _bind_aux(self, dialect: Dialect, route: str):
+        async def handler(request: web.Request) -> web.Response:
+            return await self.handle_aux(request, dialect, route)
+
+        return handler
+
     async def __aenter__(self) -> "InterceptionServer":
         app = web.Application(client_max_size=_MAX_REQUEST_BODY)
-        app.router.add_post("/v1/chat/completions", self.handle_chat)
+        for dialect in DIALECTS:
+            app.router.add_post(dialect.route, self._bind_model(dialect))
+            for aux in dialect.aux_routes:
+                app.router.add_post(aux, self._bind_aux(dialect, aux))
         self.runner = web.AppRunner(app)
         await self.runner.setup()
         site = web.TCPSite(self.runner, "127.0.0.1", 0)
@@ -254,20 +177,53 @@ class InterceptionServer:
         if self.runner is not None:
             await self.runner.cleanup()
 
-    async def handle_chat(self, request: web.Request) -> web.Response:
-        auth = request.headers.get("Authorization", "")
-        session = self.sessions.get(auth.removeprefix("Bearer "))
+    def session_for(
+        self, request: web.Request, dialect: Dialect
+    ) -> RolloutSession | None:
+        return self.sessions.get(dialect.secret(request.headers))
+
+    async def handle_aux(
+        self, request: web.Request, dialect: Dialect, route: str
+    ) -> web.Response:
+        """A side endpoint that is not a model turn (e.g. Anthropic count_tokens):
+        relayed verbatim when the client speaks the dialect, answered locally otherwise.
+        Never recorded on the trace."""
+        session = self.session_for(request, dialect)
+        if session is None:
+            return web.json_response(dialect.error_body("unauthorized"), status=401)
+        raw = await request.read()
+        if session.ctx.client.dialect == dialect.name:
+            try:
+                reply = await session.ctx.client.relay(raw, route)
+            except Exception as e:
+                return web.json_response(dialect.error_body(str(e)), status=502)
+            data = b"".join([chunk async for chunk in reply.chunks])
+            return web.Response(body=data, content_type=reply.content_type)
+        return web.json_response(dialect.handle_aux(route, json.loads(raw)))
+
+    async def handle_model(
+        self, request: web.Request, dialect: Dialect
+    ) -> web.StreamResponse:
+        session = self.session_for(request, dialect)
         if session is None:
             logger.warning("interception: unauthorized request")
-            return web.json_response({"error": "unauthorized"}, status=401)
-        body = await request.json()
-        prompt: Messages = [parse_message(m) for m in body.get("messages", [])]
-        tools = parse_tools(body.get("tools"))
+            return web.json_response(dialect.error_body("unauthorized"), status=401)
+        raw = await request.read()
+        body = json.loads(raw)
+        # Relay when the client's endpoint natively speaks this dialect; translate
+        # through the typed middle otherwise (training, cross-protocol).
+        relaying = session.ctx.client.dialect == dialect.name
+        prompt, tools = dialect.parse_request(body)
+        if dialect.streaming(body):
+            return await self.stream_turn(
+                request, session, dialect, raw, prompt, tools, relaying
+            )
+
         # A user simulator turns one program request into a multi-turn exchange: after each
         # model turn the simulator's reply is injected as a user turn and the model is
         # re-prompted, so a whole game plays out here and only the final assistant message
         # returns to the (simulator-unaware) program. Without a simulator the loop runs once.
-        last: Response | None = None
+        last: bytes | None = None  # the last turn's payload, in the dialect's wire form
         while True:
             refused = await session.refused()
             if refused is not None:
@@ -275,13 +231,21 @@ class InterceptionServer:
                 # conversation is under way, just end it and return the last turn cleanly.
                 if last is None:
                     return web.json_response(
-                        {"error": f"rollout stopped: {refused}"}, status=400
+                        dialect.error_body(f"rollout stopped: {refused}"), status=400
                     )
-                return web.json_response(serialize_completion(last, session.ctx.model))
+                return web.Response(body=last, content_type="application/json")
             try:
-                response = await session.ctx.client.get_response(
-                    prompt, session.ctx.model, session.ctx.sampling, tools
-                )
+                if relaying:
+                    reply = await session.ctx.client.relay(raw, dialect.route)
+                    data = b"".join([chunk async for chunk in reply.chunks])
+                    completion = json.loads(data)
+                    response = dialect.parse_response(completion)
+                else:
+                    response = await session.ctx.client.get_response(
+                        prompt, session.ctx.model, session.ctx.sampling, tools
+                    )
+                    completion = dialect.serialize_response(response, session.ctx.model)
+                    data = json.dumps(completion).encode()
             except OverlongPromptError:
                 # An overlong prompt is a budget limit, not a crash: end the rollout cleanly
                 # as a truncation — return the last turn if there is one, else refuse to halt
@@ -290,25 +254,80 @@ class InterceptionServer:
                 logger.debug("prompt too long: id=%s", session.trace.id)
                 if last is None:
                     return web.json_response(
-                        {"error": "rollout stopped: context_length"}, status=400
+                        dialect.error_body("rollout stopped: context_length"),
+                        status=400,
                     )
-                return web.json_response(serialize_completion(last, session.ctx.model))
+                return web.Response(body=last, content_type="application/json")
             except Exception as e:  # surface to the program as an API error
                 logger.warning("model call failed: id=%s %s", session.trace.id, e)
-                return web.json_response({"error": str(e)}, status=502)
+                return web.json_response(dialect.error_body(str(e)), status=502)
             graph.add_turn(session.trace, prompt, response)  # one node per new message;
             # branches fall out of walking the graph (see Trace.branches / verifiers.v1.graph)
-            last = response
+            last = data
             # Hand back to the program when the model wants a tool (the program runs it) or
             # when there's no user simulator to keep the conversation going.
             if response.message.tool_calls or session.user is None:
-                return web.json_response(
-                    serialize_completion(response, session.ctx.model)
-                )
+                return web.Response(body=data, content_type="application/json")
             user_messages, done = await session.user(response.message.content or "")
             if done:
                 session.trace.stop("user_completed")
-                return web.json_response(
-                    serialize_completion(response, session.ctx.model)
-                )
+                return web.Response(body=data, content_type="application/json")
             prompt = [*prompt, response.message, *user_messages]
+            if relaying:  # the continuation request is framework-authored
+                body = dialect.extend_request(body, completion, user_messages)
+                raw = json.dumps(body).encode()
+
+    async def stream_turn(
+        self,
+        request: web.Request,
+        session: RolloutSession,
+        dialect: Dialect,
+        raw: bytes,
+        prompt: Messages,
+        tools,
+        relaying: bool,
+    ) -> web.StreamResponse:
+        """One streamed (SSE) model turn. The relay arm pipes the upstream bytes through
+        as they arrive and tee-parses the accumulated stream for the trace; the translate
+        arm runs the typed client and fake-streams the completed response. Streamed turns
+        return directly to the program — a user simulator never drives them (no harness
+        contract combines the two)."""
+        refused = await session.refused()
+        if refused is not None:
+            return web.json_response(
+                dialect.error_body(f"rollout stopped: {refused}"), status=400
+            )
+        try:
+            # Both arms raise before any response byte is committed, so errors can
+            # still go back as a clean (retryable-by-the-program) JSON error.
+            if relaying:
+                reply = await session.ctx.client.relay(raw, dialect.route)
+            else:
+                typed = await session.ctx.client.get_response(
+                    prompt, session.ctx.model, session.ctx.sampling, tools
+                )
+        except OverlongPromptError:
+            session.trace.stop("context_length")
+            logger.debug("prompt too long: id=%s", session.trace.id)
+            return web.json_response(
+                dialect.error_body("rollout stopped: context_length"), status=400
+            )
+        except Exception as e:
+            logger.warning("model call failed: id=%s %s", session.trace.id, e)
+            return web.json_response(dialect.error_body(str(e)), status=502)
+        if relaying:
+            stream = web.StreamResponse()
+            stream.content_type = reply.content_type
+            await stream.prepare(request)
+            buffer = bytearray()
+            async for chunk in reply.chunks:
+                buffer.extend(chunk)
+                await stream.write(chunk)
+            await stream.write_eof()
+            graph.add_turn(session.trace, prompt, dialect.parse_stream(bytes(buffer)))
+            return stream
+        graph.add_turn(session.trace, prompt, typed)
+        return web.Response(
+            body=dialect.serialize_stream(typed, session.ctx.model),
+            content_type="text/event-stream",
+        )

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -101,14 +101,16 @@ class Rollout:
         session: RolloutSession,
     ):
         """Yield `(endpoint, secret)` for the harness — a slot on the shared `pool` if one
-        is given, else a per-rollout server exposed via this rollout's own runtime."""
+        is given, else a per-rollout server exposed via this rollout's own runtime. The
+        endpoint is the server's *root*: each harness appends what its program's SDK
+        expects (`/v1` for an OpenAI base URL; nothing for an Anthropic one)."""
         if pool is not None:
             async with pool.acquire(session) as (endpoint, secret):
                 yield endpoint, secret
         else:
             async with InterceptionServer() as server:
                 secret = server.register(session)
-                endpoint = f"{await runtime.expose(server.port)}/v1"
+                endpoint = await runtime.expose(server.port)
                 yield endpoint, secret
 
     async def run(

--- a/verifiers/v1/user.py
+++ b/verifiers/v1/user.py
@@ -62,7 +62,7 @@ async def connect_user(url: str) -> AsyncIterator[Respond]:
     from mcp import ClientSession
     from mcp.client.streamable_http import streamable_http_client
 
-    from verifiers.v1.interception import parse_message
+    from verifiers.v1.dialects import parse_message
 
     last_exc: Exception | None = None
     for attempt in range(_USER_CONNECT_ATTEMPTS):


### PR DESCRIPTION
## Summary

Stacked on #1651 (native provider clients); merges into `feat/nano-as-v1` once that lands.

This PR combines the two halves discussed in #1654: **route-detected wire dialects on ingress** (from that PR's design) and **the native provider clients on egress** (#1651), reconciled by one request-time rule:

- **Relay** — when the rollout's client natively speaks the request's dialect (`Client.dialect == Dialect.name`), the program's request **bytes** are forwarded verbatim and the provider's response (JSON or SSE) is relayed back untouched. The dialect parses a *copy* only to record the trace. No field is lost to a typed round-trip — not reasoning, not `cache_control`, not any future provider field.
- **Translate** — otherwise (training via the renderer or chat→vLLM, or any cross-protocol pairing such as a claude-code harness against a chat endpoint), the request is parsed into typed messages, the client runs it in its own wire format, and the typed `Response` is serialized back in the dialect the program spoke.

The selection is a string compare per request: no model→client tables, no `Harness.DIALECT`, no body sniffing. The harness only chooses env vars, as before.

## What's new

- **`verifiers/v1/dialects/`** — one module per native format (`chat`, `anthropic`, `responses`), each owning its route, auth carrier (`Bearer` / `x-api-key`), wire→vf parsers (`parse_request` / `parse_response` / `parse_stream`), and vf→wire serializers (`serialize_response` / `serialize_stream`, translate path only). Response parsing reuses the clients' `response_from_wire`, so `provider_state` (thinking blocks, Responses output items, `reasoning_details`) and vLLM token ids land on the trace on both arms.
- **`InterceptionServer`** mounts every dialect's routes; the SDK's URL picks the codec. Streaming relays pass SSE bytes through chunk-by-chunk and tee-parse the assembled final message for the trace; streaming translate fake-streams a minimal valid SSE. Anthropic's `count_tokens` is relayed on the relay arm and estimated (~4 chars/token) on translate. Errors come back in each dialect's native error shape.
- **Clients** keep the typed `get_response` (judges and in-env calls unaffected) and gain `dialect` + `relay(body, route)`; `RetryingClient` retries relays the same way (relay raises before any byte is returned). Renderer and Google stay translate-only (`dialect = None`) — which is exactly how training keeps typed token data.
- **Harnesses** now receive the server's **root** endpoint and append what their SDK expects (`{endpoint}/v1` for OpenAI SDKs; bare root for `ANTHROPIC_BASE_URL`). The default harness carries the eval's sampling into the program (`OPENAI_SAMPLING` env → `extra_body`) since the relay no longer injects it.

A claude-code harness now needs only `ANTHROPIC_BASE_URL={endpoint}` + `ANTHROPIC_API_KEY={secret}`: ingress (incl. streaming + count_tokens) is already served, relay applies against any anthropic-speaking endpoint (api.anthropic.com, vLLM's native `/v1/messages`), and translate covers everything else.

## Verification

Unit (`tests/v1/test_dialects.py`, 17 tests + full v1 suite, 63 passed): codec round-trips validated against the provider SDK models (`anthropic.types.Message`, `openai.types.responses.Response`), stream assembly/fake-stream round-trips, byte-verbatim relay assertions (unknown request fields survive), per-dialect auth + error shapes, aux-route relay/estimate, refusals in dialect error shape.

Live, through the real eval machinery (default harness × subprocess):

| scenario | arm | result |
|---|---|---|
| chat program → OpenAI chat endpoint | relay | reward 1.0 |
| chat program → OpenAI **Responses** client | translate (cross-protocol) | reward 1.0 |
| chat program → **Google** client | translate (cross-protocol) | reward 1.0 |
| multi-turn user-sim (`extend_request` over relay) | relay | reward 1.0, 2 turns |
| agentic bash tool calls | relay | reward 1.0 |

Live testing caught two real relay bugs, both fixed: newer openai/anthropic SDKs exclude auth from `default_headers` (now merged from `auth_headers` explicitly), and duplicate `Content-Type` headers made OpenAI reject relayed bodies (header keys now lowercased/deduped).

Not live-tested: anthropic/responses **ingress** (no claude-code/codex harness exists yet — covered by unit tests against the SDK models) and the renderer translate path (needs a vLLM engine).

## Design choices reviewers may want to veto

- **Bytes mean bytes**: the relay arm does not inject `model` or sampling. The model id already reaches the program via harness env; the default harness now carries sampling itself. On rlm's relay path, eval `--sampling.*` does not apply until rlm reads an equivalent env (translate/training keeps `ctx.sampling` pinned).
- **User-sim over relay is chat-only** (`Dialect.extend_request`); on other dialects a simulator works via the translate arm. Streamed turns never drive a simulator.
- **Anthropic translate emits reasoning as an unsigned `thinking` block** so the program displays it and echoes it back, where `parse_request` recovers it — the reasoning-passback some models hard-require, carried across protocols through the program itself.
- **Responses statefulness is not emulated** on translate (`previous_response_id` ignored; the trace graph could emulate it later); on relay the endpoint owns it.
- `count_tokens` translate-arm estimate is deliberately crude (compaction-trigger fidelity, not billing).

## Breaking

- `parse_message` / `parse_tools` / `serialize_completion` moved from `interception.server` to `verifiers.v1.dialects` (chat module).
- `Rollout`/`InterceptionPool` hand harnesses the endpoint **root** (no `/v1` suffix); out-of-tree harnesses must append their SDK's path (in-tree default/rlm/compact updated).
- `Client` gains `dialect`/`relay`; custom clients are unaffected unless they want relay.

## Follow-up (out of scope)

- claude-code / codex harnesses (env vars only).
- Egress auto-detection sugar (`-m anthropic:claude-…` scheme + host claims) so direct-API runs don't need `--client.type`.
- Optional: vf→wire request serializers for non-chat user-sim relay, `previous_response_id` emulation from the trace graph.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Core rollout path changes (interception routing, verbatim upstream relay, endpoint root contract) affect every harness model call; mistakes could break auth, streaming, or cross-protocol evals.
> 
> **Overview**
> Adds **polyglot interception**: the server mounts **chat**, **anthropic**, and **responses** routes and picks **relay** (verbatim request/response bytes when `Client.dialect` matches) vs **translate** (parse → typed client → serialize back) per request.
> 
> **New `verifiers/v1/dialects/`** holds per-format codecs (parse/serialize, streaming SSE, dialect-shaped errors, Anthropic `count_tokens` aux). Chat wire helpers move here from `interception.server`.
> 
> **Clients** gain `dialect` + `relay()` via shared `relay_post`/`relay_headers`; **RetryingClient** retries relays. **Shared `classify_model_error`** replaces duplicated context-length checks in OpenAI client code.
> 
> **Harness/rollout** expose the interception **root** (no `/v1` suffix); in-tree harnesses set `OPENAI_BASE_URL` to `{endpoint}/v1`. **Default harness** passes eval sampling as `OPENAI_SAMPLING` merged into program `extra_body` (relay no longer injects sampling).
> 
> **Tests**: new `test_dialects.py` for codecs and relay/translate server behavior; `test_clients` imports from `dialects`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 302dceeff8236aa1845d1faa7d2fabf068398639. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add dialect-routed interception server supporting Anthropic, OpenAI Chat, and OpenAI Responses
> - Refactors the interception server into a multi-dialect polyglot proxy that registers routes for Anthropic (`/v1/messages`), OpenAI Chat (`/v1/chat/completions`), and OpenAI Responses (`/v1/responses`) concurrently.
> - Introduces a `Dialect` abstraction in [verifiers/v1/dialects/](https://github.com/PrimeIntellect-ai/verifiers/pull/1657/files#diff-f0b8fa01122334bd7ec859fc1b9354f8ca74ff4fad8da0073693b45e2dfc666f) with per-dialect parse/serialize, SSE handling, auth extraction, error shaping, and aux route support.
> - Routes requests through two arms: **relay** (raw byte pass-through when the client's dialect matches the ingress dialect) and **translate** (typed conversion through the existing middle layer otherwise).
> - Adds `relay()` to `Client` and all three client implementations, backed by a shared `relay_post` helper with retry logic, streaming, and error classification via `classify_model_error`.
> - Harnesses now receive root endpoints and must append their SDK-specific path (e.g. `/v1`); all harness `OPENAI_BASE_URL` values updated accordingly.
> - Risk: Behavioral change — existing callers of `InterceptionPool._entry` and `Rollout._serve_interception` now receive root endpoints (no `/v1` suffix); harnesses must be updated or requests will 404.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 302dcee. 20 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->