### PR TITLE
feat: drive user simulator as an explicit harness feature

### DIFF
--- a/environments/compact/compact/harness.py
+++ b/environments/compact/compact/harness.py
@@ -38,6 +38,7 @@ class CompactingHarness(Harness[CompactingHarnessConfig]):
         endpoint: str,
         secret: str,
         mcp_urls: dict[str, str],
+        user_url: str | None = None,
     ) -> ProgramResult:
         env = {
             "OPENAI_BASE_URL": endpoint,

--- a/tests/v1/fixtures/pyproject.toml
+++ b/tests/v1/fixtures/pyproject.toml
@@ -17,5 +17,6 @@ include = [
     "echo_tool_v1.py",
     "echo_user_sim_v1.py",
     "tool_response_image_v1.py",
+    "tool_user_sim_v1/**/*.py",
     "pyproject.toml",
 ]

--- a/tests/v1/fixtures/tool_user_sim_v1/__init__.py
+++ b/tests/v1/fixtures/tool_user_sim_v1/__init__.py
@@ -1,0 +1,3 @@
+from tool_user_sim_v1.taskset import ToolUserSimTaskset
+
+__all__ = ["ToolUserSimTaskset"]

--- a/tests/v1/fixtures/tool_user_sim_v1/servers/tools.py
+++ b/tests/v1/fixtures/tool_user_sim_v1/servers/tools.py
@@ -1,0 +1,14 @@
+import verifiers.v1 as vf
+
+
+class CalcToolset(vf.Toolset[vf.ToolsetConfig]):
+    TOOL_PREFIX = "calc"  # the model sees `calc_add`
+
+    @vf.tool
+    def add(self, a: int, b: int) -> str:
+        """Add two integers and return their sum."""
+        return str(a + b)
+
+
+if __name__ == "__main__":
+    CalcToolset.run()

--- a/tests/v1/fixtures/tool_user_sim_v1/servers/user.py
+++ b/tests/v1/fixtures/tool_user_sim_v1/servers/user.py
@@ -1,0 +1,27 @@
+import verifiers.v1 as vf
+
+
+class CalcState(vf.State):
+    user_finished: bool = False
+
+
+class CalcUser(vf.User[vf.UserConfig, CalcState]):
+    """Poses the task's addition problems one per turn; after the last, flags `user_finished`
+    (the taskset's `@vf.stop` ends the rollout on it). The task carries no prompt, so the opening
+    `respond("")` delivers the first problem."""
+
+    async def setup_task(self, task) -> None:
+        self.problems = task.problems
+        self.i = 0
+
+    async def respond(self, message: str) -> vf.Messages:
+        if self.i >= len(self.problems):
+            self.state.user_finished = True
+            return []
+        a, b = self.problems[self.i]
+        self.i += 1
+        return [{"role": "user", "content": f"What is {a} + {b}?"}]
+
+
+if __name__ == "__main__":
+    CalcUser.run()

--- a/tests/v1/fixtures/tool_user_sim_v1/taskset.py
+++ b/tests/v1/fixtures/tool_user_sim_v1/taskset.py
@@ -1,0 +1,94 @@
+"""tool_user_sim (v1): a calculator that must call an MCP tool AND answer a simulated user.
+
+The minimal env that combines task tools with a user simulator. Each turn the user simulator
+poses an addition problem; the model calls the `calc_add` tool to compute it, then replies with
+the answer; the simulator poses the next problem, and after the last one flags `user_finished`
+(the `@vf.stop` ends the rollout). The task carries no prompt — the simulator opens the
+conversation.
+
+Tools (the harness runs its own tool loop) + a user simulator is exactly the case that forks the
+message graph under transparent user injection (see verifiers#1871): `num_branches` is 1 only
+when the conversation stays linear, so it is the regression signal for driving the user simulator
+as an explicit harness feature.
+"""
+
+import re
+
+import verifiers.v1 as vf
+
+from tool_user_sim_v1.servers.tools import CalcToolset
+from tool_user_sim_v1.servers.user import CalcState, CalcUser
+
+PROBLEMS = [
+    (2, 3),
+    (10, 20),
+    (7, 8),
+]  # the user poses these in order; their sums are the answers
+SYSTEM = (
+    "You are a calculator. For each problem the user gives you, call the `calc_add` tool to add "
+    "the two numbers, then reply with only the result inside <answer></answer> tags. Always use "
+    "the tool; do not add the numbers yourself."
+)
+
+
+class ToolUserSimTask(vf.Task):
+    problems: list[list[int]]
+    """The `(a, b)` pairs the user poses, one per turn; their sums are the expected answers."""
+
+
+class ToolUserSimConfig(vf.TasksetConfig):
+    tools: vf.ToolsetConfig = vf.ToolsetConfig()
+    user: vf.UserConfig = vf.UserConfig()
+
+
+class ToolUserSimTaskset(vf.Taskset[ToolUserSimTask, ToolUserSimConfig, CalcState]):
+    @vf.stop
+    async def user_finished(self, trace: vf.Trace) -> bool:
+        return trace.state.user_finished
+
+    def load_tasks(self) -> list[ToolUserSimTask]:
+        return [
+            ToolUserSimTask(
+                idx=0,
+                prompt=None,  # the user simulator opens the conversation
+                system_prompt=SYSTEM,
+                problems=[list(p) for p in PROBLEMS],
+            )
+        ]
+
+    def tools(self, task: ToolUserSimTask) -> list[vf.Toolset]:
+        return [CalcToolset(self.config.tools)]
+
+    def user(self, task: ToolUserSimTask) -> vf.User:
+        return CalcUser(self.config.user)
+
+    @vf.reward(weight=1.0)
+    async def solved(self, task: ToolUserSimTask, trace: vf.Trace) -> float:
+        """Fraction of the user's problems answered correctly, read from the sampled assistant
+        turns (branch-independent), so it stays correct even when the graph forks — the bug shows
+        up structurally in `num_branches`, not here."""
+        expected = [a + b for a, b in task.problems]
+        answered = [
+            int(m.group(1))
+            for msg in trace.assistant_messages
+            if (m := re.search(r"<answer>\s*(-?\d+)\s*</answer>", msg.content or ""))
+        ]
+        hits = sum(a == e for a, e in zip(answered, expected))
+        return hits / len(expected)
+
+    @vf.metric
+    async def num_branches(self, trace: vf.Trace) -> float:
+        """1 when the conversation graph is linear; >1 when transparent user injection forked it
+        (the regression — verifiers#1871)."""
+        return float(trace.num_branches)
+
+    @vf.metric
+    async def tail_branch_turns(self, trace: vf.Trace) -> float:
+        """Sampled assistant turns visible on the last branch alone — what naive
+        `trace.branches[-1]` scoring sees. Equals the true turn count only when the graph is
+        linear; a forked graph leaves only the tail here."""
+        last = trace.branches[-1] if trace.branches else None
+        return float(sum(1 for n in last.nodes if n.sampled) if last else 0)
+
+
+__all__ = ["ToolUserSimTaskset"]

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -59,6 +59,30 @@ async def test_user(run_v1, harness_runtime, user_runtime, tmp_path):
     )
     assert trace.errors == []
     assert trace.num_turns >= 2  # genuinely multi-turn
+    assert trace.num_branches == 1  # the harness carries every user turn: linear graph
+    assert trace.reward == 1.0
+
+
+@pytest.mark.e2e
+async def test_user_tool(run_v1, harness_runtime, tmp_path):
+    """Task tools (the harness runs its own tool loop) AND a user simulator together — the case
+    that forked the message graph under transparent user injection (verifiers#1871), because the
+    harness's tool round-trip re-entered the graph without the injected user turns. Driving the
+    simulator as an explicit harness feature (the `/user` endpoint) keeps every turn in the
+    harness's own conversation, so the graph stays LINEAR: `num_branches == 1` is the regression
+    signal (it was >1 before the fix). Fanned over the harness runtime."""
+    (trace,) = await run_v1(
+        "tool-user-sim-v1",
+        harness="default",
+        harness_overrides={"runtime": {"type": harness_runtime}},
+        output_dir=tmp_path,
+        max_turns=12,
+    )
+    assert trace.errors == []
+    assert (
+        trace.num_turns >= 4
+    )  # a tool call + an answer per user turn, genuinely multi-turn
+    assert trace.num_branches == 1  # no transparent-injection fork
     assert trace.reward == 1.0
 
 

--- a/verifiers/v1/dialects/base.py
+++ b/verifiers/v1/dialects/base.py
@@ -8,8 +8,7 @@ from the endpoint the program's SDK posts to — the harness declares nothing.
 The eval client relays a request's bytes verbatim to a matching endpoint, while a dialect-owned
 `StreamParser` incrementally assembles a response copy for the trace; the renderer is chat-only.
 A dialect is therefore mostly wire -> vf (`parse_request`/`parse_response`/`stream_parser`); the
-exceptions are `apply_overrides` (impose the eval's model + sampling in this format's shape) and
-`extend` (chat-only user-sim injection).
+exception is `apply_overrides` (impose the eval's model + sampling in this format's shape).
 """
 
 import json
@@ -184,15 +183,3 @@ class Dialect(ABC, Generic[ReqT, RespT]):
         """Return `body` with the eval's `model` + `sampling` imposed in this protocol's shape —
         the only mutation the proxy makes to an otherwise byte-exact forward. Model overlays;
         sampling is authoritative (the program's sampling keys are dropped, the eval's applied)."""
-
-    def extend(
-        self, body: ReqT, completion: dict | None, user_messages: Messages
-    ) -> ReqT:
-        """For user-sim multi-turn: return `body` with the model's turn (`completion`, native
-        wire) + the simulator's `user_messages` appended, in this protocol's shape. A `None`
-        `completion` appends only the user turn(s) — used to seed the opening turn of a task
-        with no prompt, before the model has spoken. Only the chat dialect implements it — the
-        one harness contract with a user simulator speaks chat."""
-        raise NotImplementedError(
-            f"user simulator is not supported over the {type(self).__name__} dialect"
-        )

--- a/verifiers/v1/dialects/chat.py
+++ b/verifiers/v1/dialects/chat.py
@@ -112,9 +112,9 @@ def parse_tools(raw: list[dict] | None) -> list[Tool] | None:
 
 
 # --- vf -> chat wire ----------------------------------------------------------
-# `message_to_wire` (chat-only): used by `extend` (user-sim turn injection), the default harness
-# (a Messages prompt), and the train client (its generate request). The proxy never
-# serializes — it relays the provider's raw bytes.
+# `message_to_wire` (chat-only): used by the default/bash harnesses (a Messages prompt), the
+# interception server (serializing the user simulator's turns for `/user`), and the train client
+# (its generate request). The proxy never serializes — it relays the provider's raw bytes.
 
 
 def _content_to_wire(content):
@@ -312,15 +312,3 @@ class ChatDialect(Dialect[dict, ChatCompletion]):
         # Forward the program's body verbatim, overlaying only what the eval owns: the model and
         # the sampling knobs it set (later keys win, so the eval's override the program's).
         return {**body, "model": model, **sampling.model_dump(exclude_none=True)}
-
-    def extend(
-        self, body: dict, completion: dict | None, user_messages: Messages
-    ) -> dict:
-        # Append the model's turn (the verbatim assistant message, so its reasoning survives for
-        # the next turn's passback) and the simulator's injected user turn(s) to the wire history.
-        # A None completion seeds the opening turn (no model message yet) — only the user turn(s).
-        messages = [*body.get("messages", [])]
-        if completion is not None:
-            messages.append(completion["choices"][0]["message"])
-        messages.extend(message_to_wire(m) for m in user_messages)
-        return {**body, "messages": messages}

--- a/verifiers/v1/dialects/responses.py
+++ b/verifiers/v1/dialects/responses.py
@@ -368,17 +368,3 @@ class ResponsesDialect(Dialect[dict, OpenAIResponse]):
             if k not in _SAMPLING_KEYS and k not in overrides
         }
         return {**steered, **overrides}
-
-    def extend(
-        self, body: dict, completion: dict | None, user_messages: Messages
-    ) -> dict:
-        """Append raw model output and the user simulator's reply for the next turn."""
-        raw = body.get("input")
-        items: ResponseInputParam = (
-            [EasyInputMessageParam(role="user", content=raw)]
-            if isinstance(raw, str)
-            else cast(ResponseInputParam, list(raw or []))
-        )
-        items.extend(cast(ResponseInputParam, (completion or {}).get("output") or []))
-        items.extend(messages_to_wire(user_messages))
-        return {**body, "input": items}

