### PR TITLE
feat: persistent runtime pool + warm in-runtime scoring

### DIFF
--- a/bench/persistent_runtime.py
+++ b/bench/persistent_runtime.py
@@ -1,0 +1,90 @@
+"""Benchmark the persistent runtime + warm scoring against the per-rollout default.
+
+Isolates the runtime/scoring overhead (no model generation, which would mask it): runs gsm8k's
+`verify.py` N times at a fixed concurrency, both ways, through the real framework API.
+
+  ephemeral:  make_runtime + start() + run_uv_script(cold) + stop() per call
+              — exactly today's per-rollout scoring path.
+  persistent: RuntimePool.acquire() + run_uv_script(warm=True) + release() per call
+              — runtimes (and their warm workers) reused; the math_verify import is paid once
+              per pooled runtime, not per call.
+
+Usage: uv run python bench/persistent_runtime.py [N=1000] [CONCURRENCY=128]
+"""
+
+import asyncio
+import sys
+import time
+from pathlib import Path
+
+from verifiers.v1.runtimes import RuntimePool, SubprocessConfig, make_runtime
+
+VERIFY = (
+    Path(__file__).resolve().parents[1] / "environments/gsm8k_v1/gsm8k_v1/verify.py"
+).read_bytes()
+GOLD, PRED = "42", "#### 42"
+
+
+async def ephemeral(n: int, concurrency: int) -> float:
+    sem = asyncio.Semaphore(concurrency)
+
+    async def one() -> None:
+        async with sem:
+            rt = make_runtime(SubprocessConfig())
+            await rt.start()
+            try:
+                r = await rt.run_uv_script(VERIFY, args=[GOLD, PRED])
+                assert r.stdout.strip().endswith("1.0"), r
+            finally:
+                await rt.stop()
+
+    t0 = time.time()
+    await asyncio.gather(*(one() for _ in range(n)))
+    return time.time() - t0
+
+
+async def persistent(n: int, concurrency: int) -> float:
+    sem = asyncio.Semaphore(concurrency)
+    cfg = SubprocessConfig(persistent=True)
+
+    async def one(pool: RuntimePool) -> None:
+        async with sem:
+            rt = await pool.acquire(cfg)
+            try:
+                r = await rt.run_uv_script(VERIFY, args=[GOLD, PRED], warm=True)
+                assert r.stdout.strip() == "1.0", r
+            finally:
+                await pool.release(rt)
+
+    async with RuntimePool() as pool:
+        t0 = time.time()
+        await asyncio.gather(*(one(pool) for _ in range(n)))
+        return time.time() - t0
+
+
+async def main(n: int, concurrency: int) -> None:
+    # warm the class-level interpreter cache once so neither mode pays uv-resolve
+    rt = make_runtime(SubprocessConfig())
+    await rt.start()
+    await rt.run_uv_script(VERIFY, args=[GOLD, PRED])
+    await rt.stop()
+
+    ephemeral_dt = await ephemeral(n, concurrency)
+    persistent_dt = await persistent(n, concurrency)
+
+    print(f"gsm8k verify scoring — n={n} concurrency={concurrency}")
+    print(
+        f"  ephemeral (runtime + import per call): {ephemeral_dt:7.2f}s  ({1000 * ephemeral_dt / n:6.2f} ms/call)"
+    )
+    print(
+        f"  persistent (pool + warm worker):       {persistent_dt:7.2f}s  ({1000 * persistent_dt / n:6.2f} ms/call)"
+    )
+    print(
+        f"  speedup:                               {ephemeral_dt / persistent_dt:6.1f}x"
+    )
+
+
+if __name__ == "__main__":
+    n = int(sys.argv[1]) if len(sys.argv) > 1 else 1000
+    concurrency = int(sys.argv[2]) if len(sys.argv) > 2 else 128
+    asyncio.run(main(n, concurrency))

--- a/environments/aime24_v1/aime24_v1/taskset.py
+++ b/environments/aime24_v1/aime24_v1/taskset.py
@@ -59,9 +59,12 @@ class AIME24Taskset(vf.Taskset[AIME24Task, AIME24Config]):
         prediction = (
             trace.assistant_messages[-1].content if trace.assistant_messages else ""
         )
+        # warm=True: on a persistent runtime, reuse a warm worker that imports math_verify once
+        # instead of execing a fresh interpreter per rollout (no-op on an ephemeral runtime).
         result = await runtime.run_uv_script(
             VERIFY,
             args=[task.answer, prediction or "", str(self.config.math_verify_timeout)],
+            warm=True,
         )
         if result.exit_code != 0:
             raise RuntimeError(f"verify.py failed: {result.stderr.strip()[-500:]}")

--- a/environments/aime24_v1/aime24_v1/verify.py
+++ b/environments/aime24_v1/aime24_v1/verify.py
@@ -1,23 +1,21 @@
 # /// script
 # dependencies = ["math-verify"]
 # ///
