### PR TITLE
fix: rich dashboard per-rollout timer includes setup

### DIFF
--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -209,14 +209,16 @@ def _tokens(trace: Trace) -> tuple[int, int, int | None, int | None, int]:
 def _groups(rollouts: list[Rollout]) -> list[list[Rollout]]:
     # The n rollouts of each task, grouped together (so they sit adjacent); groups ordered by
     # earliest start, rollouts within a group by start. Finished ones stay (never removed).
+    # Ordered by `setup.start` (the rollout's true start) so a rollout still in setup — which
+    # has no `generation.start` yet — sorts and shows in its real position, not pinned at 0.
     by_task: dict[int, list[Rollout]] = {}
     for rollout in rollouts:
         if rollout.trace is not None:
             by_task.setdefault(rollout.trace.task.idx, []).append(rollout)
     groups = list(by_task.values())
     for group in groups:
-        group.sort(key=lambda r: r.trace.timing.generation.start)
-    groups.sort(key=lambda g: g[0].trace.timing.generation.start)
+        group.sort(key=lambda r: r.trace.timing.setup.start)
+    groups.sort(key=lambda g: g[0].trace.timing.setup.start)
     return groups
 
 
@@ -253,7 +255,7 @@ def Rows(groups: list[list[Rollout]], now: float, runtime_type: str) -> Table:
             )
             runtime = f"{runtime_type}({descriptor})" if descriptor else runtime_type
             turns = t.num_turns
-            start = t.timing.generation.start
+            start = t.timing.setup.start
             end = (
                 t.timing.scoring.end
                 or t.timing.finalize.end
@@ -282,7 +284,9 @@ def Rows(groups: list[list[Rollout]], now: float, runtime_type: str) -> Table:
                 f"{format_cost_usd(cost)}" if cost is not None else "",
                 stop,  # stop condition (agent_completed / max_turns / harness_timeout), once done
             ]
-            # No start time yet (queued, not generating) → blank, not `now - 0` (~56 years).
+            # Time from `setup.start` (the rollout's true start) so it spans the whole rollout —
+            # runtime + taskset + harness setup, then generation — not just generation. Blank
+            # before setup starts → no `now - 0` (~56 years).
             elapsed = format_time(end - start) if start else ""
             rows.append((_brace(i, len(group)), state, left, result, elapsed))
     grid = Table.grid(expand=True, padding=(0, 1))

--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -258,6 +258,9 @@ def Rows(groups: list[list[Rollout]], now: float, runtime_type: str) -> Table:
                 t.timing.scoring.end
                 or t.timing.finalize.end
                 or t.timing.generation.end
+                # a rollout that errored in setup has only setup.end — freeze there once done,
+                # else (still running) the timer would grow off `now` forever
+                or (t.timing.setup.end if t.is_completed else 0)
                 or now
             )
             prompt, completion, cached, reasoning, nbranches = _tokens(t)

--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -209,8 +209,6 @@ def _tokens(trace: Trace) -> tuple[int, int, int | None, int | None, int]:
 def _groups(rollouts: list[Rollout]) -> list[list[Rollout]]:
     # The n rollouts of each task, grouped together (so they sit adjacent); groups ordered by
     # earliest start, rollouts within a group by start. Finished ones stay (never removed).
-    # Ordered by `setup.start` (the rollout's true start) so a rollout still in setup — which
-    # has no `generation.start` yet — sorts and shows in its real position, not pinned at 0.
     by_task: dict[int, list[Rollout]] = {}
     for rollout in rollouts:
         if rollout.trace is not None:
@@ -284,9 +282,7 @@ def Rows(groups: list[list[Rollout]], now: float, runtime_type: str) -> Table:
                 f"{format_cost_usd(cost)}" if cost is not None else "",
                 stop,  # stop condition (agent_completed / max_turns / harness_timeout), once done
             ]
-            # Time from `setup.start` (the rollout's true start) so it spans the whole rollout —
-            # runtime + taskset + harness setup, then generation — not just generation. Blank
-            # before setup starts → no `now - 0` (~56 years).
+            # No start time yet (queued, not generating) → blank, not `now - 0` (~56 years).
             elapsed = format_time(end - start) if start else ""
             rows.append((_brace(i, len(group)), state, left, result, elapsed))
     grid = Table.grid(expand=True, padding=(0, 1))


### PR DESCRIPTION
## Summary

Fixes #1845. In the `--rich` dashboard, each rollout's elapsed time was computed from `generation.start`, which `rollout.py` sets only *after* setup finishes — so the displayed duration excluded the setup phase (runtime start, taskset `setup`, harness setup), and a rollout still in setup showed a blank timer.

- `verifiers/v1/cli/dashboard/eval.py` — the per-rollout timer origin is now `t.timing.setup.start` (the rollout's true start, stamped at the top of `Rollout.run`) instead of `generation.start`.
- `_groups` ordering switches to `setup.start` too, so a rollout still in setup (no `generation.start` yet) sorts/shows in its real position rather than pinned at 0.
- The `end` fallback now also covers `setup.end` **once the rollout is completed**. A rollout that errored *during* setup has only `setup.end` set (no generation/finalize/scoring end), so the old chain fell through to live `now` and the timer kept growing after it finished — with the origin moved to `setup.start`. It now freezes at `setup.end`. The `is_completed` guard means an in-flight rollout still counts off `now` (its `setup.end` isn't used to freeze it mid-generation).

Queued rollouts (no trace yet) are still excluded, and `setup.start == 0` still renders blank, so there's no spurious `now - 0`.

## Verification

Rendered the real `_groups` + `Rows` (via `rich`) and asserted the displayed time column:

| scenario | timing | displayed |
| --- | --- | --- |
| normal completion | setup 8s + gen 3s + scoring 1s | `12s` (was `4s` before the fix — the bug) |
| **errored in setup** (completed) | setup 3s, nothing else, rendered at +100s | `3s` (frozen — was growing to `1m 40s`) |
| still in setup (running) | setup.start set, +7s | `7s` (live, keeps growing) |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only change in the CLI rich dashboard; no eval, scoring, or rollout execution logic is modified.
> 
> **Overview**
> Fixes the `--rich` eval dashboard so per-rollout **elapsed time** and **group ordering** use `timing.setup.start` instead of `timing.generation.start`, so setup (runtime, taskset/harness setup) counts toward the displayed duration and rollouts still in setup get a live timer instead of a blank column.
> 
> When computing the end timestamp for the timer, the chain now falls back to **`setup.end` for completed rollouts** that never reached generation/scoring (e.g. setup errors), so finished failures show a stable duration instead of growing against `now`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50b29c8c3f5e53b7afb49a0e5d690d3053b2504b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix rich dashboard per-rollout timer to start from setup instead of generation
> - Changes elapsed time calculations in [eval.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1846/files#diff-0a27b905958929f3ae9e01937dd7e3cf97a60dec137caddcbf87792784fc9035) to use `timing.setup.start` instead of `timing.generation.start` as the start reference.
> - Rollouts that complete during setup (e.g., errored in setup) now freeze their elapsed timer at `setup.end` rather than continuing to grow.
> - End time selection now considers `scoring.end`, `finalize.end`, `generation.end`, and `setup.end` in priority order.
> - Row ordering and group sorting also switch to `setup.start` for consistency.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 50b29c8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->