### PR TITLE
feat: add a reusable LLM judge

### DIFF
--- a/verifiers/v1/GUIDE.md
+++ b/verifiers/v1/GUIDE.md
@@ -295,12 +295,12 @@ The two hooks:
 
 | hook | default | override for |
 | --- | --- | --- |
-| `build_messages(*, task, trace, **fields) -> str \| Messages` | formats the `prompt` template with `task` + the fields into one user message | a system+user / non-template prompt, or reading the response off the `trace` (return a `vf.Messages` list) |
+| `build_messages(**fields) -> str \| Messages` | formats the `prompt` template with the fields into one user message | a system+user / non-template prompt (return a `vf.Messages` list) |
 | `parse(response) -> ParsedT` | the structured object if `schema` is set, else `response.text` | your verdict (`bool`, a grade `str`, a pydantic model, a `list[float]`, …) |
 
 Good to know:
 
-- **Per-task rubric** rides in via `task` (or a field) — `prompt = "{task.rubric}\n…"` with `evaluate(task=task, trace=trace, …)` (`str.format` does attribute access); or override `build_messages` to template from `task`/`trace`. For per-task *parsing*, parse in the reward, where the task is in scope.
+- **Per-task rubric** is just a field — `prompt = "{task.rubric}\n…"` with `evaluate(trace=trace, task=task, …)` (`str.format` does attribute access on a passed-in `task`). For per-task *parsing*, parse in the reward, where the task is in scope.
 - **Structured outputs**: set `schema` to a pydantic model to use OpenAI structured outputs (where the provider supports it — most do); `JudgeResponse.parsed` is then the validated object. For an unsupported model, prompt for JSON and call `Model.model_validate_json(response.text)` in `parse`.
 - **Multiple / dynamic calls per rollout** (e.g. one per table column): call the low-level `complete(messages, *, schema=, parse=)` directly with `vf.Messages` you build, recording each with `trace.record_judge`.
 - **Config**: `JudgeConfig` adds `model` + `sampling` (a `JudgeSamplingConfig`) to `BaseClientConfig` (`base_url`/`api_key_var`/`headers`, Prime auto-config). CLI-overridable: `--taskset.judge.model …`, `--taskset.judge.sampling.max-tokens …`.

--- a/verifiers/v1/GUIDE.md
+++ b/verifiers/v1/GUIDE.md
@@ -254,6 +254,58 @@ async def verify(self, task, trace, runtime) -> float:
     return float(r.stdout.strip() == "1.0")
 ```
 
+### LLM judges
+
+When grading can't be deterministic, `vf.Judge` is a reusable LLM judge: it owns the OpenAI client
+(with the Prime key/team fallback), the call, and usage/cost capture, and leaves the two things that
+differ as hooks — `build_messages` (prompt) and `parse` (verdict). Subclass it, build it once in the
+taskset `__init__`, and call it from a `@reward`:
+
+```python
+import verifiers.v1 as vf
+
+class CorrectnessJudge(vf.Judge[bool]):                 # Judge[ParsedT] — ParsedT is your verdict type
+    prompt = "Question: {question}\nAnswer: {answer}\nResponse: {response}\nCorrect? Reply yes or no."
+
+    def parse(self, response: vf.JudgeResponse[bool]) -> bool:
+        return response.text.strip().lower().startswith("yes")
+
+class MyConfig(vf.TasksetConfig):
+    judge: vf.JudgeConfig = vf.JudgeConfig(model="openai/gpt-5-mini")
+
+class MyTaskset(vf.Taskset[MyTask, MyConfig]):
+    def __init__(self, config: MyConfig) -> None:
+        super().__init__(config)
+        self.judge = CorrectnessJudge(config.judge)
+
+    @vf.reward()
+    async def correct(self, task, trace) -> float:
+        result = await self.judge.evaluate(question=task.question, answer=task.answer, response=...)
+        trace.record_judge(result)        # persist: trace.info["judge"] + fold usage/cost
+        return 1.0 if result.parsed else 0.0
+```
+
+`evaluate(**fields)` is **pure** (data in, a `JudgeResponse{text, parsed, usage}` out): it renders
+the prompt (`build_messages(**fields)`), calls the model, and parses the verdict (`parse`).
+Persisting is the explicit `trace.record_judge(result)` step — it appends the typed record to
+`trace.info["judge"]` (for debugging) and folds the call's tokens + cost into `trace.usage`, kept
+off the message graph so the trainer's token math is unaffected.
+
+The two hooks:
+
+| hook | default | override for |
+| --- | --- | --- |
+| `build_messages(**fields) -> str \| Messages` | formats the `prompt` template into one user message | a system+user or non-template prompt (return a `vf.Messages` list) |
+| `parse(response) -> ParsedT` | the structured object if `schema` is set, else `response.text` | your verdict (`bool`, a grade `str`, a pydantic model, a `list[float]`, …) |
+
+Good to know:
+
+- **Per-task rubric** rides in as a field — `prompt = "{task.rubric}\n…"` with `evaluate(task=task, …)` (`str.format` does attribute access). For per-task *parsing*, parse in the reward, where the task is in scope.
+- **Structured outputs**: set `schema` to a pydantic model to use OpenAI structured outputs (where the provider supports it — most do); `JudgeResponse.parsed` is then the validated object. For an unsupported model, prompt for JSON and call `Model.model_validate_json(response.text)` in `parse`.
+- **Multiple / dynamic calls per rollout** (e.g. one per table column): call the low-level `complete(messages, *, schema=, parse=)` directly with `vf.Messages` you build, recording each with `trace.record_judge`.
+- **Config**: `JudgeConfig` adds `model` + `sampling` (a `JudgeSamplingConfig`) to `BaseClientConfig` (`base_url`/`api_key_var`/`headers`, Prime auto-config). CLI-overridable: `--taskset.judge.model …`, `--taskset.judge.sampling.max-tokens …`.
+- **Errors propagate**: a judge API failure errors the rollout (recorded as a `TasksetError` on the trace); the OpenAI SDK already retries transient 429/5xx/connection errors.
+
 ## Stop conditions
 
 A rollout ends when the harness finishes, a framework budget trips (`--max-turns`, token caps), or

--- a/verifiers/v1/GUIDE.md
+++ b/verifiers/v1/GUIDE.md
@@ -289,8 +289,9 @@ parses the verdict (`parse`), returning a `JudgeResponse{text, parsed, usage}`. 
 **records the call onto it** — a typed record appended to `trace.info["judge"]` (for debugging) and
 the call's tokens + cost added to `trace.extra_usage`, kept separate from the agent's `trace.usage`
 and off the message graph (so the trainer's token math is unaffected); the eval dashboard shows the
-agent's usage and `+judge` separately. Omit `trace` for a pure call (e.g. in tests); the low-level
-`complete` never records (record it yourself with `trace.record_judge`).
+agent's usage and `+judge` separately. The record lands even if the judge refuses, returns an empty
+structured output, or `parse` raises (the request was already billed). Omit `trace` for a pure call
+(e.g. in tests).
 
 The two hooks:
 
@@ -303,7 +304,7 @@ Good to know:
 
 - **Per-task rubric** is just a field — `prompt = "{task.rubric}\n…"` with `evaluate(trace=trace, task=task, …)` (`str.format` does attribute access on a passed-in `task`). For per-task *parsing*, parse in the reward, where the task is in scope.
 - **Structured outputs**: set `schema` to a pydantic model to use OpenAI structured outputs (where the provider supports it — most do); `JudgeResponse.parsed` is then the validated object. For an unsupported model, prompt for JSON and call `Model.model_validate_json(response.text)` in `parse`.
-- **Multiple / dynamic calls per rollout** (e.g. one per table column): call the low-level `complete(messages, *, schema=, parse=)` directly with `vf.Messages` you build, recording each with `trace.record_judge`.
+- **Multiple / dynamic calls per rollout** (e.g. one per table column): call the low-level `complete(messages, *, trace=, schema=, parse=)` directly with `vf.Messages` you build — it records each call when passed `trace`.
 - **Config**: `JudgeConfig` adds `model` + `sampling` (a `JudgeSamplingConfig`) to `BaseClientConfig` (`base_url`/`api_key_var`/`headers`, Prime auto-config). CLI-overridable: `--taskset.judge.model …`, `--taskset.judge.sampling.max-tokens …`.
 - **Errors propagate**: a judge API failure errors the rollout (recorded as a `TasksetError` on the trace); the OpenAI SDK already retries transient 429/5xx/connection errors.
 

--- a/verifiers/v1/GUIDE.md
+++ b/verifiers/v1/GUIDE.md
@@ -254,7 +254,7 @@ async def verify(self, task, trace, runtime) -> float:
     return float(r.stdout.strip() == "1.0")
 ```
 
-### LLM judges
+### Judges
 
 When grading can't be deterministic, `vf.Judge` is a reusable LLM judge: it owns the OpenAI client
 (with the Prime key/team fallback), the call, and usage/cost capture, and leaves the two things that

--- a/verifiers/v1/GUIDE.md
+++ b/verifiers/v1/GUIDE.md
@@ -284,12 +284,13 @@ class MyTaskset(vf.Taskset[MyTask, MyConfig]):
         return 1.0 if result.parsed else 0.0
 ```
 
-`evaluate(*, task=None, trace=None, **fields)` renders the prompt (`build_messages`), calls the
-model, and parses the verdict (`parse`), returning a `JudgeResponse{text, parsed, usage}`. Passing
-`trace=` **records the call onto it** — a typed record appended to `trace.info["judge"]` (for
-debugging) and the call's tokens + cost folded into `trace.usage` (kept off the message graph, so
-the trainer's token math is unaffected). Omit `trace` for a pure call (e.g. in tests); the
-low-level `complete` never records (record it yourself with `trace.record_judge`).
+`evaluate(*, trace=None, **fields)` renders the prompt (`build_messages`), calls the model, and
+parses the verdict (`parse`), returning a `JudgeResponse{text, parsed, usage}`. Passing `trace=`
+**records the call onto it** — a typed record appended to `trace.info["judge"]` (for debugging) and
+the call's tokens + cost added to `trace.extra_usage`, kept separate from the agent's `trace.usage`
+and off the message graph (so the trainer's token math is unaffected); the eval dashboard shows the
+agent's usage and `+judge` separately. Omit `trace` for a pure call (e.g. in tests); the low-level
+`complete` never records (record it yourself with `trace.record_judge`).
 
 The two hooks:
 

--- a/verifiers/v1/GUIDE.md
+++ b/verifiers/v1/GUIDE.md
@@ -280,27 +280,27 @@ class MyTaskset(vf.Taskset[MyTask, MyConfig]):
 
     @vf.reward()
     async def correct(self, task, trace) -> float:
-        result = await self.judge.evaluate(question=task.question, answer=task.answer, response=...)
-        trace.record_judge(result)        # persist: trace.info["judge"] + fold usage/cost
+        result = await self.judge.evaluate(trace=trace, question=task.question, answer=task.answer, response=...)
         return 1.0 if result.parsed else 0.0
 ```
 
