### PR TITLE
fix: scaleswe-v1 filter on Docker Hub image_url so use_prime_registry runs are filtered too

### DIFF
--- a/examples/tasksets/scaleswe_v1/scaleswe_v1.py
+++ b/examples/tasksets/scaleswe_v1/scaleswe_v1.py
@@ -167,8 +167,21 @@ class ScaleSWETaskset(vf.Taskset[ScaleSWETask, ScaleSWEConfig]):
     def load_tasks(self) -> list[ScaleSWETask]:
         from datasets import load_dataset
 
-        rows = load_dataset(DATASET, split="train")
-        tasks = [
+        rows = list(enumerate(load_dataset(DATASET, split="train")))
+        if self.config.filter_unavailable_images:
+            # Availability is checked against the public Docker Hub `image_url` - the private
+            # Artifact Registry can't be enumerated anonymously and mirrors Docker Hub, so the
+            # public tag set stands in for it whether or not `use_prime_registry` is set.
+            available = _available_images({row["image_url"] for _, row in rows})
+            kept = [(i, row) for i, row in rows if row["image_url"] in available]
+            if len(kept) < len(rows):
+                logger.info(
+                    "scaleswe: dropped %d/%d tasks with unavailable images",
+                    len(rows) - len(kept),
+                    len(rows),
+                )
+            rows = kept
+        return [
             ScaleSWETask(
                 idx=i,
                 name=row["instance_id"],
@@ -190,19 +203,8 @@ class ScaleSWETaskset(vf.Taskset[ScaleSWETask, ScaleSWEConfig]):
                 fail_to_pass=_ids(row.get("FAIL_TO_PASS")),
                 pass_to_pass=_ids(row.get("PASS_TO_PASS")),
             )
-            for i, row in enumerate(rows)
+            for i, row in rows
         ]
-        if self.config.filter_unavailable_images:
-            available = _available_images({t.image for t in tasks})
-            kept = [t for t in tasks if t.image in available]
-            if len(kept) < len(tasks):
-                logger.info(
-                    "scaleswe: dropped %d/%d tasks with unavailable images",
-                    len(tasks) - len(kept),
-                    len(tasks),
-                )
-            tasks = kept
-        return tasks
 
     async def setup(self, task: ScaleSWETask, runtime: vf.Runtime) -> None:
         result = await runtime.run(["sh", "-c", task.pre_commands], ENV)


### PR DESCRIPTION
## Summary

Fixes the `filter_unavailable_images` check being a no-op when `use_prime_registry=true`.

- The filter checked each task's **resolved** `image`. With `use_prime_registry=true` that's a private Artifact Registry ref (`us-central1-docker.pkg.dev/...`), which `_available_images` can't enumerate anonymously and therefore **keeps unchecked** — so the filter dropped nothing exactly when images come from the GAR.
- Tasks missing from the GAR (`durandtibo_iden_pr53`, `durandtibo_feu_pr461`, `dwavesystems_dwave-cloud-client_pr429`) then still reached the runtime and failed with `IMAGE_PULL_FAILED`.
- Now the filter keys on the dataset's public Docker Hub `image_url`, independent of the resolved registry. The GAR is a mirror of Docker Hub, so the public tag set is the canonical (and only anonymously-checkable) availability signal — and it catches these in both modes. `idx` is preserved (enumerate before filtering).

## Repro / verification

```
uv run eval scaleswe-v1 -n 32 -m z-ai/glm-5.1 --harness.id rlm --shuffle \
  --taskset.use-prime-registry --harness.runtime.type prime
# before: durandtibo_iden_pr53 / durandtibo_feu_pr461 / dwave... -> ProgramError (IMAGE_PULL_FAILED)
```

After (load_tasks with `use_prime_registry=True`, `filter_unavailable_images=True`):
```
total kept: 19473   (20181 - 708)
any of the 3 present? False
sample image: us-central1-docker.pkg.dev/.../aweaiteam/scaleswe:auth0_auth0-python_pr671   # still GAR
```

`ruff check` / `ruff format` / `py_compile` clean.

> Tradeoff: a hypothetical image present in the GAR but absent from Docker Hub would be wrongly dropped. For this dataset `image_url` *is* the Docker Hub source and the GAR mirrors it, so this is the right proxy; the 3 known failures are missing from both.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `ScaleSWETaskset.load_tasks` to filter by `image_url` before applying prime registry prefix
> Previously, `load_tasks` filtered tasks after construction using the possibly registry-prefixed `task.image` value, which caused `use_prime_registry` runs to bypass the availability filter. Now, rows are filtered by the original `row['image_url']` before tasks are constructed, so the filter works regardless of registry prefix.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a440eeb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Load-time filtering only in the scaleswe v1 taskset; behavior improves for `use_prime_registry` with a documented Hub-vs-GAR mirror assumption.
> 
> **Overview**
> **`filter_unavailable_images` now runs on dataset `image_url` before tasks are built**, so it still applies when `use_prime_registry` rewrites pulls to Artifact Registry refs.
> 
> Previously filtering used each task’s resolved `image`. With `use_prime_registry`, that ref looks like a private registry host, and `_available_images` **keeps** those without checking tags—so missing images still reached rollouts and failed at pull time.
> 
> Rows are enumerated first so **`idx` stays stable** after drops. A short comment documents using Docker Hub tag listing as the availability proxy because GAR mirrors Hub and can’t be enumerated anonymously.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a440eebe196892fbbd86528fba80a01f93b63f68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->