### PR TITLE
feat(v1): thread rollout id to tool/user servers for per-rollout multiplexing

### DIFF
--- a/examples/tasksets/scratchpad_v1/pyproject.toml
+++ b/examples/tasksets/scratchpad_v1/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "scratchpad-v1"
+version = "0.1.0"
+description = "scratchpad-v1 — contrived shared, writable tool server to test per-rollout isolation."
+requires-python = ">=3.10"
+dependencies = []
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["scratchpad_v1"]

--- a/examples/tasksets/scratchpad_v1/scratchpad_v1/__init__.py
+++ b/examples/tasksets/scratchpad_v1/scratchpad_v1/__init__.py
@@ -1,0 +1,62 @@
+"""scratchpad-v1 — a contrived taskset that tests per-rollout isolation of a SHARED, writable
+tool server.
+
+Each rollout is assigned a unique word and asked to round-trip it through the shared scratchpad
+tool, then report what came back. The reward is 1 iff the model reports its own word. Without
+per-rollout isolation, concurrent rollouts clobber the shared slot and report the wrong word —
+so running `uv run eval scratchpad-v1 -n 5 -c 5` is a direct test of the multiplexing.
+"""
+
+import sys
+
+import verifiers.v1 as vf
+
+WORDS = [
+    "alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf", "hotel",
+    "india", "juliet", "kilo", "lima", "mike", "november", "oscar", "papa",
+    "quebec", "romeo", "sierra", "tango",
+]
+
+INSTRUCTION = (
+    'Call the `scratchpad_roundtrip` tool with word="{word}". It returns a string like '
+    "`X|Y`. Then reply with that returned string verbatim as your final answer — nothing else."
+)
+
+
+class ScratchpadTask(vf.Task):
+    word: str
+
+
+class ScratchpadConfig(vf.TasksetConfig):
+    # SHARED: one server for the whole eval (simulated expensive setup), reused across
+    # rollouts. It is writable + stateful — exactly the per-rollout isolation under test.
+    tools: vf.ToolsConfig = vf.ToolsConfig(colocated=False, shared=True)
+
+
+class ScratchpadTaskset(vf.Taskset[ScratchpadTask, ScratchpadConfig]):
+    def load_tasks(self) -> list[ScratchpadTask]:
+        return [
+            ScratchpadTask(idx=i, word=w, instruction=INSTRUCTION.format(word=w))
+            for i, w in enumerate(WORDS)
+        ]
+
+    def tools(self, task: ScratchpadTask) -> list[vf.Tools]:
+        return [
+            vf.Tools(
+                name="scratchpad", command=[sys.executable, "-m", "scratchpad_v1.server"]
+            )
+        ]
+
+    @vf.stop
+    async def done(self, trace: vf.Trace) -> bool:
+        # A tool call then a final answer; cap turns so a chatty model still terminates.
+        return trace.num_turns >= 4
+
+    @vf.reward(weight=1.0)
+    async def isolated(self, task: ScratchpadTask, trace: vf.Trace) -> float:
+        answer = trace.assistant_messages[-1].content if trace.assistant_messages else ""
+        return float(task.word in (answer or ""))
+
+
+def load_taskset(config: ScratchpadConfig) -> ScratchpadTaskset:
+    return ScratchpadTaskset(config)

