### PR TITLE
Avoid env-server trace recopy

### DIFF
--- a/verifiers/v1/serve/server.py
+++ b/verifiers/v1/serve/server.py
@@ -122,14 +122,15 @@ class EnvServer:
         ctx = self._context(req.client, req.model, req.sampling)
         episode = self.env.episode(self.tasks[req.task_idx], ctx, n=1)
         traces = await episode.run()
-        # dump to a dict so the `Trace[WireTask]` field re-types the concrete task to WireTask
-        return RunRolloutResponse(trace=traces[0].model_dump())
+        # Trust the concrete trace; serialize it once before client-side re-typing.
+        return RunRolloutResponse.model_construct(trace=traces[0])
 
     async def _run_group(self, req: RunGroupRequest) -> RunGroupResponse:
         ctx = self._context(req.client, req.model, req.sampling)
         episode = self.env.episode(self.tasks[req.task_idx], ctx, n=req.n)
         traces = await episode.run()
-        return RunGroupResponse(traces=[t.model_dump() for t in traces])
+        # Avoid a dump-and-validate copy for every trusted trace in the group.
+        return RunGroupResponse.model_construct(traces=traces)
 
     async def _handle(
         self, client_id: bytes, request_id: bytes, method: bytes, payload: bytes


### PR DESCRIPTION
## Overview

Keep completed V1 traces concrete inside env-server response wrappers and defer `WireTask` conversion to the existing client boundary. This removes a redundant full-trace dump and validation pass before the unchanged wire serializer.

## Mechanism

`episode.run()` already returns typed, trusted `Trace` objects. The rollout path previously dumped each concrete trace to a dictionary, then response validation rebuilt it as `Trace[WireTask]`; the response field serializer subsequently dumped that rebuilt trace again for msgpack. Group responses repeated the same work for every trace.

The response wrappers now use `model_construct` around those trusted concrete traces. Their existing field serializers still produce the wire payload once, and the client continues validating decoded responses into `Trace[WireTask]`. Request handling, response schemas, msgpack encoding, ZMQ transport, task extras, excluded state, and client-side validation remain unchanged.

## Performance

A PEP 723 response-path benchmark used one trace with one node and 1,825,000 token IDs, masks, and log probabilities (5,475,000 list entries total), producing a 27,244,201-byte msgpack response. Values below are medians of three fresh processes after warm-up on macOS.

| Metric | Previous | Current | Saved |
| --- | ---: | ---: | ---: |
| Wrapper construction | 79.289 ms | 0.018 ms | 79.271 ms (99.98%) |
| Total synchronous response work | 231.703 ms | 150.555 ms | 81.148 ms (35.02%) |
| Peak process RSS | 399.8 MiB | 358.3 MiB | 41.5 MiB (10.38%) |
| Live response RSS growth | 135.8 MiB | 94.2 MiB | 41.6 MiB (30.63%) |
| Post-cleanup RSS growth | 135.8 MiB | 94.2 MiB | 41.6 MiB (30.63%) |

The synchronous time reduction directly shortens the env-server event-loop stall for large responses. Group savings scale with the number and size of completed traces.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Server-only response construction optimization on trusted rollout output; wire encoding and client validation paths are unchanged.
> 
> **Overview**
> **Rollout and group handlers** no longer turn completed traces into dicts before building `RunRolloutResponse` / `RunGroupResponse`. They wrap the concrete `episode.run()` traces with **`model_construct`** instead of going through `model_dump()` plus full Pydantic validation on the way in.
> 
> That removes an extra full-trace copy and rebuild on the server while the existing **`trace` / `traces` field serializers** still run once when `_handle` calls **`model_dump`** for msgpack. **`WireTask` re-typing stays on the client** via `model_validate` on the decoded payload.
> 
> Group responses get the same treatment per trace, so savings grow with group size and trace payload size.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd1ea56d510cf7f100eda73a0fd6407abcf8d4e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Avoid redundant trace serialization in `EnvServer` rollout and group responses
> In [`server.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1809/files#diff-64422f6a8749fcc024415b2756129bc98000e830e74b3b5245de50a555480a22), `_run_rollout` and `_run_group` now use `model_construct` to build responses directly from existing `Trace` objects instead of calling `model_dump()` on each trace and re-validating. This skips an unnecessary serialize-then-validate round-trip per trace.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dd1ea56.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->