### PR TITLE
feat(v1/runtimes): Modal sandbox snapshot save + per-task resume

### DIFF
--- a/verifiers/v1/env.py
+++ b/verifiers/v1/env.py
@@ -283,6 +283,12 @@ class Environment:
             max_total_tokens=config.max_total_tokens,
         )
         self._warned_resources: set[tuple[str, str]] = set()
+        self._snapshot_refs: dict[int, str] = {}
+        """Per-task (`task.idx`) snapshot refs from snapshot-capable runtimes that opted in
+        (`runtime.enable_snapshot`): a finished rollout stores its end-state ref here, and the
+        next rollout of that task resumes from it (injected as `resume_from` in `episode`).
+        In-process only — it lives with this Environment, so it does not survive a restart or
+        reach other workers; concurrent rollouts of one task race to be the stored ref."""
         self._shared_urls: dict[str, str] = {}
         self._interception: InterceptionPool | None = None
         """Eval-level serving resources, live only inside `serving()`: shared tool servers
@@ -310,6 +316,15 @@ class Environment:
                 f"need >=2; got n={n} (pass -r/--num-rollouts >= 2)"
             )
         runtime_config = self.runtime_for(task)
+        # Snapshot/resume (opt-in via the runtime's `enable_snapshot`): if a prior rollout of
+        # this task stored an end-state ref, resume from it; and let this task's rollouts store
+        # their own. Keyed off the config field so non-snapshot runtimes are untouched.
+        snapshot_enabled = getattr(runtime_config, "enable_snapshot", False)
+        if snapshot_enabled and task.idx in self._snapshot_refs:
+            runtime_config = runtime_config.model_copy(
+                update={"resume_from": self._snapshot_refs[task.idx]}
+            )
+        snapshot_sink = self._snapshot_refs.__setitem__ if snapshot_enabled else None
         setup_timeout = (
             self.setup_timeout if self.setup_timeout is not None else task.timeout.setup
         )
@@ -356,6 +371,7 @@ class Environment:
                 limits=self.limits,
                 shared_urls=self._shared_urls,
                 interception=self._interception,
+                snapshot_sink=snapshot_sink,
             )
             for _ in range(n)
         ]

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -15,6 +15,7 @@ even if `run()` crashes.
 import asyncio
 import logging
 import time
+from collections.abc import Callable
 from contextlib import asynccontextmanager
 from enum import StrEnum
 
@@ -76,6 +77,7 @@ class Rollout:
         limits: RolloutLimits | None = None,
         shared_urls: dict[str, str] | None = None,
         interception: InterceptionPool | None = None,
+        snapshot_sink: Callable[[int, str], None] | None = None,
     ) -> None:
         self.task = task
         self.taskset = taskset
@@ -93,6 +95,10 @@ class Rollout:
         `Environment.serving` context — so a rollout always has them and no runner has to thread
         them in."""
         self.interception = interception
+        self.snapshot_sink = snapshot_sink
+        """When set, snapshot the runtime's end state on teardown and report `(task.idx, ref)`
+        here (the Environment's per-task snapshot store) so a later rollout of the same task
+        can resume from it. None disables it; only set for snapshot-capable runtimes."""
         self.phase = Phase.SETUP
         """Lifecycle phase for display (see `Phase`); advanced through the rollout, and
         set to DONE by the Episode once group scoring has run."""
@@ -277,6 +283,17 @@ class Rollout:
                 trace.timing.generation.end = now  # error mid-run: close generation
             if trace.timing.finalize.start and not trace.timing.finalize.end:
                 trace.timing.finalize.end = now  # error mid-finalize: close finalize
+            # Snapshot the end state before teardown (while the sandbox is still live), so a
+            # later rollout of the same task can resume from it. Best-effort: a snapshot
+            # failure must not fail the rollout or block teardown of the costly runtime.
+            if self.snapshot_sink is not None and runtime.supports_snapshot:
+                try:
+                    ref = await runtime.snapshot()
+                    self.snapshot_sink(self.task.idx, ref)
+                except Exception:
+                    logger.warning(
+                        "runtime snapshot failed (rollout %s)", trace.id, exc_info=True
+                    )
             # Tear down here — group rewards (later) need only the trace, not a live
             # runtime. `runtime` is always set: make_runtime() ran before the `try`.
             try:

