### PR TITLE
fix: retry in-sandbox /state + /task channel fetches; name us in prime expose error

### DIFF
--- a/verifiers/v1/mcp/server.py
+++ b/verifiers/v1/mcp/server.py
@@ -26,6 +26,44 @@ ConfigT = TypeVar("ConfigT", bound=BaseConfig)
 
 STATE_TIMEOUT = 30.0
 """Seconds for a state-channel GET/PUT (localhost, or a tunnel to the host)."""
+STATE_RETRIES = 4
+"""Retries for a state/task channel request. Behind a remote runtime the channel is reached over a
+host tunnel that can return a transient 5xx or reset the connection while it settles (e.g. just
+after the sandbox/tunnel comes up), so a single blip must not fail the tool call."""
+STATE_BACKOFF = 0.5
+"""Base seconds for the channel-request backoff (exponential + jitter)."""
+
+
+async def _channel_request(
+    method: str, url: str, secret: str, *, json: dict | None = None
+) -> dict:
+    """One bearer-authed call to the interception `/state` or `/task` channel, retried with
+    exponential backoff + jitter on transient failures (connection resets / 5xx from the host
+    tunnel). A 4xx is a real error (e.g. an invalid state PUT) and is not retried. Returns the
+    parsed JSON body."""
+    import asyncio
+    import random
+
+    import httpx
+
+    headers = {"Authorization": f"Bearer {secret}"}
+    for attempt in range(STATE_RETRIES + 1):
+        try:
+            async with httpx.AsyncClient(timeout=STATE_TIMEOUT) as client:
+                resp = await client.request(method, url, json=json, headers=headers)
+                resp.raise_for_status()
+                return resp.json()
+        except (httpx.TransportError, httpx.HTTPStatusError) as e:
+            transient = (
+                isinstance(e, httpx.TransportError) or e.response.status_code >= 500
+            )
+            if not transient or attempt == STATE_RETRIES:
+                raise
+            await asyncio.sleep(
+                STATE_BACKOFF * 2**attempt + random.uniform(0, STATE_BACKOFF)
+            )
+    raise AssertionError("unreachable")  # the loop returns or raises
+
 
 # A `shared` server is one process for the whole eval, so it can't take a per-rollout state channel
 # from its environment like a per-rollout server does. Instead the framework tags each rollout's URL
@@ -138,12 +176,7 @@ class ServerBase(Generic[ConfigT, StateT]):
         cls = self._state_cls
         if not url:
             return cls()
-        import httpx
-
-        async with httpx.AsyncClient(timeout=STATE_TIMEOUT) as client:
-            resp = await client.get(url, headers={"Authorization": f"Bearer {secret}"})
-            resp.raise_for_status()
-            return cls.model_validate(resp.json())
+        return cls.model_validate(await _channel_request("GET", url, secret))
 
     async def _push_state(self, before: dict) -> None:
         """Push the in-flight call's `self.state` back to the shared channel if it changed. No-op
@@ -157,13 +190,7 @@ class ServerBase(Generic[ConfigT, StateT]):
         )
         if after == before:
             return
-        import httpx
-
-        async with httpx.AsyncClient(timeout=STATE_TIMEOUT) as client:
-            resp = await client.put(
-                url, json=after, headers={"Authorization": f"Bearer {secret}"}
-            )
-            resp.raise_for_status()
+        await _channel_request("PUT", url, secret, json=after)
 
     async def _fetch_task(self, state_url: str | None, secret: str):
         """Fetch this rollout's task from the interception server's `/task` channel (the sibling of
@@ -176,14 +203,7 @@ class ServerBase(Generic[ConfigT, StateT]):
             if state_url.endswith("/state")
             else state_url
         )
