### PR TITLE
feat(v1/clients): add make_async_openai + share api-key resolution

### DIFF
--- a/tests/v1/test_make_async_openai.py
+++ b/tests/v1/test_make_async_openai.py
@@ -1,0 +1,93 @@
+"""`make_async_openai` / `_resolve_api_key`: the v1 ClientConfig -> raw AsyncOpenAI builder
+shared with `resolve_client`, plus the v0 `setup_openai_client` guard that rejects a v1 config.
+
+The api-key resolution is the bit prime-rl needs for ad-hoc engine calls (e.g. prefill scoring a
+teacher via `renderers.client.score`): the configured env var, with the Prime CLI
+config key as a fallback only for the default `PRIME_API_KEY` var on a Prime inference host.
+"""
+
+import pytest
+
+import verifiers.v1 as vf
+from verifiers.v1.clients import config as cfg
+
+
+@pytest.fixture(autouse=True)
+def _no_prime_config(monkeypatch):
+    # Default: no env key and an empty Prime config, so each test opts into exactly the
+    # resolution path it exercises. `apply_prime_config` runs at construction and also reads
+    # this, so patch it before any config is built.
+    monkeypatch.delenv("PRIME_API_KEY", raising=False)
+    monkeypatch.setattr(cfg, "load_prime_config", lambda: {})
+
+
+def test_env_var_key_is_used(monkeypatch):
+    monkeypatch.setenv("PRIME_API_KEY", "sk-from-env")
+    client = vf.make_async_openai(
+        cfg.EvalClientConfig(base_url="http://localhost:8000/v1")
+    )
+    assert client.api_key == "sk-from-env"
+
+
+def test_prime_config_fallback_on_prime_host(monkeypatch):
+    # No env var, default PRIME_API_KEY var, Prime inference host -> fall back to the CLI config
+    # key. This is the path prime-rl's hand-rolled `os.environ.get(var) or "EMPTY"` skipped,
+    # 401-ing a prime-hosted teacher with no env var set.
+    monkeypatch.setattr(cfg, "load_prime_config", lambda: {"api_key": "sk-from-prime"})
+    client = vf.make_async_openai(
+        cfg.EvalClientConfig(base_url="https://api.pinference.ai/api/v1")
+    )
+    assert client.api_key == "sk-from-prime"
+
+
+def test_no_fallback_off_prime_host():
+    # The Prime fallback must NOT fire for a non-Prime host even on the default var.
+    client = vf.make_async_openai(
+        cfg.EvalClientConfig(base_url="http://localhost:8000/v1")
+    )
+    assert client.api_key == "EMPTY"
+
+
+def test_no_fallback_for_custom_api_key_var(monkeypatch):
+    # A custom api_key_var never triggers the Prime-config fallback, even on a Prime host.
+    monkeypatch.setattr(cfg, "load_prime_config", lambda: {"api_key": "sk-from-prime"})
+    client = vf.make_async_openai(
+        cfg.EvalClientConfig(
+            base_url="https://api.pinference.ai/api/v1", api_key_var="OTHER_KEY"
+        )
+    )
+    assert client.api_key == "EMPTY"
+
+
+def test_base_url_and_headers_threaded():
+    client = vf.make_async_openai(
+        cfg.EvalClientConfig(
+            base_url="http://localhost:8000/v1", headers={"X-Data-Parallel-Rank": "3"}
+        )
+    )
+    assert str(client.base_url).rstrip("/") == "http://localhost:8000/v1"
+    assert client.default_headers.get("X-Data-Parallel-Rank") == "3"
+
+
+def test_resolve_client_shares_resolution(monkeypatch):
+    # resolve_client now routes through the same _resolve_api_key, so the TrainClient's
+    # underlying AsyncOpenAI inherits the identical key resolution.
+    monkeypatch.setenv("PRIME_API_KEY", "sk-shared")
+    client = vf.resolve_client(
+        cfg.TrainClientConfig(base_url="http://localhost:8000/v1")
+    )
+    assert isinstance(client, vf.clients.TrainClient)
+    assert client.openai.api_key == "sk-shared"
+
+
+def test_v0_setup_openai_client_rejects_v1_config():
+    # The v0 helper crashes cryptically on a v1 config; the guard turns it into a clear error
+    # pointing at the v1 builders.
+    from verifiers.utils.client_utils import setup_anthropic_client, setup_openai_client
+
+    with pytest.raises(TypeError, match="verifiers.v1"):
+        setup_openai_client(cfg.EvalClientConfig(base_url="http://localhost:8000/v1"))
+    with pytest.raises(TypeError, match="verifiers.v1"):
+        setup_anthropic_client(
+            cfg.TrainClientConfig(base_url="http://localhost:8000/v1")
+        )