-`evaluate(**fields)` is **pure** (data in, a `JudgeResponse{text, parsed, usage}` out): it renders
-the prompt (`build_messages(**fields)`), calls the model, and parses the verdict (`parse`).
-Persisting is the explicit `trace.record_judge(result)` step — it appends the typed record to
-`trace.info["judge"]` (for debugging) and folds the call's tokens + cost into `trace.usage`, kept
-off the message graph so the trainer's token math is unaffected.
+`evaluate(*, task=None, trace=None, **fields)` renders the prompt (`build_messages`), calls the
+model, and parses the verdict (`parse`), returning a `JudgeResponse{text, parsed, usage}`. Passing
+`trace=` **records the call onto it** — a typed record appended to `trace.info["judge"]` (for
+debugging) and the call's tokens + cost folded into `trace.usage` (kept off the message graph, so
+the trainer's token math is unaffected). Omit `trace` for a pure call (e.g. in tests); the
+low-level `complete` never records (record it yourself with `trace.record_judge`).
 
 The two hooks:
 
 | hook | default | override for |
 | --- | --- | --- |
-| `build_messages(**fields) -> str \| Messages` | formats the `prompt` template into one user message | a system+user or non-template prompt (return a `vf.Messages` list) |
+| `build_messages(*, task, trace, **fields) -> str \| Messages` | formats the `prompt` template with `task` + the fields into one user message | a system+user / non-template prompt, or reading the response off the `trace` (return a `vf.Messages` list) |
 | `parse(response) -> ParsedT` | the structured object if `schema` is set, else `response.text` | your verdict (`bool`, a grade `str`, a pydantic model, a `list[float]`, …) |
 
 Good to know:
 
-- **Per-task rubric** rides in as a field — `prompt = "{task.rubric}\n…"` with `evaluate(task=task, …)` (`str.format` does attribute access). For per-task *parsing*, parse in the reward, where the task is in scope.
+- **Per-task rubric** rides in via `task` (or a field) — `prompt = "{task.rubric}\n…"` with `evaluate(task=task, trace=trace, …)` (`str.format` does attribute access); or override `build_messages` to template from `task`/`trace`. For per-task *parsing*, parse in the reward, where the task is in scope.
 - **Structured outputs**: set `schema` to a pydantic model to use OpenAI structured outputs (where the provider supports it — most do); `JudgeResponse.parsed` is then the validated object. For an unsupported model, prompt for JSON and call `Model.model_validate_json(response.text)` in `parse`.
 - **Multiple / dynamic calls per rollout** (e.g. one per table column): call the low-level `complete(messages, *, schema=, parse=)` directly with `vf.Messages` you build, recording each with `trace.record_judge`.
 - **Config**: `JudgeConfig` adds `model` + `sampling` (a `JudgeSamplingConfig`) to `BaseClientConfig` (`base_url`/`api_key_var`/`headers`, Prime auto-config). CLI-overridable: `--taskset.judge.model …`, `--taskset.judge.sampling.max-tokens …`.

--- a/verifiers/v1/__init__.py
+++ b/verifiers/v1/__init__.py
@@ -38,7 +38,7 @@ from verifiers.v1.errors import (
     UserError,
 )
 from verifiers.v1.harness import Harness, HarnessConfig
