### PR TITLE
feat(v1): session-affinity routing header for cross-turn prefix reuse

### DIFF
--- a/verifiers/v1/clients/client.py
+++ b/verifiers/v1/clients/client.py
@@ -23,6 +23,13 @@ from verifiers.v1.types import Response, SamplingConfig
 
 logger = logging.getLogger(__name__)
 
+SESSION_ID_HEADER = "X-Session-ID"
+"""Per-rollout routing header. Every turn of one rollout sends the same value (the trace id),
+so a session-affinity router (e.g. vLLM's ``consistent_hash`` policy keyed on its
+``request_id_headers``) pins all of a rollout's turns to the same engine — keeping the
+growing cross-turn prefix warm in that engine's KV cache instead of re-prefilling it
+cold on a random shard each turn."""
+
 
 @dataclass
 class RelayReply:
@@ -41,10 +48,15 @@ class Client(ABC):
         body: dict,
         model: str,
         sampling_args: SamplingConfig,
+        session_id: str | None = None,
     ) -> Response:
         """Run one completion -> a vf `Response`. The proxy client forwards `body` 1:1 and
         parses the provider response via `dialect` (carrying the raw on `Response.raw`); the
-        renderer derives the typed prompt from `body` via `dialect` and tokenizes it."""
+        renderer derives the typed prompt from `body` via `dialect` and tokenizes it.
+
+        `session_id` is the rollout's stable id (the trace id); when set, the client sends it
+        as the `SESSION_ID_HEADER` so a session-affinity router keeps the rollout's turns on
+        one engine for cross-turn prefix-cache reuse."""
 
     async def relay(
         self,
@@ -52,6 +64,7 @@ class Client(ABC):
         body: dict,
         model: str,
         sampling_args: SamplingConfig,
+        session_id: str | None = None,
     ) -> RelayReply:
         """Stream a (possibly SSE) response back, relaying the provider's bytes — the proxy's
         path for a streaming request. Only the relay (eval) client supports it; the renderer
@@ -99,9 +112,10 @@ class RetryingClient(Client):
         body: dict,
         model: str,
         sampling_args: SamplingConfig,
+        session_id: str | None = None,
     ) -> Response:
         return await self._retrying(
-            self.inner.get_response, dialect, body, model, sampling_args
+            self.inner.get_response, dialect, body, model, sampling_args, session_id
         )
 
     async def relay(
@@ -110,11 +124,12 @@ class RetryingClient(Client):
         body: dict,
         model: str,
         sampling_args: SamplingConfig,
+        session_id: str | None = None,
     ) -> RelayReply:
         # Safe to retry: relay raises (and is retried) before any response byte is handed back;
         # once a `RelayReply` is returned, streaming is already underway.
         return await self._retrying(
-            self.inner.relay, dialect, body, model, sampling_args
+            self.inner.relay, dialect, body, model, sampling_args, session_id
         )
 
     async def relay_aux(self, dialect: Dialect, route: str, body: dict) -> dict:

--- a/verifiers/v1/clients/eval.py
+++ b/verifiers/v1/clients/eval.py
@@ -13,7 +13,7 @@ change. Endpoint config (base url, api key, billing headers) comes from the clie
 
 import httpx
 
-from verifiers.v1.clients.client import Client, RelayReply
+from verifiers.v1.clients.client import SESSION_ID_HEADER, Client, RelayReply
 from verifiers.v1.dialects import Dialect
 from verifiers.v1.errors import model_error
 from verifiers.v1.types import Response, SamplingConfig
@@ -40,9 +40,12 @@ class EvalClient(Client):
         body: dict,
         model: str,
         sampling_args: SamplingConfig,
+        session_id: str | None = None,
     ) -> Response:
         # Byte-exact forward, save for the eval's model + sampling (imposed by the dialect).
-        url, headers, upstream = self._upstream(dialect, body, model, sampling_args)
+        url, headers, upstream = self._upstream(
+            dialect, body, model, sampling_args, session_id
+        )
         try:
             resp = await self.http.post(url, json=upstream, headers=headers)
             resp.raise_for_status()
