### PR TITLE
fix: incomplete URL substring sanitization in quest pdf tool (CodeQL)

### DIFF
--- a/verifiers/envs/experimental/composable/tasksets/search/quest/obj_task_eval/api_tools/tool_pdf.py
+++ b/verifiers/envs/experimental/composable/tasksets/search/quest/obj_task_eval/api_tools/tool_pdf.py
@@ -234,9 +234,10 @@ class PDFParser:
                     return await response.read()
 
         data = await download(url)
-        if not data.lstrip().startswith(PDF_MAGIC) and (
-            urlparse(url).hostname or ""
-        ).lower() == "arxiv.org":
+        if (
+            not data.lstrip().startswith(PDF_MAGIC)
+            and (urlparse(url).hostname or "").lower() == "arxiv.org"
+        ):
             backup = url.replace("://arxiv.org", "://export.arxiv.org")
             try:
                 data = await download(backup)

--- a/verifiers/envs/experimental/composable/tasksets/search/quest/obj_task_eval/api_tools/tool_pdf.py
+++ b/verifiers/envs/experimental/composable/tasksets/search/quest/obj_task_eval/api_tools/tool_pdf.py
@@ -234,7 +234,9 @@ class PDFParser:
                     return await response.read()
 
         data = await download(url)
-        if not data.lstrip().startswith(PDF_MAGIC) and "arxiv.org" in url:
+        if not data.lstrip().startswith(PDF_MAGIC) and (
+            urlparse(url).hostname or ""
+        ).lower() == "arxiv.org":
             backup = url.replace("://arxiv.org", "://export.arxiv.org")
             try:
                 data = await download(backup)


### PR DESCRIPTION
## Summary
Fixes the one **high-severity CodeQL alert** (`py/incomplete-url-substring-sanitization`) failing code scanning on `feat/nano-as-v1`.

`tool_pdf.py`'s arXiv-backup fetch gated on `"arxiv.org" in url` — a substring check that `http://arxiv.org.evil.com/…` or `https://evil.com/arxiv.org` defeats. Now checks the parsed hostname equals `arxiv.org`.

## Verification
`urlparse(url).hostname == "arxiv.org"`: real arXiv → match; `arxiv.org.evil.com` / `evil.com/arxiv.org` → no match; `export.arxiv.org` backup → no re-trigger. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix incomplete URL substring check in `PDFParser._fetch_pdf_bytes` for arxiv.org fallback
> Replaces a substring check (`'arxiv.org' in url`) with an exact hostname comparison using `urlparse(url).hostname` in [tool_pdf.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1736/files#diff-dbc9a35abb39f8902e7145301d5e193bd00107dd081154159610818822df3b3f). This prevents URLs that merely contain 'arxiv.org' as a substring (e.g. a malicious or unexpected host) from triggering the fallback request to `export.arxiv.org`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e493ebf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line security hardening in PDF fetch fallback logic; behavior for legitimate `arxiv.org` URLs is unchanged.
> 
> **Overview**
> Tightens when `PDFParser._fetch_pdf_bytes` retries via `export.arxiv.org` after a non-PDF response.
> 
> The arXiv backup path is now gated on an **exact hostname** check (`urlparse(url).hostname` lowercased equals `arxiv.org`) instead of the substring `"arxiv.org" in url`, so malicious hosts like `arxiv.org.evil.com` or paths containing `arxiv.org` no longer trigger the fallback fetch (CodeQL `py/incomplete-url-substring-sanitization`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e493ebf5002604c521b285afc2cf4bd6c13ccbe5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->