--- a/verifiers/v1/harness.py
+++ b/verifiers/v1/harness.py
@@ -127,9 +127,10 @@ class Harness(ABC, Generic[ConfigT]):
     ) -> None:
         """Run the harness in `runtime` (via `launch`) and handle its exit; its model calls
         reach the interception server at `endpoint`, and `mcp_urls` are the task's tool
-        servers (name -> URL) to expose to the model. `user_url` is the interception server's
-        `/user` endpoint when the task has a user simulator and this harness supports driving one
-        (`SUPPORTS_USER_SIM`), else None — a supporting harness POSTs each no-tool-call turn there."""
+        servers (name -> URL) to expose to the model. `user_url` is the user simulator's MCP server
+        when the task has one and this harness supports driving it (`SUPPORTS_USER_SIM`), else None —
+        a supporting harness calls its `respond` tool for each user turn and injects the reply into
+        its own conversation (so the user turn is recorded as a regular user message)."""
         async with boundary(HarnessError, f"harness {self.config.id!r}"):
             result = await self.launch(
                 ctx, trace, runtime, endpoint, secret, mcp_urls, user_url
@@ -178,10 +179,10 @@ class Harness(ABC, Generic[ConfigT]):
         """Run the harness program in `runtime` to completion and return its result. The
         task is `trace.task`; model calls should reach the interception server at
         `endpoint` (bearer token `secret`); `mcp_urls` are the task's tool servers
-        (name -> URL) to wire in. `user_url` is the `/user` endpoint to drive the task's user
-        simulator over (only set for harnesses that set `SUPPORTS_USER_SIM`; None otherwise) —
-        POST `{"message": <assistant text>}` with the same bearer `secret` on each no-tool-call
-        turn, append the returned `messages`, and re-prompt until `done`. Each harness owns the env
-        its program needs — read `ctx.model` for the model id (the default/compact harnesses set
+        (name -> URL) to wire in. `user_url` is the task's user simulator's MCP server (only set for
+        harnesses that set `SUPPORTS_USER_SIM`; None otherwise) — connect to it and call its
+        `respond(message)` tool on each no-tool-call turn, append the returned user `messages` to the
+        conversation, and re-prompt (an empty reply means the simulator is done). Each harness owns
+        the env its program needs — read `ctx.model` for the model id (the default/compact harnesses set
         OPENAI_*; rlm sets RLM_* too). UV-script harnesses prepare dependencies in `setup`, then
         launch the returned argv through `runtime.run_program(...)` here."""

--- a/verifiers/v1/harness.py
+++ b/verifiers/v1/harness.py
@@ -123,12 +123,17 @@ class Harness(ABC, Generic[ConfigT]):
         endpoint: str,
         secret: str,
         mcp_urls: dict[str, str],
+        user_url: str | None = None,
     ) -> None:
         """Run the harness in `runtime` (via `launch`) and handle its exit; its model calls
         reach the interception server at `endpoint`, and `mcp_urls` are the task's tool
-        servers (name -> URL) to expose to the model."""
+        servers (name -> URL) to expose to the model. `user_url` is the interception server's
+        `/user` endpoint when the task has a user simulator and this harness supports driving one
+        (`SUPPORTS_USER_SIM`), else None — a supporting harness POSTs each no-tool-call turn there."""
         async with boundary(HarnessError, f"harness {self.config.id!r}"):
-            result = await self.launch(ctx, trace, runtime, endpoint, secret, mcp_urls)
+            result = await self.launch(
+                ctx, trace, runtime, endpoint, secret, mcp_urls, user_url
+            )
         if trace.stop_condition is not None:
             return  # a @stop refused a turn mid-rollout; the harness's exit is expected
         if result.exit_code != 0:
@@ -168,11 +173,15 @@ class Harness(ABC, Generic[ConfigT]):
         endpoint: str,
         secret: str,
         mcp_urls: dict[str, str],
+        user_url: str | None = None,
     ) -> ProgramResult:
         """Run the harness program in `runtime` to completion and return its result. The
         task is `trace.task`; model calls should reach the interception server at
         `endpoint` (bearer token `secret`); `mcp_urls` are the task's tool servers
-        (name -> URL) to wire in. Each harness owns the env its program needs — read
-        `ctx.model` for the model id (the default/compact harnesses set OPENAI_*; rlm sets
-        RLM_* too). UV-script harnesses prepare dependencies in `setup`, then launch the
-        returned argv through `runtime.run_program(...)` here."""
+        (name -> URL) to wire in. `user_url` is the `/user` endpoint to drive the task's user
+        simulator over (only set for harnesses that set `SUPPORTS_USER_SIM`; None otherwise) —
+        POST `{"message": <assistant text>}` with the same bearer `secret` on each no-tool-call
+        turn, append the returned `messages`, and re-prompt until `done`. Each harness owns the env
+        its program needs — read `ctx.model` for the model id (the default/compact harnesses set
+        OPENAI_*; rlm sets RLM_* too). UV-script harnesses prepare dependencies in `setup`, then
+        launch the returned argv through `runtime.run_program(...)` here."""

--- a/verifiers/v1/harnesses/bash/harness.py
+++ b/verifiers/v1/harnesses/bash/harness.py
@@ -42,6 +42,7 @@ class BashHarness(Harness[BashHarnessConfig]):
         endpoint: str,
         secret: str,
         mcp_urls: dict[str, str],
+        user_url: str | None = None,
     ) -> ProgramResult:
         system_prompt, prompt = self.resolve_prompt(trace.task)
         system_prompt = "\n\n".join(p for p in (BASH_SYSTEM_PROMPT, system_prompt) if p)
@@ -52,6 +53,9 @@ class BashHarness(Harness[BashHarnessConfig]):
             f"--model={ctx.model}",
             f"--system-prompt={system_prompt}",
         ]
+        if user_url:
+            # The program POSTs each no-tool-call turn to the user simulator here and re-prompts.
+            args.append(f"--user-url={user_url}")
         if mcp_urls:
             # The program connects to the tool servers over HTTP; hand it a standard
             # `mcpServers` URL config (the `mcp` client itself comes from the uv deps).

--- a/verifiers/v1/harnesses/bash/harness.py
+++ b/verifiers/v1/harnesses/bash/harness.py
@@ -54,7 +54,8 @@ class BashHarness(Harness[BashHarnessConfig]):
             f"--system-prompt={system_prompt}",
         ]
         if user_url:
-            # The program POSTs each no-tool-call turn to the user simulator here and re-prompts.
+            # The program MCP-connects to the user simulator here and calls its `respond` tool on
+            # each no-tool-call turn (the user sim is never shown to the model as a tool).
             args.append(f"--user-url={user_url}")
         if mcp_urls:
             # The program connects to the tool servers over HTTP; hand it a standard

--- a/verifiers/v1/harnesses/bash/program.py
+++ b/verifiers/v1/harnesses/bash/program.py
@@ -1,6 +1,6 @@
 # /// script
 # requires-python = ">=3.10"
-# dependencies = ["openai", "mcp", "httpx"]
+# dependencies = ["openai", "mcp"]
 # ///
 """The bash harness's program: a chat loop with a local `bash` tool (+ optional MCP tools).
 
@@ -8,15 +8,16 @@ A growing-message-list chat loop. It always offers a local `bash` tool that runs
 in the runtime; when the harness sets MCP_CONFIG (a standard `mcpServers` URL map) it also
 connects to those servers over streamable HTTP, exposes their tools to the model as
 `<server>_<tool>`, and routes those calls to the server. The loop runs until the model answers
-without a tool call — unless the task has a user simulator (`--user-url`), in which case a
-no-tool-call turn is a turn boundary: the program POSTs the assistant's text to `/user`, appends
-the simulated user reply, and re-prompts, until the simulator signals `done` (a no-prompt task is
-opened the same way). Carrying every turn in the program's own conversation keeps the recorded
-message graph linear.
+without a tool call — unless the task has a user simulator (`--user-url`, its own MCP server), in
+which case a no-tool-call turn is a turn boundary: the program calls the simulator's `respond`
+tool, appends the user message(s) it returns, and re-prompts, until it returns no further turns (a
+no-prompt task is opened the same way). Carrying every user turn in the program's own conversation
+keeps the recorded message graph linear and the user turns regular user messages.
 
-It runs as a uv script (deps: openai, mcp, httpx), so the chat + tool plumbing is just the SDKs —
-the harness bootstraps `uv` in the runtime. The interception endpoint, per-rollout secret, and
-model arrive as argv (not env), so the bash tool's local subprocesses never inherit them.
+It runs as a uv script (deps: openai, mcp), so the chat + tool plumbing — including the user
+simulator, which is just another MCP server — is just the SDKs; the harness bootstraps `uv` in the
+runtime. The interception endpoint, per-rollout secret, and model arrive as argv (not env), so the
+bash tool's local subprocesses never inherit them.
 """
 
 import argparse
@@ -26,7 +27,6 @@ import os
 import subprocess
 from contextlib import AsyncExitStack
 
-import httpx
 from openai import AsyncOpenAI
 
 BASH_TOOL = {
@@ -123,17 +123,29 @@ async def call_mcp(dispatch: dict, name: str, arguments: dict) -> str | list[dic
     return mcp_content_to_chat_content(result.content)
 
 
-async def next_user_turn(
-    http: httpx.AsyncClient, url: str, secret: str, message: str
-) -> tuple[list[dict], bool]:
-    """Drive the task's user simulator: POST the model's last text to `/user` and return its next
-    user message(s) (already OpenAI wire dicts) and whether the trajectory should now end."""
-    resp = await http.post(
-        url, json={"message": message}, headers={"Authorization": f"Bearer {secret}"}
+async def connect_user_sim(stack: AsyncExitStack, url: str):
+    """Connect to the task's user simulator — its own MCP server (a `vf.User`), never shown to the
+    model — and return an async `respond(text)` that calls its `respond` tool, returning the next
+    user message(s) as OpenAI wire dicts (an empty list = the simulator is done)."""
+    from mcp import ClientSession
+    from mcp.client.streamable_http import (
+        create_mcp_http_client,
+        streamable_http_client,
     )
-    resp.raise_for_status()
-    data = resp.json()
-    return data["messages"], data["done"]
+
+    http_client = await stack.enter_async_context(create_mcp_http_client())
+    read, write, *_ = await stack.enter_async_context(
+        streamable_http_client(url, http_client=http_client)
+    )
+    session = await stack.enter_async_context(ClientSession(read, write))
+    await session.initialize()
+
+    async def respond(text: str) -> list[dict]:
+        result = await session.call_tool("respond", {"message": text})
+        parts = [b.text for b in result.content if getattr(b, "type", None) == "text"]
+        return json.loads("\n".join(parts))["messages"]
+
+    return respond
 
 
 def parse_args() -> argparse.Namespace:
@@ -158,11 +170,7 @@ async def main() -> None:
             await connect_mcp(stack, config) if config.get("mcpServers") else ([], {})
         )
         tools = [BASH_TOOL] + mcp_tools
-        http = (
-            await stack.enter_async_context(httpx.AsyncClient(timeout=120))
-            if user_url
-            else None
-        )
+        user_respond = await connect_user_sim(stack, user_url) if user_url else None
         messages = (
             [{"role": "system", "content": args.system_prompt}]
             if args.system_prompt
@@ -177,11 +185,11 @@ async def main() -> None:
             messages.extend(initial)
         elif args.prompt:
             messages.append({"role": "user", "content": args.prompt})
-        elif user_url:
-            opening, done = await next_user_turn(http, user_url, args.api_key, "")
-            messages.extend(opening)
-            if done:
+        elif user_respond:
+            opening = await user_respond("")
+            if not opening:
                 return
+            messages.extend(opening)
         while True:
             message = await chat(client, args.model, messages, tools)
             messages.append(message.model_dump(exclude_none=True))
@@ -211,15 +219,14 @@ async def main() -> None:
                         {"role": "tool", "tool_call_id": call.id, "content": content}
                     )
                 continue
-            # No tool call: a final answer for the current user turn. With a user simulator, fetch
-            # the next user turn and re-prompt; otherwise the conversation is over.
-            if user_url:
-                reply, done = await next_user_turn(
-                    http, user_url, args.api_key, message.content or ""
-                )
-                messages.extend(reply)
-                if done:
+            # No tool call: a final answer for the current user turn. With a user simulator, ask it
+            # for the next user turn and re-prompt; an empty reply means it's done. Without one, the
+            # conversation is over.
+            if user_respond:
+                reply = await user_respond(message.content or "")
+                if not reply:
                     break
+                messages.extend(reply)
                 continue
             break
 

--- a/verifiers/v1/harnesses/bash/program.py
+++ b/verifiers/v1/harnesses/bash/program.py
@@ -1,6 +1,6 @@
 # /// script
 # requires-python = ">=3.10"
-# dependencies = ["openai", "mcp"]
+# dependencies = ["openai", "mcp", "httpx"]
 # ///
 """The bash harness's program: a chat loop with a local `bash` tool (+ optional MCP tools).
 
