### PR TITLE
Allow reasoning-only model responses

### DIFF
--- a/tests/test_client_multimodal_types.py
+++ b/tests/test_client_multimodal_types.py
@@ -3,7 +3,6 @@ from types import SimpleNamespace
 import pytest
 
 from verifiers.clients.openai_chat_completions_client import OpenAIChatCompletionsClient
-from verifiers.errors import EmptyModelResponseError
 from verifiers.types import (
     AssistantMessage,
     ImageUrlContentPart,
@@ -85,129 +84,6 @@ async def test_openai_chat_accepts_refusal_with_reasoning_native_response():
 
     assert response.message.content == "I cannot help with that."
     assert response.message.reasoning_content == "hidden chain"
-
-
-@pytest.mark.asyncio
-async def test_openai_chat_accepts_usage_only_reasoning_native_response():
-    client = OpenAIChatCompletionsClient(object())
-    native_response = SimpleNamespace(
-        id="chatcmpl_reasoning",
-        created=0,
-        model="o3",
-        usage=SimpleNamespace(
-            prompt_tokens=5,
-            completion_tokens=8,
-            total_tokens=13,
-            completion_tokens_details=SimpleNamespace(reasoning_tokens=8),
-        ),
-        choices=[
-            SimpleNamespace(
-                finish_reason="length",
-                message=_OpenAIMessage(
-                    content=None,
-                    reasoning_content=None,
-                    tool_calls=None,
-                ),
-            )
-        ],
-    )
-
-    await client.raise_from_native_response(native_response)
-    response = await client.from_native_response(native_response)
-    completion_messages = await parse_response_message(response)
-    prompt, _ = await client.to_native_prompt(completion_messages)
-
-    assert response.usage is not None
-    assert response.usage.reasoning_tokens == 8
-    assert response.message.is_truncated is True
-    assert response.message.content == ""
-    assert prompt[0]["content"] == ""
-
-
-@pytest.mark.asyncio
-async def test_openai_chat_accepts_list_reasoning_details_without_flattening():
-    client = OpenAIChatCompletionsClient(object())
-    native_response = SimpleNamespace(
-        id="chatcmpl_reasoning_details",
-        created=0,
-        model="openrouter/minimax",
-        usage=None,
-        choices=[
-            SimpleNamespace(
-                finish_reason="length",
-                message=_OpenAIMessage(
-                    content=None,
-                    reasoning_content=None,
-                    reasoning_details=[{"type": "reasoning.text", "text": "hidden"}],
-                    tool_calls=None,
-                ),
-            )
-        ],
-    )
-
-    await client.raise_from_native_response(native_response)
-    response = await client.from_native_response(native_response)
-    completion_messages = await parse_response_message(response)
-    prompt, _ = await client.to_native_prompt(completion_messages)
-
-    assert response.message.reasoning_content == ""
-    assert response.message.content is None
-    assert prompt[0]["reasoning_content"] == ""
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "reasoning_details",
-    [[], [{}], [{"type": "reasoning.text", "text": ""}]],
-)
-async def test_openai_chat_rejects_empty_reasoning_details(reasoning_details):
-    client = OpenAIChatCompletionsClient(object())
-    native_response = SimpleNamespace(
-        choices=[
-            SimpleNamespace(
-                message=_OpenAIMessage(
-                    content=None,
-                    reasoning_content=None,
-                    reasoning_details=reasoning_details,
-                    tool_calls=None,
-                )
-            )
-        ],
-        usage=None,
-    )
-
-    with pytest.raises(EmptyModelResponseError, match="Model returned no content"):
-        await client.raise_from_native_response(native_response)
-
-
-@pytest.mark.asyncio
-async def test_openai_chat_accepts_later_nonempty_reasoning_alias():
-    client = OpenAIChatCompletionsClient(object())
-    native_response = SimpleNamespace(
-        id="chatcmpl_reasoning_alias",
-        created=0,
-        model="deepseek-r1",
-        usage=None,
-        choices=[
-            SimpleNamespace(
-                finish_reason="length",
-                message=_OpenAIMessage(
-                    content=None,
-                    reasoning="",
-                    reasoning_content="hidden chain",
-                    tool_calls=None,
-                ),
-            )
-        ],
-    )
-
-    await client.raise_from_native_response(native_response)
-    response = await client.from_native_response(native_response)
-    completion_messages = await parse_response_message(response)
-    prompt, _ = await client.to_native_prompt(completion_messages)
-
-    assert response.message.reasoning_content == "hidden chain"
-    assert prompt[0]["reasoning_content"] == "hidden chain"
 
 
 @pytest.mark.asyncio
