### PR TITLE
feat: codex built-in harness

### DIFF
--- a/examples/tasksets/gsm8k_v1/verify.py
+++ b/examples/tasksets/gsm8k_v1/verify.py
@@ -18,9 +18,8 @@ import sys
 from math_verify import parse, verify
 
 gold, pred = sys.argv[1], sys.argv[2]
-# GSM8K answers come after '####'; fall back to the whole response.
-match = re.search(r"####\s*(.+)", pred)
-prediction = match.group(1).strip() if match else pred
+matches = re.findall(r"####\s*(.+)", pred)
+prediction = matches[-1].strip() if matches else pred
 try:
     score = (
         1.0

--- a/packages/harnesses/harnesses/__init__.py
+++ b/packages/harnesses/harnesses/__init__.py
@@ -2,10 +2,13 @@
 
 Re-exports each harness's class + config off the package."""
 
+from harnesses.codex import CodexHarness, CodexHarnessConfig
 from harnesses.default import DefaultHarness, DefaultHarnessConfig
 from harnesses.rlm import RLMHarness, RLMHarnessConfig
 
 __all__ = [
+    "CodexHarness",
+    "CodexHarnessConfig",
     "DefaultHarness",
     "DefaultHarnessConfig",
     "RLMHarness",

--- a/packages/harnesses/harnesses/codex/__init__.py
+++ b/packages/harnesses/harnesses/codex/__init__.py
@@ -1,0 +1,100 @@
+"""The codex harness: installs the Codex CLI into the runtime and runs `codex exec`.
+
+Codex only speaks the streaming OpenAI Responses API, so it reaches the interception server as a
+custom model provider (`wire_api = responses`) pointed at the rollout endpoint — served by the
+Responses dialect + SSE relay (see `verifiers.v1.dialects.responses`). The binary is the static
+musl release, so it drops into any linux container with no runtime deps; its bearer token (the
+session secret) is read from an env var.
+"""
+
+import logging
+
+from verifiers.v1.clients import RolloutContext
+from verifiers.v1.errors import ProgramError
+from verifiers.v1.harness import Harness, HarnessConfig
+from verifiers.v1.runtimes import ProgramResult, Runtime
+from verifiers.v1.trace import Trace
+
+logger = logging.getLogger(__name__)
+
+# The provider id we register on the fly via `-c` overrides — arbitrary, internal to codex.
+PROVIDER = "intercept"
+# The env var codex reads the provider api key (its bearer = the session secret) from.
+KEY_VAR = "CODEX_INTERCEPT_KEY"
+
+# Install the static-musl codex release (`rust-v<version>`) onto PATH, idempotently — fetching
+# curl first if the image lacks it. musl => no libc dep, so it runs in any linux container.
+INSTALL = r"""
+command -v codex >/dev/null 2>&1 && exit 0
+set -e
+command -v curl >/dev/null 2>&1 || { apt-get update -qq && apt-get install -y -qq curl >/dev/null; }
+case "$(uname -m)" in aarch64|arm64) arch=aarch64 ;; *) arch=x86_64 ;; esac
+triple="${arch}-unknown-linux-musl"
+curl -fsSL "https://github.com/openai/codex/releases/download/rust-v{version}/codex-${triple}.tar.gz" | tar -xz -C /usr/local/bin
+mv "/usr/local/bin/codex-${triple}" /usr/local/bin/codex
+chmod +x /usr/local/bin/codex
+"""
+
+
+class CodexHarnessConfig(HarnessConfig):
+    """The Codex CLI harness — which codex release to install in the runtime."""
+
+    id: str = "codex"
+    version: str = "0.137.0"
+    """Codex release to install (the `rust-v<version>` GitHub release); pinned for reproducibility."""
+
+
+class CodexHarness(Harness[CodexHarnessConfig]):
+    APPENDS_SYSTEM_PROMPT = False  # TODO
+    SUPPORTS_TASK_TOOLS = False  # TODO
+
+    async def launch(
+        self,
+        ctx: RolloutContext,
+        trace: Trace,
+        runtime: Runtime,
+        endpoint: str,
+        secret: str,
+        mcp_urls: dict[str, str],
+    ) -> ProgramResult:
+        _, instruction = self.resolve_prompt(trace.task)
+        # codex authenticates to the interception server with the session secret (its provider
+        # api key) and posts Responses calls to `{endpoint}/responses`.
+        env = {KEY_VAR: secret}
+        logger.info("codex: ensuring codex %s is installed", self.config.version)
+        install = await runtime.run(
+            ["sh", "-c", INSTALL.replace("{version}", self.config.version)], {}
+        )
+        if install.exit_code != 0:
+            raise ProgramError(f"codex install failed: {install.stderr.strip()[-500:]}")
+        # `-c` values parse as TOML, falling back to a raw string (so the url / `responses`
+        # come through literally); `requires_openai_auth=false` parses as a bool.
+        argv = [
+            "codex",
+            "exec",
+            "--dangerously-bypass-approvals-and-sandbox",
+            "--skip-git-repo-check",
+            "-m",
+            ctx.model,
+            "-c",
+            f"model_provider={PROVIDER}",
+            "-c",
+            f"model_providers.{PROVIDER}.name={PROVIDER}",
+            "-c",
+            f"model_providers.{PROVIDER}.base_url={endpoint}",
+            "-c",
+            f"model_providers.{PROVIDER}.env_key={KEY_VAR}",
+            "-c",
+            f"model_providers.{PROVIDER}.wire_api=responses",
+            "-c",
+            f"model_providers.{PROVIDER}.requires_openai_auth=false",
+            instruction,
+        ]
+        return await runtime.run(argv, env)
+
+
+def load_harness(config: CodexHarnessConfig) -> CodexHarness:
+    return CodexHarness(config)
+
+
+__all__ = ["CodexHarness", "CodexHarnessConfig", "load_harness"]

--- a/tests/v1/conftest.py
+++ b/tests/v1/conftest.py
@@ -63,8 +63,14 @@ def skip_if_unexposable():
 
 # Built-in harnesses (bundled in the `harnesses` package), composed with `runtime` for the
 # harness x runtime matrix. compact is an example harness, not built-in, so it's excluded. rlm
-# installs a heavy agent binary at rollout, so it's marked slow.
-@pytest.fixture(params=["default", pytest.param("rlm", marks=pytest.mark.slow)])
+# and codex install a heavy agent binary at rollout, so they're marked slow.
+@pytest.fixture(
+    params=[
+        "default",
+        pytest.param("rlm", marks=pytest.mark.slow),
+        pytest.param("codex", marks=pytest.mark.slow),
+    ]
+)
 def harness(request) -> str:
     return request.param
 

--- a/verifiers/v1/dialects/responses.py
+++ b/verifiers/v1/dialects/responses.py
@@ -9,7 +9,7 @@ endpoint and this dialect parses a copy for the trace. Server-side statefulness
 
 import json
 
-from openai.types.responses import Response as OpenAIResponse
+from pydantic import BaseModel, ConfigDict
 
 from verifiers.v1.dialects.base import Dialect, iter_sse
 from verifiers.v1.types import (
@@ -34,6 +34,14 @@ FINAL_EVENTS = ("response.completed", "response.incomplete", "response.failed")
 ASSISTANT_ITEMS = ("reasoning", "function_call")
 # Sampling knobs the eval owns, in this format's shape (Responses uses `max_output_tokens`).
 _SAMPLING_KEYS = frozenset({"temperature", "top_p", "max_output_tokens", "max_tokens"})
+
+
+class OpenAIResponse(BaseModel):
+    """Permissive parse-only view of a Responses object: `extra='allow'` keeps it a plain dict
+    for the trace (read via `model_dump`), so a strict SDK model can't crash the rollout on a
+    provider/SDK enum skew (e.g. a value the pinned `openai` rejects)."""
+
+    model_config = ConfigDict(extra="allow")
 
 
 def parse_content(content) -> str | list[ContentPart]:

--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -17,6 +17,7 @@ model, so a multi-turn exchange plays out within one program request, transparen
 harness. Tools are handled out-of-band (run by the harness).
 """
 
+import contextlib
 import logging
 import secrets
 from collections.abc import Awaitable, Callable
@@ -272,16 +273,16 @@ class InterceptionServer:
         except Exception as e:  # surface to the program as an API error
             logger.warning("model call failed: id=%s %s", session.trace.id, e)
             return web.json_response(dialect.error_body(str(e)), status=502)
-        resp = web.StreamResponse()
-        resp.content_type = reply.content_type.split(";")[0].strip()
-        await resp.prepare(request)
         buffer = bytearray()
         async for chunk in reply.chunks:
             buffer += chunk
-            await resp.write(chunk)
-        await resp.write_eof()
-        # Record the streamed turn: assemble the accumulated SSE into a typed Response.
         graph.add_turn(session.trace, prompt, dialect.parse_stream(bytes(buffer)))
+        resp = web.StreamResponse()
+        resp.content_type = reply.content_type.split(";")[0].strip()
+        await resp.prepare(request)
+        with contextlib.suppress(ConnectionResetError):
+            await resp.write(bytes(buffer))
+            await resp.write_eof()
         return resp
 
     async def handle_aux(


### PR DESCRIPTION
## Summary

Adds a **`codex`** built-in v1 harness that runs the Codex CLI in the rollout runtime, on top of the Responses dialect + SSE streaming relay already on this base. Codex speaks only the **streaming OpenAI Responses API**, so:

- **`codex` harness** (`packages/harnesses/harnesses/codex/`) — installs the static-musl codex release into the runtime (idempotent, arch-detected) and points it at the rollout's interception endpoint as a custom Responses model provider (`wire_api = responses`, `requires_openai_auth = false`, bearer = the session secret), then runs `codex exec` headless (`--dangerously-bypass-approvals-and-sandbox --skip-git-repo-check`). `--harness.id codex`, added to the e2e `harness x runtime` matrix.

Reuses the base's `ResponsesDialect` + streaming relay; no new wire machinery.

## Robustness fixes (surfaced by codex — the first client to hit a live `/responses` and to stream)

- **`dialects/responses`** — parse the relayed response through a permissive model (`extra='allow'`) instead of the strict `openai` SDK `Response`. The eval client only parses a copy for the trace, so a provider/SDK enum skew (OpenAI returns `in_memory`, which the pinned SDK's `Response` rejects) must not crash the rollout.
- **`interception/_stream`** — buffer the upstream stream and **record the turn before delivering it** to the program. A streaming client (codex) closes on the terminal SSE event and exits immediately; scoring runs the moment the harness exits, so recording *after* delivery raced it — the turn went missing and the reward was 0 despite a correct answer. (Delivered bytes are still the provider's verbatim SSE.)
- **`gsm8k` `verify.py`** — take the **last** `#### ` line (the prompt asks for the answer there), so a markdown-using agent's earlier `#### ` headers can't shadow the answer.

## Verification

Against Prime Inference (confirmed it serves `/responses`):
- **gsm8k-v1** single turn (`-m openai/gpt-5`): `reward=1.000` (was 0 before the `_stream` race fix — instrumentation showed an empty prediction at scoring).
- **terminal-bench-2 `fix-git`** agentic (`-m openai/gpt-5-codex`): `reward=1.000`.
- **e2e** `test_single_turn[codex × docker]` (default model, pi `/responses`): passes; `tests/v1/test_configs.py` passes; `ruff` clean.

Eval-only for now — the renderer (training) client is chat-completions only, so codex runs through the eval client against a Responses-capable upstream.

Rebased onto `feat/nano-as-v1` (the base `fix/v1-preserve-reasoning-content` was squash-merged as #1654). Supersedes #1658.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes interception streaming ordering (trace vs client delivery) and Responses parsing, which affect all `/responses` streaming rollouts; Codex install runs arbitrary shell from GitHub in the runtime.
> 
> **Overview**
> Adds a **`codex`** built-in harness that installs the pinned static-musl Codex CLI in the rollout runtime and runs `codex exec` against the interception server as a custom **Responses** provider (`wire_api=responses`, session secret as API key). It is exported from `harnesses` and included in the v1 e2e harness matrix as **slow**.
> 
> **Interception streaming** (`_stream`): the server now **buffers the full SSE**, **records the turn on the trace**, then sends the buffered bytes to the client (with `ConnectionResetError` suppressed). That fixes a race where streaming clients exit as soon as the stream ends, so scoring could run before the turn was on the trace.
> 
> **Responses dialect**: trace parsing uses a permissive Pydantic `OpenAIResponse` (`extra='allow'`) instead of the strict OpenAI SDK model, so provider/SDK enum skew does not crash rollouts.
> 
> **GSM8K verify**: uses the **last** `####` match in the prediction so earlier markdown headers do not override the final answer line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 805e01f5a073ca44e0418d95384856471cb354ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add built-in Codex CLI harness for running `codex exec` against the interception endpoint
> - Adds [`harnesses/codex/__init__.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1661/files#diff-ab47aa1c7a12e17d162ca04abcc3029df19add3aeb970d2197763898058987ff) implementing `CodexHarness`, which installs a pinned static-musl Codex CLI release at rollout time (version `0.137.0`) and runs `codex exec` against the interception endpoint using the streaming Responses API with bearer auth.
> - Replaces the `OpenAI` SDK's `OpenAIResponse` model in [`verifiers/v1/dialects/responses.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1661/files#diff-73f89a1b25536fd7a806555e765120f5189cb934eff813f4c7900838efa56b5a) with a local permissive pydantic model (`extra='allow'`) to tolerate unknown fields and avoid strict SDK enum validation.
> - Changes the interception server in [`verifiers/v1/interception/server.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1661/files#diff-84e2f8d027d609e8760ef6d533535ec9d99dfc6384d5ddb6111b4001b2010f35) to buffer the full upstream stream before recording the turn and writing the response, instead of relaying chunks incrementally; `ConnectionResetError` during write is suppressed.
> - Fixes the GSM8K verifier to use the *last* `#### <answer>` tag in predictions rather than the first.
> - Behavioral Change: interception responses are no longer streamed to clients incrementally — the full payload is buffered first, which increases latency before the client receives any bytes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 805e01f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->