### PR TITLE
fix: clear image ENTRYPOINT in ModalRuntime so keep-alive command runs

### DIFF
--- a/verifiers/v1/runtimes/modal.py
+++ b/verifiers/v1/runtimes/modal.py
@@ -88,7 +88,10 @@ class ModalRuntime(Runtime):
                     "infinity",  # keep-alive entrypoint; the harness runs via `exec`
                     app=app,
                     name=self.name,
-                    image=modal.Image.from_registry(self.config.image),
+                    # Clear the image's ENTRYPOINT so `sleep infinity` runs as the command
+                    # rather than as args to it — otherwise an image with its own entrypoint
+                    # (e.g. SWE task images) never starts the keep-alive and the sandbox dies.
+                    image=modal.Image.from_registry(self.config.image).entrypoint([]),
                     workdir=self.config.workdir,
                     cpu=self.config.cpu,
                     memory=int(self.config.memory * 1024),  # Modal memory is MB


### PR DESCRIPTION
## Summary
- Fix `ModalRuntime` so it can run images that ship their own `ENTRYPOINT`.

`ModalRuntime.start` creates the sandbox with `sleep infinity` as the keep-alive command. Modal **appends** those args to the image's `ENTRYPOINT` instead of replacing it, so an image with its own entrypoint (e.g. SWE task images such as `jefzda/sweap-images`) never actually runs `sleep infinity` — the sandbox's task exits immediately and the first `exec` fails with `Task has already finished with status failure` (and the earlier `make_directory` call returned exit `137`). Clearing the entrypoint with `.entrypoint([])` makes `sleep infinity` run as given, matching how the subprocess/prime runtimes execute the command.

## Verification
Reproduced with `swebench_pro_v1` (harbor taskset on `jefzda/sweap-images`) on the modal runtime:
- **Before:** `SandboxError: modal sandbox provisioning failed` at boot (exit 137 / "Task has already finished with status failure"), independent of memory (16 GB didn't help).
- **After:** the sandbox provisions and the rollout proceeds past boot to the agent step (codex install). Isolated probe confirms it directly: with the stock image a sandbox `exec` returns `rc=137`; with `.entrypoint([])` it returns `rc=0` (`ALIVE`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Clear image ENTRYPOINT in `ModalRuntime.start` so the keep-alive command runs
> Calls `.entrypoint([])` on the registry image before passing it to `Sandbox.create` in [modal.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1863/files#diff-a6217d92f043d6050e8609d4341d62b5d097d5db796f6197cd604e09d81683c0). Without this, the keep-alive command was passed as arguments to the image's pre-set entrypoint instead of running directly as the container command.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0c3f6ee.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line Modal image configuration change at sandbox creation; no auth, data, or broad behavioral refactors.
> 
> **Overview**
> **Modal sandbox provisioning** now clears the registry image’s Docker `ENTRYPOINT` before `Sandbox.create`, so `sleep infinity` is the container command instead of extra args to the image’s own entrypoint.
> 
> That aligns Modal with how other runtimes treat the keep-alive process and fixes boot failures (exit 137 / “Task has already finished”) on images that ship an entrypoint, such as SWE task images.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c3f6eef2b12871a935381cb22b53a4781e85aab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->