--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -107,6 +107,11 @@ class Runtime(ABC):
     subprocess / docker(--network host); remote runtimes (modal/prime) override to False (they
     need a tunnel each way: `host_endpoint` inward, `expose` outward)."""
 
+    supports_snapshot: ClassVar[bool] = False
+    """Whether this runtime can `snapshot()` its live state into a ref that a later runtime of
+    the same type restores from. False for runtimes with no provider snapshot primitive
+    (subprocess / docker / prime); a snapshot-capable runtime (modal) overrides to True."""
+
     def __init__(self, name: str | None = None) -> None:
         self.name = name or f"vf-{uuid.uuid4().hex[:12]}"
         """Resource name — the subprocess workdir, docker `--name`, prime sandbox name.
@@ -145,6 +150,14 @@ class Runtime(ABC):
         """Synchronously free the provisioned resource — best-effort and idempotent. The
         source of truth for teardown: usable from the atexit backstop where async machinery
         is dead, and run off the event loop by `stop` on the normal path. Default no-op."""
+
+    async def snapshot(self) -> str:
+        """Capture the runtime's current state and return an opaque ref string that a later
+        runtime of the same type restores from (how the ref is fed back into provisioning is
+        per-runtime — e.g. a `resume_from` config field). Only snapshot-capable runtimes
+        (`supports_snapshot`) override; the default refuses so a misconfigured resume fails
+        loudly instead of silently discarding state."""
+        raise NotImplementedError(f"{type(self).__name__} does not support snapshot")
 
     # --- execution ---
 

--- a/verifiers/v1/runtimes/modal.py
+++ b/verifiers/v1/runtimes/modal.py
@@ -48,12 +48,21 @@ class ModalConfig(BaseConfig):
     creates_per_sec: float | None = 40.0
     """Pace sandbox creation to this many per second, enforced host-wide across every
     env-server worker process (None/<= 0 disables it)."""
+    enable_snapshot: bool = False
+    """Provision the sandbox so its live state (memory + filesystem) can be captured by
+    `snapshot()`. Opt-in: Modal's memory snapshots are experimental, expire after 7 days,
+    and pin the sandbox to one instance type, so a normal rollout shouldn't pay for it."""
+    resume_from: str | None = None
+    """A snapshot id from a prior `snapshot()` to restore instead of provisioning fresh: the
+    new sandbox is an exact clone of the snapshotted one (process state, packages, workdir).
+    None provisions a clean sandbox from `image`."""
 
 
 class ModalRuntime(Runtime):
     """Runs the program in a Modal sandbox; the server is reached via a tunnel."""
 
     is_local: ClassVar[bool] = False
+    supports_snapshot: ClassVar[bool] = True
 
     def __init__(self, config: ModalConfig, name: str | None = None) -> None:
         super().__init__(name)
@@ -83,26 +92,44 @@ class ModalRuntime(Runtime):
                 creation_limiter(self.config.creates_per_sec, "modal-sandbox")
                 or contextlib.nullcontext()
             ):
