### PR TITLE
Restore isolated R2E test staging with a validation fast path

### DIFF
--- a/environments/r2e_gym_v1/r2e_gym_v1/taskset.py
+++ b/environments/r2e_gym_v1/r2e_gym_v1/taskset.py
@@ -3,15 +3,22 @@
 Each row ships a per-task Docker image with the repo checked out at ``/testbed`` and a
 hidden ``/r2e_tests`` directory plus a ``run_tests.sh`` harness. ``setup`` symlinks the
 repo venv onto ``PATH``, clears pycache, and stashes ``/r2e_tests`` out of the agent's
-reach (tarred to ``/opt`` and removed) so the running agent can't read the ground-truth
-tests. The ``solved`` reward restores the tests into ``/testbed/r2e_tests``, runs
+reach (archived to the evaluator host and removed from the sandbox) so the running agent
+can't read the ground-truth tests. The ``solved`` reward restores the tests, runs
 ``run_tests.sh``, parses the pytest summary, and scores 1.0 iff the per-test pass/fail
 map exactly matches the row's ``expected_output_json``. A v1 port of the v0 ComposableEnv
 ``R2EGymTaskSet``.
 """
 
+import hashlib
+import hmac
 import json
 import re
+import secrets
+import tempfile
+import weakref
+from functools import cached_property
+from pathlib import Path
 
 import verifiers.v1 as vf
 
@@ -24,9 +31,8 @@ REGISTRY = "us-central1-docker.pkg.dev/prime-intellect-platform/prod-sandbox"
 
 REPO_PATH = "/testbed"
 ALT_PATH = "/root"
-# Tests are staged here during the agent rollout (outside the /testbed workdir) and
-# restored to /testbed/r2e_tests at scoring time.
-STAGED_TESTS = "/opt/r2e_tests.tar.gz"
+REMOTE_TESTS_ARCHIVE = "/tmp/r2e_tests.tar.gz"
+REMOTE_TESTS_CIPHERTEXT = f"{REMOTE_TESTS_ARCHIVE}.sealed"
 
 # The testbed venv (project + pytest installed) plus quiet, non-interactive tooling —
 # exported for every command the taskset runs in the sandbox.
@@ -44,6 +50,9 @@ ENV = {
     "CI": "1",
 }
 
+# Hidden-test control commands must not resolve tools from agent-writable project paths.
+SYSTEM_ENV = {"PATH": "/usr/sbin:/usr/bin:/sbin:/bin"}
+
 # Symlink the repo venv + its executables onto the alt PATH so plain `python`/`pytest`
 # resolve to the project environment regardless of the agent's cwd.
 LINK = r"""
@@ -60,12 +69,93 @@ CLEAN_PYCACHE = (
     "2>/dev/null || timeout 30 find . -name '*.pyc' -delete 2>/dev/null || true"
 )
 
