### PR TITLE
Serialize V1 MCP state directly to bytes

### DIFF
--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -29,7 +29,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from aiohttp import web
-from pydantic import ValidationError
+from pydantic import TypeAdapter, ValidationError
 from pydantic_core import PydanticSerializationError, from_json, to_json
 
 from verifiers.v1.clients import RolloutContext
@@ -522,8 +522,12 @@ class InterceptionServer:
         if session is None:
             return web.json_response({"error": "unauthorized"}, status=401)
         logger.debug("intercept GET /state: id=%s", session.trace.id)
+        state = session.trace.state
         return web.Response(
-            text=session.trace.state.model_dump_json(), content_type="application/json"
+            # TypeAdapter emits UTF-8 bytes directly, avoiding a JSON str copy in aiohttp.
+            body=TypeAdapter(type(state)).dump_json(state),
+            content_type="application/json",
+            charset="utf-8",
         )
 
     async def handle_task_get(self, request: web.Request) -> web.Response:
@@ -550,13 +554,11 @@ class InterceptionServer:
             return web.json_response({"error": "unauthorized"}, status=401)
         logger.debug("intercept PUT /state: id=%s", session.trace.id)
         state_cls = type(session.trace.state)
+        raw = await request.read()
         try:
-            new_state = state_cls.model_validate(await request.json())
-        except (ValidationError, ValueError) as e:
-            # Malformed JSON (`request.json()` -> JSONDecodeError, a ValueError) or a pushed state
-            # that doesn't fit the trace's `State` type (almost always a `StateT` mismatch between the
-            # taskset and a server). Surface a clean 400 (with the reason) rather than a 500, so the
-            # server's failed PUT fails the rollout legibly.
+            new_state = state_cls.model_validate_json(raw)
+        except ValidationError as e:
+            # Reject malformed, over-nested, or mismatched state before it enters the shared channel.
             logger.warning("state PUT rejected: id=%s %s", session.trace.id, e)
             return web.json_response(
                 {"error": f"invalid state PUT for {state_cls.__name__}: {e}"},

--- a/verifiers/v1/mcp/server.py
+++ b/verifiers/v1/mcp/server.py
@@ -12,18 +12,21 @@ import contextlib
 import contextvars
 import functools
 import inspect
+import logging
 import os
 from typing import TYPE_CHECKING, Callable, ClassVar, Generic, TypeVar, get_args
 
+from pydantic import TypeAdapter, ValidationError
 from pydantic_config import BaseConfig
 
 from verifiers.v1.state import State, StateT, state_cls
 
 if TYPE_CHECKING:
-    from httpx import AsyncClient
+    from httpx import AsyncClient, Response
     from mcp.server.fastmcp import FastMCP
 
 ConfigT = TypeVar("ConfigT", bound=BaseConfig)
+logger = logging.getLogger(__name__)
 
 STATE_TIMEOUT = 30.0
 """Seconds for a state-channel GET/PUT (localhost, or a tunnel to the host)."""
@@ -38,13 +41,13 @@ async def _channel_request(
     url: str,
     secret: str,
     *,
-    json: dict | None = None,
+    content: bytes | None = None,
     client: AsyncClient | None = None,
-) -> dict:
+) -> Response:
     """One bearer-authed call to the interception `/state` or `/task` channel, retried with
     exponential backoff + jitter on transient failures (connection resets / 5xx from the host
     tunnel). A 4xx is a real error (e.g. an invalid state PUT) and is not retried. Returns the
-    parsed JSON body."""
+    response so typed callers can validate its JSON bytes directly."""
     import httpx
     from tenacity import (
         AsyncRetrying,
@@ -58,18 +61,21 @@ async def _channel_request(
             isinstance(e, httpx.HTTPStatusError) and e.response.status_code >= 500
         )
 
-    async def request() -> dict:
+    async def request() -> Response:
         manager = (
             contextlib.nullcontext(client)
             if client is not None
             else httpx.AsyncClient(timeout=STATE_TIMEOUT)
         )
         async with manager as request_client:
+            headers = {"Authorization": f"Bearer {secret}"}
+            if content is not None:
+                headers["Content-Type"] = "application/json"
             resp = await request_client.request(
-                method, url, json=json, headers={"Authorization": f"Bearer {secret}"}
+                method, url, content=content, headers=headers
             )
             resp.raise_for_status()
-            return resp.json()
+            return resp
 
     return await AsyncRetrying(
         stop=stop_after_attempt(STATE_RETRIES + 1),
@@ -158,6 +164,8 @@ class ServerBase(Generic[ConfigT, StateT]):
     def __init__(self, config: ConfigT) -> None:
         self.config = config
         self._state_cls = state_cls(type(self))
+        # Reuse Pydantic's public byte serializer/validator across state-channel calls.
+        self._state_adapter = TypeAdapter(self._state_cls)
         self._inert_state: StateT = self._state_cls()  # type: ignore[assignment]
         """A fresh state used outside a tool/respond call (setup, or a manual debug run) — there's
         no channel to sync, so writes to it don't escape the process (matches the no-channel case)."""
@@ -188,27 +196,31 @@ class ServerBase(Generic[ConfigT, StateT]):
         """Fetch the in-flight call's shared state from the channel (so it reflects other servers'
         writes); a fresh inert state when there's no channel."""
         url, secret = self._state_channel()
-        cls = self._state_cls
         if not url:
-            return cls()
-        return cls.model_validate(
-            await _channel_request("GET", url, secret, client=self._state_client)
-        )
+            return self._state_cls()
+        response = await _channel_request("GET", url, secret, client=self._state_client)
+        try:
+            return self._state_adapter.validate_json(response.content)
+        except ValidationError as e:
+            # Excessively nested or otherwise invalid state is a broken channel contract.
+            logger.warning(
+                "state pull rejected for %s: %s", self._state_cls.__name__, e
+            )
+            raise
 
-    async def _push_state(self, before: dict) -> None:
+    async def _push_state(self, before: bytes) -> None:
         """Push the in-flight call's `self.state` back to the shared channel if it changed. No-op
         without a channel or when nothing changed."""
         url, secret = self._state_channel()
         if not url:
             return
         state = _call_state.get()
-        after = (state if state is not None else self._inert_state).model_dump(
-            mode="json"
-        )
+        current = state if state is not None else self._inert_state
+        after = self._state_adapter.dump_json(current)
         if after == before:
             return
         await _channel_request(
-            "PUT", url, secret, json=after, client=self._state_client
+            "PUT", url, secret, content=after, client=self._state_client
         )
 
     async def _fetch_task(self, state_url: str | None, secret: str):
@@ -222,7 +234,7 @@ class ServerBase(Generic[ConfigT, StateT]):
             if state_url.endswith("/state")
             else state_url
         )
-        data = await _channel_request("GET", task_url, secret)
+        data = (await _channel_request("GET", task_url, secret)).json()
         return _import_ref(data["cls"]).model_validate_json(data["task"])
 
     async def _setup_task_from_channel(
@@ -253,7 +265,8 @@ class ServerBase(Generic[ConfigT, StateT]):
             state = await self._pull_state()
             token = _call_state.set(state)
             try:
-                before = state.model_dump(mode="json")
+                # Reuse the second serialization as the PUT body when the callback mutates state.
+                before = self._state_adapter.dump_json(state)
                 result = fn(*args, **kwargs)
                 if inspect.isawaitable(result):
                     result = await result


### PR DESCRIPTION
## Overview

Serialize V1 MCP shared state directly to Pydantic JSON bytes across the host/server state channel. This removes intermediate dictionary trees and avoids asking HTTPX or aiohttp to encode the same state again.

## Details

- Cache a public `TypeAdapter` in each MCP server for typed byte serialization and validation.
- Compare before/after serializer bytes and reuse changed bytes as the PUT request body.
- Validate pulled and pushed state directly from response/request bytes.
- Return state GET responses as bytes while preserving the existing UTF-8 JSON content type.
- Reject malformed, mismatched, or over-nested state before it enters the shared channel, with a logged 400 on PUT and a warning on pull.
- Keep authorization, retry behavior, task-envelope parsing, unchanged-state PUT suppression, and last-write-wins semantics intact.

## Performance

PEP 723 benchmark workload: one million integers, a 6.57 MiB JSON state, median of seven runs.

| Operation | Before | After | Improvement |
|---|---:|---:|---:|
| Changed-state comparison and request encoding | 43.592 ms | 20.439 ms | 53.1% faster |
| PUT parsing and typed validation | 42.873 ms | 17.933 ms | 58.2% faster |
| Changed-state peak allocation | 28.40 MiB | 13.14 MiB | 53.7% lower |
| GET response peak allocation | 13.14 MiB | 6.57 MiB | 50.0% lower |

For a million-item state that remains unchanged, byte serialization is 24.8% slower in isolation; the allocation-profiled mutation-rate break-even is 0.505%.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the shared-state sync path between tool/user servers and the interception server; behavior is intended to be equivalent but malformed JSON handling now relies on Pydantic validation only.
> 
> **Overview**
> **V1 rollout shared state** now moves over the interception `/state` channel as **Pydantic JSON bytes** instead of dict/`str` round-trips through HTTP clients.
> 
> On the **interception host**, `GET /state` returns `TypeAdapter.dump_json` bytes (UTF-8 JSON content type). `PUT /state` reads the raw body and validates with `model_validate_json`, returning **400** on `ValidationError` (including bad or over-nested payloads).
> 
> On **MCP servers**, each `ServerBase` caches a `TypeAdapter` for its `State` type. State pulls validate `response.content` directly; tool/`respond` wrappers snapshot **before** bytes, compare **after** bytes to skip unchanged PUTs, and send the same bytes as the PUT body. `_channel_request` now posts `content=` and returns the raw `Response` (task fetch still uses `.json()`).
> 
> Auth, retries, last-write-wins, and unchanged-state suppression are unchanged; the goal is lower allocation and faster encode/decode on large shared state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d9fc198c96e83212a630c52668496ca7c68bf38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Serialize V1 MCP state directly to bytes in channel communication
> - Replaces dict-based JSON serialization with `pydantic.TypeAdapter.dump_json` / `validate_json` throughout the V1 MCP server, so state is serialized to and from raw bytes rather than passing through intermediate Python dicts.
> - `_channel_request` in [server.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1806/files#diff-5eaeab5d19ee732e16b066ff6689f954f6743833a907a129acc0df250cee5b2a) now accepts `content: bytes` and returns the raw `httpx.Response` instead of parsed JSON; callers call `.json()` or `.content` as needed.
> - `ServerBase._with_state` snapshots state as bytes before a task runs and uses byte equality to detect changes before pushing.
> - The interception server's `handle_state_get` returns explicit `application/json; charset=utf-8` headers, and `handle_state_put` reads the raw request body and validates with `model_validate_json` instead of parsing via `request.json()`.
> - Behavioral Change: invalid state payloads from the channel now log a warning before re-raising `ValidationError`; PUT requests with invalid bodies return 400 with an error message instead of a generic exception.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5d9fc19.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->