### PR TITLE
Avoid gather for zero or one scoring hook

### DIFF
--- a/verifiers/v1/decorators.py
+++ b/verifiers/v1/decorators.py
@@ -45,8 +45,8 @@ def discover_decorated(obj: object, attr: str) -> list[Callable[..., Any]]:
 
 def invoke(fn: Callable[..., Any], available: dict[str, Any]) -> Any:
     """Call `fn`, passing only the items of `available` whose name it declares as a
-    parameter. `fn` is a bound method (so `self` is already excluded); the result
-    (a coroutine, since handlers are async) is returned un-awaited for `gather`."""
+    parameter. `fn` is a bound method (so `self` is already excluded); the result is
+    a coroutine because handlers are async."""
     params = inspect.signature(fn).parameters
     return fn(**{name: value for name, value in available.items() if name in params})
 

--- a/verifiers/v1/harness.py
+++ b/verifiers/v1/harness.py
@@ -6,6 +6,7 @@ runs during rollout setup; only execution counts against the harness timeout. Th
 runtime and the interception server are owned by the Rollout.
 """
 
+import asyncio
 import logging
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
@@ -139,7 +140,7 @@ class Harness(ABC, Generic[ConfigT]):
         trace.stop("agent_completed")
 
     async def score(self, trace: Trace, runtime: Runtime) -> None:
-        """Run this harness's `@metric` methods over the finished trace in priority order,
+        """Run this harness's `@metric` methods over the finished trace, concurrently,
         recording each into `trace.metrics`. Mirrors `Taskset.score` (which the
         Rollout runs in parallel with this); metrics declare what they need (`task`,
         `trace`, `runtime`) and can read what the harness left behind in the runtime.
@@ -147,7 +148,11 @@ class Harness(ABC, Generic[ConfigT]):
         available = {"task": trace.task, "trace": trace, "runtime": runtime}
         fns = discover_decorated(self, "metric")
         async with boundary(HarnessError, f"harness {self.config.id!r} metric"):
-            results = [await invoke(fn, available) for fn in fns]
+            results = (
+                [await invoke(fn, available) for fn in fns]
+                if len(fns) < 2
+                else await asyncio.gather(*(invoke(fn, available) for fn in fns))
+            )
         for fn, result in zip(fns, results):
             if isinstance(result, Mapping):
                 trace.record_metrics(result)

--- a/verifiers/v1/harness.py
+++ b/verifiers/v1/harness.py
@@ -6,7 +6,6 @@ runs during rollout setup; only execution counts against the harness timeout. Th
 runtime and the interception server are owned by the Rollout.
 """
 
-import asyncio
 import logging
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
@@ -140,7 +139,7 @@ class Harness(ABC, Generic[ConfigT]):
         trace.stop("agent_completed")
 
     async def score(self, trace: Trace, runtime: Runtime) -> None:
-        """Run this harness's `@metric` methods over the finished trace, concurrently,
+        """Run this harness's `@metric` methods over the finished trace in priority order,
         recording each into `trace.metrics`. Mirrors `Taskset.score` (which the
         Rollout runs in parallel with this); metrics declare what they need (`task`,
         `trace`, `runtime`) and can read what the harness left behind in the runtime.
@@ -148,7 +147,7 @@ class Harness(ABC, Generic[ConfigT]):
         available = {"task": trace.task, "trace": trace, "runtime": runtime}
         fns = discover_decorated(self, "metric")
         async with boundary(HarnessError, f"harness {self.config.id!r} metric"):
-            results = await asyncio.gather(*(invoke(fn, available) for fn in fns))
+            results = [await invoke(fn, available) for fn in fns]
         for fn, result in zip(fns, results):
             if isinstance(result, Mapping):
                 trace.record_metrics(result)

--- a/verifiers/v1/taskset.py
+++ b/verifiers/v1/taskset.py
@@ -15,6 +15,7 @@ For a heterogeneous taskset (different verification per task), have a single
 `@reward` branch on a typed task field.
 """
 
+import asyncio
 from collections.abc import Mapping
 from typing import ClassVar, Generic, TypeVar
 