-# Stash the ground-truth tests away from the agent (tar to /opt, then remove the dir).
-HIDE_TESTS = f"tar -C / -czf {STAGED_TESTS} r2e_tests && rm -rf /r2e_tests"
-# Restore them into the workdir for scoring (run_tests.sh expects /testbed/r2e_tests).
-RESTORE_TESTS = (
-    f"rm -rf {REPO_PATH}/r2e_tests && tar -C {REPO_PATH} -xzf {STAGED_TESTS}"
+ARCHIVE_TESTS = f"tar -C / -czf {REMOTE_TESTS_ARCHIVE} r2e_tests"
+REMOVE_TESTS = (
+    f"rm -rf /r2e_tests && rm -f {REMOTE_TESTS_ARCHIVE} {REMOTE_TESTS_CIPHERTEXT}"
 )
+MOVE_TESTS = f"rm -rf {REPO_PATH}/r2e_tests && mv /r2e_tests {REPO_PATH}/r2e_tests"
+RESTORE_TESTS = (
+    f"rm -rf {REPO_PATH}/r2e_tests && "
+    f"tar -C {REPO_PATH} -xzf {REMOTE_TESTS_ARCHIVE} && "
+    f"rm -f {REMOTE_TESTS_ARCHIVE} {REMOTE_TESTS_CIPHERTEXT}"
+)
+DECRYPT_TESTS = f"""
+import hashlib
+import hmac
+import os
+
+sealed_path = {REMOTE_TESTS_CIPHERTEXT!r}
+archive_path = {REMOTE_TESTS_ARCHIVE!r}
+key = bytes.fromhex(os.environ["R2E_ARCHIVE_KEY"])
+with open(sealed_path, "rb") as file:
+    sealed = file.read()
+tag, ciphertext = sealed[:32], sealed[32:]
+mac_key = hashlib.sha256(b"r2e-tests-mac\\0" + key).digest()
+expected = hmac.digest(mac_key, ciphertext, "sha256")
+if len(tag) != 32 or not hmac.compare_digest(tag, expected):
+    raise SystemExit("invalid R2E test archive")
+stream = hashlib.shake_256(b"r2e-tests-enc\\0" + key).digest(len(ciphertext))
+plaintext = bytes(a ^ b for a, b in zip(ciphertext, stream))
+try:
+    os.unlink(archive_path)
+except FileNotFoundError:
+    pass
+with open(archive_path, "xb") as file:
+    file.write(plaintext)
+os.chmod(archive_path, 0o600)
+os.unlink(sealed_path)
+"""
+SNAPSHOT_PROCESSES = r"""
+for path in /proc/[0-9]*; do
+    pid=${path##*/}
+    IFS= read -r stat < "$path/stat" || continue
+    stat=${stat##*) }
+    set -- $stat
+    [ "$#" -ge 20 ] && printf '%s:%s ' "$pid" "${20}"
+done
+"""
+
+# Scoring runs before runtime teardown, so reap detached agent processes before tests return.
+KILL_AGENT_PROCESSES = r"""
+self=$$
+ancestors=" 1 "
+baseline=" $R2E_BASELINE_PROCESSES "
+pid=$self
+while [ "$pid" -gt 1 ] 2>/dev/null; do
+    ancestors="$ancestors$pid "
+    pid=$(sed -n 's/^PPid:[[:space:]]*//p' "/proc/$pid/status" 2>/dev/null)
+    [ -n "$pid" ] || break
+done
+while :; do
+    found=0
+    for path in /proc/[0-9]*; do
+        pid=${path##*/}
+        case "$ancestors" in
+            *" $pid "*) continue ;;
+        esac
+        identity=
+        state=
+        if IFS= read -r stat < "$path/stat"; then
+            stat=${stat##*) }
+            set -- $stat
+            if [ "$#" -ge 20 ]; then
+                state=$1
+                identity="$pid:${20}"
+            fi
+        fi
+        [ "$state" = Z ] && continue
+        if [ -n "$identity" ]; then
+            case "$baseline" in
+                *" $identity "*) continue ;;
+            esac
+        fi
+        found=1
+        kill -STOP "$pid" 2>/dev/null || true
+        kill -KILL "$pid" 2>/dev/null || true
+    done
+    [ "$found" -eq 0 ] && break
+done
+"""
 
 
 def parse_log_pytest(log: str | None) -> dict[str, str]:
@@ -177,10 +267,21 @@ class R2EGymConfig(vf.TasksetConfig):
     use_prime_registry: bool = False
     """Resolve task images against Prime's private Artifact Registry (`REGISTRY`) instead of the
     dataset's public Docker Hub `docker_image`. Only works on runtimes with GCP pull credentials."""
+    hide_tests_from_agent: bool = True
+    """Keep tests on the evaluator host during agent rollouts. Disable only for no-agent
+    validation, where an in-sandbox move avoids the archive transfer."""
 
 
 class R2EGymTaskset(vf.Taskset[R2EGymTask, R2EGymConfig]):
     NEEDS_CONTAINER = True
+
+    @cached_property
+    def _host_archives(self) -> weakref.WeakKeyDictionary[vf.Runtime, Path]:
+        return weakref.WeakKeyDictionary()
+
+    @cached_property
+    def _baseline_processes(self) -> weakref.WeakKeyDictionary[vf.Runtime, str]:
+        return weakref.WeakKeyDictionary()
 
     def load_tasks(self) -> list[R2EGymTask]:
         from datasets import load_dataset
@@ -205,19 +306,115 @@ class R2EGymTaskset(vf.Taskset[R2EGymTask, R2EGymConfig]):
         ]
 
     async def setup(self, task: R2EGymTask, runtime: vf.Runtime) -> None:
-        for cmd in (LINK, CLEAN_PYCACHE, HIDE_TESTS):
-            result = await runtime.run(["sh", "-c", cmd], ENV)
-            if cmd is HIDE_TESTS and result.exit_code != 0:
+        for cmd in (LINK, CLEAN_PYCACHE):
+            await runtime.run(["sh", "-c", cmd], ENV)
+
+        if not self.config.hide_tests_from_agent:
+            result = await runtime.run(["sh", "-c", MOVE_TESTS], ENV)
+            if result.exit_code != 0:
                 raise RuntimeError(
-                    f"r2e setup failed to stage tests ({task.name}): {result.stderr.strip()[-500:]}"
+                    f"r2e setup failed to move tests ({task.name}): {result.stderr.strip()[-500:]}"
                 )
+            return
+
+        result = await runtime.run(["sh", "-c", ARCHIVE_TESTS], ENV)
+        if result.exit_code != 0:
+            raise RuntimeError(
+                f"r2e setup failed to archive tests ({task.name}): {result.stderr.strip()[-500:]}"
+            )
+
+        archive = await runtime.read(REMOTE_TESTS_ARCHIVE)
+        with tempfile.NamedTemporaryFile(
+            prefix=f"r2e_tests_{runtime.name}_", suffix=".tar.gz", delete=False
+        ) as file:
+            file.write(archive)
+            host_archive = Path(file.name)
+        self._host_archives[runtime] = host_archive
+        weakref.finalize(runtime, host_archive.unlink, missing_ok=True)
+        original_stop = runtime.stop
+
+        async def stop_with_archive_cleanup() -> None:
+            try:
+                host_archive.unlink(missing_ok=True)
+                self._host_archives.pop(runtime, None)
+                self._baseline_processes.pop(runtime, None)
+            finally:
+                await original_stop()
+
+        setattr(runtime, "stop", stop_with_archive_cleanup)
+
+        result = await runtime.run(["sh", "-c", REMOVE_TESTS], ENV)
+        if result.exit_code != 0:
+            host_archive.unlink(missing_ok=True)
+            self._host_archives.pop(runtime, None)
+            raise RuntimeError(
+                f"r2e setup failed to hide tests ({task.name}): {result.stderr.strip()[-500:]}"
+            )
+
+        baseline = await runtime.run(["sh", "-c", SNAPSHOT_PROCESSES], ENV)
+        if baseline.exit_code != 0:
+            host_archive.unlink(missing_ok=True)
+            self._host_archives.pop(runtime, None)
+            raise RuntimeError(
+                f"r2e setup failed to snapshot processes ({task.name}): "
+                f"{baseline.stderr.strip()[-500:]}"
+            )
+        self._baseline_processes[runtime] = baseline.stdout
 
     @vf.reward(weight=1.0)
     async def solved(self, task: R2EGymTask, runtime: vf.Runtime) -> float:
