### PR TITLE
Avoid copying trusted training token lists

### DIFF
--- a/verifiers/v1/clients/train.py
+++ b/verifiers/v1/clients/train.py
@@ -140,7 +140,9 @@ def response_from_generate(
         usage=Usage(
             prompt_tokens=len(prompt_ids), completion_tokens=len(completion_ids)
         ),
-        tokens=TurnTokens(
+        # generate() returns owned, typed lists. Skip revalidation here to avoid copying
+        # million-token contexts synchronously on the event loop.
+        tokens=TurnTokens.model_construct(
             prompt_ids=prompt_ids,
             completion_ids=completion_ids,
             completion_logprobs=result.get("completion_logprobs") or [],


### PR DESCRIPTION
## Overview

Construct renderer-generated `TurnTokens` without revalidating their token and logprob lists. The change is intentionally limited to `response_from_generate()`, the internal boundary immediately after `renderers.client.generate()` returns owned, typed data.

## Why

The renderer already materializes fresh `list[int]` prompt/completion IDs and a fresh `list[float]` of completion logprobs. Passing those values through the normal Pydantic constructor walked and shallow-copied every list before graph construction, duplicating long contexts synchronously on the event loop.

Using `TurnTokens.model_construct()` at this trusted boundary preserves those lists by identity. Downstream graph construction continues to create its own token slices, sampled masks, and node-owned logprobs, while ordinary external `TurnTokens` and `Response` validation paths remain unchanged.

## Performance

A PEP 723 benchmark used 2,000,000 prompt tokens, 10,000 completion tokens, 10,000 completion logprobs, and five repetitions:

| Metric | Before | After | Saved |
| --- | ---: | ---: | ---: |
| Median construction wall time | 12.704 ms | 0.024 ms | 12.680 ms (99.8%) |
| Median event-loop callback delay | 13.087 ms | 0.082 ms | 13.005 ms (99.4%) |
| Incremental retained allocation | 16,164,096 bytes | 4,016 bytes | 16,160,080 bytes |
| Incremental peak allocation | 16,164,584 bytes | 4,504 bytes | 16,160,080 bytes |
| Shallow list-slot copies | 16,160,000 bytes | 0 bytes | 16,160,000 bytes |

Wall time used `time.perf_counter()`; event-loop delay queued a callback immediately before synchronous construction; allocation measurements used `tracemalloc` after the input lists were allocated. The list-copy figure is the 2,020,000 copied element slots multiplied by an 8-byte pointer on 64-bit CPython.

## Scope

This is a one-file production change. It does not alter wire output, response fields, usage accounting, optional token sidecars, graph masking/logprob behavior, dependency metadata, or public validation boundaries.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single trusted internal boundary change with no wire or public API impact; skips validation only for renderer-owned lists already materialized in-process.
> 
> **Overview**
> **`response_from_generate()`** now builds **`TurnTokens`** with **`model_construct()`** instead of the normal constructor, so prompt/completion IDs, logprobs, and related sidecars keep the **same list objects** the renderer just returned.
> 
> That avoids Pydantic walking and shallow-copying very long token lists on the **async event loop** right after **`generate()`**—a path that was duplicating multi-million-token contexts for no gain because the data is already owned and typed.
> 
> The bypass is **only** at this internal post-`generate()` boundary; other **`TurnTokens` / `Response`** validation paths are unchanged, and downstream graph code still owns its own slices and masks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77d684446b766fabec319fc5a3fcf2e0c4343fd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Avoid copying large token lists by using `TurnTokens.model_construct` in `response_from_generate`
> Replaces the standard `TurnTokens(...)` initializer with `TurnTokens.model_construct(...)` in [train.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1813/files#diff-c9bcd6c691890b1de6942fe012d2e74678460b22bf335721a8bba5e939d139c3) to skip Pydantic validation, which triggers deep copying of large token list inputs. This reduces unnecessary memory allocation when processing trusted training data.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 77d6844.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->