### PR TITLE
Reduce V1 routed-expert rollout memory

### DIFF
--- a/tests/v1/test_graph.py
+++ b/tests/v1/test_graph.py
@@ -82,6 +82,10 @@ def test_routed_experts_attributed_and_aligned_across_turns():
     restored = type(trace).model_validate(trace.model_dump())
     re2 = restored.branches[-1].routed_experts
     assert re2 is not None and re2.shape == re.shape and bool((re2 == re).all())
+    assert all(
+        node.routed_experts is None or node.routed_experts.flags.owndata
+        for node in trace.nodes
+    )
 
 
 def test_routed_experts_none_when_absent():

--- a/verifiers/v1/graph.py
+++ b/verifiers/v1/graph.py
@@ -17,7 +17,7 @@ the exact `prompt_ids + completion_ids` the model saw.
 
 from __future__ import annotations
 
-import base64
+import binascii
 import hashlib
 import json
 from dataclasses import dataclass
@@ -357,8 +357,7 @@ def _attribute_routed_experts(
     branch then reports no routing rather than misaligning."""
     if payload is None:
         return
-    data = payload["data"]
-    raw = base64.b64decode(data if isinstance(data, (str, bytes)) else bytes(data))
+    raw = binascii.a2b_base64(payload["data"])
     arr = np.frombuffer(raw, dtype=np.uint8).reshape(payload["shape"])
     off = path_len - int(payload.get("start", 0) or 0)
     # The engine omits routing for the turn's final position (no forward pass follows the last
@@ -370,7 +369,8 @@ def _attribute_routed_experts(
     for nid in new_node_ids:
         n = len(trace.nodes[nid].token_ids)
         if n and 0 <= off and off + n <= arr.shape[0]:
-            trace.nodes[nid].routed_experts = np.ascontiguousarray(arr[off : off + n])
+            # Own only this node's rows; a view would retain the turn's full-context array.
+            trace.nodes[nid].routed_experts = arr[off : off + n].copy()
         off += n
 
 


### PR DESCRIPTION
## Overview

Reduce the CPU-memory cost of carrying Mixture-of-Experts router-replay metadata through the V1 message graph.

The change is intentionally narrow: routed-expert payloads are decoded without an intermediate base64 copy, and each graph node stores an owned copy of only its routing rows. Token attribution, branch reconstruction, wire representation, and trainer-facing shapes remain unchanged.

## Background

When an MoE rollout returns router-replay data, the payload contains one `uint8` expert id for every `[token, layer, top_k]` position. The inference response transports that binary array as base64. V1 decodes the turn-level array, attributes the rows belonging to newly-created message nodes, and later reconstructs a branch-wide array aligned one-to-one with `Branch.token_ids`.

This metadata exists for training: the trainer can replay the expert selections used by inference while recomputing a rollout. The memory is consumed earlier, however, while rollout workers decode responses and retain traces.

Multi-turn traces make ownership particularly important. A later generation can return routing for the full context while the graph only needs to retain routing for newly-created nodes; reused-prefix nodes already carry their original rows.

## Changes

### Decode directly from the sidecar buffer

Replace the high-level decode path with:

```python
raw = binascii.a2b_base64(payload["data"])
```

The routed-expert sidecar normally arrives as a `memoryview` into the HTTP response. The former normalization path materialized that view as `bytes` before decoding. Direct `binascii` decoding accepts the bytes-like buffer and avoids allocating a second copy of the encoded payload.

The required decoded output is still allocated; only the redundant encoded-input copy is removed.

### Give every graph node ownership of its rows

Replace:

```python
np.ascontiguousarray(arr[off : off + n])
```

with:

```python
arr[off : off + n].copy()
```

A row slice of the decoded C-contiguous routing array is already contiguous. Consequently, `np.ascontiguousarray` can return the original view rather than allocate independent storage. Although a node may reference only a small suffix, that view keeps the complete decoded turn buffer alive.

`.copy()` gives each node an allocation sized exactly to its rows. Once attribution finishes, the full turn-level decode can be released.

### Preserve the ownership invariant

The routed-expert graph coverage now asserts that every stored routing array either is absent or has `flags.owndata`. This records the intended in-process lifetime boundary directly alongside the existing multi-turn alignment and round-trip coverage.

## Ownership model

Before:

```text
node slice
  └─ view of decoded turn array
       └─ complete decoded turn bytes
```

After:

```text
node array
  └─ owned allocation containing exactly the node's rows

complete decoded turn bytes
  └─ released after attribution
```

For turns whose context grows by a fixed amount, retaining every historical full-context owner grows with the sum of context lengths. Retaining node-local rows instead grows with the unique token rows represented by the graph.

## Measured impact

Measurements used a standalone PEP 723 reproduction with isolated worker processes.

### 64 MiB decode

The input was an 85.333 MiB base64 `memoryview` representing a 64 MiB decoded payload. Values are medians across five decode trials.

| Metric | Previous path | Direct decode | Change |
| --- | ---: | ---: | ---: |
| Traced peak allocation | 149.334 MiB | 64.001 MiB | **-57.143%** |
| Decode time | 56.033 ms | 56.331 ms | +0.533% |

The 85.333 MiB difference is the eliminated encoded-input copy. Decode time is effectively neutral at this sample size.

### Four-turn routing trace

The synthetic trace used:

- four turns adding 1,024 token rows each;
- routing shapes growing from `[1024, 512, 16]` to `[4096, 512, 16]`;
- raw turn payloads of 8, 16, 24, and 32 MiB;
- eight stored node slices of shape `[512, 512, 16]`, or 4 MiB each;
- a final branch shape of `[4096, 512, 16]`, aligned with 4,096 token ids.

Values are medians across three isolated trace runs where applicable.

| Metric | Previous ownership | Node-owned slices | Change |
| --- | ---: | ---: | ---: |
| Logical routing represented by nodes | 32 MiB | 32 MiB | unchanged |
| Unique retained owners | 80 MiB | 32 MiB | **-60.000%** |
| Owner/logical ratio | 2.5x | 1.0x | exact ownership |
| Process RSS after construction | 423.609 MiB | 381.219 MiB | **-10.007%** |
| Trace construction | 238.545 ms | 235.330 ms | -1.348% |
| Msgpack round trip | 6.795 ms | 6.193 ms | -8.857% |

The exact retained-owner count is the most stable result: the previous representation retained four full-turn owners totaling 80 MiB, while the new representation retained only the eight 4 MiB node arrays required to reconstruct the 32 MiB branch. Process-wide RSS and millisecond-scale timings are included as observed and are more sensitive to allocator and scheduling noise.

## Tradeoff

Owning slices adds one bounded memory copy for each useful node segment. This costs bandwidth proportional to the routing data the graph must retain. In exchange, a small newly-created node no longer extends the lifetime of a potentially much larger full-context decode.

The tradeoff is most favorable for long, multi-turn, or branched rollouts where each generation returns substantial reused-prefix routing. A single-turn rollout whose node rows cover nearly the entire payload sees less retained-memory benefit, while direct decoding still removes the base64 input copy.

## Scope

This PR only changes routed-expert handling in the V1 graph and its graph-level ownership assertion. It does not alter message hashing, node construction, token ids, masks, logprobs, routing offsets, padding behavior, branch concatenation, or the internal msgpack format. When routed-expert metadata is absent, attribution continues to return immediately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized memory/ownership changes in routed-expert attribution; alignment and serialization paths are unchanged aside from explicit copies.
> 
> **Overview**
> Cuts CPU memory while V1 rollouts carry MoE router-replay metadata through the message graph, without changing branch shapes, wire format, or trainer-facing behavior.
> 
> **Decode:** `_attribute_routed_experts` decodes the sidecar with `binascii.a2b_base64(payload["data"])` instead of normalizing to `bytes` and using `base64.b64decode`, so a `memoryview` into the HTTP response is not copied before decode.
> 
> **Ownership:** Each node’s routing slice is stored with `.copy()` instead of `np.ascontiguousarray(...)`, so nodes own only their rows and do not keep the full turn-level decoded array alive via a view.
> 
> **Tests:** Multi-turn routed-expert coverage now asserts every non-null `node.routed_experts` has `flags.owndata`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 966d62a98eaeee642b5502b9f85462a88d653db7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `_attribute_routed_experts` to ensure per-node arrays own their memory
> - Changes per-node `routed_experts` assignment from `np.ascontiguousarray(arr[off:off+n])` to `arr[off:off+n].copy()` in [graph.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1783/files#diff-64c9d635eb215902a512c9e8ab316fd9b9967c36db03d4049aacc812cdfbd740) so each node's array owns its data rather than holding a view into the full-turn buffer.
> - Replaces `base64` import with `binascii` and decodes via `binascii.a2b_base64(payload["data"])` instead of an explicit `bytes()` conversion.
> - Adds an assertion in [test_graph.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1783/files#diff-a69f45493b76a68b88ea3c1a7a460b2584b2f9cef28f60f14c06e133cfd0adb5) that every node's `routed_experts`, when present, has `flags.owndata == True`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 966d62a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->