### PR TITLE
Optimize TextArena task generation

### DIFF
--- a/packages/tasksets/tasksets/textarena_v1/taskset.py
+++ b/packages/tasksets/tasksets/textarena_v1/taskset.py
@@ -15,6 +15,7 @@ simulator re-seeds to the same episode, so no per-game word-list or state-key kn
 needed and any single-player TextArena game fits.
 """
 
+import copy
 import json
 import random
 from typing import Literal
@@ -140,10 +141,11 @@ class TextArenaTaskset(vf.Taskset[TextArenaTask, TextArenaConfig, TextArenaState
         # is seed-invariant (Wordle, Hangman) build it once.
         nltk.download("words", quiet=True)
         nltk.download("averaged_perceptron_tagger_eng", quiet=True)
+        template = ta.make(env_id=self.config.game)
 
         def observation(seed: int) -> str:
             random.seed(seed)
-            env = ta.make(env_id=self.config.game)
+            env = copy.deepcopy(template)
             env.reset(num_players=1)
             return str(env.get_observation()[1])
 


### PR DESCRIPTION
## Overview

Construct the seed-invariant TextArena environment once in `load_tasks()`, then deep-copy that pristine template before each seeded reset. This removes repeated factory and constructor work while preserving one independent environment per generated task.

## Reasoning

Previously, every observation called `ta.make(...)`. For seed-specific games with 1,000 tasks, that means 1,002 factory calls: two calls to determine whether the initial observation varies by seed, followed by one call per task. Each factory call resolves the registered environment, instantiates the game, loads constructor-owned data such as word lists, attaches metadata, and rebuilds the default wrapper chain.

The template is created before any episode starts and is never reset or mutated. TextArena's wrapper base explicitly supports deep copying by copying the underlying environment, reconstructing the wrapper chain, and copying wrapper-owned fields. Each generated task therefore receives a fresh environment copy that is reset exactly once and discarded.

The RNG sequence is preserved: the global RNG is seeded immediately before copying and resetting, copying does not advance it, and the game reset consumes the same seeded stream as before. Per-seed reset work remains in place, including WordLadder's graph construction and search.

## Benchmark

Command:

```zsh
PYTHONHASHSEED=0 uv run --script /tmp/textarena_v1_generation_benchmark.py --num-tasks 1000 --rounds 1
```

TextArena 0.7.4 and NLTK 3.9.4; imports and initial corpus availability were warmed before the paired run.

| Game | Old | New | Change |
| --- | ---: | ---: | ---: |
| WordLadder-v0 | 361.517922s | 62.027054s | 5.83x faster |
| WordSearch-v0 | 0.240633s | 0.167425s | 1.44x faster |
| Wordle-v0 | 0.668859s | 0.465212s | 1.44x faster |
| Hangman-v0 | 0.157974s | 0.095683s | 1.65x faster |
| FifteenPuzzle-v0 | 0.013078s | 0.015558s | 0.84x |

The optimization has the largest effect on constructor-heavy games such as WordLadder. For FifteenPuzzle, whose constructor is nearly free, deep copying adds roughly 2.5ms across 1,000 generated observations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Change is limited to offline task loading; rollout and scoring paths are unchanged, with RNG-before-reset preserving episode identity.
> 
> **Overview**
> Speeds up **TextArena task generation** by building each game environment once in `load_tasks()` and using `copy.deepcopy` on that template for every seeded observation instead of calling `ta.make` on each seed.
> 
> Per-seed behavior is unchanged: the RNG is still seeded before reset, so prompts and episode reproduction match the prior approach. **Rollout** (`TextArenaUser.setup_task`) still constructs a fresh env per task and is not part of this diff.
> 
> The win is largest for constructor-heavy games (e.g. WordLadder at ~1000 tasks); very cheap games may pay a small deep-copy overhead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23ededbacf6d5032fabb90b9682b73a4cdebd1e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reuse a single environment template in `TextArenaTaskset` task generation
> Instead of calling `ta.make()` on every seed, [taskset.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1778/files#diff-81e82b07bf8c8fcdb0a8d66cc558ff9f068fac1c1b33d70e335253aaa8a4ce04) now constructs one environment template once in `load_tasks` and uses `copy.deepcopy(template)` per seed. This avoids repeated environment construction overhead during task generation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 23ededb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->