### PR TITLE
fix(v1): run prime-sandbox programs for the sandbox lifetime + retry-log wording

### DIFF
--- a/verifiers/v1/retries.py
+++ b/verifiers/v1/retries.py
@@ -97,10 +97,10 @@ async def run_with_retry(
         # collects exactly the errors that caused a retry — never the final attempt's.
         trace = state.outcome.result()
         logger.warning(
-            "retrying rollout %s (attempt %d/%d) after error: %s",
+            "retrying rollout %s (retry %d/%d) after error: %s",
             trace.id,
             state.attempt_number,
-            retry.max_retries + 1,
+            retry.max_retries,
             trace.error.type if trace.error else "?",
         )
         history.extend(trace.errors)

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -68,19 +68,15 @@ class PrimeRuntime(Runtime):
     def descriptor(self) -> str | None:
         return self._sandbox_id
 
-    @property
-    def _timeout_seconds(self) -> int:
-        return (
-            _MAX_TIMEOUT_SECONDS
-            if self.config.timeout == "auto"
-            else self.config.timeout
-        )
-
     async def start(self) -> None:
         from prime_sandboxes import AsyncSandboxClient, CreateSandboxRequest
 
         self._client = AsyncSandboxClient()
-        timeout = self._timeout_seconds
+        timeout = (
+            _MAX_TIMEOUT_SECONDS
+            if self.config.timeout == "auto"
+            else self.config.timeout
+        )
         # Map the resources onto prime's API (minutes, split GPU; memory/disk are already
         # GB). gpu_type/region are only sent when set (else provider-chosen).
         gpu_type, gpu_count = parse_gpu(self.config.gpu)
@@ -147,7 +143,11 @@ class PrimeRuntime(Runtime):
                 shlex.join(argv),
                 working_dir=self.config.workdir,
                 env=env,
-                timeout=self._timeout_seconds,
+                timeout=(
+                    _MAX_TIMEOUT_SECONDS
+                    if self.config.timeout == "auto"
+                    else self.config.timeout
+                ),
             )
         except (
             Exception

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -68,15 +68,19 @@ class PrimeRuntime(Runtime):
     def descriptor(self) -> str | None:
         return self._sandbox_id
 
-    async def start(self) -> None:
-        from prime_sandboxes import AsyncSandboxClient, CreateSandboxRequest
-
-        self._client = AsyncSandboxClient()
-        timeout = (
+    @property
+    def _timeout_seconds(self) -> int:
+        return (
             _MAX_TIMEOUT_SECONDS
             if self.config.timeout == "auto"
             else self.config.timeout
         )
+
+    async def start(self) -> None:
+        from prime_sandboxes import AsyncSandboxClient, CreateSandboxRequest
+
+        self._client = AsyncSandboxClient()
+        timeout = self._timeout_seconds
         # Map the resources onto prime's API (minutes, split GPU; memory/disk are already
         # GB). gpu_type/region are only sent when set (else provider-chosen).
         gpu_type, gpu_count = parse_gpu(self.config.gpu)
@@ -143,6 +147,7 @@ class PrimeRuntime(Runtime):
                 shlex.join(argv),
                 working_dir=self.config.workdir,
                 env=env,
+                timeout=self._timeout_seconds,
             )
         except (
             Exception


### PR DESCRIPTION
## Summary

Two fixes in the v1 prime-sandbox rollout-failure path:

- **`PrimeRuntime.run()` inherited the 15-min background-job timeout.** It called the prime-sandboxes `run_background_job()` **without a `timeout`**, so it used the SDK default of **900s (15 min)** and raised `CommandTimeoutError` at that deadline. Every harness program runs through this blocking path — `codex`/`claude_code`/`rlm` do `runtime.run(argv, env)`, uv-script/`compact` go through `run_uv_script` → `run` — so any agent running longer than 15 min was killed mid-rollout, even though the sandbox is provisioned for `config.timeout` (default **6h**, `"auto"` = 24h). Fix: pass the resolved sandbox timeout to `run_background_job`.
- **Retry log wording.** `before_sleep` fires when a retry is imminent, so the log now reads `retry N/max_retries` instead of `attempt N/(max_retries+1)` (e.g. `retry 1/1` instead of `attempt 1/2`).

## Root cause (timeout)

`run_background_job(sandbox_id, command, timeout: int = 900, ...)` waits up to `timeout` seconds then raises `CommandTimeoutError`. `start()` already resolves the sandbox lifetime (`config.timeout`, `"auto"` → 24h) for `timeout_minutes`, but `run()` never forwarded it. The `run_background()` / `nohup … &` path (MCP tool servers) is unaffected — its launcher returns immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes execution timeout behavior for all Prime blocking program runs (longer waits, different failure timing); retry logs only.
> 
> **Overview**
> **Prime sandbox programs** were capped at the SDK’s default **15-minute** `run_background_job` wait because `PrimeRuntime.run()` never forwarded `config.timeout`. Harness exec now passes the same resolved lifetime as provisioning (**6h** default, **24h** for `"auto"`), so long agent rollouts aren’t killed while the sandbox is still valid.
> 
> **Rollout retry logging** now says `retry N/max_retries` (e.g. `retry 1/1`) instead of `attempt N/(max_retries+1)`, matching that `before_sleep` only runs when another attempt is coming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07f101c817636ecf5e0b81a0a5bebcdaa9f9f091. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix prime sandbox programs to run for the full sandbox lifetime and correct retry log wording
> - Passes a `timeout` argument to `AsyncSandboxClient.run_background_job` in [`prime.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1676/files#diff-d22d61279ff7587a2b14c72ab1a0fc9d3f805a735338a70f8efc7fe19aaa8502), derived from the runtime config (`'auto'` maps to `_MAX_TIMEOUT_SECONDS`, otherwise uses the configured numeric value). Previously, background jobs relied on server-side defaults and could be killed before the sandbox lifetime ended.
> - Fixes the retry warning log in [`retries.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1676/files#diff-dd324cbc3488c3521fea600c7be4001a3f62becf8988cb8290ccbf4c9a487106): changes the label from `'attempt'` to `'retry'` and corrects the displayed total from `max_retries + 1` to `max_retries`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 07f101c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->