### PR TITLE
Omit redundant provider failure tracebacks

### DIFF
--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -20,6 +20,7 @@ from pydantic import Field, PrivateAttr
 from renderers.base import MultiModalData
 
 from verifiers.v1 import graph
+from verifiers.v1.errors import ProviderError
 from verifiers.v1.graph import MessageNode
 from verifiers.v1.state import State, StateT
 from verifiers.v1.task import TaskT, WireTask
@@ -372,12 +373,16 @@ class Trace(StrictBaseModel, Generic[TaskT, StateT]):
             self.stop_condition = condition
 
     def capture_error(self, error: Exception) -> None:
-        """Record a caught error (with traceback) and stop the rollout."""
+        """Record a caught error and stop the rollout."""
         self.errors.append(
             Error(
                 type=type(error).__name__,
                 message=str(error),
-                traceback=traceback.format_exc(),
+                # Provider errors already carry the actionable upstream diagnostic.
+                # Keep full tracebacks for every other failure.
+                traceback=None
+                if isinstance(error, ProviderError)
+                else traceback.format_exc(),
             )
         )
         self.stop("error")


### PR DESCRIPTION
## Overview

Expected provider failures already carry the actionable provider error type and diagnostic message/body. This change avoids formatting and persisting the surrounding framework traceback for `ProviderError` and its subclasses, while retaining full tracebacks for every other failure.

## Equivalent behavior

The rollout result remains semantically equivalent for provider failures:

- the error type is unchanged
- the provider diagnostic message/body is unchanged
- retry history and ordering are unchanged
- rollout stopping and logging behavior are unchanged
- non-provider and unexpected failures still retain full tracebacks

The only omitted output is the redundant framework traceback attached to an expected provider failure. Production serialization already treats `traceback` as optional, so no new result shape or compatibility path is introduced.

## Why

`traceback.format_exc()` synchronously walks and formats every frame and chained exception. Failure-heavy evaluations repeat that work across rollouts and retries, retain each formatted string in memory, and escape/copy it again during JSON serialization. The provider diagnostic already contains the information needed to act on these failures.

The implementation stays at the existing type boundary: one `isinstance(error, ProviderError)` check. This includes provider subclasses without adding configuration, deduplication, or a second error policy.

## Performance

Three-run medians, with four provider failures per rollout:

| Workload | Wall time | Capture time | Peak RSS | Results bytes |
| --- | ---: | ---: | ---: | ---: |
| 256 rollouts, before | 0.344963 s | 0.338595 s | 112,869,376 | 5,652,004 |
| 256 rollouts, after | 0.009783 s | 0.006114 s | 108,756,992 | 1,631,780 |
| 512 rollouts, before | 0.693024 s | 0.681366 s | 118,620,160 | 11,304,228 |
| 512 rollouts, after | 0.019137 s | 0.012532 s | 110,002,176 | 3,263,780 |

At 512 rollouts this saves:

- **0.673887 seconds of wall time (97.24%)**
- **8,617,984 bytes of peak RSS (7.27%)**
- **8,040,448 persisted bytes (71.13%)**
- serialization time falls from **0.011144 s to 0.006647 s**

Healthy-control result files remain byte-for-byte identical; timing and RSS differences stay within measurement noise.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single conditional in error recording; `traceback` was already optional on serialized errors, so provider failure semantics (type, message, retries) are unchanged.
> 
> **Overview**
> **Rollout error capture** no longer runs `traceback.format_exc()` or stores a traceback string when the failure is a **`ProviderError`** (including subclasses). Type and message stay the same; **`Error.traceback`** is left **`None`** for those cases.
> 
> All other exceptions still get full tracebacks. This cuts redundant framework stack text on expected provider failures during heavy evals, shrinking persisted **`results.jsonl`** payload and avoiding repeated traceback formatting work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e797b0c631c0ed84c465e760a1e154adb16f860f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Omit tracebacks for `ProviderError` in `Trace.capture_error`
> When `capture_error` captures a `ProviderError`, it now sets `traceback` to `None` on the resulting `Error` entry instead of recording the full traceback. All other exception types continue to include the full traceback. This removes redundant noise from provider failures, which are already reported through other means.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e797b0c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->