### PR TITLE
Lazily prepare bridged train prompts

### DIFF
--- a/verifiers/v1/clients/train.py
+++ b/verifiers/v1/clients/train.py
@@ -23,7 +23,7 @@ from renderers import OverlongPromptError as RendererOverlongPromptError
 from renderers import RendererConfig
 
 from verifiers.v1.clients.client import SESSION_ID_HEADER, Client
-from verifiers.v1.dialects import FINISH_REASONS, ChatDialect, Dialect
+from verifiers.v1.dialects import FINISH_REASONS, ChatDialect, Dialect, parse_tools
 from verifiers.v1.dialects.chat import message_to_wire
 from verifiers.v1.errors import OverlongPromptError, model_error
 from verifiers.v1.graph import PendingTurn
@@ -228,14 +228,19 @@ class TrainClient(Client):
                 f"{type(dialect).__name__}. Use the proxy client for this dialect, or add "
                 f"renderer support for it."
             )
-        prompt, tools = dialect.parse_request(body)
+        # Intercepted turns already own the typed prompt, so only their tools need parsing here.
         if turn is not None:
             prompt = turn.prompt
+            tools = parse_tools(body.get("tools"))
+        else:
+            prompt, tools = dialect.parse_request(body)
         renderer = self._renderer_pool(model)
         from renderers.client import _maybe_offload, generate
 
-        wire_messages = [message_to_wire(m) for m in prompt]
         wire_tools = [tool_to_wire(t) for t in tools] if tools else None
+        wire_messages = (
+            [message_to_wire(m) for m in turn.tail] if turn is not None else []
+        )
         prompt_ids: list[int] | None = None
         multi_modal_data = None
         prompt_attribution: RenderedTokens | None = None
@@ -247,7 +252,7 @@ class TrainClient(Client):
         can_bridge = (
             turn is not None
             and not _has_multimodal_content(prompt)
-            and _is_valid_incremental_tail(wire_messages[turn.tail_start :])
+            and _is_valid_incremental_tail(wire_messages)
         )
         previous_ids = turn.previous_token_ids() if can_bridge else None
         if previous_ids is not None:
@@ -257,7 +262,7 @@ class TrainClient(Client):
                 return renderer.bridge_to_next_turn(
                     previous_prompt_ids,
                     previous_completion_ids,
-                    wire_messages[turn.tail_start :],
+                    wire_messages,
                     tools=wire_tools,
                 )
 
@@ -271,6 +276,10 @@ class TrainClient(Client):
                     len(previous_prompt_ids) + len(previous_completion_ids) - 1,
                     0,
                 )
+
+        # Bridged prompt ids bypass rendering; only fallback needs the full wire prompt.
+        if prompt_ids is None:
+            wire_messages = [message_to_wire(m) for m in prompt]
 
         try:
             result = await generate(


### PR DESCRIPTION
## Overview

Reduce training-client preparation work for incremental renderer bridges by reusing the typed prompt already owned by the intercepted turn and materializing the full wire prompt only when fallback rendering is required.

## Why

The interception path already parses the request into `PendingTurn.prompt`. The train client nevertheless parsed every raw message again, discarded that duplicate typed prompt, and converted the complete authoritative prompt back to wire dictionaries.

On a successful renderer bridge, `generate()` receives prebuilt `prompt_ids` and does not render or otherwise consume those full wire messages. The context-wide parse and conversion were therefore pure transient work on the bridge-hit path.

## Changes

- Reuse `turn.prompt` and parse only the request's tool definitions when a turn is available.
- Convert only `turn.tail` before checking and invoking the incremental bridge.
- Build complete wire messages lazily when the bridge is ineligible, has no usable token anchor, or returns `None`.
- Preserve full request parsing for calls without a turn and preserve exact full-prompt rendering for every fallback path.

## Performance

A PEP 723 benchmark exercised a successful bridge over 20,001 messages for nine measured loops, using `time.perf_counter()` for wall time and `tracemalloc` for Python allocation peak.

| Metric | Before | After | Absolute saving |
| --- | ---: | ---: | ---: |
| Median preparation time | 85.712 ms | 0.950 ms | 84.762 ms |
| Median traced allocation peak | 9.170 MiB | 0.010 MiB | 9.160 MiB |

This is a 90.22× speedup, 98.89% less wall time, and 99.89% lower traced peak allocation for the measured bridge-hit workload.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized optimization in train-client preparation with explicit preservation of full parsing/rendering on non-bridge paths; no auth, security, or persistence changes.
> 
> **Overview**
> **Train client prompt prep** on intercepted turns no longer re-parses the full request or converts the entire prompt to wire form when an incremental renderer bridge succeeds.
> 
> When a `PendingTurn` is present, the client reuses `turn.prompt` and only parses tool definitions from the body. It wires **just** `turn.tail` for bridge eligibility checks and `bridge_to_next_turn`, since bridged `generate()` calls use prebuilt `prompt_ids` and do not need the full message list. Full wire messages are built **only** when bridging is skipped or fails (`prompt_ids is None`). Calls without a turn still use `dialect.parse_request` unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da20e3361c1b8bfd0aafe044c9366f596f3dc840. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Lazily prepare full prompt in `TrainClient.get_response` for bridged train turns
> - When a `PendingTurn` is present, `get_response` now assigns `prompt` directly from `turn.prompt` and parses tools via `parse_tools`, skipping a full `dialect.parse_request` call.
> - In the bridged path, only the tail messages are passed to `bridge_to_next_turn` and generation; full wire prompt rendering is deferred to the fallback path when bridging fails.
> - `_is_valid_incremental_tail` now receives the already-tail-only `wire_messages` directly instead of slicing a full message list.
> - Behavioral Change: prompt IDs from a successful bridge bypass full prompt rendering entirely; fallback behavior is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized da20e33.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->