### PR TITLE
fix: reject unsupported task system_prompt

### DIFF
--- a/verifiers/v1/harness.py
+++ b/verifiers/v1/harness.py
@@ -67,7 +67,8 @@ class Harness(ABC, Generic[ConfigT]):
     (e.g. `RLMHarness(Harness[RLMHarnessConfig])`)."""
 
     APPENDS_SYSTEM_PROMPT: ClassVar[bool] = False
-    """Emit task.system_prompt as a system message (else fold into the user message)."""
+    """Emit task.system_prompt as a system message. If False, a task that sets a system_prompt
+    is rejected."""
     SUPPORTS_TASK_TOOLS: ClassVar[bool] = True
     """Expose a task's MCP tool servers to the model; set False for harnesses without an MCP client."""
     SUPPORTS_USER_SIM: ClassVar[bool] = False
@@ -79,13 +80,14 @@ class Harness(ABC, Generic[ConfigT]):
         self.config = config
 
     def resolve_prompt(self, task: Task) -> tuple[str | None, str | Messages | None]:
-        """Resolve `(system_prompt, prompt)` for this harness. If the harness
-        appends the system prompt natively, returns it separately; otherwise folds it into
-        the user prompt (warning that it isn't sent as a system message). A `Messages`
+        """Resolve `(system_prompt, prompt)` for this harness. A harness that sets
+        `APPENDS_SYSTEM_PROMPT` returns the task's system prompt separately (emitted as a real
+        system message, or via the agent's own append mechanism); a harness that does not is given
+        the prompt with no system prompt, and a task that sets one is rejected — a system prompt is
+        never folded into the user message (that would silently change its role). A `Messages`
         prompt (e.g. an image-bearing prompt) is only allowed for harnesses that set
-        `SUPPORTS_MESSAGE_PROMPT`. A `None` prompt means the task has no prompt —
-        the user simulator opens the conversation (see `Taskset.user`); the harness emits no
-        opening user message."""
+        `SUPPORTS_MESSAGE_PROMPT`. A `None` prompt means the task has no prompt — the user simulator
+        opens the conversation (see `Taskset.user`); the harness emits no opening user message."""
         prompt = task.prompt
         if (
             prompt is not None
@@ -96,21 +98,15 @@ class Harness(ABC, Generic[ConfigT]):
                 f"Harness {self.config.id!r} does not support a Messages prompt; "
                 "task.prompt must be a string or None."
             )
-        system = task.system_prompt
-        if system is None or self.APPENDS_SYSTEM_PROMPT:
-            return system if self.APPENDS_SYSTEM_PROMPT else None, prompt
-        if not isinstance(prompt, str):
+        if task.system_prompt is not None and not self.APPENDS_SYSTEM_PROMPT:
             raise ValueError(
-                f"Harness {self.config.id!r} cannot fold a system prompt into a "
-                f"{'Messages' if prompt is not None else 'None'} prompt; set "
-                "APPENDS_SYSTEM_PROMPT to emit it as a system message."
+                f"Harness {self.config.id!r} does not support a system prompt, but the task sets "
+                "`system_prompt`. Refusing to fold it into the user prompt (that would silently "
+                "change its role). Use a harness that emits a system prompt (one with "
+                "APPENDS_SYSTEM_PROMPT, e.g. default / bash / rlm), or clear the task's "
+                "system_prompt."
             )
