### PR TITLE
fix: record a streamed turn before forwarding its terminal event

### DIFF
--- a/verifiers/v1/dialects/base.py
+++ b/verifiers/v1/dialects/base.py
@@ -151,6 +151,14 @@ class Dialect(ABC, Generic[ReqT, RespT]):
         """Whether the request asks for a streamed (SSE) response."""
         return bool(body.get("stream"))
 
+    def is_terminal_event(self, chunk: bytes) -> bool:
+        """Whether this complete SSE event ends the model's turn for the client. The
+        interception server withholds the terminal event (and anything after it) until the
+        turn is recorded, so a client that ends its turn on it can't race ahead to scoring
+        with the turn still uncommitted. Defaults to the `[DONE]` sentinel; a dialect whose
+        client ends on an earlier event (e.g. Responses' `response.completed`) overrides this."""
+        return is_sse_done_event(chunk)
+
     def error_body(self, message: str) -> dict:
         """An error payload in this format's error shape (OpenAI by default)."""
         return {"error": {"message": message, "type": "invalid_request_error"}}

--- a/verifiers/v1/dialects/responses.py
+++ b/verifiers/v1/dialects/responses.py
@@ -47,6 +47,13 @@ from verifiers.v1.types import (
 )
 
 FINAL_EVENTS = ("response.completed", "response.incomplete", "response.failed")
+# Byte markers for the terminal event types above, in both compact and spaced JSON, so the
+# interception server can cheaply spot the turn-ending event without parsing each delta.
+_TERMINAL_MARKERS = tuple(
+    marker.encode()
+    for event in FINAL_EVENTS
+    for marker in (f'"type":"{event}"', f'"type": "{event}"')
+)
 # Sampling knobs the eval owns, in this format's shape (Responses uses `max_output_tokens`).
 _SAMPLING_KEYS = frozenset({"temperature", "top_p", "max_output_tokens", "max_tokens"})
 
@@ -262,6 +269,11 @@ class ResponsesDialect(Dialect[dict, OpenAIResponse]):
     routes = ("/v1/responses",)
     upstream_path = "/responses"
     response_type = OpenAIResponse
+
+    def is_terminal_event(self, chunk: bytes) -> bool:
+        # A Responses client (e.g. codex) ends its turn on `response.completed`, before the
+        # trailing `[DONE]`, so the turn-ending event is the final event, not the sentinel.
+        return any(marker in chunk for marker in _TERMINAL_MARKERS)
 
     def parse_request(self, body: dict) -> tuple[Messages, list[Tool] | None]:
         prompt: Messages = []

--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -472,6 +472,11 @@ class InterceptionServer:
         ready = asyncio.Event()
         producer = asyncio.create_task(_queue_chunks(reply.chunks, queue, ready))
         parser_error: Exception | None = None
+        # SSE events from the turn-ending one onward (the terminal event and any trailing
+        # `[DONE]`), withheld until the turn is committed: a client that ends its turn on the
+        # terminal event (e.g. codex on `response.completed`) would otherwise reach scoring
+        # with the turn still unrecorded.
+        deferred: list[bytes] = []
         try:
             await resp.prepare(request)
             while True:
@@ -487,11 +492,19 @@ class InterceptionServer:
                 if chunk is None:
                     await producer
                     break
+                if deferred or dialect.is_terminal_event(chunk):
+                    if parser_error is None:
+                        try:
+                            if on_done is not None and is_sse_done_event(chunk):
+                                on_done()
+                            feed_event(chunk)
+                        except Exception as e:
+                            parser_error = e
+                    deferred.append(chunk)  # forwarded after the turn is committed, below
+                    continue
                 await resp.write(chunk)
                 if parser_error is None:
                     try:
-                        if on_done is not None and is_sse_done_event(chunk):
-                            on_done()
                         feed_event(chunk)
                     except Exception as e:
                         parser_error = e
@@ -511,7 +524,10 @@ class InterceptionServer:
             turn.commit(parser.finish())
             logger.debug("intercept stream turn: id=%s", session.trace.id)
         finally:
+            # Release the withheld events only now — after the commit — then close.
             with contextlib.suppress(ConnectionResetError):
