### PR TITLE
feat: codex harness + Responses dialect with fake-streaming interception

### DIFF
--- a/packages/harnesses/harnesses/__init__.py
+++ b/packages/harnesses/harnesses/__init__.py
@@ -2,10 +2,13 @@
 
 Re-exports each harness's class + config off the package."""
 
+from harnesses.codex import CodexHarness, CodexHarnessConfig
 from harnesses.default import DefaultHarness, DefaultHarnessConfig
 from harnesses.rlm import RLMHarness, RLMHarnessConfig
 
 __all__ = [
+    "CodexHarness",
+    "CodexHarnessConfig",
     "DefaultHarness",
     "DefaultHarnessConfig",
     "RLMHarness",

--- a/packages/harnesses/harnesses/codex/__init__.py
+++ b/packages/harnesses/harnesses/codex/__init__.py
@@ -1,0 +1,114 @@
+"""The codex harness: installs the Codex CLI into the runtime and runs `codex exec`.
+
+Codex only speaks the streaming OpenAI Responses API, so it reaches the interception server as a
+custom model provider (`wire_api = responses`) pointed at the rollout endpoint — the server
+fetches the completion unary and fake-streams it back (see `verifiers.v1.dialects.responses`).
+The binary is the static musl release, so it drops into any linux container with no runtime
+deps; its bearer token (the session secret) is read from an env var.
+"""
+
+import logging
+
+from verifiers.v1.clients import RolloutContext
+from verifiers.v1.errors import ProgramError
+from verifiers.v1.harness import Harness, HarnessConfig
+from verifiers.v1.runtimes import ProgramResult, Runtime
+from verifiers.v1.trace import Trace
+
+logger = logging.getLogger(__name__)
+
+# The provider id we register on the fly via `-c` overrides — arbitrary, internal to codex.
+PROVIDER = "intercept"
+# The env var codex reads the provider api key (its bearer = the session secret) from.
+KEY_VAR = "CODEX_INTERCEPT_KEY"
+
+# Install the static-musl codex release onto PATH, idempotently. musl => no libc dep, so it runs
+# in any linux container; the arch is read from `uname -m`. curl + tar are installed if missing.
+# `{version}` is filled from the harness config.
+_INSTALL = r"""
+command -v codex >/dev/null 2>&1 && exit 0
+set -e
+case "$(uname -m)" in
+  x86_64|amd64) triple=x86_64-unknown-linux-musl ;;
+  aarch64|arm64) triple=aarch64-unknown-linux-musl ;;
+  *) echo "codex: unsupported arch $(uname -m)" >&2; exit 1 ;;
+esac
+need=""
+for tool in curl tar; do command -v $tool >/dev/null 2>&1 || need="$need $tool"; done
+if [ -n "$need" ]; then
+  { apt-get update -qq && apt-get install -y -qq $need; } >/dev/null 2>&1 \
+    || apk add --no-cache $need >/dev/null 2>&1 || true
+fi
+url="https://github.com/openai/codex/releases/download/rust-v{version}/codex-${triple}.tar.gz"
+mkdir -p /tmp/codex-dl
+curl -fsSL "$url" -o /tmp/codex-dl/codex.tgz
+tar -xzf /tmp/codex-dl/codex.tgz -C /tmp/codex-dl
+mv "$(find /tmp/codex-dl -type f -name 'codex*' ! -name '*.tgz' | head -1)" /usr/local/bin/codex
+chmod +x /usr/local/bin/codex
+"""
+
+
+class CodexHarnessConfig(HarnessConfig):
+    """The Codex CLI harness — which codex release to install in the runtime."""
+
+    id: str = "codex"
+    version: str = "0.137.0"
+    """Codex release to install (the `rust-v<version>` GitHub release); pinned for reproducibility."""
+
+
+class CodexHarness(Harness[CodexHarnessConfig]):
+    APPENDS_SYSTEM_PROMPT = False  # fold any system prompt into the instruction
+    SUPPORTS_TASK_TOOLS = (
+        False  # codex runs its own shell tools, not the taskset's MCP servers
+    )
+
+    async def launch(
+        self,
+        ctx: RolloutContext,
+        trace: Trace,
+        runtime: Runtime,
+        endpoint: str,
+        secret: str,
+        mcp_urls: dict[str, str],
+    ) -> ProgramResult:
+        _, instruction = self.resolve_prompt(trace.task)
+        # codex authenticates to the interception server with the session secret (its provider
+        # api key) and posts Responses calls to `{endpoint}/responses`.
+        env = {KEY_VAR: secret}
+        logger.info("codex: ensuring codex %s is installed", self.config.version)
+        install = await runtime.run(
+            ["sh", "-c", _INSTALL.replace("{version}", self.config.version)], {}
+        )
+        if install.exit_code != 0:
+            raise ProgramError(f"codex install failed: {install.stderr.strip()[-500:]}")
+        # `-c` values parse as TOML, falling back to a raw string (so the url / `responses`
+        # come through literally); `requires_openai_auth=false` parses as a bool.
+        argv = [
+            "codex",
+            "exec",
+            "--dangerously-bypass-approvals-and-sandbox",  # headless: no prompts, no sandbox
+            "--skip-git-repo-check",
+            "-m",
+            ctx.model,
+            "-c",
+            f"model_provider={PROVIDER}",
+            "-c",
+            f"model_providers.{PROVIDER}.name={PROVIDER}",
+            "-c",
+            f"model_providers.{PROVIDER}.base_url={endpoint}",
+            "-c",
+            f"model_providers.{PROVIDER}.env_key={KEY_VAR}",
+            "-c",
+            f"model_providers.{PROVIDER}.wire_api=responses",
+            "-c",
+            f"model_providers.{PROVIDER}.requires_openai_auth=false",
+            instruction,
+        ]
+        return await runtime.run(argv, env)
+
+
+def load_harness(config: CodexHarnessConfig) -> CodexHarness:
+    return CodexHarness(config)
+
+
+__all__ = ["CodexHarness", "CodexHarnessConfig", "load_harness"]

--- a/verifiers/v1/dialects/__init__.py
+++ b/verifiers/v1/dialects/__init__.py
@@ -1,9 +1,9 @@
 """Wire dialects: per-native-format translators (wire -> vf) for the interception trace.
 
-`Dialect` is the abstraction; `chat_completions` is the OpenAI chat-completions dialect (OpenAI
-Responses / Anthropic Messages become new modules). The interception server serves each
-registered dialect's `routes`, so the wire format is resolved from the endpoint the program's
-SDK posts to — no per-harness declaration.
+`Dialect` is the abstraction; `chat_completions` is the OpenAI chat-completions dialect and
+`responses` the OpenAI Responses dialect (Anthropic Messages becomes another module). The
+interception server serves each registered dialect's `routes`, so the wire format is resolved
+from the endpoint the program's SDK posts to — no per-harness declaration.
 """
 
 from verifiers.v1.dialects.base import Dialect
@@ -14,16 +14,19 @@ from verifiers.v1.dialects.chat_completions import (
     parse_tools,
     response_from_wire,
 )
+from verifiers.v1.dialects.responses import ResponsesDialect
 
-DIALECTS: tuple[Dialect, ...] = (ChatCompletionsDialect(),)
+DIALECTS: tuple[Dialect, ...] = (ChatCompletionsDialect(), ResponsesDialect())
 """The registered dialects. The interception server serves each one's `routes` and resolves the
-wire format from the route the request arrived on. OpenAI chat completions only, for now."""
+wire format from the route the request arrived on (`/v1/chat/completions` -> chat completions,
+`/v1/responses` -> responses)."""
 
 __all__ = [
     "Dialect",
     "DIALECTS",
     "FINISH_REASONS",
     "ChatCompletionsDialect",
+    "ResponsesDialect",
     "parse_message",
     "parse_tools",
     "response_from_wire",

--- a/verifiers/v1/dialects/base.py
+++ b/verifiers/v1/dialects/base.py
@@ -13,6 +13,7 @@ chat-completions dialect; OpenAI Responses / Anthropic Messages become new modul
 """
 
 from abc import ABC, abstractmethod
+from collections.abc import Iterable
 from typing import ClassVar, Generic, TypeVar
 
 from pydantic import BaseModel
@@ -38,6 +39,13 @@ class Dialect(ABC, Generic[ReqT, RespT]):
 
     upstream_path: ClassVar[str]
     """The provider endpoint the proxy forwards to for this format (e.g. `/chat/completions`)."""
+
+    streams: ClassVar[bool] = False
+    """Whether this format's clients require `stream: true` and so must be fake-streamed: the
+    proxy still fetches the whole completion unary (the dialect forces streaming off upstream in
+    `apply_overrides`), and the interception server replays it as the SSE events `stream_events`
+    yields. Off by default (chat completions returns a JSON body); the Responses dialect sets it
+    (codex only speaks streaming Responses)."""
 
     response_type: type[RespT]
     """The native response model — used to validate the provider's raw JSON before parsing."""
@@ -72,3 +80,11 @@ class Dialect(ABC, Generic[ReqT, RespT]):
         """For user-sim multi-turn: return `body` with the model's turn (`completion`, native
         wire) and the simulator's `user_messages` appended to the conversation, in this
         protocol's shape — so a multi-turn exchange plays out within one program request."""
+
+    def stream_events(self, completion: dict) -> Iterable[dict]:
+        """Fake-streaming (only for dialects with `streams = True`): given the full buffered wire
+        response `completion`, yield the ordered SSE event objects (each a dict with a `type`)
+        that replay it for a client that asked for `stream: true`. The interception server
+        serializes each as one `event:`/`data:` SSE frame. We hold the whole response already, so
+        this is a straight replay — no partial deltas to reassemble."""
+        raise NotImplementedError(f"{type(self).__name__} does not support streaming")

--- a/verifiers/v1/dialects/responses.py
+++ b/verifiers/v1/dialects/responses.py
@@ -1,0 +1,304 @@
+"""The OpenAI Responses dialect.
+
+Translates the OpenAI Responses API wire format into vf types: requests (`parse_request`,
+the `input` item list -> vf prompt) and responses (`parse_response`, the `output` item list ->
+a vf `Response`). Responses clients (codex) only speak streaming, so this dialect sets
+`streams = True`: the proxy forces `stream` off upstream (`apply_overrides`) to fetch the whole
+response unary, and the interception server replays it as SSE via `stream_events`.
+
+Parsing mirrors the v0 responses client: `output` carries `message` (assistant `output_text`),
+`reasoning` (summary/content), and `function_call` items; `input` carries `message`,
+`function_call`, and `function_call_output` items.
+"""
+
+from collections.abc import Iterable
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+from verifiers.v1.dialects.base import Dialect
+from verifiers.v1.types import (
+    AssistantMessage,
+    FinishReason,
+    Message,
+    Messages,
+    Response,
+    SamplingConfig,
+    SystemMessage,
+    Tool,
+    ToolCall,
+    ToolMessage,
+    Usage,
+    UserMessage,
+)
+
+# Sampling knobs the eval owns: dropped from the program's request before the eval's are applied
+# (see `apply_overrides`). Responses names completion budget `max_output_tokens`; the chat
+# aliases are included so a `max_tokens` from the eval's SamplingConfig maps cleanly.
+_SAMPLING_KEYS = frozenset(
+    {"temperature", "top_p", "max_tokens", "max_completion_tokens", "max_output_tokens"}
+)
+
+
+class ResponsesResponse(BaseModel):
+    """A permissive view of a Responses API response — only the fields the trace needs, typed
+    loosely (output/usage as dicts) with `extra='allow'` so any provider's extra fields survive.
+    The program gets the verbatim raw back (`Response.raw`), so this is just for parsing."""
+
+    model_config = ConfigDict(extra="allow")
+    id: str = ""
+    created_at: float = 0.0
+    model: str = ""
+    status: str | None = None
+    output: list[dict[str, Any]] = []
+    usage: dict[str, Any] | None = None
+    incomplete_details: dict[str, Any] | None = None
+
+
+def _content_text(content: Any) -> str:
+    """Flatten Responses message content (a list of `input_text`/`output_text` parts, or a
+    plain string) to text."""
+    if isinstance(content, list):
+        return "".join(
+            p.get("text", "") for p in content if isinstance(p, dict) and "text" in p
+        )
+    return content or ""
+
+
+def parse_tools(raw: list[dict] | None) -> list[Tool] | None:
+    """Responses tools are flat (`{type, name, description, parameters}`), unlike chat's nested
+    `function` block."""
+    if not raw:
+        return None
+    return [
+        Tool(
+            name=t["name"],
+            description=t.get("description", ""),
+            parameters=t.get("parameters", {}),
+            strict=t.get("strict"),
+        )
+        for t in raw
+        if t.get("type", "function") == "function" and "name" in t
+    ]
+
+
+def parse_input_item(item: dict) -> Message | None:
+    """One Responses `input` item -> a typed Message (None for items with no prompt role, e.g.
+    reasoning)."""
+    item_type = item.get("type", "message")
+    if item_type == "function_call":
+        return AssistantMessage(
+            tool_calls=[
+                ToolCall(
+                    id=item.get("call_id", ""),
+                    name=item.get("name", ""),
+                    arguments=item.get("arguments", ""),
+                )
+            ]
+        )
+    if item_type == "function_call_output":
+        return ToolMessage(
+            tool_call_id=item.get("call_id", ""),
+            content=_content_text(item.get("output")),
+        )
+    if item_type != "message":
+        return None  # reasoning / other items don't map to a prompt message
+    role = item.get("role")
+    text = _content_text(item.get("content"))
+    if role == "system":
+        return SystemMessage(content=text)
+    if role == "assistant":
+        return AssistantMessage(content=text or None)
+    return UserMessage(content=text)
+
+
+class ResponsesDialect(Dialect[dict, ResponsesResponse]):
+    """The OpenAI Responses wire format (codex)."""
+
+    routes = ("/v1/responses",)
+    upstream_path = "/responses"
+    streams = True
+    response_type = ResponsesResponse
+
+    def parse_request(self, body: dict) -> tuple[Messages, list[Tool] | None]:
+        messages: list[Message] = []
+        instructions = body.get("instructions")
+        if isinstance(instructions, str) and instructions:
+            messages.append(SystemMessage(content=instructions))
+        for item in body.get("input", []):
+            if isinstance(item, dict) and (message := parse_input_item(item)):
+                messages.append(message)
+        return messages, parse_tools(body.get("tools"))
+
+    def parse_response(self, response: ResponsesResponse) -> Response:
+        content_chunks: list[str] = []
+        reasoning_chunks: list[str] = []
+        tool_calls: list[ToolCall] = []
+        for item in response.output:
+            item_type = item.get("type")
+            if item_type == "message":
+                for part in item.get("content", []) or []:
+                    if part.get("type") == "output_text" and part.get("text"):
+                        content_chunks.append(part["text"])
+                    elif part.get("type") == "refusal" and part.get("refusal"):
+                        content_chunks.append(part["refusal"])
+            elif item_type == "reasoning":
+                for block in (item.get("summary") or []) + (item.get("content") or []):
+                    if isinstance(block, dict) and isinstance(block.get("text"), str):
+                        reasoning_chunks.append(block["text"])
+            elif item_type == "function_call":
+                tool_calls.append(
+                    ToolCall(
+                        id=item.get("call_id", ""),
+                        name=item.get("name", ""),
+                        arguments=item.get("arguments", ""),
+                    )
+                )
+        usage = None
+        if response.usage:
+            usage = Usage(
+                prompt_tokens=response.usage.get("input_tokens", 0),
+                completion_tokens=response.usage.get("output_tokens", 0),
+            )
+        finish: FinishReason = (
+            "tool_calls"
+            if tool_calls
+            else "length"
+            if response.status == "incomplete" or response.incomplete_details
+            else "stop"
+            if response.status == "completed"
+            else None
+        )
+        return Response(
+            id=response.id,
+            created=int(response.created_at),
+            model=response.model,
+            message=AssistantMessage(
+                content="".join(content_chunks) or None,
+                reasoning_content="\n".join(reasoning_chunks) or None,
+                tool_calls=tool_calls or None,
+            ),
+            finish_reason=finish,
+            usage=usage,
+        )
+
+    def apply_overrides(self, body: dict, model: str, sampling: SamplingConfig) -> dict:
+        # Forward verbatim except what the eval owns (model overlay, sampling authoritative) and
+        # `stream`, which is forced off so the provider returns a unary body to fake-stream.
+        overrides: dict = {}
+        s = sampling.model_dump(exclude_none=True)
+        if "temperature" in s:
+            overrides["temperature"] = s["temperature"]
+        if "top_p" in s:
+            overrides["top_p"] = s["top_p"]
+        if s.get("max_tokens") is not None:
+            overrides["max_output_tokens"] = s["max_tokens"]
+        steered = {
+            k: v for k, v in body.items() if k not in _SAMPLING_KEYS and k != "stream"
+        }
+        return {**steered, "model": model, "stream": False, **overrides}
+
+    def serialize_response(self, response: Response, model: str) -> dict:
+        """A vf `Response` -> a Responses API response dict (for the renderer / fake-stream when
+        there's no raw to relay — the proxy path relays `Response.raw` instead)."""
+        output: list[dict] = []
+        if response.message.reasoning_content:
+            output.append(
+                {
+                    "id": f"rs_{response.id}",
+                    "type": "reasoning",
+                    "summary": [
+                        {
+                            "type": "summary_text",
+                            "text": response.message.reasoning_content,
+                        }
+                    ],
+                }
+            )
+        if response.message.content:
+            output.append(
+                {
+                    "id": f"msg_{response.id}",
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": response.message.content,
+                            "annotations": [],
+                        }
+                    ],
+                }
+            )
+        for call in response.message.tool_calls or []:
+            output.append(
+                {
+                    "id": call.id,
+                    "type": "function_call",
+                    "call_id": call.id,
+                    "name": call.name,
+                    "arguments": call.arguments,
+                    "status": "completed",
+                }
+            )
+        usage = (
+            {
+                "input_tokens": response.usage.prompt_tokens,
+                "output_tokens": response.usage.completion_tokens,
+                "total_tokens": response.usage.total_tokens,
+            }
+            if response.usage
+            else None
+        )
+        return {
+            "id": response.id or "vf-intercept",
+            "object": "response",
+            "created_at": float(response.created),
+            "status": "completed",
+            "model": response.model or model,
+            "output": output,
+            "usage": usage,
+        }
+
+    def extend(self, body: dict, completion: dict, user_messages: Messages) -> dict:
+        # Append the model's turn (its verbatim output items, so reasoning survives) and the
+        # simulator's user turn(s) to the Responses `input` list.
+        items = [*body.get("input", []), *completion.get("output", [])]
+        for message in user_messages:
+            items.append(
+                {
+                    "type": "message",
+                    "role": message.role,
+                    "content": [
+                        {"type": "input_text", "text": _content_text(message.content)}
+                    ],
+                }
+            )
+        return {**body, "input": items}
+
+    def stream_events(self, completion: dict) -> Iterable[dict]:
+        # Replay the buffered Responses object as the SSE sequence codex consumes: `created`,
+        # then each output item `added` + `done` (codex reads items from `output_item.done`),
+        # then `completed` carrying the whole response (codex reads usage + id from it). The
+        # stream MUST end with `response.completed` or codex errors ("stream closed before
+        # response.completed").
+        skeleton = {
+            "id": completion.get("id", ""),
+            "object": "response",
+            "status": "in_progress",
+            "output": [],
+        }
+        yield {"type": "response.created", "response": skeleton}
+        for index, item in enumerate(completion.get("output", [])):
+            yield {
+                "type": "response.output_item.added",
+                "output_index": index,
+                "item": item,
+            }
+            yield {
+                "type": "response.output_item.done",
+                "output_index": index,
+                "item": item,
+            }
+        yield {"type": "response.completed", "response": completion}