@@ -384,25 +260,6 @@ async def test_anthropic_from_native_response_always_parses_reasoning():
     response = await client.from_native_response(native_response)
     assert response.message.reasoning_content == "hidden chain"
     assert response.message.content == "final answer"
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "content_block",
-    [
-        SimpleNamespace(type="thinking", thinking=""),
-        SimpleNamespace(type="redacted_thinking", data=""),
-    ],
-)
-async def test_anthropic_rejects_empty_reasoning_blocks(content_block):
-    pytest.importorskip("anthropic")
-    from verifiers.clients.anthropic_messages_client import AnthropicMessagesClient
-
-    client = AnthropicMessagesClient(object())
-    native_response = SimpleNamespace(content=[content_block])
-
-    with pytest.raises(EmptyModelResponseError, match="Model returned no content"):
-        await client.raise_from_native_response(native_response)
 
 
 @pytest.mark.asyncio

--- a/tests/test_client_multimodal_types.py
+++ b/tests/test_client_multimodal_types.py
@@ -60,25 +60,6 @@ async def test_openai_to_native_prompt_with_typed_multimodal_content_parts():
 
 
 @pytest.mark.asyncio
-async def test_openai_chat_rejects_reasoning_only_native_response():
-    client = OpenAIChatCompletionsClient(object())
-    native_response = SimpleNamespace(
-        choices=[
-            SimpleNamespace(
-                message=_OpenAIMessage(
-                    content=None,
-                    reasoning_content="hidden chain",
-                    tool_calls=None,
-                )
-            )
-        ]
-    )
-
-    with pytest.raises(EmptyModelResponseError, match="reasoning but no content"):
-        await client.raise_from_native_response(native_response)
-
-
-@pytest.mark.asyncio
 async def test_openai_chat_accepts_refusal_with_reasoning_native_response():
     client = OpenAIChatCompletionsClient(object())
     native_response = SimpleNamespace(
@@ -104,6 +85,129 @@ async def test_openai_chat_accepts_refusal_with_reasoning_native_response():
 
     assert response.message.content == "I cannot help with that."
     assert response.message.reasoning_content == "hidden chain"
+
+
+@pytest.mark.asyncio
+async def test_openai_chat_accepts_usage_only_reasoning_native_response():
+    client = OpenAIChatCompletionsClient(object())
+    native_response = SimpleNamespace(
+        id="chatcmpl_reasoning",
+        created=0,
+        model="o3",
+        usage=SimpleNamespace(
+            prompt_tokens=5,
+            completion_tokens=8,
+            total_tokens=13,
+            completion_tokens_details=SimpleNamespace(reasoning_tokens=8),
+        ),
+        choices=[
+            SimpleNamespace(
+                finish_reason="length",
+                message=_OpenAIMessage(
+                    content=None,
+                    reasoning_content=None,
+                    tool_calls=None,
+                ),
+            )
+        ],
+    )
+
+    await client.raise_from_native_response(native_response)
+    response = await client.from_native_response(native_response)
+    completion_messages = await parse_response_message(response)
+    prompt, _ = await client.to_native_prompt(completion_messages)
+
+    assert response.usage is not None
+    assert response.usage.reasoning_tokens == 8
+    assert response.message.is_truncated is True
+    assert response.message.content == ""
+    assert prompt[0]["content"] == ""
+
+
+@pytest.mark.asyncio
+async def test_openai_chat_accepts_list_reasoning_details_without_flattening():
+    client = OpenAIChatCompletionsClient(object())
+    native_response = SimpleNamespace(
+        id="chatcmpl_reasoning_details",
+        created=0,
+        model="openrouter/minimax",
+        usage=None,
+        choices=[
+            SimpleNamespace(
+                finish_reason="length",
+                message=_OpenAIMessage(
+                    content=None,
+                    reasoning_content=None,
+                    reasoning_details=[{"type": "reasoning.text", "text": "hidden"}],
+                    tool_calls=None,
+                ),
+            )
+        ],
+    )
+
+    await client.raise_from_native_response(native_response)
+    response = await client.from_native_response(native_response)
+    completion_messages = await parse_response_message(response)
+    prompt, _ = await client.to_native_prompt(completion_messages)
+
+    assert response.message.reasoning_content == ""
+    assert response.message.content is None
+    assert prompt[0]["reasoning_content"] == ""
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "reasoning_details",
+    [[], [{}], [{"type": "reasoning.text", "text": ""}]],
+)
+async def test_openai_chat_rejects_empty_reasoning_details(reasoning_details):
+    client = OpenAIChatCompletionsClient(object())
+    native_response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=_OpenAIMessage(
+                    content=None,
+                    reasoning_content=None,
+                    reasoning_details=reasoning_details,
+                    tool_calls=None,
+                )
+            )
+        ],
+        usage=None,
+    )
+
+    with pytest.raises(EmptyModelResponseError, match="Model returned no content"):
+        await client.raise_from_native_response(native_response)
+
+
+@pytest.mark.asyncio
+async def test_openai_chat_accepts_later_nonempty_reasoning_alias():
+    client = OpenAIChatCompletionsClient(object())
+    native_response = SimpleNamespace(
+        id="chatcmpl_reasoning_alias",
+        created=0,
+        model="deepseek-r1",
+        usage=None,
+        choices=[
+            SimpleNamespace(
+                finish_reason="length",
+                message=_OpenAIMessage(
+                    content=None,
+                    reasoning="",
+                    reasoning_content="hidden chain",
+                    tool_calls=None,
+                ),
+            )
+        ],
+    )
+
+    await client.raise_from_native_response(native_response)
+    response = await client.from_native_response(native_response)
+    completion_messages = await parse_response_message(response)
+    prompt, _ = await client.to_native_prompt(completion_messages)
+
+    assert response.message.reasoning_content == "hidden chain"
+    assert prompt[0]["reasoning_content"] == "hidden chain"
 
 
 @pytest.mark.asyncio
