### PR TITLE
chore: slow eval-dashboard page rotation to 5s

### DIFF
--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -28,7 +28,7 @@ from verifiers.v1.utils.format import format_count, format_reward, format_time
 # For sizing pages to the terminal: detects the real terminal height/width each access (the live
 # view writes to the same terminal). Reused so we don't rebuild it every refresh tick.
 _CONSOLE = Console()
-_PAGE_SECONDS = 3.0  # rotate to the next page of rollouts this often when they overflow
+_PAGE_SECONDS = 5.0  # rotate to the next page of rollouts this often when they overflow
 
 _STYLE = {
     "setup": "yellow",


### PR DESCRIPTION
## Summary
- Bump `_PAGE_SECONDS` (eval dashboard page-rotation interval) from 3.0s to 5.0s, so when rollouts overflow the terminal each page stays up longer / is easier to read. Render refresh (0.25s) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Slow eval-dashboard page rotation interval from 3s to 5s
> Increases `_PAGE_SECONDS` in [eval.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1737/files#diff-0a27b905958929f3ae9e01937dd7e3cf97a60dec137caddcbf87792784fc9035) from `3.0` to `5.0`, giving each page more time before rotating when rollouts overflow the display.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1cb9e7f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant tweak for dashboard UX timing with no logic, security, or data-path changes.
> 
> **Overview**
> When the eval `--rich` dashboard has more rollout rows than fit on screen, it auto-rotates pages on a timer driven by **`_PAGE_SECONDS`** in `eval.py`. This PR **raises that interval from 3.0s to 5.0s**, so each page stays visible longer before `_paginate` advances. The live render refresh cadence is unchanged; only how often overflow pages cycle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cb9e7fe95eb03496c706dbf5ea9eebf19346928. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->