### PR TITLE
Match EvalClient pool to V1 concurrency

### DIFF
--- a/verifiers/v1/clients/eval.py
+++ b/verifiers/v1/clients/eval.py
@@ -72,7 +72,11 @@ class EvalClient(Client):
         # No timeout: agentic completions are slow and the rollout timeout is the real backstop.
         # Build full URLs ourselves (base_url + dialect.upstream_path) rather than relying on
         # httpx base-url joining, which drops the base path for a leading-slash request path.
-        self.http = httpx.AsyncClient(timeout=None)
+        # Match V1's default concurrency while retaining HTTPX's 20-idle keepalive bound.
+        self.http = httpx.AsyncClient(
+            timeout=None,
+            limits=httpx.Limits(max_connections=128, max_keepalive_connections=20),
+        )
 
     async def get_response(
         self,


### PR DESCRIPTION
## Overview

Align the shared V1 `EvalClient` HTTP connection pool with the default 128 concurrent rollouts while retaining HTTPX's existing 20-connection idle keepalive bound.

## Why

V1 can admit 128 rollouts concurrently, but the implicit HTTPX pool admits only 100 active connections. At full default concurrency, the remaining 28 requests wait for a pool slot and form a second latency wave. This change removes that internal queue without making the pool unbounded.

## Implementation

Construct the existing `httpx.AsyncClient` with `max_connections=128` and `max_keepalive_connections=20`. Request timeouts, keepalive expiry, headers, bodies, response parsing, streaming, error handling, and client shutdown remain unchanged.

## Performance and resources

A local PEP 723 benchmark ran five repetitions of 128 concurrent requests with 500 ms server latency, using fresh processes for each pool configuration.

| Metric | 100 active / 20 idle | 128 active / 20 idle |
| --- | ---: | ---: |
| Median wall time | 1.085869 s | 0.572788 s |
| Absolute time saved | — | 0.513081 s |
| Relative time saved | — | 47.251% (1.896×) |
| Peak RSS | 68,534,272 B | 70,270,976 B |
| RSS above baseline | 22,052,864 B | 23,773,184 B |
| Median event-loop stall | 24.288 ms | 22.163 ms |
| Peak active requests | 100 | 128 |
| Peak combined benchmark tasks | 330 | 386 |
| Idle connections after each burst | 20 | 20 |
| Successful responses | 128/128 | 128/128 |
| Response bytes | 1,536 B | 1,536 B |

The measured cost is 1,736,704 additional peak RSS bytes and more concurrently active transport tasks; idle resource retention does not grow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single transport tuning knob on the eval relay client; no auth, request shaping, or response handling changes.
> 
> **Overview**
> **`EvalClient`** now constructs its shared **`httpx.AsyncClient`** with explicit **`httpx.Limits`**: **`max_connections=128`** (aligned with V1’s default **`--max-concurrent`**) and **`max_keepalive_connections=20`** (HTTPX’s default idle cap).
> 
> Previously the client relied on HTTPX’s implicit **100** active connection limit, so at full default concurrency some upstream eval requests could block waiting for a pool slot instead of running in parallel. Timeouts, headers, relay/streaming behavior, and shutdown are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce0260b5d884032659f8621e9b8c94e06b6e6d14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Set explicit connection pool limits on `EvalClient` to match V1 concurrency
> Sets `httpx.Limits(max_connections=128, max_keepalive_connections=20)` on the `httpx.AsyncClient` in [`EvalClient.__init__`](https://github.com/PrimeIntellect-ai/verifiers/pull/1811/files#diff-8a1cc6d0e01dde461a22ef26597ccf8f011f4c12328b1c7297cae7acebc78df8), replacing HTTPX's defaults. The 128-connection cap aligns with V1's default concurrency level; the 20 keepalive cap retains HTTPX's built-in bound.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ce0260b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->