-"""Score one math answer by math-verify equivalence of the model's boxed answer vs the
-gold, run inside the rollout's runtime via `uv run`. uv installs `math-verify` into its
-own cache here — the dependency never touches the eval process. Takes the gold answer
-(argv[1]), the model's prediction (argv[2]), and a timeout in seconds (argv[3]); prints
-1.0 if they're equivalent, else 0.0.
+"""Score one math answer by math-verify equivalence of the model's boxed answer vs the gold,
+run inside the rollout's runtime via `uv run` (or a warm worker). uv installs `math-verify` into
+its own cache here — the dependency never touches the eval process. `main(argv)` takes the gold
+answer (argv[0]), the model's prediction (argv[1]), and a timeout in seconds (argv[2]); returns
+"1.0" if they're equivalent, else "0.0".
+
+Exposing `main(argv) -> str` (plus the `__main__` footer) lets the runtime keep this as a warm
+worker — `import math_verify` paid once, not per call (see `Runtime.run_uv_script(warm=True)`) —
+while staying `uv run verify.py <gold> <pred> <timeout>`-able cold. `main` must `return` (never
+`sys.exit`, which would kill a reused worker).
 """
 
 import sys
 
 from math_verify import parse, verify
-
-gold, pred, timeout = sys.argv[1], sys.argv[2], int(sys.argv[3])
-
-if "<think>" in pred and "</think>" not in pred:
-    print(0.0)
-    sys.exit(0)
-pred = pred.split("</think>")[-1]
 
 
 def extract_boxed(text: str) -> str:
@@ -32,20 +30,28 @@ def extract_boxed(text: str) -> str:
     return text[start + len("\\boxed{") : i - 1] if depth == 0 else ""
 
 
-answer = extract_boxed(pred)
-if not answer:
-    print(0.0)
-    sys.exit(0)
-try:
-    score = (
-        1.0
-        if verify(
-            parse("\\boxed{" + gold + "}", parsing_timeout=timeout),
-            parse("\\boxed{" + answer + "}", parsing_timeout=timeout),
-            timeout_seconds=timeout,
+def main(argv: list[str]) -> str:
+    gold, pred, timeout = argv[0], argv[1], int(argv[2])
+    if "<think>" in pred and "</think>" not in pred:
+        return "0.0"
+    pred = pred.split("</think>")[-1]
+    answer = extract_boxed(pred)
+    if not answer:
+        return "0.0"
+    try:
+        score = (
+            1.0
+            if verify(
+                parse("\\boxed{" + gold + "}", parsing_timeout=timeout),
+                parse("\\boxed{" + answer + "}", parsing_timeout=timeout),
+                timeout_seconds=timeout,
+            )
+            else 0.0
         )
-        else 0.0
-    )
-except Exception:
-    score = 0.0
-print(score)
+    except Exception:
+        score = 0.0
+    return str(score)
+
+
+if __name__ == "__main__":
+    print(main(sys.argv[1:]))

--- a/environments/gsm8k_v1/gsm8k_v1/taskset.py
+++ b/environments/gsm8k_v1/gsm8k_v1/taskset.py
@@ -50,8 +50,10 @@ class GSM8KTaskset(vf.Taskset[GSM8KTask, GSM8KConfig]):
         prediction = (
             trace.assistant_messages[-1].content if trace.assistant_messages else ""
         )
+        # warm=True: on a persistent runtime, reuse a warm worker that imports math_verify once
+        # instead of execing a fresh interpreter per rollout (no-op on an ephemeral runtime).
         result = await runtime.run_uv_script(
-            VERIFY, args=[task.answer, prediction or ""]
+            VERIFY, args=[task.answer, prediction or ""], warm=True
         )
         if result.exit_code != 0:
             raise RuntimeError(f"verify.py failed: {result.stderr.strip()[-500:]}")

--- a/environments/gsm8k_v1/gsm8k_v1/verify.py
+++ b/environments/gsm8k_v1/gsm8k_v1/verify.py
@@ -1,15 +1,18 @@
 # /// script
 # dependencies = ["math-verify"]
 # ///
-"""Score one GSM8K answer, run inside the rollout's runtime via `uv run`.
+"""Score one GSM8K answer, run inside the rollout's runtime via `uv run` (or a warm worker).
 
-uv installs `math-verify` into its own cache here — the dependency never touches
-the eval process. Takes the gold answer (`argv[1]`) and the model's prediction
-(`argv[2]`) and prints 1.0 if they match the same number, else 0.0.
+uv installs `math-verify` into its own cache here — the dependency never touches the eval
+process. `main(argv)` takes the gold answer (`argv[0]`) and the model's prediction (`argv[1]`)
+and returns "1.0" if they match the same number, else "0.0".
 
-The model is asked for its answer after '####'. Both the gold and the prediction
-are wrapped in \\boxed{} before math-verify (matching the math-env scorer) so
-parsing is robust; a malformed prediction fails to verify rather than crashing.
+Exposing `main(argv) -> str` (plus the `__main__` footer) lets the runtime keep this as a warm
+worker — `import math_verify` is paid once, not per call (see `Runtime.run_uv_script(warm=True)`)
+— while staying `uv run verify.py <gold> <pred>`-able cold. The model is asked for its answer
+after '####'. Both the gold and the prediction are wrapped in \\boxed{} before math-verify
+(matching the math-env scorer) so parsing is robust; a malformed prediction fails to verify
+rather than crashing.
 """
 
 import re
@@ -17,15 +20,23 @@ import sys
 
 from math_verify import parse, verify
 
-gold, pred = sys.argv[1], sys.argv[2]
-matches = re.findall(r"####\s*(.+)", pred)
-prediction = matches[-1].strip() if matches else pred
-try:
-    score = (
-        1.0
-        if verify(parse("\\boxed{" + gold + "}"), parse("\\boxed{" + prediction + "}"))
-        else 0.0
-    )
-except Exception:
-    score = 0.0
-print(score)
+
+def main(argv: list[str]) -> str:
+    gold, pred = argv[0], argv[1]
+    matches = re.findall(r"####\s*(.+)", pred)
+    prediction = matches[-1].strip() if matches else pred
+    try:
+        score = (
+            1.0
+            if verify(
+                parse("\\boxed{" + gold + "}"), parse("\\boxed{" + prediction + "}")
+            )
+            else 0.0
+        )
+    except Exception:
+        score = 0.0
+    return str(score)
+
+
+if __name__ == "__main__":
+    print(main(sys.argv[1:]))

--- a/environments/math_env_v1/math_env_v1/taskset.py
+++ b/environments/math_env_v1/math_env_v1/taskset.py
@@ -63,9 +63,12 @@ class MathTaskset(vf.Taskset[MathTask, MathConfig]):
         prediction = (
             trace.assistant_messages[-1].content if trace.assistant_messages else ""
         )
+        # warm=True: on a persistent runtime, reuse a warm worker that imports math_verify once
+        # instead of execing a fresh interpreter per rollout (no-op on an ephemeral runtime).
         result = await runtime.run_uv_script(
             VERIFY,
             args=[task.answer, prediction or "", str(self.config.math_verify_timeout)],
+            warm=True,
         )
         if result.exit_code != 0:
             raise RuntimeError(f"verify.py failed: {result.stderr.strip()[-500:]}")

--- a/environments/math_env_v1/math_env_v1/verify.py
+++ b/environments/math_env_v1/math_env_v1/verify.py
@@ -1,23 +1,21 @@
 # /// script
 # dependencies = ["math-verify"]
 # ///
