### PR TITLE
fix: harnesses install/run without root (pinned /tmp/vf-{harness})

### DIFF
--- a/packages/harnesses/harnesses/codex/__init__.py
+++ b/packages/harnesses/harnesses/codex/__init__.py
@@ -8,6 +8,7 @@ session secret) is read from an env var.
 """
 
 import logging
+import shlex
 
 from verifiers.v1.clients import RolloutContext
 from verifiers.v1.errors import ProgramError
@@ -22,17 +23,20 @@ PROVIDER = "intercept"
 # The env var codex reads the provider api key (its bearer = the session secret) from.
 KEY_VAR = "CODEX_INTERCEPT_KEY"
 
-# Install the static-musl codex release (`rust-v<version>`) onto PATH, idempotently — fetching
-# curl first if the image lacks it. musl => no libc dep, so it runs in any linux container.
+# Install the static-musl codex release into a user-writable dir and run it by absolute path, so
+# it needs neither root nor codex on $PATH — works on a non-root host (subprocess runtime) as
+# well as a root container. musl => no libc dep. Fetches curl first only if it's missing.
+CODEX_DIR = "/tmp/vf-codex"
+CODEX_BIN = f"{CODEX_DIR}/bin/codex"
 INSTALL = r"""
-command -v codex >/dev/null 2>&1 && exit 0
 set -e
+mkdir -p {dir}/bin
 command -v curl >/dev/null 2>&1 || { apt-get update -qq && apt-get install -y -qq curl >/dev/null; }
 case "$(uname -m)" in aarch64|arm64) arch=aarch64 ;; *) arch=x86_64 ;; esac
 triple="${arch}-unknown-linux-musl"
-curl -fsSL "https://github.com/openai/codex/releases/download/rust-v{version}/codex-${triple}.tar.gz" | tar -xz -C /usr/local/bin
-mv "/usr/local/bin/codex-${triple}" /usr/local/bin/codex
-chmod +x /usr/local/bin/codex
+curl -fsSL "https://github.com/openai/codex/releases/download/rust-v{version}/codex-${triple}.tar.gz" | tar -xz -C {dir}/bin
+mv "{dir}/bin/codex-${triple}" {bin}
+chmod +x {bin}
 """
 
 
@@ -62,15 +66,25 @@ class CodexHarness(Harness[CodexHarnessConfig]):
         # api key) and posts Responses calls to `{endpoint}/responses`.
         env = {**self.config.env, KEY_VAR: secret}
         logger.info("codex: ensuring codex %s is installed", self.config.version)
-        install = await runtime.run(
-            ["sh", "-c", INSTALL.replace("{version}", self.config.version)], {}
+        # Serialize concurrent rollouts that share one runtime (e.g. subprocess on the host),
+        # which otherwise race to download into the same dir: the first installs, the rest wait
+        # on the lock and find the binary already present.
+        script = (
+            INSTALL.replace("{version}", self.config.version)
+            .replace("{dir}", CODEX_DIR)
+            .replace("{bin}", CODEX_BIN)
         )
+        ensure = shlex.quote(f"[ -x {CODEX_BIN} ] || ({script})")
+        guarded = (
+            f"mkdir -p {CODEX_DIR} && flock {CODEX_DIR}/install.lock sh -c {ensure}"
+        )
+        install = await runtime.run(["sh", "-c", guarded], {})
         if install.exit_code != 0:
             raise ProgramError(f"codex install failed: {install.stderr.strip()[-500:]}")
         # `-c` values parse as TOML, falling back to a raw string (so the url / `responses`
         # come through literally); `requires_openai_auth=false` parses as a bool.
         argv = [
-            "codex",
+            CODEX_BIN,
             "exec",
             "--dangerously-bypass-approvals-and-sandbox",
             "--skip-git-repo-check",

--- a/packages/harnesses/harnesses/codex/__init__.py
+++ b/packages/harnesses/harnesses/codex/__init__.py
@@ -23,9 +23,6 @@ PROVIDER = "intercept"
 # The env var codex reads the provider api key (its bearer = the session secret) from.
 KEY_VAR = "CODEX_INTERCEPT_KEY"
 
-# Install the static-musl codex release into a user-writable dir and run it by absolute path, so
-# it needs neither root nor codex on $PATH — works on a non-root host (subprocess runtime) as
-# well as a root container. musl => no libc dep. Fetches curl first only if it's missing.
 CODEX_DIR = "/tmp/vf-codex"
 CODEX_BIN = f"{CODEX_DIR}/bin/codex"
 INSTALL = r"""

--- a/packages/harnesses/harnesses/rlm/__init__.py
+++ b/packages/harnesses/harnesses/rlm/__init__.py
@@ -10,6 +10,7 @@ import logging
 from verifiers.v1.harness import Harness, HarnessConfig
 from verifiers.v1.clients import RolloutContext
 from verifiers.v1.decorators import metric
