### PR TITLE
Release intercepted request bodies before inference

### DIFF
--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -242,6 +242,10 @@ class InterceptionServer:
             body = from_json(raw)
         except ValueError:
             body = json.loads(raw)
+        # Keep `read()` for aiohttp's size guard, then release its cache and our local
+        # alias after parsing so the wire body does not survive model inference.
+        request._read_bytes = None
+        del raw
         logger.debug(
             "intercept %s: id=%s stream=%s",
             request.path,


### PR DESCRIPTION
## Overview

Release aiohttp's cached intercepted request bytes immediately after JSON parsing, instead of retaining the serialized body for the duration of model inference.

## Why

`request.read()` is the correct ingestion path because it enforces aiohttp's configured request-size limit, but it also stores the complete body in `request._read_bytes`. The handler's `raw` local aliases that allocation, while parsing creates a separate Python object graph. Because the async handler remains suspended during inference, the serialized bytes otherwise stay live alongside the parsed request for the longest part of the request lifecycle.

For large prompts or tool results, this avoidably doubles the live payload representation and compounds across concurrent rollouts.

## Implementation

After either the primary `pydantic_core.from_json` parse or the stdlib fallback succeeds, the handler:

- clears aiohttp's cached body with `request._read_bytes = None`;
- deletes the local `raw` alias before entering dialect handling or inference.

The code deliberately keeps `request.read()`, preserving the existing size guard. Downstream code operates on the parsed body and does not reread the request stream.

## Performance

A PEP 723 microbenchmark ran five interleaved old/new subprocesses with a 64 MiB JSON content value (67,108,878 wire bytes), using a real aiohttp `Request.read()` and `pydantic_core.from_json`.

| Measurement | Previous | New | Change |
|---|---:|---:|---:|
| Retained Python allocations | 128.000694 MiB | 64.000649 MiB | **-64.000045 MiB (-50.0%)** |
| Retained cached wire bytes | 67,108,878 B | 0 B | **-67,108,878 B (-100%)** |
| Live logical payload representations | 134,217,742 B | 67,108,864 B | **-67,108,878 B (-50.0%)** |
| Peak Python allocations | 128.001060 MiB | 128.000834 MiB | effectively unchanged |
| Median wall time | 5.478 ms | 5.489 ms | -0.011 ms saved (-0.20%; noise-scale) |
| Median event-loop stall | 5.537 ms | 5.550 ms | -0.013 ms saved (-0.23%; noise-scale) |
| Bytes copied by guarded `request.read()` | 67,108,878 B | 67,108,878 B | unchanged |

This is a retained-memory optimization rather than a throughput optimization. Peak parsing memory remains essentially unchanged because the raw and parsed forms must briefly coexist; the benefit is that the raw form no longer survives the potentially long inference wait.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small lifecycle change in one handler after successful parse; relies on aiohttp’s `_read_bytes` cache but does not alter auth, inference, or response paths.
> 
> **Overview**
> **Frees intercepted chat-completion request memory sooner** by dropping aiohttp’s cached wire body and the local `raw` buffer immediately after JSON parsing in `handle_request`, instead of keeping both alongside the parsed `body` through model inference and user-simulator loops.
> 
> The handler still uses `request.read()` so the existing **1 GiB** `client_max_size` guard is unchanged; only the parsed dict is used downstream.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc81f93b3560d0c6df9a36c9fde1d38e574eec70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Release intercepted request body from memory before inference
> In `InterceptionServer.handle_request` in [server.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1818/files#diff-84e2f8d027d609e8760ef6d533535ec9d99dfc6384d5ddb6111b4001b2010f35), after parsing the raw request body, the handler now sets `request._read_bytes` to `None` and deletes the local `raw` reference. This reduces memory retention of the wire body during inference processing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bc81f93.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->