### PR TITLE
feat: bracketed phase markers in the eval dashboard

### DIFF
--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -1,9 +1,10 @@
 """The eval `--rich` dashboard: a config overview, a progress bar, and one line per rollout.
 
-Reads each `Rollout.trace`/`phase` every tick — no extra plumbing. Rows are colored by
-phase/outcome: setup (yellow ○), running (cyan ●), finalize (magenta ◑), scoring (blue ◐),
-success (green ✓), error (red ✗) — the reward shows only once a rollout is fully scored (phase
-DONE), so it never flips as scoring lands. A task's rollouts are grouped adjacently and joined
+Reads each `Rollout.trace`/`phase` every tick — no extra plumbing. Each row carries a bracketed
+phase marker that reads at a glance — `[setup]` (yellow), `[rollout]` (cyan), `[finalize]`
+(magenta), `[scoring]` (blue), `[success]` (green), `[error]` (red) — padded so the brackets
+line up in a column down the left edge. The reward shows only once a rollout is fully scored
+(phase DONE), so it never flips as scoring lands. A task's rollouts are grouped adjacently and joined
 by a left brace (╭│╰), so an episode (a task's n rollouts) reads as a unit. Every started
 rollout stays on screen (finished ones keep their result); the overview + progress sit on top,
 above a rule.
@@ -42,14 +43,18 @@ _STYLE = {
     "success": "green",
     "error": "red",
 }
-_MARK = {
-    "setup": "○",
-    "running": "●",
-    "finalize": "◑",
-    "scoring": "◐",
-    "success": "✓",
-    "error": "✗",
+_MARK_LABEL = {
+    "setup": "setup",
+    "running": "rollout",
+    "finalize": "finalize",
+    "scoring": "scoring",
+    "success": "success",
+    "error": "error",
 }
+_MARK_WIDTH = max(len(label) for label in _MARK_LABEL.values())
+# Each label padded to a common width and bracketed, so the `[ ]` line up in a column down the
+# left edge (label left-aligned inside) — the current phase reads at a glance.
+_MARK = {state: f"[{label:<{_MARK_WIDTH}}]" for state, label in _MARK_LABEL.items()}
 
 
 def _limits(config: EvalConfig) -> list[str]:

--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -14,6 +14,7 @@ import contextlib
 import time
 
 from rich.console import Console, Group
+from rich.markup import escape
 from rich.progress_bar import ProgressBar
 from rich.rule import Rule
 from rich.table import Table
@@ -53,8 +54,11 @@ _MARK_LABEL = {
 }
 _MARK_WIDTH = max(len(label) for label in _MARK_LABEL.values())
 # Each label padded to a common width and bracketed, so the `[ ]` line up in a column down the
-# left edge (label left-aligned inside) — the current phase reads at a glance.
-_MARK = {state: f"[{label:<{_MARK_WIDTH}}]" for state, label in _MARK_LABEL.items()}
+# left edge (label left-aligned inside) — the current phase reads at a glance. `escape` keeps the
+# brackets literal: Rich parses `[label]` in a cell as markup and would otherwise drop it.
+_MARK = {
+    state: escape(f"[{label:<{_MARK_WIDTH}}]") for state, label in _MARK_LABEL.items()
+}
 
 
 def _limits(config: EvalConfig) -> list[str]:

--- a/verifiers/v1/cli/dashboard/validate.py
+++ b/verifiers/v1/cli/dashboard/validate.py
@@ -1,8 +1,10 @@
 """The validate `--rich` dashboard: a taskset overview, a progress bar, and one row per task.
 
 The model-free counterpart of the eval dashboard — no rollout phases, tokens, turns, or
