### PR TITLE
Speed up train completion usage serialization

### DIFF
--- a/verifiers/v1/clients/train.py
+++ b/verifiers/v1/clients/train.py
@@ -13,11 +13,6 @@ from collections.abc import Mapping
 from typing import Any
 
 from openai import AsyncOpenAI, OpenAIError
-from openai.types import CompletionUsage
-from openai.types.completion_usage import (
-    CompletionTokensDetails,
-    PromptTokensDetails,
-)
 from renderers import RenderedTokens
 from renderers import OverlongPromptError as RendererOverlongPromptError
 from renderers import RendererConfig
@@ -66,23 +61,22 @@ def serialize_completion(response: Response, model: str) -> dict:
             }
             for c in response.message.tool_calls
         ]
-    usage: CompletionUsage | None = None
+    usage: dict | None = None
     if response.usage:
-        usage = CompletionUsage(
-            prompt_tokens=response.usage.input_tokens,
-            completion_tokens=response.usage.completion_tokens,
-            total_tokens=response.usage.total_tokens,
-            prompt_tokens_details=PromptTokensDetails(
-                cached_tokens=response.usage.cached_input_tokens
-            )
-            if response.usage.cached_input_tokens is not None
-            else None,
-            completion_tokens_details=CompletionTokensDetails(
-                reasoning_tokens=response.usage.reasoning_tokens
-            )
-            if response.usage.reasoning_tokens is not None
-            else None,
-        )
+        # Usage is validated earlier in the pipeline; building its wire dict directly saves time.
+        usage = {
+            "completion_tokens": response.usage.completion_tokens,
+            "prompt_tokens": response.usage.input_tokens,
+            "total_tokens": response.usage.total_tokens,
+        }
+        if response.usage.reasoning_tokens is not None:
+            usage["completion_tokens_details"] = {
+                "reasoning_tokens": response.usage.reasoning_tokens
+            }
+        if response.usage.cached_input_tokens is not None:
+            usage["prompt_tokens_details"] = {
+                "cached_tokens": response.usage.cached_input_tokens
+            }
     return {
         "id": response.id or "vf-intercept",
         "object": "chat.completion",
@@ -95,7 +89,7 @@ def serialize_completion(response: Response, model: str) -> dict:
                 "finish_reason": response.finish_reason or "stop",
             }
         ],
-        "usage": usage.model_dump(exclude_none=True) if usage is not None else None,
+        "usage": usage,
     }
 
 


### PR DESCRIPTION
## Overview

Build the OpenAI-compatible completion usage payload directly from the already-typed `vf.Usage` object in the renderer training client.

## Rationale

The previous path constructed `CompletionUsage` plus optional nested OpenAI Pydantic detail models, then immediately dumped those temporary objects back into a dictionary. Usage has already been validated earlier in the Verifiers pipeline, so reconstructing and serializing SDK models adds allocations and validation work without changing the wire contract.

The new path assembles the final dictionary directly. It preserves cached-token accounting, total-token calculation, omission of absent optional details, inclusion of zero-valued details, and `usage: null` when usage is absent. A short code comment documents why direct construction is intentional.

## Performance impact

A Python 3.13.12 microbenchmark using the real `vf.Response` and `vf.Usage` types ran 100,000 serializations across seven repetitions:

| Resource | Before | After | Saved |
| --- | ---: | ---: | ---: |
| Median wall time per 100k calls | 0.316947 s | 0.039146 s | 0.277801 s (87.65%) |
| Median wall time per call | 3.16947 µs | 0.39146 µs | 2.77801 µs |
| Peak traced Python allocation | 5,008 bytes | 2,584 bytes | 2,424 bytes (48.40%) |
| Retained traced bytes after GC | 32 bytes | 32 bytes | 0 bytes |

This keeps the optimization local to synthesized completion responses from `TrainClient`; other clients and shared usage types are unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized serialization change in the training client with the same intended wire shape; no auth, security, or shared pipeline changes.
> 
> **Overview**
> **`serialize_completion` in the renderer `TrainClient` now builds the OpenAI-style `usage` object as a plain dict** instead of instantiating `CompletionUsage` and nested token-detail Pydantic models and then calling `model_dump`.
> 
> The mapping is unchanged: `input_tokens` → `prompt_tokens`, optional `reasoning_tokens` and `cached_input_tokens` nested under `completion_tokens_details` / `prompt_tokens_details`, and `usage` stays absent when there is no usage. A short comment notes that usage is already validated upstream.
> 
> OpenAI SDK imports used only for this path are removed. Other clients and interception serialization are untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65cc626e6617160e4471e1494d19de8a34428cae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Speed up train completion usage serialization by replacing OpenAI model objects with plain dicts
> In [`serialize_completion`](https://github.com/PrimeIntellect-ai/verifiers/pull/1787/files#diff-c9bcd6c691890b1de6942fe012d2e74678460b22bf335721a8bba5e939d139c3), the `usage` field is now built as a plain Python `dict` instead of constructing an `openai.types.CompletionUsage` object and calling `model_dump()`. Sub-dicts for `completion_tokens_details` and `prompt_tokens_details` are built conditionally based on the presence of `reasoning_tokens` and `cached_input_tokens`. This avoids Pydantic model instantiation overhead on every call.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 65cc626.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->