### PR TITLE
feat(v1): per-rollout isolation for shared writable tool servers

### DIFF
--- a/environments/scratchpad_v1/pyproject.toml
+++ b/environments/scratchpad_v1/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "scratchpad-v1"
+version = "0.1.0"
+description = "scratchpad-v1 — a shared, writable tool server, per-rollout isolated via self.state."
+requires-python = ">=3.10"
+dependencies = ["verifiers"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["scratchpad_v1"]

--- a/environments/scratchpad_v1/scratchpad_v1/__init__.py
+++ b/environments/scratchpad_v1/scratchpad_v1/__init__.py
@@ -1,0 +1,3 @@
+from scratchpad_v1.taskset import ScratchpadTaskset
+
+__all__ = ["ScratchpadTaskset"]

--- a/environments/scratchpad_v1/scratchpad_v1/servers/scratchpad.py
+++ b/environments/scratchpad_v1/scratchpad_v1/servers/scratchpad.py
@@ -1,0 +1,47 @@
+"""A SHARED, writable tool server that exercises per-rollout state isolation.
+
+It is built once for the whole eval (`ToolsetConfig(shared=True)`) but written to by every rollout:
+`roundtrip` stores a word and reads it back. With isolation (the default) each rollout's write lands
+in its own `self.state` — the per-rollout shared-state channel the framework tags onto a shared
+server's URL — so concurrent rollouts never see each other's word. Set `SCRATCHPAD_ISOLATE=0` to
+bypass `self.state` and write to a process-global slot instead: with one shared process, concurrent
+rollouts then clobber that single slot and read back the wrong word (the corruption isolation
+prevents).
+"""
+
+import asyncio
+import os
+
+import verifiers.v1 as vf
+
+
+class ScratchpadState(vf.State):
+    slot: str = ""
+
+
+# A process-global slot — shared across every rollout on the one shared process. Used only by the
+# `SCRATCHPAD_ISOLATE=0` corruption demo; the isolated default writes to `self.state` instead.
+_GLOBAL_SLOT = {"value": ""}
+
+
+class ScratchpadToolset(vf.Toolset[vf.ToolsetConfig, ScratchpadState]):
+    TOOL_PREFIX = "scratchpad"
+
+    async def setup(self) -> None:
+        # Stand in for an expensive one-time build (corpus/index): paid once for the shared server.
+        await asyncio.sleep(float(os.environ.get("SCRATCHPAD_SETUP_SECONDS", "0")))
+
+    @vf.tool
+    async def roundtrip(self, word: str) -> str:
+        """Store `word` in the scratchpad, then read it back and return it."""
+        if os.environ.get("SCRATCHPAD_ISOLATE", "1") == "1":
+            self.state.slot = word
+            await asyncio.sleep(0.5)  # interleave window for concurrent rollouts
+            return self.state.slot
+        _GLOBAL_SLOT["value"] = word
+        await asyncio.sleep(0.5)
+        return _GLOBAL_SLOT["value"]
+
+
+if __name__ == "__main__":
+    ScratchpadToolset.run()

--- a/environments/scratchpad_v1/scratchpad_v1/taskset.py
+++ b/environments/scratchpad_v1/scratchpad_v1/taskset.py
@@ -1,0 +1,58 @@
+"""scratchpad-v1 — a per-rollout isolation test for a SHARED, writable tool server.
+
+Each rollout is assigned a unique word and asked to round-trip it through the shared scratchpad
+server, then report what came back. The reward is 1 iff the model reports its own word. The server
+is `shared` (one instance for the whole eval, simulating an expensive build) yet writable, so this
+is a direct test of per-rollout isolation: `uv run eval scratchpad-v1 -n 8 -r 1` should score a mean
+reward of 1.0, while bypassing isolation (`SCRATCHPAD_ISOLATE=0`) lets concurrent rollouts clobber a
+shared slot and report the wrong word.
+"""
+
+import verifiers.v1 as vf
+
+from scratchpad_v1.servers.scratchpad import ScratchpadState, ScratchpadToolset
+
+WORDS = [
+    "alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf", "hotel",
+    "india", "juliet", "kilo", "lima", "mike", "november", "oscar", "papa",
+    "quebec", "romeo", "sierra", "tango",
+]  # fmt: skip
+
+INSTRUCTION = (
+    'Call the `scratchpad_roundtrip` tool with word="{word}". It returns a single word. '
+    "Then reply with that returned word verbatim as your final answer — nothing else."
+)
+
+
+class ScratchpadTask(vf.Task):
+    word: str
+
+
+class ScratchpadConfig(vf.TasksetConfig):
+    # SHARED + writable: one instance for the whole eval (a stand-in for an expensive build), reused
+    # across rollouts. Each rollout's writes are isolated via `self.state` (the per-rollout
+    # shared-state channel) — the per-rollout isolation a writable shared server needs.
+    tools: vf.ToolsetConfig = vf.ToolsetConfig(shared=True)
+
+
+class ScratchpadTaskset(vf.Taskset[ScratchpadTask, ScratchpadConfig, ScratchpadState]):
+    def load_tasks(self) -> list[ScratchpadTask]:
+        return [
+            ScratchpadTask(idx=i, word=w, instruction=INSTRUCTION.format(word=w))
+            for i, w in enumerate(WORDS)
+        ]
+
+    def tools(self, task: ScratchpadTask) -> list[vf.Toolset]:
+        return [ScratchpadToolset(self.config.tools)]
+
+    @vf.stop
+    async def done(self, trace: vf.Trace) -> bool:
+        # A tool call then a final answer; cap turns so a chatty model still terminates.
+        return trace.num_turns >= 4
+
+    @vf.reward(weight=1.0)
+    async def isolated(self, task: ScratchpadTask, trace: vf.Trace) -> float:
+        answer = (
+            trace.assistant_messages[-1].content if trace.assistant_messages else ""
+        )
+        return float(task.word in (answer or ""))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ examples = [
     "gsm8k-v1", "wikispeedia-v1", "glossary-v1", "deepwiki-v1", "wiki-search-v1", "code-golf-v1",
     "reverse-text-v1", "math-env-v1", "aime24-v1", "color-codeword-v1",
     "wordle-v1", "terminal-bench-2-v1", "alphabet-sort-v1",
-    "r2e-gym-v1", "scaleswe-v1", "swelego-v1",
+    "r2e-gym-v1", "scaleswe-v1", "swelego-v1", "scratchpad-v1",
 ]
 
 [project.optional-dependencies]
@@ -158,6 +158,7 @@ r2e-gym-v1 = { path = "environments/r2e_gym_v1", editable = true }
 scaleswe-v1 = { path = "environments/scaleswe_v1", editable = true }
 swelego-v1 = { path = "environments/swelego_v1", editable = true }
 alphabet-sort-v1 = { path = "environments/alphabet_sort_v1", editable = true }
+scratchpad-v1 = { path = "environments/scratchpad_v1", editable = true }
 
 [tool.uv.exclude-newer-package]
 # PrimeIntellect-published on PyPI (trusted publisher)

--- a/uv.lock
+++ b/uv.lock
@@ -4909,6 +4909,17 @@ wheels = [
 ]
 
 [[package]]
+name = "scratchpad-v1"
+version = "0.1.0"
+source = { editable = "environments/scratchpad_v1" }
+dependencies = [
+    { name = "verifiers" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "verifiers" }]
+
+[[package]]
 name = "sentencepiece"
 version = "0.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -5856,6 +5867,7 @@ examples = [
     { name = "r2e-gym-v1" },
     { name = "reverse-text-v1" },
     { name = "scaleswe-v1" },
+    { name = "scratchpad-v1" },
     { name = "swelego-v1" },
     { name = "terminal-bench-2-v1" },
     { name = "wiki-search-v1" },
@@ -5957,6 +5969,7 @@ examples = [
     { name = "r2e-gym-v1", editable = "environments/r2e_gym_v1" },
     { name = "reverse-text-v1", editable = "environments/reverse_text_v1" },
     { name = "scaleswe-v1", editable = "environments/scaleswe_v1" },
+    { name = "scratchpad-v1", editable = "environments/scratchpad_v1" },
     { name = "swelego-v1", editable = "environments/swelego_v1" },
     { name = "terminal-bench-2-v1", editable = "environments/terminal_bench_2_v1" },
     { name = "wiki-search-v1", editable = "environments/wiki_search_v1" },

--- a/verifiers/v1/GUIDE.md
+++ b/verifiers/v1/GUIDE.md
@@ -235,7 +235,7 @@ taskset's own config), so it's per-server and CLI-tunable (`--taskset.tools.runt
 | own host runtime (default) | its own `subprocess` runtime on the host, reached over the host network |
 | own per-rollout runtime | `runtime = {type = "docker"/"prime"}`, reached over a tunnel |
 | colocated | `colocated = true` — inside the harness's runtime (reached in-sandbox, no tunnel) |
-| shared (tools only) | `shared = true` — one instance built once for the whole eval |
+| shared (tools only) | `shared = true` — one instance built once for the whole eval (still writable: each rollout's `self.state` stays isolated) |
 | remote (tools only) | an existing server, by `url` |
 
 ### Learn from the examples
@@ -250,7 +250,8 @@ The `*_v1` tasksets under `environments/` are the reference library — each sho
 | `alphabet-sort-v1` | multi-turn, stateful, driven by a `vf.User` simulator |
 | `glossary-v1` | the simplest tool server (own host runtime) |
 | `wikispeedia-v1` | a stateful tool server (global `setup` + per-task `setup_task`) |
-| `wiki-search-v1` | a shared tool server (built once) + an LLM judge |
+| `wiki-search-v1` | a shared, read-only tool server (built once) + an LLM judge |
+| `scratchpad-v1` | a shared, **writable** tool server — per-rollout state isolated via `self.state` |
 | `deepwiki-v1` | an existing remote tool server, by URL |
 | `color-codeword-v1` | a multimodal (image) task |
 | `scaleswe-v1`, `swelego-v1`, `r2e-gym-v1` | containerized SWE tasks (rlm harness, prime runtime) |

--- a/verifiers/v1/mcp/launch.py
+++ b/verifiers/v1/mcp/launch.py
@@ -21,10 +21,17 @@ import uuid
 from collections.abc import AsyncIterator, Awaitable, Callable
 from pathlib import Path
 from typing import TYPE_CHECKING
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from verifiers.v1.errors import ProgramError, RolloutError
-from verifiers.v1.mcp.server import ServerBase
-from verifiers.v1.runtimes import HOST, Runtime, make_runtime, reachable_url
+from verifiers.v1.mcp.server import STATE_SECRET_PARAM, STATE_URL_PARAM, ServerBase
+from verifiers.v1.runtimes import (
+    HOST,
+    Runtime,
+    make_runtime,
+    reachable_url,
+    runtime_is_local,
+)
 from verifiers.v1.runtimes.base import _ENSURE_UV
 from verifiers.v1.types import Messages
 
@@ -338,6 +345,25 @@ async def serve_shared(toolsets: list[Toolset], agent_is_local: bool = True):
         yield urls
 
 
+def _shared_url_for_rollout(
+    url: str, toolset: Toolset, state_port: int | None, state_secret: str
+) -> str:
+    """Tag a `shared` server's eval-level URL with this rollout's state-channel coordinates, so the
+    one shared process serves each rollout its OWN `self.state` (the per-rollout isolation a writable
+    shared server needs — read-only ones simply ignore it). Only when the shared server runs on a
+    local runtime, which reaches the host interception server at localhost; a remote shared runtime
+    gets the plain URL (no per-rollout state — read-only-safe, as before). The secret is the bearer
+    token the harness already holds, so tagging it on the URL is no new exposure."""
+    if state_port is None or not runtime_is_local(toolset.config.runtime):
+        return url
+    state_url = f"http://127.0.0.1:{state_port}/state"
+    parts = urlsplit(url)
+    query = dict(parse_qsl(parts.query))
+    query[STATE_URL_PARAM] = state_url
+    query[STATE_SECRET_PARAM] = state_secret
+    return urlunsplit(parts._replace(query=urlencode(query)))
+
+
 @contextlib.asynccontextmanager
 async def serve_tools(
     toolsets: list[Toolset],
@@ -363,8 +389,10 @@ async def serve_tools(
                 urls[name] = cfg.url
                 logger.info("tool server '%s' (remote): %s", name, cfg.url)
             elif name in shared_urls:  # one shared instance, started eval-level
-                urls[name] = shared_urls[name]
-                logger.info("tool server '%s' (shared): %s", name, shared_urls[name])
+                urls[name] = _shared_url_for_rollout(
+                    shared_urls[name], toolset, state_port, state_secret
+                )
+                logger.info("tool server '%s' (shared): %s", name, urls[name])
             else:
                 urls[name] = await stack.enter_async_context(
                     serve(

--- a/verifiers/v1/mcp/launch.py
+++ b/verifiers/v1/mcp/launch.py
@@ -392,7 +392,9 @@ async def serve_tools(
                 urls[name] = _shared_url_for_rollout(
                     shared_urls[name], toolset, state_port, state_secret
                 )
-                logger.info("tool server '%s' (shared): %s", name, urls[name])
+                # log the untagged base, NOT urls[name] — the per-rollout tag carries the rollout's
+                # bearer secret (`vf_state_secret`), which must not reach a log sink
+                logger.info("tool server '%s' (shared): %s", name, shared_urls[name])
             else:
                 urls[name] = await stack.enter_async_context(
                     serve(

--- a/verifiers/v1/mcp/server.py
+++ b/verifiers/v1/mcp/server.py
@@ -8,6 +8,7 @@ starts these in a runtime lives in `launch`.
 
 from __future__ import annotations
 
+import contextvars
 import functools
 import inspect
 import os
@@ -15,7 +16,7 @@ from typing import TYPE_CHECKING, Callable, ClassVar, Generic, TypeVar, get_args
 
 from pydantic_config import BaseConfig
 
-from verifiers.v1.state import StateT, state_cls
+from verifiers.v1.state import State, StateT, state_cls
 
 if TYPE_CHECKING:
     from mcp.server.fastmcp import FastMCP
@@ -24,6 +25,35 @@ ConfigT = TypeVar("ConfigT", bound=BaseConfig)
 
 STATE_TIMEOUT = 30.0
 """Seconds for a state-channel GET/PUT (localhost, or a tunnel to the host)."""
+
+# A `shared` server is one process for the whole eval, so it can't take a per-rollout state channel
+# from its environment like a per-rollout server does. Instead the framework tags each rollout's URL
+# to a shared server with that rollout's channel coordinates as these query params (`serve_tools`);
+# `_state_channel` reads them back per call from the MCP request, so `self.state` is the CALLING
+# rollout's state. The secret is the bearer token the harness already holds — no new exposure.
+STATE_URL_PARAM = "vf_state_url"
+STATE_SECRET_PARAM = "vf_state_secret"
+
+# The in-flight call's pulled `self.state`, set per call by `_with_state`. Per-call (not an instance
+# attribute) so concurrent calls — including different rollouts on one `shared` server — each see
+# their own state and never clobber each other.
+_call_state: contextvars.ContextVar[State | None] = contextvars.ContextVar(
+    "vf_call_state", default=None
+)
+
+
+def _request_query(name: str) -> str | None:
+    """A query param of the in-flight tool/respond call's HTTP request, read from MCP's per-call
+    request context (streamable HTTP threads the originating request through to the handler) — or
+    None outside an HTTP call. How a `shared` server reads the per-rollout state coordinates the
+    framework tagged on its URL."""
+    from mcp.server.lowlevel.server import request_ctx
+
+    try:
+        request = request_ctx.get().request
+    except LookupError:
+        return None
+    return request.query_params.get(name) if request is not None else None
 
 
 def _import_ref(ref: str) -> object:
@@ -62,38 +92,56 @@ class ServerBase(Generic[ConfigT, StateT]):
 
     def __init__(self, config: ConfigT) -> None:
         self.config = config
-        self.state: StateT = state_cls(type(self))()
-        """The rollout's shared runtime state, refreshed from the channel before each tool/respond
-        call (see `_with_state`). Outside a rollout it's just a fresh, inert `State`."""
+        self._state_cls = state_cls(type(self))
+        self._inert_state: StateT = self._state_cls()  # type: ignore[assignment]
+        """A fresh state used outside a tool/respond call (setup, or a manual debug run) — there's
+        no channel to sync, so writes to it don't escape the process (matches the no-channel case)."""
+
+    @property
+    def state(self) -> StateT:
+        """The rollout's shared runtime state for the in-flight tool/respond call, refreshed from the
+        interception server's channel before the call and pushed back after (see `_with_state`).
+        Backed by a per-call contextvar, so concurrent calls — including different rollouts on one
+        `shared` server — each see their own state and never clobber each other. Outside a call it's
+        a fresh, inert `State`."""
+        current = _call_state.get()
+        return current if current is not None else self._inert_state  # type: ignore[return-value]
 
     def _state_channel(self) -> tuple[str | None, str]:
-        """The interception server's state channel `(url, secret)` the framework injected for this
-        rollout — `(None, "")` when the server runs outside a rollout (a manual debug run)."""
-        return os.environ.get("VF_STATE_URL"), os.environ.get("VF_STATE_SECRET", "")
+        """The interception server's state channel `(url, secret)` for the in-flight call: the
+        per-rollout coordinates the framework tagged on a `shared` server's URL (read per call from
+        the MCP request), else the per-process channel it set in the environment (a per-rollout
+        server), else `(None, "")` (no channel — a manual debug run)."""
+        url = _request_query(STATE_URL_PARAM) or os.environ.get("VF_STATE_URL")
+        secret = _request_query(STATE_SECRET_PARAM) or os.environ.get(
+            "VF_STATE_SECRET", ""
+        )
+        return url, secret
 
-    async def _pull_state(self) -> dict:
-        """Refresh `self.state` from the shared channel (so it reflects other servers' writes) and
-        return its JSON snapshot for change detection. Without a channel, reset to a fresh state."""
+    async def _pull_state(self) -> State:
+        """Fetch the in-flight call's shared state from the channel (so it reflects other servers'
+        writes); a fresh inert state when there's no channel."""
         url, secret = self._state_channel()
-        cls = type(self.state)
+        cls = self._state_cls
         if not url:
-            self.state = cls()
-            return self.state.model_dump(mode="json")
+            return cls()
         import httpx
 
         async with httpx.AsyncClient(timeout=STATE_TIMEOUT) as client:
             resp = await client.get(url, headers={"Authorization": f"Bearer {secret}"})
             resp.raise_for_status()
-            self.state = cls.model_validate(resp.json())
-        return self.state.model_dump(mode="json")
+            return cls.model_validate(resp.json())
 
     async def _push_state(self, before: dict) -> None:
-        """Push `self.state` back to the shared channel if it changed this call. No-op without a
-        channel or when nothing changed."""
+        """Push the in-flight call's `self.state` back to the shared channel if it changed. No-op
+        without a channel or when nothing changed."""
         url, secret = self._state_channel()
         if not url:
             return
-        after = self.state.model_dump(mode="json")
+        state = _call_state.get()
+        after = (state if state is not None else self._inert_state).model_dump(
+            mode="json"
+        )
         if after == before:
             return
         import httpx
@@ -105,10 +153,12 @@ class ServerBase(Generic[ConfigT, StateT]):
             resp.raise_for_status()
 
     def _with_state(self, fn: Callable) -> Callable:
-        """Wrap a tool/respond callable so each invocation pulls the latest shared `self.state`
-        before running and pushes back any change after — the read/write channel a `@vf.tool` and
-        `respond` use via `self.state`. Preserves `fn`'s signature so FastMCP advertises the tool
-        unchanged. A no-op (fresh inert state) when the server runs outside a rollout (no channel).
+        """Wrap a tool/respond callable so each invocation pulls the latest shared state into
+        `self.state` before running and pushes back any change after — the read/write channel a
+        `@vf.tool` and `respond` use via `self.state`. The pulled state lives in a per-call
+        contextvar, so concurrent calls (and concurrent rollouts on a `shared` server) don't share
+        it. Preserves `fn`'s signature so FastMCP advertises the tool unchanged. A no-op (fresh inert
+        state) when the server runs outside a rollout (no channel).
 
         This is a whole-object read-modify-write, so it is **last-write-wins**: calls a harness runs
         concurrently (several `tool_calls` in one turn) race and can lose each other's writes; calls
@@ -116,12 +166,17 @@ class ServerBase(Generic[ConfigT, StateT]):
 
         @functools.wraps(fn)
         async def wrapper(*args, **kwargs):
-            before = await self._pull_state()
-            result = fn(*args, **kwargs)
-            if inspect.isawaitable(result):
-                result = await result
-            await self._push_state(before)
-            return result
+            state = await self._pull_state()
+            token = _call_state.set(state)
+            try:
+                before = state.model_dump(mode="json")
+                result = fn(*args, **kwargs)
+                if inspect.isawaitable(result):
+                    result = await result
+                await self._push_state(before)
+                return result
+            finally:
+                _call_state.reset(token)
 
         wrapper.__signature__ = inspect.signature(fn)  # type: ignore[attr-defined]
         return wrapper

--- a/verifiers/v1/mcp/toolset.py
+++ b/verifiers/v1/mcp/toolset.py
@@ -41,8 +41,12 @@ class ToolsetConfig(BaseConfig):
     package + `verifiers` (a per-rollout cost), so prefer the default own-runtime placement
     unless co-locating genuinely helps."""
     shared: bool = False
-    """Run one server instance for the whole eval, shared across rollouts (in its own
-    `runtime`). Mutually exclusive with `colocated`."""
+    """Run one server instance for the whole eval, shared across rollouts (in its own `runtime`) —
+    pays an expensive `setup` (a corpus/index) once. It may still be writable: each rollout reads and
+    writes its OWN `self.state` (the framework tags the per-rollout state channel onto the shared
+    server's URL), so concurrent rollouts don't corrupt each other — provided the shared server runs
+    on a local runtime (the default), which can reach the host's interception server. Mutually
+    exclusive with `colocated`."""
     runtime: RuntimeConfig = SubprocessConfig()
     """The server's own runtime, used unless `colocated` (host/subprocess by default — always
     reachable from any harness runtime; set docker/prime to isolate it in its own sandbox)."""


### PR DESCRIPTION
## Summary

A `shared` tool server (`ToolsetConfig(shared=True)`) pays its expensive `setup` once but is **one
process for the whole eval**, so it had no per-rollout state channel — safe only for **read-only**
servers (e.g. `wiki-search-v1`), since a writable one let concurrent rollouts corrupt each other.
This threads each rollout's shared-state channel to the shared server, so a writable shared server
is isolated per rollout — entirely framework-side, reusing the existing `self.state` mechanism.

- **Per-request state channel.** A shared process can't take a per-rollout channel from its
  environment (env is set once at launch). Instead, `serve_tools` tags the shared server's URL with
  this rollout's state coordinates — `vf_state_url` + `vf_state_secret` (the same bearer token the
  harness already holds, so no new exposure). `ServerBase._state_channel` reads them back **per call**
  from MCP's request context (streamable HTTP threads the originating request through to the handler),
  falling back to the per-process env channel a per-rollout server still gets. So a shared server's
  `self.state` is the **calling rollout's** state — no `current_rollout_id()`, no rollout-aware code.
- **Per-call state, not an instance attribute.** `self.state` is now backed by a per-call contextvar
  (set in `_with_state`), so concurrent calls — including different rollouts on one shared process —
  each see their own state and never clobber each other. Per-rollout servers behave exactly as before.
- **Constraint.** The shared server must run on a **local** runtime (the default), which can reach the
  host interception server; a remote shared runtime gets the plain URL (no per-rollout state —
  read-only-safe, as before).

This is the new-architecture reincarnation of the earlier shared-tool-server attempts (#1696 threaded
a bare `rollout_id` for manual namespacing; #1697 forked a process per rollout). The refactor to
native `Toolset`/`User` + the interception `/state` channel already shipped the per-rollout shared
state primitive, so the only gap was wiring it to shared servers — which this does.

## Example + e2e

`environments/scratchpad_v1/` — a **shared, writable** server that round-trips a per-rollout word
through `self.state`. Concurrent eval, one short capped rollout each:

- isolated (default): `uv run eval scratchpad-v1 -n 8 -r 1 -c 8` → **mean reward 1.0** (each rollout
  reads back its own word)
- bypass isolation (`SCRATCHPAD_ISOLATE=0`, write to a process-global slot instead of `self.state`):
  → **mean reward ~0.25** (concurrent rollouts clobber the single slot and read the wrong word)

So the shared server is genuinely shared (one process), and per-rollout isolation works under
concurrency. Per-rollout state regression-checked separately (`alphabet-sort-v1` still ends via
`self.state.user_finished` + `@vf.stop`). ruff check + format clean.

## Security

The per-rollout tag carries the rollout's interception bearer (`vf_state_secret`). It is only handed
to the harness — which already holds that secret — and is **kept out of logs**: the shared-server info
log prints the untagged base URL, never the tagged one.

## Breaking

None. `self.state` becomes a read-only property (backed by a per-call contextvar) instead of an
instance attribute — tool/respond code that *mutates* `self.state` (`self.state.x = ...`) is
unaffected; only wholesale reassignment (`self.state = ...`, which no server does) would break.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-rollout state isolation for shared writable tool servers
> - `ServerBase` in [server.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1727/files#diff-5eaeab5d19ee732e16b066ff6689f954f6743833a907a129acc0df250cee5b2a) replaces a single shared `self.state` with a per-call contextvar, so concurrent tool calls from different rollouts each see their own isolated state pulled from and pushed to a per-rollout state channel.
> - [launch.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1727/files#diff-989d87123d40d48511f9e1df74594d2e30776e9a99c11eca49d9cc20bf9e2230) adds `_shared_url_for_rollout`, which tags shared server URLs with `vf_state_url` and `vf_state_secret` query parameters so each rollout connects to its own state channel on a shared server.
> - Adds a new `scratchpad-v1` environment ([scratchpad.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1727/files#diff-d4dc1b80a143156d44ce08030abd08a3e0b420c4a8bbe8fee14a8c1a14bef637)) that demonstrates and tests shared-writable isolation: a `scratchpad_roundtrip` tool echoes a word via per-rollout state by default, or a process-global slot when `SCRATCHPAD_ISOLATE=0`.
> - Behavioral Change: shared tool servers now receive per-rollout state coordinates via request query parameters rather than environment variables; log output for shared servers no longer includes the secret-bearing tagged URL.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8148b44.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core MCP launch and `ServerBase` state sync used by all tool servers; behavior change is intentional (contextvar isolation) but concurrency and shared-server URL tagging need to stay correct under load.
> 
> **Overview**
> Enables **writable** `ToolsetConfig(shared=True)` servers without cross-rollout corruption by wiring each rollout’s existing interception `/state` channel into the one shared MCP process.
> 
> **Framework:** `serve_tools` tags per-rollout MCP URLs with `vf_state_url` / `vf_state_secret` (local shared runtime only); `ServerBase` resolves the channel per HTTP request and backs `self.state` with a **contextvar** so concurrent tool calls from different rollouts don’t share one in-memory object. Docs and `ToolsetConfig.shared` clarify writable shared servers vs read-only.
> 
> **Example:** New **`scratchpad-v1`** taskset — shared `scratchpad_roundtrip` tool with optional `SCRATCHPAD_ISOLATE=0` to demonstrate global-slot corruption under concurrency. Registered in root `pyproject.toml` / `uv.lock`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8148b448f0e9426a62dbdd45bcd5fd42d5c75fd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