@@ -8,11 +8,15 @@ A growing-message-list chat loop. It always offers a local `bash` tool that runs
 in the runtime; when the harness sets MCP_CONFIG (a standard `mcpServers` URL map) it also
 connects to those servers over streamable HTTP, exposes their tools to the model as
 `<server>_<tool>`, and routes those calls to the server. The loop runs until the model answers
-without a tool call.
+without a tool call — unless the task has a user simulator (`--user-url`), in which case a
+no-tool-call turn is a turn boundary: the program POSTs the assistant's text to `/user`, appends
+the simulated user reply, and re-prompts, until the simulator signals `done` (a no-prompt task is
+opened the same way). Carrying every turn in the program's own conversation keeps the recorded
+message graph linear.
 
-It runs as a uv script (deps: openai, mcp), so the chat + tool plumbing is just the SDKs — the
-harness bootstraps `uv` in the runtime. The interception endpoint, per-rollout secret, and model
-arrive as argv (not env), so the bash tool's local subprocesses never inherit them.
+It runs as a uv script (deps: openai, mcp, httpx), so the chat + tool plumbing is just the SDKs —
+the harness bootstraps `uv` in the runtime. The interception endpoint, per-rollout secret, and
+model arrive as argv (not env), so the bash tool's local subprocesses never inherit them.
 """
 
 import argparse
@@ -22,6 +26,7 @@ import os
 import subprocess
 from contextlib import AsyncExitStack
 
+import httpx
 from openai import AsyncOpenAI
 
 BASH_TOOL = {
@@ -118,6 +123,19 @@ async def call_mcp(dispatch: dict, name: str, arguments: dict) -> str | list[dic
     return mcp_content_to_chat_content(result.content)
 
 
+async def next_user_turn(
+    http: httpx.AsyncClient, url: str, secret: str, message: str
+) -> tuple[list[dict], bool]:
+    """Drive the task's user simulator: POST the model's last text to `/user` and return its next
+    user message(s) (already OpenAI wire dicts) and whether the trajectory should now end."""
+    resp = await http.post(
+        url, json={"message": message}, headers={"Authorization": f"Bearer {secret}"}
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    return data["messages"], data["done"]
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--base-url", required=True)
@@ -126,6 +144,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--system-prompt", default="")
     parser.add_argument("--prompt", default="")
     parser.add_argument("--mcp-config", default="")
+    parser.add_argument("--user-url", default="")
     return parser.parse_args()
 
 
@@ -133,11 +152,17 @@ async def main() -> None:
     args = parse_args()
     client = AsyncOpenAI(base_url=args.base_url, api_key=args.api_key)
     config = json.loads(args.mcp_config or "{}")
+    user_url = args.user_url or None
     async with AsyncExitStack() as stack:
         mcp_tools, dispatch = (
             await connect_mcp(stack, config) if config.get("mcpServers") else ([], {})
         )
         tools = [BASH_TOOL] + mcp_tools
+        http = (
+            await stack.enter_async_context(httpx.AsyncClient(timeout=120))
+            if user_url
+            else None
+        )
         messages = (
             [{"role": "system", "content": args.system_prompt}]
             if args.system_prompt
@@ -146,41 +171,57 @@ async def main() -> None:
         # A Messages prompt (e.g. an image-bearing prompt) arrives pre-built as OpenAI wire dicts
         # via INITIAL_MESSAGES (kept in env: it can be large multimodal content that overflows
         # argv, and it's prompt content, not a credential); otherwise --prompt is the opening
-        # message. Both empty means the task has no prompt — the user simulator seeds the opening.
+        # message. Both empty means the task has no prompt — the user simulator opens it.
         initial = json.loads(os.environ.get("INITIAL_MESSAGES", "[]"))
         if initial:
             messages.extend(initial)
         elif args.prompt:
             messages.append({"role": "user", "content": args.prompt})
+        elif user_url:
+            opening, done = await next_user_turn(http, user_url, args.api_key, "")
+            messages.extend(opening)
+            if done:
+                return
         while True:
             message = await chat(client, args.model, messages, tools)
             messages.append(message.model_dump(exclude_none=True))
-            if not message.tool_calls:
-                break
-            for call in message.tool_calls:
-                name = call.function.name
-                try:
-                    tool_args = json.loads(call.function.arguments or "{}")
-                except json.JSONDecodeError as e:
+            if message.tool_calls:
+                for call in message.tool_calls:
+                    name = call.function.name
+                    try:
+                        tool_args = json.loads(call.function.arguments or "{}")
+                    except json.JSONDecodeError as e:
+                        messages.append(
+                            {
+                                "role": "tool",
+                                "tool_call_id": call.id,
+                                "content": f"error: invalid JSON in tool arguments ({e}); resend the call with valid JSON",
+                            }
+                        )
+                        continue
+                    if name in dispatch:
+                        content = await call_mcp(dispatch, name, tool_args)
+                    elif name == "bash":
+                        content = await asyncio.to_thread(
+                            run_bash, tool_args.get("command", "")
+                        )
+                    else:
+                        content = f"error: unknown tool {name!r}"
                     messages.append(
-                        {
-                            "role": "tool",
-                            "tool_call_id": call.id,
-                            "content": f"error: invalid JSON in tool arguments ({e}); resend the call with valid JSON",
-                        }
+                        {"role": "tool", "tool_call_id": call.id, "content": content}
                     )
-                    continue
-                if name in dispatch:
-                    content = await call_mcp(dispatch, name, tool_args)
-                elif name == "bash":
-                    content = await asyncio.to_thread(
-                        run_bash, tool_args.get("command", "")
-                    )
-                else:
-                    content = f"error: unknown tool {name!r}"
-                messages.append(
-                    {"role": "tool", "tool_call_id": call.id, "content": content}
+                continue
+            # No tool call: a final answer for the current user turn. With a user simulator, fetch
+            # the next user turn and re-prompt; otherwise the conversation is over.
+            if user_url:
+                reply, done = await next_user_turn(
+                    http, user_url, args.api_key, message.content or ""
                 )
+                messages.extend(reply)
+                if done:
+                    break
+                continue
+            break
 
 
 if __name__ == "__main__":

--- a/verifiers/v1/harnesses/bash_edit/harness.py
+++ b/verifiers/v1/harnesses/bash_edit/harness.py
@@ -62,7 +62,8 @@ class BashEditHarness(Harness[BashEditHarnessConfig]):
             f"--system-prompt={system_prompt}",
         ]
         if user_url:
-            # The program POSTs each no-tool-call turn to the user simulator here and re-prompts.
+            # The program MCP-connects to the user simulator here and calls its `respond` tool on
+            # each no-tool-call turn (the user sim is never shown to the model as a tool).
             args.append(f"--user-url={user_url}")
         if mcp_urls:
             # The program connects to the tool servers over HTTP; hand it a standard

--- a/verifiers/v1/harnesses/bash_edit/harness.py
+++ b/verifiers/v1/harnesses/bash_edit/harness.py
@@ -48,6 +48,7 @@ class BashEditHarness(Harness[BashEditHarnessConfig]):
         endpoint: str,
         secret: str,
         mcp_urls: dict[str, str],
+        user_url: str | None = None,
     ) -> ProgramResult:
         system_prompt, prompt = self.resolve_prompt(trace.task)
         system_prompt = "\n\n".join(
@@ -60,6 +61,9 @@ class BashEditHarness(Harness[BashEditHarnessConfig]):
             f"--model={ctx.model}",
             f"--system-prompt={system_prompt}",
         ]
+        if user_url:
+            # The program POSTs each no-tool-call turn to the user simulator here and re-prompts.
+            args.append(f"--user-url={user_url}")
         if mcp_urls:
             # The program connects to the tool servers over HTTP; hand it a standard
             # `mcpServers` URL config (the `mcp` client itself comes from the uv deps).

--- a/verifiers/v1/harnesses/bash_edit/program.py
+++ b/verifiers/v1/harnesses/bash_edit/program.py
@@ -1,6 +1,6 @@
 # /// script
 # requires-python = ">=3.10"
-# dependencies = ["openai", "mcp"]
+# dependencies = ["openai", "mcp", "httpx"]
 # ///
 """The bash_edit harness's program: a chat loop with local `bash` + `edit` tools (+ optional MCP).
 
@@ -8,11 +8,15 @@ A growing-message-list chat loop. It always offers a local `bash` tool that runs
 the runtime and a local `edit` tool that replaces a unique string in a file; when the harness sets
 MCP_CONFIG (a standard `mcpServers` URL map) it also connects to those servers over streamable
 HTTP, exposes their tools to the model as `<server>_<tool>`, and routes those calls to the server.
-The loop runs until the model answers without a tool call.
+The loop runs until the model answers without a tool call — unless the task has a user simulator
+(`--user-url`), in which case a no-tool-call turn is a turn boundary: the program POSTs the
+assistant's text to `/user`, appends the simulated user reply, and re-prompts, until the simulator
+signals `done` (a no-prompt task is opened the same way). Carrying every turn in the program's own
+conversation keeps the recorded message graph linear.
 
