### PR TITLE
feat(v1): automatic per-rollout isolation for shared tool servers (fork)

### DIFF
--- a/examples/tasksets/scratchpad_v1/scratchpad_v1/server.py
+++ b/examples/tasksets/scratchpad_v1/scratchpad_v1/server.py
@@ -5,6 +5,11 @@ state — a module-level dict AND a file on disk — under a single FIXED slot, 
 rollouts clobber each other unless each is scoped to its own rollout. The server multiplexes
 itself by `vf.current_rollout_id()` (the framework injects the rollout id into each request's
 URL). Set SCRATCHPAD_MULTIPLEX=0 to disable namespacing and watch rollouts corrupt each other.
+
+With SCRATCHPAD_AUTOFORK=1 the server stays "dumb" (no namespacing) and isolation is handled
+*automatically* by `vf.run_mcp_server(multiplex=True)` — a fork-per-rollout multiplexer gives
+each rollout its own forked child (copy-on-write memory + private CWD), so ordinary stateful
+code is isolated with no rollout-aware logic at all.
 """
 
 import asyncio
@@ -22,14 +27,21 @@ time.sleep(float(os.environ.get("SCRATCHPAD_SETUP_SECONDS", "2")))
 print("scratchpad: setup complete", flush=True)
 
 _MULTIPLEX = os.environ.get("SCRATCHPAD_MULTIPLEX", "1") == "1"
+# When set, serve as a fork-per-rollout multiplexer (vf.run_mcp_server(multiplex=True)): the
+# server stays "dumb" (no namespacing) and the framework isolates each rollout by forking.
+_AUTOFORK = os.environ.get("SCRATCHPAD_AUTOFORK", "0") == "1"
 # Optional barrier: make every concurrent rollout finish writing before any reads, so a
 # non-namespaced shared slot is *deterministically* clobbered (independent of model timing).
 # Set SCRATCHPAD_BARRIER=<num concurrent rollouts> for the corruption demo; 0 = just sleep.
+# Skipped under autofork: each rollout is its own process, so there's no shared slot to force.
 _BARRIER_N = int(os.environ.get("SCRATCHPAD_BARRIER", "0"))
 _MEM: dict[str, str] = {}
-_DISK = Path(os.environ.get("SCRATCHPAD_DIR", "/tmp/vf_scratchpad"))
-_DISK.mkdir(parents=True, exist_ok=True)
-_FIXED = "slot"  # one fixed slot — collides across rollouts unless namespaced by rollout id
+# Under autofork each child has a private CWD, so a RELATIVE path is isolated for free;
+# otherwise an absolute shared dir (collides across rollouts unless namespaced by rollout id).
+_BASE = Path() if _AUTOFORK else Path(os.environ.get("SCRATCHPAD_DIR", "/tmp/vf_scratchpad"))
+if not _AUTOFORK:
+    _BASE.mkdir(parents=True, exist_ok=True)
+_FIXED = "slot"  # one fixed slot — collides across rollouts unless isolated
 _written = 0
 _all_written = asyncio.Event()
 
@@ -49,10 +61,10 @@ async def roundtrip(word: str) -> str:
     global _written
     ns = _ns()
     mem_key = f"{ns}/{_FIXED}"
-    disk_path = _DISK / f"{ns}.{_FIXED}"
+    disk_path = _BASE / f"{ns}.{_FIXED}"
     _MEM[mem_key] = word
     disk_path.write_text(word)
-    if _BARRIER_N:
+    if _BARRIER_N and not _AUTOFORK:
         _written += 1
         if _written >= _BARRIER_N:
             _all_written.set()
@@ -65,4 +77,4 @@ async def roundtrip(word: str) -> str:
     return f"{_MEM[mem_key]}|{disk_path.read_text()}"
 
 
-vf.run_mcp_server(mcp)
+vf.run_mcp_server(mcp, multiplex=_AUTOFORK)

--- a/verifiers/v1/multiplex.py
+++ b/verifiers/v1/multiplex.py
@@ -1,0 +1,178 @@
+"""Automatic per-rollout isolation for a shared tool server, by fork.
+
+`run_mcp_server(mcp, multiplex=True)` warms the server's (expensive) setup ONCE in a parent
+process, then forks a child per rollout id on first contact: the child inherits the warm state
+copy-on-write (so in-memory state is isolated on write) and runs in a private working directory
+(so relative-path on-disk writes are isolated too). The parent is a thin async reverse proxy
+that pins each rollout id to its child and forwards MCP traffic (streaming, so SSE works).
+Children are reaped on a `POST /vf/close?rollout_id=...` from the framework (rollout teardown),
+or by an idle TTL.
+
+Caveats: Linux/fork only; do NOT use with CUDA/GPU state or background threads in the server
+(fork copies neither safely) — fork happens from a single-threaded loop here, before any such
+state. Writes to absolute paths outside the private CWD are not isolated.
+"""
+
+import asyncio
+import contextlib
+import logging
+import os
+import shutil
+import signal
+import tempfile
+import time
+from urllib.parse import parse_qs
+
+from verifiers.v1.tools import ROLLOUT_ID_PARAM, _free_port
+
+logger = logging.getLogger(__name__)
+
+CLOSE_PATH = "/vf/close"  # framework POSTs here on rollout teardown to reap the child
+_IDLE_TTL = float(os.environ.get("VF_MULTIPLEX_TTL", "900"))  # reap idle children after N s
+_HOP_BY_HOP = {"connection", "keep-alive", "transfer-encoding", "content-length", "host"}
+
+
+class _Child:
+    def __init__(self, pid: int, port: int, cwd: str) -> None:
+        self.pid, self.port, self.cwd = pid, port, cwd
+        self.last = time.monotonic()
+
+
+def _serve_child(app, port: int, cwd: str) -> None:
+    """In the forked child: move to a private CWD and serve `app` on `port` with a fresh loop
+    (the inherited parent loop is abandoned). Never returns."""
+    import uvicorn
+
+    os.chdir(cwd)
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        loop.run_until_complete(
+            uvicorn.Server(
+                uvicorn.Config(app, host="127.0.0.1", port=port, log_level="critical")
+            ).serve()
+        )
+    finally:
+        os._exit(0)
+
+
+async def _wait_up(port: int, timeout: float = 30.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            _, w = await asyncio.open_connection("127.0.0.1", port)
+            w.close()
+            return
+        except OSError:
+            await asyncio.sleep(0.05)
+    raise RuntimeError(f"multiplex child on port {port} did not come up")
+
+
+def run_multiplexed(mcp) -> None:
+    """Serve `mcp` on `MCP_PORT` as a fork-per-rollout multiplexer (see module docstring)."""
+    import httpx
+    import uvicorn
+
+    parent_port = int(os.environ["MCP_PORT"])
+    app = mcp.streamable_http_app()  # built once in the warm parent; forked children inherit it
+    base = tempfile.mkdtemp(prefix="vf_mplex_")
+    children: dict[str, _Child] = {}
+    forking = asyncio.Lock()
+    client = httpx.AsyncClient(timeout=None)
+
+    async def ensure(rid: str) -> _Child:
+        async with forking:  # one fork at a time keeps the single-threaded fork clean
+            child = children.get(rid)
+            if child is None:
+                port = _free_port()
+                cwd = os.path.join(base, rid or "_default")
+                os.makedirs(cwd, exist_ok=True)
+                pid = os.fork()
+                if pid == 0:
+                    _serve_child(app, port, cwd)  # child: never returns
+                children[rid] = child = _Child(pid, port, cwd)
+                await _wait_up(port)
+                logger.info("multiplex: forked child pid=%d for rollout %s", pid, rid)
+            child.last = time.monotonic()
+            return child
+
+    async def reap(rid: str) -> None:
+        child = children.pop(rid, None)
+        if not child:
+            return
+        with contextlib.suppress(Exception):
+            os.kill(child.pid, signal.SIGKILL)
+        with contextlib.suppress(Exception):
+            os.waitpid(child.pid, 0)
+        shutil.rmtree(child.cwd, ignore_errors=True)
+        logger.info("multiplex: reaped child pid=%d for rollout %s", child.pid, rid)
+
+    async def _send_response(send, status: int, body: bytes) -> None:
+        await send({"type": "http.response.start", "status": status, "headers": []})
+        await send({"type": "http.response.body", "body": body})
+
+    async def proxy(scope, receive, send) -> None:
+        if scope["type"] == "lifespan":
+            # Drive the proxy app's own (empty) lifespan; children run their own.
+            while True:
+                msg = await receive()
+                if msg["type"] == "lifespan.startup":
+                    await send({"type": "lifespan.startup.complete"})
+                elif msg["type"] == "lifespan.shutdown":
+                    await send({"type": "lifespan.shutdown.complete"})
+                    return
+        if scope["type"] != "http":
+            return
+        rid = (parse_qs(scope.get("query_string", b"").decode()).get(ROLLOUT_ID_PARAM) or [""])[0]
+        if scope["path"] == CLOSE_PATH:
+            await reap(rid)
+            await _send_response(send, 200, b"closed")
+            return
+        # Read the request body, forward to the rollout's child, stream the response back.
+        body, more = b"", True
+        while more:
+            msg = await receive()
+            body += msg.get("body", b"")
+            more = msg.get("more_body", False)
+        child = await ensure(rid)
+        headers = [
+            (k.decode(), v.decode())
+            for k, v in scope["headers"]
+            if k.decode().lower() not in _HOP_BY_HOP
+        ]
+        qs = scope.get("query_string", b"").decode()
+        url = f"http://127.0.0.1:{child.port}{scope['path']}" + (f"?{qs}" if qs else "")
+        req = client.build_request(scope["method"], url, headers=headers, content=body)
+        resp = await client.send(req, stream=True)
+        out = [
+            (k.encode(), v.encode())
+            for k, v in resp.headers.items()
+            if k.lower() not in _HOP_BY_HOP
+        ]
+        await send({"type": "http.response.start", "status": resp.status_code, "headers": out})
+        async for chunk in resp.aiter_raw():
+            await send({"type": "http.response.body", "body": chunk, "more_body": True})
+        await send({"type": "http.response.body", "body": b"", "more_body": False})
+        await resp.aclose()
+
+    async def _reaper() -> None:
+        while True:
+            await asyncio.sleep(30)
+            now = time.monotonic()
+            for rid in [r for r, c in children.items() if now - c.last > _IDLE_TTL]:
+                await reap(rid)
+
+    async def _serve() -> None:
+        asyncio.ensure_future(_reaper())
+        await uvicorn.Server(
+            uvicorn.Config(proxy, host="127.0.0.1", port=parent_port, log_level="critical")
+        ).serve()
+
+    try:
+        asyncio.run(_serve())
+    finally:
+        for rid in list(children):
+            child = children[rid]
+            with contextlib.suppress(Exception):
+                os.kill(child.pid, signal.SIGKILL)
+        shutil.rmtree(base, ignore_errors=True)

--- a/verifiers/v1/tools.py
+++ b/verifiers/v1/tools.py
@@ -77,10 +77,22 @@ class Tools:
     """HTTP headers sent to a remote `url` (e.g. auth)."""
 
 
-def run_mcp_server(mcp: "FastMCP") -> None:
+def run_mcp_server(mcp: "FastMCP", multiplex: bool = False) -> None:
     """Serve a FastMCP server on the port the harness passes via `MCP_PORT`, mounting
     streamable HTTP at `/mcp`. Call this at the end of a uv-script tool server. Each request's
