### PR TITLE
Cache repeated Harbor test archives

### DIFF
--- a/verifiers/v1/tasksets/harbor_v1/taskset.py
+++ b/verifiers/v1/tasksets/harbor_v1/taskset.py
@@ -26,6 +26,7 @@ import subprocess
 import sys
 import tarfile
 import tomllib
+from functools import lru_cache
 from pathlib import Path
 
 from pydantic import Field
@@ -196,6 +197,9 @@ def parse_task(task_dir: Path, idx: int, harbor_config: HarborConfig) -> HarborT
     )
 
 
+# Harbor test directories are immutable after download, so repeated rollouts can reuse
+# the latest archive. One entry bounds retained memory to one task.
+@lru_cache(maxsize=1)
 def make_tar(directory: Path) -> bytes:
     """Tar a directory's contents (flat) into a gzipped tarball."""
     buffer = io.BytesIO()


### PR DESCRIPTION
## Overview

Cache the most recently generated Harbor test archive so repeated rollouts for the same task reuse identical bytes instead of rebuilding the same gzip tarball.

The first rollout still uses the existing archive implementation, and every rollout still uploads, extracts, and executes the same test archive. This changes no verifier behavior or archive contents; it only avoids repeated host-side filesystem reads, gzip work, allocations, and event-loop blocking.

## Why

Harbor test directories are immutable after download, but scoring currently calls `make_tar(Path(task.task_dir) / "tests")` independently for every rollout. With eight rollouts per example, that can synchronously archive the same directory eight times before the upload begins.

A standard-library `lru_cache(maxsize=1)` captures the repeated-task case while bounding persistent retention to one archive per worker. Different task paths remain misses, and the single entry is replaced rather than accumulating a dataset's archives.

## Performance and resource impact

Benchmarks imported the production function on `main` and compared the cached call with its unchanged `__wrapped__` implementation:

| Workload | Before | After | Time saved |
| --- | ---: | ---: | ---: |
| 10 KiB tests, 512 repeated rollouts | 133.52 ms | 1.99 ms | 131.53 ms (98.51%) |
| 500 KiB tests, 512 repeated rollouts | 603.62 ms | 3.58 ms | 600.03 ms (99.41%) |
| 20 MiB tests, 128 repeated rollouts | 39.163 s | 0.332 s | 38.830 s (99.15%) |

For the 20 MiB repeated workload, process CPU time fell from 38.951 seconds to 0.317 seconds. RSS growth fell from approximately 1052 MiB to 21.8 MiB and peak RSS from approximately 1454 MiB to 166 MiB, primarily by avoiding 127 redundant large archive allocations. The cache retained one 20,978,415-byte archive.

All-unique controls produced zero cache hits and retained only the latest archive. Their CPU time remained effectively unchanged, as expected.

## Behavior

- The first call runs the existing tar/gzip code unchanged.
- Cached calls return the exact archive bytes produced by that first call.
- Upload count and uploaded byte volume are unchanged.
- Test extraction, permissions, execution, and reward handling are unchanged.
- Retention is bounded to one task archive per worker.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure performance optimization with identical archive output and bounded memory; no changes to scoring or sandbox behavior.
> 
> **Overview**
> Repeated Harbor scoring no longer rebuilds the same `tests/` gzip archive on every rollout. **`make_tar`** is wrapped with **`@lru_cache(maxsize=1)`** so identical `Path` arguments return the same bytes from the first tar pass, with retention capped at one archive per worker.
> 
> Upload, extraction, and verifier execution are unchanged; only redundant host-side reads, gzip work, and allocations are skipped when multiple rollouts hit the same task directory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e469b43e1efc034195049710ecb1be9ceef79f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cache `make_tar` results in Harbor test taskset to skip repeated tar operations
> Applies `@lru_cache(maxsize=1)` to `make_tar` in [taskset.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1836/files#diff-05e2dc850a86f511dd040c28b42cb46158c0c8fe668c29a32ea5938361f1eba9) so repeated calls with the same `Path` argument return the cached bytes instead of re-running the tar operation. The cache holds only the most recent directory's archive.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7e469b4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->