### PR TITLE
Ignore unsupported Anthropic service tiers

### DIFF
--- a/verifiers/v1/clients/eval.py
+++ b/verifiers/v1/clients/eval.py
@@ -56,7 +56,7 @@ class EvalClient(Client):
         except httpx.HTTPError as e:  # connect / read timeout / transport failure
             raise model_error(str(e)) from e
         raw = resp.json()
-        response = dialect.parse_response(dialect.response_type.model_validate(raw))
+        response = dialect.parse_response(dialect.validate_response(raw))
         response.raw = raw  # the program gets the provider's bytes back 1:1
         return response
 

--- a/verifiers/v1/dialects/anthropic.py
+++ b/verifiers/v1/dialects/anthropic.py
@@ -200,6 +200,14 @@ class AnthropicDialect(Dialect[dict, AnthropicMessage]):
     def parse_response(self, response: AnthropicMessage) -> Response:
         return response_from_wire(response)
 
+    def validate_response(self, raw: dict) -> AnthropicMessage:
+        usage = raw.get("usage")
+        tier = usage.get("service_tier") if usage else None
+        if tier not in (None, "standard", "priority", "batch"):
+            raw = {**raw, "usage": usage.copy()}
+            raw["usage"].pop("service_tier")
+        return super().validate_response(raw)
+
     def parse_stream(self, raw: bytes) -> Response:
         """Assemble message_start / content_block_* / message_delta events into the complete
         message, then parse it."""
@@ -244,8 +252,7 @@ class AnthropicDialect(Dialect[dict, AnthropicMessage]):
         for index, partial in partial_json.items():
             blocks[index]["input"] = json.loads(partial or "{}")
         message["content"] = [blocks[i] for i in sorted(blocks)]
-        message.get("usage", {}).pop("service_tier", None)
-        return response_from_wire(AnthropicMessage.model_validate(message))
+        return response_from_wire(self.validate_response(message))
 
     def apply_overrides(self, body: dict, model: str, sampling: SamplingConfig) -> dict:
         # Forward verbatim except the eval's model + sampling. `temperature`/`top_p` are

--- a/verifiers/v1/dialects/base.py
+++ b/verifiers/v1/dialects/base.py
@@ -89,6 +89,10 @@ class Dialect(ABC, Generic[ReqT, RespT]):
     def parse_response(self, response: RespT) -> Response:
         """A native (non-streamed) response -> the vf `Response` we consume."""
 
+    def validate_response(self, raw: dict) -> RespT:
+        """Validate a native response, normalizing provider-compatible extensions if needed."""
+        return self.response_type.model_validate(raw)
+
     @abstractmethod
     def parse_stream(self, raw: bytes) -> Response:
         """A complete native SSE byte stream -> the vf `Response` (assembling the final message


### PR DESCRIPTION
## Summary

- preserve Anthropic's supported `standard`, `priority`, and `batch` service tiers
- remove only unknown provider-compatible tier values before SDK validation
- apply the same normalization to streamed and non-streamed responses
- keep the original provider payload unchanged when relaying it to the harness

## Why

Anthropic-compatible endpoints can return `usage.service_tier` values outside the installed Anthropic SDK's enum. Those values should not prevent trace parsing, but supported tier metadata should remain intact.

## Validation

- verified `priority` remains present after validation
- verified unknown `default` validates after normalization
- verified the original response dictionary remains unchanged
- `uv run --frozen pytest -q tests/v1 -m 'not e2e'`
- `uv run --frozen ruff check .`
- pre-commit and pre-push hooks

No test files, docs, harness changes, or lockfiles are included.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Ignore unsupported Anthropic `usage.service_tier` values in streamed and non-streamed responses
> - Adds `validate_response` to `AnthropicDialect` that strips unrecognized `usage.service_tier` values (anything outside `standard`, `priority`, `batch`) before model validation, preserving recognized ones.
> - Introduces a default `Dialect.validate_response` hook in [base.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1689/files#diff-10ccce5f7f0d991c33492a01e73014e10883deb74f7006253f1c690422d841bd) that simply calls `response_type.model_validate`, giving subclasses a single override point for provider-specific normalization.
> - Updates `EvalClient.get_response` and `AnthropicDialect.parse_stream` to route through `validate_response` instead of calling `model_validate` directly, so the normalization applies consistently to both streaming and non-streaming paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 07e4fa0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized response normalization for Anthropic parsing; no auth, persistence, or relay payload changes beyond safer validation.
> 
> **Overview**
> Anthropic-compatible providers can return `usage.service_tier` values the installed Anthropic SDK does not accept, which was breaking trace parsing on otherwise valid responses.
> 
> This adds a **`Dialect.validate_response`** hook (default: `model_validate`) and **`AnthropicDialect`** override that drops only unrecognized tiers (`standard`, `priority`, and `batch` are kept). **`EvalClient.get_response`** and **`AnthropicDialect.parse_stream`** now validate through that hook instead of calling `model_validate` directly, so streaming and non-streaming paths behave the same. Relayed **`Response.raw`** is still the provider JSON unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07e4fa0f02156e5b0a5146987e40d08204623b5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->