### PR TITLE
Move V1 tunnel teardown off the event loop

### DIFF
--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -322,8 +322,18 @@ async def host_endpoint(port: int, is_local: bool, labels: list[str] | None = No
     try:
         yield url
     finally:
+        # Delay cancellation until the synchronous stop has finished.
+        cancelled = None
+        stop_task = asyncio.create_task(asyncio.to_thread(tunnel.sync_stop))
         with contextlib.suppress(Exception):
-            tunnel.sync_stop()
+            while not stop_task.done():
+                try:
+                    await asyncio.shield(stop_task)
+                except asyncio.CancelledError as e:
+                    cancelled = e
+            stop_task.result()
+        if cancelled is not None:
+            raise cancelled
 
 
 class _Host:


### PR DESCRIPTION
## Overview

Move synchronous Prime tunnel shutdown off the asyncio event loop while continuing to await cleanup before `host_endpoint` exits.

## Why

`host_endpoint` owns a remote tunnel for the lifetime of its async context. Its finalizer previously called `tunnel.sync_stop()` directly, so a blocking close occupied the event-loop thread. When many rollout or interception endpoints closed together, nominally concurrent finalizers serialized and delayed unrelated coroutines on the same loop.

The finalizer now runs `asyncio.to_thread(tunnel.sync_stop)` in a shielded task. This lets independent closes overlap in the bounded default executor without turning cleanup into fire-and-forget work. If cancellation arrives repeatedly while the worker is running, the finalizer keeps joining it before re-raising cancellation. Tunnel startup, retry and limiter behavior, local endpoint handling, teardown ordering, and cleanup-error suppression remain unchanged.

## Performance and resources

A five-round median benchmark scheduled 64 simulated synchronous tunnel closes, each blocking for 20 ms, alongside a 1 ms event-loop heartbeat.

| Measurement | Before | After | Change |
| --- | ---: | ---: | ---: |
| Wall time | 1.549826 s | 0.090364 s | 1.459461 s saved (94.2%) |
| Worst heartbeat stall | 1548.843 ms | 0.805 ms | 1548.038 ms saved |
| Peak traced Python allocation | 68,456 B | 493,964 B | +425,508 B |
| Retained traced Python allocation | 3,879 B | 91,803 B | +87,924 B |
| Peak simultaneous closes | 1 | 20 | +19 |
| Peak asyncio tasks | 66 | 130 | +64 |
| Completed closes | 64 | 64 | unchanged |

Wall time used `time.perf_counter`; loop stall was the heartbeat's maximum scheduling delay; allocation figures used `tracemalloc` around one batch and exclude native thread stacks. The change intentionally trades roughly 415.5 KiB of peak and 85.9 KiB of retained traced allocation for a 17.1x faster teardown batch and a responsive event loop.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to tunnel teardown in `host_endpoint`; behavior is still await-before-exit with shielded cancellation, with no auth or data-path impact.
> 
> **Overview**
> Remote runtimes reach the host interception server through `host_endpoint`, which opens a Prime tunnel and must call **`tunnel.sync_stop()`** when the context exits.
> 
> **Before:** that stop ran synchronously on the asyncio event loop, so many concurrent teardowns serialized and stalled unrelated coroutines.
> 
> **After:** the finalizer schedules **`asyncio.to_thread(tunnel.sync_stop)`**, **`asyncio.shield`s** the task until it finishes, and re-raises any **`CancelledError`** captured during the wait. Startup, limiter behavior, error suppression, and the local-runtime early return are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ed4f8a72de08564af205b0a3d9ef768620b3e25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move V1 tunnel teardown off the event loop to survive cancellation
> In [`host_endpoint`](https://github.com/PrimeIntellect-ai/verifiers/pull/1812/files#diff-0811c040a163eb5a3212208f1e3a6c6388d7690fcc4780c081cc7754036232b9), the tunnel `stop()` call in the `finally` block now runs in a background thread via `asyncio.to_thread`, wrapped in an `asyncio.shield`-protected task. This ensures the synchronous stop completes even if the surrounding coroutine is cancelled; any `CancelledError` is captured and re-raised only after the stop finishes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5ed4f8a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->