+from verifiers.v1.errors import ProgramError
 from verifiers.v1.runtimes import ProgramResult, Runtime
 from verifiers.v1.trace import Trace
 
@@ -19,6 +20,11 @@ RLM_REPO = "github.com/PrimeIntellect-ai/rlm.git"
 # rlm writes its session under $RLM_HOME/sessions/<id>/; point it at a workdir-
 # relative dir so it stays in the runtime (and is cleaned up with the workdir).
 RLM_HOME = ".rlm"
+# Install uv + the rlm CLI into a user-writable dir and run the binary by absolute path, so it
+# needs neither root nor rlm on $PATH — works on a non-root host (subprocess runtime) as well as
+# a root container. install.sh fetches curl/uv itself when missing.
+RLM_DIR = "/tmp/vf-rlm"
+RLM_BIN = f"{RLM_DIR}/bin/rlm"
 
 
 class RLMHarnessConfig(HarnessConfig):
@@ -62,20 +68,26 @@ class RLMHarness(Harness[RLMHarnessConfig]):
             env["RLM_APPEND_TO_SYSTEM_PROMPT"] = system_prompt
         if self.config.tools is not None:
             env["RLM_TOOLS"] = ",".join(self.config.tools)
-        # Install rlm onto PATH only if it isn't already there (no runtime-type
-        # checks): a no-op where rlm is present, a fresh install otherwise.
+        # Install rlm only if the binary isn't already there (no runtime-type checks): a no-op
+        # where it's present, a fresh install otherwise. install.sh fetches curl/uv (and git,
+        # via the runtime's package manager) itself when missing, so the only thing we add is
+        # git for our pinned checkout — and only when it's absent, so a non-root host with git
+        # already present needs no root.
         install = (
-            "apt-get update -qq && apt-get install -y -qq git curl && "
-            f"git clone https://{RLM_REPO} /tmp/rlm && "
+            "command -v git >/dev/null 2>&1 || "
+            "{ apt-get update -qq && apt-get install -y -qq git; } && "
+            f"rm -rf /tmp/rlm && git clone https://{RLM_REPO} /tmp/rlm && "
             f"git -C /tmp/rlm checkout {self.config.version} && "
-            "UV_INSTALL_DIR=/usr/local/bin UV_TOOL_BIN_DIR=/usr/local/bin "
-            "RLM_CHECKOUT_PATH=/tmp/rlm bash /tmp/rlm/install.sh"
+            f"UV_INSTALL_DIR={RLM_DIR}/bin UV_TOOL_BIN_DIR={RLM_DIR}/bin "
+            f"RLM_CHECKOUT_PATH=/tmp/rlm bash /tmp/rlm/install.sh"
         )
         logger.info("rlm: ensuring rlm is installed (version=%s)", self.config.version)
-        await runtime.run(
-            ["sh", "-c", f"command -v rlm >/dev/null 2>&1 || ({install})"], env
+        result = await runtime.run(
+            ["sh", "-c", f"[ -x {RLM_BIN} ] || ({install})"], env
         )
-        return await runtime.run(["rlm", instruction], env)
+        if result.exit_code != 0:
+            raise ProgramError(f"rlm install failed: {result.stderr.strip()[-500:]}")
+        return await runtime.run([RLM_BIN, instruction], env)
 
     @metric
     async def rlm(self, trace: Trace, runtime: Runtime) -> dict[str, float]:

--- a/packages/harnesses/harnesses/rlm/__init__.py
+++ b/packages/harnesses/harnesses/rlm/__init__.py
@@ -21,9 +21,6 @@ RLM_REPO = "github.com/PrimeIntellect-ai/rlm.git"
 # rlm writes its session under $RLM_HOME/sessions/<id>/; point it at a workdir-
 # relative dir so it stays in the runtime (and is cleaned up with the workdir).
 RLM_HOME = ".rlm"
-# Install uv + the rlm CLI into a user-writable dir and run the binary by absolute path, so it
-# needs neither root nor rlm on $PATH — works on a non-root host (subprocess runtime) as well as
-# a root container. install.sh fetches curl/uv itself when missing.
 RLM_DIR = "/tmp/vf-rlm"
 RLM_BIN = f"{RLM_DIR}/bin/rlm"
 

--- a/packages/harnesses/harnesses/rlm/__init__.py
+++ b/packages/harnesses/harnesses/rlm/__init__.py
@@ -6,6 +6,7 @@ runtime knobs (`max_depth`, `tools`), which rlm reads from `RLM_*` env vars.
 
 import json
 import logging
+import shlex
 
 from verifiers.v1.harness import Harness, HarnessConfig
 from verifiers.v1.clients import RolloutContext
@@ -82,9 +83,12 @@ class RLMHarness(Harness[RLMHarnessConfig]):
             f"RLM_CHECKOUT_PATH=/tmp/rlm bash /tmp/rlm/install.sh"
         )
         logger.info("rlm: ensuring rlm is installed (version=%s)", self.config.version)
