### PR TITLE
fix: swallow SIGTERM KeyboardInterrupt in spawned env-server workers

### DIFF
--- a/verifiers/v1/serve/server.py
+++ b/verifiers/v1/serve/server.py
@@ -87,7 +87,13 @@ class EnvServer:
         server = cls(**kwargs)
         if address_queue is not None:
             address_queue.put(server.address)
-        asyncio.run(server.run())
+        try:
+            asyncio.run(server.run())
+        except KeyboardInterrupt:
+            # SIGTERM arrives as KeyboardInterrupt (see serve.pool._arm_teardown) so the event
+            # loop runs its cleanup finallys; swallow it for a clean spawned-worker exit instead
+            # of a spurious multiprocessing traceback, matching serve_env's own handling.
+            pass
 
     def _client(self, client_config: ClientConfig, model: str) -> Client:
         """Resolve (and cache) a `Client` for this config+model. Cached because a


### PR DESCRIPTION
## Summary

A spawned env-server pool worker is armed by `serve.pool._arm_teardown` to receive
`SIGTERM` as a `KeyboardInterrupt`, so its event loop unwinds through the
`serving()` cleanup finallys (rather than being killed abruptly and orphaning
tunnels/sandboxes). The broker (`serve_env`) already wraps its `asyncio.run` in
`except KeyboardInterrupt: pass` for a clean exit — but the **worker** path
(`_worker_entry` → `EnvServer.run_server` → `asyncio.run(server.run())`) did not.

So every `--no-rich` / pooled eval printed a spurious traceback at shutdown, even
on full success:

```
Process SpawnProcess-1:1:
Traceback (most recent call last):
  ...
  File ".../verifiers/v1/serve/pool.py", line 55, in <lambda>
    signal.signal(signal.SIGTERM, lambda *_: (_ for _ in ()).throw(KeyboardInterrupt()))
KeyboardInterrupt
```

Catch `KeyboardInterrupt` around the worker's `asyncio.run` in `run_server`,
matching `serve_env`. The cleanup finallys still run; only the spurious trace is
gone.

## Verification

`uv run eval gsm8k-v1 -n 1 --no-rich --verbose`:

- **before**: rollout succeeds (`reward 1.0`), then the `SpawnProcess … KeyboardInterrupt`
  traceback prints at shutdown.
- **after**: same success, shutdown is clean —
  ```
  INFO interception down: url=http://127.0.0.1:45029
  INFO EnvServerPool down
  ```
  zero `Traceback` / `SpawnProcess` / `KeyboardInterrupt` lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Swallow `KeyboardInterrupt` from SIGTERM in `EnvServer` spawned workers
> Wraps `asyncio.run(server.run())` in a try/except in [server.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1755/files#diff-64422f6a8749fcc024415b2756129bc98000e830e74b3b5245de50a555480a22) to catch and swallow `KeyboardInterrupt`, which is how SIGTERM surfaces in spawned worker processes. This prevents a spurious multiprocessing traceback on shutdown while still allowing the event loop cleanup to complete.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fedfa57.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Shutdown-path only; behavior matches existing serve_env and in-run() interrupt handling with no change to rollout serving logic.
> 
> **Overview**
> Spawned env-server pool workers receive **SIGTERM** as **`KeyboardInterrupt`** via `serve.pool._arm_teardown` so teardown runs through `asyncio` cleanup. The broker path (`serve_env`) already ignored that interrupt; **`EnvServer.run_server`** did not, so pooled / `--no-rich` evals printed a spurious **`SpawnProcess` / `KeyboardInterrupt` traceback** on successful shutdown.
> 
> **`run_server`** now wraps **`asyncio.run(server.run())`** in **`try` / `except KeyboardInterrupt: pass`**, aligned with `serve_env` and the pool worker entry. Event-loop **`finally`** cleanup in **`run()`** still runs; only the multiprocessing noise at exit is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fedfa570921612ffe54b418685230cdee0f2959e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->