### PR TITLE
fix: scaleswe-v1 scorer test ids via file (avoid exec command-length overflow)

### DIFF
--- a/environments/scaleswe_v1/scaleswe_v1/score.py
+++ b/environments/scaleswe_v1/scaleswe_v1/score.py
@@ -2,7 +2,8 @@
 
 Run inside the task's repo (cwd) by the testbed python (which has pytest + the project
 installed) — NOT a uv script, since the tests need the project's own environment. argv[1]
-is a JSON list of pytest node ids. We write JUnit XML and match each expected id against
+is the path to a JSON file of pytest node ids (a file, not inline, so a large id list can't
+overflow the sandbox exec command line). We write JUnit XML and match each expected id against
 it (a pytest node id and the JUnit classname/name don't line up, so we try a few forms),
 printing the score on the last line. Any failure prints 0.0.
 """
@@ -67,7 +68,7 @@ def _all_passed(xml_content: str, expected: list[str]) -> bool:
 
 
 def main() -> None:
-    expected = json.loads(sys.argv[1])
+    expected = json.load(open(sys.argv[1]))
     if not expected:
         print(0.0)
         return

--- a/environments/scaleswe_v1/scaleswe_v1/taskset.py
+++ b/environments/scaleswe_v1/scaleswe_v1/taskset.py
@@ -64,6 +64,7 @@ done
 
 PATCH = "/tmp/scaleswe_f2p.patch"
 SCORER = "/tmp/scaleswe_scorer.py"
+TEST_IDS = "/tmp/scaleswe_test_ids.json"
 SCORER_SRC = (Path(__file__).parent / "score.py").read_bytes()
 
 
@@ -224,7 +225,8 @@ class ScaleSWETaskset(vf.Taskset[ScaleSWETask, ScaleSWEConfig]):
         if task.f2p_script:
             await runtime.write("test_fail_to_pass.py", task.f2p_script.encode())
         await runtime.write(SCORER, SCORER_SRC)
-        result = await runtime.run(["python", SCORER, json.dumps(test_ids)], ENV)
+        await runtime.write(TEST_IDS, json.dumps(test_ids).encode())
+        result = await runtime.run(["python", SCORER, TEST_IDS], ENV)
         lines = result.stdout.strip().splitlines()
         return float(lines[-1]) if lines else 0.0
 


### PR DESCRIPTION
## Summary

`scaleswe_v1` scoring intermittently failed on the prime runtime with:

```
SandboxError: prime exec failed: HTTP 500 … {"error":"Command execution failed:
Failed to execute chroot command: File name too long (os error 36)"}
```

**Cause:** `solved` passed the merged FAIL_TO_PASS + **PASS_TO_PASS** test ids as a single inline `argv` element — `runtime.run(["python", SCORER, json.dumps(test_ids)])`. The prime runtime `shlex.join`s argv into one command string; for a task with a large PASS_TO_PASS list that string overflows the sandbox exec command-length limit and surfaces as `ENAMETOOLONG`. It's intermittent because only large-test tasks cross the limit. This is the exact failure mode `prime.py`'s `write()` documents and dodges via multipart upload — the scorer call just bypassed it by going through `argv`.

**Fix:** write the test ids to a file (multipart upload, like the scorer source and patches already are) and pass the *path*; `score.py` reads the file instead of `sys.argv[1]`. Removes the only unbounded payload still riding on the exec command line, so scoring can't overflow regardless of test-list size.

**Scope:** scaleswe is the only affected taskset. swelego/r2e_gym compute the reward host-side (the id list never enters the sandbox); swebench_verified/terminal_bench_2 subclass `HarborTaskset` (file-based reward); harbor stages tests via a tarball. None inline a large payload into `argv`.

## Verification

5 rollouts on the prime runtime against the fixed code — all reached scoring with **no `ENAMETOOLONG`/`SandboxError`**, including two tasks whose test-id payloads are well into the overflow range:

| task | #FAIL_TO_PASS | #PASS_TO_PASS | `json.dumps(ids)` bytes | scored |
| --- | --- | --- | --- | --- |
| 0 | 4 | 123 | 10,608 | ✓ |
| 1 | 3 | 447 | **31,309** | ✓ |
| 2 | 2 | 15 | 859 | ✓ |
| 3 | 1 | 134 | 10,004 | ✓ |
| 4 | 2 | 479 | **33,371** | ✓ |

(Rewards were 0.0 — a 1-turn `gpt-4.1-mini` smoke agent doesn't solve the tasks — but the scorer ran on every task, which is the path that was overflowing.)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix scaleswe-v1 scorer to pass test IDs via JSON file instead of inline CLI argument
> - [score.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1834/files#diff-c65860a3a9227b51636289fd2b7307cdb5f9c1869ab75a76cbc4b59082115e18) now reads `argv[1]` as a path to a JSON file rather than an inline JSON string, avoiding OS command-line length limits.
> - [taskset.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1834/files#diff-28567b3357c139929d9a6c618697aa16a198ce23f73d96df6e8582ac1333f575) writes the test ID list to `/tmp/scaleswe_test_ids.json` before invoking the scorer, passing that path as `argv[1]`.
> - Behavioral Change: the scorer CLI interface is no longer compatible with inline JSON strings; callers must now provide a file path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e400207.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to scaleswe-v1 sandbox scoring I/O; no auth, data, or reward logic changes beyond avoiding command-line length limits.
> 
> **Overview**
> Fixes intermittent **prime sandbox scoring failures** (`ENAMETOOLONG` / “File name too long”) when a task’s merged FAIL_TO_PASS + PASS_TO_PASS pytest id list is large enough that `json.dumps(test_ids)` on the exec command line exceeds the sandbox limit.
> 
> **`taskset.solved`** now uploads the id list to `/tmp/scaleswe_test_ids.json` via `runtime.write` (same pattern as the scorer script and patches) and invokes `python` with that **path** only. **`score.py`** treats `argv[1]` as a JSON file path and loads expected ids with `json.load(open(...))` instead of `json.loads(sys.argv[1])`.
> 
> Scoring behavior is unchanged once ids are loaded; only the transport into the sandbox moves off the bounded exec argv. **Note:** the scorer CLI no longer accepts inline JSON on argv—callers must pass a file path (only `scaleswe_v1` uses this scorer today).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e400207231f3114a08f2866e6ff2d2ce27e088f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->