### PR TITLE
Support external v1 harness plugins

### DIFF
--- a/tests/v1/fixtures/external_harness_v1.py
+++ b/tests/v1/fixtures/external_harness_v1.py
@@ -1,0 +1,17 @@
+"""Fixture external harness package for loader regression tests."""
+
+import verifiers.v1 as vf
+
+
+class ExternalHarnessConfig(vf.HarnessConfig):
+    custom_flag: bool = False
+
+
+class ExternalHarness(vf.Harness[ExternalHarnessConfig]):
+    SUPPORTS_MCP = False
+
+    async def launch(self, ctx, trace, runtime, endpoint, secret, mcp_urls):
+        return vf.ProgramResult(exit_code=0, stdout="", stderr="")
+
+
+__all__ = ["ExternalHarness"]

--- a/tests/v1/test_loaders.py
+++ b/tests/v1/test_loaders.py
@@ -1,0 +1,72 @@
+import sys
+from unittest.mock import AsyncMock
+
+import pytest
+
+from verifiers.v1.configs.eval import EvalConfig
+from verifiers.v1.loaders import harness_class, harness_config_type, import_harness
+from verifiers.v1.runtimes.prime import PrimeConfig, PrimeRuntime
+
+
+def test_external_hyphenated_harness_id_loads_from_flat_module(monkeypatch):
+    monkeypatch.setitem(sys.modules, "verifiers.v1.harnesses.external_harness_v1", None)
+
+    module = import_harness("external-harness-v1")
+
+    assert module.__name__ == "external_harness_v1"
+    assert harness_class("external-harness-v1").__name__ == "ExternalHarness"
+    config_type = harness_config_type("external-harness-v1")
+    assert config_type.__name__ == "ExternalHarnessConfig"
+    assert (
+        config_type.model_validate(
+            {"id": "external-harness-v1", "custom_flag": True}
+        ).custom_flag
+        is True
+    )
+
+
+def test_external_harness_config_fields_are_forwarded_from_eval_config():
+    config = EvalConfig.model_validate(
+        {
+            "taskset": {"id": "echo-v1"},
+            "harness": {"id": "external-harness-v1", "custom_flag": True},
+        }
+    )
+
+    assert type(config.harness).__name__ == "ExternalHarnessConfig"
+    assert config.harness.id == "external-harness-v1"
+    assert config.harness.custom_flag is True
+
+
+def test_external_harness_internal_import_errors_are_not_hidden(tmp_path, monkeypatch):
+    (tmp_path / "broken_harness_v1.py").write_text(
+        "import missing_dependency_for_loader_test\n"
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    with pytest.raises(ModuleNotFoundError) as exc_info:
+        harness_class("broken-harness-v1")
+
+    assert exc_info.value.name == "missing_dependency_for_loader_test"
+
+
+def test_prime_runtime_preserves_explicit_labels_exactly():
+    config = PrimeConfig(labels=["programbench"])
+
+    assert config.labels == ["programbench"]
+
+
+@pytest.mark.asyncio
+async def test_prime_runtime_poll_fallback_accepts_running_status():
+    class Sandbox:
+        status = "RUNNING"
+
+    runtime = PrimeRuntime(PrimeConfig())
+    runtime._sandbox_id = "sandbox-id"
+    runtime._client = AsyncMock()
+    runtime._client.wait_for_creation.side_effect = TimeoutError("timed out")
+    runtime._client.get.return_value = Sandbox()
+
+    await runtime._wait_until_running()
+
+    runtime._client.get.assert_awaited_once_with("sandbox-id")

--- a/verifiers/v1/ARCHITECTURE.md
+++ b/verifiers/v1/ARCHITECTURE.md
@@ -241,3 +241,9 @@ find that single subclass, and instantiate it, while `narrow_plugin_field` valid
 config dict into the plugin's concrete config type (read off the class's `Taskset[TaskT,
 ConfigT]` / `Harness[ConfigT]` generic) — so the typed CLI/TOML surfaces each plugin's own
 fields without the core knowing them ahead of time.
+
+Built-in plugins live under `verifiers.v1.tasksets` and `verifiers.v1.harnesses`, but external
+packages do not need to use those namespaces. A private package can expose a flat module whose
+normalized name matches its id (`prime-agent-headless-v1` → `prime_agent_headless_v1`) and the
+loader will import it directly after the namespaced lookup misses. This lets research teams share
+private harness packages without moving private implementation code into public Verifiers.

