### PR TITLE
Cancel failed scoring siblings

### DIFF
--- a/verifiers/v1/episode.py
+++ b/verifiers/v1/episode.py
@@ -27,6 +27,7 @@ from verifiers.v1.retries import run_with_retry
 from verifiers.v1.rollout import Phase, Rollout
 from verifiers.v1.taskset import Taskset
 from verifiers.v1.trace import Trace
+from verifiers.v1.utils.asyncio import gather_cancel_on_error
 from verifiers.v1.utils.memory import trim_memory_periodically
 
 if TYPE_CHECKING:
@@ -68,7 +69,7 @@ class Episode:
             await trim_memory_periodically()
             return trace
 
-        traces = await asyncio.gather(*(run_one(r) for r in self.rollouts))
+        traces = await gather_cancel_on_error(*(run_one(r) for r in self.rollouts))
         if group_scored:
             await self.taskset.score_group(traces)  # cross-rollout @group_rewards
             for rollout in self.rollouts:

--- a/verifiers/v1/harness.py
+++ b/verifiers/v1/harness.py
@@ -6,7 +6,6 @@ runs during rollout setup; only execution counts against the harness timeout. Th
 runtime and the interception server are owned by the Rollout.
 """
 
-import asyncio
 import logging
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
@@ -28,6 +27,7 @@ from verifiers.v1.runtimes import (
 from verifiers.v1.task import Task
 from verifiers.v1.trace import Trace
 from verifiers.v1.types import EnvId, Messages
+from verifiers.v1.utils.asyncio import gather_cancel_on_error
 
 logger = logging.getLogger(__name__)
 
@@ -151,7 +151,9 @@ class Harness(ABC, Generic[ConfigT]):
             results = (
                 [await invoke(fn, available) for fn in fns]
                 if len(fns) < 2
-                else await asyncio.gather(*(invoke(fn, available) for fn in fns))
+                else await gather_cancel_on_error(
+                    *(invoke(fn, available) for fn in fns)
+                )
             )
         for fn, result in zip(fns, results):
             if isinstance(result, Mapping):

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -46,6 +46,7 @@ from verifiers.v1.state import state_cls
 from verifiers.v1.task import Task
 from verifiers.v1.taskset import Taskset
 from verifiers.v1.trace import Trace
+from verifiers.v1.utils.asyncio import gather_cancel_on_error
 
 logger = logging.getLogger(__name__)
 
@@ -252,7 +253,7 @@ class Rollout:
                 # runtime. (Cross-rollout `@group_reward`s run later, in the Episode.) Each
                 # method types its own failures; only a timeout is attributed here.
                 await asyncio.wait_for(
-                    asyncio.gather(
+                    gather_cancel_on_error(
                         self.taskset.score(trace, runtime),
                         self.harness.score(trace, runtime),
                     ),

--- a/verifiers/v1/taskset.py
+++ b/verifiers/v1/taskset.py
@@ -15,7 +15,6 @@ For a heterogeneous taskset (different verification per task), have a single
 `@reward` branch on a typed task field.
 """
 
-import asyncio
 from collections.abc import Mapping
 from typing import ClassVar, Generic, TypeVar
 
@@ -30,6 +29,7 @@ from verifiers.v1.mcp import Toolset, User
 from verifiers.v1.state import StateT
 from verifiers.v1.task import TaskT
 from verifiers.v1.trace import Trace
+from verifiers.v1.utils.asyncio import gather_cancel_on_error
 
 
 class TasksetConfig(BaseConfig):
@@ -118,7 +118,9 @@ class Taskset(Generic[TaskT, ConfigT, StateT]):
             metric_results = (
                 [await invoke(fn, available) for fn in metrics]
                 if len(metrics) < 2
-                else await asyncio.gather(*(invoke(fn, available) for fn in metrics))
+                else await gather_cancel_on_error(
+                    *(invoke(fn, available) for fn in metrics)
+                )
             )
             for fn, result in zip(metrics, metric_results):
                 if isinstance(result, Mapping):
@@ -129,7 +131,9 @@ class Taskset(Generic[TaskT, ConfigT, StateT]):
             reward_results = (
                 [await invoke(fn, available) for fn in rewards]
                 if len(rewards) < 2
-                else await asyncio.gather(*(invoke(fn, available) for fn in rewards))
+                else await gather_cancel_on_error(
+                    *(invoke(fn, available) for fn in rewards)
+                )
             )
             for fn, result in zip(rewards, reward_results):
                 weight = getattr(fn, "_vf_weight", 1.0)
@@ -156,7 +160,9 @@ class Taskset(Generic[TaskT, ConfigT, StateT]):
             reward_results = (
                 [await invoke(fn, available) for fn in rewards]
                 if len(rewards) < 2
-                else await asyncio.gather(*(invoke(fn, available) for fn in rewards))
+                else await gather_cancel_on_error(
+                    *(invoke(fn, available) for fn in rewards)
+                )
             )
             for fn, scores in zip(rewards, reward_results):
                 weight = getattr(fn, "_vf_weight", 1.0)

