### PR TITLE
chore: run v1 tests with -n auto in a separate CI step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,11 @@ jobs:
 
       - name: Run tests
         run: |
-          uv run pytest tests/ -v --ignore=tests/test_envs.py -m "not prime_sandbox" --cov=verifiers --cov-report=xml --cov-report=term
+          uv run pytest tests/ -v --ignore=tests/test_envs.py --ignore=tests/v1 -m "not prime_sandbox" --cov=verifiers --cov-report=xml --cov-report=term
+
+      - name: Run v1 tests
+        run: |
+          uv run pytest tests/v1 -vv -n auto -m "not prime_sandbox" --cov=verifiers --cov-append --cov-report=xml --cov-report=term
   test-envs:
     name: Environments
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository

--- a/tests/v1/fixtures/pyproject.toml
+++ b/tests/v1/fixtures/pyproject.toml
@@ -13,6 +13,7 @@ build-backend = "hatchling.build"
 # be importable there. The others (echo_v1, echo_*_v0) have no server, so they never get installed.
 [tool.hatch.build]
 include = [
+    "counter_tool_v1.py",
     "echo_tool_v1.py",
     "echo_user_sim_v1.py",
     "tool_response_image_v1.py",

--- a/tests/v1/test_legacy.py
+++ b/tests/v1/test_legacy.py
@@ -21,7 +21,7 @@ def _shape(trace) -> dict:
 async def test_v0_single_turn_matches_v1_shape(run_v0, run_v1, tmp_path):
     (v0,) = await run_v0("echo-v0", output_dir=tmp_path / "v0")
     (v1,) = await run_v1(
-        "echo-v1", runtime="subprocess", output_dir=tmp_path / "v1", max_turns=2
+        "echo-v1", agent_runtime="subprocess", output_dir=tmp_path / "v1", max_turns=2
     )
     assert v0.nodes  # the bridge populated the message graph
     assert v0.num_turns == 1
@@ -32,7 +32,7 @@ async def test_v0_single_turn_matches_v1_shape(run_v0, run_v1, tmp_path):
 async def test_v0_multi_turn_matches_v1_shape(run_v0, run_v1, tmp_path):
     (v0,) = await run_v0("echo-multi-v0", output_dir=tmp_path / "v0")
     (v1,) = await run_v1(
-        "echo-v1", runtime="subprocess", output_dir=tmp_path / "v1", max_turns=2
+        "echo-v1", agent_runtime="subprocess", output_dir=tmp_path / "v1", max_turns=2
     )
     assert v0.num_turns >= 2  # genuinely multi-turn
     assert _shape(v0) == _shape(v1)

--- a/verifiers/v1/mcp/launch.py
+++ b/verifiers/v1/mcp/launch.py
@@ -156,6 +156,14 @@ async def _install_in_sandbox(server: ServerBase, runtime: Runtime) -> str:
     return f"{venv}/bin/python"
 
 
+async def log_tail(runtime: Runtime, log: str, limit: int = 2000) -> str:
+    """The tail of a program's `log` file in `runtime`, empty if it can't be read — for
+    enriching an error with what the program (e.g. a tool server) wrote before it died."""
+    with contextlib.suppress(Exception):
+        return (await runtime.read(log)).decode(errors="replace").strip()[-limit:]
+    return ""
+
+
 async def _read_back_port(runtime: Runtime, path: str) -> int:
     """The port the server bound and wrote to `path` in its runtime. The server writes it the moment
     it binds (before setup/serving), so this resolves quickly; poll because it's a separate process."""
@@ -209,25 +217,19 @@ async def serve_in_runtime(
         python = await _install_in_sandbox(server, runtime)
     log = f"vf_tool_{server.server_name}.log"
     await runtime.run_background([python, "-m", type(server).__module__], env, log)
-
-    async def _log_tail() -> str:
-        with contextlib.suppress(Exception):
-            return (await runtime.read(log)).decode(errors="replace").strip()[-2000:]
-        return ""
-
     if fixed is not None:
         port = fixed
     else:
         try:
             port = await _read_back_port(runtime, port_file)
         except ProgramError as e:
-            raise ProgramError(f"{e}: {await _log_tail()}") from e
+            raise ProgramError(f"{e}: {await log_tail(runtime, log)}") from e
     probe = await runtime.run(
         ["python3", "-c", _PROBE, f"http://127.0.0.1:{port}/mcp"], {}
     )
     if probe.exit_code != 0:
         raise ProgramError(
-            f"tool server {server.server_name!r} not serving in runtime: {await _log_tail()}"
+            f"tool server {server.server_name!r} not serving in runtime: {await log_tail(runtime, log)}"
         )
     return port
 

--- a/verifiers/v1/mcp/launch.py
+++ b/verifiers/v1/mcp/launch.py
@@ -209,16 +209,25 @@ async def serve_in_runtime(
         python = await _install_in_sandbox(server, runtime)
     log = f"vf_tool_{server.server_name}.log"
     await runtime.run_background([python, "-m", type(server).__module__], env, log)
-    port = fixed if fixed is not None else await _read_back_port(runtime, port_file)
+
+    async def _log_tail() -> str:
+        with contextlib.suppress(Exception):
+            return (await runtime.read(log)).decode(errors="replace").strip()[-2000:]
+        return ""
+
+    if fixed is not None:
+        port = fixed
+    else:
+        try:
+            port = await _read_back_port(runtime, port_file)
+        except ProgramError as e:
+            raise ProgramError(f"{e}: {await _log_tail()}") from e
     probe = await runtime.run(
         ["python3", "-c", _PROBE, f"http://127.0.0.1:{port}/mcp"], {}
     )
     if probe.exit_code != 0:
-        tail = ""
-        with contextlib.suppress(Exception):
-            tail = (await runtime.read(log)).decode(errors="replace").strip()[-2000:]
         raise ProgramError(
-            f"tool server {server.server_name!r} not serving in runtime: {tail}"
+            f"tool server {server.server_name!r} not serving in runtime: {await _log_tail()}"
         )
     return port
 


### PR DESCRIPTION
## Summary

- Run the v1 test suite (`tests/v1`) in its **own CI step** with `pytest-xdist` (`-n auto`) and `-vv`, distinguishable from the rest of the suite. Excluded from the main "Run tests" step (`--ignore=tests/v1`); coverage is appended across the two steps. `pytest-xdist` is already a dev dependency.

Along the way, fixed the pre-existing v1 e2e failures these tests surfaced (all unrelated to xdist — they reproduce serially):

- **`tests/v1/test_legacy.py`** called `run_v1(..., runtime=...)`, but the fixture/`_eval_config` (and every `test_e2e.py` caller) take `agent_runtime=` — so the legacy bridge tests raised `TypeError` whenever they ran. Fixed the kwarg.
- **`tests/v1/fixtures/pyproject.toml`** omitted `counter_tool_v1.py` from `include`. `test_tool_state` launches that toolset inside a docker/prime runtime via `python -m counter_tool_v1`, which uploads + installs the fixtures package; the missing entry meant the sandbox wheel dropped the module, so the tool server died with `No module named counter_tool_v1` (surfacing as the opaque "server did not report its port"). Subprocess was unaffected (host PYTHONPATH). Added it.
- **`verifiers/v1/mcp/launch.py`**: when a sandbox tool server never reports its port, the error now appends the **server log** (mirroring the probe-failure path) instead of a bare 180s-timeout message — which is what made the `counter_tool_v1` cause obvious.

## Verification

- Full non-prime v1 suite under xdist: **53 passed, 2 skipped** (`-m "not prime_sandbox and not prime"`).
- The docker `test_tool_state` cases pass after the fixture fix (previously timed out). `prime`-runtime cases provision real sandboxes (not run locally), but the `counter_tool_v1` fix is runtime-agnostic so it covers them too; CI runs them with `PRIME_API_KEY`.
- `ruff check` clean.

## Notes

- CI's `test` job sets `PRIME_API_KEY`, so the `e2e`-marked v1 tests run there (they skip only in a keyless env).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI orchestration and test/fixture fixes plus clearer MCP launch errors; no production auth or data-path changes.
> 
> **Overview**
> **CI** splits the test job: the main pytest run now **ignores `tests/v1`**, and a dedicated **Run v1 tests** step runs `tests/v1` with **`pytest-xdist` (`-n auto`)**, **`-vv`**, and **`--cov-append`** so coverage still rolls up.
> 
> **v1 e2e fixes** surfaced when that suite ran reliably:
> - **`test_legacy.py`** passes **`agent_runtime=`** into `run_v1` (was `runtime=`, which didn’t match `_eval_config`).
> - **`tests/v1/fixtures/pyproject.toml`** **includes `counter_tool_v1.py`** in the hatch wheel so docker/prime sandboxes can `python -m counter_tool_v1` (missing module caused port-report timeouts).
> - **`verifiers/v1/mcp/launch.py`** adds **`log_tail`** and appends the **tool server log** when port discovery or the serve probe fails, instead of opaque timeout-only errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7137c197822aa6272604d77faba675d7405fc8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Run v1 tests in a separate parallel CI step
> - Splits the CI `Verifiers` job so `tests/v1` is excluded from the primary pytest run and executed in a dedicated step using `-n auto` for parallel workers, with `--cov-append` to preserve coverage.
> - Fixes `run_v1` calls in [test_legacy.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1718/files#diff-f0db8a9e010d7b327a61b997904a4d6448fa06b8f2e0843ee7d5008ebd58471e) to pass `agent_runtime=` instead of `runtime=`.
> - Adds `counter_tool_v1.py` to the fixture package includes in [pyproject.toml](https://github.com/PrimeIntellect-ai/verifiers/pull/1718/files#diff-401558b8fc8f59d5f63969677c71b01c45abc03eee8852a3b380de37bc6853e5).
> - Introduces `log_tail()` in [launch.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1718/files#diff-989d87123d40d48511f9e1df74594d2e30776e9a99c11eca49d9cc20bf9e2230) to attach server log output to `ProgramError` messages on port-read or probe failures.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e7137c1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->