### PR TITLE
feat: validate rlm built-in skills client-side

### DIFF
--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -23,6 +23,10 @@ from verifiers.v1.trace import Trace
 
 logger = logging.getLogger(__name__)
 
+# Built-in skills rlm ships (see rlm.skills); kept in sync so configs are validated
+# client-side rather than failing at rollout time.
+BuiltinSkill = Literal["edit", "search"]
+
 RLM_REPO = "github.com/PrimeIntellect-ai/rlm.git"
 # rlm writes its session under $RLM_HOME/sessions/<id>/; point it at a workdir-
 # relative dir so it stays in the runtime (and is cleaned up with the workdir).
@@ -38,10 +42,9 @@ class RLMHarnessConfig(HarnessConfig):
     """Git ref (branch, tag, or commit) of rlm to install."""
     max_depth: int = 0
     """Recursion depth rlm may spawn sub-harnesses to (RLM_MAX_DEPTH)."""
-    skills: list[Literal["edit", "search"]] | None = None
-    """Built-in rlm skills to enable (RLM_SKILLS), e.g. `["edit"]`; None enables none.
-    Validated against the skills rlm ships (see rlm.skills); the tool set is fixed
-    (ipython), only built-in skills are selectable."""
+    skills: list[BuiltinSkill] = []
+    """Built-in rlm skills to enable (RLM_SKILLS), e.g. `["edit"]`; empty enables none.
+    The tool set is fixed (ipython); only built-in skills are selectable."""
 
     @model_validator(mode="after")
     def reject_disabled_tools(self) -> "RLMHarnessConfig":

--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -23,8 +23,6 @@ from verifiers.v1.trace import Trace
 
 logger = logging.getLogger(__name__)
 
-# Built-in skills rlm ships (see rlm.skills); kept in sync so configs are validated
-# client-side rather than failing at rollout time.
 BuiltinSkill = Literal["edit", "search"]
 
 RLM_REPO = "github.com/PrimeIntellect-ai/rlm.git"

--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -23,10 +23,6 @@ from verifiers.v1.trace import Trace
 
 logger = logging.getLogger(__name__)
 
-# Built-in skills rlm ships (see rlm.skills); kept in sync so configs are validated
-# client-side rather than failing at rollout time.
-BuiltinSkill = Literal["edit", "search"]
-
 RLM_REPO = "github.com/PrimeIntellect-ai/rlm.git"
 # rlm writes its session under $RLM_HOME/sessions/<id>/; point it at a workdir-
 # relative dir so it stays in the runtime (and is cleaned up with the workdir).
@@ -42,9 +38,10 @@ class RLMHarnessConfig(HarnessConfig):
     """Git ref (branch, tag, or commit) of rlm to install."""
     max_depth: int = 0
     """Recursion depth rlm may spawn sub-harnesses to (RLM_MAX_DEPTH)."""
-    skills: list[BuiltinSkill] | None = None
+    skills: list[Literal["edit", "search"]] | None = None
     """Built-in rlm skills to enable (RLM_SKILLS), e.g. `["edit"]`; None enables none.
-    The tool set is fixed (ipython); only built-in skills are selectable."""
+    Validated against the skills rlm ships (see rlm.skills); the tool set is fixed
+    (ipython), only built-in skills are selectable."""
 
     @model_validator(mode="after")
     def reject_disabled_tools(self) -> "RLMHarnessConfig":

--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -11,6 +11,7 @@ programmatically (`await tools_<name>(...)`), rather than via a native MCP clien
 import json
 import logging
 import shlex
+from typing import Literal
 
 from pydantic import model_validator
 
@@ -21,6 +22,10 @@ from verifiers.v1.runtimes import ProgramResult, Runtime
 from verifiers.v1.trace import Trace
 
 logger = logging.getLogger(__name__)
+
+# Built-in skills rlm ships (see rlm.skills); kept in sync so configs are validated
+# client-side rather than failing at rollout time.
+BuiltinSkill = Literal["edit", "search"]
 
 RLM_REPO = "github.com/PrimeIntellect-ai/rlm.git"
 # rlm writes its session under $RLM_HOME/sessions/<id>/; point it at a workdir-
@@ -37,7 +42,7 @@ class RLMHarnessConfig(HarnessConfig):
     """Git ref (branch, tag, or commit) of rlm to install."""
     max_depth: int = 0
     """Recursion depth rlm may spawn sub-harnesses to (RLM_MAX_DEPTH)."""
-    skills: list[str] | None = None
+    skills: list[BuiltinSkill] | None = None
     """Built-in rlm skills to enable (RLM_SKILLS), e.g. `["edit"]`; None enables none.
     The tool set is fixed (ipython); only built-in skills are selectable."""
 


### PR DESCRIPTION
## Summary

- Add a module-level `BuiltinSkill = Literal["edit", "search"]` alias and type `RLMHarnessConfig.skills` as `list[BuiltinSkill]` (was `list[str] | None`), defaulting to `[]`. A config naming an unsupported built-in skill is now rejected at **parse time** (client-side) instead of failing mid-rollout when rlm raises `RLM_SKILLS contains unknown skill(s)`.
- The literal is kept in sync with the built-in skills rlm ships (`rlm.skills`): `edit` and `search`.

Companion to the rlm-harness PR adding the built-in `search` skill (PrimeIntellect-ai/rlm-harness#109).

## Verification

```
RLMHarnessConfig().skills                     # [] (default)
RLMHarnessConfig(skills=["edit", "search"])   # ok
RLMHarnessConfig(skills=["bogus"])            # ValidationError, message lists 'edit'/'search'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Validate `RLMHarnessConfig` built-in skills client-side using a `BuiltinSkill` type
> Replaces the `skills: list[str] | None = None` field in `RLMHarnessConfig` with `skills: list[BuiltinSkill] = []`, where `BuiltinSkill = Literal["edit", "search"]`. Pydantic now rejects any value outside that set at model validation time. Risk: `None` and arbitrary skill strings that were previously accepted are now rejected, which is a breaking change for any callers passing those values.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4f318c6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config typing and validation only; rollout behavior is unchanged for valid `edit`/`search` values.
> 
> **Overview**
> **`RLMHarnessConfig.skills`** is now typed as `list[BuiltinSkill]` with `BuiltinSkill = Literal["edit", "search"]`, default **`[]`** (replacing `list[str] | None`). Invalid skill names fail when the config is constructed via Pydantic instead of during an rlm rollout (`RLM_SKILLS contains unknown skill(s)`).
> 
> The allowlist matches rlm’s built-in skills (`edit`, `search`); the field docstring now describes an empty list as enabling no built-in skills.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f318c6545c463dfef4cc68667dffb4dc4dd3b7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->