@@ -58,13 +61,22 @@ class EvalClient(Client):
         return response
 
     def _upstream(
-        self, dialect: Dialect, body: dict, model: str, sampling_args: SamplingConfig
+        self,
+        dialect: Dialect,
+        body: dict,
+        model: str,
+        sampling_args: SamplingConfig,
+        session_id: str | None = None,
     ) -> tuple[str, dict, dict]:
         """The (url, headers, steered body) for a forwarded request — shared by the non-stream
-        and streaming paths."""
+        and streaming paths. A `session_id` is forwarded as the `SESSION_ID_HEADER` so the
+        provider's router can pin the rollout's turns to one engine."""
+        headers = dialect.auth_headers(self.api_key)
+        if session_id:
+            headers = {**headers, SESSION_ID_HEADER: session_id}
         return (
             self.base_url + dialect.upstream_path,
-            dialect.auth_headers(self.api_key),
+            headers,
             dialect.apply_overrides(body, model, sampling_args),
         )
 
@@ -74,11 +86,14 @@ class EvalClient(Client):
         body: dict,
         model: str,
         sampling_args: SamplingConfig,
+        session_id: str | None = None,
     ) -> RelayReply:
         # Stream the provider's response bytes through (SSE for a streaming request). An error
         # status is read fully and mapped before any byte is handed back, so the retry +
         # truncation machinery treat a relayed call exactly like a non-streamed one.
-        url, headers, upstream = self._upstream(dialect, body, model, sampling_args)
+        url, headers, upstream = self._upstream(
+            dialect, body, model, sampling_args, session_id
+        )
         request = self.http.build_request("POST", url, json=upstream, headers=headers)
         try:
             resp = await self.http.send(request, stream=True)

--- a/verifiers/v1/clients/train.py
+++ b/verifiers/v1/clients/train.py
@@ -14,7 +14,7 @@ from openai import AsyncOpenAI, OpenAIError
 from renderers import OverlongPromptError as RendererOverlongPromptError
 from renderers import RendererConfig
 
-from verifiers.v1.clients.client import Client
+from verifiers.v1.clients.client import SESSION_ID_HEADER, Client
 from verifiers.v1.dialects import FINISH_REASONS, ChatDialect, Dialect
 from verifiers.v1.dialects.chat import message_to_wire
 from verifiers.v1.errors import OverlongPromptError, model_error
@@ -164,6 +164,7 @@ class TrainClient(Client):
         body: dict,
         model: str,
         sampling_args: SamplingConfig,
+        session_id: str | None = None,
     ) -> Response:
         # The renderer tokenizes the typed prompt for training (it needs per-token ids + logprobs
         # back), so it can't forward the raw request — it parses `body` via the dialect and renders
@@ -190,6 +191,7 @@ class TrainClient(Client):
                 model=model,
                 tools=[tool_to_wire(t) for t in tools] if tools else None,
                 sampling_params=sampling_args.model_dump(exclude_none=True),
+                extra_headers={SESSION_ID_HEADER: session_id} if session_id else None,
             )
         except RendererOverlongPromptError as e:
             raise OverlongPromptError(str(e)) from e

--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -208,7 +208,11 @@ class InterceptionServer:
                 return web.json_response(completion)
             try:
                 response = await session.ctx.client.get_response(
-                    dialect, body, session.ctx.model, session.ctx.sampling
+                    dialect,
+                    body,
+                    session.ctx.model,
+                    session.ctx.sampling,
+                    session_id=session.trace.id,
                 )
             except OverlongPromptError:
                 # An overlong prompt is a budget limit, not a crash: end the rollout cleanly
@@ -262,7 +266,11 @@ class InterceptionServer:
             )
         try:
             reply = await session.ctx.client.relay(
-                dialect, body, session.ctx.model, session.ctx.sampling
+                dialect,
+                body,
+                session.ctx.model,
+                session.ctx.sampling,
+                session_id=session.trace.id,
             )
         except OverlongPromptError:
             session.trace.stop("context_length")


### PR DESCRIPTION
## Problem

Multi-turn rollouts re-send the growing conversation each turn, so turn N+1's prompt is a strict extension of turn N's — it should hit the prior turn's KV cache on the **same engine**. But a session-affinity router (vLLM's `consistent_hash`, keyed on its `request_id_headers`) needs a **stable per-rollout key** to pin all of a rollout's turns to one engine, and the v1 clients sent none.

Result: turns scatter across DP shards and re-prefill the prefix cold every turn. Observed **~40% prefix cache hit rate** on an agentic SWE run (Qwen3.5-4B, r2e-gym, dp=8×2 replicas, external-LB) where it should approach the eviction-limited ceiling.

The existing `X-Session-ID → trajectory_id` convention in `scripts/eval.py` ("sticky DP-aware routing") never reached the v1 client path that prime-rl drives.

## Fix

Thread the rollout's stable id (`trace.id`) from the interception server into `Client.get_response` / `Client.relay`, and have both clients emit it as the **`X-Session-ID`** header:

- `TrainClient` (renderer/token path) → `generate(extra_headers={X-Session-ID: id})`
- `EvalClient` (proxy path) → merged into the forwarded upstream headers

Same value for every turn of a rollout → same engine → warm cross-turn prefix.

## Companion change

prime-rl launches the router with `--request-id-headers x-session-id` so `consistent_hash` keys on this header (PrimeIntellect-ai/prime-rl#TBD).

## Files
- `verifiers/v1/clients/client.py` — `SESSION_ID_HEADER` const; `session_id` param on the `Client` ABC + `RetryingClient`
- `verifiers/v1/clients/train.py` — emit header via `generate(extra_headers=...)`
- `verifiers/v1/clients/eval.py` — merge header into forwarded request
- `verifiers/v1/interception/server.py` — pass `session.trace.id` at both call sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `X-Session-ID` header to client requests for session-affinity routing
> - Introduces a `SESSION_ID_HEADER` constant (`X-Session-ID`) in the client base and threads an optional `session_id` parameter through `get_response` and `relay` on `Client`, `RetryingClient`, `EvalClient`, and `TrainClient`.
> - The interception server passes `session.trace.id` as the `session_id` for both streaming and non-streaming request paths, so each session consistently routes to the same upstream for prefix reuse.
> - `TrainClient` sets the header via `extra_headers` on the renderer generate call; `EvalClient` forwards it in the upstream request construction.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bfd199e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Optional header plumbing only; backward compatible when `session_id` is unset, with no changes to auth, parsing, or trace semantics.
> 
> **Overview**
> Multi-turn rollouts can now send a **stable per-rollout key** on every upstream model request so session-affinity routers (e.g. vLLM `consistent_hash` on `X-Session-ID`) pin all turns of one rollout to the same engine and reuse cross-turn KV prefix cache.
> 
> The v1 **`Client`** API gains an optional `session_id` on **`get_response`** and **`relay`**, with a shared **`SESSION_ID_HEADER`** (`X-Session-ID`). The interception server passes **`session.trace.id`** at both non-streaming and streaming call sites. **`EvalClient`** merges the header into forwarded upstream requests; **`TrainClient`** passes it via **`generate(extra_headers=...)`**. **`RetryingClient`** forwards the argument through retries.
> 
> Callers that omit `session_id` behave as before; no request body or dialect wire format changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfd199ec530280fd832cff5feade5767045636f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->