### PR TITLE
refactor(renderer): migrate to renderers `thinking_retention`

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1033,8 +1033,7 @@ with `MyConfig.model_validate(...)` or use the typed object directly.
 class ClientConfig(BaseModel):
     client_idx: int = 0
     client_type: ClientType = "openai_chat_completions"
-    preserve_all_thinking: bool = False
-    preserve_thinking_between_tool_calls: bool = False
+    renderer_config: RendererConfig | None = None
     api_key_var: str = "PRIME_API_KEY"
     api_base_url: str = "https://api.pinference.ai/api/v1"
     endpoint_configs: list[EndpointClientConfig] = []
@@ -1051,7 +1050,7 @@ class ClientConfig(BaseModel):
 
 `client_type` selects which `Client` implementation to instantiate (see [Client Classes](#client-classes)). Use `endpoint_configs` for multi-endpoint round-robin. In grouped scoring mode, groups are distributed round-robin across endpoint configs.
 
-`preserve_all_thinking` and `preserve_thinking_between_tool_calls` are forwarded to the underlying renderer when `client_type == "renderer"`. They control whether past-assistant `reasoning_content` is re-emitted on subsequent renders — `preserve_all_thinking` keeps every past-assistant turn's thinking, and `preserve_thinking_between_tool_calls` keeps thinking only inside the in-flight assistant→tool→…→assistant block after the most recent user turn (when that block contains at least one tool response). Both default to `False` (template default applies).
+`renderer_config` is a typed `renderers.RendererConfig` that drives the renderer pool when `client_type == "renderer"` (`None` is treated as `AutoRendererConfig()`). Its shared `thinking_retention` field controls whether past-assistant `reasoning_content` is re-emitted on subsequent renders: `"template"` (default) defers to the chat template, `"tool_cycle"` additionally keeps thinking inside the in-flight assistant→tool→…→assistant block after the most recent user turn (when that block contains at least one tool response), and `"all"` keeps every past-assistant turn's thinking.
 
 When `api_key_var` is `"PRIME_API_KEY"` (the default), credentials are loaded with the following precedence:
 - **API key**: `PRIME_API_KEY` env var > `~/.prime/config.json` > `"EMPTY"`

--- a/tests/test_renderer_client.py
+++ b/tests/test_renderer_client.py
@@ -91,7 +91,7 @@ def test_renderer_client_threads_chat_template_kwargs_into_pool():
 
     bases = [
         Qwen3RendererConfig(enable_thinking=True),
-        AutoRendererConfig(preserve_all_thinking=True),
+        AutoRendererConfig(thinking_retention="all"),
         None,
     ]
     for base in bases:
@@ -134,16 +134,16 @@ def test_renderer_client_threads_chat_template_kwargs_into_pool():
                 )
             )
 
