### PR TITLE
chore: revert reject unsupported task system_prompt

### DIFF
--- a/verifiers/v1/harness.py
+++ b/verifiers/v1/harness.py
@@ -66,8 +66,7 @@ class Harness(ABC, Generic[ConfigT]):
     (e.g. `RLMHarness(Harness[RLMHarnessConfig])`)."""
 
     APPENDS_SYSTEM_PROMPT: ClassVar[bool] = False
-    """Emit task.system_prompt as a system message. If False, a task that sets a system_prompt
-    is rejected."""
+    """Emit task.system_prompt as a system message (else fold into the user message)."""
     SUPPORTS_TASK_TOOLS: ClassVar[bool] = True
     """Expose a task's MCP tool servers to the model; set False for harnesses without an MCP client."""
     SUPPORTS_USER_SIM: ClassVar[bool] = False
@@ -79,14 +78,13 @@ class Harness(ABC, Generic[ConfigT]):
         self.config = config
 
     def resolve_prompt(self, task: Task) -> tuple[str | None, str | Messages | None]:
-        """Resolve `(system_prompt, prompt)` for this harness. A harness that sets
-        `APPENDS_SYSTEM_PROMPT` returns the task's system prompt separately (emitted as a real
-        system message, or via the agent's own append mechanism); a harness that does not is given
-        the prompt with no system prompt, and a task that sets one is rejected — a system prompt is
-        never folded into the user message (that would silently change its role). A `Messages`
+        """Resolve `(system_prompt, prompt)` for this harness. If the harness
+        appends the system prompt natively, returns it separately; otherwise folds it into
+        the user prompt (warning that it isn't sent as a system message). A `Messages`
         prompt (e.g. an image-bearing prompt) is only allowed for harnesses that set
-        `SUPPORTS_MESSAGE_PROMPT`. A `None` prompt means the task has no prompt — the user simulator
-        opens the conversation (see `Taskset.user`); the harness emits no opening user message."""
+        `SUPPORTS_MESSAGE_PROMPT`. A `None` prompt means the task has no prompt —
+        the user simulator opens the conversation (see `Taskset.user`); the harness emits no
+        opening user message."""
         prompt = task.prompt
         if (
             prompt is not None
@@ -97,14 +95,21 @@ class Harness(ABC, Generic[ConfigT]):
                 f"Harness {self.config.id!r} does not support a Messages prompt; "
                 "task.prompt must be a string or None."
             )
-        if task.system_prompt is not None and not self.APPENDS_SYSTEM_PROMPT:
+        system = task.system_prompt
+        if system is None or self.APPENDS_SYSTEM_PROMPT:
+            return system if self.APPENDS_SYSTEM_PROMPT else None, prompt
+        if not isinstance(prompt, str):
             raise ValueError(
-                f"Harness {self.config.id!r} does not support a system prompt, but the task sets "
-                "`system_prompt`. Use a harness that emits a system prompt (one with "
-                "APPENDS_SYSTEM_PROMPT, e.g. default / bash / rlm), or clear the task's "
-                "system_prompt."
+                f"Harness {self.config.id!r} cannot fold a system prompt into a "
+                f"{'Messages' if prompt is not None else 'None'} prompt; set "
+                "APPENDS_SYSTEM_PROMPT to emit it as a system message."
             )
-        return (task.system_prompt if self.APPENDS_SYSTEM_PROMPT else None), prompt
+        logger.warning(
+            "Harness %r does not support a separate system prompt; prepending "
+            "task.system_prompt to the user prompt.",
+            self.config.id,
+        )
+        return None, f"{system}\n\n{prompt}"
 
     async def setup(self, runtime: Runtime) -> None:
         """Provision this harness in `runtime` before its execution timeout starts."""

--- a/verifiers/v1/task.py
+++ b/verifiers/v1/task.py
@@ -68,8 +68,8 @@ class Task(StrictBaseModel):
     turn before the model is ever called."""
     system_prompt: str | None = None
     """Optional system prompt. Harnesses that set `APPENDS_SYSTEM_PROMPT` emit it as a real
-    system message (or via their own mechanism); a harness that does not rejects a task that
-    sets it. See `Harness.resolve_prompt`."""
+    system message (or their own mechanism); others prepend it to `prompt` (with a
+    warning). See `Harness.resolve_prompt`."""
     image: str | None = None
     """Container image this task needs (e.g. its harbor environment). When set, the
     runtime must be a container (docker/prime): the Environment injects it into the


### PR DESCRIPTION
## Summary

Cleanly reverts #1735 ("fix: reject unsupported task system_prompt"), restoring the prior `Harness.resolve_prompt` behavior:

- A harness without `APPENDS_SYSTEM_PROMPT` (e.g. `codex` / `kimi_code` / `mini_swe_agent`) once again **folds** `task.system_prompt` into the user prompt (`"{system}\n\n{prompt}"`, with a warning) instead of raising a `ValueError`.
- `APPENDS_SYSTEM_PROMPT` harnesses (`default` / `bash` / `rlm`) are unaffected — the system prompt is still emitted separately.
- Restores the original docstrings on `APPENDS_SYSTEM_PROMPT`, `resolve_prompt`, and `Task.system_prompt`.

Produced with `git revert cc4afd52` (the #1735 squash-merge); a clean inverse with no manual edits. The later `setup` method and boundary-error changes (#1749 / #1751) are untouched.

## Breaking

- Reverts the breaking change from #1735: tasks that set `system_prompt` on a non-`APPENDS_SYSTEM_PROMPT` harness no longer error — they fold the system prompt into the user message (with a warning) as before.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Revert rejection of tasks with unsupported system prompts in `Harness.resolve_prompt`
> - When a harness does not append system prompts (`APPENDS_SYSTEM_PROMPT=False`) and the prompt is a plain string, `resolve_prompt` now logs a warning and prepends the system prompt to the user prompt instead of raising an error.
> - A `ValueError` is still raised when the prompt is `Messages` or `None` and a system prompt is provided, as folding is not possible in those cases.
> - Updates `Task.system_prompt` field docs in [task.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1769/files#diff-a1b4a5d6915beae41831864087ea497ed41f0b67b9091ad1ee614834cbfd9399) to reflect the new prepend-with-warning behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2bccead.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->