### PR TITLE
[codex] fix v1 train client prefix bridging

### DIFF
--- a/tests/v1/test_graph.py
+++ b/tests/v1/test_graph.py
@@ -182,3 +182,55 @@ def test_prompt_supplied_assistant_messages_are_not_sampled_turns():
     assert [n.sampled for n in trace.nodes] == [False, False, False, True]
     assert trace.num_turns == 1
     assert trace.assistant_messages == [response]
+
+
+def test_prepare_turn_exposes_bridge_anchor_and_commits_on_same_prefix():
+    trace = vf.Trace(task=vf.Task(idx=0, instruction="x"))
+    user = vf.UserMessage(content="u1")
+    assistant = vf.AssistantMessage(content="a1")
+    graph.add_turn(
+        trace,
+        [user],
+        vf.Response(
+            id="a",
+            created=0,
+            model="t",
+            message=assistant,
+            finish_reason="stop",
+            tokens=TurnTokens(
+                prompt_ids=[10, 11, 12],
+                completion_ids=[20, 21],
+                message_spans=[(0, 2)],
+            ),
+        ),
+    )
+
+    user2 = vf.UserMessage(content="u2")
+    turn = graph.prepare_turn(trace, [user, assistant, user2])
+
+    assert turn.tail == [user2]
+    assert turn.path_len == 5
+    assert turn.previous_token_ids() == ([10, 11, 12], [20, 21])
+
+    turn.commit(
+        vf.Response(
+            id="b",
+            created=0,
+            model="t",
+            message=vf.AssistantMessage(content="a2"),
+            finish_reason="stop",
+            tokens=TurnTokens(
+                prompt_ids=[10, 11, 12, 20, 21, 30, 31, 32],
+                completion_ids=[40],
+                message_spans=[None, None, (5, 7)],
+            ),
+        )
+    )
+
+    assert [node.message for node in trace.branches[-1].nodes] == [
+        user,
+        assistant,
+        user2,
+        vf.AssistantMessage(content="a2"),
+    ]
+    assert trace.branches[-1].token_ids == [10, 11, 12, 20, 21, 30, 31, 32, 40]