-                self._sandbox = await modal.Sandbox.create.aio(
-                    "sleep",
-                    "infinity",  # keep-alive entrypoint; the harness runs via `exec`
-                    app=app,
-                    name=self.name,
-                    image=modal.Image.from_registry(self.config.image),
-                    workdir=self.config.workdir,
-                    cpu=self.config.cpu,
-                    memory=int(self.config.memory * 1024),  # Modal memory is MB
-                    gpu=self.config.gpu,
-                    region=self.config.region,
-                    block_network=not self.config.network_access,
-                    timeout=24 * 60 * 60,  # Maximum lifetime of any sandbox.
-                    encrypted_ports=[SERVICE_PORT],
-                )
+                if self.config.resume_from is not None:
+                    # Restore an exact clone (memory + filesystem) of a sandbox a prior
+                    # runtime snapshotted: process state, installed packages, and the workdir
+                    # come back as they were, so there's nothing to re-provision or mkdir.
+                    snapshot = await modal.SandboxSnapshot.from_id.aio(
+                        self.config.resume_from
+                    )
+                    self._sandbox = await modal.Sandbox._experimental_from_snapshot.aio(
+                        snapshot
+                    )
+                else:
+                    self._sandbox = await modal.Sandbox.create.aio(
+                        "sleep",
+                        "infinity",  # keep-alive entrypoint; the harness runs via `exec`
+                        app=app,
+                        name=self.name,
+                        image=modal.Image.from_registry(self.config.image),
+                        workdir=self.config.workdir,
+                        cpu=self.config.cpu,
+                        memory=int(self.config.memory * 1024),  # Modal memory is MB
+                        gpu=self.config.gpu,
+                        region=self.config.region,
+                        block_network=not self.config.network_access,
+                        timeout=24 * 60 * 60,  # Maximum lifetime of any sandbox.
+                        encrypted_ports=[SERVICE_PORT],
+                        # Opt-in live-state capture so `snapshot()` can clone this sandbox.
+                        _experimental_enable_snapshot=self.config.enable_snapshot,
+                    )
             self._sandbox_id = self._sandbox.object_id
             logger.info(
-                "modal: sandbox %s up (image=%s)", self._sandbox_id, self.config.image
+                "modal: sandbox %s up (%s)",
+                self._sandbox_id,
+                f"resumed from {self.config.resume_from}"
+                if self.config.resume_from is not None
+                else f"image={self.config.image}",
             )
-            await self._sandbox.filesystem.make_directory.aio(self.config.workdir)
+            if self.config.resume_from is None:
+                await self._sandbox.filesystem.make_directory.aio(self.config.workdir)
         except (
             Exception
         ) as e:  # provisioning failure is one rollout's problem, not the eval's
@@ -120,6 +147,23 @@ class ModalRuntime(Runtime):
             raise SandboxError(f"modal tunnels unavailable (port {port}): {e}") from e
         tunnel = tunnels.get(port)
         return str(tunnel.url).rstrip("/") if tunnel else None
