### PR TITLE
fix: stop EnvServerPool worker re-raising KeyboardInterrupt during shutdown

### DIFF
--- a/verifiers/v1/serve/pool.py
+++ b/verifiers/v1/serve/pool.py
@@ -44,11 +44,6 @@ logger = logging.getLogger(__name__)
 _HEALTH = msgpack.packb(HealthResponse().model_dump(mode="json"), use_bin_type=True)
 
 
-def on_sigterm(*_) -> None:
-    signal.signal(signal.SIGTERM, signal.SIG_IGN)
-    raise KeyboardInterrupt
-
-
 def _arm_teardown(death_pipe=None) -> None:
     """Arm a spawned process (serve_env broker/single server, or pool worker) for clean
     teardown: it inherits no signal handlers, so by default SIGTERM kills it abruptly, skipping
@@ -57,6 +52,11 @@ def _arm_teardown(death_pipe=None) -> None:
     - SIGTERM -> KeyboardInterrupt so the event loop runs its finallys (serve_env swallows it);
     - with `death_pipe`, self-SIGTERM when the parent dies (pipe EOF, even on its SIGKILL) so no
       child is orphaned (main -> serve_env and broker -> worker are both armed this way)."""
+
+    def on_sigterm(*_) -> None:
+        signal.signal(signal.SIGTERM, signal.SIG_IGN)
+        raise KeyboardInterrupt
+
     signal.signal(signal.SIGTERM, on_sigterm)
     if death_pipe is None:
         return

--- a/verifiers/v1/serve/pool.py
+++ b/verifiers/v1/serve/pool.py
@@ -44,6 +44,11 @@ logger = logging.getLogger(__name__)
 _HEALTH = msgpack.packb(HealthResponse().model_dump(mode="json"), use_bin_type=True)
 
 
+def on_sigterm(*_) -> None:
+    signal.signal(signal.SIGTERM, signal.SIG_IGN)
+    raise KeyboardInterrupt
+
+
 def _arm_teardown(death_pipe=None) -> None:
     """Arm a spawned process (serve_env broker/single server, or pool worker) for clean
     teardown: it inherits no signal handlers, so by default SIGTERM kills it abruptly, skipping
@@ -52,16 +57,7 @@ def _arm_teardown(death_pipe=None) -> None:
     - SIGTERM -> KeyboardInterrupt so the event loop runs its finallys (serve_env swallows it);
     - with `death_pipe`, self-SIGTERM when the parent dies (pipe EOF, even on its SIGKILL) so no
       child is orphaned (main -> serve_env and broker -> worker are both armed this way)."""
-
-    def _on_sigterm(*_) -> None:
-        # One-shot: _shutdown both closes the death-pipe (EOF -> self-SIGTERM) and calls
-        # terminate(), so two SIGTERMs land. Disarm before raising so the second can't re-raise
-        # KeyboardInterrupt mid-cleanup (e.g. inside zmq ctx.term, which re-checks signals),
-        # which would escape as a spurious traceback even though shutdown is succeeding.
-        signal.signal(signal.SIGTERM, signal.SIG_IGN)
-        raise KeyboardInterrupt
-
-    signal.signal(signal.SIGTERM, _on_sigterm)
+    signal.signal(signal.SIGTERM, on_sigterm)
     if death_pipe is None:
         return
 