--- a/tests/v1/test_train_client.py
+++ b/tests/v1/test_train_client.py
@@ -1,0 +1,186 @@
+import verifiers.v1 as vf
+from renderers import RenderedTokens
+
+from verifiers.v1 import graph
+from verifiers.v1.clients.train import TrainClient
+from verifiers.v1.dialects.chat import ChatDialect, message_to_wire
+from verifiers.v1.types import TurnTokens, content_to_parts
+
+
+class _FakeRenderer:
+    supports_tools = True
+
+    def get_stop_token_ids(self):
+        return []
+
+    def bridge_to_next_turn(
+        self,
+        previous_prompt_ids,
+        previous_completion_ids,
+        new_messages,
+        *,
+        tools=None,
+    ):
+        assert previous_prompt_ids == [10, 11, 12]
+        assert previous_completion_ids == [20, 21]
+        assert [m["role"] for m in new_messages] == ["user"]
+        return RenderedTokens(
+            token_ids=[10, 11, 12, 20, 21, 30, 31, 32],
+            message_indices=[-1, -1, -1, -1, -1, 0, 0, -1],
+            sampled_mask=[False] * 8,
+            is_content=[False, False, False, False, False, True, True, False],
+            message_roles=["user"],
+        )
+
+
+def test_chat_dialect_recovers_tool_message_name_from_assistant_call():
+    messages, _ = ChatDialect().parse_request(
+        {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_0",
+                            "type": "function",
+                            "function": {"name": "lookup", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "call_0", "content": "result"},
+            ]
+        }
+    )
+
+    assert isinstance(messages[1], vf.ToolMessage)
+    assert messages[1].name == "lookup"
+    assert message_to_wire(messages[1])["name"] == "lookup"
+
+
+async def test_train_client_uses_prepared_turn_for_renderer_bridge(monkeypatch):
+    trace = vf.Trace(task=vf.Task(idx=0, instruction="x"))
+    user = vf.UserMessage(content="u1")
+    assistant = vf.AssistantMessage(content="a1")
+    graph.add_turn(
+        trace,
+        [user],
+        vf.Response(
+            id="a",
+            created=0,
+            model="t",
+            message=assistant,
+            finish_reason="stop",
+            tokens=TurnTokens(
+                prompt_ids=[10, 11, 12],
+                completion_ids=[20, 21],
+                message_spans=[(0, 2)],
+            ),
+        ),
+    )
+    user2 = vf.UserMessage(content="u2")
+    prompt = [user, assistant, user2]
+    turn = graph.prepare_turn(trace, prompt)
+    captured = {}
+
+    async def fake_maybe_offload(renderer, fn):
+        return fn()
+
+    async def fake_generate(**kwargs):
+        captured.update(kwargs)
+        return {
+            "request_id": "r",
+            "prompt_ids": kwargs["prompt_ids"],
+            "completion_ids": [40],
+            "completion_logprobs": [-0.1],
+            "content": "a2",
+            "finish_reason": "stop",
+            "prompt_attribution": kwargs["prompt_attribution"],
+        }
+
+    monkeypatch.setattr("renderers.client._maybe_offload", fake_maybe_offload)
+    monkeypatch.setattr("renderers.client.generate", fake_generate)
+
+    client = TrainClient(openai=None)  # type: ignore[arg-type]
+    monkeypatch.setattr(client, "_renderer_pool", lambda model: _FakeRenderer())
+
+    response = await client.get_response(
+        ChatDialect(),
+        {"messages": [message_to_wire(m) for m in prompt]},
+        "model",
+        vf.SamplingConfig(),
+        session_id="trace-id",
+        turn=turn,
+    )
+
+    assert response.message.content == "a2"
+    assert captured["prompt_ids"] == [10, 11, 12, 20, 21, 30, 31, 32]
+    assert captured["sampling_params"]["routed_experts_prompt_start"] == 4
+    assert response.tokens.message_spans == [
+        None,
+        None,
+        (5, 7),
+    ]
+
+
+async def test_train_client_does_not_bridge_multimodal_prompts(monkeypatch):
+    trace = vf.Trace(task=vf.Task(idx=0, instruction="x"))
+    user = vf.UserMessage(
+        content=content_to_parts(
+            [
+                {"type": "text", "text": "look"},
+                {"type": "image_url", "image_url": {"url": "file:///tmp/a.png"}},
+            ]
+        )
+    )
+    assistant = vf.AssistantMessage(content="seen")
+    graph.add_turn(
+        trace,
+        [user],
+        vf.Response(
+            id="a",
+            created=0,
+            model="t",
+            message=assistant,
+            finish_reason="stop",
+            tokens=TurnTokens(
+                prompt_ids=[10, 11, 12],
+                completion_ids=[20, 21],
+                message_spans=[(0, 2)],
+            ),
+        ),
+    )
+    prompt = [user, assistant, vf.UserMessage(content="next")]
+    turn = graph.prepare_turn(trace, prompt)
+    captured = {}
+
+    async def fake_generate(**kwargs):
+        captured.update(kwargs)
+        return {
+            "request_id": "r",
+            "prompt_ids": [1, 2, 3],
+            "completion_ids": [4],
+            "completion_logprobs": [-0.1],
+            "content": "done",
+            "finish_reason": "stop",
+        }
+
+    class NoBridgeRenderer(_FakeRenderer):
+        def bridge_to_next_turn(self, *args, **kwargs):
+            raise AssertionError("multimodal prompts should not bridge in this PR")
+
+    monkeypatch.setattr("renderers.client.generate", fake_generate)
+    client = TrainClient(openai=None)  # type: ignore[arg-type]
+    monkeypatch.setattr(client, "_renderer_pool", lambda model: NoBridgeRenderer())
+
+    response = await client.get_response(
+        ChatDialect(),
+        {"messages": [message_to_wire(m) for m in prompt]},
+        "model",
+        vf.SamplingConfig(),
+        turn=turn,
+    )
+
+    assert response.message.content == "done"
+    assert captured["prompt_ids"] is None
+    assert captured["prompt_attribution"] is None