-It runs as a uv script (deps: openai, mcp), so the chat + tool plumbing is just the SDKs — the
-harness bootstraps `uv` in the runtime. The interception endpoint, per-rollout secret, and model
-arrive as argv (not env), so the local tools' subprocesses never inherit them.
+It runs as a uv script (deps: openai, mcp, httpx), so the chat + tool plumbing is just the SDKs —
+the harness bootstraps `uv` in the runtime. The interception endpoint, per-rollout secret, and
+model arrive as argv (not env), so the local tools' subprocesses never inherit them.
 """
 
 import argparse
@@ -23,6 +27,7 @@ import subprocess
 from contextlib import AsyncExitStack
 from pathlib import Path
 
+import httpx
 from openai import AsyncOpenAI
 
 BASH_TOOL = {
@@ -174,6 +179,19 @@ async def call_mcp(dispatch: dict, name: str, arguments: dict) -> str | list[dic
     return mcp_content_to_chat_content(result.content)
 
 
+async def next_user_turn(
+    http: httpx.AsyncClient, url: str, secret: str, message: str
+) -> tuple[list[dict], bool]:
+    """Drive the task's user simulator: POST the model's last text to `/user` and return its next
+    user message(s) (already OpenAI wire dicts) and whether the trajectory should now end."""
+    resp = await http.post(
+        url, json={"message": message}, headers={"Authorization": f"Bearer {secret}"}
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    return data["messages"], data["done"]
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--base-url", required=True)
@@ -182,6 +200,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--system-prompt", default="")
     parser.add_argument("--prompt", default="")
     parser.add_argument("--mcp-config", default="")
+    parser.add_argument("--user-url", default="")
     return parser.parse_args()
 
 
@@ -189,11 +208,17 @@ async def main() -> None:
     args = parse_args()
     client = AsyncOpenAI(base_url=args.base_url, api_key=args.api_key)
     config = json.loads(args.mcp_config or "{}")
+    user_url = args.user_url or None
     async with AsyncExitStack() as stack:
         mcp_tools, dispatch = (
             await connect_mcp(stack, config) if config.get("mcpServers") else ([], {})
         )
         tools = [BASH_TOOL, EDIT_TOOL] + mcp_tools
+        http = (
+            await stack.enter_async_context(httpx.AsyncClient(timeout=120))
+            if user_url
+            else None
+        )
         messages = (
             [{"role": "system", "content": args.system_prompt}]
             if args.system_prompt
@@ -202,48 +227,64 @@ async def main() -> None:
         # A Messages prompt (e.g. an image-bearing prompt) arrives pre-built as OpenAI wire dicts
         # via INITIAL_MESSAGES (kept in env: it can be large multimodal content that overflows
         # argv, and it's prompt content, not a credential); otherwise --prompt is the opening
-        # message. Both empty means the task has no prompt — the user simulator seeds the opening.
+        # message. Both empty means the task has no prompt — the user simulator opens it.
         initial = json.loads(os.environ.get("INITIAL_MESSAGES", "[]"))
         if initial:
             messages.extend(initial)
         elif args.prompt:
             messages.append({"role": "user", "content": args.prompt})
+        elif user_url:
+            opening, done = await next_user_turn(http, user_url, args.api_key, "")
+            messages.extend(opening)
+            if done:
+                return
         while True:
             message = await chat(client, args.model, messages, tools)
             messages.append(message.model_dump(exclude_none=True))
-            if not message.tool_calls:
-                break
-            for call in message.tool_calls:
-                name = call.function.name
-                try:
-                    tool_args = json.loads(call.function.arguments or "{}")
-                except json.JSONDecodeError as e:
+            if message.tool_calls:
+                for call in message.tool_calls:
+                    name = call.function.name
+                    try:
+                        tool_args = json.loads(call.function.arguments or "{}")
+                    except json.JSONDecodeError as e:
+                        messages.append(
+                            {
+                                "role": "tool",
+                                "tool_call_id": call.id,
+                                "content": f"error: invalid JSON in tool arguments ({e}); resend the call with valid JSON",
+                            }
+                        )
+                        continue
+                    if name in dispatch:
+                        content = await call_mcp(dispatch, name, tool_args)
+                    elif name == "bash":
+                        content = await asyncio.to_thread(
+                            run_bash, tool_args.get("command", "")
+                        )
+                    elif name == "edit":
+                        content = await asyncio.to_thread(
+                            run_edit,
+                            tool_args.get("path"),
+                            tool_args.get("old_str"),
+                            tool_args.get("new_str"),
+                        )
+                    else:
+                        content = f"error: unknown tool {name!r}"
                     messages.append(
-                        {
-                            "role": "tool",
-                            "tool_call_id": call.id,
-                            "content": f"error: invalid JSON in tool arguments ({e}); resend the call with valid JSON",
-                        }
+                        {"role": "tool", "tool_call_id": call.id, "content": content}
                     )
-                    continue
-                if name in dispatch:
-                    content = await call_mcp(dispatch, name, tool_args)
-                elif name == "bash":
-                    content = await asyncio.to_thread(
-                        run_bash, tool_args.get("command", "")
-                    )
-                elif name == "edit":
-                    content = await asyncio.to_thread(
-                        run_edit,
-                        tool_args.get("path"),
-                        tool_args.get("old_str"),
-                        tool_args.get("new_str"),
-                    )
-                else:
-                    content = f"error: unknown tool {name!r}"
-                messages.append(
-                    {"role": "tool", "tool_call_id": call.id, "content": content}
+                continue
+            # No tool call: a final answer for the current user turn. With a user simulator, fetch
+            # the next user turn and re-prompt; otherwise the conversation is over.
+            if user_url:
+                reply, done = await next_user_turn(
+                    http, user_url, args.api_key, message.content or ""
                 )
+                messages.extend(reply)
+                if done:
+                    break
+                continue
+            break
 
 
 if __name__ == "__main__":

--- a/verifiers/v1/harnesses/bash_edit/program.py
+++ b/verifiers/v1/harnesses/bash_edit/program.py
@@ -1,6 +1,6 @@
 # /// script
 # requires-python = ">=3.10"
-# dependencies = ["openai", "mcp", "httpx"]
+# dependencies = ["openai", "mcp"]
 # ///
 """The bash_edit harness's program: a chat loop with local `bash` + `edit` tools (+ optional MCP).
 
@@ -9,14 +9,16 @@ the runtime and a local `edit` tool that replaces a unique string in a file; whe
 MCP_CONFIG (a standard `mcpServers` URL map) it also connects to those servers over streamable
 HTTP, exposes their tools to the model as `<server>_<tool>`, and routes those calls to the server.
 The loop runs until the model answers without a tool call — unless the task has a user simulator
-(`--user-url`), in which case a no-tool-call turn is a turn boundary: the program POSTs the
-assistant's text to `/user`, appends the simulated user reply, and re-prompts, until the simulator
-signals `done` (a no-prompt task is opened the same way). Carrying every turn in the program's own
-conversation keeps the recorded message graph linear.
+(`--user-url`, its own MCP server), in which case a no-tool-call turn is a turn boundary: the
+program calls the simulator's `respond` tool, appends the user message(s) it returns, and
+re-prompts, until it returns no further turns (a no-prompt task is opened the same way). Carrying
+every user turn in the program's own conversation keeps the recorded message graph linear and the
+user turns regular user messages.
 
-It runs as a uv script (deps: openai, mcp, httpx), so the chat + tool plumbing is just the SDKs —
-the harness bootstraps `uv` in the runtime. The interception endpoint, per-rollout secret, and
-model arrive as argv (not env), so the local tools' subprocesses never inherit them.
+It runs as a uv script (deps: openai, mcp), so the chat + tool plumbing — including the user
+simulator, which is just another MCP server — is just the SDKs; the harness bootstraps `uv` in the
+runtime. The interception endpoint, per-rollout secret, and model arrive as argv (not env), so the
+local tools' subprocesses never inherit them.
 """
 
 import argparse
@@ -27,7 +29,6 @@ import subprocess
 from contextlib import AsyncExitStack
 from pathlib import Path
 
-import httpx
 from openai import AsyncOpenAI
 
 BASH_TOOL = {
@@ -179,17 +180,29 @@ async def call_mcp(dispatch: dict, name: str, arguments: dict) -> str | list[dic
     return mcp_content_to_chat_content(result.content)
 
 
-async def next_user_turn(
-    http: httpx.AsyncClient, url: str, secret: str, message: str
-) -> tuple[list[dict], bool]:
-    """Drive the task's user simulator: POST the model's last text to `/user` and return its next
-    user message(s) (already OpenAI wire dicts) and whether the trajectory should now end."""
-    resp = await http.post(
-        url, json={"message": message}, headers={"Authorization": f"Bearer {secret}"}
+async def connect_user_sim(stack: AsyncExitStack, url: str):
+    """Connect to the task's user simulator — its own MCP server (a `vf.User`), never shown to the
+    model — and return an async `respond(text)` that calls its `respond` tool, returning the next
+    user message(s) as OpenAI wire dicts (an empty list = the simulator is done)."""
+    from mcp import ClientSession
+    from mcp.client.streamable_http import (
+        create_mcp_http_client,
+        streamable_http_client,
     )
-    resp.raise_for_status()
-    data = resp.json()
-    return data["messages"], data["done"]
+
+    http_client = await stack.enter_async_context(create_mcp_http_client())
+    read, write, *_ = await stack.enter_async_context(
+        streamable_http_client(url, http_client=http_client)
+    )
+    session = await stack.enter_async_context(ClientSession(read, write))
+    await session.initialize()
+
+    async def respond(text: str) -> list[dict]:
+        result = await session.call_tool("respond", {"message": text})
+        parts = [b.text for b in result.content if getattr(b, "type", None) == "text"]
+        return json.loads("\n".join(parts))["messages"]
+
+    return respond
 
 
 def parse_args() -> argparse.Namespace:
@@ -214,11 +227,7 @@ async def main() -> None:
             await connect_mcp(stack, config) if config.get("mcpServers") else ([], {})
         )
         tools = [BASH_TOOL, EDIT_TOOL] + mcp_tools
-        http = (
-            await stack.enter_async_context(httpx.AsyncClient(timeout=120))
-            if user_url
-            else None
-        )
+        user_respond = await connect_user_sim(stack, user_url) if user_url else None
         messages = (
             [{"role": "system", "content": args.system_prompt}]
             if args.system_prompt
@@ -233,11 +242,11 @@ async def main() -> None:
             messages.extend(initial)
         elif args.prompt:
             messages.append({"role": "user", "content": args.prompt})
-        elif user_url:
-            opening, done = await next_user_turn(http, user_url, args.api_key, "")
-            messages.extend(opening)
-            if done:
+        elif user_respond:
+            opening = await user_respond("")
+            if not opening:
                 return
+            messages.extend(opening)
         while True:
             message = await chat(client, args.model, messages, tools)
             messages.append(message.model_dump(exclude_none=True))
@@ -274,15 +283,14 @@ async def main() -> None:
                         {"role": "tool", "tool_call_id": call.id, "content": content}
                     )
                 continue
-            # No tool call: a final answer for the current user turn. With a user simulator, fetch
-            # the next user turn and re-prompt; otherwise the conversation is over.
-            if user_url:
-                reply, done = await next_user_turn(
-                    http, user_url, args.api_key, message.content or ""
-                )
-                messages.extend(reply)
-                if done:
+            # No tool call: a final answer for the current user turn. With a user simulator, ask it
+            # for the next user turn and re-prompt; an empty reply means it's done. Without one, the
+            # conversation is over.
+            if user_respond:
+                reply = await user_respond(message.content or "")
+                if not reply:
                     break
+                messages.extend(reply)
                 continue
             break
 

--- a/verifiers/v1/harnesses/codex/harness.py
+++ b/verifiers/v1/harnesses/codex/harness.py
@@ -71,6 +71,7 @@ class CodexHarness(Harness[CodexHarnessConfig]):
         endpoint: str,
         secret: str,
         mcp_urls: dict[str, str],
+        user_url: str | None = None,
     ) -> ProgramResult:
         _, prompt = self.resolve_prompt(trace.task)
         # codex authenticates to the interception server with the session secret (its provider

--- a/verifiers/v1/harnesses/default/harness.py
+++ b/verifiers/v1/harnesses/default/harness.py
@@ -51,7 +51,8 @@ class DefaultHarness(Harness[DefaultHarnessConfig]):
         if system_prompt:
             args.append(f"--system-prompt={system_prompt}")
         if user_url:
-            # The program POSTs each no-tool-call turn to the user simulator here and re-prompts.
+            # The program MCP-connects to the user simulator here and calls its `respond` tool on
+            # each no-tool-call turn (the user sim is never shown to the model as a tool).
             args.append(f"--user-url={user_url}")
         if mcp_urls:
             # The program connects to the tool servers over HTTP; hand it a standard

--- a/verifiers/v1/harnesses/default/harness.py
+++ b/verifiers/v1/harnesses/default/harness.py
@@ -39,6 +39,7 @@ class DefaultHarness(Harness[DefaultHarnessConfig]):
         endpoint: str,
         secret: str,
         mcp_urls: dict[str, str],
+        user_url: str | None = None,
     ) -> ProgramResult:
         system_prompt, prompt = self.resolve_prompt(trace.task)
         env = {**self.config.env}
@@ -49,6 +50,9 @@ class DefaultHarness(Harness[DefaultHarnessConfig]):
         ]
         if system_prompt:
             args.append(f"--system-prompt={system_prompt}")
+        if user_url:
+            # The program POSTs each no-tool-call turn to the user simulator here and re-prompts.
+            args.append(f"--user-url={user_url}")
         if mcp_urls:
             # The program connects to the tool servers over HTTP; hand it a standard
             # `mcpServers` URL config (the `mcp` client itself comes from the uv deps).

--- a/verifiers/v1/harnesses/default/program.py
+++ b/verifiers/v1/harnesses/default/program.py
@@ -1,22 +1,23 @@
 # /// script
 # requires-python = ">=3.10"
-# dependencies = ["openai", "mcp", "httpx"]
+# dependencies = ["openai", "mcp"]
 # ///
 """The default harness's program: a chat loop with the taskset's MCP tools (and none of its own).
 
 A growing-message-list chat loop. When the harness sets MCP_CONFIG (a standard `mcpServers` URL
 map) it connects to those servers over streamable HTTP, exposes their tools to the model as
 `<server>_<tool>`, and routes those calls to the server. The loop runs until the model answers
