### PR TITLE
feat: INFO interception lifecycle + debug-log every intercepted route

### DIFF
--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -49,6 +49,8 @@ logger = logging.getLogger(__name__)
 # context window are the real limits, this is just a host-OOM backstop.
 _MAX_REQUEST_BODY = 1024**3  # 1 GiB (aiohttp's default is 1 MiB)
 _KEEPALIVE_INTERVAL_SECONDS = 3
+# The server binds loopback; callers reach it via localhost or a host tunnel (see `reachable_url`).
+_HOST = "127.0.0.1"
 
 
 @dataclass(frozen=True)
@@ -182,13 +184,14 @@ class InterceptionServer:
         app.router.add_get("/task", self.handle_task_get)
         self.runner = web.AppRunner(app)
         await self.runner.setup()
-        site = web.TCPSite(self.runner, "127.0.0.1", 0)
+        site = web.TCPSite(self.runner, _HOST, 0)
         await site.start()
         self.port = site._server.sockets[0].getsockname()[1]  # actual ephemeral port
-        logger.debug("interception up: port=%d", self.port)
+        logger.info("interception up: url=http://%s:%d", _HOST, self.port)
         return self
 
     async def __aexit__(self, *exc) -> None:
+        logger.info("interception down: url=http://%s:%d", _HOST, self.port)
         if self.runner is not None:
             await self.runner.cleanup()
 
@@ -200,6 +203,12 @@ class InterceptionServer:
             logger.warning("interception: unauthorized request")
             return web.json_response(dialect.error_body("unauthorized"), status=401)
         body = await request.json()
+        logger.debug(
+            "intercept %s: id=%s stream=%s",
+            request.path,
+            session.trace.id,
+            dialect.streaming(body),
+        )
         # `body` is forwarded to the model 1:1 (the proxy mutates only model + sampling), so no
         # provider field is lost. `prompt` is the dialect's typed parse, kept only to build the
         # trace (the renderer re-derives its own from the body it's handed). A user simulator
@@ -279,6 +288,11 @@ class InterceptionServer:
             # `Response.raw` is the wire response handed to the program 1:1 — the provider's
             # verbatim bytes (proxy) or the client's serialized completion (renderer).
             completion = response.raw
+            logger.debug(
+                "intercept turn: id=%s tools=%d",
+                session.trace.id,
+                len(response.message.tool_calls or []),
+            )
             turn.commit(response)  # one node per new message;
             # branches fall out of walking the graph (see Trace.branches / verifiers.v1.graph)
             # Hand back to the program when the model wants a tool (the program runs it) or
@@ -364,6 +378,7 @@ class InterceptionServer:
 
         try:
             turn.commit(dialect.parse_stream(bytes(buffer)))
+            logger.debug("intercept stream turn: id=%s", session.trace.id)
         finally:
             with contextlib.suppress(ConnectionResetError):
                 await resp.write_eof()
@@ -377,6 +392,7 @@ class InterceptionServer:
         session = self.sessions.get(dialect.secret(request.headers))
         if session is None:
             return web.json_response(dialect.error_body("unauthorized"), status=401)
