### PR TITLE
Track cached, reasoning, and cost usage in v1

### DIFF
--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -24,6 +24,7 @@ from verifiers.v1.configs.eval import EvalConfig
 from verifiers.v1.rollout import Phase, Rollout
 from verifiers.v1.trace import Trace
 from verifiers.v1.utils.format import format_count, format_reward, format_time
+from verifiers.utils.pricing_utils import format_cost_usd
 
 # For sizing pages to the terminal: detects the real terminal height/width each access (the live
 # view writes to the same terminal). Reused so we don't rebuild it every refresh tick.
@@ -151,7 +152,7 @@ def Progress(
     return row
 
 
-def _tokens(trace: Trace) -> str:
+def _tokens(trace: Trace) -> tuple[int, int, int | None, int | None]:
     """Input/output tokens for the main branch: output is every assistant (completion) token
     generated across the branch's turns; input is the last turn's prompt — the full final
     context the model saw. (Output can exceed the final context — reasoning tokens count toward
@@ -159,15 +160,16 @@ def _tokens(trace: Trace) -> str:
 
     Prefers the token-id counts; falls back to provider-reported usage when the endpoint returns
     no token ids (e.g. plain OpenAI completions), so the counts aren't shown as 0/0."""
+    usage = trace.usage
+    cached = usage.cached_input_tokens if usage else None
+    reasoning = usage.reasoning_tokens if usage else None
     branches = trace.branches
     if not branches or not branches[0].nodes:
-        return ""
+        return 0, 0, cached, reasoning
     b = branches[0]
     prompt = b.prompt_len or b.num_prompt_tokens
     completion = b.completion_len or b.num_completion_tokens
-    if not prompt and not completion:
-        return ""
-    return f"{format_count(prompt)}/{format_count(completion)} tokens"
+    return prompt, completion, cached, reasoning
 
 
 def _groups(rollouts: list[Rollout]) -> list[list[Rollout]]:
@@ -225,13 +227,20 @@ def Rows(groups: list[list[Rollout]], now: float, runtime_type: str) -> Table:
                 or t.timing.generation.end
                 or now
             )
+            prompt, completion, cached, reasoning = _tokens(t)
+            cost = t.usage.cost if t.usage else None
             left = [
                 f"task {label}",
                 t.id[:8],
                 runtime,
                 f"{turns} turn{'s' * (turns != 1)}",
                 f"{nbranches} branch{'es' * (nbranches != 1)}",
-                _tokens(t),
+                f"{format_count(prompt)}/{format_count(completion)} tokens"
+                if prompt or completion
+                else "",
+                f"{format_count(cached)} cached" if cached is not None else "",
+                f"{format_count(reasoning)} reasoning" if reasoning is not None else "",
+                f"{format_cost_usd(cost)} cost" if cost is not None else "",
                 stop,  # stop condition (agent_completed / max_turns / harness_timeout), once done
             ]
             # No start time yet (queued, not generating) → blank, not `now - 0` (~56 years).
@@ -245,10 +254,21 @@ def Rows(groups: list[list[Rollout]], now: float, runtime_type: str) -> Table:
         return grid
     # Pad each left section to its max width across rows (drop all-empty ones) so they align,
     # then join with " · ". Text sections left-justified, numeric right.
-    pad = (str.ljust, str.ljust, str.ljust, str.rjust, str.rjust, str.rjust, str.ljust)
-    widths = [max(len(left[i]) for _, _, left, _, _ in rows) for i in range(7)]
+    pad = (
+        str.ljust,
+        str.ljust,
+        str.ljust,
+        str.rjust,
+        str.rjust,
+        str.rjust,
+        str.rjust,
+        str.rjust,
+        str.rjust,
+        str.ljust,
+    )
+    widths = [max(len(left[i]) for _, _, left, _, _ in rows) for i in range(10)]
     for brace, state, left, result, elapsed in rows:
