### PR TITLE
Optimize General Agent V1 dynamic scoring imports

### DIFF
--- a/environments/general_agent_v1/general_agent_v1/corpus.py
+++ b/environments/general_agent_v1/general_agent_v1/corpus.py
@@ -2,7 +2,7 @@
 
 The 4,417-task corpus is large (~320 MB) and lives only in the `research-environments` repo, so it
 is NOT vendored here — `ensure_corpus()` sparse-checks-out `tasks/` at a pinned commit into a local
-cache on first start. `load_task_attr()` then dynamically imports a single task's `tools.py` (its
+cache on first start. `load_task_attrs()` then dynamically imports a single task's `tools.py` (its
 `TaskDB` / `TaskTools` / `verify`), installing a `sys.modules` shim so the raw task files'
 `from general_agent.tools import ...` resolves to this package's base classes unmodified.
 """
@@ -110,8 +110,8 @@ def _install_shim() -> None:
     _shim_installed = True
 
 
-def load_task_attr(task_dir: Path, attr: str) -> Any | None:
-    """Import a task's `tools.py` and return one of `TaskDB` / `TaskTools` / `verify`."""
+def load_task_attrs(task_dir: Path, *attrs: str) -> tuple[Any | None, ...]:
+    """Import a task's `tools.py` once and return the requested attributes."""
     _install_shim()
     path = task_dir / "tools.py"
     prev = sys.dont_write_bytecode
@@ -119,10 +119,10 @@ def load_task_attr(task_dir: Path, attr: str) -> Any | None:
     try:
         spec = importlib.util.spec_from_file_location(f"ga_task_{task_dir.name}", path)
         if spec is None or spec.loader is None:
-            return None
+            return (None,) * len(attrs)
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
-        return getattr(module, attr, None)
+        return tuple(getattr(module, attr, None) for attr in attrs)
     finally:
         sys.dont_write_bytecode = prev
 
@@ -136,8 +136,9 @@ def gold_check(task_dir: Path) -> tuple[bool, str | None]:
     gold_path = task_dir / "gold.json"
     if not gold_path.exists():
         return False, "no gold.json"
-    task_db = load_task_attr(task_dir, "TaskDB")
-    task_tools = load_task_attr(task_dir, "TaskTools")
+    task_db, task_tools, verify_fn = load_task_attrs(
+        task_dir, "TaskDB", "TaskTools", "verify"
+    )
     if task_db is None or task_tools is None:
         return False, "tools.py must define TaskDB and TaskTools"
     initial = task_tools(task_db.load(task_dir / "db.json"))
@@ -149,7 +150,6 @@ def gold_check(task_dir: Path) -> tuple[bool, str | None]:
         return False, f"gold replay failed: {type(e).__name__}: {e}"
     if initial.db.get_hash() == gold.db.get_hash():
         return False, "gold solution did not change the DB"
-    verify_fn = load_task_attr(task_dir, "verify")
     if verify_fn is None:
         return True, None
     if verify_fn(initial.db) != 0.0:

--- a/environments/general_agent_v1/general_agent_v1/servers/toolset.py
+++ b/environments/general_agent_v1/general_agent_v1/servers/toolset.py
@@ -19,7 +19,7 @@ from typing import Callable
 import verifiers.v1 as vf
 
 from general_agent_v1.common import GeneralAgentState, GeneralAgentToolsetConfig
-from general_agent_v1.corpus import load_task_attr
+from general_agent_v1.corpus import load_task_attrs
 
 
 class GeneralAgentToolset(vf.Toolset[GeneralAgentToolsetConfig, GeneralAgentState]):
