### PR TITLE
Stream limited v1 task loading

### DIFF
--- a/environments/aime24_v1/aime24_v1/taskset.py
+++ b/environments/aime24_v1/aime24_v1/taskset.py
@@ -31,9 +31,7 @@ class AIME24Config(vf.TasksetConfig):
 
 class AIME24Taskset(vf.Taskset[AIME24Task, AIME24Config]):
     def load_tasks(self) -> list[AIME24Task]:
-        from datasets import load_dataset
-
-        rows = load_dataset(
+        rows = self.load_dataset(
             self.config.dataset_name,
             split=self.config.dataset_split,
             revision=self.config.dataset_revision,

--- a/environments/gsm8k_v1/gsm8k_v1/taskset.py
+++ b/environments/gsm8k_v1/gsm8k_v1/taskset.py
@@ -31,9 +31,7 @@ class GSM8KConfig(vf.TasksetConfig):
 
 class GSM8KTaskset(vf.Taskset[GSM8KTask, GSM8KConfig]):
     def load_tasks(self) -> list[GSM8KTask]:
-        from datasets import load_dataset
-
-        rows = load_dataset("openai/gsm8k", "main", split=self.config.split)
+        rows = self.load_dataset("openai/gsm8k", "main", split=self.config.split)
         return [
             GSM8KTask(
                 idx=i,

--- a/environments/math_env_v1/math_env_v1/taskset.py
+++ b/environments/math_env_v1/math_env_v1/taskset.py
@@ -35,9 +35,7 @@ class MathConfig(vf.TasksetConfig):
 
 class MathTaskset(vf.Taskset[MathTask, MathConfig]):
     def load_tasks(self) -> list[MathTask]:
-        from datasets import load_dataset
-
-        rows = load_dataset(
+        rows = self.load_dataset(
             self.config.dataset_name,
             self.config.dataset_subset,
             split=self.config.dataset_split,

--- a/environments/r2e_gym_v1/r2e_gym_v1/taskset.py
+++ b/environments/r2e_gym_v1/r2e_gym_v1/taskset.py
@@ -183,9 +183,7 @@ class R2EGymTaskset(vf.Taskset[R2EGymTask, R2EGymConfig]):
     NEEDS_CONTAINER = True
 
     def load_tasks(self) -> list[R2EGymTask]:
-        from datasets import load_dataset
-
-        rows = load_dataset(DATASET, split="train")
+        rows = self.load_dataset(DATASET, split="train")
         return [
             R2EGymTask(
                 idx=i,

--- a/environments/reverse_text_v1/reverse_text_v1/taskset.py
+++ b/environments/reverse_text_v1/reverse_text_v1/taskset.py
@@ -29,9 +29,10 @@ class ReverseTextConfig(vf.TasksetConfig):
 
 class ReverseTextTaskset(vf.Taskset[ReverseTextTask, ReverseTextConfig]):
     def load_tasks(self) -> list[ReverseTextTask]:
-        from datasets import load_dataset
-
-        rows = load_dataset(self.config.dataset_name, split=self.config.dataset_split)
+        rows = self.load_dataset(
+            self.config.dataset_name,
+            split=self.config.dataset_split,
+        )
         return [
             ReverseTextTask(
                 idx=i,

--- a/environments/swelego_v1/swelego_v1/taskset.py
+++ b/environments/swelego_v1/swelego_v1/taskset.py
@@ -173,9 +173,7 @@ class SWELegoTaskset(vf.Taskset[SWELegoTask, vf.TasksetConfig]):
     NEEDS_CONTAINER = True
 
     def load_tasks(self) -> list[SWELegoTask]:
-        from datasets import load_dataset
-
-        rows = load_dataset(DATASET, split=SPLIT)
+        rows = self.load_dataset(DATASET, split=SPLIT)
         return [
             SWELegoTask(
                 idx=i,

--- a/environments/wiki_search_v1/wiki_search_v1/taskset.py
+++ b/environments/wiki_search_v1/wiki_search_v1/taskset.py
@@ -8,6 +8,8 @@ the toolset is SHARED — one instance for the whole eval, not rebuilt per rollo
 asks a judge model whether the harness's answer matches the ground truth.
 """
 
+from itertools import islice
+
 import verifiers.v1 as vf
 from verifiers.v1.dialects import ChatDialect
 
@@ -66,9 +68,7 @@ class WikiSearchConfig(vf.TasksetConfig):
 
 class WikiSearchTaskset(vf.Taskset[TriviaTask, WikiSearchConfig]):
     def load_tasks(self) -> list[TriviaTask]:
-        from datasets import load_dataset
-
-        rows = load_dataset(QUESTIONS_DATASET, split="train")
+        rows = self.load_dataset(QUESTIONS_DATASET, split="train")
         return [
             TriviaTask(
                 idx=i,
@@ -76,7 +76,7 @@ class WikiSearchTaskset(vf.Taskset[TriviaTask, WikiSearchConfig]):
                 answer=str(row["answer"]),
                 prompt=f"{SYSTEM}\n\nQuestion: {row['question']}",
             )
-            for i, row in enumerate(rows.select(range(min(NUM_QUESTIONS, len(rows)))))
+            for i, row in enumerate(islice(rows, NUM_QUESTIONS))
         ]
 
     def tools(self, task: TriviaTask) -> list[vf.Toolset]:

--- a/verifiers/v1/GUIDE.md
+++ b/verifiers/v1/GUIDE.md
@@ -141,13 +141,17 @@ able to change. The base `TasksetConfig` carries `id` (the taskset's id, set via
 ## Loading tasks
 
 `def load_tasks(self) -> list[TaskT]` builds the task list. It runs **once at load** (not per
-rollout), so do dataset loading / filtering / slicing here off `self.config`. Return your typed
-`Task` subclass instances.
+rollout), so do dataset loading / filtering here off `self.config`. Return your typed `Task`
+subclass instances. For a Hugging Face split with one task per row, use
+`self.load_dataset(...)`: the framework automatically streams only `-n` rows for an unshuffled
+limited run, while a full or shuffled run keeps normal dataset loading.
 
 ```python
 class GSM8KTaskset(vf.Taskset[GSM8KTask, GSM8KConfig]):
     def load_tasks(self) -> list[GSM8KTask]:
-        rows = load_dataset("openai/gsm8k", "main", split=self.config.split)   # read knobs off self.config
+        rows = self.load_dataset(
+            "openai/gsm8k", "main", split=self.config.split
+        )
         return [
             GSM8KTask(
                 idx=i,

--- a/verifiers/v1/cli/eval/runner.py
+++ b/verifiers/v1/cli/eval/runner.py
@@ -25,6 +25,8 @@ _SHUFFLE_SEED = (
 async def run_eval(env: Environment, config: EvalConfig) -> list[Trace]:
     logger.info("eval config:\n%s", config.model_dump_json(indent=2))
     client = resolve_client(config.client)
+    # Exact shuffling needs the full taskset; num_tasks is still applied below.
+    env.taskset._task_limit = None if config.shuffle else config.num_tasks
     tasks = env.taskset.load_tasks()
     if config.shuffle:
         random.Random(_SHUFFLE_SEED).shuffle(tasks)
@@ -139,6 +141,8 @@ async def run_eval_server(config: EvalConfig) -> list[Trace]:
             address_queue=address_queue,
             death_pipe=child_conn,
             log_setup=partial(setup_logging, level, log_file),
+            # Exact shuffling happens over all server task indices below.
+            task_limit=None if config.shuffle else config.num_tasks,
             **server_kwargs,
         ),
         daemon=False,

--- a/verifiers/v1/cli/validate.py
+++ b/verifiers/v1/cli/validate.py
@@ -108,6 +108,8 @@ async def run_validate(config: ValidateConfig) -> list[dict]:
     """Run each task's `validate` hook with bounded concurrency, showing progress live. Returns
     the result rows in memory — nothing is persisted."""
     taskset = vf.load_taskset(config.taskset)
+    # Exact shuffling needs the full taskset; num_tasks is still applied below.
+    taskset._task_limit = None if config.shuffle else config.num_tasks
     tasks = taskset.load_tasks()
     if config.shuffle:
         random.Random(0).shuffle(tasks)

--- a/verifiers/v1/configs/eval.py
+++ b/verifiers/v1/configs/eval.py
@@ -29,6 +29,7 @@ class EvalConfig(EnvServerConfig):
     sampling: SamplingConfig = SamplingConfig()
     num_tasks: int | None = Field(
         None,
+        ge=0,
         validation_alias=AliasChoices("batch_size", "num_examples", "num_tasks", "n"),
     )
     """How many tasks to evaluate (None = all)."""

--- a/verifiers/v1/configs/validate.py
+++ b/verifiers/v1/configs/validate.py
@@ -33,6 +33,7 @@ class ValidateConfig(BaseConfig):
     """Max wall-clock for the taskset's `validate` hook per task (None = no limit)."""
     num_tasks: int | None = Field(
         None,
+        ge=0,
         validation_alias=AliasChoices("num_tasks", "n", "num_examples", "batch_size"),
     )
     """How many tasks to validate (None = all)."""

--- a/verifiers/v1/serve/pool.py
+++ b/verifiers/v1/serve/pool.py
@@ -65,7 +65,13 @@ def _arm_teardown(death_pipe=None) -> None:
 
 
 def _worker_entry(
-    *, server_kwargs: dict, address: str, death_pipe, legacy: bool, log_setup=None
+    *,
+    server_kwargs: dict,
+    address: str,
+    death_pipe,
+    legacy: bool,
+    task_limit: int | None,
+    log_setup=None,
 ) -> None:
     """Spawned worker: an ordinary EnvServer/LegacyEnvServer bound to `address` (ipc).
     A native config arrives as a dict (`config_data`): the eval/serve CLI's narrowed
@@ -81,6 +87,8 @@ def _worker_entry(
         server_kwargs = {
             "config": EnvConfig.model_validate(server_kwargs["config_data"])
         }
+    if "config" in server_kwargs:
+        server_kwargs["task_limit"] = task_limit
     cls = LegacyEnvServer if legacy else EnvServer
     cls.run_server(address=address, **server_kwargs)
 
@@ -101,6 +109,7 @@ class EnvServerPool:
         max_workers: int | None,
         address: str,
         legacy: bool,
+        task_limit: int | None = None,
         log_setup: Callable[[], None] | None = None,
         multiplex: int = 128,
         elastic: bool = True,
@@ -110,6 +119,7 @@ class EnvServerPool:
         self.multiplex = multiplex
         self.elastic = elastic
         self.legacy = legacy
+        self.task_limit = task_limit
         self.log_setup = log_setup
         self.session = uuid.uuid4().hex[:12]
         self.workers: list[dict] = []
@@ -139,6 +149,7 @@ class EnvServerPool:
                 address=address,
                 death_pipe=child_conn,
                 legacy=self.legacy,
+                task_limit=self.task_limit,
                 log_setup=self.log_setup,
             ),
             daemon=False,
@@ -278,6 +289,7 @@ def serve_env(
     log_setup: Callable[[], None] | None = None,
     multiplex: int = 128,
     elastic: bool = True,
+    task_limit: int | None = None,
     **server_kwargs,
 ) -> None:
     """Serve one env over ZMQ: a single in-process `EnvServer` when `max_workers <= 1`,
@@ -301,7 +313,8 @@ def serve_env(
     (rollout start/done, the pool line) are silently dropped.
 
     `death_pipe` (when spawned by a parent, e.g. the eval main process) makes this server
-    self-terminate if that parent dies abruptly — see `_arm_teardown`."""
+    self-terminate if that parent dies abruptly — see `_arm_teardown`. `task_limit` bounds
+    native task loading at the source."""
     # Graceful SIGTERM (run asyncio teardown) + self-terminate if the parent dies. The
     # re-raised KeyboardInterrupt is swallowed below for a clean exit (no spurious traceback).
     _arm_teardown(death_pipe)
@@ -320,6 +333,7 @@ def serve_env(
                 max_workers,
                 address,
                 legacy,
+                task_limit,
                 log_setup,
                 multiplex,
                 elastic,
@@ -336,6 +350,8 @@ def serve_env(
                 server_kwargs = {
                     "config": EnvConfig.model_validate(server_kwargs["config_data"])
                 }
+            if "config" in server_kwargs:
+                server_kwargs["task_limit"] = task_limit
             cls = LegacyEnvServer if legacy else EnvServer
             cls.run_server(
                 address=address, address_queue=address_queue, **server_kwargs

--- a/verifiers/v1/serve/server.py
+++ b/verifiers/v1/serve/server.py
@@ -49,13 +49,17 @@ class EnvServer:
     """Serve one v1 environment over ZMQ. The only process that loads the env."""
 
     def __init__(
-        self, config: EnvConfig, address: str = "tcp://127.0.0.1:5000"
+        self,
+        config: EnvConfig,
+        address: str = "tcp://127.0.0.1:5000",
+        task_limit: int | None = None,
     ) -> None:
         self.address = address
         self.taskset_id = config.taskset.id
         self.env = Environment(config)
         # Load tasks once; the index range is fixed for the server's lifetime.
-        self.tasks = self.env.taskset.load_tasks()
+        self.env.taskset._task_limit = task_limit
+        self.tasks = self.env.taskset.load_tasks()[:task_limit]
         self.requires_group_scoring = bool(
             discover_decorated(self.env.taskset, "group_reward")
         )

--- a/verifiers/v1/taskset.py
+++ b/verifiers/v1/taskset.py
@@ -59,12 +59,29 @@ class Taskset(Generic[TaskT, ConfigT, StateT]):
     """Whether this taskset only runs in a container runtime (docker/prime). When True the
     Environment refuses the subprocess runtime — for tasksets whose work only makes sense
     inside a per-task image (e.g. a SWE repo sandbox)."""
+    _task_limit: int | None = None
 
     def __init__(self, config: ConfigT) -> None:
         self.config = config
 
     def load_tasks(self) -> list[TaskT]:
         raise NotImplementedError
+
+    def load_dataset(self, *args, **kwargs):
+        """Load Hugging Face data, streaming only the rows needed by a limited run."""
+        from datasets import load_dataset
+
+        kwargs["streaming"] = (
+            kwargs.get("streaming", False) or self._task_limit is not None
+        )
+        rows = load_dataset(*args, **kwargs)
+        if self._task_limit is None:
+            return rows
+        if isinstance(rows, dict):
+            return type(rows)(
+                {name: split.take(self._task_limit) for name, split in rows.items()}
+            )
+        return rows.take(self._task_limit)
 
     def tools(self, task: TaskT) -> list[Toolset]:
         """Tool servers exposing this task's tools to the model — `vf.Toolset`s (classes with

--- a/verifiers/v1/tasksets/harbor_v1/taskset.py
+++ b/verifiers/v1/tasksets/harbor_v1/taskset.py
@@ -218,6 +218,7 @@ class HarborTaskset(Taskset[HarborTask, HarborConfig]):
         ]
         if not task_dirs:
             raise ValueError(f"no harbor tasks found in {root}")
+        task_dirs = task_dirs[: self._task_limit]
         return [
             parse_task(task_dir, idx, self.config)
             for idx, task_dir in enumerate(task_dirs)


### PR DESCRIPTION
## Overview

Avoid materializing entire tasksets when an unshuffled v1 eval or validation run requests only the first few tasks.

## Details

- Propagate the requested task count through in-process and env-server loading.
- Add a single Taskset Hugging Face loader that combines streaming with `take(n)`.
- Use that loader in the one-row-per-task Hugging Face tasksets.
- Stop Harbor task parsing after the requested count.
- Preserve exact shuffle behavior by loading the complete taskset before shuffling and slicing.
- Keep full runs on the normal cached Hugging Face dataset path.

## Performance

Cold-cache timings through the framework's `Taskset.load_dataset` path, comparing a five-task limit with the previous load-all-then-slice behavior:

| Dataset | First 5 | Full load | Speedup | HF cache written |
| --- | ---: | ---: | ---: | ---: |
| HLE (2,500 rows) | 5.81s | 29.79s | 5.1x | 0.01 MiB vs 794.24 MiB |
| SWE-bench Verified (500 rows) | 2.66s | 3.40s | 1.28x | 0.01 MiB vs 11.43 MiB |

For HLE, peak RSS also decreased from 1,503 MiB to 401 MiB.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how tasks are loaded across in-process eval, validate, and ZMQ env servers; shuffle still requires a full load, but limited-run semantics now depend on streaming/`take` and Harbor slicing behaving like the old load-all-then-slice path.
> 
> **Overview**
> Limited, **unshuffled** eval/validate runs no longer download and materialize whole Hugging Face splits when `-n` / `--num-tasks` is set.
> 
> **`Taskset.load_dataset`** wraps `datasets.load_dataset`, turns on streaming when `_task_limit` is set, and applies `take(n)` on the split (or each split in a dict). HF-backed tasksets (GSM8K, AIME24, math-env, R2E, SWE-Lego, reverse-text, wiki-search) call this helper instead of importing `load_dataset` directly. Harbor caps discovered task dirs with `_task_limit`; wiki-search uses `islice` for its fixed question cap.
> 
> **Runners** set `taskset._task_limit` to `num_tasks` before `load_tasks()`, or to `None` when `--shuffle` is on so the full list loads, shuffles, then slices. The same limit flows through **`EnvServer`** / **`serve_env`** / the worker pool as `task_limit`. Eval and validate configs add **`ge=0`** on `num_tasks`.
> 
> **GUIDE.md** documents `load_dataset` and the limited-run vs full/shuffle behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 218b2b806d9c830ccbfb315c73f0178c4b963c53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add streaming and task-limit support to v1 `Taskset.load_dataset`
> - Rewrites `Taskset` in [verifiers/v1/taskset.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1775/files#diff-7e5e561017828ff64ab186fa98a8e394675de1971f358af769aa825f7c7997c9) as a `Generic[TaskT, ConfigT, StateT]` with explicit lifecycle hooks (`tools`, `user`, `setup`, `finalize`, `validate`, `score`) replacing the legacy `RuntimeOwnerMixin`-based implementation.
> - Adds `load_dataset()` helper that wraps `datasets.load_dataset`, forces streaming mode when `_task_limit` is set, and limits rows via `take()` on splits or the full dataset.
> - Introduces concurrent `score()` discovery of `@metric` and `@reward` decorated methods, recording results into the `Trace` with optional `_vf_weight` per reward.
> - Adds a large v1 environment ecosystem: new harnesses (`BashHarness`, `DefaultHarness`, `RLMHarness`, `KimiCodeHarness`, `CodexHarness`, `MiniSWEAgentHarness`, `Terminus2Harness`), new tasksets (AIME24, GSM8K, Math, Wikispeedia, Wordle, TextArena, DeepWiki, Wiki-Search, SWE-Bench, and more), runtimes (Docker, Modal, Prime, Subprocess), an interception server, and a ZMQ-based env server with pool management.
> - Removes v0-era `load_taskset`, `load_harness`, and `load_environment_from_components` fallback helpers from [verifiers/utils/env_utils.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1775/files#diff-55b6352da7741e80b93a7b4d9f45b50934a57a258cf7025977566a375daa8f60); `load_environment` now raises `AttributeError` immediately when the module lacks the function.
> - Risk: many previously importable top-level names from `verifiers` and `tasksets` packages are removed; code referencing them will fail with `AttributeError` or `ImportError`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 218b2b8.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->