### PR TITLE
chore: rlm harness exposes built-in skills, drop tool selector

### DIFF
--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -38,7 +38,7 @@ class RLMHarnessConfig(HarnessConfig):
     The tool set is fixed (ipython); only built-in skills are selectable."""
 
     @model_validator(mode="after")
-    def _reject_disabled_tools(self) -> "RLMHarnessConfig":
+    def reject_disabled_tools(self) -> "RLMHarnessConfig":
         # rlm's only tool is ipython, which must stay enabled, so there's nothing to disable.
         if self.disabled_tools:
             raise ValueError(

--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -1,7 +1,7 @@
 """The rlm harness: installs the rlm CLI into the runtime and runs the binary.
 
 `RLMHarnessConfig` carries both how to install rlm (repo/branch/token/path) and its
-runtime knobs (`max_depth`, `tools`), which rlm reads from `RLM_*` env vars.
+runtime knobs (`max_depth`, `skills`), which rlm reads from `RLM_*` env vars.
 """
 
 import json
@@ -31,8 +31,9 @@ class RLMHarnessConfig(HarnessConfig):
     """Git ref (branch, tag, or commit) of rlm to install."""
     max_depth: int = 0
     """Recursion depth rlm may spawn sub-harnesses to (RLM_MAX_DEPTH)."""
-    tools: list[str] | None = None
-    """Built-in rlm tools to enable (RLM_TOOLS); None uses rlm's default set."""
+    skills: list[str] | None = None
+    """Built-in rlm skills to enable (RLM_SKILLS), e.g. `["edit"]`; None enables none.
+    The tool set is fixed (ipython); only built-in skills are selectable."""
 
 
 class RLMHarness(Harness[RLMHarnessConfig]):
@@ -77,12 +78,8 @@ class RLMHarness(Harness[RLMHarnessConfig]):
         }
         if system_prompt is not None:
             env["RLM_APPEND_TO_SYSTEM_PROMPT"] = system_prompt
-        if self.config.tools is not None or self.config.disabled_tools:
-            tools = self.config.tools if self.config.tools is not None else ["ipython"]
-            disabled_tools = set(self.config.disabled_tools or [])
-            env["RLM_TOOLS"] = ",".join(
-                tool for tool in tools if tool not in disabled_tools
-            )
+        if self.config.skills:
+            env["RLM_SKILLS"] = ",".join(self.config.skills)
         return await runtime.run_program([RLM_BIN, prompt], env)
 
     @metric

--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -8,6 +8,8 @@ import json
 import logging
 import shlex
 
+from pydantic import model_validator
+
 from verifiers.v1.harness import Harness, HarnessConfig
 from verifiers.v1.clients import RolloutContext
 from verifiers.v1.decorators import metric
@@ -34,6 +36,16 @@ class RLMHarnessConfig(HarnessConfig):
     skills: list[str] | None = None
     """Built-in rlm skills to enable (RLM_SKILLS), e.g. `["edit"]`; None enables none.
     The tool set is fixed (ipython); only built-in skills are selectable."""
+
+    @model_validator(mode="after")
+    def _reject_disabled_tools(self) -> "RLMHarnessConfig":
+        # rlm's only tool is ipython, which must stay enabled, so there's nothing to disable.
+        if self.disabled_tools:
+            raise ValueError(
+                "the rlm harness has a fixed tool set (ipython) and does not support "
+                "`disabled_tools`; use `skills` to enable built-in skills instead."
+            )
+        return self
 
 
 class RLMHarness(Harness[RLMHarnessConfig]):


### PR DESCRIPTION
## Summary

- rlm's tool set is now fixed (`ipython` only), so the harness's `--harness.tools` / `RLM_TOOLS` selector no longer does anything.
- Replace `RLMHarnessConfig.tools` with **`skills`** (forwarded as `RLM_SKILLS`) to enable rlm's built-in skills, e.g. `--harness.skills '["edit"]'`.

## Breaking

- **`RLMHarnessConfig.tools` (`--harness.tools`) is removed.** Use `--harness.skills` to enable built-in rlm skills (currently `edit`).
- `--harness.disabled-tools` (a base `HarnessConfig` field) now **raises** a config error for the rlm harness — its tool set is fixed (`ipython`), so there's nothing to disable. Use `--harness.skills` to opt into built-in skills instead.

## Companion / dependency

- Companion to PrimeIntellect-ai/rlm-harness#106 (which removes the rlm `bash`/`edit` tools + `RLM_TOOLS` and adds the built-in `edit` skill).
- PrimeIntellect-ai/verifiers#1858 (rlm MCP tools) is now **merged**; `main` has been merged into this branch and the `harness.py` conflict resolved — the harness sets both `RLM_SKILLS` and `RLM_MCP_CONFIG`, and the validator/`skills` field coexist with MCP support.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `tools` with `skills` in `RLMHarnessConfig` and set `RLM_SKILLS` env var
> - Renames the `tools` field to `skills` in [`RLMHarnessConfig`](https://github.com/PrimeIntellect-ai/verifiers/pull/1859/files#diff-3955da24b5fd88f62482297bbda7ba0936f633927f15576db27fed6e58f668ec); the tool set is now fixed to `ipython` and only built-in `RLM_SKILLS` are selectable.
> - In `RLMHarness.setup`, replaces the `RLM_TOOLS`/`disabled_tools` logic with a single `RLM_SKILLS` env var set to the comma-joined list of configured skills.
> - Behavioral Change: `tools` and `disabled_tools` config fields no longer have any effect; callers must switch to `skills`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized fc0eb2a. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

