### PR TITLE
Stream SSE responses incrementally

### DIFF
--- a/verifiers/v1/clients/eval.py
+++ b/verifiers/v1/clients/eval.py
@@ -56,7 +56,8 @@ _BLOCKED_REQUEST_HEADERS = frozenset(
         "signature-input",
     }
 )
-_SSE_EVENT_END = re.compile(rb"(?:\r\n|\r|\n){2}")
+# Atomic so one CRLF cannot backtrack into two line endings and split an event mid-field.
+_SSE_EVENT_END = re.compile(rb"(?>\r\n|\r|\n){2}")
 
 
 class EvalClient(Client):

--- a/verifiers/v1/dialects/__init__.py
+++ b/verifiers/v1/dialects/__init__.py
@@ -6,7 +6,7 @@ resolved from the endpoint the program's SDK posts to — no per-harness declara
 """
 
 from verifiers.v1.dialects.anthropic import AnthropicDialect
-from verifiers.v1.dialects.base import Dialect, iter_sse
+from verifiers.v1.dialects.base import Dialect, StreamParser, iter_sse
 from verifiers.v1.dialects.chat import (
     FINISH_REASONS,
     ChatDialect,
@@ -27,6 +27,7 @@ __all__ = [
     "AnthropicDialect",
     "ChatDialect",
     "ResponsesDialect",
+    "StreamParser",
     "iter_sse",
     "parse_message",
     "parse_tools",

--- a/verifiers/v1/dialects/anthropic.py
+++ b/verifiers/v1/dialects/anthropic.py
@@ -7,11 +7,12 @@ trace. `count_tokens` is relayed verbatim (an `aux_route`), never recorded.
 """
 
 import json
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
 
 from anthropic.types import Message as AnthropicMessage
 
-from verifiers.v1.dialects.base import Dialect, iter_sse
+from verifiers.v1.dialects.base import Dialect, StreamParser, parse_sse_event
 from verifiers.v1.types import (
     AssistantMessage,
     ContentPart,
@@ -171,6 +172,76 @@ def response_from_wire(message: AnthropicMessage) -> Response:
     )
 
 
+@dataclass
+class AnthropicStreamParser(StreamParser):
+    """Incrementally assemble Anthropic message events without retaining SSE bytes."""
+
+    validate_response: Callable[[dict], AnthropicMessage]
+    message: dict = field(default_factory=dict)
+    blocks: dict[int, dict] = field(default_factory=dict)
+    block_parts: dict[int, dict[str, list[str]]] = field(default_factory=dict)
+    partial_json: dict[int, list[str]] = field(default_factory=dict)
+
+    def feed(self, raw: bytes) -> None:
+        event = parse_sse_event(raw)
+        if event is None:
+            return
+        kind = event.get("type")
+        if kind == "message_start":
+            self.message = event.get("message") or {}
+        elif kind == "content_block_start":
+            index = event["index"]
+            self.blocks[index] = dict(event.get("content_block") or {})
+            self.block_parts.pop(index, None)
+        elif kind == "content_block_delta":
+            index = event["index"]
+            block = self.blocks.setdefault(index, {"type": "text", "text": ""})
+            delta = event.get("delta") or {}
+            delta_type = delta.get("type")
+            if delta_type in (
+                "text_delta",
+                "thinking_delta",
+                "signature_delta",
+            ):
+                field_name = delta_type.removesuffix("_delta")
+                fields = self.block_parts.get(index)
+                if fields is None:
+                    fields = {}
+                    self.block_parts[index] = fields
+                parts = fields.get(field_name)
+                if parts is None:
+                    parts = [block.get(field_name, "")]
+                    fields[field_name] = parts
+                parts.append(delta.get(field_name, ""))
+            elif delta_type == "input_json_delta":
+                parts = self.partial_json.get(index)
+                if parts is None:
+                    parts = []
+                    self.partial_json[index] = parts
+                parts.append(delta.get("partial_json", ""))
+        elif kind == "message_delta":
+            self.message.update(
+                {
+                    key: value
+                    for key, value in (event.get("delta") or {}).items()
+                    if value is not None
+                }
+            )
+            self.message["usage"] = {
+                **(self.message.get("usage") or {}),
+                **(event.get("usage") or {}),
+            }
+
+    def finish(self) -> Response:
+        for index, fields in self.block_parts.items():
+            for field_name, parts in fields.items():
+                self.blocks[index][field_name] = "".join(parts)
+        for index, parts in self.partial_json.items():
+            self.blocks[index]["input"] = json.loads("".join(parts) or "{}")
+        self.message["content"] = [self.blocks[index] for index in sorted(self.blocks)]
+        return response_from_wire(self.validate_response(self.message))
+
+
 class AnthropicDialect(Dialect[dict, AnthropicMessage]):
     """The Anthropic Messages wire format."""
 
