### PR TITLE
Add per-harness tool disabling

### DIFF
--- a/packages/harnesses/harnesses/codex/harness.py
+++ b/packages/harnesses/harnesses/codex/harness.py
@@ -78,6 +78,13 @@ class CodexHarness(Harness[CodexHarnessConfig]):
         install = await runtime.run(["sh", "-c", guarded], {})
         if install.exit_code != 0:
             raise ProgramError(f"codex install failed: {install.stderr.strip()[-500:]}")
+        # Values are Codex feature names such as `shell_tool`; Codex owns validation.
+        # https://developers.openai.com/codex/config-reference#features
+        tool_config = [
+            arg
+            for tool in self.config.disabled_tools or []
+            for arg in ("--disable", tool)
+        ]
         # `-c` values parse as TOML, falling back to a raw string (so the url / `responses`
         # come through literally); `requires_openai_auth=false` parses as a bool.
         argv = [
@@ -99,6 +106,7 @@ class CodexHarness(Harness[CodexHarnessConfig]):
             f"model_providers.{PROVIDER}.wire_api=responses",
             "-c",
             f"model_providers.{PROVIDER}.requires_openai_auth=false",
+            *tool_config,
             instruction,
         ]
         return await runtime.run(argv, env)

--- a/packages/harnesses/harnesses/default/harness.py
+++ b/packages/harnesses/harnesses/default/harness.py
@@ -49,7 +49,10 @@ class DefaultHarness(Harness[DefaultHarnessConfig]):
         mcp_urls: dict[str, str],
     ) -> ProgramResult:
         system_prompt, instruction = self.resolve_prompt(trace.task)
-        if self.config.enable_bash:
+        enable_bash = self.config.enable_bash and "bash" not in (
+            self.config.disabled_tools or []
+        )
+        if enable_bash:
             system_prompt = "\n\n".join(
                 p for p in (BASH_SYSTEM_PROMPT, system_prompt) if p
             )
@@ -58,7 +61,7 @@ class DefaultHarness(Harness[DefaultHarnessConfig]):
             "OPENAI_BASE_URL": endpoint,
             "OPENAI_API_KEY": secret,
             "OPENAI_MODEL": ctx.model,
-            "ENABLE_BASH": "1" if self.config.enable_bash else "0",
+            "ENABLE_BASH": "1" if enable_bash else "0",
             "APPEND_SYSTEM_PROMPT": system_prompt or "",
         }
         if mcp_urls:

--- a/packages/harnesses/harnesses/kimi_code/harness.py
+++ b/packages/harnesses/harnesses/kimi_code/harness.py
@@ -86,6 +86,22 @@ class KimiCodeHarness(Harness[KimiCodeHarnessConfig]):
             )
 
         mcp = {"mcpServers": {name: {"url": url} for name, url in mcp_urls.items()}}
+        # Values are Kimi permission patterns such as `Bash` or `Bash(rm -rf*)`.
+        # https://moonshotai.github.io/kimi-code/en/configuration/config-files#permission
+        permission_rules = "\n".join(
+            "\n".join(
+                (
+                    "[[permission.rules]]",
+                    'decision = "deny"',
+                    'scope = "user"',
+                    f"pattern = {json.dumps(tool)}",
+                    'reason = "Disabled by Verifiers harness configuration."',
+                )
+            )
+            for tool in self.config.disabled_tools or []
+        )
+        if permission_rules:
+            await runtime.write(f"{KIMI_HOME}/config.toml", permission_rules.encode())
         await runtime.write(f"{KIMI_HOME}/mcp.json", json.dumps(mcp).encode())
         # `--prompt` is Kimi Code's non-interactive print mode.
         return await runtime.run([BINARY, "--prompt", instruction], env)

--- a/packages/harnesses/harnesses/mini_swe_agent/harness.py
+++ b/packages/harnesses/harnesses/mini_swe_agent/harness.py
@@ -31,6 +31,8 @@ class MiniSWEAgentHarness(Harness[MiniSWEAgentHarnessConfig]):
         secret: str,
         mcp_urls: dict[str, str],
     ) -> ProgramResult:
