### PR TITLE
test: mark swebench_verified_v1 as a container-only env

### DIFF
--- a/tests/v1/test_envs.py
+++ b/tests/v1/test_envs.py
@@ -21,7 +21,13 @@ ENVIRONMENTS = Path(__file__).parent.parent.parent / "environments"
 
 # v1 tasksets that need a docker/prime runtime + image-backed sandboxes, so they can't run a
 # smoke eval in plain CI — covered by the dedicated v1 e2e tests.
-NEEDS_CONTAINER = {"r2e_gym_v1", "scaleswe_v1", "swelego_v1", "terminal_bench_2_v1"}
+NEEDS_CONTAINER = {
+    "r2e_gym_v1",
+    "scaleswe_v1",
+    "swelego_v1",
+    "swebench_verified_v1",
+    "terminal_bench_2_v1",
+}
 
 
 def v1_tasksets() -> list[str]:


### PR DESCRIPTION
## Summary
- Add `swebench_verified_v1` to `NEEDS_CONTAINER` in `tests/v1/test_envs.py`.

`test_eval` smoke-evals each v1 taskset on the **subprocess** runtime and skips the ones in `NEEDS_CONTAINER` (image-backed sandboxes only). `swebench_verified_v1` is container-only like the other SWE tasksets (`r2e_gym_v1`, `scaleswe_v1`, `swelego_v1`) but was never added to the set when it was registered, so the test ran it on subprocess and failed — the framework correctly refuses a container task on subprocess.

## Verification
Before — `pytest tests/v1/test_envs.py -n auto -m "not slow"`:
```
ValueError: task 0 requires image 'swebench/sweb.eval.x86_64.astropy…:latest',
but the subprocess runtime has no container; use the docker or prime runtime
1 failed, 50 passed, 9 skipped
```
After:
```
SKIPPED tests/v1/test_envs.py: swebench_verified_v1 needs a docker/prime runtime (covered by v1 e2e tests)
```
The rest of the `-m "not slow"` v1 suite was already green (50 passed); this makes it fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Mark `swebench_verified_v1` as a container-only environment in tests
> Adds `swebench_verified_v1` to the `NEEDS_CONTAINER` set in [test_envs.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1762/files#diff-7c694d14edc9f77a0d330e4121024e79ba615b135a5e8f2da634bdd15a52b794), so test logic that checks this set will require a containerized runtime for this environment.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bf73151.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only skip list change; no production or runtime behavior is modified.
> 
> **Overview**
> Adds **`swebench_verified_v1`** to the `NEEDS_CONTAINER` set in `tests/v1/test_envs.py`, so the parametrized `test_eval` smoke run skips it on the subprocess runtime like the other image-backed SWE tasksets.
> 
> Without this, CI tried to eval that taskset without Docker and failed with a runtime error requiring a container image.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf73151031cc8de0030e789d2abbcd97fcc1abef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->