### PR TITLE
fix: green the v1 e2e harness x runtime matrix in CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -252,7 +252,6 @@ addopts = [
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "e2e: marks end-to-end eval-run tests (need a model API key; skipped without one)",
-    "prime: marks tests that run on the prime runtime (provision a real sandbox + tunnel)",
     "integration: marks tests as integration tests",
     "prime_sandbox: marks tests that provision real Prime sandbox or tunnel resources",
     "unit: marks tests as unit tests",

--- a/tests/v1/conftest.py
+++ b/tests/v1/conftest.py
@@ -25,12 +25,14 @@ from verifiers.v1.trace import Trace
 # tests/v1/fixtures, added to the path via `pythonpath` in pyproject so the v1 loader and the
 # v0 legacy bridge both resolve them by id (no install).
 
-# Built-in runtimes, modal excluded. docker needs the daemon; prime provisions real
-# sandboxes + tunnels (network + PRIME credentials), so both are marked to deselect easily.
+# Built-in runtimes, modal excluded. docker needs the daemon, so it's marked slow. prime
+# provisions real sandboxes + tunnels (network + PRIME credentials) — it's marked
+# `prime_sandbox` so CI deselects it (`-m "not prime_sandbox"`), with `slow` on top for fast
+# local runs.
 RUNTIMES = [
     "subprocess",
     pytest.param("docker", marks=pytest.mark.slow),
-    pytest.param("prime", marks=[pytest.mark.slow, pytest.mark.prime]),
+    pytest.param("prime", marks=[pytest.mark.slow, pytest.mark.prime_sandbox]),
 ]
 
 
@@ -63,7 +65,7 @@ def skip_if_unexposable():
 
 # Built-in harnesses (bundled in the `harnesses` package), composed with `runtime` for the
 # harness x runtime matrix. compact is an example harness, not built-in, so it's excluded. rlm
-# and codex install a heavy agent binary at rollout, so they're marked slow.
+# and codex install an agent binary into the runtime at rollout, so they're marked slow.
 @pytest.fixture(
     params=[
         "default",
@@ -73,6 +75,26 @@ def skip_if_unexposable():
 )
 def harness(request) -> str:
     return request.param
+
+
+# rlm installs its agent via system packages (apt: git, ripgrep) and writes to /usr/local/bin,
+# so it needs a container's root — it can't install on the host. codex installs into a
+# user-writable dir (and skips apt when its deps are present), so it runs on the host.
+HOST_INCAPABLE_HARNESSES = {"rlm"}
+
+
+@pytest.fixture(autouse=True)
+def _skip_host_incapable(request) -> None:
+    """Skip harness x runtime pairings the host (subprocess) can't support — an agent that
+    needs a container's root to install can't run on the host."""
+    names = request.fixturenames
+    if "harness" not in names or "runtime" not in names:
+        return
+    if (
+        request.getfixturevalue("runtime") == "subprocess"
+        and request.getfixturevalue("harness") in HOST_INCAPABLE_HARNESSES
+    ):
+        pytest.skip("harness needs a container (root install); host unsupported")
 
 
 @pytest.fixture

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -2,13 +2,14 @@
 
 Every task is one greedy rollout (`temperature=0`, set in `run_v1`) on a single task with
 turn/timeout caps. The reward tests fan out across the full **harness x runtime** matrix (the
-`harness` x `runtime` fixtures): the built-in harnesses (default, rlm) x the runtimes
-(subprocess/docker/prime, modal excluded).
+`harness` x `runtime` fixtures): the built-in harnesses (default, rlm, codex) x the runtimes
+(subprocess/docker/prime, modal excluded). Harnesses that need a container's root to install
+(rlm) are skipped on the host (subprocess) — see `conftest`.
 
 The capability-sensitive tests read the harness flags: the tools test expects a harness
-without `SUPPORTS_TASK_TOOLS` (rlm) to be refused up front (raise); the multi-turn test skips a
-harness without `SUPPORTS_USER_SIM` (rlm). The agentic task pins the default harness (only it
-exposes the bash tool) and varies runtime.
+without `SUPPORTS_TASK_TOOLS` (rlm, codex) to be refused up front (raise); the multi-turn test
+skips a harness without `SUPPORTS_USER_SIM` (rlm, codex). The agentic task pins the default
+harness (only it exposes the bash tool) and varies runtime.
 """
 
 import pytest
@@ -27,7 +28,9 @@ async def test_single_turn(run_v1, harness, runtime, tmp_path):
 
 
 @pytest.mark.e2e
-async def test_multi_turn(run_v1, harness, runtime, harness_supports, tmp_path):
+async def test_multi_turn(
+    run_v1, harness, runtime, harness_supports, skip_if_unexposable, tmp_path
+):
     """Multi-turn, driven by a (container-safe) user simulator. Skipped on harnesses without
     `SUPPORTS_USER_SIM` (rlm: a single-instruction interface that can't take injected turns)."""
     if not harness_supports(harness, "SUPPORTS_USER_SIM"):
@@ -39,6 +42,8 @@ async def test_multi_turn(run_v1, harness, runtime, harness_supports, tmp_path):
         output_dir=tmp_path,
         max_turns=6,
     )
+    # the colocated user sim is unreachable when prime lands a non-exposable region
+    skip_if_unexposable(trace)
     assert trace.errors == []
     assert not trace.is_truncated
     assert trace.num_turns >= 2  # genuinely multi-turn
@@ -47,7 +52,7 @@ async def test_multi_turn(run_v1, harness, runtime, harness_supports, tmp_path):
 
 @pytest.mark.e2e
 async def test_multi_turn_with_tools(
-    run_v1, harness, runtime, harness_supports, tmp_path
+    run_v1, harness, runtime, harness_supports, skip_if_unexposable, tmp_path
 ):
     """Multi-turn with a colocated tool. An harness whose `SUPPORTS_TASK_TOOLS` is False can't
     drive the task's tools, so the pairing is refused at build time instead of running."""
@@ -64,6 +69,8 @@ async def test_multi_turn_with_tools(
         output_dir=tmp_path,
         max_turns=6,
     )
+    # the colocated tool server is unreachable when prime lands a non-exposable region
+    skip_if_unexposable(trace)
     assert trace.errors == []
     assert not trace.is_truncated
     assert trace.num_turns >= 2  # tool call + answer


### PR DESCRIPTION
## Summary

Greens the v1 end-to-end harness × runtime matrix (`tests/v1/test_e2e.py`) in CI, which runs slow tests and was hitting two combinations that can't work in that environment:

- **`rlm` on the `subprocess` (host) runtime** raised `FileNotFoundError: [Errno 2] No such file or directory: 'rlm'`. rlm installs its agent via system packages (`apt`: git, ripgrep) and writes to `/usr/local/bin`, so it needs a container's root and can't install on the non-root CI host. Added a small `HOST_INCAPABLE_HARNESSES` set + an autouse guard that skips such harnesses on the host runtime (rlm is still exercised on docker/prime). `codex` installs into a user-writable dir, so it keeps running on the host.
- **The `prime` runtime** provisions a real sandbox whose non-default region can't expose a colocated server's port to the host, failing the multi-turn tests with a port-exposure `ProgramError`. Marked the prime runtime `prime_sandbox` — the established marker for real-sandbox tests — so the main CI step deselects it via the existing `-m "not prime_sandbox"` filter. Also applied the existing `skip_if_unexposable` guard to the multi-turn tests so a local prime run in a non-exposable region skips cleanly instead of failing.

Also dropped the now-unused `prime` pytest marker (`prime_sandbox` supersedes it) and refreshed the matrix docstrings (the built-ins exercised are `default` / `rlm` / `codex`).

## Verification

`uv run pytest tests/v1/test_e2e.py -m "not prime_sandbox"` now deselects every `*-prime` case (45 → 30 collected), and on the host runtime:

```
test_single_turn[rlm-subprocess]      SKIPPED  (harness needs a container; host unsupported)
test_single_turn[default-subprocess]  PASSED
```

(was: `rlm-subprocess` → `FileNotFoundError: 'rlm'`; `*-prime` multi-turn → `ProgramError: prime port exposure failed … non-default regions`.)

## Note

The fourth built-in harness, `claude-code` (added two days ago in #1669), is intentionally **not** added to the matrix here — it speaks the Anthropic Messages API, which the default prime provider doesn't serve, and getting it green needs separate relay/dialect work. Deferred to a follow-up.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix v1 e2e CI matrix by skipping tests on incompatible harness/runtime pairs
> - Replaces the `prime` pytest marker with `prime_sandbox` on the `prime` runtime entry in [conftest.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1682/files#diff-bc28790d38dc6e7e4f2c44639d40bc33dea724d6c73149abf7ba82b37d14f40b), matching the marker registered in [pyproject.toml](https://github.com/PrimeIntellect-ai/verifiers/pull/1682/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711).
> - Adds a `_skip_host_incapable` autouse fixture that skips any test where `runtime=='subprocess'` and the harness is in `HOST_INCAPABLE_HARNESSES` (currently `{'rlm'}`).
> - Updates `test_multi_turn` and `test_multi_turn_with_tools` in [test_e2e.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1682/files#diff-ebbbd919487889487f891b359a756e6c4630e106b16ddaef8ccddc6b900a96e1) to invoke `skip_if_unexposable` after `run_v1`, so tests skip rather than fail when the prime runtime lands in a region that cannot expose ports.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e0a3444.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->