### PR TITLE
feat: filter unavailable scaleswe-v1 images at load

### DIFF
--- a/examples/tasksets/scaleswe_v1/scaleswe_v1.py
+++ b/examples/tasksets/scaleswe_v1/scaleswe_v1.py
@@ -11,9 +11,12 @@ which scores 1.0 iff every expected id passed. A v1 port of the v0 ComposableEnv
 """
 
 import json
+import logging
 from pathlib import Path
 
 import verifiers.v1 as vf
+
+logger = logging.getLogger(__name__)
 
 DATASET = "AweAI-Team/Scale-SWE"
 
@@ -80,6 +83,88 @@ def _ids(raw: str | list[str] | None) -> list[str]:
     return [parsed] if isinstance(parsed, str) and parsed else []
 
 
+def _parse_ref(ref: str) -> tuple[str, str, str]:
+    """Split an image reference into (registry host, repository, tag)."""
+    head, _, rest = ref.partition("/")
+    if rest and ("." in head or ":" in head or head == "localhost"):
+        registry, remainder = head, rest
+    else:
+        registry, remainder = "registry-1.docker.io", ref
+    repo, _, tag = remainder.rpartition(":")
+    return registry, repo, tag
+
+
+def _list_tags(registry: str, repo: str) -> set[str] | None:
+    """All tags in `registry/repo` via the Docker registry v2 API, or None if the registry
+    can't be enumerated anonymously (private/no creds/unreachable)."""
+    import urllib.error
+    import urllib.request
+
+    def _get(url: str, token: str | None):
+        req = urllib.request.Request(url)
+        if token:
+            req.add_header("Authorization", f"Bearer {token}")
+        return urllib.request.urlopen(req, timeout=30)
+
+    def _token(challenge: str | None) -> str | None:
+        if not challenge or not challenge.lower().startswith("bearer "):
+            return None
+        parts = dict(
+            p.strip().split("=", 1) for p in challenge[7:].split(",") if "=" in p
+        )
+        realm = parts.get("realm", "").strip('"')
+        params = "&".join(
+            f"{k}={v.strip(chr(34))}" for k, v in parts.items() if k != "realm"
+        )
+        try:
+            return json.load(_get(f"{realm}?{params}", None)).get("token")
+        except (urllib.error.HTTPError, urllib.error.URLError, ValueError):
+            return None
+
+    tags: list[str] = []
+    url: str | None = f"https://{registry}/v2/{repo}/tags/list?n=1000"
+    token = None
+    while url:
+        try:
+            resp = _get(url, token)
+        except urllib.error.HTTPError as e:
+            if e.code == 401 and token is None:
+                token = _token(e.headers.get("WWW-Authenticate"))
+                if token:
+                    continue
+            return None
+        except urllib.error.URLError:
+            return None
+        tags.extend(json.load(resp).get("tags") or [])
+        link = resp.headers.get("Link", "")
+        nxt = link[link.find("<") + 1 : link.find(">")] if 'rel="next"' in link else ""
+        url = f"https://{registry}{nxt}" if nxt.startswith("/") else (nxt or None)
+    return set(tags)
+
+
+def _available_images(images: set[str]) -> set[str]:
+    """The subset of `images` whose tag exists in its registry. Images in a registry that
+    can't be enumerated (private, no creds, unreachable) are kept rather than dropped."""
+    by_repo: dict[tuple[str, str], set[str]] = {}
+    for ref in images:
+        registry, repo, _ = _parse_ref(ref)
+        by_repo.setdefault((registry, repo), set()).add(ref)
+    available: set[str] = set()
+    for (registry, repo), refs in by_repo.items():
+        tags = _list_tags(registry, repo)
+        if tags is None:
+            logger.warning(
+                "scaleswe: could not enumerate %s/%s - keeping %d images unchecked",
+                registry,
+                repo,
+                len(refs),
+            )
+            available |= refs
+        else:
+            available |= {r for r in refs if _parse_ref(r)[2] in tags}
+    return available
+
+
 class ScaleSWETask(vf.Task):
     base_commit: str
     """Commit the repo is reset to before the agent runs and tests are scored against."""
