### PR TITLE
Optimize V1 eval resume memory

### DIFF
--- a/verifiers/v1/cli/eval/resume.py
+++ b/verifiers/v1/cli/eval/resume.py
@@ -11,7 +11,10 @@ together), so any task that isn't fully complete is redone from scratch.
 import json
 import tomllib
 from collections import defaultdict
+from collections.abc import Iterator
 from pathlib import Path
+
+from pydantic_core import from_json
 
 from verifiers.v1.configs.eval import EvalConfig
 
@@ -45,54 +48,71 @@ def load_resume_config(resume_dir: Path) -> EvalConfig:
     return config
 
 
-def _read_results(results_path: Path) -> list[dict]:
-    """The previous run's traces as raw dicts. The on-disk dump carries computed fields a
-    strict `Trace` can't re-validate, so we read the JSON directly — resume only needs each
-    trace's `task.idx` and whether it `errors`ed."""
+def _read_results(results_path: Path) -> Iterator[tuple[int, int, bool]]:
+    """Stream `(file reference, task idx, errored)` without retaining decoded traces."""
     if not results_path.exists():
-        return []
-    return [
-        json.loads(line)
-        for line in results_path.read_text().split("\n")
-        if line.strip()
-    ]
+        return
+    with results_path.open("rb") as results:
+        while True:
+            offset = results.tell()
+            line = results.readline()
+            if not line:
+                break
+            if line.strip():
+                try:
+                    row = from_json(line)
+                except ValueError:
+                    row = json.loads(line)
+                yield offset, row["task"]["idx"], bool(row.get("errors"))
 
 
 def plan(
     resume_dir: Path, selected_idxs: list[int], num_rollouts: int, group: bool
-) -> tuple[list[dict], dict[int, int]]:
+) -> tuple[list[int], dict[int, int]]:
     """Diff the saved results against the run's target (`num_rollouts` per selected task).
-    Returns (rows to keep in `results.jsonl`, rollouts owed per task idx). An errored trace is
-    dropped and re-run; a group-scored task is kept only if fully complete, else its whole
-    group is redone."""
-    by_idx: dict[int, list[dict]] = defaultdict(list)
-    for row in _read_results(resume_dir / "results.jsonl"):
-        by_idx[row["task"]["idx"]].append(row)
-    keep: list[dict] = []
+    Returns (byte offsets of rows to keep, rollouts owed per task idx). An errored trace is
+    dropped and re-run; a group-scored task is kept only if fully complete, else its whole group
+    is redone."""
+    # Retain only the offsets resume can reuse; trace payloads stay on disk.
+    selected = set(selected_idxs)
+    by_idx: dict[int, list[int]] = defaultdict(list)
+    for offset, idx, errored in _read_results(resume_dir / "results.jsonl"):
+        if idx in selected and not errored and len(by_idx[idx]) < num_rollouts:
+            by_idx[idx].append(offset)
+    keep: list[int] = []
     owed: dict[int, int] = {}
     for idx in selected_idxs:
-        good = [row for row in by_idx.get(idx, []) if not row.get("errors")]
+        good = by_idx.get(idx, [])
         if group:
             if len(good) >= num_rollouts:
-                keep.extend(good[:num_rollouts])
+                keep.extend(good)
             else:
                 owed[idx] = num_rollouts  # re-run the whole group; keep none of it
         else:
-            keep.extend(good[:num_rollouts])
-            missing = num_rollouts - min(len(good), num_rollouts)
+            keep.extend(good)
+            missing = num_rollouts - len(good)
             if missing:
                 owed[idx] = missing
     return keep, owed
 
 
-def rewrite_results(resume_dir: Path, keep: list[dict]) -> None:
+def rewrite_results(resume_dir: Path, keep: list[int]) -> None:
     """Replace `results.jsonl` with just the kept (good) traces; resumed rollouts append. Via a
     temp file + atomic rename, so an interrupted resume can't corrupt the prior good results."""
     path = resume_dir / "results.jsonl"
     tmp = path.with_suffix(".jsonl.tmp")
