### PR TITLE
fix: add backoff to per-call retries; let harness clients retry the relay

### DIFF
--- a/packages/harnesses/harnesses/bash/program.py
+++ b/packages/harnesses/harnesses/bash/program.py
@@ -39,9 +39,6 @@ BASH_TOOL = {
     },
 }
 
-# base_url + api_key come from OPENAI_BASE_URL / OPENAI_API_KEY. The SDK's default retries (with
-# exponential backoff) stay on: the relay retries the upstream model, and these retry the relay's
-# own transient 502s — backstopping an outage that outlasts the relay's retries.
 client = AsyncOpenAI()
 
 

--- a/packages/harnesses/harnesses/bash/program.py
+++ b/packages/harnesses/harnesses/bash/program.py
@@ -39,9 +39,10 @@ BASH_TOOL = {
     },
 }
 
-# base_url + api_key come from OPENAI_BASE_URL / OPENAI_API_KEY. max_retries=0: the framework
-# already retries model calls at the interception relay, so the SDK's own retries would just nest.
-client = AsyncOpenAI(max_retries=0)
+# base_url + api_key come from OPENAI_BASE_URL / OPENAI_API_KEY. The SDK's default retries (with
+# exponential backoff) stay on: the relay retries the upstream model, and these retry the relay's
+# own transient 502s — backstopping an outage that outlasts the relay's retries.
+client = AsyncOpenAI()
 
 
 def run_bash(command: str) -> str:

--- a/packages/harnesses/harnesses/default/program.py
+++ b/packages/harnesses/harnesses/default/program.py
@@ -22,9 +22,6 @@ from contextlib import AsyncExitStack
 
 from openai import AsyncOpenAI
 
-# base_url + api_key come from OPENAI_BASE_URL / OPENAI_API_KEY. The SDK's default retries (with
-# exponential backoff) stay on: the relay retries the upstream model, and these retry the relay's
-# own transient 502s — backstopping an outage that outlasts the relay's retries.
 client = AsyncOpenAI()
 
 

--- a/packages/harnesses/harnesses/default/program.py
+++ b/packages/harnesses/harnesses/default/program.py
@@ -22,9 +22,10 @@ from contextlib import AsyncExitStack
 
 from openai import AsyncOpenAI
 
-# base_url + api_key come from OPENAI_BASE_URL / OPENAI_API_KEY. max_retries=0: the framework
-# already retries model calls at the interception relay, so the SDK's own retries would just nest.
-client = AsyncOpenAI(max_retries=0)
+# base_url + api_key come from OPENAI_BASE_URL / OPENAI_API_KEY. The SDK's default retries (with
+# exponential backoff) stay on: the relay retries the upstream model, and these retry the relay's
+# own transient 502s — backstopping an outage that outlasts the relay's retries.
+client = AsyncOpenAI()
 
 
 async def chat(messages: list[dict], tools: list[dict]):

--- a/verifiers/v1/clients/client.py
+++ b/verifiers/v1/clients/client.py
@@ -15,6 +15,7 @@ from tenacity import (
     retry_if_exception_type,
     retry_if_not_exception_type,
     stop_after_attempt,
+    wait_exponential_jitter,
 )
 
 from verifiers.v1.dialects import Dialect