-from verifiers.v1.judge import BinaryJudge, Judge, JudgeConfig, JudgeResponse
+from verifiers.v1.judge import Judge, JudgeConfig, JudgeResponse, JudgeSamplingConfig
 from verifiers.v1.loaders import (
     default_harness_id,
     harness_config_type,
@@ -192,8 +192,8 @@ __all__ = [
     "default_harness_id",
     # judge
     "Judge",
-    "BinaryJudge",
     "JudgeConfig",
+    "JudgeSamplingConfig",
     "JudgeResponse",
     # mcp
     "Toolset",

--- a/verifiers/v1/__init__.py
+++ b/verifiers/v1/__init__.py
@@ -38,6 +38,7 @@ from verifiers.v1.errors import (
     UserError,
 )
 from verifiers.v1.harness import Harness, HarnessConfig
+from verifiers.v1.judge import BinaryJudge, Judge, JudgeConfig, JudgeResponse
 from verifiers.v1.loaders import (
     default_harness_id,
     harness_config_type,
@@ -189,6 +190,11 @@ __all__ = [
     "taskset_config_type",
     "harness_config_type",
     "default_harness_id",
+    # judge
+    "Judge",
+    "BinaryJudge",
+    "JudgeConfig",
+    "JudgeResponse",
     # mcp
     "Toolset",
     "ToolsetConfig",

--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -245,13 +245,15 @@ def _breakdown(done: list[Trace]) -> Table | None:
             details.append(f"{format_count(total_cached)} cached")
         if have_reasoning:
             details.append(f"{format_count(total_reasoning)} reasoning")
-        if have_judge:
-            details.append(
-                f"+{format_count(total_judge_in)}/{format_count(total_judge_out)} judge"
-            )
         if details:
             tokens += f" ({', '.join(details)})"
         usage = [tokens]
+        # Judge tokens are additional to the agent's headline (the parens above are subsets of it),
+        # so they read `+in/out judge`; the judge's cost, by contrast, is part of the total below.
+        if have_judge:
+            usage.append(
+                f"+{format_count(total_judge_in)}/{format_count(total_judge_out)} judge"
+            )
         if have_cost:
             cost = f"total {format_cost_usd(total_cost)}"
             if have_judge and total_judge_cost:

--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -250,12 +250,12 @@ def _breakdown(done: list[Trace]) -> Table | None:
         usage = [tokens]
         if have_judge:
             usage.append(
-                f"+{format_count(total_judge_in)}/{format_count(total_judge_out)} judge"
+                f"+ {format_count(total_judge_in)}/{format_count(total_judge_out)} judge"
             )
         if have_cost:
             cost = format_cost_usd(total_cost)
             if total_judge_cost:
-                cost += f" +{format_cost_usd(total_judge_cost)} judge"
+                cost += f" + {format_cost_usd(total_judge_cost)} judge"
             usage.append(cost)
         grid.add_row("usage", "  ·  ".join(usage))
     time_segments = [

--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -253,10 +253,9 @@ def _breakdown(done: list[Trace]) -> Table | None:
                 f"+{format_count(total_judge_in)}/{format_count(total_judge_out)} judge"
             )
         if have_cost:
-            cost = f"total {format_cost_usd(total_cost)}"
-            if have_judge and total_judge_cost:
-                cost += f" ({format_cost_usd(total_judge_cost)} judge)"
-            usage.append(cost)
+            usage.append(format_cost_usd(total_cost - total_judge_cost))
+            if total_judge_cost:
+                usage.append(f"+{format_cost_usd(total_judge_cost)} judge")
         grid.add_row("usage", "  ·  ".join(usage))
     time_segments = [
         f"{phase} {format_time(phase_secs[phase] / phase_count[phase])}"
@@ -351,7 +350,12 @@ def Rows(groups: list[list[Rollout]], now: float, runtime_type: str) -> Table:
                 or now
             )
             prompt, completion, cached, reasoning, nbranches = _tokens(t)
+            # Agent-only cost, to match the agent-only token counts on this row (judge spend is
+            # broken out in the overview's usage row, not per rollout).
             cost = t.usage.cost if t.usage else None
+            judge = Usage.aggregate(t.extra_usage)
+            if cost is not None and judge is not None and judge.cost is not None:
+                cost -= judge.cost
             tokens = ""
             if prompt or completion:
                 tokens = f"{format_count(prompt)}/{format_count(completion)} tokens"

--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -216,7 +216,7 @@ def _breakdown(done: list[Trace]) -> Table | None:
             total_reasoning += reasoning
             have_reasoning = True
         if trace.usage is not None and trace.usage.cost is not None:
-            total_cost += trace.usage.cost  # includes judge (extra_usage)
+            total_cost += trace.usage.cost
             have_cost = True
         # Judge / auxiliary scoring calls (off the message graph) shown separately from the agent's.
         judge = Usage.aggregate(trace.extra_usage)
@@ -253,9 +253,10 @@ def _breakdown(done: list[Trace]) -> Table | None:
                 f"+{format_count(total_judge_in)}/{format_count(total_judge_out)} judge"
             )
         if have_cost:
-            usage.append(format_cost_usd(total_cost - total_judge_cost))
+            cost = format_cost_usd(total_cost)
             if total_judge_cost:
-                usage.append(f"+{format_cost_usd(total_judge_cost)} judge")
+                cost += f" +{format_cost_usd(total_judge_cost)} judge"
+            usage.append(cost)
         grid.add_row("usage", "  ·  ".join(usage))
     time_segments = [
         f"{phase} {format_time(phase_secs[phase] / phase_count[phase])}"
@@ -277,12 +278,8 @@ def _tokens(trace: Trace) -> tuple[int, int, int | None, int | None, int]:
 
     Prefers the token-id counts; falls back to provider-reported usage when the endpoint returns
     no token ids (e.g. plain OpenAI completions), so the counts aren't shown as 0/0. Returns
-    the branch count from the same derived view so each dashboard tick materializes it once.
-
-    cached/reasoning come from the sampled nodes' usage (not `trace.usage`, which also folds in
-    `extra_usage`) so they describe the same calls as the in/out counts — judge usage is shown
-    separately by the caller."""
-    usage = Usage.aggregate([n.usage for n in trace.nodes if n.usage is not None])
+    the branch count from the same derived view so each dashboard tick materializes it once."""
+    usage = trace.usage
     cached = usage.cached_input_tokens if usage else None
     reasoning = usage.reasoning_tokens if usage else None
     branches = trace.branches
@@ -350,12 +347,7 @@ def Rows(groups: list[list[Rollout]], now: float, runtime_type: str) -> Table:
                 or now
             )
             prompt, completion, cached, reasoning, nbranches = _tokens(t)
-            # Agent-only cost, to match the agent-only token counts on this row (judge spend is
-            # broken out in the overview's usage row, not per rollout).
             cost = t.usage.cost if t.usage else None
-            judge = Usage.aggregate(t.extra_usage)
-            if cost is not None and judge is not None and judge.cost is not None:
-                cost -= judge.cost
             tokens = ""
             if prompt or completion:
                 tokens = f"{format_count(prompt)}/{format_count(completion)} tokens"

--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -25,6 +25,7 @@ from verifiers.v1.cli.output import output_path
 from verifiers.v1.configs.eval import EvalConfig
 from verifiers.v1.rollout import Phase, Rollout
 from verifiers.v1.trace import Trace
+from verifiers.v1.types import Usage
 from verifiers.v1.utils.format import format_count, format_mean, format_time
 from verifiers.utils.pricing_utils import format_cost_usd
 
@@ -199,8 +200,9 @@ def _breakdown(done: list[Trace]) -> Table | None:
     # cost are summed; each timing phase is averaged over the rollouts that have it timed (averaged
     # per phase rather than summed, since phases run concurrently across rollouts).
     total_in = total_out = total_cached = total_reasoning = 0
-    total_cost = 0.0
-    have_cost = have_cached = have_reasoning = False
+    total_judge_in = total_judge_out = 0
+    total_cost = total_judge_cost = 0.0
+    have_cost = have_cached = have_reasoning = have_judge = False
     phase_secs: dict[str, float] = {}
     phase_count: dict[str, int] = {}
     for trace in done:
@@ -214,25 +216,47 @@ def _breakdown(done: list[Trace]) -> Table | None:
             total_reasoning += reasoning
             have_reasoning = True
         if trace.usage is not None and trace.usage.cost is not None:
-            total_cost += trace.usage.cost
+            total_cost += trace.usage.cost  # includes judge (extra_usage)
             have_cost = True
+        # Judge / auxiliary scoring calls (off the message graph) shown separately from the agent's.
+        judge = Usage.aggregate(trace.extra_usage)
+        if judge is not None:
+            total_judge_in += judge.input_tokens
+            total_judge_out += judge.completion_tokens
+            if judge.cost is not None:
+                total_judge_cost += judge.cost
+            have_judge = True
         for phase in ("setup", "generation", "finalize", "scoring"):
             span = getattr(trace.timing, phase)
             if span.end:  # phase was timed for this rollout
                 phase_secs[phase] = phase_secs.get(phase, 0.0) + span.duration
                 phase_count[phase] = phase_count.get(phase, 0) + 1
-    if total_in or total_out or have_cost or have_cached or have_reasoning:
+    if (
+        total_in
+        or total_out
+        or have_cost
+        or have_cached
+        or have_reasoning
+        or have_judge
+    ):
         tokens = f"{format_count(total_in)}/{format_count(total_out)} tokens"
         details = []
         if have_cached:
             details.append(f"{format_count(total_cached)} cached")
         if have_reasoning:
             details.append(f"{format_count(total_reasoning)} reasoning")
+        if have_judge:
+            details.append(
+                f"+{format_count(total_judge_in)}/{format_count(total_judge_out)} judge"
+            )
         if details:
             tokens += f" ({', '.join(details)})"
         usage = [tokens]
         if have_cost:
-            usage.append(f"total {format_cost_usd(total_cost)}")
+            cost = f"total {format_cost_usd(total_cost)}"
+            if have_judge and total_judge_cost:
+                cost += f" ({format_cost_usd(total_judge_cost)} judge)"
+            usage.append(cost)
         grid.add_row("usage", "  ·  ".join(usage))
     time_segments = [
         f"{phase} {format_time(phase_secs[phase] / phase_count[phase])}"
@@ -254,8 +278,12 @@ def _tokens(trace: Trace) -> tuple[int, int, int | None, int | None, int]:
 
     Prefers the token-id counts; falls back to provider-reported usage when the endpoint returns
     no token ids (e.g. plain OpenAI completions), so the counts aren't shown as 0/0. Returns
-    the branch count from the same derived view so each dashboard tick materializes it once."""
-    usage = trace.usage
+    the branch count from the same derived view so each dashboard tick materializes it once.
+
+    cached/reasoning come from the sampled nodes' usage (not `trace.usage`, which also folds in
+    `extra_usage`) so they describe the same calls as the in/out counts — judge usage is shown
+    separately by the caller."""
+    usage = Usage.aggregate([n.usage for n in trace.nodes if n.usage is not None])
     cached = usage.cached_input_tokens if usage else None
     reasoning = usage.reasoning_tokens if usage else None
     branches = trace.branches

--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -248,8 +248,6 @@ def _breakdown(done: list[Trace]) -> Table | None:
         if details:
             tokens += f" ({', '.join(details)})"
         usage = [tokens]
-        # Judge tokens are additional to the agent's headline (the parens above are subsets of it),
-        # so they read `+in/out judge`; the judge's cost, by contrast, is part of the total below.
         if have_judge:
             usage.append(
                 f"+{format_count(total_judge_in)}/{format_count(total_judge_out)} judge"

--- a/verifiers/v1/clients/config.py
+++ b/verifiers/v1/clients/config.py
@@ -88,7 +88,9 @@ ClientConfig = Annotated[
 ]
 
 
-def resolve_client(config: BaseClientConfig) -> Client:
+def resolve_api_key(config: BaseClientConfig) -> str:
+    """The API key for `config`: its env var, falling back to the Prime CLI config for a
+    `PRIME_API_KEY`-keyed pinference endpoint. `"EMPTY"` when unset."""
     api_key = os.environ.get(config.api_key_var)
     host = urlparse(config.base_url).hostname or ""
     if (
@@ -97,19 +99,29 @@ def resolve_client(config: BaseClientConfig) -> Client:
         and (host == PRIME_INFERENCE_HOST or host.endswith(f".{PRIME_INFERENCE_HOST}"))
     ):
         api_key = load_prime_config().get("api_key")
-    api_key = api_key or "EMPTY"
+    return api_key or "EMPTY"
+
+
+def build_async_openai(config: BaseClientConfig) -> AsyncOpenAI:
+    """An `AsyncOpenAI` for `config` (resolved key + extra headers) — for in-env model calls
+    (e.g. a judge) and the training client's engine connection."""
+    return AsyncOpenAI(
+        base_url=config.base_url,
+        api_key=resolve_api_key(config),
+        default_headers=config.headers or None,
+    )
+
+
+def resolve_client(config: BaseClientConfig) -> Client:
     if isinstance(config, TrainClientConfig):
         # The renderer calls a vLLM `/inference/v1/generate` engine through the OpenAI SDK.
-        openai = AsyncOpenAI(
-            base_url=config.base_url,
-            api_key=api_key,
-            default_headers=config.headers or None,
-        )
         return TrainClient(
-            openai,
+            build_async_openai(config),
             pool_size=config.pool_size,
             config=config.renderer,
             renderer_model_name=config.renderer_model_name,
         )
     # The proxy is a raw httpx forwarder; the dialect supplies the auth scheme + upstream path.
-    return EvalClient(config.base_url, api_key, headers=config.headers or None)
+    return EvalClient(
+        config.base_url, resolve_api_key(config), headers=config.headers or None
+    )

--- a/verifiers/v1/dialects/chat.py
+++ b/verifiers/v1/dialects/chat.py
@@ -169,25 +169,7 @@ def response_from_wire(completion: ChatCompletion) -> Response:
     finish: FinishReason = (
         choice.finish_reason if choice.finish_reason in FINISH_REASONS else None
     )
-    usage = None
-    if completion.usage:
-        cached = (
-            completion.usage.prompt_tokens_details.cached_tokens
-            if completion.usage.prompt_tokens_details
-            else None
-        )
-        reasoning = (
-            completion.usage.completion_tokens_details.reasoning_tokens
-            if completion.usage.completion_tokens_details
-            else None
-        )
-        usage = Usage(
-            prompt_tokens=completion.usage.prompt_tokens - (cached or 0),
-            completion_tokens=completion.usage.completion_tokens,
-            cached_input_tokens=cached,
-            reasoning_tokens=reasoning,
-            cost=getattr(completion.usage, "cost", None),
-        )
+    usage = Usage.from_openai(completion.usage)
     return Response(
         id=completion.id,
         created=completion.created,

--- a/verifiers/v1/judge.py
+++ b/verifiers/v1/judge.py
@@ -24,9 +24,9 @@ in which case `JudgeResponse.parsed` is the validated pydantic object.
         return float(result.parsed)
 
 Passing `trace=` records the call onto it — a typed record appended to `trace.info["judge"]` and
-the call's tokens + cost folded into `trace.extra_usage` (-> `trace.usage`), so judge behaviour and
-spend are no longer invisible. Omit `trace` for a pure call (e.g. in tests); the low-level
-`complete` never records (record it yourself with `trace.record_judge`).
+the call's tokens + cost added to `trace.extra_usage` (kept separate from the agent's `trace.usage`),
+so judge behaviour and spend are no longer invisible. Omit `trace` for a pure call (e.g. in tests);
+the low-level `complete` never records (record it yourself with `trace.record_judge`).
 """
 
 from __future__ import annotations

--- a/verifiers/v1/judge.py
+++ b/verifiers/v1/judge.py
@@ -133,7 +133,12 @@ class Judge(Generic[ParsedT]):
             completion = await self.client.beta.chat.completions.parse(
                 response_format=schema, **kwargs
             )
-            parsed = completion.choices[0].message.parsed
+            message = completion.choices[0].message
+            if message.refusal is not None:
+                raise RuntimeError(
+                    f"judge refused structured output: {message.refusal}"
+                )
+            parsed = message.parsed
         else:
             completion = await self.client.chat.completions.create(**kwargs)
         text = completion.choices[0].message.content or ""

--- a/verifiers/v1/judge.py
+++ b/verifiers/v1/judge.py
@@ -8,8 +8,11 @@ leaves the two things that actually differ as hooks: `build_messages` (prompt se
 (verdict parsing). Set `schema` to use OpenAI structured outputs (where the provider supports it),
 in which case `JudgeResponse.parsed` is the validated pydantic object.
 
-    class CorrectnessJudge(vf.BinaryJudge):
+    class CorrectnessJudge(vf.Judge[bool]):
         prompt = "Question: {question}\\nAnswer: {answer}\\nResponse: {response}\\nCorrect? yes/no"
+
+        def parse(self, response: vf.JudgeResponse[bool]) -> bool:
+            return response.text.strip().lower().startswith("yes")
 
     self.judge = CorrectnessJudge(self.config.judge)  # self.config.judge: vf.JudgeConfig
 
@@ -28,7 +31,6 @@ longer invisible.
 from __future__ import annotations
 
 import os
-import re
 from typing import TYPE_CHECKING, Any, Callable, Generic, TypeVar, cast
 from urllib.parse import urlparse
 
@@ -40,24 +42,27 @@ from verifiers.v1.clients.config import (
     PRIME_INFERENCE_HOST,
     BaseClientConfig,
 )
-from verifiers.v1.types import StrictBaseModel, Usage
+from verifiers.v1.types import SamplingConfig, StrictBaseModel, Usage
 
 if TYPE_CHECKING:
     from verifiers.v1.trace import Trace
 
 ParsedT = TypeVar("ParsedT")
 
-_YES_NO = re.compile(r"\b(yes|no)\b")
+
+class JudgeSamplingConfig(SamplingConfig):
+    """Sampling knobs for a judge call (`temperature` / `top_p` / `reasoning_effort` /
+    `max_tokens`, plus provider-specific keys via `extra='allow'`). Same shape as the rollout's
+    `SamplingConfig` — set e.g. `judge.sampling.max_tokens`."""
 
 
 class JudgeConfig(BaseClientConfig):
     """An LLM-judge endpoint. Inherits `base_url` / `api_key_var` / `headers` (with the Prime
-    auto-config) from `BaseClientConfig`; adds the model and sampling knobs. Subclass to add
-    taskset-specific fields (e.g. a `prompt` override)."""
+    auto-config) from `BaseClientConfig`; adds the model, sampling, and prompt override. Subclass
+    to add taskset-specific fields."""
 
     model: str = "openai/gpt-4.1-mini"
-    temperature: float | None = None
-    max_tokens: int | None = None
+    sampling: JudgeSamplingConfig = JudgeSamplingConfig()
     prompt: str | None = None
     """Override the judge's default prompt template (the `Judge.prompt` class attribute), so a
     taskset's grading prompt is tunable from config without subclassing."""
@@ -67,7 +72,6 @@ class JudgeResponse(StrictBaseModel, Generic[ParsedT]):
     """One judge call's result — returned to the caller and (JSON-serialized) appended to
     `trace.info["judge"]` for debugging, including the provider-reported `usage` (tokens + cost)."""
 
-    model: str
     text: str
     """The judge's raw reply."""
     parsed: ParsedT | None = None
@@ -153,10 +157,7 @@ class Judge(Generic[ParsedT]):
             else list(messages)
         )
         kwargs: dict[str, Any] = {"model": self.config.model, "messages": wire}
-        if self.config.temperature is not None:
-            kwargs["temperature"] = self.config.temperature
-        if self.config.max_tokens is not None:
-            kwargs["max_tokens"] = self.config.max_tokens
+        kwargs.update(self.config.sampling.model_dump(exclude_none=True))
         kwargs.update(sampling)
 
         parsed: Any = None
@@ -170,7 +171,6 @@ class Judge(Generic[ParsedT]):
         text = completion.choices[0].message.content or ""
 
         response: JudgeResponse[Any] = JudgeResponse(
-            model=self.config.model,
             text=text,
             parsed=parsed,
             usage=Usage.from_openai(completion.usage),
@@ -192,13 +192,3 @@ class Judge(Generic[ParsedT]):
         return await self.complete(
             messages, trace=trace, schema=self.schema, parse=self.parse
         )
-
-
-class BinaryJudge(Judge[bool]):
-    """A yes/no judge. `parse` reads the first standalone `yes`/`no` word in the reply, so a
-    verbose verdict ("No, the response mentions yes but ...") is graded on its verdict, not on
-    any `yes` it happens to contain. Set `prompt` (asking the model to answer "yes" or "no")."""
-
-    def parse(self, response: JudgeResponse[bool]) -> bool:
-        match = _YES_NO.search(response.text.lower())
-        return bool(match and match.group(1) == "yes")

--- a/verifiers/v1/judge.py
+++ b/verifiers/v1/judge.py
@@ -19,19 +19,21 @@ in which case `JudgeResponse.parsed` is the validated pydantic object.
     @vf.reward
     async def correct(self, task, trace) -> float:
         result = await self.judge.evaluate(
-            trace=trace, question=task.question, answer=task.answer, response=...
+            question=task.question, answer=task.answer, response=...
         )
+        trace.record_judge(result)
         return float(result.parsed)
 
-The judge's tokens + cost land on `trace.extra_usage` (folded into `trace.usage`), and a typed
-record of every call is appended to `trace.info["judge"]`, so judge behaviour and spend are no
-longer invisible.
+`evaluate` (and the low-level `complete`) are pure — data in, `JudgeResponse` out. Call
+`trace.record_judge(result)` to append a typed record to `trace.info["judge"]` and fold the
+call's tokens + cost into `trace.extra_usage` (-> `trace.usage`), so judge behaviour and spend
+are no longer invisible.
 """
 
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING, Any, Callable, Generic, TypeVar, cast
+from typing import Any, Callable, Generic, TypeVar, cast
 from urllib.parse import urlparse
 
 from openai import AsyncOpenAI
@@ -43,9 +45,6 @@ from verifiers.v1.clients.config import (
     BaseClientConfig,
 )
 from verifiers.v1.types import SamplingConfig, StrictBaseModel, Usage
-
-if TYPE_CHECKING:
-    from verifiers.v1.trace import Trace
 
 ParsedT = TypeVar("ParsedT")
 
@@ -143,14 +142,14 @@ class Judge(Generic[ParsedT]):
         self,
         messages: str | list[dict[str, Any]],
         *,
-        trace: "Trace | None" = None,
         schema: type[BaseModel] | None = None,
         parse: Callable[[JudgeResponse[Any]], Any] | None = None,
         **sampling: Any,
     ) -> JudgeResponse[Any]:
-        """Call the judge once: send `messages`, capture usage/cost, record to the trace, and
-        return the `JudgeResponse`. `schema` opts into structured outputs; `parse` sets
-        `JudgeResponse.parsed` from the reply (the structured object, if any, is set first)."""
+        """Call the judge once: send `messages`, capture usage/cost, and return the
+        `JudgeResponse`. Pure — pass the result to `Trace.record_judge` to persist it. `schema`
+        opts into structured outputs; `parse` sets `JudgeResponse.parsed` from the reply (the
+        structured object, if any, is set first)."""
         wire = (
             [{"role": "user", "content": messages}]
             if isinstance(messages, str)
@@ -177,18 +176,10 @@ class Judge(Generic[ParsedT]):
         )
         if parse is not None:
             response.parsed = parse(response)
-        if trace is not None:
-            trace.info.setdefault("judge", []).append(response.model_dump(mode="json"))
-            if response.usage is not None:
-                trace.extra_usage.append(response.usage)
         return response
 
-    async def evaluate(
-        self, *, trace: "Trace | None" = None, **fields: Any
-    ) -> JudgeResponse[ParsedT]:
+    async def evaluate(self, **fields: Any) -> JudgeResponse[ParsedT]:
         """Render the prompt (`build_messages`), call the judge, and parse the verdict (`parse`).
-        Returns the `JudgeResponse` with `.parsed` set to the verdict."""
+        Pure — pass the returned `JudgeResponse` to `Trace.record_judge` to persist it."""
         messages = self.build_messages(**fields)
-        return await self.complete(
-            messages, trace=trace, schema=self.schema, parse=self.parse
-        )
+        return await self.complete(messages, schema=self.schema, parse=self.parse)

--- a/verifiers/v1/judge.py
+++ b/verifiers/v1/judge.py
@@ -1,0 +1,199 @@
+"""A reusable per-task LLM judge for v1 tasksets.
+
+Most tasksets that can't grade deterministically reach for the same shape: an OpenAI-compatible
+endpoint, a prompt built from `(question, answer, response)`, one chat call, and a verdict parsed
+out of the reply. `Judge` centralizes that — the client construction (incl. the Prime key/team
+fallback), the call, usage/cost capture, and recording each call to `trace.info["judge"]` — and
+leaves the two things that actually differ as hooks: `build_messages` (prompt setup) and `parse`
+(verdict parsing). Set `schema` to use OpenAI structured outputs (where the provider supports it),
+in which case `JudgeResponse.parsed` is the validated pydantic object.
+
+    class CorrectnessJudge(vf.BinaryJudge):
+        prompt = "Question: {question}\\nAnswer: {answer}\\nResponse: {response}\\nCorrect? yes/no"
+
+    self.judge = CorrectnessJudge(self.config.judge)  # self.config.judge: vf.JudgeConfig
+
+    @vf.reward
+    async def correct(self, task, trace) -> float:
+        result = await self.judge.evaluate(
+            trace=trace, question=task.question, answer=task.answer, response=...
+        )
+        return float(result.parsed)
+
+The judge's tokens + cost land on `trace.extra_usage` (folded into `trace.usage`), and a typed
+record of every call is appended to `trace.info["judge"]`, so judge behaviour and spend are no
+longer invisible.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from typing import TYPE_CHECKING, Any, Callable, Generic, TypeVar, cast
+from urllib.parse import urlparse
+
+from openai import AsyncOpenAI
+from pydantic import BaseModel
+
+from verifiers.utils.client_utils import load_prime_config
+from verifiers.v1.clients.config import (
+    PRIME_INFERENCE_HOST,
+    BaseClientConfig,
+)
+from verifiers.v1.types import StrictBaseModel, Usage
+
+if TYPE_CHECKING:
+    from verifiers.v1.trace import Trace
+
+ParsedT = TypeVar("ParsedT")
+
+_YES_NO = re.compile(r"\b(yes|no)\b")
+
+
+class JudgeConfig(BaseClientConfig):
+    """An LLM-judge endpoint. Inherits `base_url` / `api_key_var` / `headers` (with the Prime
+    auto-config) from `BaseClientConfig`; adds the model and sampling knobs. Subclass to add
+    taskset-specific fields (e.g. a `prompt` override)."""
+
+    model: str = "openai/gpt-4.1-mini"
+    temperature: float | None = None
+    max_tokens: int | None = None
+
+
+class JudgeResponse(StrictBaseModel, Generic[ParsedT]):
+    """One judge call's result — returned to the caller and (JSON-serialized) appended to
+    `trace.info["judge"]` for debugging, including the provider-reported `usage` (tokens + cost)."""
+
+    model: str
+    text: str
+    """The judge's raw reply."""
+    parsed: ParsedT | None = None
+    """The verdict the taskset acts on (`parse`'s output, or the structured object for `schema`)."""
+    usage: Usage | None = None
+
+
+class Judge(Generic[ParsedT]):
+    """A per-task LLM judge over an OpenAI-compatible endpoint.
+
+    Override `build_messages` (prompt setup) and `parse` (verdict parsing) — or just set the
+    `prompt` template and use the defaults — then call `evaluate(trace=..., **fields)`. Set
+    `schema` to opt into structured outputs.
+    """
+
+    prompt: str | None = None
+    """Default template for `build_messages`, formatted with the `evaluate` kwargs and sent as a
+    single user message. Override `build_messages` for system+user or non-template prompts."""
+    schema: type[BaseModel] | None = None
+    """Pydantic schema for OpenAI structured outputs. When set, the call uses
+    `response_format=schema` and `JudgeResponse.parsed` is the validated object (provider must
+    support structured outputs)."""
+
+    def __init__(self, config: JudgeConfig | None = None) -> None:
+        self.config = config or JudgeConfig()
+        self._client: AsyncOpenAI | None = None
+
+    @property
+    def client(self) -> AsyncOpenAI:
+        if self._client is None:
+            cfg = self.config
+            api_key = os.environ.get(cfg.api_key_var)
+            host = urlparse(cfg.base_url).hostname or ""
+            if (
+                not api_key
+                and cfg.api_key_var == "PRIME_API_KEY"
+                and (
+                    host == PRIME_INFERENCE_HOST
+                    or host.endswith(f".{PRIME_INFERENCE_HOST}")
+                )
+            ):
+                api_key = load_prime_config().get("api_key")
+            self._client = AsyncOpenAI(
+                base_url=cfg.base_url,
+                api_key=api_key or "EMPTY",
+                default_headers=cfg.headers or None,
+            )
+        return self._client
+
+    def build_messages(self, **fields: Any) -> str | list[dict[str, Any]]:
+        """Prompt-setup hook: turn the `evaluate` fields into the messages to send. The default
+        formats `prompt` into a single user message."""
+        if self.prompt is None:
+            raise ValueError(
+                f"{type(self).__name__} has no `prompt`; set it or override build_messages"
+            )
+        return self.prompt.format(**fields)
+
+    def parse(self, response: JudgeResponse[ParsedT]) -> ParsedT:
+        """Parsing hook: turn a `JudgeResponse` into the verdict. The default returns the
+        structured object when `schema` is set, otherwise the raw reply text."""
+        if self.schema is not None:
+            return cast(ParsedT, response.parsed)
+        return cast(ParsedT, response.text)
+
+    async def complete(
+        self,
+        messages: str | list[dict[str, Any]],
+        *,
+        trace: "Trace | None" = None,
+        schema: type[BaseModel] | None = None,
+        parse: Callable[[JudgeResponse[Any]], Any] | None = None,
+        **sampling: Any,
+    ) -> JudgeResponse[Any]:
+        """Call the judge once: send `messages`, capture usage/cost, record to the trace, and
+        return the `JudgeResponse`. `schema` opts into structured outputs; `parse` sets
+        `JudgeResponse.parsed` from the reply (the structured object, if any, is set first)."""
+        wire = (
+            [{"role": "user", "content": messages}]
+            if isinstance(messages, str)
+            else list(messages)
+        )
+        kwargs: dict[str, Any] = {"model": self.config.model, "messages": wire}
+        if self.config.temperature is not None:
+            kwargs["temperature"] = self.config.temperature
+        if self.config.max_tokens is not None:
+            kwargs["max_tokens"] = self.config.max_tokens
+        kwargs.update(sampling)
+
+        parsed: Any = None
+        if schema is not None:
+            completion = await self.client.beta.chat.completions.parse(
+                response_format=schema, **kwargs
+            )
+            parsed = completion.choices[0].message.parsed
+        else:
+            completion = await self.client.chat.completions.create(**kwargs)
+        text = completion.choices[0].message.content or ""
+
+        response: JudgeResponse[Any] = JudgeResponse(
+            model=self.config.model,
+            text=text,
+            parsed=parsed,
+            usage=Usage.from_openai(completion.usage),
+        )
+        if parse is not None:
+            response.parsed = parse(response)
+        if trace is not None:
+            trace.info.setdefault("judge", []).append(response.model_dump(mode="json"))
+            if response.usage is not None:
+                trace.extra_usage.append(response.usage)
+        return response
+
+    async def evaluate(
+        self, *, trace: "Trace | None" = None, **fields: Any
+    ) -> JudgeResponse[ParsedT]:
+        """Render the prompt (`build_messages`), call the judge, and parse the verdict (`parse`).
+        Returns the `JudgeResponse` with `.parsed` set to the verdict."""
+        messages = self.build_messages(**fields)
+        return await self.complete(
+            messages, trace=trace, schema=self.schema, parse=self.parse
+        )
+
+
+class BinaryJudge(Judge[bool]):
+    """A yes/no judge. `parse` reads the first standalone `yes`/`no` word in the reply, so a
+    verbose verdict ("No, the response mentions yes but ...") is graded on its verdict, not on
+    any `yes` it happens to contain. Set `prompt` (asking the model to answer "yes" or "no")."""
+
+    def parse(self, response: JudgeResponse[bool]) -> bool:
+        match = _YES_NO.search(response.text.lower())
+        return bool(match and match.group(1) == "yes")

--- a/verifiers/v1/judge.py
+++ b/verifiers/v1/judge.py
@@ -32,18 +32,13 @@ are no longer invisible.
 
 from __future__ import annotations
 
-import os
 from typing import Any, Callable, Generic, TypeVar, cast
-from urllib.parse import urlparse
 
 from openai import AsyncOpenAI
+from openai.types.chat import ChatCompletionMessageParam
 from pydantic import BaseModel
 
-from verifiers.utils.client_utils import load_prime_config
-from verifiers.v1.clients.config import (
-    PRIME_INFERENCE_HOST,
-    BaseClientConfig,
-)
+from verifiers.v1.clients.config import BaseClientConfig, build_async_openai
 from verifiers.v1.types import SamplingConfig, StrictBaseModel, Usage
 
 ParsedT = TypeVar("ParsedT")
@@ -57,14 +52,11 @@ class JudgeSamplingConfig(SamplingConfig):
 
 class JudgeConfig(BaseClientConfig):
     """An LLM-judge endpoint. Inherits `base_url` / `api_key_var` / `headers` (with the Prime
-    auto-config) from `BaseClientConfig`; adds the model, sampling, and prompt override. Subclass
-    to add taskset-specific fields."""
+    auto-config) from `BaseClientConfig`; adds the model and sampling. Subclass to add
+    taskset-specific fields."""
 
     model: str = "openai/gpt-4.1-mini"
     sampling: JudgeSamplingConfig = JudgeSamplingConfig()
-    prompt: str | None = None
-    """Override the judge's default prompt template (the `Judge.prompt` class attribute), so a
-    taskset's grading prompt is tunable from config without subclassing."""
 
 
 class JudgeResponse(StrictBaseModel, Generic[ParsedT]):
@@ -82,8 +74,8 @@ class Judge(Generic[ParsedT]):
     """A per-task LLM judge over an OpenAI-compatible endpoint.
 
     Override `build_messages` (prompt setup) and `parse` (verdict parsing) — or just set the
-    `prompt` template and use the defaults — then call `evaluate(trace=..., **fields)`. Set
-    `schema` to opt into structured outputs.
+    `prompt` template and use the defaults — then call `evaluate(**fields)`. Set `schema` to opt
+    into structured outputs.
     """
 
     prompt: str | None = None
@@ -96,40 +88,16 @@ class Judge(Generic[ParsedT]):
 
     def __init__(self, config: JudgeConfig | None = None) -> None:
         self.config = config or JudgeConfig()
-        self._client: AsyncOpenAI | None = None
+        self.client: AsyncOpenAI = build_async_openai(self.config)
 
-    @property
-    def client(self) -> AsyncOpenAI:
-        if self._client is None:
-            cfg = self.config
-            api_key = os.environ.get(cfg.api_key_var)
-            host = urlparse(cfg.base_url).hostname or ""
-            if (
-                not api_key
-                and cfg.api_key_var == "PRIME_API_KEY"
-                and (
-                    host == PRIME_INFERENCE_HOST
-                    or host.endswith(f".{PRIME_INFERENCE_HOST}")
-                )
-            ):
-                api_key = load_prime_config().get("api_key")
-            self._client = AsyncOpenAI(
-                base_url=cfg.base_url,
-                api_key=api_key or "EMPTY",
-                default_headers=cfg.headers or None,
-            )
-        return self._client
-
-    def build_messages(self, **fields: Any) -> str | list[dict[str, Any]]:
+    def build_messages(self, **fields: Any) -> str | list[ChatCompletionMessageParam]:
         """Prompt-setup hook: turn the `evaluate` fields into the messages to send. The default
-        formats the prompt template (the config override, else the `prompt` class attribute) into
-        a single user message."""
-        template = self.config.prompt or self.prompt
-        if template is None:
+        formats the `prompt` class attribute into a single user message."""
+        if self.prompt is None:
             raise ValueError(
                 f"{type(self).__name__} has no `prompt`; set it or override build_messages"
             )
-        return template.format(**fields)
+        return self.prompt.format(**fields)
 
     def parse(self, response: JudgeResponse[ParsedT]) -> ParsedT:
         """Parsing hook: turn a `JudgeResponse` into the verdict. The default returns the
@@ -140,7 +108,7 @@ class Judge(Generic[ParsedT]):
 
     async def complete(
         self,
-        messages: str | list[dict[str, Any]],
+        messages: str | list[ChatCompletionMessageParam],
         *,
         schema: type[BaseModel] | None = None,
         parse: Callable[[JudgeResponse[Any]], Any] | None = None,

--- a/verifiers/v1/judge.py
+++ b/verifiers/v1/judge.py
@@ -19,20 +19,19 @@ in which case `JudgeResponse.parsed` is the validated pydantic object.
     @vf.reward
     async def correct(self, task, trace) -> float:
         result = await self.judge.evaluate(
-            question=task.question, answer=task.answer, response=...
+            trace=trace, question=task.question, answer=task.answer, response=...
         )
-        trace.record_judge(result)
         return float(result.parsed)
 
-`evaluate` (and the low-level `complete`) are pure — data in, `JudgeResponse` out. Call
-`trace.record_judge(result)` to append a typed record to `trace.info["judge"]` and fold the
-call's tokens + cost into `trace.extra_usage` (-> `trace.usage`), so judge behaviour and spend
-are no longer invisible.
+Passing `trace=` records the call onto it — a typed record appended to `trace.info["judge"]` and
+the call's tokens + cost folded into `trace.extra_usage` (-> `trace.usage`), so judge behaviour and
+spend are no longer invisible. Omit `trace` for a pure call (e.g. in tests); the low-level
+`complete` never records (record it yourself with `trace.record_judge`).
 """
 
 from __future__ import annotations
 
-from typing import Any, Callable, Generic, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Callable, Generic, TypeVar, cast
 
 from openai import AsyncOpenAI
 from pydantic import BaseModel
@@ -40,6 +39,9 @@ from pydantic import BaseModel
 from verifiers.v1.clients.config import BaseClientConfig, build_async_openai
 from verifiers.v1.dialects.chat import message_to_wire
 from verifiers.v1.types import Messages, SamplingConfig, StrictBaseModel, Usage
+
+if TYPE_CHECKING:
+    from verifiers.v1.trace import Trace
 
 ParsedT = TypeVar("ParsedT")
 
@@ -90,15 +92,18 @@ class Judge(Generic[ParsedT]):
         self.config = config or JudgeConfig()
         self.client: AsyncOpenAI = build_async_openai(self.config)
 
-    def build_messages(self, **fields: Any) -> str | Messages:
-        """Prompt-setup hook: turn the `evaluate` fields into the messages to send (a single user
-        message as a plain `str`, or a `vf.Messages` list). The default formats the `prompt` class
-        attribute into a single user message."""
+    def build_messages(
+        self, *, task: Any = None, trace: "Trace | None" = None, **fields: Any
+    ) -> str | Messages:
+        """Prompt-setup hook: transform the `task` / `trace` / extra fields into the messages to
+        send (a single user message as a plain `str`, or a `vf.Messages` list). The default formats
+        the `prompt` template with `task` + the extra fields (`{task.question}`, `{answer}`, …);
+        override it to read the response off the `trace`, build a system+user prompt, etc."""
         if self.prompt is None:
             raise ValueError(
                 f"{type(self).__name__} has no `prompt`; set it or override build_messages"
             )
-        return self.prompt.format(**fields)
+        return self.prompt.format(task=task, **fields)
 
     def parse(self, response: JudgeResponse[ParsedT]) -> ParsedT:
         """Parsing hook: turn a `JudgeResponse` into the verdict. The default returns the
@@ -159,8 +164,14 @@ class Judge(Generic[ParsedT]):
             response.parsed = parse(response)
         return response
 
-    async def evaluate(self, **fields: Any) -> JudgeResponse[ParsedT]:
+    async def evaluate(
+        self, *, task: Any = None, trace: "Trace | None" = None, **fields: Any
+    ) -> JudgeResponse[ParsedT]:
         """Render the prompt (`build_messages`), call the judge, and parse the verdict (`parse`).
-        Pure — pass the returned `JudgeResponse` to `Trace.record_judge` to persist it."""
-        messages = self.build_messages(**fields)
-        return await self.complete(messages, schema=self.schema, parse=self.parse)
+        `task` / `trace` / extra fields are handed to `build_messages`; when a `trace` is given the
+        call is recorded onto it (`trace.record_judge`: `info["judge"]` + folded usage)."""
+        messages = self.build_messages(task=task, trace=trace, **fields)
+        response = await self.complete(messages, schema=self.schema, parse=self.parse)
+        if trace is not None:
+            trace.record_judge(response)
+        return response

--- a/verifiers/v1/judge.py
+++ b/verifiers/v1/judge.py
@@ -55,7 +55,7 @@ class JudgeConfig(BaseClientConfig):
     auto-config) from `BaseClientConfig`; adds the model and sampling. Subclass to add
     taskset-specific fields."""
 
-    model: str = "openai/gpt-4.1-mini"
+    model: str = "openai/gpt-5-mini"
     sampling: JudgeSamplingConfig = JudgeSamplingConfig()
 
 
@@ -133,12 +133,19 @@ class Judge(Generic[ParsedT]):
             completion = await self.client.beta.chat.completions.parse(
                 response_format=schema, **kwargs
             )
-            message = completion.choices[0].message
-            if message.refusal is not None:
+            choice = completion.choices[0]
+            if choice.message.refusal is not None:
                 raise RuntimeError(
-                    f"judge refused structured output: {message.refusal}"
+                    f"judge refused structured output: {choice.message.refusal}"
                 )
-            parsed = message.parsed
+            parsed = choice.message.parsed
+            if parsed is None:
+                # No refusal but no object either — e.g. a truncated/malformed reply. Surface it
+                # rather than returning a None verdict callers read as a (falsy) failure.
+                raise RuntimeError(
+                    f"judge returned no parseable structured output "
+                    f"(finish_reason={choice.finish_reason})"
+                )
         else:
             completion = await self.client.chat.completions.create(**kwargs)
         text = completion.choices[0].message.content or ""

--- a/verifiers/v1/judge.py
+++ b/verifiers/v1/judge.py
@@ -35,11 +35,11 @@ from __future__ import annotations
 from typing import Any, Callable, Generic, TypeVar, cast
 
 from openai import AsyncOpenAI
-from openai.types.chat import ChatCompletionMessageParam
 from pydantic import BaseModel
 
 from verifiers.v1.clients.config import BaseClientConfig, build_async_openai
-from verifiers.v1.types import SamplingConfig, StrictBaseModel, Usage
+from verifiers.v1.dialects.chat import message_to_wire
+from verifiers.v1.types import Messages, SamplingConfig, StrictBaseModel, Usage
 
 ParsedT = TypeVar("ParsedT")
 
@@ -90,9 +90,10 @@ class Judge(Generic[ParsedT]):
         self.config = config or JudgeConfig()
         self.client: AsyncOpenAI = build_async_openai(self.config)
 
-    def build_messages(self, **fields: Any) -> str | list[ChatCompletionMessageParam]:
-        """Prompt-setup hook: turn the `evaluate` fields into the messages to send. The default
-        formats the `prompt` class attribute into a single user message."""
+    def build_messages(self, **fields: Any) -> str | Messages:
+        """Prompt-setup hook: turn the `evaluate` fields into the messages to send (a single user
+        message as a plain `str`, or a `vf.Messages` list). The default formats the `prompt` class
+        attribute into a single user message."""
         if self.prompt is None:
             raise ValueError(
                 f"{type(self).__name__} has no `prompt`; set it or override build_messages"
@@ -108,7 +109,7 @@ class Judge(Generic[ParsedT]):
 
     async def complete(
         self,
-        messages: str | list[ChatCompletionMessageParam],
+        messages: str | Messages,
         *,
         schema: type[BaseModel] | None = None,
         parse: Callable[[JudgeResponse[Any]], Any] | None = None,
@@ -121,7 +122,7 @@ class Judge(Generic[ParsedT]):
         wire = (
             [{"role": "user", "content": messages}]
             if isinstance(messages, str)
-            else list(messages)
+            else [message_to_wire(m) for m in messages]
         )
         kwargs: dict[str, Any] = {"model": self.config.model, "messages": wire}
         kwargs.update(self.config.sampling.model_dump(exclude_none=True))

--- a/verifiers/v1/judge.py
+++ b/verifiers/v1/judge.py
@@ -3,8 +3,8 @@
 Most tasksets that can't grade deterministically reach for the same shape: an OpenAI-compatible
 endpoint, a prompt built from `(question, answer, response)`, one chat call, and a verdict parsed
 out of the reply. `Judge` centralizes that — the client construction (incl. the Prime key/team
-fallback), the call, usage/cost capture, and recording each call to `trace.info["judge"]` — and
-leaves the two things that actually differ as hooks: `build_messages` (prompt setup) and `parse`
+fallback), the call, and usage/cost capture — and leaves the two things that actually differ as
+hooks: `build_messages` (prompt setup) and `parse`
 (verdict parsing). Set `schema` to use OpenAI structured outputs (where the provider supports it),
 in which case `JudgeResponse.parsed` is the validated pydantic object.
 

--- a/verifiers/v1/judge.py
+++ b/verifiers/v1/judge.py
@@ -58,6 +58,9 @@ class JudgeConfig(BaseClientConfig):
     model: str = "openai/gpt-4.1-mini"
     temperature: float | None = None
     max_tokens: int | None = None
+    prompt: str | None = None
+    """Override the judge's default prompt template (the `Judge.prompt` class attribute), so a
+    taskset's grading prompt is tunable from config without subclassing."""
 
 
 class JudgeResponse(StrictBaseModel, Generic[ParsedT]):
@@ -116,12 +119,14 @@ class Judge(Generic[ParsedT]):
 
     def build_messages(self, **fields: Any) -> str | list[dict[str, Any]]:
         """Prompt-setup hook: turn the `evaluate` fields into the messages to send. The default
-        formats `prompt` into a single user message."""
-        if self.prompt is None:
+        formats the prompt template (the config override, else the `prompt` class attribute) into
+        a single user message."""
+        template = self.config.prompt or self.prompt
+        if template is None:
             raise ValueError(
                 f"{type(self).__name__} has no `prompt`; set it or override build_messages"
             )
-        return self.prompt.format(**fields)
+        return template.format(**fields)
 
     def parse(self, response: JudgeResponse[ParsedT]) -> ParsedT:
         """Parsing hook: turn a `JudgeResponse` into the verdict. The default returns the

--- a/verifiers/v1/judge.py
+++ b/verifiers/v1/judge.py
@@ -92,18 +92,15 @@ class Judge(Generic[ParsedT]):
         self.config = config or JudgeConfig()
         self.client: AsyncOpenAI = build_async_openai(self.config)
 
-    def build_messages(
-        self, *, task: Any = None, trace: "Trace | None" = None, **fields: Any
-    ) -> str | Messages:
-        """Prompt-setup hook: transform the `task` / `trace` / extra fields into the messages to
-        send (a single user message as a plain `str`, or a `vf.Messages` list). The default formats
-        the `prompt` template with `task` + the extra fields (`{task.question}`, `{answer}`, …);
-        override it to read the response off the `trace`, build a system+user prompt, etc."""
+    def build_messages(self, **fields: Any) -> str | Messages:
+        """Prompt-setup hook: turn the `evaluate` fields into the messages to send (a single user
+        message as a plain `str`, or a `vf.Messages` list). The default formats the `prompt`
+        template with the fields; override it for a system+user / non-template prompt."""
         if self.prompt is None:
             raise ValueError(
                 f"{type(self).__name__} has no `prompt`; set it or override build_messages"
             )
-        return self.prompt.format(task=task, **fields)
+        return self.prompt.format(**fields)
 
     def parse(self, response: JudgeResponse[ParsedT]) -> ParsedT:
         """Parsing hook: turn a `JudgeResponse` into the verdict. The default returns the
@@ -165,12 +162,12 @@ class Judge(Generic[ParsedT]):
         return response
 
     async def evaluate(
-        self, *, task: Any = None, trace: "Trace | None" = None, **fields: Any
+        self, *, trace: "Trace | None" = None, **fields: Any
     ) -> JudgeResponse[ParsedT]:
-        """Render the prompt (`build_messages`), call the judge, and parse the verdict (`parse`).
-        `task` / `trace` / extra fields are handed to `build_messages`; when a `trace` is given the
-        call is recorded onto it (`trace.record_judge`: `info["judge"]` + folded usage)."""
-        messages = self.build_messages(task=task, trace=trace, **fields)
+        """Render the prompt (`build_messages(**fields)`), call the judge, and parse the verdict
+        (`parse`). When a `trace` is given the call is recorded onto it (`trace.record_judge`:
+        `info["judge"]` + folded usage)."""
+        messages = self.build_messages(**fields)
         response = await self.complete(messages, schema=self.schema, parse=self.parse)
         if trace is not None:
             trace.record_judge(response)

--- a/verifiers/v1/judge.py
+++ b/verifiers/v1/judge.py
@@ -25,8 +25,9 @@ in which case `JudgeResponse.parsed` is the validated pydantic object.
 
 Passing `trace=` records the call onto it — a typed record appended to `trace.info["judge"]` and
 the call's tokens + cost added to `trace.extra_usage` (kept separate from the agent's `trace.usage`),
-so judge behaviour and spend are no longer invisible. Omit `trace` for a pure call (e.g. in tests);
-the low-level `complete` never records (record it yourself with `trace.record_judge`).
+so judge behaviour and spend are no longer invisible. The record lands even if the judge refuses, an
+empty structured output comes back, or `parse` raises (the request was already billed). Omit `trace`
+for a pure call (e.g. in tests).
 """
 
 from __future__ import annotations
@@ -113,14 +114,15 @@ class Judge(Generic[ParsedT]):
         self,
         messages: str | Messages,
         *,
+        trace: "Trace | None" = None,
         schema: type[BaseModel] | None = None,
         parse: Callable[[JudgeResponse[Any]], Any] | None = None,
         **sampling: Any,
     ) -> JudgeResponse[Any]:
-        """Call the judge once: send `messages`, capture usage/cost, and return the
-        `JudgeResponse`. Pure — pass the result to `Trace.record_judge` to persist it. `schema`
-        opts into structured outputs; `parse` sets `JudgeResponse.parsed` from the reply (the
-        structured object, if any, is set first)."""
+        """Call the judge once: send `messages`, build the `JudgeResponse`, and — when a `trace` is
+        given — record it (`Trace.record_judge`) in a `finally`, so the call's tokens + cost are
+        captured even when a refusal / empty structured output / `parse` hook raises after the
+        billed request. `schema` opts into structured outputs; `parse` sets `JudgeResponse.parsed`."""
         wire = (
             [{"role": "user", "content": messages}]
             if isinstance(messages, str)
@@ -130,45 +132,49 @@ class Judge(Generic[ParsedT]):
         kwargs.update(self.config.sampling.model_dump(exclude_none=True))
         kwargs.update(sampling)
 
-        parsed: Any = None
-        if schema is not None:
-            completion = await self.client.beta.chat.completions.parse(
-                response_format=schema, **kwargs
-            )
-            choice = completion.choices[0]
-            if choice.message.refusal is not None:
-                raise RuntimeError(
-                    f"judge refused structured output: {choice.message.refusal}"
+        response: JudgeResponse[Any] | None = None
+        try:
+            if schema is not None:
+                completion = await self.client.beta.chat.completions.parse(
+                    response_format=schema, **kwargs
                 )
-            parsed = choice.message.parsed
-            if parsed is None:
-                # No refusal but no object either — e.g. a truncated/malformed reply. Surface it
-                # rather than returning a None verdict callers read as a (falsy) failure.
-                raise RuntimeError(
-                    f"judge returned no parseable structured output "
-                    f"(finish_reason={choice.finish_reason})"
+                choice = completion.choices[0]
+                response = JudgeResponse(
+                    text=choice.message.content or "",
+                    parsed=choice.message.parsed,
+                    usage=Usage.from_openai(completion.usage),
                 )
-        else:
-            completion = await self.client.chat.completions.create(**kwargs)
-        text = completion.choices[0].message.content or ""
-
-        response: JudgeResponse[Any] = JudgeResponse(
-            text=text,
-            parsed=parsed,
-            usage=Usage.from_openai(completion.usage),
-        )
-        if parse is not None:
-            response.parsed = parse(response)
-        return response
+                if choice.message.refusal is not None:
+                    raise RuntimeError(
+                        f"judge refused structured output: {choice.message.refusal}"
+                    )
+                if response.parsed is None:
+                    # No refusal but no object either — e.g. a truncated/malformed reply. Surface it
+                    # rather than returning a None verdict callers read as a (falsy) failure.
+                    raise RuntimeError(
+                        f"judge returned no parseable structured output "
+                        f"(finish_reason={choice.finish_reason})"
+                    )
+            else:
+                completion = await self.client.chat.completions.create(**kwargs)
+                response = JudgeResponse(
+                    text=completion.choices[0].message.content or "",
+                    usage=Usage.from_openai(completion.usage),
+                )
+            if parse is not None:
+                response.parsed = parse(response)
+            return response
+        finally:
+            if trace is not None and response is not None:
+                trace.record_judge(response)
 
     async def evaluate(
         self, *, trace: "Trace | None" = None, **fields: Any
     ) -> JudgeResponse[ParsedT]:
         """Render the prompt (`build_messages(**fields)`), call the judge, and parse the verdict
-        (`parse`). When a `trace` is given the call is recorded onto it (`trace.record_judge`:
-        `info["judge"]` + folded usage)."""
+        (`parse`). When a `trace` is given the call is recorded onto it (`trace.info["judge"]` +
+        usage on `trace.extra_usage`), even if a refusal / empty output / parse raises."""
         messages = self.build_messages(**fields)
-        response = await self.complete(messages, schema=self.schema, parse=self.parse)
-        if trace is not None:
-            trace.record_judge(response)
-        return response
+        return await self.complete(
+            messages, trace=trace, schema=self.schema, parse=self.parse
+        )

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -399,7 +399,7 @@ class Trace(StrictBaseModel, Generic[TaskT, StateT]):
         """Persist a judge call (`Judge.evaluate` / `Judge.complete` is pure): append the typed
         response to `info["judge"]` for debugging and fold its tokens + cost into `extra_usage`
         (→ `usage`)."""
-        self.info.setdefault("judge", []).append(response.model_dump(mode="json"))
+        self.info.setdefault("judge", []).append(response.model_dump())
         if response.usage is not None:
             self.extra_usage.append(response.usage)
 

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -246,10 +246,11 @@ class Trace(StrictBaseModel, Generic[TaskT, StateT]):
     to the base `State`."""
 
     extra_usage: list[Usage] = Field(default_factory=list)
-    """Token usage from model calls that aren't part of the message graph — LLM judges and
-    other auxiliary scoring calls (see `verifiers.v1.judge`). Folded into `usage` so the
-    rollout's reported tokens + cost account for them, but kept off the graph so branch/turn
-    counts and the trainer's token math (`total_tokens`, `branches`) see only sampled nodes."""
+    """Token usage from model calls that aren't part of the message graph — LLM judges and other
+    auxiliary scoring calls (see `verifiers.v1.judge`). Kept separate from `usage` (the agent's own
+    spend) and off the graph, so branch/turn counts and the trainer's token math (`total_tokens`,
+    `branches`) see only sampled nodes; consumers that want a grand total add the two (e.g. the eval
+    dashboard shows the agent's usage and `+judge` separately)."""
 
     is_completed: bool = False
     stop_condition: str | None = None
@@ -300,14 +301,10 @@ class Trace(StrictBaseModel, Generic[TaskT, StateT]):
 
     @property
     def usage(self) -> Usage | None:
-        """Provider-reported usage summed once per actual model call in this rollout —
-        the sampled message nodes plus any `extra_usage` (judge / auxiliary scoring calls)."""
-        return Usage.aggregate(
-            [
-                *(n.usage for n in self.nodes if n.usage is not None),
-                *self.extra_usage,
-            ]
-        )
+        """The agent's provider-reported usage, summed once per actual model call in this rollout's
+        message graph (the sampled nodes). Judge / auxiliary scoring calls are kept separate in
+        `extra_usage` — not folded in here — so consumers add the two when they want a grand total."""
+        return Usage.aggregate(n.usage for n in self.nodes if n.usage is not None)
 
     @property
     def has_response(self) -> bool:

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -242,6 +242,12 @@ class Trace(StrictBaseModel, Generic[TaskT, StateT]):
     / `to_record`), unlike `info` which persists. Type it via `Taskset[Task, Config, MyState]`; defaults
     to the base `State`."""
 
+    extra_usage: list[Usage] = Field(default_factory=list)
+    """Token usage from model calls that aren't part of the message graph — LLM judges and
+    other auxiliary scoring calls (see `verifiers.v1.judge`). Folded into `usage` so the
+    rollout's reported tokens + cost account for them, but kept off the graph so branch/turn
+    counts and the trainer's token math (`total_tokens`, `branches`) see only sampled nodes."""
+
     is_completed: bool = False
     stop_condition: str | None = None
     errors: list[Error] = Field(default_factory=list)
@@ -291,8 +297,14 @@ class Trace(StrictBaseModel, Generic[TaskT, StateT]):
 
     @property
     def usage(self) -> Usage | None:
-        """Provider-reported usage summed once per actual model call in this rollout."""
-        return Usage.aggregate(n.usage for n in self.nodes if n.usage is not None)
+        """Provider-reported usage summed once per actual model call in this rollout —
+        the sampled message nodes plus any `extra_usage` (judge / auxiliary scoring calls)."""
+        return Usage.aggregate(
+            [
+                *(n.usage for n in self.nodes if n.usage is not None),
+                *self.extra_usage,
+            ]
+        )
 
     @property
     def has_response(self) -> bool:

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -301,9 +301,7 @@ class Trace(StrictBaseModel, Generic[TaskT, StateT]):
 
     @property
     def usage(self) -> Usage | None:
-        """The agent's provider-reported usage, summed once per actual model call in this rollout's
-        message graph (the sampled nodes). Judge / auxiliary scoring calls are kept separate in
-        `extra_usage` — not folded in here — so consumers add the two when they want a grand total."""
+        """Provider-reported usage summed once per actual model call in this rollout."""
         return Usage.aggregate(n.usage for n in self.nodes if n.usage is not None)
 
     @property

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -13,11 +13,14 @@ import time
 import traceback
 import uuid
 from collections.abc import Mapping
-from typing import Any, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 import numpy as np
 from pydantic import Field, PrivateAttr
 from renderers.base import MultiModalData
+
+if TYPE_CHECKING:
+    from verifiers.v1.judge import JudgeResponse
 
 from verifiers.v1 import graph
 from verifiers.v1.errors import ProviderError
@@ -391,6 +394,14 @@ class Trace(StrictBaseModel, Generic[TaskT, StateT]):
         e.g. an harness's depth/calls/tokens). Each key warns on override as above."""
         for name, value in values.items():
             self.record_metric(name, value)
+
+    def record_judge(self, response: "JudgeResponse") -> None:
+        """Persist a judge call (`Judge.evaluate` / `Judge.complete` is pure): append the typed
+        response to `info["judge"]` for debugging and fold its tokens + cost into `extra_usage`
+        (→ `usage`)."""
+        self.info.setdefault("judge", []).append(response.model_dump(mode="json"))
+        if response.usage is not None:
+            self.extra_usage.append(response.usage)
 
     def record_reward(self, name: str, value: float, weight: float = 1.0) -> None:
         """Record a `@reward`/`@group_reward` contribution under `name` (weight

--- a/verifiers/v1/types.py
+++ b/verifiers/v1/types.py
@@ -161,6 +161,25 @@ class Usage(StrictBaseModel):
     cost: float | None = None
 
     @classmethod
+    def from_openai(cls, usage: Any | None) -> "Usage | None":
+        """Build from an OpenAI chat-completion `usage` object (the `.usage` on a
+        `ChatCompletion`), or `None` when the provider reported none. Splits cache-read tokens
+        out of `prompt_tokens` and carries the reasoning subset + provider-reported `cost`."""
+        if usage is None:
+            return None
+        prompt_details = getattr(usage, "prompt_tokens_details", None)
+        cached = prompt_details.cached_tokens if prompt_details else None
+        completion_details = getattr(usage, "completion_tokens_details", None)
+        reasoning = completion_details.reasoning_tokens if completion_details else None
+        return cls(
+            prompt_tokens=usage.prompt_tokens - (cached or 0),
+            completion_tokens=usage.completion_tokens,
+            cached_input_tokens=cached,
+            reasoning_tokens=reasoning,
+            cost=getattr(usage, "cost", None),
+        )
+
+    @classmethod
     def aggregate(cls, usages: Iterable["Usage"]) -> "Usage | None":
         """Sum per-response usage while preserving whether cache usage was reported."""
         values = list(usages)

--- a/verifiers/v1/types.py
+++ b/verifiers/v1/types.py
@@ -191,7 +191,9 @@ class Usage(StrictBaseModel):
             if usage.cached_input_tokens is not None
         ]
         reasoning = [usage.reasoning_tokens for usage in values]
-        costs = [usage.cost for usage in values]
+        # Sum the reported costs; only None when no response reported a cost — so one cost-less
+        # response (e.g. a judge on a provider that omits cost) doesn't null out the whole total.
+        costs = [usage.cost for usage in values if usage.cost is not None]
         return cls(
             prompt_tokens=sum(usage.prompt_tokens for usage in values),
             completion_tokens=sum(usage.completion_tokens for usage in values),
@@ -199,7 +201,7 @@ class Usage(StrictBaseModel):
             reasoning_tokens=sum(reasoning)
             if all(v is not None for v in reasoning)
             else None,
-            cost=sum(costs) if all(v is not None for v in costs) else None,
+            cost=sum(costs) if costs else None,
         )
 
     @property

--- a/verifiers/v1/types.py
+++ b/verifiers/v1/types.py
@@ -185,22 +185,21 @@ class Usage(StrictBaseModel):
         values = list(usages)
         if not values:
             return None
+        # For the optional fields (cached / reasoning / cost), sum the responses that report them
+        # and yield None only when *no* response does — so one response omitting a field (e.g. a
+        # judge whose provider doesn't report reasoning or cost) doesn't null out the whole total.
         cached = [
-            usage.cached_input_tokens
-            for usage in values
-            if usage.cached_input_tokens is not None
+            u.cached_input_tokens for u in values if u.cached_input_tokens is not None
         ]
-        reasoning = [usage.reasoning_tokens for usage in values]
-        # Sum the reported costs; only None when no response reported a cost — so one cost-less
-        # response (e.g. a judge on a provider that omits cost) doesn't null out the whole total.
-        costs = [usage.cost for usage in values if usage.cost is not None]
+        reasoning = [
+            u.reasoning_tokens for u in values if u.reasoning_tokens is not None
+        ]
+        costs = [u.cost for u in values if u.cost is not None]
         return cls(
             prompt_tokens=sum(usage.prompt_tokens for usage in values),
             completion_tokens=sum(usage.completion_tokens for usage in values),
             cached_input_tokens=sum(cached) if cached else None,
-            reasoning_tokens=sum(reasoning)
-            if all(v is not None for v in reasoning)
-            else None,
+            reasoning_tokens=sum(reasoning) if reasoning else None,
             cost=sum(costs) if costs else None,
         )
 


### PR DESCRIPTION
## Summary

Add `verifiers/v1/judge.py`: a reusable per-task LLM judge so tasksets stop duplicating the same boilerplate (a `JudgeConfig` + a hand-rolled `AsyncOpenAI` client with the Prime key/team fallback + ad-hoc verdict parsing).

- **`JudgeConfig(BaseClientConfig)`** — `model` (default `openai/gpt-5-mini`) + a nested **`sampling: JudgeSamplingConfig`**; inherits `base_url`/`api_key_var`/`headers` with the Prime auto-config.
- **`JudgeSamplingConfig(SamplingConfig)`** — judge sampling knobs (`judge.sampling.max_tokens`, `temperature`, …), same shape as the rollout's `SamplingConfig`.
- **`Judge[ParsedT]`** — owns the client (public `judge.client`, built once) + the chat call + usage/cost capture. Two hooks differ per env: **`build_messages(**fields)`** (prompt setup) and **`parse(response)`** (verdict). `evaluate(*, trace=None, **fields)` renders → calls → parses, and **records onto `trace` when given** (else a pure call). `complete(messages, *, schema=, parse=)` is the pure low-level primitive.
- **`JudgeResponse`** — typed `{text, parsed, usage}`.
- **`schema`** — opt into OpenAI structured outputs (`response_format=schema`); `parsed` is the validated pydantic object. Raises on a refusal or an empty/unparseable structured reply rather than returning a `None` verdict.
- Shared client plumbing extracted to `clients/config.py` (`resolve_api_key`/`build_async_openai`); `Usage.from_openai` extracted from the chat dialect.

**Visibility** — `trace.record_judge(result)` (called automatically by `evaluate(trace=...)`) appends the typed record to **`trace.info["judge"]`** and folds the call's tokens + cost into the new **`Trace.extra_usage`** → `trace.usage` (so the eval cost row counts judge spend), but kept **off the message graph** so branch/turn counts and the trainer's token math see only sampled nodes. `Usage.aggregate` sums the *reported* cost/reasoning (None only when none report), so a cost/reasoning-less judge call doesn't null the rollout's totals.

## Authoring a judge

```python
import verifiers.v1 as vf

class CorrectnessJudge(vf.Judge[bool]):                 # Judge[ParsedT] — ParsedT is your verdict type
    prompt = "Question: {question}\nAnswer: {answer}\nResponse: {response}\nCorrect? Reply yes or no."

    def parse(self, response: vf.JudgeResponse[bool]) -> bool:
        return response.text.strip().lower().startswith("yes")

class MyConfig(vf.TasksetConfig):
    judge: vf.JudgeConfig = vf.JudgeConfig()             # defaults to gpt-5-mini

class MyTaskset(vf.Taskset[MyTask, MyConfig]):
    def __init__(self, config: MyConfig) -> None:
        super().__init__(config)
        self.judge = CorrectnessJudge(config.judge)

    @vf.reward()
    async def correct(self, task, trace) -> float:
        result = await self.judge.evaluate(trace=trace, question=task.question, answer=task.answer, response=...)
        return 1.0 if result.parsed else 0.0            # passing trace= auto-records the call
```

**Hooks.** `build_messages(**fields)` — the default formats the `prompt` template with the fields into one user message; override it for a system+user / non-template prompt (return a `vf.Messages` list). A **per-task rubric** is just a field: `prompt = "{task.rubric}\n…"` + `evaluate(trace=trace, task=task, …)`. `parse(response) -> ParsedT` — read `response.text` (or `response.parsed` for `schema`); per-task parsing: do it in the reward (which has the task).

**Structured outputs** (`schema`) work on most pinference models; for one that doesn't, prompt for JSON and `Model.model_validate_json` in `parse`. **Multiple/dynamic calls per rollout**: use `complete(...)` directly. **Errors propagate** (a judge failure errors the rollout; the SDK retries transient 429/5xx/connection).

See `verifiers/v1/GUIDE.md` → "Judges" for the full walkthrough. Companion PR ports the research-environments v1 envs onto this (PrimeIntellect-ai/research-environments#590).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New scoring path issues billable LLM calls during rollouts and records usage even when parsing fails; failures propagate as rollout errors. Changes are additive for existing tasksets but affect cost visibility and optional usage aggregation behavior.
> 
> **Overview**
> Adds **`verifiers/v1/judge.py`**: a subclassable **`Judge[ParsedT]`** with **`JudgeConfig`** / **`JudgeSamplingConfig`**, **`evaluate`** / **`complete`**, optional structured outputs via **`schema`**, and customizable **`build_messages`** / **`parse`** hooks—so tasksets can grade with an LLM without duplicating OpenAI client setup (Prime key/team fallback lives in shared **`resolve_api_key`** / **`build_async_openai`**).
> 
> When **`trace=`** is passed, **`Trace.record_judge`** appends debug records to **`trace.info["judge"]`** and stacks usage on new **`trace.extra_usage`**, keeping judge spend off the message graph and out of trainer token math. The eval dashboard shows agent tokens/cost with a separate **`+judge`** line.
> 
> **`Usage.from_openai`** centralizes usage parsing (chat dialect now uses it); **`Usage.aggregate`** only nulls optional cached/reasoning/cost fields when *no* response reports them. Public API and **GUIDE.md** document the Judges pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a760c4b96da84877e93dd67630d2e2338fd15fbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add a reusable `Judge` class for LLM-based evaluation with trace integration
> - Adds [`judge.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1874/files#diff-0e1e3671e09d4b88a199baa90ea1f6044c2ecaefa8c4a7f6b1b75eac606aca56) with `Judge[ParsedT]`, `JudgeConfig`, `JudgeSamplingConfig`, and `JudgeResponse[ParsedT]` — a generic LLM judge supporting structured and unstructured outputs, configurable sampling, and subclassing via `evaluate`/`complete` hooks.
> - `Judge.complete()` records each call onto a `Trace` via a new `trace.record_judge()` method, which appends the response to `trace.info['judge']` and accumulates token/cost usage in a new `trace.extra_usage` field separate from the agent message graph.
> - The eval dashboard in [`cli/dashboard/eval.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1874/files#diff-0a27b905958929f3ae9e01937dd7e3cf97a60dec137caddcbf87792784fc9035) now displays aggregated judge token counts and costs alongside agent usage.
> - Centralizes OpenAI usage conversion into `Usage.from_openai()` and fixes `Usage.aggregate()` to retain optional fields (cost, reasoning tokens) when at least one entry reports them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a760c4b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->