### PR TITLE
fix: pin swebench-verified-v1 task workdir to /testbed

### DIFF
--- a/environments/swebench_verified_v1/swebench_verified_v1/taskset.py
+++ b/environments/swebench_verified_v1/swebench_verified_v1/taskset.py
@@ -54,5 +54,9 @@ class SWEBenchVerifiedTaskset(
             image = (
                 f"{REGISTRY_PREFIX}/{base}" if self.config.use_prime_registry else base
             )
-            tasks.append(task.model_copy(update={"image": image}))
+            # SWE-bench instance images check out the repo at /testbed (the image's WORKDIR);
+            # without pinning it the runtime's default workdir drops the agent in an empty dir.
+            tasks.append(
+                task.model_copy(update={"image": image, "workdir": "/testbed"})
+            )
         return tasks


### PR DESCRIPTION
## Summary
- `swebench_verified_v1` set each task's `image` but not its `workdir`, so the agent started in the runtime's default workdir (e.g. an empty `/app`) instead of the repo. SWE-bench instance images check out the repo at **`/testbed`** (the image's `WORKDIR`), so pin `workdir="/testbed"` on each task (same shape scaleswe uses with its dataset `workdir`).

## Notes
Not e2e-verified here — it needs the prebuilt SWE-bench instance image (container runtime + registry pull creds); covered by the dedicated v1 e2e tests. The change is a one-field addition mirroring the existing scaleswe workdir handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin swebench-verified-v1 task working directory to `/testbed`
> Sets `workdir` to `"/testbed"` for each task loaded by `SWEBenchVerifiedTaskset.load_tasks` in [taskset.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1765/files#diff-9360d91568099a567b83aeb3813028f0763a9c9bd07769b85db79a455c47b0c4), matching the `WORKDIR` set in SWE-bench instance images. Previously, tasks relied on the runtime's default working directory.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1e90434.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-field task metadata in one taskset loader; fixes agent cwd with no auth, data, or broad behavioral changes.
> 
> **Overview**
> **SWE-bench Verified v1** already overrides each harbor task’s `image` to the SWE-bench instance image (or Prime registry mirror). This change also sets **`workdir="/testbed"`** in the same `model_copy` update in `SWEBenchVerifiedTaskset.load_tasks`.
> 
> Without that field, the sandbox uses its default working directory (often an empty path like `/app`), so the agent never lands in the repo that the instance image places at `/testbed`. The pin matches SWE-bench image `WORKDIR` and aligns with how other SWE-style tasksets (e.g. Scale-SWE’s per-row `workdir`) tell the runtime where the codebase lives.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e90434dccd4d8473e1e46a88f18518afec7fa72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->