### PR TITLE
feat: own per-call retries in the SDKs; drop framework model/runtime retries

### DIFF
--- a/verifiers/v1/ARCHITECTURE.md
+++ b/verifiers/v1/ARCHITECTURE.md
@@ -41,10 +41,10 @@ Episode (task, n)
 Each stage is bounded by its own `asyncio.wait_for` (`rollout.py`), so a wedge in any one
 phase is a budget event, not a hang — a `harness_timeout` scores what's there; a
 `finalize`/`scoring` timeout errors the rollout. Defaults are no-limit, so production configs
-set `TimeoutConfig` explicitly. Retries wrap the loop at two granularities: per-call
-(`RetryingClient`, `RetryingRuntime` — rerun just the failed model/runtime call, keeping
-progress) and whole-rollout (`retries.py::run_with_retry` — re-run if the trace ends in a
-retryable error type). Per-rollout budgets (`RolloutLimits`) are checked between turns.
+set `TimeoutConfig` explicitly. Per-call retries are owned by the SDKs (the harness's model SDK,
+the prime/modal runtime SDKs); the framework keeps only whole-rollout retries
+(`retries.py::run_with_retry` — re-run if the trace ends in a retryable error type). Per-rollout
+budgets (`RolloutLimits`) are checked between turns.
 
 ## The trace is a message graph
 
