### PR TITLE
Persist model retry diagnostics in eval outputs

### DIFF
--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -253,7 +253,11 @@ When `--shuffle` is enabled, Verifiers shuffles the full evaluation dataset firs
 
 By default, scoring runs interleaved with generation. Use `--no-interleave-scoring` to score all rollouts after generation completes.
 
-The `--max-retries` flag enables automatic retry with exponential backoff when rollouts fail due to transient infrastructure errors (e.g., sandbox timeouts, API failures).
+The `--max-retries` flag enables automatic retry with exponential backoff when rollouts fail due to transient infrastructure or model-response errors, such as sandbox timeouts, API failures, or empty model responses.
+
+When a rollout retries, its saved output includes a `retry` block. It records attempt count, exhaustion status, elapsed retry time, and the retryable errors that triggered each attempt. Retry events also include model request metadata when available, so a failed empty-response attempt can be traced by `request_id` even if a later retry succeeds.
+
+Model calls record lightweight request diagnostics in the rollout state. `last_model_request` identifies the most recent model request. `last_model_error` is present when the latest model request failed.
 
 The `--num-workers` flag controls how many worker processes the env server spawns. Each worker owns its own environment instance and runs rollouts independently. The default `auto` scales with concurrency.
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -185,11 +185,16 @@ class RolloutOutput(dict):
     error: str | None
     stop_condition: str | None
     token_usage: TokenUsage
+    retry: RetryData
+    last_model_request: dict[str, str]
+    last_model_error: dict[str, str]
     trajectory: list[TrajectoryStep]
     tool_defs: list[Tool] | None
 ```
 
 Serialized output from a rollout. This is a `dict` subclass that provides typed access to known fields while supporting arbitrary additional fields from `state_columns`. All values must be JSON-serializable. Used in `GenerateOutputs` and for saving results to disk.
+
+The `retry` field appears when `max_retries` caused at least one retry. It records attempts, retry count, exhaustion status, elapsed retry time, and per-attempt error summaries. Retry events include model request metadata when available. `last_model_request` identifies the most recent model call and `last_model_error` is present when that call failed.
 
 ### TrajectoryStep
 

--- a/skills/evaluate-environments/SKILL.md
+++ b/skills/evaluate-environments/SKILL.md
@@ -35,6 +35,7 @@ prime eval run owner/my-env -m openai/gpt-4.1-mini -n 200 -r 3 --shuffle -s
 prime eval run my-env
 prime eval run my-env -m openai/gpt-4.1-mini
 ```
+8. When debugging transient failures in saved results, inspect `retry`, `last_model_request`, and `last_model_error` in `results.jsonl` before assuming the model, sandbox, or scorer caused the failure.
 
 ## Endpoint Shortcuts And Model Family Choice
 1. Encourage users to define endpoint aliases in `configs/endpoints.toml` so model, base URL, and key wiring stay reusable.

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -652,6 +652,50 @@ class TestMaybeRetry:
 
         assert states[0].get("error") is None
         assert env.call_counts[0] == 3
+        assert states[0]["retry"]["attempts"] == 3
+        assert states[0]["retry"]["retry_count"] == 2
+        assert states[0]["retry"]["exhausted"] is False
+
+    @pytest.mark.asyncio
+    async def test_empty_model_response_retries_and_records_request(
+        self, mock_client, sample_dataset, make_input
+    ):
+        env = SimpleEnvironment(
+            dataset=sample_dataset,
+            parser=Parser(),
+            rubric=Rubric(),
+        )
+        mock_client.get_response = AsyncMock(
+            side_effect=[
+                vf.EmptyModelResponseError("provider returned only reasoning"),
+                Response(
+                    id="ok",
+                    created=0,
+                    model="test-model",
+                    message=ResponseMessage(
+                        role="assistant",
+                        content="Recovered",
+                        finish_reason="stop",
+                        is_truncated=False,
+                    ),
+                ),
+            ]
+        )
+
+        outputs = await env.generate(
+            [make_input()],
+            client=mock_client,
+            model="test-model",
+            max_retries=1,
+        )
+
+        rollout = outputs["outputs"][0]
+        assert rollout["error"] is None
+        assert rollout["completion"][-1]["content"] == "Recovered"
+        assert rollout["retry"]["retry_count"] == 1
+        assert rollout["retry"]["events"][0]["error"] == "EmptyModelResponseError"
+        assert rollout["retry"]["events"][0]["request_id"].startswith("model_")
+        assert rollout["retry"]["events"][0]["model"] == "test-model"
 
     @pytest.mark.asyncio
     async def test_no_retry_after_non_retryable_error(self, mock_client, make_input):
