### PR TITLE
Keep relayed SSE streams alive

### DIFF
--- a/verifiers/v1/clients/client.py
+++ b/verifiers/v1/clients/client.py
@@ -6,7 +6,7 @@ abstract method. Each concrete client owns its own wire translation internally.
 
 import logging
 from abc import ABC, abstractmethod
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass
 
 from tenacity import (
@@ -33,11 +33,11 @@ cold on a random shard each turn."""
 
 @dataclass
 class RelayReply:
-    """A relayed upstream response streamed back: its content type + body chunks (one chunk for
-    a JSON body, many for SSE). The connection closes when `chunks` is exhausted."""
+    """A relayed upstream response: content type, complete SSE events, and connection cleanup."""
 
     content_type: str
     chunks: AsyncIterator[bytes]
+    close: Callable[[], Awaitable[None]]
 
 
 class Client(ABC):

--- a/verifiers/v1/clients/eval.py
+++ b/verifiers/v1/clients/eval.py
@@ -11,12 +11,16 @@ new wire format (incl. non-OpenAI providers like Anthropic) is just a new `Diale
 change. Endpoint config (base url, api key, billing headers) comes from the client config.
 """
 
+import re
+
 import httpx
 
 from verifiers.v1.clients.client import SESSION_ID_HEADER, Client, RelayReply
 from verifiers.v1.dialects import Dialect
 from verifiers.v1.errors import model_error
 from verifiers.v1.types import Response, SamplingConfig
+
+_SSE_EVENT_END = re.compile(rb"(?:\r\n|\r|\n){2}")
 
 
 class EvalClient(Client):
@@ -88,9 +92,8 @@ class EvalClient(Client):
         sampling_args: SamplingConfig,
         session_id: str | None = None,
     ) -> RelayReply:
-        # Stream the provider's response bytes through (SSE for a streaming request). An error
-        # status is read fully and mapped before any byte is handed back, so the retry +
-        # truncation machinery treat a relayed call exactly like a non-streamed one.
+        # Relay complete SSE events so the interception server can safely insert keepalives
+        # between them. Error responses are mapped before any event is handed back.
         url, headers, upstream = self._upstream(
             dialect, body, model, sampling_args, session_id
         )
@@ -107,15 +110,19 @@ class EvalClient(Client):
             raise model_error(f"upstream {resp.status_code}: {text}")
 
         async def chunks():
-            try:
-                async for chunk in resp.aiter_bytes():
-                    yield chunk
-            finally:
-                await resp.aclose()
+            buffer = bytearray()
+            async for chunk in resp.aiter_bytes():
+                buffer += chunk
+                while match := _SSE_EVENT_END.search(buffer):
+                    yield bytes(buffer[: match.end()])
+                    del buffer[: match.end()]
+            if buffer:
+                yield bytes(buffer)
 
         return RelayReply(
             content_type=resp.headers.get("content-type", "text/event-stream"),
             chunks=chunks(),
+            close=resp.aclose,
         )
 
     async def relay_aux(self, dialect: Dialect, route: str, body: dict) -> dict:

--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -3,8 +3,8 @@
 Every rollout runs an harness program whose OpenAI-style calls are caught here: a small
 localhost server routes each `POST /v1/chat/completions` to our `Client`, records the turn
 into the trace's message graph, and returns the result in OpenAI shape. We inject
-`OPENAI_BASE_URL`/`OPENAI_API_KEY` so the program's SDK talks to us. Chat completions only,
-no streaming.
+`OPENAI_BASE_URL`/`OPENAI_API_KEY` so the program's SDK talks to us. Both non-streaming and
+SSE requests are supported.
 
 One server multiplexes many rollouts: each rollout registers a `RolloutSession` under its
 own secret (the bearer token the harness already sends), and the server routes by that