@@ -105,7 +106,7 @@ class Taskset(Generic[TaskT, ConfigT, StateT]):
 
     async def score(self, trace: Trace, runtime: Runtime) -> None:
         """Score one rollout: run all `@metric` then `@reward` over its trace,
-        in priority order within each phase. Each metric is recorded in `trace.metrics`
+        concurrently within each phase. Each metric is recorded in `trace.metrics`
         (a number, or a mapping merged in); each reward (weighted — likewise a number or a
         mapping merged in) in `trace.rewards`, which `trace.reward` sums. Signals declare
         what they need — `task`, `trace`,
@@ -114,19 +115,23 @@ class Taskset(Generic[TaskT, ConfigT, StateT]):
         available = {"task": trace.task, "trace": trace, "runtime": runtime}
         async with boundary(TasksetError, f"taskset {type(self).__name__} scoring"):
             metrics = discover_decorated(self, "metric")
-            for fn, result in zip(
-                metrics,
-                [await invoke(fn, available) for fn in metrics],
-            ):
+            metric_results = (
+                [await invoke(fn, available) for fn in metrics]
+                if len(metrics) < 2
+                else await asyncio.gather(*(invoke(fn, available) for fn in metrics))
+            )
+            for fn, result in zip(metrics, metric_results):
                 if isinstance(result, Mapping):
                     trace.record_metrics(result)
                 else:
                     trace.record_metric(fn.__name__, result)
             rewards = discover_decorated(self, "reward")
-            for fn, result in zip(
-                rewards,
-                [await invoke(fn, available) for fn in rewards],
-            ):
+            reward_results = (
+                [await invoke(fn, available) for fn in rewards]
+                if len(rewards) < 2
+                else await asyncio.gather(*(invoke(fn, available) for fn in rewards))
+            )
+            for fn, result in zip(rewards, reward_results):
                 weight = getattr(fn, "_vf_weight", 1.0)
                 if isinstance(result, Mapping):
                     for name, value in result.items():
@@ -148,10 +153,12 @@ class Taskset(Generic[TaskT, ConfigT, StateT]):
         async with boundary(
             TasksetError, f"taskset {type(self).__name__} group scoring"
         ):
-            for fn, scores in zip(
-                rewards,
-                [await invoke(fn, available) for fn in rewards],
-            ):
+            reward_results = (
+                [await invoke(fn, available) for fn in rewards]
+                if len(rewards) < 2
+                else await asyncio.gather(*(invoke(fn, available) for fn in rewards))
+            )
+            for fn, scores in zip(rewards, reward_results):
                 weight = getattr(fn, "_vf_weight", 1.0)
                 for trace, score in zip(traces, scores):
                     trace.record_reward(fn.__name__, score, weight)

--- a/verifiers/v1/taskset.py
+++ b/verifiers/v1/taskset.py
@@ -15,7 +15,6 @@ For a heterogeneous taskset (different verification per task), have a single
 `@reward` branch on a typed task field.
 """
 
-import asyncio
 from collections.abc import Mapping
 from typing import ClassVar, Generic, TypeVar
 
@@ -106,7 +105,7 @@ class Taskset(Generic[TaskT, ConfigT, StateT]):
 
     async def score(self, trace: Trace, runtime: Runtime) -> None:
         """Score one rollout: run all `@metric` then `@reward` over its trace,
-        concurrently within each phase. Each metric is recorded in `trace.metrics`
+        in priority order within each phase. Each metric is recorded in `trace.metrics`
         (a number, or a mapping merged in); each reward (weighted — likewise a number or a
         mapping merged in) in `trace.rewards`, which `trace.reward` sums. Signals declare
         what they need — `task`, `trace`,
@@ -117,7 +116,7 @@ class Taskset(Generic[TaskT, ConfigT, StateT]):
             metrics = discover_decorated(self, "metric")
             for fn, result in zip(
                 metrics,
-                await asyncio.gather(*(invoke(fn, available) for fn in metrics)),
+                [await invoke(fn, available) for fn in metrics],
             ):
                 if isinstance(result, Mapping):
                     trace.record_metrics(result)
@@ -126,7 +125,7 @@ class Taskset(Generic[TaskT, ConfigT, StateT]):
             rewards = discover_decorated(self, "reward")
             for fn, result in zip(
                 rewards,
-                await asyncio.gather(*(invoke(fn, available) for fn in rewards)),
+                [await invoke(fn, available) for fn in rewards],
             ):
                 weight = getattr(fn, "_vf_weight", 1.0)
                 if isinstance(result, Mapping):
@@ -151,7 +150,7 @@ class Taskset(Generic[TaskT, ConfigT, StateT]):
         ):
             for fn, scores in zip(
                 rewards,
-                await asyncio.gather(*(invoke(fn, available) for fn in rewards)),
+                [await invoke(fn, available) for fn in rewards],
             ):
                 weight = getattr(fn, "_vf_weight", 1.0)
                 for trace, score in zip(traces, scores):


### PR DESCRIPTION
## Overview

Avoid `asyncio.gather` overhead when a v1 scoring phase has zero or one hook, while preserving concurrent execution for phases with multiple hooks.

## Details

Taskset metrics, taskset rewards, group rewards, and harness metrics now choose their execution path from the discovered hook count. Empty phases produce an empty result list, and a single hook is awaited directly in the existing scoring task without allocating a child task or gathering future. Two or more hooks continue through `asyncio.gather`, preserving concurrent asynchronous work, input-ordered results, and existing multi-hook exception scheduling.

Results are still fully collected before anything is recorded on the trace. Taskset and harness scoring also remain concurrent with each other at the rollout level.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Avoid `asyncio.gather` for zero or one scoring hook in harness and taskset
> Scoring methods in [`harness.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1810/files#diff-05e981bb3680a934fbc6865d9dff3b25fc692d0c9970684bf8d41f4aea7ee384) and [`taskset.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1810/files#diff-7e5e561017828ff64ab186fa98a8e394675de1971f358af769aa825f7c7997c9) previously wrapped all metric/reward coroutines in `asyncio.gather` regardless of count. Each method now awaits coroutines directly when fewer than two are present, using `asyncio.gather` only for two or more.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5b97c9c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoring behavior is unchanged for multi-hook phases; only the single-hook path avoids extra asyncio tasks, with no auth or data-model impact.
> 
> **Overview**
> Scoring phases in `Harness.score`, `Taskset.score` (metrics and rewards), and `Taskset.score_group` no longer always wrap hooks in `asyncio.gather`. When a phase has **fewer than two** decorated methods, results are collected with a direct `await` per hook (including an empty list when there are none); **two or more** hooks in the same phase still run concurrently via `gather`.
> 
> Recording on the trace is unchanged: all hook results for a phase are gathered into a list first, then applied in discovery order. The `invoke` docstring is tightened to describe the returned coroutine without mentioning `gather`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b97c9c78d3e686ae14e1caae7b7466b9d63e630. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->