-"""Score one math answer by math-verify equivalence of the model's boxed answer vs the
-gold, run inside the rollout's runtime via `uv run`. uv installs `math-verify` into its
-own cache here — the dependency never touches the eval process. Takes the gold answer
-(argv[1]), the model's prediction (argv[2]), and a timeout in seconds (argv[3]); prints
-1.0 if they're equivalent, else 0.0.
+"""Score one math answer by math-verify equivalence of the model's boxed answer vs the gold,
+run inside the rollout's runtime via `uv run` (or a warm worker). uv installs `math-verify` into
+its own cache here — the dependency never touches the eval process. `main(argv)` takes the gold
+answer (argv[0]), the model's prediction (argv[1]), and a timeout in seconds (argv[2]); returns
+"1.0" if they're equivalent, else "0.0".
+
+Exposing `main(argv) -> str` (plus the `__main__` footer) lets the runtime keep this as a warm
+worker — `import math_verify` paid once, not per call (see `Runtime.run_uv_script(warm=True)`) —
+while staying `uv run verify.py <gold> <pred> <timeout>`-able cold. `main` must `return` (never
+`sys.exit`, which would kill a reused worker).
 """
 
 import sys
 
 from math_verify import parse, verify
-
-gold, pred, timeout = sys.argv[1], sys.argv[2], int(sys.argv[3])
-
-if "<think>" in pred and "</think>" not in pred:
-    print(0.0)
-    sys.exit(0)
-pred = pred.split("</think>")[-1]
 
 
 def extract_boxed(text: str) -> str:
@@ -32,20 +30,28 @@ def extract_boxed(text: str) -> str:
     return text[start + len("\\boxed{") : i - 1] if depth == 0 else ""
 
 
-answer = extract_boxed(pred)
-if not answer:
-    print(0.0)
-    sys.exit(0)
-try:
-    score = (
-        1.0
-        if verify(
-            parse("\\boxed{" + gold + "}", parsing_timeout=timeout),
-            parse("\\boxed{" + answer + "}", parsing_timeout=timeout),
-            timeout_seconds=timeout,
+def main(argv: list[str]) -> str:
+    gold, pred, timeout = argv[0], argv[1], int(argv[2])
+    if "<think>" in pred and "</think>" not in pred:
+        return "0.0"
+    pred = pred.split("</think>")[-1]
+    answer = extract_boxed(pred)
+    if not answer:
+        return "0.0"
+    try:
+        score = (
+            1.0
+            if verify(
+                parse("\\boxed{" + gold + "}", parsing_timeout=timeout),
+                parse("\\boxed{" + answer + "}", parsing_timeout=timeout),
+                timeout_seconds=timeout,
+            )
+            else 0.0
         )
-        else 0.0
-    )
-except Exception:
-    score = 0.0
-print(score)
+    except Exception:
+        score = 0.0
+    return str(score)
+
+
+if __name__ == "__main__":
+    print(main(sys.argv[1:]))

--- a/verifiers/v1/GUIDE.md
+++ b/verifiers/v1/GUIDE.md
@@ -224,6 +224,25 @@ async def verified(self, task, trace, runtime) -> float:
     return float(r.stdout.strip() == "1.0")
 ```
 
+By default each `run_uv_script` execs a fresh interpreter, so a heavy import (`math-verify` pulls
+in sympy, ~0.2s) is paid every rollout. Pass `warm=True` to instead route to a long-lived worker
+that imports once and answers many calls — provided the script exposes `main(argv) -> str` (its
+result is the call's stdout) and stays `uv run`-able cold via a
+`if __name__ == "__main__": print(main(sys.argv[1:]))` footer:
+
+```python
+r = await runtime.run_uv_script(VERIFY, args=[...], warm=True)
+```
+
+The worker lives as long as the runtime, so warm only pays off on a **persistent** runtime
+(`--harness.runtime.persistent true`): runtimes are then taken from an eval/train-level pool and
+reused across rollouts (workspace `reset` between uses, torn down only at the end), so the import
+is paid once per pooled runtime instead of per rollout — ~12x faster gsm8k scoring at 1000
+rollouts / 128 concurrency, more as the run gets longer (`bench/persistent_runtime.py`). On an
+ephemeral runtime `warm=True` is a no-op (runs cold). Currently warm-capable on the subprocess
+runtime; persistence itself works on every runtime (and on remote runtimes also skips the
+per-rollout sandbox+tunnel provisioning).
+
 ## Stop conditions
 
 A rollout ends when the harness finishes, a framework budget trips (`--max-turns`, token caps), or
@@ -265,7 +284,7 @@ isolated environment. On a `runtime` you can call:
 | method | what |
 | --- | --- |
 | `run(argv, env)` | exec a command to completion → `ProgramResult(exit_code, stdout, stderr)` |
-| `run_uv_script(src, args, env)` | run a PEP 723 script (inline deps resolve in-runtime); `args` are shell-`"$@"`-safe |
+| `run_uv_script(src, args, env, warm=False)` | run a PEP 723 script (inline deps resolve in-runtime); `args` are shell-`"$@"`-safe. `warm=True` reuses a long-lived worker (import once) on a persistent runtime — see [In-runtime scoring](#in-runtime-scoring) |
 | `run_background(argv, env, log)` | start a long-lived process (e.g. a colocated server) |
 | `read(path)` / `write(path, data)` | workspace files (bytes), across the container/sandbox boundary |
 | `expose(port)` | publish a port *inside* the runtime to a host-reachable URL (`None` when local) |

--- a/verifiers/v1/env.py
+++ b/verifiers/v1/env.py
@@ -28,6 +28,7 @@ from verifiers.v1.retries import RetryConfig
 from verifiers.v1.rollout import Rollout
 from verifiers.v1.runtimes import (
     RuntimeConfig,
+    RuntimePool,
     SubprocessConfig,
     runtime_is_local,
 )
@@ -274,9 +275,11 @@ class Environment:
         self._warned_resources: set[tuple[str, str]] = set()
         self._shared_urls: dict[str, str] = {}
         self._interception: InterceptionPool | None = None
+        self._runtime_pool: RuntimePool | None = None
         """Eval-level serving resources, live only inside `serving()`: shared tool servers
-        ({name: url}) and the interception pool. `episode()` injects them into every rollout
-        so neither runner has to thread them through `Episode.run`/`Rollout.run`."""
+        ({name: url}), the interception pool, and (when the harness runtime is `persistent`) the
+        runtime pool. `episode()` injects them into every rollout so neither runner has to thread
+        them through `Episode.run`/`Rollout.run`."""
 
     def runtime_for(self, task: Task) -> RuntimeConfig:
         """Resolve the runtime config for a task off the harness's runtime (see
@@ -332,6 +335,7 @@ class Environment:
                 limits=self.limits,
                 shared_urls=self._shared_urls,
                 interception=self._interception,
+                runtime_pool=self._runtime_pool,
             )
             for _ in range(n)
         ]
@@ -340,21 +344,36 @@ class Environment:
     @contextlib.asynccontextmanager
     async def serving(self, tasks: list[Task]):
         """Hold the env-level serving resources for the duration of an eval: the shared tool
-        servers (built once, see `shared_tools`) and the interception pool. Stash them so
-        every `episode()` built inside this context injects them into its rollouts — that's
-        what keeps both eval runners (in-process and env-server) on one serving path. Build
-        episodes inside this context; the resources are torn down on exit."""
+        servers (built once, see `shared_tools`), the interception pool, and — when the harness
+        runtime is `persistent` — the runtime pool (reused across rollouts, torn down here at
+        eval/train end). Stash them so every `episode()` built inside this context injects them
+        into its rollouts — that's what keeps both eval runners (in-process and env-server) on one
+        serving path. Build episodes inside this context; the resources are torn down on exit."""
         async with (
             self.shared_tools(tasks) as shared_urls,
             self.interception_pool() as interception,
+            self.runtime_pool() as runtime_pool,
         ):
             self._shared_urls = shared_urls
             self._interception = interception
+            self._runtime_pool = runtime_pool
             try:
                 yield
             finally:
                 self._shared_urls = {}
                 self._interception = None