@@ -696,6 +740,11 @@ class TestMaybeRetry:
         assert rollout_outputs[0].get("error") is not None
         error_data = rollout_outputs[0]["error"]
         assert "InfraError" == error_data["error"]
+        retry = rollout_outputs[0]["retry"]
+        assert retry["attempts"] == 3
+        assert retry["retry_count"] == 2
+        assert retry["exhausted"] is True
+        assert retry["events"][-1]["error"] == "InfraError"
 
     @pytest.mark.asyncio
     async def test_retries_serialized_infra_error_subclass(self):
@@ -720,6 +769,36 @@ class TestMaybeRetry:
         result = await maybe_retry(attempt, max_retries=2, initial=0.0, max_wait=0.0)()
         assert calls["n"] == 3  # 1 initial + 2 retries (InfraError is retryable)
         assert result["error"] == serialized  # last result returned after exhaustion
+
+    @pytest.mark.asyncio
+    async def test_group_retry_metadata_uses_retryable_state_index(self):
+        """Retry metadata should point at the state that actually triggered retry."""
+        from verifiers.utils.async_utils import maybe_retry
+
+        calls = {"n": 0}
+
+        async def attempt():
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return [
+                    {"error": vf.ToolError("bad tool call")},
+                    {"error": vf.InfraError("worker timed out")},
+                ]
+            return [
+                {"error": None},
+                {"error": None},
+            ]
+
+        result = await maybe_retry(
+            attempt,
+            max_retries=1,
+            initial=0.0,
+            max_wait=0.0,
+        )()
+
+        assert calls["n"] == 2
+        assert result[0]["retry"]["events"][0]["state_index"] == "1"
+        assert result[1]["retry"]["events"][0]["state_index"] == "1"
 
 
 class TestEmptyModelResponseErrors:

--- a/tests/test_save_utils.py
+++ b/tests/test_save_utils.py
@@ -289,6 +289,47 @@ class TestSavingResults:
         assert result[0].get("foo") == "bar"  # custom field from make_state fixture
         assert result[0]["reward"] == 1.0
 
+    def test_states_to_outputs_includes_retry_and_model_request_metadata(
+        self, make_state
+    ):
+        state = make_state()
+        state["retry"] = {
+            "attempts": 2,
+            "max_retries": 1,
+            "retry_count": 1,
+            "exhausted": False,
+            "elapsed_seconds": 0.25,
+            "events": [
+                {
+                    "attempt": 1,
+                    "error": "EmptyModelResponseError",
+                    "message": "empty response",
+                    "error_chain_str": "EmptyModelResponseError",
+                    "next_sleep_seconds": 0.1,
+                }
+            ],
+        }
+        state["last_model_request"] = {
+            "request_id": "model_123",
+            "model": "test-model",
+            "trajectory_id": "traj",
+        }
+        state["last_model_error"] = {
+            "request_id": "model_123",
+            "model": "test-model",
+            "trajectory_id": "traj",
+            "error": "EmptyModelResponseError",
+            "message": "empty response",
+            "error_chain_repr": "EmptyModelResponseError('empty response')",
+            "error_chain_str": "EmptyModelResponseError",
+        }
+
+        outputs = states_to_outputs([state], state_columns=[])
+
+        assert outputs[0]["retry"] == state["retry"]
+        assert outputs[0]["last_model_request"] == state["last_model_request"]
+        assert outputs[0]["last_model_error"] == state["last_model_error"]
+
     def test_states_to_outputs_requires_example_id(self, make_state):
         state = make_state()
         del state["example_id"]

