### PR TITLE
Extend the V1 bash tool timeout

### DIFF
--- a/packages/harnesses/harnesses/default/program.py
+++ b/packages/harnesses/harnesses/default/program.py
@@ -46,7 +46,7 @@ client = AsyncOpenAI()
 def run_bash(command: str) -> str:
     try:
         result = subprocess.run(
-            ["bash", "-c", command], capture_output=True, text=True, timeout=60 * 60
+            ["bash", "-c", command], capture_output=True, text=True, timeout=3600
         )
         return result.stdout + result.stderr
     except Exception as e:

--- a/packages/harnesses/harnesses/default/program.py
+++ b/packages/harnesses/harnesses/default/program.py
@@ -46,7 +46,7 @@ client = AsyncOpenAI()
 def run_bash(command: str) -> str:
     try:
         result = subprocess.run(
-            ["bash", "-c", command], capture_output=True, text=True, timeout=60
+            ["bash", "-c", command], capture_output=True, text=True, timeout=60 * 60
         )
         return result.stdout + result.stderr
     except Exception as e:


### PR DESCRIPTION
## Overview

Extend the built-in V1 bash tool execution window from one minute to one hour so long-running shell commands can complete within agent workflows.

## Details

- Changes the default harness `subprocess.run` timeout from `60` seconds to `60 * 60` seconds.
- Keeps the timeout local to each bash invocation; rollout and runtime-level limits continue to provide the surrounding execution budget.
- The compact harness does not expose a subprocess-backed bash tool, so it has no corresponding 60-second timeout to update.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Extend `run_bash` timeout from 60 to 3600 seconds
> Increases the `subprocess.run` timeout in [program.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1701/files#diff-d76a0706629e763126a9527179f8a652aaae490a3efcaf8f8134a94ce9b82c80) from 60 to 3600 seconds. Behavioral Change: bash commands now run for up to one hour before timing out instead of one minute.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 56fe99b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Long-running local shell commands can tie up agent runtimes longer and increase resource use, though scope is limited to the optional default harness bash tool.
> 
> **Overview**
> Raises the per-invocation `subprocess.run` limit in the default harness **`run_bash`** from **60** to **3600** seconds so agent-driven shell commands can run up to an hour before the harness kills them.
> 
> **Behavioral change:** bash tool calls that previously failed around the one-minute mark can now block the tool thread for much longer; outer rollout/runtime caps are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56fe99b795055e3aa502296b8b5dfcb658b5fe73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->