### PR TITLE
Avoid full-context routed-expert padding

### DIFF
--- a/verifiers/v1/graph.py
+++ b/verifiers/v1/graph.py
@@ -376,18 +376,20 @@ def _attribute_routed_experts(
     raw = binascii.a2b_base64(payload["data"])
     arr = np.frombuffer(raw, dtype=np.uint8).reshape(payload["shape"])
     off = path_len - int(payload.get("start", 0) or 0)
-    # The engine omits routing for the turn's final position (no forward pass follows the last
-    # generated token), so the array is one row short of the turn's new tokens. Pad the tail
-    # with a copy of the last row so the final node still aligns 1:1 with its tokens.
     needed = off + sum(len(trace.nodes[nid].token_ids) for nid in new_node_ids)
-    if arr.shape[0] and 0 < needed - arr.shape[0] <= 1:
-        arr = np.concatenate([arr, arr[-1:]], axis=0)
     for nid in new_node_ids:
         n = len(trace.nodes[nid].token_ids)
-        if n and 0 <= off and off + n <= arr.shape[0]:
+        end = off + n
+        if n and 0 <= off and end <= arr.shape[0]:
             # Own only this node's rows; a view would retain the turn's full-context array.
-            trace.nodes[nid].routed_experts = arr[off : off + n].copy()
-        off += n
+            trace.nodes[nid].routed_experts = arr[off:end].copy()
+        elif n and arr.shape[0] and 0 <= off and end == needed == arr.shape[0] + 1:
+            # The engine omits the turn's final position because no forward pass follows it.
+            # Pad only the final node's suffix instead of copying the full-context array.
+            trace.nodes[nid].routed_experts = np.concatenate(
+                [arr[off:], arr[-1:]], axis=0
+            )
+        off = end
 
 
 def _commit_turn(turn: PendingTurn, response: Response) -> None:


### PR DESCRIPTION
## Overview

Keep the V1 routed-expert payload unchanged and construct the engine's one-row-short padding only for the final node slice. Node alignment and owned-array behavior stay the same, while the transient work scales with the retained suffix instead of the full prompt context.

## Design

The engine may omit routing for the final token because no forward pass follows it. Attribution still repeats the last available routing row, but now does so when the final token-bearing node ends exactly one row beyond the payload. Complete slices continue to receive their existing owned copies, and empty or out-of-range slices remain unset.

This localizes the padding to `arr[off:]` plus the final row. It avoids materializing a padded full-context array that is immediately discarded after new-node attribution.

## Performance

A PEP 723 benchmark used a `uint8` routed-expert tensor shaped `(1,000,000, 8, 4)`, with 900,000 reused rows and 100,001 retained new rows:

| Measurement | Before | After | Saved |
| --- | ---: | ---: | ---: |
| Median synchronous copy time | 0.495 ms | 0.046 ms | 0.449 ms (90.7%) |
| Peak traced allocation | 33.570 MiB | 3.052 MiB | 30.518 MiB (90.9%) |
| Fresh-process maximum RSS | 98.141 MiB | 67.391 MiB | 30.750 MiB (31.3%) |
| Large-array bytes copied | 35,200,064 B | 3,200,032 B | 32,000,032 B (90.9%) |

The retained result remains 3,200,032 bytes in both cases; the savings come entirely from removing the context-sized temporary copy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to MoE routing attribution in graph commit; behavior preserved for normal slices and the one-row-short final-token case, with lower memory/copy cost.
> 
> **Overview**
> **`_attribute_routed_experts`** no longer prepends a full-context copy when the engine’s routing payload is one row short. Complete node slices still get an owned `arr[off:end].copy()` as before.
> 
> When only the **last** token-bearing node needs that missing row (`end == needed == arr.shape[0] + 1`), padding is applied to that node’s suffix via `np.concatenate([arr[off:], arr[-1:]], axis=0)` instead of extending the entire turn array first. Offset tracking uses `end = off + n` consistently.
> 
> Same 1:1 token↔routing alignment and unset behavior for out-of-range slices; less transient allocation and copying on long reused prefixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1e6c58c81da86cae86b3e4cae4ac278d99fcfe6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix padding in `_attribute_routed_experts` to only pad the final MoE node
> Previously, [graph.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1794/files#diff-64c9d635eb215902a512c9e8ab316fd9b9967c36db03d4049aacc812cdfbd740) applied a global tail-pad to the routed-experts array whenever the routing array was one row short, affecting all nodes. Now only the final node receives a one-row suffix pad (by repeating the last row), while earlier nodes slice the original array without modification. Per-node slicing uses a computed `end` index updated after each node.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c1e6c58.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->