### PR TITLE
feat(v1): capture MoE router-replay routed_experts on Trace/Graph

### DIFF
--- a/tests/v1/test_graph.py
+++ b/tests/v1/test_graph.py
@@ -17,7 +17,9 @@ def _response(message: vf.AssistantMessage) -> vf.Response:
     )
 
 
-def _routed_payload(num_tokens: int, start: int, base: int, layers: int = 2, top_k: int = 1):
+def _routed_payload(
+    num_tokens: int, start: int, base: int, layers: int = 2, top_k: int = 1
+):
     """A fake `generate` router-replay sidecar (uint8 `[num_tokens, layers, top_k]`, base64)."""
     arr = (
         np.arange(num_tokens * layers * top_k)
@@ -25,7 +27,11 @@ def _routed_payload(num_tokens: int, start: int, base: int, layers: int = 2, top
         .astype(np.uint8)
         + base
     )
-    return {"data": base64.b64encode(arr.tobytes()).decode(), "shape": list(arr.shape), "start": start}
+    return {
+        "data": base64.b64encode(arr.tobytes()).decode(),
+        "shape": list(arr.shape),
+        "start": start,
+    }
 
 
 def test_routed_experts_attributed_and_aligned_across_turns():
@@ -39,11 +45,16 @@ def test_routed_experts_attributed_and_aligned_across_turns():
         trace,
         [user],
         vf.Response(
-            id="a", created=0, model="t",
-            message=vf.AssistantMessage(content="a1"), finish_reason="stop",
+            id="a",
+            created=0,
+            model="t",
+            message=vf.AssistantMessage(content="a1"),
+            finish_reason="stop",
             tokens=TurnTokens(
-                prompt_ids=[10, 11, 12], completion_ids=[20, 21],
-                message_spans=[(0, 2)], routed_experts=_routed_payload(5, 0, 0),
+                prompt_ids=[10, 11, 12],
+                completion_ids=[20, 21],
+                message_spans=[(0, 2)],
+                routed_experts=_routed_payload(5, 0, 0),
             ),
         ),
     )
@@ -51,11 +62,16 @@ def test_routed_experts_attributed_and_aligned_across_turns():
         trace,
         [user, vf.AssistantMessage(content="a1"), vf.UserMessage(content="u2")],
         vf.Response(
-            id="b", created=0, model="t",
-            message=vf.AssistantMessage(content="a2"), finish_reason="stop",
+            id="b",
+            created=0,
+            model="t",
+            message=vf.AssistantMessage(content="a2"),
+            finish_reason="stop",
             tokens=TurnTokens(
-                prompt_ids=[10, 11, 12, 20, 21, 30, 31], completion_ids=[40, 41],
-                message_spans=[(0, 2), None, (5, 7)], routed_experts=_routed_payload(9, 0, 100),
+                prompt_ids=[10, 11, 12, 20, 21, 30, 31],
+                completion_ids=[40, 41],
+                message_spans=[(0, 2), None, (5, 7)],
+                routed_experts=_routed_payload(9, 0, 100),
             ),
         ),
     )
@@ -77,9 +93,14 @@ def test_routed_experts_none_when_absent():
         trace,
         [vf.UserMessage(content="u1")],
         vf.Response(
-            id="a", created=0, model="t",
-            message=vf.AssistantMessage(content="a1"), finish_reason="stop",
-            tokens=TurnTokens(prompt_ids=[1, 2], completion_ids=[3], message_spans=[(0, 2)]),
+            id="a",
+            created=0,
+            model="t",
+            message=vf.AssistantMessage(content="a1"),
+            finish_reason="stop",
+            tokens=TurnTokens(
+                prompt_ids=[1, 2], completion_ids=[3], message_spans=[(0, 2)]
+            ),
         ),
     )
     assert trace.branches[-1].routed_experts is None

--- a/tests/v1/test_graph.py
+++ b/tests/v1/test_graph.py
@@ -1,5 +1,10 @@
+import base64
+
+import numpy as np
+
 import verifiers.v1 as vf
 from verifiers.v1 import graph
