### PR TITLE
feat: show per-reward/metric running means under the eval progress bar

### DIFF
--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -23,7 +23,12 @@ from verifiers.v1.cli.output import output_path
 from verifiers.v1.configs.eval import EvalConfig
 from verifiers.v1.rollout import Phase, Rollout
 from verifiers.v1.trace import Trace
-from verifiers.v1.utils.format import format_count, format_reward, format_time
+from verifiers.v1.utils.format import (
+    format_count,
+    format_mean,
+    format_reward,
+    format_time,
+)
 from verifiers.utils.pricing_utils import format_cost_usd
 
 # For sizing pages to the terminal: detects the real terminal height/width each access (the live
@@ -154,33 +159,36 @@ def Progress(
 
 
 def _breakdown(done: list[Trace]) -> Text | None:
-    """The per-component view under the headline (summed) reward: a running mean of each named
-    `@reward` contribution then each `@metric`, over the non-errored completed traces (the same
-    denominator as the headline reward). `None` when nothing has scored yet, so the bar shows
+    """The per-component view under the headline (summed) reward: each named `@reward`
+    contribution then each `@metric`, formatted exactly like the headline reward — the
+    error-corrected mean, with the global mean (an errored trace's value counting as 0) in parens
+    when some errored (see `format_mean`). `None` when nothing has scored yet, so the bar shows
     alone."""
-    clean = [t for t in done if not t.has_error]
-    if not clean:
+    if not any(not t.has_error for t in done):
         return None
     line = Text(style="dim")
     for label, source in (("rewards", "rewards"), ("metrics", "metrics")):
-        means = _means(clean, source)
-        if not means:
+        names = _names(done, source)
+        if not names:
             continue
+        segments = [
+            f"{name} {format_mean(done, lambda t, n=name, s=source: getattr(t, s).get(n, 0.0))}"
+            for name in names
+        ]
         if line:  # rewards group already written — space before the metrics group
             line.append("      ")
         line.append(f"{label}  ", style="dim cyan")
-        line.append("  ·  ".join(f"{name} {mean:.2f}" for name, mean in means))
+        line.append("  ·  ".join(segments))
     return line or None
 
 
-def _means(traces: list[Trace], source: str) -> list[tuple[str, float]]:
-    """Mean of each `source` (`rewards` / `metrics`) entry across the `traces` that recorded it,
-    in first-seen order (a trace records only the functions that ran for it, so keys can vary)."""
-    values: dict[str, list[float]] = {}
+def _names(traces: list[Trace], source: str) -> list[str]:
+    """Every `source` (`rewards` / `metrics`) key seen across `traces`, in first-seen order (a
+    trace records only the functions that ran for it, so keys can vary)."""
+    names: list[str] = []
     for trace in traces:
-        for name, value in getattr(trace, source).items():
-            values.setdefault(name, []).append(value)
-    return [(name, sum(vals) / len(vals)) for name, vals in values.items()]
+        names.extend(n for n in getattr(trace, source) if n not in names)
+    return names
 
 
 def _tokens(trace: Trace) -> tuple[int, int, int | None, int | None]:

--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -166,7 +166,7 @@ def _breakdown(done: list[Trace]) -> Table | None:
     if not any(not t.has_error for t in done):
         return None
     grid = Table.grid(padding=(0, 2))
-    grid.add_column(style="dim", min_width=_LABEL_WIDTH)  # align values with the Overview
+    grid.add_column(style="dim", min_width=_LABEL_WIDTH)
     grid.add_column()
     for label, source in (("rewards", "rewards"), ("metrics", "metrics")):
         # every key seen across traces, first-seen order (a trace records only the functions

--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -30,6 +30,9 @@ from verifiers.utils.pricing_utils import format_cost_usd
 # view writes to the same terminal). Reused so we don't rebuild it every refresh tick.
 _CONSOLE = Console()
 _PAGE_SECONDS = 5.0  # rotate to the next page of rollouts this often when they overflow
+# The under-bar breakdown pads its label column to the Overview's widest label, so the two
+# `label  value` grids (above and below the progress bar) line their values up.
+_LABEL_WIDTH = len("timeouts")
 
 _STYLE = {
     "setup": "yellow",
@@ -163,7 +166,7 @@ def _breakdown(done: list[Trace]) -> Table | None:
     if not any(not t.has_error for t in done):
         return None
     grid = Table.grid(padding=(0, 2))
-    grid.add_column(style="dim")
+    grid.add_column(style="dim", min_width=_LABEL_WIDTH)  # align values with the Overview
     grid.add_column()
     for label, source in (("rewards", "rewards"), ("metrics", "metrics")):
         # every key seen across traces, first-seen order (a trace records only the functions

--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -153,15 +153,18 @@ def Progress(
     return Group(row, breakdown) if breakdown is not None else Group(row)
 
 
-def _breakdown(done: list[Trace]) -> Text | None:
-    """The per-component view under the headline (summed) reward: each named `@reward`
-    contribution then each `@metric`, formatted exactly like the headline reward — the
+def _breakdown(done: list[Trace]) -> Table | None:
+    """The per-component view under the headline (summed) reward: a `rewards` row of each named
+    `@reward` contribution and a `metrics` row of each `@metric`, laid out like the Overview (dim
+    label column). Each component is formatted exactly like the headline reward — the
     error-corrected mean, with the global mean (an errored trace's value counting as 0) in parens
     when some errored (see `format_mean`). `None` when nothing has scored yet, so the bar shows
     alone."""
     if not any(not t.has_error for t in done):
         return None
-    line = Text(style="dim")
+    grid = Table.grid(padding=(0, 2))
+    grid.add_column(style="dim")
+    grid.add_column()
     for label, source in (("rewards", "rewards"), ("metrics", "metrics")):
         # every key seen across traces, first-seen order (a trace records only the functions
         # that ran for it, so keys can vary)
@@ -174,11 +177,8 @@ def _breakdown(done: list[Trace]) -> Text | None:
             f"{name} {format_mean(done, lambda t, n=name, s=source: getattr(t, s).get(n, 0.0))}"
             for name in names
         ]
-        if line:  # rewards group already written — space before the metrics group
-            line.append("      ")
-        line.append(f"{label}  ", style="dim cyan")
-        line.append("  ·  ".join(segments))
-    return line or None
+        grid.add_row(label, "  ·  ".join(segments))
+    return grid if grid.row_count else None
 
 
 def _tokens(trace: Trace) -> tuple[int, int, int | None, int | None]:

--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -130,7 +130,7 @@ def Overview(config: EvalConfig) -> Table:
 
 def Progress(
     rollouts: list[Rollout], start: float, page: tuple[int, int] | None = None
-) -> Table:
+) -> Table | Group:
     done = [r.trace for r in rollouts if r.phase == Phase.DONE]  # fully scored
     # Headline reward = mean over non-errored; when any errored, `format_reward` appends the
     # global avg (errored count as 0) in parens. `err` is the share that errored.
