### PR TITLE
Add s1-deepresearch-v1 environment

### DIFF
--- a/environments/s1_deepresearch_v1/README.md
+++ b/environments/s1_deepresearch_v1/README.md
@@ -1,0 +1,37 @@
+# s1-deepresearch-v1
+
+A `verifiers.v1` taskset for ScienceOne-AI's [`S1-DeepResearch-15k`](https://huggingface.co/datasets/ScienceOne-AI/S1-DeepResearch-15k) deep-research dataset: answer multi-hop research questions by searching the web, scored against the released ground truth.
+
+## What it does
+
+- **Tasks** — loads the **verifiable** (`Closed-ended Multi-hop Resolution`) subset of the dataset, each a multi-hop question with a ground-truth `answer` (English + Chinese).
+- **Tools** — a shared, read-only `vf.Toolset` exposing `web_search` (Serper) and `web_visit` (fetch + parse a URL, HTML or PDF).
+- **Scoring** — one `@reward`: a normalized exact-match shortcut, then an LLM-as-judge (the BROWSECOMP answer-match prompt) returning binary correctness (`1.0`/`0.0`). A `@metric` records whether a final answer was produced.
+
+## Loading note
+
+The upstream repo declares its `meta` column with the `Json` feature type, which only exists in `datasets>=4.7` (verifiers pins `datasets<4.7`), so `load_dataset` raises `Feature type 'Json' not found`. This taskset downloads the raw `data.jsonl` (cached via `huggingface_hub`) and parses it line by line.
+
+## Run
+
+```bash
+# needs SERPER_API_KEY (search) and PRIME_API_KEY (judge, default Prime inference)
+SERPER_API_KEY=... PRIME_API_KEY=... uv run eval s1-deepresearch-v1 -n 5 -r 2 --harness.id rlm
+```
+
+## Config (`--taskset.*`)
+
+| flag | default | meaning |
+|---|---|---|
+| `dataset_name` | `ScienceOne-AI/S1-DeepResearch-15k` | HF dataset repo. |
+| `data_file` | `data.jsonl` | Raw JSONL artifact parsed from the repo. |
+| `verifiable_only` | `True` | Keep only closed-ended rows (those with a ground-truth answer). |
+| `language` | `None` | Optional language filter (`en` / `zh`). |
+| `max_examples` | `None` | Optional cap on the number of tasks loaded. |
+| `use_exact_match_shortcut` | `True` | Skip the judge when the normalized answer matches exactly. |
+| `judge.model` | `openai/gpt-5.4-mini` | OpenAI-compatible judge model. |
+| `judge.base_url` / `judge.api_key_var` | Prime inference / `PRIME_API_KEY` | Judge endpoint (inherited from `BaseClientConfig`). |
+| `tools.shared` | `True` | One web-search server for the whole eval (stateless tools). |
+| `tools.num_results` | `5` | Organic Serper results per `web_search`. |
+
+> The first load downloads the full ~1.4 GB `data.jsonl` (then cached); `max_examples` caps the tasks built, not the download.

