### PR TITLE
fix: guarantee final-assistant text is a str in v1 example env scoring

### DIFF
--- a/environments/code_golf_v1/code_golf_v1/taskset.py
+++ b/environments/code_golf_v1/code_golf_v1/taskset.py
@@ -29,7 +29,9 @@ SYSTEM = (
 
 def extract_program(trace: vf.Trace) -> str:
     """The python from the last assistant message's code block (or its raw text)."""
-    text = trace.assistant_messages[-1].content if trace.assistant_messages else ""
+    text = (
+        (trace.assistant_messages[-1].content or "") if trace.assistant_messages else ""
+    )
     match = re.search(r"```(?:python)?\n(.*?)```", text or "", re.DOTALL)
     return (match.group(1) if match else text or "").strip()
 

--- a/environments/deepwiki_v1/deepwiki_v1/taskset.py
+++ b/environments/deepwiki_v1/deepwiki_v1/taskset.py
@@ -53,5 +53,9 @@ class DeepWikiTaskset(vf.Taskset[DeepWikiTask, DeepWikiConfig]):
     async def answered(
         self, task: DeepWikiTask, trace: vf.Trace, runtime: vf.Runtime
     ) -> float:
-        last = trace.assistant_messages[-1].content if trace.assistant_messages else ""
+        last = (
+            (trace.assistant_messages[-1].content or "")
+            if trace.assistant_messages
+            else ""
+        )
         return float(task.answer.lower() in (last or "").lower())

--- a/environments/glossary_v1/glossary_v1/taskset.py
+++ b/environments/glossary_v1/glossary_v1/taskset.py
@@ -44,5 +44,9 @@ class GlossaryTaskset(vf.Taskset[GlossaryTask, GlossaryConfig]):
         self, task: GlossaryTask, trace: vf.Trace, runtime: vf.Runtime
     ) -> float:
         # The fact only reaches the answer if the model called the MCP tool.
-        last = trace.assistant_messages[-1].content if trace.assistant_messages else ""
+        last = (
+            (trace.assistant_messages[-1].content or "")
+            if trace.assistant_messages
+            else ""
+        )
         return float(task.answer.lower() in (last or "").lower())

--- a/environments/gsm8k_v1/gsm8k_v1/taskset.py
+++ b/environments/gsm8k_v1/gsm8k_v1/taskset.py
@@ -48,7 +48,9 @@ class GSM8KTaskset(vf.Taskset[GSM8KTask, GSM8KConfig]):
         self, task: GSM8KTask, trace: vf.Trace, runtime: vf.Runtime
     ) -> float:
         prediction = (
-            trace.assistant_messages[-1].content if trace.assistant_messages else ""
+            (trace.assistant_messages[-1].content or "")
+            if trace.assistant_messages
+            else ""
         )
         result = await runtime.run_uv_script(
             VERIFY, args=[task.answer, prediction or ""]

--- a/environments/reverse_text_v1/reverse_text_v1/taskset.py
+++ b/environments/reverse_text_v1/reverse_text_v1/taskset.py
@@ -50,7 +50,9 @@ class ReverseTextTaskset(vf.Taskset[ReverseTextTask, ReverseTextConfig]):
     @vf.reward(weight=1.0)
     async def lcs(self, task: ReverseTextTask, trace: vf.Trace) -> float:
         completion = (
-            trace.assistant_messages[-1].content if trace.assistant_messages else ""
+            (trace.assistant_messages[-1].content or "")
+            if trace.assistant_messages
+            else ""
         )
         match = _TAG.search(completion or "")
         response = match.group(1).strip() if match else ""

--- a/environments/scratchpad_v1/scratchpad_v1/taskset.py
+++ b/environments/scratchpad_v1/scratchpad_v1/taskset.py
@@ -58,6 +58,8 @@ class ScratchpadTaskset(vf.Taskset[ScratchpadTask, ScratchpadConfig, ScratchpadS
     @vf.reward(weight=1.0)
     async def isolated(self, task: ScratchpadTask, trace: vf.Trace) -> float:
         answer = (
-            trace.assistant_messages[-1].content if trace.assistant_messages else ""
+            (trace.assistant_messages[-1].content or "")
+            if trace.assistant_messages
+            else ""
         )
         return float(task.word in (answer or ""))

--- a/environments/wiki_search_v1/wiki_search_v1/taskset.py
+++ b/environments/wiki_search_v1/wiki_search_v1/taskset.py
@@ -87,7 +87,9 @@ class WikiSearchTaskset(vf.Taskset[TriviaTask, WikiSearchConfig]):
         self, task: TriviaTask, trace: vf.Trace, runtime: vf.Runtime
     ) -> float:
         response = (
-            trace.assistant_messages[-1].content if trace.assistant_messages else ""
+            (trace.assistant_messages[-1].content or "")
+            if trace.assistant_messages
+            else ""
         )
         prompt = JUDGE_PROMPT.format(
             question=task.question, answer=task.answer, response=response or ""


### PR DESCRIPTION
## Summary

`AssistantMessage.content` is typed `str | None` (and is `None` for a tool-call-only final turn — providers return `content: null`), so the common scoring idiom

```python
trace.assistant_messages[-1].content if trace.assistant_messages else ""
```

guards the empty-list case but not the `None`-content case → it can yield `None`, not a str.

Normalize the v1 example tasksets to:

```python
(trace.assistant_messages[-1].content or "") if trace.assistant_messages else ""
```

so the final-assistant text is a **guaranteed str at the assignment**, independent of any downstream guard. 7 files. (Companion to the same sweep in research-environments.)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix final assistant message content to always be a string in v1 example environment scoring
> Across seven v1 environment tasksets, reward methods accessed `trace.assistant_messages[-1].content` directly, which could be `None` and cause type errors during scoring. Each affected file now coalesces the content to an empty string using `(trace.assistant_messages[-1].content or "") if trace.assistant_messages else ""`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 80814af.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->