### PR TITLE
feat(v1/trace): add Trace.to_record() for training-payload-stripped dumps

### DIFF
--- a/tests/v1/test_trace.py
+++ b/tests/v1/test_trace.py
@@ -5,8 +5,6 @@ dump without importing the originating taskset."""
 
 import json
 
-import pytest
-
 import verifiers.v1 as vf
 from verifiers.v1.graph import MessageNode
 from verifiers.v1.types import AssistantMessage, UserMessage
@@ -84,53 +82,3 @@ def test_wire_trace_round_trip():
 
     # the env-server wire form (a plain model_dump) loads too
     assert vf.WireTrace.model_validate(tr.model_dump()).num_branches == 2
-
-
-def test_to_record_excludes_node_tensors_and_round_trips():
-    """`to_record` is the disk/W&B record: it strips the per-node training tensors that can't
-    round-trip JSON (the plain json dump crashes on real expert ids) and the result reloads as
-    a WireTrace, while token_ids/mask/logprobs/usage are kept."""
-    import numpy as np
-    from renderers.base import MultiModalData
-
-    from verifiers.v1.types import Usage
-
-    # uint8 expert ids with a real (>0x7F) value, plus a multimodal numpy item — both ride the
-    # wire as raw bytes but cannot UTF-8 decode for JSON.
-    routed = np.array([[[200]], [[3]]], dtype=np.uint8)
-    mmd = MultiModalData(
-        mm_items={"image": [{"pixel_values": np.array([200], np.uint8)}]}
-    )
-    tr = vf.Trace(
-        task=MyTask(idx=0, prompt="q", answer="a"),
-        nodes=[
-            MessageNode(parent=None, message=UserMessage(content="q"), sampled=False),
-            MessageNode(
-                parent=0,
-                message=AssistantMessage(content="a"),
-                sampled=True,
-                token_ids=[1, 2],
-                mask=[True, True],
-                logprobs=[-0.1, -0.2],
-                usage=Usage(prompt_tokens=1, completion_tokens=2),
-                routed_experts=routed,
-                multi_modal_data=mmd,
-            ),
-        ],
-    )
-
-    # The load-bearing reason for the exclude: a plain json dump crashes on the raw tensor bytes.
-    with pytest.raises(UnicodeDecodeError):
-        tr.model_dump(mode="json")
-
-    rec = tr.to_record()
-    json.dumps(rec)  # genuinely JSON-serializable
-    node = rec["nodes"][1]
-    assert "routed_experts" not in node and "multi_modal_data" not in node
-    # Training payload that DOES round-trip is kept.
-    assert node["token_ids"] == [1, 2] and node["mask"] == [True, True]
-    assert node["usage"]["completion_tokens"] == 2
-    assert "state" not in rec  # transient, never dumped
-    # Reloads as a WireTrace with the graph intact.
-    rt = vf.WireTrace.model_validate(rec)
-    assert rt.num_branches == 1 and rt.num_turns == 1 and rt.completion_len == 2

--- a/tests/v1/test_trace.py
+++ b/tests/v1/test_trace.py
@@ -5,6 +5,8 @@ dump without importing the originating taskset."""
 
 import json
 
+import pytest
+
 import verifiers.v1 as vf
 from verifiers.v1.graph import MessageNode
 from verifiers.v1.types import AssistantMessage, UserMessage
@@ -82,3 +84,53 @@ def test_wire_trace_round_trip():
 
     # the env-server wire form (a plain model_dump) loads too
     assert vf.WireTrace.model_validate(tr.model_dump()).num_branches == 2
