### PR TITLE
fix: make general-agent-v1 toolset work when colocated in a sandbox

### DIFF
--- a/environments/general_agent_v1/README.md
+++ b/environments/general_agent_v1/README.md
@@ -10,6 +10,11 @@ The **4,417-task corpus is not vendored** — `corpus.ensure_corpus()` sparse-ch
 `PrimeIntellect-ai/research-environments` at a pinned commit into `~/.cache/verifiers/general_agent/`
 on first use (needs read access to that repo; override the location with `GENERAL_AGENT_CACHE_DIR`).
 
+The tool server defaults to its own host runtime, where that cache lives. It also runs in a sandbox —
+colocated in the harness's runtime (`--taskset.tools.colocated`) or its own (`--taskset.tools.runtime.type`) —
+which can't reach the host cache, so the two files it loads (`tools.py`, `db.json`) are shipped with each
+task in that case.
+
 Run under any MCP-tool-capable harness (`bash`, `default`):
 
 ```bash

--- a/environments/general_agent_v1/general_agent_v1/servers/toolset.py
+++ b/environments/general_agent_v1/general_agent_v1/servers/toolset.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import inspect
 import json
+import tempfile
 from pathlib import Path
 from typing import Callable
 
@@ -25,12 +26,30 @@ class GeneralAgentToolset(vf.Toolset[GeneralAgentToolsetConfig, GeneralAgentStat
     TOOL_PREFIX = "tools"  # the model sees `tools_<name>` for each of the task's tools
 
     async def setup_task(self, task) -> None:
-        task_dir = Path(task.dir)
+        task_dir = self._task_dir(task)
         task_db = load_task_attr(task_dir, "TaskDB")
         task_tools = load_task_attr(task_dir, "TaskTools")
         if task_db is None or task_tools is None:
             raise ValueError(f"tools.py must define TaskDB and TaskTools: {task_dir}")
         self._tools = task_tools(task_db.load(task_dir / "db.json"))
+
+    @staticmethod
+    def _task_dir(task) -> Path:
+        """Where this rollout's `tools.py` + `db.json` live in *this* runtime. Own-host: the host
+        cache (`task.dir`). Colocated in a sandbox: that host path isn't here (and the corpus repo
+        is private), so materialize the files shipped with the task over `/task` into a temp dir."""
+        task_dir = Path(task.dir)
+        if (task_dir / "tools.py").exists():
+            return task_dir
+        if not task.files:
+            raise RuntimeError(
+                f"task dir {task_dir} not present in this runtime and no files were shipped with "
+                "the task — the corpus is host-side, so the toolset can't load it here"
+            )
+        tmp = Path(tempfile.mkdtemp(prefix=f"ga-{task.name}-"))
+        for name, content in task.files.items():
+            (tmp / name).write_text(content)
+        return tmp
 
     def _register(self, mcp) -> None:
         for name, method in sorted(self._tools.tool_methods.items()):

--- a/environments/general_agent_v1/general_agent_v1/taskset.py
+++ b/environments/general_agent_v1/general_agent_v1/taskset.py
@@ -32,9 +32,13 @@ from general_agent_v1.servers.toolset import GeneralAgentToolset
 
 class GeneralAgentTask(vf.Task):
     dir: str
-    """Absolute path to the task's directory in the local cache."""
+    """Absolute path to the task's directory in the local (host) cache."""
     tier: int = 0
     """Difficulty tier (0 = easiest .. 4 = hardest), from the task's `task.toml`."""
+    files: dict[str, str] = {}
+    """The task's `tools.py` + `db.json` contents, embedded only when the toolset runs in a sandbox
+    (colocated or its own non-host runtime) — where the host-side `dir` isn't reachable. The toolset
+    materializes these per rollout; empty for the default own-host placement (which reads `dir`)."""
 
 
 class GeneralAgentConfig(vf.TasksetConfig):
@@ -60,6 +64,12 @@ class GeneralAgentSolverTaskset(
 ):
     def load_tasks(self) -> list[GeneralAgentTask]:
         tasks_dir = ensure_corpus(self.config.ref)
+        # A tool server in a sandbox (colocated, or its own non-host runtime) can't reach the
+        # host-side corpus, so ship the two files it loads with each task; own-host reads `dir`.
+        embed = (
+            self.config.tools.colocated
+            or self.config.tools.runtime.type != "subprocess"
+        )
         tasks: list[GeneralAgentTask] = []
         for task_dir in sorted(tasks_dir.iterdir()):
             if not task_dir.is_dir() or not (task_dir / "task.toml").exists():
@@ -83,6 +93,14 @@ class GeneralAgentSolverTaskset(
                 self.config.max_pass_rate,
             ):
                 continue
+            files = (
+                {
+                    "tools.py": (task_dir / "tools.py").read_text(),
+                    "db.json": (task_dir / "db.json").read_text(),
+                }
+                if embed
+                else {}
+            )
             tasks.append(
                 GeneralAgentTask(
                     idx=len(tasks),
@@ -90,6 +108,7 @@ class GeneralAgentSolverTaskset(
                     dir=str(task_dir),
                     tier=tier,
                     prompt=(task_dir / "instruction.md").read_text().strip(),
+                    files=files,
                 )
             )
         if not tasks:


### PR DESCRIPTION
## Summary

Fixes `general-agent-v1` rollouts failing with `ProgramError: tool server 'tools' not serving in
runtime` when the toolset runs **colocated** in a sandbox (e.g. `--harness.runtime.type modal` +
`--taskset.tools.colocated`).

- The toolset loaded each task from `Path(task.dir)` — a path in the **host** cache — and the corpus
  lives in a **private** repo (`git@github.com:…/research-environments`). A colocated tool server runs
  *inside* the harness's sandbox, which has neither the host cache nor git credentials, so `setup_task`
  crashed before the server could serve → the host's readiness probe reported "not serving".
- Now the two files the toolset actually loads (`tools.py`, `db.json`; median ~6 KB) are **shipped with
  each task** over the existing `/task` channel, and `setup_task` materializes them into a temp dir when
  `task.dir` isn't present in its runtime. The files are embedded **only when the toolset runs in a
  sandbox** (`colocated`, or its own non-`subprocess` runtime), so the default own-host placement carries
  no extra payload. Scoring is unaffected — it already runs host-side.

## Verification

Single rollout, `bash` harness in a `docker` runtime with the toolset colocated in it:

```bash
uv run eval general-agent-v1 -n 1 -r 1 --taskset.tasks calendar_scheduling --taskset.max-tier 0 \
  --harness.id bash --harness.runtime.type docker --taskset.tools.colocated true -m openai/gpt-5.4-mini