+from verifiers.v1.types import TurnTokens
 
 
 def _response(message: vf.AssistantMessage) -> vf.Response:
@@ -10,6 +15,74 @@ def _response(message: vf.AssistantMessage) -> vf.Response:
         message=message,
         finish_reason="stop",
     )
+
+
+def _routed_payload(num_tokens: int, start: int, base: int, layers: int = 2, top_k: int = 1):
+    """A fake `generate` router-replay sidecar (uint8 `[num_tokens, layers, top_k]`, base64)."""
+    arr = (
+        np.arange(num_tokens * layers * top_k)
+        .reshape(num_tokens, layers, top_k)
+        .astype(np.uint8)
+        + base
+    )
+    return {"data": base64.b64encode(arr.tobytes()).decode(), "shape": list(arr.shape), "start": start}
+
+
+def test_routed_experts_attributed_and_aligned_across_turns():
+    """Each turn's full routing (start=0) is attributed to the nodes it created; the new turn's
+    nodes get this turn's slice and reused nodes keep theirs, so `Branch.routed_experts`
+    concatenates back to a `[tokens, layers, top_k]` array aligned 1:1 with `branch.token_ids` —
+    and survives the base64 wire round-trip."""
+    trace = vf.Trace(task=vf.Task(idx=0, instruction="x"))
+    user = vf.UserMessage(content="u1")
+    graph.add_turn(
+        trace,
+        [user],
+        vf.Response(
+            id="a", created=0, model="t",
+            message=vf.AssistantMessage(content="a1"), finish_reason="stop",
+            tokens=TurnTokens(
+                prompt_ids=[10, 11, 12], completion_ids=[20, 21],
+                message_spans=[(0, 2)], routed_experts=_routed_payload(5, 0, 0),
+            ),
+        ),
+    )
+    graph.add_turn(
+        trace,
+        [user, vf.AssistantMessage(content="a1"), vf.UserMessage(content="u2")],
+        vf.Response(
+            id="b", created=0, model="t",
+            message=vf.AssistantMessage(content="a2"), finish_reason="stop",
+            tokens=TurnTokens(
+                prompt_ids=[10, 11, 12, 20, 21, 30, 31], completion_ids=[40, 41],
+                message_spans=[(0, 2), None, (5, 7)], routed_experts=_routed_payload(9, 0, 100),
+            ),
+        ),
+    )
+    branch = trace.branches[-1]
+    re = branch.routed_experts
+    assert re is not None
+    assert re.shape[0] == len(branch.token_ids)
+
+    restored = type(trace).model_validate(trace.to_wire())
+    re2 = restored.branches[-1].routed_experts
+    assert re2 is not None and re2.shape == re.shape and bool((re2 == re).all())
+
+
+def test_routed_experts_none_when_absent():
+    """No routing captured (engine ran without `enable_return_routed_experts`) -> the branch
+    reports None and the trainer simply skips replay."""
+    trace = vf.Trace(task=vf.Task(idx=0, instruction="x"))
+    graph.add_turn(
+        trace,
+        [vf.UserMessage(content="u1")],
+        vf.Response(
+            id="a", created=0, model="t",
+            message=vf.AssistantMessage(content="a1"), finish_reason="stop",
+            tokens=TurnTokens(prompt_ids=[1, 2], completion_ids=[3], message_spans=[(0, 2)]),
+        ),
+    )
+    assert trace.branches[-1].routed_experts is None
 
 
 def test_tool_call_hash_matches_v0_content_and_arguments_normalization():

--- a/verifiers/v1/clients/train.py
+++ b/verifiers/v1/clients/train.py
@@ -128,6 +128,9 @@ def response_from_generate(result: dict, model: str) -> Response:
             completion_logprobs=result.get("completion_logprobs") or [],
             message_spans=message_spans,
             multi_modal_data=result.get("multi_modal_data"),
+            # MoE router-replay sidecar (present only when the engine ran with
+            # `enable_return_routed_experts`); attributed per node by `graph.add_turn`.
+            routed_experts=result.get("routed_experts"),
         ),
     )
 