+                for event in deferred:
+                    await resp.write(event)
                 await resp.write_eof()
         return resp
 

--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -500,7 +500,8 @@ class InterceptionServer:
                             feed_event(chunk)
                         except Exception as e:
                             parser_error = e
-                    deferred.append(chunk)  # forwarded after the turn is committed, below
+                    # forwarded after the turn is committed, below
+                    deferred.append(chunk)
                     continue
                 await resp.write(chunk)
                 if parser_error is None:


### PR DESCRIPTION
## Summary

- Fix a streaming-relay race that silently zeroes rewards for codex-style search rollouts.
- A streamed (SSE) model turn was committed to the trace only **after** the full response was relayed to the client (`InterceptionServer._stream`: `turn.commit(parser.finish())` ran after the loop). A client that ends its turn on the terminal event and exits immediately — e.g. **codex on `response.completed`** — lets the harness return and the Rollout reach **scoring before the commit lands**. At scoring time `trace.assistant_messages` is empty (`num_turns == 0`), so a boxed-answer / last-message reward reads `""` and returns `0`. The turn *is* committed by end of run, so the saved trace looks fine — the bug only manifests as silently-zero live rewards.
- Fix: **withhold the turn-ending SSE event (and anything after it) until the turn is committed**, then flush it. A new `Dialect.is_terminal_event` identifies that event — the `[DONE]` sentinel by default, overridden by the Responses dialect to `response.completed` / `response.incomplete` / `response.failed` (codex ends there, before `[DONE]`).
- The non-streaming path already commits before responding, so chat / default / rlm harnesses were unaffected.

## Verification

`eval --taskset.id papersearchqa_v1 --harness.id codex -m deepseek/deepseek-v4-flash -n 8` (deepseek-v4-flash answering biomedical QA with codex's built-in web search):

| | turns at scoring | live mean reward |
| --- | --- | --- |
| **before** | `turns=0` for 8/8 | **0.00** |
| **after** | `turns=1` for 8/8 | **0.50** |

Before the fix, re-scoring the same run's *final* (end-of-run) traces offline gave ~0.72 — confirming the agent answered correctly and only the scoring-time trace was empty. After the fix the live score matches.

Existing `tests/test_interception_utils.py` + `tests/test_openai_responses_client.py` pass; `ruff check` / `ruff format` clean.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Record a streamed turn before forwarding its terminal SSE event
> - The interception proxy now defers the terminal SSE event (and any subsequent chunks, including `[DONE]`) until after `turn.commit()` is called, ensuring the turn is recorded before the client receives the final event.
> - A new `is_terminal_event(chunk)` method on `Dialect` identifies the turn-ending event; the base implementation detects the `[DONE]` sentinel, while `ResponsesDialect` overrides it to match `response.completed`, `response.incomplete`, or `response.failed` using precomputed byte markers.
> - `on_done()` is now only invoked when the `[DONE]` sentinel is encountered during the deferred phase, not during normal streaming.
> - Behavioral Change: clients now receive the terminal event and stream close slightly later, after the turn has been committed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 53b65d7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core SSE relay ordering for all streamed dialects; wrong terminal detection could delay or mis-order events, but scope is narrow and default behavior matches the prior `[DONE]` sentinel.
> 
> **Overview**
> Fixes a race where **codex-style** clients finish a turn on `response.completed` (before `[DONE]`) and the harness can **score while the trace still has zero turns**, yielding silent **0 rewards** even though the saved trace looks correct later.
> 
> The interception server now **buffers the turn-ending SSE event and everything after it** until `turn.commit()` runs, then flushes that buffer to the client. **`Dialect.is_terminal_event`** identifies that event: default **`[DONE]`**; **Responses** overrides with cheap byte markers for `response.completed` / `response.incomplete` / `response.failed`. Deferred chunks are still fed to the stream parser (including `on_done` on `[DONE]`) but are not written to the client until after commit.
> 
> **Behavioral change:** clients see the terminal event slightly later (commit latency). Non-streaming paths are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53b65d7b69247bb9250c5f99c8494fed4d158ab4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->