### PR TITLE
perf: run subprocess uv-scripts via a cached interpreter, not per-call uv run

### DIFF
--- a/verifiers/v1/runtimes/subprocess.py
+++ b/verifiers/v1/runtimes/subprocess.py
@@ -3,13 +3,27 @@
 Each rollout gets a fresh `/tmp/<name>` workspace (created on `start`, removed on
 `stop`/`cleanup`) used as the program's cwd, so concurrent local rollouts are isolated
 and trivially cleaned up. Relative `read`/`write` paths resolve against it.
+
+`run_uv_script` is specialized here: instead of `uv run` per call (which re-resolves,
+re-locks the cache, re-materializes the ephemeral env and re-probes for `uv` on EVERY
+invocation — overhead that dominates and serializes at high concurrency), it pre-resolves
+one venv per distinct PEP 723 dependency set ONCE and execs that interpreter directly. The
+hot path becomes a bare `python <script>` with no `uv` in it. docker/prime keep the base
+`uv run` (their deps live in the sandbox, not on the host).
 """
 
 import asyncio
 import contextlib
+import fcntl
+import hashlib
 import os
+import re
 import shutil
 import signal
+import subprocess
+import sys
+import tomllib
+import uuid
 from pathlib import Path
 from typing import Literal
 
@@ -24,6 +38,59 @@ from verifiers.v1.runtimes.base import ProgramResult, Runtime
 # (see `run`). A container/sandbox is isolated and inherits nothing, so this
 # allow-by-default model is subprocess-only.
 
+# One venv per distinct PEP 723 dependency set, built once and reused by every rollout, so
+# the per-rollout hot path is a bare interpreter exec (no `uv run`). Local + persistent.
+_SCRIPT_VENV_ROOT = Path(
+    os.environ.get("VF_SCRIPT_ENV_ROOT", Path.home() / ".cache" / "vf-script-venvs")
+)
+# PEP 723 inline-metadata block (the spec's reference regex).
+_PEP723_RE = r"(?m)^# /// (?P<type>[a-zA-Z0-9-]+)$\s(?P<content>(^#(| .*)$\s)+)^# ///$"
+
+
+def _pep723_dependencies(source: str) -> list[str]:
+    """The `dependencies` of a PEP 723 `script` block (empty list if there's no block)."""
+    blocks = [m for m in re.finditer(_PEP723_RE, source) if m.group("type") == "script"]
+    if not blocks:
+        return []
+    content = "".join(
+        line[2:] if line.startswith("# ") else line[1:]
+        for line in blocks[0].group("content").splitlines(keepends=True)
+    )
+    return list(tomllib.loads(content).get("dependencies", []))
+
+
+def _build_script_venv(venv: Path, deps: list[str]) -> None:
+    """Create `venv` with `deps` installed — once, race-safe across processes. An exclusive
+    flock serializes concurrent first-callers; a `.ready` sentinel (written only after a clean
+    install) makes a crash-interrupted build rebuild instead of being reused half-finished.
+    uv hardlinks wheels from its warm cache, so this is a one-time, near-instant cost."""
+    ready = venv / ".ready"
+    venv.parent.mkdir(parents=True, exist_ok=True)
+    with open(venv.parent / f"{venv.name}.lock", "w") as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX)
+        if ready.exists():
+            return
+        env = {
+            **os.environ,
+            "PATH": f"{Path.home() / '.local' / 'bin'}:{os.environ.get('PATH', '')}",
+        }
+        subprocess.run(["uv", "venv", "--quiet", str(venv)], check=True, env=env)
+        if deps:
+            subprocess.run(
+                [
+                    "uv",
+                    "pip",
+                    "install",
+                    "--quiet",
+                    "--python",
+                    str(venv / "bin" / "python"),
+                    *deps,
+                ],
+                check=True,
+                env=env,
+            )
+        ready.write_text("ok")
+
 
 class SubprocessConfig(BaseConfig):
     type: Literal["subprocess"] = "subprocess"
@@ -31,6 +98,11 @@ class SubprocessConfig(BaseConfig):
 
 class SubprocessRuntime(Runtime):
     """Runs the program as a local subprocess in a unique /tmp workspace."""
+
+    # Shared across the per-rollout runtime instances on a worker: dep-set hash -> interpreter
+    # path, and a per-hash build lock (so concurrent first-callers build once, in-process).
+    _venv_cache: dict[str, str] = {}
+    _venv_locks: dict[str, asyncio.Lock] = {}
 
     def __init__(self, config: SubprocessConfig, name: str | None = None) -> None:
         super().__init__(name)