--- a/verifiers/v1/clients/train.py
+++ b/verifiers/v1/clients/train.py
@@ -128,8 +128,6 @@ def response_from_generate(result: dict, model: str) -> Response:
             completion_logprobs=result.get("completion_logprobs") or [],
             message_spans=message_spans,
             multi_modal_data=result.get("multi_modal_data"),
-            # MoE router-replay sidecar (present only when the engine ran with
-            # `enable_return_routed_experts`); attributed per node by `graph.add_turn`.
             routed_experts=result.get("routed_experts"),
         ),
     )

--- a/verifiers/v1/graph.py
+++ b/verifiers/v1/graph.py
@@ -273,6 +273,12 @@ def _attribute_routed_experts(
     raw = base64.b64decode(data if isinstance(data, (str, bytes)) else bytes(data))
     arr = np.frombuffer(raw, dtype=np.uint8).reshape(payload["shape"])
     off = path_len - int(payload.get("start", 0) or 0)
+    # The engine omits routing for the turn's final position (no forward pass follows the last
+    # generated token), so the array is one row short of the turn's new tokens. Pad the tail
+    # with a copy of the last row so the final node still aligns 1:1 with its tokens.
+    needed = off + sum(len(trace.nodes[nid].token_ids) for nid in new_node_ids)
+    if arr.shape[0] and 0 < needed - arr.shape[0] <= 1:
+        arr = np.concatenate([arr, arr[-1:]], axis=0)
     for nid in new_node_ids:
         n = len(trace.nodes[nid].token_ids)
         if n and 0 <= off and off + n <= arr.shape[0]:

--- a/verifiers/v1/graph.py
+++ b/verifiers/v1/graph.py
@@ -94,6 +94,12 @@ class MessageNode(StrictBaseModel):
     """Provider-reported token usage for this message's response (assistant nodes). Transient
     (excluded from wire/disk); lets the live dashboard show token counts even when the endpoint
     returns no token ids (so `token_ids` is empty)."""
+    routed_experts: np.ndarray | None = None
+    """This node's slice of the MoE router-replay sidecar — uint8 `[len(token_ids), layers,
+    top_k]`, the expert ids inference selected for exactly this node's tokens. Attributed from
+    the turn's `generate` payload by `_attribute_routed_experts`; `Branch.routed_experts`
+    concatenates these along the path into the trainer's router-replay input. Rides the wire as
+    a base64 `__nd__` dict; kept off disk by the dump-site `exclude` in prime-rl."""
 
     model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
 
@@ -140,6 +146,20 @@ class MessageNode(StrictBaseModel):
                 for modality, items in (value.get("mm_items") or {}).items()
             },
         )
+
+    @field_serializer("routed_experts")
+    def _ser_routed_experts(self, re: np.ndarray | None) -> dict | None:
+        """uint8 routing array -> base64 `__nd__` dict so it rides the wire (numpy can't JSON)."""
+        return None if re is None else _encode_ndarray(re)
+
+    @field_validator("routed_experts", mode="before")
+    @classmethod
+    def _val_routed_experts(cls, value: Any) -> np.ndarray | None:
+        if value is None or isinstance(value, np.ndarray):
+            return value
+        if isinstance(value, dict) and value.get("__nd__"):
+            return _decode_ndarray(value)
+        raise TypeError(f"cannot build routed_experts from {type(value).__name__}")
 
 
 def _content_str(content) -> str:
@@ -233,6 +253,32 @@ def _attribute_mm(
             )
 
 
