### PR TITLE
Honor rollout concurrency for grouped V1 evals

### DIFF
--- a/verifiers/v1/cli/eval/runner.py
+++ b/verifiers/v1/cli/eval/runner.py
@@ -182,8 +182,13 @@ async def run_eval_server(config: EvalConfig) -> list[Trace]:
                 config.model,
             )
         logger.info("results: %s", out)
+        request_concurrency = config.max_concurrent
+        if request_concurrency and info.requires_group_scoring:
+            # max_concurrent is a rollout resource bound, not a request-throughput target.
+            # A group is indivisible, so one oversized group must still be allowed to run.
+            request_concurrency = max(1, request_concurrency // config.num_rollouts)
         semaphore = (
-            asyncio.Semaphore(config.max_concurrent) if config.max_concurrent else None
+            asyncio.Semaphore(request_concurrency) if request_concurrency else None
         )
         write_lock = asyncio.Lock()
 

--- a/verifiers/v1/serve/pool.py
+++ b/verifiers/v1/serve/pool.py
@@ -37,7 +37,7 @@ import zmq.asyncio
 
 from verifiers.v1.env import EnvConfig
 from verifiers.v1.serve.server import EnvServer
-from verifiers.v1.serve.types import HealthResponse
+from verifiers.v1.serve.types import HealthResponse, RunGroupRequest
 
 logger = logging.getLogger(__name__)
 
@@ -161,7 +161,7 @@ class EnvServerPool:
             self._poller.register(dealer, zmq.POLLIN)
 
     def _maybe_scale_up(self, in_flight: int) -> None:
-        """Spawn one more worker when in-flight requests reach 90% of current capacity.
+        """Spawn one more worker when in-flight rollout slots reach 90% of capacity.
 
         A new worker starts at `active=0`, so least-busy dispatch funnels the backlog to
         it as it comes online (a few seconds to load the env) — fine, since we only scale
@@ -188,7 +188,8 @@ class EnvServerPool:
         # (`max_workers` is a concrete count when elastic is off).
         for _ in range(1 if self.elastic else (self.max_workers or 1)):
             self._spawn_worker()
-        pending: dict[bytes, dict] = {}  # request_id -> {client_id, worker}
+        # request_id -> {client_id, worker, rollout_slots}
+        pending: dict[bytes, dict] = {}
         logger.info(
             "EnvServerPool up: address=%s workers=%d/%s multiplex=%d elastic=%s",
             self.address,
@@ -198,6 +199,7 @@ class EnvServerPool:
             self.elastic,
         )
         try:
+            in_flight = 0
             while True:
                 events = dict(await self._poller.poll())
                 if self.frontend in events:
@@ -212,16 +214,29 @@ class EnvServerPool:
                             [client_id, request_id, _HEALTH]
                         )
                     else:
+                        # Pool capacity is measured in rollouts; one group request carries n.
+                        rollout_slots = 1
+                        if method == b"run_group":
+                            with contextlib.suppress(Exception):
+                                request = RunGroupRequest.model_validate(
+                                    msgpack.unpackb(payload, raw=False)
+                                )
+                                rollout_slots = max(1, request.n)
                         worker = min(self.workers, key=lambda w: w["active"])
-                        worker["active"] += 1
-                        pending[request_id] = {"client_id": client_id, "worker": worker}
+                        worker["active"] += rollout_slots
+                        pending[request_id] = {
+                            "client_id": client_id,
+                            "worker": worker,
+                            "rollout_slots": rollout_slots,
+                        }
+                        in_flight += rollout_slots
                         # forward without client_id — the DEALER identity is the worker's
                         # `client_id`; we hold the real one in `pending`.
                         await worker["dealer"].send_multipart(
                             [request_id, method, payload]
                         )
                         if self.elastic:
-                            self._maybe_scale_up(len(pending))
+                            self._maybe_scale_up(in_flight)
                 for w in self.workers:
                     if w["dealer"] in events:
                         request_id, data = await w["dealer"].recv_multipart(copy=False)
@@ -229,7 +244,8 @@ class EnvServerPool:
                         entry = pending.pop(request_id.bytes, None)
                         if entry is None:
                             continue
