### PR TITLE
fix: feed malformed tool-call JSON back to the model instead of crashing the rollout

### DIFF
--- a/packages/harnesses/harnesses/bash/program.py
+++ b/packages/harnesses/harnesses/bash/program.py
@@ -159,8 +159,6 @@ async def main() -> None:
                 break
             for call in message.tool_calls:
                 name = call.function.name
-                # A model can emit malformed/truncated JSON args; feed the parse error back as
-                # the tool result so it can retry, instead of crashing the whole rollout.
                 try:
                     tool_args = json.loads(call.function.arguments or "{}")
                 except json.JSONDecodeError as e:

--- a/packages/harnesses/harnesses/bash/program.py
+++ b/packages/harnesses/harnesses/bash/program.py
@@ -159,7 +159,19 @@ async def main() -> None:
                 break
             for call in message.tool_calls:
                 name = call.function.name
-                tool_args = json.loads(call.function.arguments or "{}")
+                # A model can emit malformed/truncated JSON args; feed the parse error back as
+                # the tool result so it can retry, instead of crashing the whole rollout.
+                try:
+                    tool_args = json.loads(call.function.arguments or "{}")
+                except json.JSONDecodeError as e:
+                    messages.append(
+                        {
+                            "role": "tool",
+                            "tool_call_id": call.id,
+                            "content": f"error: invalid JSON in tool arguments ({e}); resend the call with valid JSON",
+                        }
+                    )
+                    continue
                 if name in dispatch:
                     content = await call_mcp(dispatch, name, tool_args)
                 elif name == "bash":

--- a/packages/harnesses/harnesses/default/program.py
+++ b/packages/harnesses/harnesses/default/program.py
@@ -131,8 +131,6 @@ async def main() -> None:
                 break
             for call in message.tool_calls:
                 name = call.function.name
-                # A model can emit malformed/truncated JSON args; feed the parse error back as
-                # the tool result so it can retry, instead of crashing the whole rollout.
                 try:
                     tool_args = json.loads(call.function.arguments or "{}")
                 except json.JSONDecodeError as e:

--- a/packages/harnesses/harnesses/default/program.py
+++ b/packages/harnesses/harnesses/default/program.py
@@ -131,7 +131,19 @@ async def main() -> None:
                 break
             for call in message.tool_calls:
                 name = call.function.name
-                tool_args = json.loads(call.function.arguments or "{}")
+                # A model can emit malformed/truncated JSON args; feed the parse error back as
+                # the tool result so it can retry, instead of crashing the whole rollout.
+                try:
+                    tool_args = json.loads(call.function.arguments or "{}")
+                except json.JSONDecodeError as e:
+                    messages.append(
+                        {
+                            "role": "tool",
+                            "tool_call_id": call.id,
+                            "content": f"error: invalid JSON in tool arguments ({e}); resend the call with valid JSON",
+                        }
+                    )
+                    continue
                 if name in dispatch:
                     content = await call_mcp(dispatch, name, tool_args)
                 else:


### PR DESCRIPTION
## Summary

- The `default` and `bash` harness chat loops parsed `call.function.arguments` with an unguarded `json.loads(...)`. When a model emits **malformed or truncated JSON** in a tool call, the parse raises `JSONDecodeError`, which crashes the harness program (exit 1) and loses the **entire rollout** as a `HarnessError`.
- Catch `JSONDecodeError` and return the parse error to the model as the tool result (tagged with the offending `tool_call_id`), then continue the loop — so the model can re-emit a valid call instead of the rollout dying.

## Verification

Observed running `qwen3.6-35b` on SWE tasks via the `bash` harness: ~25% of rollouts (4/16 on a scaleswe run) died with a `HarnessError` bottoming out at:

```
File ".../bash/program.py", line 162, in main
    tool_args = json.loads(call.function.arguments or "{}")
json.decoder.JSONDecodeError: Expecting ',' delimiter: line 1 column 184 (char 183)
```

The model produced tool calls with invalid JSON arguments — some genuinely malformed (short offsets), some truncated mid-arguments (e.g. char 1281). This is the same model behavior that elsewhere surfaces as an `upstream 400 invalid_request` when a harness forwards the bad call to the provider; here it crashed the client-side loop instead.

**After:** the malformed call becomes a recoverable tool-error turn (`error: invalid JSON in tool arguments (...)`) and the rollout continues. (Mechanism change; the recovery rate on a re-run isn't quantified in this PR.)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Feed malformed tool-call JSON back to the model instead of crashing the rollout
> Previously, invalid JSON in tool call arguments caused an unhandled exception in the bash and default harness entrypoints. Both [bash/program.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1763/files#diff-27ee2dc5088132d165c7d067499e2c5b18f662c4153fa19e56e8645704f8bd7e) and [default/program.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1763/files#diff-d76a0706629e763126a9527179f8a652aaae490a3efcaf8f8134a94ce9b82c80) now catch `json.JSONDecodeError`, append a `tool` role message with the error and `tool_call_id` to the conversation, and skip dispatching that tool call so the loop continues normally.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a2ba1fd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to error handling in harness chat loops; no auth, security, or data-path changes—only converts a crash into a recoverable tool error turn.
> 
> **Overview**
> **Malformed tool arguments no longer abort harness rollouts.** In both `bash/program.py` and `default/program.py`, parsing `call.function.arguments` with `json.loads` is wrapped in `try/except json.JSONDecodeError`.
> 
> On parse failure, the loop appends a **`tool`** message tied to the offending `tool_call_id` with text like `error: invalid JSON in tool arguments (...); resend the call with valid JSON`, then **`continue`**s without dispatching bash/MCP. The chat loop keeps running so the model can fix the call instead of the process exiting with a `HarnessError`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2ba1fd494daa3fab786c3a9e1024b824312640a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->