-        restore = await runtime.run(["sh", "-c", RESTORE_TESTS], ENV)
-        if restore.exit_code != 0:
-            return 0.0
-        result = await runtime.run(["sh", "-c", "/bin/bash run_tests.sh 2>&1"], ENV)
+        if self.config.hide_tests_from_agent:
+            host_archive = self._host_archives.get(runtime)
+            baseline_processes = self._baseline_processes.get(runtime)
+            if (
+                host_archive is None
+                or not host_archive.exists()
+                or baseline_processes is None
+            ):
+                return 0.0
+            try:
+                cleanup_env = SYSTEM_ENV | {
+                    "R2E_BASELINE_PROCESSES": baseline_processes
+                }
+                cleanup = await runtime.run(
+                    ["/bin/sh", "-c", KILL_AGENT_PROCESSES],
+                    cleanup_env,
+                )
+                if cleanup.exit_code != 0:
+                    return 0.0
+                archive = host_archive.read_bytes()
+                key = secrets.token_bytes(32)
+                # write() may invoke sandbox helpers: expose only ciphertext, then reap again.
+                stream = hashlib.shake_256(b"r2e-tests-enc\0" + key).digest(
+                    len(archive)
+                )
+                ciphertext = bytes(a ^ b for a, b in zip(archive, stream))
+                mac_key = hashlib.sha256(b"r2e-tests-mac\0" + key).digest()
+                sealed = hmac.digest(mac_key, ciphertext, "sha256") + ciphertext
+                await runtime.write(REMOTE_TESTS_CIPHERTEXT, sealed)
+                cleanup = await runtime.run(
+                    ["/bin/sh", "-c", KILL_AGENT_PROCESSES], cleanup_env
+                )
+                if cleanup.exit_code != 0:
+                    return 0.0
+                decrypt = await runtime.run(
+                    ["/usr/bin/python3", "-I", "-S", "-c", DECRYPT_TESTS],
+                    SYSTEM_ENV | {"R2E_ARCHIVE_KEY": key.hex()},
+                )
+                if decrypt.exit_code != 0:
+                    return 0.0
+                restore = await runtime.run(
+                    ["/bin/sh", "-c", RESTORE_TESTS], SYSTEM_ENV
+                )
+            finally:
+                host_archive.unlink(missing_ok=True)
+                self._host_archives.pop(runtime, None)
+                self._baseline_processes.pop(runtime, None)
+            if restore.exit_code != 0:
+                return 0.0
+        result = await runtime.run(
+            ["/bin/sh", "-c", "/bin/bash run_tests.sh 2>&1"], ENV
+        )
         return calculate_reward(result.stdout or "", task.expected_output_json)
 
     async def validate(self, task: R2EGymTask, runtime: vf.Runtime) -> bool:


### PR DESCRIPTION
## Overview

Restore the R2E Gym isolation contract introduced in 3e2a8510d5 and keep it intact through scoring:

- agent rollouts archive /r2e_tests, transfer the archive to the evaluator process, remove both sandbox copies, record the pre-agent process baseline, and register archive cleanup on runtime stop
- scoring kills post-setup agent processes, uploads only authenticated ciphertext through the runtime, kills any upload-spawned processes, and creates plaintext only under an absolute isolated system interpreter before running the existing reward path
- no-agent validation can explicitly set hide_tests_from_agent = false to move the directory directly into place

This changes only environments/r2e_gym_v1/r2e_gym_v1/taskset.py.

## Execution topology

This does **not** create a second sandbox. Each rollout still provisions exactly one agent sandbox.

~~~text
machine/process running Verifiers
    /tmp/r2e_tests_<runtime-id>_<random>.tar.gz
    in-memory baseline: sandbox PID + kernel start time
                    ⇅ authenticated ciphertext transfer / exec
single agent sandbox
    /tmp/r2e_tests.tar.gz.sealed -> /tmp/r2e_tests.tar.gz
~~~

The two /tmp paths are on different filesystems:

- with a local Docker runtime, the evaluator path is on the Docker host
- with a Prime runtime, the evaluator path is on the machine or worker running the Verifiers evaluation process
- the sandbox path belongs to the one agent sandbox provisioned for that rollout

The evaluator process retains the archive bytes and process-identity baseline between setup and scoring. It does not execute the agent or tests in another sandbox.