--- a/verifiers/v1/utils/asyncio.py
+++ b/verifiers/v1/utils/asyncio.py
@@ -1,0 +1,21 @@
+"""Asyncio helpers shared by the v1 execution path."""
+
+import asyncio
+from collections.abc import Awaitable
+from typing import TypeVar
+
+T = TypeVar("T")
+
+
+async def gather_cancel_on_error(*awaitables: Awaitable[T]) -> list[T]:
+    """Gather in order, cancelling and draining siblings before re-raising a failure."""
+    tasks = [asyncio.ensure_future(awaitable) for awaitable in awaitables]
+    try:
+        return await asyncio.gather(*tasks)
+    except BaseException:
+        # Failed siblings can retain live traces and runtimes after gather returns.
+        # Cancel and drain them before preserving the original flat exception.
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        raise


### PR DESCRIPTION
## Overview

Cancel and drain unfinished scoring and episode fan-out siblings before propagating a failure. Successful fan-outs keep their existing ordering and concurrency, while failures retain the original flat exception instead of introducing `ExceptionGroup` semantics.

## Why

`asyncio.gather` propagates the first child failure without cancelling unfinished siblings. In scoring paths, those orphaned coroutines can keep live traces, runtimes, and verifier payloads referenced after the rollout has already started teardown.

Ordinary rollout failures remain isolated: `Rollout.run` still captures them into `Trace(error=...)`, so they do not cancel other rollouts. Episode siblings are cancelled only when an exception escapes the rollout abstraction and the episode itself is failing.

## Changes

- Add a small gather helper that cancels and drains sibling tasks, then re-raises the original exception object.
- Use it for taskset metric/reward/group-reward fan-outs, harness metrics, concurrent taskset/harness scoring, and episode rollout fan-out.
- Preserve the existing direct-await fast path for zero or one scoring hook.

## Performance

A standalone benchmark ran 300 sequential failed fan-outs with a sleeping 1 MiB sibling. Ten fresh-process runs produced these medians:

| Measurement | Previous | Current | Difference |
| --- | ---: | ---: | ---: |
| Retained RSS | 333.6 MiB | 142.3 MiB | 191.3 MiB lower (57.3%) |
| Peak RSS | 333.6 MiB | 142.3 MiB | 191.3 MiB lower (57.3%) |
| RSS growth | 307.1 MiB | 115.8 MiB | 191.3 MiB lower (62.3%) |
| Orphan tasks | 300 | 0 | 300 eliminated |
| Workload wall time | 37.4 ms | 46.1 ms | 8.7 ms slower across 300 failures |

The sleeping workload has no sibling CPU work to save, so it exposes the cleanup cost—about 29 µs per failed fan-out—rather than a time saving. The improvement is bounded resource lifetime: all 300 sibling cleanups complete before the failure returns, instead of leaving their traces and payloads alive.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core v1 concurrency on scoring and multi-rollout episodes; behavior on failure differs from stock `gather`, though successful paths and ordering should match.
> 
> **Overview**
> Adds **`gather_cancel_on_error`**, a small asyncio helper that wraps `asyncio.gather`: when one concurrent task fails, it **cancels and drains sibling tasks** before re-raising the **original** exception (no `ExceptionGroup`).
> 
> That helper replaces plain `asyncio.gather` anywhere v1 fans out concurrent scoring or episode work: **episode rollout fan-out**, **taskset + harness scoring** inside a rollout, **taskset** `@metric` / `@reward` / `@group_reward` hooks, and **harness** `@metric` hooks. The existing **direct-await** path for zero or one hook is unchanged.
> 
> The goal is to stop orphaned scoring coroutines from holding **live traces, runtimes, and verifier payloads** after a sibling has already failed and teardown has started. Per-rollout failures that stay inside `Rollout.run` (captured on the trace) are unchanged; episode-level cancellation applies when an error **escapes** the rollout boundary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d3dbf301dd3206feea5a95f71b909b346ae6c74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cancel sibling scoring tasks on failure across rollout and harness execution
> - Adds `gather_cancel_on_error` in [`verifiers/v1/utils/asyncio.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1821/files#diff-b20c9a8d9577590ba2018848fdd4eb04d458714279e9a0e598cbb5966940f1f2), a drop-in replacement for `asyncio.gather` that cancels and drains all sibling tasks when any task raises, then re-raises the original exception.
> - Replaces `asyncio.gather` with `gather_cancel_on_error` in [`episode.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1821/files#diff-ea3591865e4c7653852776e680f3abbf509a3f3a406d518c8dce528669aa0abf), [`rollout.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1821/files#diff-f886b7f4717cf8fce9270bd4ff4790f3182aa1016abb9efb7f6e57efe18d1bf2), [`harness.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1821/files#diff-05e981bb3680a934fbc6865d9dff3b25fc692d0c9970684bf8d41f4aea7ee384), and [`taskset.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1821/files#diff-7e5e561017828ff64ab186fa98a8e394675de1971f358af769aa825f7c7997c9) to apply consistent cancellation behavior across all concurrent scoring phases.
> - Result ordering on success is preserved in all call sites.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2d3dbf3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->