-    with tmp.open("w") as f:
-        for row in keep:
-            f.write(json.dumps(row) + "\n")
+    if not keep:
+        tmp.write_bytes(b"")
+        tmp.replace(path)
+        return
+    # Re-read retained rows by offset while building the atomic replacement.
+    with path.open("rb") as results, tmp.open("wb") as output:
+        for offset in keep:
+            results.seek(offset)
+            raw = results.readline()
+            output.write(raw)
+            if not raw.endswith(b"\n"):
+                output.write(b"\n")
     tmp.replace(path)
 
 


### PR DESCRIPTION
## Overview

Optimize V1 eval resume planning so large `results.jsonl` files do not expand into a retained graph of decoded Python traces. The change is intentionally limited to `verifiers/v1/cli/eval/resume.py`.

## Design

Resume planning only needs each row's task index, error status, and the first requested number of good rows for selected tasks. The reader now streams binary JSONL lines, extracts that metadata with pydantic-core, and falls back to the standard library for valid traces that exceed pydantic-core's nesting limit.

Instead of retaining decoded traces or full row bytes, planning stores one byte offset per reusable rollout and caps those offsets at the target rollout count. The atomic rewrite then seeks back to those rows and copies their original bytes into the replacement file. This keeps planning memory proportional to selected tasks × target rollouts, plus the largest individual trace, while preserving group-resume, errored-row, ordering, and final-newline behavior.

## Measured impact

Measured as the median of three fresh-process runs on a 257,592,739-byte JSONL corpus with 35,000 realistic rows across 6,000 tasks, including 3,000 errored rows and deeply nested trace metadata:

| Mode | Wall time | Peak RSS |
| --- | --- | --- |
| Non-group | 1.0554 s → 0.4048 s (61.6% lower, 2.61× faster) | 1,327,087,616 B → 34,357,248 B (97.4% lower, 38.6× smaller) |
| Group | 0.8392 s → 0.3266 s (61.1% lower, 2.57× faster) | 1,326,907,392 B → 34,127,872 B (97.4% lower, 38.9× smaller) |

The offset rewrite performs a second read of retained rows, but avoids full-file text splitting, long-lived decoded trace graphs, and JSON reserialization.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to eval resume I/O in `resume.py`; behavior is intended to match prior group/errored-row logic while reducing memory on large result files.
> 
> **Overview**
> **V1 eval resume** no longer loads every `results.jsonl` row into Python dicts during planning. `_read_results` streams the file in binary, parses each line only far enough to get task index and error status (`pydantic_core.from_json`, with `json.loads` fallback for deeply nested traces), and yields **byte offsets** instead of full traces.
> 
> `plan` keeps a capped list of offsets per selected task (good, non-errored rollouts up to `num_rollouts`) and still computes owed rollouts for group vs non-group resume. `rewrite_results` atomically rebuilds `results.jsonl` by **seeking to those offsets and copying original line bytes**, avoiding JSON re-serialization and holding the whole results file in memory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb549729139ee7602e4949fd439c8a8cb7262e68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Optimize V1 eval resume memory by streaming results file instead of loading full rows
> - Refactors [`resume.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1807/files#diff-fa57536955ac6c644296a0f3317271ffdc94b2611e7ad3d0c2266c436b96a4f8) to avoid materializing decoded JSON rows in memory during eval resume.
> - `_read_results` is now a generator yielding `(byte_offset, task_idx, errored)` tuples, reading the file in binary mode and using `pydantic_core.from_json` for faster decoding.
> - `plan` now returns byte offsets of rows to keep instead of decoded dicts, and filters/caps offsets per idx without holding trace payloads in memory.
> - `rewrite_results` now seeks to each stored offset and copies the original bytes verbatim, avoiding re-serialization of row dicts.
> - Behavioral Change: result rows are now written as their original on-disk bytes rather than re-encoded JSON, which may change whitespace or key ordering in the output file.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bb54972.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->