### PR TITLE
feat: show usage and time totals under the eval progress bar

### DIFF
--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -183,13 +183,14 @@ def _breakdown(done: list[Trace]) -> Table | None:
         ]
         grid.add_row(label, "  ·  ".join(segments))
 
-    # Resource totals over every completed rollout (errored ones still spent tokens/time): tokens
-    # and cost are summed; wall-clock time is averaged, since rollouts run concurrently and summing
-    # their durations would overcount.
+    # Resource use over every completed rollout (errored ones still spent tokens/time): tokens and
+    # cost are summed; each timing phase is averaged over the rollouts that have it timed (averaged
+    # per phase rather than summed, since phases run concurrently across rollouts).
     total_in = total_out = total_cached = total_reasoning = 0
     total_cost = 0.0
     have_cost = have_cached = have_reasoning = False
-    times: list[float] = []
+    phase_secs: dict[str, float] = {}
+    phase_count: dict[str, int] = {}
     for trace in done:
         prompt, completion, cached, reasoning, _ = _tokens(trace)
         total_in += prompt
@@ -203,15 +204,11 @@ def _breakdown(done: list[Trace]) -> Table | None:
         if trace.usage is not None and trace.usage.cost is not None:
             total_cost += trace.usage.cost
             have_cost = True
-        start = trace.timing.setup.start
-        end = (
-            trace.timing.scoring.end
-            or trace.timing.finalize.end
-            or trace.timing.generation.end
-            or (trace.timing.setup.end if trace.is_completed else 0)
-        )
-        if start and end:
-            times.append(end - start)
+        for phase in ("setup", "generation", "finalize", "scoring"):
+            span = getattr(trace.timing, phase)
+            if span.end:  # phase was timed for this rollout
+                phase_secs[phase] = phase_secs.get(phase, 0.0) + span.duration
+                phase_count[phase] = phase_count.get(phase, 0) + 1
     if total_in or total_out or have_cost or have_cached or have_reasoning:
         tokens = f"{format_count(total_in)}/{format_count(total_out)} tokens"
         details = []
@@ -225,8 +222,13 @@ def _breakdown(done: list[Trace]) -> Table | None:
         if have_cost:
             usage.append(format_cost_usd(total_cost))
         grid.add_row("usage", "  ·  ".join(usage))
-    if times:
-        grid.add_row("time", f"mean {format_time(sum(times) / len(times))}")
+    time_segments = [
+        f"{phase} {format_time(phase_secs[phase] / phase_count[phase])}"
+        for phase in ("setup", "generation", "finalize", "scoring")
+        if phase_count.get(phase)
+    ]
+    if time_segments:
+        grid.add_row("time", "  ·  ".join(time_segments))
     return grid if grid.row_count else None
 
 

--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -220,7 +220,7 @@ def _breakdown(done: list[Trace]) -> Table | None:
             tokens += f" ({', '.join(details)})"
         usage = [tokens]
         if have_cost:
-            usage.append(format_cost_usd(total_cost))
+            usage.append(f"total {format_cost_usd(total_cost)}")
         grid.add_row("usage", "  ·  ".join(usage))
     time_segments = [
         f"{phase} {format_time(phase_secs[phase] / phase_count[phase])}"

--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -158,11 +158,12 @@ def Progress(
 
 def _breakdown(done: list[Trace]) -> Table | None:
     """The per-component view under the headline (summed) reward: a `rewards` row of each named
-    `@reward` contribution and a `metrics` row of each `@metric`, laid out like the Overview (dim
-    label column). Each component is formatted exactly like the headline reward — the
-    error-corrected mean, with the global mean (an errored trace's value counting as 0) in parens
-    when some errored (see `format_mean`). `None` when nothing has scored yet, so the bar shows
-    alone."""
+    `@reward` contribution and a `metrics` row of each `@metric`, then a `usage` row (tokens and
+    cost summed over all completed rollouts) and a `time` row (mean wall-clock per rollout), laid
+    out like the Overview (dim label column). Reward/metric components are formatted exactly like
+    the headline reward — the error-corrected mean, with the global mean (an errored trace's value
+    counting as 0) in parens when some errored (see `format_mean`). `None` when nothing has scored
+    yet, so the bar shows alone."""
     if not any(not t.has_error for t in done):
         return None
     grid = Table.grid(padding=(0, 2))
@@ -181,6 +182,37 @@ def _breakdown(done: list[Trace]) -> Table | None:
             for name in names
         ]
         grid.add_row(label, "  ·  ".join(segments))
+
+    # Resource totals over every completed rollout (errored ones still spent tokens/time): tokens
+    # and cost are summed; wall-clock time is averaged, since rollouts run concurrently and summing
+    # their durations would overcount.
+    total_in = total_out = 0
+    total_cost = 0.0
+    have_cost = False
+    times: list[float] = []
+    for trace in done:
+        prompt, completion, _, _, _ = _tokens(trace)
+        total_in += prompt
+        total_out += completion
+        if trace.usage is not None and trace.usage.cost is not None:
+            total_cost += trace.usage.cost
+            have_cost = True
+        start = trace.timing.setup.start
+        end = (
+            trace.timing.scoring.end
+            or trace.timing.finalize.end
+            or trace.timing.generation.end
+            or (trace.timing.setup.end if trace.is_completed else 0)
+        )
+        if start and end:
+            times.append(end - start)
+    if total_in or total_out or have_cost:
+        usage = [f"{format_count(total_in)}/{format_count(total_out)} tokens"]
+        if have_cost:
+            usage.append(format_cost_usd(total_cost))
+        grid.add_row("usage", "  ·  ".join(usage))
+    if times:
+        grid.add_row("time", f"mean {format_time(sum(times) / len(times))}")
     return grid if grid.row_count else None
 
 

--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -159,17 +159,20 @@ def Progress(
 def _breakdown(done: list[Trace]) -> Table | None:
     """The per-component view under the headline (summed) reward: a `rewards` row of each named
     `@reward` contribution and a `metrics` row of each `@metric`, then a `usage` row (tokens and
-    cost summed over all completed rollouts) and a `time` row (mean wall-clock per rollout), laid
-    out like the Overview (dim label column). Reward/metric components are formatted exactly like
-    the headline reward — the error-corrected mean, with the global mean (an errored trace's value
-    counting as 0) in parens when some errored (see `format_mean`). `None` when nothing has scored
-    yet, so the bar shows alone."""
-    if not any(not t.has_error for t in done):
-        return None
+    cost summed over completed rollouts) and a `time` row (each phase averaged over the rollouts
+    that have it timed), laid out like the Overview (dim label column). Reward/metric components
+    are error-corrected means, with the global mean (an errored trace's value counting as 0) in
+    parens when some errored (see `format_mean`); they're skipped when every rollout errored (no
+    clean mean to show), while usage/time still appear — those resources were spent regardless.
+    `None` when no rollout has completed."""
     grid = Table.grid(padding=(0, 2))
     grid.add_column(style="dim", min_width=_LABEL_WIDTH)
     grid.add_column()
-    for label, source in (("rewards", "rewards"), ("metrics", "metrics")):
+    # rewards/metrics are error-corrected means — skip when every rollout errored (no clean mean to
+    # show); usage/time below still cover errored rollouts (their resources were spent regardless).
+    has_clean = any(not t.has_error for t in done)
+    score_rows = (("rewards", "rewards"), ("metrics", "metrics")) if has_clean else ()
+    for label, source in score_rows:
         # every key seen across traces, first-seen order (a trace records only the functions
         # that ran for it, so keys can vary)
         names: list[str] = []

--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -186,14 +186,20 @@ def _breakdown(done: list[Trace]) -> Table | None:
     # Resource totals over every completed rollout (errored ones still spent tokens/time): tokens
     # and cost are summed; wall-clock time is averaged, since rollouts run concurrently and summing
     # their durations would overcount.
-    total_in = total_out = 0
+    total_in = total_out = total_cached = total_reasoning = 0
     total_cost = 0.0
-    have_cost = False
+    have_cost = have_cached = have_reasoning = False
     times: list[float] = []
     for trace in done:
-        prompt, completion, _, _, _ = _tokens(trace)
+        prompt, completion, cached, reasoning, _ = _tokens(trace)
         total_in += prompt
         total_out += completion
+        if cached is not None:
+            total_cached += cached
+            have_cached = True
+        if reasoning is not None:
+            total_reasoning += reasoning
+            have_reasoning = True
         if trace.usage is not None and trace.usage.cost is not None:
             total_cost += trace.usage.cost
             have_cost = True
@@ -206,8 +212,16 @@ def _breakdown(done: list[Trace]) -> Table | None:
         )
         if start and end:
             times.append(end - start)
-    if total_in or total_out or have_cost:
-        usage = [f"{format_count(total_in)}/{format_count(total_out)} tokens"]
+    if total_in or total_out or have_cost or have_cached or have_reasoning:
+        tokens = f"{format_count(total_in)}/{format_count(total_out)} tokens"
+        details = []
+        if have_cached:
+            details.append(f"{format_count(total_cached)} cached")
+        if have_reasoning:
+            details.append(f"{format_count(total_reasoning)} reasoning")
+        if details:
+            tokens += f" ({', '.join(details)})"
+        usage = [tokens]
         if have_cost:
             usage.append(format_cost_usd(total_cost))
         grid.add_row("usage", "  ·  ".join(usage))
@@ -301,10 +315,10 @@ def Rows(groups: list[list[Rollout]], now: float, runtime_type: str) -> Table:
             if prompt or completion:
                 tokens = f"{format_count(prompt)}/{format_count(completion)} tokens"
                 details = []
-                if reasoning is not None:
-                    details.append(f"{format_count(reasoning)} reasoning")
                 if cached is not None:
                     details.append(f"{format_count(cached)} cached")
+                if reasoning is not None:
+                    details.append(f"{format_count(reasoning)} reasoning")
                 if details:
                     tokens += f" ({', '.join(details)})"
             left = [


### PR DESCRIPTION
## Summary

- Add two rows to the v1 eval dashboard's under-bar breakdown (`verifiers/v1/cli/dashboard/eval.py`, `_breakdown`), beneath the existing `rewards`/`metrics` rows:
  - **usage** — summed input/output tokens, with summed cached and reasoning tokens in parentheses (cached first, then reasoning), and summed cost (labeled `total` to distinguish it from the per-rollout cost in the rows).
  - **time** — per-phase averages (`setup`, `generation`, `finalize`, `scoring`), each averaged over the rollouts that actually have that phase timed. (Per phase rather than a single total, since phases run concurrently across rollouts.)
- Tokens reuse the same per-rollout `_tokens()` view shown in the rollout rows (input = final context, output = all completion tokens; cached/reasoning from `Trace.usage`); cost reuses `Trace.usage.cost`; phase durations from `Trace.timing.<phase>.duration`. Summed/averaged over completed rollouts, including errored ones (they still spent tokens/time).
- Reorder the per-rollout row's token details to `cached, reasoning` (was `reasoning, cached`) so the per-rollout and aggregate views match.
- `usage`/`time` show for any completed rollouts, including a run where every rollout errored (those traces still spent tokens/time) — only the error-corrected `rewards`/`metrics` means are skipped in that case. Each segment is omitted when its data isn't available.

## Before / After

Live dashboard, under the progress bar (2 rollouts):

**Before**

```
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2/2 · 3m 20s · reward 0.62 · err 0.00
rewards   correct 0.62
metrics   format 0.88
```

**After**

```
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2/2 · 3m 20s · reward 0.62 · err 0.00
rewards   correct 0.62
metrics   format 0.88
usage     3.6K/1.6K tokens (1.9K cached, 666 reasoning)  ·  total $0.1010
time      setup 15s  ·  generation 1m 41s  ·  finalize 0.5s  ·  scoring 5s
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only CLI dashboard formatting; no changes to eval execution, scoring, or persistence.
> 
> **Overview**
> Extends the v1 eval **rich** dashboard under-bar breakdown in `_breakdown` with **usage** and **time** rows, alongside existing **rewards** / **metrics**.
> 
> **usage** sums input/output tokens (via `_tokens`), optional cached and reasoning totals in parentheses (**cached** before **reasoning**), and summed cost labeled `total`. **time** shows per-phase averages for `setup`, `generation`, `finalize`, and `scoring` over rollouts that recorded each phase. Both include completed errored rollouts; reward/metric rows are omitted only when every rollout errored. The breakdown can still render when only usage/time apply (previously it disappeared if all traces errored).
> 
> Per-rollout rows reorder token parentheticals to **cached, reasoning** so they match the aggregate line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bcedbbd33d19519e703efdd09cf7a209630ad21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add usage and time totals to eval progress bar breakdown
> - Adds a `usage` row to the breakdown table in [`eval.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1869/files#diff-0a27b905958929f3ae9e01937dd7e3cf97a60dec137caddcbf87792784fc9035) showing summed tokens in/out, optional cached/reasoning tokens, and total cost across completed rollouts.
> - Adds a `time` row showing average per-phase durations (setup, generation, finalize, scoring) over rollouts that recorded each phase.
> - Rewards/metrics rows are now omitted only when every rollout errored, rather than hiding the entire section; the breakdown returns `None` only when no rollout has completed.
> - Reorders token detail annotations so `cached` appears before `reasoning` in the per-row display.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9bcedbb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->