--- a/environments/s1_deepresearch_v1/pyproject.toml
+++ b/environments/s1_deepresearch_v1/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "s1-deepresearch-v1"
+version = "0.1.0"
+description = "s1-deepresearch-v1 — deep-research QA over the web (Serper search/visit tools + answer-match judge)."
+requires-python = ">=3.11"
+dependencies = ["verifiers", "huggingface_hub", "httpx", "pdfminer.six"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["s1_deepresearch_v1"]

--- a/environments/s1_deepresearch_v1/s1_deepresearch_v1/__init__.py
+++ b/environments/s1_deepresearch_v1/s1_deepresearch_v1/__init__.py
@@ -1,0 +1,3 @@
+from s1_deepresearch_v1.taskset import S1DeepResearchTaskset
+
+__all__ = ["S1DeepResearchTaskset"]

--- a/environments/s1_deepresearch_v1/s1_deepresearch_v1/servers/__init__.py
+++ b/environments/s1_deepresearch_v1/s1_deepresearch_v1/servers/__init__.py
@@ -1,0 +1,1 @@
+"""Self-launching tool servers for s1-deepresearch-v1."""

--- a/environments/s1_deepresearch_v1/s1_deepresearch_v1/servers/search.py
+++ b/environments/s1_deepresearch_v1/s1_deepresearch_v1/servers/search.py
@@ -1,0 +1,227 @@
+"""Web-search tools for s1-deepresearch-v1: `web_search` (Serper) + `web_visit` (fetch).
+
+A stateless, read-only `vf.Toolset` — runs `shared` (one server for the whole eval). Both
+tools need `SERPER_API_KEY` (search) / network access (visit) in the server process env;
+the default host (`subprocess`) runtime inherits the eval process's environment.
+"""
+
+from __future__ import annotations
+
+import html
+import io
+import logging
+import os
+import re
+from html.parser import HTMLParser
+from urllib.parse import urljoin
+
+import httpx
+
+import verifiers.v1 as vf
+
+SERPER_URL = "https://google.serper.dev/search"
+_PDF_HEADER = b"%PDF-"
+
+
+class WebSearchConfig(vf.ToolsetConfig):
+    num_results: int = 5
+    """Organic Serper results to include per search."""
+    search_timeout: float = 45.0
+    visit_timeout: float = 30.0
+    max_search_chars: int = 8192
+    max_visit_chars: int = 50000
+
+
+def _truncate(output: str, max_output: int) -> str:
+    if max_output <= 0 or len(output) <= max_output:
+        return output if max_output > 0 else ""
+    marker = f"\n... [output truncated, {len(output)} chars total] ...\n"
+    if len(marker) >= max_output:
+        return marker[:max_output]
+    remaining = max_output - len(marker)
+    head = remaining // 2
+    tail = remaining - head
+    return output[:head] + marker + (output[-tail:] if tail else "")
+
+
+def _format_serper_results(data: dict, query: str, num_results: int) -> str:
+    sections: list[str] = []
+    kg = data.get("knowledgeGraph")
+    if kg:
+        kg_lines: list[str] = []
+        title = (kg.get("title") or "").strip()
+        if title:
+            kg_lines.append(f"Knowledge Graph: {title}")
+        description = (kg.get("description") or "").strip()
+        if description:
+            kg_lines.append(description)
+        for key, value in (kg.get("attributes") or {}).items():
+            text = str(value).strip()
+            if text:
+                kg_lines.append(f"{key}: {text}")
+        if kg_lines:
+            sections.append("\n".join(kg_lines))
+    for i, result in enumerate((data.get("organic") or [])[:num_results]):
+        title = (result.get("title") or "").strip() or "Untitled"
+        lines = [f"Result {i}: {title}"]
+        link = (result.get("link") or "").strip()
+        if link:
+            lines.append(f"URL: {link}")
+        snippet = (result.get("snippet") or "").strip()
+        if snippet:
+            lines.append(snippet)
+        sections.append("\n".join(lines))
+    if not sections:
+        return f"No results returned for query: {query}"
+    return "\n\n---\n\n".join(sections)
+
+
+def _looks_like_html(ct: str, body: bytes) -> bool:
+    if "text/html" in ct or "application/xhtml+xml" in ct:
+        return True
+    sample = body[:2048].lstrip().lower()
+    return sample.startswith((b"<!doctype html", b"<html")) or b"<html" in sample[:512]
+
+
+def _looks_like_pdf(url: str, headers: dict[str, str], body: bytes) -> bool:
+    ct = (headers.get("content-type") or headers.get("Content-Type") or "").lower()
+    disp = (
+        headers.get("content-disposition") or headers.get("Content-Disposition") or ""
+    ).lower()
+    if body.startswith(_PDF_HEADER) or "application/pdf" in ct or "application/x-pdf" in ct:
+        return True
+    if _looks_like_html(ct, body):
+        return False
+    path = url.split("?", 1)[0].lower()
+    ambiguous = not ct or "octet-stream" in ct or "application/download" in ct
+    return ambiguous and (path.endswith(".pdf") or ("filename=" in disp and ".pdf" in disp))
+
+
+def _pdf_to_text(pdf_bytes: bytes) -> str:
+    from pdfminer.high_level import extract_text
+
+    logging.getLogger("pdfminer").setLevel(logging.ERROR)
+    with io.BytesIO(pdf_bytes) as f:
+        return extract_text(f) or ""
+
+
+class _HTMLTextExtractor(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self._chunks: list[str] = []
+        self._skip_depth = 0
+
+    def handle_starttag(self, tag, attrs):
+        if tag in {"script", "style", "noscript", "svg"}:
+            self._skip_depth += 1
+            return
+        if self._skip_depth == 0 and tag in {"br", "p", "div", "li", "tr", "td", "th", "hr"}:
+            self._chunks.append("\n")
+
+    def handle_endtag(self, tag):
+        if tag in {"script", "style", "noscript", "svg"}:
+            if self._skip_depth > 0:
+                self._skip_depth -= 1
+            return
+        if self._skip_depth == 0 and tag in {"p", "div", "li", "tr", "td", "th"}:
+            self._chunks.append("\n")
+
+    def handle_data(self, data):
+        if self._skip_depth == 0 and data:
+            self._chunks.append(data)
+
+    def get_text(self) -> str:
+        return "".join(self._chunks)
+
+
+def _html_to_text(html_text: str) -> str:
+    parser = _HTMLTextExtractor()
+    try:
+        parser.feed(html_text)
+        parser.close()
+    except Exception:
+        return ""
+    text = html.unescape(parser.get_text()).replace("\xa0", " ")
+    return re.sub(r"[ \t]{2,}", " ", text)
+
+
+def _clean(text: str) -> str:
+    text = re.sub(r"[ \t]+\n", "\n", text)
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    text = re.sub(r"(\w+)-\n(\w+)", r"\1\2", text)
+    text = text.replace("\f", "\n\n---\n\n")
+    return text.strip()
+
+
+async def _fetch_page(url: str, timeout: float) -> str:
+    headers = {"User-Agent": "Mozilla/5.0"}
+    try:
+        async with httpx.AsyncClient(
+            timeout=timeout, follow_redirects=True, headers=headers
+        ) as client:
+            response = await client.get(url)
+            response.raise_for_status()
+            body = response.content
+            ct = (response.headers.get("content-type") or "").lower()
+            if _looks_like_pdf(url, dict(response.headers), body):
+                try:
+                    return _clean(_pdf_to_text(body))
+                except Exception as e:
+                    return f"Error parsing PDF {url}: {e}"
+            text = body.decode(response.encoding or "utf-8", errors="ignore")
+            if "text/html" in ct or "<html" in text.lower():
+                embed = re.search(
+                    r'(?:<embed|<iframe)[^>]+src=["\']([^"\']+\.pdf)[^"\']*["\']', text, re.I
+                )
+                if embed:
+                    return await _fetch_page(urljoin(url, embed.group(1)), timeout)
+                return _clean(_html_to_text(text))
+            return _clean(text)
+    except httpx.HTTPStatusError as e:
+        status = e.response.status_code if e.response is not None else "?"
+        return f"Error fetching {url}: HTTP {status}"
+    except httpx.HTTPError as e:
+        return f"Error fetching {url}: {e}"
+    except Exception as e:
+        return f"Error rendering {url}: {e}"
+
+
+class WebSearchToolset(vf.Toolset[WebSearchConfig]):
+    """Read-only web search + page fetch. The model sees `web_search` and `web_visit`."""
+
+    TOOL_PREFIX = "web"
+
+    @vf.tool
+    async def search(self, query: str) -> str:
+        """Search Google via Serper for a query and return the top results (title, URL,
+        snippet). Use it to find sources, then `web_visit` a URL to read the full page."""
+        api_key = os.environ.get("SERPER_API_KEY", "")
+        if not api_key:
+            return "Error: SERPER_API_KEY is not set in the tool server environment."
+        try:
+            async with httpx.AsyncClient(timeout=self.config.search_timeout) as client:
+                resp = await client.post(
+                    SERPER_URL,
+                    json={"q": query},
+                    headers={"X-API-KEY": api_key, "Content-Type": "application/json"},
+                )
+                resp.raise_for_status()
+                data = resp.json()
+        except httpx.HTTPStatusError as e:
+            body = e.response.text if e.response is not None else ""
+            return f"Serper search error ({e.response.status_code}): {body[:500]}"
+        except Exception as e:
+            return f"Error searching for {query!r}: {e}"
+        formatted = _format_serper_results(data, query, self.config.num_results)
+        return _truncate(f'Results for query "{query}":\n\n{formatted}', self.config.max_search_chars)
+
+    @vf.tool
+    async def visit(self, url: str) -> str:
+        """Fetch a URL and return its readable text content (handles HTML and PDF). Use it
+        to read a page found via `web_search`."""
+        text = await _fetch_page(url, self.config.visit_timeout)
+        return _truncate(text, self.config.max_visit_chars)
+
+
+if __name__ == "__main__":
+    WebSearchToolset.run()

--- a/environments/s1_deepresearch_v1/s1_deepresearch_v1/taskset.py
+++ b/environments/s1_deepresearch_v1/s1_deepresearch_v1/taskset.py
@@ -1,0 +1,270 @@
+"""s1-deepresearch: answer deep-research questions by searching the web (web tools + judge).
+
+A v1 port of the ScienceOne-AI ``S1-DeepResearch-15k`` deep-research dataset. The taskset
+loads the verifiable (closed-ended) subset of the dataset, exposes ``web_search`` /
+``web_visit`` tools over Serper + a page fetcher (a shared ``vf.Toolset``), and scores the
+model's final answer against the released ground truth with a normalized exact-match
+shortcut plus an LLM-as-judge (the BROWSECOMP answer-match prompt).
+
+The upstream repo declares its ``meta`` column with the ``Json`` feature type, which only
+exists in ``datasets>=4.7``; verifiers pins ``datasets<4.7``, so ``load_dataset`` raises
+``Feature type 'Json' not found``. We download the raw ``data.jsonl`` (cached via
+``huggingface_hub``) and parse it line by line instead.
+"""
+
+import json
+import re
+import unicodedata
+from typing import Any
+
+import verifiers.v1 as vf
+from verifiers.v1.dialects import ChatDialect
+
+from s1_deepresearch_v1.servers.search import WebSearchConfig, WebSearchToolset
+
+DEFAULT_DATASET = "ScienceOne-AI/S1-DeepResearch-15k"
+DEFAULT_DATA_FILE = "data.jsonl"
+
+# The dataset mixes verifiable closed-ended tasks (which carry a ground-truth answer) with
+# open-ended exploration tasks (which do not). Only the former can be answer-matched.
+VERIFIABLE_TASK_TYPE = "Closed-ended Multi-hop Resolution"
+
+INSTRUCTION = (
+    "You are a deep research assistant. Research the question below using the `web_search` "
+    "and `web_visit` tools: decompose it into sub-queries, gather and cross-check evidence "
+    "across multiple sources, then give a single concise final answer. End your final "
+    "message with the answer and the supporting source URLs; do not include scratch "
+    "reasoning or tool traces in it."
+)
+
+# DeepTraceHub's released BROWSECOMP answer-match judge prompt (the same convention the
+# REDSearcher/OpenSeeker backends use). S1-DeepResearch does not publish its own RL reward.
+JUDGE_PROMPT = """\
+Based on the given question, standard answer, and model-predicted answer, evaluate whether the model's response is correct. Your task is to classify the result as: [CORRECT] or [INCORRECT].
+
+First, we'll list examples for each category, then you'll evaluate a new question's predicted answer.
+Here are examples of [CORRECT] responses:
+```
+Question: What are the names of Barack Obama's children?
+Standard Answer: Malia Obama and Sasha Obama
+Model Prediction 1: Malia Obama and Sasha Obama
+Model Prediction 2: Malia and Sasha
+Model Prediction 3: Most would say Malia and Sasha, but I'm not sure, I should verify
+Model Prediction 4: Barack Obama has two daughters, Malia Ann and Natasha Marian, commonly known as Malia Obama and Sasha Obama.
+```
+These responses are all [CORRECT] because they:
+    - Fully include the important information from the standard answer.
+    - Don't contain any information that contradicts the standard answer.
+    - Focus only on semantic content; language, capitalization, punctuation, grammar, and order aren't important.
+    - Vague statements or guesses are acceptable as long as they include the standard answer and don't contain incorrect information or contradictions.
+
+Here are examples of [INCORRECT] responses:
+```
+Question: What are the names of Barack Obama's children?
+Standard Answer: Malia Obama and Sasha Obama
+Model Prediction 1: Malia
+Model Prediction 2: Malia, Sasha and Susan or Sasha Obama or Malia Obama, or Natasha Marian, or Einstein
+Model Prediction 3: While I don't know their exact names, I can tell you Barack Obama has two children.
+Model Prediction 4: You might be thinking of Betsy and Olivia. But you should verify the details with the latest references. Is that the correct answer?
+Model Prediction 5: Barack Obama's children
+```
+These responses are all [INCORRECT] because they:
+    - Contain factual statements that contradict the standard answer.
+    - Are empty or merely repeat the question.
+    - Enumerate multiple answers or repeat the answer.
+
+Pay special attention to the following:
+- The standard answer may contain responses to multiple aspects of the question, and within the same aspect, there might be different descriptions, all of which are correct and are given in the same bracket, connected by commas. For example, for the question "What is the name of ByteDance's AI model?", the standard answer is "[[Doubao, Skylark]]":
+    - Predicted answers "Doubao", "Doubao, Skylark", "Skylark", etc. are all [CORRECT].
+- For standard answers containing responses to different aspects, the model needs to provide answers to all aspects to be considered correct; otherwise, it's directly judged as [INCORRECT]. There is no [PARTIALLY CORRECT] output option. These answers will be given in different brackets. For example, for the question "Who are the members of TFBOYS?", the standard answer is "[[Wang Junkai][Wang Yuan][Yi Yangqianxi]]":
+    - Predicted answers like "Wang Junkai, Wang Yuan, Yi Yangqianxi" that include all answers are [CORRECT].
+    - Predicted answers like "Wang Junkai, Yi Yangqianxi" that don't include all answers are [INCORRECT].
+
+Also note the following points:
+- For questions with numerical standard answers, the predicted answer should match the standard answer. For example, for the question "What is the total length in meters of the Huangpu River Bridge on the Jinshan Railway?", the standard answer is "3518.17":
+    - Predicted answers "3518", "3518.1", "3518.17" are all [CORRECT].
+    - Predicted answers "3520" and "3600" are [INCORRECT].
+- If the model prediction doesn't directly answer the question, attempts to circumvent or fails to directly provide the standard answer, it's considered an [INCORRECT] answer.
+- If the standard answer contains more information than the question asks for, the predicted answer only needs to include the information mentioned in the question.
+    - For example, for the question "What is the main chemical component of magnesite?", with the standard answer "Magnesium carbonate (MgCO3)", "Magnesium carbonate" or "MgCO3" are both considered [CORRECT].
+- If information omitted in the predicted answer can be clearly inferred from the question, it's considered correct.
+- If it's clear that different translations of a name refer to the same person, it's considered correct.
+- You should focus more on the match between the standard answer and the model prediction, rather than whether the standard answer itself is correct.
+
+Below is a new question example. Please reply with only [CORRECT] or [INCORRECT], without apologies or corrections to your own errors, just evaluate the answer.
+```
+Question: {question}
+Standard Answer: {correct_answer}
+Predicted Answer: {response}
+```
+
+Evaluate this new question's predicted answer as one of the following:
+A. [CORRECT]
+B. [INCORRECT]
+
+Return only the option representing [CORRECT] or [INCORRECT], i.e. just return A or B, without adding any other text.
+"""
+
+
+def _coerce_answer(value: Any) -> str:
+    """Normalize a ``meta.answer`` value to a string (a few report tasks carry a dict/list)."""
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value.strip()
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, ensure_ascii=False).strip()
+    return str(value).strip()
+
+
+def _normalize_for_match(value: str) -> str:
+    text = unicodedata.normalize("NFKC", value).casefold()
+    text = re.sub(r"https?://\S+", " ", text)
+    text = re.sub(r"[^a-z0-9]+", " ", text)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _exact_answer_match(*, response: str, answer: str) -> bool:
+    normalized_answer = _normalize_for_match(answer)
+    normalized_response = _normalize_for_match(response)
+    if not normalized_answer or not normalized_response:
+        return False
+    return normalized_answer == normalized_response
+
+
+def _parse_judge_choice(content: str) -> float | None:
+    text = (content or "").strip()
+    if not text:
+        return None
+    first_line = text.splitlines()[0].strip("`*_ \t")
+    upper = first_line.upper()
+    if re.match(r"^\[?INCORRECT\]?(?:[\s.):\]-]|$)", upper) or re.match(
+        r"^B(?:[\s.):\]-]|$)", upper
+    ):
+        return 0.0
+    if re.match(r"^\[?CORRECT\]?(?:[\s.):\]-]|$)", upper) or re.match(
+        r"^A(?:[\s.):\]-]|$)", upper
+    ):
+        return 1.0
+    return None
+
+
+class S1DeepResearchTask(vf.Task):
+    question: str
+    answer: str
+    language: str = ""
+    source_id: str | None = None
+
+
+class JudgeConfig(vf.BaseClientConfig):
+    # base_url / api_key_var / Prime team-billing are inherited from BaseClientConfig
+    # (default: Prime inference + PRIME_API_KEY), matching the composable backends.
+    model: str = "openai/gpt-5.4-mini"
+
+
+class S1DeepResearchConfig(vf.TasksetConfig):
+    dataset_name: str = DEFAULT_DATASET
+    data_file: str = DEFAULT_DATA_FILE
+    verifiable_only: bool = True
+    """Keep only `Closed-ended Multi-hop Resolution` rows (those with a ground-truth answer)."""
+    language: str | None = None
+    """Optional language filter (`en` or `zh`)."""
+    max_examples: int | None = None
+    """Optional cap on the number of tasks loaded."""
+    use_exact_match_shortcut: bool = True
+    judge: JudgeConfig = JudgeConfig()
+    # SHARED: the web-search tools are stateless/read-only, so one server serves the whole
+    # eval (CLI-tunable, e.g. `--taskset.tools.shared false`).
+    tools: WebSearchConfig = WebSearchConfig(shared=True)
+
+
+class S1DeepResearchTaskset(
+    vf.Taskset[S1DeepResearchTask, S1DeepResearchConfig]
+):
+    def load_tasks(self) -> list[S1DeepResearchTask]:
+        from huggingface_hub import hf_hub_download
+
+        path = hf_hub_download(
+            repo_id=self.config.dataset_name,
+            filename=self.config.data_file,
+            repo_type="dataset",
+        )
+        tasks: list[S1DeepResearchTask] = []
+        with open(path, encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    meta = json.loads(line).get("meta")
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(meta, dict):
+                    continue
+                task_type = str(meta.get("type") or "").strip()
+                if self.config.verifiable_only and task_type != VERIFIABLE_TASK_TYPE:
+                    continue
+                language = str(meta.get("language") or "").strip()
+                if self.config.language is not None and language != self.config.language:
+                    continue
+                question = str(meta.get("question") or "").strip()
+                answer = _coerce_answer(meta.get("answer"))
+                if not question or not answer:
+                    continue
+                tasks.append(
+                    S1DeepResearchTask(
+                        idx=len(tasks),
+                        prompt=f"{INSTRUCTION}\n\nQuestion: {question}",
+                        question=question,
+                        answer=answer,
+                        language=language,
+                        source_id=meta.get("id"),
+                    )
+                )
+                if (
+                    self.config.max_examples is not None
+                    and len(tasks) >= self.config.max_examples
+                ):
+                    break
+        if not tasks:
+            raise ValueError(
+                f"S1-DeepResearch produced no tasks from {self.config.dataset_name!r} "
+                f"(verifiable_only={self.config.verifiable_only}, "
+                f"language={self.config.language!r})"
+            )
+        return tasks
+
+    def tools(self, task: S1DeepResearchTask) -> list[vf.Toolset]:
+        return [WebSearchToolset(self.config.tools)]
+
+    @vf.metric()
+    async def answered(self, trace: vf.Trace) -> float:
+        return float(bool(trace.assistant_messages and trace.assistant_messages[-1].content))
+
+    @vf.reward(weight=1.0)
+    async def answer_match(self, task: S1DeepResearchTask, trace: vf.Trace) -> float:
+        response = (
+            trace.assistant_messages[-1].content if trace.assistant_messages else ""
+        ) or ""
+        response = response.strip()
+        if not response:
+            return 0.0
+        if self.config.use_exact_match_shortcut and _exact_answer_match(
+            response=response, answer=task.answer
+        ):
+            return 1.0
+        prompt = JUDGE_PROMPT.format(
+            question=task.question, correct_answer=task.answer, response=response
+        )
+        client = vf.resolve_client(self.config.judge)
+        try:
+            verdict = await client.get_response(
+                ChatDialect(),
+                {"messages": [{"role": "user", "content": prompt}]},
+                self.config.judge.model,
+                vf.SamplingConfig(),
+            )
+        finally:
+            await client.close()
+        parsed = _parse_judge_choice(verdict.message.content or "")
+        return parsed if parsed is not None else 0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ examples = [
     "wordle-v1", "terminal-bench-2-v1", "alphabet-sort-v1",
     "r2e-gym-v1", "scaleswe-v1", "swelego-v1", "scratchpad-v1",
     "general-agent-v1", "swebench-verified-v1", "tau2-bench-v1",
+    "s1-deepresearch-v1",
 ]
 
 [project.optional-dependencies]
@@ -156,6 +157,7 @@ scratchpad-v1 = { path = "environments/scratchpad_v1", editable = true }
 general-agent-v1 = { path = "environments/general_agent_v1", editable = true }
 swebench-verified-v1 = { path = "environments/swebench_verified_v1", editable = true }
 tau2-bench-v1 = { path = "environments/tau2_bench_v1", editable = true }
+s1-deepresearch-v1 = { path = "environments/s1_deepresearch_v1", editable = true }
 
 [tool.uv.exclude-newer-package]
 # PrimeIntellect-published on PyPI (trusted publisher)

--- a/uv.lock
+++ b/uv.lock
@@ -3899,6 +3899,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pdfminer-six"
+version = "20260107"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "charset-normalizer" },
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/34/a4/5cec1112009f0439a5ca6afa8ace321f0ab2f48da3255b7a1c8953014670/pdfminer_six-20260107.tar.gz", hash = "sha256:96bfd431e3577a55a0efd25676968ca4ce8fd5b53f14565f85716ff363889602", size = 8512094, upload-time = "2026-01-07T13:29:12.937Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/8b/28c4eaec9d6b036a52cb44720408f26b1a143ca9bce76cc19e8f5de00ab4/pdfminer_six-20260107-py3-none-any.whl", hash = "sha256:366585ba97e80dffa8f00cebe303d2f381884d8637af4ce422f1df3ef38111a9", size = 6592252, upload-time = "2026-01-07T13:29:10.742Z" },
+]
+
+[[package]]
 name = "peft"
 version = "0.19.1"
 source = { registry = "https://pypi.org/simple" }
