### PR TITLE
fix: carry v0 truncation flag through legacy bridge + declare compact's verifiers dep

### DIFF
--- a/environments/compact/pyproject.toml
+++ b/environments/compact/pyproject.toml
@@ -3,7 +3,7 @@ name = "compact"
 version = "0.1.0"
 description = "compact — a context-rewrite harness for v1 (branches every turn)."
 requires-python = ">=3.10"
-dependencies = []
+dependencies = ["verifiers"]
 
 [build-system]
 requires = ["hatchling"]

--- a/verifiers/v1/legacy.py
+++ b/verifiers/v1/legacy.py
@@ -185,13 +185,35 @@ def _timing(raw: Any) -> Timing:
     )
 
 
+# v0 records truncation in a dedicated ``is_truncated`` flag and names stop conditions after the
+# env's stop functions; v1 has no such flag and derives ``Trace.is_truncated`` from the stop name
+# (plus the final turn's ``finish_reason``). Translate the v0 stop names that mean truncation into
+# the v1 vocabulary so the derived flag survives the bridge.
+_V0_TO_V1_TRUNCATION_STOP = {
+    "max_turns_reached": "max_turns",
+    "prompt_too_long": "context_length",
+    "timeout_reached": "harness_timeout",
+    "max_total_completion_tokens_reached": "max_output_tokens",
+}
+
+
+def _v1_stop_condition(out: dict) -> str | None:
+    """The v1 stop condition for a v0 rollout. When v0 flagged the rollout truncated, return a
+    name in v1's truncation vocabulary so ``Trace.is_truncated`` derives ``True`` — mapping the
+    known v0 stop names and falling back to ``max_output_tokens`` for the rest. An untruncated
+    rollout keeps its v0 stop condition unchanged."""
+    stop = out.get("stop_condition")
+    if not out.get("is_truncated"):
+        return stop
+    return _V0_TO_V1_TRUNCATION_STOP.get(stop, "max_output_tokens")
+
+
 def rollout_output_to_trace(out: dict, task_idx: int) -> Trace:
     """Map a v0 ``RolloutOutput`` into a v1 ``Trace``, preserving the meta a native v1
     trace carries: per-turn prompt messages, the response message (content / reasoning /
     tool calls), ``finish_reason`` and ``usage``, the token ids/logprobs, and the task's
-    system prompt / prompt / answer. The v0 ``is_truncated`` flag is carried over explicitly
-    (as ``truncated``) since v0 stop names don't map onto the v1 vocabulary that
-    ``Trace.is_truncated`` otherwise derives truncation from."""
+    system prompt / prompt / answer. A truncated v0 rollout is mapped to a v1 truncation
+    stop condition (see ``_v1_stop_condition``) so ``Trace.is_truncated`` derives ``True``."""
     model = str(out.get("model") or "")
 
     error = None
@@ -211,8 +233,7 @@ def rollout_output_to_trace(out: dict, task_idx: int) -> Trace:
         rewards={"reward": float(out.get("reward") or 0.0)},
         metrics={k: float(v) for k, v in (out.get("metrics") or {}).items()},
         is_completed=bool(out.get("is_completed", True)),
-        stop_condition=out.get("stop_condition"),
-        truncated=bool(out.get("is_truncated", False)),
+        stop_condition=_v1_stop_condition(out),
         errors=[error] if error else [],
         timing=_timing(out.get("timing")),
     )

--- a/verifiers/v1/legacy.py
+++ b/verifiers/v1/legacy.py
@@ -189,8 +189,9 @@ def rollout_output_to_trace(out: dict, task_idx: int) -> Trace:
     """Map a v0 ``RolloutOutput`` into a v1 ``Trace``, preserving the meta a native v1
     trace carries: per-turn prompt messages, the response message (content / reasoning /
     tool calls), ``finish_reason`` and ``usage``, the token ids/logprobs, and the task's
