### PR TITLE
Revert "Use native JSON bytes for upstream eval traffic"

### DIFF
--- a/verifiers/v1/clients/eval.py
+++ b/verifiers/v1/clients/eval.py
@@ -13,11 +13,9 @@ change. Endpoint config (base url, api key, billing headers) comes from the clie
 """
 
 from collections.abc import Mapping
-import math
 import re
 
 import httpx
-from pydantic_core import from_json, to_json
 
 from verifiers.v1.clients.client import SESSION_ID_HEADER, Client, RelayReply
 from verifiers.v1.dialects import ChatDialect, Dialect
@@ -91,7 +89,7 @@ class EvalClient(Client):
             dialect.apply_overrides(body, model, sampling_args),
             self._headers(dialect, headers, session_id),
         )
-        raw = from_json(resp.content)
+        raw = resp.json()
         response = dialect.parse_response(dialect.validate_response(raw))
         response.raw = raw  # the program gets the provider's bytes back 1:1
         return response
@@ -128,22 +126,7 @@ class EvalClient(Client):
         *,
         stream: bool = False,
     ) -> httpx.Response:
-        # HTTPX rejects non-finite floats. Preserve that policy without inspecting or copying
-        # string payloads, which commonly dominate large upstream requests.
-        pending = [body]
-        while pending:
-            value = pending.pop()
-            if isinstance(value, float) and not math.isfinite(value):
-                raise ValueError(
-                    f"Out of range float values are not JSON compliant: {value}"
-                )
-            if isinstance(value, dict):
-                pending.extend(value.values())
-            elif isinstance(value, (list, tuple)):
-                pending.extend(value)
-        content = to_json(body)
-        headers.setdefault("content-type", "application/json")
-        request = self.http.build_request("POST", url, content=content, headers=headers)
+        request = self.http.build_request("POST", url, json=body, headers=headers)
         try:
             response = await self.http.send(request, stream=stream)
         except httpx.TimeoutException as e:
@@ -217,7 +200,7 @@ class EvalClient(Client):
             body,
             self._headers(dialect, None, None),
         )
-        return from_json(resp.content)
+        return resp.json()
 
     async def close(self) -> None:
         await self.http.aclose()


### PR DESCRIPTION
Reverts PrimeIntellect-ai/verifiers#1798

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how all upstream eval bodies are encoded and parsed, which can differ from the reverted path on edge cases (non-finite floats, JSON wire shape) even though it restores prior behavior.
> 
> **Overview**
> Reverts the **native JSON bytes** path in `EvalClient` and restores **httpx’s built-in JSON** for upstream eval and aux relays.
> 
> `_request` again uses `build_request(..., json=body)` instead of manually serializing with `pydantic_core.to_json`, setting `content-type`, and walking the body to reject non-finite floats. Response handling switches from `from_json(resp.content)` back to **`resp.json()`** in `get_response` and `relay_aux`. Unused `math` and `pydantic_core` imports are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0552d450d072e15c9edaa96a2c11880e3a72be2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Revert native JSON serialization in `EvalClient` to use httpx defaults
> Reverts the `EvalClient` in [eval.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1800/files#diff-8a1cc6d0e01dde461a22ef26597ccf8f011f4c12328b1c7297cae7acebc78df8) to use httpx's built-in JSON handling instead of `pydantic_core`. Removes manual pre-validation of non-finite floats and explicit content-type headers, replacing `pydantic_core.to_json`/`from_json` calls with `json=body` and `resp.json()` throughout. Risk: non-finite float values (e.g. `NaN`, `Infinity`) in request bodies are no longer rejected before serialization.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e0552d4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->