### PR TITLE
Add harness environment variables

### DIFF
--- a/packages/harnesses/harnesses/codex/__init__.py
+++ b/packages/harnesses/harnesses/codex/__init__.py
@@ -60,7 +60,7 @@ class CodexHarness(Harness[CodexHarnessConfig]):
         _, instruction = self.resolve_prompt(trace.task)
         # codex authenticates to the interception server with the session secret (its provider
         # api key) and posts Responses calls to `{endpoint}/responses`.
-        env = {KEY_VAR: secret}
+        env = {**self.config.env, KEY_VAR: secret}
         logger.info("codex: ensuring codex %s is installed", self.config.version)
         install = await runtime.run(
             ["sh", "-c", INSTALL.replace("{version}", self.config.version)], {}

--- a/packages/harnesses/harnesses/default/harness.py
+++ b/packages/harnesses/harnesses/default/harness.py
@@ -54,6 +54,7 @@ class DefaultHarness(Harness[DefaultHarnessConfig]):
                 p for p in (BASH_SYSTEM_PROMPT, system_prompt) if p
             )
         env = {
+            **self.config.env,
             "OPENAI_BASE_URL": endpoint,
             "OPENAI_API_KEY": secret,
             "OPENAI_MODEL": ctx.model,

--- a/packages/harnesses/harnesses/rlm/__init__.py
+++ b/packages/harnesses/harnesses/rlm/__init__.py
@@ -51,6 +51,7 @@ class RLMHarness(Harness[RLMHarnessConfig]):
         # rlm reaches the interception server via OPENAI_BASE_URL/API_KEY (its
         # provider precedence falls back to OPENAI_*), and reads RLM_* for itself.
         env = {
+            **self.config.env,
             "OPENAI_BASE_URL": endpoint,
             "OPENAI_API_KEY": secret,
             "RLM_MODEL": ctx.model,

--- a/verifiers/v1/harness.py
+++ b/verifiers/v1/harness.py
@@ -13,6 +13,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Mapping
 from typing import ClassVar, Generic, TypeVar
 
+from pydantic import Field
 from pydantic_config import BaseConfig
 
 from verifiers.v1.clients import RolloutContext
@@ -39,6 +40,9 @@ class HarnessConfig(BaseConfig):
     runtime: RuntimeConfig = DockerConfig()
     """Where the harness runs (subprocess / docker / prime). Lives on the harness — it's
     the harness's box; tool servers have their own placement (see `TasksetConfig.tools`)."""
+    env: dict[str, str] = Field(default_factory=dict)
+    """Additional environment variables for the harness program. Harness-owned endpoint,
+    authentication, and model variables take precedence."""
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
## Overview

Add a shared way to pass environment variables into built-in harness programs.

## Details

- Add an `env` mapping to `HarnessConfig` so every harness config accepts the same TOML shape.
- Merge configured values into the Default, RLM, and Codex program environments.
- Keep harness-owned endpoint, authentication, and model values authoritative when names overlap.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `env` field to `HarnessConfig` and pass it to codex, default, and RLM harness subprocesses
> - Adds an `env: dict[str, str]` field (default empty) to [`HarnessConfig`](https://github.com/PrimeIntellect-ai/verifiers/pull/1668/files#diff-05e981bb3680a934fbc6865d9dff3b25fc692d0c9970684bf8d41f4aea7ee384) so callers can inject arbitrary environment variables into harness runs.
> - Updates [`CodexHarness`](https://github.com/PrimeIntellect-ai/verifiers/pull/1668/files#diff-ab47aa1c7a12e17d162ca04abcc3029df19add3aeb970d2197763898058987ff), [`DefaultHarness`](https://github.com/PrimeIntellect-ai/verifiers/pull/1668/files#diff-ba919078d5a21cb75a7ccf31926f5fb794e176f71940e3c24d98e98ed2d6d3ed), and [`RLMHarness`](https://github.com/PrimeIntellect-ai/verifiers/pull/1668/files#diff-1f7b1e73dfbd0dff5058e375e55bad6a99b1cd7e5295bb68ec82c5f532973c90) to prepend `self.config.env` when building the subprocess environment map.
> - Built-in keys (provider secrets, endpoint, model, etc.) are set after `config.env` and therefore take precedence on conflicts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fa63f15.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive config with an empty default; built-in endpoint and secret env vars still override user-supplied names on conflict.
> 
> **Overview**
> Adds an **`env`** map on **`HarnessConfig`** so TOML can inject extra environment variables into harness subprocesses.
> 
> **Default**, **RLM**, and **Codex** harnesses now spread **`self.config.env`** into the program environment before setting endpoint, auth, and model variables, so configured values cannot override harness-owned keys like **`OPENAI_API_KEY`** or **`CODEX_INTERCEPT_KEY`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa63f15d24a6e60171b2e864c7fe034fff2aeb4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->