### PR TITLE
Support multiple endpoints in Verifiers V1

### DIFF
--- a/verifiers/v1/cli/runner.py
+++ b/verifiers/v1/cli/runner.py
@@ -24,12 +24,20 @@ _SHUFFLE_SEED = (
 
 async def run_eval(env: Environment, config: EvalConfig) -> list[Trace]:
     logger.info("eval config:\n%s", config.model_dump_json(indent=2))
-    client = resolve_client(config.client)
     tasks = env.taskset.load_tasks()
     if config.shuffle:
         random.Random(_SHUFFLE_SEED).shuffle(tasks)
     tasks = tasks if config.num_tasks is None else tasks[: config.num_tasks]
-    ctx = RolloutContext(client=client, model=config.model, sampling=config.sampling)
+    base_urls = (
+        [config.client.base_url]
+        if isinstance(config.client.base_url, str)
+        else config.client.base_url
+    )
+    clients = [resolve_client(config.client, i) for i in range(len(base_urls))]
+    contexts = [
+        RolloutContext(client=client, model=config.model, sampling=config.sampling)
+        for client in clients
+    ]
     # One episode of `num_rollouts` rollouts per task; the shared semaphore bounds total
     # concurrent rollouts (across episodes), so group rewards still see their whole episode.
     semaphore = (
@@ -49,7 +57,7 @@ async def run_eval(env: Environment, config: EvalConfig) -> list[Trace]:
             print(resume.nothing_to_resume_msg(out, len(tasks), config.num_rollouts))
             raise SystemExit(0)
         tasks = [task for task in tasks if owed.get(task.idx)]
-        episodes = [env.episode(task, ctx, n=owed[task.idx]) for task in tasks]
+        episodes = [env.episode(task, contexts, n=owed[task.idx]) for task in tasks]
         resume.rewrite_results(out, keep)
         logger.info(
             "resuming %s: %d task(s), %d rollout(s) owed",
@@ -58,7 +66,9 @@ async def run_eval(env: Environment, config: EvalConfig) -> list[Trace]:
             sum(owed.values()),
         )
     else:
-        episodes = [env.episode(task, ctx, n=config.num_rollouts) for task in tasks]
+        episodes = [
+            env.episode(task, contexts, n=config.num_rollouts) for task in tasks
+        ]
         save_config(config, out)
         logger.info(
             "running %dx%d rollouts on %s",
@@ -91,7 +101,7 @@ async def run_eval(env: Environment, config: EvalConfig) -> list[Trace]:
             )
         )
     traces = [trace for episode_traces in results for trace in episode_traces]
-    await client.close()
+    await asyncio.gather(*(client.close() for client in clients))
     return traces
 
 

--- a/verifiers/v1/clients/config.py
+++ b/verifiers/v1/clients/config.py
@@ -1,8 +1,8 @@
-"""Client configs: describe an OpenAI-compatible endpoint and resolve it to a Client.
+"""Client configs: describe OpenAI-compatible endpoints and resolve them to a Client.
 
-A `BaseClientConfig` is an OpenAI-compatible endpoint (base_url + API-key env var
+A `BaseClientConfig` is one or more OpenAI-compatible endpoints (base_url + API-key env var
 + extra headers) that `resolve_client` turns into a `Client`. Prime team-billing
-is baked in via a validator, so it's handled in one place. Both the eval entrypoint
+is handled while resolving each endpoint. Both the eval entrypoint
 (its model client) and in-env LLM calls (e.g. a judge reward) build clients from
 these — inherit `BaseClientConfig` to get the endpoint/header handling for free.
 `ClientConfig` is the CLI-selectable discriminated union (eval | train).
@@ -12,7 +12,7 @@ import os
 from typing import Annotated, Literal
 
 from openai import AsyncOpenAI
-from pydantic import Field, model_validator
+from pydantic import Field
 from pydantic_config import BaseConfig
 from renderers import RendererConfig
 
@@ -25,21 +25,15 @@ PRIME_TEAM_ID_HEADER = "X-Prime-Team-ID"
 
 
 class BaseClientConfig(BaseConfig):
-    """An OpenAI-compatible endpoint. The API key is read from an env var."""
+    """OpenAI-compatible endpoint(s). The API key is read from an env var."""
 
-    base_url: str = "https://api.pinference.ai/api/v1"
+    base_url: str | Annotated[list[str], Field(min_length=1)] = (
+        "https://api.pinference.ai/api/v1"
+    )
+    """One URL, or URLs assigned round-robin across rollouts."""
     api_key_var: str = "PRIME_API_KEY"
     headers: dict[str, str] = Field(default_factory=dict)
     """Extra HTTP headers sent on every request."""
-
-    @model_validator(mode="after")
-    def add_prime_team_id(self) -> "BaseClientConfig":
-        # Prime inference bills the personal balance unless a team is named; on
-        # that endpoint, route billing to PRIME_TEAM_ID when set (explicit wins).
-        team_id = os.environ.get("PRIME_TEAM_ID")
-        if PRIME_INFERENCE_HOST in self.base_url and team_id:
-            self.headers.setdefault(PRIME_TEAM_ID_HEADER, team_id)
-        return self
 
 
 class EvalClientConfig(BaseClientConfig):
@@ -72,14 +66,23 @@ ClientConfig = Annotated[
 ]
 
 
-def resolve_client(config: BaseClientConfig) -> Client:
+def resolve_client(config: BaseClientConfig, endpoint_idx: int = 0) -> Client:
+    """Resolve one configured endpoint."""
+    base_urls = (
+        [config.base_url] if isinstance(config.base_url, str) else config.base_url
+    )
+    base_url = base_urls[endpoint_idx % len(base_urls)]
     api_key = os.environ.get(config.api_key_var, "EMPTY")
+    headers = dict(config.headers)
+    team_id = os.environ.get("PRIME_TEAM_ID")
+    if PRIME_INFERENCE_HOST in base_url and team_id:
+        headers.setdefault(PRIME_TEAM_ID_HEADER, team_id)
     if isinstance(config, TrainClientConfig):
         # The renderer calls a vLLM `/inference/v1/generate` engine through the OpenAI SDK.
         openai = AsyncOpenAI(
-            base_url=config.base_url,
+            base_url=base_url,
             api_key=api_key,
-            default_headers=config.headers or None,
+            default_headers=headers or None,
         )
         return TrainClient(
             openai,
@@ -88,4 +91,4 @@ def resolve_client(config: BaseClientConfig) -> Client:
             renderer_model_name=config.renderer_model_name,
         )
     # The proxy is a raw httpx forwarder; the dialect supplies the auth scheme + upstream path.
-    return EvalClient(config.base_url, api_key, headers=config.headers or None)
+    return EvalClient(base_url, api_key, headers=headers or None)

--- a/verifiers/v1/env.py
+++ b/verifiers/v1/env.py
@@ -252,6 +252,7 @@ class Environment:
             max_total_tokens=config.max_total_tokens,
         )
         self._warned_resources: set[tuple[str, str]] = set()
+        self._context_idx = 0
 
     def runtime_for(self, task: Task) -> RuntimeConfig:
         """Resolve the runtime config for a task off the harness's runtime (see
@@ -260,11 +261,17 @@ class Environment:
             self.harness.config.runtime, task, self._warned_resources
         )
 
-    def episode(self, task: Task, ctx: RolloutContext, n: int = 1) -> Episode:
+    def episode(
+        self,
+        task: Task,
+        ctx: RolloutContext | list[RolloutContext],
+        n: int = 1,
+    ) -> Episode:
         """Resolve `task` into a runnable episode of `n` rollouts: pick its runtime
         (image + resources) and its timeouts (cli/toml > task > default, None = no limit),
         build one `Rollout` per sample sharing them, and wrap them in an `Episode` (which
-        runs them and applies the taskset's `@group_reward`s across their traces).
+        runs them and applies the taskset's `@group_reward`s across their traces). When
+        multiple contexts are given, assign them round-robin across episodes.
 
         A taskset with `@group_reward`s compares a task's rollouts, so it needs >=2 of
         them — refuse `n < 2` there (rather than silently scoring a group of one)."""
@@ -273,6 +280,9 @@ class Environment:
                 f"taskset defines @group_reward(s), which compare a task's rollouts and "
                 f"need >=2; got n={n} (pass -r/--num-rollouts >= 2)"
             )
+        contexts = ctx if isinstance(ctx, list) else [ctx]
+        context_idx = self._context_idx
+        self._context_idx += n
         runtime_config = self.runtime_for(task)
         setup_timeout = (
             self.setup_timeout if self.setup_timeout is not None else task.setup_timeout
@@ -298,7 +308,7 @@ class Environment:
                 task=task,
                 taskset=self.taskset,
                 harness=self.harness,
-                ctx=ctx,
+                ctx=contexts[(context_idx + i) % len(contexts)],
                 runtime_config=runtime_config,
                 setup_timeout=setup_timeout,
                 harness_timeout=harness_timeout,
@@ -308,7 +318,7 @@ class Environment:
                 model_retries=retries.model.max_retries,
                 runtime_retries=retries.runtime.max_retries,
             )
-            for _ in range(n)
+            for i in range(n)
         ]
         return Episode(rollouts, self.taskset, retry=retries.rollout)
 

--- a/verifiers/v1/legacy.py
+++ b/verifiers/v1/legacy.py
@@ -305,6 +305,10 @@ class LegacyEnvServer(EnvServer):
         sampling — never drives tokenizer loading. An OpenAI config (chat-completions, eval)
         builds a v0 chat-completions client. The per-request ``model`` selects the sampling
         target in ``run_rollout``."""
+        if not isinstance(client_config.base_url, str):
+            raise ValueError(
+                "multiple client base URLs require a native v1 environment"
+            )
         is_renderer = isinstance(client_config, TrainClientConfig)
         renderer_model = (
             client_config.renderer_model_name if is_renderer else None
@@ -380,6 +384,8 @@ def _eval_client(client_config: ClientConfig, model: str):
     from verifiers.clients import resolve_client
     from verifiers.types import ClientConfig as V0ClientConfig
 
+    if not isinstance(client_config.base_url, str):
+        raise ValueError("multiple client base URLs require a native v1 environment")
     return resolve_client(
         V0ClientConfig(
             client_type="openai_chat_completions",

--- a/verifiers/v1/serve/server.py
+++ b/verifiers/v1/serve/server.py
@@ -4,9 +4,9 @@ A ZMQ ROUTER front end (msgpack frames) over a v1 `Environment`. The server
 owns the environment — taskset, harness, runtime — and is the only process that ever
 loads it. A caller (e.g. the orchestrator) stays env-agnostic: it asks `info` for
 the task count + whether group scoring is needed, then `run_rollout` / `run_group`
-by task index. Per request the server resolves a `Client` from the request's
-`client` config (cached, so a renderer's tokenizer is built once), wraps it in a
-`RolloutContext`, and runs `env.episode(task, ctx, n).run()`, returning each
+by task index. Per request the server resolves the `Client`s from the request's
+`client` config (cached, so renderer tokenizers are built once), wraps them in
+`RolloutContext`s, and runs `env.episode(task, contexts, n).run()`, returning each
 `Trace` as a JSON dict (with its computed `branches`).
 
 Minimal port of `verifiers.serve` (ROUTER + msgpack), single async process: each
@@ -59,9 +59,8 @@ class EnvServer:
         self.requires_group_scoring = bool(
             discover_decorated(self.env.taskset, "group_reward")
         )
-        self._clients: dict[
-            tuple[str, str], Client
-        ] = {}  # (client_config, model) -> Client
+        self._clients: dict[tuple[str, str, int], Client] = {}
+        """(client config, model, endpoint index) -> Client."""
         self.pool: InterceptionPool | None = None  # set in run() (v1 only)
 
         self.ctx = zmq.asyncio.Context()
@@ -86,21 +85,25 @@ class EnvServer:
             address_queue.put(server.address)
         asyncio.run(server.run())
 
-    def _client(self, client_config: ClientConfig, model: str) -> Client:
-        """Resolve (and cache) a `Client` for this config+model. Cached because a
-        renderer client builds the model's tokenizer pool on first use — doing that
-        per request would be ruinous."""
-        key = (client_config.model_dump_json(), model)
-        if key not in self._clients:
-            self._clients[key] = resolve_client(client_config)
-        return self._clients[key]
-
-    def _context(
+    def _contexts(
         self, client_config: ClientConfig, model: str, sampling: SamplingConfig
-    ) -> RolloutContext:
-        return RolloutContext(
-            client=self._client(client_config, model), model=model, sampling=sampling
+    ) -> list[RolloutContext]:
+        """Build and cache one context per endpoint."""
+        base_urls = (
+            [client_config.base_url]
+            if isinstance(client_config.base_url, str)
+            else client_config.base_url
         )
+        clients = []
+        for i in range(len(base_urls)):
+            key = (client_config.model_dump_json(), model, i)
+            if key not in self._clients:
+                self._clients[key] = resolve_client(client_config, i)
+            clients.append(self._clients[key])
+        return [
+            RolloutContext(client=client, model=model, sampling=sampling)
+            for client in clients
+        ]
 
     def interception_pool(self):
         """Context for the server's shared interception pool, entered for the server's
@@ -109,14 +112,14 @@ class EnvServer:
         return self.env.interception_pool()
 
     async def _run_rollout(self, req: RunRolloutRequest) -> RunRolloutResponse:
-        ctx = self._context(req.client, req.model, req.sampling)
-        episode = self.env.episode(self.tasks[req.task_idx], ctx, n=1)
+        contexts = self._contexts(req.client, req.model, req.sampling)
+        episode = self.env.episode(self.tasks[req.task_idx], contexts, n=1)
         traces = await episode.run(interception=self.pool)
         return RunRolloutResponse(trace=traces[0].to_wire())
 
     async def _run_group(self, req: RunGroupRequest) -> RunGroupResponse:
-        ctx = self._context(req.client, req.model, req.sampling)
-        episode = self.env.episode(self.tasks[req.task_idx], ctx, n=req.n)
+        contexts = self._contexts(req.client, req.model, req.sampling)
+        episode = self.env.episode(self.tasks[req.task_idx], contexts, n=req.n)
         traces = await episode.run(interception=self.pool)
         return RunGroupResponse(traces=[t.to_wire() for t in traces])
 


### PR DESCRIPTION
## Overview

Allow native Verifiers V1 client configuration to provide multiple API base URLs and distribute rollouts across them.

## Details

- Accept either a single URL or a non-empty URL list in `BaseClientConfig.base_url`.
- Resolve and cache one client per configured endpoint.
- Assign endpoint contexts round-robin as each environment creates rollouts.
- Keep a rollout pinned to its selected client for its complete lifecycle.
- Preserve the scalar URL requirement at the legacy V0 bridge boundary.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Support multiple endpoints in Verifiers V1 with round-robin context distribution
> - `config.client.base_url` now accepts a `str` or `list[str]`; `resolve_client` in [config.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1706/files#diff-052fb75ebcf125bca5326c84afdabf150d579712daa8474171035d7268a42be1) selects a concrete URL by endpoint index (modulo list length) and injects the team ID header at resolution time.
> - `Environment.episode` in [env.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1706/files#diff-69be10bd5960e88d88f219d4f261d0bdd16586857f9126451b04d05bac4c2cbb) accepts a single `RolloutContext` or a list, distributing rollouts round-robin across contexts using a shared `_context_idx` counter.
> - The CLI runner in [runner.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1706/files#diff-3d708e6dbc4cd4b549bfca1be17b1385b52b7cd03992bf82522e225f4aaaadbf) constructs one client and context per configured endpoint and closes all clients on teardown.
> - `EnvServer` in [server.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1706/files#diff-64422f6a8749fcc024415b2756129bc98000e830e74b3b5245de50a555480a22) replaces the single `_client` cache with a per-endpoint `_contexts` helper that caches one client per URL and passes the full context list to `env.episode`.
> - Legacy v0 paths in [legacy.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1706/files#diff-96c5091f7d2968ddfbe984f433163f21cab745ea95174158e924984d55abbfed) now raise `ValueError` when `base_url` is a list, preventing ambiguous client resolution.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 58ef617. 5 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->