### PR TITLE
feat: default the harness runtime to subprocess

### DIFF
--- a/configs/alphabet_sort.toml
+++ b/configs/alphabet_sort.toml
@@ -12,4 +12,3 @@ max_turns = 2
 
 [harness]
 id = "default"
-runtime = { type = "subprocess" }

--- a/configs/gsm8k_rlm.toml
+++ b/configs/gsm8k_rlm.toml
@@ -14,4 +14,3 @@ id = "gsm8k-v1"
 [harness]
 id = "rlm"
 version = "main"
-runtime = { type = "subprocess" }

--- a/configs/textarena.toml
+++ b/configs/textarena.toml
@@ -1,7 +1,7 @@
 # textarena-v1 — single-player TextArena games driven by a user simulator (vf.User).
 # Supported (--taskset.game): Wordle-v0, Wordle-v0-long, Hangman-v0, WordLadder-v0,
 # WordSearch-v0. The framework's interception server plays the game; the harness never sees
-# it. The user sim runs colocated, so use the subprocess runtime.
+# it. The user sim runs colocated in the harness's runtime.
 #
 #   uv run eval @ configs/textarena.toml --model <small-instruct-model>
 num_tasks = 5
@@ -15,4 +15,3 @@ num_tasks = 50  # pool of seeded episodes to draw the eval's tasks from
 
 [harness]
 id = "default"
-runtime = { type = "subprocess" }

--- a/configs/wordle.toml
+++ b/configs/wordle.toml
@@ -11,4 +11,3 @@ num_tasks = 50  # pool of seeded episodes to draw the eval's tasks from
 
 [harness]
 id = "default"
-runtime = { type = "subprocess" }

--- a/verifiers/v1/GUIDE.md
+++ b/verifiers/v1/GUIDE.md
@@ -30,7 +30,7 @@ trains on.
 
 ```bash
 uv sync                          # core + shipped packages + examples
-uv run eval gsm8k-v1 -n 5 -r 3   # 5 tasks, 3 rollouts each; default harness, docker runtime
+uv run eval gsm8k-v1 -n 5 -r 3   # 5 tasks, 3 rollouts each; default harness, subprocess runtime
 uv run eval -h                   # typed help (lists local tasksets + harnesses)
 ```
 
@@ -327,8 +327,8 @@ The same `Runtime` contract backs the harness (`--harness.runtime`), a task's to
 (`--taskset.tools.runtime`), and the user simulator:
 
 ```bash
-uv run eval gsm8k-v1 -n 1 --harness.runtime.type subprocess  # local process
-uv run eval gsm8k-v1 -n 1 --harness.runtime.type docker      # local container (eval default)
+uv run eval gsm8k-v1 -n 1 --harness.runtime.type subprocess  # local process (eval default)
+uv run eval gsm8k-v1 -n 1 --harness.runtime.type docker      # local container
 uv run eval gsm8k-v1 -n 1 --harness.runtime.type prime       # remote prime sandbox
 uv run eval gsm8k-v1 -n 1 --harness.runtime.type modal       # remote modal sandbox
 ```

--- a/verifiers/v1/README.md
+++ b/verifiers/v1/README.md
@@ -34,7 +34,7 @@ uv sync   # core + the shipped packages + examples (eval, serve, all runtimes)
 
 ```bash
 uv run init my-task-v1           # scaffold a new environment (--add-tool/--add-user/--add-harness)
-uv run eval gsm8k-v1 -n 5 -r 3   # single-turn math; default harness; docker runtime
+uv run eval gsm8k-v1 -n 5 -r 3   # single-turn math; default harness; subprocess runtime
 uv run validate gsm8k-v1 -n 5    # model-free: run each task's gold check (the `validate` hook)
 uv run eval -h                   # typed help (+ the local example tasksets/harnesses)
 ```
@@ -143,8 +143,8 @@ uv run eval gsm8k-v1 -n 1 --harness.id codex  # the codex harness
 simulator (`--taskset.user.runtime`) — all structurally MCP servers in a runtime:
 
 ```bash
-uv run eval gsm8k-v1 -n 1 --harness.runtime.type subprocess  # local process
-uv run eval gsm8k-v1 -n 1 --harness.runtime.type docker      # local container (default)
+uv run eval gsm8k-v1 -n 1 --harness.runtime.type subprocess  # local process (default)
+uv run eval gsm8k-v1 -n 1 --harness.runtime.type docker      # local container
 uv run eval gsm8k-v1 -n 1 --harness.runtime.type prime       # remote prime sandbox (requires auth)
 uv run eval gsm8k-v1 -n 1 --harness.runtime.type modal       # remote modal sandbox (requires auth)
 ```