-        sections = [pad[i](left[i], widths[i]) for i in range(7) if widths[i]]
+        sections = [pad[i](left[i], widths[i]) for i in range(10) if widths[i]]
         grid.add_row(
             f"{brace} {_MARK[state]} " + " · ".join(sections),
             f"{result} ·" if result else "",  # trailing dot only when there's a result

--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -229,18 +229,24 @@ def Rows(groups: list[list[Rollout]], now: float, runtime_type: str) -> Table:
             )
             prompt, completion, cached, reasoning = _tokens(t)
             cost = t.usage.cost if t.usage else None
+            tokens = ""
+            if prompt or completion:
+                tokens = f"{format_count(prompt)}/{format_count(completion)} tokens"
+                details = []
+                if reasoning is not None:
+                    details.append(f"{format_count(reasoning)} reasoning")
+                if cached is not None:
+                    details.append(f"{format_count(cached)} cached")
+                if details:
+                    tokens += f" ({', '.join(details)})"
             left = [
                 f"task {label}",
                 t.id[:8],
                 runtime,
                 f"{turns} turn{'s' * (turns != 1)}",
                 f"{nbranches} branch{'es' * (nbranches != 1)}",
-                f"{format_count(prompt)}/{format_count(completion)} tokens"
-                if prompt or completion
-                else "",
-                f"{format_count(cached)} cached" if cached is not None else "",
-                f"{format_count(reasoning)} reasoning" if reasoning is not None else "",
-                f"{format_cost_usd(cost)} cost" if cost is not None else "",
+                tokens,
+                f"{format_cost_usd(cost)}" if cost is not None else "",
                 stop,  # stop condition (agent_completed / max_turns / harness_timeout), once done
             ]
             # No start time yet (queued, not generating) → blank, not `now - 0` (~56 years).
@@ -260,15 +266,13 @@ def Rows(groups: list[list[Rollout]], now: float, runtime_type: str) -> Table:
         str.ljust,
         str.rjust,
         str.rjust,
-        str.rjust,
-        str.rjust,
-        str.rjust,
+        str.ljust,
         str.rjust,
         str.ljust,
     )
-    widths = [max(len(left[i]) for _, _, left, _, _ in rows) for i in range(10)]
+    widths = [max(len(left[i]) for _, _, left, _, _ in rows) for i in range(8)]
     for brace, state, left, result, elapsed in rows:
-        sections = [pad[i](left[i], widths[i]) for i in range(10) if widths[i]]
+        sections = [pad[i](left[i], widths[i]) for i in range(8) if widths[i]]
         grid.add_row(
             f"{brace} {_MARK[state]} " + " · ".join(sections),
             f"{result} ·" if result else "",  # trailing dot only when there's a result

--- a/verifiers/v1/clients/train.py
+++ b/verifiers/v1/clients/train.py
@@ -13,6 +13,11 @@ from collections.abc import Mapping
 from typing import Any
 
 from openai import AsyncOpenAI, OpenAIError
+from openai.types import CompletionUsage
+from openai.types.completion_usage import (
+    CompletionTokensDetails,
+    PromptTokensDetails,
+)
 from renderers import RenderedTokens
 from renderers import OverlongPromptError as RendererOverlongPromptError
 from renderers import RendererConfig
@@ -61,15 +66,23 @@ def serialize_completion(response: Response, model: str) -> dict:
             }
             for c in response.message.tool_calls
         ]
-    usage = (
-        {
-            "prompt_tokens": response.usage.prompt_tokens,
-            "completion_tokens": response.usage.completion_tokens,
-            "total_tokens": response.usage.total_tokens,
-        }
-        if response.usage
-        else None
-    )
+    usage: CompletionUsage | None = None
+    if response.usage:
+        usage = CompletionUsage(
+            prompt_tokens=response.usage.input_tokens,
+            completion_tokens=response.usage.completion_tokens,
+            total_tokens=response.usage.total_tokens,
+            prompt_tokens_details=PromptTokensDetails(
+                cached_tokens=response.usage.cached_input_tokens
+            )
+            if response.usage.cached_input_tokens is not None
+            else None,
+            completion_tokens_details=CompletionTokensDetails(
+                reasoning_tokens=response.usage.reasoning_tokens
+            )
+            if response.usage.reasoning_tokens is not None
+            else None,
+        )
     return {
         "id": response.id or "vf-intercept",
         "object": "chat.completion",
@@ -82,7 +95,7 @@ def serialize_completion(response: Response, model: str) -> dict:
                 "finish_reason": response.finish_reason or "stop",
             }
         ],