--- a/examples/tasksets/scratchpad_v1/scratchpad_v1/server.py
+++ b/examples/tasksets/scratchpad_v1/scratchpad_v1/server.py
@@ -1,0 +1,68 @@
+"""scratchpad tool server — DELIBERATELY stateful, to exercise per-rollout isolation.
+
+Shared across the whole eval (built once via `ToolsConfig(shared=True)`), it holds mixed
+state — a module-level dict AND a file on disk — under a single FIXED slot, so concurrent
+rollouts clobber each other unless each is scoped to its own rollout. The server multiplexes
+itself by `vf.current_rollout_id()` (the framework injects the rollout id into each request's
+URL). Set SCRATCHPAD_MULTIPLEX=0 to disable namespacing and watch rollouts corrupt each other.
+"""
+
+import asyncio
+import os
+import time
+from pathlib import Path
+
+import verifiers.v1 as vf
+from mcp.server.fastmcp import FastMCP
+
+# Simulated expensive setup — paid ONCE for the shared server (proves "built once": this runs
+# a single time for the whole eval, not per rollout).
+print("scratchpad: starting expensive setup...", flush=True)
+time.sleep(float(os.environ.get("SCRATCHPAD_SETUP_SECONDS", "2")))
+print("scratchpad: setup complete", flush=True)
+
+_MULTIPLEX = os.environ.get("SCRATCHPAD_MULTIPLEX", "1") == "1"
+# Optional barrier: make every concurrent rollout finish writing before any reads, so a
+# non-namespaced shared slot is *deterministically* clobbered (independent of model timing).
+# Set SCRATCHPAD_BARRIER=<num concurrent rollouts> for the corruption demo; 0 = just sleep.
+_BARRIER_N = int(os.environ.get("SCRATCHPAD_BARRIER", "0"))
+_MEM: dict[str, str] = {}
+_DISK = Path(os.environ.get("SCRATCHPAD_DIR", "/tmp/vf_scratchpad"))
+_DISK.mkdir(parents=True, exist_ok=True)
+_FIXED = "slot"  # one fixed slot — collides across rollouts unless namespaced by rollout id
+_written = 0
+_all_written = asyncio.Event()
+
+mcp = FastMCP("scratchpad")
+
+
+def _ns() -> str:
+    """Per-rollout namespace from the framework-injected id (or a single shared bucket when
+    multiplexing is disabled, which is the corruption-demo case)."""
+    rid = vf.current_rollout_id() if _MULTIPLEX else None
+    return rid or "_shared"
+
+
+@mcp.tool()
+async def roundtrip(word: str) -> str:
+    """Store `word` in the scratchpad, then read it back and return `<mem>|<disk>`."""
+    global _written
+    ns = _ns()
+    mem_key = f"{ns}/{_FIXED}"
+    disk_path = _DISK / f"{ns}.{_FIXED}"
+    _MEM[mem_key] = word
+    disk_path.write_text(word)
+    if _BARRIER_N:
+        _written += 1
+        if _written >= _BARRIER_N:
+            _all_written.set()
+        try:
+            await asyncio.wait_for(_all_written.wait(), timeout=15)
+        except asyncio.TimeoutError:
+            pass
+    else:
+        await asyncio.sleep(0.5)  # interleave window for concurrent writers
+    return f"{_MEM[mem_key]}|{disk_path.read_text()}"
+
+
+vf.run_mcp_server(mcp)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ examples = [
     "gsm8k-v1", "wikispeedia-v1", "glossary-v1", "deepwiki-v1", "wiki-search-v1", "code-golf-v1",
     "reverse-text-v1", "math-env-v1", "aime24-v1", "color-codeword-v1",
     "wordle-v1", "terminal-bench-2-v1", "alphabet-sort-v1",
-    "r2e-gym-v1", "scaleswe-v1", "swelego-v1",
+    "r2e-gym-v1", "scaleswe-v1", "swelego-v1", "scratchpad-v1",
 ]
 
 [project.optional-dependencies]
@@ -158,6 +158,7 @@ r2e-gym-v1 = { path = "examples/tasksets/r2e_gym_v1", editable = true }
 scaleswe-v1 = { path = "examples/tasksets/scaleswe_v1", editable = true }
 swelego-v1 = { path = "examples/tasksets/swelego_v1", editable = true }
 alphabet-sort-v1 = { path = "examples/tasksets/alphabet_sort_v1", editable = true }
+scratchpad-v1 = { path = "examples/tasksets/scratchpad_v1", editable = true }
 
 [tool.uv.exclude-newer-package]
 # PrimeIntellect-published on PyPI (trusted publisher)

--- a/uv.lock
+++ b/uv.lock
@@ -4889,6 +4889,11 @@ wheels = [
 ]
 
 [[package]]