+def _attribute_routed_experts(
+    trace: "Trace",
+    new_node_ids: "list[int]",
+    path_len: int,
+    payload: Any,
+) -> None:
+    """Attach each new node's slice of this turn's MoE router-replay sidecar. The `generate`
+    payload's array covers the turn's prompt+completion from `payload["start"]` (0 = from token
+    0); the nodes created this turn tile sequence positions `[path_len:]` in creation order, so
+    we hand each node `arr[off : off+len(node.token_ids)]` and advance. Reused-prefix nodes keep
+    the routing attributed when they were first created. A node whose slice falls outside the
+    array (a `start` past `path_len`, e.g. an unexpected prefix-cache delta) is left unset — the
+    branch then reports no routing rather than misaligning."""
+    if payload is None:
+        return
+    data = payload["data"]
+    raw = base64.b64decode(data if isinstance(data, (str, bytes)) else bytes(data))
+    arr = np.frombuffer(raw, dtype=np.uint8).reshape(payload["shape"])
+    off = path_len - int(payload.get("start", 0) or 0)
+    for nid in new_node_ids:
+        n = len(trace.nodes[nid].token_ids)
+        if n and 0 <= off and off + n <= arr.shape[0]:
+            trace.nodes[nid].routed_experts = np.ascontiguousarray(arr[off : off + n])
+        off += n
+
+
 def add_turn(trace: "Trace", prompt: "list[Message]", response: Response) -> None:
     """Insert one model turn (its prompt messages + its response) into the graph. Reuses any
     existing prefix nodes (by `(parent, hash)`), creates a node per new message attributing
@@ -306,6 +352,14 @@ def add_turn(trace: "Trace", prompt: "list[Message]", response: Response) -> Non
 
     # Attribute this turn's images onto the input nodes that introduced them (by content part).
     _attribute_mm(trace, path, num_reused, tokens.multi_modal_data if tokens else None)
+
+    # Attribute this turn's router-replay sidecar onto the nodes created this turn (new input
+    # nodes in creation order, then the assistant node), each getting the routing for its tokens.
+    new_node_ids = [nid for nid, _ in path[num_reused:]]
+    new_node_ids.append(len(trace.nodes) - 1)
+    _attribute_routed_experts(
+        trace, new_node_ids, path_len, tokens.routed_experts if tokens else None
+    )
 
 
 # --- walking the graph (views) ---------------------------------------------------------

--- a/verifiers/v1/graph.py
+++ b/verifiers/v1/graph.py
@@ -41,20 +41,21 @@ if TYPE_CHECKING:
 
 
 def _encode_ndarray(arr: np.ndarray) -> dict:
-    """A numpy array as a JSON/msgpack-safe dict (dtype + shape + base64 bytes)."""
+    """A numpy array as a msgpack-safe dict (dtype + shape + raw bytes). The bytes ride the
+    env-server wire natively via msgpack's `bin` type — no base64 — so the response must be
+    packed from `model_dump(mode="python")` (`mode="json"` would coerce the bytes to str)."""
     arr = np.ascontiguousarray(arr)
     return {
         "__nd__": True,
         "dtype": str(arr.dtype),
         "shape": list(arr.shape),
-        "data": base64.b64encode(arr.tobytes()).decode("ascii"),
+        "data": arr.tobytes(),
     }
 
 
 def _decode_ndarray(d: dict) -> np.ndarray:
     """Reverse :func:`_encode_ndarray`."""
-    raw = base64.b64decode(d["data"])
-    return np.frombuffer(raw, dtype=np.dtype(d["dtype"])).reshape(d["shape"])
+    return np.frombuffer(d["data"], dtype=np.dtype(d["dtype"])).reshape(d["shape"])
 
 
 class MessageNode(StrictBaseModel):
@@ -88,25 +89,25 @@ class MessageNode(StrictBaseModel):
     """The renderer items for the images this message's content introduces (pixel tensors,
     grids, hashes, placeholders) — the only carrier of the pixels from the env server to the
     trainer. `Branch.multi_modal_data` concatenates them along the path into the training
