### PR TITLE
feat: make scaleswe-v1 Prime Artifact Registry opt-in

### DIFF
--- a/examples/tasksets/scaleswe_v1/scaleswe_v1.py
+++ b/examples/tasksets/scaleswe_v1/scaleswe_v1.py
@@ -17,9 +17,10 @@ import verifiers.v1 as vf
 
 DATASET = "AweAI-Team/Scale-SWE"
 
-# The dataset's `image_url` (`aweaiteam/scaleswe:<tag>`) names a public Docker Hub mirror that
-# is missing some task images. Prime's Artifact Registry holds the complete, runtime-pullable
-# set, so resolve every image against it (matching the v0 ScaleSWE taskset).
+# Prime's private Artifact Registry holds the complete image set, but only runtimes with GCP
+# credentials (e.g. Prime sandboxes) can pull from it. By default images are taken straight from
+# the dataset's `image_url` (the public `aweaiteam/scaleswe` Docker Hub mirror, missing some
+# tags); set `use_prime_registry` to resolve against this registry instead.
 REGISTRY = "us-central1-docker.pkg.dev/prime-intellect-platform/prod-sandbox"
 
 # The testbed conda env (with the project + pytest installed) and quiet, non-interactive
@@ -95,7 +96,13 @@ class ScaleSWETask(vf.Task):
     pass_to_pass: list[str] = []
 
 
-class ScaleSWETaskset(vf.Taskset[ScaleSWETask, vf.TasksetConfig]):
+class ScaleSWEConfig(vf.TasksetConfig):
+    use_prime_registry: bool = False
+    """Resolve task images against Prime's private Artifact Registry (`REGISTRY`) instead of the
+    dataset's public Docker Hub `image_url`. Only works on runtimes with GCP pull credentials."""
+
+
+class ScaleSWETaskset(vf.Taskset[ScaleSWETask, ScaleSWEConfig]):
     NEEDS_CONTAINER = True
 
     def load_tasks(self) -> list[ScaleSWETask]:
@@ -107,7 +114,11 @@ class ScaleSWETaskset(vf.Taskset[ScaleSWETask, vf.TasksetConfig]):
                 idx=i,
                 name=row["instance_id"],
                 instruction=row["problem_statement"],
-                image=f"{REGISTRY}/{row['image_url']}",
+                image=(
+                    f"{REGISTRY}/{row['image_url']}"
+                    if self.config.use_prime_registry
+                    else row["image_url"]
+                ),
                 workdir=row["workdir"],
                 resources=vf.Resources(cpu=4, memory=4, disk=10),
                 base_commit=row.get("parent_commit") or row.get("base_commit") or "",
@@ -175,5 +186,5 @@ class ScaleSWETaskset(vf.Taskset[ScaleSWETask, vf.TasksetConfig]):
         return False
 
 
-def load_taskset(config: vf.TasksetConfig) -> ScaleSWETaskset:
+def load_taskset(config: ScaleSWEConfig) -> ScaleSWETaskset:
     return ScaleSWETaskset(config)


### PR DESCRIPTION
## Summary

- #1677 made `scaleswe-v1` resolve task images against Prime's **private** Artifact Registry (`us-central1-docker.pkg.dev/prime-intellect-platform/prod-sandbox`). That only works on runtimes with GCP pull credentials (e.g. the **prime** sandbox runtime); a local `docker` runtime gets `denied: Unauthenticated request` and every rollout dies at container start.
- Make it **opt-in**: add `ScaleSWEConfig(vf.TasksetConfig)` with `use_prime_registry: bool = False`.
  - **Default (False)** — images come straight from the dataset's `image_url` (public `aweaiteam/scaleswe` Docker Hub mirror); works on any runtime, but ~708/20,181 tags are missing there.
  - **`use_prime_registry = true`** — prepend the Artifact Registry prefix; complete image set, but requires a credentialed runtime.

## Behavior change

- Reverts the default introduced in #1677: out of the box, images again come from Docker Hub (not the GAR). Set `use_prime_registry = true` in the taskset config to restore the registry path.

## Notes

- Not even the GAR is a strict superset: on the prime runtime, the same 3 tasks that 404 on Docker Hub (`durandtibo_iden_pr53`, `durandtibo_feu_pr461`, `dwavesystems_dwave-cloud-client_pr429`) fail with `IMAGE_PULL_FAILED` — they appear unbuilt in both registries.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make Prime Artifact Registry opt-in for `ScaleSWETaskset`
> Adds a `use_prime_registry` boolean field to a new `ScaleSWEConfig` class (defaulting to `False`). When `False`, `load_tasks` uses the raw `image_url` from the dataset; when `True`, it prefixes with the private `REGISTRY` path, restoring the previous behavior. Behavioral Change: the default behavior changes — tasks now use dataset-provided image URLs rather than the private registry.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d367fc5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default behavior change affects every rollout’s container image resolution; most environments get Docker Hub (with known missing tags) unless config explicitly enables the registry path.
> 
> **Overview**
> **Reverts the #1677 default** where every task image was forced through Prime’s private Artifact Registry. Rollouts on uncredentialed runtimes (e.g. local Docker) no longer fail at pull with unauthenticated GAR errors.
> 
> Introduces **`ScaleSWEConfig`** with **`use_prime_registry: bool = False`**. `ScaleSWETaskset` is typed on that config; **`load_taskset`** now takes `ScaleSWEConfig`. In **`load_tasks`**, the task **`image`** is `row["image_url"]` by default, and only `f"{REGISTRY}/{row['image_url']}"` when **`use_prime_registry`** is true. Module comments document the tradeoff: public Hub mirror vs complete GAR set with GCP credentials.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d367fc5b41062fcec0fd5fd5668e1846dd6b1ab1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->