### PR TITLE
Add Prime image builds for Harbor tasks

### DIFF
--- a/packages/tasksets/tasksets/harbor_v1/images.py
+++ b/packages/tasksets/tasksets/harbor_v1/images.py
@@ -2,113 +2,74 @@
 
 import os
 import re
-import tarfile
-import tempfile
+import subprocess
 import time
 import tomllib
 from pathlib import Path
 
-import httpx
-from prime_sandboxes import APIClient, APIError
+from prime_sandboxes import APIClient
 
 IMAGE_TAG = "latest"
-IMAGE_PAGE_SIZE = 250
+IMAGE_SEARCH_LIMIT = 10_000
 IMAGE_BUILD_TIMEOUT = 600.0
 IMAGE_POLL_INTERVAL = 5.0
-ACTIVE_STATUSES = {"PENDING", "BUILDING", "UPLOADING"}
+ACTIVE_STATUSES = frozenset({"PENDING", "BUILDING", "UPLOADING"})
 
 ImageRow = dict[str, object]
 
 
 def prime_image_name(dataset: str, task_dir: Path) -> str:
     """Return the stable Prime image name for a Harbor dataset task."""
-    dataset_name = dataset.split("@", 1)[0].rsplit("/", 1)[-1]
-    source = (
-        dataset_name
-        if task_dir.name == dataset_name
-        else f"{dataset_name}-{task_dir.name}"
-    )
-    image_name = re.sub(r"[^a-z0-9._-]+", "-", source.lower()).strip("._-")
+    source = f"{dataset}-{task_dir.name}".lower()
+    image_name = re.sub(r"[^a-z0-9._-]+", "-", source).strip("._-")
     if not image_name:
         raise ValueError(f"cannot derive a Prime image name for {task_dir}")
     return f"{image_name}:{IMAGE_TAG}"
 
 
 def _find_prime_images(client: APIClient, targets: set[str]) -> dict[str, ImageRow]:
-    """Find the newest container-image row for each target."""
+    """Find the best available container-image row for each target."""
     names = sorted(image.rsplit(":", 1)[0] for image in targets)
-    search = os.path.commonprefix(names)
+    params: dict[str, str | int] = {
+        "limit": IMAGE_SEARCH_LIMIT,
+        "search": os.path.commonprefix(names),
+    }
+    if client.config.team_id:
+        params["teamId"] = client.config.team_id
+
     found: dict[str, ImageRow] = {}
-    offset = 0
-
-    while True:
-        params: dict[str, str | int] = {
-            "limit": IMAGE_PAGE_SIZE,
-            "offset": offset,
-            "search": search,
-        }
-        if client.config.team_id:
-            params["teamId"] = client.config.team_id
-        try:
-            response = client.request("GET", "/images", params=params)
-        except APIError as error:
-            raise RuntimeError(f"failed to search Prime images: {error}") from error
-
-        rows = response.get("data", [])
-        for row in rows:
-            name, tag = row.get("imageName"), row.get("imageTag")
-            image = f"{name}:{tag}"
-            if (
-                image in targets
-                and image not in found
-                and row.get("artifactType") == "CONTAINER_IMAGE"
-            ):
-                found[image] = row
-        offset += len(rows)
-        total_count = int(response.get("total_count", offset))
-        if targets <= found.keys() or not rows or offset >= total_count:
-            break
+    for row in client.request("GET", "/images", params=params)["data"]:
+        image = f"{row.get('imageName')}:{row.get('imageTag')}"
+        if image not in targets or row.get("artifactType") != "CONTAINER_IMAGE":
+            continue
+        current = found.get(image)
+        if current and (
+            current.get("status") == "COMPLETED"
+            or row.get("status") != "COMPLETED"
+            and current.get("status") in ACTIVE_STATUSES
+        ):
+            continue
+        found[image] = row
 
     return found
 
 
-def _create_prime_image(client: APIClient, image: str, task_dir: Path) -> None:
-    """Upload a Harbor task's unchanged environment context to Prime."""
+def _create_prime_image(image: str, task_dir: Path) -> None:
+    """Have the Prime CLI build the task's unchanged environment context."""
     environment = task_dir / "environment"
-    image_name, image_tag = image.rsplit(":", 1)
-    payload: dict[str, str] = {
-        "image_name": image_name,
-        "image_tag": image_tag,
-        "dockerfile_path": "Dockerfile",
-        "platform": "linux/amd64",
-    }
-    if client.config.team_id:
-        payload["teamId"] = client.config.team_id
-
     print(f"Creating Prime image {image} for Harbor task {task_dir.name}...")
-    with tempfile.TemporaryFile() as archive:
-        with tarfile.open(fileobj=archive, mode="w:gz") as tar:
-            tar.add(environment, arcname=".")
-        archive.seek(0)
-
-        try:
-            build = client.request("POST", "/images/build", json=payload)
-            upload = httpx.put(
-                build["upload_url"],
-                content=archive,
-                headers={"Content-Type": "application/octet-stream"},
-                timeout=IMAGE_BUILD_TIMEOUT,
-            )
-            upload.raise_for_status()
-            client.request(
-                "POST",
-                f"/images/build/{build['build_id']}/start",
-                json={"context_uploaded": True},
-            )
-        except (APIError, httpx.HTTPError) as error:
-            raise RuntimeError(
-                f"failed to create Prime image {image}: {error}"
-            ) from error
+    subprocess.run(
+        [
+            "prime",
+            "images",
+            "--plain",
+            "push",
+            image,
+            "--context",
+            str(environment),
+        ],
+        check=True,
+    )
 
 
 def ensure_prime_images(dataset: str, task_dirs: list[Path]) -> dict[Path, str]:
@@ -137,7 +98,6 @@ def ensure_prime_images(dataset: str, task_dirs: list[Path]) -> dict[Path, str]:
     rows = _find_prime_images(client, set(targets.values()))
     resolved: dict[str, str] = {}
     pending: set[str] = set()
-    previous_rows: dict[str, tuple[object, object]] = {}
     deadlines: dict[str, float] = {}
 
     for image, task_dir in build_dirs.items():
@@ -147,9 +107,7 @@ def ensure_prime_images(dataset: str, task_dirs: list[Path]) -> dict[Path, str]:
             resolved[image] = str(row.get("displayRef") or row["fullImagePath"])
             continue
         if status not in ACTIVE_STATUSES:
-            if row:
-                previous_rows[image] = (row.get("id"), status)
-            _create_prime_image(client, image, task_dir)
+            _create_prime_image(image, task_dir)
         pending.add(image)
         deadlines[image] = time.monotonic() + timeouts[image]
 
@@ -162,10 +120,6 @@ def ensure_prime_images(dataset: str, task_dirs: list[Path]) -> dict[Path, str]:
             if not row:
                 continue
             status = row.get("status")
-            marker = (row.get("id"), status)
-            if marker == previous_rows.get(image):
-                continue
-            previous_rows.pop(image, None)
             if status == "COMPLETED":
                 resolved[image] = str(row.get("displayRef") or row["fullImagePath"])
                 pending.remove(image)