@@ -215,62 +286,8 @@ class AnthropicDialect(Dialect[dict, AnthropicMessage]):
             raw["usage"].pop("service_tier")
         return super().validate_response(raw)
 
-    def parse_stream(self, raw: bytes) -> Response:
-        """Assemble message_start / content_block_* / message_delta events into the complete
-        message, then parse it."""
-        message: dict = {}
-        blocks: dict[int, dict] = {}
-        block_parts: dict[int, dict[str, list[str]]] = {}
-        partial_json: dict[int, list[str]] = {}
-        for event in iter_sse(raw):
-            kind = event.get("type")
-            if kind == "message_start":
-                message = event.get("message") or {}
-            elif kind == "content_block_start":
-                index = event["index"]
-                blocks[index] = dict(event.get("content_block") or {})
-                block_parts.pop(index, None)
-            elif kind == "content_block_delta":
-                index = event["index"]
-                block = blocks.setdefault(index, {"type": "text", "text": ""})
-                delta = event.get("delta") or {}
-                delta_type = delta.get("type")
-                if delta_type in ("text_delta", "thinking_delta", "signature_delta"):
-                    field = delta_type.removesuffix("_delta")
-                    fields = block_parts.get(index)
-                    if fields is None:
-                        fields = {}
-                        block_parts[index] = fields
-                    parts = fields.get(field)
-                    if parts is None:
-                        parts = [block.get(field, "")]
-                        fields[field] = parts
-                    parts.append(delta.get(field, ""))
-                elif delta_type == "input_json_delta":
-                    parts = partial_json.get(index)
-                    if parts is None:
-                        parts = []
-                        partial_json[index] = parts
-                    parts.append(delta.get("partial_json", ""))
-            elif kind == "message_delta":
-                message.update(
-                    {
-                        k: v
-                        for k, v in (event.get("delta") or {}).items()
-                        if v is not None
-                    }
-                )
-                message["usage"] = {
-                    **(message.get("usage") or {}),
-                    **(event.get("usage") or {}),
-                }
-        for index, fields in block_parts.items():
-            for field, parts in fields.items():
-                blocks[index][field] = "".join(parts)
-        for index, parts in partial_json.items():
-            blocks[index]["input"] = json.loads("".join(parts) or "{}")
-        message["content"] = [blocks[i] for i in sorted(blocks)]
-        return response_from_wire(self.validate_response(message))
+    def stream_parser(self) -> StreamParser:
+        return AnthropicStreamParser(self.validate_response)
 
     def apply_overrides(self, body: dict, model: str, sampling: SamplingConfig) -> dict:
         # Forward verbatim except the eval's model + sampling. `temperature`/`top_p` are

--- a/verifiers/v1/dialects/base.py
+++ b/verifiers/v1/dialects/base.py
@@ -29,6 +29,19 @@ RespT = TypeVar("RespT", bound=BaseModel)
 logger = logging.getLogger(__name__)
 
 
