### PR TITLE
fix(v1): retry sandbox provisioning failures

### DIFF
--- a/verifiers/v1/utils/sandbox_utils.py
+++ b/verifiers/v1/utils/sandbox_utils.py
@@ -724,59 +724,60 @@ async def create_sandbox(
         else None,
         guaranteed=bool(sandbox_config.get("guaranteed", False)),
     )
-    create_task = asyncio.create_task(
-        with_sandbox_retry(lambda: client.create(request))
-    )
-    try:
-        create_waiter = asyncio.shield(create_task)
-        if sandbox_config.get("create_timeout") is not None:
-            sandbox = await asyncio.wait_for(
-                create_waiter, int_config(sandbox_config, "create_timeout", 0)
-            )
-        else:
-            sandbox = await create_waiter
-    except (asyncio.CancelledError, TimeoutError):
-        try:
-            sandbox = cast(SandboxRecord, await asyncio.shield(create_task))
-        except BaseException:
-            if owns_client:
-                await close_sandbox_client(client)
-            raise
-        await asyncio.shield(
-            delete_sandbox_id(
-                client,
-                str(sandbox.id),
-                close_client=owns_client,
-                reason="cancelled creation",
-            )
+    async def _create_and_wait_once() -> str:
+        create_task = asyncio.create_task(
+            with_sandbox_retry(lambda: client.create(request))
         )
-        raise
+        try:
+            create_waiter = asyncio.shield(create_task)
+            if sandbox_config.get("create_timeout") is not None:
+                sandbox = await asyncio.wait_for(
+                    create_waiter, int_config(sandbox_config, "create_timeout", 0)
+                )
+            else:
+                sandbox = await create_waiter
+        except (asyncio.CancelledError, TimeoutError):
+            sandbox = cast(SandboxRecord, await asyncio.shield(create_task))
+            await asyncio.shield(
+                delete_sandbox_id(
+                    client,
+                    str(sandbox.id),
+                    close_client=False,
+                    reason="cancelled creation",
+                )
+            )
+            raise
+        sandbox_id = str(sandbox.id)
+        try:
+            wait = client.wait_for_creation(
+                sandbox_id,
+                max_attempts=SANDBOX_WAIT_FOR_CREATION_ATTEMPTS,
+            )
+            if sandbox_config.get("wait_timeout") is not None:
+                await asyncio.wait_for(
+                    wait, int_config(sandbox_config, "wait_timeout", 0)
+                )
+            else:
+                await wait
+        except BaseException:
+            delete_task = asyncio.create_task(
+                delete_sandbox_id(
+                    client,
+                    sandbox_id,
+                    close_client=False,
+                    reason="creation failure",
+                )
+            )
+            await asyncio.shield(delete_task)
+            raise
+        return sandbox_id
+
+    try:
+        return await with_sandbox_retry(_create_and_wait_once)
     except BaseException:
         if owns_client:
             await close_sandbox_client(client)
         raise
-    sandbox_id = str(sandbox.id)
-    try:
-        wait = client.wait_for_creation(
-            sandbox_id,
-            max_attempts=SANDBOX_WAIT_FOR_CREATION_ATTEMPTS,
-        )
-        if sandbox_config.get("wait_timeout") is not None:
-            await asyncio.wait_for(wait, int_config(sandbox_config, "wait_timeout", 0))
-        else:
-            await wait
-    except BaseException:
-        delete_task = asyncio.create_task(
-            delete_sandbox_id(
-                client,
-                sandbox_id,
-                close_client=owns_client,
-                reason="creation failure",
-            )
-        )
-        await asyncio.shield(delete_task)
-        raise
-    return sandbox_id
 
 
 async def delete_sandbox_id(

--- a/verifiers/v1/utils/sandbox_utils.py
+++ b/verifiers/v1/utils/sandbox_utils.py
@@ -725,9 +725,7 @@ async def create_sandbox(
         guaranteed=bool(sandbox_config.get("guaranteed", False)),
     )
     async def _create_and_wait_once() -> str:
-        create_task = asyncio.create_task(
-            with_sandbox_retry(lambda: client.create(request))
-        )
+        create_task = asyncio.create_task(client.create(request))
         try:
             create_waiter = asyncio.shield(create_task)
             if sandbox_config.get("create_timeout") is not None:
@@ -736,7 +734,21 @@ async def create_sandbox(
                 )
             else:
                 sandbox = await create_waiter
-        except (asyncio.CancelledError, TimeoutError):
+        except asyncio.CancelledError as cancel_exc:
+            try:
+                sandbox = cast(SandboxRecord, await asyncio.shield(create_task))
+            except BaseException:
+                raise cancel_exc
+            await asyncio.shield(
+                delete_sandbox_id(
+                    client,
+                    str(sandbox.id),
+                    close_client=False,
+                    reason="cancelled creation",
+                )
+            )
+            raise
+        except TimeoutError:
             sandbox = cast(SandboxRecord, await asyncio.shield(create_task))
             await asyncio.shield(
                 delete_sandbox_id(


### PR DESCRIPTION
## Summary
- Retry the full sandbox create-and-wait provisioning cycle using the existing sandbox retry helper.
- Delete failed or cancelled provisioning attempts without closing the shared client between retry attempts.
- Preserve the existing create/wait timeout and cleanup behavior while provisioning a fresh sandbox on each retry.

## Test plan
- `uv run python -m py_compile verifiers/v1/utils/sandbox_utils.py`
- Cursor lints: no diagnostics for `verifiers/v1/utils/sandbox_utils.py`


Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Retry the full create-and-wait sequence on sandbox provisioning failures
> - Refactors `create_sandbox` in [sandbox_utils.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1714/files#diff-b1154f3be7f28191532de46fbe23a973a5f93e1450a71beb9c93910e358fda13) to wrap both the creation call and the post-creation wait into a single inner function `_create_and_wait_once`, which is passed to `with_sandbox_retry` so the entire sequence is retried on failure.
> - On cancellation or timeout after the create call has already returned a sandbox, the sandbox is deleted (without closing the client) before the exception propagates.
> - On any failure during the wait phase, the sandbox is deleted with reason `"creation failure"`. The client is only closed by the outer handler when `owns_client=True`.
> - Behavioral Change: previously only the `client.create` call was retried; now retries cover the full create+wait path, which may result in more sandbox deletions on transient failures.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 2105581. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->