### PR TITLE
Optimize Color Codeword V1 image rendering

### DIFF
--- a/environments/color_codeword_v1/color_codeword_v1/taskset.py
+++ b/environments/color_codeword_v1/color_codeword_v1/taskset.py
@@ -59,14 +59,6 @@ def color_data_url(color: str, size: int = 100) -> str:
     return f"data:image/png;base64,{base64.b64encode(buf.getvalue()).decode()}"
 
 
-def image_content(colors: list[str], text: str) -> list[dict]:
-    """An OpenAI content list — one image part per color, then the text. Used by the user
-    simulator's later turns (the interception server re-types it, preserving the images)."""
-    return [
-        {"type": "image_url", "image_url": {"url": color_data_url(c)}} for c in colors
-    ] + [{"type": "text", "text": text}]
-
-
 def turn_text(turn: int, count: int, max_turns: int, total: int) -> str:
     """The user text shown alongside a turn's squares (mirrors the v0 wording)."""
     if turn == 0:
@@ -116,6 +108,7 @@ class ColorCodewordTaskset(
         c = self.config
         rng = random.Random(SEED)
         colors = list(COLOR_MAP)
+        color_urls = {color: color_data_url(color) for color in colors}
         length = c.images_per_turn * MAX_TURNS
         tasks: list[ColorCodewordTask] = []
         for idx in range(c.num_examples):
@@ -128,9 +121,7 @@ class ColorCodewordTaskset(
             turn0 = colors_per_turn[0]
             text = turn_text(0, len(turn0), MAX_TURNS, len(turn0))
             parts = [
-                vf.ImageUrlContentPart(
-                    image_url=vf.ImageUrlSource(url=color_data_url(col))
-                )
+                vf.ImageUrlContentPart(image_url=vf.ImageUrlSource(url=color_urls[col]))
                 for col in turn0
             ] + [vf.TextContentPart(text=text)]
             tasks.append(

--- a/tests/v1/test_color_codeword_tasks.py
+++ b/tests/v1/test_color_codeword_tasks.py
@@ -1,0 +1,18 @@
+from color_codeword_v1 import taskset
+
+
+def test_color_images_are_rendered_once(monkeypatch) -> None:
+    calls: list[str] = []
+    render = taskset.color_data_url
+
+    def counted(color: str, size: int = 100) -> str:
+        calls.append(color)
+        return render(color, size)
+
+    monkeypatch.setattr(taskset, "color_data_url", counted)
+    tasks = taskset.ColorCodewordTaskset(
+        taskset.ColorCodewordConfig(num_examples=100)
+    ).load_tasks()
+
+    assert len(tasks) == 100
+    assert calls == list(taskset.COLOR_MAP)


### PR DESCRIPTION
## Overview

Optimize Color Codeword V1 task generation by reusing pre-rendered palette image data URLs.

## Details

- Render each of the nine fixed palette colors once per taskset load and reuse those URLs across first-turn prompts.
- Remove the unused image-content helper from the taskset module.
- Add focused regression coverage that keeps image rendering bounded to one call per palette color.

## Impact

Default task generation avoids repeated PNG encoding while preserving deterministic task construction and prompt contents.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-only change to synthetic task construction with a regression test; prompt URLs and task semantics are unchanged.
> 
> **Overview**
> **Color Codeword V1** task generation now builds a `color_urls` map once in `load_tasks` (one `color_data_url` call per palette color) and reuses those URLs when assembling turn-0 image parts, instead of re-encoding PNGs on every square reference across all examples.
> 
> The unused `image_content` helper is removed from `taskset.py`. A regression test in `tests/v1/test_color_codeword_tasks.py` monkeypatches `color_data_url` and asserts that loading 100 tasks triggers exactly nine renders—one per `COLOR_MAP` key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3468b572376aaa4cfaef69de8ec130d5c806399b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Optimize color data URL rendering in `ColorCodewordTaskset.load_tasks` by caching per-color URLs
> - Introduces a `color_urls` cache in [`load_tasks`](https://github.com/PrimeIntellect-ai/verifiers/pull/1781/files#diff-670a3ac71c7ae2502e0ecda54e958e9597535495d80646d7ad8c6ebce36dce55) that computes each color's data URL once, replacing repeated `color_data_url()` calls per task/image.
> - Removes the `image_content` helper function, which previously built OpenAI-style content lists; callers that imported it will now fail.
> - Adds a unit test in [`test_color_codeword_tasks.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1781/files#diff-12f7c53d81fe06f1ba40075b2b7e71b92d8b2827265a2ac07306331de438c02b) that verifies `color_data_url` is called exactly once per color across 100 tasks.
> - Risk: `image_content` is no longer exported; any external code importing `taskset.image_content` will break at import or runtime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3468b57.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->