+def is_sse_done_event(raw: bytes) -> bool:
+    """Whether one complete SSE event carries the DONE sentinel."""
+    # Ordinary OpenAI events carry JSON objects; reject their hot path before splitting lines.
+    if raw.startswith((b"data: {", b"data:{")):
+        return False
+    data = b"\n".join(
+        line.removeprefix(b"data:").strip()
+        for line in raw.splitlines()
+        if line.startswith(b"data:")
+    )
+    return data == b"[DONE]"
+
+
 def parse_sse_event(raw: bytes) -> dict | None:
     """Parse one complete SSE event's JSON data payload, ignoring comments and sentinels."""
     data = b"\n".join(

--- a/verifiers/v1/dialects/base.py
+++ b/verifiers/v1/dialects/base.py
@@ -94,6 +94,9 @@ class StreamParser(ABC):
     feed: Callable[[bytes], None]
     """Consume one complete SSE event without retaining its raw bytes."""
 
+    on_done: Callable[[], None] | None = None
+    """Preserve terminal state before events following the DONE sentinel."""
+
     @abstractmethod
     def finish(self) -> Response:
         """Finalize and return the assembled response after the stream ends."""

--- a/verifiers/v1/dialects/base.py
+++ b/verifiers/v1/dialects/base.py
@@ -5,17 +5,17 @@ trace from the program's native request + the provider's native response. The se
 every registered dialect's `routes` (see `dialects.DIALECTS`), so a request's format is resolved
 from the endpoint the program's SDK posts to — the harness declares nothing.
 
-The eval client relays a request's bytes verbatim to a matching endpoint, so the dialect only
-parses a *copy* for the trace (incl. assembling a relayed SSE stream via `parse_stream`); the
-renderer is chat-only. A dialect is therefore mostly wire -> vf
-(`parse_request`/`parse_response`/`parse_stream`); the exceptions are `apply_overrides` (impose
-the eval's model + sampling in this format's shape) and `extend` (chat-only user-sim injection).
+The eval client relays a request's bytes verbatim to a matching endpoint, while a dialect-owned
+`StreamParser` incrementally assembles a response copy for the trace; the renderer is chat-only.
+A dialect is therefore mostly wire -> vf (`parse_request`/`parse_response`/`stream_parser`); the
+exceptions are `apply_overrides` (impose the eval's model + sampling in this format's shape) and
+`extend` (chat-only user-sim injection).
 """
 
 import json
 import logging
 from abc import ABC, abstractmethod
-from collections.abc import Iterator, Mapping
+from collections.abc import Callable, Iterator, Mapping
 from typing import ClassVar, Generic, TypeVar
 
 from pydantic import BaseModel
@@ -27,6 +27,24 @@ ReqT = TypeVar("ReqT")
 RespT = TypeVar("RespT", bound=BaseModel)
 
 logger = logging.getLogger(__name__)
+
+
+def parse_sse_event(raw: bytes) -> dict | None:
+    """Parse one complete SSE event's JSON data payload, ignoring comments and sentinels."""
+    data = b"\n".join(
+        line.removeprefix(b"data:").strip()
+        for line in raw.splitlines()
+        if line.startswith(b"data:")
+    )
+    if not data or data == b"[DONE]":
+        return None
+    try:
+        return from_json(data)
+    except ValueError:
+        logger.warning(
+            "SSE JSON fast-path failed; falling back to stdlib with invalid UTF-8 replacement"
+        )
+        return json.loads(data.decode("utf-8", errors="replace"))
 
 
 def iter_sse(raw: bytes) -> Iterator[dict]:
@@ -44,19 +62,9 @@ def iter_sse(raw: bytes) -> Iterator[dict]:
         if end == -1:
             end = len(raw)
         block = raw[start:end]
-        data = b"\n".join(
-            line.removeprefix(b"data:").strip()
-            for line in block.splitlines()
-            if line.startswith(b"data:")
-        )
-        if data and data != b"[DONE]":
-            try:
-                yield from_json(data)
-            except ValueError:
-                logger.warning(
-                    "SSE JSON fast-path failed; falling back to stdlib with invalid UTF-8 replacement"
-                )
-                yield json.loads(data.decode("utf-8", errors="replace"))
+        event = parse_sse_event(block)
+        if event is not None:
+            yield event
         start = end + len(separator)
 
 
@@ -78,6 +86,17 @@ def iter_sse_reverse(raw: bytes) -> Iterator[dict]:
         if not data or data == "[DONE]":
             continue
         yield json.loads(data)
+
+
+class StreamParser(ABC):
+    """Incrementally assemble one native SSE stream into a vf response."""
+
+    feed: Callable[[bytes], None]
+    """Consume one complete SSE event without retaining its raw bytes."""
+
+    @abstractmethod
+    def finish(self) -> Response:
+        """Finalize and return the assembled response after the stream ends."""
 
 
 class Dialect(ABC, Generic[ReqT, RespT]):
@@ -133,9 +152,8 @@ class Dialect(ABC, Generic[ReqT, RespT]):
         return self.response_type.model_validate(raw)
 
     @abstractmethod
-    def parse_stream(self, raw: bytes) -> Response:
-        """A complete native SSE byte stream -> the vf `Response` (assembling the final message
-        from the events), to record a relayed stream on the trace."""
+    def stream_parser(self) -> StreamParser:
+        """Create the per-request incremental parser for a native SSE response."""
 
     @abstractmethod
     def apply_overrides(self, body: ReqT, model: str, sampling: SamplingConfig) -> ReqT:

--- a/verifiers/v1/dialects/chat.py
+++ b/verifiers/v1/dialects/chat.py
@@ -8,11 +8,12 @@ read them in the same precedence (`reasoning` / `reasoning_content` / `reasoning
 
 import time
 from collections.abc import Mapping
+from dataclasses import dataclass, field as dataclass_field
 from typing import Any
 
 from openai.types.chat import ChatCompletion
 
-from verifiers.v1.dialects.base import Dialect, iter_sse
+from verifiers.v1.dialects.base import Dialect, StreamParser, parse_sse_event
 from verifiers.v1.types import (
     AssistantMessage,
     FinishReason,
@@ -202,6 +203,101 @@ def response_from_wire(completion: ChatCompletion) -> Response:
     )
 
 
+@dataclass
+class ChatStreamParser(StreamParser):
+    """Incrementally assemble Chat Completions deltas without retaining SSE bytes."""
+
+    message: dict = dataclass_field(
+        default_factory=lambda: {"role": "assistant", "content": None}
+    )
+    message_parts: dict[str, list[str]] = dataclass_field(
+        default_factory=lambda: {key: [] for key in REASONING_FIELDS[:2] + ("content",)}
+    )
+    tool_calls: dict[int, dict] = dataclass_field(default_factory=dict)
+    tool_arguments: dict[int, list[str]] = dataclass_field(default_factory=dict)
+    reasoning_details: list[dict] = dataclass_field(default_factory=list)
+    reasoning_detail_parts: dict[int, list[str]] = dataclass_field(default_factory=dict)
+    finish_reason: str | None = None
+    usage: dict | None = None
+    head: dict | None = None
+
+    def feed(self, raw: bytes) -> None:
+        chunk = parse_sse_event(raw)
+        if chunk is None:
+            return
+        if self.head is None:
+            self.head = chunk
+        self.usage = chunk.get("usage") or self.usage
+        for choice in chunk.get("choices") or []:
+            if choice.get("index", 0) != 0:
+                continue
+            self.finish_reason = choice.get("finish_reason") or self.finish_reason
+            delta = choice.get("delta") or {}
+            for key in ("content", "reasoning_content", "reasoning"):
+                if delta.get(key) is not None:
+                    self.message_parts[key].append(delta[key])
+            for detail in delta.get("reasoning_details") or []:
+                previous = self.reasoning_details[-1] if self.reasoning_details else {}
+                if detail.get("type") == previous.get("type") == "reasoning.text":
+                    self.reasoning_detail_parts.setdefault(
+                        len(self.reasoning_details) - 1,
+                        [previous.get("text") or ""],
+                    ).append(detail.get("text") or "")
+                    for field_name in ("signature", "format"):
+                        previous[field_name] = previous.get(field_name) or detail.get(
+                            field_name
+                        )
+                else:
+                    self.reasoning_details.append(detail)
+            for tool_call in delta.get("tool_calls") or []:
+                index = tool_call.get("index", 0)
+                slot = self.tool_calls.setdefault(
+                    index,
+                    {"type": "function", "function": {"name": "", "arguments": ""}},
+                )
+                slot["id"] = tool_call.get("id") or slot.get("id", "")
+                function = tool_call.get("function") or {}
+                if function.get("name"):
+                    slot["function"]["name"] = function["name"]
+                self.tool_arguments.setdefault(index, []).append(
+                    function.get("arguments") or ""
+                )
+
+    def finish(self) -> Response:
+        for key, parts in self.message_parts.items():
+            if parts:
+                self.message[key] = "".join(parts)
+        for index, parts in self.reasoning_detail_parts.items():
+            self.reasoning_details[index]["text"] = "".join(parts)
+        for index, parts in self.tool_arguments.items():
+            self.tool_calls[index]["function"]["arguments"] = "".join(parts)
+        if self.tool_calls:
+            self.message["tool_calls"] = [
+                self.tool_calls[index] for index in sorted(self.tool_calls)
+            ]
+        if self.reasoning_details:
+            self.message["reasoning_details"] = self.reasoning_details
+        head = self.head or {}
+        return response_from_wire(
+            ChatCompletion.model_validate(
+                {
+                    "id": head.get("id", "vf-intercept"),
+                    "object": "chat.completion",
+                    "created": head.get("created", int(time.time())),
+                    "model": head.get("model", ""),
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": self.message,
+                            "finish_reason": self.finish_reason or "stop",
+                        }
+                    ],
+                    "usage": self.usage,
+                }
+            )
+        )
+
+
 class ChatDialect(Dialect[dict, ChatCompletion]):
     """The OpenAI chat-completions wire format."""
 
@@ -227,84 +323,8 @@ class ChatDialect(Dialect[dict, ChatCompletion]):
     def parse_response(self, response: ChatCompletion) -> Response:
         return response_from_wire(response)
 
-    def parse_stream(self, raw: bytes) -> Response:
-        """Assemble `chat.completion.chunk` deltas into one completion, then parse it."""
-        message: dict = {"role": "assistant", "content": None}
-        # Join streamed fields once; repeated concatenation recopies the growing response.
-        message_parts = {key: [] for key in REASONING_FIELDS[:2] + ("content",)}
-        tool_calls: dict[int, dict] = {}
-        tool_arguments: dict[int, list[str]] = {}
-        reasoning_details: list[dict] = []
-        reasoning_detail_parts: dict[int, list[str]] = {}
-        finish_reason = None
-        usage = None
-        head = None
-        for chunk in iter_sse(raw):
-            if head is None:
-                head = chunk
-            usage = chunk.get("usage") or usage
-            for choice in chunk.get("choices") or []:
-                if choice.get("index", 0) != 0:
-                    continue
-                finish_reason = choice.get("finish_reason") or finish_reason
-                delta = choice.get("delta") or {}
-                for key in ("content", "reasoning_content", "reasoning"):
-                    if delta.get(key) is not None:
-                        message_parts[key].append(delta[key])
-                for detail in delta.get("reasoning_details") or []:
-                    previous = reasoning_details[-1] if reasoning_details else {}
-                    if detail.get("type") == previous.get("type") == "reasoning.text":
-                        reasoning_detail_parts.setdefault(
-                            len(reasoning_details) - 1, [previous.get("text") or ""]
-                        ).append(detail.get("text") or "")
-                        for field in ("signature", "format"):
-                            previous[field] = previous.get(field) or detail.get(field)
-                    else:
-                        reasoning_details.append(detail)
-                for tc in delta.get("tool_calls") or []:
-                    index = tc.get("index", 0)
-                    slot = tool_calls.setdefault(
-                        index,
-                        {"type": "function", "function": {"name": "", "arguments": ""}},
-                    )
-                    slot["id"] = tc.get("id") or slot.get("id", "")
-                    fn = tc.get("function") or {}
-                    if fn.get("name"):
-                        slot["function"]["name"] = fn["name"]
-                    tool_arguments.setdefault(index, []).append(
-                        fn.get("arguments") or ""
-                    )
-        for key, parts in message_parts.items():
-            if parts:
-                message[key] = "".join(parts)
-        for index, parts in reasoning_detail_parts.items():
-            reasoning_details[index]["text"] = "".join(parts)
-        for index, parts in tool_arguments.items():
-            tool_calls[index]["function"]["arguments"] = "".join(parts)
-        if tool_calls:
-            message["tool_calls"] = [tool_calls[i] for i in sorted(tool_calls)]
-        if reasoning_details:
-            message["reasoning_details"] = reasoning_details
-        if head is None:
-            head = {}
-        return response_from_wire(
-            ChatCompletion.model_validate(
-                {
-                    "id": head.get("id", "vf-intercept"),
-                    "object": "chat.completion",
-                    "created": head.get("created", int(time.time())),
-                    "model": head.get("model", ""),
-                    "choices": [
-                        {
-                            "index": 0,
-                            "message": message,
-                            "finish_reason": finish_reason or "stop",
-                        }
-                    ],
-                    "usage": usage,
-                }
-            )
-        )
+    def stream_parser(self) -> StreamParser:
+        return ChatStreamParser()
 
     def apply_overrides(self, body: dict, model: str, sampling: SamplingConfig) -> dict:
         # Forward the program's body verbatim, overlaying only what the eval owns: the model and

--- a/verifiers/v1/dialects/responses.py
+++ b/verifiers/v1/dialects/responses.py
@@ -8,6 +8,7 @@ endpoint and this dialect parses a copy for the trace. Server-side statefulness
 """
 
 import json
+from collections import deque
 from typing import Any, cast
 
 from openai.types.responses import (
@@ -26,7 +27,7 @@ from openai.types.responses.response_usage import (
 )
 from pydantic import BaseModel, ConfigDict
 
-from verifiers.v1.dialects.base import Dialect, iter_sse_reverse
+from verifiers.v1.dialects.base import Dialect, StreamParser, iter_sse_reverse
 from verifiers.v1.types import (
     AssistantMessage,
     ContentPart,
@@ -233,6 +234,22 @@ def response_from_wire(response: OpenAIResponse) -> Response:
     )
 
 
+class ResponsesStreamParser(StreamParser):
+    """Retain only the complete terminal response event and trailing DONE event."""
+
+    def __init__(self) -> None:
+        self.events: deque[bytes] = deque(maxlen=2)
+        self.feed = self.events.append
+
+    def finish(self) -> Response:
+        for event in iter_sse_reverse(b"".join(self.events)):
+            if event.get("type") in FINAL_EVENTS:
+                return response_from_wire(
+                    OpenAIResponse.model_validate(event["response"])
+                )
+        raise ValueError("Responses stream ended without a terminal event")
+
+
 class ResponsesDialect(Dialect[dict, OpenAIResponse]):
     """The OpenAI Responses wire format."""
 
@@ -295,15 +312,8 @@ class ResponsesDialect(Dialect[dict, OpenAIResponse]):
     def parse_response(self, response: OpenAIResponse) -> Response:
         return response_from_wire(response)
 
-    def parse_stream(self, raw: bytes) -> Response:
-        """The terminal event (`response.completed` / `.incomplete` / `.failed`) carries the
-        full response object — parse that."""
-        for event in iter_sse_reverse(raw):
-            if event.get("type") in FINAL_EVENTS:
-                return response_from_wire(
-                    OpenAIResponse.model_validate(event["response"])
-                )
-        raise ValueError("Responses stream ended without a terminal event")
+    def stream_parser(self) -> StreamParser:
+        return ResponsesStreamParser()
 
     def apply_overrides(self, body: dict, model: str, sampling: SamplingConfig) -> dict:
         # Forward verbatim except the eval's model + sampling, mapped to the Responses shape

--- a/verifiers/v1/dialects/responses.py
+++ b/verifiers/v1/dialects/responses.py
@@ -240,9 +240,15 @@ class ResponsesStreamParser(StreamParser):
     def __init__(self) -> None:
         self.events: deque[bytes] = deque(maxlen=2)
         self.feed = self.events.append
+        self.terminal_events: tuple[bytes, ...] | None = None
+
+    def on_done(self) -> None:
+        # Freeze the terminal tail before later relay chunks can evict it.
+        self.terminal_events = tuple(self.events)
 
     def finish(self) -> Response:
-        for event in iter_sse_reverse(b"".join(self.events)):
+        events = self.terminal_events or self.events
+        for event in iter_sse_reverse(b"".join(events)):
             if event.get("type") in FINAL_EVENTS:
                 return response_from_wire(
                     OpenAIResponse.model_validate(event["response"])

--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -411,8 +411,8 @@ class InterceptionServer:
         prompt: Messages,
     ) -> web.StreamResponse:
         """A streamed (SSE) model turn: relay the provider's stream through to the program,
-        accumulating the bytes to record the turn on the trace. Single-shot — a streamed turn
-        never drives a user simulator (the only client that streams is the eval relay)."""
+        incrementally assembling the response to record on the trace. Single-shot — a streamed
+        turn never drives a user simulator (the only client that streams is the eval relay)."""
         try:
             refused = await session.refused()
         except RolloutError as e:
@@ -460,13 +460,16 @@ class InterceptionServer:
             headers={"Cache-Control": "no-cache", "Connection": "keep-alive"}
         )
         resp.content_type = reply.content_type.split(";")[0].strip()
-        buffer = bytearray()
+        # Parse complete events as they relay, avoiding a full-stream byte copy.
+        parser = dialect.stream_parser()
+        feed_event = parser.feed
         # One bounded producer avoids per-event tasks; keepalive timeouts only cancel readiness waits.
         queue: asyncio.Queue[bytes | None] = asyncio.Queue(
             maxsize=_STREAM_QUEUE_MAXSIZE
         )
         ready = asyncio.Event()
         producer = asyncio.create_task(_queue_chunks(reply.chunks, queue, ready))
+        parser_error: Exception | None = None
         try:
             await resp.prepare(request)
             while True:
@@ -482,8 +485,12 @@ class InterceptionServer:
                 if chunk is None:
                     await producer
                     break
-                buffer += chunk
                 await resp.write(chunk)
+                if parser_error is None:
+                    try:
+                        feed_event(chunk)
+                    except Exception as e:
+                        parser_error = e
         except ConnectionResetError:
             return resp
         finally:
@@ -495,7 +502,9 @@ class InterceptionServer:
             await reply.close()
 
         try:
-            turn.commit(dialect.parse_stream(bytes(buffer)))
+            if parser_error is not None:
+                raise parser_error
+            turn.commit(parser.finish())
             logger.debug("intercept stream turn: id=%s", session.trace.id)
         finally:
             with contextlib.suppress(ConnectionResetError):

--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -57,6 +57,7 @@ logger = logging.getLogger(__name__)
 _MAX_REQUEST_BODY = 1024**3  # 1 GiB (aiohttp's default is 1 MiB)
 _KEEPALIVE_INTERVAL_SECONDS = 3
 _STREAM_QUEUE_MAXSIZE = 16
+_SSE_DONE_EVENTS = frozenset({b"data: [DONE]\n\n", b"data: [DONE]\r\n\r\n"})
 # The server binds loopback; callers reach it via localhost or a host tunnel (see `reachable_url`).
 _HOST = "127.0.0.1"
 
@@ -463,6 +464,7 @@ class InterceptionServer:
         # Parse complete events as they relay, avoiding a full-stream byte copy.
         parser = dialect.stream_parser()
         feed_event = parser.feed
+        on_done = parser.on_done
         # One bounded producer avoids per-event tasks; keepalive timeouts only cancel readiness waits.
         queue: asyncio.Queue[bytes | None] = asyncio.Queue(
             maxsize=_STREAM_QUEUE_MAXSIZE
@@ -488,6 +490,8 @@ class InterceptionServer:
                 await resp.write(chunk)
                 if parser_error is None:
                     try:
+                        if on_done is not None and chunk in _SSE_DONE_EVENTS:
+                            on_done()
                         feed_event(chunk)
                     except Exception as e:
                         parser_error = e

--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -34,6 +34,7 @@ from pydantic_core import PydanticSerializationError, from_json, to_json
 
 from verifiers.v1.clients import RolloutContext
 from verifiers.v1.dialects import DIALECTS, Dialect
+from verifiers.v1.dialects.base import is_sse_done_event
 from verifiers.v1 import graph
 from verifiers.v1.errors import (
     OverlongPromptError,
@@ -57,7 +58,6 @@ logger = logging.getLogger(__name__)
 _MAX_REQUEST_BODY = 1024**3  # 1 GiB (aiohttp's default is 1 MiB)
 _KEEPALIVE_INTERVAL_SECONDS = 3
 _STREAM_QUEUE_MAXSIZE = 16
-_SSE_DONE_EVENTS = frozenset({b"data: [DONE]\n\n", b"data: [DONE]\r\n\r\n"})
 # The server binds loopback; callers reach it via localhost or a host tunnel (see `reachable_url`).
 _HOST = "127.0.0.1"
 
@@ -490,7 +490,7 @@ class InterceptionServer:
                 await resp.write(chunk)
                 if parser_error is None:
                     try:
-                        if on_done is not None and chunk in _SSE_DONE_EVENTS:
+                        if on_done is not None and is_sse_done_event(chunk):
                             on_done()
                         feed_event(chunk)
                     except Exception as e:


### PR DESCRIPTION
## Summary

This keeps streamed-response behavior the same while removing the interception server's full raw-stream copy.

- Relay every SSE event to the caller byte-for-byte, as before.
- Parse complete events incrementally for trace construction instead of buffering and reparsing the entire stream at EOF.
- For OpenAI Responses, retain a two-event tail and freeze its terminal candidate at `[DONE]`; terminal events already carry the complete response object.
- For Chat Completions and Anthropic Messages, preserve the existing delta reconstruction while retaining only semantic state, not raw SSE bytes.
- Handle CRLF event delimiters without allowing a single CRLF to be misidentified as a blank-line boundary.

## Why

Previously, the server appended every relayed event to a growing `bytearray`, copied that buffer again to immutable `bytes`, and then parsed the complete stream. That duplicated all wire bytes and added an avoidable second pass.

The new dialect-owned stream parsers consume each complete event once. Responses uses a two-entry deque with a bound `append`, keeping the per-delta hot path minimal. Chat and Anthropic maintain the same content, reasoning, tool-call, usage, and finish-state reconstruction as before, then join accumulated fields once at EOF.

## Functional equivalence

This changes internal data ownership, not externally visible behavior:

- Client-visible stream bytes and ordering are unchanged.
- Completed, incomplete, and failed Responses terminal events produce the same trace responses.
- Comments or other relay chunks after the terminal event cannot evict the frozen terminal candidate.
- DONE detection uses the same `data:` extraction semantics as event parsing, including no-space and CR-only framing.
- Missing terminal events still fail.
- Parser errors are deferred until the complete upstream stream has been relayed, matching the previous parse-after-relay behavior.
- Disconnect and cancellation cleanup, the bounded producer task, and connection counts are unchanged.
- Chat and Anthropic still reconstruct the same final typed responses from their deltas.

## Performance

Local PEP 723 microbenchmarks used 200,000 one-character deltas plus comments and ignored events around `[DONE]`. They measured median wall time with `perf_counter_ns`; retained and peak Python allocations were measured separately with `tracemalloc` after GC.

### Responses capture

Workload: 200,005 events and 11,400,315 wire bytes; 101 timing loops. This measures the full historical capture-plus-terminal-parse path against the new terminal snapshot path.

| Measurement | Before | After | Saved |
| --- | ---: | ---: | ---: |
| Median capture + terminal parse | 15.144 ms | 6.227 ms | 8.917 ms (58.88%) |
| Retained traced allocation | 11,405,370 B | 6,534 B | 11,398,836 B (99.94%) |
| Peak traced allocation | 55,549,759 B | 10,088 B | 55,539,671 B (99.98%) |
| Bytes relayed to caller | 11,400,315 B | 11,400,315 B | unchanged |

The old path copied the full wire payload into a `bytearray`, copied it again to `bytes`, and decoded the complete stream during reverse parsing. The new path retains a bounded two-event tail and freezes that tail at `[DONE]`, so later comments or ignored events cannot evict the terminal response.

### Chat and Anthropic parsing

| Dialect | Wire bytes | Before | After | Time saved | Peak allocation before | Peak allocation after | Peak saved |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Chat | 15,600,161 B | 184.427 ms | 152.693 ms | 31.734 ms (17.21%) | 42,134,799 B | 10,231,321 B | 75.72% |
| Anthropic | 17,800,501 B | 174.697 ms | 142.814 ms | 31.883 ms (18.25%) | 46,636,721 B | 10,233,702 B | 78.05% |

Retained semantic output remained effectively identical; the reduction is in redundant raw-stream storage and copies.

## Validation

- Focused local stream validation: 13/13 cases passed, including exact relay bytes, terminal statuses, spaced CRLF DONE, no-space LF DONE, no-space CR-only DONE, comments before `[DONE]`, arbitrary events after `[DONE]`, chunk boundaries, missing terminals, deferred parse errors, disconnect/cancellation, and Chat/Anthropic reconstruction. The test file is intentionally not part of this production-only PR.
- `ruff check`: passed.
- `ruff format --check`: passed.
- Scoped pre-commit hooks: passed.
- Pre-push type-check parity hook: passed.

No tests, benchmark scripts, dependency files, or lockfiles are changed by this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core streaming/trace path for all three wire dialects; behavior is meant to be equivalent but parsing and terminal-event handling are subtle enough that regressions in long streams or edge SSE framing are possible.
> 
> **Overview**
> **SSE trace capture no longer buffers the entire stream.** The interception server creates a per-request `stream_parser()` and calls `feed()` on each complete relayed event, then `finish()` for the trace—instead of growing a `bytearray` and calling `parse_stream(raw)` at EOF.
> 
> **New `StreamParser` API** on `Dialect` with shared helpers `parse_sse_event` and `is_sse_done_event`. Chat and Anthropic parsers accumulate semantic deltas (content, reasoning, tools, usage) without retaining raw SSE; Responses keeps a two-event deque and **freezes** the terminal tail at `[DONE]` via `on_done()` so post-terminal comments cannot evict the completion event.
> 
> **Eval client** uses an atomic regex for SSE event boundaries so CRLF cannot be mis-split across chunk boundaries.
> 
> Relay bytes, ordering, and reconstructed trace responses are intended to stay the same; parser errors are still deferred until after the full upstream stream is relayed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4c2eaf57c05dd07d103ade0021281a3df6f64be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stream SSE responses incrementally across all dialect parsers
> - Replaces the one-shot `parse_stream(raw: bytes) -> Response` method on the `Dialect` ABC with a new `stream_parser() -> StreamParser` method, requiring all dialects to implement incremental parsing.
> - Adds `StreamParser`, an abstract base class in [base.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1838/files#diff-10ccce5f7f0d991c33492a01e73014e10883deb74f7006253f1c690422d841bd) defining `feed()`, `on_done()`, and `finish()` for assembling a response event-by-event.
> - Implements `StreamParser` for each dialect: `ChatStreamParser` for OpenAI Chat, `ResponsesStreamParser` for OpenAI Responses (retains only the tail via a `deque(maxlen=2)`), and `AnthropicStreamParser` for Anthropic.
> - Adds `parse_sse_event` and `is_sse_done_event` helpers in [base.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1838/files#diff-10ccce5f7f0d991c33492a01e73014e10883deb74f7006253f1c690422d841bd), and fixes an SSE boundary regex in [eval.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1838/files#diff-8a1cc6d0e01dde461a22ef26597ccf8f011f4c12328b1c7297cae7acebc78df8) to use atomic grouping to prevent CRLF from splitting events.
> - Behavioral Change: callers that previously called `dialect.parse_stream(raw)` must now call `dialect.stream_parser()`, feed events incrementally, and call `finish()` to get the response.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b4c2eaf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->