@@ -283,20 +387,21 @@ async def test_anthropic_from_native_response_always_parses_reasoning():
 
 
 @pytest.mark.asyncio
-async def test_anthropic_rejects_reasoning_only_native_response():
+@pytest.mark.parametrize(
+    "content_block",
+    [
+        SimpleNamespace(type="thinking", thinking=""),
+        SimpleNamespace(type="redacted_thinking", data=""),
+    ],
+)
+async def test_anthropic_rejects_empty_reasoning_blocks(content_block):
     pytest.importorskip("anthropic")
     from verifiers.clients.anthropic_messages_client import AnthropicMessagesClient
 
     client = AnthropicMessagesClient(object())
-    native_response = SimpleNamespace(
-        id="msg_think",
-        model="claude-haiku-4-5",
-        stop_reason="end_turn",
-        usage=SimpleNamespace(input_tokens=1, output_tokens=1),
-        content=[SimpleNamespace(type="thinking", thinking="hidden chain")],
-    )
+    native_response = SimpleNamespace(content=[content_block])
 
-    with pytest.raises(EmptyModelResponseError, match="reasoning but no content"):
+    with pytest.raises(EmptyModelResponseError, match="Model returned no content"):
         await client.raise_from_native_response(native_response)
 
 

--- a/tests/test_openai_responses_client.py
+++ b/tests/test_openai_responses_client.py
@@ -8,7 +8,6 @@ from verifiers.clients.openai_responses_client import (
     OPENAI_RESPONSES_OUTPUT_FIELD,
     OpenAIResponsesClient,
 )
-from verifiers.errors import EmptyModelResponseError
 from verifiers.types import (
     AssistantMessage,
     ClientConfig,
@@ -132,24 +131,6 @@ async def test_get_native_response_normalizes_sampling_args_and_tools():
             "strict": True,
         }
     ]