-    `mm_kwargs`. Rides the wire via a base64 (de)serializer since pydantic can't JSON the numpy;
+    `mm_kwargs`. Rides the wire as raw bytes (msgpack `bin`) since pydantic can't JSON the numpy;
     kept off disk by the dump-site `exclude` in prime-rl (the tensors bloat the rollout jsonl)."""
     usage: Usage | None = Field(default=None, exclude=True)
     """Provider-reported token usage for this message's response (assistant nodes). Transient
     (excluded from wire/disk); lets the live dashboard show token counts even when the endpoint
     returns no token ids (so `token_ids` is empty)."""
     routed_experts: np.ndarray | None = None
-    """This node's slice of the MoE router-replay sidecar — uint8 `[len(token_ids), layers,
+    """This node's slice of the MoE expert-routing array — uint8 `[len(token_ids), layers,
     top_k]`, the expert ids inference selected for exactly this node's tokens. Attributed from
     the turn's `generate` payload by `_attribute_routed_experts`; `Branch.routed_experts`
     concatenates these along the path into the trainer's router-replay input. Rides the wire as
-    a base64 `__nd__` dict; kept off disk by the dump-site `exclude` in prime-rl."""
+    a raw-bytes `__nd__` dict; kept off disk by the dump-site `exclude` in prime-rl."""
 
     model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
 
     @field_serializer("multi_modal_data")
-    def _ser_multi_modal_data(self, mmd: MultiModalData | None) -> dict | None:
-        """`MultiModalData` -> JSON/msgpack-safe dict so the pixel tensors ride the wire; numpy
-        `mm_items` values become base64 `__nd__` dicts (every renderer emits `return_tensors="np"`)."""
+    def serialize_multi_modal_data(self, mmd: MultiModalData | None) -> dict | None:
+        """`MultiModalData` -> msgpack-safe dict so the pixel tensors ride the wire; numpy
+        `mm_items` values become raw-bytes `__nd__` dicts (every renderer emits `return_tensors="np"`)."""
         if mmd is None:
             return None
         return {
@@ -125,7 +126,7 @@ class MessageNode(StrictBaseModel):
 
     @field_validator("multi_modal_data", mode="before")
     @classmethod
-    def _val_multi_modal_data(cls, value: Any) -> MultiModalData | None:
+    def deserialize_multi_modal_data(cls, value: Any) -> MultiModalData | None:
         if value is None or isinstance(value, MultiModalData):
             return value
         if not isinstance(value, dict):
@@ -148,13 +149,13 @@ class MessageNode(StrictBaseModel):
         )
 
     @field_serializer("routed_experts")
-    def _ser_routed_experts(self, re: np.ndarray | None) -> dict | None:
-        """uint8 routing array -> base64 `__nd__` dict so it rides the wire (numpy can't JSON)."""
+    def serialize_routed_experts(self, re: np.ndarray | None) -> dict | None:
+        """uint8 routing array -> raw-bytes `__nd__` dict so it rides the wire (numpy can't JSON)."""
         return None if re is None else _encode_ndarray(re)
 
     @field_validator("routed_experts", mode="before")
     @classmethod
-    def _val_routed_experts(cls, value: Any) -> np.ndarray | None:
+    def deserialize_routed_experts(cls, value: Any) -> np.ndarray | None:
         if value is None or isinstance(value, np.ndarray):
             return value
         if isinstance(value, dict) and value.get("__nd__"):
@@ -259,7 +260,7 @@ def _attribute_routed_experts(
     path_len: int,
     payload: Any,
 ) -> None:
-    """Attach each new node's slice of this turn's MoE router-replay sidecar. The `generate`
+    """Attach each new node's slice of this turn's MoE expert-routing array. The `generate`
     payload's array covers the turn's prompt+completion from `payload["start"]` (0 = from token
     0); the nodes created this turn tile sequence positions `[path_len:]` in creation order, so
     we hand each node `arr[off : off+len(node.token_ids)]` and advance. Reused-prefix nodes keep
@@ -353,7 +354,7 @@ def add_turn(trace: "Trace", prompt: "list[Message]", response: Response) -> Non
     # Attribute this turn's images onto the input nodes that introduced them (by content part).
     _attribute_mm(trace, path, num_reused, tokens.multi_modal_data if tokens else None)
 
-    # Attribute this turn's router-replay sidecar onto the nodes created this turn (new input
+    # Attribute this turn's expert-routing array onto the nodes created this turn (new input
     # nodes in creation order, then the assistant node), each getting the routing for its tokens.
     new_node_ids = [nid for nid, _ in path[num_reused:]]
     new_node_ids.append(len(trace.nodes) - 1)

--- a/verifiers/v1/serve/server.py
+++ b/verifiers/v1/serve/server.py
@@ -24,6 +24,7 @@ import msgpack
 import zmq
 import zmq.asyncio
 
+from verifiers.utils.serve_utils import msgpack_encoder
 from verifiers.v1.clients import RolloutContext, resolve_client
 from verifiers.v1.clients.client import Client
 from verifiers.v1.clients.config import ClientConfig
@@ -147,7 +148,11 @@ class EnvServer:
         ) as e:  # a failed request is data, not a crash — report and keep serving
             logger.warning("request failed: %s", e, exc_info=True)
             response = BaseResponse(success=False, error=f"{type(e).__name__}: {e}")
