### PR TITLE
Skip empty base State synchronization

### DIFF
--- a/verifiers/v1/mcp/server.py
+++ b/verifiers/v1/mcp/server.py
@@ -262,15 +262,18 @@ class ServerBase(Generic[ConfigT, StateT]):
 
         @functools.wraps(fn)
         async def wrapper(*args, **kwargs):
-            state = await self._pull_state()
+            # Base State has no fields and rejects extras, so only subclasses need channel sync.
+            sync_state = self._state_cls is not State
+            state = await self._pull_state() if sync_state else State()
             token = _call_state.set(state)
             try:
                 # Reuse the second serialization as the PUT body when the callback mutates state.
-                before = self._state_adapter.dump_json(state)
+                before = self._state_adapter.dump_json(state) if sync_state else None
                 result = fn(*args, **kwargs)
                 if inspect.isawaitable(result):
                     result = await result
-                await self._push_state(before)
+                if before is not None:
+                    await self._push_state(before)
                 return result
             finally:
                 _call_state.reset(token)


### PR DESCRIPTION
## Overview

Skip state-channel synchronization when an MCP tool or user server uses the exact base `State` type. Calls still receive a fresh context-local `State`; typed `State` subclasses retain the existing pull, snapshot, and change-only push path.

## Reasoning

Base `State` has no fields and rejects extras, so pulling it cannot introduce rollout data and pushing it cannot persist a mutation. The previous path still paid for a state-channel GET and two model dumps on every tool or `respond` call. Selecting the state once at the wrapper boundary removes that work without duplicating callable execution or weakening per-call isolation.

The exact-type check is deliberate: subclasses may carry mutable rollout state and continue synchronizing exactly as before. Context reset remains in the existing `finally` block, including exceptions and cancellation.

## Performance

Real streamable-HTTP MCP on the nano-v1 branch at `15359acd`, one shared server, concurrency 128.

| Workload | Wall before | Wall after | Saved | CPU before/after | RSS before/after | State GETs |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| 128 rollouts x 2 calls | 1.776 s | 1.447 s | 0.329 s (18.5%) | 1.606 -> 1.323 s | 222.4 -> 222.8 MB | 256 -> 0 |
| 128 rollouts x 4 calls | 3.765 s | 2.028 s | 1.737 s (46.1%) | 3.101 -> 1.843 s | 356.6 -> 352.6 MB | 512 -> 0 |
| 512 rollouts x 2 calls | 7.527 s | 5.339 s | 2.188 s (29.1%) | 7.217 -> 5.193 s | 316.3 -> 310.6 MB | 1024 -> 0 |
| 512 rollouts x 4 calls | 9.675 s | 7.744 s | 1.931 s (20.0%) | 9.299 -> 7.584 s | 346.2 -> 348.9 MB | 2048 -> 0 |

An independent 128-rollout x 4-call run measured 2.511 s -> 2.013 s wall time (19.8%), tool-call p50 40.79 -> 22.63 ms, and p95 92.64 -> 58.96 ms.

The change removes one state-channel GET per base-`State` call and avoids both state snapshots. No PUTs are expected in either path because base `State` cannot change.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip state channel GET/PUT in `ServerBase._with_state` when using the base `State` class
> When a server is parametrized with the base `State` type, there is no meaningful state to sync, so the channel round-trips are unnecessary overhead. `_with_state` now checks if `self._state_cls is State` and, when true, skips `_pull_state()`, snapshot serialization, and `_push_state()`, instead passing a fresh ephemeral `State()` to the wrapped tool or respond call.
>
> Behavioral Change: servers using the base `State` class no longer read from or write to the state channel on every tool invocation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8532e84.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized optimization in `_with_state`; behavior for custom `State` subclasses is unchanged, and base `State` could not persist mutations anyway.
> 
> **Overview**
> **`_with_state`** now detects when the server uses the exact base **`State`** type (`self._state_cls is not State`) and skips the state-channel **GET**, JSON snapshot, and conditional **PUT** on each tool/`respond` call. Those calls still bind a fresh context-local **`State()`** and reset the contextvar in **`finally`**, so per-call isolation is unchanged.
> 
> **`State` subclasses** keep the existing pull → run → change-only push path, so rollout-shared mutable state still synchronizes across servers as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8532e8420d7522668e1e33ee3ebd0e7e3d71a403. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->