### PR TITLE
fix: cap concurrent CPU-bound scoring scripts on the subprocess runtime

### DIFF
--- a/environments/aime24_v1/aime24_v1/taskset.py
+++ b/environments/aime24_v1/aime24_v1/taskset.py
@@ -62,6 +62,7 @@ class AIME24Taskset(vf.Taskset[AIME24Task, AIME24Config]):
         result = await runtime.run_uv_script(
             VERIFY,
             args=[task.answer, prediction or "", str(self.config.math_verify_timeout)],
+            cpu_bound=True,
         )
         if result.exit_code != 0:
             raise vf.ProgramError(f"verify.py failed: {result.stderr.strip()[-500:]}")

--- a/environments/gsm8k_v1/gsm8k_v1/taskset.py
+++ b/environments/gsm8k_v1/gsm8k_v1/taskset.py
@@ -51,7 +51,7 @@ class GSM8KTaskset(vf.Taskset[GSM8KTask, GSM8KConfig]):
             trace.assistant_messages[-1].content if trace.assistant_messages else ""
         )
         result = await runtime.run_uv_script(
-            VERIFY, args=[task.answer, prediction or ""]
+            VERIFY, args=[task.answer, prediction or ""], cpu_bound=True
         )
         if result.exit_code != 0:
             raise vf.ProgramError(f"verify.py failed: {result.stderr.strip()[-500:]}")
@@ -63,7 +63,7 @@ class GSM8KTaskset(vf.Taskset[GSM8KTask, GSM8KConfig]):
         answer as a well-formed `#### N` prediction and require a 1.0 score — catching rows the
         verifier can't parse or grade (the model-free counterpart of the `correct` reward)."""
         result = await runtime.run_uv_script(
-            VERIFY, args=[task.answer, f"#### {task.answer}"]
+            VERIFY, args=[task.answer, f"#### {task.answer}"], cpu_bound=True
         )
         if result.exit_code != 0:
             raise vf.ProgramError(f"verify.py failed: {result.stderr.strip()[-500:]}")

--- a/environments/math_env_v1/math_env_v1/taskset.py
+++ b/environments/math_env_v1/math_env_v1/taskset.py
@@ -66,6 +66,7 @@ class MathTaskset(vf.Taskset[MathTask, MathConfig]):
         result = await runtime.run_uv_script(
             VERIFY,
             args=[task.answer, prediction or "", str(self.config.math_verify_timeout)],
+            cpu_bound=True,
         )
         if result.exit_code != 0:
             raise vf.ProgramError(f"verify.py failed: {result.stderr.strip()[-500:]}")

--- a/verifiers/v1/GUIDE.md
+++ b/verifiers/v1/GUIDE.md
@@ -265,7 +265,7 @@ isolated environment. On a `runtime` you can call:
 | method | what |
 | --- | --- |
 | `run(argv, env)` | exec a command to completion → `ProgramResult(exit_code, stdout, stderr)` |
-| `run_uv_script(src, args, env)` | run a PEP 723 script (inline deps resolve in-runtime); `args` are shell-`"$@"`-safe |
+| `run_uv_script(src, args, env, cpu_bound=False)` | run a PEP 723 script (inline deps resolve in-runtime); `args` are shell-`"$@"`-safe. Pass `cpu_bound=True` for a CPU-heavy scoring script (e.g. a sympy-based verifier): the subprocess runtime then caps concurrent such runs at the core count, so a batch of scores finishing together won't oversubscribe the cores and blow the scoring timeout |
 | `run_background(argv, env, log)` | start a long-lived process (e.g. a colocated server) |
 | `read(path)` / `write(path, data)` | workspace files (bytes), across the container/sandbox boundary |
 | `expose(port)` | publish a port *inside* the runtime to a host-reachable URL (`None` when local) |

--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -151,10 +151,18 @@ class Runtime(ABC):
     # --- execution ---
 
     @abstractmethod