+name = "scratchpad-v1"
+version = "0.1.0"
+source = { editable = "examples/tasksets/scratchpad_v1" }
+
+[[package]]
 name = "sentencepiece"
 version = "0.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -5836,6 +5841,7 @@ examples = [
     { name = "r2e-gym-v1" },
     { name = "reverse-text-v1" },
     { name = "scaleswe-v1" },
+    { name = "scratchpad-v1" },
     { name = "swelego-v1" },
     { name = "terminal-bench-2-v1" },
     { name = "wiki-search-v1" },
@@ -5937,6 +5943,7 @@ examples = [
     { name = "r2e-gym-v1", editable = "examples/tasksets/r2e_gym_v1" },
     { name = "reverse-text-v1", editable = "examples/tasksets/reverse_text_v1" },
     { name = "scaleswe-v1", editable = "examples/tasksets/scaleswe_v1" },
+    { name = "scratchpad-v1", editable = "examples/tasksets/scratchpad_v1" },
     { name = "swelego-v1", editable = "examples/tasksets/swelego_v1" },
     { name = "terminal-bench-2-v1", editable = "examples/tasksets/terminal_bench_2_v1" },
     { name = "wiki-search-v1", editable = "examples/tasksets/wiki_search_v1" },

--- a/verifiers/v1/__init__.py
+++ b/verifiers/v1/__init__.py
@@ -50,7 +50,7 @@ from verifiers.v1.runtimes import (
 )
 from verifiers.v1.task import Resources, Task, WireTask
 from verifiers.v1.taskset import Taskset, TasksetConfig, ToolsConfig
-from verifiers.v1.tools import Tools, run_mcp_server
+from verifiers.v1.tools import Tools, current_rollout_id, run_mcp_server
 from verifiers.v1.graph import MessageNode
 from verifiers.v1.trace import (
     Branch,
@@ -166,6 +166,7 @@ __all__ = [
     # mcp
     "Tools",
     "run_mcp_server",
+    "current_rollout_id",
     # user simulator
     "User",
 ]

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -165,12 +165,14 @@ class Rollout:
                         colocated=tools.colocated,
                         tool_runtime_config=tools.runtime,
                         shared_urls=shared_urls,
+                        rollout_id=trace.id,
                     ) as urls,
                     serve_user(
                         self.taskset.user(self.task),
                         self.taskset.config.user.runtime,
                         agent_runtime=runtime,
                         colocated=self.taskset.config.user.colocated,
+                        rollout_id=trace.id,
                     ) as session.user,
                 ):
                     # setup done — the harness is now driving