-        data = msgpack.packb(response.model_dump(mode="json"), use_bin_type=True)
+        data = msgpack.packb(
+            response.model_dump(mode="python"),
+            default=msgpack_encoder,
+            use_bin_type=True,
+        )
         try:
             await self.frontend.send_multipart([client_id, request_id, data])
         except zmq.ZMQError as e:

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -135,7 +135,7 @@ class Branch(StrictBaseModel):
 
     @property
     def routed_experts(self) -> np.ndarray | None:
-        """The branch's MoE router-replay sidecar — every node's expert ids concatenated in path
+        """The branch's MoE expert-routing array — every node's expert ids concatenated in path
         (token) order, uint8 `[len(token_ids), layers, top_k]` aligned 1:1 with `token_ids`.
         All-or-nothing: returns None unless every token-bearing node carries routing and the
         concatenation matches the branch length (partial routing can't be safely aligned, so the
@@ -375,7 +375,12 @@ class Trace(StrictBaseModel, Generic[TaskT]):
         timing durations. A strict `Trace` can't round-trip them as input, and the
         consumer recomputes them, so we avoid re-running branching + duplicating the
         trajectory on every reply. The full `model_dump` (with derived fields) is what
-        gets written to disk."""
+        gets written to disk.
+
+        Dumped in `mode="python"` (not `"json"`) so per-node numpy arrays survive as raw bytes
+        in their `__nd__` dicts — the env-server packs the result with a numpy-aware msgpack
+        encoder so the arrays ride the `bin` wire untouched. `mode="json"` would coerce the
+        bytes to str."""
         exclude: dict = {field: True for field in type(self).model_computed_fields}
         # Drop each timing span's computed `duration` — derived per `TimeSpan` field of
         # `Timing` (setup/generation/scoring, and any future span) so none leaks to the wire.
@@ -384,7 +389,7 @@ class Trace(StrictBaseModel, Generic[TaskT]):
             for name, info in Timing.model_fields.items()
             if info.annotation is TimeSpan
         }
-        return self.model_dump(mode="json", exclude=exclude)
+        return self.model_dump(mode="python", exclude=exclude)
 
 
 TraceT = TypeVar("TraceT", bound=Trace)  # type: ignore[type-arg]

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -15,6 +15,7 @@ import uuid
 from collections.abc import Mapping
 from typing import Any, Generic, TypeVar
 
+import numpy as np
 from pydantic import Field, PrivateAttr, computed_field
 from renderers.base import MultiModalData
 
@@ -131,6 +132,20 @@ class Branch(StrictBaseModel):
             for modality, hashes in mmd.mm_hashes.items():
                 merged.mm_hashes.setdefault(modality, []).extend(hashes)
         return merged if found else None