--- a/verifiers/v1/serve/pool.py
+++ b/verifiers/v1/serve/pool.py
@@ -52,7 +52,16 @@ def _arm_teardown(death_pipe=None) -> None:
     - SIGTERM -> KeyboardInterrupt so the event loop runs its finallys (serve_env swallows it);
     - with `death_pipe`, self-SIGTERM when the parent dies (pipe EOF, even on its SIGKILL) so no
       child is orphaned (main -> serve_env and broker -> worker are both armed this way)."""
-    signal.signal(signal.SIGTERM, lambda *_: (_ for _ in ()).throw(KeyboardInterrupt()))
+
+    def _on_sigterm(*_) -> None:
+        # One-shot: _shutdown both closes the death-pipe (EOF -> self-SIGTERM) and calls
+        # terminate(), so two SIGTERMs land. Disarm before raising so the second can't re-raise
+        # KeyboardInterrupt mid-cleanup (e.g. inside zmq ctx.term, which re-checks signals),
+        # which would escape as a spurious traceback even though shutdown is succeeding.
+        signal.signal(signal.SIGTERM, signal.SIG_IGN)
+        raise KeyboardInterrupt
+
+    signal.signal(signal.SIGTERM, _on_sigterm)
     if death_pipe is None:
         return
 


### PR DESCRIPTION
## Summary
- Fixes #1878: a successful v1 eval prints a noisy `KeyboardInterrupt` traceback (plus `Task exception was never retrieved`) from an `EnvServerPool` worker during shutdown, even though it exits `0` with clean results.

## Root cause
`EnvServerPool._shutdown()` tears down each worker with **two** signals:
- `w["pipe"].close()` → the worker's death-pipe `recv()` hits EOF → its watch thread does `os.kill(self, SIGTERM)`, and
- `w["process"].terminate()` → another `SIGTERM`.

The worker's `SIGTERM` handler (`_arm_teardown`) raises `KeyboardInterrupt` so the event loop runs its cleanup `finally`. The **first** signal does exactly that; the **second** arrives *while* that cleanup is running — notably inside `zmq` `ctx.term()`, which re-checks pending signals via `PyErr_CheckSignals()` — and re-raises `KeyboardInterrupt` from within the `finally`. That escapes the worker as a spawned-process traceback and leaves the `EnvServer.run()` task's exception unretrieved.

## Fix
Make the `SIGTERM` handler one-shot: disarm to `SIG_IGN` *before* raising, so only the first signal interrupts and the cleanup (`ctx.term()`, client/socket close, asyncio teardown) runs to completion uninterrupted. One change in `_arm_teardown`, covering every armed path (pool worker, broker, `serve_env` single server).

## Verification
Minimal repro (`_arm_teardown` + a serve loop whose cleanup `finally` is interrupted by a second SIGTERM):

| | before | after |
|---|---|---|
| traceback printed | **yes** | no |
| `KeyboardInterrupt` in stderr | **yes** | no |
| exit code | 0 | 0 |

Also ran a real `eval ... --harness.runtime.type subprocess` (which spawns the pool) to completion with the fix: **0** `KeyboardInterrupt`/`Traceback`/`SpawnProcess` lines at teardown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `EnvServerPool` worker re-raising `KeyboardInterrupt` on repeated SIGTERM during shutdown
> In [pool.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1879/files#diff-0c9c59578214be2580d340bc524321e352f48038207a68945637d00fc399600c), the `_arm_teardown` SIGTERM handler now sets SIGTERM to `SIG_IGN` before raising `KeyboardInterrupt`, so any subsequent SIGTERM signals received during shutdown are ignored rather than re-invoking the handler and raising again.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b775692.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to shutdown signal handling in spawned serve processes; behavior is intentionally stricter (ignore duplicate SIGTERM) with no auth or data-path impact.
> 
> **Overview**
> Fixes noisy shutdown tracebacks from `EnvServerPool` workers during v1 eval teardown (#1878).
> 
> Shutdown can deliver **two** `SIGTERM`s (death-pipe EOF plus `process.terminate()`). The old handler raised `KeyboardInterrupt` on every signal, so a second `SIGTERM` during cleanup (e.g. in `zmq` `ctx.term()`) re-raised and printed a spurious traceback while the eval still exited 0.
> 
> Adds **`on_sigterm`**: set `SIGTERM` to **`SIG_IGN`** before raising `KeyboardInterrupt`, so only the first signal interrupts the loop and cleanup finishes. **`_arm_teardown`** now registers this handler for pool workers, the broker, and single-server `serve_env` paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba0c69b2b102847d84a6db99e5fa15f1f6640217. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->