### PR TITLE
test(envs): keep test_envs.py v0-only, add tests/v1/test_envs.py for v1 envs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,4 +100,4 @@ jobs:
             export CHANGED_ENVS="${{ steps.changed-envs.outputs.all_changed_files || 'none' }}"
             echo "CHANGED_ENVS: $CHANGED_ENVS"
           fi
-          uv run pytest tests/test_envs.py -vv
+          uv run pytest tests/test_envs.py -vv -n auto

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,4 +100,4 @@ jobs:
             export CHANGED_ENVS="${{ steps.changed-envs.outputs.all_changed_files || 'none' }}"
             echo "CHANGED_ENVS: $CHANGED_ENVS"
           fi
-          uv run pytest tests/test_envs.py -vv -n auto
+          uv run pytest tests/test_envs.py -vv

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -9,7 +9,7 @@ import tomllib
 INSTALL_TIMEOUT = 600  # 10 minutes for venv creation + package install
 IMPORT_TIMEOUT = 120  # 2 minutes for importing a package
 LOAD_TIMEOUT = 300  # 5 minutes for loading an environment (may download datasets)
-EVAL_TIMEOUT = 600  # 10 minutes for running vf-eval with -n 1 -r 1
+EVAL_TIMEOUT = 600  # 10 minutes for running a capped eval (-n 1 -r 1)
 
 SKIPPED_ENVS = [
     # Requires fix for completion dataset setup
@@ -28,6 +28,12 @@ SKIPPED_ENVS = [
     # Uses prime-tunnel which is still experimental and has low usage limits
     "terminus_harbor",
     "opencode_harbor",
+    # v1 SWE / container tasksets: need a docker/prime runtime + image-backed
+    # sandboxes, so they can't run in plain CI — covered by dedicated v1 e2e tests.
+    "r2e_gym_v1",
+    "scaleswe_v1",
+    "swelego_v1",
+    "terminal_bench_2_v1",
 ]
 
 SKIPPED_ENV_LOADING_ENVS = [
@@ -38,6 +44,20 @@ SKIPPED_ENV_LOADING_ENVS = [
     # R2E-Gym pulls a full image-backed SWE taskset; cover it with dedicated v1 tests.
     "rlm_swe_v1",
 ]
+
+# v1 plugins are resolved by id (a `_v1` taskset, or the `compact` harness) instead of
+# `verifiers.load_environment`, so they don't follow the v0 hub-env conventions (tags +
+# README) and are evaluated through the unified `eval` CLI, not `vf-eval`.
+V1_HARNESSES = {"compact"}
+
+# Envs that install/import/load fine but can't run the capped smoke eval here:
+#   self_reward: scores only with @group_reward (no individual reward), but the v0 legacy
+#                `--id` bridge scores per-rollout (requires an individual-level reward).
+SKIPPED_EVAL_ENVS = {"self_reward"}
+
+
+def is_v1(env_dir: Path) -> bool:
+    return env_dir.name.endswith("_v1") or env_dir.name in V1_HARNESSES
 
 
 def get_environments() -> list[Path]:
@@ -67,7 +87,8 @@ def test_pyproject_exists(env_dir: Path):
 
 @pytest.mark.parametrize("env_dir", get_environments(), ids=lambda x: x.name)
 def test_pyproject_has_metadata(env_dir: Path):
-    """Test that the pyproject.toml file has the required metadata."""
+    """Test that the pyproject.toml file has the required metadata. `tags` are a v0 hub-env
+    convention, so they're only required of v0 envs (v1 plugins are resolved by id)."""
     with open(env_dir / "pyproject.toml", "rb") as f:
         pyproject = tomllib.load(f)
     assert "name" in pyproject["project"], "pyproject.toml does not have a name"
@@ -78,15 +99,19 @@ def test_pyproject_has_metadata(env_dir: Path):
     assert pyproject["project"]["description"] != "Your environment description here", (
         "Still uses placeholder description"
     )
-    assert "tags" in pyproject["project"], "pyproject.toml does not have tags"
-    assert pyproject["project"]["tags"] != ["placeholder-tag", "train", "eval"], (
-        "Still uses placeholder tags"
-    )
+    if not is_v1(env_dir):
+        assert "tags" in pyproject["project"], "pyproject.toml does not have tags"
+        assert pyproject["project"]["tags"] != ["placeholder-tag", "train", "eval"], (
+            "Still uses placeholder tags"
+        )
 
 
 @pytest.mark.parametrize("env_dir", get_environments(), ids=lambda x: x.name)
 def test_readme_exists(env_dir: Path):
-    """Test that the README.md file exists for the given environment directory."""
+    """Test that the README.md file exists for the given environment directory (v0 hub
+    convention; v1 plugins are documented in their module docstring instead)."""
+    if is_v1(env_dir):
+        pytest.skip(f"{env_dir.name} is a v1 plugin (no hub README requirement)")
     assert (env_dir / "README.md").exists(), "README.md does not exist"
 
 
@@ -130,66 +155,88 @@ def test_env(env_dir: Path, tmp_path_factory: pytest.TempPathFactory):
     help_test_can_eval_env(tmp_venv_dir, env_dir)
 
 
-def help_test_can_import_env(tmp_venv_dir: Path, env_dir: Path):
-    """Test that the environment can be imported as a package."""
-    import_cmd = f"cd {tmp_venv_dir} && source .venv/bin/activate && uv run python -c 'import {env_dir.name}'"
+def _run_in_venv(tmp_venv_dir: Path, inner: str, timeout: int, what: str, env_name: str):
+    cmd = f"cd {tmp_venv_dir} && source .venv/bin/activate && {inner}"
     try:
         process = subprocess.run(
-            import_cmd,
+            cmd,
             shell=True,
             executable="/bin/bash",
             capture_output=True,
             text=True,
-            timeout=IMPORT_TIMEOUT,
+            timeout=timeout,
         )
     except subprocess.TimeoutExpired:
-        pytest.fail(f"Timed out after {IMPORT_TIMEOUT}s importing {env_dir.name}")
-    assert process.returncode == 0, "Failed to import environment"
+        pytest.fail(f"Timed out after {timeout}s {what} {env_name}")
+    assert process.returncode == 0, (
+        f"Failed to {what} {env_name}: {(process.stderr or process.stdout)[-2000:]}"
+    )
+
+
+def help_test_can_import_env(tmp_venv_dir: Path, env_dir: Path):
+    """Test that the environment can be imported as a package."""
+    _run_in_venv(
+        tmp_venv_dir,
+        f"uv run python -c 'import {env_dir.name}'",
+        IMPORT_TIMEOUT,
+        "importing",
+        env_dir.name,
+    )
 
 
 def help_test_can_load_env(tmp_venv_dir: Path, env_dir: Path):
-    """Test that the environment can be loaded."""
-    load_cmd = f"""cd {tmp_venv_dir} && source .venv/bin/activate && uv run python -c 'import verifiers as vf; vf.load_environment("{env_dir.name}")'"""
-    try:
-        process = subprocess.run(
-            load_cmd,
-            shell=True,
-            executable="/bin/bash",
-            capture_output=True,
-            text=True,
-            timeout=LOAD_TIMEOUT,
+    """Test that the environment can be loaded — a v0 env via `verifiers.load_environment`,
+    a v1 plugin via its id-based loader (taskset, or harness for `compact`)."""
+    if env_dir.name in V1_HARNESSES:
+        inner = (
+            f"uv run python -c 'from verifiers.v1.loaders import harness_class; "
+            f'harness_class("{env_dir.name}")\''
         )
-    except subprocess.TimeoutExpired:
-        pytest.fail(f"Timed out after {LOAD_TIMEOUT}s loading {env_dir.name}")
-    assert process.returncode == 0, "Failed to load environment"
+    elif is_v1(env_dir):
+        inner = (
+            f"uv run python -c 'from verifiers.v1.loaders import taskset_class; "
+            f'taskset_class("{env_dir.name}")\''
+        )
+    else:
+        inner = (
+            f'uv run python -c \'import verifiers as vf; vf.load_environment("{env_dir.name}")\''
+        )
+    _run_in_venv(tmp_venv_dir, inner, LOAD_TIMEOUT, "loading", env_dir.name)
 
 
 def help_test_can_eval_env(tmp_venv_dir: Path, env_dir: Path):
-    """Test that the environment can be run via vf-eval."""
-    if env_dir.name == "tau2_bench_v1" and not os.getenv("PRIME_API_KEY"):
-        pytest.skip(
-            "Skipping tau2 default eval because PRIME_API_KEY is not configured"
-        )
+    """Smoke-eval the environment through the unified `eval` CLI: a v1 taskset via
+    `--taskset.id`/`--harness.id`, a v0 env via the legacy `--id` bridge. Capped to one
+    short rollout so CI stays quick."""
+    if env_dir.name in V1_HARNESSES:
+        pytest.skip(f"{env_dir.name} is a harness, not an evaluatable taskset")
+    if env_dir.name in SKIPPED_EVAL_ENVS:
+        pytest.skip(f"{env_dir.name}: not runnable via the capped `eval` smoke test")
     if os.getenv("PRIME_API_KEY"):
-        model_flags = "-m openai/gpt-4.1-mini -b https://api.pinference.ai/api/v1 -k PRIME_API_KEY"
-    elif os.getenv("OPENAI_API_KEY"):
-        model_flags = "-m gpt-4.1-mini -b https://api.openai.com/v1 -k OPENAI_API_KEY"
-    else:
-        pytest.skip("Skipping vf-eval smoke test because no API key is configured")
-
-    eval_cmd = (
-        f"cd {tmp_venv_dir} && source .venv/bin/activate && "
-        f"uv run vf-eval {env_dir.name} {model_flags} -n 1 -r 1 -t 512"
-    )
-    try:
-        process = subprocess.run(
-            eval_cmd,
-            shell=True,
-            executable="/bin/bash",
-            capture_output=True,
-            text=True,
-            timeout=EVAL_TIMEOUT,
+        model_flags = (
+            "-m openai/gpt-4.1-mini "
+            "--client.base-url https://api.pinference.ai/api/v1 "
+            "--client.api-key-var PRIME_API_KEY"
         )
-    except subprocess.TimeoutExpired:
-        pytest.fail(f"Timed out after {EVAL_TIMEOUT}s evaluating {env_dir.name}")
-    assert process.returncode == 0, "Failed to evaluate environment"
+    elif os.getenv("OPENAI_API_KEY"):
+        model_flags = (
+            "-m gpt-4.1-mini "
+            "--client.base-url https://api.openai.com/v1 "
+            "--client.api-key-var OPENAI_API_KEY"
+        )
+    else:
+        pytest.skip("Skipping eval smoke test because no API key is configured")
+
+    # `-r 2`: a taskset with @group_reward(s) needs >=2 rollouts to compare.
+    caps = "-n 1 -r 2 --max-turns 4 --sampling.max-tokens 512 --rich false"
+    if is_v1(env_dir):
+        selector = f"--taskset.id {env_dir.name} --harness.id default"
+    else:
+        selector = f"--id {env_dir.name}"
+    _run_in_venv(
+        tmp_venv_dir,
+        f"uv run eval {selector} {model_flags} {caps}",
+        EVAL_TIMEOUT,
+        "evaluating",
+        env_dir.name,
+    )

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -9,7 +9,7 @@ import tomllib
 INSTALL_TIMEOUT = 600  # 10 minutes for venv creation + package install
 IMPORT_TIMEOUT = 120  # 2 minutes for importing a package
 LOAD_TIMEOUT = 300  # 5 minutes for loading an environment (may download datasets)
-EVAL_TIMEOUT = 600  # 10 minutes for running a capped eval (-n 1 -r 1)
+EVAL_TIMEOUT = 600  # 10 minutes for running vf-eval with -n 1 -r 1
 
 SKIPPED_ENVS = [
     # Requires fix for completion dataset setup
@@ -28,12 +28,6 @@ SKIPPED_ENVS = [
     # Uses prime-tunnel which is still experimental and has low usage limits
     "terminus_harbor",
     "opencode_harbor",
-    # v1 SWE / container tasksets: need a docker/prime runtime + image-backed
-    # sandboxes, so they can't run in plain CI — covered by dedicated v1 e2e tests.
-    "r2e_gym_v1",
-    "scaleswe_v1",
-    "swelego_v1",
-    "terminal_bench_2_v1",
 ]
 
 SKIPPED_ENV_LOADING_ENVS = [
@@ -45,20 +39,6 @@ SKIPPED_ENV_LOADING_ENVS = [
     "rlm_swe_v1",
 ]
 
-# v1 plugins are resolved by id (a `_v1` taskset, or the `compact` harness) instead of
-# `verifiers.load_environment`, so they don't follow the v0 hub-env conventions (tags +
-# README) and are evaluated through the unified `eval` CLI, not `vf-eval`.
-V1_HARNESSES = {"compact"}
-
-# Envs that install/import/load fine but can't run the capped smoke eval here:
-#   self_reward: scores only with @group_reward (no individual reward), but the v0 legacy
-#                `--id` bridge scores per-rollout (requires an individual-level reward).
-SKIPPED_EVAL_ENVS = {"self_reward"}
-
-
-def is_v1(env_dir: Path) -> bool:
-    return env_dir.name.endswith("_v1") or env_dir.name in V1_HARNESSES
-
 
 def get_environments() -> list[Path]:
     """Get all subdirectories of `environments/`, or only changed environments if CHANGED_ENVS is set."""
@@ -66,6 +46,14 @@ def get_environments() -> list[Path]:
 
     # Filter out skipped environments
     all_envs = [env for env in all_envs if env.name not in SKIPPED_ENVS]
+
+    # These are v0 smoke tests (vf.load_environment + vf-eval). The v1 plugins (the `_v1`
+    # tasksets + the `compact` harness) are id-referenced and covered by tests/v1/test_envs.py.
+    all_envs = [
+        env
+        for env in all_envs
+        if not env.name.endswith("_v1") and env.name != "compact"
+    ]
 
     # Filter environments if CHANGED_ENVS is set (for PRs)
     changed_envs = os.getenv("CHANGED_ENVS")
@@ -87,8 +75,7 @@ def test_pyproject_exists(env_dir: Path):
 
 @pytest.mark.parametrize("env_dir", get_environments(), ids=lambda x: x.name)
 def test_pyproject_has_metadata(env_dir: Path):
-    """Test that the pyproject.toml file has the required metadata. `tags` are a v0 hub-env
-    convention, so they're only required of v0 envs (v1 plugins are resolved by id)."""
+    """Test that the pyproject.toml file has the required metadata."""
     with open(env_dir / "pyproject.toml", "rb") as f:
         pyproject = tomllib.load(f)
     assert "name" in pyproject["project"], "pyproject.toml does not have a name"
@@ -99,19 +86,15 @@ def test_pyproject_has_metadata(env_dir: Path):
     assert pyproject["project"]["description"] != "Your environment description here", (
         "Still uses placeholder description"
     )
-    if not is_v1(env_dir):
-        assert "tags" in pyproject["project"], "pyproject.toml does not have tags"
-        assert pyproject["project"]["tags"] != ["placeholder-tag", "train", "eval"], (
-            "Still uses placeholder tags"
-        )
+    assert "tags" in pyproject["project"], "pyproject.toml does not have tags"
+    assert pyproject["project"]["tags"] != ["placeholder-tag", "train", "eval"], (
+        "Still uses placeholder tags"
+    )
 
 
 @pytest.mark.parametrize("env_dir", get_environments(), ids=lambda x: x.name)
 def test_readme_exists(env_dir: Path):
-    """Test that the README.md file exists for the given environment directory (v0 hub
-    convention; v1 plugins are documented in their module docstring instead)."""
-    if is_v1(env_dir):
-        pytest.skip(f"{env_dir.name} is a v1 plugin (no hub README requirement)")
+    """Test that the README.md file exists for the given environment directory."""
     assert (env_dir / "README.md").exists(), "README.md does not exist"
 
 
@@ -155,88 +138,66 @@ def test_env(env_dir: Path, tmp_path_factory: pytest.TempPathFactory):
     help_test_can_eval_env(tmp_venv_dir, env_dir)
 
 
-def _run_in_venv(
-    tmp_venv_dir: Path, inner: str, timeout: int, what: str, env_name: str
-):
-    cmd = f"cd {tmp_venv_dir} && source .venv/bin/activate && {inner}"
+def help_test_can_import_env(tmp_venv_dir: Path, env_dir: Path):
+    """Test that the environment can be imported as a package."""
+    import_cmd = f"cd {tmp_venv_dir} && source .venv/bin/activate && uv run python -c 'import {env_dir.name}'"
     try:
         process = subprocess.run(
-            cmd,
+            import_cmd,
             shell=True,
             executable="/bin/bash",
             capture_output=True,
             text=True,
-            timeout=timeout,
+            timeout=IMPORT_TIMEOUT,
         )
     except subprocess.TimeoutExpired:
-        pytest.fail(f"Timed out after {timeout}s {what} {env_name}")
-    assert process.returncode == 0, (
-        f"Failed to {what} {env_name}: {(process.stderr or process.stdout)[-2000:]}"
-    )
-
-
-def help_test_can_import_env(tmp_venv_dir: Path, env_dir: Path):
-    """Test that the environment can be imported as a package."""
-    _run_in_venv(
-        tmp_venv_dir,
-        f"uv run python -c 'import {env_dir.name}'",
-        IMPORT_TIMEOUT,
-        "importing",
-        env_dir.name,
-    )
+        pytest.fail(f"Timed out after {IMPORT_TIMEOUT}s importing {env_dir.name}")
+    assert process.returncode == 0, "Failed to import environment"
 
 
 def help_test_can_load_env(tmp_venv_dir: Path, env_dir: Path):
-    """Test that the environment can be loaded — a v0 env via `verifiers.load_environment`,
-    a v1 plugin via its id-based loader (taskset, or harness for `compact`)."""
-    if env_dir.name in V1_HARNESSES:
-        inner = (
-            f"uv run python -c 'from verifiers.v1.loaders import harness_class; "
-            f'harness_class("{env_dir.name}")\''
+    """Test that the environment can be loaded."""
+    load_cmd = f"""cd {tmp_venv_dir} && source .venv/bin/activate && uv run python -c 'import verifiers as vf; vf.load_environment("{env_dir.name}")'"""
+    try:
+        process = subprocess.run(
+            load_cmd,
+            shell=True,
+            executable="/bin/bash",
+            capture_output=True,
+            text=True,
+            timeout=LOAD_TIMEOUT,
         )
-    elif is_v1(env_dir):
-        inner = (
-            f"uv run python -c 'from verifiers.v1.loaders import taskset_class; "
-            f'taskset_class("{env_dir.name}")\''
-        )
-    else:
-        inner = f"uv run python -c 'import verifiers as vf; vf.load_environment(\"{env_dir.name}\")'"
-    _run_in_venv(tmp_venv_dir, inner, LOAD_TIMEOUT, "loading", env_dir.name)
+    except subprocess.TimeoutExpired:
+        pytest.fail(f"Timed out after {LOAD_TIMEOUT}s loading {env_dir.name}")
+    assert process.returncode == 0, "Failed to load environment"
 
 
 def help_test_can_eval_env(tmp_venv_dir: Path, env_dir: Path):
-    """Smoke-eval the environment through the unified `eval` CLI: a v1 taskset via
-    `--taskset.id`/`--harness.id`, a v0 env via the legacy `--id` bridge. Capped to one
-    short rollout so CI stays quick."""
-    if env_dir.name in V1_HARNESSES:
-        pytest.skip(f"{env_dir.name} is a harness, not an evaluatable taskset")
-    if env_dir.name in SKIPPED_EVAL_ENVS:
-        pytest.skip(f"{env_dir.name}: not runnable via the capped `eval` smoke test")
+    """Test that the environment can be run via vf-eval."""
+    if env_dir.name == "tau2_bench_v1" and not os.getenv("PRIME_API_KEY"):
+        pytest.skip(
+            "Skipping tau2 default eval because PRIME_API_KEY is not configured"
+        )
     if os.getenv("PRIME_API_KEY"):
-        model_flags = (
-            "-m openai/gpt-4.1-mini "
-            "--client.base-url https://api.pinference.ai/api/v1 "
-            "--client.api-key-var PRIME_API_KEY"
-        )
+        model_flags = "-m openai/gpt-4.1-mini -b https://api.pinference.ai/api/v1 -k PRIME_API_KEY"
     elif os.getenv("OPENAI_API_KEY"):
-        model_flags = (
-            "-m gpt-4.1-mini "
-            "--client.base-url https://api.openai.com/v1 "
-            "--client.api-key-var OPENAI_API_KEY"
-        )
+        model_flags = "-m gpt-4.1-mini -b https://api.openai.com/v1 -k OPENAI_API_KEY"
     else:
-        pytest.skip("Skipping eval smoke test because no API key is configured")
+        pytest.skip("Skipping vf-eval smoke test because no API key is configured")
 
-    # `-r 2`: a taskset with @group_reward(s) needs >=2 rollouts to compare.
-    caps = "-n 1 -r 2 --max-turns 4 --sampling.max-tokens 512 --rich false"
-    if is_v1(env_dir):
-        selector = f"--taskset.id {env_dir.name} --harness.id default"
-    else:
-        selector = f"--id {env_dir.name}"
-    _run_in_venv(
-        tmp_venv_dir,
-        f"uv run eval {selector} {model_flags} {caps}",
-        EVAL_TIMEOUT,
-        "evaluating",
-        env_dir.name,
+    eval_cmd = (
+        f"cd {tmp_venv_dir} && source .venv/bin/activate && "
+        f"uv run vf-eval {env_dir.name} {model_flags} -n 1 -r 1 -t 512"
     )
+    try:
+        process = subprocess.run(
+            eval_cmd,
+            shell=True,
+            executable="/bin/bash",
+            capture_output=True,
+            text=True,
+            timeout=EVAL_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired:
+        pytest.fail(f"Timed out after {EVAL_TIMEOUT}s evaluating {env_dir.name}")
+    assert process.returncode == 0, "Failed to evaluate environment"

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -155,7 +155,9 @@ def test_env(env_dir: Path, tmp_path_factory: pytest.TempPathFactory):
     help_test_can_eval_env(tmp_venv_dir, env_dir)
 
 
-def _run_in_venv(tmp_venv_dir: Path, inner: str, timeout: int, what: str, env_name: str):
+def _run_in_venv(
+    tmp_venv_dir: Path, inner: str, timeout: int, what: str, env_name: str
+):
     cmd = f"cd {tmp_venv_dir} && source .venv/bin/activate && {inner}"
     try:
         process = subprocess.run(
@@ -198,9 +200,7 @@ def help_test_can_load_env(tmp_venv_dir: Path, env_dir: Path):
             f'taskset_class("{env_dir.name}")\''
         )
     else:
-        inner = (
-            f'uv run python -c \'import verifiers as vf; vf.load_environment("{env_dir.name}")\''
-        )
+        inner = f"uv run python -c 'import verifiers as vf; vf.load_environment(\"{env_dir.name}\")'"
     _run_in_venv(tmp_venv_dir, inner, LOAD_TIMEOUT, "loading", env_dir.name)
 
 

--- a/tests/v1/test_envs.py
+++ b/tests/v1/test_envs.py
@@ -1,0 +1,69 @@
+"""Smoke-eval every v1 example taskset in `environments/` through the `eval` CLI.
+
+The v0 counterpart (`tests/test_envs.py`) covers v0 envs (`vf.load_environment` + `vf-eval`);
+here we run each `_v1` taskset with the default harness for one short, capped rollout and
+require it to succeed — so a broken example taskset fails CI. `compact` is excluded (it's a
+harness, not a taskset); SWE/container tasksets need a docker/prime runtime and are covered by
+the dedicated v1 e2e tests instead.
+"""
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+EVAL_TIMEOUT = 600  # 10 minutes for a capped eval (-n 1 -r 2)
+
+ENVIRONMENTS = Path(__file__).parent.parent.parent / "environments"
+
+# v1 tasksets that need a docker/prime runtime + image-backed sandboxes, so they can't run a
+# smoke eval in plain CI — covered by the dedicated v1 e2e tests.
+NEEDS_CONTAINER = {"r2e_gym_v1", "scaleswe_v1", "swelego_v1", "terminal_bench_2_v1"}
+
+
+def v1_tasksets() -> list[str]:
+    if not ENVIRONMENTS.is_dir():
+        return []
+    return sorted(
+        d.name for d in ENVIRONMENTS.iterdir() if d.is_dir() and d.name.endswith("_v1")
+    )
+
+
+@pytest.mark.parametrize("taskset", v1_tasksets())
+def test_eval(taskset: str):
+    """Run one capped rollout of `taskset` with the default harness and require success."""
+    if taskset in NEEDS_CONTAINER:
+        pytest.skip(f"{taskset} needs a docker/prime runtime (covered by v1 e2e tests)")
+    if os.getenv("PRIME_API_KEY"):
+        model = [
+            "-m", "openai/gpt-4.1-mini",
+            "--client.base-url", "https://api.pinference.ai/api/v1",
+            "--client.api-key-var", "PRIME_API_KEY",
+        ]  # fmt: skip
+    elif os.getenv("OPENAI_API_KEY"):
+        model = [
+            "-m", "gpt-4.1-mini",
+            "--client.base-url", "https://api.openai.com/v1",
+            "--client.api-key-var", "OPENAI_API_KEY",
+        ]  # fmt: skip
+    else:
+        pytest.skip("no model API key configured")
+
+    cmd = [
+        "uv", "run", "--no-sync", "eval",
+        "--taskset.id", taskset, "--harness.id", "default",
+        *model,
+        # -r 2: a taskset with @group_reward(s) needs >=2 rollouts to compare.
+        "-n", "1", "-r", "2", "--max-turns", "4",
+        "--sampling.max-tokens", "512", "--rich", "false",
+    ]  # fmt: skip
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=EVAL_TIMEOUT)
+    except subprocess.TimeoutExpired:
+        pytest.fail(f"Timed out after {EVAL_TIMEOUT}s evaluating {taskset}")
+    assert proc.returncode == 0, (
+        f"eval {taskset} failed: {(proc.stderr or proc.stdout)[-2000:]}"
+    )


### PR DESCRIPTION
## Summary

Split the env smoke tests by version instead of forcing the v0 contract onto v1 plugins.

- **`tests/test_envs.py` stays as-is, but v0-only.** `get_environments()` now filters out the `_v1` tasksets and the `compact` harness, so the v0 checks (`vf.load_environment` + `vf-eval`, `tags`/README metadata) only run on v0 envs — no more v1 failures there.
- **New `tests/v1/test_envs.py`.** Smoke-evals every `_v1` taskset in `environments/` through the unified `eval` CLI (`--taskset.id <id> --harness.id default`) for one short capped rollout (`-n 1 -r 2 --max-turns 4 --sampling.max-tokens 512 --rich false`) and requires success. Marked `e2e`, so it skips without a model key and runs with one (the `test` job sets `PRIME_API_KEY`). `-r 2` because a taskset with `@group_reward`s needs ≥2 rollouts.
  - `compact` is excluded (a harness, not a taskset).
  - The SWE/container tasksets (`r2e_gym_v1`, `scaleswe_v1`, `swelego_v1`, `terminal_bench_2_v1`) skip — they need a docker/prime runtime and are covered by the dedicated v1 e2e tests.

## Verification

- `tests/v1/test_envs.py`: **12 passed, 4 skipped** locally (every runnable `_v1` taskset evaluates through `eval` with a real model).
- `tests/test_envs.py` now collects v0 envs only (no `_v1`, no `compact`).
- `ruff check` + `ruff format --check` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor with no production code changes; CI may gain additional e2e eval time when API keys are set.
> 
> **Overview**
> **Splits environment smoke coverage by version** so v0 checks no longer run against v1 plugins.
> 
> `get_environments()` in `tests/test_envs.py` now drops directories ending in `_v1` and the `compact` harness, keeping the existing `vf.load_environment` / `vf-eval` and metadata tests on v0 envs only.
> 
> **Adds `tests/v1/test_envs.py`**, which parametrizes over every `_v1` taskset under `environments/` and runs a capped `eval` CLI smoke (`--taskset.id`, `--harness.id default`, `-n 1 -r 2`, low turn/token limits). Tests are marked `e2e` and skip without `PRIME_API_KEY` or `OPENAI_API_KEY`. Four container-backed tasksets (`r2e_gym_v1`, `scaleswe_v1`, `swelego_v1`, `terminal_bench_2_v1`) are skipped here in favor of dedicated v1 e2e coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94612a7f3f31b4086fb4bac043f8f4c3890e32f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep `tests/test_envs.py` v0-only and add `tests/v1/test_envs.py` for v1 tasksets
> - [tests/test_envs.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1721/files#diff-322278bedd5f93c63d9ecb9703956bc1b75262db3c52e4432954b5ad4f080e17) now filters out environments ending with `_v1` and the `compact` harness, so its parametrized suite covers only v0 environments.
> - [tests/v1/test_envs.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1721/files#diff-7c694d14edc9f77a0d330e4121024e79ba615b135a5e8f2da634bdd15a52b794) discovers tasksets by scanning for subdirectories ending with `_v1` and runs a smoke eval via subprocess for each, using `uv run --no-sync eval` with one eval, two rollouts, max-turns 4, and max-tokens 512.
> - Tests skip if neither `PRIME_API_KEY` nor `OPENAI_API_KEY` is set, or if the taskset is listed in `NEEDS_CONTAINER`.
> - Behavioral Change: v1 test runs spawn external processes and enforce a 600s timeout per taskset.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 94612a7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->