### PR TITLE
fix: allow auto-install of private envs

### DIFF
--- a/verifiers/utils/client_utils.py
+++ b/verifiers/utils/client_utils.py
@@ -1,9 +1,7 @@
-import json
 import logging
 import os
 from collections.abc import Mapping
 from typing import Any
-from pathlib import Path
 
 import httpx
 from anthropic import AsyncAnthropic
@@ -14,7 +12,10 @@ from verifiers.types import (
     ClientConfig,
     EndpointClientConfig,
 )
+from verifiers.utils.install_utils import load_prime_config
 from verifiers.utils.response_utils import strip_routed_experts_data
+
+__all__ = ["load_prime_config"]
 
 logger = logging.getLogger(__name__)
 
@@ -47,19 +48,6 @@ def resolve_client_configs(config: ClientConfig) -> list[ClientConfig]:
     if config.endpoint_configs:
         return [_merge_endpoint(config, ep) for ep in config.endpoint_configs]
     return [resolve_client_config(config)]
-
-
-def load_prime_config() -> dict:
-    try:
-        config_file = Path.home() / ".prime" / "config.json"
-        if config_file.exists():
-            data = json.loads(config_file.read_text())
-            if isinstance(data, dict):
-                return data
-            logger.warning("Invalid prime config: expected dict")
-    except (RuntimeError, json.JSONDecodeError, OSError) as e:
-        logger.warning(f"Failed to load prime config: {e}")
-    return {}
 
 
 def _build_headers_and_api_key(

--- a/verifiers/utils/install_utils.py
+++ b/verifiers/utils/install_utils.py
@@ -1,7 +1,12 @@
 import importlib
+import io
+import json
 import logging
+import os
 import subprocess
 import sys
+import tarfile
+import tempfile
 from pathlib import Path
 from typing import Optional
 from urllib.parse import urlparse
@@ -16,6 +21,36 @@ ENVIRONMENTS_HUB_URL = "https://api.primeintellect.ai/api/v1/environmentshub"
 def _uv_pip_cmd(subcommand: str, *args: str) -> list[str]:
     """Run uv pip against the active Python interpreter for this process."""
     return ["uv", "pip", subcommand, "--python", sys.executable, *args]
+
+
+def load_prime_config() -> dict:
+    """Read `~/.prime/config.json` (the prime CLI's credential store), or {} if absent."""
+    try:
+        config_file = Path.home() / ".prime" / "config.json"
+        if config_file.exists():
+            data = json.loads(config_file.read_text())
+            if isinstance(data, dict):
+                return data
+            logger.warning("Invalid prime config: expected dict")
+    except (RuntimeError, json.JSONDecodeError, OSError) as e:
+        logger.warning(f"Failed to load prime config: {e}")
+    return {}
+
+
+def prime_auth_headers() -> dict[str, str]:
+    """Resolve the prime API credentials the same way the eval client does: `PRIME_API_KEY`
+    (or `~/.prime/config.json`) for the bearer token, `PRIME_TEAM_ID` (or the config) for
+    the team header. The Hub's metadata endpoint 404s an unauthenticated request even for
+    PUBLIC envs the caller can otherwise list, so every Hub request sends these."""
+    prime_config = load_prime_config()
+    headers: dict[str, str] = {}
+    api_key = os.getenv("PRIME_API_KEY") or prime_config.get("api_key", "")
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    team_id = os.getenv("PRIME_TEAM_ID") or prime_config.get("team_id")
+    if team_id:
+        headers["X-Prime-Team-ID"] = team_id
+    return headers
 
 
 def normalize_package_name(name: str) -> str:
@@ -121,7 +156,7 @@ def install_from_hub(env_id: str) -> bool:
 
     try:
         url = f"{ENVIRONMENTS_HUB_URL}/{owner}/{name}/@{version}"
-        response = requests.get(url, timeout=30)
+        response = requests.get(url, headers=prime_auth_headers(), timeout=30)
         response.raise_for_status()
         data = response.json()
         details = data.get("data", data)
@@ -145,15 +180,14 @@ def install_from_hub(env_id: str) -> bool:
         except Exception:
             wheel_url = None
 
+    # Private envs publish no wheel/index, only a (presigned) source archive — download and
+    # build it locally, the same source-pull-and-build path `prime env install` takes.
     if not simple_index_url and not wheel_url:
-        if details.get("visibility") == "PRIVATE":
-            logger.error(
-                f"Cannot install private environment '{env_id}'. "
-                "Use 'prime env pull' to download and install locally."
-            )
-        else:
+        package_url = details.get("package_url")
+        if not package_url:
             logger.error(f"No installation method available for '{env_id}'")
-        return False
+            return False
+        return _install_from_source_archive(env_id, package_url)
 
     pkg_name = normalize_package_name(name)
 
@@ -178,6 +212,42 @@ def install_from_hub(env_id: str) -> bool:
     logger.debug(f"Command: {' '.join(cmd)}")
 
     result = subprocess.run(cmd, capture_output=True, text=True)
+
+    if result.returncode != 0:
+        logger.error(f"Installation failed: {result.stderr}")
+        return False
+
+    logger.info(f"Successfully installed {env_id}")
+    importlib.invalidate_caches()
+    return True
+
+
+def _install_from_source_archive(env_id: str, package_url: str) -> bool:
+    """Download a source archive (`package_url`) and build+install it with uv.
+
+    Private Hub envs publish no wheel or simple index, only this source tarball. The
+    metadata fetch that yields `package_url` is authenticated, but the URL itself is
+    presigned, so the download needs no further credentials."""
+    logger.info(f"Installing {env_id} from source archive...")
+    try:
+        resp = requests.get(package_url, timeout=120)
+        resp.raise_for_status()
+    except requests.RequestException as e:
+        logger.error(f"Failed to download source archive: {e}")
+        return False
+
+    with tempfile.TemporaryDirectory() as tmp:
+        src = Path(tmp) / "src"
+        with tarfile.open(fileobj=io.BytesIO(resp.content)) as tar:
+            try:
+                tar.extractall(src, filter="data")  # py3.12+: refuse unsafe members
+            except TypeError:
+                tar.extractall(src)
+        result = subprocess.run(
+            [*_uv_pip_cmd("install"), "--upgrade", str(src)],
+            capture_output=True,
+            text=True,
+        )
 
     if result.returncode != 0:
         logger.error(f"Installation failed: {result.stderr}")


### PR DESCRIPTION
## Summary
- `install_from_hub` fetched env metadata with an **unauthenticated** `requests.get`, so the Hub returned **404 for any private env** — the metadata endpoint requires auth even for public envs the caller could otherwise list. The v1 `eval <org/name>` auto-install (and `vf-install`/`prime`-driven installs) therefore failed for private environments before any rollout.
- It also bailed out of private envs by design (`"Cannot install private environment, use prime env pull"`), because private envs publish **only a source archive** (`package_url`) — no `wheel_url`/`simple_index_url`.

This PR makes the verifiers Hub-install path authenticate and handle private envs, mirroring what `prime env install` already does:

- **Authenticate every Hub request** — send `Authorization: Bearer <token>` + `X-Prime-Team-ID`, resolving credentials via `PRIME_API_KEY` → `~/.prime/config.json` (the same resolution `verifiers/utils/client_utils.py` already uses for the eval client). New `load_prime_config` / `prime_auth_headers` in `install_utils.py`.
- **Install private envs from source** — when the metadata exposes only a presigned `package_url`, download the archive, extract it, and `uv pip install` the source tree (build-from-source, the path `prime env install` takes for private envs).
- **Single source of truth** — `load_prime_config` now lives in `install_utils` and is re-exported from `client_utils` (no duplication, no import cycle).

## Verification
Tested with a real private env (`mikasenghaas/vf-v1-test`) and a fresh uv venv that did **not** have the env installed.

**Before** (private env, unauthenticated metadata fetch):
```
Failed to fetch environment details: 404 Client Error: Not Found for url:
  https://api.primeintellect.ai/api/v1/environmentshub/mikasenghaas/vf-v1-test/@latest
ModuleNotFoundError: could not install 'mikasenghaas/vf-v1-test' from the environments hub
```

**After** (same private env, fresh venv):
```
Fetching environment details for mikasenghaas/vf-v1-test@latest...
Installing mikasenghaas/vf-v1-test from source archive...
Successfully installed mikasenghaas/vf-v1-test
```
End-to-end `eval mikasenghaas/vf-v1-test -n 2 -r 1` then auto-installs the private env and runs: both rollouts `reward=1.000`, no errors.

Also confirmed:
- **No public-env regression** — public auto-install still works through the `wheel_url`/`simple_index_url` path with the added auth header.
- `tests/test_install_utils.py` — all 27 pass; `ruff check` / `ruff format` clean.

### Repro setup
```bash
# fresh venv with v1-capable verifiers, env NOT installed
uv venv && uv pip install -e /path/to/verifiers
# private env on the hub; PRIME_API_KEY (or ~/.prime/config.json) available
eval mikasenghaas/vf-v1-test -n 2 -r 1 --rich False
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix auto-install of private Hub environments via source archive fallback
> - Adds `prime_auth_headers()` in [install_utils.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1852/files#diff-ca28d0118bcd076868308cfdd643b96bb32de6a28ec91748981b898343c8b9dd) that reads `PRIME_API_KEY`/`PRIME_TEAM_ID` env vars (falling back to `~/.prime/config.json`) and injects them into Hub metadata requests.
> - When a Hub package provides neither a wheel nor a simple index URL, `install_from_hub` now falls back to downloading and installing a source tarball via `package_url` instead of failing.
> - The new `_install_from_source_archive` helper extracts the tarball to a temp directory and runs `uv pip install --upgrade` on the source path.
> - `load_prime_config` is moved from [client_utils.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1852/files#diff-115f7c6465eb15fbfda8768948af933ae7033df60ce7bc69865346c3e88894a0) to [install_utils.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1852/files#diff-ca28d0118bcd076868308cfdd643b96bb32de6a28ec91748981b898343c8b9dd) and re-exported; `client_utils` now declares `__all__ = ["load_prime_config"]`.
> - Risk: star-imports from `verifiers.utils.client_utils` will now only expose `load_prime_config` instead of all previously public names.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 03422cb. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->