@@ -100,6 +185,9 @@ class ScaleSWEConfig(vf.TasksetConfig):
     use_prime_registry: bool = False
     """Resolve task images against Prime's private Artifact Registry (`REGISTRY`) instead of the
     dataset's public Docker Hub `image_url`. Only works on runtimes with GCP pull credentials."""
+    filter_unavailable_images: bool = True
+    """Drop tasks whose image isn't present in the registry (a quick tags/list check at load),
+    so rollouts don't fail at container start. Registries that can't be enumerated are kept."""
 
 
 class ScaleSWETaskset(vf.Taskset[ScaleSWETask, ScaleSWEConfig]):
@@ -109,7 +197,7 @@ class ScaleSWETaskset(vf.Taskset[ScaleSWETask, ScaleSWEConfig]):
         from datasets import load_dataset
 
         rows = load_dataset(DATASET, split="train")
-        return [
+        tasks = [
             ScaleSWETask(
                 idx=i,
                 name=row["instance_id"],
@@ -133,6 +221,17 @@ class ScaleSWETaskset(vf.Taskset[ScaleSWETask, ScaleSWEConfig]):
             )
             for i, row in enumerate(rows)
         ]
+        if self.config.filter_unavailable_images:
+            available = _available_images({t.image for t in tasks})
+            kept = [t for t in tasks if t.image in available]
+            if len(kept) < len(tasks):
+                logger.info(
+                    "scaleswe: dropped %d/%d tasks with unavailable images",
+                    len(tasks) - len(kept),
+                    len(tasks),
+                )
+            tasks = kept
+        return tasks
 
     async def setup(self, task: ScaleSWETask, runtime: vf.Runtime) -> None:
         result = await runtime.run(["sh", "-c", task.pre_commands], ENV)

--- a/examples/tasksets/scaleswe_v1/scaleswe_v1.py
+++ b/examples/tasksets/scaleswe_v1/scaleswe_v1.py
@@ -115,21 +115,24 @@ def _docker_hub_tags(repo: str) -> set[str] | None:
 def _available_images(images: set[str]) -> set[str]:
     """Subset of `images` known to exist. Only the public Docker Hub mirror is enumerated
     anonymously; images on other registries (e.g. the private Artifact Registry) are kept."""
-    repos: dict[str, set[str]] = {}
+    by_repo: dict[str, set[tuple[str, str]]] = {}
     available: set[str] = set()
     for ref in images:
         head = ref.split("/", 1)
         # a leading registry host (with "." or ":") isn't anonymously enumerable - keep it
         if len(head) == 2 and ("." in head[0] or ":" in head[0]):
             available.add(ref)
-        else:
-            repos.setdefault(ref.rsplit(":", 1)[0], set()).add(ref)
-    for repo, refs in repos.items():
+            continue
+        repo, sep, tag = ref.rpartition(":")
+        if not sep:  # no tag -> implicit "latest"
+            repo, tag = ref, "latest"
+        by_repo.setdefault(repo, set()).add((ref, tag))
+    for repo, refs in by_repo.items():
         tags = _docker_hub_tags(repo)
         if tags is None:
-            available |= refs
+            available |= {ref for ref, _ in refs}
         else:
-            available |= {r for r in refs if r.rsplit(":", 1)[1] in tags}
+            available |= {ref for ref, tag in refs if tag in tags}
     return available
 
 

--- a/examples/tasksets/scaleswe_v1/scaleswe_v1.py
+++ b/examples/tasksets/scaleswe_v1/scaleswe_v1.py
@@ -83,85 +83,53 @@ def _ids(raw: str | list[str] | None) -> list[str]:
     return [parsed] if isinstance(parsed, str) and parsed else []
 
 
-def _parse_ref(ref: str) -> tuple[str, str, str]:
-    """Split an image reference into (registry host, repository, tag)."""
-    head, _, rest = ref.partition("/")
-    if rest and ("." in head or ":" in head or head == "localhost"):
-        registry, remainder = head, rest
-    else:
-        registry, remainder = "registry-1.docker.io", ref
-    repo, _, tag = remainder.rpartition(":")
-    return registry, repo, tag
+def _docker_hub_tags(repo: str) -> set[str] | None:
+    """Every tag in a public Docker Hub `repo` via the registry v2 API, or None if unreadable."""
+    import httpx
 
-
-def _list_tags(registry: str, repo: str) -> set[str] | None:
-    """All tags in `registry/repo` via the Docker registry v2 API, or None if the registry
-    can't be enumerated anonymously (private/no creds/unreachable)."""
-    import urllib.error
-    import urllib.request
-
-    def _get(url: str, token: str | None):
-        req = urllib.request.Request(url)
-        if token:
-            req.add_header("Authorization", f"Bearer {token}")
-        return urllib.request.urlopen(req, timeout=30)
-
-    def _token(challenge: str | None) -> str | None:
-        if not challenge or not challenge.lower().startswith("bearer "):
-            return None
-        parts = dict(
-            p.strip().split("=", 1) for p in challenge[7:].split(",") if "=" in p
-        )
-        realm = parts.get("realm", "").strip('"')
-        params = "&".join(
-            f"{k}={v.strip(chr(34))}" for k, v in parts.items() if k != "realm"
-        )
-        try:
-            return json.load(_get(f"{realm}?{params}", None)).get("token")
-        except (urllib.error.HTTPError, urllib.error.URLError, ValueError):
-            return None
-
-    tags: list[str] = []
-    url: str | None = f"https://{registry}/v2/{repo}/tags/list?n=1000"
-    token = None
-    while url:
-        try:
-            resp = _get(url, token)
-        except urllib.error.HTTPError as e:
-            if e.code == 401 and token is None:
-                token = _token(e.headers.get("WWW-Authenticate"))
-                if token:
-                    continue
-            return None
-        except urllib.error.URLError:
-            return None
-        tags.extend(json.load(resp).get("tags") or [])
-        link = resp.headers.get("Link", "")
-        nxt = link[link.find("<") + 1 : link.find(">")] if 'rel="next"' in link else ""
-        url = f"https://{registry}{nxt}" if nxt.startswith("/") else (nxt or None)
-    return set(tags)
+    base = "https://registry-1.docker.io"
+    try:
+        token = httpx.get(
+            "https://auth.docker.io/token",
+            params={
+                "service": "registry.docker.io",
+                "scope": f"repository:{repo}:pull",
+            },
+            timeout=30,
+        ).json()["token"]
+        tags: list[str] = []
+        url: str | None = f"{base}/v2/{repo}/tags/list?n=1000"
+        while url:
+            resp = httpx.get(
+                url, headers={"Authorization": f"Bearer {token}"}, timeout=30
+            )
+            resp.raise_for_status()
+            tags += resp.json().get("tags") or []
+            nxt = resp.links.get("next", {}).get("url")
+            url = f"{base}{nxt}" if nxt else None
+        return set(tags)
+    except (httpx.HTTPError, KeyError):
+        return None
 
 
 def _available_images(images: set[str]) -> set[str]:
-    """The subset of `images` whose tag exists in its registry. Images in a registry that
-    can't be enumerated (private, no creds, unreachable) are kept rather than dropped."""
-    by_repo: dict[tuple[str, str], set[str]] = {}
-    for ref in images:
-        registry, repo, _ = _parse_ref(ref)
-        by_repo.setdefault((registry, repo), set()).add(ref)
+    """Subset of `images` known to exist. Only the public Docker Hub mirror is enumerated
+    anonymously; images on other registries (e.g. the private Artifact Registry) are kept."""
+    repos: dict[str, set[str]] = {}
     available: set[str] = set()
-    for (registry, repo), refs in by_repo.items():
-        tags = _list_tags(registry, repo)
+    for ref in images:
+        head = ref.split("/", 1)
+        # a leading registry host (with "." or ":") isn't anonymously enumerable - keep it
+        if len(head) == 2 and ("." in head[0] or ":" in head[0]):
+            available.add(ref)
+        else:
+            repos.setdefault(ref.rsplit(":", 1)[0], set()).add(ref)
+    for repo, refs in repos.items():
+        tags = _docker_hub_tags(repo)
         if tags is None:
-            logger.warning(
-                "scaleswe: could not enumerate %s/%s - keeping %d images unchecked",
-                registry,
-                repo,
-                len(refs),
-            )
             available |= refs
         else:
-            available |= {r for r in refs if _parse_ref(r)[2] in tags}
+            available |= {r for r in refs if r.rsplit(":", 1)[1] in tags}
     return available
 
 


### PR DESCRIPTION
## Summary

- Add `ScaleSWEConfig.filter_unavailable_images: bool = True`. At load, the taskset enumerates each image's registry via the Docker registry **v2 `tags/list`** API and drops tasks whose tag isn't present, so rollouts don't die at container start with `manifest unknown` / `ErrImagePull`.
- Registries that can't be enumerated anonymously (private / no creds / unreachable — e.g. the GAR when `use_prime_registry=true`) are **kept unchecked** rather than dropped, and a warning is logged. So the check is most effective on the default public Docker Hub path; it never silently nukes a private-registry run.
- Logs how many tasks were dropped (no silent truncation).

## Why (and v0 comparison)

v0 has **no** runtime availability check — it mirrors images into the Prime registry and publishes *pre-filtered* datasets offline via `prime-data` (+ a generic `filter_fn` predicate). This load-time check is a complementary, zero-setup alternative for v1.

## Verification

Ran the availability check over the **full dataset** (all 20,181 `image_url`s, default Docker Hub):

```
total dataset images: 20181
available: 19473  dropped: 708  (14.3s)
dropped == independently-measured missing set? True
```

The 708 dropped exactly match the tags that return HTTP 404 on Docker Hub (incl. `durandtibo_iden_pr53`, `durandtibo_feu_pr461`, `dwavesystems_dwave-cloud-client_pr429`). `ruff check` / `ruff format` / `py_compile` clean.

> Note: this validates the load-time **image filter** across the full dataset. It does **not** run the per-task gold-patch `validate` entrypoint on all 20k tasks — that needs a credentialed sandbox runtime (GAR) and is a separate large run.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Filter unavailable Docker images from scaleswe-v1 taskset at load time
> - Adds `_docker_hub_tags` and `_available_images` helpers in [scaleswe_v1.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1679/files#diff-36bea5e7297c25b676c8aced7cf3199c741954c63278004be8b67c17e44ec6df) to query the Docker Hub Registry v2 API and determine which image refs actually exist.
> - Adds a `filter_unavailable_images` flag to `ScaleSWEConfig` (defaults to `True`) that causes `load_tasks` to drop tasks whose images are absent from the registry.
> - Registries with an explicit host (containing `.` or `:`) are skipped during enumeration and always kept; images whose tags cannot be fetched are also kept.
> - Logs an info message with the count of dropped tasks when filtering occurs.
> - Risk: task loading now performs network I/O against Docker Hub, which adds latency and a potential failure point on every load.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a478f57.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default-on filtering shrinks the task set (~708/20k on Docker Hub) and adds network calls at dataset load; private-registry paths are preserved but public runs silently exclude missing-image tasks unless the flag is disabled.
> 
> **Overview**
> **ScaleSWE v1** can now drop dataset rows at **load time** when their container image tag is not on the public Docker Hub mirror, so rollouts are less likely to fail with pull errors at container start.
> 
> A new **`filter_unavailable_images`** flag on `ScaleSWEConfig` defaults to **on**. When enabled, `load_tasks` collects unique image refs, checks tag presence via the Docker registry **v2 `tags/list`** API (Bearer auth + pagination through `httpx`), and keeps only tasks whose tag exists. **Private or non-enumerable registries** (e.g. GAR when `use_prime_registry` is true) are **left unfiltered** so credentialed runs are not emptied. An **info log** reports how many tasks were dropped.
> 
> This is load-time filtering only; **`setup` / `solved` / scoring behavior is unchanged**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a478f574119f0f5c039c8da300f65fa0eb7ab370. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->