### PR TITLE
Add TMax v1 taskset

### DIFF
--- a/configs/tmax-v1-smoke.toml
+++ b/configs/tmax-v1-smoke.toml
@@ -1,0 +1,26 @@
+# tmax-v1 smoke config. TMax is loaded from the runnable Harbor dataset; these
+# five task ids have prebuilt public Prime images.
+num_tasks = 5
+num_rollouts = 1
+max_concurrent = 1
+
+[taskset]
+id = "tmax-v1"
+tasks = [
+    "task_000004_aeddda76",
+    "task_000047_9e04faa8",
+    "task_000075_827b7baa",
+    "task_000102_23d0bca1",
+    "task_000105_0594c6f6",
+]
+
+[taskset.image_map]
+task_000004_aeddda76 = "team-clyvldofb0000gg1kx39rgzjq/tmax-smoke-task-000004-aeddda76:20260623"
+task_000047_9e04faa8 = "team-clyvldofb0000gg1kx39rgzjq/tmax-smoke-task-000047-9e04faa8:20260623"
+task_000075_827b7baa = "team-clyvldofb0000gg1kx39rgzjq/tmax-smoke-task-000075-827b7baa:20260623"
+task_000102_23d0bca1 = "team-clyvldofb0000gg1kx39rgzjq/tmax-smoke-task-000102-23d0bca1:20260623"
+task_000105_0594c6f6 = "team-clyvldofb0000gg1kx39rgzjq/tmax-smoke-task-000105-0594c6f6:20260623"
+
+[harness]
+id = "bash"
+runtime = { type = "prime" }

--- a/verifiers/v1/GUIDE.md
+++ b/verifiers/v1/GUIDE.md
@@ -492,6 +492,11 @@ The `*_v1` tasksets under `environments/` are the reference library — each sho
 | `scaleswe-v1`, `swelego-v1`, `r2e-gym-v1` | containerized SWE tasks (rlm harness, prime runtime) |
 | `swebench-verified-v1` | SWE-bench Verified via `harbor-v1` on prime's prebuilt images (no Dockerfile build) |
 | `wordle-v1`, `terminal-bench-2-v1` | thin configs over the shipped `textarena-v1` / `harbor-v1` integrations |
+| `tmax-v1` | built-in Harbor TMax taskset pinned to `tmax/TMax-15K-Harbor@latest`; requires `[taskset.image_map]` for selected task ids |
+
+For `tmax-v1`, use Harbor as the runnable source. The TMax paper, GitHub repo, and Hugging
+Face records are provenance only; execution comes from Harbor task directories plus the Prime
+image mapped for each selected task.
 
 ---
 

--- a/verifiers/v1/README.md
+++ b/verifiers/v1/README.md
@@ -78,6 +78,7 @@ Taskset examples (the `*_v1` packages under `environments/`):
 | `deepwiki-v1` | an **existing remote** tool server, by URL |
 | `wordle-v1` | configuring the vendored `textarena-v1` integration |
 | `terminal-bench-2-v1` | configuring the vendored `harbor-v1` integration |
+| `tmax-v1` | a built-in Harbor specialization pinned to TMax, with per-task Prime images |
 
 Harness examples (under `environments/`):
 
@@ -237,6 +238,21 @@ image — e.g. Terminal-Bench 2:
 
 ```bash
 uv run eval harbor-v1 --taskset.dataset terminal-bench/terminal-bench-2 -n 10 --harness.id rlm
+```
+
+`tmax-v1` is a built-in Harbor specialization pinned to the runnable
+`tmax/TMax-15K-Harbor@latest` dataset. Treat Harbor as the execution source; the TMax paper,
+GitHub repo, and Hugging Face records are provenance checks, not the runtime contract. TMax
+tasks use Dockerfile environments, so select only tasks with prebuilt images and provide a
+mapping keyed by Harbor task directory id:
+
+```toml
+[taskset]
+id = "tmax-v1"
+tasks = ["task_000004_aeddda76"]
+
+[taskset.image_map]
+task_000004_aeddda76 = "team-clyvldofb0000gg1kx39rgzjq/tmax-smoke-task-000004-aeddda76:20260623"
 ```
 
 ## Backwards compatibility

