### PR TITLE
feat: add math500-v1 taskset

### DIFF
--- a/configs/math500.toml
+++ b/configs/math500.toml
@@ -1,0 +1,8 @@
+# math500-v1 — MATH-500 competition math, default harness; a few tasks with several rollouts each.
+#
+#   uv run eval math500-v1 @ configs/math500.toml
+num_tasks = 5
+num_rollouts = 3
+
+[taskset]
+id = "math500-v1"

--- a/environments/math500_v1/math500_v1/__init__.py
+++ b/environments/math500_v1/math500_v1/__init__.py
@@ -1,0 +1,3 @@
+from math500_v1.taskset import Math500Taskset
+
+__all__ = ["Math500Taskset"]

--- a/environments/math500_v1/math500_v1/taskset.py
+++ b/environments/math500_v1/math500_v1/taskset.py
@@ -1,0 +1,69 @@
+"""math500: MATH-500 competition math (single-turn, in-runtime scoring).
+
+The eval analog of `math-env`: load the 500 MATH-500 problems, prompt the model to reason
+and box its final answer, and score by math equivalence (`math-verify`) of the boxed answer
+against the gold — the same in-runtime uv-script verifier as `aime24` / `math-env`.
+"""
+
+from pathlib import Path
+
+import verifiers.v1 as vf
+
+# Appended after the problem to match the v0 `math500` env's prompt.
+INSTRUCTION = (
+    "\nPlease reason step by step, and put your final answer within \\boxed{}."
+)
+VERIFY = (Path(__file__).parent / "verify.py").read_bytes()
+
+
+class Math500Task(vf.Task):
+    answer: str
+    """The ground-truth answer — math-verify compares the model's boxed answer to this."""
+
+
+class Math500Config(vf.TasksetConfig):
+    dataset_name: str = "HuggingFaceH4/MATH-500"
+    dataset_split: str = "test"
+    dataset_revision: str = "6e4ed1a2a79af7d8630a6b768ec859cb5af4d3be"
+    math_verify_timeout: int = 5
+    """Per-answer wall-clock budget for the math-verify comparison, in seconds."""
+
+
+class Math500Taskset(vf.Taskset[Math500Task, Math500Config]):
+    def load_tasks(self) -> list[Math500Task]:
+        from datasets import load_dataset
+
+        rows = load_dataset(
+            self.config.dataset_name,
+            split=self.config.dataset_split,
+            revision=self.config.dataset_revision,
+        )
+        return [
+            Math500Task(
+                idx=i,
+                prompt=row["problem"] + INSTRUCTION,
+                answer=str(row["answer"]),
+            )
+            for i, row in enumerate(rows)
+        ]
+
+    @vf.stop
+    async def single_turn(self, trace: vf.Trace) -> bool:
+        # MATH-500 is single-turn: refuse a second turn so the model answers once.
+        return trace.num_turns >= 1
+
+    @vf.reward(weight=1.0)
+    async def correct(
+        self, task: Math500Task, trace: vf.Trace, runtime: vf.Runtime
+    ) -> float:
+        prediction = (
+            trace.assistant_messages[-1].content if trace.assistant_messages else ""
+        )
+        result = await runtime.run_uv_script(
+            VERIFY,
+            args=[task.answer, prediction or "", str(self.config.math_verify_timeout)],
+        )
+        if result.exit_code != 0:
+            raise RuntimeError(f"verify.py failed: {result.stderr.strip()[-500:]}")
+        lines = result.stdout.strip().splitlines()
+        return float(lines[-1]) if lines else 0.0

--- a/environments/math500_v1/math500_v1/verify.py
+++ b/environments/math500_v1/math500_v1/verify.py
@@ -1,0 +1,51 @@
+# /// script
+# dependencies = ["math-verify"]
+# ///
+"""Score one math answer by math-verify equivalence of the model's boxed answer vs the
+gold, run inside the rollout's runtime via `uv run`. uv installs `math-verify` into its
+own cache here — the dependency never touches the eval process. Takes the gold answer
+(argv[1]), the model's prediction (argv[2]), and a timeout in seconds (argv[3]); prints
+1.0 if they're equivalent, else 0.0.
+"""
+
+import sys
+
+from math_verify import parse, verify
+
+gold, pred, timeout = sys.argv[1], sys.argv[2], int(sys.argv[3])
+
+if "<think>" in pred and "</think>" not in pred:
+    print(0.0)
+    sys.exit(0)
+pred = pred.split("</think>")[-1]
+
+
+def extract_boxed(text: str) -> str:
+    """Content of the last ``\\boxed{...}`` in ``text``, or "" if there is none."""
+    start = text.rfind("\\boxed{")
+    if start == -1:
+        return ""
+    i, depth = start + len("\\boxed{"), 1
+    while i < len(text) and depth:
+        depth += (text[i] == "{") - (text[i] == "}")
+        i += 1
+    return text[start + len("\\boxed{") : i - 1] if depth == 0 else ""
+
+
+answer = extract_boxed(pred)
+if not answer:
+    print(0.0)
+    sys.exit(0)
+try:
+    score = (
+        1.0
+        if verify(
+            parse("\\boxed{" + gold + "}", parsing_timeout=timeout),
+            parse("\\boxed{" + answer + "}", parsing_timeout=timeout),
+            timeout_seconds=timeout,
+        )
+        else 0.0
+    )
+except Exception:
+    score = 0.0
+print(score)