-                        entry["worker"]["active"] -= 1
+                        entry["worker"]["active"] -= entry["rollout_slots"]
+                        in_flight -= entry["rollout_slots"]
                         with contextlib.suppress(zmq.ZMQError):
                             await self.frontend.send_multipart(
                                 [entry["client_id"], request_id, data], copy=False


### PR DESCRIPTION
## Overview

Honor `max_concurrent` as a rollout-level resource bound for group-scored V1 server evals. A group request owns `num_rollouts` inseparable rollouts, so the runner now derives request concurrency as `max(1, max_concurrent // num_rollouts)`.

This keeps cross-rollout scoring groups intact, guarantees progress for a group larger than the cap, and leaves independent server rollouts, local eval, resume behavior, and output handling unchanged.

## Reasoning

The env-server semaphore previously counted requests. That is equivalent to rollout concurrency for independent scoring, but a group-scored request expands into multiple rollouts inside the worker. With a rollout cap of 128 and group size 8, 128 request permits therefore allowed 1,024 live rollouts.

Scaling group-request permits by group size aligns the server path with the rollout-level meaning of `max_concurrent`. Floor division intentionally leaves spare capacity for non-divisible group sizes; one oversized group still receives a permit because group scoring cannot split it.

Reducing request permits must not suppress elastic worker fan-out, so the broker now counts a `run_group` request as load `n` for least-busy dispatch and scale-up. Other requests consume one rollout slot.

## Performance and resource impact

A scheduler-focused reproduction used 256 groups × 8 rollouts, cap 128, and 64 KiB retained per active rollout. Values are medians from three fresh processes per variant.

| Measurement | Before | After | Saved |
| --- | ---: | ---: | ---: |
| Peak group requests | 128 | 16 | 112 (87.5%) |
| Peak live rollouts | 1,024 | 128 | 896 (87.5%) |
| Peak traced allocation | 65.139 MiB | 9.036 MiB | 56.103 MiB (86.1%) |
| Peak RSS | 195.641 MiB | 124.344 MiB | 71.297 MiB (36.4%) |
| Retained RSS increase | 84.172 MiB | 12.938 MiB | 71.234 MiB (84.6%) |
| Maximum event-loop lag | 46.257 ms | 41.786 ms | 4.471 ms (9.7%) |
| Wall time | 0.068005 s | 0.206936 s | **-0.138931 s (-204.3%)** |
| Returned traces | 2,048 | 2,048 | unchanged |

The wall-time result is deliberately reported as negative time saved: enforcing the resource cap creates more request waves in an unconstrained synthetic workload. This is a resource-bound correction, not a throughput claim.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes scheduling and pool scaling for group-scored server evals; mis-parsing `run_group` payloads would fall back to one slot, but normal paths use validated `RunGroupRequest.n`.
> 
> **Overview**
> **Group-scored env-server evals** now treat `max_concurrent` as a cap on **rollouts**, not on in-flight `run_group` HTTP/ZMQ requests. When `requires_group_scoring` is true, the client semaphore limit becomes `max(1, max_concurrent // num_rollouts)` so each permit roughly covers one task’s full group while a group larger than the cap can still start (`max(1, …)`).
> 
> **`EnvServerPool`** weights load the same way: a `run_group` request consumes `n` rollout slots on the chosen worker, and elastic scale-up uses total **in-flight rollout slots** instead of counting one slot per request. Non-group methods still count as one slot.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a5e75242ba56e767c23126b917734e42e9cfc99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Honor rollout concurrency for grouped V1 evals by counting slots per group
> - In [runner.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1815/files#diff-65be4a576330571f2729a3bbcdbe92ac81bbcba450c313597c1bdca3a1c3f2e4), the `asyncio.Semaphore` for `run_eval_server` now uses `max(1, max_concurrent // num_rollouts)` as its limit when group scoring is required, so concurrent group calls are bounded correctly.
> - In [pool.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1815/files#diff-0c9c59578214be2580d340bc524321e352f48038207a68945637d00fc399600c), `EnvServerPool.run` tracks rollout slots instead of raw request count: `run_group` requests consume `n` slots, and worker routing, active counts, and elastic scaling all use this slot-based `in_flight` total.
> - Behavioral Change: `run_group` requests with `n > 1` now consume proportionally more concurrency capacity, which may reduce parallelism compared to the previous behavior where each request counted as one slot.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3a5e752.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->