-        result = await runtime.run(
-            ["sh", "-c", f"[ -x {RLM_BIN} ] || ({install})"], env
-        )
+        # Serialize concurrent rollouts that share one runtime (e.g. subprocess on the host),
+        # which otherwise race to clone/install into the same /tmp dirs: the first installs, the
+        # rest wait on the lock and find the binary already present.
+        ensure = shlex.quote(f"[ -x {RLM_BIN} ] || ({install})")
+        guarded = f"mkdir -p {RLM_DIR} && flock {RLM_DIR}/install.lock sh -c {ensure}"
+        result = await runtime.run(["sh", "-c", guarded], env)
         if result.exit_code != 0:
             raise ProgramError(f"rlm install failed: {result.stderr.strip()[-500:]}")
         return await runtime.run([RLM_BIN, instruction], env)


### PR DESCRIPTION
## Summary

The built-in CLI harnesses installed into **root-only** dirs (`/usr/local/bin`, plus an unconditional `apt-get`) and then exec'd a **bare** binary off `$PATH`. On the **subprocess** runtime (which runs on the host and inherits its `$PATH`), a non-root host couldn't install, the binary wasn't on `$PATH`, and the rollout crashed with `FileNotFoundError`. It only ever worked on the root-sandbox runtimes (prime/docker), or when the binary happened to already be on the host `$PATH`.

Standardize all install-bearing harnesses on a **`/tmp/vf-{harness}`** convention:

- **Install into a user-writable dir** (`/tmp/vf-rlm`, `/tmp/vf-codex`) and **run by absolute path** → no root, no `$PATH` dependency. Works on a non-root host and a root container alike.
- **System packages only when missing** — rlm's `install.sh` already fetches curl/uv itself; we only `apt-get` git (rlm) / curl (codex) when absent, so a host that has them needs no root.
- **`flock`-serialize the install** so concurrent rollouts sharing one runtime don't race to clone/download into the same dir (first installs; the rest wait and reuse).
- **Clean `ProgramError`** on install failure instead of an uncaught `FileNotFoundError`.

Harnesses touched: **rlm** and **codex**. **default** has no install step (nothing to pin). No change to the prime/docker path (it can still write `/tmp` and install as root when needed).

## Verification

**rlm, subprocess runtime, e2e** (the original repro):
```
$ uv run eval gsm8k-v1 --harness.id rlm --harness.runtime.type subprocess -n 5
5/5 · reward 1.00 · err 0.00
```
- No `FileNotFoundError`; rlm installed non-root under `/tmp/vf-rlm`.
- An intermediate run (before the `flock` commit) gave 3/5 `rlm install failed: destination path '/tmp/rlm' already exists` — the concurrent-install race; 5/5 after serializing.

**codex, subprocess runtime, e2e**:
```
$ uv run eval gsm8k-v1 --harness.id codex --harness.runtime.type subprocess -n 2
2/2 · reward 1.00 · err 0.00
```
Installed non-root to `/tmp/vf-codex/bin/codex`, no `FileNotFoundError`.

`ruff check` / `ruff format` / `py_compile` clean on both files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rollout bootstrap (git clone, curl downloads, apt when tools missing) for two harnesses; behavior is localized but affects every codex/rlm eval on shared subprocess runtimes.
> 
> **Overview**
> **Codex** and **rlm** harnesses no longer install into `/usr/local/bin` or rely on `$PATH`. Both now download/build under **`/tmp/vf-codex`** and **`/tmp/vf-rlm`**, exec the binary by **absolute path**, and gate installs with **`flock`** so concurrent subprocess rollouts don’t race on the same dirs.
> 
> **rlm** only runs `apt-get` for git when git is missing (curl/uv stay delegated to `install.sh`); checkout is refreshed with `rm -rf /tmp/rlm` before clone. **codex** installs curl via apt only when absent. Failed installs now raise **`ProgramError`** with stderr instead of surfacing **`FileNotFoundError`** on launch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2491ee68fae3bd47545a64b8806ed212d062b4a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix harness install and run without root by using pinned /tmp directories
> - Both `CodexHarness` and `RLMHarness` now install their binaries into pinned `/tmp/vf-{harness}/bin/` directories instead of `/usr/local/bin`, removing the need for root access.
> - Installation is serialized with `flock` on a per-harness lock file and skipped when the binary already exists and is executable.
> - Execution switches from resolving the binary via `PATH` to invoking the absolute `/tmp/vf-{harness}/bin/{binary}` path directly.
> - `RLMHarness` also installs `git` conditionally (only when missing) and raises a `ProgramError` on non-zero install exit.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2491ee6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->