### PR TITLE
test: skip test_multi_turn on prime (colocated user-sim port exposure region-limited)

### DIFF
--- a/tests/v1/conftest.py
+++ b/tests/v1/conftest.py
@@ -47,18 +47,21 @@ def server_runtime(request) -> str:
 
 
 @pytest.fixture
-def skip_if_unexposable(server_runtime):
-    """Skip the own-runtime prime cases for now: a tool / user-sim server in its own prime
-    sandbox can't publish its port back to the host yet — native `expose` is region-limited (see
-    `PrimeRuntime.public_url`), and the host has no other route to a port inside the sandbox.
-    subprocess/docker share the host network, so they never hit this.
+def skip_if_unexposable():
+    """Skip when a trace failed because the server's runtime couldn't publish its port to the
+    host — a prime sandbox whose region doesn't support port exposure (a known infra limit, not
+    a code bug). subprocess/docker share the host network, so they never hit this.
 
-    TODO: drop this skip and re-enable the prime case once prime supports port exposure in all
-    regions (or once the runtime publishes the port via an in-sandbox tunnel instead)."""
-    if server_runtime == "prime":
-        pytest.skip(
-            "prime port exposure is region-limited; re-enable once supported everywhere"
-        )
+    TODO: re-enable the prime cases once prime supports port exposure in all regions (or the
+    runtime publishes the port via an in-sandbox tunnel)."""
+
+    def _skip(trace) -> None:
+        if any("port exposure" in str(e) for e in trace.errors):
+            pytest.skip(
+                "runtime can't publish a port to the host (pin a prime region that supports port exposure)"
+            )
+
+    return _skip
 
 
 # Built-in harnesses (bundled in the `harnesses` package), composed with `runtime` for the

--- a/tests/v1/conftest.py
+++ b/tests/v1/conftest.py
@@ -47,18 +47,18 @@ def server_runtime(request) -> str:
 
 
 @pytest.fixture
-def skip_if_unexposable():
-    """Skip when a trace failed because the server's runtime couldn't publish its port to the
-    host — a prime sandbox whose region doesn't support port exposure (a known infra limit, not
-    a code bug). subprocess/docker share the host network, so they never hit this."""
+def skip_if_unexposable(server_runtime):
+    """Skip the own-runtime prime cases for now: a tool / user-sim server in its own prime
+    sandbox can't publish its port back to the host yet — native `expose` is region-limited (see
+    `PrimeRuntime.public_url`), and the host has no other route to a port inside the sandbox.
+    subprocess/docker share the host network, so they never hit this.
 
-    def _skip(trace) -> None:
-        if any("port exposure" in str(e) for e in trace.errors):
-            pytest.skip(
-                "runtime can't publish a port to the host (pin a prime region that supports port exposure)"
-            )
-
-    return _skip
+    TODO: drop this skip and re-enable the prime case once prime supports port exposure in all
+    regions (or once the runtime publishes the port via an in-sandbox tunnel instead)."""
+    if server_runtime == "prime":
+        pytest.skip(
+            "prime port exposure is region-limited; re-enable once supported everywhere"
+        )
 
 
 # Built-in harnesses (bundled in the `harnesses` package), composed with `runtime` for the

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -27,7 +27,9 @@ async def test_single_turn(run_v1, harness, runtime, tmp_path):
 
 
 @pytest.mark.e2e
-async def test_multi_turn(run_v1, harness, runtime, harness_supports, tmp_path):
+async def test_multi_turn(
+    run_v1, harness, runtime, harness_supports, skip_if_unexposable, tmp_path
+):
     """Multi-turn, driven by a (container-safe) user simulator. Skipped on harnesses without
     `SUPPORTS_USER_SIM` (rlm: a single-instruction interface that can't take injected turns)."""
     if not harness_supports(harness, "SUPPORTS_USER_SIM"):
@@ -39,6 +41,8 @@ async def test_multi_turn(run_v1, harness, runtime, harness_supports, tmp_path):
         output_dir=tmp_path,
         max_turns=6,
     )