@@ -5215,6 +5228,25 @@ wheels = [
 ]
 
 [[package]]
+name = "s1-deepresearch-v1"
+version = "0.1.0"
+source = { editable = "environments/s1_deepresearch_v1" }
+dependencies = [
+    { name = "httpx" },
+    { name = "huggingface-hub" },
+    { name = "pdfminer-six" },
+    { name = "verifiers" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx" },
+    { name = "huggingface-hub" },
+    { name = "pdfminer-six" },
+    { name = "verifiers" },
+]
+
+[[package]]
 name = "safetensors"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -6331,6 +6363,7 @@ examples = [
     { name = "math-env-v1" },
     { name = "r2e-gym-v1" },
     { name = "reverse-text-v1" },
+    { name = "s1-deepresearch-v1" },
     { name = "scaleswe-v1" },
     { name = "scratchpad-v1" },
     { name = "swebench-verified-v1" },
@@ -6425,6 +6458,7 @@ examples = [
     { name = "math-env-v1", editable = "environments/math_env_v1" },
     { name = "r2e-gym-v1", editable = "environments/r2e_gym_v1" },
     { name = "reverse-text-v1", editable = "environments/reverse_text_v1" },
+    { name = "s1-deepresearch-v1", editable = "environments/s1_deepresearch_v1" },
     { name = "scaleswe-v1", editable = "environments/scaleswe_v1" },
     { name = "scratchpad-v1", editable = "environments/scratchpad_v1" },
     { name = "swebench-verified-v1", editable = "environments/swebench_verified_v1" },


### PR DESCRIPTION
## Summary
- Add `s1-deepresearch-v1`, a **`verifiers.v1`** taskset for [`ScienceOne-AI/S1-DeepResearch-15k`](https://huggingface.co/datasets/ScienceOne-AI/S1-DeepResearch-15k): load the verifiable (closed-ended) subset, research each question with bundled `web_search` / `web_visit` tools (Serper + page fetch, a shared `vf.Toolset`), and score the final answer against the released ground truth.
- Scoring is a single `@vf.reward` — a normalized exact-match shortcut, then the BROWSECOMP answer-match LLM judge. No hand-rolled group/advantage logic; the trainer owns advantage.
- Loads the raw `data.jsonl` line by line (the dataset's `meta` `Json` feature breaks `load_dataset` on the pinned `datasets<4.7`).

**Supersedes #1849** (the composable-taskset version of the same dataset), per the "implement it as a v1 task instead" request.

## Test plan
- [x] `uv sync` builds + installs; `uv run eval s1-deepresearch-v1 -h` resolves it with all `--taskset.*` flags.
- [x] Smoke tests: id discovery, `load_tasks` filtering (verifiable / language / max_examples), reward exact-match path + metric, `web_search`/`web_visit` registration, Serper formatting/truncation. `ruff` clean.
- [ ] Live eval (needs `SERPER_API_KEY` + `PRIME_API_KEY` + the ~1.4 GB dataset download): `uv run eval s1-deepresearch-v1 -n 5 -r 2 --harness.id rlm`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Self-contained example environment and lockfile updates; evals depend on external Serper/Prime APIs and outbound HTTP but do not change core verifiers training or auth paths.
> 
> **Overview**
> Adds **`s1-deepresearch-v1`**, a new vendored `verifiers.v1` example for [S1-DeepResearch-15k](https://huggingface.co/datasets/ScienceOne-AI/S1-DeepResearch-15k): closed-ended multi-hop questions, **Serper `web_search` / `web_visit`** (HTML + PDF fetch), and scoring via normalized exact match plus a **BROWSECOMP-style LLM judge** (default Prime inference).
> 
> Because the dataset’s `Json` feature breaks `load_dataset` on pinned `datasets<4.7`, tasks are built by downloading and streaming **`data.jsonl`** from Hugging Face. The package is registered in root **`examples`** / **`tool.uv.sources`** and **`uv.lock`** picks up **`pdfminer-six`** for PDF text extraction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e9506fc77c1be8333a070935c4b38aa0b88e78d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add s1-deepresearch-v1 environment for multi-hop QA evaluation
> - Adds a new `S1DeepResearchTaskset` that loads verifiable multi-hop QA tasks from a HuggingFace JSONL dataset and scores completions via exact-match or an LLM judge (default `openai/gpt-5.4-mini`) using a BROWSECOMP-style prompt.
> - Provides a `WebSearchToolset` with two tools — `web.search` (via Serper API) and `web.visit` (async HTTP fetch with HTML/PDF parsing) — available to agents during evaluation.
> - Supports filtering by language and task type, an optional `max_examples` cap, and an exact-match shortcut to skip the judge when normalized strings match.
> - Registers the environment as an editable optional dependency in the root [pyproject.toml](https://github.com/PrimeIntellect-ai/verifiers/pull/1850/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711).
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 1e9506f. 6 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->