--- a/packages/tasksets/tasksets/harbor_v1/images.py
+++ b/packages/tasksets/tasksets/harbor_v1/images.py
@@ -1,0 +1,183 @@
+"""Resolve Harbor Dockerfiles to images in the Prime registry."""
+
+import os
+import re
+import tarfile
+import tempfile
+import time
+import tomllib
+from pathlib import Path
+
+import httpx
+from prime_sandboxes import APIClient, APIError
+
+IMAGE_TAG = "latest"
+IMAGE_PAGE_SIZE = 250
+IMAGE_BUILD_TIMEOUT = 600.0
+IMAGE_POLL_INTERVAL = 5.0
+ACTIVE_STATUSES = {"PENDING", "BUILDING", "UPLOADING"}
+
+ImageRow = dict[str, object]
+
+
+def prime_image_name(dataset: str, task_dir: Path) -> str:
+    """Return the stable Prime image name for a Harbor dataset task."""
+    dataset_name = dataset.split("@", 1)[0].rsplit("/", 1)[-1]
+    source = (
+        dataset_name
+        if task_dir.name == dataset_name
+        else f"{dataset_name}-{task_dir.name}"
+    )
+    image_name = re.sub(r"[^a-z0-9._-]+", "-", source.lower()).strip("._-")
+    if not image_name:
+        raise ValueError(f"cannot derive a Prime image name for {task_dir}")
+    return f"{image_name}:{IMAGE_TAG}"
+
+
+def _find_prime_images(client: APIClient, targets: set[str]) -> dict[str, ImageRow]:
+    """Find the newest container-image row for each target."""
+    names = sorted(image.rsplit(":", 1)[0] for image in targets)
+    search = os.path.commonprefix(names)
+    found: dict[str, ImageRow] = {}
+    offset = 0
+
+    while True:
+        params: dict[str, str | int] = {
+            "limit": IMAGE_PAGE_SIZE,
+            "offset": offset,
+            "search": search,
+        }
+        if client.config.team_id:
+            params["teamId"] = client.config.team_id
+        try:
+            response = client.request("GET", "/images", params=params)
+        except APIError as error:
+            raise RuntimeError(f"failed to search Prime images: {error}") from error
+
+        rows = response.get("data", [])
+        for row in rows:
+            name, tag = row.get("imageName"), row.get("imageTag")
+            image = f"{name}:{tag}"
+            if (
+                image in targets
+                and image not in found
+                and row.get("artifactType") == "CONTAINER_IMAGE"
+            ):
+                found[image] = row
+        offset += len(rows)
+        total_count = int(response.get("total_count", offset))
+        if targets <= found.keys() or not rows or offset >= total_count:
+            break
+
+    return found
+
+
+def _create_prime_image(client: APIClient, image: str, task_dir: Path) -> None:
+    """Upload a Harbor task's unchanged environment context to Prime."""
+    environment = task_dir / "environment"
+    image_name, image_tag = image.rsplit(":", 1)
+    payload: dict[str, str] = {
+        "image_name": image_name,
+        "image_tag": image_tag,
+        "dockerfile_path": "Dockerfile",
+        "platform": "linux/amd64",
+    }
+    if client.config.team_id:
+        payload["teamId"] = client.config.team_id
+
+    print(f"Creating Prime image {image} for Harbor task {task_dir.name}...")
+    with tempfile.TemporaryFile() as archive:
+        with tarfile.open(fileobj=archive, mode="w:gz") as tar:
+            tar.add(environment, arcname=".")
+        archive.seek(0)
+
+        try:
+            build = client.request("POST", "/images/build", json=payload)
+            upload = httpx.put(
+                build["upload_url"],
+                content=archive,
+                headers={"Content-Type": "application/octet-stream"},
+                timeout=IMAGE_BUILD_TIMEOUT,
+            )
+            upload.raise_for_status()
+            client.request(
+                "POST",
+                f"/images/build/{build['build_id']}/start",
+                json={"context_uploaded": True},
+            )
+        except (APIError, httpx.HTTPError) as error:
+            raise RuntimeError(
+                f"failed to create Prime image {image}: {error}"
+            ) from error
+
+
+def ensure_prime_images(dataset: str, task_dirs: list[Path]) -> dict[Path, str]:
+    """Reuse or build Prime images for tasks that only declare a Dockerfile."""
+    targets: dict[Path, str] = {}
+    build_dirs: dict[str, Path] = {}
+    timeouts: dict[str, float] = {}
+    for task_dir in task_dirs:
+        config = tomllib.loads((task_dir / "task.toml").read_text())
+        environment = config.get("environment", {})
+        if environment.get("docker_image"):
+            continue
+        if not (task_dir / "environment" / "Dockerfile").is_file():
+            continue
+        image = prime_image_name(dataset, task_dir)
+        targets[task_dir] = image
+        build_dirs.setdefault(image, task_dir)
+        timeouts[image] = float(
+            environment.get("build_timeout_sec", IMAGE_BUILD_TIMEOUT)
+        )
+
+    if not targets:
+        return {}
+
+    client = APIClient()
+    rows = _find_prime_images(client, set(targets.values()))
+    resolved: dict[str, str] = {}
+    pending: set[str] = set()
+    previous_rows: dict[str, tuple[object, object]] = {}
+    deadlines: dict[str, float] = {}
+
+    for image, task_dir in build_dirs.items():
+        row = rows.get(image)
+        status = row.get("status") if row else None
+        if row and status == "COMPLETED":
+            resolved[image] = str(row.get("displayRef") or row["fullImagePath"])
+            continue
+        if status not in ACTIVE_STATUSES:
+            if row:
+                previous_rows[image] = (row.get("id"), status)
+            _create_prime_image(client, image, task_dir)
+        pending.add(image)
+        deadlines[image] = time.monotonic() + timeouts[image]
+
+    while pending:
+        time.sleep(IMAGE_POLL_INTERVAL)
+        rows = _find_prime_images(client, pending)
+        now = time.monotonic()
+        for image in list(pending):
+            row = rows.get(image)
+            if not row:
+                continue
+            status = row.get("status")
+            marker = (row.get("id"), status)
+            if marker == previous_rows.get(image):
+                continue
+            previous_rows.pop(image, None)
+            if status == "COMPLETED":
+                resolved[image] = str(row.get("displayRef") or row["fullImagePath"])
+                pending.remove(image)
+                print(f"Prime image {image} is ready.")
+                continue
+            if status not in ACTIVE_STATUSES:
+                detail = row.get("errorMessage") or status
+                raise RuntimeError(f"Prime image {image} failed to build: {detail}")
+
+        timed_out = [image for image in pending if now >= deadlines[image]]
+        if timed_out:
+            images = ", ".join(sorted(timed_out))
+            raise RuntimeError(f"timed out waiting for Prime images: {images}")
+
+    return {task_dir: resolved[image] for task_dir, image in targets.items()}

--- a/packages/tasksets/tasksets/harbor_v1/taskset.py
+++ b/packages/tasksets/tasksets/harbor_v1/taskset.py
@@ -11,11 +11,11 @@ The harness runs in a container and edits /app; then the task's verifier
 taskset (the `solved` reward), so a harbor task runs under ANY harness.
 
 A task's declared [environment].docker_image becomes a first-class `Task.image`