```

- **Before:** `✗ ProgramError: tool server 'tools' not serving in runtime` (crash in
  `setup_task → load_task_attr(Path(task.dir), "TaskDB")`, turns=0).
- **After:** `✓ reward 1.00 · err 0.00` — the colocated toolset serves, the agent solves the task, and
  scoring fires.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `general-agent-v1` toolset to load task files when colocated in a sandbox
> - When the toolset runs in a sandbox (colocated or separate runtime), it may not have access to the host-side task directory containing `tools.py` and `db.json`.
> - `GeneralAgentSolverTaskset.load_tasks` now embeds `tools.py` and `db.json` contents directly into each `GeneralAgentTask.files` dict when the toolset is sandboxed; tasks for own-host runtimes retain an empty `files` dict.
> - `GeneralAgentToolset._task_dir` resolves the correct directory at setup time: if the host path exists it uses it, otherwise it materializes the shipped files into a temp directory and returns that path.
> - Risk: if a task is sandboxed but `files` is empty (no files shipped), `_task_dir` raises a `RuntimeError` instead of silently failing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a09dcb5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to general-agent-v1 tool loading and task payload; host-side scoring unchanged and embedding is gated to sandbox placements only.
> 
> **Overview**
> Fixes colocated/sandboxed **general-agent-v1** tool servers failing before MCP serve because `setup_task` read `tools.py` and `db.json` from the host-only corpus cache path.
> 
> When the toolset is **colocated** or uses a **non-subprocess** runtime, `load_tasks` now embeds `tools.py` and `db.json` on each `GeneralAgentTask` via a new `files` field; default host placement leaves `files` empty. `GeneralAgentToolset._task_dir` uses the host `task.dir` when present, otherwise writes shipped `files` into a per-rollout temp directory. Missing both path and payload raises a clear `RuntimeError`. README documents the sandbox vs host behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a09dcb5a675e7fb30aa04665e6c2a7ecaf124e37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->