-without a tool call (immediately, when no tools are offered) — unless the task has a user
-simulator (`--user-url`), in which case a no-tool-call turn is a turn boundary: the program POSTs
-the assistant's text to `/user`, appends the simulated user reply, and re-prompts, until the
-simulator signals `done`. A no-prompt task is opened the same way (POST `/user` with an empty
-message before the first model call). Carrying every turn in the program's own conversation keeps
-the recorded message graph linear.
+without a tool call (immediately, when no tools are offered) — unless the task has a user simulator
+(`--user-url`, its own MCP server), in which case a no-tool-call turn is a turn boundary: the
+program calls the simulator's `respond` tool, appends the user message(s) it returns, and
+re-prompts, until the simulator returns no further turns. A no-prompt task is opened the same way
+(`respond("")` before the first model call). Carrying every user turn in the program's own
+conversation keeps the recorded message graph linear and the user turns regular user messages.
 
-It runs as a uv script (deps: openai, mcp, httpx), so the chat + tool plumbing is just the
-SDKs — the harness bootstraps `uv` in the runtime. The interception endpoint, per-rollout
-secret, and model arrive as argv (not env), so nothing the program spawns inherits them.
+It runs as a uv script (deps: openai, mcp), so the chat + tool plumbing — including the user
+simulator, which is just another MCP server — is just the SDKs; the harness bootstraps `uv` in the
+runtime. The interception endpoint, per-rollout secret, and model arrive as argv (not env), so
+nothing the program spawns inherits them.
 """
 
 import argparse
@@ -25,7 +26,6 @@ import json
 import os
 from contextlib import AsyncExitStack
 
-import httpx
 from openai import AsyncOpenAI
 
 
@@ -97,17 +97,29 @@ async def call_mcp(dispatch: dict, name: str, arguments: dict) -> str | list[dic
     return mcp_content_to_chat_content(result.content)
 
 
-async def next_user_turn(
-    http: httpx.AsyncClient, url: str, secret: str, message: str
-) -> tuple[list[dict], bool]:
-    """Drive the task's user simulator: POST the model's last text to `/user` and return its next
-    user message(s) (already OpenAI wire dicts) and whether the trajectory should now end."""
-    resp = await http.post(
-        url, json={"message": message}, headers={"Authorization": f"Bearer {secret}"}
+async def connect_user_sim(stack: AsyncExitStack, url: str):
+    """Connect to the task's user simulator — its own MCP server (a `vf.User`), never shown to the
+    model — and return an async `respond(text)` that calls its `respond` tool, returning the next
+    user message(s) as OpenAI wire dicts (an empty list = the simulator is done)."""
+    from mcp import ClientSession
+    from mcp.client.streamable_http import (
+        create_mcp_http_client,
+        streamable_http_client,
     )
-    resp.raise_for_status()
-    data = resp.json()
-    return data["messages"], data["done"]
+
+    http_client = await stack.enter_async_context(create_mcp_http_client())
+    read, write, *_ = await stack.enter_async_context(
+        streamable_http_client(url, http_client=http_client)
+    )
+    session = await stack.enter_async_context(ClientSession(read, write))
+    await session.initialize()
+
+    async def respond(text: str) -> list[dict]:
+        result = await session.call_tool("respond", {"message": text})
+        parts = [b.text for b in result.content if getattr(b, "type", None) == "text"]
+        return json.loads("\n".join(parts))["messages"]
+
+    return respond
 
 
 def parse_args() -> argparse.Namespace:
@@ -131,11 +143,7 @@ async def main() -> None:
         tools, dispatch = (
             await connect_mcp(stack, config) if config.get("mcpServers") else ([], {})
         )
-        http = (
-            await stack.enter_async_context(httpx.AsyncClient(timeout=120))
-            if user_url
-            else None
-        )
+        user_respond = await connect_user_sim(stack, user_url) if user_url else None
         messages = (
             [{"role": "system", "content": args.system_prompt}]
             if args.system_prompt
@@ -150,11 +158,11 @@ async def main() -> None:
             messages.extend(initial)
         elif args.prompt:
             messages.append({"role": "user", "content": args.prompt})
-        elif user_url:
-            opening, done = await next_user_turn(http, user_url, args.api_key, "")
-            messages.extend(opening)
-            if done:
+        elif user_respond:
+            opening = await user_respond("")
+            if not opening:
                 return
+            messages.extend(opening)
         while True:
             message = await chat(client, args.model, messages, tools)
             messages.append(message.model_dump(exclude_none=True))
@@ -180,15 +188,14 @@ async def main() -> None:
                         {"role": "tool", "tool_call_id": call.id, "content": content}
                     )
                 continue
-            # No tool call: a final answer for the current user turn. With a user simulator, fetch
-            # the next user turn and re-prompt; otherwise the conversation is over.
-            if user_url:
-                reply, done = await next_user_turn(
-                    http, user_url, args.api_key, message.content or ""
-                )
-                messages.extend(reply)
-                if done:
+            # No tool call: a final answer for the current user turn. With a user simulator, ask it
+            # for the next user turn and re-prompt; an empty reply means it's done. Without one, the
+            # conversation is over.
+            if user_respond:
+                reply = await user_respond(message.content or "")
+                if not reply:
                     break
+                messages.extend(reply)
                 continue
             break
 

--- a/verifiers/v1/harnesses/default/program.py
+++ b/verifiers/v1/harnesses/default/program.py
@@ -1,15 +1,20 @@
 # /// script
 # requires-python = ">=3.10"
-# dependencies = ["openai", "mcp"]
+# dependencies = ["openai", "mcp", "httpx"]
 # ///
 """The default harness's program: a chat loop with the taskset's MCP tools (and none of its own).
 
 A growing-message-list chat loop. When the harness sets MCP_CONFIG (a standard `mcpServers` URL
 map) it connects to those servers over streamable HTTP, exposes their tools to the model as
 `<server>_<tool>`, and routes those calls to the server. The loop runs until the model answers
-without a tool call (immediately, when no tools are offered).
+without a tool call (immediately, when no tools are offered) — unless the task has a user
+simulator (`--user-url`), in which case a no-tool-call turn is a turn boundary: the program POSTs
+the assistant's text to `/user`, appends the simulated user reply, and re-prompts, until the
+simulator signals `done`. A no-prompt task is opened the same way (POST `/user` with an empty
+message before the first model call). Carrying every turn in the program's own conversation keeps
+the recorded message graph linear.
 
-It runs as a uv script (deps: openai, mcp), so the chat + tool plumbing is just the
+It runs as a uv script (deps: openai, mcp, httpx), so the chat + tool plumbing is just the
 SDKs — the harness bootstraps `uv` in the runtime. The interception endpoint, per-rollout
 secret, and model arrive as argv (not env), so nothing the program spawns inherits them.
 """
@@ -20,6 +25,7 @@ import json
 import os
 from contextlib import AsyncExitStack
 
+import httpx
 from openai import AsyncOpenAI
 
 
@@ -91,6 +97,19 @@ async def call_mcp(dispatch: dict, name: str, arguments: dict) -> str | list[dic
     return mcp_content_to_chat_content(result.content)
 
 
+async def next_user_turn(
+    http: httpx.AsyncClient, url: str, secret: str, message: str
+) -> tuple[list[dict], bool]:
+    """Drive the task's user simulator: POST the model's last text to `/user` and return its next
+    user message(s) (already OpenAI wire dicts) and whether the trajectory should now end."""
+    resp = await http.post(
+        url, json={"message": message}, headers={"Authorization": f"Bearer {secret}"}
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    return data["messages"], data["done"]
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--base-url", required=True)
@@ -99,6 +118,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--system-prompt", default="")
     parser.add_argument("--prompt", default="")
     parser.add_argument("--mcp-config", default="")
+    parser.add_argument("--user-url", default="")
     return parser.parse_args()
 
 
@@ -106,9 +126,15 @@ async def main() -> None:
     args = parse_args()
     client = AsyncOpenAI(base_url=args.base_url, api_key=args.api_key)
     config = json.loads(args.mcp_config or "{}")
+    user_url = args.user_url or None
     async with AsyncExitStack() as stack:
         tools, dispatch = (
             await connect_mcp(stack, config) if config.get("mcpServers") else ([], {})
+        )
+        http = (
+            await stack.enter_async_context(httpx.AsyncClient(timeout=120))
+            if user_url
+            else None
         )
         messages = (
             [{"role": "system", "content": args.system_prompt}]
@@ -118,37 +144,53 @@ async def main() -> None:
         # A Messages prompt (e.g. an image-bearing prompt) arrives pre-built as OpenAI wire dicts
         # via INITIAL_MESSAGES (kept in env: it can be large multimodal content that overflows
         # argv, and it's prompt content, not a credential); otherwise --prompt is the opening
-        # message. Both empty means the task has no prompt — the user simulator seeds the opening.
+        # message. Both empty means the task has no prompt — the user simulator opens it.
         initial = json.loads(os.environ.get("INITIAL_MESSAGES", "[]"))
         if initial:
             messages.extend(initial)
         elif args.prompt:
             messages.append({"role": "user", "content": args.prompt})
+        elif user_url:
+            opening, done = await next_user_turn(http, user_url, args.api_key, "")
+            messages.extend(opening)
+            if done:
+                return
         while True:
             message = await chat(client, args.model, messages, tools)
             messages.append(message.model_dump(exclude_none=True))
-            if not message.tool_calls:
-                break
-            for call in message.tool_calls:
-                name = call.function.name
-                try:
-                    tool_args = json.loads(call.function.arguments or "{}")
-                except json.JSONDecodeError as e:
+            if message.tool_calls:
+                for call in message.tool_calls:
+                    name = call.function.name
+                    try:
+                        tool_args = json.loads(call.function.arguments or "{}")
+                    except json.JSONDecodeError as e:
+                        messages.append(
+                            {
+                                "role": "tool",
+                                "tool_call_id": call.id,
+                                "content": f"error: invalid JSON in tool arguments ({e}); resend the call with valid JSON",
+                            }
+                        )
+                        continue
+                    if name in dispatch:
+                        content = await call_mcp(dispatch, name, tool_args)
+                    else:
+                        content = f"error: unknown tool {name!r}"
                     messages.append(
-                        {
-                            "role": "tool",
-                            "tool_call_id": call.id,
-                            "content": f"error: invalid JSON in tool arguments ({e}); resend the call with valid JSON",
-                        }
+                        {"role": "tool", "tool_call_id": call.id, "content": content}
                     )
-                    continue
-                if name in dispatch:
-                    content = await call_mcp(dispatch, name, tool_args)
-                else:
-                    content = f"error: unknown tool {name!r}"
-                messages.append(
-                    {"role": "tool", "tool_call_id": call.id, "content": content}
+                continue
+            # No tool call: a final answer for the current user turn. With a user simulator, fetch
+            # the next user turn and re-prompt; otherwise the conversation is over.
+            if user_url:
+                reply, done = await next_user_turn(
+                    http, user_url, args.api_key, message.content or ""
                 )
+                messages.extend(reply)
+                if done:
+                    break
+                continue
+            break
 
 
 if __name__ == "__main__":

--- a/verifiers/v1/harnesses/kimi_code/harness.py
+++ b/verifiers/v1/harnesses/kimi_code/harness.py
@@ -70,6 +70,7 @@ class KimiCodeHarness(Harness[KimiCodeHarnessConfig]):
         endpoint: str,
         secret: str,
         mcp_urls: dict[str, str],
+        user_url: str | None = None,
     ) -> ProgramResult:
         _, prompt = self.resolve_prompt(trace.task)
         env = {

--- a/verifiers/v1/harnesses/mini_swe_agent/harness.py
+++ b/verifiers/v1/harnesses/mini_swe_agent/harness.py
@@ -33,6 +33,7 @@ class MiniSWEAgentHarness(Harness[MiniSWEAgentHarnessConfig]):
         endpoint: str,
         secret: str,
         mcp_urls: dict[str, str],
+        user_url: str | None = None,
     ) -> ProgramResult:
         if self.config.disabled_tools:
             raise ValueError("mini-swe-agent does not support disabling tools")

--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -84,6 +84,7 @@ class RLMHarness(Harness[RLMHarnessConfig]):
         endpoint: str,
         secret: str,
         mcp_urls: dict[str, str],
+        user_url: str | None = None,
     ) -> ProgramResult:
         system_prompt, prompt = self.resolve_prompt(trace.task)
         env = {

--- a/verifiers/v1/harnesses/terminus_2/harness.py
+++ b/verifiers/v1/harnesses/terminus_2/harness.py
@@ -45,6 +45,7 @@ class Terminus2Harness(Harness[Terminus2HarnessConfig]):
         endpoint: str,
         secret: str,
         mcp_urls: dict[str, str],
+        user_url: str | None = None,
     ) -> ProgramResult:
         if self.config.disabled_tools:
             raise ValueError("Terminus 2 does not support disabling tools")

--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -11,12 +11,14 @@ own secret (the bearer token the harness already sends), and the server routes b
 secret to the right session. So N rollouts need one server (and, behind a remote runtime,
 one tunnel) per pool member rather than one each — see `interception.pool`.
 
-When a rollout sets a user simulator (see `verifiers.v1.mcp.user`), the session also drives it:
-after each model turn it injects the simulator's reply as a user turn and re-prompts the
-model, so a multi-turn exchange plays out within one program request, transparently to the
-harness. When the task carries no prompt (`task.prompt is None`), the simulator also
-opens the conversation: its first turn is seeded before the model is ever called. Tools are
-handled out-of-band (run by the harness).
+When a rollout sets a user simulator (see `verifiers.v1.mcp.user`), a harness that supports it
+(`Harness.SUPPORTS_USER_SIM`) drives it explicitly over the `/user` endpoint: on a model turn
+with no tool call the harness POSTs the assistant's text, gets the simulator's next user turn(s)
+back (or `done`), appends them to its OWN conversation, and re-prompts. So every user turn flows
+through the harness's own next request and the message graph stays linear — model calls here are
+a pure 1:1 proxy, never an inject-and-re-prompt. When the task carries no prompt (`task.prompt is
+None`), the harness opens the conversation by POSTing `/user` with an empty message before the
+first model call. Tools are likewise handled out-of-band (run by the harness).
 """
 
 import asyncio