-        "usage": usage,
+        "usage": usage.model_dump(exclude_none=True) if usage is not None else None,
     }
 
 
@@ -128,6 +141,8 @@ def response_from_generate(
             tool_calls=tool_calls,
         ),
         finish_reason=finish,
+        # /inference/v1/generate returns exact token ids but no usage details, so the
+        # completion's reasoning-token subset is unknown.
         usage=Usage(
             prompt_tokens=len(prompt_ids), completion_tokens=len(completion_ids)
         ),

--- a/verifiers/v1/dialects/anthropic.py
+++ b/verifiers/v1/dialects/anthropic.py
@@ -135,13 +135,18 @@ def response_from_wire(message: AnthropicMessage) -> Response:
                 )
             )
     finish: FinishReason = STOP_REASONS.get(data.get("stop_reason") or "")
-    usage = (
-        Usage(
-            prompt_tokens=data["usage"].get("input_tokens", 0),
-            completion_tokens=data["usage"].get("output_tokens", 0),
-        )
-        if data.get("usage")
-        else None
+    provider_usage = message.usage
+    output_details = data["usage"].get("output_tokens_details") or {}
+    # Anthropic reports three disjoint input buckets. Cache writes are uncached work;
+    # cache reads are the reusable subset exposed separately by vf.Usage.
+    usage = Usage(
+        prompt_tokens=provider_usage.input_tokens
+        + (provider_usage.cache_creation_input_tokens or 0),
+        completion_tokens=provider_usage.output_tokens,
+        cached_input_tokens=provider_usage.cache_read_input_tokens,
+        # This is a re-tokenized raw-thinking estimate inside output_tokens, not the
+        # token count of the visible thinking summary.
+        reasoning_tokens=output_details.get("thinking_tokens"),
     )
     return Response(
         id=data.get("id", ""),

--- a/verifiers/v1/dialects/anthropic.py
+++ b/verifiers/v1/dialects/anthropic.py
@@ -136,7 +136,7 @@ def response_from_wire(message: AnthropicMessage) -> Response:
             )
     finish: FinishReason = STOP_REASONS.get(data.get("stop_reason") or "")
     provider_usage = message.usage
-    output_details = data["usage"].get("output_tokens_details") or {}
+    output_details = data.get("usage", {}).get("output_tokens_details")
     # Anthropic reports three disjoint input buckets. Cache writes are uncached work;
     # cache reads are the reusable subset exposed separately by vf.Usage.
     usage = Usage(
@@ -146,7 +146,9 @@ def response_from_wire(message: AnthropicMessage) -> Response:
         cached_input_tokens=provider_usage.cache_read_input_tokens,
         # This is a re-tokenized raw-thinking estimate inside output_tokens, not the
         # token count of the visible thinking summary.
-        reasoning_tokens=output_details.get("thinking_tokens"),
+        reasoning_tokens=output_details.get("thinking_tokens")
+        if output_details
+        else None,
     )
     return Response(
         id=data.get("id", ""),

--- a/verifiers/v1/dialects/anthropic.py
+++ b/verifiers/v1/dialects/anthropic.py
@@ -149,6 +149,7 @@ def response_from_wire(message: AnthropicMessage) -> Response:
         reasoning_tokens=output_details.get("thinking_tokens")
         if output_details
         else None,
+        cost=getattr(provider_usage, "cost", None),
     )
     return Response(
         id=data.get("id", ""),

--- a/verifiers/v1/dialects/chat.py
+++ b/verifiers/v1/dialects/chat.py
@@ -155,14 +155,25 @@ def response_from_wire(completion: ChatCompletion) -> Response:
     finish: FinishReason = (
         choice.finish_reason if choice.finish_reason in FINISH_REASONS else None
     )
-    usage = (
-        Usage(
-            prompt_tokens=completion.usage.prompt_tokens,
-            completion_tokens=completion.usage.completion_tokens,
+    usage = None
+    if completion.usage:
+        cached = (
+            completion.usage.prompt_tokens_details.cached_tokens
+            if completion.usage.prompt_tokens_details
+            else None
         )
-        if completion.usage
-        else None
-    )
+        reasoning = (
+            completion.usage.completion_tokens_details.reasoning_tokens
+            if completion.usage.completion_tokens_details
+            else None
+        )
+        usage = Usage(
+            prompt_tokens=completion.usage.prompt_tokens - (cached or 0),
+            completion_tokens=completion.usage.completion_tokens,
+            cached_input_tokens=cached,
+            reasoning_tokens=reasoning,
+            cost=getattr(completion.usage, "cost", None),
+        )
     return Response(
         id=completion.id,
         created=completion.created,

--- a/verifiers/v1/dialects/responses.py
+++ b/verifiers/v1/dialects/responses.py
@@ -10,6 +10,10 @@ endpoint and this dialect parses a copy for the trace. Server-side statefulness
 import json
 
 from openai.types.responses import ResponseUsage
+from openai.types.responses.response_usage import (
+    InputTokensDetails,
+    OutputTokensDetails,
+)
 from pydantic import BaseModel, ConfigDict
 
 from verifiers.v1.dialects.base import Dialect, iter_sse
@@ -37,13 +41,20 @@ ASSISTANT_ITEMS = ("reasoning", "function_call")
 _SAMPLING_KEYS = frozenset({"temperature", "top_p", "max_output_tokens", "max_tokens"})
 
 
+class ProviderUsage(ResponseUsage):
+    """Responses usage with optional detail objects for OpenAI-compatible providers."""
+
+    input_tokens_details: InputTokensDetails | None = None
+    output_tokens_details: OutputTokensDetails | None = None
+
+
 class OpenAIResponse(BaseModel):
     """Permissive parse-only view of a Responses object: `extra='allow'` keeps it a plain dict
     for the trace (read via `model_dump`), so a strict SDK model can't crash the rollout on a
     provider/SDK enum skew (e.g. a value the pinned `openai` rejects)."""
 
     model_config = ConfigDict(extra="allow")
-    usage: ResponseUsage | None = None
+    usage: ProviderUsage | None = None
 
 
 def parse_content(content) -> str | list[ContentPart]:
@@ -134,12 +145,16 @@ def response_from_wire(response: OpenAIResponse) -> Response:
     usage = None
     if response.usage:
         provider_usage = response.usage
-        cached = provider_usage.input_tokens_details.cached_tokens
+        input_details = provider_usage.input_tokens_details
+        output_details = provider_usage.output_tokens_details
+        cached = input_details.cached_tokens if input_details else None
         usage = Usage(
-            prompt_tokens=provider_usage.input_tokens - cached,
+            prompt_tokens=provider_usage.input_tokens - (cached or 0),
             completion_tokens=provider_usage.output_tokens,
             cached_input_tokens=cached,
-            reasoning_tokens=provider_usage.output_tokens_details.reasoning_tokens,
+            reasoning_tokens=output_details.reasoning_tokens
+            if output_details
+            else None,
         )
     return Response(
         id=data.get("id", ""),

--- a/verifiers/v1/dialects/responses.py
+++ b/verifiers/v1/dialects/responses.py
@@ -155,6 +155,7 @@ def response_from_wire(response: OpenAIResponse) -> Response:
             reasoning_tokens=output_details.reasoning_tokens
             if output_details
             else None,
+            cost=getattr(provider_usage, "cost", None),
         )
     return Response(
         id=data.get("id", ""),

--- a/verifiers/v1/dialects/responses.py
+++ b/verifiers/v1/dialects/responses.py
@@ -9,6 +9,7 @@ endpoint and this dialect parses a copy for the trace. Server-side statefulness
 
 import json
 
+from openai.types.responses import ResponseUsage
 from pydantic import BaseModel, ConfigDict
 
 from verifiers.v1.dialects.base import Dialect, iter_sse
@@ -42,6 +43,7 @@ class OpenAIResponse(BaseModel):
     provider/SDK enum skew (e.g. a value the pinned `openai` rejects)."""
 
     model_config = ConfigDict(extra="allow")
+    usage: ResponseUsage | None = None
 
 
 def parse_content(content) -> str | list[ContentPart]:
@@ -129,14 +131,16 @@ def response_from_wire(response: OpenAIResponse) -> Response:
         if data.get("status") == "incomplete"
         else ("tool_calls" if tool_calls else "stop")
     )
-    usage = (
-        Usage(
-            prompt_tokens=data["usage"].get("input_tokens", 0),
-            completion_tokens=data["usage"].get("output_tokens", 0),
+    usage = None
+    if response.usage:
+        provider_usage = response.usage
+        cached = provider_usage.input_tokens_details.cached_tokens
+        usage = Usage(
+            prompt_tokens=provider_usage.input_tokens - cached,
+            completion_tokens=provider_usage.output_tokens,
+            cached_input_tokens=cached,
+            reasoning_tokens=provider_usage.output_tokens_details.reasoning_tokens,
         )
-        if data.get("usage")
-        else None
-    )
     return Response(
         id=data.get("id", ""),
         created=data.get("created_at", 0),

--- a/verifiers/v1/graph.py
+++ b/verifiers/v1/graph.py
@@ -92,10 +92,9 @@ class MessageNode(StrictBaseModel):
     trainer. `Branch.multi_modal_data` concatenates them along the path into the training
     `mm_kwargs`. Rides the wire as raw bytes (msgpack `bin`) since pydantic can't JSON the numpy;
     kept off disk by the dump-site `exclude` in prime-rl (the tensors bloat the rollout jsonl)."""
-    usage: Usage | None = Field(default=None, exclude=True)
-    """Provider-reported token usage for this message's response (assistant nodes). Transient
-    (excluded from wire/disk); lets the live dashboard show token counts even when the endpoint
-    returns no token ids (so `token_ids` is empty)."""
+    usage: Usage | None = None
+    """Provider-reported token usage for this message's response (assistant nodes). Preserved
+    on the wire and on disk, including cache-read tokens when the provider reports them."""
     routed_experts: np.ndarray | None = None
     """This node's slice of the MoE expert-routing array — uint8 `[len(token_ids), layers,
     top_k]`, the expert ids inference selected for exactly this node's tokens. Attributed from

--- a/verifiers/v1/legacy.py
+++ b/verifiers/v1/legacy.py
@@ -128,9 +128,13 @@ def _to_v1_response(raw: Any, model: str, tokens: TurnTokens | None = None) -> R
     usage_raw = raw.get("usage")
     usage = None
     if isinstance(usage_raw, dict) and "prompt_tokens" in usage_raw:
+        cached = usage_raw.get("cached_input_tokens")
+        reasoning = usage_raw.get("reasoning_tokens")
         usage = Usage(
             prompt_tokens=int(usage_raw.get("prompt_tokens") or 0),
             completion_tokens=int(usage_raw.get("completion_tokens") or 0),
+            cached_input_tokens=int(cached) if cached is not None else None,
+            reasoning_tokens=int(reasoning) if reasoning is not None else None,
         )
     # v0 records finish_reason on the response message; v1 puts it on the response.
     finish = msg.get("finish_reason") or raw.get("finish_reason")

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -264,7 +264,6 @@ class Trace(StrictBaseModel, Generic[TaskT, StateT]):
         completion) — used for token batching."""
         return sum(branch.total_tokens for branch in self.branches)
 
-    @computed_field
     @property
     def usage(self) -> Usage | None:
         """Provider-reported usage summed once per actual model call in this rollout."""

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -28,6 +28,7 @@ from verifiers.v1.types import (
     Messages,
     StrictBaseModel,
     ToolMessage,
+    Usage,
 )
 
 logger = logging.getLogger(__name__)
@@ -164,19 +165,25 @@ class Branch(StrictBaseModel):
         return self.total_tokens - last_completion
 
     @property
+    def usage(self) -> Usage | None:
+        """Provider-reported usage summed over model calls in this branch."""
+        return Usage.aggregate(n.usage for n in self.nodes if n.usage is not None)
+
+    @property
     def num_prompt_tokens(self) -> int:
         """Final-turn input tokens from provider-reported usage — a fallback for display when
         the endpoint returns no token ids (so `prompt_len` is 0); 0 if no usage was reported."""
         last = next(
             (n.usage for n in reversed(self.nodes) if n.usage is not None), None
         )
-        return last.prompt_tokens if last else 0
+        return last.input_tokens if last else 0
 
     @property
     def num_completion_tokens(self) -> int:
         """All completion tokens across the branch from provider-reported usage — a fallback for
         display when the endpoint returns no token ids; 0 if no usage was reported."""
-        return sum(n.usage.completion_tokens for n in self.nodes if n.usage is not None)
+        usage = self.usage
+        return usage.completion_tokens if usage else 0
 
 
 class Trace(StrictBaseModel, Generic[TaskT, StateT]):
@@ -256,6 +263,12 @@ class Trace(StrictBaseModel, Generic[TaskT, StateT]):
         """Total sequence length summed over branches (each branch's final-turn prompt +
         completion) — used for token batching."""
         return sum(branch.total_tokens for branch in self.branches)
+
+    @computed_field
+    @property
+    def usage(self) -> Usage | None:
+        """Provider-reported usage summed once per actual model call in this rollout."""
+        return Usage.aggregate(n.usage for n in self.nodes if n.usage is not None)
 
     @property
     def has_response(self) -> bool:

--- a/verifiers/v1/types.py
+++ b/verifiers/v1/types.py
@@ -6,6 +6,7 @@ place raw provider dicts enter is the client implementation, which validates
 them into these models explicitly.
 """
 
+from collections.abc import Iterable
 from typing import Annotated, Any, Literal
 
 from pydantic import AfterValidator, AliasChoices, BaseModel, ConfigDict, Field
@@ -142,14 +143,51 @@ FinishReason = Literal["stop", "length", "tool_calls"] | None
 
 
 class Usage(StrictBaseModel):
-    """Token usage for one model response (total_tokens is derived)."""
+    """Token usage for one model response.
+
+    ``prompt_tokens`` excludes cache-read tokens; ``cached_input_tokens`` carries that
+    disjoint portion when the provider reports it. ``input_tokens`` and ``total_tokens``
+    reconstruct the full logical sequence sizes. ``reasoning_tokens`` is an optional subset
+    of ``completion_tokens`` and is not added again to totals. ``cost`` is the optional
+    provider-reported cost for the response.
+    """
 
     prompt_tokens: int
     completion_tokens: int
+    cached_input_tokens: int | None = None
+    reasoning_tokens: int | None = None
+    cost: float | None = None
+
+    @classmethod
+    def aggregate(cls, usages: Iterable["Usage"]) -> "Usage | None":
+        """Sum per-response usage while preserving whether cache usage was reported."""
+        values = list(usages)
+        if not values:
+            return None
+        cached = [
+            usage.cached_input_tokens
+            for usage in values
+            if usage.cached_input_tokens is not None
+        ]
+        reasoning = [usage.reasoning_tokens for usage in values]
+        costs = [usage.cost for usage in values]
+        return cls(
+            prompt_tokens=sum(usage.prompt_tokens for usage in values),
+            completion_tokens=sum(usage.completion_tokens for usage in values),
+            cached_input_tokens=sum(cached) if cached else None,
+            reasoning_tokens=sum(reasoning)
+            if all(v is not None for v in reasoning)
+            else None,
+            cost=sum(costs) if all(v is not None for v in costs) else None,
+        )
+
+    @property
+    def input_tokens(self) -> int:
+        return self.prompt_tokens + (self.cached_input_tokens or 0)
 
     @property
     def total_tokens(self) -> int:
-        return self.prompt_tokens + self.completion_tokens
+        return self.input_tokens + self.completion_tokens
 
 
 class RoutedExperts(TypedDict):


### PR DESCRIPTION
## Overview

Add provider-reported usage telemetry to v1 traces and surface it consistently across evaluation, training serialization, persistence, and the rich dashboard.

## Details

- Extend `Usage` with cached input tokens, reasoning tokens, and provider-reported cost, with per-call aggregation across a rollout.
- Preserve response usage on sampled message nodes so it survives wire and disk serialization.
- Map OpenAI Chat Completions, OpenAI Responses, and Anthropic usage details into the shared v1 representation using their SDK models.
- Keep provider usage separate from renderer-derived training sequence lengths while carrying cache and reasoning details through the training and legacy bridges.
- Show cached input, reasoning tokens, and accumulated cost alongside token counts in the rich dashboard.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared usage semantics and serialization (`MessageNode.usage` now persisted; `num_prompt_tokens` uses total input including cache), which can affect dashboards and downstream consumers of trace dumps, but changes are additive with clear provider mapping.
> 
> **Overview**
> **v1 usage telemetry** is expanded so provider-reported **cached input**, **reasoning**, and **cost** ride on traces end-to-end, not just raw prompt/completion counts.
> 
> The shared `Usage` type gains `cached_input_tokens`, `reasoning_tokens`, and `cost`, plus `aggregate()` and `input_tokens` so totals treat cache reads separately from uncached prompt tokens. **Chat**, **Responses**, and **Anthropic** dialect parsers now fill those fields from SDK usage detail objects (and optional provider `cost`); OpenAI-style parsers subtract cached tokens from `prompt_tokens` so they stay disjoint from `cached_input_tokens`.
> 
> **Persistence and rollups:** `MessageNode.usage` is no longer excluded from serialization, so usage survives wire/disk dumps. `Branch` and `Trace` expose aggregated `usage`; display fallbacks use `input_tokens` for prompt size and branch-summed completion tokens.
> 
> **Bridges and UI:** The train client’s synthetic chat completion usage includes cached/reasoning details; legacy v0→v1 mapping passes through the new fields. The rich eval dashboard shows reasoning/cached breakdowns in the token column and adds per-rollout **cost**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 921ca74daf380dc5c57e12fb9736f22bd2febbd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Track cached, reasoning, and cost usage across v1 traces and dialects
> - Expands the `Usage` model in [types.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1704/files#diff-88a4e4ee0c58ac5dc7344161a011374082a3767eda2ad32af97c942dca982112) to include `cached_input_tokens`, `reasoning_tokens`, and `cost`, with an `aggregate` classmethod and an `input_tokens` derived property.
> - Updates OpenAI Chat, Responses, and Anthropic dialect parsers to populate the new fields from provider-returned token detail structures; `prompt_tokens` is adjusted to exclude cached tokens.
> - Adds `usage` and updated `num_prompt_tokens`/`num_completion_tokens` properties to `Branch` and `Trace` in [trace.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1704/files#diff-834820c3aa80d87ee1c1c57fb54c74f09c66ac727036d964e6005c8613c00b5e) and [graph.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1704/files#diff-64c9d635eb215902a512c9e8ab316fd9b9967c36db03d4049aacc812cdfbd740); `MessageNode.usage` is now included in serialized output.
> - Updates the eval dashboard in [eval.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1704/files#diff-0a27b905958929f3ae9e01937dd7e3cf97a60dec137caddcbf87792784fc9035) to display cached tokens, reasoning tokens, and cost as separate columns.
> - Behavioral Change: `Branch.num_prompt_tokens` now returns total input tokens (prompt + cached) from the last node with usage, and `MessageNode.usage` is no longer excluded from model dumps.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1704 opened
>
> - Added cost tracking to usage metrics in verifiers v1 dialects [fe090cf]
> - Consolidated token usage display in `eval.Rows` function [921ca74]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1542ed1.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->