--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -1,10 +1,15 @@
-"""The interception server: harness chat-completions, caught and proxied.
+"""The interception server: harness model calls, caught and proxied.
 
 Every rollout runs an harness program whose OpenAI-style calls are caught here: a small
-localhost server routes each `POST /v1/chat/completions` to our `Client`, records the turn
-into the trace's message graph, and returns the result in OpenAI shape. We inject
-`OPENAI_BASE_URL`/`OPENAI_API_KEY` so the program's SDK talks to us. Chat completions only,
-no streaming.
+localhost server serves each registered dialect's routes (`/v1/chat/completions`,
+`/v1/responses`), routes each to our `Client`, records the turn into the trace's message graph,
+and returns the result in that wire format. We inject `OPENAI_BASE_URL`/`OPENAI_API_KEY` so the
+program's SDK talks to us.
+
+The proxy always fetches the completion unary; a dialect whose clients require `stream: true`
+(the Responses dialect, for codex) is fake-streamed back — `_reply` replays the whole buffered
+completion as the dialect's SSE event sequence in one write. We hold the entire response, so
+there's no chunk queue, keepalive, or partial-flush to get wrong.
 
 One server multiplexes many rollouts: each rollout registers a `RolloutSession` under its
 own secret (the bearer token the harness already sends), and the server routes by that
