### PR TITLE
Transfer V1 completion logprobs without copying

### DIFF
--- a/verifiers/v1/graph.py
+++ b/verifiers/v1/graph.py
@@ -478,7 +478,8 @@ def _commit_turn(turn: PendingTurn, response: Response) -> None:
             sampled=True,
             token_ids=[*gen_prompt, *comp_ids],
             mask=[False] * len(gen_prompt) + [True] * len(comp_ids),
-            logprobs=list(tokens.completion_logprobs) if tokens else [],
+            # TurnTokens is discarded after commit, so transfer its logprobs without copying.
+            logprobs=tokens.completion_logprobs if tokens else [],
             finish_reason=response.finish_reason,
             usage=response.usage,
         )


### PR DESCRIPTION
## Overview

Transfer the transient `TurnTokens.completion_logprobs` list directly into the assistant `MessageNode` during graph commit instead of materializing a second list.

## Reasoning

`_commit_turn` constructs the node with `MessageNode.model_construct`, so it can preserve the already-typed list's identity without another validation or copy. `TurnTokens` is a per-response carrier that is discarded after commit, while graph and training consumers treat node logprobs as read-only. The graph node can therefore become the long-lived owner without changing logprob values, ordering, serialization, branching, or partial-logprob behavior.

## Performance

A PEP 723 microbenchmark measured 2,000,000 logprob values over nine repetitions using `time.perf_counter` and `tracemalloc`:

| Path | Median wall time | Peak traced allocation |
| --- | ---: | ---: |
| List copy | 2.818 ms | 15.26 MiB |
| Ownership transfer | 0.005 ms | 0.00 MiB |
| Saved | 2.813 ms (99.83%) | 15.26 MiB (100%) |

This removes 2,000,000 copied references (about 16,000,000 bytes of pointer storage) and the transient duplicate list buffer. Long-lived trace storage remains unchanged at one logprob list.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line ownership change in graph commit with no intended change to logprob values or training semantics; only risk is if something mutates the list before discard (unchanged from prior copy behavior for readers).
> 
> **Overview**
> When committing an assistant turn in `_commit_turn`, the graph node now **takes ownership** of `TurnTokens.completion_logprobs` instead of building a second list with `list(...)`.
> 
> `TurnTokens` is only used for that commit path and is dropped afterward, so the assistant `MessageNode` becomes the long-lived holder of the same list. This matches the existing `model_construct` pattern for large token slices and avoids extra allocation on long completions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2daa0c3e06192bec58ce0d36d0bfd37d6d5a0921. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Transfer V1 completion logprobs without copying in `_commit_turn`
> In [`graph.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1804/files#diff-64c9d635eb215902a512c9e8ab316fd9b9967c36db03d4049aacc812cdfbd740), `_commit_turn` now assigns `tokens.completion_logprobs` directly to `MessageNode.logprobs` instead of wrapping it in `list()`. Since `TurnTokens` is discarded after commit, the copy was unnecessary.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2daa0c3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->