+                self._runtime_pool = None
+
+    @contextlib.asynccontextmanager
+    async def runtime_pool(self):
+        """Yield the persistent runtime pool when the harness runtime opts into `persistent`,
+        else `None` (rollouts provision their own ephemeral runtime). Held for the whole serving
+        context, so a persistent runtime is reused across rollouts and torn down only here."""
+        if not self.harness.config.runtime.persistent:
+            yield None
+            return
+        async with RuntimePool() as pool:
+            yield pool
 
     def interception_pool(self) -> InterceptionPool:
         """The shared interception pool for this env's rollouts — one server (+ tunnel

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -32,6 +32,7 @@ from verifiers.v1.runtimes import (
     HOST,
     Runtime,
     RuntimeConfig,
+    RuntimePool,
     make_runtime,
     reachable_url,
 )
@@ -70,6 +71,7 @@ class Rollout:
         limits: RolloutLimits | None = None,
         shared_urls: dict[str, str] | None = None,
         interception: InterceptionPool | None = None,
+        runtime_pool: RuntimePool | None = None,
     ) -> None:
         self.task = task
         self.taskset = taskset
@@ -87,6 +89,10 @@ class Rollout:
         `Environment.serving` context — so a rollout always has them and no runner has to thread
         them in."""
         self.interception = interception
+        self.runtime_pool = runtime_pool
+        """Eval-level pool of persistent runtimes (injected by `Environment.episode` when the
+        harness runtime is `persistent`); when set, the rollout acquires/releases a reused
+        runtime instead of provisioning + tearing down its own. None = ephemeral per rollout."""
         self.phase = Phase.SETUP
         """Lifecycle phase for display (see `Phase`); advanced through the rollout, and
         set to DONE by the Episode once group scoring has run."""
@@ -134,22 +140,31 @@ class Rollout:
         trace: Trace = Trace(task=self.task, state=state_cls(type(self.taskset))())
         self.trace = trace  # expose for the --rich dashboard
         trace.timing.setup.start = time.time()
-        self.runtime = make_runtime(
-            self.runtime_config, name=trace.id
-        )  # ref set first → always tearable-down; named after the rollout for traceability
-        runtime = self.runtime
+        pool = self.runtime_pool
+        runtime: Runtime | None = None
+        if pool is None:
+            # ref set first → always tearable-down; named after the rollout for traceability.
+            # A pooled runtime is acquired below (in the try, so a provisioning failure is
+            # captured on the trace like a non-pooled `start()` failure).
+            runtime = make_runtime(self.runtime_config, name=trace.id)
+            self.runtime = runtime
         ctx = self.ctx
         stops = discover_decorated(self.taskset, "stop")
         logger.info(
-            "rollout start: id=%s task=%s harness=%s runtime=%s",
+            "rollout start: id=%s task=%s harness=%s runtime=%s%s",
             trace.id,
             self.task.idx,
             self.harness.config.name,
             self.runtime_config.type,
+            " (pooled)" if pool is not None else "",
         )
         try:
             session = RolloutSession(ctx, trace, stops, self.limits)