@@ -35,6 +37,7 @@ from pydantic_core import PydanticSerializationError, from_json, to_json
 from verifiers.v1.clients import RolloutContext
 from verifiers.v1.dialects import DIALECTS, Dialect
 from verifiers.v1.dialects.base import is_sse_done_event
+from verifiers.v1.dialects.chat import message_to_wire
 from verifiers.v1 import graph
 from verifiers.v1.errors import (
     OverlongPromptError,
@@ -135,14 +138,9 @@ class RolloutSession:
     limits: RolloutLimits = field(default_factory=RolloutLimits)
     user: "Respond | None" = None
     """A user simulator the rollout sets before the harness runs (see `verifiers.v1.mcp.user`).
-    When set, each model turn with no tool call is followed by the simulator's reply,
-    injected as a user turn, and the model is re-prompted — all within one program request,
-    transparently to the harness."""
-    opening: Messages | None = None
-    """Cached opening `respond("")` messages for a no-prompt task. Computed once and re-injected on
-    every request until the first turn lands on the trace — so a retried opening request (e.g. the
-    harness SDK retrying a transient model 502, before any turn is recorded) never calls `respond`
-    twice and advances the simulator's queue past the opening."""
+    When set, a harness that supports it drives it over the `/user` endpoint (`handle_user`): on a
+    no-tool-call turn it POSTs the assistant's text and appends the returned user turn(s) to its own
+    conversation. The interception server never injects user turns itself."""
     error: "RolloutError | None" = None
     """The latest unresolved model-call failure. The harness only sees it as an HTTP error
     (and may swallow it, or exit non-zero), so the rollout re-raises this original error once the
@@ -219,6 +217,9 @@ class InterceptionServer:
         # A forked shared server (see `verifiers.v1.mcp.multiplex`) fetches its rollout's task here
         # to run `setup_task` per child — a shared server gets no task via env, keyed by the secret.
         app.router.add_get("/task", self.handle_task_get)
+        # A harness that supports a user simulator drives it here: POST the model's last message,
+        # get the next user turn(s) back (see `handle_user`), keyed by the same bearer secret.
+        app.router.add_post("/user", self.handle_user)
         self.runner = web.AppRunner(app)
         await self.runner.setup()
         site = web.TCPSite(self.runner, _HOST, 0)
@@ -270,138 +271,81 @@ class InterceptionServer:
         )
         # `body` is forwarded to the model 1:1 (the proxy mutates only model + sampling), so no
         # provider field is lost. `prompt` is the dialect's typed parse, kept only to build the
-        # trace (the renderer re-derives its own from the body it's handed). A user simulator
-        # extends both each turn (`dialect.extend` for the wire, `prompt` for the trace).
+        # trace (the renderer re-derives its own from the body it's handed).
         prompt: Messages
         prompt, _ = dialect.parse_request(body)
-        # A task with no prompt has its conversation opened by the user simulator: before the
-        # first model call, seed the simulator's opening user turn(s) into both the wire request
-        # and the trace prompt, so the model answers the user rather than an empty prompt. Guarded
-        # to the opening (`num_turns == 0`), so a later program request (e.g. after a tool call)
-        # never re-seeds. The opening `respond("")` is cached on the session and reused, so a
-        # retried opening request (e.g. the harness SDK retrying a transient model 502, before any
-        # turn is recorded) doesn't advance the simulator's queue and skip the opening turn. The
-        # post-turn loop below then drives the remaining turns as usual.
-        if (
-            session.user is not None
-            and session.trace.task.prompt is None
-            and session.trace.num_turns == 0
-        ):
-            if session.opening is None:
-                session.opening = await session.user("")
-            body = dialect.extend(body, None, session.opening)
-            prompt = [*prompt, *session.opening]
-            # If the simulator ended at the open (its taskset's `@stop` now fires), the loop's
-            # `refused()` below halts the harness before any model call — no special-casing here.
         if dialect.streaming(body):
             return await self._stream(request, session, dialect, body, prompt)