+
+
+def test_to_record_excludes_node_tensors_and_round_trips():
+    """`to_record` is the disk/W&B record: it strips the per-node training tensors that can't
+    round-trip JSON (the plain json dump crashes on real expert ids) and the result reloads as
+    a WireTrace, while token_ids/mask/logprobs/usage are kept."""
+    import numpy as np
+    from renderers.base import MultiModalData
+
+    from verifiers.v1.types import Usage
+
+    # uint8 expert ids with a real (>0x7F) value, plus a multimodal numpy item — both ride the
+    # wire as raw bytes but cannot UTF-8 decode for JSON.
+    routed = np.array([[[200]], [[3]]], dtype=np.uint8)
+    mmd = MultiModalData(
+        mm_items={"image": [{"pixel_values": np.array([200], np.uint8)}]}
+    )
+    tr = vf.Trace(
+        task=MyTask(idx=0, prompt="q", answer="a"),
+        nodes=[
+            MessageNode(parent=None, message=UserMessage(content="q"), sampled=False),
+            MessageNode(
+                parent=0,
+                message=AssistantMessage(content="a"),
+                sampled=True,
+                token_ids=[1, 2],
+                mask=[True, True],
+                logprobs=[-0.1, -0.2],
+                usage=Usage(prompt_tokens=1, completion_tokens=2),
+                routed_experts=routed,
+                multi_modal_data=mmd,
+            ),
+        ],
+    )
+
+    # The load-bearing reason for the exclude: a plain json dump crashes on the raw tensor bytes.
+    with pytest.raises(UnicodeDecodeError):
+        tr.model_dump(mode="json")
+
+    rec = tr.to_record()
+    json.dumps(rec)  # genuinely JSON-serializable
+    node = rec["nodes"][1]
+    assert "routed_experts" not in node and "multi_modal_data" not in node
+    # Training payload that DOES round-trip is kept.
+    assert node["token_ids"] == [1, 2] and node["mask"] == [True, True]
+    assert node["usage"]["completion_tokens"] == 2
+    assert "state" not in rec  # transient, never dumped
+    # Reloads as a WireTrace with the graph intact.
+    rt = vf.WireTrace.model_validate(rec)
+    assert rt.num_branches == 1 and rt.num_turns == 1 and rt.completion_len == 2

--- a/verifiers/v1/ARCHITECTURE.md
+++ b/verifiers/v1/ARCHITECTURE.md
@@ -68,10 +68,14 @@ several. A branch *is* a training sample: concatenating its nodes' `token_ids` r
 `logprobs` line up — no agent-specific export code. This is why compaction and subagents train
 end to end: each surviving context window is just another root→leaf path.
 
-`Trace.to_wire()` (`trace.py`) is `model_dump` minus what shouldn't travel: computed views
-(`reward`, `branches`, `num_turns`), per-span `duration`s (recomputed on the far side), and
-`usage`. Multimodal pixel tensors *do* travel — base64-encoded by a field serializer on
-`MessageNode.multi_modal_data` (`graph.py`) so they survive JSON + msgpack to the trainer.
+`Trace.to_record()` (`trace.py`) is the JSON record dump (`model_dump(mode="json")`) for
+`results.jsonl` / W&B tables, minus the per-node training tensors (`MessageNode.multi_modal_data`,
+`routed_experts`, via `_NODE_DUMP_EXCLUDE`): those hold raw numpy bytes that can't round-trip JSON
+(the dump raises `UnicodeDecodeError` on real expert ids) and bloat every line. Computed views
+(`reward`, `branches`, `num_turns`, per-span `duration`) are pydantic properties, so they're never
+serialized and recompute on load; `state` is excluded. The tensors still reach the trainer over the
+env-server *wire*, which uses msgpack `model_dump(mode="python")` and carries them as raw `bin` bytes
+(not base64) via the field serializers on `MessageNode` (`graph.py`); only the JSON record strips them.
 
 ### Branching: message-level vs renderer-level, and the token invariant
 

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -201,6 +201,16 @@ class Branch(StrictBaseModel):
         return usage.completion_tokens if usage else 0
 
 
+_NODE_DUMP_EXCLUDE: dict = {
+    "nodes": {"__all__": {"multi_modal_data", "routed_experts"}}
+}
+"""The per-node fields `Trace.to_record` strips from a JSON dump: the multimodal `mm_kwargs`
+carrier and the router-replay `routed_experts` array. Both hold raw numpy bytes (msgpack `bin`)
+that the env-server wire carries fine but JSON cannot — `model_dump(mode="json")` raises
+`UnicodeDecodeError` on real (>0x7F) expert ids — and they bloat every record line besides.
+Lives with the schema it excludes so a new tensor field can't silently start crashing dumps."""
+
+
 class Trace(StrictBaseModel, Generic[TaskT, StateT]):
     """The full record of one rollout. Subclass to add typed fields."""
 
@@ -229,7 +239,7 @@ class Trace(StrictBaseModel, Generic[TaskT, StateT]):
     """Transient per-rollout runtime state (see `verifiers.v1.state.State`): shared with the tool/user
     servers as `self.state` (synced over the interception server) and read+written by scoring. Runtime
     scratch (counters, game progress, end-of-trajectory flags) — excluded from every dump (`model_dump`
-    + `to_wire`), unlike `info` which persists. Type it via `Taskset[Task, Config, MyState]`; defaults
+    / `to_record`), unlike `info` which persists. Type it via `Taskset[Task, Config, MyState]`; defaults
     to the base `State`."""
 
     is_completed: bool = False