-            await runtime.start()
+            if pool is not None:
+                runtime = await pool.acquire(self.runtime_config)
+                self.runtime = runtime
+            else:
+                await runtime.start()
             async with boundary(TasksetError, "taskset setup"):
                 await asyncio.wait_for(
                     self.taskset.setup(self.task, runtime), self.setup_timeout
@@ -260,14 +275,19 @@ class Rollout:
                 trace.timing.generation.end = now  # error mid-run: close generation
             if trace.timing.finalize.start and not trace.timing.finalize.end:
                 trace.timing.finalize.end = now  # error mid-finalize: close finalize
-            # Tear down here — group rewards (later) need only the trace, not a live
-            # runtime. `runtime` is always set: make_runtime() ran before the `try`.
-            try:
-                await runtime.stop()
-            except Exception:
-                logger.warning(
-                    "runtime teardown failed (rollout %s)", trace.id, exc_info=True
-                )
+            # Release/tear down here — group rewards (later) need only the trace, not a live
+            # runtime. A pooled runtime goes back to the pool (reused, torn down at eval/train
+            # end); an ephemeral one is stopped. `runtime` is None only if pool.acquire() failed.
+            if runtime is not None:
+                try:
+                    if pool is not None:
+                        await pool.release(runtime)
+                    else:
+                        await runtime.stop()
+                except Exception:
+                    logger.warning(
+                        "runtime teardown failed (rollout %s)", trace.id, exc_info=True
+                    )
         logger.info(
             "rollout done: id=%s task=%s reward=%.3f turns=%d stop=%s",
             trace.id,

--- a/verifiers/v1/runtimes/__init__.py
+++ b/verifiers/v1/runtimes/__init__.py
@@ -4,15 +4,13 @@ Each runtime decides WHERE the program runs and HOW it reaches the host
 interception server: subprocess (local), docker (local container), or prime /
 modal (remote sandbox). They share the `Runtime` contract, so the Environment is
 runtime-agnostic. `RuntimeConfig` is the discriminated config union and
-`make_runtime` builds the runtime matching a config.
+`make_runtime` builds the runtime matching a config; `RuntimePool` reuses
+`persistent` runtimes across rollouts.
 """
-
-from typing import Annotated
-
-from pydantic import Field
 
 from verifiers.v1.runtimes.base import (
     HOST,
+    BaseRuntimeConfig,
     ProgramResult,
     Runtime,
     host_endpoint,
@@ -20,48 +18,27 @@ from verifiers.v1.runtimes.base import (
     register,
 )
 from verifiers.v1.runtimes.docker import DockerConfig, DockerRuntime
+from verifiers.v1.runtimes.factory import (
+    RuntimeConfig,
+    make_runtime,
+    runtime_is_local,
+)
 from verifiers.v1.runtimes.modal import ModalConfig, ModalRuntime
+from verifiers.v1.runtimes.pool import RuntimePool
 from verifiers.v1.runtimes.prime import PrimeConfig, PrimeRuntime
 from verifiers.v1.runtimes.subprocess import SubprocessConfig, SubprocessRuntime
-
-RuntimeConfig = Annotated[
-    SubprocessConfig | DockerConfig | PrimeConfig | ModalConfig,
-    Field(discriminator="type"),
-]
-
-
-def _runtime_cls(config: RuntimeConfig) -> type[Runtime]:
-    if isinstance(config, PrimeConfig):
-        return PrimeRuntime
-    if isinstance(config, ModalConfig):
-        return ModalRuntime
-    if isinstance(config, DockerConfig):
-        return DockerRuntime
-    return SubprocessRuntime
-
-
-def make_runtime(config: RuntimeConfig, name: str | None = None) -> Runtime:
-    runtime = _runtime_cls(config)(config, name)
-    register(runtime)
-    return runtime
-
-
-def runtime_is_local(config: RuntimeConfig) -> bool:
-    """Whether a runtime of this config shares the host network (so a program inside it reaches a
-    host service at localhost, no tunnel) — read off the runtime class, without provisioning one.
-    The interception pool / rollout use it to decide whether to tunnel their host port via
-    `host_endpoint`."""
-    return _runtime_cls(config).is_local
-
 
 __all__ = [
     "ProgramResult",
     "Runtime",
+    "BaseRuntimeConfig",
     "RuntimeConfig",
+    "RuntimePool",
     "make_runtime",
     "runtime_is_local",
     "host_endpoint",
     "reachable_url",
+    "register",
     "HOST",
     "SubprocessConfig",
     "SubprocessRuntime",

--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -18,9 +18,25 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import ClassVar, TypeVar
 
+from pydantic_config import BaseConfig
+
 from verifiers.v1.retries import retrying
 
 logger = logging.getLogger(__name__)
+
+
+class BaseRuntimeConfig(BaseConfig):
+    """Fields shared by every runtime config. Concrete configs (subprocess / docker / prime /
+    modal) subclass this and pin their `type`."""
+
+    persistent: bool = False
+    """Reuse this runtime across rollouts instead of provisioning a fresh one each time. A
+    persistent runtime is taken from an eval-level pool, has its per-rollout workspace `reset`
+    between uses, and is torn down only at the end of the eval / training run — so expensive
+    provisioning (container / sandbox create) and warm in-runtime workers (see
+    `run_uv_script(..., warm=True)`) are paid once, not per rollout. Suits tasksets whose
+    per-rollout state is workspace-local (e.g. gsm8k / math)."""
+
 
 # Ensure `uv` is available to run our PEP 723 scripts (the harness + tool servers): use it
 # if present, else bootstrap it — via pip; else via the standalone installer (curl/wget),
@@ -143,6 +159,12 @@ class Runtime(ABC):
         source of truth for teardown: usable from the atexit backstop where async machinery
         is dead, and run off the event loop by `stop` on the normal path. Default no-op."""
 
+    async def reset(self) -> None:
+        """Clear per-rollout state so a persistent runtime can be reused by the next rollout
+        without cross-contamination — clears the per-rollout workspace, while the provisioned
+        resource (container / sandbox) and any warm workers survive. Called by the runtime pool
+        on acquire; default no-op (an ephemeral runtime is never reset)."""
+
     # --- execution ---
 
     @abstractmethod
@@ -173,9 +195,19 @@ class Runtime(ABC):
         script: str | bytes,
         args: list[str] | None = None,
         env: dict[str, str] | None = None,
+        warm: bool = False,
     ) -> ProgramResult:
         """Run a self-contained uv script (PEP 723 inline deps) in this runtime, with
         `args` as its positional arguments (the script's `sys.argv[1:]`).
+
+        `warm=True` asks the runtime to keep a long-lived worker for this script — importing
+        its (heavy) deps once and answering many `args -> stdout` calls — instead of execing a
+        fresh interpreter per call. A warm-able script must expose `main(argv) -> str` (the
+        worker calls it; the result is the call's stdout) while staying `uv run`-able cold via a
+        `if __name__ == "__main__": print(main(sys.argv[1:]))` footer. Honored only when the
+        runtime can warm AND is `persistent` (else the worker would die with the rollout that
+        spawned it); otherwise this transparently runs cold. The base runtime has no warm
+        backing, so it always runs cold.
 
         Writes `script`, ensures `uv` is present, and runs `uv run` — so the script's
         dependencies resolve into uv's cache inside the runtime, never the eval process.

--- a/verifiers/v1/runtimes/docker.py
+++ b/verifiers/v1/runtimes/docker.py
@@ -12,15 +12,18 @@ import subprocess
 from pathlib import PurePosixPath
 from typing import Literal
 
-from pydantic_config import BaseConfig
-
 from verifiers.v1.errors import SandboxError
-from verifiers.v1.runtimes.base import ProgramResult, Runtime, parse_gpu
+from verifiers.v1.runtimes.base import (
+    BaseRuntimeConfig,
+    ProgramResult,
+    Runtime,
+    parse_gpu,
+)
 
 logger = logging.getLogger(__name__)
 
 
-class DockerConfig(BaseConfig):
+class DockerConfig(BaseRuntimeConfig):
     type: Literal["docker"] = "docker"
     image: str = "python:3.11-slim"
     workdir: str = "/app"
@@ -185,6 +188,14 @@ class DockerRuntime(Runtime):
             raise SandboxError(
                 f"write {path!r}: {stderr.decode(errors='replace').strip()}"
             )
+
+    async def reset(self) -> None:
+        """Empty the workdir so a persistent container can be reused by the next rollout (the
+        container itself survives). Best-effort: a clear failure shouldn't fail the rollout."""
+        wd = shlex.quote(self.config.workdir)
+        await self.run(
+            ["sh", "-c", f"find {wd} -mindepth 1 -delete 2>/dev/null || true"], {}
+        )
 
     def cleanup(self) -> None:
         if self._container is None or self._stopped:

--- a/verifiers/v1/runtimes/factory.py
+++ b/verifiers/v1/runtimes/factory.py
@@ -1,0 +1,44 @@
+"""The runtime config union and the factory that builds a runtime from a config.
+
+Split out from the package `__init__` so submodules (e.g. the runtime pool) can build runtimes
+without importing the package itself (a cycle). `__init__` re-exports these.
+"""
+
+from typing import Annotated
+
+from pydantic import Field
+
+from verifiers.v1.runtimes.base import Runtime, register
+from verifiers.v1.runtimes.docker import DockerConfig, DockerRuntime
+from verifiers.v1.runtimes.modal import ModalConfig, ModalRuntime
+from verifiers.v1.runtimes.prime import PrimeConfig, PrimeRuntime
+from verifiers.v1.runtimes.subprocess import SubprocessConfig, SubprocessRuntime
+
+RuntimeConfig = Annotated[
+    SubprocessConfig | DockerConfig | PrimeConfig | ModalConfig,
+    Field(discriminator="type"),
+]
+
+
+def _runtime_cls(config: RuntimeConfig) -> type[Runtime]:
+    if isinstance(config, PrimeConfig):
+        return PrimeRuntime
+    if isinstance(config, ModalConfig):
+        return ModalRuntime
+    if isinstance(config, DockerConfig):
+        return DockerRuntime
+    return SubprocessRuntime
+
+
+def make_runtime(config: RuntimeConfig, name: str | None = None) -> Runtime:
+    runtime = _runtime_cls(config)(config, name)
+    register(runtime)
+    return runtime
+
+
+def runtime_is_local(config: RuntimeConfig) -> bool:
+    """Whether a runtime of this config shares the host network (so a program inside it reaches a
+    host service at localhost, no tunnel) — read off the runtime class, without provisioning one.
+    The interception pool / rollout use it to decide whether to tunnel their host port via
+    `host_endpoint`."""
+    return _runtime_cls(config).is_local

--- a/verifiers/v1/runtimes/modal.py
+++ b/verifiers/v1/runtimes/modal.py
@@ -14,10 +14,13 @@ import shlex
 from pathlib import PurePosixPath
 from typing import ClassVar, Literal
 
-from pydantic_config import BaseConfig
-
 from verifiers.v1.errors import SandboxError
-from verifiers.v1.runtimes.base import SERVICE_PORT, ProgramResult, Runtime
+from verifiers.v1.runtimes.base import (
+    SERVICE_PORT,
+    BaseRuntimeConfig,
+    ProgramResult,
+    Runtime,
+)
 from verifiers.v1.runtimes.limiters import creation_limiter
 
 logger = logging.getLogger(__name__)
@@ -30,7 +33,7 @@ _MAX_TIMEOUT_SECONDS = 24 * 60 * 60
 _APP_NAME = "verifiers-v1"
 
 
-class ModalConfig(BaseConfig):
+class ModalConfig(BaseRuntimeConfig):
     type: Literal["modal"] = "modal"
     image: str = "python:3.11-slim"
     workdir: str = "/app"
@@ -187,6 +190,14 @@ class ModalRuntime(Runtime):
             await self._sandbox.filesystem.write_bytes.aio(data, target)
         except Exception as e:
             raise SandboxError(f"write {path!r}: {e}") from e
+
+    async def reset(self) -> None:
+        """Empty the workdir so a persistent sandbox can be reused by the next rollout (the
+        sandbox itself survives). Best-effort: a clear failure shouldn't fail the rollout."""
+        wd = shlex.quote(self.config.workdir)
+        await self.run(
+            ["sh", "-c", f"find {wd} -mindepth 1 -delete 2>/dev/null || true"], {}
+        )
 
     def cleanup(self) -> None:
         # Synchronous atexit backstop (the async API can't run once the loop is gone): terminate

--- a/verifiers/v1/runtimes/pool.py
+++ b/verifiers/v1/runtimes/pool.py
@@ -1,0 +1,76 @@
+"""An eval-level pool of persistent runtimes.
+
+When a runtime is `persistent`, the rollout takes one from this pool instead of provisioning
+its own: an idle runtime of the same config is reused, its per-rollout workspace `reset`, and
+returned to the pool on release — torn down only when the pool closes (the end of the eval /
+training run). So expensive provisioning (container / sandbox create) and warm in-runtime
+workers are paid once across many rollouts, not once per rollout.
+
+Runtimes are pooled per resolved config (`RuntimeConfig.model_dump_json()`), so a taskset with
+per-task images keeps a separate warm pool per image; the common case (one config for every
+rollout, e.g. gsm8k subprocess) is a single pool.
+"""
+
+import asyncio
+import logging
+
+from verifiers.v1.runtimes.base import Runtime
+from verifiers.v1.runtimes.factory import RuntimeConfig, make_runtime
+
+logger = logging.getLogger(__name__)
+
+
+class RuntimePool:
+    def __init__(self) -> None:
+        self._idle: dict[str, list[Runtime]] = {}
+        self._all: list[Runtime] = []
+        self._lock = asyncio.Lock()
+        self._created = 0
+
+    @staticmethod
+    def _key(config: RuntimeConfig) -> str:
+        return config.model_dump_json()
+
+    async def acquire(self, config: RuntimeConfig) -> Runtime:
+        """Return a started runtime for `config` — an idle one if available, else a freshly
+        provisioned one — with its per-rollout workspace reset, ready for a new rollout."""
+        key = self._key(config)
+        async with self._lock:
+            idle = self._idle.get(key)
+            runtime = idle.pop() if idle else None
+        if runtime is None:
+            async with self._lock:
+                self._created += 1
+                name = f"vf-pool-{self._created}"
+            runtime = make_runtime(config, name=name)
+            async with self._lock:
+                self._all.append(
+                    runtime
+                )  # tracked before start, so aclose frees a failed start
+            await runtime.start()
+        await runtime.reset()
+        return runtime
+
+    async def release(self, runtime: Runtime) -> None:
+        """Return a runtime to the idle set for reuse (it stays alive — no teardown)."""
+        key = self._key(runtime.config)
+        async with self._lock:
+            self._idle.setdefault(key, []).append(runtime)
+
+    async def aclose(self) -> None:
+        """Tear down every pooled runtime — the end of the eval / training run."""
+        async with self._lock:
+            runtimes = list(self._all)
+            self._all.clear()
+            self._idle.clear()
+        if runtimes:
+            logger.info(
+                "runtime pool: tearing down %d persistent runtime(s)", len(runtimes)
+            )
+        await asyncio.gather(*(rt.stop() for rt in runtimes), return_exceptions=True)
+
+    async def __aenter__(self) -> "RuntimePool":
+        return self
+
+    async def __aexit__(self, *exc) -> None:
+        await self.aclose()

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -13,10 +13,14 @@ import shlex
 from pathlib import PurePosixPath
 from typing import ClassVar, Literal
 
-from pydantic_config import BaseConfig
-
 from verifiers.v1.errors import SandboxError
-from verifiers.v1.runtimes.base import SERVICE_PORT, ProgramResult, Runtime, parse_gpu
+from verifiers.v1.runtimes.base import (
+    SERVICE_PORT,
+    BaseRuntimeConfig,
+    ProgramResult,
+    Runtime,
+    parse_gpu,
+)
 from verifiers.v1.runtimes.limiters import creation_limiter
 
 logger = logging.getLogger(__name__)
@@ -26,7 +30,7 @@ logger = logging.getLogger(__name__)
 _MAX_TIMEOUT_SECONDS = 24 * 60 * 60
 
 
-class PrimeConfig(BaseConfig):
+class PrimeConfig(BaseRuntimeConfig):
     type: Literal["prime"] = "prime"
     image: str = "python:3.11-slim"
     workdir: str = "/app"
@@ -210,6 +214,14 @@ class PrimeRuntime(Runtime):
             )
         except Exception as e:
             raise SandboxError(f"write {path!r}: {e}") from e
