### PR TITLE
Ignore Anthropic service tier metadata

### DIFF
--- a/verifiers/v1/dialects/anthropic.py
+++ b/verifiers/v1/dialects/anthropic.py
@@ -244,6 +244,7 @@ class AnthropicDialect(Dialect[dict, AnthropicMessage]):
         for index, partial in partial_json.items():
             blocks[index]["input"] = json.loads(partial or "{}")
         message["content"] = [blocks[i] for i in sorted(blocks)]
+        message.get("usage", {}).pop("service_tier", None)
         return response_from_wire(AnthropicMessage.model_validate(message))
 
     def apply_overrides(self, body: dict, model: str, sampling: SamplingConfig) -> dict:


### PR DESCRIPTION
## Overview

Ignore `usage.service_tier` while parsing relayed Anthropic Messages streams.

## Details

Verifiers does not consume service-tier metadata, while compatible providers may return values outside the Anthropic SDK's enum. The parser now removes that field from its internal assembled message before validation. The response bytes relayed to the harness remain unchanged.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Strip `service_tier` from Anthropic usage metadata before response parsing
> Removes the `service_tier` key from the `usage` sub-dictionary in [anthropic.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1671/files#diff-abc86b3ad07c2d6ab09cd923f50271c4f6c4cb928a9bb82c12f6e97aac17b04d) before passing the message to `AnthropicMessage.model_validate()`. This prevents validation failures when Anthropic includes this unrecognized field in API responses.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 86dfffb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-field removal in stream assembly for parsing only; no relay, auth, or business-logic changes.
> 
> **Overview**
> **Anthropic streamed responses** can include `usage.service_tier` values that fall outside the Anthropic SDK enum, which breaks internal trace parsing when the dialect reassembles SSE into a message and runs `AnthropicMessage.model_validate()`.
> 
> `parse_stream` now **drops `service_tier` from the assembled `usage` dict** immediately before validation. Relayed response bytes to the harness are unchanged; only the copy used for the trace is adjusted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86dfffb15765c00ff727021bec58cd642f3ba534. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->