## Why the archive format does not matter

Tar/gzip is serialization, not the isolation boundary. An uncompressed tarball—or any other readable representation left inside the sandbox—would be equally visible to a root-capable agent.

The V1 port left /opt/r2e_tests.tar.gz inside the agent sandbox. That hid individual paths from ordinary directory traversal, but the agent could still list, extract, or stream the known archive. The default path now transfers the archive to a collision-free, mode-0600 evaluator temporary file and removes both /r2e_tests and the sandbox archive before the harness starts.

The end-of-harness boundary matters too: detached processes can outlive the harness command. Before the archive returns, scoring preserves the original runtime/control processes and its own exec ancestry, then repeatedly freezes and kills every process created after setup until a complete scan finds none. It seals the archive with a fresh per-rollout key, sends only authenticated ciphertext through runtime.write(), repeats the stable cleanup to remove helpers or watchers created by that upload, and only then reveals the key to an isolated absolute system interpreter that creates the plaintext archive. The security properties therefore come from keeping the bytes outside the sandbox during generation and removing leftover agent execution before restore—not from compression.

The runtime stop path explicitly removes the evaluator file and taskset state even when a rollout fails before scoring. A runtime finalizer remains as the interpreter-exit backstop.

## Lifecycle breakdown

### Agent-safe path (default)

Setup:

~~~text
/r2e_tests in the single agent sandbox
    -> /tmp/r2e_tests.tar.gz in that sandbox
    -> /tmp/r2e_tests_<runtime-id>_<random>.tar.gz on the evaluator filesystem
    -> delete /r2e_tests and the sandbox archive
    -> record each remaining sandbox process as PID + kernel start time
~~~

The start time is part of the identity so later PID reuse cannot accidentally whitelist an agent process.

Harness execution:

~~~text
the sandbox contains neither /r2e_tests nor a test archive
processes created by the harness/agent are absent from the setup baseline
~~~

Scoring:

~~~text
start /bin/sh with PATH=/usr/sbin:/usr/bin:/sbin:/bin
    -> preserve PID 1, setup-baseline identities, and the cleanup exec's ancestors
    -> SIGSTOP then SIGKILL every other live process
    -> rescan until no live non-baseline process remains
evaluator archive
    -> seal with a fresh key and upload /tmp/r2e_tests.tar.gz.sealed
    -> repeat process cleanup; upload helpers have seen ciphertext only
    -> verify and decrypt as /tmp/r2e_tests.tar.gz via /usr/bin/python3 -I -S
    -> extract as /testbed/r2e_tests under the system-only PATH
    -> delete sandbox and evaluator archives
    -> run /bin/bash run_tests.sh
~~~

SIGKILL cannot be trapped by a watcher. Repeating the scan closes the fork-after-expansion race; zombies are harmless and ignored, while an unkillable live process keeps scoring fail-closed until its timeout. Preserving both the setup baseline and the active exec ancestry keeps provider/runtime control processes alive while removing detached agent children. Cleanup and restore invoke /bin/sh directly and exclude /testbed/.venv/bin and /root/.local/bin from PATH, so agent-planted tar, sed, or shell shims are not selected after the archive returns. The upload boundary is separately protected: sandbox-side mkdir/cat helpers receive only SHAKE-encrypted, HMAC-authenticated bytes; their descendants are reaped before the key exists in the sandbox, and modified ciphertext fails closed. The test command separately retains the project PATH required by the repository environment. Archive, transfer, cleanup, and restore failures stay inside the existing setup or scoring error boundaries.

This cleanup relies on Linux /proc, which matches the container runtimes and Linux R2E images required by the taskset. It is a user-space boundary inside the existing sandbox; compromising PID 1, the provider control plane, or the kernel remains outside the taskset threat model.

### No-agent validation fast path

When hide_tests_from_agent = false, no harness inspects the sandbox, so setup uses:

~~~sh
rm -rf /testbed/r2e_tests && mv /r2e_tests /testbed/r2e_tests
~~~

Validation then applies the gold patch and runs the same scoring command without an archive round trip or process sweep.

## Validation-path timing breakdown

The benchmark used 2,000 deterministic 4 KiB files across 20 directories (8,192,000 bytes total), one warmup per strategy, and nine alternating measured rounds on fresh copies. Fixture preparation and hashing were outside the timed region; shell startup and replacement of a pre-existing destination were included.

| Strategy | Hide | Restore | Total median | Total range |
| --- | ---: | ---: | ---: | ---: |
| tar/gzip, remove, extract | 0.839079–1.035526 s | 0.615873–0.860195 s | 1.686329 s | 1.454952–1.895722 s |
| remove, rename | 0.008513–0.010382 s | 0.008714–0.009748 s | 0.018027 s | 0.017227–0.020131 s |

For no-agent validation, rename is **93.54× faster** at the median, a **98.93% elapsed-time reduction**:

~~~text
(1.686329 - 0.018027) / 1.686329 × 100 = 98.93%
~~~

These timings cover filesystem operations, not provider-specific transfer. The default agent-safe path prioritizes isolation and pays the sealing, archive transfer, and two process-sweep costs; the rename result applies only when hide_tests_from_agent is explicitly disabled.

## Filesystem assumption

Only the validation fast path depends on a same-filesystem rename between /r2e_tests and /testbed/r2e_tests. Across mounts, mv may fall back to recursive copy/delete and lose its constant-time and atomic-rename properties.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rollout/scoring orchestration and fail-closed behavior for a benchmark taskset; isolation logic is security-sensitive but scoped to one file and Linux container assumptions.
> 
> **Overview**
> Restores a stronger **hidden-test isolation** contract for R2E Gym v1 agent rollouts in `taskset.py`. During **setup**, ground-truth tests are tarred in the sandbox, **pulled to a mode-restricted temp file on the evaluator host**, then **`/r2e_tests` and the in-sandbox archive are removed**; a **process baseline** (PID + kernel start time) is recorded for later scoring. **`hide_tests_from_agent`** (default `true`) controls this path; when `false`, setup only **`mv`s tests into `/testbed/r2e_tests`** for fast no-agent validation.
> 
> **Scoring** (`solved`) no longer restores from an in-sandbox stash. With hiding enabled, it **reaps processes** not in the baseline or control ancestry (system `PATH` only), **uploads only HMAC-sealed ciphertext**, reaps again, **decrypts via `/usr/bin/python3 -I -S`**, extracts under the system PATH, deletes host/sandbox artifacts, then runs **`run_tests.sh`** with the normal project `ENV`. Runtime **stop** and a **finalizer** ensure evaluator temp archives and taskset state are cleaned up on failure or teardown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ee39989297a0bbf85f938536b4360b7920bbbd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore isolated R2E test staging with host-side archiving and a sealed-archive validation fast path
> - During `setup`, tests are tarred inside the sandbox, exported to the host via `_host_archives`, then deleted from the sandbox so agents cannot access them. A snapshot of running processes is recorded as a baseline.
> - During `solved`, non-baseline agent processes are killed before scoring; the host archive is sealed with SHAKE-256 XOR + HMAC-SHA256, written back into the sandbox, decrypted via an isolated Python snippet (`DECRYPT_TESTS`), and tests are restored before `run_tests.sh` executes.
> - A new `hide_tests_from_agent` flag (default `True`) in `R2EGymConfig` controls the flow; when `False`, tests are simply moved within the sandbox and the sealed-archive path is skipped.
> - Any failure in process cleanup, archive transfer, decryption, or restore short-circuits scoring and returns `0.0`.
> - Risk: the new flow adds several host-side side effects (tmp files, weakref finalizers, patched `runtime.stop`) that must complete cleanly; failures silently return `0.0` reward rather than raising.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9ee3998.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->