### PR TITLE
Optimize V1 SSE relay and Responses parsing

### DIFF
--- a/verifiers/v1/clients/eval.py
+++ b/verifiers/v1/clients/eval.py
@@ -175,11 +175,15 @@ class EvalClient(Client):
 
         async def chunks():
             buffer = bytearray()
+            search_from = 0
             async for chunk in resp.aiter_bytes():
                 buffer += chunk
-                while match := _SSE_EVENT_END.search(buffer):
+                while match := _SSE_EVENT_END.search(buffer, search_from):
                     yield bytes(buffer[: match.end()])
                     del buffer[: match.end()]
+                    search_from = 0
+                # A delimiter is at most four bytes and can straddle chunks.
+                search_from = max(0, len(buffer) - 3)
             if buffer:
                 yield bytes(buffer)
 

--- a/verifiers/v1/dialects/base.py
+++ b/verifiers/v1/dialects/base.py
@@ -14,7 +14,7 @@ the eval's model + sampling in this format's shape) and `extend` (chat-only user
 
 import json
 from abc import ABC, abstractmethod
-from collections.abc import Mapping
+from collections.abc import Iterator, Mapping
 from typing import ClassVar, Generic, TypeVar
 
 from pydantic import BaseModel
@@ -39,6 +39,19 @@ def iter_sse(raw: bytes) -> list[dict]:
             continue
         events.append(json.loads(data))
     return events
+
+
+def iter_sse_reverse(raw: bytes) -> Iterator[dict]:
+    """Yield JSON SSE payloads from the end without decoding earlier events."""
+    for block in reversed(raw.decode("utf-8", errors="replace").split("\n\n")):
+        data = "\n".join(
+            line.removeprefix("data:").strip()
+            for line in block.splitlines()
+            if line.startswith("data:")
+        )
+        if not data or data == "[DONE]":
+            continue
+        yield json.loads(data)
 
 
 class Dialect(ABC, Generic[ReqT, RespT]):

--- a/verifiers/v1/dialects/responses.py
+++ b/verifiers/v1/dialects/responses.py
@@ -26,7 +26,7 @@ from openai.types.responses.response_usage import (
 )
 from pydantic import BaseModel, ConfigDict
 
-from verifiers.v1.dialects.base import Dialect, iter_sse
+from verifiers.v1.dialects.base import Dialect, iter_sse_reverse
 from verifiers.v1.types import (
     AssistantMessage,
     ContentPart,
@@ -298,7 +298,7 @@ class ResponsesDialect(Dialect[dict, OpenAIResponse]):
     def parse_stream(self, raw: bytes) -> Response:
         """The terminal event (`response.completed` / `.incomplete` / `.failed`) carries the
         full response object — parse that."""
-        for event in reversed(iter_sse(raw)):
+        for event in iter_sse_reverse(raw):
             if event.get("type") in FINAL_EVENTS:
                 return response_from_wire(
                     OpenAIResponse.model_validate(event["response"])


### PR DESCRIPTION
## Overview

This improves two V1 SSE hot paths without changing the provider bytes emitted by the relay or the normalized `vf.Response` produced for traces:

- relay fragmented SSE events without repeatedly rescanning the full buffered event
- locate the terminal OpenAI Responses event from the tail without JSON-decoding every preceding delta

The change is limited to three production files and introduces no public API, configuration, dependency, persistence, or wire-format changes.

## Incremental SSE delimiter search

The eval relay must buffer upstream HTTP fragments until it has a complete SSE event, because network chunks can split the blank-line delimiter and keepalives may only be inserted between complete events.

Previously, every incoming fragment restarted the delimiter regex at offset zero. For an event of size `N` arriving in fragments of size `c`, that repeatedly scanned the growing buffer and required approximately `Θ(N²/c)` delimiter-search work.

The relay now keeps a search cursor. After an unsuccessful search, it resumes at the final three bytes of the previous buffer. The supported delimiter regex is at most four bytes long, so any delimiter completed by the next fragment must start within that three-byte overlap. When an event is emitted and removed from the buffer, the cursor resets to zero so additional events already present in the same network chunk are still discovered.

This reduces delimiter-search work to `Θ(N)` while preserving cross-fragment LF, CRLF, and mixed newline boundaries. Buffering and output-copy behavior are unchanged, so this is intentionally a CPU optimization rather than a memory-layout change.

## Reverse Responses terminal parsing

Responses streams may contain many incremental events, but `response.completed`, `response.incomplete`, and `response.failed` carry the complete terminal Response object needed by the trace.

The previous parser decoded every SSE event into a Python dictionary, retained the entire event list, and then traversed that list backward. The new reverse SSE iterator starts at the stream tail, skips empty blocks and `[DONE]`, and JSON-decodes only the suffix needed to reach a terminal event.

The complete byte stream is still UTF-8-decoded and split into SSE blocks, so overall parsing remains `Θ(N)`. The improvement comes from avoiding JSON parsing and Python object allocation for the usually large prefix of delta events. Missing terminal events continue to raise the existing error, and the last terminal event remains authoritative.

## Measured impact

Measurements used alternating execution order, `perf_counter` medians, and isolated `tracemalloc` heap peaks. Fixture construction was outside the timed and traced regions.

### 8 MiB fragmented SSE event

The serialized event was exactly 8,388,608 bytes. Its body arrived in 2,048 fragments of at most 4 KiB, followed by the two delimiter newlines as separate one-byte fragments, for 2,050 fragments total.

| Implementation | Median | Peak Python heap |
| --- | ---: | ---: |
| Full-buffer rescan | 44.446357 s | 24.245 MiB |
| Incremental cursor | 0.043243 s | 24.245 MiB |

This is a **1,027.82× speedup** and a **99.90% reduction in elapsed time**. Both paths emitted the same single 8 MiB SSE chunk byte-for-byte. Peak memory is unchanged because both retain the same event buffer and output copies.

### 100,000-delta Responses stream

The stream contained 100,000 delta events, one `response.completed` event, and a trailing `[DONE]`, totaling 5,700,325 bytes.

| Implementation | Median | Peak Python heap |
| --- | ---: | ---: |
| Decode every event | 0.075646 s | 43.305 MiB |
| Reverse terminal lookup | 0.005692 s | 15.358 MiB |

This is a **13.29× speedup**, a **92.48% reduction in elapsed time**, and a **64.54% reduction in peak Python heap**. Both paths produced the same terminal Response, including content, finish reason, and usage.

## Impact

Large or highly fragmented provider events no longer monopolize the event loop with repeated regex work, while long Responses streams require substantially fewer JSON allocations during trace construction. Normal streams retain the same event boundaries, relay output, terminal-event selection, and error behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal CPU/memory optimizations in relay buffering and trace parsing only; no public API, config, or wire-format changes, with the same error and output behavior.
> 
> **Overview**
> Speeds up two V1 SSE hot paths without changing relayed provider bytes or normalized trace output.
> 
> The eval client’s streaming relay now resumes SSE delimiter regex search from a cursor (with a three-byte overlap for split delimiters) instead of rescanning the whole buffer on every fragment, cutting repeated work on large fragmented events.
> 
> For OpenAI **Responses** streams, a new `iter_sse_reverse` walks SSE blocks from the tail and JSON-decodes only until a terminal event (`response.completed` / `.incomplete` / `.failed`), replacing the prior decode-all-then-reverse approach in `parse_stream`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a30e735c6596426880eb3003eabbeaad342d519d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Optimize SSE relay and reverse stream parsing in V1 Responses dialect
> - Introduces an incremental `search_from` index in [`EvalClient.get_response`](https://github.com/PrimeIntellect-ai/verifiers/pull/1784/files#diff-8a1cc6d0e01dde461a22ef26597ccf8f011f4c12328b1c7297cae7acebc78df8) so the SSE event-boundary regex scans only the tail of the buffer on each chunk, fixing missed delimiters that straddle chunk boundaries.
> - Adds `iter_sse_reverse` in [`base.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1784/files#diff-10ccce5f7f0d991c33492a01e73014e10883deb74f7006253f1c690422d841bd), a helper that splits on double newlines and walks from the end, yielding JSON payloads from `data:` lines while skipping empty entries and the `[DONE]` sentinel.
> - [`ResponsesDialect.parse_stream`](https://github.com/PrimeIntellect-ai/verifiers/pull/1784/files#diff-73f89a1b25536fd7a806555e765120f5189cb934eff813f4c7900838efa56b5a) now uses `iter_sse_reverse` directly instead of `reversed(iter_sse(raw))`, returning on the first terminal event found.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a30e735.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->