-the Environment injects into the runtime (docker/prime both pull it). A task whose
-environment is only a `Dockerfile` has no pullable image — we don't build Dockerfiles
-(a locally-built image isn't pullable by a remote sandbox) — so it's rejected unless
-`ignore_dockerfile`, which runs it on the harness runtime's image instead. A task with
-no environment at all also runs on that image, unless `require_image`.
+the Environment injects into the runtime. For a task that only ships an
+environment/Dockerfile, the taskset reuses a matching image from the authenticated
+Prime image list or creates one with the Prime CLI. `ignore_dockerfile` instead runs
+the task on the harness runtime's image. A task with no environment also runs on that
+image, unless `require_image`.
 """
 
 import io
@@ -26,6 +26,7 @@ from pathlib import Path
 
 from pydantic import Field
 
+from tasksets.harbor_v1.images import ensure_prime_images
 from verifiers.v1.decorators import reward
 from verifiers.v1.errors import ProgramError
 from verifiers.v1.runtimes import Runtime
@@ -49,14 +50,11 @@ class HarborConfig(TasksetConfig):
     """Scale each task's CPU, memory, and disk requests. GPU requests are unchanged."""
     require_image: bool = False
     """For a task with NO declared environment at all (no docker_image, no Dockerfile),
-    whether to reject it (True) or run it on the runtime's default image (False). A task
-    whose environment is a `Dockerfile` is rejected too (building Dockerfiles isn't
-    supported), unless `ignore_dockerfile`."""
+    whether to reject it (True) or run it on the runtime's default image (False)."""
     ignore_dockerfile: bool = False
     """Run a task whose environment is only a `Dockerfile` on the harness runtime's image
-    instead of rejecting it. The Dockerfile is NOT built, so the task scores against the
-    harness image rather than its declared environment — only correct when that image already
-    has what the task needs (e.g. you've pointed the runtime at the right image)."""
+    instead of resolving or building a Prime image. Only correct when the harness image
+    already has what the task needs."""
 
 
 class Author(StrictBaseModel):
@@ -66,7 +64,7 @@ class Author(StrictBaseModel):
 
 class HarborTask(Task):
     """A Harbor task. The base fields carry instruction.md (`prompt`), the
-    resolved container `image`, the `harness_timeout`/`scoring_timeout`/`resources`
+    resolved container `image`, the `timeout`/`resources`
     (from task.toml's [harness]/[verifier]/[environment]), and [task].name/description;
     the rest mirror [metadata]."""
 
@@ -101,26 +99,18 @@ def resolve_image(
     config: dict,
     require_image: bool,
     ignore_dockerfile: bool = False,
+    prime_image: str | None = None,
 ) -> str | None:
-    """The task's declared registry image (usable by docker or prime). A pullable
-    `[environment].docker_image` is used directly. A task whose environment is a
-    `Dockerfile` is rejected — we don't build Dockerfiles, and running it on the default
-    image would silently score against the wrong environment (e.g. SWE-bench's `/testbed`
-    repo would be missing) — unless `ignore_dockerfile`, which returns None to run it on the
-    harness runtime's image. A task with no environment at all runs on that image too, unless
-    `require_image`. None means "use the runtime's own image"."""
+    """Resolve a declared image, a Prime-built Dockerfile image, or the runtime image."""
     declared = config.get("environment", {}).get("docker_image")
     if declared:
         return declared
-    if (task_dir / "environment" / "Dockerfile").exists():
+    if (task_dir / "environment" / "Dockerfile").is_file():
         if ignore_dockerfile:
             return None
-        raise ValueError(
-            f"{task_dir.name}: environment is a Dockerfile, not a pullable "
-            "[environment].docker_image — building Dockerfiles isn't supported, so this "
-            "task can't run (it would otherwise score against the wrong default image). "
-            "Pass --taskset.ignore-dockerfile to run it on the harness runtime's image instead."
-        )
+        if prime_image:
+            return prime_image
+        raise RuntimeError(f"{task_dir.name}: Prime image resolution returned no image")
     if require_image:
         raise ValueError(
             f"{task_dir.name}: no [environment].docker_image and require_image=True"
@@ -138,7 +128,12 @@ def parse_resources(env: dict, multiplier: float = 1.0) -> TaskResources:
     )
 
 
-def parse_task(task_dir: Path, idx: int, harbor_config: HarborConfig) -> HarborTask:
+def parse_task(
+    task_dir: Path,
+    idx: int,
+    harbor_config: HarborConfig,
+    prime_image: str | None = None,
+) -> HarborTask:
     """Read a harbor task dir (task.toml + instruction.md) into a typed task,
     handling both the [task].authors and legacy [metadata].author_name layouts."""
     config = tomllib.loads((task_dir / "task.toml").read_text())
@@ -157,7 +152,8 @@ def parse_task(task_dir: Path, idx: int, harbor_config: HarborConfig) -> HarborT
             task_dir,
             config,
             harbor_config.require_image,
-            harbor_config.ignore_dockerfile,
+            ignore_dockerfile=harbor_config.ignore_dockerfile,
+            prime_image=prime_image,
         ),
         timeout=TaskTimeout(
             harness=harness_timeout * harbor_config.timeout_multiplier
@@ -201,8 +197,18 @@ class HarborTaskset(Taskset[HarborTask, HarborConfig]):
         ]
         if not task_dirs:
             raise ValueError(f"no harbor tasks found in {root}")
+        prime_images = (
+            {}
+            if self.config.ignore_dockerfile
+            else ensure_prime_images(self.config.dataset, task_dirs)
+        )
         return [
-            parse_task(task_dir, idx, self.config)
+            parse_task(
+                task_dir,
+                idx,
+                self.config,
+                prime_image=prime_images.get(task_dir),
+            )
             for idx, task_dir in enumerate(task_dirs)
         ]
 

--- a/tests/v1/test_harbor_taskset.py
+++ b/tests/v1/test_harbor_taskset.py
@@ -1,0 +1,299 @@
+import tarfile
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+
+from tasksets.harbor_v1 import images
+from tasksets.harbor_v1 import taskset as harbor
+
+
+def write_task(
+    root: Path,
+    name: str,
+    *,
+    dockerfile: bool = True,
+    docker_image: str | None = None,
+) -> Path:
+    task_dir = root / name
+    task_dir.mkdir(parents=True)
+    environment = task_dir / "environment"
+    environment.mkdir()
+    config = [
+        "[task]",
+        f'name = "{name}"',
+        "",
+        "[environment]",
+        "build_timeout_sec = 30",
+    ]
+    if docker_image:
+        config.append(f'docker_image = "{docker_image}"')
+    (task_dir / "task.toml").write_text("\n".join(config))
+    (task_dir / "instruction.md").write_text("Fix it.")
+    if dockerfile:
+        (environment / "Dockerfile").write_text("FROM alpine:latest\n")
+    return task_dir
+
+
+@pytest.mark.parametrize(
+    ("dataset", "task_name", "expected"),
+    [
+        (
+            "openthoughts/openthoughts-tblite",
+            "broken-python",
+            "openthoughts-tblite-broken-python:latest",
+        ),
+        ("hello-world@1.0", "hello-world", "hello-world:latest"),
+    ],
+)
+def test_prime_image_name(dataset: str, task_name: str, expected: str) -> None:
+    assert images.prime_image_name(dataset, Path(task_name)) == expected
+
+
+def test_find_prime_images_searches_later_pages() -> None:
+    target = "dataset-task:latest"
+    calls = []
+
+    class Client:
+        config = SimpleNamespace(team_id="team-example")
+
+        def request(self, method, endpoint, params=None):
+            assert params is not None
+            calls.append((method, endpoint, params))
+            if params["offset"] == 0:
+                return {
+                    "data": [{"imageName": "other", "imageTag": "latest"}],
+                    "total_count": 251,
+                }
+            return {
+                "data": [
+                    {
+                        "imageName": "dataset-task",
+                        "imageTag": "latest",
+                        "artifactType": "CONTAINER_IMAGE",
+                        "status": "COMPLETED",
+                    }
+                ],
+                "total_count": 251,
+            }
+
+    client = cast(images.APIClient, Client())
+    assert images._find_prime_images(client, {target})[target]["status"] == "COMPLETED"
+    assert calls == [
+        (
+            "GET",
+            "/images",
+            {
+                "limit": 250,
+                "offset": 0,
+                "search": "dataset-task",
+                "teamId": "team-example",
+            },
+        ),
+        (
+            "GET",
+            "/images",
+            {
+                "limit": 250,
+                "offset": 1,
+                "search": "dataset-task",
+                "teamId": "team-example",
+            },
+        ),
+    ]
+
+
+def test_ensure_prime_images_reuses_completed_image(tmp_path, monkeypatch) -> None:
+    task_dir = write_task(tmp_path, "broken-python")
+    image = "openthoughts-tblite-broken-python:latest"
+    display_ref = f"team-example/{image}"
+    monkeypatch.setattr(images, "APIClient", object)
+    monkeypatch.setattr(
+        images,
+        "_find_prime_images",
+        lambda client, targets: {
+            image: {
+                "id": "existing",
+                "status": "COMPLETED",
+                "displayRef": display_ref,
+            }
+        },
+    )
+    monkeypatch.setattr(
+        images,
+        "_create_prime_image",
+        lambda client, image, task_dir: pytest.fail(
+            "completed images must not be rebuilt"
+        ),
+    )
+
+    resolved = images.ensure_prime_images(
+        "openthoughts/openthoughts-tblite", [task_dir]
+    )
+
+    assert resolved == {task_dir: display_ref}
+
+
+def test_ensure_prime_images_ignores_declared_images(tmp_path, monkeypatch) -> None:
+    task_dir = write_task(
+        tmp_path, "broken-python", docker_image="example/broken-python:v1"
+    )
+    monkeypatch.setattr(
+        images,
+        "APIClient",
+        lambda: pytest.fail("declared images must not query Prime"),
+    )
+
+    assert images.ensure_prime_images("org/dataset", [task_dir]) == {}
+
+
+def test_ensure_prime_images_pushes_missing_image(tmp_path, monkeypatch) -> None:
+    task_dir = write_task(tmp_path, "broken-python")
+    image = "openthoughts-tblite-broken-python:latest"
+    display_ref = f"team-example/{image}"
+    image_lists = iter(
+        [
+            {},
+            {
+                image: {
+                    "id": "new-build",
+                    "status": "COMPLETED",
+                    "displayRef": display_ref,
+                }
+            },
+        ]
+    )
+    pushed = []
+    monkeypatch.setattr(images, "APIClient", object)
+    monkeypatch.setattr(
+        images, "_find_prime_images", lambda client, targets: next(image_lists)
+    )
+    monkeypatch.setattr(
+        images,
+        "_create_prime_image",
+        lambda client, image, task_dir: pushed.append((image, task_dir)),
+    )
+    monkeypatch.setattr(images.time, "sleep", lambda seconds: None)
+
+    resolved = images.ensure_prime_images(
+        "openthoughts/openthoughts-tblite", [task_dir]
+    )
+
+    assert pushed == [(image, task_dir)]
+    assert resolved == {task_dir: display_ref}
+
+
+def test_ensure_prime_images_rebuilds_failed_image(tmp_path, monkeypatch) -> None:
+    task_dir = write_task(tmp_path, "broken-python")
+    image = "openthoughts-tblite-broken-python:latest"
+    display_ref = f"team-example/{image}"
+    image_lists = iter(
+        [
+            {image: {"id": "image-row", "status": "FAILED"}},
+            {
+                image: {
+                    "id": "image-row",
+                    "status": "COMPLETED",
+                    "displayRef": display_ref,
+                }
+            },
+        ]
+    )
+    pushed = []
+    monkeypatch.setattr(images, "APIClient", object)
+    monkeypatch.setattr(
+        images, "_find_prime_images", lambda client, targets: next(image_lists)
+    )
+    monkeypatch.setattr(
+        images,
+        "_create_prime_image",
+        lambda client, image, task_dir: pushed.append((image, task_dir)),
+    )
+    monkeypatch.setattr(images.time, "sleep", lambda seconds: None)
+
+    resolved = images.ensure_prime_images(
+        "openthoughts/openthoughts-tblite", [task_dir]
+    )
+
+    assert pushed == [(image, task_dir)]
+    assert resolved == {task_dir: display_ref}
+
+
+def test_create_prime_image_uploads_unchanged_environment_context(
+    tmp_path, monkeypatch
+) -> None:
+    task_dir = write_task(tmp_path, "broken-python")
+    calls = []
+    uploaded = {}
+
+    class Client:
+        config = SimpleNamespace(team_id="team-example")
+
+        def request(self, method, endpoint, json=None):
+            calls.append((method, endpoint, json))
+            if endpoint == "/images/build":
+                return {
+                    "build_id": "build-123",
+                    "upload_url": "https://upload.example",
+                }
+            return {}
+
+    def put(url, *, content, headers, timeout):
+        with tarfile.open(fileobj=content, mode="r:gz") as archive:
+            dockerfile = next(
+                name for name in archive.getnames() if name.endswith("/Dockerfile")
+            )
+            dockerfile_file = archive.extractfile(dockerfile)
+            assert dockerfile_file is not None
+            uploaded["dockerfile"] = dockerfile_file.read()
+        uploaded["request"] = (url, headers, timeout)
+        return SimpleNamespace(raise_for_status=lambda: None)
+
+    monkeypatch.setattr(images.httpx, "put", put)
+
+    client = cast(images.APIClient, Client())
+    images._create_prime_image(client, "dataset-broken-python:latest", task_dir)
+
+    assert uploaded == {
+        "dockerfile": b"FROM alpine:latest\n",
+        "request": (
+            "https://upload.example",
+            {"Content-Type": "application/octet-stream"},
+            600.0,
+        ),
+    }
+    assert calls == [
+        (
+            "POST",
+            "/images/build",
+            {
+                "image_name": "dataset-broken-python",
+                "image_tag": "latest",
+                "dockerfile_path": "Dockerfile",
+                "platform": "linux/amd64",
+                "teamId": "team-example",
+            },
+        ),
+        (
+            "POST",
+            "/images/build/build-123/start",
+            {"context_uploaded": True},
+        ),
+    ]
+
+
+def test_harbor_taskset_uses_resolved_prime_image(tmp_path, monkeypatch) -> None:
+    task_dir = write_task(tmp_path, "broken-python")
+    display_ref = "team-example/dataset-broken-python:latest"
+    monkeypatch.setattr(harbor, "dataset_dir", lambda dataset: tmp_path)
+    monkeypatch.setattr(
+        harbor,
+        "ensure_prime_images",
+        lambda dataset, task_dirs: {task_dir: display_ref},
+    )
+
+    taskset = harbor.HarborTaskset(harbor.HarborConfig(dataset="org/dataset"))
+    (task,) = taskset.load_tasks()
+
+    assert task.image == display_ref

--- a/tests/v1/test_harbor_taskset.py
+++ b/tests/v1/test_harbor_taskset.py
@@ -1,4 +1,3 @@
-import tarfile
 from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
@@ -42,16 +41,16 @@ def write_task(
         (
             "openthoughts/openthoughts-tblite",
             "broken-python",
-            "openthoughts-tblite-broken-python:latest",
+            "openthoughts-openthoughts-tblite-broken-python:latest",
         ),
-        ("hello-world@1.0", "hello-world", "hello-world:latest"),
+        ("hello-world@1.0", "hello-world", "hello-world-1.0-hello-world:latest"),
     ],
 )
 def test_prime_image_name(dataset: str, task_name: str, expected: str) -> None:
     assert images.prime_image_name(dataset, Path(task_name)) == expected
 
 
-def test_find_prime_images_searches_later_pages() -> None:
+def test_find_prime_images_prefers_completed_row() -> None:
     target = "dataset-task:latest"
     calls = []
 
@@ -59,23 +58,22 @@ def test_find_prime_images_searches_later_pages() -> None:
         config = SimpleNamespace(team_id="team-example")
 
         def request(self, method, endpoint, params=None):
-            assert params is not None
             calls.append((method, endpoint, params))
-            if params["offset"] == 0:
-                return {
-                    "data": [{"imageName": "other", "imageTag": "latest"}],
-                    "total_count": 251,
-                }
             return {
                 "data": [
                     {
                         "imageName": "dataset-task",
                         "imageTag": "latest",
                         "artifactType": "CONTAINER_IMAGE",
+                        "status": "FAILED",
+                    },
+                    {
+                        "imageName": "dataset-task",
+                        "imageTag": "latest",
+                        "artifactType": "CONTAINER_IMAGE",
                         "status": "COMPLETED",
-                    }
-                ],
-                "total_count": 251,
+                    },
+                ]
             }
 
     client = cast(images.APIClient, Client())
@@ -85,28 +83,17 @@ def test_find_prime_images_searches_later_pages() -> None:
             "GET",
             "/images",
             {
-                "limit": 250,
-                "offset": 0,
+                "limit": 10_000,
                 "search": "dataset-task",
                 "teamId": "team-example",
             },
-        ),
-        (
-            "GET",
-            "/images",
-            {
-                "limit": 250,
-                "offset": 1,
-                "search": "dataset-task",
-                "teamId": "team-example",
-            },
-        ),
+        )
     ]
 
 
 def test_ensure_prime_images_reuses_completed_image(tmp_path, monkeypatch) -> None:
     task_dir = write_task(tmp_path, "broken-python")
-    image = "openthoughts-tblite-broken-python:latest"
+    image = "openthoughts-openthoughts-tblite-broken-python:latest"
     display_ref = f"team-example/{image}"
     monkeypatch.setattr(images, "APIClient", object)
     monkeypatch.setattr(
@@ -123,9 +110,7 @@ def test_ensure_prime_images_reuses_completed_image(tmp_path, monkeypatch) -> No
     monkeypatch.setattr(
         images,
         "_create_prime_image",
-        lambda client, image, task_dir: pytest.fail(
-            "completed images must not be rebuilt"
-        ),
+        lambda image, task_dir: pytest.fail("completed images must not be rebuilt"),
     )
 
     resolved = images.ensure_prime_images(
@@ -150,7 +135,7 @@ def test_ensure_prime_images_ignores_declared_images(tmp_path, monkeypatch) -> N
 
 def test_ensure_prime_images_pushes_missing_image(tmp_path, monkeypatch) -> None:
     task_dir = write_task(tmp_path, "broken-python")
-    image = "openthoughts-tblite-broken-python:latest"
+    image = "openthoughts-openthoughts-tblite-broken-python:latest"
     display_ref = f"team-example/{image}"
     image_lists = iter(
         [
@@ -172,7 +157,7 @@ def test_ensure_prime_images_pushes_missing_image(tmp_path, monkeypatch) -> None
     monkeypatch.setattr(
         images,
         "_create_prime_image",
-        lambda client, image, task_dir: pushed.append((image, task_dir)),
+        lambda image, task_dir: pushed.append((image, task_dir)),
     )
     monkeypatch.setattr(images.time, "sleep", lambda seconds: None)
 
@@ -186,7 +171,7 @@ def test_ensure_prime_images_pushes_missing_image(tmp_path, monkeypatch) -> None
 
 def test_ensure_prime_images_rebuilds_failed_image(tmp_path, monkeypatch) -> None:
     task_dir = write_task(tmp_path, "broken-python")
-    image = "openthoughts-tblite-broken-python:latest"
+    image = "openthoughts-openthoughts-tblite-broken-python:latest"
     display_ref = f"team-example/{image}"
     image_lists = iter(
         [
@@ -208,7 +193,7 @@ def test_ensure_prime_images_rebuilds_failed_image(tmp_path, monkeypatch) -> Non
     monkeypatch.setattr(
         images,
         "_create_prime_image",
-        lambda client, image, task_dir: pushed.append((image, task_dir)),
+        lambda image, task_dir: pushed.append((image, task_dir)),
     )
     monkeypatch.setattr(images.time, "sleep", lambda seconds: None)
 
@@ -220,66 +205,34 @@ def test_ensure_prime_images_rebuilds_failed_image(tmp_path, monkeypatch) -> Non
     assert resolved == {task_dir: display_ref}
 
 
-def test_create_prime_image_uploads_unchanged_environment_context(
+def test_create_prime_image_delegates_environment_context_to_cli(
     tmp_path, monkeypatch
 ) -> None:
     task_dir = write_task(tmp_path, "broken-python")
     calls = []
-    uploaded = {}
 
-    class Client:
-        config = SimpleNamespace(team_id="team-example")
+    monkeypatch.setattr(
+        images.subprocess,
+        "run",
+        lambda command, **kwargs: calls.append((command, kwargs)),
+    )
 
-        def request(self, method, endpoint, json=None):
-            calls.append((method, endpoint, json))
-            if endpoint == "/images/build":
-                return {
-                    "build_id": "build-123",
-                    "upload_url": "https://upload.example",
-                }
-            return {}
+    images._create_prime_image("dataset-broken-python:latest", task_dir)
 
-    def put(url, *, content, headers, timeout):
-        with tarfile.open(fileobj=content, mode="r:gz") as archive:
-            dockerfile = next(
-                name for name in archive.getnames() if name.endswith("/Dockerfile")
-            )
-            dockerfile_file = archive.extractfile(dockerfile)
-            assert dockerfile_file is not None
-            uploaded["dockerfile"] = dockerfile_file.read()
-        uploaded["request"] = (url, headers, timeout)
-        return SimpleNamespace(raise_for_status=lambda: None)
-
-    monkeypatch.setattr(images.httpx, "put", put)
-
-    client = cast(images.APIClient, Client())
-    images._create_prime_image(client, "dataset-broken-python:latest", task_dir)
-
-    assert uploaded == {
-        "dockerfile": b"FROM alpine:latest\n",
-        "request": (
-            "https://upload.example",
-            {"Content-Type": "application/octet-stream"},
-            600.0,
-        ),
-    }
+    environment = task_dir / "environment"
     assert calls == [
         (
-            "POST",
-            "/images/build",
-            {
-                "image_name": "dataset-broken-python",
-                "image_tag": "latest",
-                "dockerfile_path": "Dockerfile",
-                "platform": "linux/amd64",
-                "teamId": "team-example",
-            },
-        ),
-        (
-            "POST",
-            "/images/build/build-123/start",
-            {"context_uploaded": True},
-        ),
+            [
+                "prime",
+                "images",
+                "--plain",
+                "push",
+                "dataset-broken-python:latest",
+                "--context",
+                str(environment),
+            ],
+            {"check": True},
+        )
     ]
 
 

--- a/verifiers/v1/README.md
+++ b/verifiers/v1/README.md
@@ -244,8 +244,9 @@ uv run eval gsm8k-v1 -n 1 --retries.rollout.max-retries 3 --retries.rollout.incl
 Some tasksets wrap a whole benchmark family rather than a single task — shipped, installed by
 default. For example, `textarena-v1` (TextArena games) and `harbor-v1` (the agentic-
 benchmark registry). Harbor is the showcase: it pulls tasks straight from the Harbor registry
-via the `harbor` CLI (`uv tool install harbor`), each in its own declared, pullable container
-image — e.g. Terminal-Bench 2:
+via the `harbor` CLI (`uv tool install harbor`). Declared container images are used directly;
+Dockerfile-only tasks reuse a matching Prime image or create one through the authenticated
+Prime API — e.g. Terminal-Bench 2:
 
 ```bash
 uv run eval harbor-v1 --taskset.dataset terminal-bench/terminal-bench-2 -n 10 --harness.id rlm

--- a/verifiers/v1/README.md
+++ b/verifiers/v1/README.md
@@ -246,7 +246,7 @@ default. For example, `textarena-v1` (TextArena games) and `harbor-v1` (the agen
 benchmark registry). Harbor is the showcase: it pulls tasks straight from the Harbor registry
 via the `harbor` CLI (`uv tool install harbor`). Declared container images are used directly;
 Dockerfile-only tasks reuse a matching Prime image or create one through the authenticated
-Prime API — e.g. Terminal-Bench 2:
+Prime CLI (`uv tool install prime`) — e.g. Terminal-Bench 2:
 
 ```bash
 uv run eval harbor-v1 --taskset.dataset terminal-bench/terminal-bench-2 -n 10 --harness.id rlm


### PR DESCRIPTION
## Overview

Allow Harbor v1 tasks that provide an `environment/Dockerfile` without a declared image to resolve to Prime registry images automatically.

## Details

- Derive collision-resistant image names from the full Harbor dataset id/ref and task name.
- Find matching images with one filtered Prime registry request and prefer completed images over active or failed rows.
- Delegate missing image builds to `prime images push` with the task's unchanged `environment/` directory as its context.
- Preserve existing behavior for tasks with a declared `docker_image` or no environment.
- Document the Prime CLI requirement and cover lookup, creation, reuse, rebuild, and task loading paths.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Task load can block on remote image builds, call external Prime API/CLI, and fail at load time without Prime auth or CLI—behavior change from immediate rejection for Dockerfile-only tasks.
> 
> **Overview**
> Harbor v1 no longer **rejects** tasks that only ship `environment/Dockerfile` without `[environment].docker_image`. Those tasks now get a pullable container image by reusing or building in the Prime registry.
> 
> A new **`images`** module derives stable image names from the dataset id and task name, looks up existing container images via the Prime API (preferring **COMPLETED** rows), and triggers **`prime images push`** with the task’s `environment/` context when needed, then polls until builds finish or time out. **`HarborTaskset.load_tasks`** runs this resolution before parsing tasks and passes the registry ref into **`resolve_image`**. Declared `docker_image` values are unchanged; **`ignore_dockerfile`** still skips Prime and runs on the harness runtime image.
> 
> Tests cover naming, lookup preference, reuse, push/rebuild paths, CLI delegation, and task loading. The v1 README notes the Prime CLI requirement for Dockerfile-only Harbor tasks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fc567cc4c2a2d87b77ca04421a048753c87e73b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Prime image builds for Dockerfile-only Harbor tasks
> - Adds `ensure_prime_images` in [images.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1726/files#diff-165c91fd9e5a87dde13b9ed38ae7a7d06e38794c1ef15f045dfc5a41787bf7a0) to scan Harbor task directories, build missing or failed Prime images via the Prime CLI, and poll until they reach `COMPLETED`.
> - Adds `prime_image_name` to generate deterministic image names from dataset id and task directory, and `_find_prime_images` to query the Prime API and select the best existing image per target (preferring `COMPLETED` over `ACTIVE` over failed).
> - Updates `HarborTaskset.load_tasks` to call `ensure_prime_images` for Dockerfile-only tasks and pass resolved image refs into `parse_task`; skipped when `ignore_dockerfile=True`.
> - Updates `resolve_image` to accept a `prime_image` argument and return it for Dockerfile-only tasks, raising `RuntimeError` if no Prime image is resolved and `ignore_dockerfile` is not set.
> - Behavioral Change: tasks with only a `Dockerfile` (no declared `docker_image`) now build and reuse a Prime image instead of being rejected; `ignore_dockerfile=True` opts out and falls back to the harness image.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4fc567c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->