### PR TITLE
fix: don't retry the rollout's program exec (forked duplicate trace branches)

### DIFF
--- a/packages/harnesses/harnesses/codex/harness.py
+++ b/packages/harnesses/harnesses/codex/harness.py
@@ -109,4 +109,4 @@ class CodexHarness(Harness[CodexHarnessConfig]):
             *tool_config,
             prompt,
         ]
-        return await runtime.run(argv, env)
+        return await runtime.run_program(argv, env)

--- a/packages/harnesses/harnesses/kimi_code/harness.py
+++ b/packages/harnesses/harnesses/kimi_code/harness.py
@@ -104,4 +104,4 @@ class KimiCodeHarness(Harness[KimiCodeHarnessConfig]):
             await runtime.write(f"{KIMI_HOME}/config.toml", permission_rules.encode())
         await runtime.write(f"{KIMI_HOME}/mcp.json", json.dumps(mcp).encode())
         # `--prompt` is Kimi Code's non-interactive print mode.
-        return await runtime.run([BINARY, "--prompt", prompt], env)
+        return await runtime.run_program([BINARY, "--prompt", prompt], env)

--- a/packages/harnesses/harnesses/rlm/harness.py
+++ b/packages/harnesses/harnesses/rlm/harness.py
@@ -92,7 +92,7 @@ class RLMHarness(Harness[RLMHarnessConfig]):
         result = await runtime.run(["sh", "-c", guarded], env)
         if result.exit_code != 0:
             raise ProgramError(f"rlm install failed: {result.stderr.strip()[-500:]}")
-        return await runtime.run([RLM_BIN, prompt], env)
+        return await runtime.run_program([RLM_BIN, prompt], env)
 
     @metric
     async def rlm(self, trace: Trace, runtime: Runtime) -> dict[str, float]:

--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -294,7 +294,8 @@ class RetryingRuntime(Runtime):
         return await self._retry(self.inner.run, argv, env)
 
     async def run_program(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
-        # The rollout's program exec is NOT retried (see the class docstring) — straight to inner.
+        """The rollout's program exec is NOT retried (see the class docstring) — straight to
+        inner."""
         return await self.inner.run(argv, env)
 
     async def run_background(

--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -154,6 +154,16 @@ class Runtime(ABC):
     async def run(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
         """Run `argv` (with the interception env vars `env`) to completion."""
 
+    async def run_program(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
+        """Run the harness's MAIN program — the rollout itself (a possibly long-lived, stateful,
+        agentic run) — as opposed to the short idempotent infra ops (write / mv / install /
+        provisioning) that go through `run`. Identical to `run` here; `RetryingRuntime` overrides it
+        to NOT retry, because re-running the program against the rollout's persistent trace would
+        fork a duplicate branch (and re-execute against a runtime already mutated by the first
+        attempt). A transient transport fault mid-program surfaces as a ProgramError for this
+        rollout instead of a silent full restart."""
+        return await self.run(argv, env)
+
     async def run_background(
         self, argv: list[str], env: dict[str, str], log: str
     ) -> None:
@@ -193,7 +203,9 @@ class Runtime(ABC):
             ["sh", "-c", f"mv -f {shlex.quote(tmp)} {shlex.quote(path)}"], {}
         )
         command = f'{_ENSURE_UV}; exec uv run {shlex.quote(path)} "$@"'
-        return await self.run(["sh", "-c", command, path, *(args or [])], env or {})
+        # The write/mv above are idempotent infra (retried); the script run is the rollout's
+        # program — `run_program`, so it is not retried (see Runtime.run_program).
+        return await self.run_program(["sh", "-c", command, path, *(args or [])], env or {})
 
     # --- filesystem ---
 
@@ -232,8 +244,12 @@ class RetryingRuntime(Runtime):
     exit), not an exception, so retries fire only on infra/transport faults — provisioning,
     exec transport, file I/O across the runtime boundary. `CancelledError` (a
     `BaseException`) and `NotImplementedError` (an unsupported op) are never retried. Sync
-    teardown (`cleanup`) and display (`descriptor`) delegate straight through;
-    `run_uv_script` is inherited, so it runs over the retrying `write`/`run`."""
+    teardown (`cleanup`) and display (`descriptor`) delegate straight through. The rollout's
+    program exec (`run_program`, including the script run inside `run_uv_script`) is deliberately
+    NOT retried: re-running a stateful/agentic program against the rollout's persistent trace would
+    fork a duplicate branch (and re-run against a runtime the first attempt already mutated), so a
+    mid-program transport fault surfaces as a ProgramError for that rollout. `run_uv_script`'s
+    write/mv staging still runs over the retrying `write`/`run`."""
 
     def __init__(self, inner: Runtime, max_retries: int) -> None:
         super().__init__(inner.name)
@@ -274,6 +290,10 @@ class RetryingRuntime(Runtime):
 
     async def run(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
         return await self._retry(self.inner.run, argv, env)
+
+    async def run_program(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
+        # The rollout's program exec is NOT retried (see the class docstring) — straight to inner.
+        return await self.inner.run(argv, env)
 
     async def run_background(
         self, argv: list[str], env: dict[str, str], log: str

--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -205,7 +205,9 @@ class Runtime(ABC):
         command = f'{_ENSURE_UV}; exec uv run {shlex.quote(path)} "$@"'
         # The write/mv above are idempotent infra (retried); the script run is the rollout's
         # program — `run_program`, so it is not retried (see Runtime.run_program).
-        return await self.run_program(["sh", "-c", command, path, *(args or [])], env or {})
+        return await self.run_program(
+            ["sh", "-c", command, path, *(args or [])], env or {}
+        )
 
     # --- filesystem ---
 


### PR DESCRIPTION
## Summary

Fixes a runtime-retry bug that silently **re-ran the whole agent program** mid-rollout, forking duplicate branches into the trace and corrupting stateful scoring.

**Bug.** `harness.launch` runs the rollout's program as a single `runtime.run(...)` / `run_uv_script(...)` call. `RetryingRuntime.run` retries *any* call on *any* `Exception` (up to `retries.runtime.max_retries`, default 3). So a transient transport fault mid-program (e.g. a modal exec/stream drop behind the run's 502s) didn't retry one model call — it **re-executed the entire program from turn 0**. The interception session/trace is keyed by rollout id and persists across the re-run, so attempt 2 rebuilt the conversation from the prompt and **forked a new branch at the task-prompt node**, up to 3 extra full re-runs. Consequences:
- duplicate/abandoned branches leak into the graph (and into training samples — one per branch);
- attempt 2 runs against a runtime already mutated by attempt 1 → corrupted scoring for stateful tasks (e.g. files already moved out of `/app/...`);
- wasted tokens/wall-clock (the agent ran to completion twice).

This affected **every** program-exec path: `run_uv_script` (bash / default / mini-swe) and the direct-`run()` CLI agents (codex / kimi_code / rlm).

**Fix.** Introduce `Runtime.run_program(argv, env)` — the rollout's *main program* exec, distinct from short idempotent infra ops (write / mv / install / provisioning) that keep going through `run`. It's identical to `run` on a plain runtime, but **`RetryingRuntime.run_program` does not retry** (straight to `inner.run`). `run_uv_script`'s script exec and the codex/kimi/rlm program execs now use `run_program`; their install/staging/metric `run`/`write` calls stay retried. A mid-program transport fault now surfaces as a `ProgramError` for that rollout instead of a silent restart.

## Why this is the right layer

Whole-rollout retries belong to the **rollout** layer, which re-runs cleanly: `run_with_retry` re-invokes `rollout.run()` per attempt, and each `rollout.run()` builds a **fresh `Trace`** and a **fresh `make_runtime(...)`**, tearing the previous runtime down in its `finally` (`runtime.stop()`). So a configured `retries.rollout` retry re-runs from scratch on a new sandbox + new trace (no dirty state, no duplicate branch); with the default `retries.rollout.max_retries = 0` the rollout simply errors — no silent restart. Runtime-level retries stay for the genuinely idempotent infra ops.

## Verification

- Unit: wrapping a runtime whose `run` always raises, `RetryingRuntime.run` makes 4 attempts (1 + 3 retries) while `RetryingRuntime.run_program` makes exactly 1 (no retry).
- `run_uv_script`'s script exec routes through `run_program` (write/mv staging still via the retrying `write`/`run`); codex/kimi/rlm program execs route through `run_program`, installs stay on `run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix rollout harnesses to skip retries on main program execution
> - Introduces `Runtime.run_program` in [base.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1739/files#diff-0811c040a163eb5a3212208f1e3a6c6388d7690fcc4780c081cc7754036232b9) as a distinct method for executing the harness's main program; the default delegates to `run`.
> - `RetryingRuntime.run_program` overrides this to bypass the retry wrapper and call the inner runtime directly, so transport faults surface immediately instead of spawning duplicate trace branches.
> - Updates [codex/harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1739/files#diff-3fcf41ec082917a3c3ee1d3025d225deeef740cef1e0d36fda152403eb17505e), [kimi_code/harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1739/files#diff-53b398dd7185324fe13275f044d19ab09f3786652d18f0335ee5cb1643a34406), and [rlm/harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1739/files#diff-7584c8a365dfca01f409c655799153ef7388d852da78db0068d9bd1c1d92ae0a) to call `run_program` for the final program invocation; install/staging steps continue to use `run` and remain retried.
> - Behavioral Change: main rollout program execution now runs exactly once under `RetryingRuntime`; previously a transport fault would trigger a retry, producing forked duplicate trace branches.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized d00b0b0. 4 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core rollout execution semantics under `RetryingRuntime`: mid-program transport failures now fail the rollout instead of silent full restarts, which is correct but alters failure behavior for all harness program paths.
> 
> **Overview**
> Fixes **`RetryingRuntime`** re-executing the full harness/agent program after a transient transport error, which could **fork duplicate trace branches** and re-run against an already-mutated sandbox.
> 
> Adds **`Runtime.run_program`** for the rollout’s main (stateful) exec; on **`RetryingRuntime`** it bypasses tenacity and calls **`inner.run`** directly, while short infra work (install, write/mv, metrics `cat`, etc.) still uses **`run`**. **`run_uv_script`** now runs the **`uv run`** step via **`run_program`**; codex, kimi-code, and rlm **`launch`** paths do the same for their CLI invocations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86be08dfca3f948c3143ad65adffc6b0d8dfff4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->