### PR TITLE
feat: add run-totals usage section to eval summary

### DIFF
--- a/verifiers/utils/eval_display.py
+++ b/verifiers/utils/eval_display.py
@@ -954,6 +954,70 @@ class EvalDisplay(BaseDisplay):
             self._tail_task = None
         await super().__aexit__(exc_type, exc_val, exc_tb)
 
+    def _make_totals_section(self) -> Group | None:
+        """Aggregate usage and time across all evaluated envs for the run summary.
+
+        Tokens and cost are summed (totals across the whole run); wall-clock time
+        is averaged across envs, since envs are evaluated concurrently and summing
+        their elapsed times would overcount.
+        """
+        total_input = 0.0
+        total_output = 0.0
+        total_cost = 0.0
+        have_usage = False
+        have_cost = False
+        times: list[float] = []
+
+        for idx in range(len(self.configs)):
+            env_state = self.state.envs[idx]
+            if env_state.status in ("completed", "failed"):
+                times.append(env_state.elapsed_time)
+
+            results = env_state.results
+            if results is not None:
+                for output in results["outputs"]:
+                    usage = output.get("token_usage")
+                    if isinstance(usage, dict):
+                        total_input += float(usage.get("input_tokens", 0.0))
+                        total_output += float(usage.get("output_tokens", 0.0))
+                        have_usage = True
+                cost = results["metadata"].get("cost")
+            else:
+                cost = env_state.cost
+            if cost is not None:
+                total_cost += float(cost["total_usd"])
+                have_cost = True
+
+        if not (have_usage or have_cost or times):
+            return None
+
+        rows: list[RenderableType] = []
+        if have_usage or have_cost:
+            kv: dict[str, object] = {}
+            if have_usage:
+                kv["input"] = format_numeric(total_input)
+                kv["output"] = format_numeric(total_output)
+                kv["total"] = format_numeric(total_input + total_output)
+            if have_cost:
+                kv["cost (all)"] = format_cost_usd(total_cost)
+            rows.append(
+                make_kv_line(kv, prefix="  ", prefix_style="dim", section_label="usage")
+            )
+        if times:
+            mean_time = sum(times) / len(times)
+            mins, secs = divmod(int(mean_time), 60)
+            time_str = f"{mins}m {secs:02d}s" if mins > 0 else f"{secs}s"
+            rows.append(
+                make_kv_line(
+                    {"mean": time_str},
+                    prefix="  ",
+                    prefix_style="dim",
+                    section_label="time",
+                )
+            )
+
+        return Group(Text("Totals", style="bold"), *rows)
+
     def print_final_summary(self) -> None:
         """Print a comprehensive summary after the display closes."""
         self.console.print()
@@ -1082,6 +1146,10 @@ class EvalDisplay(BaseDisplay):
 
         self.console.print()
         self.console.print(table)
+        totals = self._make_totals_section()
+        if totals is not None:
+            self.console.print()
+            self.console.print(totals)
         self.console.print()
 
     def _make_settings_panel(


### PR DESCRIPTION
## Summary

- Add a **Totals** section under the `Evaluation Summary` table printed at the
  end of an eval run (`EvalDisplay.print_final_summary`).
- Aggregates across all evaluated envs:
  - **usage** — summed token counts (`input`, `output`, `total`) and summed
    `cost (all)`, grouped on a single usage line.
  - **time** — `mean` wall-clock time per env. Time is averaged rather than
    summed because envs are evaluated concurrently, so summing elapsed times
    would overcount.
- The section is omitted entirely when no usage/cost/time data is available.

The per-env table is unchanged. Its `input`/`output` columns remain per-rollout
means; the new section reports run-wide sums (matching the existing `cost (all)`
total), which is why it's labeled `Totals`.

## Before / After

Same eval run (2 envs, 10 rollouts each), rendered to text.

**Before** — table only:

```
                                       Evaluation Summary
┏━━━━━━┳━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━┳━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━┓
┃ eval ┃ status ┃ examples ┃ rollouts ┃ reward ┃ input ┃ output ┃ cost (all) ┃ errors ┃  time  ┃
┡━━━━━━╇━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━╇━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━┩
│ math │  done  │    5     │    2     │ 0.732  │ 1450  │  612   │  $0.0300   │  0.0%  │ 1m 13s │
│ code │  done  │    5     │    2     │ 0.515  │ 2200  │  980   │  $0.0710   │  5.0%  │ 2m 25s │
└──────┴────────┴──────────┴──────────┴────────┴───────┴────────┴────────────┴────────┴────────┘
```

**After** — table + `Totals`:

```
                                       Evaluation Summary
┏━━━━━━┳━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━┳━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━┓
┃ eval ┃ status ┃ examples ┃ rollouts ┃ reward ┃ input ┃ output ┃ cost (all) ┃ errors ┃  time  ┃
┡━━━━━━╇━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━╇━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━┩
│ math │  done  │    5     │    2     │ 0.732  │ 1450  │  612   │  $0.0300   │  0.0%  │ 1m 13s │
│ code │  done  │    5     │    2     │ 0.515  │ 2200  │  980   │  $0.0710   │  5.0%  │ 2m 25s │
└──────┴────────┴──────────┴──────────┴────────┴───────┴────────┴────────────┴────────┴────────┘

Totals
  usage  input 36500   output 15920   total 52420   cost (all) $0.1010
  time  mean 1m 49s
```


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add run-totals section to eval final summary
> Adds a `_make_totals_section` helper to [`EvalDisplay`](https://github.com/PrimeIntellect-ai/verifiers/pull/1868/files#diff-7ba36dbd2991f8c14234abe01fbec7b40beecccad828712a04bfe49f466b0001) that aggregates token usage, cost (USD), and mean wall-clock time across all environments. The totals section is appended to the output of `print_final_summary` when any aggregated data is available.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized cd1a71e. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->