### PR TITLE
Make the echo smoke prompt explicit

### DIFF
--- a/tests/v1/fixtures/echo_v1.py
+++ b/tests/v1/fixtures/echo_v1.py
@@ -34,7 +34,17 @@ class EchoConfig(vf.TasksetConfig):
 class EchoTaskset(vf.Taskset[EchoTask, EchoConfig]):
     def load_tasks(self) -> list[EchoTask]:
         return [
-            EchoTask(idx=i, prompt=phrase, system_prompt=SYSTEM, answer=phrase)
+            # Keep coding-agent harnesses on the direct-response path instead of
+            # spending this single-turn smoke task on a tool call.
+            EchoTask(
+                idx=i,
+                prompt=(
+                    "Do not call tools or execute code. Reply immediately and include "
+                    f"this exact phrase in your final response: {phrase}"
+                ),
+                system_prompt=SYSTEM,
+                answer=phrase,
+            )
             for i, phrase in enumerate(self.config.phrases)
         ]
 


### PR DESCRIPTION
## Overview

Make the single-turn echo fixture tell agent-style harnesses to answer immediately, avoid tools, and include the existing phrase.

This keeps the smoke task's functionality unchanged: the phrases, expected answers, system prompt, stop condition, reward logic, and harness/runtime coverage are all the same. The prompt now makes the intended direct-response path explicit instead of leaving a bare phrase open to interpretation.

## Why

Coding-agent harnesses can interpret a bare `hello world` as a greeting or a reason to start a tool-driven workflow. Because this fixture intentionally stops after one model turn, either interpretation can produce reward 0 even when the evaluated infrastructure is healthy.

The task instruction now directly describes the behavior the fixture already scores. No assertions or production harness behavior change.

## Time and resource impact

An affected CI workflow occupies roughly 13–14 minutes of wall time. Its three Python-version jobs consume about 40 runner-minutes in aggregate, with the environment job adding roughly another minute. Avoiding a flaky rerun saves that compute as well as repeated dependency and agent installation, Docker runtime work, and live inference calls.

The normal path remains one model turn with no tool work. The change adds no dependency, retained memory, generated artifact, temporary file, or lockfile update.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test fixture prompt text only; no production harness, assertion, or reward logic changes.
> 
> **Overview**
> The **echo-v1** single-turn e2e fixture no longer sends the target phrase alone as the user prompt. Each task now instructs the model to **not call tools or execute code**, reply immediately, and include the **exact phrase** in the final response.
> 
> Phrases, expected answers, system prompt, single-turn stop rule, and lenient echo reward are unchanged—the change only clarifies the intended direct-response path so agent-style harnesses are less likely to start tool workflows and fail the smoke test with reward 0.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 292748397abc1db6014a101125f8f6eb8cd0e12a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make echo smoke test prompt explicit with a directive to include the phrase
> Updates `EchoTaskset.load_tasks` in [echo_v1.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1840/files#diff-b4e7e4af98ad06a6ec33db52400950698b349733bc9f2aecfc4c407c96dc0795) to replace the bare phrase as the prompt with a full directive string. The directive instructs the assistant not to call tools or execute code, and to include the exact phrase in its response.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2927483.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->