### PR TITLE
Add Claude Code harness

### DIFF
--- a/packages/harnesses/harnesses/__init__.py
+++ b/packages/harnesses/harnesses/__init__.py
@@ -2,11 +2,14 @@
 
 Re-exports each harness's class + config off the package."""
 
+from harnesses.claude_code import ClaudeCodeHarness, ClaudeCodeHarnessConfig
 from harnesses.codex import CodexHarness, CodexHarnessConfig
 from harnesses.default import DefaultHarness, DefaultHarnessConfig
 from harnesses.rlm import RLMHarness, RLMHarnessConfig
 
 __all__ = [
+    "ClaudeCodeHarness",
+    "ClaudeCodeHarnessConfig",
     "CodexHarness",
     "CodexHarnessConfig",
     "DefaultHarness",

--- a/packages/harnesses/harnesses/claude_code/__init__.py
+++ b/packages/harnesses/harnesses/claude_code/__init__.py
@@ -93,13 +93,7 @@ class ClaudeCodeHarness(Harness[ClaudeCodeHarnessConfig]):
             }
             argv += ["--mcp-config", json.dumps(config)]
         argv.append(instruction)
-        result = await runtime.run(argv, env)
-        if result.exit_code != 0:
-            detail = result.stderr.strip() or result.stdout.strip()
-            raise ProgramError(
-                f"Claude Code exited {result.exit_code}: {detail[-2000:]}"
-            )
-        return result
+        return await runtime.run(argv, env)
 
 
 def load_harness(config: ClaudeCodeHarnessConfig) -> ClaudeCodeHarness:

--- a/packages/harnesses/harnesses/claude_code/__init__.py
+++ b/packages/harnesses/harnesses/claude_code/__init__.py
@@ -81,6 +81,7 @@ class ClaudeCodeHarness(Harness[ClaudeCodeHarnessConfig]):
             "project",
             "--model",
             ctx.model,
+            "--strict-mcp-config",
         ]
         if system_prompt:
             argv += ["--append-system-prompt", system_prompt]
@@ -90,7 +91,7 @@ class ClaudeCodeHarness(Harness[ClaudeCodeHarnessConfig]):
                     name: {"type": "http", "url": url} for name, url in mcp_urls.items()
                 }
             }
-            argv += ["--strict-mcp-config", "--mcp-config", json.dumps(config)]
+            argv += ["--mcp-config", json.dumps(config)]
         argv.append(instruction)
         result = await runtime.run(argv, env)
         if result.exit_code != 0:

--- a/packages/harnesses/harnesses/claude_code/__init__.py
+++ b/packages/harnesses/harnesses/claude_code/__init__.py
@@ -58,6 +58,7 @@ class ClaudeCodeHarness(Harness[ClaudeCodeHarnessConfig]):
             "CLAUDE_CODE_DISABLE_AUTO_MEMORY": "1",
             "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
             "DISABLE_UPDATES": "1",
