### PR TITLE
Read Prime files through the download API

### DIFF
--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -7,11 +7,11 @@ direction (a program in the sandbox reaching a host service) is the shared host-
 """
 
 import asyncio
-import base64
 import contextlib
 import logging
 import shlex
-from pathlib import PurePosixPath
+import tempfile
+from pathlib import Path, PurePosixPath
 from typing import ClassVar, Literal
 
 from pydantic_config import BaseConfig
@@ -176,10 +176,22 @@ class PrimeRuntime(Runtime):
             )
 
     async def read(self, path: str) -> bytes:
-        result = await self.run(["sh", "-c", f"base64 {shlex.quote(path)}"], {})
-        if result.exit_code != 0:
-            raise SandboxError(f"read {path!r}: {result.stderr.strip()}")
-        return base64.b64decode(result.stdout)
+        # Avoid background-job log limits and base64 overhead by downloading binary data directly.
+        # The temporary file is removed on every exit, and its byte read stays off the event loop.
+        target = (
+            path
+            if path.startswith("/")
+            else f"{self.config.workdir.rstrip('/')}/{path}"
+        )
+        try:
+            with tempfile.TemporaryDirectory() as directory:
+                download = Path(directory) / "download"
+                await self._client.download_file(
+                    self._sandbox_id, target, str(download)
+                )
+                return await asyncio.to_thread(download.read_bytes)
+        except Exception as e:
+            raise SandboxError(f"read {path!r}: {e}") from e
 
     async def write(self, path: str, data: bytes) -> None:
         # Upload via the gateway (multipart) — never inline the bytes on the command line


### PR DESCRIPTION
## Overview

Read files from Prime sandboxes through the SDK's binary download API instead of transporting their contents through background-job stdout. Relative paths are resolved against the configured workdir, the download is scoped to a temporary file, and the final byte read runs off the event loop.

## Reasoning

The previous route launched `base64` in the sandbox, polled the background job, downloaded textual stdout, and decoded it into bytes on the event loop. That route expands the transferred payload, temporarily owns both encoded text and decoded bytes, and makes file reads subject to the background-job log limit.

The download endpoint preserves binary data directly and avoids shell startup, job polling, stdout-log transport, and base64 decoding. A temporary file bounds the SDK/download handoff and is removed on every exit; SDK failures continue to surface as `SandboxError`.

## Performance and resource impact

For a 4 MiB authenticated Prime sandbox read:

| Measurement | Previous path | Download path | Saved |
|---|---:|---:|---:|
| End-to-end wall time | 0.974 s | 0.236 s | 0.738 s (75.7%) |
| Base64/raw payload bytes | 5,592,408 B | 4,194,304 B | 1,398,104 B (25.0%) |

A deterministic 4 MiB mechanism benchmark measured:

| Measurement | Previous path | Download path | Saved |
|---|---:|---:|---:|
| Median wall time/read | 6.230 ms | 1.896 ms | 4.334 ms (69.6%) |
| Event-loop maximum gap | 6.777 ms | 1.225 ms | 5.552 ms (81.9%) |
| Peak Python allocations | 15,379,429 B | 4,209,999 B | 11,169,430 B (72.6%) |
| Retained allocations with result alive | 4,194,337 B | 4,197,462 B | effectively unchanged |

The download path adds 8,388,608 bytes of local temporary-file I/O for a 4 MiB read (one write and one read). The current SDK still buffers the raw HTTP response before writing it, so this change removes base64/log overhead without claiming fully streaming memory behavior.

## Behavior

The public `read(path) -> bytes` contract is unchanged. Binary/NUL/invalid UTF-8 data remains byte-exact, absolute paths remain absolute, relative paths remain workdir-relative, temporary files are always cleaned up, and failures retain the existing `SandboxError` boundary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-method implementation swap with preserved error type and path semantics; no auth or API contract changes.
> 
> **Overview**
> **`PrimeRuntime.read`** no longer shells out to `base64` and pulls file bytes through background-job stdout. It now resolves paths the same way as **`write`** (absolute vs workdir-relative), calls **`AsyncSandboxClient.download_file`** into a temp directory, and loads bytes with **`asyncio.to_thread`** so large reads do not block the event loop.
> 
> Failures from the download path are still raised as **`SandboxError`**. The public **`read(path) -> bytes`** contract is unchanged; the change mainly cuts payload expansion, log-limit risk, and read latency/memory for larger files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd2a5a7eb6d0794ae54a81bd36887b9909d9e377. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Read Prime sandbox files via the download API instead of base64 shell commands
> Replaces the `PrimeRuntime.read` method's approach of running a `base64` command inside the sandbox and decoding stdout with a direct file download using the sandbox client. The file is downloaded to a `TemporaryDirectory`, then read via `asyncio.to_thread`. Relative paths are now resolved against `config.workdir` before downloading, and exceptions are wrapped in `SandboxError`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 777b6f5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->