### PR TITLE
fix: reuse pool tunnel for colocated tool/user state channel

### DIFF
--- a/verifiers/v1/mcp/launch.py
+++ b/verifiers/v1/mcp/launch.py
@@ -255,6 +255,7 @@ async def serve(
     *,
     state_port: int | None = None,
     state_secret: str = "",
+    state_base: str | None = None,
 ):
     """The single internal launcher for a vf-native server — a `Toolset` OR a `User`. Brings it
     up in its configured placement and yields one reachable URL, tearing down any runtime it
@@ -311,10 +312,18 @@ async def serve(
         # no channel (state is per-rollout; `state_port` is None for them).
         state_url = None
         if state_port is not None:
-            state_base = await stack.enter_async_context(
-                reachable_url(HOST, state_port, consumer=runtime)
-            )
-            state_url = f"{state_base.rstrip('/')}/state"
+            # A colocated server shares the harness's runtime, so the interception URL the harness
+            # already reaches (`state_base` — the pool's tunnel behind a remote runtime) is reachable
+            # from it too; reuse it instead of opening a second host tunnel to the same port (at high
+            # concurrency one per rollout swamps the tunnel service). A server in its own runtime
+            # can't assume that reach, so it bridges to the host port itself.
+            if state_base is not None and runtime is harness_runtime:
+                base = state_base
+            else:
+                base = await stack.enter_async_context(
+                    reachable_url(HOST, state_port, consumer=runtime)
+                )
+            state_url = f"{base.rstrip('/')}/state"
         port = await serve_in_runtime(
             server,
             runtime,
@@ -448,6 +457,7 @@ async def serve_tools(
                         harness_runtime,
                         state_port=state_port,
                         state_secret=state_secret,
+                        state_base=state_base,
                     )
                 )
                 logger.info("tool server '%s': %s", name, urls[name])
@@ -527,6 +537,7 @@ async def serve_user(
     *,
     state_port: int | None = None,
     state_secret: str = "",
+    state_base: str | None = None,
 ) -> AsyncIterator[Respond | None]:
     """Bring a rollout's user server up (via the shared `serve` launcher, `for_host=True` since
     the framework drives the user from the HOST) and yield the async `respond` the interception
@@ -545,6 +556,7 @@ async def serve_user(
         for_host=True,
         state_port=state_port,
         state_secret=state_secret,
+        state_base=state_base,
     ) as url:
         async with connect_user(url) as respond:
             yield respond

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -193,6 +193,7 @@ class Rollout:
                         harness_runtime=runtime,
                         state_port=state_port,
                         state_secret=secret,
+                        state_base=state_base,
                     ) as session.user,
                 ):
                     if self.task.prompt is None and session.user is None:


### PR DESCRIPTION
## Summary

A per-rollout server (`Toolset` / `User`) launched **colocated** in the harness's
runtime opened its **own** `host_endpoint` tunnel to the interception server's
`/state` port — even though the harness already reaches that exact port through
the (pooled) interception tunnel. The shared-server path already reuses that
reachable base URL (`_shared_url_for_rollout`); only the per-rollout path
re-bridged, via `reachable_url(HOST, state_port, consumer=runtime)` in `serve()`.

Behind a **remote runtime** this makes tunnel count scale 1:1 with concurrency:
N rollouts → ~N state tunnels on top of the ~N/`multiplex` interception tunnels.

- Thread the already-reachable `state_base` into `serve()` / `serve_tools()` /
  `serve_user()`.
- In `serve()`, when the server runs in the harness's runtime (colocated),
  reuse `state_base` for the `/state` URL instead of opening a second tunnel.
  A server in its **own** runtime can't assume that reach, so it still bridges
  to the host port itself (unchanged).

This collapses the per-rollout state tunnels onto the shared interception
tunnels. The colocated tool/user server is reached in-sandbox at localhost (no
tunnel of its own), so the state back-channel was its only tunnel — removing it
means a colocated server behind a remote runtime now adds **zero** tunnels.

## Verification

`general-agent-v1`, bash harness, **prime** runtime, colocated tools, shuffle,
`gpt-5.4-mini`, 512 concurrent rollouts (`-n 512 -r 1 -c 512`):

| | before | after |
| --- | --- | --- |
| rollouts failed | **291 / 512 (57%)** | **0 / 512** |
| `ProgramError: host tunnel failed … send Login request to plugin error` | 290 | 0 |
| `agent_completed` | 212 | 489 |
| `max_turns` | 9 | 23 |
| reward (succeeded) | 0.553 | 0.538 |

Before the fix, all 291 failures hit in a tight cold-start burst (283 within one
30s window) as hundreds of concurrent tunnel logins overwhelmed the
`prime_tunnel` control plane (`send Login`/`NewProxy request to plugin error`,
30s timeouts); tunnel creation isn't retried, so each killed its rollout at
`turns=0`. After the fix: zero tunnel failures, solve quality unchanged.

```bash
uv run eval general-agent-v1 -n 512 -r 1 -c 512 -s \
  --harness.id bash --harness.runtime.type prime \
  --taskset.tools.colocated true --max-turns 12 \
  --rich false -m openai/gpt-5.4-mini
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reuse pool tunnel for colocated tool/user state channel
> When a server's runtime matches the harness runtime (i.e. colocated), the state channel URL now reuses a provided `state_base` instead of opening a new tunnel to `state_port`. This avoids redundant tunnel creation for colocated deployments.
>
> - [`launch.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1752/files#diff-989d87123d40d48511f9e1df74594d2e30776e9a99c11eca49d9cc20bf9e2230): `serve` accepts a new optional `state_base` parameter; when the server is colocated, `state_base` is used directly instead of calling `reachable_url(HOST, state_port, consumer=runtime)`
> - `serve_tools` and `serve_user` propagate `state_base` to their underlying `serve` calls
> - [`rollout.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1752/files#diff-f886b7f4717cf8fce9270bd4ff4790f3182aa1016abb9efb7f6e57efe18d1bf2): passes `state_base` through to `serve_user` in the rollout execution flow
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4763446.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches rollout networking and shared-state URL wiring for colocated MCP servers; behavior change is scoped to the colocated + `state_base` path, with non-colocated bridging unchanged.
> 
> **Overview**
> Colocated per-rollout **tool** and **user** servers no longer open a separate host tunnel to the interception `/state` port when the harness already has a reachable `state_base` (e.g. from the shared interception pool behind a remote runtime).
> 
> **`serve`** takes optional `state_base` and, when the server runs in the harness runtime, builds `VF_STATE_URL` from that base instead of calling `reachable_url(HOST, state_port, …)`. Servers in their own runtime still bridge to the host port as before. **`serve_tools`** and **`serve_user`** forward `state_base`; **`rollout.py`** passes it into **`serve_user`** alongside the existing tool path.
> 
> This removes redundant per-rollout state tunnels that scaled 1:1 with concurrency and could overwhelm the tunnel control plane at high parallelism.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4763446cffc35af54c890d4e692063779912abee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->