### PR TITLE
Use one producer task per V1 SSE stream

### DIFF
--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -24,7 +24,7 @@ import contextlib
 import json
 import logging
 import secrets
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -56,6 +56,7 @@ logger = logging.getLogger(__name__)
 # context window are the real limits, this is just a host-OOM backstop.
 _MAX_REQUEST_BODY = 1024**3  # 1 GiB (aiohttp's default is 1 MiB)
 _KEEPALIVE_INTERVAL_SECONDS = 3
+_STREAM_QUEUE_MAXSIZE = 16
 # The server binds loopback; callers reach it via localhost or a host tunnel (see `reachable_url`).
 _HOST = "127.0.0.1"
 
@@ -67,6 +68,20 @@ def _completion_response(completion: dict | None) -> web.Response:
     except PydanticSerializationError:
         return web.json_response(completion)
     return web.Response(body=body, content_type="application/json", charset="utf-8")
+
+
+async def _queue_chunks(
+    chunks: AsyncIterator[bytes],
+    queue: asyncio.Queue[bytes | None],
+    ready: asyncio.Event,
+) -> None:
+    try:
+        async for chunk in chunks:
+            await queue.put(chunk)
+            ready.set()
+    finally:
+        await queue.put(None)
+        ready.set()
 
 
 @dataclass(frozen=True)
@@ -446,28 +461,37 @@ class InterceptionServer:
         )
         resp.content_type = reply.content_type.split(";")[0].strip()
         buffer = bytearray()
-        chunks = reply.chunks.__aiter__()
-        next_chunk = asyncio.create_task(anext(chunks, None))
+        # One bounded producer avoids per-event tasks; keepalive timeouts only cancel readiness waits.
+        queue: asyncio.Queue[bytes | None] = asyncio.Queue(
+            maxsize=_STREAM_QUEUE_MAXSIZE
+        )
+        ready = asyncio.Event()
+        producer = asyncio.create_task(_queue_chunks(reply.chunks, queue, ready))
         try:
             await resp.prepare(request)
             while True:
-                done, _ = await asyncio.wait(
-                    {next_chunk}, timeout=_KEEPALIVE_INTERVAL_SECONDS
-                )
-                if not done:
+                try:
+                    async with asyncio.timeout(_KEEPALIVE_INTERVAL_SECONDS):
+                        await ready.wait()
+                except TimeoutError:
                     await resp.write(b": keepalive\n\n")
                     continue
-                chunk = next_chunk.result()
+                chunk = queue.get_nowait()
+                if queue.empty():
+                    ready.clear()
                 if chunk is None:
+                    await producer
                     break
                 buffer += chunk
                 await resp.write(chunk)
-                next_chunk = asyncio.create_task(anext(chunks, None))
         except ConnectionResetError:
             return resp
         finally:
-            next_chunk.cancel()
-            await asyncio.gather(next_chunk, return_exceptions=True)
+            producer.cancel()
+            # Let a canceled producer enqueue EOF while unwinding.
+            if queue.full():
+                queue.get_nowait()
+            await asyncio.gather(producer, return_exceptions=True)
             await reply.close()
 
         try:


### PR DESCRIPTION
## Overview

Use one producer task for each relayed V1 SSE response and pass complete events through a bounded 16-event queue. The interception handler remains the sole owner of keepalives, downstream writes, trace buffering, parsing, and response completion.

## Design

The previous control flow kept only one upstream `anext()` task live at a time, but replaced that task after every event. A stream with N events therefore created N+1 tasks and repeated one-element `asyncio.wait` scheduling for the full response.

The producer now owns upstream iteration for the lifetime of the stream. After enqueueing an event—or the final EOF sentinel—it sets a level-triggered readiness event. Keepalive timeouts wait on that readiness signal rather than on `queue.get()`, so timeout cancellation cannot consume or lose a queued payload. Once ready, the consumer dequeues synchronously, clears readiness only when the queue is empty, and awaits the producer at EOF so the task remains the exception and cancellation channel.

The 16-event bound preserves backpressure for slow downstream consumers. Cleanup cancels and joins the producer before closing the upstream response; when cancellation finds a full queue, one slot is released so the producer can finish its EOF cleanup without blocking.

## Performance

Measured on CPython 3.13.12 with 100,000 immediately available 21-byte SSE events (2,100,000 bytes total), using three uninstrumented timing samples and separate resource passes:

| Metric | Per-event task path | One producer | Difference |
| --- | ---: | ---: | ---: |
| Median wall time | 4.706034 s | 0.352644 s | 4.353390 s saved (92.51%) |
| Median CPU time | 1.378559 s | 0.215393 s | 1.163166 s saved (84.38%) |
| Throughput | 21,249 events/s | 283,572 events/s | 13.34x |
| Stream tasks created | 100,001 | 1 | 100,000 fewer |
| Maximum loop-heartbeat lateness | 0.548042 ms | 0.339125 ms | 0.208917 ms lower (38.12%) |
| Peak Python allocation | 2,166,234 B | 2,173,170 B | +6,936 B |
| Retained RSS | 34,734,080 B | 34,668,544 B | -65,536 B |

Both paths buffered the same 2,100,000 bytes and produced the same SHA-256 digest. Memory remains effectively flat; the material savings are task creation, CPU time, wall time, and maximum observed event-loop stall.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized asyncio refactor in the interception server's SSE path; streaming semantics and trace recording are unchanged, with explicit cleanup for cancel/EOF edge cases.
> 
> **Overview**
> **Refactors streamed model turns** in `InterceptionServer._stream` so upstream SSE chunks are drained by one long-lived producer instead of spawning a new `anext()` task after every chunk.
> 
> A bounded queue (`maxsize=16`) plus a level-triggered `ready` event decouple upstream reads from downstream writes. Keepalives use `asyncio.timeout` on `ready.wait()` (not `queue.get()`), so a timeout cannot drop a queued chunk. Cleanup cancels the producer, may free one slot if the queue is full, then closes the upstream reply as before—buffering, parse, and trace commit behavior stay the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8194b618fa34fa081d30953807a0fff68c94d8a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use a single producer task per V1 SSE stream in `InterceptionServer.handle_request`
> - Replaces the per-chunk task pattern (creating a new task for each `anext` call) with a single `_queue_chunks` producer task that enqueues chunks into a bounded `asyncio.Queue` (size 16) and signals readiness via an `asyncio.Event`.
> - The consumer loop in `handle_request` waits on the event with a timeout; on timeout it writes a keepalive line and retries, rather than creating a new task.
> - On EOF (sentinel `None` received), the handler awaits the producer before breaking; the `finally` block cancels the producer and drains the queue if full before gathering.
> - Behavioral Change: keepalive lines are now emitted on any timeout waiting for data readiness, and the producer task lifecycle is explicitly managed with cancel/drain/gather on cleanup.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8194b61.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->