### PR TITLE
feat: add Trace/Branch.final_assistant_content helper

### DIFF
--- a/environments/code_golf_v1/code_golf_v1/taskset.py
+++ b/environments/code_golf_v1/code_golf_v1/taskset.py
@@ -29,7 +29,7 @@ SYSTEM = (
 
 def extract_program(trace: vf.Trace) -> str:
     """The python from the last assistant message's code block (or its raw text)."""
-    text = trace.assistant_messages[-1].content if trace.assistant_messages else ""
+    text = trace.final_assistant_content or ""
     match = re.search(r"```(?:python)?\n(.*?)```", text or "", re.DOTALL)
     return (match.group(1) if match else text or "").strip()
 

--- a/environments/deepwiki_v1/deepwiki_v1/taskset.py
+++ b/environments/deepwiki_v1/deepwiki_v1/taskset.py
@@ -53,5 +53,5 @@ class DeepWikiTaskset(vf.Taskset[DeepWikiTask, DeepWikiConfig]):
     async def answered(
         self, task: DeepWikiTask, trace: vf.Trace, runtime: vf.Runtime
     ) -> float:
-        last = trace.assistant_messages[-1].content if trace.assistant_messages else ""
-        return float(task.answer.lower() in (last or "").lower())
+        last = trace.final_assistant_content or ""
+        return float(task.answer.lower() in last.lower())

--- a/environments/glossary_v1/glossary_v1/taskset.py
+++ b/environments/glossary_v1/glossary_v1/taskset.py
@@ -44,5 +44,5 @@ class GlossaryTaskset(vf.Taskset[GlossaryTask, GlossaryConfig]):
         self, task: GlossaryTask, trace: vf.Trace, runtime: vf.Runtime
     ) -> float:
         # The fact only reaches the answer if the model called the MCP tool.
-        last = trace.assistant_messages[-1].content if trace.assistant_messages else ""
-        return float(task.answer.lower() in (last or "").lower())
+        last = trace.final_assistant_content or ""
+        return float(task.answer.lower() in last.lower())

--- a/environments/gsm8k_v1/gsm8k_v1/taskset.py
+++ b/environments/gsm8k_v1/gsm8k_v1/taskset.py
@@ -47,12 +47,8 @@ class GSM8KTaskset(vf.Taskset[GSM8KTask, GSM8KConfig]):
     async def correct(
         self, task: GSM8KTask, trace: vf.Trace, runtime: vf.Runtime
     ) -> float:
-        prediction = (
-            trace.assistant_messages[-1].content if trace.assistant_messages else ""
-        )
-        result = await runtime.run_uv_script(
-            VERIFY, args=[task.answer, prediction or ""]
-        )
+        prediction = trace.final_assistant_content or ""
+        result = await runtime.run_uv_script(VERIFY, args=[task.answer, prediction])
         if result.exit_code != 0:
             raise RuntimeError(f"verify.py failed: {result.stderr.strip()[-500:]}")
         lines = result.stdout.strip().splitlines()

--- a/environments/reverse_text_v1/reverse_text_v1/taskset.py
+++ b/environments/reverse_text_v1/reverse_text_v1/taskset.py
@@ -49,9 +49,7 @@ class ReverseTextTaskset(vf.Taskset[ReverseTextTask, ReverseTextConfig]):
 
     @vf.reward(weight=1.0)
     async def lcs(self, task: ReverseTextTask, trace: vf.Trace) -> float:
-        completion = (
-            trace.assistant_messages[-1].content if trace.assistant_messages else ""
-        )
-        match = _TAG.search(completion or "")
+        completion = trace.final_assistant_content or ""
+        match = _TAG.search(completion)
         response = match.group(1).strip() if match else ""
         return SequenceMatcher(None, response, task.answer).ratio()