@@ -73,6 +145,47 @@ class SubprocessRuntime(Runtime):
             stdout=stdout.decode(errors="replace"),
             stderr=stderr.decode(errors="replace"),
         )
+
+    async def run_uv_script(
+        self,
+        script: str | bytes,
+        args: list[str] | None = None,
+        env: dict[str, str] | None = None,
+    ) -> ProgramResult:
+        """Run a PEP 723 script via a pre-resolved cached interpreter instead of `uv run`.
+
+        uv keys an environment by dependency set; we build that env ONCE (`_build_script_venv`)
+        and exec its python directly. This drops uv's per-invocation resolve, cache-lock,
+        ephemeral-env materialization, and `command -v uv` probe from the per-rollout hot path —
+        the overhead that dominates and serializes (cache-lock contention) at high concurrency.
+        The script is written once to a stable, content-addressed path (so its absolute path is
+        constant) and execed with the cached interpreter as a bare subprocess (isolated cwd,
+        own process group, killable on timeout — exactly like `run`)."""
+        data = script.encode() if isinstance(script, str) else script
+        path = Path("/tmp/vf-scripts") / f"{hashlib.sha256(data).hexdigest()}.py"
+        if not path.exists():
+            path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = path.with_name(f"{path.name}.{uuid.uuid4().hex}.tmp")
+            tmp.write_bytes(data)
+            os.replace(tmp, path)  # atomic publish; concurrent writers are idempotent
+        python = await self._script_python(data.decode(errors="replace"))
+        return await self.run([python, str(path), *(args or [])], env or {})
+
+    async def _script_python(self, source: str) -> str:
+        """The cached interpreter for a script's PEP 723 deps, building its venv on first use.
+        Stdlib-only scripts (no deps) just use the host interpreter."""
+        deps = _pep723_dependencies(source)
+        if not deps:
+            return sys.executable
+        key = hashlib.sha256("\x00".join(sorted(deps)).encode()).hexdigest()
+        if key not in self._venv_cache:
+            lock = self._venv_locks.setdefault(key, asyncio.Lock())
+            async with lock:
+                if key not in self._venv_cache:
+                    venv = _SCRIPT_VENV_ROOT / key
+                    await asyncio.to_thread(_build_script_venv, venv, deps)
+                    self._venv_cache[key] = str(venv / "bin" / "python")
+        return self._venv_cache[key]
 
     async def run_background(
         self, argv: list[str], env: dict[str, str], log: str

--- a/verifiers/v1/runtimes/subprocess.py
+++ b/verifiers/v1/runtimes/subprocess.py
@@ -3,33 +3,21 @@
 Each rollout gets a fresh `/tmp/<name>` workspace (created on `start`, removed on
 `stop`/`cleanup`) used as the program's cwd, so concurrent local rollouts are isolated
 and trivially cleaned up. Relative `read`/`write` paths resolve against it.
-
-`run_uv_script` is specialized here: instead of `uv run` per call (which re-resolves,
-re-locks the cache, re-materializes the ephemeral env and re-probes for `uv` on EVERY
-invocation — overhead that dominates and serializes at high concurrency), it pre-resolves
-one venv per distinct PEP 723 dependency set ONCE and execs that interpreter directly. The
-hot path becomes a bare `python <script>` with no `uv` in it. docker/prime keep the base
-`uv run` (their deps live in the sandbox, not on the host).
 """
 
 import asyncio
 import contextlib
-import fcntl
 import hashlib
 import os
-import re
+import shlex
 import shutil
 import signal
-import subprocess
-import sys
-import tomllib
-import uuid
 from pathlib import Path
 from typing import Literal
 
 from pydantic_config import BaseConfig
 
-from verifiers.v1.runtimes.base import ProgramResult, Runtime
+from verifiers.v1.runtimes.base import _ENSURE_UV, ProgramResult, Runtime
 
 # A local subprocess inherits the host environment EXCEPT any var whose name
 # contains "API_KEY" — so it can never reach a real provider with the host's API
@@ -37,59 +25,6 @@ from verifiers.v1.runtimes.base import ProgramResult, Runtime
 # ...). The harness injects its own interception endpoint over OPENAI_* on top
 # (see `run`). A container/sandbox is isolated and inherits nothing, so this
 # allow-by-default model is subprocess-only.
-
-# One venv per distinct PEP 723 dependency set, built once and reused by every rollout, so
-# the per-rollout hot path is a bare interpreter exec (no `uv run`). Local + persistent.
-_SCRIPT_VENV_ROOT = Path(
-    os.environ.get("VF_SCRIPT_ENV_ROOT", Path.home() / ".cache" / "vf-script-venvs")
-)
-# PEP 723 inline-metadata block (the spec's reference regex).
-_PEP723_RE = r"(?m)^# /// (?P<type>[a-zA-Z0-9-]+)$\s(?P<content>(^#(| .*)$\s)+)^# ///$"
-
-
-def _pep723_dependencies(source: str) -> list[str]:
-    """The `dependencies` of a PEP 723 `script` block (empty list if there's no block)."""
-    blocks = [m for m in re.finditer(_PEP723_RE, source) if m.group("type") == "script"]
-    if not blocks:
-        return []
-    content = "".join(
-        line[2:] if line.startswith("# ") else line[1:]
-        for line in blocks[0].group("content").splitlines(keepends=True)
-    )
-    return list(tomllib.loads(content).get("dependencies", []))
-
-
-def _build_script_venv(venv: Path, deps: list[str]) -> None:
-    """Create `venv` with `deps` installed — once, race-safe across processes. An exclusive
-    flock serializes concurrent first-callers; a `.ready` sentinel (written only after a clean
-    install) makes a crash-interrupted build rebuild instead of being reused half-finished.
-    uv hardlinks wheels from its warm cache, so this is a one-time, near-instant cost."""
-    ready = venv / ".ready"
-    venv.parent.mkdir(parents=True, exist_ok=True)
-    with open(venv.parent / f"{venv.name}.lock", "w") as lock:
-        fcntl.flock(lock, fcntl.LOCK_EX)
-        if ready.exists():
-            return
-        env = {
-            **os.environ,
-            "PATH": f"{Path.home() / '.local' / 'bin'}:{os.environ.get('PATH', '')}",
-        }
-        subprocess.run(["uv", "venv", "--quiet", str(venv)], check=True, env=env)
-        if deps:
-            subprocess.run(
-                [
-                    "uv",
-                    "pip",
-                    "install",
-                    "--quiet",
-                    "--python",
-                    str(venv / "bin" / "python"),
-                    *deps,
-                ],
-                check=True,
-                env=env,
-            )
-        ready.write_text("ok")
 
 
 class SubprocessConfig(BaseConfig):
@@ -99,10 +34,10 @@ class SubprocessConfig(BaseConfig):
 class SubprocessRuntime(Runtime):
     """Runs the program as a local subprocess in a unique /tmp workspace."""
 
-    # Shared across the per-rollout runtime instances on a worker: dep-set hash -> interpreter
-    # path, and a per-hash build lock (so concurrent first-callers build once, in-process).
-    _venv_cache: dict[str, str] = {}
-    _venv_locks: dict[str, asyncio.Lock] = {}
+    # script-sha -> the interpreter for that script's deps, resolved once and shared across
+    # the worker's per-rollout runtimes (+ a per-sha lock so first-callers provision once).
+    _interpreters: dict[str, str] = {}
+    _locks: dict[str, asyncio.Lock] = {}
 
     def __init__(self, config: SubprocessConfig, name: str | None = None) -> None:
         super().__init__(name)
@@ -152,40 +87,41 @@ class SubprocessRuntime(Runtime):
         args: list[str] | None = None,
         env: dict[str, str] | None = None,
     ) -> ProgramResult:
-        """Run a PEP 723 script via a pre-resolved cached interpreter instead of `uv run`.
+        """Run a PEP 723 script via a pre-provisioned interpreter instead of `uv run` per call.
 
-        uv keys an environment by dependency set; we build that env ONCE (`_build_script_venv`)
-        and exec its python directly. This drops uv's per-invocation resolve, cache-lock,
-        ephemeral-env materialization, and `command -v uv` probe from the per-rollout hot path —
-        the overhead that dominates and serializes (cache-lock contention) at high concurrency.
-        The script is written once to a stable, content-addressed path (so its absolute path is
-        constant) and execed with the cached interpreter as a bare subprocess (isolated cwd,
-        own process group, killable on timeout — exactly like `run`)."""
+        uv keeps a persistent env per script under its cache; we resolve that env's interpreter
+        ONCE and exec it directly, keeping uv's per-invocation resolve, cache-lock, ephemeral-env
+        materialization and `command -v uv` probe out of the per-rollout hot path (the subprocess
+        runtime launches two uv-scripts per rollout — the harness program and, for math, verify).
+        docker/prime keep the base `uv run` — their deps live in the sandbox, not on the host."""
         data = script.encode() if isinstance(script, str) else script
-        path = Path("/tmp/vf-scripts") / f"{hashlib.sha256(data).hexdigest()}.py"
-        if not path.exists():
-            path.parent.mkdir(parents=True, exist_ok=True)
-            tmp = path.with_name(f"{path.name}.{uuid.uuid4().hex}.tmp")
-            tmp.write_bytes(data)
-            os.replace(tmp, path)  # atomic publish; concurrent writers are idempotent
-        python = await self._script_python(data.decode(errors="replace"))
-        return await self.run([python, str(path), *(args or [])], env or {})
+        sha = hashlib.sha256(data).hexdigest()
+        path = Path("/tmp/vf-scripts") / f"{sha}.py"
+        if sha not in self._interpreters:
+            async with self._locks.setdefault(sha, asyncio.Lock()):
+                if sha not in self._interpreters:
+                    path.parent.mkdir(parents=True, exist_ok=True)
+                    path.write_bytes(data)
+                    self._interpreters[sha] = await self._provision(path)
+        return await self.run(
+            [self._interpreters[sha], str(path), *(args or [])], env or {}
+        )
 
-    async def _script_python(self, source: str) -> str:
-        """The cached interpreter for a script's PEP 723 deps, building its venv on first use.
-        Stdlib-only scripts (no deps) just use the host interpreter."""
-        deps = _pep723_dependencies(source)
-        if not deps:
-            return sys.executable
-        key = hashlib.sha256("\x00".join(sorted(deps)).encode()).hexdigest()
-        if key not in self._venv_cache:
-            lock = self._venv_locks.setdefault(key, asyncio.Lock())
-            async with lock:
-                if key not in self._venv_cache:
-                    venv = _SCRIPT_VENV_ROOT / key
-                    await asyncio.to_thread(_build_script_venv, venv, deps)
-                    self._venv_cache[key] = str(venv / "bin" / "python")
-        return self._venv_cache[key]
+    async def _provision(self, path: Path) -> str:
+        """uv syncs the script's persistent env (it locks its own cache, so this is safe across
+        workers building the same script) and prints that env's interpreter."""
+        s = shlex.quote(str(path))
+        result = await self.run(
+            [
+                "sh",
+                "-c",
+                f"{_ENSURE_UV}; uv sync --script {s} -q && uv python find --script {s}",
+            ],
+            {},
+        )
+        if result.exit_code != 0:
+            raise RuntimeError(f"failed to provision env for {path}: {result.stderr}")
+        return result.stdout.strip().splitlines()[-1]
 
     async def run_background(
         self, argv: list[str], env: dict[str, str], log: str

--- a/verifiers/v1/runtimes/subprocess.py
+++ b/verifiers/v1/runtimes/subprocess.py
@@ -102,26 +102,19 @@ class SubprocessRuntime(Runtime):
                 if sha not in self._interpreters:
                     path.parent.mkdir(parents=True, exist_ok=True)
                     path.write_bytes(data)
-                    self._interpreters[sha] = await self._provision(path)
+                    # `uv sync` locks its own cache, so concurrent workers building the same
+                    # script are safe; `uv python find` prints the resolved env's interpreter.
+                    s = shlex.quote(str(path))
+                    cmd = f"{_ENSURE_UV}; uv sync --script {s} -q && uv python find --script {s}"
+                    provision = await self.run(["sh", "-c", cmd], {})
+                    if provision.exit_code != 0:
+                        raise RuntimeError(
+                            f"failed to provision env for {path}: {provision.stderr}"
+                        )
+                    self._interpreters[sha] = provision.stdout.strip().splitlines()[-1]
         return await self.run(
             [self._interpreters[sha], str(path), *(args or [])], env or {}
         )
-
-    async def _provision(self, path: Path) -> str:
-        """uv syncs the script's persistent env (it locks its own cache, so this is safe across
-        workers building the same script) and prints that env's interpreter."""
-        s = shlex.quote(str(path))
-        result = await self.run(
-            [
-                "sh",
-                "-c",
-                f"{_ENSURE_UV}; uv sync --script {s} -q && uv python find --script {s}",
-            ],
-            {},
-        )
-        if result.exit_code != 0:
-            raise RuntimeError(f"failed to provision env for {path}: {result.stderr}")
-        return result.stdout.strip().splitlines()[-1]
 
     async def run_background(
         self, argv: list[str], env: dict[str, str], log: str


### PR DESCRIPTION
## Summary

- `SubprocessRuntime.run_uv_script` runs a PEP 723 script via a **pre-provisioned interpreter** instead of `uv run` per call: `uv sync --script` keeps a persistent env per script under uv's cache, `uv python find --script` returns its interpreter, and we resolve it **once** (cached per script-sha) and exec it directly thereafter.
- Keeps uv's per-invocation resolve, cache-lock, ephemeral-env materialization, and `command -v uv` probe out of the **per-rollout hot path** — the subprocess runtime launches *two* uv-scripts per rollout (the harness chat-loop program, and the verify script for math).
- Cross-worker safe for free: `uv sync` locks its own cache, so concurrent workers syncing the same script serialize internally; `uv python find` is read-only. No app-level lock, no PEP 723 parsing, no hand-rolled venv (+50/−1 LoC).
- Scoped to the **subprocess runtime only**. docker/prime keep the base `uv run` — their deps live in the sandbox, not on the host.

## Why (what the bottleneck actually is)

Profiling the math scoring path at 512-concurrency on a 30-core box (warm, local uv cache):

| 512× | wall |
|---|---|
| `uv run verify.py` (base) | 8.83s |
| pre-provisioned `python verify.py` (this PR) | ~8.1s |
| bare `python -c pass` storm | 0.65–0.80s |
| `python -c "import math_verify"` storm | **7.3–7.5s** |

On a **warm local cache, uv is not the bottleneck** — the per-call cost is ~95% the script's *own* imports (sympy/latex2sympy via `math_verify`), which a fresh subprocess re-pays regardless of launcher. This PR's win is therefore **removing uv's cache-lock contention + per-call fork from the hot path** — benign on a warm local cache, but pathological on an **NFS-backed uv cache** and under sustained high concurrency, where the global cache lock serializes every launch. It does **not** speed up the local-warm case (import-dominated); eliminating the import cost itself requires in-process scoring (a taskset change, out of scope here).

## Verification

- Functional: 512/512 pre-provisioned `verify.py` calls return the correct score; a wrong answer scores `0.0`; the interpreter is resolved once then reused.
- `ruff format`/`check` clean (isolated).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rollout execution for local subprocess scoring/harness paths and adds shared class-level interpreter cache; wrong provisioning or stale cache could break concurrent rollouts, but scope is limited to subprocess runtime only.
> 
> **Overview**
> **SubprocessRuntime** now overrides **`run_uv_script`** so PEP 723 scripts run through a **cached interpreter** instead of invoking **`uv run`** on every rollout.
> 
> On first use per script content (SHA-256), the runtime writes the script under `/tmp/vf-scripts`, runs **`uv sync --script`** plus **`uv python find --script`** (with **`_ENSURE_UV`**), and stores the resolved interpreter in class-level **`_interpreters`**, guarded by per-SHA **`asyncio.Lock`** for one-time provisioning. Later calls exec **`[interpreter, script_path, …args]`** directly, avoiding per-invocation uv resolve, cache locking, and env materialization on the hot path (notably two uv-scripts per rollout: harness + verify).
> 
> **Docker/prime** runtimes keep the base **`uv run`** behavior; only the local subprocess path changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcc915a11d6e4e1468bab5f0808112219ac3315e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cache uv-resolved interpreter in `SubprocessRuntime.run_uv_script` to avoid per-call `uv run`
> - Adds `run_uv_script` to [subprocess.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1660/files#diff-f36f9994618d7a28baaf498b61eb6f129dcfda77500d165d18537426dfcdd6e2) for executing PEP 723 scripts using a pre-provisioned interpreter rather than invoking `uv run` on every call.
> - On first use per script, computes a SHA-256 of the script content, writes it to `/tmp/vf-scripts/<sha>.py`, runs `uv sync --script` then `uv python find --script` to resolve the interpreter, and caches the path in a class-level dict.
> - Per-SHA `asyncio.Lock` serializes provisioning across concurrent callers within the process, ensuring the setup runs only once.
> - On provisioning failure, raises `RuntimeError` with stderr. Subsequent calls use the cached interpreter directly via the existing `run` method.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized dcc915a. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->