+
+    @property
+    def routed_experts(self) -> np.ndarray | None:
+        """The branch's MoE router-replay sidecar — every node's expert ids concatenated in path
+        (token) order, uint8 `[len(token_ids), layers, top_k]` aligned 1:1 with `token_ids`.
+        All-or-nothing: returns None unless every token-bearing node carries routing and the
+        concatenation matches the branch length (partial routing can't be safely aligned, so the
+        trainer skips replay). None when the rollout ran without `enable_return_routed_experts`."""
+        nodes = [n for n in self.nodes if n.token_ids]
+        if not nodes or any(n.routed_experts is None for n in nodes):
+            return None
+        merged = np.concatenate([n.routed_experts for n in nodes], axis=0)
+        total = sum(len(n.token_ids) for n in nodes)
+        return merged if merged.shape[0] == total else None
 
     @property
     def completion_len(self) -> int:

--- a/verifiers/v1/types.py
+++ b/verifiers/v1/types.py
@@ -12,8 +12,8 @@ from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 from renderers.base import MultiModalData
 
 
-class RoutedExpertsPayload(TypedDict):
-    """The raw MoE expert-routing sidecar a `generate` response carries for router replay:
+class RoutedExperts(TypedDict):
+    """The raw MoE expert-routing data a `generate` response carries for router replay:
     base64 `data` (uint8 `[tokens, layers, top_k]`), its `shape`, and `start` — the prompt
     offset where the routing begins (0 = full prompt+completion). Kept opaque (`Any` data)
     so pydantic never validates the encoded blob."""
@@ -172,10 +172,10 @@ class TurnTokens(StrictBaseModel):
     # Transient carrier (excluded): the renderer's multimodal sidecar (image tensors + offsets),
     # attributed per node by `graph.add_turn`, then dropped — never persisted.
     multi_modal_data: MultiModalData | None = Field(default=None, exclude=True)
-    # Transient carrier (excluded): the MoE router-replay sidecar from `generate` (expert ids
+    # Transient carrier (excluded): the MoE expert-routing data from `generate` (expert ids
     # per token), attributed per node by `graph.add_turn` into `MessageNode.routed_experts`,
     # then dropped. None unless the engine ran with `enable_return_routed_experts`.
-    routed_experts: RoutedExpertsPayload | None = Field(default=None, exclude=True)
+    routed_experts: RoutedExperts | None = Field(default=None, exclude=True)
 
 
 class Response(StrictBaseModel):

--- a/verifiers/v1/types.py
+++ b/verifiers/v1/types.py
@@ -6,10 +6,21 @@ place raw provider dicts enter is the client implementation, which validates
 them into these models explicitly.
 """
 
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Literal, TypedDict
 
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 from renderers.base import MultiModalData
+
+
+class RoutedExpertsPayload(TypedDict):
+    """The raw MoE expert-routing sidecar a `generate` response carries for router replay:
+    base64 `data` (uint8 `[tokens, layers, top_k]`), its `shape`, and `start` — the prompt
+    offset where the routing begins (0 = full prompt+completion). Kept opaque (`Any` data)
+    so pydantic never validates the encoded blob."""
+
+    data: Any
+    shape: list[int]
+    start: int
 
 
 class StrictBaseModel(BaseModel):
@@ -161,6 +172,10 @@ class TurnTokens(StrictBaseModel):
     # Transient carrier (excluded): the renderer's multimodal sidecar (image tensors + offsets),
     # attributed per node by `graph.add_turn`, then dropped — never persisted.
     multi_modal_data: MultiModalData | None = Field(default=None, exclude=True)
+    # Transient carrier (excluded): the MoE router-replay sidecar from `generate` (expert ids
+    # per token), attributed per node by `graph.add_turn` into `MessageNode.routed_experts`,
+    # then dropped. None unless the engine ran with `enable_return_routed_experts`.
+    routed_experts: RoutedExpertsPayload | None = Field(default=None, exclude=True)
 
 
 class Response(StrictBaseModel):


### PR DESCRIPTION
## Summary

Captures the MoE **router-replay** routing through the v1 trace/graph so the trainer can replay the exact experts inference selected, wires it (and multimodal tensors) over the env-server RPC as **raw bytes** (no base64), and fixes the final-node alignment that blocked e2e.

