### PR TITLE
Trace advantage authoring surface

### DIFF
--- a/tests/v1/test_graph.py
+++ b/tests/v1/test_graph.py
@@ -103,6 +103,50 @@ def test_routed_experts_none_when_absent():
     assert trace.branches[-1].routed_experts is None
 
 
+def test_branch_advantage_annotations_are_plain_lists():
+    trace = vf.Trace(task=vf.Task(idx=0, prompt="x"))
+    graph.prepare_turn(trace, [vf.UserMessage(content="u1")]).commit(
+        vf.Response(
+            id="a",
+            created=0,
+            model="t",
+            message=vf.AssistantMessage(content="a1"),
+            finish_reason="stop",
+            tokens=TurnTokens(
+                prompt_ids=[1, 2], completion_ids=[3], message_spans=[(0, 2)]
+            ),
+        )
+    )
+
+    branch = trace.branches[0]
+    branch.advantages = [0.0, 0.0, 1.0]
+    branch.mask = [False, False, True]
+
+    assert trace.branches[0].advantages == [0.0, 0.0, 1.0]
+    assert trace.branches[0].mask == [False, False, True]
+    branch.advantages = [1.0]
+    assert trace.branches[0].advantages == [1.0]
+
+
+def test_advantage_decorator_records_loss_metadata():
+    @vf.advantage(loss="ce", scope="rollout")
+    async def sft(traces: list[vf.Trace]) -> list[vf.Trace]:
+        return traces
+
+    assert sft.advantage is True
+    assert sft.advantage_loss == "ce"
+    assert sft.advantage_scope == "rollout"
+
+
+def test_trace_model_metadata_is_keyed_by_model_id():
+    trace = vf.Trace(task=vf.Task(idx=0, prompt="x"))
+    trace.actor = "teacher"
+    trace.models["teacher"] = vf.EvalClientConfig(model="teacher-model")
+
+    assert trace.actor == "teacher"
+    assert trace.models["teacher"].model == "teacher-model"
+
+
 def test_tool_call_hash_matches_v0_content_and_arguments_normalization():
     left = vf.AssistantMessage(
         content=None,

--- a/verifiers/v1/__init__.py
+++ b/verifiers/v1/__init__.py
@@ -12,10 +12,12 @@ from verifiers.v1.clients import (
     BaseClientConfig,
     Client,
     ClientConfig,
+    EvalClientConfig,
     RolloutContext,
+    TrainClientConfig,
     resolve_client,
 )
-from verifiers.v1.decorators import group_reward, metric, reward, stop, tool
+from verifiers.v1.decorators import advantage, group_reward, metric, reward, stop, tool
 from verifiers.v1.env import (
     ElasticPoolConfig,
     EnvConfig,
@@ -135,6 +137,7 @@ __all__ = [
     "TimeSpan",
     "Error",
     # decorators
+    "advantage",
     "stop",
     "tool",
     "metric",
@@ -154,6 +157,8 @@ __all__ = [
     "Client",
     "BaseClientConfig",
     "ClientConfig",
+    "EvalClientConfig",
+    "TrainClientConfig",
     "resolve_client",
     # taskset / harness / runtime / environment
     "Taskset",

--- a/verifiers/v1/clients/config.py
+++ b/verifiers/v1/clients/config.py
@@ -30,6 +30,10 @@ PRIME_TEAM_ID_HEADER = "X-Prime-Team-ID"
 class BaseClientConfig(BaseConfig):
     """An OpenAI-compatible endpoint. The API key is read from an env var."""
 
+    model: str | None = None
+    """Served model name. Optional for ordinary eval configs because callers often pass the
+    request model separately; prime-rl stamps it when a trace needs to reconnect to this
+    client without additional prime-rl context."""
     base_url: str = DEFAULT_PRIME_INFERENCE_URL
     api_key_var: str = "PRIME_API_KEY"
     headers: dict[str, str] = Field(default_factory=dict)

--- a/verifiers/v1/decorators.py
+++ b/verifiers/v1/decorators.py
@@ -26,7 +26,7 @@ runtime is recorded per rollout as a `@metric` first.
 """
 
 import inspect
-from typing import Any, Callable, TypeVar, overload
+from typing import Any, Callable, Literal, TypeVar, overload
 
 F = TypeVar("F", bound=Callable[..., Any])
 
@@ -121,4 +121,27 @@ def group_reward(
     of trace metadata. Each score is weighted and summed into that trace's reward,
     alongside the per-rollout rewards."""
     decorator = mark("group_reward", group_reward_priority=priority, _vf_weight=weight)
+    return decorator if func is None else decorator(func)
+
+
+@overload
+def advantage(
+    func: F,
+    loss: Literal["rl", "ce"] = "rl",
+    scope: Literal["rollout", "group"] = "group",
+) -> F: ...
+@overload
+def advantage(
+    func: None = None,
+    loss: Literal["rl", "ce"] = "rl",
+    scope: Literal["rollout", "group"] = "group",
+) -> Callable[[F], F]: ...
+def advantage(
+    func: F | None = None,
+    loss: Literal["rl", "ce"] = "rl",
+    scope: Literal["rollout", "group"] = "group",
+) -> F | Callable[[F], F]:
+    """Mark a trace transform as an advantage function. The trainer/orchestrator imports
+    and runs these; verifiers only records the target loss metadata."""
+    decorator = mark("advantage", advantage_loss=loss, advantage_scope=scope)
     return decorator if func is None else decorator(func)

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -20,6 +20,7 @@ from pydantic import Field, PrivateAttr
 from renderers.base import MultiModalData
 
 from verifiers.v1 import graph
+from verifiers.v1.clients.config import ClientConfig
 from verifiers.v1.graph import MessageNode
 from verifiers.v1.state import State, StateT
 from verifiers.v1.task import TaskT, WireTask
@@ -74,6 +75,10 @@ class Branch(StrictBaseModel):
 
     index: int
     nodes: list[MessageNode]
+    advantages: list[float] = Field(default_factory=list)
+    """Per-token training scores aligned to `token_ids`, written by advantage functions."""
+    mask: list[bool] = Field(default_factory=list)
+    """Per-token participation mask aligned to `token_ids`, written by advantage functions."""
 
     @property
     def num_turns(self) -> int:
@@ -223,10 +228,18 @@ class Trace(StrictBaseModel, Generic[TaskT, StateT]):
     """Every error captured across attempts, oldest first (more than one only when the
     rollout was retried). `error` exposes the most recent."""
     timing: Timing = Field(default_factory=Timing)
+    actor: str = "policy"
+    """Model key that sampled this trace. Prime-rl stamps this before advantage functions run."""
+    models: dict[str, ClientConfig] = Field(default_factory=dict)
+    """Model endpoint descriptors keyed by user-facing model id. These are connection configs,
+    not live clients or owned pools. Environments do not populate this during rollout."""
 
     _head_index: dict = PrivateAttr(default_factory=dict)
     """`(parent, msg_hash) -> node_id` for the graph builder (`graph.prepare_turn` / `commit`);
     rebuilt lazily from `nodes` after deserialization."""
+    _branches_cache: list[Branch] | None = PrivateAttr(default=None)
+    _branches_cache_node_count: int = PrivateAttr(default=-1)
+    """Stable branch view for post-rollout branch annotations."""
 
     @property
     def reward(self) -> float:
@@ -280,6 +293,10 @@ class Trace(StrictBaseModel, Generic[TaskT, StateT]):
         """The conversation segmented into linear branches — a view over the graph: each
         leaf's root→leaf path is a branch (one when linear, several under compaction or
         subagents). Branching falls out of walking each leaf's parents back to its root."""
+        if self._branches_cache is not None and self._branches_cache_node_count == len(
+            self.nodes
+        ):
+            return self._branches_cache
         branches: list[Branch] = []
         for i, leaf in enumerate(graph.leaves(self)):
             path: list[int] = []
@@ -289,6 +306,8 @@ class Trace(StrictBaseModel, Generic[TaskT, StateT]):
                 nid = self.nodes[nid].parent
             path.reverse()
             branches.append(Branch(index=i, nodes=[self.nodes[n] for n in path]))
+        self._branches_cache = branches
+        self._branches_cache_node_count = len(self.nodes)
         return branches
 
     @property


### PR DESCRIPTION
## Summary

Adds the minimal public verifiers surface needed by prime-rl trace-native advantage functions.

- Adds branch-level `advantages` and `mask` annotations aligned to branch `token_ids`.
- Adds `Trace.actor` and keyed `Trace.models` endpoint descriptors.
- Adds optional `model` metadata to v1 client configs so traces carry enough reconnect information.
- Exposes `@vf.advantage(loss="rl" | "ce", scope="rollout" | "group")` metadata without importing prime-rl.

This targets `feat/nano-as-v1` (verifiers PR #1576). The prime-rl sibling PR consumes commit `af3fd017` through `deps/verifiers`.

## Validation

- `uv run --no-sync ruff check verifiers/v1/decorators.py verifiers/v1/trace.py verifiers/v1/clients/config.py verifiers/v1/__init__.py tests/v1/test_graph.py`
- `uv run --no-sync pytest tests/v1/test_graph.py -q`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive v1 trace/decorator fields and branch caching; no changes to rollout scoring or client resolution behavior beyond optional config metadata.
> 
> **Overview**
> Adds the minimal **verifiers v1** API that **prime-rl** needs to author and consume trace-native advantage functions without pulling in the trainer.
> 
> **Branch** gains per-token **`advantages`** and **`mask`** lists (aligned to `token_ids`) for advantage code to write training scores. **`Trace.branches`** is now cached by node count so repeated reads return the same **`Branch`** instances and in-place annotation survives until the graph grows.
> 
> **Trace** adds **`actor`** (which model key sampled the rollout) and **`models`**, a map of user-facing model ids to **`ClientConfig`** endpoint descriptors for reconnecting after rollouts. **`BaseClientConfig`** gets an optional **`model`** field for that stamped metadata.
> 
> A new **`@vf.advantage(loss="rl"|"ce", scope="rollout"|"group")`** decorator tags transforms with **`advantage_loss`** / **`advantage_scope`** only—execution stays in the orchestrator. **`advantage`**, **`EvalClientConfig`**, and **`TrainClientConfig`** are exported from **`verifiers.v1`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af3fd017da672650e769ea05371070b2d58e97b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add advantage authoring surface to traces with caching and decorator support
> - Adds `advantages: list[float]` and `mask: list[bool]` fields to `Branch` in [trace.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1760/files#diff-834820c3aa80d87ee1c1c57fb54c74f09c66ac727036d964e6005c8613c00b5e) for per-token training annotations written by advantage functions.
> - Adds `actor: str` and `models: dict[str, ClientConfig]` fields to `Trace` for recording which model sampled the trace and storing endpoint metadata.
> - Caches the `Trace.branches` property using node count so repeated accesses return the same `Branch` objects, preserving any mutations (e.g. advantage scores) until the graph changes.
> - Introduces an `@advantage(loss=..., scope=...)` decorator in [decorators.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1760/files#diff-f988770651db72dcffc1d37435431286a4bde4698027b25e030e75f2424369ec) that marks functions with `advantage_loss` and `advantage_scope` metadata; exports it alongside `EvalClientConfig` and `TrainClientConfig` from `verifiers.v1`.
> - Adds an optional `model: str | None` field to `BaseClientConfig` in [config.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1760/files#diff-052fb75ebcf125bca5326c84afdabf150d579712daa8474171035d7268a42be1).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized af3fd01.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
