### PR TITLE
fix(v1): ModalRuntime.read resolves relative paths; tail tool logs un-retried

### DIFF
--- a/verifiers/v1/mcp/launch.py
+++ b/verifiers/v1/mcp/launch.py
@@ -166,8 +166,11 @@ async def _install_in_sandbox(server: ServerBase, runtime: Runtime) -> str:
 async def log_tail(runtime: Runtime, log: str, limit: int = 2000) -> str:
     """The tail of a program's `log` file in `runtime`, empty if it can't be read — for
     enriching an error with what the program (e.g. a tool server) wrote before it died."""
+    # Best-effort, so read through the un-retrying inner runtime (like `_read_back_port`): a
+    # failed read here just yields an empty tail, not a `retrying runtime.read` retry storm.
+    reader = getattr(runtime, "inner", runtime)
     with contextlib.suppress(Exception):
-        return (await runtime.read(log)).decode(errors="replace").strip()[-limit:]
+        return (await reader.read(log)).decode(errors="replace").strip()[-limit:]
     return ""
 
 

--- a/verifiers/v1/mcp/launch.py
+++ b/verifiers/v1/mcp/launch.py
@@ -166,11 +166,8 @@ async def _install_in_sandbox(server: ServerBase, runtime: Runtime) -> str:
 async def log_tail(runtime: Runtime, log: str, limit: int = 2000) -> str:
     """The tail of a program's `log` file in `runtime`, empty if it can't be read — for
     enriching an error with what the program (e.g. a tool server) wrote before it died."""
-    # Best-effort, so read through the un-retrying inner runtime (like `_read_back_port`): a
-    # failed read here just yields an empty tail, not a `retrying runtime.read` retry storm.
-    reader = getattr(runtime, "inner", runtime)
     with contextlib.suppress(Exception):
-        return (await reader.read(log)).decode(errors="replace").strip()[-limit:]
+        return (await runtime.read(log)).decode(errors="replace").strip()[-limit:]
     return ""
 
 

--- a/verifiers/v1/runtimes/modal.py
+++ b/verifiers/v1/runtimes/modal.py
@@ -30,6 +30,12 @@ _MAX_TIMEOUT_SECONDS = 24 * 60 * 60
 _APP_NAME = "verifiers-v1"
 
 
+def abs_path(path: str, workdir: str) -> str:
+    """Resolve a remote `path` to absolute: absolute passes through, relative resolves
+    against `workdir`. Modal's filesystem API only accepts absolute remote paths."""
+    return path if path.startswith("/") else f"{workdir.rstrip('/')}/{path}"
+
+
 class ModalConfig(BaseConfig):
     type: Literal["modal"] = "modal"
     image: str = "python:3.11-slim"
@@ -164,20 +170,19 @@ class ModalRuntime(Runtime):
                 f"modal background launch failed: {result.stderr.strip()}"
             )
 
-    def _abs(self, path: str) -> str:
-        # Modal's filesystem API only accepts absolute remote paths; resolve a relative one
-        # against the workdir (the cwd `run`/`run_background` use) so callers can pass either.
-        return path if path.startswith("/") else f"{self.config.workdir.rstrip('/')}/{path}"
+    def abs_path(self, path: str) -> str:
+        """Resolve `path` against this runtime's workdir (see `abs_path`)."""
+        return abs_path(path, self.config.workdir)
 
     async def read(self, path: str) -> bytes:
         try:
-            return await self._sandbox.filesystem.read_bytes.aio(self._abs(path))
+            return await self._sandbox.filesystem.read_bytes.aio(self.abs_path(path))
         except Exception as e:
             raise SandboxError(f"read {path!r}: {e}") from e
 
     async def write(self, path: str, data: bytes) -> None:
         # Create the parent first (Modal's write does not mkdir).
-        target = self._abs(path)
+        target = self.abs_path(path)
         try:
             await self._sandbox.filesystem.make_directory.aio(
                 str(PurePosixPath(target).parent)

--- a/verifiers/v1/runtimes/modal.py
+++ b/verifiers/v1/runtimes/modal.py
@@ -164,22 +164,22 @@ class ModalRuntime(Runtime):
                 f"modal background launch failed: {result.stderr.strip()}"
             )
 
-    def abs_path(self, path: str) -> str:
-        """`path` resolved against the runtime's workdir; Modal's filesystem API only
-        accepts absolute remote paths (an absolute path passes through)."""
+    def _abs(self, path: str) -> str:
+        # Modal's filesystem API only accepts absolute remote paths; resolve a relative
+        # one against the workdir (the cwd run/run_background use).
         if path.startswith("/"):
             return path
         return f"{self.config.workdir.rstrip('/')}/{path}"
 
     async def read(self, path: str) -> bytes:
         try:
-            return await self._sandbox.filesystem.read_bytes.aio(self.abs_path(path))
+            return await self._sandbox.filesystem.read_bytes.aio(self._abs(path))
         except Exception as e:
             raise SandboxError(f"read {path!r}: {e}") from e
 
     async def write(self, path: str, data: bytes) -> None:
         # Create the parent first (Modal's write does not mkdir).