@@ -215,9 +215,12 @@ data, not a crash. The whole model is four mechanisms, each in one place (`error
    rollouts. `BaseException` (`CancelledError`, `KeyboardInterrupt`) still propagates, so shutdown is
    unaffected.
 
-Retries (`retries.py`) sit on top: per-call `RetryingClient`/`RetryingRuntime` rerun a single failed
-model/runtime call, and whole-rollout `run_with_retry` reruns a trajectory whose trace ends with a
-retryable error (`--retries.rollout.include` matches by type name). All share one `retrying()` policy.
+Retries: per-call faults are retried by the SDKs themselves — the harness's model SDK (the
+interception server is a faithful proxy: it relays the provider's status code so the SDK retries
+5xx/429/timeout and not 4xx) and the prime/modal runtime SDKs. The framework adds targeted retries
+only where no SDK retries underneath (e.g. `open_tunnel`, via the shared `retrying()` policy). On top
+sits whole-rollout `run_with_retry` (`retries.py`), which reruns a trajectory whose trace ends with a
+retryable error (`--retries.rollout.include` matches by type name); off by default.
 
 ## The v0 bridge
 

--- a/verifiers/v1/GUIDE.md
+++ b/verifiers/v1/GUIDE.md
@@ -602,7 +602,7 @@ uv run eval gsm8k-v1 -n 5 -r 3 \
 | budgets | `--max-turns`, `--max-input-tokens`, `--max-output-tokens`, `--max-total-tokens` (all None) |
 | sampling | `--sampling.temperature`, `--sampling.top-p`, `--sampling.max-tokens`, `--sampling.reasoning-effort` (provider keys pass through) |
 | timeouts | `--timeout.setup`, `--timeout.rollout`, `--timeout.finalize`, `--timeout.scoring` (None = no limit) |
-| retries | `--retries.model.max-retries` (3), `--retries.runtime.max-retries` (3), `--retries.rollout.max-retries` (0), `--retries.rollout.include`/`.exclude` (by exception name) |
+| retries | `--retries.rollout.max-retries` (0), `--retries.rollout.include`/`.exclude` (by exception name); per-call model/runtime retries are owned by the harness/runtime SDKs |
 | client | `--client.type` (`eval`\|`train`), `--client.base-url`, `--client.api-key-var` |
 | runtime | `--harness.runtime.type` (`subprocess`), `--harness.env`, `--harness.disabled-tools` |
 | concurrency | `-c`/`--max-concurrent` (128), `--multiplex` (32), `--pool.type` (`elastic`\|`static`) |
@@ -639,7 +639,6 @@ uv run validate gsm8k-v1 -n 20 --runtime.type subprocess
 | `<taskset-id>` / `--taskset.id` | — | taskset to validate |
 | `--runtime.type` | `docker` | runtime for `setup` + `validate` (a gold check often needs the task's container) |
 | `--setup-timeout` / `--validate-timeout` | None | per-hook wall-clock caps |
-| `--retries.runtime.max-retries` | 3 | the only retry that applies (fresh runtime per try) |
 | `-n`/`--num-tasks`, `-s`/`--shuffle`, `-c`/`--max-concurrent` (128) | | task selection + concurrency |
 | `-v`/`--verbose`, `--no-rich` | | logging / disable the dashboard |
 

--- a/verifiers/v1/README.md
+++ b/verifiers/v1/README.md
@@ -45,7 +45,6 @@ wall-clock timeouts — are all framework-enforced and apply to any environment:
 ```bash
 uv run eval gsm8k-v1 -n 5 -r 3 \
   --max-turns 8 --max-total-tokens 8192 \
-  --retries.model.max-retries 3 --retries.runtime.max-retries 3 \
   --retries.rollout.max-retries 3 --retries.rollout.include SandboxError \
   --timeout.setup 120 --timeout.rollout 600 --timeout.finalize 120 --timeout.scoring 120
 ```
@@ -235,8 +234,7 @@ uv run eval gsm8k-v1 -n 1 --max-total-tokens 8192        # cap prompt+completion
 
 uv run eval gsm8k-v1 -n 1 --timeout.rollout 600 --timeout.scoring 120  # per-stage wall-clock caps (s)
 
-uv run eval gsm8k-v1 -n 1 --retries.model.max-retries 5 --retries.runtime.max-retries 5  # per-call retries
-uv run eval gsm8k-v1 -n 1 --retries.rollout.max-retries 3 --retries.rollout.include SandboxError  # whole-rollout, by exception type
+uv run eval gsm8k-v1 -n 1 --retries.rollout.max-retries 3 --retries.rollout.include SandboxError  # whole-rollout, by exception type (per-call model/runtime retries are owned by the SDKs)
 ```
 
 ### Integrations

--- a/verifiers/v1/__init__.py
+++ b/verifiers/v1/__init__.py
@@ -47,7 +47,7 @@ from verifiers.v1.loaders import (
     task_type,
     taskset_config_type,
 )
-from verifiers.v1.retries import CallRetryConfig, RetryConfig, RolloutRetryConfig
+from verifiers.v1.retries import RetryConfig, RolloutRetryConfig
 from verifiers.v1.rollout import Rollout
 from verifiers.v1.runtimes import (
     DockerConfig,
@@ -174,7 +174,6 @@ __all__ = [
     "StaticPoolConfig",
     "ElasticPoolConfig",
     "pool_serve_kwargs",
-    "CallRetryConfig",
     "RetryConfig",
     "RolloutRetryConfig",
     "TimeoutConfig",

--- a/verifiers/v1/cli/validate.py
+++ b/verifiers/v1/cli/validate.py
@@ -30,7 +30,7 @@ from verifiers.v1.cli.resolve import (
 )
 from verifiers.v1.configs.validate import ValidateConfig
 from verifiers.v1.env import resolve_runtime_config
-from verifiers.v1.runtimes import RetryingRuntime, make_runtime
+from verifiers.v1.runtimes import make_runtime
 from verifiers.v1.taskset import Taskset
 
 logger = logging.getLogger(__name__)
@@ -76,8 +76,6 @@ async def _validate_task(taskset: Taskset, task, config: ValidateConfig) -> dict
     runtime = make_runtime(
         resolve_runtime_config(config.runtime, task), name=f"validate-{task.idx}"
     )
-    if config.retries.runtime.max_retries > 0:
-        runtime = RetryingRuntime(runtime, config.retries.runtime.max_retries)
     setup_timeout = (
         config.setup_timeout if config.setup_timeout is not None else task.timeout.setup
     )

--- a/verifiers/v1/clients/__init__.py
+++ b/verifiers/v1/clients/__init__.py
@@ -1,6 +1,6 @@
 """The client abstraction and its OpenAI-compatible + renderer implementations."""
 
-from verifiers.v1.clients.client import Client, RetryingClient, RolloutContext
+from verifiers.v1.clients.client import Client, RolloutContext
 from verifiers.v1.clients.config import (
     BaseClientConfig,
     ClientConfig,
@@ -13,7 +13,6 @@ from verifiers.v1.clients.train import TrainClient
 
 __all__ = [
     "Client",
-    "RetryingClient",
     "RolloutContext",
     "BaseClientConfig",
     "ClientConfig",

--- a/verifiers/v1/clients/client.py
+++ b/verifiers/v1/clients/client.py
@@ -10,9 +10,7 @@ from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
 from dataclasses import dataclass
 
 from verifiers.v1.dialects import Dialect
-from verifiers.v1.errors import OverlongPromptError, ProviderError
 from verifiers.v1.graph import PendingTurn
-from verifiers.v1.retries import retrying
 from verifiers.v1.types import Response, Sampling, SamplingConfig
 
 logger = logging.getLogger(__name__)
@@ -76,75 +74,6 @@ class Client(ABC):
 
     async def close(self) -> None:
         """Release any underlying resources. Default no-op."""
-
-
-class RetryingClient(Client):
-    """Wraps a client to retry each completion on a transient `ProviderError` (tenacity, up to
-    `max_retries` retries) with exponential backoff + jitter between attempts — so retries don't
-    fire back-to-back into the same brief endpoint outage, and concurrent rollouts hitting a shared
-    endpoint stagger their retries instead of re-thundering it. An `OverlongPromptError` is never
-    retried — it's a budget limit the interception server turns into a clean truncation, not a
-    transient fault."""
-
-    def __init__(self, inner: Client, max_retries: int) -> None:
-        self.inner = inner
-        self.max_retries = max_retries
-        # One Retrying, reused across (and concurrent within) calls: the control flow runs
-        # off a per-call RetryCallState, so only its bookkeeping `.statistics` is shared.
-        self._retrying = retrying(
-            on=ProviderError,
-            give_up=OverlongPromptError,
-            retries=max_retries,
-            label="model call",
-        )
-
-    async def get_response(
-        self,
-        dialect: Dialect,
-        body: dict,
-        model: str,
-        sampling_args: SamplingConfig,
-        session_id: str | None = None,
-        turn: PendingTurn | None = None,
-        headers: Mapping[str, str] | None = None,
-    ) -> Response:
-        return await self._retrying(
-            self.inner.get_response,
-            dialect,
-            body,
-            model,
-            sampling_args,
-            session_id=session_id,
-            turn=turn,
-            headers=headers,
-        )
-
-    async def relay(
-        self,
-        dialect: Dialect,
-        body: dict,
-        model: str,
-        sampling_args: SamplingConfig,
-        session_id: str | None = None,
-        headers: Mapping[str, str] | None = None,
-    ) -> RelayReply:
-        # Safe to retry: relay raises (and is retried) before any response byte is handed back;
-        # once a `RelayReply` is returned, streaming is already underway.
-        return await self._retrying(
-            self.inner.relay,
-            dialect,
-            body,
-            model,
-            sampling_args,
-            headers=headers,
-            session_id=session_id,
-        )
-
-    async def relay_aux(self, dialect: Dialect, route: str, body: dict) -> dict:
-        return await self._retrying(self.inner.relay_aux, dialect, route, body)
-
-    async def close(self) -> None:
-        await self.inner.close()
 
 
 @dataclass(frozen=True)

--- a/verifiers/v1/clients/eval.py
+++ b/verifiers/v1/clients/eval.py
@@ -129,16 +129,20 @@ class EvalClient(Client):
         request = self.http.build_request("POST", url, json=body, headers=headers)
         try:
             response = await self.http.send(request, stream=stream)
+        except httpx.TimeoutException as e:
+            raise model_error(str(e), status_code=504) from e
         except httpx.HTTPError as e:
-            raise model_error(str(e)) from e
+            raise model_error(str(e), status_code=503) from e
         if not stream:
             try:
                 response.raise_for_status()
             except httpx.HTTPStatusError as e:
-                # include the status — an empty/HTML body (e.g. a 404 from a base_url missing
-                # `/v1`) would otherwise make an information-free ProviderError
+                # relay the provider's status (and body) so the harness SDK retries 5xx/429 and not
+                # 4xx; an empty/HTML body (e.g. a 404 from a base_url missing `/v1`) would otherwise
+                # make an information-free ProviderError
                 raise model_error(
-                    f"upstream {e.response.status_code}: {e.response.text}"
+                    f"upstream {e.response.status_code}: {e.response.text}",
+                    status_code=e.response.status_code,
                 ) from e
             return response
         if response.status_code < 400:
@@ -147,7 +151,9 @@ class EvalClient(Client):
             text = (await response.aread()).decode("utf-8", errors="replace")
         finally:
             await response.aclose()
-        raise model_error(f"upstream {response.status_code}: {text}")
+        raise model_error(
+            f"upstream {response.status_code}: {text}", status_code=response.status_code
+        )
 
     async def relay(
         self,

--- a/verifiers/v1/configs/validate.py
+++ b/verifiers/v1/configs/validate.py
@@ -11,7 +11,6 @@ resume / dry-run.
 from pydantic import AliasChoices, Field, SerializeAsAny, model_validator
 from pydantic_config import BaseConfig
 
-from verifiers.v1.retries import RetryConfig
 from verifiers.v1.runtimes import DockerConfig, RuntimeConfig
 from verifiers.v1.taskset import TasksetConfig
 
@@ -28,9 +27,6 @@ class ValidateConfig(BaseConfig):
     (subprocess), a gold check often needs the task's declared container; a SWE task overrides
     the image per task. Use `--runtime.type subprocess` for a check that needs no container —
     one that only reads task data or runs a uv-script verifier (e.g. gsm8k)."""
-    retries: RetryConfig = RetryConfig()
-    """Reused only for `retries.runtime` — retry a task on a transient runtime fault (sandbox
-    create/exec), each retry on a fresh runtime. Model/rollout retries don't apply here."""
     setup_timeout: float | None = None
     """Max wall-clock for the taskset's `setup` hook per task (None = no limit)."""
     validate_timeout: float | None = None

--- a/verifiers/v1/env.py
+++ b/verifiers/v1/env.py
@@ -330,8 +330,6 @@ class Environment:
                 finalize_timeout=finalize_timeout,
                 scoring_timeout=scoring_timeout,
                 limits=self.limits,
-                model_retries=retries.model.max_retries,
-                runtime_retries=retries.runtime.max_retries,
                 shared_urls=self._shared_urls,
                 interception=self._interception,
             )

--- a/verifiers/v1/errors.py
+++ b/verifiers/v1/errors.py
@@ -32,7 +32,14 @@ class RolloutError(Exception):
 
 
 class ProviderError(RolloutError):
-    """A model-provider call failed (transport, HTTP status, timeout, or malformed response)."""
+    """A model-provider call failed (transport, HTTP status, timeout, or malformed response).
+    `status_code` is the HTTP status surfaced to the harness so its SDK retries transient faults
+    (5xx/429/timeout) and not deterministic ones (4xx) — relayed from the provider, or chosen for a
+    transport fault."""
+
+    def __init__(self, message: str = "", *, status_code: int = 502) -> None:
+        super().__init__(message)
+        self.status_code = status_code
 
 
 class OverlongPromptError(ProviderError):
@@ -99,14 +106,33 @@ _CONTEXT_LENGTH_PHRASES = (
 )
 
 
-def model_error(e: OpenAIError | str) -> ProviderError:
-    """Map a provider failure to our error type: an overlong prompt (a budget limit the
-    interception server turns into a clean truncation) is told apart from any other provider
-    call failure (auth, rate limit, transport, a genuine bad request, ...), which becomes a
-    plain `ProviderError`. Accepts either an SDK error (the renderer) or the provider's raw
-    error body (the httpx proxy)."""
+def _provider_status(e: OpenAIError | str) -> int:
+    """The HTTP status to surface for an SDK error: the provider's own for an HTTP status error, a
+    retryable 5xx for a transport/timeout fault, else 502."""
+    from openai import APIConnectionError, APIStatusError, APITimeoutError
+
+    if isinstance(e, APIStatusError):
+        return e.status_code
+    if isinstance(e, APITimeoutError):  # subclass of APIConnectionError — check first
+        return 504
+    if isinstance(e, APIConnectionError):
+        return 503
+    return 502
+
+
+def model_error(
+    e: OpenAIError | str, *, status_code: int | None = None
+) -> ProviderError:
+    """Map a provider failure to our error type: an overlong prompt (a budget limit the interception
+    server turns into a clean truncation) is told apart from any other provider call failure, which
+    becomes a plain `ProviderError`. `status_code` is the HTTP status surfaced to the harness (whose
+    SDK then retries 5xx/429/timeout and not 4xx); derived from an SDK error when not given. Accepts
+    an SDK error (the renderer) or the provider's raw error body (the httpx proxy)."""
     # Some SDK errors stringify empty; fall back to the type so the message is never blank.
     text = str(e) or (type(e).__name__ if isinstance(e, BaseException) else "")
     if any(phrase in text.casefold() for phrase in _CONTEXT_LENGTH_PHRASES):
         return OverlongPromptError(text)
-    return ProviderError(text)
+    return ProviderError(
+        text,
+        status_code=status_code if status_code is not None else _provider_status(e),
+    )

--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -214,7 +214,10 @@ class InterceptionServer:
         logger.warning(
             "rollout %s failed: %s: %s", session.trace.id, type(error).__name__, error
         )
-        return web.json_response(dialect.error_body(str(error)), status=502)
+        return web.json_response(
+            dialect.error_body(str(error)),
+            status=getattr(error, "status_code", 502),
+        )
 
     async def handle_request(
         self, request: web.Request, dialect: Dialect
@@ -309,7 +312,8 @@ class InterceptionServer:
                     )
                 return web.json_response(completion)
             except RolloutError as e:
-                # Stash the real cause; the rollout re-raises it after the harness returns.
+                # Stash the real cause; the rollout re-raises it after the harness returns. Relay
+                # the provider's status so the harness SDK retries 5xx/429 and not 4xx.
                 session.error = e
                 logger.warning(
                     "model call failed: id=%s %s: %s",
@@ -317,7 +321,9 @@ class InterceptionServer:
                     type(e).__name__,
                     e,
                 )
-                return web.json_response(dialect.error_body(str(e)), status=502)
+                return web.json_response(
+                    dialect.error_body(str(e)), status=getattr(e, "status_code", 502)
+                )
             except Exception as e:  # surface to the program as an API error
                 logger.warning(
                     "model call failed: id=%s %s: %s",
@@ -410,7 +416,9 @@ class InterceptionServer:
                 type(e).__name__,
                 e,
             )
-            return web.json_response(dialect.error_body(str(e)), status=502)
+            return web.json_response(
+                dialect.error_body(str(e)), status=getattr(e, "status_code", 502)
+            )
         except Exception as e:  # surface to the program as an API error
             logger.warning("model call failed: id=%s %s", session.trace.id, e)
             return web.json_response(dialect.error_body(str(e)), status=502)
@@ -473,7 +481,9 @@ class InterceptionServer:
                 type(e).__name__,
                 e,
             )
-            return web.json_response(dialect.error_body(str(e)), status=502)
+            return web.json_response(
+                dialect.error_body(str(e)), status=getattr(e, "status_code", 502)
+            )
         except Exception as e:
             logger.warning("aux call failed: id=%s %s", session.trace.id, e)
             return web.json_response(dialect.error_body(str(e)), status=502)

--- a/verifiers/v1/retries.py
+++ b/verifiers/v1/retries.py
@@ -1,12 +1,12 @@
-"""Retries at two granularities: per-call (model, runtime) and whole-rollout.
+"""Whole-rollout retries (per-call model/runtime retries are owned by the SDKs, not us).
 
-`RetryConfig` lives on `EnvConfig.retries`. Per-call retries wrap a single model or
-runtime call (`RetryingClient` / `RetryingRuntime`), rerunning just the failed call so
-the rest of the rollout's progress is kept — the cheap, default-on layer. Whole-rollout
-retries (`run_with_retry`) rerun an entire trajectory when its trace ends with a retryable
-error (matched by exception type name against include/exclude), accumulating each failed
-attempt's error onto the returned trace's `errors`; off by default (parity with v0, but
-superseded by the finer per-call retries).
+Transient model-call faults are retried by the harness's own SDK (the interception server is a
+faithful proxy — it relays the provider's status), and transient runtime faults by each runtime
+SDK (prime/modal); the framework adds targeted retries only where there's no SDK underneath (e.g.
+`open_tunnel`, via the shared `retrying()` policy). `RetryConfig` (on `EnvConfig.retries`) keeps one
+knob: whole-rollout retries. `run_with_retry` reruns an entire trajectory when its trace ends with a
+retryable error (matched by exception type name against include/exclude), accumulating each failed
+attempt's error onto the returned trace's `errors`; off by default.
 """
 
 from __future__ import annotations
@@ -40,11 +40,11 @@ def retrying(
     retries: int,
     label: str | None = None,
 ) -> AsyncRetrying:
-    """The shared per-call retry policy (tenacity): retry on `on` (minus `give_up`) up to `retries`
-    times with exponential backoff + jitter, logging each retry. Drives the model/runtime call
-    wrappers (`RetryingClient` / `RetryingRuntime`) and `open_tunnel`. `label` names the operation
-    in the log; omitted, it falls back to the retried callable's name (set by the `retrying(fn, ...)`
-    call form; the `async for attempt in retrying(...)` form should pass `label`)."""
+    """The shared retry policy (tenacity): retry on `on` (minus `give_up`) up to `retries` times with
+    exponential backoff + jitter, logging each retry. For the framework's own targeted retries where
+    no SDK retries underneath (e.g. `open_tunnel`). `label` names the operation in the log; omitted,
+    it falls back to the retried callable's name (set by the `retrying(fn, ...)` call form; the
+    `async for attempt in retrying(...)` form should pass `label`)."""
 
     def _log(state: RetryCallState) -> None:
         exc = state.outcome.exception()
@@ -66,14 +66,6 @@ def retrying(
     )
 
 
-class CallRetryConfig(BaseConfig):
-    """Retries around a single model or runtime call (tenacity). Reruns just the failed
-    call, so the rest of the rollout's progress survives a transient failure."""
-
-    max_retries: int = Field(3, ge=0)
-    """Retries for one call beyond the first attempt (0 = no retry, N = up to N retries)."""
-
-
 class RolloutRetryConfig(BaseConfig):
     """Retry a whole rollout when it ends with a captured error (parity with v0's
     rollout-level retries). Matching is by the error's exception type name, so
@@ -81,7 +73,7 @@ class RolloutRetryConfig(BaseConfig):
 
     max_retries: int = Field(0, ge=0)
     """Whole-rollout retries beyond the first attempt (0 = no retry, the default, N = up to N
-    retries). Off by default — per-call `model`/`runtime` retries already cover transient faults;
+    retries). Off by default — the harness/runtime SDKs already retry transient per-call faults;
     rerunning a whole trajectory is opt-in (set this, plus `include`/`exclude`)."""
     include: list[str] = []
     """Only retry errors whose type is listed. Empty = retry anything not excluded."""
@@ -90,13 +82,10 @@ class RolloutRetryConfig(BaseConfig):
 
 
 class RetryConfig(BaseConfig):
-    """All of a rollout's retries: per-call `model` + `runtime` (rerun a single failed
-    call) and whole-`rollout` (rerun the whole trajectory on a captured error)."""
+    """A rollout's retries. Per-call model/runtime retries are owned by the harness/runtime SDKs;
+    the framework keeps only whole-`rollout` retries (rerun the whole trajectory on a captured
+    retryable error)."""
 
-    model: CallRetryConfig = CallRetryConfig()
-    """Retries around each model/provider call (the interception server's completion)."""
-    runtime: CallRetryConfig = CallRetryConfig()
-    """Retries around each runtime call (provision, exec, file read/write)."""
     rollout: RolloutRetryConfig = RolloutRetryConfig()
     """Retries of the whole rollout, on a captured retryable error."""
 

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -16,11 +16,10 @@ import asyncio
 import logging
 import time
 from contextlib import asynccontextmanager
-from dataclasses import replace
 from enum import StrEnum
 
 from verifiers.v1.harness import Harness
-from verifiers.v1.clients import RetryingClient, RolloutContext
+from verifiers.v1.clients import RolloutContext
 from verifiers.v1.decorators import discover_decorated
 from verifiers.v1.errors import RolloutError, TasksetError, ToolsetError, boundary
 from verifiers.v1.interception import (
@@ -31,7 +30,6 @@ from verifiers.v1.interception import (
 )
 from verifiers.v1.runtimes import (
     HOST,
-    RetryingRuntime,
     Runtime,
     RuntimeConfig,
     make_runtime,
@@ -70,8 +68,6 @@ class Rollout:
         finalize_timeout: float | None = None,
         scoring_timeout: float | None = None,
         limits: RolloutLimits | None = None,
-        model_retries: int = 0,
-        runtime_retries: int = 0,
         shared_urls: dict[str, str] | None = None,
         interception: InterceptionPool | None = None,
     ) -> None:
@@ -85,8 +81,6 @@ class Rollout:
         self.finalize_timeout = finalize_timeout
         self.scoring_timeout = scoring_timeout
         self.limits = limits or RolloutLimits()
-        self.model_retries = model_retries
-        self.runtime_retries = runtime_retries
         self.shared_urls = shared_urls or {}
         """Eval-level shared tool servers ({name: url}) to reuse instead of starting per rollout;
         the eval-level interception pool. Both injected by `Environment.episode` from the active
@@ -143,12 +137,8 @@ class Rollout:
         self.runtime = make_runtime(
             self.runtime_config, name=trace.id
         )  # ref set first → always tearable-down; named after the rollout for traceability
-        if self.runtime_retries > 0:
-            self.runtime = RetryingRuntime(self.runtime, self.runtime_retries)
         runtime = self.runtime
         ctx = self.ctx
-        if self.model_retries > 0:
-            ctx = replace(ctx, client=RetryingClient(ctx.client, self.model_retries))
         stops = discover_decorated(self.taskset, "stop")
         logger.info(
             "rollout start: id=%s task=%s harness=%s runtime=%s",

--- a/verifiers/v1/runtimes/__init__.py
+++ b/verifiers/v1/runtimes/__init__.py
@@ -14,7 +14,6 @@ from pydantic import Field
 from verifiers.v1.runtimes.base import (
     HOST,
     ProgramResult,
-    RetryingRuntime,
     Runtime,
     host_endpoint,
     reachable_url,
@@ -57,7 +56,6 @@ def runtime_is_local(config: RuntimeConfig) -> bool:
 
 __all__ = [
     "ProgramResult",
-    "RetryingRuntime",
     "Runtime",
     "RuntimeConfig",
     "make_runtime",

--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -152,11 +152,10 @@ class Runtime(ABC):
     async def run_program(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
         """Run the harness's MAIN program — the rollout itself (a possibly long-lived, stateful,
         agentic run) — as opposed to the short idempotent infra ops (write / mv / install /
-        provisioning) that go through `run`. Identical to `run` here; `RetryingRuntime` overrides it
-        to NOT retry, because re-running the program against the rollout's persistent trace would
-        fork a duplicate branch (and re-execute against a runtime already mutated by the first
-        attempt). A transient transport fault mid-program surfaces as a SandboxError for this
-        rollout instead of a silent full restart."""
+        provisioning) that go through `run`. A distinct seam from `run` so the rollout's program is
+        never blindly retried: re-running a stateful/agentic program against the rollout's persistent
+        trace would fork a duplicate branch (and re-execute against an already-mutated runtime).
+        Transient infra faults are retried by the runtime SDK (prime/modal) inside `run`, not here."""
         return await self.run(argv, env)
 
     async def run_background(
@@ -233,83 +232,6 @@ class Runtime(ABC):
         `client.expose`), torn down with the sandbox in `stop()`. The reverse of `host_endpoint`
         (which reaches a host port from inside a runtime)."""
         return None
-
-
-class RetryingRuntime(Runtime):
-    """Wraps a runtime to retry each call on a transient error (tenacity, up to
-    `max_retries` retries). A program's own failure surfaces as a `ProgramResult` (non-zero
-    exit), not an exception, so retries fire only on infra/transport faults — provisioning,
-    exec transport, file I/O across the runtime boundary. `CancelledError` (a
-    `BaseException`) and `NotImplementedError` (an unsupported op) are never retried. Sync
-    teardown (`cleanup`) and display (`descriptor`) delegate straight through. The rollout's
-    program exec (`run_program`, including the script run inside `run_uv_script`) is deliberately
-    NOT retried: re-running a stateful/agentic program against the rollout's persistent trace would
-    fork a duplicate branch (and re-run against a runtime the first attempt already mutated), so a
-    mid-program transport fault surfaces as a SandboxError for that rollout. `run_uv_script`'s
-    write/mv staging still runs over the retrying `write`/`run`."""
-
-    def __init__(self, inner: Runtime, max_retries: int) -> None:
-        super().__init__(inner.name)
-        self.inner = inner
-        self.max_retries = max_retries
-        # One Retrying, reused across (and concurrent within) calls: the control flow runs
-        # off a per-call RetryCallState, so only its bookkeeping `.statistics` is shared. A
-        # program's own failure is a `ProgramResult` (non-zero exit), not an exception, so
-        # retries fire only on infra/transport faults; an unsupported op (`NotImplementedError`)
-        # is never retried.
-        self._retrying = retrying(
-            on=Exception, give_up=NotImplementedError, retries=max_retries
-        )
-
-    async def _retry(self, fn, *args):
-        return await self._retrying(fn, *args)
-
-    async def start(self) -> None:
-        await self._retry(self.inner.start)
-
-    async def stop(self) -> None:
-        await self._retry(self.inner.stop)
-
-    def cleanup(self) -> None:
-        self.inner.cleanup()
-
-    async def run(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
-        return await self._retry(self.inner.run, argv, env)
-
-    async def run_program(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
-        """The rollout's program exec is NOT retried (see the class docstring) — straight to
-        inner."""
-        return await self.inner.run(argv, env)
-
-    async def run_background(
-        self, argv: list[str], env: dict[str, str], log: str
-    ) -> None:
-        await self._retry(self.inner.run_background, argv, env, log)
-
-    @property
-    def type(self) -> str:
-        return self.inner.type
-
-    @property
-    def published_port(self) -> int | None:
-        return self.inner.published_port
-
-    @property
-    def is_local(self) -> bool:
-        return self.inner.is_local
-
-    @property
-    def descriptor(self) -> str | None:
-        return self.inner.descriptor
-
-    async def expose(self, port: int) -> str | None:
-        return await self._retry(self.inner.expose, port)
-
-    async def read(self, path: str) -> bytes:
-        return await self._retry(self.inner.read, path)
-
-    async def write(self, path: str, data: bytes) -> None:
-        await self._retry(self.inner.write, path, data)
 
 
 TunnelT = TypeVar("TunnelT")


### PR DESCRIPTION
## Summary

Per-call model/runtime retries were a redundant second layer on top of the SDKs that already do this — and for the runtime, a *worse* one. This removes them and leans on the SDKs, making the interception server a faithful proxy so the harness's SDK can retry correctly.

- **Model**: the harness's OpenAI SDK already retries (2 by default, status-aware — 408/409/429/5xx/timeout). `RetryingClient` just stacked a second layer and, because the interception server flattened every failure to `502`, the harness SDK couldn't tell a retryable 429 from a terminal 400.
- **Runtime**: `prime_sandboxes` already retries carefully (idempotency- and status-aware: only idempotent requests on `{502,503,504}` + transient `ReadError`s). `RetryingRuntime` retried **everything** — non-idempotent ops *and* deterministic failures like `SandboxFileNotFoundError` — 3× each. modal's gRPC client retries similarly. docker/subprocess are local (no network), so transient faults are rare and no framework retry is needed.

## Changes

- Remove **`RetryingClient`** and **`RetryingRuntime`**, the **`retries.model`/`retries.runtime`** config, the **`CallRetryConfig`** type, and the `model_retries`/`runtime_retries` plumbing in `Rollout` / `Environment.episode` / `validate`.
- **Faithful proxy**: `ProviderError` now carries `status_code`. `eval.py` relays the provider's real status (and uses 504/503 for upstream timeout/connection faults); `train.py` derives it from the SDK error type. The interception server returns that status to the harness, so its SDK retries 5xx/429/timeout and **not** 4xx. Overlong stays a `400` `context_length` truncation.
- Keep **whole-rollout retries** (`run_with_retry`) as the backstop, and the shared **`retrying()`** helper for targeted framework retries where no SDK retries underneath (`open_tunnel`).
- Docs (README/GUIDE/ARCHITECTURE) updated to describe SDK-owned per-call retries.

## Breaking

- The CLI flags **`--retries.model.*`** and **`--retries.runtime.*`** are removed, along with `vf.CallRetryConfig` and `verifiers.v1.clients.RetryingClient` / `verifiers.v1.runtimes.RetryingRuntime`. Per-call model retries are now configured on the harness's own client (e.g. the OpenAI SDK's `max_retries`); runtime retries are the SDK's. `--retries.rollout.*` (whole-rollout) is unchanged.

## Notes / to verify

- A persistently-failing provider/runtime now surfaces after the harness/runtime SDK exhausts *its* retries (then the rollout records the typed error / re-raises the stashed cause) rather than after our extra layer.
- modal's internal retry behavior is assumed similar to prime's; worth a confirmation on a real modal run.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Drop framework per-call retries and delegate them to provider/runtime SDKs
> - Removes `RetryingClient`, `RetryingRuntime`, and `CallRetryConfig` — per-call retries for model and runtime are no longer managed by the framework; SDKs are expected to handle them natively.
> - `ProviderError` now carries a `status_code` (default 502), derived from OpenAI SDK exceptions via a new `_provider_status` helper, and the interception server relays this code so SDKs can distinguish retryable 5xx/429/timeouts from 4xx errors.
> - `RetryConfig` is simplified to only `RolloutRetryConfig`; the `retries.model` and `retries.runtime` config blocks are removed from `ValidateConfig` and `Rollout`.
> - Whole-rollout retries remain in the framework but are off by default.
> - Risk: any callers importing `RetryingClient`, `RetryingRuntime`, or `CallRetryConfig` from `verifiers.v1` will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 91d9a49.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking API/CLI removals affect anyone using `RetryingClient`, `RetryingRuntime`, or model/runtime retry flags; rollout failure timing now follows SDK retry policies, and status relay changes harness retry behavior vs the old flat-502 path.
> 
> **Overview**
> **Per-call retries move out of the framework.** `RetryingClient`, `RetryingRuntime`, `CallRetryConfig`, and the `--retries.model.*` / `--retries.runtime.*` config are removed; `Rollout` and `validate` no longer wrap clients or runtimes. **Whole-rollout** retries (`--retries.rollout.*`) and the shared `retrying()` helper (e.g. `open_tunnel`) stay unchanged.
> 
> **The interception stack becomes a faithful HTTP proxy for failures.** `ProviderError` gains a `status_code`; `EvalClient` maps upstream and transport faults to the right codes, and the interception server returns that status to the harness instead of always **502**—so the harness OpenAI SDK can retry **5xx/429/timeouts** and not **4xx**.
> 
> Docs and public exports are updated to describe SDK-owned per-call retries and the slimmer `RetryConfig`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91d9a494e3bd4ad529a5e2fea362963923ca9165. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->