### PR TITLE
Optimize Wikispeedia V1 loading

### DIFF
--- a/environments/wikispeedia_v1/wikispeedia_v1/graph.py
+++ b/environments/wikispeedia_v1/wikispeedia_v1/graph.py
@@ -56,14 +56,18 @@ def _parse_tsv_lines(path: Path) -> list[str]:
         return [s for line in f if (s := line.strip()) and not s.startswith("#")]
 
 
-def _load_articles(graph_dir: Path, articles_dir: Path) -> dict[str, str]:
+def _load_articles(
+    graph_dir: Path, articles_dir: Path, include_text: bool = True
+) -> dict[str, str]:
     articles: dict[str, str] = {}
     for name in _parse_tsv_lines(graph_dir / "articles.tsv"):
         text_path = articles_dir / f"{name}.txt"
         if text_path.exists():
-            articles[name] = text_path.read_text(
-                encoding="utf-8", errors="replace"
-            ).strip()
+            articles[name] = (
+                text_path.read_text(encoding="utf-8", errors="replace").strip()
+                if include_text
+                else ""
+            )
     return articles
 
 
@@ -76,18 +80,14 @@ def _load_links(graph_dir: Path, valid: set[str]) -> dict[str, list[str]]:
     return adj
 
 
-def _load_distance_matrix(
-    graph_dir: Path, names: list[str]
-) -> dict[str, dict[str, int]]:
+def _load_distance_matrix(graph_dir: Path, names: list[str]) -> dict[str, str]:
     """Each row is single-digit distances ('_' = unreachable), one char per target."""
-    distances: dict[str, dict[str, int]] = {}
-    for i, row in enumerate(
-        _parse_tsv_lines(graph_dir / "shortest-path-distance-matrix.txt")
-    ):
-        distances[names[i]] = {
-            names[j]: int(ch) for j, ch in enumerate(row) if ch != "_"
-        }
-    return distances
+    return {
+        names[i]: row
+        for i, row in enumerate(
+            _parse_tsv_lines(graph_dir / "shortest-path-distance-matrix.txt")
+        )
+    }
 
 
 class WikiGraph:
@@ -97,12 +97,15 @@ class WikiGraph:
         self.articles = articles
         self.links = links
         self.distances = distances
+        self._distance_index = {name: i for i, name in enumerate(distances)}
         self._name_lookup = {name.lower(): name for name in articles}
 
     @classmethod
-    def load(cls, cache_dir: Path | None = None) -> WikiGraph:
+    def load(
+        cls, cache_dir: Path | None = None, include_text: bool = True
+    ) -> WikiGraph:
         graph_dir, articles_dir = _ensure_data(cache_dir or DEFAULT_CACHE_DIR)
-        articles = _load_articles(graph_dir, articles_dir)
+        articles = _load_articles(graph_dir, articles_dir, include_text)
         valid = set(articles)
         links = _load_links(graph_dir, valid)
         order = [n for n in _parse_tsv_lines(graph_dir / "articles.tsv") if n in valid]
@@ -113,7 +116,12 @@ class WikiGraph:
         return sorted(self.links.get(article, []))
 
     def shortest_path_length(self, source: str, target: str) -> int | None:
-        return self.distances.get(source, {}).get(target)
+        row = self.distances.get(source)
+        index = self._distance_index.get(target)
+        if row is None or index is None:
+            return None
+        distance = row[index]
+        return None if distance == "_" else int(distance)
 
     def normalize_name(self, name: str) -> str | None:
         """Match a user-provided name to a canonical article name."""

--- a/environments/wikispeedia_v1/wikispeedia_v1/servers/wiki.py
+++ b/environments/wikispeedia_v1/wikispeedia_v1/servers/wiki.py
@@ -50,9 +50,11 @@ class WikiToolset(vf.Toolset[WikiToolsetConfig]):
         for name in rows(gdir / "articles.tsv"):
             text = adir / f"{name}.txt"
             if text.exists():
-                self.articles[name] = text.read_text(
-                    encoding="utf-8", errors="replace"
-                ).strip()
+                self.articles[name] = (
+                    text.read_text(encoding="utf-8", errors="replace").strip()
+                    if not self.config.links_only
+                    else ""
+                )
         self.links = {name: [] for name in self.articles}
         for line in rows(gdir / "links.tsv"):
             src, _, dst = line.partition("\t")

--- a/environments/wikispeedia_v1/wikispeedia_v1/taskset.py
+++ b/environments/wikispeedia_v1/wikispeedia_v1/taskset.py
@@ -23,15 +23,6 @@ SYSTEM = (
     "destination."
 )
 
-_wiki: WikiGraph | None = None
-
-
-def graph() -> WikiGraph:
-    global _wiki
-    if _wiki is None:
-        _wiki = WikiGraph.load()
-    return _wiki
-
 
 def sample_pairs(wiki: WikiGraph, n: int, lo: int, hi: int, seed: int):
     """Sample `n` unique `(source, target, dist)` tuples within the distance band."""
@@ -70,7 +61,7 @@ class WikispeediaConfig(vf.TasksetConfig):
 
 class WikispeediaTaskset(vf.Taskset[WikiTask, WikispeediaConfig]):
     def load_tasks(self) -> list[WikiTask]:
