### PR TITLE
Decode large env replies off the event loop

### DIFF
--- a/verifiers/v1/serve/client.py
+++ b/verifiers/v1/serve/client.py
@@ -50,8 +50,9 @@ class EnvClient:
         self.socket.setsockopt(zmq.SNDHWM, 0)
         self.socket.setsockopt(zmq.RCVHWM, 0)
         self.socket.connect(address)
-        self._pending: dict[str, asyncio.Future] = {}
+        self._pending: dict[str, asyncio.Future[bytes]] = {}
         self._receiver: asyncio.Task | None = None
+        self._decode_lock = asyncio.Lock()
 
     def _ensure_receiver(self) -> None:
         if self._receiver is None:
@@ -65,7 +66,7 @@ class EnvClient:
                 break
             future = self._pending.pop(request_id_bytes.decode(), None)
             if future is not None and not future.done():
-                future.set_result(msgpack.unpackb(data, raw=False))
+                future.set_result(data)
 
     async def _request(
         self,
@@ -77,18 +78,38 @@ class EnvClient:
         `timeout` is only used for health polling — rollouts run untimed."""
         self._ensure_receiver()
         request_id = uuid.uuid4().hex
-        future: asyncio.Future = asyncio.get_running_loop().create_future()
+        future: asyncio.Future[bytes] = asyncio.get_running_loop().create_future()
         self._pending[request_id] = future
         payload = msgpack.packb(request.model_dump(mode="json"), use_bin_type=True)
         await self.socket.send_multipart(
             [request_id.encode(), request.method.encode(), payload]
         )
         try:
-            raw = await asyncio.wait_for(future, timeout)
+            data = await asyncio.wait_for(future, timeout)
         except (asyncio.TimeoutError, asyncio.CancelledError):
             self._pending.pop(request_id, None)
             raise
-        response = response_type.model_validate(raw)
+        if response_type in (HealthResponse, InfoResponse):
+            response = response_type.model_validate(msgpack.unpackb(data, raw=False))
+        else:
+            # Keep large trace replies compact on the loop and expand only one at a time.
+            await self._decode_lock.acquire()
+            decoding = asyncio.create_task(
+                asyncio.to_thread(
+                    lambda: response_type.model_validate(
+                        msgpack.unpackb(data, raw=False)
+                    )
+                )
+            )
+            # The worker owns the slot so caller cancellation cannot overlap decodes.
+            decoding.add_done_callback(lambda _: self._decode_lock.release())
+            try:
+                response = await asyncio.shield(decoding)
+            except asyncio.CancelledError:
+                decoding.add_done_callback(
+                    lambda task: None if task.cancelled() else task.exception()
+                )
+                raise
         if not response.success:
             raise RuntimeError(response.error or "env server request failed")
         return response

--- a/verifiers/v1/serve/client.py
+++ b/verifiers/v1/serve/client.py
@@ -52,7 +52,7 @@ class EnvClient:
         self.socket.connect(address)
         self._pending: dict[str, asyncio.Future[bytes]] = {}
         self._receiver: asyncio.Task | None = None
-        self._decode_lock = asyncio.Lock()
+        self._decode_slots = asyncio.BoundedSemaphore(1)
 
     def _ensure_receiver(self) -> None:
         if self._receiver is None:
@@ -93,7 +93,7 @@ class EnvClient:
             response = response_type.model_validate(msgpack.unpackb(data, raw=False))
         else:
             # Keep large trace replies compact on the loop and expand only one at a time.
-            await self._decode_lock.acquire()
+            await self._decode_slots.acquire()
             decoding = asyncio.create_task(
                 asyncio.to_thread(
                     lambda: response_type.model_validate(
@@ -101,8 +101,8 @@ class EnvClient:
                     )
                 )
             )
-            # The worker owns the slot so caller cancellation cannot overlap decodes.
-            decoding.add_done_callback(lambda _: self._decode_lock.release())
+            # Hold the slot until the worker finishes so cancellation cannot overlap decodes.
+            decoding.add_done_callback(lambda _: self._decode_slots.release())
             try:
                 response = await asyncio.shield(decoding)
             except asyncio.CancelledError:


### PR DESCRIPTION
## Overview

Keep env-server reply bytes compact on the asyncio event loop, then unpack and validate large trace responses in a worker thread. A client-level decode lock limits expansion to one large representation at a time, while small health and info responses retain their direct synchronous path.

## Why

The receiver previously unpacked msgpack before completing each request future, and the request coroutine then performed Pydantic validation on the same event loop. Large queued traces could therefore block unrelated coroutines while several expanded raw object graphs were retained by their futures.

Routing compact bytes through the receiver keeps request matching lightweight. Large replies acquire one decode slot and perform msgpack expansion plus typed validation together in a worker. The slot is released when the worker physically finishes, so caller cancellation cannot permit overlapping giant decodes. Wire format, typed responses, timeout cleanup, and public client methods remain unchanged.

## Performance

The reproduction used three concurrent, distinct 25,934,052-byte replies (77,802,156 bytes total). Each reply contained 1,000 message nodes with 2,000 token IDs, masks, and log probabilities per node. Values below are medians across three separate processes on macOS.

| Measurement | Before | After | Difference |
|---|---:|---:|---:|
| Wall time | 367.596 ms | 372.706 ms | +5.111 ms (+1.39%) |
| Maximum event-loop gap | 367.585 ms | 68.015 ms | −299.571 ms (81.50% saved) |
| Peak RSS increase during decode | 516.719 MiB | 469.000 MiB | −47.719 MiB (9.23% saved) |
| Retained RSS increase after release/GC | 142.969 MiB | 121.078 MiB | −21.891 MiB (15.31% saved) |
| RSS with all typed results retained | 751.734 MiB | 751.969 MiB | effectively unchanged |

The final typed representations necessarily occupy the same memory. The reduction comes from avoiding simultaneous expanded msgpack intermediates. The new path adds one reusable worker thread and preserves a maximum decoder concurrency of one.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes async timing and cancellation behavior for large env-server responses; correctness depends on shielded background decode and semaphore release on all paths, but scope is limited to the ZMQ client.
> 
> **Overview**
> **`EnvClient`** no longer unpacks msgpack in the ZMQ receive loop; pending futures now carry raw reply **`bytes`**, and **`_request`** decides where decoding happens.
> 
> **Health** and **info** responses still **`msgpack.unpackb`** and **`model_validate`** on the event loop. Rollout/trace-style replies acquire a client-wide **`BoundedSemaphore(1)`**, run unpack + Pydantic validation in **`asyncio.to_thread`**, and **`asyncio.shield`** the decode task so caller cancellation cannot overlap large expansions; the slot releases only when the worker finishes.
> 
> Public wire format, timeouts, and client methods are unchanged; under concurrent large replies, decode is serialized (possible extra latency) in exchange for shorter event-loop stalls and lower peak intermediate memory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e575251006d888d4d982185b3761b196d400aab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Decode large env replies off the event loop in `EnvClient`
> - `_receive_loop` now sets raw `bytes` on pending futures instead of decoding with `msgpack.unpackb` at receive time, moving decode work out of the hot path.
> - `_request` offloads msgpack unpacking and Pydantic validation for non-health/info responses to a background thread via `asyncio.to_thread`, with concurrency limited to 1 via a `BoundedSemaphore`.
> - The decode task is shielded from cancellation via `asyncio.shield`; if the caller is cancelled, a done callback observes any exception before re-raising to avoid unobserved-exception noise.
> - `HealthResponse` and `InfoResponse` are still decoded inline on the event loop.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7e57525.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->