### PR TITLE
Avoid duplicate bridge completion copy

### DIFF
--- a/verifiers/v1/graph.py
+++ b/verifiers/v1/graph.py
@@ -274,7 +274,8 @@ class PendingTurn:
         for nid in self.prefix_node_ids[:-1]:
             prompt_ids.extend(self.trace.nodes[nid].token_ids)
         prompt_ids.extend(last.token_ids[:first_sampled])
-        completion_ids = list(last.token_ids[first_sampled:])
+        # Slicing already returns an independent list; avoid a second completion-sized copy.
+        completion_ids = last.token_ids[first_sampled:]
         if not prompt_ids or not completion_ids:
             return None
         return prompt_ids, completion_ids


### PR DESCRIPTION
## Overview

Avoid a redundant completion-sized list copy when preparing previous-turn token IDs for v1 renderer bridging.

## Reasoning

`last.token_ids[first_sampled:]` already creates an independent list. Wrapping that slice in `list(...)` allocated a second list and copied every completion-token reference again without adding ownership isolation. Returning the slice directly preserves the mutable, trace-independent result while removing one linear allocation and copy.

## Performance impact

A standalone benchmark used a 1,900,000-token completion and reported the median of 9 runs:

| Metric | Before | After | Saved |
| --- | ---: | ---: | ---: |
| Wall time | 6.360 ms | 2.532 ms | 3.828 ms (60.2%) |
| Peak traced allocation | 30,400,136 B (28.99 MiB) | 15,200,080 B (14.50 MiB) | 15,200,056 B (50.0%) |
| Token references copied | 3,800,000 | 1,900,000 | 1,900,000 (50.0%) |

The required returned list remains 15,200,056 bytes at this scale; the reduction is the eliminated transient second list. Absolute savings scale linearly with completion length.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line allocation change in a read path for bridging; behavior for consumers remains a distinct completion ID list.
> 
> **Overview**
> **`PendingTurn.previous_token_ids`** now returns the completion segment as `last.token_ids[first_sampled:]` instead of wrapping that slice in `list(...)`.
> 
> Slicing already allocates a new list with the completion token IDs needed for v1 renderer bridging, so the extra `list()` only duplicated references and memory on long completions. Prompt assembly is unchanged; callers still get a separate mutable list for the bridge anchor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57f3188fed517c2c0d4b03726a293c3893042426. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Avoid duplicate list copy in `PendingTurn.previous_token_ids`
> In [graph.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1790/files#diff-64c9d635eb215902a512c9e8ab316fd9b9967c36db03d4049aacc812cdfbd740), removes a redundant `list()` wrapper around a slice in `PendingTurn.previous_token_ids`. Slicing already returns an independent list, so wrapping it in `list()` was creating an unnecessary second copy of the completion-sized data.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 57f3188.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->