### PR TITLE
fix(v1): retry sandbox provisioning failures

### DIFF
--- a/verifiers/v1/utils/sandbox_utils.py
+++ b/verifiers/v1/utils/sandbox_utils.py
@@ -690,59 +690,60 @@ async def create_sandbox(
         else None,
         guaranteed=bool(sandbox_config.get("guaranteed", False)),
     )
-    create_task = asyncio.create_task(
-        with_sandbox_retry(lambda: client.create(request))
-    )
-    try:
-        create_waiter = asyncio.shield(create_task)
-        if sandbox_config.get("create_timeout") is not None:
-            sandbox = await asyncio.wait_for(
-                create_waiter, int_config(sandbox_config, "create_timeout", 0)
-            )
-        else:
-            sandbox = await create_waiter
-    except (asyncio.CancelledError, TimeoutError):
-        try:
-            sandbox = cast(SandboxRecord, await asyncio.shield(create_task))
-        except BaseException:
-            if owns_client:
-                await close_sandbox_client(client)
-            raise
-        await asyncio.shield(
-            delete_sandbox_id(
-                client,
-                str(sandbox.id),
-                close_client=owns_client,
-                reason="cancelled creation",
-            )
+    async def _create_and_wait_once() -> str:
+        create_task = asyncio.create_task(
+            with_sandbox_retry(lambda: client.create(request))
         )
-        raise
+        try:
+            create_waiter = asyncio.shield(create_task)
+            if sandbox_config.get("create_timeout") is not None:
+                sandbox = await asyncio.wait_for(
+                    create_waiter, int_config(sandbox_config, "create_timeout", 0)
+                )
+            else:
+                sandbox = await create_waiter
+        except (asyncio.CancelledError, TimeoutError):
+            sandbox = cast(SandboxRecord, await asyncio.shield(create_task))
+            await asyncio.shield(
+                delete_sandbox_id(
+                    client,
+                    str(sandbox.id),
+                    close_client=False,
+                    reason="cancelled creation",
+                )
+            )
+            raise
+        sandbox_id = str(sandbox.id)
+        try:
+            wait = client.wait_for_creation(
+                sandbox_id,
+                max_attempts=SANDBOX_WAIT_FOR_CREATION_ATTEMPTS,
+            )
+            if sandbox_config.get("wait_timeout") is not None:
+                await asyncio.wait_for(
+                    wait, int_config(sandbox_config, "wait_timeout", 0)
+                )
+            else:
+                await wait
+        except BaseException:
+            delete_task = asyncio.create_task(
+                delete_sandbox_id(
+                    client,
+                    sandbox_id,
+                    close_client=False,
+                    reason="creation failure",
+                )
+            )
+            await asyncio.shield(delete_task)
+            raise
+        return sandbox_id
+
+    try:
+        return await with_sandbox_retry(_create_and_wait_once)
     except BaseException:
         if owns_client:
             await close_sandbox_client(client)
         raise
-    sandbox_id = str(sandbox.id)
-    try:
-        wait = client.wait_for_creation(
-            sandbox_id,
-            max_attempts=SANDBOX_WAIT_FOR_CREATION_ATTEMPTS,
-        )
-        if sandbox_config.get("wait_timeout") is not None:
-            await asyncio.wait_for(wait, int_config(sandbox_config, "wait_timeout", 0))
-        else:
-            await wait
-    except BaseException:
-        delete_task = asyncio.create_task(
-            delete_sandbox_id(
-                client,
-                sandbox_id,
-                close_client=owns_client,
-                reason="creation failure",
-            )
-        )
-        await asyncio.shield(delete_task)
-        raise
-    return sandbox_id
 
 
 async def delete_sandbox_id(


### PR DESCRIPTION
## Summary
- Retry the full sandbox create-and-wait provisioning cycle with the existing sandbox retry helper.
- Delete failed or cancelled provisioning attempts without closing the shared client between retry attempts.
- Preserve existing create/wait timeout and cleanup behavior while provisioning a fresh sandbox on each retry.

## Test plan
- `uv run python -m py_compile verifiers/v1/utils/sandbox_utils.py`
- Cursor lints: no diagnostics for `verifiers/v1/utils/sandbox_utils.py`


Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Retry sandbox provisioning failures in `create_sandbox`
> - Refactors [`sandbox_utils.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1716/files#diff-b1154f3be7f28191532de46fbe23a973a5f93e1450a71beb9c93910e358fda13) to extract the create-and-wait flow into an inner coroutine `_create_and_wait_once`, wrapped with `with_sandbox_retry` so the full operation retries on failure.
> - On cancellation or timeout during creation, the partially created sandbox is deleted before re-raising, preventing orphaned sandboxes.
> - On failure during the post-creation wait, the sandbox is also deleted with `close_client=False`, with client cleanup centralized in the outer handler.
> - Behavioral Change: `SandboxClient` is now closed only once in the outer scope when `owns_client` is True, rather than inline at each failure site.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6a110de.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->