-
-
-@pytest.mark.asyncio
-async def test_raise_from_native_response_rejects_reasoning_only_response():
-    native_response = SimpleNamespace(
-        output=[
-            {
-                "type": "reasoning",
-                "id": "rs_1",
-                "summary": [{"type": "summary_text", "text": "thinking"}],
-                "status": "completed",
-            }
-        ]
-    )
-    client = OpenAIResponsesClient(object())
-
-    with pytest.raises(EmptyModelResponseError, match="reasoning but no content"):
-        await client.raise_from_native_response(native_response)
 
 
 @pytest.mark.asyncio
@@ -284,6 +265,36 @@ async def test_from_native_response_uses_none_content_for_tool_call_only_respons
     assert response.message.tool_calls == [
         ToolCall(id="call_1", name="lookup", arguments='{"q":"x"}')
     ]
+
+
+@pytest.mark.asyncio
+async def test_usage_only_reasoning_response_is_replayable():
+    native_response = SimpleNamespace(
+        id="resp_reasoning",
+        created_at=123.0,
+        model="o3",
+        status="incomplete",
+        incomplete_details={"reason": "max_output_tokens"},
+        usage={
+            "input_tokens": 5,
+            "output_tokens": 8,
+            "total_tokens": 13,
+            "output_tokens_details": {"reasoning_tokens": 8},
+        },
+        output=None,
+    )
+    client = OpenAIResponsesClient(object())
+
+    await client.raise_from_native_response(native_response)
+    response = await client.from_native_response(native_response)
+    completion_messages = await parse_response_message(response)
+    prompt, _ = await client.to_native_prompt(completion_messages)
+
+    assert response.usage is not None
+    assert response.usage.reasoning_tokens == 8
+    assert response.message.is_truncated is True
+    assert response.message.content == ""
+    assert prompt == [{"type": "message", "role": "assistant", "content": ""}]
 
 
 @pytest.mark.asyncio

--- a/tests/test_openai_responses_client.py
+++ b/tests/test_openai_responses_client.py
@@ -268,36 +268,6 @@ async def test_from_native_response_uses_none_content_for_tool_call_only_respons
 
 
 @pytest.mark.asyncio