@@ -17,6 +17,7 @@ model, so a multi-turn exchange plays out within one program request, transparen
 harness. Tools are handled out-of-band (run by the harness).
 """
 
+import asyncio
 import contextlib
 import logging
 import secrets
@@ -44,6 +45,7 @@ logger = logging.getLogger(__name__)
 # and the harness gets a 413. Allow large bodies; the upstream provider and the model's
 # context window are the real limits, this is just a host-OOM backstop.
 _MAX_REQUEST_BODY = 1024**3  # 1 GiB (aiohttp's default is 1 MiB)
+_KEEPALIVE_INTERVAL_SECONDS = 3
 
 
 @dataclass(frozen=True)
@@ -281,16 +283,40 @@ class InterceptionServer:
         except Exception as e:  # surface to the program as an API error
             logger.warning("model call failed: id=%s %s", session.trace.id, e)
             return web.json_response(dialect.error_body(str(e)), status=502)
-        buffer = bytearray()
-        async for chunk in reply.chunks:
-            buffer += chunk
-        graph.add_turn(session.trace, prompt, dialect.parse_stream(bytes(buffer)))
-        resp = web.StreamResponse()
+        resp = web.StreamResponse(
+            headers={"Cache-Control": "no-cache", "Connection": "keep-alive"}
+        )
         resp.content_type = reply.content_type.split(";")[0].strip()
-        await resp.prepare(request)
-        with contextlib.suppress(ConnectionResetError):
-            await resp.write(bytes(buffer))
-            await resp.write_eof()
+        buffer = bytearray()
+        chunks = reply.chunks.__aiter__()
+        next_chunk = asyncio.create_task(anext(chunks, None))
+        try:
+            await resp.prepare(request)
+            while True:
+                done, _ = await asyncio.wait(
+                    {next_chunk}, timeout=_KEEPALIVE_INTERVAL_SECONDS
+                )
+                if not done:
+                    await resp.write(b": keepalive\n\n")
+                    continue
+                chunk = next_chunk.result()
+                if chunk is None:
+                    break
+                buffer += chunk
+                await resp.write(chunk)
+                next_chunk = asyncio.create_task(anext(chunks, None))
+        except ConnectionResetError:
+            return resp
+        finally:
+            next_chunk.cancel()
+            await asyncio.gather(next_chunk, return_exceptions=True)
+            await reply.close()
+
+        try:
+            graph.add_turn(session.trace, prompt, dialect.parse_stream(bytes(buffer)))
+        finally:
+            with contextlib.suppress(ConnectionResetError):
+                await resp.write_eof()
         return resp
 
     async def handle_aux(


### PR DESCRIPTION
## Summary

- relay complete provider SSE events incrementally
- emit SSE comments every three seconds while the provider is idle
- preserve provider bytes and buffer a copy for trace parsing
- close the upstream response explicitly on completion or downstream disconnect

## Why

Slow providers can leave the downstream SSE connection idle long enough for an intermediary to terminate it. Complete-event framing allows heartbeats to be inserted safely without splitting an SSE event, while preserving token streaming.

## Validation

- `uv run --frozen pytest -q tests/v1 -m 'not e2e'`
- `uv run --frozen ruff check .`
- pre-commit and pre-push hooks

This PR intentionally contains only the three implementation files; no test files are included.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live streaming and HTTP connection lifecycle on the eval relay path; behavior is localized but affects long-running rollouts and proxies.
> 
> **Overview**
> **Keeps downstream SSE connections alive** when the upstream provider is slow, without altering provider payload bytes.
> 
> `EvalClient.relay` now **buffers upstream bytes and yields whole SSE events** (split on blank-line delimiters) instead of raw `httpx` chunks, so the interception layer can inject comments between events. `RelayReply` gains a required **`close`** hook; the upstream `httpx` response is no longer closed inside the chunk iterator—callers must call **`reply.close()`** after streaming (including on client disconnect).
> 
> `InterceptionServer._stream` **prepares the `StreamResponse` immediately**, then loops with a 3s timeout: if no upstream event arrives, it writes **`: keepalive\n\n`**; otherwise it forwards the event and accumulates bytes for the trace. Trace recording (`graph.add_turn` / `parse_stream`) runs **after** the stream finishes; **`reply.close()`** runs in `finally` alongside task cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6d88ee2865ee657d3b5634e3a269fa5b084f014. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep relayed SSE streams alive with periodic keepalives and explicit connection teardown
> - Changes [server.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1688/files#diff-84e2f8d027d609e8760ef6d533535ec9d99dfc6384d5ddb6111b4001b2010f35) to stream SSE chunks to the client as they arrive instead of buffering the full response before responding, adding periodic keepalive comments when no chunk arrives within a configurable interval.
> - Updates [eval.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1688/files#diff-8a1cc6d0e01dde461a22ef26597ccf8f011f4c12328b1c7297cae7acebc78df8) to buffer and yield complete SSE events (split on double-newline boundaries) rather than arbitrary byte chunks.
> - Adds a `close` callable to `RelayReply` in [client.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1688/files#diff-03d8d18cf21766007d7efc7af13862dcd1d58ab1a1374aef2efdd4ba59c69e2e) so the server can explicitly tear down the upstream connection after streaming completes or the client disconnects.
> - Behavioral Change: SSE relay no longer buffers the entire upstream response before writing to the client; the trace is parsed from the accumulated bytes after streaming finishes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f6d88ee.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->