--- a/tests/test_v1_runtime_lifecycle.py
+++ b/tests/test_v1_runtime_lifecycle.py
@@ -1092,6 +1092,10 @@ async def test_base_program_submits_system_prompt_before_prompt() -> None:
     ]
     assert state["prompt"][0]["role"] == "system"
     assert state["completion"][-1]["content"] == "ok"
+    request_id = state["trajectory"][0]["extras"]["model_request_id"]
+    assert request_id.startswith("model_")
+    assert state["last_model_request"]["request_id"] == request_id
+    assert state["last_model_request"]["model"] == "fake"
 
 
 @pytest.mark.asyncio
@@ -1123,6 +1127,28 @@ async def test_model_request_reservation_released_when_client_resolution_fails()
         )
 
     assert harness.runtime.visible_model_requests(state) == 0
+    assert state["trajectory"] == []
+
+
+@pytest.mark.asyncio
+async def test_empty_v1_model_response_records_request_context() -> None:
+    harness = make_harness(
+        client=cast(
+            Client,
+            RaisingModelClient(vf.EmptyModelResponseError("empty provider response")),
+        ),
+        model="fake",
+        max_turns=1,
+    )
+    task = vf.Task({"prompt": [{"role": "user", "content": "hi"}]}).freeze()
+
+    state = await harness.run(task)
+
+    assert state["error"]["error"] == "EmptyModelResponseError"
+    assert state["last_model_error"]["error"] == "EmptyModelResponseError"
+    assert state["last_model_error"]["message"] == "empty provider response"
+    assert state["last_model_error"]["request_id"].startswith("model_")
+    assert state["last_model_error"]["model"] == "fake"
     assert state["trajectory"] == []
 
 

--- a/verifiers/envs/environment.py
+++ b/verifiers/envs/environment.py
@@ -72,6 +72,7 @@ from verifiers.utils.async_utils import (
     with_sem,
 )
 from verifiers.utils.error_utils import ErrorChain