--- a/verifiers/v1/configs/validate.py
+++ b/verifiers/v1/configs/validate.py
@@ -2,9 +2,10 @@
 
 Validation is per-task and model-free — it runs the taskset's `validate` hook (apply a gold
 solution, run a verifier) in a runtime, not a harness rollout. So the config carries just the
-taskset, the `runtime` its hook runs in (docker by default, like `eval`), the stage timeouts,
-and the run knobs. No harness, model, or sampling — and it's fire-and-forget: nothing is
-written to disk, so there's no output dir / resume / dry-run.
+taskset, the `runtime` its hook runs in (docker by default — a gold check often needs the
+task's declared container), the stage timeouts, and the run knobs. No harness, model, or
+sampling — and it's fire-and-forget: nothing is written to disk, so there's no output dir /
+resume / dry-run.
 """
 
 from pydantic import AliasChoices, Field, SerializeAsAny, model_validator
@@ -19,13 +20,14 @@ class ValidateConfig(BaseConfig):
     """A taskset plus how to validate it. The taskset is selected by `--taskset.id` (with a
     bare positional shorthand, `validate gsm8k-v1`); its fields stay typed and overridable
     via dotted flags (`--taskset.split test`). The `validate` hook runs in `--runtime.*`
-    (docker by default, like `eval`; SWE rows carry their own per-task image)."""
+    (docker by default; SWE rows carry their own per-task image)."""
 
     taskset: SerializeAsAny[TasksetConfig] = TasksetConfig()
     runtime: RuntimeConfig = DockerConfig()
-    """Where each task's `validate` hook runs. Docker by default (like `eval`); a SWE task
-    overrides the image per task. Use `--runtime.type subprocess` for a check that needs no
-    container — one that only reads task data or runs a uv-script verifier (e.g. gsm8k)."""
+    """Where each task's `validate` hook runs. Docker by default — unlike the eval harness
+    (subprocess), a gold check often needs the task's declared container; a SWE task overrides
+    the image per task. Use `--runtime.type subprocess` for a check that needs no container —
+    one that only reads task data or runs a uv-script verifier (e.g. gsm8k)."""
     retries: RetryConfig = RetryConfig()
     """Reused only for `retries.runtime` — retry a task on a transient runtime fault (sandbox
     create/exec), each retry on a fresh runtime. Model/rollout retries don't apply here."""

--- a/verifiers/v1/harness.py
+++ b/verifiers/v1/harness.py
@@ -20,7 +20,12 @@ from verifiers.v1.clients import RolloutContext
 from verifiers.v1.decorators import discover_decorated, invoke
 from verifiers.v1.errors import ProgramError
 from verifiers.v1.ids import EnvId, env_name
-from verifiers.v1.runtimes import ProgramResult, Runtime, RuntimeConfig, SubprocessConfig
+from verifiers.v1.runtimes import (
+    ProgramResult,
+    Runtime,
+    RuntimeConfig,
+    SubprocessConfig,
+)
 from verifiers.v1.task import Task
 from verifiers.v1.trace import Trace
 from verifiers.v1.types import Messages

--- a/verifiers/v1/harness.py
+++ b/verifiers/v1/harness.py
@@ -20,7 +20,7 @@ from verifiers.v1.clients import RolloutContext
 from verifiers.v1.decorators import discover_decorated, invoke
 from verifiers.v1.errors import ProgramError
 from verifiers.v1.ids import EnvId, env_name
-from verifiers.v1.runtimes import DockerConfig, ProgramResult, Runtime, RuntimeConfig
+from verifiers.v1.runtimes import ProgramResult, Runtime, RuntimeConfig, SubprocessConfig
 from verifiers.v1.task import Task
 from verifiers.v1.trace import Trace
 from verifiers.v1.types import Messages
@@ -37,9 +37,11 @@ class HarnessConfig(BaseConfig):
     """The harness id, which selects this harness: a local package, or an
     `org/name[@version]` package installed on demand from the Environments Hub (see
     `EnvId`). Set via `--harness.id`."""
-    runtime: RuntimeConfig = DockerConfig()
-    """Where the harness runs (subprocess / docker / prime). Lives on the harness — it's
-    the harness's box; tool servers have their own placement (see `TasksetConfig.tools`)."""
+    runtime: RuntimeConfig = SubprocessConfig()
+    """Where the harness runs (subprocess / docker / prime). Subprocess by default — a local
+    process on the host; a taskset that needs a container (its own image, or NEEDS_CONTAINER)
+    selects `--harness.runtime.type docker` (or prime/modal). Lives on the harness — it's the
+    harness's box; tool servers have their own placement (see `TasksetConfig.tools`)."""
     env: dict[str, str] = Field(default_factory=dict)
     """Additional environment variables for the harness program. Harness-owned endpoint,
     authentication, and model variables take precedence."""


### PR DESCRIPTION
## Summary

- Default `HarnessConfig.runtime` to `SubprocessConfig()` instead of `DockerConfig()`. Eval/train runs without an explicit `--harness.runtime.type` now run the harness as a local process — the common, dependency-free case — instead of trying to start a container.
- Tasksets that genuinely need a container opt in with `--harness.runtime.type docker` (or `prime`/`modal`). The container-requiring paths stay guarded: a task carrying a per-task `image` or a `NEEDS_CONTAINER` taskset already raises a clear error against the subprocess runtime, pointing at the docker/prime override.
- This aligns the harness with tool servers (`TasksetConfig.tools`) and the user simulator (`Taskset.user`), which already default to subprocess.
- Drop the now-redundant `runtime = { type = "subprocess" }` from the example configs (`alphabet_sort`, `textarena`, `wordle`, `gsm8k_rlm`); docker stays explicit where it's actually required (`terminal-bench-2`, `harbor`).
- `validate` keeps its docker default (a model-free gold check often needs the task's declared container, e.g. SWE rows); reworded its docs since they can no longer say "like `eval`".
- Updated the v1 README/GUIDE quickstart lines and runtime tables to mark subprocess as the default.

## Breaking

- The default harness runtime changes from docker to subprocess. Any eval/train/serve run that relied on the implicit docker default (no `--harness.runtime.type` set) now runs on the host as a local process. To keep the old behavior, pass `--harness.runtime.type docker` (or set `runtime = { type = "docker" }` under `[harness]` in the TOML). Tasksets that require a container are unaffected — they already need an explicit container runtime and error clearly otherwise.

## Verification

- `HarnessConfig().runtime` resolves to `SubprocessConfig`; `ValidateConfig().runtime` stays `DockerConfig`.
- The four edited example configs parse and resolve their harness runtime to `SubprocessConfig` via the new default.
- `ruff check` clean on changed files; `pytest tests/v1/test_configs.py -m "not slow"` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default `HarnessConfig` runtime to subprocess instead of docker
> Changes the default `runtime` field in `HarnessConfig` from `DockerConfig()` to `SubprocessConfig()`, so harnesses that don't explicitly set a runtime now run in a local subprocess. Config files and documentation are updated to remove now-redundant explicit subprocess runtime settings.
>
> Behavioral Change: any harness previously relying on the docker default without explicitly setting a runtime will now run in a subprocess instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8fa31c5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking for workflows that relied on implicit Docker for the harness; those runs now execute on the host unless `--harness.runtime.type docker` is set.
> 
> **Overview**
> **Eval harnesses now default to a local subprocess** instead of Docker when `[harness]` omits `runtime` or `--harness.runtime.type` is unset. `HarnessConfig.runtime` is `SubprocessConfig()`; container-heavy tasksets still opt in with `docker` / `prime` / `modal`.
> 
> Example TOMLs (`alphabet_sort`, `gsm8k_rlm`, `textarena`, `wordle`) drop redundant `runtime = { type = "subprocess" }`. **v1 README/GUIDE** quickstart and runtime sections label subprocess as the eval default.
> 
> **`validate` is unchanged** (`ValidateConfig` still defaults to Docker); docs now explain that gold checks often need the task container, unlike the eval harness default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fa31c54c7171faa305a10f27df19b9b626fecba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->