### PR TITLE
Avoid multimodal path allocation on text-only turns

### DIFF
--- a/verifiers/v1/graph.py
+++ b/verifiers/v1/graph.py
@@ -402,6 +402,7 @@ def _commit_turn(turn: PendingTurn, response: Response) -> None:
     trace = turn.trace
     prompt = turn.prompt
     tokens = response.tokens
+    multi_modal_data = tokens.multi_modal_data if tokens else None
     prompt_ids = tokens.prompt_ids if tokens else []
     spans = tokens.message_spans if tokens else None
     idx = _head_index(trace)
@@ -436,9 +437,12 @@ def _commit_turn(turn: PendingTurn, response: Response) -> None:
     parent = prefix[-1] if prefix else None
     # cursor: in prompt_ids, the end of the previous *new* message's tokens
     cursor: int | None = None
-    # (node_id, message) per prompt message (reused prefix first, then new), for multimodal
-    # attribution; `num_reused` marks where the newly-created nodes begin.
-    path: list[tuple[int, Message]] = [(nid, prompt[i]) for i, nid in enumerate(prefix)]
+    # Track new nodes separately so routed-expert attribution does not need this full path.
+    new_node_ids: list[int] = []
+    # Materialize the reused message path only for multimodal cursor attribution.
+    mm_path: list[tuple[int, Message]] | None = None
+    if multi_modal_data is not None:
+        mm_path = [(nid, prompt[i]) for i, nid in enumerate(prefix)]
     for i, msg in enumerate(prompt[num_reused:], start=num_reused):
         key = (parent, message_hash(msg))
         start = path_len if cursor is None else cursor
@@ -457,7 +461,9 @@ def _commit_turn(turn: PendingTurn, response: Response) -> None:
         )
         parent = len(trace.nodes) - 1
         idx[key] = parent
-        path.append((parent, msg))
+        new_node_ids.append(parent)
+        if mm_path is not None:
+            mm_path.append((parent, msg))
         cursor = end
 
     # Assistant node: trailing scaffold (the generation prompt) + the sampled completion.
@@ -477,15 +483,16 @@ def _commit_turn(turn: PendingTurn, response: Response) -> None:
         )
     )
     # Register the assistant so the next turn's prompt (which restates it) reuses this node.
-    idx[(parent, message_hash(response.message))] = len(trace.nodes) - 1
+    assistant_id = len(trace.nodes) - 1
+    idx[(parent, message_hash(response.message))] = assistant_id
+    new_node_ids.append(assistant_id)
 
     # Attribute this turn's images onto the input nodes that introduced them (by content part).
-    _attribute_mm(trace, path, num_reused, tokens.multi_modal_data if tokens else None)
+    if mm_path is not None:
+        _attribute_mm(trace, mm_path, num_reused, multi_modal_data)
 
     # Attribute this turn's expert-routing array onto the nodes created this turn (new input
     # nodes in creation order, then the assistant node), each getting the routing for its tokens.
-    new_node_ids = [nid for nid, _ in path[num_reused:]]
-    new_node_ids.append(len(trace.nodes) - 1)
     _attribute_routed_experts(
         trace, new_node_ids, path_len, tokens.routed_experts if tokens else None
     )


### PR DESCRIPTION
## Overview

Avoid materializing a full `(node_id, message)` path for text-only V1 turns. New node IDs are tracked independently for routed-expert attribution, while multimodal turns continue to build the complete prompt path needed for cursor alignment.

## Why

`_commit_turn` previously built a tuple path for every reused prompt message before calling `_attribute_mm`. On text-only turns, `multi_modal_data` is absent and that helper returns immediately, leaving an O(P) container allocation and pass with no multimodal work to perform.

Training responses still perform the required O(P) token-prefix validation. This change removes the separate, redundant path construction; it does not claim to make training commits sublinear.

## Implementation

- Read the turn's multimodal sidecar once and create the full message path only when it is present.
- Record new input and assistant node IDs as nodes are appended, preserving routed-expert attribution without depending on the multimodal structure.
- Preserve full-prefix scanning for later multimodal turns so reused images advance modality cursors and new images attach to the correct nodes.

## Performance

An isolated PEP 723 microbenchmark used 200,000 reused text messages, three repetitions, `time.perf_counter()` for median wall time, and `tracemalloc` for Python allocations.

| Metric | Previous | New | Saved |
|---|---:|---:|---:|
| Median wall time | 0.110177 s | 0.046306 s | 0.063871 s (58.0%) |
| Peak traced allocation | 14,626,822 B | 1,802,766 B | 12,824,056 B (87.7%) |
| Live traced allocation after return | 1,914,217 B | 1,802,137 B | 112,080 B |

The benchmark isolates the removed allocation. End-to-end training gains may be smaller because token-prefix validation remains, while the peak temporary-memory reduction directly reflects the eliminated list and tuple containers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized refactor in graph commit logic; multimodal and routed-expert behavior are preserved by construction, with no auth or data-model changes.
> 
> **Overview**
> **`_commit_turn`** no longer builds a full `(node_id, message)` path on every turn. Text-only commits track new nodes in **`new_node_ids`** as they are created and skip the O(prefix) list/tuple work that **`_attribute_mm`** would not use anyway.
> 
> When **`multi_modal_data`** is present, the reused prefix is materialized into **`mm_path`** and extended for new input messages so image cursor attribution is unchanged. Routed-expert slicing still uses the same **`new_node_ids`** ordering (new inputs, then the assistant node).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cf96d98baddf8055589cb7f351019678f4d523a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip multimodal path allocation in `_commit_turn` on text-only turns
> In [`graph.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1789/files#diff-64c9d635eb215902a512c9e8ab316fd9b9967c36db03d4049aacc812cdfbd740), `_commit_turn` previously built a unified `path` list and called `_attribute_mm` unconditionally, even when no multimodal data was present. This refactor splits `path` into `new_node_ids` (always tracked) and `mm_path` (only materialized when `multi_modal_data` exists), and gates the `_attribute_mm` call on `mm_path` being non-None.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8cf96d9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->