+            "IS_SANDBOX": "1",
         }
         logger.info(
             "claude-code: ensuring Claude Code %s is installed", self.config.version

--- a/packages/harnesses/harnesses/claude_code/__init__.py
+++ b/packages/harnesses/harnesses/claude_code/__init__.py
@@ -1,0 +1,107 @@
+"""The Claude Code harness: installs the CLI into the runtime and runs it headlessly.
+
+Claude Code speaks the Anthropic Messages API, so `ANTHROPIC_BASE_URL` points it at the
+rollout interception endpoint. Task-owned MCP servers are passed as explicit HTTP configs.
+"""
+
+import json
+import logging
+
+from verifiers.v1.clients import RolloutContext
+from verifiers.v1.errors import ProgramError
+from verifiers.v1.harness import Harness, HarnessConfig
+from verifiers.v1.runtimes import ProgramResult, Runtime
+from verifiers.v1.trace import Trace
+
+logger = logging.getLogger(__name__)
+
+INSTALL = r"""
+set -e
+bin="/tmp/vf-claude-code/.local/bin/claude"
+if [ -x "$bin" ] && [ "$("$bin" --version 2>/dev/null | cut -d ' ' -f1)" = "{version}" ]; then
+    exit 0
+fi
+command -v curl >/dev/null || { apt-get update -qq && apt-get install -y -qq curl >/dev/null; }
+curl -fsSL https://claude.ai/install.sh | HOME=/tmp/vf-claude-code bash -s {version}
+"""
+
+
+class ClaudeCodeHarnessConfig(HarnessConfig):
+    """The Claude Code CLI harness."""
+
+    id: str = "claude-code"
+    version: str = "2.1.177"
+    """Claude Code release to install, pinned for reproducibility."""
+
+
+class ClaudeCodeHarness(Harness[ClaudeCodeHarnessConfig]):
+    APPENDS_SYSTEM_PROMPT = True
+    SUPPORTS_TASK_TOOLS = True
+
+    async def launch(
+        self,
+        ctx: RolloutContext,
+        trace: Trace,
+        runtime: Runtime,
+        endpoint: str,
+        secret: str,
+        mcp_urls: dict[str, str],
+    ) -> ProgramResult:
+        system_prompt, instruction = self.resolve_prompt(trace.task)
+        env = {
+            **self.config.env,
+            # Harness endpoints end in /v1 for OpenAI clients; Anthropic appends /v1/messages.
+            "ANTHROPIC_BASE_URL": endpoint.removesuffix("/v1"),
+            "ANTHROPIC_API_KEY": secret,
+            "ANTHROPIC_CUSTOM_MODEL_OPTION": ctx.model,
+            "CLAUDE_CONFIG_DIR": ".vf-claude",
+            "CLAUDE_CODE_DISABLE_AUTO_MEMORY": "1",
+            "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+            "DISABLE_UPDATES": "1",
+        }
+        logger.info(
+            "claude-code: ensuring Claude Code %s is installed", self.config.version
+        )
+        install = await runtime.run(
+            ["sh", "-c", INSTALL.replace("{version}", self.config.version)], {}
+        )
+        if install.exit_code != 0:
+            raise ProgramError(
+                f"Claude Code install failed: {install.stderr.strip()[-500:]}"
+            )
+
+        binary = "/tmp/vf-claude-code/.local/bin/claude"
+        argv = [
+            binary,
+            "--print",
+            "--dangerously-skip-permissions",
+            "--no-session-persistence",
+            "--setting-sources",
+            "project",
+            "--model",
+            ctx.model,
+        ]
+        if system_prompt:
+            argv += ["--append-system-prompt", system_prompt]
+        if mcp_urls:
+            config = {
+                "mcpServers": {
+                    name: {"type": "http", "url": url} for name, url in mcp_urls.items()
+                }
+            }
+            argv += ["--strict-mcp-config", "--mcp-config", json.dumps(config)]
+        argv.append(instruction)
+        result = await runtime.run(argv, env)
+        if result.exit_code != 0:
+            detail = result.stderr.strip() or result.stdout.strip()
+            raise ProgramError(
+                f"Claude Code exited {result.exit_code}: {detail[-2000:]}"
+            )
+        return result
+
+
+def load_harness(config: ClaudeCodeHarnessConfig) -> ClaudeCodeHarness:
+    return ClaudeCodeHarness(config)
+
+
+__all__ = ["ClaudeCodeHarness", "ClaudeCodeHarnessConfig", "load_harness"]

--- a/packages/harnesses/harnesses/claude_code/__init__.py
+++ b/packages/harnesses/harnesses/claude_code/__init__.py
@@ -54,6 +54,7 @@ class ClaudeCodeHarness(Harness[ClaudeCodeHarnessConfig]):
             "ANTHROPIC_BASE_URL": endpoint.removesuffix("/v1"),
             "ANTHROPIC_API_KEY": secret,
             "ANTHROPIC_CUSTOM_MODEL_OPTION": ctx.model,
+            "API_FORCE_IDLE_TIMEOUT": "0",
             "CLAUDE_CONFIG_DIR": ".vf-claude",
             "CLAUDE_CODE_DISABLE_AUTO_MEMORY": "1",
             "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",

--- a/packages/harnesses/harnesses/claude_code/__init__.py
+++ b/packages/harnesses/harnesses/claude_code/__init__.py
@@ -77,8 +77,6 @@ class ClaudeCodeHarness(Harness[ClaudeCodeHarnessConfig]):
             "--print",
             "--dangerously-skip-permissions",
             "--no-session-persistence",
-            "--setting-sources",
-            "project",
             "--model",
             ctx.model,
             "--strict-mcp-config",

--- a/verifiers/v1/clients/client.py
+++ b/verifiers/v1/clients/client.py
@@ -117,6 +117,9 @@ class RetryingClient(Client):
             self.inner.relay, dialect, body, model, sampling_args
         )
 
+    async def relay_aux(self, dialect: Dialect, route: str, body: dict) -> dict:
+        return await self._retrying(self.inner.relay_aux, dialect, route, body)
+
     async def close(self) -> None:
         await self.inner.close()
 


### PR DESCRIPTION
## Overview

Add Claude Code as a built-in v1 harness using the Anthropic Messages interception path.

## Details

- Install a pinned Claude Code release into the selected runtime.
- Run Claude Code headlessly with the rollout model, endpoint, and credentials.
- Forward task-owned MCP servers through Claude Code's HTTP MCP configuration.
- Export the harness and its typed configuration from the bundled harness package.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Claude Code harness for headless CLI execution
> - Adds a new `ClaudeCodeHarness` and `ClaudeCodeHarnessConfig` in [`harnesses/claude_code/__init__.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1669/files#diff-9d0c70c3f25cea6321b397f4102867728ec83765a9cd2dce659181957907c173), supporting appended system prompts and task-owned MCP servers via strict HTTP config.
> - The harness installs the Claude Code CLI at a pinned version (`2.1.177`) if not already present, then invokes it headlessly with `--print`, configured env vars, and optional MCP server JSON.
> - Installation failures raise `ProgramError` with the tail of stderr.
> - Adds `relay_aux` retry support to `RetryingClient` in [`client.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1669/files#diff-03d8d18cf21766007d7efc7af13862dcd1d58ab1a1374aef2efdd4ba59c69e2e), consistent with other retried methods.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f284eb4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New harness runs a third-party install script and invokes Claude Code with `--dangerously-skip-permissions` in sandboxes; `relay_aux` retries could affect auxiliary API behavior on failures.
> 
> **Overview**
> Adds a new built-in **`claude-code`** harness that installs a pinned Claude Code CLI in the rollout runtime and runs it headlessly against the interception stack via the **Anthropic Messages** path (`ANTHROPIC_BASE_URL`, rollout secret, and model from context).
> 
> The harness appends task system prompts, forwards task MCP servers as HTTP `--mcp-config`, and uses sandbox-oriented env flags (no session persistence, strict MCP, skip permissions for automated eval). It is registered alongside existing harnesses in the `harnesses` package.
> 
> **`RetryingClient`** now wraps **`relay_aux`** with the same transient-`ModelError` retry policy as `relay` and `get_response`, so auxiliary Anthropic routes (e.g. token counting) get consistent resilience during rollouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f284eb420ba7e1ff90287a3be8090eed1dd8752b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. `codex/harness-env-support`
2. **#1669** 👈 current
<!-- stack:links:end -->