@@ -87,8 +88,11 @@ class Client(ABC):
 
 class RetryingClient(Client):
     """Wraps a client to retry each completion on a transient `ModelError` (tenacity, up to
-    `max_retries` retries). An `OverlongPromptError` is never retried — it's a budget limit
-    the interception server turns into a clean truncation, not a transient fault."""
+    `max_retries` retries) with exponential backoff + jitter between attempts — so retries don't
+    fire back-to-back into the same brief endpoint outage, and concurrent rollouts hitting a shared
+    endpoint stagger their retries instead of re-thundering it. An `OverlongPromptError` is never
+    retried — it's a budget limit the interception server turns into a clean truncation, not a
+    transient fault."""
 
     def __init__(self, inner: Client, max_retries: int) -> None:
         self.inner = inner
@@ -97,6 +101,7 @@ class RetryingClient(Client):
         # off a per-call RetryCallState, so only its bookkeeping `.statistics` is shared.
         self._retrying = AsyncRetrying(
             stop=stop_after_attempt(max_retries + 1),
+            wait=wait_exponential_jitter(initial=0.5, max=30),
             retry=retry_if_exception_type(ModelError)
             & retry_if_not_exception_type(OverlongPromptError),
             before_sleep=self._log_retry,

--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -23,6 +23,7 @@ from tenacity import (
     retry_if_exception_type,
     retry_if_not_exception_type,
     stop_after_attempt,
+    wait_exponential_jitter,
 )
 
 logger = logging.getLogger(__name__)
@@ -261,6 +262,7 @@ class RetryingRuntime(Runtime):
         # off a per-call RetryCallState, so only its bookkeeping `.statistics` is shared.
         self._retrying = AsyncRetrying(
             stop=stop_after_attempt(max_retries + 1),
+            wait=wait_exponential_jitter(initial=0.5, max=30),
             retry=retry_if_exception_type(Exception)
             & retry_if_not_exception_type(NotImplementedError),
             before_sleep=self._log_retry,


### PR DESCRIPTION
## Summary

Two fixes to model-call retry resilience when the endpoint disconnects for more than an instant:

- **Backoff on per-call retries.** `RetryingClient` (model calls) and `RetryingRuntime` (runtime
  calls) set `stop` / `retry` / `before_sleep` but no `wait=`, so tenacity defaulted to `wait_none`
  — all attempts fired back-to-back in ~1s and hit the same brief outage together. Both now use
  `wait_exponential_jitter(initial=0.5, max=30)`, so retries spread out and concurrent rollouts on a
  shared endpoint stagger their retries instead of re-thundering it. (With the default 3 retries the
  attempts now span ~5s instead of ~1s.)
- **Harness clients retry the relay.** The `bash` / `default` harness programs ran
  `AsyncOpenAI(max_retries=0)`, so when the relay exhausted its retries and returned a 502 they
  raised immediately → `ProgramError`. Dropping the override restores the OpenAI SDK's default
  retries (which have their own exponential backoff), so the program also retries the relay's
  transient 502s — a backstop for an outage that outlasts the relay's own retries.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add exponential backoff with jitter to per-call retries and re-enable retries in harness clients
> - `RetryingClient` and `RetryingRuntime` now use `wait_exponential_jitter(initial=0.5, max=30)` instead of retrying immediately with no delay.
> - Harness clients in [bash/program.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1744/files#diff-27ee2dc5088132d165c7d067499e2c5b18f662c4153fa19e56e8645704f8bd7e) and [default/program.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1744/files#diff-d76a0706629e763126a9527179f8a652aaae490a3efcaf8f8134a94ce9b82c80) revert from `max_retries=0` to the SDK default, allowing the OpenAI client to retry relay calls on its own.
> - Behavioral Change: retry loops that previously hammered endpoints without delay will now back off up to 30 seconds between attempts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b3ef853.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Retry timing and total attempt behavior change under outages (longer waits, more layered retries), which can delay failure or increase load—but only on transient errors, with unchanged non-retry cases like OverlongPromptError and non-retried program runs.
> 
> **Overview**
> Improves resilience when model or runtime endpoints briefly fail by **spacing out retries** instead of hammering them in ~1s.
> 
> **Framework layer:** `RetryingClient` (eval model completions/relay) and `RetryingRuntime` (infra `write`/`run`/etc.) now use **`wait_exponential_jitter(initial=0.5, max=30)`** on tenacity. Retries still honor the same stop/retry rules (`ModelError` only for clients; `OverlongPromptError` still never retried).
> 
> **Harness layer:** `bash` and `default` harness programs switch from **`AsyncOpenAI(max_retries=0)`** to the SDK default client, so harness chat loops can **retry transient relay 502s** after the interception relay’s own retries are exhausted (SDK backoff), instead of failing immediately with `ProgramError`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3ef85336905397d70bdb541471cba1e53db7a96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->