+
+    async def reset(self) -> None:
+        """Empty the workdir so a persistent sandbox can be reused by the next rollout (the
+        sandbox itself survives). Best-effort: a clear failure shouldn't fail the rollout."""
+        wd = shlex.quote(self.config.workdir)
+        await self.run(
+            ["sh", "-c", f"find {wd} -mindepth 1 -delete 2>/dev/null || true"], {}
+        )
 
     def cleanup(self) -> None:
         # Synchronous atexit backstop (the async client can't run once the loop is gone): delete

--- a/verifiers/v1/runtimes/subprocess.py
+++ b/verifiers/v1/runtimes/subprocess.py
@@ -8,16 +8,21 @@ and trivially cleaned up. Relative `read`/`write` paths resolve against it.
 import asyncio
 import contextlib
 import hashlib
+import json
 import os
 import shlex
 import shutil
 import signal
+import tempfile
 from pathlib import Path
 from typing import Literal
 
-from pydantic_config import BaseConfig
-
-from verifiers.v1.runtimes.base import _ENSURE_UV, ProgramResult, Runtime
+from verifiers.v1.runtimes.base import (
+    _ENSURE_UV,
+    BaseRuntimeConfig,
+    ProgramResult,
+    Runtime,
+)
 
 # A local subprocess inherits the host environment EXCEPT any var whose name
 # contains "API_KEY" — so it can never reach a real provider with the host's API
@@ -31,8 +36,55 @@ from verifiers.v1.runtimes.base import _ENSURE_UV, ProgramResult, Runtime
 # own runtime (docker/prime) or have it fetch the key itself.
 
 
