### PR TITLE
fix: relax MCP DNS-rebinding guard for tunneled host-bound servers

### DIFF
--- a/verifiers/v1/mcp/server.py
+++ b/verifiers/v1/mcp/server.py
@@ -178,14 +178,11 @@ class ServerBase(Generic[ConfigT, StateT]):
                 await self.setup_task(task)
 
         asyncio.run(_setup())
-        # Bound to 0.0.0.0 means a sandbox tunnel reaches us at a non-loopback host (e.g. modal's
-        # *.modal.host); FastMCP's default DNS-rebinding guard allows only localhost and would 421
-        # the tunnel host, so relax it (the tunnel is the trust boundary).
-        security = None
-        if host == "0.0.0.0":
-            from mcp.server.transport_security import TransportSecuritySettings
+        # Relax FastMCP's DNS-rebinding guard: it 421s a non-localhost Host, but our servers are
+        # reached only by our own harness over localhost or a tunnel (never a browser).
+        from mcp.server.transport_security import TransportSecuritySettings
 
-            security = TransportSecuritySettings(enable_dns_rebinding_protection=False)
+        security = TransportSecuritySettings(enable_dns_rebinding_protection=False)
         mcp = FastMCP(self.server_name, transport_security=security)
         self._register(mcp)
         server = uvicorn.Server(


### PR DESCRIPTION
## Summary

Relax FastMCP's DNS-rebinding guard **unconditionally** in `ServerBase._serve` — it was only disabled when the server bound `0.0.0.0` (a self-publishing modal/prime runtime).

A **host-bound** server (`127.0.0.1` — a subprocess/docker tool) reached by a **remote** harness over a `host_endpoint` tunnel was left with the guard on. FastMCP's guard allows only a localhost `Host` and `421`s anything else, so the tunnel's `Host` (e.g. `…tunnel.pinfra.io`) was rejected. These servers are reached only by our own harness over localhost or one of our tunnels (never a browser), so the guard adds no security here — relax it in all cases.

## Verification

The failing CI cells on `feat/nano-as-v1` (Test job):

- `test_tool[in-prime-with-tool-in-subprocess]`
- `test_tool[in-prime-with-tool-in-docker]`
- `test_tool[in-prime-with-tool-shared]`

each errored with:

```
ProgramError: harness exited 1: ... httpx.HTTPStatusError: Client error '421 Misdirected Request'
for url 'https://t-1-….tunnel.pinfra.io/mcp' ... DNS rebinding protection check
```

i.e. the prime harness reaching a host-bound tool over a tunnel. After the fix the guard no longer rejects the tunnel `Host`.

Local subprocess cells (`test_tool` / `test_user` / `test_tool_state`, `-m "not slow"`) stay green — relaxing the guard doesn't change the localhost path. The `in-prime` cells need prime infra and weren't run locally; they're the cells this targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable FastMCP DNS-rebinding protection unconditionally in `ServerBase._serve`
> Previously, `TransportSecuritySettings(enable_dns_rebinding_protection=False)` was only applied when the bind host was `0.0.0.0`. Tunneled host-bound servers still had protection enabled, causing FastMCP to 421-reject requests with non-localhost `Host` headers. The fix removes the host check and always disables DNS-rebinding protection in [server.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1715/files#diff-5eaeab5d19ee732e16b066ff6689f954f6743833a907a129acc0df250cee5b2a).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 30493f5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrows transport hardening for all MCP servers, but only in a harness-controlled path where DNS rebinding is not the trust boundary.
> 
> **Overview**
> **Always** disables FastMCP DNS-rebinding protection when starting MCP in `ServerBase._serve`, instead of only when binding `0.0.0.0`.
> 
> Host-bound tools (`127.0.0.1`) reached by a remote prime harness through a tunnel were still using the default guard, which rejects non-localhost `Host` headers with **421**. Tunneled `in-prime` subprocess/docker/shared tool tests failed for that reason. The comment now states that these servers are only used from the harness over localhost or an internal tunnel, not from a browser.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30493f59d3569c5a8d95b883b17a229a10c389e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->