-        target = self.abs_path(path)
+        target = self._abs(path)
         try:
             await self._sandbox.filesystem.make_directory.aio(
                 str(PurePosixPath(target).parent)

--- a/verifiers/v1/runtimes/modal.py
+++ b/verifiers/v1/runtimes/modal.py
@@ -164,20 +164,20 @@ class ModalRuntime(Runtime):
                 f"modal background launch failed: {result.stderr.strip()}"
             )
 
+    def _abs(self, path: str) -> str:
+        # Modal's filesystem API only accepts absolute remote paths; resolve a relative one
+        # against the workdir (the cwd `run`/`run_background` use) so callers can pass either.
+        return path if path.startswith("/") else f"{self.config.workdir.rstrip('/')}/{path}"
+
     async def read(self, path: str) -> bytes:
         try:
-            return await self._sandbox.filesystem.read_bytes.aio(path)
+            return await self._sandbox.filesystem.read_bytes.aio(self._abs(path))
         except Exception as e:
             raise SandboxError(f"read {path!r}: {e}") from e
 
     async def write(self, path: str, data: bytes) -> None:
-        # Resolve a relative path against the workdir and create its parent first (Modal's
-        # write does not mkdir).
-        target = (
-            path
-            if path.startswith("/")
-            else f"{self.config.workdir.rstrip('/')}/{path}"
-        )
+        # Create the parent first (Modal's write does not mkdir).
+        target = self._abs(path)
         try:
             await self._sandbox.filesystem.make_directory.aio(
                 str(PurePosixPath(target).parent)

--- a/verifiers/v1/runtimes/modal.py
+++ b/verifiers/v1/runtimes/modal.py
@@ -30,12 +30,6 @@ _MAX_TIMEOUT_SECONDS = 24 * 60 * 60
 _APP_NAME = "verifiers-v1"
 
 
-def abs_path(path: str, workdir: str) -> str:
-    """Resolve a remote `path` to absolute: absolute passes through, relative resolves
-    against `workdir`. Modal's filesystem API only accepts absolute remote paths."""
-    return path if path.startswith("/") else f"{workdir.rstrip('/')}/{path}"
-
-
 class ModalConfig(BaseConfig):
     type: Literal["modal"] = "modal"
     image: str = "python:3.11-slim"
@@ -171,8 +165,11 @@ class ModalRuntime(Runtime):
             )
 
     def abs_path(self, path: str) -> str:
-        """Resolve `path` against this runtime's workdir (see `abs_path`)."""
-        return abs_path(path, self.config.workdir)
+        """`path` resolved against the runtime's workdir; Modal's filesystem API only
+        accepts absolute remote paths (an absolute path passes through)."""
+        if path.startswith("/"):
+            return path
+        return f"{self.config.workdir.rstrip('/')}/{path}"
 
     async def read(self, path: str) -> bytes:
         try:


### PR DESCRIPTION
## Summary
- `ModalRuntime.read` now resolves its path against the runtime's `workdir` (via a private `_abs` helper, shared with `write`) before calling `Sandbox.filesystem.read_bytes`, which only accepts **absolute** remote paths. Previously `read` passed the path through verbatim.

## Bug
On the Modal runtime, a colocated tool server (e.g. the general-agent `tools` toolset) writes its log to a **relative** `vf_tool_<name>.log` (resolved to `<workdir>/…` by `run_background`'s shell cwd). When the server fails to come up, `log_tail(runtime, log)` → `runtime.read(log)` tried to surface that log, but `read` passed the relative path straight to Modal's filesystem API:

```
read 'vf_tool_tools.log': Sandbox.filesystem.read_bytes() currently only supports absolute remote_path values
```

`read` was the only runtime read that didn't resolve relative paths — subprocess/docker/prime all run their reads in the workdir, and Modal's own `write` already resolved them. This makes `read` consistent.

## Notes
- This bug masked the **real** failure (the tool server not coming up) behind a confusing path error. With `read` fixed, `log_tail` can read the log and the actual startup error surfaces.
- The `retrying runtime.read (retry 3/3)` warning some runs showed came from the now-removed `RetryingRuntime` (dropped in #1756); on current `feat/nano-as-v1` the runtime isn't retry-wrapped, and `log_tail` already swallows an unreadable log (`contextlib.suppress`), so no `log_tail` change is needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized path-resolution fix in Modal runtime I/O; no auth, data, or API contract changes.
> 
> **Overview**
> **Modal `read` now resolves relative paths** the same way `write` already did, using a shared `_abs` helper that prefixes paths with the runtime `workdir` before calling Modal's filesystem API (which only accepts absolute remote paths).
> 
> Previously, `read` passed paths through verbatim, so `log_tail` and similar callers using relative tool log names (e.g. `vf_tool_tools.log`) failed with a misleading Modal error instead of surfacing the real startup failure from the log file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c0cc1594e662eaec8911f3f1c8076d108315b95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `ModalRuntime.read` to resolve relative paths against workdir
> - Adds a `_abs` helper to [modal.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1761/files#diff-a6217d92f043d6050e8609d4341d62b5d097d5db796f6197cd604e09d81683c0) that resolves relative paths against the configured `workdir`, returning absolute paths unchanged.
> - `read` now passes paths through `_abs` before the filesystem operation, fixing a bug where relative paths were passed through unchanged.
> - `write` is refactored to use `_abs` instead of its own inline resolution logic.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7c0cc15.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->