### PR TITLE
fix: resolve scaleswe-v1 task images via Prime Artifact Registry

### DIFF
--- a/examples/tasksets/scaleswe_v1/scaleswe_v1.py
+++ b/examples/tasksets/scaleswe_v1/scaleswe_v1.py
@@ -17,6 +17,11 @@ import verifiers.v1 as vf
 
 DATASET = "AweAI-Team/Scale-SWE"
 
+# The dataset's `image_url` (`aweaiteam/scaleswe:<tag>`) names a public Docker Hub mirror that
+# is missing some task images. Prime's Artifact Registry holds the complete, runtime-pullable
+# set, so resolve every image against it (matching the v0 ScaleSWE taskset).
+REGISTRY = "us-central1-docker.pkg.dev/prime-intellect-platform/prod-sandbox"
+
 # The testbed conda env (with the project + pytest installed) and quiet, non-interactive
 # tooling — exported for every command the taskset runs in the sandbox.
 ENV = {
@@ -102,7 +107,7 @@ class ScaleSWETaskset(vf.Taskset[ScaleSWETask, vf.TasksetConfig]):
                 idx=i,
                 name=row["instance_id"],
                 instruction=row["problem_statement"],
-                image=row["image_url"],
+                image=f"{REGISTRY}/{row['image_url']}",
                 workdir=row["workdir"],
                 resources=vf.Resources(cpu=4, memory=4, disk=10),
                 base_commit=row.get("parent_commit") or row.get("base_commit") or "",


### PR DESCRIPTION
## Summary

- `scaleswe-v1` passed the dataset's bare `image_url` (`aweaiteam/scaleswe:<tag>`) straight to the runtime, which resolves to the **public Docker Hub** mirror.
- That mirror is missing **708 of the 20,181** task images, so those rows fail at container start with `docker: ... manifest unknown` (observed in eval runs as `stop=ProgramError`, 0 turns).
- Resolve every image against Prime's **Artifact Registry** (`us-central1-docker.pkg.dev/prime-intellect-platform/prod-sandbox`) — the complete, runtime-pullable source — matching the v0 ComposableEnv ScaleSWE taskset (`verifiers/envs/experimental/composable/tasksets/swe/scale_swe/taskset.py`, which already prepends this prefix).

## Verification

- v0 already uses this exact registry prefix in production, so the path is known-good.
- The Docker Hub gap was measured directly against the registry API: repo `aweaiteam/scaleswe` is public, 22,120 tags total; of the 20,181 the dataset references, 19,473 are pullable and 708 return HTTP 404 (incl. `durandtibo_iden_pr53`, `durandtibo_feu_pr461`, `dwavesystems_dwave-cloud-client_pr429`, which errored in recent eval runs).
- Note: the Artifact Registry is private, so the runtime executing rollouts must have GAR pull credentials configured (the Prime sandbox runtime does; a local `docker` runtime needs `gcloud auth configure-docker us-central1-docker.pkg.dev`). I could not independently confirm GAR holds all 708 from this box (no `gcloud`/creds available).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prefix scaleswe-v1 task image URLs with the Prime Artifact Registry path
> Adds a `REGISTRY` constant pointing to `us-central1-docker.pkg.dev/prime-intellect-platform/prod-sandbox` in [scaleswe_v1.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1677/files#diff-36bea5e7297c25b676c8aced7cf3199c741954c63278004be8b67c17e44ec6df) and prefixes each task's `image` field with this registry path instead of using the raw `image_url` from the dataset.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5f17401.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-path image URL change mirroring an already-used v0 pattern; rollout runtimes need GAR pull access (Prime sandbox already has it).
> 
> **Overview**
> **scaleswe-v1** no longer uses the dataset’s bare `image_url` (Docker Hub `aweaiteam/scaleswe:<tag>`), which is missing hundreds of task images and caused rollout failures (`manifest unknown` / `ProgramError` at container start).
> 
> The taskset now defines a `REGISTRY` constant for `us-central1-docker.pkg.dev/prime-intellect-platform/prod-sandbox` and sets each task’s `image` to `{REGISTRY}/{image_url}`, aligning with the v0 ComposableEnv ScaleSWE taskset’s image resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f17401ac3c94fbdc4886c978049e50c023fb4da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->