-class SubprocessConfig(BaseConfig):
+class SubprocessConfig(BaseRuntimeConfig):
     type: Literal["subprocess"] = "subprocess"
+
+
+# Wrapper that turns a `main(argv)`-exposing uv script into a long-lived warm worker: it loads
+# the script as a module ONCE (its top-level deps — e.g. math_verify — imported here, once), then
+# answers one request per stdin line (JSON args list) with one JSON line (`main`'s return value).
+_WARM_WORKER = """\
+import importlib.util, json, sys
+spec = importlib.util.spec_from_file_location("warm_user_script", sys.argv[1])
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+sys.stdout.write("READY\\n"); sys.stdout.flush()
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    try:
+        out = mod.main(json.loads(line))
+    except Exception as e:
+        out = "__ERR__ " + repr(e)
+    sys.stdout.write(json.dumps(out) + "\\n"); sys.stdout.flush()
+"""
+
+
+class _WarmWorker:
+    """A long-lived `_WARM_WORKER` process for one script. Its stdio is a serial request channel,
+    so `call` is guarded by a lock (one in-flight request at a time)."""
+
+    def __init__(self, proc: asyncio.subprocess.Process, log: Path) -> None:
+        self.proc = proc
+        self.log = log
+        self.lock = asyncio.Lock()
+
+    async def call(self, args: list[str]) -> ProgramResult:
+        async with self.lock:
+            assert self.proc.stdin is not None and self.proc.stdout is not None
+            self.proc.stdin.write((json.dumps(args) + "\n").encode())
+            await self.proc.stdin.drain()
+            line = await self.proc.stdout.readline()
+            if not line:  # worker died mid-request
+                detail = self.log.read_text(errors="replace").strip()[-500:]
+                raise RuntimeError(f"warm worker died: {detail or '<no output>'}")
+            out = json.loads(line.decode())
+            if isinstance(out, str) and out.startswith("__ERR__"):
+                return ProgramResult(
+                    exit_code=1, stdout="", stderr=out[len("__ERR__ ") :]
+                )
+            return ProgramResult(exit_code=0, stdout=str(out), stderr="")
 
 
 class SubprocessRuntime(Runtime):
@@ -48,6 +100,11 @@ class SubprocessRuntime(Runtime):
         self.config = config
         self.workdir: Path | None = None
         self._background: list[asyncio.subprocess.Process] = []
+        # script-sha -> warm worker (one per distinct script); persists across this runtime's
+        # rollouts, so a persistent runtime imports each warm script's deps once. Separate from
+        # `_background`/the workspace: untouched by `reset`, reaped in `cleanup`.
+        self._warm: dict[str, _WarmWorker] = {}
+        self._warm_locks: dict[str, asyncio.Lock] = {}
 
     @property
     def descriptor(self) -> str | None:
@@ -85,20 +142,12 @@ class SubprocessRuntime(Runtime):
             stderr=stderr.decode(errors="replace"),
         )
 
-    async def run_uv_script(
-        self,
-        script: str | bytes,
-        args: list[str] | None = None,
-        env: dict[str, str] | None = None,
-    ) -> ProgramResult:
-        """Run a PEP 723 script via a pre-provisioned interpreter instead of `uv run` per call.
-
-        uv keeps a persistent env per script under its cache; we resolve that env's interpreter
-        ONCE and exec it directly, keeping uv's per-invocation resolve, cache-lock, ephemeral-env
-        materialization and `command -v uv` probe out of the per-rollout hot path (the subprocess
-        runtime launches two uv-scripts per rollout — the harness program and, for math, verify).
-        docker/prime keep the base `uv run` — their deps live in the sandbox, not on the host."""
-        data = script.encode() if isinstance(script, str) else script
+    async def _resolve_interpreter(self, data: bytes) -> tuple[str, Path]:
+        """Resolve (and cache) the uv env interpreter for a script's deps, returning
+        `(interpreter, script_path)`. uv keeps a persistent env per script under its cache; we
+        resolve that env's interpreter ONCE (per sha, shared across this worker's runtimes) and
+        exec it directly, keeping uv's per-invocation resolve, cache-lock, ephemeral-env
+        materialization and `command -v uv` probe out of the per-rollout hot path."""
         sha = hashlib.sha256(data).hexdigest()
         path = Path("/tmp/vf-scripts") / f"{sha}.py"
         if sha not in self._interpreters:
@@ -116,9 +165,68 @@ class SubprocessRuntime(Runtime):
                             f"failed to provision env for {path}: {provision.stderr}"
                         )
                     self._interpreters[sha] = provision.stdout.strip().splitlines()[-1]