-        logger.warning(
-            "Harness %r does not support a separate system prompt; prepending "
-            "task.system_prompt to the user prompt.",
-            self.config.id,
-        )
-        return None, f"{system}\n\n{prompt}"
+        return (task.system_prompt if self.APPENDS_SYSTEM_PROMPT else None), prompt
 
     async def run(
         self,

--- a/verifiers/v1/harness.py
+++ b/verifiers/v1/harness.py
@@ -101,8 +101,7 @@ class Harness(ABC, Generic[ConfigT]):
         if task.system_prompt is not None and not self.APPENDS_SYSTEM_PROMPT:
             raise ValueError(
                 f"Harness {self.config.id!r} does not support a system prompt, but the task sets "
-                "`system_prompt`. Refusing to fold it into the user prompt (that would silently "
-                "change its role). Use a harness that emits a system prompt (one with "
+                "`system_prompt`. Use a harness that emits a system prompt (one with "
                 "APPENDS_SYSTEM_PROMPT, e.g. default / bash / rlm), or clear the task's "
                 "system_prompt."
             )

--- a/verifiers/v1/task.py
+++ b/verifiers/v1/task.py
@@ -68,8 +68,8 @@ class Task(StrictBaseModel):
     turn before the model is ever called."""
     system_prompt: str | None = None
     """Optional system prompt. Harnesses that set `APPENDS_SYSTEM_PROMPT` emit it as a real
-    system message (or their own mechanism); others prepend it to `prompt` (with a
-    warning). See `Harness.resolve_prompt`."""
+    system message (or via their own mechanism); a harness that does not rejects a task that
+    sets it. See `Harness.resolve_prompt`."""
     image: str | None = None
     """Container image this task needs (e.g. its harbor environment). When set, the
     runtime must be a container (docker/prime): the Environment injects it into the


### PR DESCRIPTION
## Summary

`Harness.resolve_prompt` previously **folded** `task.system_prompt` into the user prompt (prepended `"{system}\n\n{prompt}"`, with a warning) when the harness didn't set `APPENDS_SYSTEM_PROMPT` — silently demoting the prompt from the **system** role to the **user** role. That's a quiet behavior change a taskset author wouldn't expect, and it differs per harness.

This **refuses** instead: if a harness can't emit a system prompt (`APPENDS_SYSTEM_PROMPT = False`) and the task sets `system_prompt`, raise a descriptive `ValueError` so the rollout doesn't run with a misplaced prompt. `APPENDS_SYSTEM_PROMPT` harnesses (default / bash / rlm) are unchanged — the system prompt is still emitted separately.

```
Harness 'codex' does not support a system prompt, but the task sets `system_prompt`. Use
a harness that emits a system prompt (one with APPENDS_SYSTEM_PROMPT, e.g. default / bash
/ rlm), or clear the task's system_prompt.
```

Also drops the now-unused fold path (and its warning) and updates the `APPENDS_SYSTEM_PROMPT` / `Task.system_prompt` docs.

## Breaking

- A task that sets `system_prompt` run on a **non-`APPENDS_SYSTEM_PROMPT`** harness (currently `codex`, `kimi_code`, `mini_swe_agent`) now **errors** instead of folding the system prompt into the user message. Migration: use a harness that emits a system prompt (`default` / `bash` / `rlm`), clear the task's `system_prompt`, or give that harness native system-prompt support (e.g. codex `base_instructions` — the `# TODO`).

## Verification

`resolve_prompt` exercised directly:
- non-APPENDS harness + `system_prompt` → raises the descriptive `ValueError` (no fold);
- non-APPENDS harness + no system prompt → `(None, prompt)` (unchanged);
- APPENDS harness + `system_prompt` → `(system, prompt)` (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking behavior for tasksets that relied on silent folding on harnesses like codex/kimi/mini_swe_agent; rollouts that previously ran will now fail until harness or task config is fixed.
> 
> **Overview**
> **`Harness.resolve_prompt`** no longer prepends `task.system_prompt` into the user prompt (with a warning) when `APPENDS_SYSTEM_PROMPT` is false. It now raises a **`ValueError`** with migration guidance so rollouts cannot run with system instructions silently demoted to the user role.
> 
> Harnesses with **`APPENDS_SYSTEM_PROMPT`** still return `(system_prompt, prompt)` unchanged; tasks without a system prompt on non-append harnesses still get `(None, prompt)`.
> 
> Docstrings on **`APPENDS_SYSTEM_PROMPT`**, **`resolve_prompt`**, and **`Task.system_prompt`** are updated to describe rejection instead of folding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c6b27b2f75551d8f9b45190735f401031adca68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject tasks with `system_prompt` in harnesses where `APPENDS_SYSTEM_PROMPT` is False
> Previously, `Harness.resolve_prompt` would silently prepend a task's `system_prompt` to the user message when the harness did not support appending system prompts. Now it raises a `ValueError` instead, making the incompatibility explicit. Behavioral Change: tasks that set `system_prompt` will now fail at prompt resolution time rather than being silently modified when used with a non-supporting harness.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6c6b27b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->