### PR TITLE
Use zero-copy ZMQ response relay

### DIFF
--- a/verifiers/v1/serve/pool.py
+++ b/verifiers/v1/serve/pool.py
@@ -224,14 +224,15 @@ class EnvServerPool:
                             self._maybe_scale_up(len(pending))
                 for w in self.workers:
                     if w["dealer"] in events:
-                        request_id, data = await w["dealer"].recv_multipart()
-                        entry = pending.pop(request_id, None)
+                        request_id, data = await w["dealer"].recv_multipart(copy=False)
+                        # Copy only the routing key; relay the response Frames unchanged.
+                        entry = pending.pop(request_id.bytes, None)
                         if entry is None:
                             continue
                         entry["worker"]["active"] -= 1
                         with contextlib.suppress(zmq.ZMQError):
                             await self.frontend.send_multipart(
-                                [entry["client_id"], request_id, data]
+                                [entry["client_id"], request_id, data], copy=False
                             )
         except (asyncio.CancelledError, KeyboardInterrupt):
             pass

--- a/verifiers/v1/serve/server.py
+++ b/verifiers/v1/serve/server.py
@@ -165,7 +165,10 @@ class EnvServer:
             use_bin_type=True,
         )
         try:
-            await self.frontend.send_multipart([client_id, request_id, data])
+            # Let ZMQ retain the packed response instead of copying large traces.
+            await self.frontend.send_multipart(
+                [client_id, request_id, data], copy=False
+            )
         except zmq.ZMQError as e:
             logger.warning("failed to send response: %s", e)
 


### PR DESCRIPTION
## Overview

Use zero-copy PyZMQ frames for V1 env-server responses and pool relays. The wire protocol, request routing, health handling, and response serialization remain unchanged; the PR only changes the two production transport files.

## Why

Large training traces are already materialized once by msgpack. The previous transport path then copied the full payload when the worker server queued its response, copied it again when the pool received it as Python bytes, and copied it once more when the pool forwarded it to the client. Those payload-sized copies consume event-loop time, memory bandwidth, and transient RSS at the point where completed rollouts converge.

## Changes

- Send the packed server response with `copy=False`, allowing PyZMQ to retain the immutable buffer until libzmq finishes with it.
- Receive worker responses as `zmq.Frame` objects in the pool.
- Materialize only the small request ID for the pending-request dictionary lookup.
- Forward the original request-ID and payload frames with `copy=False`.

## Performance

A TCP loopback benchmark queued one 128 MiB response and measured the critical send/relay section plus process RSS after the queue settled. Each mode ran three times; the table reports medians.

| Path | Before | After | Time saved | RSS before | RSS after | RSS saved |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Server send | 7.901 ms | 0.649 ms | 7.252 ms (91.8%) | +256.1 MiB | +128.2 MiB | 127.9 MiB (49.9%) |
| Pool relay | 13.872 ms | 0.066 ms | 13.806 ms (99.5%) | +256.1 MiB | +128.0 MiB | 128.1 MiB (50.0%) |

The remaining RSS is common receiver-side queue storage in the same-process benchmark. The removed portion is the avoidable payload duplication at the PyZMQ API boundaries. Small frames continue to follow PyZMQ's copy-threshold behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Transport-only optimization with no protocol or routing logic changes; relies on PyZMQ buffer lifetime semantics for `copy=False`, which is standard for large frames.
> 
> **Overview**
> Large msgpack rollout responses no longer get copied at the PyZMQ send/recv boundaries on the v1 env server and worker pool.
> 
> **`EnvServer`** sends the packed response with `copy=False`, so libzmq can hold the immutable msgpack buffer until the send completes.
> 
> **`EnvServerPool`** receives worker replies with `copy=False` (as `zmq.Frame`s), uses only `request_id.bytes` for the `pending` lookup, and relays `request_id` and the payload frame to the client ROUTER with `copy=False`. Request routing, health handling, and serialization are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dbdb5d57d97a7d91ccc97ab8f48bf4fe52569b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use zero-copy ZMQ multipart message relay in broker and server
> Switches ZMQ recv/send calls in the broker loop and server request handler to use `copy=False`, avoiding buffer copies when receiving and forwarding multipart messages.
>
> - In [pool.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1803/files#diff-0c9c59578214be2580d340bc524321e352f48038207a68945637d00fc399600c), worker socket receives with `recv_multipart(copy=False)` and forwards via `send_multipart(..., copy=False)`; pending lookup uses `request_id.bytes` since `request_id` is now a `zmq.Frame`.
> - In [server.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1803/files#diff-64422f6a8749fcc024415b2756129bc98000e830e74b3b5245de50a555480a22), response is sent with `send_multipart(..., copy=False)` to avoid copying the payload frame.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5dbdb5d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->