-        headers = request.headers.copy()
-        # A user simulator turns one program request into a multi-turn exchange: after each
-        # model turn the simulator's reply is injected as a user turn and the model is
-        # re-prompted, so a whole game plays out here and only the final assistant message
-        # returns to the (simulator-unaware) program. Without a simulator the loop runs once.
-        completion: dict | None = (
-            None  # the latest turn's response, returned to the program
-        )
-        while True:
-            try:
-                refused = await session.refused()
-            except RolloutError as e:
-                return self._fail(session, dialect, e)
-            except Exception as e:
-                return self._fail(
-                    session,
-                    dialect,
-                    TasksetError(f"@stop failed: {type(e).__name__}: {e}"),
-                )
-            if refused is not None:
-                # Refuse the first model call to halt the harness; once a simulated
-                # conversation is under way, just end it and return the last turn cleanly.
-                if completion is None:
-                    return web.json_response(
-                        dialect.error_body(f"rollout stopped: {refused}"), status=400
-                    )
-                return _completion_response(completion)
-            turn = graph.prepare_turn(session.trace, prompt)
-            session.error = None
-            try:
-                response = await session.ctx.client.get_response(
-                    dialect,
-                    body,
-                    session.ctx.model,
-                    session.ctx.sampling,
-                    headers=headers,
-                    session_id=session.trace.id,
-                    turn=turn,
-                )
-            except OverlongPromptError:
-                # An overlong prompt is a budget limit, not a crash: end the rollout cleanly
-                # as a truncation — return the last turn if there is one, else refuse to halt
-                # the harness (same shape as `refused` above).
-                session.trace.stop("context_length")
-                logger.debug("prompt too long: id=%s", session.trace.id)
-                if completion is None:
-                    return web.json_response(
-                        dialect.error_body("rollout stopped: context_length"),
-                        status=400,
-                    )
-                return _completion_response(completion)
-            except RolloutError as e:
-                # Stash the real cause; the rollout re-raises it after the harness returns. Relay
-                # the provider's status so the harness SDK retries 5xx/429 and not 4xx.
-                session.error = e
-                logger.warning(
-                    "model call failed: id=%s %s: %s",
-                    session.trace.id,
-                    type(e).__name__,
-                    e,
-                )
-                return web.json_response(
-                    dialect.error_body(str(e)), status=getattr(e, "status_code", 502)
-                )
-            except Exception as e:  # surface to the program as an API error
-                logger.warning(
-                    "model call failed: id=%s %s: %s",
-                    session.trace.id,
-                    type(e).__name__,
-                    e,
-                )
-                return web.json_response(dialect.error_body(str(e)), status=502)
-            # `Response.raw` is the wire response handed to the program 1:1 — the provider's
-            # verbatim bytes (proxy) or the client's serialized completion (renderer).
-            completion = response.raw
-            logger.debug(
-                "intercept turn: id=%s tools=%d",
-                session.trace.id,
-                len(response.message.tool_calls or []),
+        # One model call, recorded and returned to the harness 1:1 — no internal multi-turn. A
+        # user simulator (if any) is driven by the harness over `/user` (see `handle_user`), so
+        # every user turn arrives in the harness's own next request and the graph stays linear.
+        try:
+            refused = await session.refused()
+        except RolloutError as e:
+            return self._fail(session, dialect, e)
+        except Exception as e:
+            return self._fail(
+                session, dialect, TasksetError(f"@stop failed: {type(e).__name__}: {e}")
             )
-            turn.commit(response)  # one node per new message;
-            # branches fall out of walking the graph (see Trace.branches / verifiers.v1.graph)
-            # Hand back to the program when the model wants a tool (the program runs it) or
-            # when there's no user simulator to keep the conversation going.
-            if response.message.tool_calls or session.user is None:
-                return _completion_response(completion)
-            try:
-                user_messages = await session.user(response.message.content or "")
-            except RolloutError as e:
-                return self._fail(session, dialect, e)
-            except Exception as e:
-                return self._fail(
-                    session,
-                    dialect,
-                    UserError(f"user simulator failed: {type(e).__name__}: {e}"),
-                )
-            # Inject the model turn + the simulator's user turn(s): into the wire request for the
-            # next model call (`dialect.extend`, which keeps the model turn verbatim so reasoning
-            # survives) and into the typed prompt for the trace. The simulator ends the trajectory
-            # through its taskset's `@stop` (e.g. a `user_finished` flag it set on `self.state`),
-            # caught by `refused()` at the top of the next iteration — the interception server holds
-            # no opinion about the state's contents.
-            body = dialect.extend(body, completion, user_messages)
-            prompt = [*prompt, response.message, *user_messages]
-            # The simulator changed the payload, so this is a new operation rather than a retry.
-            headers.popall("idempotency-key", None)
-            headers.popall("x-idempotency-key", None)
+        if refused is not None:
+            # A refused turn errors the harness's model call; `Harness.run` treats its exit as a
+            # clean stop (the stop condition is already set on the trace).
+            return web.json_response(
+                dialect.error_body(f"rollout stopped: {refused}"), status=400
+            )
+        turn = graph.prepare_turn(session.trace, prompt)
+        session.error = None
+        try:
+            response = await session.ctx.client.get_response(
+                dialect,
+                body,
+                session.ctx.model,
+                session.ctx.sampling,
+                headers=request.headers,
+                session_id=session.trace.id,
+                turn=turn,
+            )
+        except OverlongPromptError:
+            # An overlong prompt is a budget limit, not a crash: end the rollout cleanly as a
+            # truncation (the harness's resulting exit is a clean stop, like `refused`).
+            session.trace.stop("context_length")
+            logger.debug("prompt too long: id=%s", session.trace.id)
+            return web.json_response(
+                dialect.error_body("rollout stopped: context_length"), status=400
+            )
+        except RolloutError as e:
+            # Stash the real cause; the rollout re-raises it after the harness returns. Relay the
+            # provider's status so the harness SDK retries 5xx/429 and not 4xx.
+            session.error = e
+            logger.warning(
+                "model call failed: id=%s %s: %s",
+                session.trace.id,
+                type(e).__name__,
+                e,
+            )
+            return web.json_response(
+                dialect.error_body(str(e)), status=getattr(e, "status_code", 502)
+            )
+        except Exception as e:  # surface to the program as an API error
+            logger.warning(
+                "model call failed: id=%s %s: %s",
+                session.trace.id,
+                type(e).__name__,
+                e,
+            )
+            return web.json_response(dialect.error_body(str(e)), status=502)
+        # `Response.raw` is the wire response handed to the program 1:1 — the provider's verbatim
+        # bytes (proxy) or the client's serialized completion (renderer).
+        completion = response.raw
+        logger.debug(
+            "intercept turn: id=%s tools=%d",
+            session.trace.id,
+            len(response.message.tool_calls or []),
+        )
+        turn.commit(
+            response
+        )  # one node per new message; branches fall out of the graph walk
+        return _completion_response(completion)
 
     async def _stream(
         self,
@@ -620,3 +564,55 @@ class InterceptionServer:
             )
         session.trace.state = new_state
         return web.json_response({"ok": True})
+
+    async def handle_user(self, request: web.Request) -> web.Response:
+        """Drive the rollout's user simulator for a harness that supports it (`SUPPORTS_USER_SIM`):
+        POST the model's last assistant text (`{"message": ...}`, empty `""` to open a no-prompt
+        conversation), get back the simulator's next user turn(s) and whether the trajectory should
+        now end (`{"messages": [...], "done": bool}`). The harness appends the messages to its OWN
+        conversation and re-prompts, so every user turn flows through its requests and the graph
+        stays linear; it stops when `done`. Keyed by the same bearer secret as the model routes.
+        `done` is the framework's `@stop`/limit check, run after the simulator responds — so the
+        simulator still ends the trajectory the usual way (a `self.state` flag a taskset `@vf.stop`
+        reads), the interception server holding no opinion about the state's contents."""
+        session = self._session_for(request)
+        if session is None:
+            return web.json_response({"error": "unauthorized"}, status=401)
+        if session.user is None:
+            return web.json_response(
+                {"error": "rollout has no user simulator"}, status=400
+            )
+        message = (await request.json()).get("message", "")
+        logger.debug("intercept POST /user: id=%s", session.trace.id)
+        session.error = None
+        try:
+            user_messages = await session.user(message)
+        except RolloutError as e:
+            session.error = e  # the rollout re-raises it as the real cause after the harness returns
+            logger.warning(
+                "user simulator failed: id=%s %s: %s",
+                session.trace.id,
+                type(e).__name__,
+                e,
+            )
+            return web.json_response(
+                {"error": str(e)}, status=getattr(e, "status_code", 502)
+            )
+        except Exception as e:
+            err = UserError(f"user simulator failed: {type(e).__name__}: {e}")
+            session.error = err
+            logger.warning("user simulator failed: id=%s %s", session.trace.id, e)
+            return web.json_response({"error": str(err)}, status=502)
+        try:
+            done = await session.refused() is not None
+        except RolloutError as e:
+            session.error = e
+            return web.json_response(
+                {"error": str(e)}, status=getattr(e, "status_code", 502)
+            )
+        except Exception as e:
+            err = TasksetError(f"@stop failed: {type(e).__name__}: {e}")
+            session.error = err
+            return web.json_response({"error": str(err)}, status=502)
+        wire = [m if isinstance(m, dict) else message_to_wire(m) for m in user_messages]
+        return web.json_response({"messages": wire, "done": done})

--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -11,14 +11,15 @@ own secret (the bearer token the harness already sends), and the server routes b
 secret to the right session. So N rollouts need one server (and, behind a remote runtime,
 one tunnel) per pool member rather than one each — see `interception.pool`.
 
-When a rollout sets a user simulator (see `verifiers.v1.mcp.user`), a harness that supports it
-(`Harness.SUPPORTS_USER_SIM`) drives it explicitly over the `/user` endpoint: on a model turn
-with no tool call the harness POSTs the assistant's text, gets the simulator's next user turn(s)
-back (or `done`), appends them to its OWN conversation, and re-prompts. So every user turn flows
-through the harness's own next request and the message graph stays linear — model calls here are
-a pure 1:1 proxy, never an inject-and-re-prompt. When the task carries no prompt (`task.prompt is
-None`), the harness opens the conversation by POSTing `/user` with an empty message before the
-first model call. Tools are likewise handled out-of-band (run by the harness).
+A user simulator (see `verifiers.v1.mcp.user`) is not the interception server's concern: it is its
+own MCP server, and a harness that supports it (`Harness.SUPPORTS_USER_SIM`) drives it directly —
+calling its `respond` tool for each user turn and injecting the reply into its own conversation
+(append for a chat loop; `codex exec resume` / stream-json stdin for a CLI). So every user turn
+arrives in the harness's own next model call and is recorded as a regular user message on the
+single branch — model calls here are a pure 1:1 proxy, never an inject-and-re-prompt. Tools are
+likewise handled out-of-band (run by the harness). The simulator ends the trajectory by returning
+no further turns and setting a `self.state` flag a taskset `@stop` checks, caught here over the
+`/state` channel like any other state.
 """
 
 import asyncio
@@ -28,7 +29,6 @@ import logging
 import secrets
 from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
 
 from aiohttp import web
 from pydantic import TypeAdapter, ValidationError
@@ -37,19 +37,14 @@ from pydantic_core import PydanticSerializationError, from_json, to_json
 from verifiers.v1.clients import RolloutContext
 from verifiers.v1.dialects import DIALECTS, Dialect
 from verifiers.v1.dialects.base import is_sse_done_event
-from verifiers.v1.dialects.chat import message_to_wire
 from verifiers.v1 import graph
 from verifiers.v1.errors import (
     OverlongPromptError,
     RolloutError,
     TasksetError,
-    UserError,
 )
 from verifiers.v1.trace import Trace
 from verifiers.v1.types import Messages
-
-if TYPE_CHECKING:
-    from verifiers.v1.mcp import Respond
 
 logger = logging.getLogger(__name__)
 
@@ -128,19 +123,16 @@ class RolloutLimits:
 class RolloutSession:
     """One rollout's interception state, served by a (possibly shared) `InterceptionServer`
     and keyed there by its secret. Holds everything a single rollout's chat-completions need:
-    the client/model context, the trace to record turns onto, the framework limits + `@stop`s
-    checked before each turn, and (optionally) a user simulator the rollout sets before the
-    harness runs."""
+    the client/model context, the trace to record turns onto, and the framework limits + `@stop`s
+    checked before each turn. A user simulator is not held here — the harness drives it directly
+    over its own MCP server (see `verifiers.v1.mcp.user`), so the interception server is a pure
+    model proxy that knows nothing about user simulation (the simulator's `@stop` flag still reaches
+    it over the `/state` channel like any other state)."""
 
     ctx: RolloutContext
     trace: Trace
     stops: list[Callable[[Trace], Awaitable[bool]]] = field(default_factory=list)
     limits: RolloutLimits = field(default_factory=RolloutLimits)
-    user: "Respond | None" = None
-    """A user simulator the rollout sets before the harness runs (see `verifiers.v1.mcp.user`).
-    When set, a harness that supports it drives it over the `/user` endpoint (`handle_user`): on a
-    no-tool-call turn it POSTs the assistant's text and appends the returned user turn(s) to its own
-    conversation. The interception server never injects user turns itself."""
     error: "RolloutError | None" = None
     """The latest unresolved model-call failure. The harness only sees it as an HTTP error
     (and may swallow it, or exit non-zero), so the rollout re-raises this original error once the
@@ -217,9 +209,6 @@ class InterceptionServer:
         # A forked shared server (see `verifiers.v1.mcp.multiplex`) fetches its rollout's task here
         # to run `setup_task` per child — a shared server gets no task via env, keyed by the secret.
         app.router.add_get("/task", self.handle_task_get)
-        # A harness that supports a user simulator drives it here: POST the model's last message,
-        # get the next user turn(s) back (see `handle_user`), keyed by the same bearer secret.
-        app.router.add_post("/user", self.handle_user)
         self.runner = web.AppRunner(app)
         await self.runner.setup()
         site = web.TCPSite(self.runner, _HOST, 0)
@@ -277,8 +266,9 @@ class InterceptionServer:
         if dialect.streaming(body):
             return await self._stream(request, session, dialect, body, prompt)
         # One model call, recorded and returned to the harness 1:1 — no internal multi-turn. A
-        # user simulator (if any) is driven by the harness over `/user` (see `handle_user`), so
-        # every user turn arrives in the harness's own next request and the graph stays linear.
+        # user simulator (if any) is driven by the harness against its own MCP server (it injects
+        # each user turn into its conversation), so every user turn arrives in the harness's own
+        # next request here and the graph stays linear.
         try:
             refused = await session.refused()
         except RolloutError as e:
@@ -564,55 +554,3 @@ class InterceptionServer:
             )
         session.trace.state = new_state
         return web.json_response({"ok": True})
-
-    async def handle_user(self, request: web.Request) -> web.Response:
-        """Drive the rollout's user simulator for a harness that supports it (`SUPPORTS_USER_SIM`):
-        POST the model's last assistant text (`{"message": ...}`, empty `""` to open a no-prompt
-        conversation), get back the simulator's next user turn(s) and whether the trajectory should
-        now end (`{"messages": [...], "done": bool}`). The harness appends the messages to its OWN
-        conversation and re-prompts, so every user turn flows through its requests and the graph
-        stays linear; it stops when `done`. Keyed by the same bearer secret as the model routes.
-        `done` is the framework's `@stop`/limit check, run after the simulator responds — so the
-        simulator still ends the trajectory the usual way (a `self.state` flag a taskset `@vf.stop`
-        reads), the interception server holding no opinion about the state's contents."""
-        session = self._session_for(request)
-        if session is None:
-            return web.json_response({"error": "unauthorized"}, status=401)
-        if session.user is None:
-            return web.json_response(
-                {"error": "rollout has no user simulator"}, status=400
-            )
-        message = (await request.json()).get("message", "")
-        logger.debug("intercept POST /user: id=%s", session.trace.id)
-        session.error = None
-        try:
-            user_messages = await session.user(message)
-        except RolloutError as e:
-            session.error = e  # the rollout re-raises it as the real cause after the harness returns
-            logger.warning(
-                "user simulator failed: id=%s %s: %s",
-                session.trace.id,
-                type(e).__name__,
-                e,
-            )
-            return web.json_response(
-                {"error": str(e)}, status=getattr(e, "status_code", 502)
-            )
-        except Exception as e:
-            err = UserError(f"user simulator failed: {type(e).__name__}: {e}")
-            session.error = err
-            logger.warning("user simulator failed: id=%s %s", session.trace.id, e)
-            return web.json_response({"error": str(err)}, status=502)
-        try:
-            done = await session.refused() is not None
-        except RolloutError as e:
-            session.error = e
-            return web.json_response(
-                {"error": str(e)}, status=getattr(e, "status_code", 502)
-            )
-        except Exception as e:
-            err = TasksetError(f"@stop failed: {type(e).__name__}: {e}")
-            session.error = err
-            return web.json_response({"error": str(err)}, status=502)
-        wire = [m if isinstance(m, dict) else message_to_wire(m) for m in user_messages]
-        return web.json_response({"messages": wire, "done": done})