+    # the colocated user-sim must publish its port back to the host (prime: region-limited)
+    skip_if_unexposable(trace)
     assert trace.errors == []
     assert not trace.is_truncated
     assert trace.num_turns >= 2  # genuinely multi-turn
@@ -104,6 +108,7 @@ async def test_task_tools_own_runtime(
             "tools": {"colocated": False, "runtime": {"type": server_runtime}}
         },
     )
+    skip_if_unexposable(trace)
     assert trace.errors == []
     assert trace.reward == 1.0
 
@@ -121,6 +126,7 @@ async def test_user_own_runtime(run_v1, server_runtime, skip_if_unexposable, tmp
         max_turns=6,
         taskset_overrides={"user": {"runtime": {"type": server_runtime}}},
     )
+    skip_if_unexposable(trace)
     assert trace.errors == []
     assert trace.num_turns >= 2
     assert trace.reward == 1.0

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -104,7 +104,6 @@ async def test_task_tools_own_runtime(
             "tools": {"colocated": False, "runtime": {"type": server_runtime}}
         },
     )
-    skip_if_unexposable(trace)
     assert trace.errors == []
     assert trace.reward == 1.0
 
@@ -122,7 +121,6 @@ async def test_user_own_runtime(run_v1, server_runtime, skip_if_unexposable, tmp
         max_turns=6,
         taskset_overrides={"user": {"runtime": {"type": server_runtime}}},
     )
-    skip_if_unexposable(trace)
     assert trace.errors == []
     assert trace.num_turns >= 2
     assert trace.reward == 1.0


### PR DESCRIPTION
## Summary

`test_multi_turn[*-prime]` (e.g. `test_multi_turn[default-prime]`) fails on the prime runtime: the test's user simulator is **colocated** in the agent's prime sandbox (the default) and is host-consumed, so its port must be published back to the host via native `expose` — which is **region-limited** (see `PrimeRuntime.public_url`). Unlike `test_task_tools_own_runtime` / `test_user_own_runtime`, `test_multi_turn` had **no** `skip_if_unexposable` guard, so instead of skipping it hard-failed.

Add the existing `skip_if_unexposable` guard to `test_multi_turn`, and a TODO on the fixture.

```python
async def test_multi_turn(run_v1, harness, runtime, harness_supports, skip_if_unexposable, tmp_path):
    ...
    # the colocated user-sim must publish its port back to the host (prime: region-limited)
    skip_if_unexposable(trace)
```

## Scope

Only `test_multi_turn` is touched — `subprocess`/`docker` are unaffected (host network), and the own-runtime tests already had the guard. The fixture's conditional behavior is unchanged (it skips when the trace error mentions "port exposure"); I only added a TODO to drop the skip once prime supports port exposure in all regions (or the runtime publishes the port via an in-sandbox tunnel).

> Note: couldn't run the prime e2e to confirm green — the account can't currently provision sandboxes (they terminate immediately). `ruff` + `py_compile` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes; no production runtime or harness behavior is modified.
> 
> **Overview**
> **`test_multi_turn`** now uses the existing **`skip_if_unexposable`** fixture so prime matrix runs that fail because the **colocated user simulator** cannot publish its port to the host (region-limited **`expose`**) **skip** instead of failing assertions—matching **`test_user_own_runtime`** / **`test_task_tools_own_runtime`**.
> 
> The **`skip_if_unexposable`** docstring in **`conftest.py`** adds a **TODO** to drop this workaround once prime supports port exposure in all regions or tunnels the port in-sandbox.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 986951c63addb12561e13c20ec1491601d290a1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip `test_multi_turn` on prime when colocated user-sim port exposure is unavailable
> Adds the `skip_if_unexposable` fixture to `test_multi_turn` in [test_e2e.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1686/files#diff-ebbbd919487889487f891b359a756e6c4630e106b16ddaef8ccddc6b900a96e1) so the test skips when the trace contains a port exposure error. Also updates the docstring in [conftest.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1686/files#diff-bc28790d38dc6e7e4f2c44639d40bc33dea724d6c73149abf7ba82b37d14f40b) to note the sandbox/region limitation and adds a TODO to re-enable prime cases once port exposure is broadly supported.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 986951c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->