### PR TITLE
Serialize intercepted completions directly to JSON bytes

### DIFF
--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -30,7 +30,7 @@ from typing import TYPE_CHECKING
 
 from aiohttp import web
 from pydantic import ValidationError
-from pydantic_core import from_json
+from pydantic_core import PydanticSerializationError, from_json, to_json
 
 from verifiers.v1.clients import RolloutContext
 from verifiers.v1.dialects import DIALECTS, Dialect
@@ -58,6 +58,15 @@ _MAX_REQUEST_BODY = 1024**3  # 1 GiB (aiohttp's default is 1 MiB)
 _KEEPALIVE_INTERVAL_SECONDS = 3
 # The server binds loopback; callers reach it via localhost or a host tunnel (see `reachable_url`).
 _HOST = "127.0.0.1"
+
+
+def _completion_response(completion: dict | None) -> web.Response:
+    """Serialize a model's JSON-native response without an intermediate string."""
+    try:
+        body = to_json(completion, inf_nan_mode="constants")
+    except PydanticSerializationError:
+        return web.json_response(completion)
+    return web.Response(body=body, content_type="application/json", charset="utf-8")
 
 
 @dataclass(frozen=True)
@@ -292,7 +301,7 @@ class InterceptionServer:
                     return web.json_response(
                         dialect.error_body(f"rollout stopped: {refused}"), status=400
                     )
-                return web.json_response(completion)
+                return _completion_response(completion)
             turn = graph.prepare_turn(session.trace, prompt)
             session.error = None
             try:
@@ -316,7 +325,7 @@ class InterceptionServer:
                         dialect.error_body("rollout stopped: context_length"),
                         status=400,
                     )
-                return web.json_response(completion)
+                return _completion_response(completion)
             except RolloutError as e:
                 # Stash the real cause; the rollout re-raises it after the harness returns. Relay
                 # the provider's status so the harness SDK retries 5xx/429 and not 4xx.
@@ -351,7 +360,7 @@ class InterceptionServer:
             # Hand back to the program when the model wants a tool (the program runs it) or
             # when there's no user simulator to keep the conversation going.
             if response.message.tool_calls or session.user is None:
-                return web.json_response(completion)
+                return _completion_response(completion)
             try:
                 user_messages = await session.user(response.message.content or "")
             except RolloutError as e:


### PR DESCRIPTION
## Overview

Serialize non-streaming intercepted model completions directly to JSON bytes before returning them to harnesses. This keeps the response contract unchanged while reducing synchronous work and transient allocations on the shared interception-server event loop.

## Why

The previous completion-return paths called `web.json_response(completion)`. That route first uses stdlib `json.dumps` to materialize a complete Python string, then asks aiohttp to UTF-8 encode that string into the final response bytes.

Large completions therefore held the JSON string, encoder working memory, and final byte body at the same time. Serialization is synchronous, so it also stalled every rollout multiplexed through that interception server.

## Implementation

A focused `_completion_response` helper now:

- serializes the JSON-native completion with `pydantic_core.to_json`;
- passes the resulting bytes directly to `web.Response`;
- preserves `application/json; charset=utf-8`, status, `null`, and the existing `NaN`/`Infinity` policy;
- falls back to `web.json_response` when pydantic-core cannot encode an otherwise stdlib-compatible value, including escaped lone Unicode surrogates.

Only the three successful model-completion return sites use the helper: ordinary/tool returns, user-simulator stop returns, and context-length returns after a completed turn. Error, streaming, auxiliary, state, task, and upstream client codec paths are unchanged.

## Performance

Measured with a 32 MiB completion over 10-loop medians:

| Metric | Before | After | Saved |
| --- | ---: | ---: | ---: |
| Serialization wall time | 33.330 ms | 8.955 ms | 24.375 ms (73.1%) |
| Event-loop stall | 33.386 ms | 8.988 ms | 24.398 ms (73.1%) |
| Peak traced allocation | 72.001 MiB | 32.002 MiB | 39.999 MiB (55.6%) |
| Retained traced allocation | 32.002 MiB | 32.002 MiB | unchanged |

The retained allocation is the final response body, which must remain alive until aiohttp writes it. The peak reduction comes from eliminating the intermediate JSON string and full-body string-to-bytes encoding pass. These figures isolate response serialization rather than model or network latency.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to response encoding on the interception hot path with a stdlib-compatible fallback; wire shape and status behavior for errors are unchanged.
> 
> **Overview**
> Non-streaming **successful model completion** responses from the interception server now go through a new **`_completion_response`** helper instead of **`web.json_response(completion)`**.
> 
> The helper encodes the completion dict with **`pydantic_core.to_json`** (`inf_nan_mode="constants"`) into bytes and returns **`web.Response`** with `application/json; charset=utf-8`. If pydantic-core cannot serialize the payload, it **falls back** to the previous **`web.json_response`** path.
> 
> Only the three **happy-path** completion returns in **`handle_request`** use this helper: after a **@stop/limit** with a prior turn, after **context_length** truncation with a prior turn, and on the normal **tool / no-user-simulator** return. Error, streaming, aux, and state routes are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf1b40069a9445592fbd1522bfabf75c1a0e7963. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Serialize intercepted completions directly to JSON bytes using `pydantic_core.to_json`
> Adds a `_completion_response` helper in [server.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1795/files#diff-84e2f8d027d609e8760ef6d533535ec9d99dfc6384d5ddb6111b4001b2010f35) that serializes completion dicts to bytes via `pydantic_core.to_json` with `inf_nan_mode="constants"`, returning a `web.Response` with explicit `application/json` content type. Falls back to `aiohttp.web.json_response` on `PydanticSerializationError`. All three completion-returning branches in `handle_request` (refusal, context-length exceeded, tool/no-user-simulator) now use this helper.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cf1b400.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->