### PR TITLE
fix: sum eval dashboard tokens across all branches

### DIFF
--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -185,10 +185,12 @@ def _breakdown(done: list[Trace]) -> Table | None:
 
 
 def _tokens(trace: Trace) -> tuple[int, int, int | None, int | None, int]:
-    """Input/output tokens for the main branch: output is every assistant (completion) token
-    generated across the branch's turns; input is the last turn's prompt — the full final
-    context the model saw. (Output can exceed the final context — reasoning tokens count toward
-    completions but aren't re-fed — so it's not derived by subtraction.)
+    """Input/output tokens summed across all branches: per branch, output is every assistant
+    (completion) token generated across its turns and input is its last turn's prompt — the full
+    final context the model saw. A rollout yields one training sample per branch (a linear trace
+    is a single branch; compaction and subagents add more), so the totals sum them — matching
+    `Trace.prompt_len` / `Trace.completion_len`. (Output can exceed the final context — reasoning
+    tokens count toward completions but aren't re-fed — so it's not derived by subtraction.)
 
     Prefers the token-id counts; falls back to provider-reported usage when the endpoint returns
     no token ids (e.g. plain OpenAI completions), so the counts aren't shown as 0/0. Returns
@@ -198,11 +200,8 @@ def _tokens(trace: Trace) -> tuple[int, int, int | None, int | None, int]:
     reasoning = usage.reasoning_tokens if usage else None
     branches = trace.branches
     nbranches = len(branches)
-    if not branches or not branches[0].nodes:
-        return 0, 0, cached, reasoning, nbranches
-    b = branches[0]
-    prompt = b.prompt_len or b.num_prompt_tokens
-    completion = b.completion_len or b.num_completion_tokens
+    prompt = sum(b.prompt_len or b.num_prompt_tokens for b in branches)
+    completion = sum(b.completion_len or b.num_completion_tokens for b in branches)
     return prompt, completion, cached, reasoning, nbranches
 
 


### PR DESCRIPTION
## Summary

- The eval dashboard's `_tokens()` reported input/output tokens for `branches[0]` only ("the main branch"). Any rollout with more than one branch — i.e. compaction or subagents — undercounted its tokens, dropping everything past the first branch.
- Fix: sum the per-branch counts across **all** branches, matching the existing `Trace.prompt_len` / `Trace.completion_len` (which already aggregate over branches). The per-branch `prompt_len or num_prompt_tokens` fallback is preserved, so the result is correct for both the **train** client (token ids present) and the **eval** client (provider-reported usage only).

```python
# before
b = branches[0]
prompt = b.prompt_len or b.num_prompt_tokens
completion = b.completion_len or b.num_completion_tokens

# after
prompt = sum(b.prompt_len or b.num_prompt_tokens for b in branches)
completion = sum(b.completion_len or b.num_completion_tokens for b in branches)
```

(`Trace.usage` is intentionally left alone — it sums each unique model call once, which is correct for cost; summing per branch there would double-count shared-prefix calls.)

## Verification

A single `terminal-bench/fix-git` (terminal-bench-2) rollout, rlm harness, forced to compact (17 branches), then `_tokens()` evaluated on the saved trace:

| | input | output |
|---|---|---|
| **before** (`branches[0]`) | 1,049 | 395 |
| **after** (sum all 17 branches) | 25,720 | 6,648 |

This was the **eval** client (no token ids), so the counts came entirely from the per-branch usage fallback — exactly the path that was being truncated to one branch. The before value (1,049/395) is just the first branch; the rollout actually consumed 25,720/6,648 across its branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `_tokens` in eval dashboard to sum token counts across all branches
> Previously, `_tokens` in [eval.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1867/files#diff-0a27b905958929f3ae9e01937dd7e3cf97a60dec137caddcbf87792784fc9035) only read token counts from the first branch, causing undercounts for multi-branch traces. It also returned early with zeros when the first branch had no nodes. Now prompt and completion tokens are summed across all branches, and empty branch lists still yield 0/0.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 233a6bd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only change in the eval CLI dashboard; no rollout, scoring, or billing logic is modified.
> 
> **Overview**
> The rich eval dashboard’s **`_tokens()`** helper no longer reads prompt/completion counts from **`branches[0]` only**. It **sums** each branch’s `prompt_len or num_prompt_tokens` and `completion_len or num_completion_tokens`, so multi-branch rollouts (compaction, subagents) show totals aligned with **`Trace.prompt_len`** / **`Trace.completion_len`**.
> 
> The docstring is updated to describe branch-wise aggregation. The old early return that yielded **0/0** when the first branch had no nodes is removed; an empty branch list still sums to zero.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 233a6bded1f6782c64b5c39a457171e8c8978239. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->