### PR TITLE
interception server: raise client_max_size 24MB -> 48MB

### DIFF
--- a/verifiers/utils/interception_utils.py
+++ b/verifiers/utils/interception_utils.py
@@ -38,7 +38,7 @@ logger = logging.getLogger(__name__)
 KEEPALIVE_INTERVAL_SECONDS = float(
     os.environ.get("INTERCEPTION_SERVER_KEEPALIVE_INTERVAL_SECONDS", "3.0")
 )
-DEFAULT_CLIENT_MAX_SIZE_BYTES = 24 * 1024 * 1024
+DEFAULT_CLIENT_MAX_SIZE_BYTES = 48 * 1024 * 1024
 
 
 class StreamInterrupted(InfraError):


### PR DESCRIPTION
## Summary

The `/vf/*` bridge (aiohttp `web.Application`) rejects model-call payloads over 24MB with `Invalid JSON: Request Entity Too Large`. Multimodal/browser rollouts that retain many images (per-turn screenshots + multi-page PDF page renders) can exceed 24MB on long rollouts, aborting otherwise-valid rollouts. This raises the default `client_max_size` from 24MB to 48MB.

## Test plan

This only widens the aiohttp body limit (`DEFAULT_CLIENT_MAX_SIZE_BYTES`) and changes no behavior otherwise.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant change that only widens the accepted request body limit; no auth, routing, or interception logic changes.
> 
> **Overview**
> Raises the default maximum HTTP request body size for the sandbox **interception server** (`InterceptionServer` aiohttp app) from **24MB to 48MB** via `DEFAULT_CLIENT_MAX_SIZE_BYTES`.
> 
> This avoids **Request Entity Too Large** / invalid JSON failures on large intercepted model-call payloads—especially long multimodal or browser rollouts that accumulate screenshots and PDF page images in the chat history.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bbd07d5ee7fd80b6cf7e5ea4f2d76dffdb0c30d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Raise interception server `DEFAULT_CLIENT_MAX_SIZE_BYTES` from 24MB to 48MB
> Doubles the max request body size in [`interception_utils.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1833/files#diff-ef080b90140e72f3d7e2a9d41a24c81e05204ced0d633125a3d66240df58af73) from 24 MiB to 48 MiB. Behavioral Change: any server using this constant will now accept request bodies up to 48 MiB.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6bbd07d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->