### PR TITLE
Optimize V1 trace graph hashing and turn commits

### DIFF
--- a/verifiers/v1/graph.py
+++ b/verifiers/v1/graph.py
@@ -33,6 +33,7 @@ from verifiers.v1.types import (
     Message,
     Response,
     StrictBaseModel,
+    TextContentPart,
     ToolMessage,
     Usage,
 )
@@ -163,16 +164,6 @@ class MessageNode(StrictBaseModel):
         raise TypeError(f"cannot build routed_experts from {type(value).__name__}")
 
 
-def _content_str(content) -> str:
-    """A message body as a stable string for hashing — plain text as-is, a content-part list as
-    canonical JSON (so two messages carrying the same text/images hash equal), None as ""."""
-    if content is None:
-        return ""
-    if isinstance(content, str):
-        return content
-    return json.dumps([p.model_dump() for p in content], sort_keys=True)
-
-
 def _canonical_tool_arguments(arguments: str) -> str:
     try:
         return json.dumps(json.loads(arguments), sort_keys=True, separators=(",", ":"))
@@ -186,18 +177,42 @@ def message_hash(message: Message) -> str:
     tool call id. Two messages hash equal iff they're the same conversational message, so a
     re-stated prefix message dedups to one node. The dedup key for sharing a prefix across
     turns/branches; salt-free so it is identical across processes and after deserialization."""
-    parts: list[str] = [type(message).__name__, _content_str(message.content)]
+    digest = hashlib.blake2b(digest_size=16)
+
+    def add(value: str) -> None:
+        data = value.encode()
+        digest.update(len(data).to_bytes(8, "big"))
+        digest.update(data)
+
+    add(type(message).__name__)
+    if isinstance(message.content, list):
+        add("content_parts")
+        for part in message.content:
+            add(part.type)
+            if isinstance(part, TextContentPart):
+                add(part.text)
+            else:
+                add(part.image_url.url)
+    else:
+        add("content_text")
+        add(message.content or "")
     if isinstance(message, AssistantMessage):
         if message.reasoning_content is not None:
-            parts += ["reasoning_content", message.reasoning_content]
+            add("reasoning_content")
+            add(message.reasoning_content)
         if message.provider_state:
             # Signed/encrypted continuation state distinguishes otherwise equal turns.
-            parts.append(json.dumps(message.provider_state, sort_keys=True))
+            add("provider_state")
+            add(json.dumps(message.provider_state, sort_keys=True))
         for tc in message.tool_calls or []:
-            parts += [tc.id, tc.name, _canonical_tool_arguments(tc.arguments)]
+            add("tool_call")
+            add(tc.id)
+            add(tc.name)
+            add(_canonical_tool_arguments(tc.arguments))
     elif isinstance(message, ToolMessage):
-        parts.append(message.tool_call_id)
-    return hashlib.blake2b("\x00".join(parts).encode(), digest_size=16).hexdigest()
+        add("tool_call_id")
+        add(message.tool_call_id)
+    return digest.hexdigest()
 
 
 def _head_index(trace: Trace) -> dict[tuple[int | None, str], int]:
@@ -387,7 +402,7 @@ def _commit_turn(turn: PendingTurn, response: Response) -> None:
     trace = turn.trace
     prompt = turn.prompt
     tokens = response.tokens
-    prompt_ids = list(tokens.prompt_ids) if tokens else []
+    prompt_ids = tokens.prompt_ids if tokens else []
     spans = tokens.message_spans if tokens else None
     idx = _head_index(trace)
 
@@ -431,7 +446,9 @@ def _commit_turn(turn: PendingTurn, response: Response) -> None:
         end = span[1] if span else start
         node_tokens = prompt_ids[start:end]
         trace.nodes.append(
-            MessageNode(
+            # Every value is already typed framework data; avoid revalidating and copying
+            # potentially huge token slices a second time.
+            MessageNode.model_construct(
                 parent=parent,
                 message=msg,
                 token_ids=node_tokens,
@@ -444,11 +461,11 @@ def _commit_turn(turn: PendingTurn, response: Response) -> None:
         cursor = end
 
     # Assistant node: trailing scaffold (the generation prompt) + the sampled completion.
-    comp_ids = list(tokens.completion_ids) if tokens else []
+    comp_ids = tokens.completion_ids if tokens else []
     gen_start = path_len if cursor is None else cursor
     gen_prompt = prompt_ids[gen_start:]
     trace.nodes.append(
-        MessageNode(
+        MessageNode.model_construct(
             parent=parent,
             message=response.message,
             sampled=True,


### PR DESCRIPTION
## Overview

This change reduces transient memory and CPU overhead in the two data-heavy parts of V1 trace-graph construction:

- message identity hashing, especially for typed multimodal content with inline image data
- committing large prompt/completion token arrays into `MessageNode` objects

The graph semantics remain the same: repeated conversational prefixes still resolve through `(parent, message_hash)`, branch token paths still reconstruct the model-visible sequence, tool arguments retain canonical JSON hashing, and committed logprobs remain independently owned.

## Trace-graph context

A V1 trace stores a conversation as parent-linked message nodes. Each new model turn restates some or all of the prior prompt, so the graph hashes messages to identify the longest reusable prefix and stores only the new tail.

```mermaid
flowchart LR
    A["Prepared model turn"] --> B["Hash prompt messages"]
    B --> C["Match (parent, message_hash)"]
    C --> D["Reuse existing prefix nodes"]
    C --> E["Create nodes for the new prompt tail"]
    D --> F["Commit sampled assistant node"]
    E --> F
    F --> G["Root-to-leaf token path"]
```

This makes hashing sensitive to large message payloads and makes node construction sensitive to large token arrays. The changes address those workloads independently.

## Incremental typed message hashing

### Previous allocation flow

Multimodal content was converted to dictionaries and serialized as one canonical JSON string. The role, content, reasoning, provider state, and tool fields were then joined into another complete string before UTF-8 encoding and hashing.

```mermaid
flowchart LR
    A["Typed multimodal message"] --> B["model_dump every content part"]
    B --> C["Serialize complete part list as JSON"]
    C --> D["Join all message fields with NUL separators"]
    D --> E["Encode complete joined string"]
    E --> F["BLAKE2b-128"]
```

For an inline `data:image/...;base64,...` field, the original URL, JSON serialization, joined string, and encoded bytes can all be multi-megabyte allocations. A remote image URL is short and does not create the same pressure.

### New allocation flow

The new encoder feeds typed fields into BLAKE2b as they are visited. It does not materialize a JSON representation of the content-part list or a final combined message string.

```mermaid
flowchart LR
    A["Message class"] --> H["BLAKE2b-128"]
    B["Content-kind tag"] --> H
    C["Content-part type"] --> H
    D["Text or image URL"] --> H
    E["Reasoning/provider-state tag + value"] --> H
    F["Tool-call tag + canonical fields"] --> H
    G["Tool-result call id"] --> H
```

Every value uses the same frame:

```text
frame(value) = uint64_big_endian(len(UTF8(value))) || UTF8(value)
```

The logical stream is:

```text
frame(message class)

frame("content_text") + frame(content or "")
    or
frame("content_parts") + (frame(part type) + frame(text or image URL))*

assistant suffix:
    [frame("reasoning_content") + frame(reasoning)]
    [frame("provider_state") + frame(sorted JSON)]
    (frame("tool_call") + frame(id) + frame(name) + frame(canonical arguments))*

tool suffix:
    frame("tool_call_id") + frame(id)
```

The explicit content-kind and field tags preserve type boundaries, while eight-byte UTF-8 lengths preserve value boundaries. A separator-like substring inside content can no longer be interpreted as a boundary between fields.

### Preserved hashing semantics

- `None` and empty assistant content remain equivalent.
- Plain content and typed content-part lists remain distinct.
- Text/image part ordering remains significant.
- Tool-call ordering remains significant.
- Valid tool arguments still pass through `json.loads` followed by sorted, compact `json.dumps`.
- Invalid tool-argument JSON remains hashed as its original string.
- Provider-state dictionary key order remains normalized with sorted JSON; provider-state list order remains significant.
- The digest remains a salt-free, 16-byte BLAKE2b value represented by 32 hexadecimal characters.

## Image and payload workload differences

| Message shape | Hash workload | Expected impact |
| --- | --- | --- |
| Short plain text | Encode the text and a few tags | Small reduction in joined-string overhead |
| Remote image URL | Encode a short URL and typed tags | Small absolute change |
| Inline base64 image | Encode the large URL once without full content JSON and joined-message copies | Largest hashing memory/time improvement |
| Multiple multimodal parts | Visit each typed part independently | Avoids building one complete JSON content document |
| Large provider state | Canonical sorted JSON is still materialized | Framing removes the final joined-message allocation, but JSON canonicalization remains |
| Large tool arguments | Canonical JSON is still materialized for valid JSON | Tool semantics are unchanged; the final message join is removed |

Base64 text is approximately one third larger than its decoded bytes. A 4 MiB decoded image can therefore occupy roughly 5.33 MiB before the data-URL header, making avoidance of additional whole-payload strings especially useful.

## Trusted MessageNode construction

### Previous token path

```mermaid
flowchart LR
    A["TurnTokens.prompt_ids"] --> B["Copy complete prompt list"]
    B --> C["Slice tokens for a new message"]
    C --> D["Pydantic validates every token"]
    D --> E["Pydantic copies the list into MessageNode"]
```

The same pattern copied completion IDs before immediately expanding them into the assistant node. On long-context training workloads, list copies are material even when integer objects are shared: one million list slots alone are roughly 8 MiB on a 64-bit runtime.

### New token path

```mermaid
flowchart LR
    A["Validated TurnTokens.prompt_ids"] --> B["Slice tokens owned by the new input node"]
    B --> C["MessageNode.model_construct"]
    D["Validated completion_ids"] --> E["Fresh assistant token list"]
    E --> C
    F["Fresh masks and copied completion logprobs"] --> C
```

`_commit_turn` already operates on framework-owned, validated objects:

- `Response` provides a typed assistant message, finish reason, and usage
- `TurnTokens` provides typed integer token lists and float logprobs
- prompt messages are typed `Message` instances
- parent indices, masks, and token slices are constructed locally

Using `MessageNode.model_construct` avoids repeating validation and avoids a second copy of each newly created input-node token slice.

## Ownership boundaries

The optimization deliberately removes only redundant copies:

- `prompt_ids` is referenced during attribution, but every new input node receives a list slice that it owns.
- `completion_ids` is referenced directly, but the assistant node receives a fresh `[*gen_prompt, *completion_ids]` list.
- input and assistant masks are always newly allocated.
- completion logprobs remain an explicit `list(tokens.completion_logprobs)` copy, so later mutation of response tokens cannot mutate the committed trace.
- typed messages and usage objects are reused as framework values, matching their existing ownership behavior.

The root-to-leaf invariant remains:

```text
concat(node.token_ids along the committed path)
    == prompt_ids + completion_ids
```

## Representative workload characteristics

The hashing workload used a 4 MiB inline image field hashed 25 times. The graph workload committed one million total tokens into two nodes. Hot-path time excludes process/import setup; maximum RSS covers the complete command process.

| Workload | Previous hot time | New hot time | Time change | Previous max RSS | New max RSS | RSS change |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| 4 MiB image field, 25 hashes | 0.190460 s | 0.071753 s | 62.326% lower / 2.654x throughput | 220.469 MiB | 116.047 MiB | 47.364% lower |
| 1,000,000-token graph commit | 0.015201 s | 0.000670 s | 95.592% lower / 22.688x throughput | 156.719 MiB | 126.484 MiB | 19.292% lower |

These figures describe graph bookkeeping rather than end-to-end model latency. Inference remains the dominant workload in typical evaluations; the practical improvement is lower transient memory and CPU overhead around large messages and token arrays.

## Collision and compatibility considerations

Length framing removes structural ambiguity from separator-based concatenation: embedded NULs or tag-like substrings remain payload bytes rather than potential field boundaries.

The digest is still BLAKE2b truncated to 128 bits, giving 128-bit preimage strength and approximately 64-bit birthday collision strength. It remains a deduplication key rather than an externally persisted identity.

Digest bytes intentionally change because the serialized hash input changes. This does not require trace migration: `Trace._head_index` is private, is not serialized, and is rebuilt from stored message nodes after deserialization using the active hashing format.

Future content-part types should add an explicit typed payload branch so their conversationally relevant fields participate in the framed stream.

## Scope

This PR changes only `verifiers/v1/graph.py`. It does not include test files, dependency/configuration changes, routed-expert decoding changes, or routed-expert slice-ownership changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Message-hash digests change (affects in-process dedup only, not persisted traces), and skipping Pydantic validation on commit assumes inputs are already trusted framework types—incorrect callers could slip invalid data into nodes.
> 
> **Overview**
> **V1 trace graph** work in `graph.py` cuts CPU and transient memory on prefix dedup and turn commit without changing graph behavior (same `(parent, message_hash)` reuse, token-prefix tightening, and `prompt_ids + completion_ids` path invariant).
> 
> **`message_hash`** no longer builds canonical JSON for multimodal content or one big NUL-joined string. It streams length-framed UTF-8 chunks into BLAKE2b-128, walking typed content parts (`TextContentPart` text vs image URL) and tagged assistant/tool fields. Large inline base64 images avoid extra multi-megabyte string copies; **digest hex values change** because the serialized input format changed—`_head_index` is rebuilt after load with the new hasher.
> 
> **`_commit_turn`** drops redundant `list()` copies of `prompt_ids`/`completion_ids` and builds new nodes with **`MessageNode.model_construct`** so huge token slices are not validated or copied twice; assistant nodes still get fresh combined token lists, masks, and an explicit copy of completion logprobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 880a494a47f3f6ca46ea31f15bd5c2a5931b3553. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Optimize V1 trace graph hashing and `_commit_turn` performance
> - Replaces the string-concatenation hashing in `message_hash` ([graph.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1780/files#diff-64c9d635eb215902a512c9e8ab316fd9b9967c36db03d4049aacc812cdfbd740)) with an incremental blake2b digest using length-prefixed, labeled fields, distinguishing content parts by type (text vs. image URL) and explicitly labeling `provider_state`, `reasoning_content`, and `tool_call` segments.
> - Removes the `_content_str` helper, folding its logic directly into the new `message_hash` implementation.
> - Avoids unnecessary list copies in `_commit_turn` by using slices directly for `prompt_ids`/`completion_ids` and switching to `MessageNode.model_construct` to skip Pydantic revalidation.
> - Risk: `message_hash` now produces different digests for the same inputs — any stored or compared hashes from the previous implementation will not match.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 880a494.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->