-    system prompt / prompt / answer. ``is_truncated`` is a computed v1 field derived
-    from the final turn's ``finish_reason`` and the stop condition."""
+    system prompt / prompt / answer. The v0 ``is_truncated`` flag is carried over explicitly
+    (as ``truncated``) since v0 stop names don't map onto the v1 vocabulary that
+    ``Trace.is_truncated`` otherwise derives truncation from."""
     model = str(out.get("model") or "")
 
     error = None
@@ -211,6 +212,7 @@ def rollout_output_to_trace(out: dict, task_idx: int) -> Trace:
         metrics={k: float(v) for k, v in (out.get("metrics") or {}).items()},
         is_completed=bool(out.get("is_completed", True)),
         stop_condition=out.get("stop_condition"),
+        truncated=bool(out.get("is_truncated", False)),
         errors=[error] if error else [],
         timing=_timing(out.get("timing")),
     )

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -219,6 +219,11 @@ class Trace(StrictBaseModel, Generic[TaskT, StateT]):
 
     is_completed: bool = False
     stop_condition: str | None = None
+    truncated: bool | None = None
+    """Authoritative truncation flag when the derivation can't be trusted. Native v1 leaves
+    this `None` and `is_truncated` is derived from `stop_condition` + the final turn's
+    `finish_reason`; the v0→v1 bridge sets it from the v0 rollout's own flag, whose stop names
+    don't map onto v1's vocabulary."""
     errors: list[Error] = Field(default_factory=list)
     """Every error captured across attempts, oldest first (more than one only when the
     rollout was retried). `error` exposes the most recent."""
@@ -308,7 +313,10 @@ class Trace(StrictBaseModel, Generic[TaskT, StateT]):
         own terms: the framework halted it (`max_turns`, a token budget, or
         `harness_timeout`), the prompt outgrew the model's context window
         (`context_length`), or the final turn hit the token cap (`finish_reason ==
-        "length"`)."""
+        "length"`). An explicit `truncated` flag (set by the v0→v1 bridge) takes
+        precedence over the derivation."""
+        if self.truncated is not None:
+            return self.truncated
         if self.stop_condition in (
             "max_turns",
             "max_input_tokens",

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -219,11 +219,6 @@ class Trace(StrictBaseModel, Generic[TaskT, StateT]):
 
     is_completed: bool = False
     stop_condition: str | None = None
-    truncated: bool | None = None
-    """Authoritative truncation flag when the derivation can't be trusted. Native v1 leaves
-    this `None` and `is_truncated` is derived from `stop_condition` + the final turn's
-    `finish_reason`; the v0→v1 bridge sets it from the v0 rollout's own flag, whose stop names
-    don't map onto v1's vocabulary."""
     errors: list[Error] = Field(default_factory=list)
     """Every error captured across attempts, oldest first (more than one only when the
     rollout was retried). `error` exposes the most recent."""
@@ -313,10 +308,7 @@ class Trace(StrictBaseModel, Generic[TaskT, StateT]):
         own terms: the framework halted it (`max_turns`, a token budget, or
         `harness_timeout`), the prompt outgrew the model's context window
         (`context_length`), or the final turn hit the token cap (`finish_reason ==