@@ -400,6 +410,18 @@ class Trace(StrictBaseModel, Generic[TaskT, StateT]):
             )
         )
         self.stop("error")
+
+    def to_record(self) -> dict[str, Any]:
+        """A JSON-serializable record of this rollout for `results.jsonl` / W&B tables.
+
+        `model_dump(mode="json")` minus the per-node training tensors (`_NODE_DUMP_EXCLUDE`):
+        those carry raw numpy bytes that JSON can't encode (the plain dump raises
+        `UnicodeDecodeError` on real expert ids) and that bloat every line. Everything else —
+        including `token_ids` / `mask` / `logprobs` / `is_content` and provider `usage` — is
+        kept; `state` and the computed-property views (`reward`, `branches`, `duration`) are
+        absent by construction (excluded / never serialized). The tensors still reach the
+        trainer over the env-server wire (msgpack raw bytes); only this record path strips them."""
+        return self.model_dump(mode="json", exclude=_NODE_DUMP_EXCLUDE)
 
 
 TraceT = TypeVar("TraceT", bound=Trace)  # type: ignore[type-arg]


### PR DESCRIPTION
## What

Adds `Trace.to_record() -> dict`: `model_dump(mode="json")` minus the per-node training tensors (`multi_modal_data`, `routed_experts`) via a co-located `_NODE_DUMP_EXCLUDE`. The exclude lives **with the schema** it excludes, so a future tensor field can't silently start crashing dumps.

`token_ids` / `mask` / `logprobs` / `is_content` / provider `usage` are kept; `state` and the computed-property views (`reward`, `branches`, `duration`) are absent by construction.

## Why

Those two node fields hold raw numpy bytes (msgpack `bin`) that ride the env-server wire fine but **cannot round-trip JSON** — `model_dump(mode="json")` raises `UnicodeDecodeError` on real (>0x7F) expert ids (verified) — and they bloat every record line. prime-rl hand-codes this exact exclude (`ROLLOUT_DUMP_EXCLUDE`) at its `results.jsonl` / W&B dump sites; `to_record()` moves it next to the schema.

Also fixes stale docs: `ARCHITECTURE.md` and the `state` docstring referenced a nonexistent `Trace.to_wire()`, claimed base64 encoding (it's raw msgpack `bin`), and claimed `usage` is excluded (it's kept).

## Tests

1 new test (`tests/v1/test_trace.py`): asserts the plain json dump **crashes** on real expert ids (pins the load-bearing reason), then `to_record()` strips both tensors, is JSON-serializable, keeps `token_ids`/`mask`/`usage`, and reloads as a `WireTrace`. No regressions.

## Cross-repo

verifiers-only. prime-rl replaces `r.model_dump(mode="json", exclude=ROLLOUT_DUMP_EXCLUDE)` with `r.to_record()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API and documentation; no change to wire serialization or rollout behavior beyond a dedicated JSON dump helper.
> 
> **Overview**
> Adds **`Trace.to_record()`** as the canonical path for `results.jsonl` / W&B: `model_dump(mode="json")` with a co-located **`_NODE_DUMP_EXCLUDE`** that drops per-node **`multi_modal_data`** and **`routed_experts`** (raw bytes that break JSON and bloat lines). Training fields like **`token_ids`**, **`mask`**, **`logprobs`**, and provider **`usage`** stay in the record; env-server **msgpack** wire is unchanged.
> 
> **`ARCHITECTURE.md`** and the **`state`** docstring stop referring to nonexistent **`to_wire()`** and instead document **`to_record()`** vs wire (raw **`bin`**, not base64).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d9186d585c235a1ba769e3d6d6c40ea282acc36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `Trace.to_record()` for JSON dumps that strip per-node training tensors
> Adds `Trace.to_record()` to [trace.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1844/files#diff-834820c3aa80d87ee1c1c57fb54c74f09c66ac727036d964e6005c8613c00b5e), which returns a JSON-serializable `model_dump` of a rollout trace while excluding `multi_modal_data` and `routed_experts` from each node via the new `_NODE_DUMP_EXCLUDE` constant. Fields like `token_ids`, `mask`, `logprobs`, `is_content`, and provider `usage` are retained. Architecture docs are updated to clarify that tensors still traverse the env-server wire via msgpack; only this JSON record strips them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9d9186d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->