+
+    async def snapshot(self) -> str:
+        # Capture the sandbox's live state (memory + filesystem) and return the snapshot id a
+        # later runtime feeds back via `resume_from`. Requires the sandbox to have been created
+        # with `enable_snapshot` (Modal refuses otherwise).
+        if self._sandbox is None:
+            raise SandboxError("cannot snapshot a modal sandbox that is not running")
+        try:
+            snapshot = await self._sandbox._experimental_snapshot.aio()
+        except Exception as e:
+            raise SandboxError(f"modal snapshot failed: {e}") from e
+        logger.info(
+            "modal: snapshotted sandbox %s -> %s",
+            self._sandbox_id,
+            snapshot.object_id,
+        )
+        return snapshot.object_id
 
     async def run(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
         try:


### PR DESCRIPTION
## What

Adds the ability to **save a sandbox's state after a rollout and restart a later rollout from that exact past state**, on the Modal runtime.

Opt-in via the Modal runtime config (`enable_snapshot=True`). Per `task.idx`:
1. A rollout runs, and on teardown snapshots its sandbox end-state (memory + filesystem) *before* terminating, storing the snapshot ref.
2. The next rollout of that task injects the ref as `resume_from` and restores an exact clone instead of cold-booting.

## Changes

- **`runtimes/base.py`** — extends the `Runtime` contract additively: a `supports_snapshot` capability flag and an optional `async snapshot() -> str` (default raises `NotImplementedError`, so a misconfigured resume fails loudly instead of silently discarding state). Runtime-agnostic.
- **`runtimes/modal.py`** — `ModalConfig` gains `enable_snapshot` and `resume_from`; `start()` branches to restore a memory+fs clone (`SandboxSnapshot.from_id` → `_experimental_from_snapshot`) when resuming, else provisions fresh with snapshotting opt-in; `snapshot()` wraps `_experimental_snapshot()`.
- **`rollout.py`** — optional `snapshot_sink` callback; snapshots the runtime end-state in the teardown `finally` (best-effort — a snapshot failure never fails the rollout or blocks teardown) and reports `(task.idx, ref)`.
- **`env.py`** — in-process per-task snapshot store; injects `resume_from` and wires the sink in `episode()`.

No behavior change for non-snapshot runtimes — everything is gated on `enable_snapshot` and defaults off.

## Verified

- ✅ `ruff check` + `ruff format` (pre-commit) pass on all four files.
- ✅ Compiles; non-snapshot runtimes (subprocess/docker/prime) untouched (guarded by `getattr(config, "enable_snapshot", False)`).

## Not yet verified — needs a live Modal smoke test

- The experimental Modal APIs (`SandboxSnapshot.from_id`, `_experimental_from_snapshot`, `_experimental_snapshot`) — written to the documented signatures but **not executed** (no Modal creds in the dev env; the local venv also has an unrelated `renderers` import mismatch that blocks the test suite here).
- **Whether a restored sandbox re-acquires its port tunnel** — Modal forwards `encrypted_ports` at create-time; if restore doesn't re-establish it, the harness can't reach a server inside the box. Highest-risk unknown.

## Known limitations (by design, this pass)

- **In-process store only**: the per-task store lives on the `Environment` instance, so resume works within one process but does not survive a restart or reach distributed prime-rl workers. Persistent store is the follow-up.
- **`n>1` concurrency**: sibling rollouts of one task all start before any snapshot completes, so last-to-finish wins the stored ref. Clean for `n=1`.
- Modal memory snapshots expire after 7 days and pin the sandbox to one instance type (upstream Modal constraints).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Uses experimental Modal snapshot APIs and unverified restore/tunnel behavior; snapshot failures are swallowed so resume may silently fall back to cold start.
> 
> **Overview**
> Adds **opt-in Modal sandbox snapshot/resume** so a later rollout of the same task can cold-start from the previous rollout’s end state instead of a fresh image.
> 
> The **`Runtime`** contract gains `supports_snapshot` and `async snapshot() -> str` (default raises). **Modal** adds `enable_snapshot` / `resume_from` on config, restores via experimental snapshot APIs on `start()`, and captures state in `snapshot()`. **`Rollout`** takes an optional `snapshot_sink` and best-effort snapshots before `stop()` in teardown. **`Environment`** keeps an in-process `task.idx → ref` map, injects `resume_from` when building episodes, and wires the sink—gated on `enable_snapshot` so other runtimes are unchanged.
> 
> **Limitations:** store is in-process only; concurrent `n>1` rollouts race on the stored ref; restored sandboxes’ port tunnels are not yet verified live.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86ab57212d061f881464928cbd7abee2236b66ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Modal sandbox snapshot save and per-task resume to the v1 runtime
> - Adds `enable_snapshot` and `resume_from` fields to `ModalConfig` and implements `snapshot()` on `ModalRuntime`, which captures live sandbox state via Modal's experimental API and returns a snapshot object ID.
> - At the end of each rollout, if the runtime supports snapshots, `Rollout.run` calls `snapshot()` and passes the result to an optional `snapshot_sink(task_idx, ref)` callback; failures are logged as warnings and do not fail the rollout.
> - `Environment` stores per-task snapshot refs in `_snapshot_refs` and, when `enable_snapshot` is set, injects `resume_from` into the `runtime_config` for subsequent rollouts on the same task so the sandbox is restored from the snapshot instead of provisioned fresh.
> - Behavioral Change: sandboxes created with `enable_snapshot=True` call Modal's `_experimental_enable_snapshot` API; `make_directory(workdir)` is skipped when resuming from a snapshot.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 86ab572.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->