-        "length"`). An explicit `truncated` flag (set by the v0→v1 bridge) takes
-        precedence over the derivation."""
-        if self.truncated is not None:
-            return self.truncated
+        "length"`)."""
         if self.stop_condition in (
             "max_turns",
             "max_input_tokens",


### PR DESCRIPTION
## Summary

Two fixes to the v1 surface, both from review of the nano-as-v1 branch:

- **`compact` package missing `verifiers` dependency.** `environments/compact/compact/harness.py` imports `verifiers.v1`, but the package declared `dependencies = []`. Installing or publishing the harness wheel on its own would fail at import time. Now declares `dependencies = ["verifiers"]`, matching the other v1 environment packages.

- **Legacy v0→v1 bridge dropped truncation.** `rollout_output_to_trace` copied `stop_condition` from the v0 `RolloutOutput` but never accounted for v0's `is_truncated` flag. `Trace.is_truncated` is a *derived* property keyed off the *v1* stop-condition vocabulary (`max_turns`, `context_length`, …) plus the final turn's `finish_reason`. v0 stop names (`max_turns_reached`, `prompt_too_long`, …) don't map onto that vocabulary, so legacy traces derived `is_truncated=False` even when the v0 rollout was truncated — undercounting truncation in eval/training metrics.

  Rather than store a flag on `Trace` (kept purely derived), the bridge now translates a truncated v0 rollout's stop name into v1's vocabulary so the property derives `True`:

  | v0 stop condition | v1 stop condition |
  |---|---|
  | `max_turns_reached` | `max_turns` |
  | `prompt_too_long` | `context_length` |
  | `timeout_reached` | `harness_timeout` |
  | `max_total_completion_tokens_reached` | `max_output_tokens` |
  | *(any other, when v0 `is_truncated`)* | `max_output_tokens` (fallback) |

  An untruncated v0 rollout keeps its original `stop_condition` unchanged, so `is_truncated` still derives `False` (faithful to v0, including the v0 quirk where hitting `max_turns` with all-normal turns isn't flagged truncated).

## Verification

Mapped a v0 rollout truncated via max-turns (v0 name `max_turns_reached`, not in v1's set) whose final turn ended normally (`finish_reason="stop"`):

| | `trace.is_truncated` |
|---|---|
| before | `False` (wrong) |
| after | `True` |

Also checked: `prompt_too_long`/custom truncated stops derive `True`; the value survives the env-server wire path (`model_dump()` → `WireTrace.model_validate()`); untruncated rollouts (incl. non-truncated `max_turns_reached`) still derive `False`; `Trace` gains no new field. `tests/v1/test_trace.py` passes.

## Note for prime-rl

prime-rl's `generation_truncated` metric excludes the v0 name (`stop_condition != "prompt_too_long"`). With this change a prompt-overflow legacy truncation surfaces as `context_length` (matching native v1, which already emits `context_length`), so that exclusion should be updated to key off `context_length` to keep excluding prompt-overflow from generation truncation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging fix plus localized legacy mapping logic; no new Trace fields or auth/data paths.
> 
> **Overview**
> **`compact`** now lists **`verifiers`** in `pyproject.toml` so the harness can import `verifiers.v1` when the wheel is installed on its own.
> 
> The v0→v1 **`rollout_output_to_trace`** path no longer copies `stop_condition` blindly. When v0 sets **`is_truncated`**, **`_v1_stop_condition`** rewrites known v0 stop names (`max_turns_reached`, `prompt_too_long`, etc.) into v1’s truncation vocabulary so **`Trace.is_truncated`** (derived from stop name + final `finish_reason`) is **`True`**. Untruncated rollouts keep the original stop string unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73bae9e1c90cf5aa088f1c16f9fe8388adeed800. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix v0 truncation stop condition mapping in legacy bridge and declare `verifiers` dependency for compact
> - In [`verifiers/v1/legacy.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1824/files#diff-96c5091f7d2968ddfbe984f433163f21cab745ea95174158e924984d55abbfed), `rollout_output_to_trace` now maps v0 truncation stop names (e.g. `max_turns_reached`, `prompt_too_long`) to their v1 equivalents via a new `_v1_stop_condition` helper, falling back to `max_output_tokens` for unknown stops. Untruncated rollouts keep their original stop condition.
> - In [`environments/compact/pyproject.toml`](https://github.com/PrimeIntellect-ai/verifiers/pull/1824/files#diff-c478b99806d59bec08ecd3678007813a1f0268cd1ce9bb9097fcd17cb80e105f), adds `verifiers` as an explicit runtime dependency for the compact environment package.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 73bae9e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->