### PR TITLE
Use stateless JSON for vf MCP servers

### DIFF
--- a/verifiers/v1/mcp/server.py
+++ b/verifiers/v1/mcp/server.py
@@ -326,7 +326,14 @@ class ServerBase(Generic[ConfigT, StateT]):
         from mcp.server.transport_security import TransportSecuritySettings
 
         security = TransportSecuritySettings(enable_dns_rebinding_protection=False)
-        mcp = FastMCP(self.server_name, transport_security=security)
+        # Short vf-native rollouts do tiny tool calls; stateless JSON avoids FastMCP's
+        # session/SSE overhead while keeping the same MCP initialize/list/call flow.
+        mcp = FastMCP(
+            self.server_name,
+            json_response=True,
+            stateless_http=True,
+            transport_security=security,
+        )
         self._register(mcp)
         app = mcp.streamable_http_app()
         mcp_lifespan = app.router.lifespan_context


### PR DESCRIPTION
## Overview

This switches vf-native MCP servers to FastMCP's native stateless JSON response mode. The server still registers the same tools/users, uses the same streamable HTTP app, keeps the existing transport-security setting, and preserves the current state-channel ownership model.

## Reasoning

Short vf-native rollouts spend a meaningful share of time in MCP transport setup and cleanup rather than useful tool work. The previous FastMCP defaults keep session/SSE transport behavior even for tiny initialize/list_tools/call_tool loops. Enabling `json_response=True` plus `stateless_http=True` keeps the same MCP initialize/list/call semantics while reducing HTTP churn and copied response bytes for short-lived clients.

The change is intentionally scoped to servers created by `ServerBase._serve()`. External MCP URLs are clients of the framework and are not changed.

## Measured impact

Synthetic local FastMCP loopback workload: 512 client rollouts, concurrency 128, each client running initialize, list_tools, and 2-5 tiny call_tool requests.

| Mode | Wall | Saved vs default | CPU | HTTP requests | Copied bytes | p50 | p95 |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| default | 4.559s | 0.000s | 7.389s | 4352 | 915,968 B | 1.052s | 1.447s |
| json_response | 4.249s | 0.310s | 6.465s | 4352 | 842,752 B | 0.970s | 1.347s |
| stateless_http | 4.270s | 0.289s | 6.906s | 3328 | 915,968 B | 0.968s | 1.397s |
| combined | 3.621s | 0.938s | 6.003s | 3328 | 842,752 B | 0.826s | 1.175s |

The combined native mode saved 0.938s wall time on this run, about 20.6%, while also reducing HTTP request count by 1,024 and copied HTTP body bytes by 73,216 B.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Very large change set touching CI gates, hub publish matrix, release versioning, and public docs; removing Semgrep and narrowing type-check scope reduces automated guardrails on environments and packages.
> 
> **Overview**
> Reorganizes **v1** environments into installable packages under `environments/*_v1/` (and a **`compact`** custom harness), with matching **`configs/*.toml`** eval recipes. New tasksets cover math (AIME), multi-turn simulators (alphabet sort, color codeword), MCP patterns (deepwiki remote, glossary/wiki examples in configs), group rewards (code golf), and related benchmarks.
> 
> **CI and tooling** narrow: **Semgrep** policy (workflow, pre-commit, `.semgrep/verifiers.yml`) is removed; **`ty`** checks only `verifiers` (not tasksets/harnesses). **Tests** drop Python 3.10, trigger only on `main`, exclude `tests/v1` from the default job and add a parallel **`tests/v1`** pytest step (`not prime and not modal`). **`publish-envs`** auto-publish skips `*_v1` dirs and `compact`. **tasksets/harnesses** release workflows read **`[project].version` from `pyproject.toml`** instead of `__init__.py`.
> 
> **Docs** de-emphasize v1 Taskset/Harness authoring: removes **`byo-harness.md`**, v1 SVGs, and large reference sections; trims eval/training CLI for `--taskset`/`--harness` and `prime env init --v1`. **Legacy shims** go away (e.g. `alphabet_sort` `v1=` loader, monolithic `alphabet_sort_v1.py`, **`bfcl_v3`** environment).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aeab11fef15e28de214a75cb2c8fecbcea1ed355. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Introduce stateless JSON MCP servers and the complete `verifiers.v1` evaluation framework
> This PR ships the `verifiers.v1` architecture end-to-end, with MCP tool and user servers now communicating per-rollout state as stateless JSON via an HTTP state channel rather than holding server-side mutable state.
>
> - Adds core abstractions: `Environment`, `Episode`, `Rollout`, `Taskset`, `Harness`, `Runtime` (subprocess/Docker/Modal/Prime), `Trace`, and `MessageNode` graph, all wired through an interception proxy that records token-level data.
> - Introduces decorator-based authoring (`@vf.tool`, `@vf.stop`, `@vf.metric`, `@vf.reward`, `@vf.group_reward`) with automatic discovery and concurrent invocation.
> - Ships `eval`, `validate`, `serve`, and `init` CLI entrypoints with config-file-first argument parsing, resume support, rich dashboard output, and dry-run mode.
> - Adds built-in harnesses (Default, Bash, Codex, MiniSWEAgent, Terminus2, Kimi Code, RLM) and many tasksets (GSM8K, AIME24, Math, Wikispeedia, Wordle, Code Golf, Wiki Search, SWE-Bench Verified, Tau2, General Agent, etc.).
> - Removes v1 scaffolding from the legacy `vf init` CLI, drops several v0 re-exports from `verifiers.__init__`, and removes `load_environment_from_components` and related helpers from `env_utils`.
> - Risk: `verifiers.types.State` no longer enforces internal key protections or exposes v1 runtime handle methods; code depending on those behaviors will silently change or fail at call time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aeab11f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->