### PR TITLE
fix: keep the swebench/ org in swebench-verified-v1 prime-registry image paths

### DIFF
--- a/environments/swebench_verified_v1/swebench_verified_v1/taskset.py
+++ b/environments/swebench_verified_v1/swebench_verified_v1/taskset.py
@@ -49,10 +49,10 @@ class SWEBenchVerifiedTaskset(
         tasks = []
         for task in super().load_tasks():
             base = from_image(Path(task.task_dir))
+            # The mirror keeps the source repo path (`swebench/sweb.eval.*`), matching the
+            # composable swebench taskset's `{REGISTRY}/{instance_image_key}`.
             image = (
-                f"{REGISTRY_PREFIX}/{base.rsplit('/', 1)[-1]}"
-                if self.config.use_prime_registry
-                else base
+                f"{REGISTRY_PREFIX}/{base}" if self.config.use_prime_registry else base
             )
             tasks.append(task.model_copy(update={"image": image}))
         return tasks


### PR DESCRIPTION
## Summary

- `swebench-verified-v1.load_tasks` built the `use_prime_registry=true` image as `{REGISTRY_PREFIX}/{base.rsplit('/', 1)[-1]}`, which **strips the `swebench/` org** from the Dockerfile `FROM` (`swebench/sweb.eval.*`) and resolves to `prod-sandbox/sweb.eval.*` — a path that doesn't exist in the registry, so every rollout failed with `ErrImagePull`.
- The prime mirror keeps the source repo path. Drop the `rsplit` so the image resolves to `{REGISTRY_PREFIX}/swebench/sweb.eval.x86_64.<instance>:latest`, matching the composable swebench taskset (`{REGISTRY}/{test_spec.instance_image_key}`, where `make_test_spec(..., namespace="swebench").instance_image_key` keeps the `swebench/` org).

## Verification

Debug eval `eval swebench-verified-v1 -n 1 --harness.id rlm --harness.runtime.type prime --taskset.use-prime-registry true` on a prime sandbox:

- **Before:** `SandboxImagePullError: IMAGE_PULL_FAILED ... ErrImagePull` (3 retries) for `.../prod-sandbox/sweb.eval.x86_64.astropy_1776_astropy-12907:latest`.
- **After:** `prime: sandbox ... up (image=.../prod-sandbox/swebench/sweb.eval.x86_64.astropy_1776_astropy-12907:latest)` — pulls clean, rollout proceeds.

Isolation check: on the same prime sandbox, `r2e-gym-v1`'s prime-registry image and the public `swebench/sweb.eval.*` image both pull fine — confirming this was the path, not credentials or a missing mirror.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix swebench-verified-v1 prime-registry image paths to preserve the `swebench/` org prefix
> In [`taskset.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1740/files#diff-9360d91568099a567b83aeb3813028f0763a9c9bd07769b85db79a455c47b0c4), when `config.use_prime_registry` is `True`, the image reference was built using only the basename of the source image path (via `rsplit('/', 1)[-1]`), stripping the `swebench/` org segment. The fix prefixes `REGISTRY_PREFIX` to the full base image path so the mirrored path matches the source repo structure.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eeef9b1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line image URL construction change with no auth or scoring logic; fixes incorrect pull paths when `use_prime_registry` is true.
> 
> **Overview**
> When **`use_prime_registry`** is enabled, **`load_tasks`** now builds the sandbox image as **`{REGISTRY_PREFIX}/{full FROM path}`** instead of prefixing only the image basename. That keeps the **`swebench/`** segment (e.g. **`swebench/sweb.eval.*`**) so pulls hit the mirrored path in Artifact Registry rather than a non-existent **`prod-sandbox/sweb.eval.*`** ref that caused **`ErrImagePull`** on prime rollouts.
> 
> The behavior aligns with how other tasksets (e.g. composable swebench) compose registry URLs with the full source repo path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eeef9b152db61dface2b11f81117a3ba2da29861. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->