### PR TITLE
feat: add web_search mode to the codex harness

### DIFF
--- a/verifiers/v1/harnesses/codex/harness.py
+++ b/verifiers/v1/harnesses/codex/harness.py
@@ -9,6 +9,7 @@ session secret) is read from an env var.
 
 import logging
 import shlex
+from typing import Literal
 
 from verifiers.v1.clients import RolloutContext
 from verifiers.v1.harness import Harness, HarnessConfig
@@ -41,6 +42,11 @@ class CodexHarnessConfig(HarnessConfig):
 
     version: str = "0.137.0"
     """Codex release to install (the `rust-v<version>` GitHub release); pinned for reproducibility."""
+    web_search: Literal["disabled", "cached", "live"] | None = None
+    """Codex's web search mode, passed as `-c web_search=<mode>`. None leaves Codex's own
+    default. Web search is a server-side Responses hosted tool (`{"type": "web_search"}`): it
+    only returns results when the model provider's `/responses` endpoint executes it — which
+    Prime inference does. `live` hits the live web, `cached` an indexed snapshot."""
 
 
 class CodexHarness(Harness[CodexHarnessConfig]):
@@ -83,6 +89,8 @@ class CodexHarness(Harness[CodexHarnessConfig]):
             for tool in self.config.disabled_tools or []
             for arg in ("--disable", tool)
         ]
+        if self.config.web_search:
+            tool_config += ["-c", f"web_search={self.config.web_search}"]
         # `-c` values parse as TOML, falling back to a raw string (so the url / `responses`
         # come through literally); `requires_openai_auth=false` parses as a bool.
         argv = [


### PR DESCRIPTION
## Summary

- Add an opt-in `web_search` field (`disabled` / `cached` / `live`) to `CodexHarnessConfig`, passed to the CLI as `-c web_search=<mode>`. `None` (the default) leaves Codex's own default, so the change is non-breaking.
- Codex's web search is a **server-side Responses hosted tool** (`{"type": "web_search"}`) that the model provider's `/responses` endpoint executes. Prime inference executes it — verified by a direct `/responses` call carrying the hosted tool, which returns real web-search results for `deepseek/deepseek-v4-flash`. Use `--harness.web_search live` to give a Codex rollout live web access.

## Notes

- This enables web search for models that speak OpenAI-structured tool calls through the provider. A model that emits a *non-OpenAI native* tool-call format as plain text (rather than structured calls) won't have its calls consumed by Codex — a model/provider concern, independent of this change.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `web_search` mode configuration to the Codex harness
> Adds an optional `web_search` field to `CodexHarnessConfig` in [harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1862/files#diff-904c37fe437bb3b42e0238258ed85a8c6cede02461216bcf9c7417c5f3b72b7b), accepting `'disabled'`, `'cached'`, or `'live'`. When set, `CodexHarness.setup` appends `-c web_search=<value>` to the spawned `codex` process arguments, controlling its server-side web search behavior. When unset, behavior is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dfef38f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->