### PR TITLE
fix(runtimes): make _ENSURE_UV robust to old/stale uv in base images

### DIFF
--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -41,9 +41,13 @@ _DOWNLOAD_UV = (
 )
 _ENSURE_UV = (
     'export PATH="$HOME/.local/bin:$PATH" UV_INSTALL_DIR="$HOME/.local/bin"; '
-    "command -v uv >/dev/null 2>&1 "
-    "|| pip install -q uv 2>/dev/null "
-    f"|| {{ {_INSTALL_CURL}; {_DOWNLOAD_UV}; }}"
+    # Reuse the image's uv only if it supports inline-script metadata (`uv sync --script`,
+    # which prepare_uv_script relies on). Old base images can ship a uv that predates `--script`
+    # (or a stale one shadowing on PATH), so otherwise install a fresh uv into $HOME/.local/bin
+    # (ahead of any system uv on PATH); fall back to pip when no downloader is available.
+    "{ command -v uv >/dev/null 2>&1 && uv sync --help 2>/dev/null | grep -q -- --script; } "
+    f"|| {{ {_INSTALL_CURL}; {_DOWNLOAD_UV}; }} "
+    "|| pip install -q -U uv 2>/dev/null"
 )
 
 # The single port a self-publishing runtime (modal/prime) forwards to a public URL for a server

--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -41,11 +41,12 @@ _DOWNLOAD_UV = (
 )
 _ENSURE_UV = (
     'export PATH="$HOME/.local/bin:$PATH" UV_INSTALL_DIR="$HOME/.local/bin"; '
-    # Reuse the image's uv only if it supports inline-script metadata (`uv sync --script`,
-    # which prepare_uv_script relies on). Old base images can ship a uv that predates `--script`
-    # (or a stale one shadowing on PATH), so otherwise install a fresh uv into $HOME/.local/bin
-    # (ahead of any system uv on PATH); fall back to pip when no downloader is available.
-    "{ command -v uv >/dev/null 2>&1 && uv sync --help 2>/dev/null | grep -q -- --script; } "
+    # Reuse the image's uv only if it supports inline-script metadata. Probe `uv python find
+    # --script` specifically: it gained `--script` later than `uv sync`, so some images have a uv
+    # that accepts `uv sync --script` but not `uv python find --script` (prepare_uv_script runs
+    # both). Otherwise install a fresh uv into $HOME/.local/bin (ahead of any system uv on PATH);
+    # fall back to pip when no downloader is available.
+    "{ command -v uv >/dev/null 2>&1 && uv python find --help 2>/dev/null | grep -q -- --script; } "
     f"|| {{ {_INSTALL_CURL}; {_DOWNLOAD_UV}; }} "
     "|| pip install -q -U uv 2>/dev/null"
 )

--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -41,13 +41,11 @@ _DOWNLOAD_UV = (
 )
 _ENSURE_UV = (
     'export PATH="$HOME/.local/bin:$PATH" UV_INSTALL_DIR="$HOME/.local/bin"; '
-    # Reuse the image's uv only if it supports inline-script metadata. Probe `uv python find
-    # --script` specifically: it gained `--script` later than `uv sync`, so some images have a uv
-    # that accepts `uv sync --script` but not `uv python find --script` (prepare_uv_script runs
-    # both). Otherwise install a fresh uv into $HOME/.local/bin (ahead of any system uv on PATH);
-    # fall back to pip when no downloader is available.
-    "{ command -v uv >/dev/null 2>&1 && uv python find --help 2>/dev/null | grep -q -- --script; } "
-    f"|| {{ {_INSTALL_CURL}; {_DOWNLOAD_UV}; }} "
+    # Always install the latest uv into $HOME/.local/bin (ahead of any image uv on PATH) rather
+    # than reusing whatever the image ships: base images carry wildly varying uvs (too old for the
+    # `uv sync --script` / `uv python find --script` that prepare_uv_script runs, or stale/shadowed
+    # on PATH). Installing fresh sidesteps all version probing. Falls back to pip when no downloader.
+    f"{{ {_INSTALL_CURL}; {_DOWNLOAD_UV}; }} "
     "|| pip install -q -U uv 2>/dev/null"
 )
 


