### PR TITLE
Cache trace branches by node count

### DIFF
--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -242,6 +242,9 @@ class Trace(StrictBaseModel, Generic[TaskT, StateT]):
     _head_index: dict = PrivateAttr(default_factory=dict)
     """`(parent, msg_hash) -> node_id` for the graph builder (`graph.prepare_turn` / `commit`);
     rebuilt lazily from `nodes` after deserialization."""
+    _branch_cache: list[Branch] = PrivateAttr(default_factory=list)
+    _branch_cache_node_count: int = PrivateAttr(default=-1)
+    """The derived branch view, rebuilt whenever the graph grows."""
 
     @property
     def reward(self) -> float:
@@ -295,6 +298,10 @@ class Trace(StrictBaseModel, Generic[TaskT, StateT]):
         """The conversation segmented into linear branches — a view over the graph: each
         leaf's root→leaf path is a branch (one when linear, several under compaction or
         subagents). Branching falls out of walking each leaf's parents back to its root."""
+        node_count = len(self.nodes)
+        if self._branch_cache_node_count == node_count:
+            return self._branch_cache.copy()
+
         branches: list[Branch] = []
         for i, leaf in enumerate(graph.leaves(self)):
             path: list[int] = []
@@ -304,11 +311,15 @@ class Trace(StrictBaseModel, Generic[TaskT, StateT]):
                 nid = self.nodes[nid].parent
             path.reverse()
             branches.append(Branch(index=i, nodes=[self.nodes[n] for n in path]))
-        return branches
+        self._branch_cache = branches
+        self._branch_cache_node_count = node_count
+        return branches.copy()
 
     @property
     def num_branches(self) -> int:
         """How many branches (1 = linear; >1 = compaction/subagents)."""
+        if self._branch_cache_node_count == len(self.nodes):
+            return len(self._branch_cache)
         return len(graph.leaves(self))
 
     @property


### PR DESCRIPTION
## Overview

Cache the derived `Trace.branches` view by `len(trace.nodes)` so repeated trace properties reuse the same branch materialization. Token-limit evaluation keeps using the existing `Trace` API and preserves its current semantics.

## What changed

- Add a private branch cache and cached node count to `Trace`.
- Return a shallow copy of the cached branch list while the node count is unchanged, preserving caller isolation.
- Rebuild the view after nodes are appended.
- Let `num_branches` reuse the cached branch count when warm, while retaining its cheap leaf scan on cold count-only access.

## Why

`prompt_len`, `completion_len`, and `total_tokens` each read `Trace.branches`. Token-limit checks can therefore reconstruct the same graph paths three times. Caching the derived view at its owner removes those repeated graph walks for every caller without adding topology-specific counting logic to the interception server.

The public property still returns an independent outer list, so caller operations such as sorting, popping, or clearing do not mutate the internal cache.

## Performance

Median wall time with all three token limits enabled:

| Workload | Before | Cache miss | Cache hit |
|---|---:|---:|---:|
| 200k-node linear, 1 token/node | 131.509 ms | 66.529 ms | 31.925 ms |
| 2k nodes / 1k branches, 1 token/node | 256.453 ms | 146.099 ms | 88.978 ms |
| 2k-node linear, 32 tokens/node | 0.824 ms | 0.479 ms | 0.286 ms |
| 2k nodes / 10 branches, 32 tokens/node | 5.705 ms | 3.631 ms | 2.534 ms |
| 10k nodes / 10 branches, 32 tokens/node | 28.442 ms | 17.964 ms | 12.643 ms |

A cache miss represents the normal case after the trace grows; a hit represents repeated reads at the same node count.

Warm `num_branches` reads improve from 346.4 µs to 0.659 µs for a 10k-node linear trace and from 100.2 µs to 0.672 µs for a shared-prefix trace with 1k leaves. Cold count-only reads continue using `graph.leaves` and avoid materializing full branch paths.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized performance optimization on a derived view; semantics stay the same as long as branches only change when nodes are appended (existing rollout model).
> 
> **Overview**
> Adds a **private branch cache** on `Trace` keyed by `len(nodes)` so the expensive root→leaf branch materialization runs once per graph size instead of on every access.
> 
> **`branches`** now returns a cached copy when the node count is unchanged; otherwise it rebuilds, stores the result, and returns a copy (same outward behavior as before). **`num_branches`** reads `len(_branch_cache)` when the cache is warm and still falls back to `graph.leaves(self)` for cold count-only access.
> 
> This mainly speeds repeated reads of `prompt_len`, `completion_len`, and `total_tokens` (each iterates `branches`), including token-limit checks that previously walked the graph multiple times at the same node count.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec04697fd7118d65bb47d395d687e8c8932fa4e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cache trace branches by node count in `Trace`
> Adds memoization to `Trace.branches` and `Trace.num_branches` in [trace.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1799/files#diff-834820c3aa80d87ee1c1c57fb54c74f09c66ac727036d964e6005c8613c00b5e) to avoid recomputing branches on every access. The cache is keyed by node count and invalidated automatically when the graph grows. Both properties return results from `_branch_cache` when the node count matches, and fall back to full recomputation otherwise.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ec04697.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->