-        return await self.run(
-            [self._interpreters[sha], str(path), *(args or [])], env or {}
-        )
+        return self._interpreters[sha], path
+
+    async def run_uv_script(
+        self,
+        script: str | bytes,
+        args: list[str] | None = None,
+        env: dict[str, str] | None = None,
+        warm: bool = False,
+    ) -> ProgramResult:
+        """Run a PEP 723 script via a pre-provisioned interpreter instead of `uv run` per call
+        (the subprocess runtime launches two uv-scripts per rollout — the harness program and,
+        for math, verify). docker/prime keep the base `uv run` — their deps live in the sandbox.
+
+        `warm=True` on a `persistent` runtime routes to a long-lived worker that imports the
+        script's deps once (see `_run_warm`); otherwise the script is exec'd fresh each call (the
+        warm worker would die with the rollout that spawned it, so it only pays off when reused)."""
+        data = script.encode() if isinstance(script, str) else script
+        interpreter, path = await self._resolve_interpreter(data)
+        if warm and self.config.persistent:
+            return await self._run_warm(data, interpreter, path, args or [])
+        return await self.run([interpreter, str(path), *(args or [])], env or {})
+
+    async def _run_warm(
+        self, data: bytes, interpreter: str, path: Path, args: list[str]
+    ) -> ProgramResult:
+        """Route a call to this runtime's warm worker for `path`, spawning it on first use. The
+        worker outlives the rollout (reaped in `cleanup`), so a persistent runtime imports the
+        script's deps once across all its rollouts."""
+        sha = hashlib.sha256(data).hexdigest()
+        worker = self._warm.get(sha)
+        if worker is None:
+            async with self._warm_locks.setdefault(sha, asyncio.Lock()):
+                worker = self._warm.get(sha)
+                if worker is None:
+                    worker = await self._spawn_warm(interpreter, path, sha)
+                    self._warm[sha] = worker
+        return await worker.call(args)
+
+    async def _spawn_warm(self, interpreter: str, path: Path, sha: str) -> _WarmWorker:
+        wrapper = Path("/tmp/vf-scripts") / "_warm_worker.py"
+        if not wrapper.exists():
+            wrapper.write_text(_WARM_WORKER)
+        log = Path("/tmp/vf-scripts") / f"{sha}.warm.log"
+        # cwd is /tmp (not the resettable per-rollout workspace), so `reset` never pulls it out
+        # from under a running worker; stderr -> a log so a crash is diagnosable on death.
+        with log.open("wb") as f:
+            proc = await asyncio.create_subprocess_exec(
+                interpreter, str(wrapper), str(path),
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=f,
+                cwd=tempfile.gettempdir(),
+                start_new_session=True,  # own group, so cleanup reaps the whole tree
+            )  # fmt: skip
+        assert proc.stdout is not None
+        ready = await proc.stdout.readline()
+        if ready.strip() != b"READY":
+            detail = log.read_text(errors="replace").strip()[-500:]
+            raise RuntimeError(
+                f"warm worker failed to start: {detail or '<no output>'}"
+            )
+        return _WarmWorker(proc, log)
 
     async def run_background(
         self, argv: list[str], env: dict[str, str], log: str
@@ -149,12 +257,21 @@ class SubprocessRuntime(Runtime):
         target.parent.mkdir(parents=True, exist_ok=True)
         await asyncio.to_thread(target.write_bytes, data)
 
+    async def reset(self) -> None:
+        """Recreate the per-rollout workspace for the next rollout. Warm workers (cwd /tmp, in
+        `_warm`) and the interpreter cache are untouched, so they carry over to the next rollout."""
+        if self.workdir is not None:
+            await asyncio.to_thread(shutil.rmtree, self.workdir, ignore_errors=True)
+            await asyncio.to_thread(self.workdir.mkdir)
+
     def cleanup(self) -> None:
-        for proc in self._background:
+        procs = self._background + [w.proc for w in self._warm.values()]
+        for proc in procs:
             # Kill the whole group (start_new_session => pgid == pid), not just proc.pid, so a
             # background server's children (sh -> uv -> python) are reaped too.
             with contextlib.suppress(ProcessLookupError, PermissionError):
                 os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
         self._background = []
+        self._warm = {}
         if self.workdir is not None:
             shutil.rmtree(self.workdir, ignore_errors=True)


### PR DESCRIPTION
## Summary

Adds a **persistent runtime** mode + **warm in-runtime scoring** so the heavy per-rollout costs (sandbox/container provisioning, and re-`import`ing a verifier's deps every rollout) are paid **once per run** instead of once per rollout.

- **`persistent` on the base runtime config** (`BaseRuntimeConfig.persistent`, inherited by subprocess/docker/prime/modal; CLI `--harness.runtime.persistent true`). A persistent runtime is taken from an eval/train-level **`RuntimePool`**, reused across rollouts, and torn down only at the end of the run.
- **Wired into `Environment.serving()`** alongside the existing shared-tools / interception pools, and injected into every `Rollout` via `episode()` — so it covers **both** the eval CLI and the env server. The env server's `serving()` spans the whole run, so on **training** the pool lives for the entire run.
- **`Rollout`** acquires/releases a pooled runtime instead of `make_runtime`/`stop` (ephemeral path unchanged). Acquire happens inside the rollout's `try`, so a provisioning failure is captured on the trace like a normal `start()` failure.
- **`Runtime.reset()`** clears the per-rollout workspace between reuses (subprocess recreates `/tmp/<name>`; docker/prime/modal empty the workdir) so reuse stays isolated; the provisioned resource **and** warm workers survive. Persistent mode therefore suits tasksets whose per-rollout state is workspace-local (e.g. gsm8k / math).
- **`run_uv_script(..., warm=True)`** — the subprocess runtime routes to a long-lived worker that loads the script as a module **once** (its heavy top-level imports paid once) and answers many `args → stdout` calls. Gated on `persistent` (a worker would otherwise die with its rollout). Scripts opt in by exposing `main(argv) -> str` while staying `uv run`-able cold via a `if __name__ == "__main__": print(main(sys.argv[1:]))` footer.
- **gsm8k-v1 / aime24-v1 / math-env-v1** opt in: each `verify.py` converted to the dual-mode `main(argv)` shape (the math ones return instead of `sys.exit`, so a reused worker survives the early-out paths) and the `correct` reward passes `warm=True`.
- Split the runtime factory (`RuntimeConfig` / `make_runtime` / `runtime_is_local`) into `runtimes/factory.py` so the pool can build runtimes without importing the package (avoids a cycle); `runtimes/__init__` re-exports.

## Why two layers

The provisioning win (skip re-creating a container/sandbox per rollout) needs only the **pool**, and helps remote runtimes most (the tb2 bench measured 2.5–7.4s sandbox+tunnel provisioning per rollout). The *import-once* win needs a **warm worker**, which only survives if the runtime persists — so the pool is the foundation and warm scoring rides on it. For subprocess, provisioning is ~free (`start`/`stop` is 0.2 ms); the entire per-rollout cost is the fresh-process `import math_verify` (~0.22 s), which the warm worker removes.

## Verification

`uv run python bench/persistent_runtime.py <N> <concurrency>` — runs gsm8k's real `verify.py` through the framework API (no model generation, to isolate runtime/scoring overhead). `ephemeral` = `make_runtime + start + run_uv_script(cold) + stop` per call (today's per-rollout scoring path); `persistent` = `pool.acquire + run_uv_script(warm=True) + release`.

| N | concurrency | ephemeral | persistent | speedup |
|---|---|---|---|---|
| 256  | 128 | 3.95s (15.5 ms/call) | 1.21s (4.7 ms/call) | **3.3x** |
| 1000 | 128 | 15.31s (15.3 ms/call) | 1.27s (1.27 ms/call) | **12.0x** |
| 4000 | 128 | 63.28s (15.8 ms/call) | 2.16s (0.54 ms/call) | **29.4x** |

The win grows with N: ephemeral stays pinned at ~15.3 ms/call (the per-call import), while persistent's one-time worker import (one per pooled runtime) amortizes away — so it peaks when `N ≫ concurrency` (a long training run).

Correctness: a small gsm8k-v1 eval with `--harness.runtime.persistent true` vs default produces identical rewards (`reward=1.000`, 0 errors), logs rollouts as `(pooled)`, and tears the pool down at the end (`runtime pool: tearing down N persistent runtime(s)`). Warm worker output verified correct across edge cases (e.g. `1,000`, malformed → `0.0`). `ruff` clean; `tests/v1/test_configs.py` green; full test suite collects.

## Scope / follow-ups

- Warm workers are currently implemented on the **subprocess** runtime. **Persistence** works on every runtime (and on remote runtimes also skips the per-rollout sandbox+tunnel provisioning). Warm workers on docker/prime/modal (a small in-runtime HTTP service reached via the existing `expose`/`host_endpoint` plumbing — structurally like a tool server) are a natural follow-up.
- Persistent mode reuses a runtime across rollouts/tasks; the per-rollout workspace is `reset`, but anything a taskset installs **outside** the workspace persists — so it's opt-in and best for workspace-local state. Tasks with per-task images get a separate pool per image (pool keyed by resolved config).

## Breaking

None. `persistent` defaults to `False` (ephemeral, today's behavior); `warm` defaults to `False`. `run_uv_script` gains an optional trailing `warm` kwarg.
