### PR TITLE
feat: expose task MCP tools to the rlm harness

### DIFF
--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -2,6 +2,10 @@
 
 `RLMHarnessConfig` carries both how to install rlm (repo/branch/token/path) and its
 runtime knobs (`max_depth`, `tools`), which rlm reads from `RLM_*` env vars.
+
+A task's MCP tool servers are passed to rlm via `RLM_MCP_CONFIG` (a standard `mcpServers`
+URL map); rlm exposes each tool as a pre-imported IPython skill the agent calls
+programmatically (`await tools_<name>(...)`), rather than via a native MCP client.
 """
 
 import json
@@ -37,7 +41,6 @@ class RLMHarnessConfig(HarnessConfig):
 
 class RLMHarness(Harness[RLMHarnessConfig]):
     APPENDS_SYSTEM_PROMPT = True
-    SUPPORTS_MCP = False
 
     async def setup(self, runtime: Runtime) -> None:
         # install.sh fetches curl/uv itself; add git only when the image lacks it.
@@ -82,6 +85,13 @@ class RLMHarness(Harness[RLMHarnessConfig]):
             disabled_tools = set(self.config.disabled_tools or [])
             env["RLM_TOOLS"] = ",".join(
                 tool for tool in tools if tool not in disabled_tools
+            )
+        if mcp_urls:
+            # rlm has no MCP client in its tool-call loop; it exposes each tool server's
+            # tools as pre-imported IPython skills the agent calls programmatically. Hand
+            # it the same standard `mcpServers` URL config the other harnesses use.
+            env["RLM_MCP_CONFIG"] = json.dumps(
+                {"mcpServers": {name: {"url": url} for name, url in mcp_urls.items()}}
             )
         return await runtime.run_program([RLM_BIN, prompt], env)
 

--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -87,9 +87,6 @@ class RLMHarness(Harness[RLMHarnessConfig]):
                 tool for tool in tools if tool not in disabled_tools
             )
         if mcp_urls:
-            # rlm has no MCP client in its tool-call loop; it exposes each tool server's
-            # tools as pre-imported IPython skills the agent calls programmatically. Hand
-            # it the same standard `mcpServers` URL config the other harnesses use.
             env["RLM_MCP_CONFIG"] = json.dumps(
                 {"mcpServers": {name: {"url": url} for name, url in mcp_urls.items()}}
             )


### PR DESCRIPTION
## Summary

- Make the `rlm` harness MCP-capable so tasks that expose tool servers run under `--harness.id rlm`.
  - Drop `SUPPORTS_MCP = False` (it now inherits the base default `True`).
  - In `launch`, forward the task's tool servers to rlm via `RLM_MCP_CONFIG` — the same standard `mcpServers` URL map the `default` / `bash` / `kimi-code` harnesses already build from `mcp_urls`.
- rlm has no MCP client in its native tool-call loop; instead it exposes each tool as a pre-imported IPython skill the agent calls programmatically (`await tools_<name>(...)`). See the companion rlm PR.
- This unblocks MCP-tool tasksets (e.g. `general-agent-v1`) under the rlm harness, which previously raised `Harness 'rlm' does not support MCP tools, but taskset ... exposes tool servers`.

The change is scoped to `verifiers/v1/harnesses/rlm/harness.py`. The e2e tool tests (`test_tool` / `test_tool_state`) run on the `default` harness, so flipping rlm's flag does not enroll rlm into them.

## Verification

Ran `general-agent-v1` (each task ships its own MCP tool server; reward depends on the tools actually mutating server-side state) end-to-end under the rlm harness:

```
eval general-agent-v1 -n 1 -r 1 --taskset.tasks calendar_scheduling --taskset.max-tier 0 \
  --harness.id rlm --harness.version feat/mcp-tools-as-skills -m openai/gpt-5.4-mini
→ reward=1.000  (db_hash=1.0, verify=1.0)  rlm_programmatic_tool_calls_python=2
```

The agent called the task tools as Python functions from the IPython REPL (`await tools_list_events(...)`, `await tools_create_event(...)`).

## Dependency

PrimeIntellect-ai/rlm-harness#105 is **merged** to rlm `main`. The harness clones rlm at `--harness.version` (default `main`), so default runs now pick up the feature; pinning an older rlm ref ignores `RLM_MCP_CONFIG` and silently skips the tools.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose MCP tools to the RLM harness via `RLM_MCP_CONFIG`
> - Sets the `RLM_MCP_CONFIG` environment variable to a JSON `mcpServers` URL map before launching the `rlm` process when `mcp_urls` is non-empty in [`RLMHarness.launch`](https://github.com/PrimeIntellect-ai/verifiers/pull/1858/files#diff-3955da24b5fd88f62482297bbda7ba0936f633927f15576db27fed6e58f668ec).
> - Removes the `SUPPORTS_MCP = False` class attribute from `RLMHarness`, effectively enabling MCP support.
> - Risk: code that checks `RLMHarness.SUPPORTS_MCP` will now get an `AttributeError` instead of `False`.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1858 opened
>
> - Removed explanatory comment block from `RLMHarness.launch` method in the `verifiers.v1.harnesses.rlm` module [ca4d661]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized ca4d661. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated harness launch change; behavior depends on the pinned rlm version honoring RLM_MCP_CONFIG.
> 
> **Overview**
> **Enables MCP-backed tasksets on the `rlm` harness** by treating it as MCP-capable and wiring task tool servers into the rlm process the same way other harnesses use a standard `mcpServers` URL map.
> 
> `RLMHarness` no longer sets `SUPPORTS_MCP = False`, so load-time checks allow tasksets that expose MCP servers (e.g. `general-agent-v1`) instead of failing with “harness does not support MCP tools.” In `launch`, when `mcp_urls` is non-empty, the harness sets **`RLM_MCP_CONFIG`** to JSON `{"mcpServers": {name: {"url": ...}}}`; rlm consumes that env var and surfaces tools as pre-imported IPython skills (`await tools_<name>(...)`) rather than a native MCP client in its tool loop. The module docstring documents that behavior.
> 
> **Requires a recent rlm build** that understands `RLM_MCP_CONFIG`; older pinned `--harness.version` refs may ignore the env var and skip tools silently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca4d661991c0ce4c0da809994395dde4ddd0697f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->