### PR DESCRIPTION
## Problem

The bash harness (and any `prepare_uv_script`-based program) fails to start on base images that ship an old or shadowed `uv`. Every rollout dies in `Harness.setup()` with:

```
HarnessError: harness setup: RuntimeError: failed to prepare uv script:
  error: unexpected argument '--script' found
```

`prepare_uv_script` runs `uv sync --script … && uv python find --script …`, which require a `uv` new enough for PEP 723 inline-script metadata (`--script`). But `_ENSURE_UV` reused **any** `uv` already on `PATH` (`command -v uv >/dev/null`), so an image whose `uv` predates `--script` — or where a stale `uv` shadows a newer one — is used as-is and rejects `--script`. The rollout never makes a model call (`turns=0`), so there's also **no inference traffic** and the training batch never fills.

Observed in the wild on the `aweaiteam/scaleswe:*` SWE images: 273 rollouts started, all `stop=HarnessError` at `turns=0`.

## Fix

Gate reuse of the image's `uv` on **capability**, not mere presence: keep it only if `uv sync --help` advertises `--script`; otherwise install a fresh `uv` into `$HOME/.local/bin` (already prepended to `PATH`, so it shadows any system `uv`) via the astral installer, falling back to `pip install -U uv`.

```diff
-    "command -v uv >/dev/null 2>&1 "
-    "|| pip install -q uv 2>/dev/null "
-    f"|| {{ {_INSTALL_CURL}; {_DOWNLOAD_UV}; }}"
+    "{ command -v uv >/dev/null 2>&1 && uv sync --help 2>/dev/null | grep -q -- --script; } "
+    f"|| {{ {_INSTALL_CURL}; {_DOWNLOAD_UV}; }} "
+    "|| pip install -q -U uv 2>/dev/null"
```

Images with a modern `uv` are untouched (just a cheap `--help` probe); only inadequate ones trigger a reinstall. Install order is now astral-installer-first (deterministic location + latest, guaranteed to shadow the old binary) with `pip -U` as the no-downloader fallback.

## Verification

- Confirmed the failing command (`uv sync --script` / `uv python find --script`) works on uv 0.11.x and that `uv sync --help` lists `--script`, so the capability probe is accurate.
- `uv run ruff check verifiers/v1/runtimes/base.py` passes; module imports and the generated shell string is well-formed.

Not yet run as a full sandbox e2e — flagging for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Always reinstall latest uv in `_ENSURE_UV` to avoid stale versions in base images
> The `_ENSURE_UV` shell snippet in [base.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1848/files#diff-0811c040a163eb5a3212208f1e3a6c6388d7690fcc4780c081cc7754036232b9) previously skipped installation if `uv` was already on PATH, leaving stale or outdated versions in place. It now always attempts to install the latest `uv` via the Astral install script into `$HOME/.local/bin`, falling back to `pip install -U uv` only if the download fails.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c3141f0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes runtime provisioning for every rollout that runs `_ENSURE_UV`, adding network-dependent install work and shifting which `uv` binary runs, but confined to bootstrap shell with a pip fallback.
> 
> **Overview**
> **`_ENSURE_UV` no longer skips installation when `uv` is already on `PATH`.** It always tries the Astral curl/wget installer into `$HOME/.local/bin` (after the existing curl/ca-cert bootstrap), then falls back to `pip install -q -U uv` if that fails.
> 
> Previously the shell snippet reused any image `uv` or tried `pip install` before the standalone installer. That left old or shadowed binaries in place, so `prepare_uv_script` could hit `uv sync --script` / `uv python find --script` on a build without `--script` and fail harness setup at `turns=0`. Prepending `$HOME/.local/bin` to `PATH` is unchanged; the new behavior ensures the `uv` used there is freshly installed rather than whatever the base image shipped.
> 
> **Trade-off:** environments that already had a suitable `uv` will pay an install on every path that runs `_ENSURE_UV` (harness `prepare_uv_script` and MCP sandbox venv setup in `launch.py`), not only when the probe would have failed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3141f0e5e0d98c793a004d283dd128efc03ae08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->