--- a/verifiers/v1/tools.py
+++ b/verifiers/v1/tools.py
@@ -14,12 +14,14 @@ launcher. The wire types the model sees (`Tool`, `ToolCall`, …) live in `types
 """
 
 import contextlib
+import contextvars
 import logging
 import os
 import random
 import socket
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
+from urllib.parse import parse_qs, quote, urlsplit
 
 from verifiers.v1.errors import ProgramError
 from verifiers.v1.runtimes import Runtime, RuntimeConfig, make_runtime
@@ -29,6 +31,30 @@ if TYPE_CHECKING:
     from mcp.server.fastmcp import FastMCP
 
 logger = logging.getLogger(__name__)
+
+# The framework tags every tool/user-server URL it hands out with the rollout's id as this
+# query param (in `serve_tools`); `run_mcp_server` reads it back into `_rollout_id` per
+# request. A server reads it via `current_rollout_id()` to scope (multiplex) its state by
+# rollout. Entirely framework-side — the harness/program carry the URL verbatim.
+ROLLOUT_ID_PARAM = "rollout_id"
+_rollout_id: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "vf_rollout_id", default=None
+)
+
+
+def current_rollout_id() -> str | None:
+    """The id of the rollout that issued the in-flight tool call, or None — set per request
+    by `run_mcp_server` from the framework-injected `rollout_id` URL param. Lets a shared
+    tool server namespace per-rollout state so concurrent rollouts don't corrupt each other."""
+    return _rollout_id.get()
+
+
+def _with_rollout_id(url: str, rollout_id: str | None) -> str:
+    """Tag a framework-built tool-server URL with the rollout id so the server can read it."""
+    if not rollout_id:
+        return url
+    sep = "&" if urlsplit(url).query else "?"
+    return f"{url}{sep}{ROLLOUT_ID_PARAM}={quote(rollout_id, safe='')}"
 
 
 @dataclass(frozen=True)
@@ -53,12 +79,26 @@ class Tools:
 
 def run_mcp_server(mcp: "FastMCP") -> None:
     """Serve a FastMCP server on the port the harness passes via `MCP_PORT`, mounting
-    streamable HTTP at `/mcp`. Call this at the end of a uv-script tool server."""
+    streamable HTTP at `/mcp`. Call this at the end of a uv-script tool server. Each request's
+    `rollout_id` URL param is exposed to the server's tools via `current_rollout_id()`."""
     import uvicorn
 
     port = int(os.environ["MCP_PORT"])
+    app = mcp.streamable_http_app()
+
+    async def with_rollout_id(scope, receive, send):
+        if scope["type"] != "http":
+            await app(scope, receive, send)
+            return
+        params = parse_qs(scope.get("query_string", b"").decode())
+        token = _rollout_id.set((params.get(ROLLOUT_ID_PARAM) or [None])[0])
+        try:
+            await app(scope, receive, send)
+        finally:
+            _rollout_id.reset(token)
+
     config = uvicorn.Config(
-        mcp.streamable_http_app(), host="127.0.0.1", port=port, log_level="critical"
+        with_rollout_id, host="127.0.0.1", port=port, log_level="critical"
     )
     uvicorn.Server(config).run()
 
@@ -163,11 +203,13 @@ async def serve_tools(
     host_reachable: bool = False,
     tool_runtime_config: RuntimeConfig | None = None,
     shared_urls: dict[str, str] | None = None,
+    rollout_id: str | None = None,
 ):
     """Bring up the declared tool servers for a rollout; yield `{name: url}`. A colocated
     server is reached in-sandbox (localhost) by default — set `host_reachable` for one the
     framework consumes from the host (a user simulator), so its port is published back to the
-    host (a remote sandbox's `public_url`, else localhost)."""
+    host (a remote sandbox's `public_url`, else localhost). Each framework-built URL is tagged
+    with `rollout_id` so a (shared) server can scope its state per rollout."""
     shared_urls = shared_urls or {}
     tool_runtimes: list[Runtime] = []  # per-rollout tool runtimes to tear down
     urls: dict[str, str] = {}
@@ -177,7 +219,9 @@ async def serve_tools(
                 urls[server.name] = server.url
                 logger.info("tool server '%s' (remote): %s", server.name, server.url)
             elif server.name in shared_urls:  # one shared instance, started eval-level
-                urls[server.name] = shared_urls[server.name]
+                urls[server.name] = _with_rollout_id(
+                    shared_urls[server.name], rollout_id
+                )
                 logger.info(
                     "tool server '%s' (shared): %s",
                     server.name,
@@ -193,7 +237,9 @@ async def serve_tools(
                     if host_reachable
                     else f"http://127.0.0.1:{port}"
                 )
-                urls[server.name] = f"{base.rstrip('/')}/mcp"
+                urls[server.name] = _with_rollout_id(
+                    f"{base.rstrip('/')}/mcp", rollout_id
+                )
                 logger.info("tool server '%s' colocated on port %d", server.name, port)
             else:  # its own runtime; reachability resolved per where it runs
                 port = _free_port()
@@ -201,8 +247,8 @@ async def serve_tools(
                 tool_runtimes.append(tool_runtime)
                 await tool_runtime.start()
                 await serve_in_runtime(server, tool_runtime, port)
-                urls[server.name] = await _resolve_url(
-                    tool_runtime, agent_runtime, port
+                urls[server.name] = _with_rollout_id(
+                    await _resolve_url(tool_runtime, agent_runtime, port), rollout_id
                 )
                 logger.info(
                     "tool server '%s' on %s: %s",

--- a/verifiers/v1/user.py
+++ b/verifiers/v1/user.py
@@ -113,6 +113,7 @@ async def serve_user(
     runtime_config: RuntimeConfig,
     agent_runtime: "Runtime | None" = None,
     colocated: bool = True,
+    rollout_id: str | None = None,
 ) -> AsyncIterator[Respond | None]:
     """Bring a rollout's user server up and yield the async `respond` the interception server
     drives — or `None` when the taskset has no user server. The framework always drives the user
@@ -126,7 +127,7 @@ async def serve_user(
         return
     if colocated and agent_runtime is not None:
         async with serve_tools(
-            [user], agent_runtime, colocated=True, host_reachable=True
+            [user], agent_runtime, colocated=True, host_reachable=True, rollout_id=rollout_id
         ) as urls:
             async with connect_user(next(iter(urls.values()))) as respond:
                 yield respond
@@ -135,7 +136,7 @@ async def serve_user(
     await runtime.start()
     try:
         async with serve_tools(
-            [user], runtime, colocated=True, host_reachable=True
+            [user], runtime, colocated=True, host_reachable=True, rollout_id=rollout_id
         ) as urls:
             async with connect_user(next(iter(urls.values()))) as respond:
                 yield respond


### PR DESCRIPTION
## Summary

A **shared** tool server (`ToolsConfig(shared=True)`) pays its expensive setup once but had
**no per-rollout isolation** — safe only for read-only servers, since a writable one lets
concurrent rollouts corrupt each other. This PR gives the server a per-rollout identity so it
can **multiplex itself**, entirely framework-side (PR1 of 2; PR2 will make isolation automatic).

- **Framework injects, not the harness.** `serve_tools` tags every URL it builds with
  `?rollout_id=<trace.id>` (shared / colocated / own-runtime), and `serve_user` routes through
  `serve_tools` so the **user-sim server gets it too**. The harness and `program.py` connect to
  the URL verbatim — **no harness/program changes**.
- **Server-side read:** `run_mcp_server` wraps `mcp.streamable_http_app()` with a tiny ASGI
  middleware that puts the request's `rollout_id` into a `ContextVar`; a server reads it via the
  new `vf.current_rollout_id()` to namespace its state.

## Example + e2e

`examples/tasksets/scratchpad_v1/` — a contrived **shared, writable** server with mixed
in-memory + on-disk state under a single fixed slot, multiplexed by `current_rollout_id()`.

In-process eval, 5 concurrent rollouts:
- multiplexing **on**: `uv run eval scratchpad-v1 -n 5 -c 5 -m <model>` → **mean reward 1.0**
- multiplexing **off** (`SCRATCHPAD_MULTIPLEX=0 SCRATCHPAD_BARRIER=5`) → **mean reward 0.2**
  (4/5 rollouts read another rollout's value from the shared slot)

`current_rollout_id()` exported from `verifiers.v1`; ruff + `uv lock` clean.

## Note (scope)

Shared tool servers are only built eval-wide on the **in-process** path (`run_eval`); the
env-server path (`run_eval_server`, i.e. `--no-rich` / how prime-rl trains) starts a server
**per rollout** today, so "shared" isn't actually shared there. The rollout id is injected on
**both** paths; wiring `shared` eval-wide into the server path is a separate follow-up. The
e2e above therefore runs on the in-process path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Thread rollout ID to tool and user servers for per-rollout multiplexing
> - Adds a `current_rollout_id()` function (via a `ContextVar`) in [tools.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1696/files#diff-5138ae71664684ced94354cd576fb5d89ba4d7a7a18d7892607c9835296db3b8) that tool server handlers can call to read the rollout ID scoped to the current HTTP request.
> - Appends the rollout ID as a `rollout_id` query parameter to MCP tool server URLs in `serve_tools` and `serve_user`, and a middleware in `run_mcp_server` parses it and sets the `ContextVar` for each request.
> - Adds a `scratchpad_v1` example taskset that demonstrates per-rollout state isolation vs. shared state using in-memory and on-disk storage keyed by rollout ID.
> - Exports `current_rollout_id` from the `verifiers.v1` public API.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f5bc006.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->