--- a/verifiers/v1/mcp/__init__.py
+++ b/verifiers/v1/mcp/__init__.py
@@ -3,8 +3,9 @@
 A server is a class authored from a config (`server.ServerBase`), self-launched via its env module's
 `__main__` (`ServerBase.run`). The host side (`launch`) brings servers up in a runtime and reaches
 them: `serve` (one server, any placement), `serve_tools` / `serve_shared` / `serve_user` (a
-rollout's tools / the eval's shared tools / the user sim), and `connect_user` (the MCP client the
-framework drives the user sim through).
+rollout's tools / the eval's shared tools / the user sim — all harness-reachable). The harness
+drives the user sim itself by calling its `respond` tool; `connect_user` is the host-side MCP client
+for a harness whose conversation loop runs on the host (a CLI-wrapper harness).
 """
 
 from verifiers.v1.mcp.launch import (

--- a/verifiers/v1/mcp/launch.py
+++ b/verifiers/v1/mcp/launch.py
@@ -478,10 +478,13 @@ async def serve_tools(
 
 @contextlib.asynccontextmanager
 async def connect_user(url: str) -> AsyncIterator[Respond]:
-    """Open an MCP client session to a user server at `url` and yield an async
-    `respond(message)` that calls its `respond` tool, parsing the JSON it returns
-    (`{"messages": [...]}`) into typed `Messages`. End-of-trajectory is signalled out-of-band: the
-    server sets a flag on the shared state (a taskset `@vf.stop` checks it), not in this reply.
+    """HOST-side driver for a user simulator: open an MCP client session to a user server at `url`
+    and yield an async `respond(message)` that calls its `respond` tool, parsing the JSON it returns
+    (`{"messages": [...]}`) into typed `Messages` (an empty list = the simulator is done). For
+    harnesses whose conversation loop runs on the host (a CLI-wrapper harness driving `codex exec
+    resume` / Claude Code stream-json); in-runtime chat-loop programs instead MCP-connect to the same
+    server themselves (see the default harness program). End-of-trajectory is signalled by an empty
+    reply (and a `self.state` flag a taskset `@vf.stop` also checks), not a special return value.
 
     Retries the connect — under high concurrency the colocated user server can be slow to
     accept (or briefly refuse) a connection. A server that stays unreachable raises
@@ -548,14 +551,16 @@ async def serve_user(
     state_port: int | None = None,
     state_secret: str = "",
     state_base: str | None = None,
-) -> AsyncIterator[Respond | None]:
-    """Bring a rollout's user server up (via the shared `serve` launcher, `for_host=True` since
-    the framework drives the user from the HOST) and yield the async `respond` the interception
-    server drives — or `None` when the taskset has no user server. Placement is the user's
-    `config` (colocated in the harness's runtime, or its own); the rollout's `task` is shipped to
-    the server for its `setup`. `state_port`/`state_secret` wire it to the shared-state channel — how
-    the user sim's `respond` reads/writes `self.state` (and ends the trajectory via a flag a taskset
-    `@vf.stop` checks)."""
+) -> AsyncIterator[str | None]:
+    """Bring a rollout's user simulator up as a HARNESS-reachable MCP server (via the shared `serve`
+    launcher, like a tool server — but the harness never shows it to the model) and yield its URL —
+    or `None` when the taskset has no user simulator. The harness drives it itself: it connects and
+    calls the server's `respond` tool for each user turn, injecting the reply into its own
+    conversation (see the default harness program / a CLI wrapper), so the user turn is a regular
+    user message and the message graph stays linear. Placement is the user's `config` (colocated in
+    the harness's runtime, or its own); the rollout's `task` is shipped for its `setup`;
+    `state_port`/`state_secret`/`state_base` wire the shared-state channel — how `respond`
+    reads/writes `self.state` (and ends the trajectory via a flag a taskset `@vf.stop` checks)."""
     if user is None:
         yield None
         return
@@ -563,10 +568,9 @@ async def serve_user(
         user,
         task,
         harness_runtime,
-        for_host=True,
+        for_host=False,
         state_port=state_port,
         state_secret=state_secret,
         state_base=state_base,
     ) as url:
-        async with connect_user(url) as respond:
-            yield respond
+        yield url

--- a/verifiers/v1/mcp/user.py
+++ b/verifiers/v1/mcp/user.py
@@ -2,13 +2,16 @@
 
 A taskset registers a `User` via `Taskset.user` — a vf-native class (like `Toolset`, served as an
 MCP server with a runtime) exposing a single `respond` tool. Unlike a tool server it is never handed
-to the model: the framework drives it. After each model turn the interception server calls `respond`
-with the model's last message, appends the simulated user message(s), and re-prompts — so a
-multi-turn game plays out as alternating assistant/user turns in the trace, the harness none the
-wiser. When the task carries no prompt (`task.prompt is None`), the simulator also opens the
-conversation: the interception server calls `respond("")` once before the first model turn and seeds
-its reply as the initial user message. The host side that drives it lives in `launch` (`serve_user` /
-`connect_user`).
+to the model: a harness that supports user simulation (`Harness.SUPPORTS_USER_SIM`) drives it. On a
+model turn with no tool call the harness calls `respond` with the model's last message and injects
+the simulated user message(s) into its OWN conversation, then re-prompts — so a multi-turn game
+plays out as alternating assistant/user turns recorded on the single branch (the user turns are
+regular user messages). When the task carries no prompt (`task.prompt is None`), the harness opens
+the conversation by calling `respond("")` before the first model turn. The simulator ends the
+trajectory by returning no further turns (and setting a `self.state` flag a taskset `@vf.stop`
+checks, a backstop the interception server catches over the `/state` channel). The host side that
+serves it lives in `launch` (`serve_user`; `connect_user` is the host-side client for a CLI-wrapper
+harness).
 """
 
 from __future__ import annotations

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -206,6 +206,20 @@ class Rollout:
                             "conversation; set task.prompt or have Taskset.user return "
                             "a simulator"
                         )
+                    if session.user is not None and not self.harness.SUPPORTS_USER_SIM:
+                        raise HarnessError(
+                            f"taskset has a user simulator but harness "
+                            f"{self.harness.config.id!r} does not support driving one "
+                            "(set SUPPORTS_USER_SIM and POST /user in its loop)"
+                        )
+                    # The harness drives the user simulator over this `/user` endpoint (only when
+                    # one is set and the harness supports it); the base reaches the same server as
+                    # the model routes / `/state` channel.
+                    user_url = (
+                        f"{state_base.rstrip('/')}/user"
+                        if session.user is not None
+                        else None
+                    )
                     # setup done — the harness is now driving
                     now = time.time()
                     trace.timing.setup.end = now
@@ -219,7 +233,7 @@ class Rollout:
                     try:
                         await asyncio.wait_for(
                             self.harness.run(
-                                ctx, trace, runtime, endpoint, secret, urls
+                                ctx, trace, runtime, endpoint, secret, urls, user_url
                             ),
                             self.harness_timeout,
                         )

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -198,28 +198,21 @@ class Rollout:
                         state_port=state_port,
                         state_secret=secret,
                         state_base=state_base,
-                    ) as session.user,
+                    ) as user_url,
                 ):
-                    if self.task.prompt is None and session.user is None:
+                    # `user_url` is the user simulator's MCP server (harness-reachable), or None.
+                    if self.task.prompt is None and user_url is None:
                         raise TasksetError(
                             "task has no prompt and no user simulator to open the "
                             "conversation; set task.prompt or have Taskset.user return "
                             "a simulator"
                         )
-                    if session.user is not None and not self.harness.SUPPORTS_USER_SIM:
+                    if user_url is not None and not self.harness.SUPPORTS_USER_SIM:
                         raise HarnessError(
                             f"taskset has a user simulator but harness "
                             f"{self.harness.config.id!r} does not support driving one "
-                            "(set SUPPORTS_USER_SIM and POST /user in its loop)"
+                            "(set SUPPORTS_USER_SIM and call its `respond` tool in the loop)"
                         )
-                    # The harness drives the user simulator over this `/user` endpoint (only when
-                    # one is set and the harness supports it); the base reaches the same server as
-                    # the model routes / `/state` channel.
-                    user_url = (
-                        f"{state_base.rstrip('/')}/user"
-                        if session.user is not None
-                        else None
-                    )
                     # setup done — the harness is now driving
                     now = time.time()
                     trace.timing.setup.end = now


### PR DESCRIPTION
## Summary

Makes the **user simulator an explicit harness feature** instead of a transparent interception trick, fixing the message-graph fork that happened whenever a rollout combined **task tools with a user simulator** (verifiers#1871).

The user simulator is already an MCP server — `vf.User` exposes a `respond` tool. So instead of the interception server playing out the exchange and handing the harness only the final assistant message (which forked the graph), the **harness drives the simulator itself over MCP**, exactly the way it already talks to tool servers:

- The `vf.User` is served as a **harness-reachable MCP server** (like a tool, but never shown to the model).
- On a no-tool-call turn, the harness's conversation driver calls the simulator's `respond` tool, appends the returned user message(s) to **its own** conversation, and re-prompts. A no-prompt task is opened by `respond("")` before the first model call. An empty reply means the simulator is done.
- So every user turn arrives in the harness's own next model call and is recorded as a **regular user message on the single branch** — no fork, no transparent injection.
- The **interception server drops out of the user-sim path entirely**: it's now a pure 1:1 model proxy that knows nothing about user simulation. The simulator's end-of-trajectory `@vf.stop` flag still reaches it over the existing `/state` channel like any other state.

This is the **same mechanism for every harness** — owned chat loops and external CLI agents alike (see below). No bespoke HTTP endpoint, no extra dependency: the program reuses the `mcp` client it already uses for tools.

### Changes
- **interception** (`server.py`): `handle_request` is a 1:1 model proxy; removed the internal inject-and-re-prompt loop, the opening-turn seed, and the `RolloutSession.user` field. (No `/user` endpoint, no `Dialect.extend` — both removed.)
- **launch** (`serve_user`): serves the `vf.User` harness-reachable (like a tool) and yields its MCP URL; `connect_user` stays as the host-side driver utility (for CLI-wrapper harnesses).
- **harness**: `Harness.run`/`launch` thread `user_url` (the simulator's MCP server); the rollout **gates** on `SUPPORTS_USER_SIM` (loud failure, not silent corruption).
- **default / bash / bash_edit** programs connect to the simulator's MCP server and call `respond` (a small `connect_user_sim` helper); deps stay `["openai", "mcp"]`.
- `rlm` / `codex` / others get the threaded param but keep `SUPPORTS_USER_SIM = False`.

## Why

Under transparent injection the interception server played the whole user/assistant exchange inside one program request and returned only the final assistant message to the harness. A harness that runs its own tool loop then re-prompted with its **own** view — which omitted the injected user turns — so `graph.prepare_turn` matched only a short prefix and forked the graph (`sampled=False` duplicate branches). Single-turn and tool-less user-sim rollouts were unaffected; **tools + user-sim** (e.g. BFCL v3 multi-turn) forked every turn, and naive `trace.branches[-1]` scoring saw only the tail. An OpenAI chat response can carry back only one assistant message, so there's no way to keep the harness's conversation correct while keeping it sim-unaware — the simulator has to be a capability the harness opts into.

## How CLI agents fit (same mechanism)

The user turn always comes from the simulator's `respond` tool and is injected through the harness's **native multi-turn input**, so it's a real user message and the graph stays linear — only the injection verb differs per agent (and it's each agent's real entry point, not a hack):

- **Codex** headless ([resume](https://developers.openai.com/codex/cli/reference)): `codex exec "<open>"` then, per turn, `respond(...)` → `codex exec resume <session_id> "<user msg>"`. Codex reconstructs context from its transcript and re-prompts with the user turn in history.
- **Claude Code** headless ([stream-json](https://code.claude.com/docs/en/headless)): `claude -p --input-format stream-json --output-format stream-json` is a bidirectional session — `respond(...)` → write a `{"type":"user",...}` line to stdin; Claude appends it and re-prompts.

In both, the host-side wrapper calls the same `respond` tool (via `connect_user`) and feeds the result into the CLI's own resume/stdin channel. (These two harnesses still set `SUPPORTS_USER_SIM = False` here — implementing their drivers is a follow-up; Codex also can't yet use our MCP *tools*, `SUPPORTS_MCP = False`.)

## Verification

New toy taskset `tool_user_sim_v1` (a calculator that must call a `calc_add` MCP tool **and** answer a user simulator across turns; no prompt, so the simulator opens it), plus an e2e regression test asserting the graph stays linear. On the `default` harness against `deepseek/deepseek-v4-flash`:

| | reward | `num_branches` |
|---|---|---|
| **before** (transparent injection) | 0.67 | **4** |
| **after** (harness-driven MCP) | 1.00 | **1** |

After, the graph is a single linear path: `system → user(2+3) → assistant(tool call) → tool(5) → assistant(<answer>5</answer>) → user(10+20) → …`. `bash` and `bash_edit` were smoke-checked on the same env (reward 1.0, `num_branches == 1`).

No regressions on the existing envs (all reward 1.0, `num_branches == 1`):
- `echo_user_sim_v1` (tool-less user sim, previously relied on transparent injection)
- `alphabet_sort_v1` (user sim, opens the conversation)
- `counter_tool_v1` (pure tools, no user sim)

Closes #1871.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