--- a/verifiers/v1/loaders.py
+++ b/verifiers/v1/loaders.py
@@ -48,6 +48,19 @@ def narrow_plugin_field(
         data[field] = resolve(ident).model_validate({**raw, "id": ident})
 
 
+def _has_module(import_name: str) -> bool:
+    """Whether `import_name` can be imported without importing it.
+
+    `find_spec("verifiers.v1.harnesses.foo")` can raise `ModuleNotFoundError` when a
+    parent package is absent in a lean install. Treat that as a missing candidate so private
+    flat plugin packages can still be imported by normalized module name.
+    """
+    try:
+        return importlib.util.find_spec(import_name) is not None
+    except ModuleNotFoundError:
+        return False
+
+
 def _import_plugin(plugin_id: str, kind: str, group: str) -> ModuleType:
     """Import a plugin by id. A built-in id resolves to its namespaced module under the
     `group` package (`verifiers.v1.harnesses` / `verifiers.v1.tasksets`); a hub
@@ -55,16 +68,23 @@ def _import_plugin(plugin_id: str, kind: str, group: str) -> ModuleType:
     (hyphens → underscores)."""
     module = ensure_installed(plugin_id)
     namespaced = f"{group}.{module}"
-    target = namespaced if importlib.util.find_spec(namespaced) else module
-    try:
-        return importlib.import_module(target)
-    except ModuleNotFoundError as e:
-        raise ModuleNotFoundError(
-            f"{kind} {plugin_id!r} not found (tried to import {target!r}). A {kind} is a "
-            f"package exporting its {kind.capitalize()} subclass via `__all__` — the built-in "
-            f"ones ship with verifiers in the `{group}` package, installed from "
-            f"the Environments Hub (`org/name`), or authored yourself."
-        ) from e
+    targets = [namespaced] if _has_module(namespaced) else [module]
+    if module not in targets:
+        targets.append(module)
+    for target in targets:
+        try:
+            return importlib.import_module(target)
+        except ModuleNotFoundError as e:
+            if e.name != target:
+                raise
+    tried = ", ".join(repr(target) for target in targets)
+    raise ModuleNotFoundError(
+        f"{kind} {plugin_id!r} not found (normalized module {module!r}; tried imports: "
+        f"{tried}). A {kind} is a package exporting its {kind.capitalize()} subclass via "
+        f"`__all__` — the built-in ones ship with verifiers in the `{group}` package, "
+        f"installed from the Environments Hub (`org/name`), installed from a private package "
+        f"(for example with `uv --with '<package> @ git+ssh://...'`), or authored yourself."
+    )
 
 
 def _plugin_class(module: ModuleType, base: type, kind: str) -> type:

--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -72,6 +72,42 @@ class PrimeRuntime(Runtime):
     def published_port(self) -> int | None:
         return SERVICE_PORT
 
+    async def _wait_until_running(self) -> None:
+        assert self._client is not None
+        assert self._sandbox_id is not None
+        try:
+            await self._client.wait_for_creation(self._sandbox_id)
+            return
+        except Exception as wait_error:
+            logger.warning(
+                "prime: wait_for_creation failed for sandbox %s; polling status: %s",
+                self._sandbox_id,
+                wait_error,
+            )
+            delay = 1.0
+            deadline = asyncio.get_running_loop().time() + 180
+            last_status = "unknown"
+            while asyncio.get_running_loop().time() < deadline:
+                with contextlib.suppress(Exception):
+                    sandbox = await self._client.get(self._sandbox_id)
+                    last_status = sandbox.status
+                    if sandbox.status == "RUNNING":
+                        logger.info(
+                            "prime: sandbox %s reported RUNNING after wait fallback",
+                            self._sandbox_id,
+                        )
+                        return
+                    if sandbox.status in {"FAILED", "TERMINATED", "ERROR"}:
+                        break
+                sleep_for = min(delay, deadline - asyncio.get_running_loop().time())
+                if sleep_for > 0:
+                    await asyncio.sleep(sleep_for)
+                delay = min(delay * 1.2, 5.0)
+            raise SandboxError(
+                f"prime sandbox {self._sandbox_id} did not reach RUNNING after "
+                f"wait_for_creation failed (last status={last_status!r})"
+            ) from wait_error
+
     async def start(self) -> None:
         from prime_sandboxes import AsyncSandboxClient, CreateSandboxRequest
 
@@ -107,7 +143,7 @@ class PrimeRuntime(Runtime):
                     )
                 )
             self._sandbox_id = sandbox.id
-            await self._client.wait_for_creation(self._sandbox_id)
+            await self._wait_until_running()
             logger.info(
                 "prime: sandbox %s up (image=%s)", self._sandbox_id, self.config.image
             )


### PR DESCRIPTION
## Summary

Adds generic v1 support for external harness packages without vendoring their implementation into public Verifiers.

- allows flat external plugin modules to be selected by normalized id
- preserves internal plugin import errors instead of masking missing dependencies as missing plugins
- adds a Prime runtime wait fallback that polls `get()` if `wait_for_creation()` times out and continues when the sandbox is actually `RUNNING`
- documents the generic external plugin contract in architecture docs
- adds regression tests for external harness loading, custom config forwarding, exact label preservation, and the Prime wait fallback

This lets research teams install private harness packages alongside Verifiers while keeping harness source in private repositories.

## Testing

```bash
uv run --isolated --no-project   --with-editable .   --with pytest   --with pytest-asyncio   --with renderers==0.1.8.dev43   python -m pytest tests/v1/test_loaders.py
```

```bash
uv run --isolated --no-project --with ruff ruff check   verifiers/v1/ARCHITECTURE.md   verifiers/v1/loaders.py   verifiers/v1/runtimes/prime.py   tests/v1/fixtures/external_harness_v1.py   tests/v1/test_loaders.py
```

```bash
git diff --check
```
