### PR TITLE
Use Prime CLI config for v1 eval

### DIFF
--- a/verifiers/v1/clients/config.py
+++ b/verifiers/v1/clients/config.py
@@ -10,6 +10,7 @@ client) and in-env LLM calls (e.g. a judge reward) build clients from these.
 
 import os
 from typing import Annotated, Literal
+from urllib.parse import urlparse
 
 from openai import AsyncOpenAI
 from pydantic import Field, model_validator
@@ -22,6 +23,7 @@ from verifiers.v1.clients.eval import EvalClient
 from verifiers.v1.clients.train import TrainClient
 
 DEFAULT_PRIME_INFERENCE_URL = "https://api.pinference.ai/api/v1"
+PRIME_INFERENCE_HOST = "pinference.ai"
 PRIME_TEAM_ID_HEADER = "X-Prime-Team-ID"
 
 
@@ -45,7 +47,10 @@ class BaseClientConfig(BaseConfig):
         )
         if "base_url" not in self.model_fields_set:
             self.base_url = prime_base_url
-        if self.base_url.rstrip("/") != prime_base_url.rstrip("/"):
+        host = urlparse(self.base_url).hostname or ""
+        if host != PRIME_INFERENCE_HOST and not host.endswith(
+            f".{PRIME_INFERENCE_HOST}"
+        ):
             return self
         team_id = os.environ.get("PRIME_TEAM_ID") or prime_config.get("team_id")
         if team_id:
@@ -85,15 +90,13 @@ ClientConfig = Annotated[
 
 def resolve_client(config: BaseClientConfig) -> Client:
     api_key = os.environ.get(config.api_key_var)
-    if not api_key and config.api_key_var == "PRIME_API_KEY":
-        prime_config = load_prime_config()
-        prime_base_url = (
-            os.environ.get("PRIME_INFERENCE_URL")
-            or prime_config.get("inference_url")
-            or DEFAULT_PRIME_INFERENCE_URL
-        )
-        if config.base_url.rstrip("/") == prime_base_url.rstrip("/"):
-            api_key = prime_config.get("api_key")
+    host = urlparse(config.base_url).hostname or ""
+    if (
+        not api_key
+        and config.api_key_var == "PRIME_API_KEY"
+        and (host == PRIME_INFERENCE_HOST or host.endswith(f".{PRIME_INFERENCE_HOST}"))
+    ):
+        api_key = load_prime_config().get("api_key")
     api_key = api_key or "EMPTY"
     if isinstance(config, TrainClientConfig):
         # The renderer calls a vLLM `/inference/v1/generate` engine through the OpenAI SDK.

--- a/verifiers/v1/clients/config.py
+++ b/verifiers/v1/clients/config.py
@@ -21,13 +21,14 @@ from verifiers.v1.clients.client import Client
 from verifiers.v1.clients.eval import EvalClient
 from verifiers.v1.clients.train import TrainClient
 
+DEFAULT_PRIME_INFERENCE_URL = "https://api.pinference.ai/api/v1"
 PRIME_TEAM_ID_HEADER = "X-Prime-Team-ID"
 
 
 class BaseClientConfig(BaseConfig):
     """An OpenAI-compatible endpoint. The API key is read from an env var."""
 
-    base_url: str = "https://api.pinference.ai/api/v1"
+    base_url: str = DEFAULT_PRIME_INFERENCE_URL
     api_key_var: str = "PRIME_API_KEY"
     headers: dict[str, str] = Field(default_factory=dict)
     """Extra HTTP headers sent on every request."""
@@ -37,12 +38,15 @@ class BaseClientConfig(BaseConfig):
         if self.api_key_var != "PRIME_API_KEY":
             return self
         prime_config = load_prime_config()
+        prime_base_url = (
+            os.environ.get("PRIME_INFERENCE_URL")
+            or prime_config.get("inference_url")
+            or DEFAULT_PRIME_INFERENCE_URL
+        )
         if "base_url" not in self.model_fields_set:
-            self.base_url = (
-                os.environ.get("PRIME_INFERENCE_URL")
-                or prime_config.get("inference_url")
-                or self.base_url
-            )
+            self.base_url = prime_base_url
+        if self.base_url.rstrip("/") != prime_base_url.rstrip("/"):
+            return self
         team_id = os.environ.get("PRIME_TEAM_ID") or prime_config.get("team_id")
         if team_id:
             self.headers.setdefault(PRIME_TEAM_ID_HEADER, team_id)
@@ -82,7 +86,14 @@ ClientConfig = Annotated[
 def resolve_client(config: BaseClientConfig) -> Client:
     api_key = os.environ.get(config.api_key_var)
     if not api_key and config.api_key_var == "PRIME_API_KEY":
-        api_key = load_prime_config().get("api_key")
+        prime_config = load_prime_config()
+        prime_base_url = (
+            os.environ.get("PRIME_INFERENCE_URL")
+            or prime_config.get("inference_url")
+            or DEFAULT_PRIME_INFERENCE_URL
+        )
+        if config.base_url.rstrip("/") == prime_base_url.rstrip("/"):
+            api_key = prime_config.get("api_key")
     api_key = api_key or "EMPTY"
     if isinstance(config, TrainClientConfig):
         # The renderer calls a vLLM `/inference/v1/generate` engine through the OpenAI SDK.

--- a/verifiers/v1/clients/config.py
+++ b/verifiers/v1/clients/config.py
@@ -1,10 +1,10 @@
 """Client configs: describe an OpenAI-compatible endpoint and resolve it to a Client.
 
 A `BaseClientConfig` is an OpenAI-compatible endpoint (base_url + API-key env var
-+ extra headers) that `resolve_client` turns into a `Client`. Prime team-billing
-is baked in via a validator, so it's handled in one place. Both the eval entrypoint
-(its model client) and in-env LLM calls (e.g. a judge reward) build clients from
-these — inherit `BaseClientConfig` to get the endpoint/header handling for free.
++ extra headers) that `resolve_client` turns into a `Client`. The default Prime
+endpoint, API key, and team fall back to the active Prime CLI config, so direct
+`uv run eval` calls behave like `prime eval`. Both the eval entrypoint (its model
+client) and in-env LLM calls (e.g. a judge reward) build clients from these.
 `ClientConfig` is the CLI-selectable discriminated union (eval | train).
 """
 
@@ -16,11 +16,11 @@ from pydantic import Field, model_validator
 from pydantic_config import BaseConfig
 from renderers import RendererConfig
 
+from verifiers.utils.client_utils import load_prime_config
 from verifiers.v1.clients.client import Client
 from verifiers.v1.clients.eval import EvalClient
 from verifiers.v1.clients.train import TrainClient
 
-PRIME_INFERENCE_HOST = "pinference.ai"
 PRIME_TEAM_ID_HEADER = "X-Prime-Team-ID"
 
 
@@ -33,11 +33,18 @@ class BaseClientConfig(BaseConfig):
     """Extra HTTP headers sent on every request."""
 
     @model_validator(mode="after")
-    def add_prime_team_id(self) -> "BaseClientConfig":
-        # Prime inference bills the personal balance unless a team is named; on
-        # that endpoint, route billing to PRIME_TEAM_ID when set (explicit wins).
-        team_id = os.environ.get("PRIME_TEAM_ID")
-        if PRIME_INFERENCE_HOST in self.base_url and team_id:
+    def apply_prime_config(self) -> "BaseClientConfig":
+        if self.api_key_var != "PRIME_API_KEY":
+            return self
+        prime_config = load_prime_config()
+        if "base_url" not in self.model_fields_set:
+            self.base_url = (
+                os.environ.get("PRIME_INFERENCE_URL")
+                or prime_config.get("inference_url")
+                or self.base_url
+            )
+        team_id = os.environ.get("PRIME_TEAM_ID") or prime_config.get("team_id")
+        if team_id:
             self.headers.setdefault(PRIME_TEAM_ID_HEADER, team_id)
         return self
 
@@ -73,7 +80,10 @@ ClientConfig = Annotated[
 
 
 def resolve_client(config: BaseClientConfig) -> Client:
-    api_key = os.environ.get(config.api_key_var, "EMPTY")
+    api_key = os.environ.get(config.api_key_var)
+    if not api_key and config.api_key_var == "PRIME_API_KEY":
+        api_key = load_prime_config().get("api_key")
+    api_key = api_key or "EMPTY"
     if isinstance(config, TrainClientConfig):
         # The renderer calls a vLLM `/inference/v1/generate` engine through the OpenAI SDK.
         openai = AsyncOpenAI(


### PR DESCRIPTION
## Overview

Make direct v1 `uv run eval` calls use the active Prime CLI inference settings when the default Prime client is selected.

## Details

- Fall back to `~/.prime/config.json` for the API key and inference URL when matching environment variables are absent.
- Apply the configured Prime team ID as the billing header.
- Preserve explicit client settings and environment variables as higher-precedence overrides.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes credential resolution and team billing headers for Prime inference; wrong fallbacks could mis-route billing or send requests without a valid key.
> 
> **Overview**
> Direct **`uv run eval`** with the default Prime client now picks up the same inference URL, API key, and team billing as **`prime eval`**, by falling back to **`~/.prime/config.json`** when env vars are missing.
> 
> **`BaseClientConfig`** replaces **`add_prime_team_id`** with **`apply_prime_config`**: only when **`api_key_var`** is **`PRIME_API_KEY`**, it resolves **`base_url`** from **`PRIME_INFERENCE_URL` → CLI `inference_url` → default**, and sets **`X-Prime-Team-ID`** from **`PRIME_TEAM_ID` or CLI `team_id`** only if the host is Prime inference. Explicit **`base_url`** in config still wins.
> 
> **`resolve_client`** loads the API key from the Prime CLI config when **`PRIME_API_KEY`** is unset and the endpoint is Prime-hosted, instead of defaulting straight to **`"EMPTY"`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ff7fe1c3bbb84d7fdab1662b6f695df01f291cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use Prime CLI config as fallback for base URL, team ID, and API key in v1 eval
> - `BaseClientConfig.apply_prime_config` (in [config.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1703/files#diff-052fb75ebcf125bca5326c84afdabf150d579712daa8474171035d7268a42be1)) now sets `base_url` from `PRIME_INFERENCE_URL` env var or CLI config when not explicitly provided, and injects the `X-Prime-Team-ID` header from `PRIME_TEAM_ID` env var or CLI config for `pinference.ai` hosts.
> - `resolve_client` falls back to the Prime CLI config `api_key` for `pinference.ai` hosts when the expected env var is unset, reducing cases where `'EMPTY'` is used as the key.
> - Behavioral Change: clients targeting `pinference.ai` that previously required explicit env vars will now silently pick up values from the local Prime CLI config if those vars are absent.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4ff7fe1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->