--- a/verifiers/utils/client_utils.py
+++ b/verifiers/utils/client_utils.py
@@ -116,8 +116,23 @@ async def post_chat_completion_with_routed_experts_sidecar(
     return response
 
 
+def _reject_v1_config(config: object) -> None:
+    """v1 client configs (`verifiers.v1.clients.config.{Eval,Train}ClientConfig`) are a
+    different shape and otherwise crash deep inside `resolve_client_config` with a cryptic
+    `AttributeError: ... has no attribute 'endpoint_configs'`. Catch the mistake here with
+    an actionable message. Checked by module rather than `isinstance` to avoid importing v1
+    into v0 (v1's config imports `load_prime_config` from this module — a circular import)."""
+    if type(config).__module__.startswith("verifiers.v1"):
+        raise TypeError(
+            f"{type(config).__name__} is a verifiers.v1 client config; build its client with "
+            f"verifiers.v1.resolve_client(config) or verifiers.v1.make_async_openai(config), "
+            f"not the v0 setup_openai_client/setup_anthropic_client."
+        )
+
+
 def setup_openai_client(config: ClientConfig) -> AsyncOpenAI:
     """Setup an AsyncOpenAI client from config."""
+    _reject_v1_config(config)
     resolved_config = resolve_client_config(config)
     headers, api_key = _build_headers_and_api_key(resolved_config)
     return AsyncOpenAI(
@@ -130,6 +145,7 @@ def setup_openai_client(config: ClientConfig) -> AsyncOpenAI:
 
 def setup_anthropic_client(config: ClientConfig) -> AsyncAnthropic:
     """Setup an AsyncAnthropic client from config."""
+    _reject_v1_config(config)
     resolved_config = resolve_client_config(config)
     headers, api_key = _build_headers_and_api_key(resolved_config)
     return AsyncAnthropic(

--- a/verifiers/v1/__init__.py
+++ b/verifiers/v1/__init__.py
@@ -13,6 +13,7 @@ from verifiers.v1.clients import (
     Client,
     ClientConfig,
     RolloutContext,
+    make_async_openai,
     resolve_client,
 )
 from verifiers.v1.decorators import group_reward, metric, reward, stop, tool
@@ -155,6 +156,7 @@ __all__ = [
     "Client",
     "BaseClientConfig",
     "ClientConfig",
+    "make_async_openai",
     "resolve_client",
     # taskset / harness / runtime / environment
     "Taskset",

--- a/verifiers/v1/clients/__init__.py
+++ b/verifiers/v1/clients/__init__.py
@@ -6,6 +6,7 @@ from verifiers.v1.clients.config import (
     ClientConfig,
     EvalClientConfig,
     TrainClientConfig,
+    make_async_openai,
     resolve_client,
 )
 from verifiers.v1.clients.eval import EvalClient
@@ -18,6 +19,7 @@ __all__ = [
     "ClientConfig",
     "EvalClientConfig",
     "TrainClientConfig",
+    "make_async_openai",
     "resolve_client",
     "EvalClient",
     "TrainClient",

--- a/verifiers/v1/clients/config.py
+++ b/verifiers/v1/clients/config.py
@@ -88,7 +88,11 @@ ClientConfig = Annotated[
 ]
 
 
-def resolve_client(config: BaseClientConfig) -> Client:
+def _resolve_api_key(config: BaseClientConfig) -> str:
+    """The api-key resolution shared by `resolve_client` and `make_async_openai`: the
+    configured env var, falling back to the active Prime CLI config's key only for the
+    default `PRIME_API_KEY` var on a Prime inference host. Returns "EMPTY" when nothing
+    resolves (vLLM and other local engines ignore the key)."""
     api_key = os.environ.get(config.api_key_var)
     host = urlparse(config.base_url).hostname or ""
     if (
@@ -97,19 +101,33 @@ def resolve_client(config: BaseClientConfig) -> Client:
         and (host == PRIME_INFERENCE_HOST or host.endswith(f".{PRIME_INFERENCE_HOST}"))
     ):
         api_key = load_prime_config().get("api_key")
-    api_key = api_key or "EMPTY"
+    return api_key or "EMPTY"
+
+
+def make_async_openai(config: BaseClientConfig) -> AsyncOpenAI:
+    """Build a raw `AsyncOpenAI` for `config`'s endpoint with the same api-key / base-url
+    / Prime-config + header resolution `resolve_client` applies — but unwrapped (no
+    `Train`/`Eval` `Client`). For ad-hoc OpenAI-compatible calls that aren't a rollout turn,
+    e.g. prefill-scoring a teacher's token ids via `renderers.client.score`;
+    use `resolve_client` for rollouts. Resolution is identical regardless of `config.type` —
+    a direct engine call needs only an endpoint + key, not the renderer/relay wrapper."""
+    return AsyncOpenAI(
+        base_url=config.base_url,
+        api_key=_resolve_api_key(config),
+        default_headers=config.headers or None,
+    )
+
+
+def resolve_client(config: BaseClientConfig) -> Client:
     if isinstance(config, TrainClientConfig):
         # The renderer calls a vLLM `/inference/v1/generate` engine through the OpenAI SDK.
-        openai = AsyncOpenAI(
-            base_url=config.base_url,
-            api_key=api_key,
-            default_headers=config.headers or None,
-        )
         return TrainClient(
-            openai,
+            make_async_openai(config),
             pool_size=config.pool_size,
             config=config.renderer,
             renderer_model_name=config.renderer_model_name,
         )
     # The proxy is a raw httpx forwarder; the dialect supplies the auth scheme + upstream path.
-    return EvalClient(config.base_url, api_key, headers=config.headers or None)
+    return EvalClient(
+        config.base_url, _resolve_api_key(config), headers=config.headers or None
+    )


### PR DESCRIPTION
## What

Adds `make_async_openai(config: BaseClientConfig) -> AsyncOpenAI`: the config → raw OpenAI client build with the **same** api-key / base-url / Prime-config + header resolution as `resolve_client`, but **unwrapped** (no `Train`/`Eval` `Client`). For ad-hoc OpenAI-compatible calls that aren't a rollout turn — e.g. prefill-scoring a teacher's token ids via `renderers.client.score_prompt_logprobs`. `resolve_client` stays the rollout path.

The shared resolution is extracted into a private `_resolve_api_key`, so `resolve_client` and `make_async_openai` are a single path.

Also guards the **v0** `setup_openai_client` / `setup_anthropic_client` to raise a clear `TypeError` (pointing at the v1 builders) when handed a v1 `ClientConfig`, instead of today's cryptic `AttributeError: ... 'endpoint_configs'`.

## Why

prime-rl currently hand-rolls `AsyncOpenAI(api_key=os.environ.get(var) or "EMPTY", ...)` for teacher scoring, which **skips the `PRIME_API_KEY` → prime-config fallback** — a latent `Bearer EMPTY` → 401 for a prime-hosted teacher with no env var set. Routing through `make_async_openai` fixes that for free.

This is the verifiers half of the OPD/OPSD prefill-scoring co-design: verifiers owns config→client resolution; renderers owns the scoring wire (`score_prompt_logprobs`); prime-rl composes them.

## Tests

7 new tests (`tests/v1/test_make_async_openai.py`): env-var key, the Prime-config fallback (the 401 fix), no-fallback off-host / for custom var, base_url + headers threading, `resolve_client` shares the resolution, and the v0 guard. No regressions in existing client-config tests.

## Cross-repo

Independent of the renderers PR (doesn't import the new renderers symbol). prime-rl consumes `vf.make_async_openai` to build the client it hands to `renderers.score_prompt_logprobs`, deleting its hand-rolled construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how API keys are resolved for v1 clients (including Prime CLI fallback), which can fix or alter auth for Prime-hosted endpoints; scope is limited to client construction with tests covering the main paths.
> 
> **Overview**
> Adds **`verifiers.v1.make_async_openai`**, which builds an unwrapped `AsyncOpenAI` from v1 `BaseClientConfig` using the same endpoint, headers, and API key rules as **`resolve_client`**—intended for ad-hoc calls (e.g. teacher prefill scoring) instead of rollout `Train`/`Eval` clients.
> 
> API key lookup is centralized in **`_resolve_api_key`**: env var first, then Prime CLI `api_key` only when `api_key_var` is `PRIME_API_KEY` and `base_url` is a Prime inference host; otherwise `"EMPTY"`. **`resolve_client`** now uses that helper and **`make_async_openai`** for `TrainClient`’s underlying SDK client.
> 
> v0 **`setup_openai_client`** / **`setup_anthropic_client`** call **`_reject_v1_config`** so passing a v1 config raises a clear **`TypeError`** pointing at the v1 builders instead of a deep `endpoint_configs` **`AttributeError`**.
> 
> Seven tests in **`tests/v1/test_make_async_openai.py`** cover resolution paths, header threading, shared resolution with **`resolve_client`**, and the v0 guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65ae75863f9efc6ebfa984bbc977fcff357826b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `make_async_openai` to v1 clients and share API key resolution logic
> - Adds `make_async_openai` in [`verifiers/v1/clients/config.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1842/files#diff-052fb75ebcf125bca5326c84afdabf150d579712daa8474171035d7268a42be1) as a standalone builder that constructs an `AsyncOpenAI` with the same base URL, headers, and API key resolution used by `resolve_client`.
> - Extracts API key resolution into `_resolve_api_key`, which reads the configured env var, falls back to `load_prime_config()['api_key']` only for Prime hosts with the default `PRIME_API_KEY` var, and returns `'EMPTY'` when nothing resolves.
> - Refactors `resolve_client` to use `_resolve_api_key` and `make_async_openai` internally so all paths share the same resolution semantics.
> - Adds a `_reject_v1_config` guard to `setup_openai_client` and `setup_anthropic_client` in [`verifiers/utils/client_utils.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1842/files#diff-115f7c6465eb15fbfda8768948af933ae7033df60ce7bc69865346c3e88894a0) that raises `TypeError` when a v1 config is passed, directing callers to use `verifiers.v1.resolve_client` or `verifiers.v1.make_async_openai` instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 65ae758.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->