### PR TITLE
feat: add free-form `info` field on Trace for taskset-scraped metadata

### DIFF
--- a/verifiers/v1/GUIDE.md
+++ b/verifiers/v1/GUIDE.md
@@ -108,7 +108,7 @@ A rollout runs `setup → harness → finalize → scoring`, each independently 
 (`--timeout.{setup,rollout,finalize,scoring}`). A taskset can hook any stage (all `async`):
 
 - `setup(task, runtime)` — per-task prep before the harness runs (clone a repo, start a service).
-- `finalize(task, trace, runtime)` — after the harness, before scoring (apply a diff, snapshot state).
+- `finalize(task, trace, runtime)` — after the harness, before scoring (apply a diff, snapshot state, scrape runtime artifacts into `trace.info`).
 - `validate(task, runtime)` — model-free gold check (does the reference solution pass?), run by `uv run validate`.
 
 ### Runtime access
@@ -141,12 +141,22 @@ class SWETaskset(vf.Taskset[SWETask, SWEConfig]):
         await runtime.run(["git", "clone", task.repo_url, "/repo"], {})
         await runtime.run(["git", "-C", "/repo", "checkout", task.base_commit], {})
 
+    async def finalize(self, task: SWETask, trace: vf.Trace, runtime: vf.Runtime) -> None:
+        # scrape the agent's diff off the live runtime into trace.info; it persists to results.jsonl
+        diff = await runtime.run(["git", "-C", "/repo", "diff"], {})
+        trace.info["diff"] = diff.stdout
+
     @vf.reward()
     async def tests_pass(self, task: SWETask, trace: vf.Trace, runtime: vf.Runtime) -> float:
         # the agent edited /repo during the rollout; run the task's tests in that same runtime
         result = await runtime.run(["bash", "-lc", task.test_cmd], {})
         return 1.0 if result.exit_code == 0 else 0.0
 ```
+
+`trace.info` is a free-form, JSON-serializable dict for anything that isn't a reward or metric —
+runtime artifacts (the diff above, captured logs, command output) you want persisted with the
+trace for inspection. Like the rewards/metrics it rides along to `results.jsonl`; use `metrics`
+for numbers that aggregate, `trace.info` for everything else.
 
 Since `@group_reward` has no runtime, fold any runtime-derived signal (here, pass/fail) into a
 per-rollout `@reward`/`@metric` first, then compare those across the task's rollouts.

--- a/verifiers/v1/taskset.py
+++ b/verifiers/v1/taskset.py
@@ -128,8 +128,8 @@ class Taskset(Generic[TaskT, ConfigT]):
     async def finalize(self, task: TaskT, trace: Trace, runtime: Runtime) -> None:
         """Post-process the live runtime after the harness finishes, before scoring. No-op
         by default; override to do per-rollout work the rewards depend on — apply/commit the
-        agent's diff, run a build, snapshot state, pull artifacts into the trace. Runs while
-        the runtime is still live (after generation, before `@reward`/`@metric`); the
+        agent's diff, run a build, snapshot state, scrape runtime artifacts into `trace.info`.
+        Runs while the runtime is still live (after generation, before `@reward`/`@metric`); the
         symmetric counterpart to `setup`. Errors propagate and fail the rollout."""
         return None
 

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -13,7 +13,7 @@ import time
 import traceback
 import uuid
 from collections.abc import Mapping
-from typing import Generic, TypeVar
+from typing import Any, Generic, TypeVar
 
 from pydantic import Field, PrivateAttr, computed_field
 from renderers.base import MultiModalData
@@ -182,6 +182,14 @@ class Trace(StrictBaseModel, Generic[TaskT]):
     """Per-`@reward`-function contributions, with each function's weight applied."""
     metrics: dict[str, float] = Field(default_factory=dict)
     """Per-`@metric`-function values (unweighted; not summed into the reward)."""
+    info: dict[str, Any] = Field(default_factory=dict)
+    """Free-form, JSON-serializable scratch space for taskset-specific metadata that is neither
+    a reward nor a metric — anything an author wants to scrape off the live runtime and persist
+    with the trace (captured logs, command output, container/runtime state, artifact paths).
+    Populate it from the runtime in `finalize` (or a `@reward`/`@metric`) by assigning into the
+    dict (`trace.info["build_log"] = ...`); it round-trips through the wire to `results.jsonl`.
+    Use `metrics` for numbers that aggregate, this for everything else. Values must be
+    JSON-serializable — a non-serializable value fails the trace dump rather than being dropped."""
 
     is_completed: bool = False
     stop_condition: str | None = None


### PR DESCRIPTION
## Summary

- Add an `info: dict[str, Any]` field to `Trace` (`verifiers/v1/trace.py`), alongside `rewards`/`metrics` — a free-form, JSON-serializable per-rollout scratch space where taskset authors can stash arbitrary metadata scraped off the live runtime (captured logs, command output, container/runtime state, artifact paths).
- Authors populate it by assigning into the dict (`trace.info["build_log"] = ...`). It's a plain (non-computed) field, so it travels over the wire (`to_wire`) **and** persists to `results.jsonl` (`model_dump_json`). Defaults to `{}`, so the change is fully backward-compatible.
- Point `Taskset.finalize`'s docstring at `trace.info` concretely — `finalize` (after generation, before scoring, runtime still live) is the canonical hook for scraping.
- Document the field in the authoring guide (`verifiers/v1/GUIDE.md`) as a `finalize` use case: the canonical SWE example now scrapes the agent's diff into `trace.info`.

Use `metrics` for numbers that aggregate; use `info` for everything else.

## Verification

- `info` round-trips through `to_wire()` → strict `Trace` reconstruction (worker→runner transport), including nested JSON values.
- `info` appears in the on-disk `model_dump_json` line; empty default serializes as `{}`.
- `ruff check` + `ruff format --check` clean on the changed files.
- `tests/v1/test_graph.py` and `tests/v1/test_legacy.py` pass (legacy API-key tests skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add free-form `info` field to `Trace` for taskset-scraped metadata
> Adds an `info: dict[str, Any]` field to the [`Trace`](https://github.com/PrimeIntellect-ai/verifiers/pull/1664/files#diff-834820c3aa80d87ee1c1c57fb54c74f09c66ac727036d964e6005c8613c00b5e) pydantic model, defaulting to an empty dict, intended as scratch space for taskset-specific runtime artifacts (e.g. git diffs). Updates [`GUIDE.md`](https://github.com/PrimeIntellect-ai/verifiers/pull/1664/files#diff-c2ca7f62523b24001d6019e37e36351dc73dd3e91a9ac126847e7eb5c55d63a1) with an example `finalize` hook that populates `trace.info`. Risk: non-JSON-serializable values stored in `info` will surface as serialization errors on `model_dump(mode="json")`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5944b17.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, backward-compatible field on the trace model and documentation only; no changes to scoring or rollout control flow.
> 
> **Overview**
> Adds **`trace.info`**, a JSON-serializable `dict[str, Any]` on `Trace` (default `{}`) for per-rollout metadata that is not a reward or metric—logs, command output, diffs, paths, etc. Authors set it in **`finalize`** (or scoring hooks); it is included in **`to_wire`** transport and **`results.jsonl`** via normal Pydantic serialization.
> 
> Docs now describe **`finalize`** as the place to scrape runtime artifacts into **`trace.info`**, with a SWE example that stores `git diff` in **`trace.info["diff"]`**, and clarify **`metrics`** vs **`info`** (aggregate numbers vs everything else).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5944b174e8a979d5a061c7d4c7d45e2cc3f6b69b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->