--- a/verifiers/v1/clients/client.py
+++ b/verifiers/v1/clients/client.py
@@ -19,6 +19,7 @@ from tenacity import (
 
 from verifiers.v1.dialects import Dialect
 from verifiers.v1.errors import ModelError, OverlongPromptError
+from verifiers.v1.graph import PendingTurn
 from verifiers.v1.types import Response, SamplingConfig
 
 logger = logging.getLogger(__name__)
@@ -49,6 +50,7 @@ class Client(ABC):
         model: str,
         sampling_args: SamplingConfig,
         session_id: str | None = None,
+        turn: PendingTurn | None = None,
     ) -> Response:
         """Run one completion -> a vf `Response`. The proxy client forwards `body` 1:1 and
         parses the provider response via `dialect` (carrying the raw on `Response.raw`); the
@@ -56,7 +58,8 @@ class Client(ABC):
 
         `session_id` is the rollout's stable id (the trace id); when set, the client sends it
         as the `SESSION_ID_HEADER` so a session-affinity router keeps the rollout's turns on
-        one engine for cross-turn prefix-cache reuse."""
+        one engine for cross-turn prefix-cache reuse. `turn` is the graph-resolved prompt
+        prefix; train clients may use it for renderer bridging, while relay clients ignore it."""
 
     async def relay(
         self,
@@ -113,9 +116,16 @@ class RetryingClient(Client):
         model: str,
         sampling_args: SamplingConfig,
         session_id: str | None = None,
+        turn: PendingTurn | None = None,
     ) -> Response:
         return await self._retrying(
-            self.inner.get_response, dialect, body, model, sampling_args, session_id
+            self.inner.get_response,
+            dialect,
+            body,
+            model,
+            sampling_args,
+            session_id,
+            turn,
         )
 
     async def relay(

--- a/verifiers/v1/clients/eval.py
+++ b/verifiers/v1/clients/eval.py
@@ -18,6 +18,7 @@ import httpx
 from verifiers.v1.clients.client import SESSION_ID_HEADER, Client, RelayReply
 from verifiers.v1.dialects import Dialect
 from verifiers.v1.errors import model_error
+from verifiers.v1.graph import PendingTurn
 from verifiers.v1.types import Response, SamplingConfig
 
 _SSE_EVENT_END = re.compile(rb"(?:\r\n|\r|\n){2}")
@@ -45,6 +46,7 @@ class EvalClient(Client):
         model: str,
         sampling_args: SamplingConfig,
         session_id: str | None = None,
+        turn: PendingTurn | None = None,
     ) -> Response:
         # Byte-exact forward, save for the eval's model + sampling (imposed by the dialect).
         url, headers, upstream = self._upstream(

--- a/verifiers/v1/clients/train.py
+++ b/verifiers/v1/clients/train.py
@@ -9,8 +9,10 @@ needs a running vLLM engine.
 """
 
 import json
+from typing import Any
 
 from openai import AsyncOpenAI, OpenAIError
+from renderers import RenderedTokens
 from renderers import OverlongPromptError as RendererOverlongPromptError
 from renderers import RendererConfig
 
@@ -18,6 +20,7 @@ from verifiers.v1.clients.client import SESSION_ID_HEADER, Client
 from verifiers.v1.dialects import FINISH_REASONS, ChatDialect, Dialect
 from verifiers.v1.dialects.chat import message_to_wire
 from verifiers.v1.errors import OverlongPromptError, model_error
+from verifiers.v1.graph import PendingTurn
 from verifiers.v1.types import (
     AssistantMessage,
     FinishReason,
@@ -82,7 +85,9 @@ def serialize_completion(response: Response, model: str) -> dict:
     }
 
 