@@ -149,7 +149,38 @@ def Progress(
         ProgressBar(total=len(rollouts) or 1, completed=len(done)),
         Text(stats),
     )
-    return row
+    breakdown = _breakdown(done)
+    return Group(row, breakdown) if breakdown is not None else row
+
+
+def _breakdown(done: list[Trace]) -> Text | None:
+    """The per-component view under the headline (summed) reward: a running mean of each named
+    `@reward` contribution then each `@metric`, over the non-errored completed traces (the same
+    denominator as the headline reward). `None` when nothing has scored yet, so the bar shows
+    alone."""
+    clean = [t for t in done if not t.has_error]
+    if not clean:
+        return None
+    line = Text(style="dim")
+    for label, source in (("rewards", "rewards"), ("metrics", "metrics")):
+        means = _means(clean, source)
+        if not means:
+            continue
+        if line:  # rewards group already written — space before the metrics group
+            line.append("      ")
+        line.append(f"{label}  ", style="dim cyan")
+        line.append("  ·  ".join(f"{name} {mean:.2f}" for name, mean in means))
+    return line or None
+
+
+def _means(traces: list[Trace], source: str) -> list[tuple[str, float]]:
+    """Mean of each `source` (`rewards` / `metrics`) entry across the `traces` that recorded it,
+    in first-seen order (a trace records only the functions that ran for it, so keys can vary)."""
+    values: dict[str, list[float]] = {}
+    for trace in traces:
+        for name, value in getattr(trace, source).items():
+            values.setdefault(name, []).append(value)
+    return [(name, sum(vals) / len(vals)) for name, vals in values.items()]
 
 
 def _tokens(trace: Trace) -> tuple[int, int, int | None, int | None]:

--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -23,12 +23,7 @@ from verifiers.v1.cli.output import output_path
 from verifiers.v1.configs.eval import EvalConfig
 from verifiers.v1.rollout import Phase, Rollout
 from verifiers.v1.trace import Trace
-from verifiers.v1.utils.format import (
-    format_count,
-    format_mean,
-    format_reward,
-    format_time,
-)
+from verifiers.v1.utils.format import format_count, format_mean, format_time
 from verifiers.utils.pricing_utils import format_cost_usd
 
 # For sizing pages to the terminal: detects the real terminal height/width each access (the live