--- a/environments/math500_v1/pyproject.toml
+++ b/environments/math500_v1/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "math500-v1"
+version = "0.1.0"
+description = "math500-v1 — MATH-500 competition math (single-turn eval, math-verify scoring)."
+requires-python = ">=3.10"
+dependencies = ["datasets"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["math500_v1"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ dev = [
 # from this repo. The built-in tasksets/harnesses ship inside verifiers (verifiers/v1/...).
 examples = [
     "compact",
-    "gsm8k-v1", "glossary-v1", "deepwiki-v1", "wiki-search-v1", "code-golf-v1",
+    "gsm8k-v1", "math500-v1", "glossary-v1", "deepwiki-v1", "wiki-search-v1", "code-golf-v1",
     "reverse-text-v1", "color-codeword-v1",
     "wordle-v1", "alphabet-sort-v1", "scratchpad-v1",
 ]
@@ -137,6 +137,7 @@ glossary-v1 = { path = "environments/glossary_v1", editable = true }
 deepwiki-v1 = { path = "environments/deepwiki_v1", editable = true }
 wiki-search-v1 = { path = "environments/wiki_search_v1", editable = true }
 gsm8k-v1 = { path = "environments/gsm8k_v1", editable = true }
+math500-v1 = { path = "environments/math500_v1", editable = true }
 code-golf-v1 = { path = "environments/code_golf_v1", editable = true }
 reverse-text-v1 = { path = "environments/reverse_text_v1", editable = true }
 reverse-text = { path = "environments/reverse_text", editable = true }

--- a/uv.lock
+++ b/uv.lock
@@ -2272,6 +2272,17 @@ wheels = [
 ]
 
 [[package]]
+name = "math500-v1"
+version = "0.1.0"
+source = { editable = "environments/math500_v1" }
+dependencies = [
+    { name = "datasets" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "datasets" }]
+
+[[package]]
 name = "matplotlib"
 version = "3.10.9"
 source = { registry = "https://pypi.org/simple" }
@@ -5728,6 +5739,7 @@ examples = [
     { name = "deepwiki-v1" },
     { name = "glossary-v1" },
     { name = "gsm8k-v1" },
+    { name = "math500-v1" },
     { name = "reverse-text-v1" },
     { name = "scratchpad-v1" },
     { name = "wiki-search-v1" },
@@ -5812,6 +5824,7 @@ examples = [
     { name = "deepwiki-v1", editable = "environments/deepwiki_v1" },
     { name = "glossary-v1", editable = "environments/glossary_v1" },
     { name = "gsm8k-v1", editable = "environments/gsm8k_v1" },
+    { name = "math500-v1", editable = "environments/math500_v1" },
     { name = "reverse-text-v1", editable = "environments/reverse_text_v1" },
     { name = "scratchpad-v1", editable = "environments/scratchpad_v1" },
     { name = "wiki-search-v1", editable = "environments/wiki_search_v1" },


### PR DESCRIPTION
## Summary

- Port MATH-500 to a v1 taskset: `environments/math500_v1` (`math500-v1`), modeled on `aime24-v1` / `math-env-v1`.
  - Loads `HuggingFaceH4/MATH-500` (split `test`, pinned revision), single-turn (`@vf.stop`).
  - Keeps the **v0 `math500` prompt** verbatim (`<problem>\nPlease reason step by step, and put your final answer within \boxed{}.`) so behavior matches the original.
  - Scores the model's boxed answer against the gold with the shared in-runtime `math-verify` uv-script verifier (same `verify.py` as `aime24-v1`), so its deps never touch the eval process.
- Registered in `pyproject.toml` (`[tool.uv.sources]` + the `examples` group) and added `configs/math500.toml`.

## Verification (no regression vs v0)

Ran **64 rollouts on old and new** with the default harness, `deepseek/deepseek-v4-flash` @ temperature 0 (deterministic), same first 64 problems (`-s False`):

- **new**: `math500-v1` taskset → `uv run eval math500-v1 -n 64 -r 1`
- **old**: the v0 `math500` env through the legacy bridge → `uv run eval --id math500 -n 64 -r 1`

| | correct | mean reward |
|---|---|---|
| old (v0 `MathRubric`) | 63/63 | 1.0000 |
| new (`math500-v1`) | 63/63 | 1.0000 |

**0 per-task mismatches.** The old and new scores come from two independent scoring paths (v0 `MathRubric` vs the v1 `math-verify` uv-script), and they agree on every task — no regression. (The model solved the whole subset at temp 0, so there were no incorrect cases for the scorers to diverge on.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `math500-v1` taskset for evaluating math reasoning on the MATH-500 benchmark
> - Adds a new environment in [environments/math500_v1/](https://github.com/PrimeIntellect-ai/verifiers/pull/1872/files#diff-8f6a79e2bfb9a94e6713676f318f7a4a1b185b5fd1b3ab8bc449fd9e5eb52e13) that loads the MATH-500 dataset from HuggingFace and wraps it as a single-turn taskset.
> - Scoring is done by an embedded [verify.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1872/files#diff-5824688fcce9f247d7df35a6133cee266ecac87a28b2fefb9b83211936aa6aa3) script that extracts the last `\boxed{...}` from the model response and compares it to the gold answer using `math-verify`, returning 1.0 or 0.0.
> - Adds [configs/math500.toml](https://github.com/PrimeIntellect-ai/verifiers/pull/1872/files#diff-50876282d12a7fb525e727f62668dfecbc16453633d9f7e0f81bc4b73da302f6) to run the taskset with 5 tasks and 3 rollouts via `uv run eval math500-v1 @ configs/math500.toml`.
> - Registers `math500-v1` in the root [pyproject.toml](https://github.com/PrimeIntellect-ai/verifiers/pull/1872/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711) as an editable path dependency under the `examples` extra.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 76d8e6d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->