### PR TITLE
Warn when non-default harnesses use the local subprocess runtime

### DIFF
--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -57,6 +57,16 @@ def Overview(config: EvalConfig) -> Table:
         "env",
         f"{config.taskset.name}  ·  {config.harness.name} harness  ·  {config.harness.runtime.type} runtime",
     )
+    if config.harness.id != "default" and config.harness.runtime.type == "subprocess":
+        grid.add_row(
+            "warning",
+            Text(
+                "Runs on the local system; local files and settings may affect this "
+                "evaluation. Use subprocess only for debugging, or use docker or prime "
+                "for an isolated run.",
+                style="yellow",
+            ),
+        )
     grid.add_row("model", f"{config.model}  ({sampling})")
     grid.add_row("output", str(output_path(config)))
     return grid

--- a/verifiers/v1/env.py
+++ b/verifiers/v1/env.py
@@ -251,6 +251,16 @@ class Environment:
                 "(NEEDS_CONTAINER), but the harness runs on the subprocess runtime; "
                 "use --harness.runtime.type docker or prime."
             )
+        if self.harness.config.id != "default" and isinstance(
+            self.harness.config.runtime, SubprocessConfig
+        ):
+            logger.warning(
+                "Harness %r is running in the subprocess runtime on the local system. "
+                "Local files and settings may affect the evaluation; use subprocess only "
+                "for debugging. Use --harness.runtime.type docker or prime for an isolated "
+                "run.",
+                self.harness.config.id,
+            )
         self.setup_timeout = config.timeout.setup
         self.harness_timeout = config.timeout.rollout
         self.finalize_timeout = config.timeout.finalize


### PR DESCRIPTION
## Overview

Warn users when a non-default harness runs through the local subprocess runtime, where host files and settings can affect evaluation behavior.

## Details

- Emit a warning during environment construction for log-based evaluation paths.
- Surface the same guidance in the rich evaluation dashboard.
- Direct users to Docker or Prime when they need an isolated run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing warnings only; no change to execution, validation, or scoring behavior.
> 
> **Overview**
> Adds **soft warnings** when a **non-default harness** runs on the **subprocess** runtime, where the host machine can influence eval results.
> 
> On **`Environment`** construction, a **log warning** is emitted (alongside the existing hard error for tasksets that **require** containers). The **rich eval dashboard** `Overview` shows the same message as a **yellow “warning”** row when `harness.id != "default"` and `runtime.type == "subprocess"`. Both tell users to treat subprocess as **debug-only** and use **docker** or **prime** for isolation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ead1e4b9667569f4afc18ffb904a2ab71d4e863. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Warn when non-default harnesses use the local subprocess runtime
> Adds a warning when a non-default harness is configured with the subprocess runtime, since this runs on the local system and local files or settings may affect evaluation. The warning appears in two places: as a log message in [`Environment.__init__`](https://github.com/PrimeIntellect-ai/verifiers/pull/1722/files#diff-69be10bd5960e88d88f219d4f261d0bdd16586857f9126451b04d05bac4c2cbb) and as a yellow warning row in the eval dashboard overview in [`eval.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1722/files#diff-0a27b905958929f3ae9e01937dd7e3cf97a60dec137caddcbf87792784fc9035). Both recommend using Docker or Prime for isolation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5ead1e4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->