### PR TITLE
[codex] Rename RLM ref to version

### DIFF
--- a/configs/gsm8k_rlm.toml
+++ b/configs/gsm8k_rlm.toml
@@ -13,5 +13,5 @@ id = "gsm8k-v1"
 
 [harness]
 id = "rlm"
-ref = "main"
+version = "main"
 runtime = { type = "subprocess" }

--- a/packages/harnesses/harnesses/rlm/__init__.py
+++ b/packages/harnesses/harnesses/rlm/__init__.py
@@ -26,7 +26,7 @@ class RLMHarnessConfig(HarnessConfig):
 
     id: str = "rlm"
 
-    ref: str = "main"
+    version: str = "main"
     """Git ref (branch, tag, or commit) of rlm to install."""
     max_depth: int = 0
     """Recursion depth rlm may spawn sub-harnesses to (RLM_MAX_DEPTH)."""
@@ -66,11 +66,11 @@ class RLMHarness(Harness[RLMHarnessConfig]):
         install = (
             "apt-get update -qq && apt-get install -y -qq git curl && "
             f"git clone https://{RLM_REPO} /tmp/rlm && "
-            f"git -C /tmp/rlm checkout {self.config.ref} && "
+            f"git -C /tmp/rlm checkout {self.config.version} && "
             "UV_INSTALL_DIR=/usr/local/bin UV_TOOL_BIN_DIR=/usr/local/bin "
             "RLM_CHECKOUT_PATH=/tmp/rlm bash /tmp/rlm/install.sh"
         )
-        logger.info("rlm: ensuring rlm is installed (ref=%s)", self.config.ref)
+        logger.info("rlm: ensuring rlm is installed (version=%s)", self.config.version)
         await runtime.run(
             ["sh", "-c", f"command -v rlm >/dev/null 2>&1 || ({install})"], env
         )


### PR DESCRIPTION
## Overview

Align the RLM harness with the existing harness-specific `version` configuration convention.

## Changes

- Rename `RLMHarnessConfig.ref` to `version` while preserving its git-ref behavior.
- Update the checked-in RLM configuration to use `version`.

## Impact

RLM now uses the same `--harness.version` configuration name already exposed by Codex, without changing installation behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config field rename only; install still checks out the same git ref with no logic changes beyond the property name.
> 
> **Overview**
> Renames the RLM harness pin field from **`ref`** to **`version`** so TOML and CLI config match the Codex harness (`--harness.version`), while still treating the value as a git branch, tag, or commit for `git checkout` during install.
> 
> Updates **`RLMHarnessConfig`**, install/logging in **`RLMHarness`**, and **`configs/gsm8k_rlm.toml`** (`ref = "main"` → `version = "main"`). No change to install or rollout behavior beyond the config key name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 669e9ed61a12e4844420a8e2ed60b13f78cf1549. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename `ref` to `version` in `RLMHarnessConfig`
> Renames the `ref` field to `version` in [`RLMHarnessConfig`](https://github.com/PrimeIntellect-ai/verifiers/pull/1667/files#diff-1f7b1e73dfbd0dff5058e375e55bad6a99b1cd7e5295bb68ec82c5f532973c90) and updates all usages in `RLMHarness.launch`, including the git checkout command and log label. The config file [`configs/gsm8k_rlm.toml`](https://github.com/PrimeIntellect-ai/verifiers/pull/1667/files#diff-b40cd0ef1e793bab3d99640ab3a056c9b49fa0464bc75e129bf7152b74389de5) is updated to match.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 669e9ed.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->