+        logger.debug("intercept aux %s: id=%s", route, session.trace.id)
         try:
             result = await session.ctx.client.relay_aux(
                 dialect, route, await request.json()
@@ -399,6 +415,7 @@ class InterceptionServer:
         session = self._session_for(request)
         if session is None:
             return web.json_response({"error": "unauthorized"}, status=401)
+        logger.debug("intercept GET /state: id=%s", session.trace.id)
         return web.json_response(session.trace.state.model_dump(mode="json"))
 
     async def handle_task_get(self, request: web.Request) -> web.Response:
@@ -407,6 +424,7 @@ class InterceptionServer:
         session = self._session_for(request)
         if session is None:
             return web.json_response({"error": "unauthorized"}, status=401)
+        logger.debug("intercept GET /task: id=%s", session.trace.id)
         task = session.trace.task
         return web.json_response(
             {
@@ -422,6 +440,7 @@ class InterceptionServer:
         session = self._session_for(request)
         if session is None:
             return web.json_response({"error": "unauthorized"}, status=401)
+        logger.debug("intercept PUT /state: id=%s", session.trace.id)
         state_cls = type(session.trace.state)
         try:
             new_state = state_cls.model_validate(await request.json())


### PR DESCRIPTION
## Summary

Make the interception server's traffic observable.

- **Lifecycle at INFO, with the full base url.** The server's `up`/`down` move
  from DEBUG to INFO and log `url=http://127.0.0.1:<port>`, so the proxy's
  address is visible at the default level (a `down` log is added; there was none).
- **A DEBUG line on every intercepted route**, each tagged with the rollout's
  trace id, so one rollout's whole intercepted traffic is greppable under
  `--verbose`:
  - dialect model routes — `intercept <path>: id=… stream=…` on the way in, plus
    `intercept turn: id=… tools=…` (non-stream) / `intercept stream turn: id=…`
    when the turn commits;
  - `intercept aux <route>: id=…` for aux routes (e.g. Anthropic `count_tokens`);
  - `intercept GET/PUT /state: id=…` and `intercept GET /task: id=…` for the
    tool/user back-channels.
- The loopback host is now a single `_HOST` constant (bind + logs).

No behavior change beyond logging.

## Verification

`-v --no-rich` single rollouts (`openai/gpt-5.4-mini`). Each route fires, every
line tagged with the one rollout's trace id:

- **gsm8k-v1** (no tools) — model route only:
  ```
  INFO  interception up: url=http://127.0.0.1:36241
  DEBUG intercept /v1/chat/completions: id=eb44… stream=False
  DEBUG intercept turn: id=eb44… tools=0
  INFO  interception down: url=http://127.0.0.1:36241
  ```
- **alphabet-sort-v1** (user sim) — `/task` + `/state` interleaved with turns
  (`GET /task` → model → `GET /state` → turn → `PUT /state`).
- **wikispeedia-v1** (`WikiToolset`) — `model → turn tools=1 → GET /state`
  repeating per navigation step.
- **general-agent-v1 colocated in docker** — the harness *and* its colocated
  tool server run in the container, both reaching the host interceptor (the tool
  server over the reused state tunnel). All routes share one trace id:
  ```
  INFO  rollout start: id=d535be50… harness=bash runtime=docker
  INFO  interception up: url=http://127.0.0.1:45539
  DEBUG intercept GET /task: id=d535be50…
  DEBUG intercept /v1/chat/completions: id=d535be50… stream=False
  DEBUG intercept turn: id=d535be50… tools=1
  DEBUG intercept GET /state: id=d535be50…
  DEBUG intercept PUT /state: id=d535be50…
  …
  INFO  rollout done: id=d535be50… reward=1.000 turns=3 stop=agent_completed
  INFO  interception down: url=http://127.0.0.1:45539
  ```
  (distinct trace ids across every intercept line: exactly one.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add INFO lifecycle logs and DEBUG request logs to `InterceptionServer`
> - Startup and shutdown of `InterceptionServer` now log at INFO level with the full URL (`http://127.0.0.1:<port>`) instead of DEBUG with port only.
> - All route handlers (`handle_request`, `handle_aux`, `handle_state_get`, `handle_task_get`, `handle_state_put`) emit DEBUG logs with the route path, trace id, and relevant metadata (streaming flag, tool call count, etc.).
> - A module-level `_HOST` constant replaces the inline `"127.0.0.1"` string in [server.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1754/files#diff-84e2f8d027d609e8760ef6d533535ec9d99dfc6384d5ddb6111b4001b2010f35).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f9d2f9a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only changes; no routing, auth, or proxy behavior is modified.
> 
> **Overview**
> Improves **observability** of the interception proxy without changing request handling.
> 
> **Lifecycle** logs move from DEBUG to **INFO** and include the full base URL (`http://127.0.0.1:<port>`). Shutdown now logs at INFO as well (previously unlogged). Bind address is centralized in a `_HOST` constant.
> 
> **Per-request DEBUG** lines tag every intercepted path with the rollout **trace id** (model routes with stream flag and tool count, aux relays, and `/state` / `/task` back-channels), so a single rollout’s traffic is greppable under verbose logging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9d2f9a30019e60ddeeab7d6a506c3986deb76c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->