-        expected_preserve_all = (
-            base.preserve_all_thinking
+        expected_retention = (
+            base.thinking_retention
             if isinstance(base, AutoRendererConfig)
-            else False
+            else "template"
         )
         create_pool_mock.assert_called_once_with(
             "Qwen/Qwen3-8B",
             Qwen3RendererConfig(
                 enable_thinking=False,
-                preserve_all_thinking=expected_preserve_all,
+                thinking_retention=expected_retention,
             ),
             size=1,
         )

--- a/verifiers/clients/renderer_client.py
+++ b/verifiers/clients/renderer_client.py
@@ -392,8 +392,8 @@ def _resolve_renderer_config(
     inside ``renderers.create_renderer``), we pull resolution forward via
     ``MODEL_RENDERER_MAP`` so kwargs land on the concrete config variant
     and pydantic validates them against the actual renderer's schema —
-    ``AutoRendererConfig`` intentionally carries only ``preserve_*`` and
-    would reject template kwargs like ``enable_thinking``. ``renderer_model``
+    ``AutoRendererConfig`` intentionally carries only ``thinking_retention``
+    and would reject template kwargs like ``enable_thinking``. ``renderer_model``
     must match what the pool will tokenize with (i.e.
     ``ClientConfig.renderer_model_name`` when set, else the request model),
     so resolution agrees with the tokenizer the renderer will hold.
@@ -408,7 +408,7 @@ def _resolve_renderer_config(
 
     # Resolve auto → concrete (mirrors ``renderers._resolve_auto``) so
     # ``enable_thinking`` etc. validate against the right schema instead of
-    # ``AutoRendererConfig``'s minimal one. Carries ``preserve_*`` across.
+    # ``AutoRendererConfig``'s minimal one. Carries ``thinking_retention`` across.
     if base is None or isinstance(base, AutoRendererConfig):
         renderer_name = MODEL_RENDERER_MAP.get(renderer_model, "default")
         # ``config_from_name`` returns ``None`` only for ``"auto"``, which
@@ -417,10 +417,7 @@ def _resolve_renderer_config(
         assert concrete is not None
         if isinstance(base, AutoRendererConfig):
             concrete = concrete.model_copy(
-                update={
-                    "preserve_all_thinking": base.preserve_all_thinking,
-                    "preserve_thinking_between_tool_calls": base.preserve_thinking_between_tool_calls,
-                }
+                update={"thinking_retention": base.thinking_retention}
             )
         base = cast(RendererConfig, concrete)
 


### PR DESCRIPTION
## What

The `renderers` package replaced the two boolean flags `preserve_all_thinking` and `preserve_thinking_between_tool_calls` with a single ordinal field:

```python
thinking_retention: Literal["template", "tool_cycle", "all"] = "template"
```

(See renderers PR: PrimeIntellect-ai/renderers#88.)

## Changes

- **`verifiers/clients/renderer_client.py`** — `_resolve_renderer_config` carried the old booleans from `AutoRendererConfig` onto the resolved concrete config by name. Now carries the single `thinking_retention` field (mirrors renderers' own auto carry-over):
  ```python
  concrete = concrete.model_copy(update={"thinking_retention": base.thinking_retention})
  ```
- **`tests/test_renderer_client.py`** — `AutoRendererConfig(thinking_retention="all")` and the corresponding expectation.
- **`docs/reference.md`** — the `ClientConfig` snippet still listed `preserve_*` as top-level fields, but the real config exposes the renderer settings via the typed `renderer_config`. Fixed the snippet + the explanatory paragraph to describe `thinking_retention`.

`ClientConfig` itself does not re-declare these fields — it holds a typed `renderer_config: RendererConfig`, so the field flows through pydantic; this PR only updates the by-name access in `_resolve_renderer_config`.

## ⚠️ Gating / dependency

Requires a `renderers` release that includes `thinking_retention`. The current floor `renderers>=0.1.8.dev28` is `>=`, so it auto-picks up the new release — but **CI will fail until renderers publishes** a version with `thinking_retention`, and the floor should be raised to that version once it's out. Verified locally against the renderers branch (`refactor/thinking-retention`): the affected `test_renderer_client` cases pass.

## Test plan

- [x] `ruff check` clean on changed files
- [x] `tests/test_renderer_client.py -k "threads_chat_template_kwargs or auto_resolves"` pass against the local renderers branch
- [ ] CI (blocked on renderers release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow adapter/docs/test updates for a renderers API rename; behavior is intended to match the old booleans once the matching renderers release is installed.
> 
> **Overview**
> Aligns verifiers with the **renderers** package replacing `preserve_all_thinking` / `preserve_thinking_between_tool_calls` with a single **`thinking_retention`** field (`"template"` | `"tool_cycle"` | `"all"`).
> 
> **`RendererClient._resolve_renderer_config`** now copies only `thinking_retention` from `AutoRendererConfig` onto the resolved concrete config when merging `chat_template_kwargs` (instead of the two booleans).
> 
> **Tests** use `AutoRendererConfig(thinking_retention="all")` and expect `"template"` for non-auto bases.
> 
> **`docs/reference.md`** documents renderer thinking via typed **`renderer_config`** and **`thinking_retention`**, not obsolete top-level `preserve_*` flags on `ClientConfig`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4e5c199a5e9c510bdd2437fe2cbdee7f591644d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Migrate renderer client to unified `thinking_retention` field in `RendererConfig`
> Replaces the two boolean fields `preserve_all_thinking` and `preserve_thinking_between_tool_calls` with a single `thinking_retention` field accepting `'template'` (default), `'tool_cycle'`, or `'all'`.
>
> - [`_resolve_renderer_config`](https://github.com/PrimeIntellect-ai/verifiers/pull/1743/files#diff-4309037b1656944b1991edc5baa1d16760d74155d7adc9fef41a2080ce8605e1) now propagates `thinking_retention` instead of the prior boolean flags when resolving `AutoRendererConfig` into a concrete `RendererConfig`
> - `ClientConfig` replaces the two preserve booleans with a `renderer_config: RendererConfig | None` field, where `None` is treated as `AutoRendererConfig()`
> - Behavioral Change: any code passing `preserve_all_thinking=True` must switch to `thinking_retention='all'`; `preserve_thinking_between_tool_calls` maps to `thinking_retention='tool_cycle'`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c4e5c19.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->