### PR TITLE
feat: make r2e-gym-v1 Prime Artifact Registry opt-in

### DIFF
--- a/examples/tasksets/r2e_gym_v1/r2e_gym_v1.py
+++ b/examples/tasksets/r2e_gym_v1/r2e_gym_v1.py
@@ -17,9 +17,10 @@ import verifiers.v1 as vf
 
 DATASET = "R2E-Gym/R2E-Gym-Subset"
 
-# R2E-Gym images live in the Prime Intellect prod sandbox registry; rows carry the bare
-# repository:tag in ``docker_image`` and we prefix it here.
-REGISTRY_PREFIX = "us-central1-docker.pkg.dev/prime-intellect-platform/prod-sandbox"
+# `docker_image` is a public Docker Hub ref (`namanjain12/<repo>_final:<commit>`); Prime mirrors
+# these into its private Artifact Registry. By default images come straight from Docker Hub; set
+# `use_prime_registry` to resolve against the registry instead (needs GCP pull credentials).
+REGISTRY = "us-central1-docker.pkg.dev/prime-intellect-platform/prod-sandbox"
 
 REPO_PATH = "/testbed"
 ALT_PATH = "/root"
@@ -172,7 +173,13 @@ class R2EGymTask(vf.Task):
     """R2E-Gym commit JSON; gold patch is reconstructed from it for validation/dummy rollouts."""
 
 
-class R2EGymTaskset(vf.Taskset[R2EGymTask, vf.TasksetConfig]):
+class R2EGymConfig(vf.TasksetConfig):
+    use_prime_registry: bool = False
+    """Resolve task images against Prime's private Artifact Registry (`REGISTRY`) instead of the
+    dataset's public Docker Hub `docker_image`. Only works on runtimes with GCP pull credentials."""
+
+
+class R2EGymTaskset(vf.Taskset[R2EGymTask, R2EGymConfig]):
     NEEDS_CONTAINER = True
 
     def load_tasks(self) -> list[R2EGymTask]:
@@ -184,7 +191,11 @@ class R2EGymTaskset(vf.Taskset[R2EGymTask, vf.TasksetConfig]):
                 idx=i,
                 name=row.get("commit_hash") or f"r2e-{i}",
                 instruction=row["problem_statement"],
-                image=f"{REGISTRY_PREFIX}/{row['docker_image']}",
+                image=(
+                    f"{REGISTRY}/{row['docker_image']}"
+                    if self.config.use_prime_registry
+                    else row["docker_image"]
+                ),
                 workdir=REPO_PATH,
                 expected_output_json=row["expected_output_json"],
                 parsed_commit_content=row.get("parsed_commit_content") or "",
@@ -231,5 +242,5 @@ class R2EGymTaskset(vf.Taskset[R2EGymTask, vf.TasksetConfig]):
             )
 
 
-def load_taskset(config: vf.TasksetConfig) -> R2EGymTaskset:
+def load_taskset(config: R2EGymConfig) -> R2EGymTaskset:
     return R2EGymTaskset(config)


### PR DESCRIPTION
## Summary

- `r2e-gym-v1` hardcoded the GAR prefix on every image (`f"{REGISTRY}/{docker_image}"`). That only pulls on runtimes with GCP credentials (e.g. the **prime** sandbox runtime); a local `docker` runtime fails with `denied: Unauthenticated request`.
- Make it **opt-in**, mirroring the scaleswe-v1 change (#1678): add `R2EGymConfig(vf.TasksetConfig)` with `use_prime_registry: bool = False`.
  - **Default (False)** — images come straight from the dataset's `docker_image`, a public Docker Hub ref (`namanjain12/<repo>_final:<commit>`); works on any runtime.
  - **`use_prime_registry = true`** — prepend the Artifact Registry prefix; requires a credentialed runtime.

## Behavior change

- Default flips from GAR → Docker Hub. Set `use_prime_registry = true` in the taskset config to restore the previous (registry) behavior.

## Verification

- All **4578** R2E-Gym-Subset `docker_image`s are public on Docker Hub (10 `namanjain12/*_final` repos, 0 missing), so the default works everywhere.
- v0 (`composable/.../r2e_gym/taskset.py`) and v1 both already point exclusively at the GAR, so the mirror exists there by design — though it's private and couldn't be enumerated anonymously to confirm independently.
- `ruff check` / `ruff format` / `py_compile` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default image resolution flips from GAR to Docker Hub, which can break Prime-only workflows until `use_prime_registry` is set; scoring/setup logic is unchanged.
> 
> **Overview**
> **`r2e-gym-v1` no longer always prefixes task images with Prime’s Artifact Registry.** It now uses each dataset row’s public Docker Hub `docker_image` by default, so local `docker` runtimes can pull without GCP credentials.
> 
> A new **`R2EGymConfig`** adds **`use_prime_registry`** (default **`false`**). When **`true`**, image refs are built as `{REGISTRY}/{docker_image}` like before. **`load_taskset`** is typed to accept **`R2EGymConfig`**, and **`R2EGymTaskset`** is parameterized on that config. Comments rename **`REGISTRY_PREFIX`** → **`REGISTRY`** and document Hub vs registry behavior.
> 
> **Default behavior changes:** registry-prefixed pulls → Docker Hub unless config opts back in.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8ea17d131e469bfc201dbb079f14f9ae5fac7d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make Prime Artifact Registry opt-in for r2e-gym-v1 task images
> - Introduces `R2EGymConfig` with a `use_prime_registry` boolean (default `False`) in [r2e_gym_v1.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1681/files#diff-e3167437ebe5c5371ffbc4bac1c11d88284643e8c41edcc1ca877fdf5b8a611f), replacing the always-on private registry prefix.
> - Task images now resolve to the dataset's public Docker Hub reference by default; set `use_prime_registry=True` to resolve against the private Artifact Registry path instead.
> - Behavioral Change: previously all images were prefixed with the private registry; now the public Docker Hub ref is used unless explicitly opted in.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d8ea17d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->