### PR TITLE
Stream and join V1 SSE responses once

### DIFF
--- a/verifiers/v1/dialects/anthropic.py
+++ b/verifiers/v1/dialects/anthropic.py
@@ -122,15 +122,15 @@ def response_from_wire(message: AnthropicMessage) -> Response:
     data = message.model_dump()
     blocks = data.get("content") or []
     state = [block for block in blocks if block["type"] in THINKING]
-    content = ""
-    reasoning = ""
+    content: list[str] = []
+    reasoning: list[str] = []
     calls: list[ToolCall] = []
     for block in blocks:
         kind = block.get("type")
         if kind == "text":
-            content += block.get("text", "")
+            content.append(block.get("text", ""))
         elif kind == "thinking":
-            reasoning += block.get("thinking", "")
+            reasoning.append(block.get("thinking", ""))
         elif kind == "tool_use":
             calls.append(
                 ToolCall(
@@ -161,8 +161,8 @@ def response_from_wire(message: AnthropicMessage) -> Response:
         created=0,
         model=data.get("model", ""),
         message=AssistantMessage(
-            content=content or None,
-            reasoning_content=reasoning or None,
+            content="".join(content) or None,
+            reasoning_content="".join(reasoning) or None,
             tool_calls=calls or None,
             provider_state=state or None,
         ),
@@ -220,30 +220,38 @@ class AnthropicDialect(Dialect[dict, AnthropicMessage]):
         message, then parse it."""
         message: dict = {}
         blocks: dict[int, dict] = {}
-        partial_json: dict[int, str] = {}
+        block_parts: dict[int, dict[str, list[str]]] = {}
+        partial_json: dict[int, list[str]] = {}
         for event in iter_sse(raw):
             kind = event.get("type")
             if kind == "message_start":
                 message = event.get("message") or {}
             elif kind == "content_block_start":
-                blocks[event["index"]] = dict(event.get("content_block") or {})
+                index = event["index"]
+                blocks[index] = dict(event.get("content_block") or {})
+                block_parts.pop(index, None)
             elif kind == "content_block_delta":
-                block = blocks.setdefault(event["index"], {"type": "text", "text": ""})
+                index = event["index"]
+                block = blocks.setdefault(index, {"type": "text", "text": ""})
                 delta = event.get("delta") or {}
-                if delta.get("type") == "text_delta":
-                    block["text"] = block.get("text", "") + delta.get("text", "")
-                elif delta.get("type") == "thinking_delta":
-                    block["thinking"] = block.get("thinking", "") + delta.get(
-                        "thinking", ""
-                    )
-                elif delta.get("type") == "signature_delta":
-                    block["signature"] = block.get("signature", "") + delta.get(
-                        "signature", ""
-                    )
-                elif delta.get("type") == "input_json_delta":
-                    partial_json[event["index"]] = partial_json.get(
-                        event["index"], ""
-                    ) + delta.get("partial_json", "")
+                delta_type = delta.get("type")
+                if delta_type in ("text_delta", "thinking_delta", "signature_delta"):
+                    field = delta_type.removesuffix("_delta")
+                    fields = block_parts.get(index)
+                    if fields is None:
+                        fields = {}
+                        block_parts[index] = fields
+                    parts = fields.get(field)
+                    if parts is None:
+                        parts = [block.get(field, "")]
+                        fields[field] = parts
+                    parts.append(delta.get(field, ""))
+                elif delta_type == "input_json_delta":
+                    parts = partial_json.get(index)
+                    if parts is None:
+                        parts = []
+                        partial_json[index] = parts
+                    parts.append(delta.get("partial_json", ""))
             elif kind == "message_delta":
                 message.update(
                     {
@@ -256,8 +264,11 @@ class AnthropicDialect(Dialect[dict, AnthropicMessage]):
                     **(message.get("usage") or {}),
                     **(event.get("usage") or {}),
                 }
-        for index, partial in partial_json.items():
-            blocks[index]["input"] = json.loads(partial or "{}")
+        for index, fields in block_parts.items():
+            for field, parts in fields.items():
+                blocks[index][field] = "".join(parts)
+        for index, parts in partial_json.items():
+            blocks[index]["input"] = json.loads("".join(parts) or "{}")
         message["content"] = [blocks[i] for i in sorted(blocks)]
         return response_from_wire(self.validate_response(message))
 

--- a/verifiers/v1/dialects/base.py
+++ b/verifiers/v1/dialects/base.py
@@ -13,37 +13,63 @@ the eval's model + sampling in this format's shape) and `extend` (chat-only user
 """
 
 import json
+import logging
 from abc import ABC, abstractmethod
 from collections.abc import Iterator, Mapping
 from typing import ClassVar, Generic, TypeVar
 
 from pydantic import BaseModel
+from pydantic_core import from_json
 
 from verifiers.v1.types import Messages, Response, SamplingConfig, Tool
 
 ReqT = TypeVar("ReqT")
 RespT = TypeVar("RespT", bound=BaseModel)
 
+logger = logging.getLogger(__name__)
 
-def iter_sse(raw: bytes) -> list[dict]:
-    """Parse a complete SSE byte stream into its JSON data payloads, in order (skipping
-    non-JSON sentinels like OpenAI's `data: [DONE]`). Shared by the dialects' `parse_stream`."""
-    events: list[dict] = []
-    for block in raw.decode("utf-8", errors="replace").split("\n\n"):
-        data = "\n".join(
-            line.removeprefix("data:").strip()
+
+def iter_sse(raw: bytes) -> Iterator[dict]:
+    """Yield JSON SSE payloads in order without retaining prior events."""
+    # Detect the wire line ending once, then scan without retaining prior payloads.
+    first_newline = raw.find(b"\n")
+    separator = (
+        b"\r\n\r\n"
+        if first_newline > 0 and raw[first_newline - 1] == ord("\r")
+        else b"\n\n"
+    )
+    start = 0
+    while start < len(raw):
+        end = raw.find(separator, start)
+        if end == -1:
+            end = len(raw)
+        block = raw[start:end]
+        data = b"\n".join(
+            line.removeprefix(b"data:").strip()
             for line in block.splitlines()
-            if line.startswith("data:")
+            if line.startswith(b"data:")
         )
-        if not data or data == "[DONE]":
-            continue
-        events.append(json.loads(data))
-    return events
+        if data and data != b"[DONE]":
+            try:
+                yield from_json(data)
+            except ValueError:
+                logger.warning(
+                    "SSE JSON fast-path failed; falling back to stdlib with invalid UTF-8 replacement"
+                )
+                yield json.loads(data.decode("utf-8", errors="replace"))
+        start = end + len(separator)
 
 
 def iter_sse_reverse(raw: bytes) -> Iterator[dict]:
     """Yield JSON SSE payloads from the end without decoding earlier events."""
-    for block in reversed(raw.decode("utf-8", errors="replace").split("\n\n")):
+    decoded = raw.decode("utf-8", errors="replace")
+    first_newline = decoded.find("\n")
+    separator = (
+        "\r\n\r\n"
+        if first_newline > 0 and decoded[first_newline - 1] == "\r"
+        else "\n\n"
+    )
+    for block in reversed(decoded.split(separator)):
         data = "\n".join(
             line.removeprefix("data:").strip()
             for line in block.splitlines()

--- a/verifiers/v1/dialects/chat.py
+++ b/verifiers/v1/dialects/chat.py
@@ -229,13 +229,19 @@ class ChatDialect(Dialect[dict, ChatCompletion]):
 
     def parse_stream(self, raw: bytes) -> Response:
         """Assemble `chat.completion.chunk` deltas into one completion, then parse it."""
-        chunks = iter_sse(raw)
         message: dict = {"role": "assistant", "content": None}
+        # Join streamed fields once; repeated concatenation recopies the growing response.
+        message_parts = {key: [] for key in REASONING_FIELDS[:2] + ("content",)}
         tool_calls: dict[int, dict] = {}
+        tool_arguments: dict[int, list[str]] = {}
         reasoning_details: list[dict] = []
+        reasoning_detail_parts: dict[int, list[str]] = {}
         finish_reason = None
         usage = None
-        for chunk in chunks:
+        head = None
+        for chunk in iter_sse(raw):
+            if head is None:
+                head = chunk
             usage = chunk.get("usage") or usage
             for choice in chunk.get("choices") or []:
                 if choice.get("index", 0) != 0:
@@ -244,32 +250,43 @@ class ChatDialect(Dialect[dict, ChatCompletion]):
                 delta = choice.get("delta") or {}
                 for key in ("content", "reasoning_content", "reasoning"):
                     if delta.get(key) is not None:
-                        message[key] = (message.get(key) or "") + delta[key]
+                        message_parts[key].append(delta[key])
                 for detail in delta.get("reasoning_details") or []:
                     previous = reasoning_details[-1] if reasoning_details else {}
                     if detail.get("type") == previous.get("type") == "reasoning.text":
-                        previous["text"] = (previous.get("text") or "") + (
-                            detail.get("text") or ""
-                        )
+                        reasoning_detail_parts.setdefault(
+                            len(reasoning_details) - 1, [previous.get("text") or ""]
+                        ).append(detail.get("text") or "")
                         for field in ("signature", "format"):
                             previous[field] = previous.get(field) or detail.get(field)
                     else:
                         reasoning_details.append(detail)
                 for tc in delta.get("tool_calls") or []:
+                    index = tc.get("index", 0)
                     slot = tool_calls.setdefault(
-                        tc.get("index", 0),
+                        index,
                         {"type": "function", "function": {"name": "", "arguments": ""}},
                     )
                     slot["id"] = tc.get("id") or slot.get("id", "")
                     fn = tc.get("function") or {}
                     if fn.get("name"):
                         slot["function"]["name"] = fn["name"]
-                    slot["function"]["arguments"] += fn.get("arguments") or ""
+                    tool_arguments.setdefault(index, []).append(
+                        fn.get("arguments") or ""
+                    )
+        for key, parts in message_parts.items():
+            if parts:
+                message[key] = "".join(parts)
+        for index, parts in reasoning_detail_parts.items():
+            reasoning_details[index]["text"] = "".join(parts)
+        for index, parts in tool_arguments.items():
+            tool_calls[index]["function"]["arguments"] = "".join(parts)
         if tool_calls:
             message["tool_calls"] = [tool_calls[i] for i in sorted(tool_calls)]
         if reasoning_details:
             message["reasoning_details"] = reasoning_details
-        head = chunks[0] if chunks else {}
+        if head is None:
+            head = {}
         return response_from_wire(
             ChatCompletion.model_validate(
                 {


### PR DESCRIPTION
## Overview

Stream and assemble V1 Chat and Anthropic SSE responses in one pass, keeping only the current parsed event and joining accumulated output fragments once.

## Why

The forward SSE path decoded and split the complete stream into a list, retaining every event until assembly finished. Chat and Anthropic then repeatedly concatenated immutable content, reasoning, signature, and tool-argument strings, recopying the full accumulated prefix for each delta. Long responses therefore incurred both event-list retention and quadratic string-copy work on the synchronous interception path.

## Changes

- Scan forward SSE blocks incrementally, supporting LF and CRLF boundaries.
- Parse with the existing `pydantic_core` fast path and fall back to stdlib JSON with invalid UTF-8 replacement, logging whenever that fallback is used.
- Track Chat response metadata from the first event and collect content, reasoning details, and tool arguments as fragments before joining once.
- Collect Anthropic text, thinking, signatures, partial tool JSON, and final content blocks before joining once.
- Preserve the reverse Responses strategy while accepting CRLF boundaries there as well.

## Performance impact

Measured with 20,000 streamed deltas of 256 bytes each; wall time uses `perf_counter`, and allocation figures use `tracemalloc` after constructing the raw input.

| Path | Before | After | Saved |
| --- | ---: | ---: | ---: |
| Chat wall time | 0.6875 s | 0.0229 s | 0.6646 s (96.7%) |
| Anthropic wall time | 0.6959 s | 0.0232 s | 0.6727 s (96.7%) |
| Chat peak allocation | 31.3906 MiB | 10.7201 MiB | 20.6705 MiB (65.9%) |
| Anthropic peak allocation | 28.2069 MiB | 10.7224 MiB | 17.4845 MiB (62.0%) |
| 100k-event iterator peak | 27.2626 MiB | 0.0015 MiB | 27.2611 MiB (>99.99%) |

The retained completed response remains approximately 4.9 MiB in both paths; the savings come from removing transient event retention and growing intermediate strings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavioral change is limited to trace assembly on the synchronous interception path; output should match prior assembly logic with slightly different JSON decode and UTF-8 fallback behavior.
> 
> **Overview**
> **Refactors V1 SSE handling on the interception trace path** so long streamed model responses no longer materialize every event or repeatedly grow strings while assembling the final message.
> 
> `iter_sse` now **yields** parsed events from a single forward scan over raw bytes (with **LF vs CRLF** frame detection), using **`pydantic_core.from_json`** and logging a fallback to stdlib JSON when the fast path fails. **`iter_sse_reverse`** gets the same CRLF-aware splitting.
> 
> **Chat** and **Anthropic** `parse_stream` (and Anthropic non-stream `response_from_wire` for text/thinking) **append deltas to fragment lists**—content, reasoning, signatures, tool JSON, tool arguments—and **`"".join` once** after the stream ends, instead of concatenating on every chunk. Chat keeps stream metadata from the **first** chunk while iterating, rather than indexing a fully built event list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb7a519214620a7416862b621c4d47a8d989ac81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stream and join SSE responses incrementally in V1 dialects
> - Converts `iter_sse` in [base.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1793/files#diff-10ccce5f7f0d991c33492a01e73014e10883deb74f7006253f1c690422d841bd) from a list-returning function to a generator that yields parsed events one at a time, avoiding holding the full stream in memory.
> - Reworks string accumulation in `ChatDialect.parse_stream` and `AnthropicDialect.parse_stream` (and `response_from_wire`) to collect fragments in lists and join once after the loop, replacing repeated string concatenation.
> - Adds CRLF separator support to both `iter_sse` and `iter_sse_reverse`, and switches JSON parsing to use `pydantic_core.from_json` on raw bytes with a fallback to `json.loads` and a warning log.
> - Behavioral Change: `iter_sse` no longer retains previously yielded events; callers that iterated the returned list more than once will need to collect results themselves.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fb7a519.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->