--- a/environments/scratchpad_v1/scratchpad_v1/taskset.py
+++ b/environments/scratchpad_v1/scratchpad_v1/taskset.py
@@ -57,7 +57,5 @@ class ScratchpadTaskset(vf.Taskset[ScratchpadTask, ScratchpadConfig, ScratchpadS
 
     @vf.reward(weight=1.0)
     async def isolated(self, task: ScratchpadTask, trace: vf.Trace) -> float:
-        answer = (
-            trace.assistant_messages[-1].content if trace.assistant_messages else ""
-        )
-        return float(task.word in (answer or ""))
+        answer = trace.final_assistant_content or ""
+        return float(task.word in answer)

--- a/environments/wiki_search_v1/wiki_search_v1/taskset.py
+++ b/environments/wiki_search_v1/wiki_search_v1/taskset.py
@@ -86,9 +86,7 @@ class WikiSearchTaskset(vf.Taskset[TriviaTask, WikiSearchConfig]):
     async def judged(
         self, task: TriviaTask, trace: vf.Trace, runtime: vf.Runtime
     ) -> float:
-        response = (
-            trace.assistant_messages[-1].content if trace.assistant_messages else ""
-        )
+        response = trace.final_assistant_content or ""
         prompt = JUDGE_PROMPT.format(
             question=task.question, answer=task.answer, response=response or ""
         )

--- a/tests/v1/test_trace.py
+++ b/tests/v1/test_trace.py
@@ -82,3 +82,25 @@ def test_wire_trace_round_trip():
 
     # the env-server wire form (a plain model_dump) loads too
     assert vf.WireTrace.model_validate(tr.model_dump()).num_branches == 2
+
+
+def test_final_assistant_content_uses_latest_branch():
+    # Two leaves off one root → branch[0] ends at "a1", the later branch[1] ends at "a2"; the
+    # trace's final content is the latest branch's (the compaction case).
+    tr = vf.Trace(
+        task=vf.Task(idx=0, prompt="q"),
+        nodes=[
+            MessageNode(parent=None, message=UserMessage(content="q"), sampled=False),
+            MessageNode(parent=0, message=AssistantMessage(content="a1"), sampled=True),
+            MessageNode(parent=0, message=AssistantMessage(content="a2"), sampled=True),
+        ],
+    )
+    branches = tr.branches
+    assert branches[0].final_assistant_content == "a1"
+    assert branches[-1].final_assistant_content == "a2"
+    assert tr.final_assistant_content == "a2"
+
+
+def test_final_assistant_content_none_without_response():
+    tr = vf.Trace(task=vf.Task(idx=0, prompt="q"))
+    assert tr.final_assistant_content is None

--- a/verifiers/v1/GUIDE.md
+++ b/verifiers/v1/GUIDE.md
@@ -66,7 +66,7 @@ class ReverseTaskset(vf.Taskset[ReverseTask, ReverseConfig]):
 
     @vf.reward()
     async def exact_match(self, task: ReverseTask, trace: vf.Trace) -> float:
-        return float(trace.assistant_messages[-1].content.strip() == task.answer)
+        return float((trace.final_assistant_content or "").strip() == task.answer)
 
 
 __all__ = ["ReverseTaskset"]   # vf resolves the taskset by finding this Taskset subclass
@@ -250,7 +250,7 @@ VERIFY = (Path(__file__).parent / "verify.py").read_text()   # PEP 723 header de
 
 @vf.reward()
 async def verify(self, task, trace, runtime) -> float:
-    r = await runtime.run_uv_script(VERIFY, args=[task.answer, trace.assistant_messages[-1].content])
+    r = await runtime.run_uv_script(VERIFY, args=[task.answer, trace.final_assistant_content or ""])
     return float(r.stdout.strip() == "1.0")
 ```
 
@@ -263,7 +263,7 @@ a taskset `@vf.stop` fires. A stop is an `async (self, trace) -> bool` checked b
 ```python
 @vf.stop
 async def saw_answer(self, trace) -> bool:
-    last = trace.assistant_messages[-1].content or ""
+    last = trace.final_assistant_content or ""
     return "FINAL:" in last
 ```
 

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -88,6 +88,15 @@ class Branch(StrictBaseModel):
         return [n.message for n in self.nodes]
 
     @property
+    def final_assistant_content(self) -> str | None:
+        """The text content of this branch's last model-produced assistant message (its final
+        answer), or None if the branch produced no assistant content."""
+        for node in reversed(self.nodes):
+            if node.sampled and isinstance(node.message, AssistantMessage):
+                return node.message.content
+        return None
+
+    @property
     def token_ids(self) -> list[int]:
         """The branch's full token sequence — every node's tokens concatenated in order
         (final-turn prompt + every completion). The training sample's input ids."""
@@ -299,6 +308,14 @@ class Trace(StrictBaseModel, Generic[TaskT, StateT]):
         """Whether the most recent assistant message produced non-empty content."""
         last = self._last_assistant()
         return bool(last and last.message.content)
+
+    @property
+    def final_assistant_content(self) -> str | None:
+        """The rollout's final assistant content: the last assistant message of the most recent
+        branch. Under compaction or subagents the final answer lives on the latest branch
+        (`branches[-1]`, last in time), not the first; a linear trace has a single branch. None
+        when no branch produced an assistant response."""
+        return self.branches[-1].final_assistant_content if self.branches else None
 
     @property
     def branches(self) -> list[Branch]:


### PR DESCRIPTION
## Summary

- Add `Branch.final_assistant_content` — the text content of a branch's last model-produced (`sampled`) assistant message, or `None`.
- Add `Trace.final_assistant_content` — the same for the **most recent branch** (`branches[-1]`, last in time). Under compaction or subagents the final answer lives on the latest branch, not the first (`branches[0]`); a linear trace has a single branch.
- Replace the repeated `trace.assistant_messages[-1].content if trace.assistant_messages else ""` boilerplate with `trace.final_assistant_content or ""` in the example envs (`code_golf_v1`, `deepwiki_v1`, `scratchpad_v1`, `reverse_text_v1`, `gsm8k_v1`, `glossary_v1`, `wiki_search_v1`) and in `verifiers/v1/GUIDE.md`.

## Verification

- `pytest tests/v1/test_trace.py` — added two tests (latest-branch selection on a 2-branch/compaction trace; `None` when no response); all pass. ruff clean.
- On a real 17-branch `terminal-bench/fix-git` rollout (rlm harness, forced compaction): `trace.final_assistant_content == branches[-1].final_assistant_content` and equals the old `assistant_messages[-1].content`, while `branches[0].final_assistant_content` differs — confirming it reads the final answer from the last branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `final_assistant_content` property to `Trace` and `Branch`
> - Adds `Branch.final_assistant_content` in [trace.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1870/files#diff-834820c3aa80d87ee1c1c57fb54c74f09c66ac727036d964e6005c8613c00b5e) that scans nodes in reverse to find the last sampled `AssistantMessage` and returns its content (or `None`).
> - Adds `Trace.final_assistant_content` that delegates to the latest branch's property.
> - Updates seven environment tasksets and the [GUIDE.md](https://github.com/PrimeIntellect-ai/verifiers/pull/1870/files#diff-c2ca7f62523b24001d6019e37e36351dc73dd3e91a9ac126847e7eb5c55d63a1) to use `trace.final_assistant_content` instead of `trace.assistant_messages[-1].content`, so reward functions now evaluate the final content of the latest branch rather than the last item in the flat message list.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4610825.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->