@@ -17,6 +22,7 @@ model, so a multi-turn exchange plays out within one program request, transparen
 harness. Tools are handled out-of-band (run by the harness).
 """
 
+import json
 import logging
 import secrets
 from collections.abc import Awaitable, Callable
@@ -142,7 +148,7 @@ class InterceptionServer:
         """Bind a route's dialect to the request handler — the route the SDK posts to is what
         selects the wire format (see `dialects.DIALECTS`)."""
 
-        async def handler(request: web.Request) -> web.Response:
+        async def handler(request: web.Request) -> web.StreamResponse:
             return await self.handle_request(request, dialect)
 
         return handler
@@ -166,13 +172,16 @@ class InterceptionServer:
 
     async def handle_request(
         self, request: web.Request, dialect: Dialect
-    ) -> web.Response:
+    ) -> web.StreamResponse:
         auth = request.headers.get("Authorization", "")
         session = self.sessions.get(auth.removeprefix("Bearer "))
         if session is None:
             logger.warning("interception: unauthorized request")
             return web.json_response({"error": "unauthorized"}, status=401)
         body = await request.json()
+        # The program's `stream` flag (from the first request) selects how each turn's completion
+        # is returned; it takes effect only if the dialect can fake-stream (`streams`).
+        wants_stream = bool(body.get("stream")) and dialect.streams
         # `body` is forwarded to the model 1:1 (the proxy mutates only model + sampling), so no
         # provider field is lost. `prompt` is the dialect's typed parse, kept only to build the
         # trace (the renderer re-derives its own from the body it's handed). A user simulator
@@ -195,7 +204,7 @@ class InterceptionServer:
                     return web.json_response(
                         {"error": f"rollout stopped: {refused}"}, status=400
                     )
-                return web.json_response(completion)
+                return await self._reply(request, completion, wants_stream, dialect)
             try:
                 response = await session.ctx.client.get_response(
                     body, dialect, session.ctx.model, session.ctx.sampling
@@ -210,7 +219,7 @@ class InterceptionServer:
                     return web.json_response(
                         {"error": "rollout stopped: context_length"}, status=400
                     )
-                return web.json_response(completion)
+                return await self._reply(request, completion, wants_stream, dialect)
             except Exception as e:  # surface to the program as an API error
                 logger.warning("model call failed: id=%s %s", session.trace.id, e)
                 return web.json_response({"error": str(e)}, status=502)
@@ -226,13 +235,39 @@ class InterceptionServer:
             # Hand back to the program when the model wants a tool (the program runs it) or
             # when there's no user simulator to keep the conversation going.
             if response.message.tool_calls or session.user is None:
-                return web.json_response(completion)
+                return await self._reply(request, completion, wants_stream, dialect)
             user_messages, done = await session.user(response.message.content or "")
             if done:
                 session.trace.stop("user_completed")
-                return web.json_response(completion)
+                return await self._reply(request, completion, wants_stream, dialect)
             # Inject the model turn + the simulator's user turn(s): into the wire request for the
             # next model call (`dialect.extend`, which keeps the model turn verbatim so reasoning
             # survives) and into the typed prompt for the trace.
             body = dialect.extend(body, completion, user_messages)
             prompt = [*prompt, response.message, *user_messages]
+
+    async def _reply(
+        self,
+        request: web.Request,
+        completion: dict,
+        wants_stream: bool,
+        dialect: Dialect,
+    ) -> web.StreamResponse:
+        """Return the model's `completion` to the program: a JSON body, or — when the program
+        asked for `stream: true` and the dialect fake-streams — the dialect's SSE event replay.
+        We hold the whole completion, so the SSE frames are built and written in one shot, then
+        closed: no chunk queue, keepalive, or partial-flush races."""
+        if not wants_stream:
+            return web.json_response(completion)
+        response = web.StreamResponse(
+            status=200,
+            headers={"Content-Type": "text/event-stream", "Cache-Control": "no-cache"},
+        )
+        await response.prepare(request)
+        frames = "".join(
+            f"event: {event['type']}\ndata: {json.dumps(event)}\n\n"
+            for event in dialect.stream_events(completion)
+        )
+        await response.write(frames.encode())
+        await response.write_eof()
+        return response


### PR DESCRIPTION
## Summary

Integrates **Codex** as a new built-in v1 harness. Codex only speaks the **streaming OpenAI Responses API**, so this builds on the dialect work in `fix/v1-preserve-reasoning-content` and adds a Responses dialect + streaming support to the interception server.

- **`ResponsesDialect`** (`verifiers/v1/dialects/responses.py`) — the `/v1/responses` wire format. Parses the Responses `input` item list into a vf prompt and the `output` items (`message` / `reasoning` / `function_call`) into a vf `Response` (mirrors the v0 responses client). `apply_overrides` imposes the eval's model + sampling and forces `stream` **off** upstream so the proxy fetches the completion unary. Registered in `dialects.DIALECTS`, so the server serves `/v1/responses` automatically.
- **Fake-streaming in the interception server** — a `Dialect` can set `streams = True` and implement `stream_events(completion)`. When a request arrives with `stream: true`, the server (`_reply`) replays the buffered completion as that dialect's SSE event sequence: `response.created` → `response.output_item.added`/`done` per output item → `response.completed` (carrying the full response + usage; the stream must end with it or codex errors). Because we already hold the entire response, the SSE frames are built and written in **one shot, then `write_eof`** — no chunk queue, keepalive comments, or partial-flush races (the v0 interception server's sources of fragility).
- **`codex` harness** (`packages/harnesses/harnesses/codex/`) — installs the static-musl codex release into the runtime (idempotent; arch-detected; portable across linux containers), points it at the rollout's interception endpoint via a custom Responses model provider (`wire_api = responses`, `requires_openai_auth = false`, bearer token = the session secret read from an env var), and runs `codex exec` headless (`--dangerously-bypass-approvals-and-sandbox --skip-git-repo-check`). Registered in `harnesses/__init__.py` (`--harness.id codex`).

**Scope:** eval-only for now — the renderer (training) client speaks the chat-completions dialect only, so codex runs through the proxy client against a Responses-capable upstream. Chat-completions clients are unaffected (`streams = False`, non-streaming JSON as before).

## Verification

Run against OpenAI `gpt-5-codex` as the upstream (`--client.base_url https://api.openai.com/v1 --client.api_key_var OPENAI_API_KEY`), `--harness.id codex --harness.runtime.type docker`:

- **gsm8k-v1** (single turn): `reward=1.000` — codex's real system prompt + `danger-full-access`/`never` permissions appear in the trace, confirming codex drove it through the responses dialect + fake-streaming.
- **terminal-bench-2 `fix-git`** (`--taskset.tasks '["fix-git"]'`): **38-turn agentic loop**, `reward=1.000`, `stop=agent_completed`, trace `errors: []`.

Also covered by an in-process test of `ResponsesDialect` (parse_request / parse_response / apply_overrides / stream_events) driven through the live interception server with a stub client (streaming SSE ends with `response.completed` and carries the text; non-streaming returns JSON; the trace records the assistant message). `ruff check`/`format` clean; `tests/v1/test_configs.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Codex harness and OpenAI Responses dialect with fake-streaming SSE support
> - Adds [`CodexHarness`](https://github.com/PrimeIntellect-ai/verifiers/pull/1658/files#diff-ab47aa1c7a12e17d162ca04abcc3029df19add3aeb970d2197763898058987ff) that installs a pinned `codex` CLI binary at runtime and runs it wired to the interception server using a provider named `intercept`.
> - Adds [`ResponsesDialect`](https://github.com/PrimeIntellect-ai/verifiers/pull/1658/files#diff-73f89a1b25536fd7a806555e765120f5189cb934eff813f4c7900838efa56b5a) implementing the `/v1/responses` wire format, including request/response parsing, tool calls, reasoning fields, and serialization back to the Responses shape.
> - Extends [`InterceptionServer`](https://github.com/PrimeIntellect-ai/verifiers/pull/1658/files#diff-84e2f8d027d609e8760ef6d533535ec9d99dfc6384d5ddb6111b4001b2010f35) with fake-streaming: when a dialect sets `streams=True` and the request includes `stream: true`, the server replays a buffered completion as SSE frames instead of returning a JSON body.
> - Adds a `stream_events` hook and `streams` capability flag to the [`Dialect` base class](https://github.com/PrimeIntellect-ai/verifiers/pull/1658/files#diff-10ccce5f7f0d991c33492a01e73014e10883deb74f7006253f1c690422d841bd) for dialects to implement SSE serialization.
> - Risk: the codex binary is fetched via `curl`/`tar` at harness launch time; network failures or version unavailability will raise a `ProgramError`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4af433a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->