### PR TITLE
feat: swebench-verified harbor taskset (prime prebuilt images)

### DIFF
--- a/environments/swebench_verified_v1/pyproject.toml
+++ b/environments/swebench_verified_v1/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "swebench-verified-v1"
+version = "0.1.0"
+description = "SWE-bench Verified — harbor taskset using prime's prebuilt instance images."
+requires-python = ">=3.10"
+dependencies = ["tasksets"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["swebench_verified_v1"]

--- a/environments/swebench_verified_v1/swebench_verified_v1/__init__.py
+++ b/environments/swebench_verified_v1/swebench_verified_v1/__init__.py
@@ -1,0 +1,3 @@
+from swebench_verified_v1.taskset import SWEBenchVerifiedTaskset
+
+__all__ = ["SWEBenchVerifiedTaskset"]

--- a/environments/swebench_verified_v1/swebench_verified_v1/taskset.py
+++ b/environments/swebench_verified_v1/swebench_verified_v1/taskset.py
@@ -31,6 +31,14 @@ class SWEBenchVerifiedConfig(HarborConfig):
     `scaleswe-v1` / `r2e-gym-v1`."""
 
 
+def from_image(task_dir: Path) -> str:
+    """The image a task's Dockerfile builds on (`FROM swebench/sweb.eval.*`)."""
+    for line in (task_dir / "environment" / "Dockerfile").read_text().splitlines():
+        if line.strip().upper().startswith("FROM "):
+            return line.split(None, 1)[1].strip()
+    raise ValueError(f"{task_dir.name}: no FROM in environment/Dockerfile")
+
+
 class SWEBenchVerifiedTaskset(
     HarborTaskset, vf.Taskset[HarborTask, SWEBenchVerifiedConfig]
 ):
@@ -40,7 +48,7 @@ class SWEBenchVerifiedTaskset(
         # resolve the prebuilt image here at all.
         tasks = []
         for task in super().load_tasks():
-            base = _from_image(Path(task.task_dir))
+            base = from_image(Path(task.task_dir))
             image = (
                 f"{REGISTRY_PREFIX}/{base.rsplit('/', 1)[-1]}"
                 if self.config.use_prime_registry
@@ -48,11 +56,3 @@ class SWEBenchVerifiedTaskset(
             )
             tasks.append(task.model_copy(update={"image": image}))
         return tasks
-
-
-def _from_image(task_dir: Path) -> str:
-    """The image a task's Dockerfile builds on (`FROM swebench/sweb.eval.*`)."""
-    for line in (task_dir / "environment" / "Dockerfile").read_text().splitlines():
-        if line.strip().upper().startswith("FROM "):
-            return line.split(None, 1)[1].strip()
-    raise ValueError(f"{task_dir.name}: no FROM in environment/Dockerfile")

--- a/environments/swebench_verified_v1/swebench_verified_v1/taskset.py
+++ b/environments/swebench_verified_v1/swebench_verified_v1/taskset.py
@@ -1,0 +1,51 @@
+"""swebench-verified-v1 — SWE-bench Verified on harbor, using prime's prebuilt images.
+
+A thin wrapper over `harbor-v1` pinned to the `swebench-verified` dataset. Those harbor tasks ship a
+Dockerfile (`FROM swebench/sweb.eval.*`, the public SWE-bench instance image) rather than a pullable
+`[environment].docker_image`, so harbor-v1 would reject them (it doesn't build Dockerfiles). Instead
+we point each task at prime's prebuilt mirror of that same image, which the prime runtime pulls
+directly — no build.
+
+Needs the `harbor` CLI (`uv tool install harbor`) and a container runtime that can reach the registry
+(prime).
+"""
+
+from pathlib import Path
+from typing import Literal
+
+import verifiers.v1 as vf
+from tasksets.harbor_v1 import HarborConfig, HarborTask, HarborTaskset
+
+# Prime's Artifact Registry mirror of the SWE-bench instance images.
+REGISTRY_PREFIX = "us-central1-docker.pkg.dev/prime-intellect-platform/prod-sandbox"
+
+
+class SWEBenchVerifiedConfig(HarborConfig):
+    dataset: Literal["swebench-verified"] = "swebench-verified"
+    use_harness_image: bool = True
+    """Keep harbor from rejecting the Dockerfile-only tasks; `load_tasks` sets the real image."""
+
+
+class SWEBenchVerifiedTaskset(
+    HarborTaskset, vf.Taskset[HarborTask, SWEBenchVerifiedConfig]
+):
+    def load_tasks(self) -> list[HarborTask]:
+        # TODO: once we have persistent public image caches, build each task's Dockerfile
+        # (FROM swebench/sweb.eval.*) dynamically and cache the result — then we won't need to
+        # rewrite the image to prime's prebuilt mirror here.
+        return [
+            task.model_copy(update={"image": _prime_image(Path(task.task_dir))})
+            for task in super().load_tasks()
+        ]
+
+
+def _prime_image(task_dir: Path) -> str:
+    """Map a task's Dockerfile `FROM swebench/sweb.eval.*` to prime's prebuilt mirror image."""
+    for line in (task_dir / "environment" / "Dockerfile").read_text().splitlines():
+        if line.strip().upper().startswith("FROM "):
+            base = line.split(None, 1)[1].strip().rsplit("/", 1)[-1]
+            return f"{REGISTRY_PREFIX}/{base}"
+    raise ValueError(f"{task_dir.name}: no FROM in environment/Dockerfile")
+
+
+__all__ = ["SWEBenchVerifiedTaskset"]

--- a/environments/swebench_verified_v1/swebench_verified_v1/taskset.py
+++ b/environments/swebench_verified_v1/swebench_verified_v1/taskset.py
@@ -24,27 +24,37 @@ class SWEBenchVerifiedConfig(HarborConfig):
     dataset: Literal["swebench-verified"] = "swebench-verified"
     use_harness_image: bool = True
     """Keep harbor from rejecting the Dockerfile-only tasks; `load_tasks` sets the real image."""
+    use_prime_registry: bool = False
+    """Resolve task images against prime's Artifact Registry (`REGISTRY_PREFIX`) instead of the
+    dataset's public Docker Hub `swebench/sweb.eval.*` image. Only works on runtimes with GCP
+    pull credentials (e.g. prime training); the default public image works anywhere. Mirrors
+    `scaleswe-v1` / `r2e-gym-v1`."""
 
 
 class SWEBenchVerifiedTaskset(
     HarborTaskset, vf.Taskset[HarborTask, SWEBenchVerifiedConfig]
 ):
     def load_tasks(self) -> list[HarborTask]:
-        # TODO: once we have persistent public image caches, build each task's Dockerfile
-        # (FROM swebench/sweb.eval.*) dynamically and cache the result — then we won't need to
-        # rewrite the image to prime's prebuilt mirror here.
         return [
-            task.model_copy(update={"image": _prime_image(Path(task.task_dir))})
+            task.model_copy(update={"image": self._image(Path(task.task_dir))})
             for task in super().load_tasks()
         ]
 
+    def _image(self, task_dir: Path) -> str:
+        # TODO: once we have persistent public image caches, build each task's Dockerfile
+        # (FROM swebench/sweb.eval.*) dynamically and cache the result — then we won't need to
+        # resolve the prebuilt image here at all.
+        base = _from_image(task_dir)
+        if self.config.use_prime_registry:
+            return f"{REGISTRY_PREFIX}/{base.rsplit('/', 1)[-1]}"
+        return base
 
-def _prime_image(task_dir: Path) -> str:
-    """Map a task's Dockerfile `FROM swebench/sweb.eval.*` to prime's prebuilt mirror image."""
+
+def _from_image(task_dir: Path) -> str:
+    """The image a task's Dockerfile builds on (`FROM swebench/sweb.eval.*`)."""
     for line in (task_dir / "environment" / "Dockerfile").read_text().splitlines():
         if line.strip().upper().startswith("FROM "):
-            base = line.split(None, 1)[1].strip().rsplit("/", 1)[-1]
-            return f"{REGISTRY_PREFIX}/{base}"
+            return line.split(None, 1)[1].strip()
     raise ValueError(f"{task_dir.name}: no FROM in environment/Dockerfile")
 
 

--- a/environments/swebench_verified_v1/swebench_verified_v1/taskset.py
+++ b/environments/swebench_verified_v1/swebench_verified_v1/taskset.py
@@ -22,7 +22,7 @@ REGISTRY_PREFIX = "us-central1-docker.pkg.dev/prime-intellect-platform/prod-sand
 
 class SWEBenchVerifiedConfig(HarborConfig):
     dataset: Literal["swebench-verified"] = "swebench-verified"
-    use_harness_image: bool = True
+    ignore_dockerfile: bool = True
     """Keep harbor from rejecting the Dockerfile-only tasks; `load_tasks` sets the real image."""
     use_prime_registry: bool = False
     """Resolve task images against prime's Artifact Registry (`REGISTRY_PREFIX`) instead of the
@@ -35,19 +35,19 @@ class SWEBenchVerifiedTaskset(
     HarborTaskset, vf.Taskset[HarborTask, SWEBenchVerifiedConfig]
 ):
     def load_tasks(self) -> list[HarborTask]:
-        return [
-            task.model_copy(update={"image": self._image(Path(task.task_dir))})
-            for task in super().load_tasks()
-        ]
-
-    def _image(self, task_dir: Path) -> str:
         # TODO: once we have persistent public image caches, build each task's Dockerfile
         # (FROM swebench/sweb.eval.*) dynamically and cache the result — then we won't need to
         # resolve the prebuilt image here at all.
-        base = _from_image(task_dir)
-        if self.config.use_prime_registry:
-            return f"{REGISTRY_PREFIX}/{base.rsplit('/', 1)[-1]}"
-        return base
+        tasks = []
+        for task in super().load_tasks():
+            base = _from_image(Path(task.task_dir))
+            image = (
+                f"{REGISTRY_PREFIX}/{base.rsplit('/', 1)[-1]}"
+                if self.config.use_prime_registry
+                else base
+            )
+            tasks.append(task.model_copy(update={"image": image}))
+        return tasks
 
 
 def _from_image(task_dir: Path) -> str:
@@ -56,6 +56,3 @@ def _from_image(task_dir: Path) -> str:
         if line.strip().upper().startswith("FROM "):
             return line.split(None, 1)[1].strip()
     raise ValueError(f"{task_dir.name}: no FROM in environment/Dockerfile")
-
-
-__all__ = ["SWEBenchVerifiedTaskset"]

--- a/packages/tasksets/tasksets/harbor_v1/taskset.py
+++ b/packages/tasksets/tasksets/harbor_v1/taskset.py
@@ -14,7 +14,7 @@ A task's declared [environment].docker_image becomes a first-class `Task.image`
 the Environment injects into the runtime (docker/prime both pull it). A task whose
 environment is only a `Dockerfile` has no pullable image — we don't build Dockerfiles
 (a locally-built image isn't pullable by a remote sandbox) — so it's rejected unless
-`use_harness_image`, which runs it on the harness runtime's image instead. A task with
+`ignore_dockerfile`, which runs it on the harness runtime's image instead. A task with
 no environment at all also runs on that image, unless `require_image`.
 """
 
@@ -51,8 +51,8 @@ class HarborConfig(TasksetConfig):
     """For a task with NO declared environment at all (no docker_image, no Dockerfile),
     whether to reject it (True) or run it on the runtime's default image (False). A task
     whose environment is a `Dockerfile` is rejected too (building Dockerfiles isn't
-    supported), unless `use_harness_image`."""
-    use_harness_image: bool = False
+    supported), unless `ignore_dockerfile`."""
+    ignore_dockerfile: bool = False
     """Run a task whose environment is only a `Dockerfile` on the harness runtime's image
     instead of rejecting it. The Dockerfile is NOT built, so the task scores against the
     harness image rather than its declared environment — only correct when that image already
@@ -100,26 +100,26 @@ def resolve_image(
     task_dir: Path,
     config: dict,
     require_image: bool,
-    use_harness_image: bool = False,
+    ignore_dockerfile: bool = False,
 ) -> str | None:
     """The task's declared registry image (usable by docker or prime). A pullable
     `[environment].docker_image` is used directly. A task whose environment is a
     `Dockerfile` is rejected — we don't build Dockerfiles, and running it on the default
     image would silently score against the wrong environment (e.g. SWE-bench's `/testbed`
-    repo would be missing) — unless `use_harness_image`, which returns None to run it on the
+    repo would be missing) — unless `ignore_dockerfile`, which returns None to run it on the
     harness runtime's image. A task with no environment at all runs on that image too, unless
     `require_image`. None means "use the runtime's own image"."""
     declared = config.get("environment", {}).get("docker_image")
     if declared:
         return declared
     if (task_dir / "environment" / "Dockerfile").exists():
-        if use_harness_image:
+        if ignore_dockerfile:
             return None
         raise ValueError(
             f"{task_dir.name}: environment is a Dockerfile, not a pullable "
             "[environment].docker_image — building Dockerfiles isn't supported, so this "
             "task can't run (it would otherwise score against the wrong default image). "
-            "Pass --taskset.use-harness-image to run it on the harness runtime's image instead."
+            "Pass --taskset.ignore-dockerfile to run it on the harness runtime's image instead."
         )
     if require_image:
         raise ValueError(
@@ -157,7 +157,7 @@ def parse_task(task_dir: Path, idx: int, harbor_config: HarborConfig) -> HarborT
             task_dir,
             config,
             harbor_config.require_image,
-            harbor_config.use_harness_image,
+            harbor_config.ignore_dockerfile,
         ),
         timeout=TaskTimeout(
             harness=harness_timeout * harbor_config.timeout_multiplier

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ examples = [
     "reverse-text-v1", "math-env-v1", "aime24-v1", "color-codeword-v1",
     "wordle-v1", "terminal-bench-2-v1", "alphabet-sort-v1",
     "r2e-gym-v1", "scaleswe-v1", "swelego-v1", "scratchpad-v1",
-    "general-agent-v1",
+    "general-agent-v1", "swebench-verified-v1",
 ]
 
 [project.optional-dependencies]
@@ -160,6 +160,7 @@ swelego-v1 = { path = "environments/swelego_v1", editable = true }
 alphabet-sort-v1 = { path = "environments/alphabet_sort_v1", editable = true }
 scratchpad-v1 = { path = "environments/scratchpad_v1", editable = true }
 general-agent-v1 = { path = "environments/general_agent_v1", editable = true }
+swebench-verified-v1 = { path = "environments/swebench_verified_v1", editable = true }
 
 [tool.uv.exclude-newer-package]
 # PrimeIntellect-published on PyPI (trusted publisher)

--- a/uv.lock
+++ b/uv.lock
@@ -5177,6 +5177,17 @@ wheels = [
 ]
 
 [[package]]
+name = "swebench-verified-v1"
+version = "0.1.0"
+source = { editable = "environments/swebench_verified_v1" }
+dependencies = [
+    { name = "tasksets" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "tasksets" }]
+
+[[package]]
 name = "swelego-v1"
 version = "0.1.0"
 source = { editable = "environments/swelego_v1" }
@@ -5829,6 +5840,7 @@ examples = [
     { name = "reverse-text-v1" },
     { name = "scaleswe-v1" },
     { name = "scratchpad-v1" },
+    { name = "swebench-verified-v1" },
     { name = "swelego-v1" },
     { name = "terminal-bench-2-v1" },
     { name = "wiki-search-v1" },
@@ -5927,6 +5939,7 @@ examples = [
     { name = "reverse-text-v1", editable = "environments/reverse_text_v1" },
     { name = "scaleswe-v1", editable = "environments/scaleswe_v1" },
     { name = "scratchpad-v1", editable = "environments/scratchpad_v1" },
+    { name = "swebench-verified-v1", editable = "environments/swebench_verified_v1" },
     { name = "swelego-v1", editable = "environments/swelego_v1" },
     { name = "terminal-bench-2-v1", editable = "environments/terminal_bench_2_v1" },
     { name = "wiki-search-v1", editable = "environments/wiki_search_v1" },

--- a/verifiers/v1/README.md
+++ b/verifiers/v1/README.md
@@ -113,10 +113,10 @@ filesystem, so run it under a containerized runtime: `docker` locally, or a remo
 `modal` sandbox (not the default `subprocess`). 
 
 ```bash
-uv run eval harbor-v1 -n 1 --taskset.use-harness-image --harness.runtime.type docker --harness.id bash            # bash-only agent
-uv run eval harbor-v1 -n 1 --taskset.use-harness-image --harness.runtime.type docker --harness.id mini-swe-agent  # the mini-swe-agent CLI
-uv run eval harbor-v1 -n 1 --taskset.use-harness-image --harness.runtime.type docker --harness.id rlm             # the rlm CLI agent
-uv run eval harbor-v1 -n 1 --taskset.use-harness-image --harness.runtime.type docker --harness.id codex           # the codex CLI agent
+uv run eval harbor-v1 -n 1 --taskset.ignore-dockerfile --harness.runtime.type docker --harness.id bash            # bash-only agent
+uv run eval harbor-v1 -n 1 --taskset.ignore-dockerfile --harness.runtime.type docker --harness.id mini-swe-agent  # the mini-swe-agent CLI
+uv run eval harbor-v1 -n 1 --taskset.ignore-dockerfile --harness.runtime.type docker --harness.id rlm             # the rlm CLI agent
+uv run eval harbor-v1 -n 1 --taskset.ignore-dockerfile --harness.runtime.type docker --harness.id codex           # the codex CLI agent
 ```
 
 ### Swappable runtime


### PR DESCRIPTION
## Summary

Adds **`swebench-verified-v1`** — SWE-bench Verified runnable through harbor.

The `harbor download swebench-verified` dataset (500 tasks) ships each task as a **Dockerfile**
(`FROM swebench/sweb.eval.x86_64.<instance>:latest`, the public SWE-bench instance image) rather than
a pullable `[environment].docker_image`, so plain `harbor-v1` rejects them (it doesn't build
Dockerfiles). This taskset is a thin wrapper over `harbor-v1` that **extends `load_tasks` to rewrite
each task's image to prime's prebuilt mirror** of that same image
(`us-central1-docker.pkg.dev/prime-intellect-platform/prod-sandbox/<image>`), which the prime runtime
pulls directly — no build.

```python
class SWEBenchVerifiedTaskset(HarborTaskset, vf.Taskset[HarborTask, SWEBenchVerifiedConfig]):
    def load_tasks(self):
        # TODO: once we have persistent public image caches, build each task's Dockerfile
        # (FROM swebench/sweb.eval.*) dynamically and cache it — then drop this image rewrite.
        return [t.model_copy(update={"image": _prime_image(Path(t.task_dir))}) for t in super().load_tasks()]
```

Run on a container runtime that can reach the registry (prime):

```bash
uv run eval swebench-verified-v1 -n 1 --harness.id bash --harness.runtime.type prime -m <model>
```

## Breaking

- harbor-v1: `--taskset.use-harness-image` → `--taskset.ignore-dockerfile` (config field
  `use_harness_image` → `ignore_dockerfile`). Clearer now that a subclass can *ignore* the
  Dockerfile and set its own image (e.g. swebench-verified-v1), not just run on the harness image.

## Verification

- `load_tasks` image resolution: default → public `swebench/sweb.eval.x86_64.<instance>:latest`;
  `--taskset.use-prime-registry` → `us-central1-docker.pkg.dev/.../prod-sandbox/<image>` (mirrors
  `scaleswe-v1` / `r2e-gym-v1`).
- **Single debug rollout** (`astropy__astropy-12907`, `bash` harness, **prime** runtime, default
  public image): runs **end-to-end** — the sandbox pulls the image, the agent runs, the harbor
  verifier scores → `reward 0.0`, `stop=agent_completed`, `errors: []`. (gpt-5-mini didn't fix the
  bug; a generic bash agent also runs base `python` without activating the SWE-bench `testbed` conda
  env — use `mini-swe-agent` / activate the env for a real attempt.)
- The GAR path (`use_prime_registry`) `ErrImagePull`s on the plain prime runtime — it needs GCP pull
  credentials on the runtime (same constraint as `scaleswe-v1` / `r2e-gym-v1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Renaming harbor-v1 config/CLI flags is a breaking change for existing scripts; the new image rewrite path is on the critical path for correct SWE-bench sandbox environments.
> 
> **Overview**
> Introduces **`swebench-verified-v1`**, a thin `harbor-v1` wrapper pinned to the `swebench-verified` dataset. Harbor tasks there only ship a **Dockerfile** (`FROM swebench/sweb.eval.*`), which base harbor rejects; this taskset enables **`ignore_dockerfile`** and **overrides `load_tasks`** to set each task's **`image`** from that `FROM` line—defaulting to the public SWE-bench image, or Prime's Artifact Registry mirror when **`--taskset.use-prime-registry`** is set (same pattern as `scaleswe-v1` / `r2e-gym-v1`).
> 
> **Breaking:** harbor-v1 renames **`use_harness_image`** / **`--taskset.use-harness-image`** to **`ignore_dockerfile`** / **`--taskset.ignore-dockerfile`** (semantics unchanged: allow Dockerfile-only tasks without building, optionally run on harness image or let a subclass supply the real image). Docs and workspace **`pyproject.toml`** / **`uv.lock`** register the new example package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b803830d3fb54596975e52c81c81c47dc446f006. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add SWEBench Verified Harbor taskset with prime prebuilt image support
> - Adds a new `SWEBenchVerifiedTaskset` in [environments/swebench_verified_v1](https://github.com/PrimeIntellect-ai/verifiers/pull/1738/files#diff-69d954697fb01013da178a4ad22f5474a4433f139e7f202a815e7192a40fbd53) that loads the `swebench-verified` dataset as a Harbor taskset.
> - Reads the base image from each task's Dockerfile `FROM` line and sets `task.image` directly, bypassing the need to build Dockerfiles at runtime.
> - When `use_prime_registry=True`, resolves base images to a GCP Artifact Registry mirror instead of the upstream registry.
> - Renames `HarborConfig.use_harness_image` to `ignore_dockerfile` in [packages/tasksets/tasksets/harbor_v1/taskset.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1738/files#diff-6daceb49954dc062c2e3030212a4508a4ac3884aa0f36e6cfd784283e1a948c7); functional behavior is unchanged.
> - Risk: existing callers passing `use_harness_image` to `HarborConfig` or `resolve_image` will break due to the rename.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 023e499. 3 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->