-def response_from_generate(result: dict, model: str) -> Response:
+def response_from_generate(
+    result: dict, model: str, bridged_turn: PendingTurn | None = None
+) -> Response:
     """Parse a `renderers.client.generate` result dict into a typed `Response`,
     mirroring the chat client's `response_from_wire` (plus the token encoding)."""
     finish: FinishReason = (
@@ -104,11 +109,14 @@ def response_from_generate(result: dict, model: str) -> Response:
     prompt_ids = result.get("prompt_ids") or []
     completion_ids = result.get("completion_ids") or []
     # Per-message token spans (the renderer's attribution) let the trace graph store each
-    # message's tokens once; carried transiently on TurnTokens and consumed by `graph.add_turn`.
+    # message's tokens once; carried transiently on TurnTokens and consumed by turn.commit().
     attribution = result.get("prompt_attribution")
-    message_spans = (
-        attribution.message_token_spans() if attribution is not None else None
-    )
+    if attribution is None:
+        message_spans = None
+    elif bridged_turn is not None:
+        message_spans = bridged_turn.prompt_message_spans(attribution)
+    else:
+        message_spans = attribution.message_token_spans()
     return Response(
         id=result.get("request_id", ""),
         created=0,
@@ -131,6 +139,29 @@ def response_from_generate(result: dict, model: str) -> Response:
             routed_experts=result.get("routed_experts"),
         ),
     )
+
+
+def _is_valid_incremental_tail(messages: list[dict[str, Any]]) -> bool:
+    """Renderer bridges may extend sampled assistant turns with tool calls and/or a new user."""
+    if not messages:
+        return False
+    roles = []
+    for message in messages:
+        role = message.get("role")
+        roles.append(role if isinstance(role, str) else None)
+    if roles[-1] == "user":
+        return all(role == "tool" for role in roles[:-1])
+    return all(role == "tool" for role in roles)
+
+
+def _has_multimodal_content(messages) -> bool:
+    for message in messages:
+        content = getattr(message, "content", None)
+        if not isinstance(content, list):
+            continue
+        if any(getattr(part, "type", None) == "image_url" for part in content):
+            return True
+    return False
 
 
 class TrainClient(Client):
@@ -165,6 +196,7 @@ class TrainClient(Client):
         model: str,
         sampling_args: SamplingConfig,
         session_id: str | None = None,
+        turn: PendingTurn | None = None,
     ) -> Response:
         # The renderer tokenizes the typed prompt for training (it needs per-token ids + logprobs
         # back), so it can't forward the raw request — it parses `body` via the dialect and renders
@@ -180,24 +212,64 @@ class TrainClient(Client):
                 f"renderer support for it."
             )
         prompt, tools = dialect.parse_request(body)
+        if turn is not None:
+            prompt = turn.prompt
         renderer = self._renderer_pool(model)
-        from renderers.client import generate
+        from renderers.client import _maybe_offload, generate
+
+        wire_messages = [message_to_wire(m) for m in prompt]
+        wire_tools = [tool_to_wire(t) for t in tools] if tools else None
+        prompt_ids: list[int] | None = None
+        multi_modal_data = None
+        prompt_attribution: RenderedTokens | None = None
+        sampling_params = sampling_args.model_dump(exclude_none=True)
+        bridged_turn: PendingTurn | None = None
+
+        previous_ids = turn.previous_token_ids() if turn is not None else None
+        if (
+            previous_ids is not None
+            and not _has_multimodal_content(prompt)
+            and _is_valid_incremental_tail(wire_messages[turn.tail_start :])
+        ):
+            previous_prompt_ids, previous_completion_ids = previous_ids
+
+            def bridge():
+                return renderer.bridge_to_next_turn(
+                    previous_prompt_ids,
+                    previous_completion_ids,
+                    wire_messages[turn.tail_start :],
+                    tools=wire_tools,
+                )
+
+            bridged = await _maybe_offload(renderer, bridge)
+            if bridged is not None:
+                prompt_ids = bridged.token_ids
+                multi_modal_data = bridged.multi_modal_data
+                prompt_attribution = bridged
+                bridged_turn = turn
+                sampling_params["routed_experts_prompt_start"] = max(
+                    len(previous_prompt_ids) + len(previous_completion_ids) - 1,
+                    0,
+                )
 
         try:
             result = await generate(
                 client=self.openai,
                 renderer=renderer,
-                messages=[message_to_wire(m) for m in prompt],
+                messages=wire_messages,
                 model=model,
-                tools=[tool_to_wire(t) for t in tools] if tools else None,
-                sampling_params=sampling_args.model_dump(exclude_none=True),
+                prompt_ids=prompt_ids,
+                multi_modal_data=multi_modal_data,
+                prompt_attribution=prompt_attribution,
+                tools=wire_tools,
+                sampling_params=sampling_params,
                 extra_headers={SESSION_ID_HEADER: session_id} if session_id else None,
             )
         except RendererOverlongPromptError as e:
             raise OverlongPromptError(str(e)) from e
         except OpenAIError as e:
             raise model_error(e) from e