+        if self.config.disabled_tools:
+            raise ValueError("mini-swe-agent does not support disabling tools")
         _, instruction = self.resolve_prompt(trace.task)
         args = [
             "--model",

--- a/packages/harnesses/harnesses/rlm/harness.py
+++ b/packages/harnesses/harnesses/rlm/harness.py
@@ -64,8 +64,12 @@ class RLMHarness(Harness[RLMHarnessConfig]):
         }
         if system_prompt is not None:
             env["RLM_APPEND_TO_SYSTEM_PROMPT"] = system_prompt
-        if self.config.tools is not None:
-            env["RLM_TOOLS"] = ",".join(self.config.tools)
+        if self.config.tools is not None or self.config.disabled_tools:
+            tools = self.config.tools if self.config.tools is not None else ["ipython"]
+            disabled_tools = set(self.config.disabled_tools or [])
+            env["RLM_TOOLS"] = ",".join(
+                tool for tool in tools if tool not in disabled_tools
+            )
         # Install rlm only if the binary isn't already there (no runtime-type checks): a no-op
         # where it's present, a fresh install otherwise. install.sh fetches curl/uv (and git,
         # via the runtime's package manager) itself when missing, so the only thing we add is

--- a/verifiers/v1/harness.py
+++ b/verifiers/v1/harness.py
@@ -50,6 +50,8 @@ class HarnessConfig(BaseConfig):
     env: dict[str, str] = Field(default_factory=dict)
     """Additional environment variables for the harness program. Harness-owned endpoint,
     authentication, and model variables take precedence."""
+    disabled_tools: list[str] | None = None
+    """Harness-specific tool names to disable."""
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
## Overview

Add an optional `disabled_tools` list to V1 harness configuration and translate those names through each harness's native tool controls. Tool names are harness-specific, and task-owned MCP tools remain unchanged.

## CLI setup

For example, run Kimi Code in Docker while denying its `Bash` and `Write` tools:

```bash
uv run eval gsm8k-v1 \
  --harness.id kimi-code \
  --harness.runtime.type docker \
  --harness.disabled-tools Bash Write
```

## TOML setup

The equivalent configuration is:

```toml
num_tasks = 1

[taskset]
id = "gsm8k-v1"

[harness]
id = "kimi-code"
runtime = { type = "docker" }
disabled_tools = ["Bash", "Write"]
```

## Harness behavior

- The default harness recognizes `bash` and suppresses its opt-in bash tool.
- Codex forwards feature names such as `shell_tool` through repeated `--disable` arguments.
- RLM removes names such as `ipython` from its configured built-in tool set.
- Kimi Code writes static deny permission rules for patterns such as `Bash`, `Write`, or `Bash(rm -rf*)`.
- mini-swe-agent cannot disable its native tools and raises an error when `disabled_tools` is configured.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `disabled_tools` config field to per-harness tool disabling
> Adds an optional `disabled_tools: list[str] | None` field to `HarnessConfig` and implements it differently per harness:
> - [codex/harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1723/files#diff-3fcf41ec082917a3c3ee1d3025d225deeef740cef1e0d36fda152403eb17505e): passes `--disable <tool>` CLI flags to the Codex process
> - [default/harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1723/files#diff-ba919078d5a21cb75a7ccf31926f5fb794e176f71940e3c24d98e98ed2d6d3ed): suppresses the Bash system prompt and sets `ENABLE_BASH=0` if `bash` is in `disabled_tools`
> - [kimi_code/harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1723/files#diff-53b398dd7185324fe13275f044d19ab09f3786652d18f0335ee5cb1643a34406): writes TOML deny rules to `config.toml` before launch
> - [rlm/harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1723/files#diff-7584c8a365dfca01f409c655799153ef7388d852da78db0068d9bd1c1d92ae0a): filters `RLM_TOOLS`, defaulting to `['ipython']` when `tools` is unset
> - [mini_swe_agent/harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1723/files#diff-1bbc83d9af75642ac51399b4df6251212c43591b1e7afd6e4b1ce0f057ad9663): raises `ValueError` immediately — tool disabling is not supported
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c75bb2a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->