### PR TITLE
fix: unified, robust env-server teardown (no leaked tunnels/sandboxes)

### DIFF
--- a/verifiers/v1/cli/eval/runner.py
+++ b/verifiers/v1/cli/eval/runner.py
@@ -126,7 +126,7 @@ async def run_eval_server(config: EvalConfig) -> list[Trace]:
     address_queue: mp.Queue = mpctx.Queue()
     # Death pipe: serve_env (and, transitively, its workers/tunnels/sandboxes) self-terminates
     # if this main process dies abruptly. We keep parent_conn; its close — even on our SIGKILL —
-    # signals death to the child's watch (see _arm_child). Mirrors the broker -> worker pipe.
+    # signals death to the child's watch (see _arm_teardown). Mirrors the broker -> worker pipe.
     parent_conn, child_conn = mpctx.Pipe()
     proc = mpctx.Process(
         target=serve_env,

--- a/verifiers/v1/cli/eval/runner.py
+++ b/verifiers/v1/cli/eval/runner.py
@@ -124,6 +124,10 @@ async def run_eval_server(config: EvalConfig) -> list[Trace]:
     log_file = str(output_path(config) / "eval.log")
     mpctx = mp.get_context("spawn")
     address_queue: mp.Queue = mpctx.Queue()
+    # Death pipe: serve_env (and, transitively, its workers/tunnels/sandboxes) self-terminates
+    # if this main process dies abruptly. We keep parent_conn; its close — even on our SIGKILL —
+    # signals death to the child's watch (see _arm_child). Mirrors the broker -> worker pipe.
+    parent_conn, child_conn = mpctx.Pipe()
     proc = mpctx.Process(
         target=serve_env,
         kwargs=dict(
@@ -131,12 +135,14 @@ async def run_eval_server(config: EvalConfig) -> list[Trace]:
             legacy=legacy,
             address="tcp://127.0.0.1:0",
             address_queue=address_queue,
+            death_pipe=child_conn,
             log_setup=partial(setup_logging, level, log_file),
             **server_kwargs,
         ),
         daemon=False,
     )
     proc.start()
+    child_conn.close()  # the child holds its end; we keep parent_conn so our exit closes it
     try:
         address = await asyncio.to_thread(address_queue.get, timeout=600)
         client = EnvClient(address=address)
@@ -217,3 +223,5 @@ async def run_eval_server(config: EvalConfig) -> list[Trace]:
         proc.terminate()
         with contextlib.suppress(Exception):
             await asyncio.to_thread(proc.join, 10)
+        with contextlib.suppress(Exception):
+            parent_conn.close()

--- a/verifiers/v1/serve/pool.py
+++ b/verifiers/v1/serve/pool.py
@@ -44,22 +44,14 @@ logger = logging.getLogger(__name__)
 _HEALTH = msgpack.packb(HealthResponse().model_dump(mode="json"), use_bin_type=True)
 
 
-def _arm_child(death_pipe=None) -> None:
-    """Make a spawned process (env-server broker, single in-process server, or pool worker)
-    tear down cleanly — the one teardown contract every `serve_env`/worker process arms.
+def _arm_teardown(death_pipe=None) -> None:
+    """Arm a spawned process (serve_env broker/single server, or pool worker) for clean
+    teardown: it inherits no signal handlers, so by default SIGTERM kills it abruptly, skipping
+    asyncio.run()'s serving() cleanup and orphaning host_endpoint tunnels (and sandboxes).
 
-    A spawned process inherits no signal handlers, so without this a SIGTERM hits Python's
-    default and kills it abruptly, skipping `asyncio.run()`'s unwinding of the serving()
-    context and orphaning the interception server's `host_endpoint` tunnels (and sandboxes):
-
-    - SIGTERM -> KeyboardInterrupt so the event loop runs its finallys (tunnels/sandboxes torn
-      down); `serve_env` swallows the re-raised KeyboardInterrupt for a clean exit. It can fire
-      inside a C call (e.g. zmq), raising in the loop machinery rather than at an `await`, but
-      `asyncio.run` still tears the server down via task cancellation.
-    - if `death_pipe` is given, self-SIGTERM when the parent dies: the parent holds the other
-      end, which the OS closes even on the parent's SIGKILL, so the blocking `recv` returns and
-      the child shuts itself down — no orphan holding a tunnel/sandbox when the parent dies
-      abruptly (main -> serve_env, and broker -> worker, are both armed this way)."""
+    - SIGTERM -> KeyboardInterrupt so the event loop runs its finallys (serve_env swallows it);
+    - with `death_pipe`, self-SIGTERM when the parent dies (pipe EOF, even on its SIGKILL) so no
+      child is orphaned (main -> serve_env and broker -> worker are both armed this way)."""
     signal.signal(signal.SIGTERM, lambda *_: (_ for _ in ()).throw(KeyboardInterrupt()))
     if death_pipe is None:
         return
@@ -82,7 +74,7 @@ def _worker_entry(
     logging so per-rollout logs surface — a spawned worker inherits no handlers."""
     from verifiers.v1.legacy import LegacyEnvServer
 
-    _arm_child(death_pipe)
+    _arm_teardown(death_pipe)
     if log_setup is not None:
         log_setup()
     if "config_data" in server_kwargs:
@@ -308,10 +300,10 @@ def serve_env(
     (rollout start/done, the pool line) are silently dropped.
 
     `death_pipe` (when spawned by a parent, e.g. the eval main process) makes this server
-    self-terminate if that parent dies abruptly — see `_arm_child`."""
+    self-terminate if that parent dies abruptly — see `_arm_teardown`."""
     # Graceful SIGTERM (run asyncio teardown) + self-terminate if the parent dies. The
     # re-raised KeyboardInterrupt is swallowed below for a clean exit (no spurious traceback).
-    _arm_child(death_pipe)
+    _arm_teardown(death_pipe)
     if log_setup is not None:
         log_setup()
     try:

--- a/verifiers/v1/serve/pool.py
+++ b/verifiers/v1/serve/pool.py
@@ -44,17 +44,32 @@ logger = logging.getLogger(__name__)
 _HEALTH = msgpack.packb(HealthResponse().model_dump(mode="json"), use_bin_type=True)
 
 
-def _monitor_parent(conn) -> None:
-    """Self-SIGTERM when the parent (broker) dies: its write end of the pipe closes on
-    exit (even on SIGKILL), so the blocking `recv` returns/raises and we shut down —
-    no orphaned worker holding a sandbox."""
+def _arm_child(death_pipe=None) -> None:
+    """Make a spawned process (env-server broker, single in-process server, or pool worker)
+    tear down cleanly — the one teardown contract every `serve_env`/worker process arms.
 
-    def watch() -> None:
+    A spawned process inherits no signal handlers, so without this a SIGTERM hits Python's
+    default and kills it abruptly, skipping `asyncio.run()`'s unwinding of the serving()
+    context and orphaning the interception server's `host_endpoint` tunnels (and sandboxes):
+
+    - SIGTERM -> KeyboardInterrupt so the event loop runs its finallys (tunnels/sandboxes torn
+      down); `serve_env` swallows the re-raised KeyboardInterrupt for a clean exit. It can fire
+      inside a C call (e.g. zmq), raising in the loop machinery rather than at an `await`, but
+      `asyncio.run` still tears the server down via task cancellation.
+    - if `death_pipe` is given, self-SIGTERM when the parent dies: the parent holds the other
+      end, which the OS closes even on the parent's SIGKILL, so the blocking `recv` returns and
+      the child shuts itself down — no orphan holding a tunnel/sandbox when the parent dies
+      abruptly (main -> serve_env, and broker -> worker, are both armed this way)."""
+    signal.signal(signal.SIGTERM, lambda *_: (_ for _ in ()).throw(KeyboardInterrupt()))
+    if death_pipe is None:
+        return
+
+    def _watch() -> None:
         with contextlib.suppress(Exception):
-            conn.recv()
+            death_pipe.recv()
         os.kill(os.getpid(), signal.SIGTERM)
 
-    threading.Thread(target=watch, daemon=True).start()
+    threading.Thread(target=_watch, daemon=True).start()
 
 
 def _worker_entry(
@@ -67,9 +82,9 @@ def _worker_entry(
     logging so per-rollout logs surface — a spawned worker inherits no handlers."""
     from verifiers.v1.legacy import LegacyEnvServer
 
+    _arm_child(death_pipe)
     if log_setup is not None:
         log_setup()
-    _monitor_parent(death_pipe)
     if "config_data" in server_kwargs:
         server_kwargs = {
             "config": EnvConfig.model_validate(server_kwargs["config_data"])
@@ -266,6 +281,7 @@ def serve_env(
     legacy: bool = False,
     address: str = "tcp://127.0.0.1:5000",
     address_queue=None,
+    death_pipe=None,
     log_setup: Callable[[], None] | None = None,
     multiplex: int = 128,
     elastic: bool = True,
@@ -289,13 +305,13 @@ def serve_env(
 
     `log_setup` (a picklable callable) configures logging for this process and every
     spawned worker — without it a spawned server inherits no handlers and its INFO logs
-    (rollout start/done, the pool line) are silently dropped."""
-    # SIGTERM -> KeyboardInterrupt so a killed server runs its teardown (pool: kill the
-    # workers; single: close clients). It can fire inside a C call (e.g. zmq getsockopt),
-    # raising in the loop machinery rather than at an `await`, so it escapes the server's
-    # own run loop; `asyncio.run` still tears the server down via task cancellation, and we
-    # swallow the re-raised KeyboardInterrupt here for a clean exit (no spurious traceback).
-    signal.signal(signal.SIGTERM, lambda *_: (_ for _ in ()).throw(KeyboardInterrupt()))
+    (rollout start/done, the pool line) are silently dropped.
+
+    `death_pipe` (when spawned by a parent, e.g. the eval main process) makes this server
+    self-terminate if that parent dies abruptly — see `_arm_child`."""
+    # Graceful SIGTERM (run asyncio teardown) + self-terminate if the parent dies. The
+    # re-raised KeyboardInterrupt is swallowed below for a clean exit (no spurious traceback).
+    _arm_child(death_pipe)
     if log_setup is not None:
         log_setup()
     try:


### PR DESCRIPTION
## Summary

Unifies env-server teardown into one robust contract so no interception `host_endpoint` `prime_tunnel` (or sandbox) is ever orphaned, across all eval modes.

**Bug:** with the env-server **worker pool** path (`eval --no-rich` → `run_eval_server`), the host-side reverse tunnel the interception server opens for a *remote* runtime (prime/modal) was **never torn down** — it stayed `connected` forever, accumulating hundreds of leaked tunnels. Root cause: a worker is spawned with `mp.get_context("spawn")`, so it inherits **none** of the broker's signal handlers, and `_worker_entry` installed none either. On shutdown the worker got SIGTERM (broker `terminate()` / `_monitor_parent` self-kill) → Python's **default** handler killed it abruptly → `asyncio.run(server.run())` never unwound `async with serving()` → `host_endpoint`'s `finally: tunnel.sync_stop()` never ran. Separately, the **main → `serve_env`** boundary had no parent-death detection, so an abrupt main exit orphaned the server and everything under it.

**Fix:** one teardown contract, `_arm_teardown(death_pipe=None)`, armed first thing by every spawned process (the `serve_env` broker/single server **and** pool workers):

- `SIGTERM → KeyboardInterrupt` so `asyncio.run()` runs its `finally`s (interception pool / tunnels / sandboxes torn down) instead of an abrupt default-SIGTERM exit;
- when `death_pipe` is given, **self-SIGTERM on parent death** (pipe EOF, fires even on the parent's `SIGKILL`).

And the previously-missing **death pipe at the main → `serve_env` boundary** is added (mirrors the existing broker → worker pipe). This removes the worker-only `_monitor_parent`, de-duplicates the handler that was copy-pasted in 3 places, and keeps the `spawn` start method.

### Teardown, now uniform at every process boundary

| boundary | graceful SIGTERM | parent-death self-clean |
|---|---|---|
| main → `serve_env` (broker/single) | ✅ `_arm_teardown` | ✅ **new** death pipe |
| broker → worker | ✅ `_arm_teardown` | ✅ death pipe (kept) |
| in-process (`--rich`, no env server) | ✅ (main-process handler + `async with serving()`) | n/a (top process) |

### Why not another mp start method?

`fork` would let children inherit the parent's handler (dropping the per-child install), but it's unsafe with the `zmq.asyncio` loop + the watch thread + asyncio (fork-after-loop/thread deadlocks) — which is why `spawn` is used — and it wouldn't provide parent-death detection anyway. The death pipe is the portable primitive; this PR just makes it uniform.

## Verification

Repro/fix exercised with the **prime runtime** over the `--no-rich` pool path (`eval gsm8k-v1 -m … -n 1 --no-rich --harness.runtime.type prime`), watching `prime tunnel list` for the rollout's tunnel:

- **subprocess runtime:** no tunnel created (interception reached at `127.0.0.1`).
- **prime, normal exit:** tunnel opens during the rollout, **`terminated`** after — was `connected` indefinitely before the fix.
- **prime, abrupt `SIGKILL -9` of the main process mid-rollout:** tunnel **`terminated`** within ~1s via the death pipe, with **no orphaned `serve_env`/worker processes** — previously this orphaned the server, tunnel, and sandbox.

Post-run: 0 leaked tunnels, 0 orphan processes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes multiprocess shutdown and signal handling on the eval env-server path; incorrect behavior could still orphan resources or delay exit, but scope is teardown-only with a clear prior leak fix.
> 
> **Overview**
> Fixes **leaked `host_endpoint` tunnels and sandboxes** when env-server workers or the whole `serve_env` tree shut down abruptly (especially `spawn` pool workers that never ran `serving()` teardown).
> 
> Introduces **`_arm_teardown(death_pipe=None)`** in `pool.py`, replacing the worker-only `_monitor_parent` and duplicated SIGTERM handlers: **SIGTERM is turned into `KeyboardInterrupt`** so `asyncio.run()` can run `finally` blocks (tunnel `sync_stop`, etc.), and an optional **death pipe** triggers self-SIGTERM when the parent exits (including SIGKILL via pipe EOF).
> 
> **`run_eval_server`** now passes a **`death_pipe`** into spawned `serve_env` (mirroring broker → worker) and closes **`parent_conn`** in `finally`, so an abrupt eval main exit tears down the server subtree instead of orphaning it.
> 
> **`serve_env`** accepts `death_pipe` and arms teardown at entry; pool workers call the same helper at the start of `_worker_entry`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4842a919ce720ffb8f1c9d668a8ff102ffd46ffe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix env-server teardown to prevent leaked tunnels and sandboxes on abrupt parent exit
> - Introduces a bidirectional `Pipe` between the main process and the spawned `serve_env` process in [runner.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1733/files#diff-65be4a576330571f2729a3bbcdbe92ac81bbcba450c313597c1bdca3a1c3f2e4); closing the parent end signals the child to self-terminate.
> - Adds `_arm_teardown` in [pool.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1733/files#diff-0c9c59578214be2580d340bc524321e352f48038207a68945637d00fc399600c) to replace the old `_monitor_parent` helper, consolidating SIGTERM→`KeyboardInterrupt` conversion and death-pipe watching into one utility used by both `serve_env` and `_worker_entry`.
> - Worker processes now also receive graceful SIGTERM handling and exit when their parent broker dies via the death pipe.
> - Behavioral Change: `serve_env` and worker processes will now self-terminate on parent death rather than persisting as orphans.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4842a91.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->