-        response = response_from_generate(result, model)
+        response = response_from_generate(result, model, bridged_turn)
         # No provider response to relay (we generated), so serialize one for the program; the
         # interception server hands `Response.raw` back regardless of client.
         response.raw = serialize_completion(response, model)

--- a/verifiers/v1/dialects/chat.py
+++ b/verifiers/v1/dialects/chat.py
@@ -65,6 +65,7 @@ def parse_message(raw: dict) -> Message:
         return ToolMessage(
             tool_call_id=raw.get("tool_call_id", ""),
             content=content_to_parts(content),
+            name=raw.get("name"),
         )
     if role == "assistant":
         calls = [
@@ -131,11 +132,14 @@ def message_to_wire(message: Message) -> dict:
             ]
         return wire
     if message.role == "tool":
-        return {
+        wire = {
             "role": "tool",
             "tool_call_id": message.tool_call_id,
             "content": _content_to_wire(message.content),
         }
+        if message.name:
+            wire["name"] = message.name
+        return wire
     return {"role": message.role, "content": _content_to_wire(message.content)}
 
 
@@ -181,9 +185,19 @@ class ChatDialect(Dialect[dict, ChatCompletion]):
     response_type = ChatCompletion
 
     def parse_request(self, body: dict) -> tuple[Messages, list[Tool] | None]:
-        return [parse_message(m) for m in body.get("messages", [])], parse_tools(
-            body.get("tools")
-        )
+        messages: Messages = []
+        tool_names: dict[str, str] = {}
+        for raw in body.get("messages", []):
+            message = parse_message(raw)
+            if isinstance(message, ToolMessage) and message.name is None:
+                name = tool_names.get(message.tool_call_id)
+                if name is not None:
+                    message = message.model_copy(update={"name": name})
+            messages.append(message)
+            if isinstance(message, AssistantMessage):
+                for call in message.tool_calls or []:
+                    tool_names[call.id] = call.name
+        return messages, parse_tools(body.get("tools"))
 
     def parse_response(self, response: ChatCompletion) -> Response:
         return response_from_wire(response)

--- a/verifiers/v1/graph.py
+++ b/verifiers/v1/graph.py
@@ -20,11 +20,12 @@ from __future__ import annotations
 import base64
 import hashlib
 import json
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from pydantic import ConfigDict, Field, field_serializer, field_validator
-from renderers.base import MultiModalData, PlaceholderRange
+from renderers.base import MultiModalData, PlaceholderRange, RenderedTokens
 
 from verifiers.v1.types import (
     AssistantMessage,
@@ -197,7 +198,7 @@ def message_hash(message: Message) -> str:
     return hashlib.blake2b("\x00".join(parts).encode(), digest_size=16).hexdigest()
 
 
-def _head_index(trace: "Trace") -> dict[tuple[int | None, str], int]:
+def _head_index(trace: Trace) -> dict[tuple[int | None, str], int]:
     """`(parent, msg_hash) -> node_id`, rebuilt lazily from `nodes` after deserialization."""
     if not trace._head_index and trace.nodes:
         trace._head_index = {
@@ -207,14 +208,101 @@ def _head_index(trace: "Trace") -> dict[tuple[int | None, str], int]:
     return trace._head_index
 
 
+@dataclass(frozen=True)
+class PendingTurn:
+    """A resolved prompt waiting on model inference.
+
+    `prepare_turn` does the one canonical graph prefix walk. Training clients use the resolved
+    prefix for renderer bridging before inference, and `commit` uses the same prefix after
+    inference to add only the prompt tail plus the sampled assistant response.
+    """
+
+    trace: Trace
+    prompt: list[Message]
+    prefix_node_ids: list[int]
+    path_len: int
+
+    @property
+    def tail_start(self) -> int:
+        return len(self.prefix_node_ids)
+
+    @property
+    def tail(self) -> list[Message]:
+        return self.prompt[self.tail_start :]
+
+    @property
+    def parent(self) -> int | None:
+        return self.prefix_node_ids[-1] if self.prefix_node_ids else None
+
+    def previous_token_ids(self) -> tuple[list[int], list[int]] | None:
+        """Return `(previous_prompt_ids, previous_completion_ids)` for a bridge anchor.
+
+        The anchor must end at a sampled assistant node. That node stores generation-prompt
+        scaffold followed by sampled completion tokens, so split at the first sampled token.
+        """
+        if not self.prefix_node_ids:
+            return None
+        last = self.trace.nodes[self.prefix_node_ids[-1]]
+        if not last.sampled:
+            return None
+        first_sampled = next(
+            (i for i, sampled in enumerate(last.mask) if sampled), None
+        )
+        if first_sampled is None:
+            return None
+        if any(not sampled for sampled in last.mask[first_sampled:]):
+            return None
+
+        prompt_ids = [
+            token
+            for nid in self.prefix_node_ids[:-1]
+            for token in self.trace.nodes[nid].token_ids
+        ]
+        prompt_ids.extend(last.token_ids[:first_sampled])
+        completion_ids = list(last.token_ids[first_sampled:])
+        if not prompt_ids or not completion_ids:
+            return None
+        return prompt_ids, completion_ids
+
+    def prompt_message_spans(
+        self, tail_attribution: RenderedTokens
+    ) -> list[tuple[int, int] | None]:
+        """Convert tail-relative bridge spans into full-prompt message spans."""
+        return [None] * self.tail_start + tail_attribution.message_token_spans()
+
+    def commit(self, response: Response) -> None:
+        _commit_turn(self, response)
+
+
+def prepare_turn(trace: Trace, prompt: list[Message]) -> PendingTurn:
+    """Resolve `prompt` against the trace graph without mutating it."""
+    idx = _head_index(trace)
+    parent: int | None = None
+    path_len = 0
+    prefix_node_ids: list[int] = []
+    for msg in prompt:
+        existing = idx.get((parent, message_hash(msg)))
+        if existing is None:
+            break
+        prefix_node_ids.append(existing)
+        parent = existing
+        path_len += len(trace.nodes[existing].token_ids)
+    return PendingTurn(
+        trace=trace,
+        prompt=prompt,
+        prefix_node_ids=prefix_node_ids,
+        path_len=path_len,
+    )
+
+
 def _part_modality(part) -> str | None:
     """The multimodal modality a content part introduces (currently only images), or None."""
     return "image" if getattr(part, "type", None) == "image_url" else None
 
 
 def _attribute_mm(
-    trace: "Trace",
-    path: "list[tuple[int, Message]]",
+    trace: Trace,
+    path: list[tuple[int, Message]],
     num_reused: int,
     mmd: MultiModalData | None,
 ) -> None:
@@ -255,8 +343,8 @@ def _attribute_mm(
 
 
 def _attribute_routed_experts(
-    trace: "Trace",
-    new_node_ids: "list[int]",
+    trace: Trace,
+    new_node_ids: list[int],
     path_len: int,
     payload: Any,
 ) -> None:
@@ -286,11 +374,8 @@ def _attribute_routed_experts(
         off += n
 
 
-def add_turn(trace: "Trace", prompt: "list[Message]", response: Response) -> None:
-    """Insert one model turn (its prompt messages + its response) into the graph. Reuses any
-    existing prefix nodes (by `(parent, hash)`), creates a node per new message attributing
-    its tokens, and appends a fresh assistant node holding the generation-prompt scaffold +
-    the sampled completion.
+def _commit_turn(turn: PendingTurn, response: Response) -> None:
+    """Insert one prepared model turn into the graph.
 
     Token attribution anchors new tokens to the cumulative *stored* length of the reused
     prefix (`path_len`), not message spans — the previous assistant's closing scaffold lives
@@ -299,28 +384,25 @@ def add_turn(trace: "Trace", prompt: "list[Message]", response: Response) -> Non
     messages by span (leading template scaffold folds into the following message), and the
     trailing generation prompt goes on the assistant node before its sampled completion. By
     construction `concat(node.token_ids along the path) == prompt_ids + completion_ids`."""
+    trace = turn.trace
+    prompt = turn.prompt
     tokens = response.tokens
     prompt_ids = list(tokens.prompt_ids) if tokens else []
     spans = tokens.message_spans if tokens else None
     idx = _head_index(trace)
 
-    parent: int | None = None
-    path_len = 0  # cumulative stored token length of the reused prefix
+    parent = turn.parent
+    path_len = turn.path_len  # cumulative stored token length of the reused prefix
     # cursor: in prompt_ids, the end of the previous *new* message's tokens
     cursor: int | None = None
     # (node_id, message) per prompt message (reused prefix first, then new), for multimodal
     # attribution; `num_reused` marks where the newly-created nodes begin.
-    path: list[tuple[int, Message]] = []
-    num_reused = 0
-    for i, msg in enumerate(prompt):
+    path: list[tuple[int, Message]] = [
+        (nid, prompt[i]) for i, nid in enumerate(turn.prefix_node_ids)
+    ]
+    num_reused = len(turn.prefix_node_ids)
+    for i, msg in enumerate(prompt[num_reused:], start=num_reused):
         key = (parent, message_hash(msg))
-        existing = idx.get(key)
-        if cursor is None and existing is not None:  # still extending the shared prefix
-            parent = existing
-            path_len += len(trace.nodes[existing].token_ids)
-            path.append((existing, msg))
-            num_reused += 1
-            continue
         start = path_len if cursor is None else cursor
         span = spans[i] if spans and i < len(spans) else None
         end = span[1] if span else start
@@ -369,10 +451,15 @@ def add_turn(trace: "Trace", prompt: "list[Message]", response: Response) -> Non
     )
 
 
+def add_turn(trace: Trace, prompt: list[Message], response: Response) -> None:
+    """Compatibility helper for callers that do not need pre-inference turn planning."""
+    prepare_turn(trace, prompt).commit(response)
+
+
 # --- walking the graph (views) ---------------------------------------------------------
 
 
-def leaves(trace: "Trace") -> list[int]:
+def leaves(trace: Trace) -> list[int]:
     """Node ids that are no node's parent — one per branch (the last node of each). The
     `Trace.branches` view walks each leaf's parents back to its root to build the branch."""
     has_child = {n.parent for n in trace.nodes if n.parent is not None}

--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -208,6 +208,7 @@ class InterceptionServer:
                         dialect.error_body(f"rollout stopped: {refused}"), status=400
                     )
                 return web.json_response(completion)
+            turn = graph.prepare_turn(session.trace, prompt)
             try:
                 response = await session.ctx.client.get_response(
                     dialect,
@@ -215,6 +216,7 @@ class InterceptionServer:
                     session.ctx.model,
                     session.ctx.sampling,
                     session_id=session.trace.id,
+                    turn=turn,
                 )
             except OverlongPromptError:
                 # An overlong prompt is a budget limit, not a crash: end the rollout cleanly
@@ -234,7 +236,7 @@ class InterceptionServer:
             # `Response.raw` is the wire response handed to the program 1:1 — the provider's
             # verbatim bytes (proxy) or the client's serialized completion (renderer).
             completion = response.raw
-            graph.add_turn(session.trace, prompt, response)  # one node per new message;
+            turn.commit(response)  # one node per new message;
             # branches fall out of walking the graph (see Trace.branches / verifiers.v1.graph)
             # Hand back to the program when the model wants a tool (the program runs it) or
             # when there's no user simulator to keep the conversation going.
@@ -267,6 +269,7 @@ class InterceptionServer:
                 dialect.error_body(f"rollout stopped: {refused}"), status=400
             )
         try:
+            turn = graph.prepare_turn(session.trace, prompt)
             reply = await session.ctx.client.relay(
                 dialect,
                 body,
@@ -313,7 +316,7 @@ class InterceptionServer:
             await reply.close()
 
         try:
-            graph.add_turn(session.trace, prompt, dialect.parse_stream(bytes(buffer)))
+            turn.commit(dialect.parse_stream(bytes(buffer)))
         finally:
             with contextlib.suppress(ConnectionResetError):
                 await resp.write_eof()

--- a/verifiers/v1/types.py
+++ b/verifiers/v1/types.py
@@ -116,6 +116,8 @@ class ToolMessage(StrictBaseModel):
     role: Literal["tool"] = "tool"
     tool_call_id: str
     content: MessageContent
+    name: str | None = None
+    """The originating tool/function name when it can be recovered from the prompt."""
 
 
 Message = Annotated[


### PR DESCRIPTION
## Summary

- Adds a graph-owned pending turn lifecycle so v1 resolves a prompt prefix once before inference and commits the response onto that same resolved path afterward.
- Teaches the v1 `TrainClient` to use the pending turn for renderer `bridge_to_next_turn(...)` on text/tool prompts, falling back to the existing full render path for multimodal prompts.
- Stores recovered tool names on `ToolMessage` during chat request parsing so renderer tool-message tails can bridge without client-side reconstruction.

## Root Cause

v1 graph storage already deduplicated prompt prefixes after inference, but the train client did not use that prefix information before calling the renderer. As a result, multi-turn training requests rerendered the full prompt instead of extending from prior sampled tokens.

## Validation

- `uv run ruff check verifiers/v1 tests/v1`
- `uv run ruff format --check verifiers/v1 tests/v1`
- `uv run pytest tests/v1`

Latest local result: `22 passed, 48 skipped`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix v1 train client prefix bridging across turns in `TrainClient`
> - Adds `PendingTurn` dataclass and `prepare_turn` function to [graph.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1709/files#diff-64c9d635eb215902a512c9e8ab316fd9b9967c36db03d4049aacc812cdfbd740), enabling a non-mutating view of a turn's graph prefix that can later be committed after a response is received.
> - Updates `TrainClient.get_response` in [train.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1709/files#diff-c9bcd6c691890b1de6942fe012d2e74678460b22bf335721a8bba5e939d139c3) to accept a `PendingTurn` and attempt renderer bridging: reuses previous prompt/completion token ids, adjusts `routed_experts_prompt_start`, and updates `message_spans` with `None` placeholders for the reused prefix.
> - Updates `InterceptionServer` in [server.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1709/files#diff-84e2f8d027d609e8760ef6d533535ec9d99dfc6384d5ddb6111b4001b2010f35) to use `prepare_turn`/`commit` instead of `graph.add_turn` for both the handle and relay paths.
> - Adds `name` field recovery to `ToolMessage` in [chat.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1709/files#diff-5d2fcbf59a03489b63b0626038a853eee89543b591074597161ee29aab901280): reconstructs the tool name from the originating assistant `tool_calls` when not explicitly present on the wire.
> - Behavioral Change: multimodal prompts and turns with invalid tails (not matching zero-or-more `tool` messages optionally followed by a `user`) skip bridging entirely.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6cbbf04.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->