### PR TITLE
Cache immutable MCP source archives

### DIFF
--- a/verifiers/v1/mcp/launch.py
+++ b/verifiers/v1/mcp/launch.py
@@ -19,6 +19,7 @@ import sys
 import tarfile
 import uuid
 from collections.abc import AsyncIterator, Awaitable, Callable
+from functools import cache
 from pathlib import Path
 from typing import TYPE_CHECKING
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
@@ -44,7 +45,7 @@ logger = logging.getLogger(__name__)
 # The verifiers source tree's wheel-build inputs — uploaded into a sandbox so it installs the
 # developer's working-tree verifiers (deps resolve from PyPI off the uploaded pyproject), with no
 # publish or git pin to keep in sync.
-VF_BUILD_INPUTS = ["pyproject.toml", "README.md", "LICENSE", "verifiers"]
+VF_BUILD_INPUTS = ("pyproject.toml", "README.md", "LICENSE", "verifiers")
 
 # The model's last assistant text in; the next user messages out. The user sim ends the trajectory
 # by setting a flag on the shared `self.state` that the taskset's `@vf.stop` checks, not via a return
@@ -100,17 +101,23 @@ _TAR_EXCLUDE = {
 and can be gigabytes (a `.venv` alone is many GB), which would otherwise stall the upload."""
 
 
-def _tar_source(src: Path, members: list[str] | None = None) -> bytes:
+@cache
+def _tar_source(src: Path, members: tuple[str, ...] = ()) -> bytes:
     """Gzipped tarball of a local package dir, rooted at `src.name/`, skipping `_TAR_EXCLUDE` dirs.
     `members` limits it to those top-level entries (the verifiers tree only needs its package +
-    project files); otherwise the whole dir (a small env package)."""
+    project files); otherwise the whole dir (a small env package).
+
+    An eval worker's imported code is already a startup snapshot, so its source archives are too.
+    If development-time source mutation becomes supported, replace this process cache with an
+    explicit cache scoped to that lifecycle rather than serving stale global data.
+    """
 
     def keep(info: tarfile.TarInfo) -> tarfile.TarInfo | None:
         return None if _TAR_EXCLUDE & set(info.name.split("/")) else info
 
     buf = io.BytesIO()
     with tarfile.open(fileobj=buf, mode="w:gz") as tar:
-        for member in members or [""]:
+        for member in members or ("",):
             path = src / member if member else src
             if path.exists():
                 tar.add(path, arcname=f"{src.name}/{member}".rstrip("/"), filter=keep)


### PR DESCRIPTION
## Overview

Cache immutable source archives used to provision sandboxed MCP tool and user runtimes, avoiding repeated tar and gzip work within an eval worker.

## Reasoning

Each sandbox launch uploads the same Verifiers checkout and environment package. Archive construction happens synchronously while evaluating the arguments to `runtime.write`, before the coroutine can yield, so rebuilding an identical archive adds startup latency, blocks the event loop, and allocates a fresh compression buffer for every runtime.

An eval worker already treats imported code as a startup snapshot. This change applies the same lifetime to its source archives: `VF_BUILD_INPUTS` and the member selector become immutable tuples, and `_tar_source` is cached by source root plus member tuple. Different roots and filters remain distinct cache keys. Tar contents, exclusions, sandbox upload bytes, extraction, and installation behavior are unchanged.

If development-time source mutation becomes a supported workflow, the cache should move to an explicit shorter lifecycle rather than refreshing process-global data implicitly.

## Performance impact

A five-call repeated-build benchmark used the 624,058-byte Verifiers archive containing 353 tar members. Timings use `time.perf_counter`; transient allocations use `tracemalloc`.

| Metric | Before | After | Saved |
| --- | ---: | ---: | ---: |
| Median wall time per repeated call | 236.046750 ms | 0.006334 ms | 236.040416 ms (99.9973%) |
| Synchronous event-loop stall per repeated call | 236.046750 ms | 0.006334 ms | 236.040416 ms (99.9973%) |
| Five-call wall time | 1,200.168833 ms | 0.033917 ms | 1,200.134916 ms (99.9972%) |
| Median peak traced allocation | 1,277,922 bytes | 80 bytes | 1,277,842 bytes (99.9937%) |

The first build for each distinct key is unchanged. A cached key retains its immutable archive payload (624,058 bytes in this workload) for the worker lifetime, while upload volume remains unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Process-local memoization only; tarball bytes and sandbox install paths are unchanged, with stale archives possible only if on-disk source changes mid-worker (already the eval snapshot model).
> 
> **Overview**
> **Caches gzipped source archives** used when `_install_in_sandbox` uploads the Verifiers checkout and env package, so repeated sandbox launches in the same worker do not rebuild identical tarballs on every `runtime.write`.
> 
> `_tar_source` is wrapped with **`functools.cache`**, keyed by source `Path` and the member filter tuple. **`VF_BUILD_INPUTS`** and the default member list are tuples so they are hashable cache keys. Tar layout, exclusions, and upload/install behavior are unchanged.
> 
> The docstring notes that archives are treated like the worker’s startup code snapshot; if live source edits become supported, the cache should move to an explicit shorter lifecycle instead of process-global reuse.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 587e25d9fecab1376123bbf7cb7aee0692001c12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cache `_tar_source` results to avoid re-tarring identical MCP source archives
> Decorates `_tar_source` in [launch.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1792/files#diff-989d87123d40d48511f9e1df74594d2e30776e9a99c11eca49d9cc20bf9e2230) with `@functools.cache` so repeated calls with the same `(src, members)` arguments return cached bytes. Also converts `VF_BUILD_INPUTS` from a list to a tuple to support hashability. Risk: passing a list for `members` will now raise `TypeError` at call time due to cache key hashing requirements.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 587e25d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->