### PR TITLE
Serialize upstream eval JSON directly to bytes

### DIFF
--- a/verifiers/v1/clients/eval.py
+++ b/verifiers/v1/clients/eval.py
@@ -16,6 +16,7 @@ from collections.abc import Mapping
 import re
 
 import httpx
+from pydantic_core import from_json, to_json
 
 from verifiers.v1.clients.client import SESSION_ID_HEADER, Client, RelayReply
 from verifiers.v1.dialects import ChatDialect, Dialect
@@ -89,7 +90,7 @@ class EvalClient(Client):
             dialect.apply_overrides(body, model, sampling_args),
             self._headers(dialect, headers, session_id),
         )
-        raw = resp.json()
+        raw = from_json(resp.content)
         response = dialect.parse_response(dialect.validate_response(raw))
         response.raw = raw  # the program gets the provider's bytes back 1:1
         return response
@@ -126,7 +127,13 @@ class EvalClient(Client):
         *,
         stream: bool = False,
     ) -> httpx.Response:
-        request = self.http.build_request("POST", url, json=body, headers=headers)
+        headers.setdefault("content-type", "application/json")
+        request = self.http.build_request(
+            "POST",
+            url,
+            content=to_json(body, inf_nan_mode="null"),
+            headers=headers,
+        )
         try:
             response = await self.http.send(request, stream=stream)
         except httpx.TimeoutException as e:
@@ -200,7 +207,7 @@ class EvalClient(Client):
             body,
             self._headers(dialect, None, None),
         )
-        return resp.json()
+        return from_json(resp.content)
 
     async def close(self) -> None:
         await self.http.aclose()


### PR DESCRIPTION
## Overview

Serialize V1 eval upstream requests and responses directly as JSON bytes, avoiding the full intermediate strings created by HTTPX's stdlib JSON helpers.

## Why

HTTPX's `json=body` path serializes the complete body to a Python `str` and then encodes it to UTF-8 bytes. Large prompts, tool output, and base64 content therefore create another payload-sized object and synchronously block the event loop before the request is sent.

Likewise, `Response.json()` materializes a decoded JSON source before constructing the returned object, adding another full-payload allocation and synchronous stall after the provider response arrives.

## Implementation

- Encode request bodies with `pydantic_core.to_json(..., inf_nan_mode="null")` and pass those bytes through HTTPX's `content=` path.
- Serialize non-finite floats as standard JSON `null`, avoiding invalid `NaN`/`Infinity` constants without a separate traversal or fallback serialization.
- Parse non-streaming model and auxiliary responses directly from `resp.content` with `pydantic_core.from_json`.
- Keep provider status handling, header/auth routing, dialect validation, wire size, task/connection count, and SSE response streaming unchanged.

## Performance

Measured on CPython 3.13.12 with a 32 MiB JSON payload, two warmups, seven timed loops, `time.perf_counter()` for synchronous/event-loop stall, and `tracemalloc` for peak traced allocation:

| Operation | Before | After | Absolute saved | Reduction |
| --- | ---: | ---: | ---: | ---: |
| Encode stall | 51.824 ms | 9.240 ms | 42.584 ms | 82.2% |
| Encode peak allocation | 72.00 MiB | 32.01 MiB | 39.99 MiB | 55.5% |
| Decode stall | 17.423 ms | 1.588 ms | 15.835 ms | 90.9% |
| Decode peak allocation | 64.00 MiB | 32.00 MiB | 32.00 MiB | 50.0% |

The request and response wire sizes are unchanged; the savings come from removing one full-payload transient materialization in each direction.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized transport change in the eval relay client with equivalent wire semantics aside from NaN/Infinity serialized as null; streaming and auth paths are untouched.
> 
> **Overview**
> **`EvalClient`** now encodes upstream POST bodies with **`pydantic_core.to_json`** and sends them through HTTPX’s **`content=`** path instead of **`json=`**, and parses non-streaming provider JSON from **`resp.content`** via **`from_json`** (model completions and **`relay_aux`**).
> 
> Request encoding sets **`content-type: application/json`** explicitly and uses **`inf_nan_mode="null"`** so non-finite floats become standard JSON **`null`** rather than invalid literals. **SSE streaming**, header/auth routing, dialect validation, and error handling are unchanged; only the encode/decode path is swapped for lower allocation and event-loop blocking on large payloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1311498f1282c74cfc324b7c1c60ae6fe1cda5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Serialize upstream eval JSON directly to bytes using `pydantic_core`
> - Replaces `httpx` `Response.json()` with `pydantic_core.from_json` on raw response bytes in `get_response` and `relay_aux` in [eval.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1802/files#diff-8a1cc6d0e01dde461a22ef26597ccf8f011f4c12328b1c7297cae7acebc78df8).
> - Replaces `httpx`'s `json=` parameter with `pydantic_core.to_json` (via `content=`) for request serialization, ensuring `NaN`/`Infinity` float values are serialized as `null`.
> - Sets `content-type: application/json` automatically on outgoing requests if not already present.
> - Behavioral Change: request bodies containing `NaN` or `Infinity` now serialize as `null` instead of producing invalid JSON.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e131149.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->