+from verifiers.utils.error_utils import error_data
 from verifiers.utils.message_utils import normalize_messages
 from verifiers.utils.save_utils import (
     GenerateOutputsBuilder,
@@ -523,13 +524,26 @@ class Environment(ABC):
 
         self._get_usage_tracker(state, create_if_missing=True)
 
-        response = await client.get_response(
-            prompt=prompt,
-            model=model,
-            tools=tool_defs,
-            sampling_args=sampling_args,
-            state=state,
-        )
+        request_id = f"model_{uuid.uuid4().hex}"
+        state["last_model_request"] = {
+            "request_id": request_id,
+            "model": model,
+            "trajectory_id": str(state.get("trajectory_id", "")),
+        }
+        try:
+            response = await client.get_response(
+                prompt=prompt,
+                model=model,
+                tools=tool_defs,
+                sampling_args=sampling_args,
+                state=state,
+            )
+        except vf.Error as error:
+            state["last_model_error"] = {
+                **state["last_model_request"],
+                **error_data(error),
+            }
+            raise
         self.increment_state_usage_from_response(state, response)
 
         return response

--- a/verifiers/types.py
+++ b/verifiers/types.py
@@ -399,6 +399,27 @@ class ErrorData(TypedDict):
     error_chain_str: str
 
 
+class RetryEvent(TypedDict):
+    attempt: int
+    error: str
+    message: str
+    error_chain_str: str
+    next_sleep_seconds: NotRequired[float]
+    state_index: NotRequired[str]
+    request_id: NotRequired[str]
+    model: NotRequired[str]
+    trajectory_id: NotRequired[str]
+
+
+class RetryData(TypedDict):
+    attempts: int
+    max_retries: int
+    retry_count: int
+    exhausted: bool
+    elapsed_seconds: float
+    events: list[RetryEvent]
+
+
 class RolloutOutput(dict):
     """Serialized output from a rollout (mirrors RolloutInput).
 
@@ -409,7 +430,7 @@ class RolloutOutput(dict):
     Required fields: example_id, prompt, completion, reward, timing,
                      is_completed, is_truncated, metrics
     Optional fields: answer, info, error, stop_condition, trajectory, tool_defs,
-                     token_usage
+                     token_usage, retry
     Additional fields: arbitrary serializable state_columns
     """
 
@@ -430,6 +451,7 @@ class RolloutOutput(dict):
     trajectory: list["TrajectoryStep"]
     tool_defs: list[Tool]
     token_usage: TokenUsage
+    retry: RetryData
 
 
 _MISSING = object()

--- a/verifiers/utils/async_utils.py
+++ b/verifiers/utils/async_utils.py
@@ -1,6 +1,7 @@
 import asyncio
 import inspect
 import logging
+import time
 from collections import deque
 from collections.abc import Mapping
 from collections.abc import Coroutine
@@ -13,6 +14,7 @@ from pydantic import BaseModel
 
 import verifiers as vf
 from verifiers.utils.error_utils import ErrorChain
+from verifiers.utils.error_utils import error_data
 from verifiers.utils.error_utils import error_from_data, is_error_data
 from verifiers.utils.logging_utils import print_time
 
@@ -161,43 +163,128 @@ def maybe_retry(
     if max_retries <= 0:
         return func
 
-    def reraise_one(err, error_types: tuple[type[Exception], ...]):
+    retry_started_at = 0.0
+    retry_events: list[dict[str, Any]] = []
+    last_result = None
+
+    def summarize_error(error: BaseException | Mapping[str, Any]) -> dict[str, str]:
+        if isinstance(error, Mapping) and is_error_data(error):
+            return {
+                "error": error["error"],
+                "message": error["message"],
+                "error_chain_str": error["error_chain_str"],
+            }
+        if isinstance(error, BaseException):
+            data = error_data(error)
+            return {
+                "error": data["error"],
+                "message": data["message"],
+                "error_chain_str": data["error_chain_str"],
+            }
+        return {
+            "error": type(error).__name__,
+            "message": str(error),
+            "error_chain_str": type(error).__name__,
+        }
+
+    def retryable_error(
+        err, error_types: tuple[type[Exception], ...]
+    ) -> Exception | None:
         if not err:
-            return
+            return None
         if any(isinstance(err, err_type) for err_type in error_types):
-            raise err
+            return err
         # Rebuild serialized ErrorData so base types match (SandboxError -> InfraError).
         if isinstance(err, Mapping) and is_error_data(err):
             rebuilt = error_from_data(err)
             if isinstance(rebuilt, error_types):
-                raise rebuilt
+                return rebuilt
+        return None
+
+    def first_retryable_state_error(
+        result, error_types: tuple[type[Exception], ...]
+    ) -> tuple[str, Exception] | None:
+        if isinstance(result, dict):
+            retryable = retryable_error(result.get("error"), error_types)
+            return ("", retryable) if retryable is not None else None
+        if isinstance(result, list):
+            for index, state in enumerate(result):
+                retryable = retryable_error(state.get("error"), error_types)
+                if retryable is not None:
+                    return (str(index), retryable)
+        return None
+
+    def retry_event_context(result, state_index: str) -> dict[str, str]:
+        state = result
+        if isinstance(result, list) and state_index:
+            try:
+                state = result[int(state_index)]
+            except (IndexError, ValueError):
+                state = None
+        if not isinstance(state, Mapping):
+            return {}
+        for key in ("last_model_error", "last_model_request"):
+            value = state.get(key)
+            if not isinstance(value, Mapping):
+                continue
+            context = {}
+            for field in ("request_id", "model", "trajectory_id"):
+                field_value = value.get(field)
+                if isinstance(field_value, str):
+                    context[field] = field_value
+            return context
+        return {}
 
     def reraise_error_from_state(result, error_types: tuple[type[Exception], ...]):
         """Re-raise specified errors from state(s) to trigger tenacity retry."""
+        retryable = first_retryable_state_error(result, error_types)
+        if retryable is not None:
+            raise retryable[1]
+
+    def attach_retry_info(result, *, exhausted: bool = False) -> None:
+        if not retry_events:
+            return
+        attempts = len(retry_events) + (0 if exhausted else 1)
+        summary = {
+            "attempts": attempts,
+            "max_retries": max_retries,
+            "retry_count": min(max_retries, max(0, attempts - 1)),
+            "exhausted": exhausted,
+            "elapsed_seconds": time.time() - retry_started_at,
+            "events": retry_events,
+        }
         if isinstance(result, dict):
-            reraise_one(result.get("error"), error_types)
+            result["retry"] = summary
         elif isinstance(result, list):
             for state in result:
-                reraise_one(state.get("error"), error_types)
+                state["retry"] = summary
+
+    def begin_retry_call(retry_state: tc.RetryCallState) -> None:
+        nonlocal last_result, retry_events, retry_started_at
+        if retry_state.attempt_number == 1:
+            last_result = None
+            retry_events = []
+            retry_started_at = time.time()
 
     def log_retry(retry_state: tc.RetryCallState) -> None:
         """Log a warning with the exception and the number of attempts."""
         caller = retry_state.fn.__name__ if retry_state.fn else "unknown function"
-        error_chain = (
-            repr(
-                ErrorChain(
-                    retry_state.outcome.exception() or Exception("Unknown exception")
-                )
-            )
-            if retry_state.outcome
-            else None
-        )
+        error = retry_state.outcome.exception() if retry_state.outcome else None
+        error_chain = repr(ErrorChain(error or Exception("Unknown exception")))
         next_action = retry_state.next_action.sleep if retry_state.next_action else 0
+        if retry_events and retry_events[-1]["attempt"] == retry_state.attempt_number:
+            retry_events[-1]["next_sleep_seconds"] = next_action
+        else:
+            retry_events.append(
+                {
+                    "attempt": retry_state.attempt_number,
+                    "next_sleep_seconds": next_action,
+                    **summarize_error(error or Exception("Unknown exception")),
+                }
+            )
         logger.warning(
             f"Caught {error_chain} in {caller}. Retrying in {print_time(next_action)} (retry {retry_state.attempt_number}/{max_retries})"
         )
-
-    last_result = None
 
     def return_last_result(retry_state: tc.RetryCallState):
         """Return the last result when retries are exhausted (instead of raising)."""
@@ -215,13 +302,31 @@ def maybe_retry(
             f"Retries exhausted for {caller} after {max_retries} attempts. "
             f"Last error: {error_chain}. Continuing with error in state."
         )
+        if last_result is not None:
+            attach_retry_info(last_result, exhausted=True)
         return last_result
 
     async def wrapper(*args, **kwargs):
         nonlocal last_result
         result = await func(*args, **kwargs)
         last_result = result  # store result
-        reraise_error_from_state(result, error_types)
+        retryable_state_error = first_retryable_state_error(result, error_types)
+        try:
+            reraise_error_from_state(result, error_types)
+        except error_types as error:
+            state_index = (
+                retryable_state_error[0] if retryable_state_error is not None else ""
+            )
+            retry_events.append(
+                {
+                    "attempt": len(retry_events) + 1,
+                    "state_index": state_index,
+                    **retry_event_context(result, state_index),
+                    **summarize_error(error),
+                }
+            )
+            raise
+        attach_retry_info(result)
         return result
 
     wrapper.__name__ = getattr(func, "__name__", "unknown")
@@ -231,6 +336,7 @@ def maybe_retry(
         retry=tc.retry_if_exception_type(error_types),
         stop=tc.stop_after_attempt(max_retries + 1),
         wait=tc.wait_exponential_jitter(initial=initial, max=max_wait),
+        before=begin_retry_call,
         before_sleep=log_retry,
         retry_error_callback=return_last_result,
         reraise=True,

--- a/verifiers/utils/save_utils.py
+++ b/verifiers/utils/save_utils.py
@@ -294,6 +294,17 @@ def state_to_output(
         output.pop("answer")
     if "info" in output and not output["info"]:
         output.pop("info")
+    retry = state.get("retry")
+    if retry is not None:
+        if not is_json_serializable(retry):
+            raise ValueError("state.retry must be JSON-serializable.")
+        output["retry"] = retry
+    for key in ("last_model_request", "last_model_error"):
+        value = state.get(key)
+        if value is not None:
+            if not is_json_serializable(value):
+                raise ValueError(f"state.{key} must be JSON-serializable.")
+            output[key] = value
     # flatten metrics to top-level keys (backwards compatibility)
     state_metrics = state.get("metrics") or {}
     for k, v in state_metrics.items():

--- a/verifiers/v1/runtime.py
+++ b/verifiers/v1/runtime.py
@@ -20,11 +20,13 @@ from typing import (
     runtime_checkable,
 )
 
+import verifiers as vf
 from verifiers.clients import Client, resolve_client
 from verifiers.types import Messages, Response, ResponseMessage, Tool
 from verifiers.types import ClientConfig, ClientType, SamplingArgs
 from verifiers.utils.async_utils import maybe_call_with_named_args
 from verifiers.utils.client_utils import resolve_client_config
+from verifiers.utils.error_utils import error_data
 from verifiers.utils.message_utils import normalize_messages
 from verifiers.utils.response_utils import parse_response_message, parse_response_tokens
 from verifiers.utils.tool_utils import convert_func_to_tool_def
@@ -882,17 +884,31 @@ class Runtime:
         if not reserved:
             return self._completed_model_response(state)
         released = False
+        request_id = context.endpoint_request_id or f"model_{uuid.uuid4().hex}"
+        request_meta = {
+            "request_id": request_id,
+            "source": context.source,
+            "model": self.model(state),
+            "trajectory_id": str(state["trajectory_id"]),
+        }
+        if context.endpoint_request_id is not None:
+            request_meta["endpoint_request_id"] = context.endpoint_request_id
+        state["last_model_request"] = request_meta
         try:
             prompt = await self._prepare_prompt(prompt, state)
             client = self.model_client(state)
             request_start = time.time()
-            response = await client.get_response(
-                prompt=prompt,
-                model=self.model(state),
-                tools=tool_defs,
-                sampling_args=self.sampling_args(state),
-                state=state,
-            )
+            try:
+                response = await client.get_response(
+                    prompt=prompt,
+                    model=self.model(state),
+                    tools=tool_defs,
+                    sampling_args=self.sampling_args(state),
+                    state=state,
+                )
+            except vf.Error as error:
+                state["last_model_error"] = {**request_meta, **error_data(error)}
+                raise
             request_end = time.time()
             state.record_model_timing(request_start, request_end)
             record_response_usage(state, response)
@@ -901,6 +917,8 @@ class Runtime:
             is_truncated = response.message.is_truncated or (
                 tokens is not None and bool(tokens.get("is_truncated"))
             )
+            extras = context.extras()
+            extras["model_request_id"] = request_id
             step = {
                 "prompt": serializable(prompt),
                 "completion": serializable(completion),
@@ -910,7 +928,7 @@ class Runtime:
                 "advantage": None,
                 "is_truncated": bool(is_truncated),
                 "trajectory_id": str(state["trajectory_id"]),
-                "extras": context.extras(),
+                "extras": extras,
             }
             if context.trajectory_visibility == "append":
                 state["trajectory"].append(step)


### PR DESCRIPTION
## Summary
- persist retry summaries on rollout outputs when max_retries retries a transient failure
- attach model request ids to retry events, legacy model calls, and v1 trajectory extras
- save last_model_request and last_model_error so empty or invalid provider responses are debuggable after the eval finishes
- document the new fields in eval docs, reference docs, and the evaluate skill

This is aimed at the open empty-response and request-id debugging problems in #1607 and #1563.

## Checks
- uv run pytest tests/test_environment.py::TestMaybeRetry tests/test_save_utils.py::TestSavingResults::test_states_to_outputs_includes_retry_and_model_request_metadata tests/test_v1_runtime_lifecycle.py::test_base_program_submits_system_prompt_before_prompt tests/test_v1_runtime_lifecycle.py::test_empty_v1_model_response_records_request_context -q
- uv run ruff check verifiers/utils/async_utils.py verifiers/envs/environment.py verifiers/v1/runtime.py verifiers/types.py verifiers/utils/save_utils.py tests/test_environment.py tests/test_save_utils.py tests/test_v1_runtime_lifecycle.py
- uv run python -m compileall verifiers
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive serialization and diagnostics around existing retry and model-call paths; behavior changes are limited to richer saved output and clearer retry attribution in groups.
> 
> **Overview**
> Rollout **saved outputs** now carry debugging metadata when `--max-retries` is used or when model calls fail, so post-hoc analysis in `results.jsonl` does not depend on live logs.
> 
> **`maybe_retry`** builds a **`retry`** summary (attempts, exhaustion, elapsed time, per-attempt events) and attaches it to the returned state(s), including **group rollouts** where events record the **`state_index`** of the rollout that triggered the retry. Retry events can include **`request_id`**, **model**, and **trajectory_id** pulled from the failing state’s model-call context.
> 
> **Legacy `Environment.get_model_response`** and **v1 `runtime.submit_model_request`** assign **`last_model_request`** before each call and **`last_model_error`** when a `vf.Error` is raised; v1 also stores **`model_request_id`** on trajectory step extras. **`states_to_outputs` / `RolloutOutput`** types document and serialize **`retry`**, **`last_model_request`**, and **`last_model_error`**.
> 
> Docs and the evaluate skill describe inspecting these fields when debugging transient failures (e.g. empty provider responses retried then recovered).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf1963579f8472d9bbacce0e8eca01823a7e7323. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Persist model retry diagnostics in eval outputs
> - `maybe_retry` in [`async_utils.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1730/files#diff-5e5c0a475b1277fb889a3c5958da1b55d5dc86df6eed010149e9ec0208d57fea) now captures per-attempt retry events (errors, request IDs, elapsed time) and attaches a `retry` summary to returned state(s); when retries are exhausted, it returns the last result with `retry.exhausted=True` instead of raising.
> - [`environment.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1730/files#diff-066aa9922fcaf4d3d3fc471b078fbfa64512119dbb81392b7feba435fc92c0aa) and [`runtime.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1730/files#diff-7c2c1b88c61b8a75e00bb82f7ece60290f886d4a3ed87e97a5e1cbf86b26973d) now write `last_model_request` (request ID, model, trajectory ID) to state before each model call, and `last_model_error` on `vf.Error` failures.
> - [`save_utils.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1730/files#diff-e4491159a12a733bc8861a33ba9d2d09b27942f04c4baa1629f0806efa07547d) propagates `retry`, `last_model_request`, and `last_model_error` from state into saved `RolloutOutput` entries in `results.jsonl`.
> - New `RetryEvent` and `RetryData` TypedDicts are added to [`types.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1730/files#diff-8bc45ba080ed8ff01ee6adbafb54c0346181c6f292928e53c2a94dd9ed5156c3); `RolloutOutput` gains an optional `retry` field.
> - Behavioral Change: exhausted retries no longer raise — callers that previously caught exceptions from `maybe_retry` will now receive a result with `retry.exhausted=True` instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bf19635.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->