@@ -135,11 +130,11 @@ def Overview(config: EvalConfig) -> Table:
 
 def Progress(
     rollouts: list[Rollout], start: float, page: tuple[int, int] | None = None
-) -> Table | Group:
+) -> Group:
     done = [r.trace for r in rollouts if r.phase == Phase.DONE]  # fully scored
-    # Headline reward = mean over non-errored; when any errored, `format_reward` appends the
+    # Headline reward = mean over non-errored; when any errored, `format_mean` appends the
     # global avg (errored count as 0) in parens. `err` is the share that errored.
-    reward = format_reward(done)
+    reward = format_mean(done, lambda t: t.reward)
     err = f"{sum(t.has_error for t in done) / len(done):.2f}" if done else "—"
     stats = (
         f"{len(done)}/{len(rollouts)} · {format_time(time.time() - start)} · "
@@ -155,7 +150,7 @@ def Progress(
         Text(stats),
     )
     breakdown = _breakdown(done)
-    return Group(row, breakdown) if breakdown is not None else row
+    return Group(row, breakdown) if breakdown is not None else Group(row)
 
 
 def _breakdown(done: list[Trace]) -> Text | None:
@@ -168,7 +163,11 @@ def _breakdown(done: list[Trace]) -> Text | None:
         return None
     line = Text(style="dim")
     for label, source in (("rewards", "rewards"), ("metrics", "metrics")):
-        names = _names(done, source)
+        # every key seen across traces, first-seen order (a trace records only the functions
+        # that ran for it, so keys can vary)
+        names: list[str] = []
+        for trace in done:
+            names.extend(n for n in getattr(trace, source) if n not in names)
         if not names:
             continue
         segments = [
@@ -180,15 +179,6 @@ def _breakdown(done: list[Trace]) -> Text | None:
         line.append(f"{label}  ", style="dim cyan")
         line.append("  ·  ".join(segments))
     return line or None
-
-
-def _names(traces: list[Trace], source: str) -> list[str]:
-    """Every `source` (`rewards` / `metrics`) key seen across `traces`, in first-seen order (a
-    trace records only the functions that ran for it, so keys can vary)."""
-    names: list[str] = []
-    for trace in traces:
-        names.extend(n for n in getattr(trace, source) if n not in names)
-    return names
 
 
 def _tokens(trace: Trace) -> tuple[int, int, int | None, int | None]:

--- a/verifiers/v1/utils/__init__.py
+++ b/verifiers/v1/utils/__init__.py
@@ -1,3 +1,3 @@
 """Small shared helpers for v1, by concern: `format` (display), `install` (env-id /
 on-demand hub install), `logging` (route stdlib logs through loguru), `memory` (worker RSS).
-Import from the submodule, e.g. `from verifiers.v1.utils.format import format_reward`."""
+Import from the submodule, e.g. `from verifiers.v1.utils.format import format_mean`."""

--- a/verifiers/v1/utils/format.py
+++ b/verifiers/v1/utils/format.py
@@ -50,9 +50,3 @@ def format_mean(
     if len(clean) < len(traces):  # some errored → show the raw global avg alongside
         mean += f" ({sum(value(t) for t in traces) / len(traces):.{digits}f})"
     return mean
-
-
-def format_reward(traces: list[Trace], digits: int = 2) -> str:
-    """Headline reward over completed `traces` — the error-corrected mean of `trace.reward`
-    (see `format_mean`)."""
-    return format_mean(traces, lambda t: t.reward, digits)

--- a/verifiers/v1/utils/format.py
+++ b/verifiers/v1/utils/format.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -33,17 +34,25 @@ def format_count(n: int) -> str:
     return f"{n / 1e6:.1f}M"
 
 
-def format_reward(traces: list[Trace], digits: int = 2) -> str:
-    """Headline reward over completed `traces`: the mean over the non-errored ones
-    (error-corrected). When some errored, also append the global mean — over *all*
-    completed, errored counting as 0 — in parens, so both the error-corrected and the
-    raw reward are visible. "—" when nothing has completed (or all errored)."""
+def format_mean(
+    traces: list[Trace], value: Callable[[Trace], float], digits: int = 2
+) -> str:
+    """Mean of `value` over completed `traces`: the mean over the non-errored ones
+    (error-corrected). When some errored, also append the global mean — over *all* completed,
+    an errored trace's value counting as 0 — in parens, so both the error-corrected and the raw
+    mean are visible. "—" when nothing has completed (or all errored)."""
     if not traces:
         return "—"
     clean = [t for t in traces if not t.has_error]
     if not clean:
         return "—"
-    reward = f"{sum(t.reward for t in clean) / len(clean):.{digits}f}"
+    mean = f"{sum(value(t) for t in clean) / len(clean):.{digits}f}"
     if len(clean) < len(traces):  # some errored → show the raw global avg alongside
-        reward += f" ({sum(t.reward for t in traces) / len(traces):.{digits}f})"
-    return reward
+        mean += f" ({sum(value(t) for t in traces) / len(traces):.{digits}f})"
+    return mean
+
+
+def format_reward(traces: list[Trace], digits: int = 2) -> str:
+    """Headline reward over completed `traces` — the error-corrected mean of `trace.reward`
+    (see `format_mean`)."""
+    return format_mean(traces, lambda t: t.reward, digits)


### PR DESCRIPTION
## Summary

The `--rich` eval dashboard's progress bar shows the headline reward (the
summed, error-corrected mean). This adds two lines directly beneath the bar — a
`rewards` row and a `metrics` row — with a **running mean of each named
`@reward` contribution and each `@metric`**, so the per-component breakdown (the
individual rewards that sum into the headline, plus diagnostic metrics) is
visible live, not only in the final `results.jsonl`.

- New `format_mean(traces, value)` in `utils/format.py` holds the error
  correction that was in `format_reward`; the headline reward and every
  breakdown component use it, so each shows the non-errored mean with the global
  mean (an errored trace's value counting as 0) in parens when some rollouts
  errored.
- New `_breakdown(done)` in `cli/dashboard/eval.py`: a `rewards` row then a
  `metrics` row, laid out as a `Table.grid` with the same dim label column and
  `(0, 2)` padding as the Overview — and its label column padded to the
  Overview's widest label, so the breakdown's values line up with the Overview's
  across the bar.
- `Progress(...)` always returns a `Group` (bar alone until something scores,
  then bar + breakdown). The page-sizing measurement already accounts for the
  extra lines.
- No new config/flag; nothing changes for `--no-rich`.

## Breaking

- `verifiers.v1.utils.format.format_reward` is removed. It had one caller (the
  dashboard); replace any use with `format_mean(traces, lambda t: t.reward)`.

## Verification

`general-agent-v1`, bash harness (`solved` reward; `db_hash` / `verify`
metrics), live `--rich` — the breakdown lines up under the Overview:

```
model     openai/gpt-5.4-mini  via https://api.pinference.ai/api/v1
output    outputs/…
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 3/3 · 18s · reward 0.67 · err 0.00
rewards   solved 0.67
metrics   db_hash 0.00  ·  verify 0.67
```

With an errored rollout in the mix, each component mirrors the headline's
error-corrected `mean (global)` form:

```
3/3 · 12s · reward 0.50 (0.33) · err 0.33
rewards   solved 0.50 (0.33)
metrics   db_hash 0.50 (0.33)  ·  verify 1.00 (0.67)
```

Before anything scores, the bar shows alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard-only display and a small format helper rename with a single caller; no eval execution or scoring behavior changes.
> 
> **Overview**
> The **`--rich` eval dashboard** now shows **live running means** for each named `@reward` and `@metric` directly under the progress bar, using the same error-corrected formatting as the headline reward.
> 
> **`format_reward`** is replaced by **`format_mean(traces, value)`**, which generalizes the non-errored mean plus optional global mean (errors as 0) for any trace scalar. The headline reward and every breakdown component call it.
> 
> **`Progress`** returns a **`Group`** (bar only until at least one non-errored trace has scored, then bar + **`_breakdown`**). The breakdown is a two-row grid (`rewards` / `metrics`) aligned with the Overview via a shared label column width.
> 
> **Breaking:** remove **`verifiers.v1.utils.format.format_reward`**; use **`format_mean(traces, lambda t: t.reward)`** instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e0e777cd92305776c0e0142d5918e627d0717bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show per-reward/metric running means under the eval progress bar
> - Adds a `_breakdown` helper in [eval.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1753/files#diff-0a27b905958929f3ae9e01937dd7e3cf97a60dec137caddcbf87792784fc9035) that builds a two-column grid of per-component reward and metric means for completed, non-errored traces.
> - The `Progress` component now returns a `Group` containing the progress bar and the breakdown grid (when available), replacing the previous single `Table` return.
> - Generalizes `format_reward` into `format_mean(traces, value)` in [format.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1753/files#diff-d29ec5b44e74af4fcb516857a1700368c3c32c14d1ed3092baef1307fafb163c), where callers supply a value extractor (e.g. `lambda t: t.reward`); errored traces count as 0 when computing the global mean shown in parentheses.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0e0e777.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->