-reward, just each task's validation outcome: pending ○ / running ● / valid ✓ / invalid ✗ /
-error ✗ / timeout ⏱. The runner advances a `TaskProgress` per task; this reads them each tick.
+reward, just each task's validation outcome, shown as a bracketed marker that reads at a
+glance — `[pending]` / `[running]` / `[valid]` / `[invalid]` / `[error]` / `[timeout]`,
+padded so the brackets line up in a column. The runner advances a `TaskProgress` per task;
+this reads them each tick.
 """
 
 import contextlib
@@ -27,14 +29,10 @@ _STYLE = {
     "error": "red",
     "timeout": "red",
 }
-_MARK = {
-    "pending": "○",
-    "running": "●",
-    "valid": "✓",
-    "invalid": "✗",
-    "error": "✗",
-    "timeout": "⏱",
-}
+_MARK_WIDTH = max(len(state) for state in _STYLE)
+# Each state name padded to a common width and bracketed, so the `[ ]` line up in a column with
+# the name left-aligned inside — the outcome reads at a glance.
+_MARK = {state: f"[{state:<{_MARK_WIDTH}}]" for state in _STYLE}
 _DONE = ("valid", "invalid", "error", "timeout")
 
 

--- a/verifiers/v1/cli/dashboard/validate.py
+++ b/verifiers/v1/cli/dashboard/validate.py
@@ -12,6 +12,7 @@ import time
 from dataclasses import dataclass
 
 from rich.console import Group
+from rich.markup import escape
 from rich.progress_bar import ProgressBar
 from rich.rule import Rule
 from rich.table import Table
@@ -31,8 +32,9 @@ _STYLE = {
 }
 _MARK_WIDTH = max(len(state) for state in _STYLE)
 # Each state name padded to a common width and bracketed, so the `[ ]` line up in a column with
-# the name left-aligned inside — the outcome reads at a glance.
-_MARK = {state: f"[{state:<{_MARK_WIDTH}}]" for state in _STYLE}
+# the name left-aligned inside — the outcome reads at a glance. `escape` keeps the brackets
+# literal: Rich parses `[name]` in a cell as markup and would otherwise drop it.
+_MARK = {state: escape(f"[{state:<{_MARK_WIDTH}}]") for state in _STYLE}
 _DONE = ("valid", "invalid", "error", "timeout")
 
 


### PR DESCRIPTION
## Summary

- Replace the per-state glyphs (`○ ● ◑ ◐ ✓ ✗ ⏱`) on each row of both `--rich` dashboards (eval and validate) with explicit bracketed labels, so the current phase/outcome reads at a glance instead of having to recall what each symbol means.
- Pad every label to a common width and bracket it, so the `[ ]` line up in a column down the left edge with the label text left-aligned inside.
- In the eval dashboard the `running` phase is labelled `[rollout]` to match the lifecycle-stage naming used elsewhere (the `setup`/`rollout`/`finalize`/`scoring` timeout stages). The validate dashboard keeps its own state names (no lifecycle stages there).
- Update both module docstrings to describe the new markers.

Marks stay fixed-width, so the dot-separated sections after them keep aligning exactly as before; styling (color per state) is unchanged.

## Before / After

Eval dashboard — before:

```
╭ ○ task name=foo · 12ab34cd · 3 turns
│ ● task name=foo · 12ab34cd · 3 turns
╰ ◑ task name=foo · 12ab34cd · 3 turns
```

Eval dashboard — after:

```
╭ [setup   ] task name=foo · 12ab34cd · 3 turns
│ [rollout ] task name=foo · 12ab34cd · 3 turns
╰ [finalize] task name=foo · 12ab34cd · 3 turns
  [scoring ] task name=foo · 12ab34cd · 3 turns
  [success ] task name=foo · 12ab34cd · 3 turns
  [error   ] task name=foo · 12ab34cd · 3 turns
```

Validate dashboard — before → after:

```
● task name=foo        ->   [running] task name=foo
✓ task name=foo        ->   [valid  ] task name=foo
✗ task name=foo        ->   [invalid] task name=foo
⏱ task name=foo        ->   [timeout] task name=foo
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Terminal-only display tweaks in CLI dashboards; no runtime, auth, or data-path changes.
> 
> **Overview**
> **Eval and validate `--rich` dashboards** now show **padded bracketed text** (`[setup]`, `[rollout]`, `[valid]`, etc.) instead of single-character glyphs, so phase/outcome is readable without memorizing symbols.
> 
> In **eval**, `running` is labeled **`[rollout]`** to match timeout/lifecycle naming; labels share a fixed width so brackets align in a column. **`rich.markup.escape`** wraps each marker so Rich does not treat `[...]` as markup. Per-state **colors** and row layout are unchanged; module docstrings describe the new markers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fc6522571740bba8af2b7a7d811a5c264c95319. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace symbol markers with bracketed text labels in the eval and validate dashboards
> - Phase markers in [eval.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1866/files#diff-0a27b905958929f3ae9e01937dd7e3cf97a60dec137caddcbf87792784fc9035) change from Unicode symbols (○ ● ◑ ✓ ✗) to padded bracketed labels like `[setup]`, `[rollout]`, `[finalize]`, `[scoring]`, `[success]`, `[error]`.
> - Validation markers in [validate.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1866/files#diff-2ded55a5b55a7c27d925b91343c516de853d005e99d07590ceb341bdc9e9149e) similarly switch from symbols to bracketed state names like `[pending]`, `[running]`, `[valid]`, `[invalid]`, `[error]`, `[timeout]`.
> - Labels are left-aligned and padded to a common width so they form a consistent column. Brackets are wrapped with `escape()` from `rich.markup` to prevent Rich from interpreting them as markup.
> - Behavioral Change: the display label for the `running` eval phase changes from a symbol to the text `rollout`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2fc6522.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->