### PR TITLE
Fix mini-swe-agent V1 E2E matrix

### DIFF
--- a/tests/v1/conftest.py
+++ b/tests/v1/conftest.py
@@ -65,17 +65,26 @@ def skip_if_unexposable():
 
 
 # Built-in harnesses (bundled in the `harnesses` package), composed with `runtime` for the
-# harness x runtime matrix. compact is an example harness, not built-in, so it's excluded.
-# Agent CLI harnesses install their dependencies at rollout, so they're marked slow.
+# plain-task harness x runtime matrix. compact is an example harness, not built-in, so it's
+# excluded. Agent CLI harnesses install their dependencies at rollout, so they're marked slow.
 @pytest.fixture(
     params=[
         "default",
         pytest.param("rlm", marks=pytest.mark.slow),
         pytest.param("codex", marks=pytest.mark.slow),
-        pytest.param("mini-swe-agent", marks=pytest.mark.slow),
     ]
 )
 def harness(request) -> str:
+    return request.param
+
+
+@pytest.fixture(
+    params=[
+        "default",
+        pytest.param("mini-swe-agent", marks=pytest.mark.slow),
+    ]
+)
+def agentic_harness(request) -> str:
     return request.param
 
 

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -6,9 +6,9 @@ turn/timeout caps. The reward tests fan out across the full **harness x runtime*
 (subprocess/docker/prime, modal excluded).
 
 The capability-sensitive tests read the harness flags: the tools test expects a harness
-without `SUPPORTS_TASK_TOOLS` (rlm) to be refused up front (raise); the multi-turn test skips a
-harness without `SUPPORTS_USER_SIM` (rlm). The agentic task pins the default harness (only it
-exposes the bash tool) and varies runtime.
+without `SUPPORTS_TASK_TOOLS` to be refused up front (raise); the multi-turn test skips a
+harness without `SUPPORTS_USER_SIM`. Bash-first harnesses use the agentic task instead of the
+direct-response task.
 """
 
 import pytest
@@ -75,13 +75,12 @@ async def test_multi_turn_with_tools(
 
 
 @pytest.mark.e2e
-async def test_agentic(run_v1, runtime, tmp_path):
-    """Agentic: write a phrase to a file with the bash tool, checked in the runtime. Only the
-    default harness exposes the bash tool, so this varies runtime but pins the harness."""
+async def test_agentic(run_v1, agentic_harness, runtime, tmp_path):
+    """Agentic: write a phrase to a file with the harness's bash tool, checked in the runtime."""
     (trace,) = await run_v1(
         "echo-agentic-v1",
-        harness="default",
-        enable_bash=True,
+        harness=agentic_harness,
+        enable_bash=agentic_harness == "default",
         runtime=runtime,
         output_dir=tmp_path,
         max_turns=10,


### PR DESCRIPTION
## Overview

Align the mini-swe-agent harness with the agentic V1 end-to-end matrix.

## Details

- Keep direct-response harnesses, including Codex, in the ordinary harness matrix.
- Add an agentic harness fixture covering the default and mini-swe-agent harnesses.
- Run both agentic harnesses against the existing `echo-agentic-v1` task across all runtime variants.
- Enable the optional bash tool only for the default harness because mini-swe-agent provides its own native bash tool.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix mini-swe-agent V1 E2E matrix to run under a dedicated `agentic_harness` fixture
> - Moves the `mini-swe-agent` harness out of the general `harness` fixture in [conftest.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1693/files#diff-bc28790d38dc6e7e4f2c44639d40bc33dea724d6c73149abf7ba82b37d14f40b) and into a new `agentic_harness` fixture alongside `default`.
> - Updates `test_agentic` in [test_e2e.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1693/files#diff-ebbbd919487889487f891b359a756e6c4630e106b16ddaef8ccddc6b900a96e1) to accept `agentic_harness` instead of pinning `harness='default'`, so the test now runs for both `default` and `mini-swe-agent`.
> - Enables bash only when `agentic_harness == 'default'`, since the mini-swe-agent harness provides its own bash tool.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 03f3f26.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only fixture and E2E matrix changes; no production eval or harness runtime behavior is modified.
> 
> **Overview**
> **Splits the V1 E2E harness matrix** so agent-style harnesses are not mixed with plain direct-response cases.
> 
> `mini-swe-agent` is removed from the shared `harness` fixture (which now covers `default`, `rlm`, and `codex` for echo/tool/multi-turn tests). A new **`agentic_harness`** fixture parametrizes `default` and `mini-swe-agent` for the agentic path.
> 
> `test_agentic` uses `agentic_harness` instead of pinning `default`, so **`echo-agentic-v1` runs for both harnesses across all runtimes**. `enable_bash` is set only when the harness is `default`, because mini-swe-agent brings its own bash tool.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03f3f261b961f329981352e91b8844fbfdb0327a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->