### PR TITLE
fix: swebench-verified ensures uv on PATH before scoring

### DIFF
--- a/environments/swebench_verified_v1/swebench_verified_v1/taskset.py
+++ b/environments/swebench_verified_v1/swebench_verified_v1/taskset.py
@@ -14,7 +14,10 @@ from pathlib import Path
 from typing import Literal
 
 import verifiers.v1 as vf
+from verifiers.v1.runtimes import Runtime
+from verifiers.v1.runtimes.base import _ENSURE_UV
 from verifiers.v1.tasksets.harbor_v1 import HarborConfig, HarborTask, HarborTaskset
+from verifiers.v1.trace import Trace
 
 # Prime's Artifact Registry mirror of the SWE-bench instance images.
 REGISTRY_PREFIX = "us-central1-docker.pkg.dev/prime-intellect-platform/prod-sandbox"
@@ -60,3 +63,9 @@ class SWEBenchVerifiedTaskset(
                 task.model_copy(update={"image": image, "workdir": "/testbed"})
             )
         return tasks
+
+    async def finalize(self, task: HarborTask, trace: Trace, runtime: Runtime) -> None:
+        # The SWE-bench verifier runs `uv run parser.py` but never installs uv, relying on the
+        # harness to leave one on PATH. rlm pins uv off PATH, so the grader hits `uv: command not
+        # found` and scores 0 even for correct fixes. Ensure uv before scoring, under any harness.
+        await runtime.run(["sh", "-c", _ENSURE_UV], {})


### PR DESCRIPTION
## Summary
- Fixes SWE-bench Verified (v1) scoring under the **rlm** harness, where every rollout scored **0** — even when the agent's fix was correct and the tests passed.
- Root cause: the SWE-bench verifier (`tests/test.sh`) grades by running `uv run parser.py` after `export PATH="/root/.local/bin:$PATH"`, but **never installs `uv`** — it relies on the harness having left one on PATH. The **bash** harness installs uv into `/root/.local/bin` (so it works by luck), but the **rlm** harness pins uv to `/tmp/vf-rlm/bin` (off that PATH). So the grader died with `uv: command not found` → `test.sh` exited 127 → `reward.txt` was forced to `0`, regardless of the test outcome.
- Fix: `SWEBenchVerifiedTaskset.finalize()` runs `_ENSURE_UV` right before scoring, so a working `uv` is on `/root/.local/bin` under any harness. Scoped to the swebench taskset's `finalize` hook rather than the generic harbor `solved()`, so other harbor scoring isn't burdened with a uv install.
- Builds on #1848 (`_ENSURE_UV` always installs the latest uv into `$HOME/.local/bin`).

## Verification
Confirmed by instrumenting the scorer (temporarily capturing `git diff` + the full `test.sh` output): on correct-fix rollouts the suite printed `Ran N tests … OK`, yet `test.sh` still exited **127** on the `uv run parser.py` line.

`z-ai/glm-4.5-air`, `swebench-verified-v1`, **rlm** harness, 32 rollouts (same task set):

| | reward=1.0 | reward=0 | solve rate |
| --- | --- | --- | --- |
| before | 0 | 32 | **0%** |
| after | 17 | 15 | **~53%** |

For reference the **bash** harness gets ~34% (11/32) on the same tasks, and v0 composable+rlm (which uses a different, pytest-based scorer with no `uv run`) was never affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Ensure `uv` is on PATH before scoring in `SWEBenchVerifiedTaskset`
> Adds a `finalize` method to `SWEBenchVerifiedTaskset` in [taskset.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1851/files#diff-9360d91568099a567b83aeb3813028f0763a9c9bd07769b85db79a455c47b0c4) that runs `_ENSURE_UV` via a shell command in the runtime before scoring completes. This fixes cases where `uv` was not available on PATH at score time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5250ba7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, taskset-scoped pre-score setup using an existing runtime helper; no auth, data, or broad harbor behavior changes.
> 
> **Overview**
> Fixes **false zero rewards** on SWE-bench Verified when using the **rlm** harness: the upstream verifier grades with `uv run parser.py` but assumes `uv` is already on PATH, while rlm keeps `uv` elsewhere so scoring fails with `uv: command not found` even when tests pass.
> 
> **`SWEBenchVerifiedTaskset`** now overrides **`finalize`** to run the shared **`_ENSURE_UV`** shell snippet in the live runtime immediately before rewards run, installing a current `uv` into `$HOME/.local/bin` regardless of harness. The hook is limited to this taskset so other harbor tasks are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5250ba7f8045ba2a1c1aab97b475681867cab659. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->