-async def test_usage_only_reasoning_response_is_replayable():
-    native_response = SimpleNamespace(
-        id="resp_reasoning",
-        created_at=123.0,
-        model="o3",
-        status="incomplete",
-        incomplete_details={"reason": "max_output_tokens"},
-        usage={
-            "input_tokens": 5,
-            "output_tokens": 8,
-            "total_tokens": 13,
-            "output_tokens_details": {"reasoning_tokens": 8},
-        },
-        output=None,
-    )
-    client = OpenAIResponsesClient(object())
-
-    await client.raise_from_native_response(native_response)
-    response = await client.from_native_response(native_response)
-    completion_messages = await parse_response_message(response)
-    prompt, _ = await client.to_native_prompt(completion_messages)
-
-    assert response.usage is not None
-    assert response.usage.reasoning_tokens == 8
-    assert response.message.is_truncated is True
-    assert response.message.content == ""
-    assert prompt == [{"type": "message", "role": "assistant", "content": ""}]
-
-
-@pytest.mark.asyncio
 async def test_response_message_extras_round_trip_into_next_prompt():
     response = Response(
         id="resp_1",

--- a/tests/test_renderer_client.py
+++ b/tests/test_renderer_client.py
@@ -356,14 +356,6 @@ async def test_renderer_client_rejects_empty_dict_native_response():
 
 
 @pytest.mark.asyncio
-async def test_renderer_client_rejects_reasoning_only_native_response():
-    client = object.__new__(RendererClient)
-
-    with pytest.raises(EmptyModelResponseError, match="reasoning but no content"):
-        await client.raise_from_native_response({"reasoning_content": "hidden chain"})
-
-
-@pytest.mark.asyncio
 async def test_from_native_response_uses_request_id_and_token_lengths():
     """vLLM's /inference/v1/generate returns ``request_id`` (not ``id``) and
     no ``usage``/``model``/``created``. ``Response.id`` should pick up

--- a/verifiers/clients/anthropic_messages_client.py
+++ b/verifiers/clients/anthropic_messages_client.py
@@ -390,14 +390,14 @@ class AnthropicMessagesClient(
                 has_text = True
             elif block_type == "tool_use":
                 has_tool_call = True
-            elif block_type in {"thinking", "redacted_thinking"}:
+            elif block_type == "thinking" and getattr(content_block, "thinking", None):
+                has_reasoning = True
+            elif block_type == "redacted_thinking" and getattr(
+                content_block, "data", None
+            ):
                 has_reasoning = True
 
-        if not (has_text or has_tool_call):
-            if has_reasoning:
-                raise EmptyModelResponseError(
-                    "Model returned reasoning but no content and did not call any tools"
-                )
+        if not (has_text or has_tool_call or has_reasoning):
             raise EmptyModelResponseError(
                 "Model returned no content and did not call any tools"
             )

--- a/verifiers/clients/openai_chat_completions_client.py
+++ b/verifiers/clients/openai_chat_completions_client.py
@@ -100,6 +100,12 @@ def get_usage_field(usage: Any, key: str) -> Any:
     return getattr(usage, key, None)
 
 
+def _get_reasoning_tokens(usage: Any) -> int:
+    completion_details = get_usage_field(usage, "completion_tokens_details")
+    reasoning_tokens = get_usage_field(completion_details, "reasoning_tokens")
+    return reasoning_tokens if isinstance(reasoning_tokens, int) else 0
+
+
 def content_to_text(content: Any) -> str:
     """Get all text content from OAI message content."""
     if isinstance(content, str):
@@ -142,8 +148,19 @@ def parse_reasoning_content(message: Any) -> str | None:
 
     for field in DEFAULT_REASONING_FIELDS:
         value = message_dict.get(field)
-        if isinstance(value, str):
+        if isinstance(value, str) and value:
             return value
+    details = message_dict.get("reasoning_details")
+    if isinstance(details, list) and any(
+        isinstance(detail, Mapping)
+        and any(
+            detail.get(field)
+            for field in ("text", "summary", "data", "signature", "encrypted_content")
+        )
+        for detail in details
+    ):
+        # Keep structured provider reasoning as a replayable marker without flattening it.
+        return ""
     return None
 
 
@@ -345,12 +362,11 @@ class OpenAIChatCompletionsClient(
             or parse_refusal_content(message)
         )
         has_tool_calls = bool(getattr(message, "tool_calls", None))
-        has_reasoning = bool(parse_reasoning_content(message))
-        if not (has_content or has_tool_calls):
-            if has_reasoning:
-                raise EmptyModelResponseError(
-                    "Model returned reasoning but no content and did not call any tools"
-                )
+        has_reasoning = (
+            parse_reasoning_content(message) is not None
+            or _get_reasoning_tokens(getattr(response, "usage", None)) > 0
+        )
+        if not (has_content or has_tool_calls or has_reasoning):
             raise EmptyModelResponseError(
                 "Model returned no content and did not call any tools"
             )
@@ -442,6 +458,7 @@ class OpenAIChatCompletionsClient(
                 prompt_tokens = get_usage_field(usage, "input_tokens")
                 completion_tokens = get_usage_field(usage, "output_tokens")
             total_tokens = get_usage_field(usage, "total_tokens")
+            reasoning_tokens = _get_reasoning_tokens(usage)
             if not isinstance(prompt_tokens, int) or not isinstance(
                 completion_tokens, int
             ):
@@ -450,7 +467,7 @@ class OpenAIChatCompletionsClient(
                 total_tokens = prompt_tokens + completion_tokens
             return Usage(
                 prompt_tokens=prompt_tokens,
-                reasoning_tokens=0,
+                reasoning_tokens=reasoning_tokens,
                 completion_tokens=completion_tokens,
                 total_tokens=total_tokens,
             )
@@ -528,17 +545,29 @@ class OpenAIChatCompletionsClient(
         if not isinstance(model, str):
             model = ""
 
+        message = response.choices[0].message
+        content = parse_content(response)
+        reasoning_content = parse_reasoning_content(message)
+        tool_calls = parse_tool_calls(response)
+        if (
+            content is None
+            and reasoning_content is None
+            and not tool_calls
+            and _get_reasoning_tokens(getattr(response, "usage", None)) > 0
+        ):
+            content = ""
+
         return Response(
             id=response_id,
             created=created,
             model=model,
             usage=parse_usage(response),
             message=ResponseMessage(
-                content=parse_content(response),
-                reasoning_content=parse_reasoning_content(response.choices[0].message),
+                content=content,
+                reasoning_content=reasoning_content,
                 finish_reason=parse_finish_reason(response),
                 is_truncated=parse_is_truncated(response),
                 tokens=parse_tokens(response),
-                tool_calls=parse_tool_calls(response) or None,
+                tool_calls=tool_calls or None,
             ),
         )

--- a/verifiers/clients/openai_responses_client.py
+++ b/verifiers/clients/openai_responses_client.py
@@ -53,6 +53,12 @@ def _model_dump(value: Any) -> dict[str, Any]:
     return {}
 
 
+def _get_reasoning_tokens(usage: Any) -> int:
+    output_details = get_usage_field(usage, "output_tokens_details")
+    reasoning_tokens = get_usage_field(output_details, "reasoning_tokens")
+    return reasoning_tokens if isinstance(reasoning_tokens, int) else 0
+
+
 class OpenAIResponsesClient(
     Client[
         AsyncOpenAI,
@@ -171,7 +177,7 @@ class OpenAIResponsesClient(
                     return raw_items
 
                 items: list[dict[str, Any]] = []
-                if content_to_text(message.content):
+                if content_to_text(message.content) or message.content == "":
                     items.append(
                         {
                             "type": "message",
@@ -267,9 +273,14 @@ class OpenAIResponsesClient(
             message = _get_field(error, "message", "Model response failed")
             raise InvalidModelResponseError(str(message))
 
+        has_usage_reasoning = (
+            _get_reasoning_tokens(getattr(response, "usage", None)) > 0
+        )
         output = getattr(response, "output", None)
-        if output is None:
+        if output is None and not has_usage_reasoning:
             raise EmptyModelResponseError("Model returned no output")
+        if output is None:
+            output = []
         if not isinstance(output, Iterable):
             raise InvalidModelResponseError("Model returned invalid output")
 
@@ -293,11 +304,8 @@ class OpenAIResponsesClient(
                     ):
                         has_text = True
 
-        if not (has_text or has_tool_call):
-            if has_reasoning:
-                raise EmptyModelResponseError(
-                    "Model returned reasoning but no content and did not call any tools"
-                )
+        has_reasoning = has_reasoning or has_usage_reasoning
+        if not (has_text or has_tool_call or has_reasoning):
             raise EmptyModelResponseError(
                 "Model returned no content and did not call any tools"
             )
@@ -374,20 +382,13 @@ class OpenAIResponsesClient(
             prompt_tokens = get_usage_field(usage, "input_tokens")
             completion_tokens = get_usage_field(usage, "output_tokens")
             total_tokens = get_usage_field(usage, "total_tokens")
-            output_details = get_usage_field(usage, "output_tokens_details")
-            reasoning_tokens = (
-                get_usage_field(output_details, "reasoning_tokens")
-                if output_details is not None
-                else 0
-            )
+            reasoning_tokens = _get_reasoning_tokens(usage)
             if not isinstance(prompt_tokens, int) or not isinstance(
                 completion_tokens, int
             ):
                 return None
             if not isinstance(total_tokens, int):
                 total_tokens = prompt_tokens + completion_tokens
-            if not isinstance(reasoning_tokens, int):
-                reasoning_tokens = 0
             return Usage(
                 prompt_tokens=prompt_tokens,
                 reasoning_tokens=reasoning_tokens,
@@ -421,14 +422,27 @@ class OpenAIResponsesClient(
         if not isinstance(model, str):
             model = ""
 
+        output_items = raw_output_items(response)
+        content = parse_content(response)
+        reasoning_content = parse_reasoning_content(response)
+        tool_calls = parse_tool_calls(response)
+        if (
+            not output_items
+            and content is None
+            and reasoning_content is None
+            and not tool_calls
+            and _get_reasoning_tokens(getattr(response, "usage", None)) > 0
+        ):
+            content = ""
+
         message_data: dict[str, Any] = {
-            "content": parse_content(response),
-            "reasoning_content": parse_reasoning_content(response),
+            "content": content,
+            "reasoning_content": reasoning_content,
             "finish_reason": parse_finish_reason(response),
             "is_truncated": parse_is_truncated(response),
             "tokens": None,
-            "tool_calls": parse_tool_calls(response) or None,
-            OPENAI_RESPONSES_OUTPUT_FIELD: raw_output_items(response),
+            "tool_calls": tool_calls or None,
+            OPENAI_RESPONSES_OUTPUT_FIELD: output_items,
         }
 
         return Response(

--- a/verifiers/clients/renderer_client.py
+++ b/verifiers/clients/renderer_client.py
@@ -641,11 +641,7 @@ class RendererClient(
         # model having tried to call a tool, so we don't filter by status here.
         has_tool_calls = bool(response.get("tool_calls"))
         has_reasoning = bool(response.get("reasoning_content"))
-        if not (has_content or has_tool_calls):
-            if has_reasoning:
-                raise EmptyModelResponseError(
-                    "Model returned reasoning but no content and did not call any tools"
-                )
+        if not (has_content or has_tool_calls or has_reasoning):
             raise EmptyModelResponseError(
                 "Model returned no content and did not call any tools"
             )


### PR DESCRIPTION
## Overview

Treat reasoning-only model output as a normal assistant response in the legacy client layer, matching the V1 response contract.

## Details

- Accept reasoning as valid output in the legacy OpenAI Chat Completions, OpenAI Responses, renderer, and Anthropic clients.
- Preserve `EmptyModelResponseError` for responses with no text, tool calls, or reasoning.
- Remove obsolete tests that required reasoning-only responses to raise that error.

Reasoning models can consume their output budget before producing visible answer text. Classifying those responses as empty turns a valid truncated generation into a provider failure and prevents downstream scoring from handling it normally.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow reasoning-only model responses across all client types
> - Removes the special-case error that rejected responses containing only reasoning content (no text or tool calls) in `AnthropicMessagesClient`, `OpenAIChatCompletionsClient`, `OpenAIResponsesClient`, and `RendererClient`.
> - Adds `_get_reasoning_tokens` helpers to detect reasoning via usage metadata (`completion_tokens_details` / `output_tokens_details`) when no explicit reasoning blocks are present.
> - When a response contains only reasoning tokens, clients now emit an empty-string `content` message rather than treating the response as empty.
> - `OpenAIResponsesClient.to_native_prompt` now preserves empty assistant content as a native message item so round-trips stay consistent.
> - Behavioral Change: responses that previously raised `EmptyModelResponseError` due to missing text/tool content but present reasoning are now accepted as valid.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 382c8ce.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior change: downstream code that assumed reasoning-only turns were errors must accept empty `content` with reasoning or usage-only reasoning; risk is moderate across all provider client paths.
> 
> **Overview**
> **Reasoning-only completions are no longer treated as empty failures** across the legacy OpenAI Chat Completions, OpenAI Responses, Anthropic Messages, and renderer clients.
> 
> Validation now counts **non-empty reasoning** (and, for OpenAI, **non-zero `usage` reasoning tokens**) alongside visible text and tool calls. The old path that raised `EmptyModelResponseError` with *"reasoning but no content"* is removed; truly empty responses still raise the generic empty error.
> 
> **OpenAI Chat Completions** tightens `parse_reasoning_content` (non-empty strings; structured `reasoning_details` returns `""` as a replay marker), fills **`reasoning_tokens`** from usage, and can set **`content=""`** when only usage shows reasoning. **OpenAI Responses** mirrors usage-based reasoning, allows missing `output` when usage has reasoning tokens, and replays assistant messages with empty string content. **Anthropic** only marks reasoning when thinking/redacted blocks have payload. **Renderer** treats `reasoning_content` as sufficient to pass validation.
> 
> Tests that asserted reasoning-only responses must error are deleted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 382c8ce43996bd82f93a80d36f3d48de30ef8745. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->