### PR TITLE
feat(v1/trace): add Branch.input_len/output_len best-available token lengths

### DIFF
--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -260,8 +260,8 @@ def _tokens(trace: Trace) -> tuple[int, int, int | None, int | None, int]:
     reasoning = usage.reasoning_tokens if usage else None
     branches = trace.branches
     nbranches = len(branches)
-    prompt = sum(b.prompt_len or b.num_prompt_tokens for b in branches)
-    completion = sum(b.completion_len or b.num_completion_tokens for b in branches)
+    prompt = sum(b.input_len for b in branches)
+    completion = sum(b.output_len for b in branches)
     return prompt, completion, cached, reasoning, nbranches
 
 

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -200,6 +200,22 @@ class Branch(StrictBaseModel):
         usage = self.usage
         return usage.completion_tokens if usage else 0
 
+    @property
+    def input_len(self) -> int:
+        """Best-available input-context size: the token-id `prompt_len`, falling back to
+        provider-reported `num_prompt_tokens` when the endpoint returns no token ids (so it isn't
+        reported as 0). For display/metrics — use `prompt_len` when you need the strict token-id
+        count (e.g. token-cap enforcement)."""
+        return self.prompt_len or self.num_prompt_tokens
+
+    @property
+    def output_len(self) -> int:
+        """Best-available completion size: the token-id `completion_len`, falling back to
+        provider-reported `num_completion_tokens` when the endpoint returns no token ids (so it
+        isn't reported as 0). For display/metrics — use `completion_len` when you need the strict
+        token-id count (e.g. training, token-cap enforcement)."""
+        return self.completion_len or self.num_completion_tokens
+
 
 _NODE_DUMP_EXCLUDE: dict = {
     "nodes": {"__all__": {"multi_modal_data", "routed_experts"}}


### PR DESCRIPTION
## Why

The eval dashboard and prime-rl's eval sink independently reach for the same fallback when reporting token counts:

```python
prompt_len     or num_prompt_tokens
completion_len or num_completion_tokens
```

`completion_len`/`prompt_len` are token-id-derived (sum of masks). On the **token-less `openai_chat_completions` relay** there are no token ids, so they're `0`, and the provider-reported `num_*_tokens` (from `usage`) is the only signal — hence the `or`. The policy was duplicated across two repos.

## What

Fold that fallback into two `Branch` accessors:

- `Branch.input_len`  → `prompt_len or num_prompt_tokens`
- `Branch.output_len` → `completion_len or num_completion_tokens`

and rewire the eval dashboard `_tokens()` to use them.

**The strict fields are untouched.** `completion_len`/`prompt_len`/`total_tokens` keep their exact token-id semantics — they're load-bearing for training and for `RolloutLimits.reached()` token-cap enforcement (`max_output_tokens` → `completion_len`). The new accessors are *best-available* lengths for display/metrics only: token-id counts stay authoritative when present, provider `usage` is purely the fallback.

This lets prime-rl's eval sink replace its inline `sum(b.completion_len or b.num_completion_tokens for b in r.branches)` with `sum(b.output_len for b in r.branches)`, so the OR lives in exactly one place.

## Verification

- New accessors checked both ways: token-bearing branch → `output_len == completion_len` (provider `usage` ignored even when it disagrees); token-less, usage-bearing branch → `completion_len == 0` but `output_len == usage.completion_tokens`.
- `tests/v1/test_trace.py` + `tests/test_eval_display.py` pass; `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `Branch.input_len` and `Branch.output_len` properties with fallback token counts
> Adds two new properties to `Branch` in [trace.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1875/files#diff-834820c3aa80d87ee1c1c57fb54c74f09c66ac727036d964e6005c8613c00b5e): `input_len` returns `prompt_len` (token-id count) when available, falling back to `num_prompt_tokens` (provider-reported); `output_len` does the same for completion tokens. Updates the `_tokens` utility in [eval.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1875/files#diff-0a27b905958929f3ae9e01937dd7e3cf97a60dec137caddcbf87792784fc9035) to use these properties instead of inline fallback logic.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 201b418.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display/metrics-only refactor; strict token-id fields and enforcement paths are unchanged.
> 
> **Overview**
> Centralizes the duplicated **token-id vs provider usage** fallback for branch-level counts on `Branch`: **`input_len`** (`prompt_len` or `num_prompt_tokens`) and **`output_len`** (`completion_len` or `num_completion_tokens`), documented as display/metrics-only while **`prompt_len` / `completion_len`** stay strict for training and token caps.
> 
> The eval rich dashboard **`_tokens()`** now sums `b.input_len` / `b.output_len` instead of inlining the same `or` logic, so token-less OpenAI-style endpoints still show non-zero counts in one place.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 201b418167e1d0b834bf8510876e355a6e13cc2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->