### PR TITLE
[codex] Add truncated reasoning response error

### DIFF
--- a/tests/test_error_chain.py
+++ b/tests/test_error_chain.py
@@ -1,7 +1,12 @@
 """Tests for verifiers.utils.error_utils.ErrorChain."""
 
 import verifiers as vf
-from verifiers.utils.error_utils import ErrorChain, get_vf_error_chain
+from verifiers.utils.error_utils import (
+    ErrorChain,
+    error_data,
+    error_from_data,
+    get_vf_error_chain,
+)
 
 
 class TestErrorChain:
@@ -147,3 +152,11 @@ class TestErrorChain:
         # error1 and error2 have same type, should be counted together
         assert counter[ErrorChain(ValueError("any"))] == 2
         assert counter[ErrorChain(TypeError("any"))] == 1
+
+    def test_truncated_reasoning_error_round_trips(self):
+        error = vf.TruncatedReasoningError("truncated reasoning")
+
+        rebuilt = error_from_data(error_data(error))
+
+        assert isinstance(rebuilt, vf.TruncatedReasoningError)
+        assert isinstance(rebuilt, vf.EmptyModelResponseError)

--- a/tests/test_renderer_client.py
+++ b/tests/test_renderer_client.py
@@ -16,7 +16,7 @@ from verifiers.clients.renderer_client import (
     _step_token_ids,
     _to_renderer_message,
 )
-from verifiers.errors import EmptyModelResponseError
+from verifiers.errors import EmptyModelResponseError, TruncatedReasoningError
 from verifiers.types import (
     AssistantMessage,
     SystemMessage,
@@ -361,6 +361,19 @@ async def test_renderer_client_rejects_reasoning_only_native_response():
 
     with pytest.raises(EmptyModelResponseError, match="reasoning but no content"):
         await client.raise_from_native_response({"reasoning_content": "hidden chain"})
+
+
+@pytest.mark.asyncio
+async def test_renderer_client_rejects_truncated_reasoning_native_response():
+    client = object.__new__(RendererClient)
+
+    with pytest.raises(
+        TruncatedReasoningError, match="length limit after reasoning"
+    ) as exc_info:
+        await client.raise_from_native_response(
+            {"reasoning_content": "hidden chain", "finish_reason": "length"}
+        )
+    assert isinstance(exc_info.value, EmptyModelResponseError)
 
 
 @pytest.mark.asyncio

--- a/verifiers/clients/renderer_client.py
+++ b/verifiers/clients/renderer_client.py
@@ -39,7 +39,11 @@ from verifiers.clients.client import Client
 from verifiers.clients.openai_chat_completions_client import (
     handle_openai_overlong_prompt,
 )
-from verifiers.errors import EmptyModelResponseError, OverlongPromptError
+from verifiers.errors import (
+    EmptyModelResponseError,
+    OverlongPromptError,
+    TruncatedReasoningError,
+)
 from verifiers.types import (
     AssistantMessage,
     ClientConfig,
@@ -643,6 +647,10 @@ class RendererClient(
         has_reasoning = bool(response.get("reasoning_content"))
         if not (has_content or has_tool_calls):
             if has_reasoning:
+                if response.get("finish_reason") == "length":
+                    raise TruncatedReasoningError(
+                        "Model hit length limit after reasoning but before content or tool calls"
+                    )
                 raise EmptyModelResponseError(
                     "Model returned reasoning but no content and did not call any tools"
                 )

--- a/verifiers/errors.py
+++ b/verifiers/errors.py
@@ -20,6 +20,12 @@ class EmptyModelResponseError(InvalidModelResponseError):
     pass
 
 
+class TruncatedReasoningError(EmptyModelResponseError):
+    """Model hit a length limit before returning content or tool calls."""
+
+    pass
+
+
 class OverlongPromptError(Error):
     """Used to catch overlong prompt errors (e.g. prompt + requested number of tokens exceeds model context length)"""
 

--- a/verifiers/utils/error_utils.py
+++ b/verifiers/utils/error_utils.py
@@ -115,6 +115,7 @@ def vf_error_types() -> tuple[type[vf.Error], ...]:
         vf.SandboxError,
         vf.TunnelError,
         vf.InfraError,
+        vf.TruncatedReasoningError,
         vf.EmptyModelResponseError,
         vf.InvalidModelResponseError,
         vf.ModelError,


### PR DESCRIPTION
## Summary

Adds a narrow `TruncatedReasoningError` for renderer responses that hit `finish_reason == "length"` after emitting reasoning but before producing content or tool calls.

The new error subclasses `EmptyModelResponseError`, so existing retry/catch behavior remains compatible while downstream logs can distinguish true empty responses from length-truncated reasoning-only responses.

## Validation

- `uv run ruff format verifiers/errors.py verifiers/clients/renderer_client.py verifiers/utils/error_utils.py tests/test_renderer_client.py tests/test_error_chain.py`
- `uv run ruff check verifiers/errors.py verifiers/clients/renderer_client.py verifiers/utils/error_utils.py tests/test_renderer_client.py tests/test_error_chain.py`
- `uv run pytest tests/test_renderer_client.py::test_renderer_client_rejects_reasoning_only_native_response tests/test_renderer_client.py::test_renderer_client_rejects_truncated_reasoning_native_response tests/test_error_chain.py::TestErrorChain::test_truncated_reasoning_error_round_trips`
- Replayed saved Nemotron Nano SWE repro with `PYTHONPATH=/root/git/verifiers`; the capped response now classifies as `TruncatedReasoningError` with `finish_reason=length`, `content_len=0`, `tool_call_count=0`, and `reasoning_len=611`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `TruncatedReasoningError` for responses that hit length limit during reasoning
> - Adds `TruncatedReasoningError` as a subclass of `EmptyModelResponseError` in [verifiers/errors.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1768/files#diff-1a63e3834df0345e5df7fae38d22291a0a93ef0aa144b1c66c0fe2ffcc4500c0) to distinguish length-truncated reasoning responses from generic empty responses.
> - Updates `RendererClient.raise_from_native_response` in [renderer_client.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1768/files#diff-4309037b1656944b1991edc5baa1d16760d74155d7adc9fef41a2080ce8605e1) to raise `TruncatedReasoningError` instead of `EmptyModelResponseError` when a response has `reasoning_content`, no content or tool calls, and `finish_reason == 'length'`.
> - Registers `TruncatedReasoningError` in `vf_error_types` so it round-trips correctly through error serialization.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6808f92.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->