-        import httpx
-
-        async with httpx.AsyncClient(timeout=STATE_TIMEOUT) as client:
-            resp = await client.get(
-                task_url, headers={"Authorization": f"Bearer {secret}"}
-            )
-            resp.raise_for_status()
-            data = resp.json()
+        data = await _channel_request("GET", task_url, secret)
         return _import_ref(data["cls"]).model_validate_json(data["task"])
 
     async def _setup_task_from_channel(

--- a/verifiers/v1/mcp/server.py
+++ b/verifiers/v1/mcp/server.py
@@ -30,8 +30,6 @@ STATE_RETRIES = 4
 """Retries for a state/task channel request. Behind a remote runtime the channel is reached over a
 host tunnel that can return a transient 5xx or reset the connection while it settles (e.g. just
 after the sandbox/tunnel comes up), so a single blip must not fail the tool call."""
-STATE_BACKOFF = 0.5
-"""Base seconds for the channel-request backoff (exponential + jitter)."""
 
 
 async def _channel_request(
@@ -41,28 +39,33 @@ async def _channel_request(
     exponential backoff + jitter on transient failures (connection resets / 5xx from the host
     tunnel). A 4xx is a real error (e.g. an invalid state PUT) and is not retried. Returns the
     parsed JSON body."""
-    import asyncio
-    import random
-
     import httpx
+    from tenacity import (
+        AsyncRetrying,
+        retry_if_exception,
+        stop_after_attempt,
+        wait_exponential_jitter,
+    )
 
-    headers = {"Authorization": f"Bearer {secret}"}
-    for attempt in range(STATE_RETRIES + 1):
-        try:
-            async with httpx.AsyncClient(timeout=STATE_TIMEOUT) as client:
-                resp = await client.request(method, url, json=json, headers=headers)
-                resp.raise_for_status()
-                return resp.json()
-        except (httpx.TransportError, httpx.HTTPStatusError) as e:
-            transient = (
-                isinstance(e, httpx.TransportError) or e.response.status_code >= 500
+    def transient(e: BaseException) -> bool:
+        return isinstance(e, httpx.TransportError) or (
+            isinstance(e, httpx.HTTPStatusError) and e.response.status_code >= 500
+        )
+
+    async def request() -> dict:
+        async with httpx.AsyncClient(timeout=STATE_TIMEOUT) as client:
+            resp = await client.request(
+                method, url, json=json, headers={"Authorization": f"Bearer {secret}"}
             )
-            if not transient or attempt == STATE_RETRIES:
-                raise
-            await asyncio.sleep(
-                STATE_BACKOFF * 2**attempt + random.uniform(0, STATE_BACKOFF)
-            )
-    raise AssertionError("unreachable")  # the loop returns or raises
+            resp.raise_for_status()
+            return resp.json()
+
+    return await AsyncRetrying(
+        stop=stop_after_attempt(STATE_RETRIES + 1),
+        wait=wait_exponential_jitter(initial=0.5, max=30),
+        retry=retry_if_exception(transient),
+        reraise=True,
+    )(request)
 
 
 # A `shared` server is one process for the whole eval, so it can't take a per-rollout state channel

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -156,18 +156,17 @@ class PrimeRuntime(Runtime):
 
     async def expose(self, port: int) -> str | None:
         # Publish a server hosted IN the sandbox via the SDK's native port exposure → a public
-        # HTTPS URL reachable from anywhere (incl. another sandbox). The exposure is removed when
-        # the sandbox is deleted in stop(), so a tool in its own prime sandbox needs no host tunnel.
-        # TODO: `client.expose` currently only works in a default-region sandbox (port <= 9000), so
-        # a tool/user-sim in its own prime sandbox needs the region pinned. Fix once prime supports
-        # port exposure in any region (then drop the e2e `skip_if_unexposable` guard).
+        # HTTPS URL. Removed when the sandbox is deleted in stop(), so a tool in its own prime
+        # sandbox needs no host tunnel. Port exposure is region-gated: many regions (incl. the
+        # backend default, which lands in us-central) 400 it; `us` supports it. TODO: re-enable the
+        # prime cases in the e2e `skip_if_unexposable` guard once prime exposes ports in any region.
         try:
             exposed = await self._client.expose(self._sandbox_id, port)
         except Exception as e:  # surface prime's exposure constraints actionably
             raise SandboxError(
-                "prime port exposure failed — `client.expose` currently needs a default-region "
-                "sandbox and port <= 9000; pin `tools.runtime.region` to a supported "
-                f"region, or use a host/docker tools.runtime instead. ({e})"
+                "prime port exposure failed — port exposure isn't supported in this sandbox's "
+                "region; pin `tools.runtime.region` to a region that supports it (e.g. `us`), or "
+                f"use a colocated / docker / modal tools.runtime instead. ({e})"
             ) from e
         logger.info("prime: exposed sandbox port %d at %s", port, exposed.url)
         return exposed.url.rstrip("/")


### PR DESCRIPTION
## Summary

Two fixes for tool/user servers running behind a **remote runtime** (prime/modal),
where the interception `/state` + `/task` channels are reached over a host tunnel.

**1. Retry the in-sandbox server's channel fetches.** `self.state` GET/PUT
(`_pull_state`/`_push_state`) and the startup `/task` fetch (`_fetch_task`) had
no retry — a transient 5xx or connection reset from the tunnel (common right
after the sandbox/tunnel comes up) hit `raise_for_status()` and failed the tool
call or tool-server setup outright. Observed on prime: a colocated tool's
`PUT /state` got a `500` → `create_event` errored → reward 0.
- New `_channel_request`: one bearer-authed call wrapped in tenacity's
  `AsyncRetrying` + `wait_exponential_jitter` (matching `clients/client.py`),
  retried on a transient predicate (transport errors / 5xx); a 4xx (e.g. an
  invalid state PUT) is a real error and is not retried.
  `_pull_state`/`_push_state`/`_fetch_task` all route through it.

**2. Prime port-exposure error names `us`.** Port exposure is region-gated — the
backend default lands in `us-central`, which 400s it; `us` supports it. The
`SandboxError` now says to pin `tools.runtime.region` to a supported region
(e.g. `us`), and the stale "default-region / port <= 9000" wording is corrected.
(Non-colocated prime tools may still be unreachable across regions — that's a
separate prime infra limit; use colocated / docker / modal.)

## Verification

- **Retry unit check** — local flaky server returning `500, 500, 200`:
  `_channel_request` recovers and returns the body; a `400` raises immediately
  (not retried).
- **No regression** — `general-agent-v1`, subprocess + colocated: reward 1.0,
  `db_hash`/`verify` 1, no errors.
- **prime + colocated** (the case that previously failed on a `/state` 500):
  reward 1.0, `db_hash`/`verify` 1, `agent_completed`, no errors. Matches
  modal-colocated (same tunnel), which already passed intermittently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared state sync and task bootstrap over the tunnel; retries could delay surfacing persistent 5xx but 4xx behavior is unchanged. Prime error text only.
> 
> **Overview**
> Adds **retries with exponential backoff + jitter** for bearer-authed `/state` and `/task` channel calls from in-sandbox MCP servers (`_pull_state`, `_push_state`, `_fetch_task`), via a shared `_channel_request` helper. Transient **transport errors and 5xx** are retried (up to 4 retries); **4xx** still fail immediately so invalid state writes are not masked.
> 
> Updates **Prime `expose` failure messaging** to reflect region-gated port exposure (e.g. default `us-central` vs pinning **`us`**) and drops outdated “default-region / port ≤ 9000” wording; suggests colocated/docker/modal runtimes as alternatives.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9685a2252dbb4559d4483a5844a0f4b56a3f6ab6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Retry transient failures in sandbox `/state` and `/task` channel fetches
> - Adds a `_channel_request` helper in [server.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1759/files#diff-5eaeab5d19ee732e16b066ff6689f954f6743833a907a129acc0df250cee5b2a) that wraps GET/PUT calls to the `/state` and `/task` channels with tenacity retry logic: exponential backoff with jitter, up to `STATE_RETRIES = 4` additional attempts on `httpx.TransportError` or 5xx responses, and immediate re-raise on 4xx.
> - Refactors `_pull_state`, `_push_state`, and `_fetch_task` in `ServerBase` to use `_channel_request` instead of direct `httpx` calls.
> - Updates the `PrimeRuntime.expose` error message in [prime.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1759/files#diff-d22d61279ff7587a2b14c72ab1a0fc9d3f805a735338a70f8efc7fe19aaa8502) to indicate that port exposure is not supported in the current region and suggests pinning `tools.runtime.region` to `'us'`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9685a22.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->