-    async def run(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
-        """Run `argv` (with the interception env vars `env`) to completion."""
+    async def run(
+        self, argv: list[str], env: dict[str, str], cpu_bound: bool = False
+    ) -> ProgramResult:
+        """Run `argv` (with the interception env vars `env`) to completion. `cpu_bound` flags a
+        CPU-heavy command (e.g. a verifier that cold-imports sympy): the subprocess runtime caps
+        how many such run at once (≈ the core count) so a burst of scores at an eval's start
+        doesn't oversubscribe the cores — a no-op on isolated runtimes (their work runs in a
+        sandbox, off the host)."""
 
-    async def run_program(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
+    async def run_program(
+        self, argv: list[str], env: dict[str, str], cpu_bound: bool = False
+    ) -> ProgramResult:
         """Run the harness's MAIN program — the rollout itself (a possibly long-lived, stateful,
         agentic run) — as opposed to the short idempotent infra ops (write / mv / install /
         provisioning) that go through `run`. Identical to `run` here; `RetryingRuntime` overrides it
@@ -162,7 +170,7 @@ class Runtime(ABC):
         fork a duplicate branch (and re-execute against a runtime already mutated by the first
         attempt). A transient transport fault mid-program surfaces as a ProgramError for this
         rollout instead of a silent full restart."""
-        return await self.run(argv, env)
+        return await self.run(argv, env, cpu_bound)
 
     async def run_background(
         self, argv: list[str], env: dict[str, str], log: str
@@ -179,9 +187,12 @@ class Runtime(ABC):
         script: str | bytes,
         args: list[str] | None = None,
         env: dict[str, str] | None = None,
+        cpu_bound: bool = False,
     ) -> ProgramResult:
         """Run a self-contained uv script (PEP 723 inline deps) in this runtime, with
-        `args` as its positional arguments (the script's `sys.argv[1:]`).
+        `args` as its positional arguments (the script's `sys.argv[1:]`). `cpu_bound` flags a
+        CPU-heavy script (e.g. a math verifier) for the subprocess runtime's concurrency cap
+        (see `run`); pass it for scoring scripts so a burst at an eval's start doesn't thrash.
 
         Writes `script`, ensures `uv` is present, and runs `uv run` — so the script's
         dependencies resolve into uv's cache inside the runtime, never the eval process.
@@ -206,7 +217,7 @@ class Runtime(ABC):
         # The write/mv above are idempotent infra (retried); the script run is the rollout's
         # program — `run_program`, so it is not retried (see Runtime.run_program).
         return await self.run_program(
-            ["sh", "-c", command, path, *(args or [])], env or {}
+            ["sh", "-c", command, path, *(args or [])], env or {}, cpu_bound
         )
 
     # --- filesystem ---
@@ -290,13 +301,17 @@ class RetryingRuntime(Runtime):
     def cleanup(self) -> None:
         self.inner.cleanup()
 
-    async def run(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
-        return await self._retry(self.inner.run, argv, env)
+    async def run(
+        self, argv: list[str], env: dict[str, str], cpu_bound: bool = False
+    ) -> ProgramResult:
+        return await self._retry(self.inner.run, argv, env, cpu_bound)
 
-    async def run_program(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
+    async def run_program(
+        self, argv: list[str], env: dict[str, str], cpu_bound: bool = False
+    ) -> ProgramResult:
         """The rollout's program exec is NOT retried (see the class docstring) — straight to
         inner."""
-        return await self.inner.run(argv, env)
+        return await self.inner.run(argv, env, cpu_bound)
 
     async def run_background(
         self, argv: list[str], env: dict[str, str], log: str

--- a/verifiers/v1/runtimes/docker.py
+++ b/verifiers/v1/runtimes/docker.py
@@ -120,7 +120,9 @@ class DockerRuntime(Runtime):
             self.config.image,
         )
 
-    async def run(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
+    async def run(
+        self, argv: list[str], env: dict[str, str], cpu_bound: bool = False
+    ) -> ProgramResult:
         env_args = [arg for k, v in env.items() for arg in ("--env", f"{k}={v}")]
         return await docker(
             "exec", *env_args, "--workdir", self.config.workdir, self._container, *argv

--- a/verifiers/v1/runtimes/modal.py
+++ b/verifiers/v1/runtimes/modal.py
@@ -132,7 +132,9 @@ class ModalRuntime(Runtime):
         tunnel = tunnels.get(port)
         return str(tunnel.url).rstrip("/") if tunnel else None
 
-    async def run(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
+    async def run(
+        self, argv: list[str], env: dict[str, str], cpu_bound: bool = False
+    ) -> ProgramResult:
         try:
             proc = await self._sandbox.exec.aio(
                 *argv, workdir=self.config.workdir, env=env

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -131,7 +131,9 @@ class PrimeRuntime(Runtime):
         ) as e:  # provisioning failure is one rollout's problem, not the eval's
             raise ProgramError(f"prime sandbox provisioning failed: {e}") from e
 
-    async def run(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
+    async def run(
+        self, argv: list[str], env: dict[str, str], cpu_bound: bool = False
+    ) -> ProgramResult:
         try:
             result = await self._client.run_background_job(
                 self._sandbox_id,

--- a/verifiers/v1/runtimes/subprocess.py
+++ b/verifiers/v1/runtimes/subprocess.py
@@ -41,6 +41,27 @@ class SubprocessRuntime(Runtime):
     # the worker's per-rollout runtimes (+ a per-sha lock so first-callers provision once).
     _interpreters: dict[str, str] = {}
     _locks: dict[str, asyncio.Lock] = {}
+    # Process-wide cap on concurrently-running `cpu_bound` subprocesses (shared across all
+    # per-rollout runtimes), created lazily on the eval's loop.
+    _cpu_semaphore: asyncio.Semaphore | None = None
+
+    @classmethod
+    def _cpu_limiter(cls) -> asyncio.Semaphore:
+        """Cap concurrent `cpu_bound` subprocesses at the cores available to this process (override
+        with VF_SUBPROCESS_CPU_SLOTS). At an eval's start the whole in-flight batch finishes
+        generation together and fires its scoring scripts at once; uncapped they oversubscribe the
+        cores N:1, each cold-import (sympy) thrashes, and the per-score wall-clock — which the
+        scoring timeout bounds — balloons. Capping at the core count keeps each on its own core."""
+        if cls._cpu_semaphore is None:
+            override = os.environ.get("VF_SUBPROCESS_CPU_SLOTS")
+            try:
+                cores = len(os.sched_getaffinity(0))
+            except AttributeError:  # not Linux
+                cores = os.cpu_count() or 1
+            cls._cpu_semaphore = asyncio.Semaphore(
+                int(override) if override else max(1, cores)
+            )
+        return cls._cpu_semaphore
 
     def __init__(self, config: SubprocessConfig, name: str | None = None) -> None:
         super().__init__(name)
@@ -56,39 +77,48 @@ class SubprocessRuntime(Runtime):
         self.workdir = Path("/tmp") / self.name
         self.workdir.mkdir()
 
-    async def run(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
-        full_env = {k: v for k, v in os.environ.items() if "API_KEY" not in k.upper()}
-        full_env.update(env)
-        proc = await asyncio.create_subprocess_exec(
-            *argv,
-            env=full_env,
-            cwd=self.workdir,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            start_new_session=True,  # own process group, so we can reap the whole tree
-        )
-        try:
-            stdout, stderr = await proc.communicate()
-        finally:
-            # If the await didn't finish, the caller cancelled it (e.g. the rollout's
-            # scoring_timeout / harness_timeout fired): communicate() leaves the process
-            # running, so SIGKILL its whole group (start_new_session => pgid == pid) — otherwise
-            # a hung child (a wedged uv/sympy verify) outlives the rollout and leaks CPU. A
-            # no-op once it has exited on its own.
-            if proc.returncode is None:
-                with contextlib.suppress(ProcessLookupError, PermissionError):
-                    os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
-        return ProgramResult(
-            exit_code=proc.returncode or 0,
-            stdout=stdout.decode(errors="replace"),
-            stderr=stderr.decode(errors="replace"),
-        )
+    async def run(
+        self, argv: list[str], env: dict[str, str], cpu_bound: bool = False
+    ) -> ProgramResult:
+        # A `cpu_bound` command holds a core slot for its whole run, so a herd of scores at an
+        # eval's start drains through the cores instead of thrashing all at once (see _cpu_limiter).
+        limiter = self._cpu_limiter() if cpu_bound else contextlib.nullcontext()
+        async with limiter:
+            full_env = {
+                k: v for k, v in os.environ.items() if "API_KEY" not in k.upper()
+            }
+            full_env.update(env)
+            proc = await asyncio.create_subprocess_exec(
+                *argv,
+                env=full_env,
+                cwd=self.workdir,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                start_new_session=True,  # own process group, so we can reap the whole tree
+            )
+            try:
+                stdout, stderr = await proc.communicate()
+            finally:
+                # If the await didn't finish, the caller cancelled it (e.g. the rollout's
+                # scoring_timeout / harness_timeout fired): communicate() leaves the process
+                # running, so SIGKILL its whole group (start_new_session => pgid == pid) —
+                # otherwise a hung child (a wedged uv/sympy verify) outlives the rollout and leaks
+                # CPU. A no-op once it has exited on its own.
+                if proc.returncode is None:
+                    with contextlib.suppress(ProcessLookupError, PermissionError):
+                        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            return ProgramResult(
+                exit_code=proc.returncode or 0,
+                stdout=stdout.decode(errors="replace"),
+                stderr=stderr.decode(errors="replace"),
+            )
 
     async def run_uv_script(
         self,
         script: str | bytes,
         args: list[str] | None = None,
         env: dict[str, str] | None = None,
+        cpu_bound: bool = False,
     ) -> ProgramResult:
         """Run a PEP 723 script via a pre-provisioned interpreter instead of `uv run` per call.
 
@@ -116,7 +146,7 @@ class SubprocessRuntime(Runtime):
                         )
                     self._interpreters[sha] = provision.stdout.strip().splitlines()[-1]
         return await self.run(
-            [self._interpreters[sha], str(path), *(args or [])], env or {}
+            [self._interpreters[sha], str(path), *(args or [])], env or {}, cpu_bound
         )
 
     async def run_background(


### PR DESCRIPTION
## Summary

At an eval's start the whole in-flight batch finishes generation at roughly the same time and fires
its per-rollout scoring at once. On the **subprocess** runtime each math/gsm8k/aime score is a fresh
process that cold-imports `sympy` (`math-verify`) — CPU- and memory-heavy. N≫cores of them launching
together oversubscribe the cores and stack memory; the per-rollout scoring wall-clock — which the 30s
`scoring_timeout` bounds — balloons past the timeout for the unlucky rollouts. Once the herd clears,
scoring drops back to ~normal.

This adds a `cpu_bound` flag to the runtime exec API and uses it to cap how many such scripts run at
once on the host:

- **`Runtime.run` / `run_program` / `run_uv_script`** gain `cpu_bound: bool = False`.
- The **subprocess runtime** caps concurrently-running `cpu_bound` subprocesses at the available core
  count — a process-wide `asyncio.Semaphore` sized to `len(os.sched_getaffinity(0))`, override with
  `VF_SUBPROCESS_CPU_SLOTS`. The herd then drains through the cores instead of thrashing all at once,
  and peak concurrent verifiers (≈ peak memory) is bounded.
- The long-lived, **I/O-bound harness program** does *not* set the flag, so rollout concurrency is
  untouched — only the short CPU-bound scoring scripts are throttled.
- **Isolated runtimes** (docker / modal / prime) accept the flag and ignore it — their scripts run in
  a sandbox, off the host.
- Tags the three sympy-based verifiers `cpu_bound=True`: **gsm8k-v1**, **aime24-v1**, **math_env-v1**.

## Verification

Repro: fire N concurrent gsm8k verifiers (each cold-imports sympy) on the subprocess runtime,
measuring per-call wall-clock (what the scoring timeout sees), `cpu_bound=False` vs `True`.

On an idle 30-core / 283 GB box (no memory pressure, fast CPU — so it can't hit the 30s wall, but the
oversubscription effect is clear):

```
  n=256  cpu_bound=False  p50= 2.5s  p90= 3.4s  max= 3.5s
  n=256  cpu_bound=True   p50= 1.8s  p90= 3.1s  max= 3.4s
  n=512  cpu_bound=False  p50= 4.8s  p90= 7.6s  max= 7.8s
  n=512  cpu_bound=True   p50= 3.2s  p90= 5.5s  max= 6.1s
```

Pinned to 8 cores (simulating the eval sharing a node with vLLM + the trainer) the uncapped case
lands right on the 30s cliff — the user's exact symptom — and the cap roughly halves it:

```
  n=256  cpu_bound=False  p50= 9.7s  p90=13.6s  max=13.8s
  n=256  cpu_bound=True   p50= 4.2s  p90= 7.5s  max= 8.4s
  n=512  cpu_bound=False  p50=17.4s  p90=28.7s  max=29.3s   <- right at the 30s scoring_timeout
  n=512  cpu_bound=True   p50= 8.1s  p90=14.5s  max=16.2s
```

The cap reaches the semaphore through the **production default path** too
(`RetryingRuntime(SubprocessRuntime)` → `run_uv_script` → `run_program` → `inner.run`): with the cap
pinned to 1, four concurrent `cpu_bound=True` calls serialize (~4×) while `cpu_bound=False` calls run
in parallel.

## Breaking

- `Runtime.run` / `run_program` / `run_uv_script` gain a trailing `cpu_bound: bool = False` parameter
  (additive, defaulted). A **custom `Runtime` subclass** that overrides `run` must add the parameter to
  match the ABC — the base `run_uv_script` now calls `self.run(..., cpu_bound)`. The four built-in
  runtimes are updated.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cap concurrent CPU-bound scoring scripts on the subprocess runtime
> - Adds a process-wide `asyncio.Semaphore` to [`SubprocessRuntime`](https://github.com/PrimeIntellect-ai/verifiers/pull/1742/files#diff-f36f9994618d7a28baaf498b61eb6f129dcfda77500d165d18537426dfcdd6e2) that limits concurrent CPU-bound subprocesses to the number of CPU cores (or `VF_SUBPROCESS_CPU_SLOTS` env var override).
> - Extends the `cpu_bound: bool = False` flag through the full runtime hierarchy: `Runtime.run`, `run_program`, `run_uv_script`, and all implementations in Docker, Modal, Prime (accepted but unused), and subprocess runtimes.
> - AIME24, GSM8K, and MATH scoring/validation calls to `run_uv_script` now pass `cpu_bound=True` to opt into throttling.
> - Behavioral Change: on the subprocess runtime, concurrent verifier executions are now capped at core count by default; other runtimes are unaffected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 20f4883.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->