@@ -27,8 +27,7 @@ class GeneralAgentToolset(vf.Toolset[GeneralAgentToolsetConfig, GeneralAgentStat
 
     async def setup_task(self, task) -> None:
         task_dir = self._task_dir(task)
-        task_db = load_task_attr(task_dir, "TaskDB")
-        task_tools = load_task_attr(task_dir, "TaskTools")
+        task_db, task_tools = load_task_attrs(task_dir, "TaskDB", "TaskTools")
         if task_db is None or task_tools is None:
             raise ValueError(f"tools.py must define TaskDB and TaskTools: {task_dir}")
         self._tools = task_tools(task_db.load(task_dir / "db.json"))

--- a/environments/general_agent_v1/general_agent_v1/taskset.py
+++ b/environments/general_agent_v1/general_agent_v1/taskset.py
@@ -23,7 +23,7 @@ from general_agent_v1.corpus import (
     CORPUS_REF,
     ensure_corpus,
     gold_check,
-    load_task_attr,
+    load_task_attrs,
     matches_pass_rate,
     task_matches,
 )
@@ -119,16 +119,43 @@ class GeneralAgentSolverTaskset(
         return [GeneralAgentToolset(self.config.tools)]
 
     @vf.metric
-    async def db_hash(self, task: GeneralAgentTask, trace: vf.Trace) -> float:
-        return self._db_hash(task, trace)
+    async def checks(self, task: GeneralAgentTask, trace: vf.Trace) -> dict[str, float]:
+        """Compute both checks from one reconstructed agent DB."""
+        task_dir = Path(task.dir)
+        try:
+            task_db, task_tools, verify_fn = load_task_attrs(
+                task_dir, "TaskDB", "TaskTools", "verify"
+            )
+            agent = (
+                task_db.model_validate(trace.state.db)
+                if trace.state.db is not None and task_db is not None
+                else None
+            )
+        except Exception:
+            return {"db_hash": 0.0, "verify": 0.0}
 
-    @vf.metric
-    async def verify(self, task: GeneralAgentTask, trace: vf.Trace) -> float:
-        return self._verify(task, trace)
+        db_hash = 0.0
+        try:
+            gold_path = task_dir / "gold.json"
+            if agent is not None and task_db is not None and task_tools is not None:
+                tools = task_tools(task_db.load(task_dir / "db.json"))
+                for tool_name, kwargs in json.loads(gold_path.read_text()):
+                    tools.call_tool(tool_name, **kwargs)
+                db_hash = float(agent.get_hash() == tools.db.get_hash())
+        except Exception:
+            pass
+
+        verified = 0.0
+        try:
+            if agent is not None and verify_fn is not None:
+                verified = float(verify_fn(agent))
+        except Exception:
+            pass
+        return {"db_hash": db_hash, "verify": verified}
 
     @vf.reward(weight=1.0)
-    async def solved(self, task: GeneralAgentTask, trace: vf.Trace) -> float:
-        return max(self._db_hash(task, trace), self._verify(task, trace))
+    async def solved(self, trace: vf.Trace) -> float:
+        return max(trace.metrics["db_hash"], trace.metrics["verify"])
 
     async def validate(self, task: GeneralAgentTask, runtime: vf.Runtime) -> bool:
         """Gold-check (model-free), run by `uv run validate`: the gold chain must change the DB,
@@ -141,47 +168,6 @@ class GeneralAgentSolverTaskset(
     def _metadata(self, task_dir: Path) -> dict:
         with open(task_dir / "task.toml", "rb") as f:
             return tomllib.load(f).get("metadata", {})
-
-    def _agent_db(self, task: GeneralAgentTask, trace: vf.Trace):
-        """Reconstruct the agent's final DB from the dict the toolset synced onto `trace.state`."""
-        if trace.state.db is None:
-            return None
-        task_db = load_task_attr(Path(task.dir), "TaskDB")
-        return task_db.model_validate(trace.state.db) if task_db is not None else None
-
-    def _gold_db(self, task: GeneralAgentTask):
-        """Replay the gold tool-call chain on a fresh DB → the reference final DB."""
-        task_dir = Path(task.dir)
-        gold_path = task_dir / "gold.json"
-        if not gold_path.exists():
-            return None
-        task_db = load_task_attr(task_dir, "TaskDB")
-        task_tools = load_task_attr(task_dir, "TaskTools")
-        if task_db is None or task_tools is None:
-            return None
-        tools = task_tools(task_db.load(task_dir / "db.json"))
-        for tool_name, kwargs in json.loads(gold_path.read_text()):
-            tools.call_tool(tool_name, **kwargs)
-        return tools.db
-
-    def _db_hash(self, task: GeneralAgentTask, trace: vf.Trace) -> float:
-        try:
-            agent, gold = self._agent_db(task, trace), self._gold_db(task)
-            if agent is None or gold is None:
-                return 0.0
-            return float(agent.get_hash() == gold.get_hash())
-        except Exception:
-            return 0.0
-
-    def _verify(self, task: GeneralAgentTask, trace: vf.Trace) -> float:
-        try:
-            agent = self._agent_db(task, trace)
-            verify_fn = load_task_attr(Path(task.dir), "verify")
-            if agent is None or verify_fn is None:
-                return 0.0
-            return float(verify_fn(agent))
-        except Exception:
-            return 0.0
 
 
 __all__ = ["GeneralAgentSolverTaskset"]


### PR DESCRIPTION
## Overview

General Agent V1 dynamically executes each task's `tools.py` to obtain its database model, tool implementation, and optional verifier. Before this change, every symbol lookup re-executed the complete module, and the reward phase recomputed work already performed by the metric phase.

This change loads related task symbols together, reconstructs the agent database once, computes both scoring checks in one metric, and derives the solved reward from those recorded metrics. The public metric keys and reward rule remain `db_hash`, `verify`, and `max(db_hash, verify)`.

## Call-count change

For the normal scoring path—a final agent database, a valid gold chain, and a task-defined `verify` function—the old path executed `tools.py` ten times per rollout:

```text
OLD Taskset.score
├─ metric db_hash
│  ├─ reconstruct agent DB: load TaskDB                     ×1
│  └─ construct gold DB:    load TaskDB + TaskTools         ×2
├─ metric verify
│  ├─ reconstruct agent DB: load TaskDB                     ×1
│  └─ load verify                                           ×1
└─ reward solved
   ├─ recompute db_hash                                     ×3
   └─ recompute verify                                      ×2
TOTAL tools.py executions                                 ×10
```

The new path loads all three symbols once and lets the reward consume the completed metric values:

```text
NEW Taskset.score
├─ metric checks
│  ├─ load TaskDB + TaskTools + verify together             ×1
│  ├─ reconstruct agent DB                                  ×1
│  ├─ replay gold                                           ×1
│  └─ invoke verify                                         ×1
└─ reward solved: max(trace.metrics["db_hash"], trace.metrics["verify"])
   └─ additional task-module execution                      ×0
TOTAL tools.py executions                                  ×1
```

| Operation | Before | After | Reduction |
|---|---:|---:|---:|
| `tools.py` executions per full score | 10 | 1 | 90% |
| Agent DB reconstructions per full score | 4 | 1 | 75% |
| Gold replays per full score | 2 | 1 | 50% |
| Verifier invocations per full score | 2 | 1 | 50% |
| `tools.py` executions during tool setup | 2 | 1 | 50% |
| `tools.py` executions during gold validation | 3 | 1 | 67% |

These counts are structural rather than timing-dependent. Early-failure paths can execute fewer calls in both implementations, but the new path still performs at most one task-module execution for a scoring attempt.

## Benchmark

A standalone PEP 723 reproduction compared the complete clean-base scoring implementation with this implementation through the real `Taskset.score` orchestration.

### Methodology

- Representative Pydantic task database with `TaskDB`, `TaskTools`, and `verify` defined in a dynamically loaded `tools.py`.
- Three-tool gold chain and an exact final agent database.
- macOS arm64, Python 3.13.12, Pydantic 2.13.4, Verifiers 0.1.15.dev344.
- `time.perf_counter_ns` around the full `Taskset.score` call.
- Trace construction and result assertions excluded from the timed region.
- 25 warm-up scores per path.
- 21 samples per path, 50 scores per sample: 1,050 timed scores per implementation.
- Old/new execution order alternated for each sample.
- Garbage collection ran before and was disabled during each timed sample.

| Path | Minimum | Median | Mean | p95 | Maximum |
|---|---:|---:|---:|---:|---:|
| Before | 3.285091 ms | 3.466641 ms | 3.479128 ms | 3.645246 ms | 3.869715 ms |
| After | 0.550926 ms | 0.571889 ms | 0.584150 ms | 0.620060 ms | 0.709429 ms |

**Median result: 6.062× faster, reducing scoring time by 83.50%.** The exact timings are host- and task-dependent; the call-count reduction is deterministic. The measured gain comes primarily from avoiding repeated dynamic module execution and Pydantic class construction, with additional savings from reconstructing and replaying each database only once.

## Scoring semantics

- `checks` returns a metric mapping, so `trace.metrics` still contains the same `db_hash` and `verify` keys.
- `solved` still computes `max(db_hash, verify)`, but reads values produced by the metric phase rather than rerunning task code.
- A task import or final-database reconstruction failure returns `db_hash=0.0` and `verify=0.0`.
- A gold load, replay, or hash failure only zeros `db_hash`; the verifier remains eligible to accept the final database.
- A missing or failing verifier only zeros `verify`; an exact database-hash match remains valid.

## Behavioral boundary and risk

Task modules are expected to be declarative definitions of `TaskDB`, `TaskTools`, and `verify`. Those symbols now come from one module instance, and module-level code executes fewer times. A task that intentionally depends on repeated import-time side effects or on separate module-global state between the hash and verifier paths would observe different behavior. That pattern is outside the intended deterministic corpus contract, and sharing one module instance is the intended dynamic-import behavior.

## Files changed

- `corpus.py`: replace single-symbol loading with `load_task_attrs` and use one load in gold validation.
- `servers/toolset.py`: load `TaskDB` and `TaskTools` together during setup.
- `taskset.py`: combine hash/verifier metrics, reconstruct once, and consume recorded metrics in the reward.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor focused on fewer imports and shared scoring paths; scoring semantics and fail-soft error handling are intended to stay the same.
> 
> **Overview**
> Reduces repeated dynamic imports of each task’s `tools.py` by replacing `load_task_attr` with **`load_task_attrs`**, which executes the module once and returns several symbols (`TaskDB`, `TaskTools`, `verify`). Call sites in **`corpus.gold_check`**, tool setup, and scoring now use a single load where they previously imported the same file multiple times.
> 
> Rollout scoring is consolidated: separate **`db_hash`** and **`verify`** metrics become one **`checks`** metric that rebuilds the agent DB once, replays gold for the hash check, runs **`verify`** on the same agent object, and returns both values. The **`solved`** reward takes **`max(db_hash, verify)`** from **`trace.metrics`** instead of recomputing via removed **`_agent_db` / `_gold_db`** helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2071fc0b2ae2627e7eb58237348b239cdbfc99da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consolidate dynamic scoring imports and metrics in General Agent V1
> - Replaces `load_task_attr` with `load_task_attrs` in [corpus.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1779/files#diff-fa7fcbab78ae1e53a86d24ea281b948307c7a2bfcd726e88cef723e4fd1dcd17) and [toolset.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1779/files#diff-29351550017944becd6235248a7975c1d322b68d3b0061419420a19c71124848), batching multiple attribute lookups into a single `tools.py` import per call.
> - Replaces the separate `db_hash` and `verify` metric methods in [taskset.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1779/files#diff-56492f60444bb45e3208e4e9a95e21a3db1af35ba33ab91e4bd9ec847c041f87) with a single `checks` metric that computes and returns both values as a dict.
> - The `solved` reward method now reads precomputed values from `trace.metrics` instead of recomputing them, and drops the `task` parameter from its signature.
> - Behavioral Change: `db_hash` and `verify` are no longer individually exposed as metric methods; callers must use `trace.metrics["db_hash"]` and `trace.metrics["verify"]` instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2071fc0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->