-        wiki = graph()
+        wiki = WikiGraph.load(include_text=not self.config.tools.links_only)
         pairs = sample_pairs(
             wiki,
             self.config.num_tasks,


### PR DESCRIPTION
## Overview

This change makes the default links-only Wikispeedia V1 loading path substantially lighter while preserving the graph, sampled tasks, rendered link menus, and constant-time shortest-path queries.

The main savings come from keeping the SNAP shortest-path matrix in its compact on-disk row representation and avoiding article-body reads when the configured experience only exposes links.

## What changed

- Store each shortest-path matrix row as its original compact string instead of expanding every reachable cell into a nested Python dictionary.
- Build one target-name-to-column index and resolve a distance with a source-row lookup plus one character access. Unreachable `_` cells continue to return `None`; digit conversion now happens only when queried.
- Add an `include_text` loading option while retaining full-text loading as the direct `WikiGraph.load()` default.
- Load the task-side graph with article text only when `tools.links_only` is disabled.
- Skip reading and decoding article bodies during tool-server setup when `links_only` is enabled, while retaining the same article key set and link filtering.
- Remove the process-global task graph so each taskset load follows its own text-display configuration.

## Why this matters

The cached dataset has 4,604 articles, 119,882 links, and a 4,604 × 4,604 shortest-path matrix. The previous representation eagerly created 18,592,839 nested-dictionary entries for reachable cells and retained 97,738,042 decoded article characters even though the default links-only UI never rendered those bodies.

The new representation keeps 4,604 compact row strings plus a 4,604-entry target index. Shortest-path lookup remains O(1), but the large per-cell dictionary allocation disappears. Default task and server loading also avoid roughly 98 MB of plaintext file reads and decoded strings.

## Performance impact

Measurements used the real, already-downloaded and extracted `~/.cache/wikispeedia` dataset on an Apple M4 Max with 64 GiB RAM, macOS 27.0 arm64, Python 3.13.12, and uv 0.11.23. Each retained sample ran in a fresh Python process after cache warm-up; network transfer and archive extraction were outside the timed region. Values below are medians of three runs, with observed wall-clock ranges included.

| Loading path | Before | After | Impact |
|---|---:|---:|---:|
| Default taskset wall time | 1.293671750 s (1.267792291–1.302689250 s) | 0.067841042 s (0.062917875–0.067891208 s) | 19.07× faster; 94.76% lower |
| Default taskset peak RSS | 851.84375 MiB | 135.0625 MiB | 84.14% lower |
| Links-only tool server wall time | 0.200488208 s (0.175955042–0.207624416 s) | 0.049766500 s (0.047387292–0.049897417 s) | 4.03× faster; 75.18% lower |
| Links-only tool server peak RSS | 330.59375 MiB | 116.828125 MiB | 64.66% lower |

The taskset path still produces the same 20 seeded tasks, shortest-path checksum, and links-only prompt size. The server retains the same 4,604-article key set and 119,882 valid links; only the unused article-body values are omitted in links-only mode.

## Tradeoffs

- Distance digits are converted to integers at lookup time instead of load time; this is a tiny per-query cost in exchange for avoiding millions of Python objects.
- Repeated calls to `load_tasks()` now reload the graph rather than sharing a process-global instance. Normal environment construction loads once, and removing the singleton prevents one configuration's text-loading choice from leaking into another.
- Links-only loading still ensures the article archive is present and checks article-file existence, preserving the article set. It skips content I/O and decoding rather than changing first-install dataset requirements.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance and memory optimizations in a benchmark environment; behavior for links-only and full-text modes is preserved with no auth or production data paths touched.
> 
> **Overview**
> **Wikispeedia V1** default and links-only loading is much lighter while keeping the same graph, tasks, link menus, and O(1) shortest-path behavior.
> 
> `WikiGraph` now keeps each shortest-path matrix **row as a compact string** (with a target-name index) instead of building nested per-cell dicts; `shortest_path_length` reads one character and converts digits on demand. **`include_text`** on `WikiGraph.load()` / article loading skips reading and decoding article bodies when only the link graph is needed.
> 
> The taskset loads with `include_text=not tools.links_only` and **drops the process-global graph cache** so each load respects that setting. The wiki tool server likewise stores empty article values when **`links_only`** is enabled, avoiding ~98MB of plaintext I/O without changing article keys or link filtering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 048da909a09ec1d5f9259827ebc7aa39b58f22ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Optimize Wikispeedia V1 loading by skipping article text and lazy-parsing distance matrix
> - `WikiGraph.load` and `WikispeediaTaskset.load_tasks` now skip reading article plaintext when `links_only` is `True`, storing empty strings instead.
> - The distance matrix loader now returns raw row strings keyed by source article, replacing the nested `dict[str, dict[str, int]]` structure; `shortest_path_length` parses individual characters on demand.
> - The module-level `graph()` singleton cache in [taskset.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1782/files#diff-8738966ec46e5a376fc07c549ba5de84472a6faacd26644b9e1b608a1971ca27) is removed; callers must load the graph directly via `WikiGraph.load`.
> - Behavioral Change: distance matrix is no longer eagerly parsed into integers — non-reachable targets are represented by `'_'` in the raw row string and resolved at query time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 048da90.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->