### Capture
- `types.py` — `RoutedExperts` TypedDict (`data`/`shape`/`start`); `Node.routed_experts` (uint8 `[len(token_ids), layers, top_k]`).
- `graph.py` — `_attribute_routed_experts` slices the turn's routing per node; `Branch.routed_experts` concatenates along the path, aligned 1:1 with `branch.token_ids`.
- `trace.py` / `clients/train.py` — pull routing off the `generate` payload + wiring.

### Raw-bytes wire
- `_encode/_decode_ndarray` use raw `tobytes()`/`frombuffer`; `Trace.to_wire()` dumps `mode="python"`; env-server packs with the numpy-aware `serve_utils.msgpack_encoder`. Removes base64 inflation for routed_experts **and** multimodal tensors on the env-server → orchestrator hop.
- `serialize_*`/`deserialize_*` method names.

### Final-node alignment fix (unblocked e2e)
- The engine returns routing for the turn's tokens **minus one** (no forward pass follows the last generated token), so the final node overflowed the array and was left unattributed → `Branch.routed_experts` went all-or-nothing `None` → trainer crashed. `_attribute_routed_experts` now **tail-pads** the one missing row so the final node aligns 1:1.

Consumed prime-rl side by `_encode_routed_experts` (PrimeIntellect-ai/prime-rl#2808). E2E verified on Qwen3-30B-A3B: mismatch_kl drops with replay (0.0005/0.0002/0.0002 vs 0.0015/0.0015/0.0005 @ steps 0/1/2).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes trace wire encoding (python dump + raw bytes) and training-path data alignment; incorrect routing attribution would silently break router replay, though behavior is guarded by all-or-nothing branch checks and new tests.
> 
> **Overview**
> Adds end-to-end **MoE router-replay** support in v1: expert routing from `generate` is carried on `TurnTokens`, sliced onto graph nodes in `add_turn`, and exposed on **`Branch.routed_experts`** aligned 1:1 with `token_ids` (all-or-nothing when any node lacks routing). `TrainClient` forwards `routed_experts` from the engine payload.
> 
> **Wire format:** ndarray payloads (routing and multimodal tensors) use **raw bytes** in `__nd__` dicts instead of base64; `Trace.to_wire()` uses `mode="python"` and the env-server packs with `msgpack_encoder` so bytes stay on msgpack `bin`.
> 
> **Alignment fix:** `_attribute_routed_experts` tail-pads when the engine returns one fewer routing row than tokens (last position has no forward pass), so the final node is attributed and branch-level replay does not collapse to `None`.
> 
> New graph tests cover multi-turn attribution, wire round-trip, and absent routing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56f055baa2e7e0b9abbd4d4aca29e86b2c0411f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Capture MoE router-replay `routed_experts` on Trace graph nodes
> - Adds `RoutedExperts` and a `routed_experts` field to `TurnTokens` in [types.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1672/files#diff-88a4e4ee0c58ac5dc7344161a011374082a3767eda2ad32af97c942dca982112) to carry router-replay payloads from generate results through to graph attribution.
> - Adds `_attribute_routed_experts` in [graph.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1672/files#diff-64c9d635eb215902a512c9e8ab316fd9b9967c36db03d4049aacc812cdfbd740) to slice per-token expert routing arrays onto each `MessageNode` created by `add_turn`, with padding for the final generated token if omitted by the engine.
> - Switches numpy serialization in `_encode_ndarray`/`_decode_ndarray` and `Trace.to_wire` from base64 strings to raw bytes in `__nd__` dicts, aligning with msgpack binary transport.
> - Updates `EnvServer._serve_one` in [server.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1672/files#diff-64422f6a8749fcc024415b2756129bc98000e830e74b3b5245de50a555480a22) to use `model_dump(mode='python')` with a `msgpack_encoder` so numpy-backed fields encode as raw bytes over ZMQ.
> - Risk: wire payload format for all numpy-backed fields (including `multi_modal_data`) changes from base64 strings to msgpack bin; consumers must handle the new `__nd__` raw-bytes structure.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 56f055b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->