--- a/verifiers/v1/tasksets/__init__.py
+++ b/verifiers/v1/tasksets/__init__.py
@@ -5,5 +5,6 @@ here — it imports the optional `textarena` dependency at module load — but s
 `verifiers.v1.tasksets.textarena_v1`."""
 
 from verifiers.v1.tasksets.harbor_v1 import HarborConfig, HarborTaskset
+from verifiers.v1.tasksets.tmax_v1 import TMaxConfig, TMaxTaskset
 
-__all__ = ["HarborConfig", "HarborTaskset"]
+__all__ = ["HarborConfig", "HarborTaskset", "TMaxConfig", "TMaxTaskset"]

--- a/verifiers/v1/tasksets/tmax_v1/__init__.py
+++ b/verifiers/v1/tasksets/tmax_v1/__init__.py
@@ -1,0 +1,3 @@
+from verifiers.v1.tasksets.tmax_v1.taskset import TMaxConfig, TMaxTaskset
+
+__all__ = ["TMaxConfig", "TMaxTaskset"]

--- a/verifiers/v1/tasksets/tmax_v1/taskset.py
+++ b/verifiers/v1/tasksets/tmax_v1/taskset.py
@@ -1,0 +1,41 @@
+"""tmax-v1: TMax Harbor tasks with explicit prebuilt Prime images."""
+
+from pathlib import Path
+from typing import Literal
+
+from pydantic import Field, field_validator
+
+import verifiers.v1 as vf
+from verifiers.v1.tasksets.harbor_v1 import HarborConfig, HarborTask, HarborTaskset
+
+
+class TMaxConfig(HarborConfig):
+    dataset: Literal["tmax/TMax-15K-Harbor@latest"] = "tmax/TMax-15K-Harbor@latest"
+    ignore_dockerfile: bool = True
+    """Keep Harbor from rejecting Dockerfile-only tasks; `image_map` supplies the image."""
+    image_map: dict[str, str] = Field(default_factory=dict)
+    """Prime image by Harbor task directory id, e.g. `task_000004_aeddda76`."""
+
+    @field_validator("tasks", mode="before")
+    @classmethod
+    def coerce_single_task(cls, tasks: object) -> object:
+        if isinstance(tasks, str):
+            return [tasks]
+        return tasks
+
+
+class TMaxTaskset(HarborTaskset, vf.Taskset[HarborTask, TMaxConfig]):
+    NEEDS_CONTAINER = True
+
+    def load_tasks(self) -> list[HarborTask]:
+        tasks: list[HarborTask] = []
+        for task in super().load_tasks():
+            task_id = Path(task.task_dir).name
+            image = self.config.image_map.get(task_id)
+            if image is None:
+                raise ValueError(
+                    f"tmax-v1 task {task_id!r} has no image mapping. Add "
+                    f'`{task_id} = "..."` under `[taskset.image_map]`.'
+                )
+            tasks.append(task.model_copy(update={"image": image}))
+        return tasks


### PR DESCRIPTION
## Summary
- Add built-in `tmax-v1` under `verifiers.v1.tasksets` as a narrow Harbor specialization pinned to `tmax/TMax-15K-Harbor@latest`.
- Require an explicit `[taskset.image_map]` entry for each selected TMax task and set the mapped Prime image on the loaded Harbor task.
- Add `configs/tmax-v1-smoke.toml` with the five pushed public Prime smoke images and document Harbor as the runnable source.

## Validation
- `uv run ruff check verifiers/v1/tasksets/tmax_v1/__init__.py verifiers/v1/tasksets/tmax_v1/taskset.py verifiers/v1/tasksets/__init__.py`
- `uv run python -m py_compile verifiers/v1/tasksets/tmax_v1/__init__.py verifiers/v1/tasksets/tmax_v1/taskset.py verifiers/v1/tasksets/__init__.py`
- `uv lock --check`
- `uv run --python 3.13 ty check verifiers`
- `git diff --check HEAD~1..HEAD`
- `uv run eval @ configs/tmax-v1-smoke.toml --taskset.tasks task_000004_aeddda76 -m openai/gpt-5.5 -n 1 -r 1 -c 1 --rich false -o outputs/smokes/tmax-v1-20260623T211516Z`
  - `results.jsonl`: `tmax/task_000004_aeddda76`, `solved=1.0`, completed, no errors

No unit tests were added, per the requested scope.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive built-in taskset and docs; runtime behavior is inherited from harbor-v1 with explicit image injection and clear errors for missing mappings.
> 
> **Overview**
> Adds a built-in **`tmax-v1`** taskset that specializes **`harbor-v1`** for the TMax Harbor dataset **`tmax/TMax-15K-Harbor@latest`**. **`TMaxConfig`** pins that dataset, sets **`ignore_dockerfile`** so Dockerfile-only tasks are not rejected, and requires **`[taskset.image_map]`** entries keyed by Harbor task directory id. **`TMaxTaskset.load_tasks`** loads Harbor tasks then injects the mapped Prime image on each row, failing fast if a selected task has no mapping.
> 
> Package exports and docs (**`GUIDE.md`**, **`README.md`**) describe Harbor as the execution source and the image-map workflow. **`configs/tmax-v1-smoke.toml`** wires five smoke task ids to public Prime images with bash harness on prime runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6201f27df8899c7c6f0d529aa537d9c72af88726. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add TMax v1 taskset backed by Harbor with per-task Prime image mapping
> - Adds `TMaxTaskset` and `TMaxConfig` in [taskset.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1847/files#diff-60337ea804dbb66cab6feb05f3ca7e4dd789420eb5be4f91957e68964a808114), a `HarborTaskset` subclass that loads tasks from `tmax/TMax-15K-Harbor@latest` and injects a Prime image per task from a required `image_map`.
> - Missing `image_map` entries cause a hard failure at load time, so all selected tasks must have a mapped image before the taskset can run.
> - Adds a smoke config in [configs/tmax-v1-smoke.toml](https://github.com/PrimeIntellect-ai/verifiers/pull/1847/files#diff-ba6232f1572c30b2c806d872eca9a0c9e3adba66f237b01f046c1149fc9b9ed8) with 5 tasks, 1 rollout, and `max_concurrent=1`.
> - Updates `verifiers/v1/tasksets/__init__.py` to export `TMaxConfig` and `TMaxTaskset`, and adds documentation in the v1 README and GUIDE.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6201f27.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->