### PR TITLE
Reduce Prime background job polling latency

### DIFF
--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -129,11 +129,13 @@ class PrimeRuntime(Runtime):
                 working_dir=self.config.workdir,
                 env=env,
             )
+            delay = 0.1
             while True:
                 result = await self._client.get_background_job(self._sandbox_id, job)
                 if result.completed:
                     break
-                await asyncio.sleep(3)
+                await asyncio.sleep(delay)
+                delay = min(delay * 2, 3)
         except (
             Exception
         ) as e:  # a sandbox/API failure is one rollout's problem, not the eval's


### PR DESCRIPTION
## Overview

Adjust PrimeRuntime's background-job polling from a fixed three-second interval to a 100 ms exponential backoff capped at three seconds. This preserves the existing long-job cadence while allowing short Prime commands to be observed much closer to their actual completion time.

The change is intentionally local to the Prime polling loop. It does not change the runtime interface, command execution, timeout ownership, result handling, sandbox lifecycle, or the Modal, Docker, and subprocess runtimes.

## Reasoning

Prime returns a background-job handle, so Verifiers must ask the Prime API whether the command has completed. With the fixed interval, a command that completed shortly after the initial status request remained unobserved until the next request roughly three seconds later.

The adaptive schedule checks immediately, then sleeps for 0.1, 0.2, 0.4, 0.8, 1.6, and finally 3 seconds between incomplete responses:

```text
poll times: 0, 0.1, 0.3, 0.7, 1.5, 3.1, 6.1, ...
```

After the initial ramp, long-running jobs return to one request every three seconds. The steady-state API request rate therefore remains unchanged, with at most four additional early status requests per long job.

## Timing setups

Two complementary setups were used to characterize the behavior.

### Deterministic mocked timeline

This setup assumes zero API latency and makes completion observable at the first scheduled poll after the nominal command duration.

| Nominal duration | Fixed 3 s polling | Adaptive polling |
| --- | --- | --- |
| 0.5 s | detected at 3.0 s, 2 requests | detected at 0.7 s, 4 requests |
| 1.0 s | detected at 3.0 s, 2 requests | detected at 1.5 s, 5 requests |
| 10.0 s | detected at 12.0 s, 5 requests | detected at 12.1 s, 9 requests |

The 10-second case shows the long-job tradeoff clearly: both policies retain an approximately three-second worst-case detection delay, while the adaptive schedule pays a fixed four-request startup cost and then has the same sustained rate.

### Live Prime sandbox before/after control

Both policies ran sequentially in the same authenticated Prime sandbox using the same image, resources, workdir, and shell workload. The patched PrimeRuntime supplied the adaptive measurements. A control loop reproducing the previous fixed three-second interval supplied the before measurements.

End-to-end time starts immediately before the background-job creation request and ends when the completed status response is received. Sandbox provisioning is excluded. Commands differed only in their output marker:

```sh
sh -c 'sleep 0.5; printf adaptive-0.5'
sh -c 'sleep 1.0; printf adaptive-1.0'
sh -c 'sleep 0.5; printf legacy-0.5'
sh -c 'sleep 1.0; printf legacy-1.0'
```

| Nominal duration | Previous fixed interval | Adaptive interval | Reduction |
| --- | --- | --- | --- |
| 0.5 s | 3.727727 s, 2 polls | 1.166087 s, 3 polls | 2.561640 s / 68.72% |
| 1.0 s | 3.721793 s, 2 polls | 1.708813 s, 4 polls | 2.012980 s / 54.09% |

The live request counts are lower than the zero-latency model because each Prime status request itself takes time; command progress continues while those requests are in flight. The measurements therefore include both the intended sleep schedule and real provider/API latency.

## Impact

Short Prime commands and short shell wrappers used to launch background services return sooner. Long commands retain the previous three-second steady-state polling interval. Completion handling and error behavior remain unchanged: completed jobs produce the same ProgramResult, while sandbox and API failures continue through the existing SandboxError path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-loop timing change in PrimeRuntime.run with no API or result-shape changes; main effect is slightly more early status requests on short jobs.
> 
> **Overview**
> **PrimeRuntime** now polls background-job completion with **exponential backoff** (100 ms initial sleep, doubling each incomplete response, **capped at 3 s**) instead of a fixed **3 s** wait between status checks.
> 
> Short Prime commands can be observed much closer to when they finish, while long-running jobs still settle on roughly the same steady-state poll interval as before. **ProgramResult** handling, sandbox errors, and other runtimes are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1629b8b912f84787d239b7bdd35ba1248b3f217. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reduce Prime background job polling latency with exponential backoff
> Replaces the fixed 3s sleep in `PrimeRuntime.run` with exponential backoff starting at 0.1s and doubling up to a 3s maximum. This reduces time-to-detection for fast jobs while keeping polling frequency low for long-running ones.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c1629b8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->