-    `rollout_id` URL param is exposed to the server's tools via `current_rollout_id()`."""
+    `rollout_id` URL param is exposed to the server's tools via `current_rollout_id()`.
+
+    With `multiplex=True`, serve as a fork-per-rollout multiplexer (see `verifiers.v1.multiplex`):
+    expensive setup runs once in the parent, then each rollout gets its own forked child
+    (copy-on-write memory + a private working dir) — so an ordinary *stateful* server is
+    isolated per rollout automatically, with no `current_rollout_id()` namespacing in the
+    tool code."""
+    if multiplex:
+        from verifiers.v1.multiplex import run_multiplexed
+
+        run_multiplexed(mcp)
+        return
+
     import uvicorn
 
     port = int(os.environ["MCP_PORT"])


### PR DESCRIPTION
## Summary

Stacked on #1696 (rollout-id threading). Makes shared-tool-server isolation **fully automatic** —
the tool author writes ordinary stateful code and the framework isolates each rollout, no
`current_rollout_id()` namespacing.

`run_mcp_server(mcp, multiplex=True)` (new `verifiers/v1/multiplex.py`):
- expensive setup runs **once** in a parent process;
- on first contact from a new rollout id the parent **`fork()`s a child** that inherits the warm
  state **copy-on-write** (in-memory state isolated on write) and runs in a **private working
  directory** (relative-path on-disk writes isolated);
- the parent is a thin async **reverse proxy** that pins each rollout id to its child and streams
  MCP traffic (SSE-safe); fork happens from a single-threaded loop (safe).
- children are reaped by **idle TTL** and on **eval-end teardown**; a `POST /vf/close?rollout_id=…`
  endpoint is provided for explicit reaping.

## e2e (in-process, 5 concurrent rollouts, the **same dumb** server)

`scratchpad_v1` gains an autofork mode (no `current_rollout_id`):
- `SCRATCHPAD_AUTOFORK=1 SCRATCHPAD_MULTIPLEX=0` → **mean reward 1.0** (auto-isolated)
- `SCRATCHPAD_MULTIPLEX=0 SCRATCHPAD_BARRIER=5` (no fork) → **mean reward 0.2** (corrupts)
- no child processes leak after the eval.

So fork alone turns a corrupting dumb server into a correct one.

## Caveats / scope
- **Linux/fork only**; not for CUDA/GPU state or background threads in the server (fork copies
  neither safely — fork here is from a single-threaded loop, before any such state).
- Absolute-path writes outside the private CWD are not isolated.
- Wiring the per-rollout `/vf/close` into rollout teardown (tighter reaping for long runs) is a
  follow-up; idle TTL + eval-end teardown handle reaping today.
- Like #1696, the shared lifetime is the in-process eval path (`run_eval`); the env-server path
  is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add fork-per-rollout multiplexing to isolate shared MCP tool servers per rollout
> - Adds a new [multiplex.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1697/files#diff-4795e6391788a002a2cc639eb82ee62e2667e04759378b127239826bf8799000) module that runs a parent ASGI reverse proxy which forks a child process per rollout ID on demand, each with a private CWD and ephemeral localhost port.
> - Child processes inherit the MCP app via `fork()` (copy-on-write memory), serve it with a fresh uvicorn/event loop, and are reaped on `POST /vf/close` or after a TTL idle timeout (`VF_MULTIPLEX_TTL`).
> - Extends `run_mcp_server()` in [tools.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1697/files#diff-5138ae71664684ced94354cd576fb5d89ba4d7a7a18d7892607c9835296db3b8) with a `multiplex=True` flag that delegates to the new multiplexer; default behavior is unchanged.
> - Updates the scratchpad v1 server to opt in via `SCRATCHPAD_AUTOFORK=1`, switching to relative paths within each child's CWD and skipping the write barrier under autofork.
> - Risk: forked children that are not explicitly closed rely on TTL-based reaping; misconfigured TTL or missing `/vf/close` calls may leave orphan processes.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 4cb5612. 3 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->