### PR TITLE
chore: make harness MCP support opt-in (SUPPORTS_MCP defaults False)

### DIFF
--- a/verifiers/v1/GUIDE.md
+++ b/verifiers/v1/GUIDE.md
@@ -571,7 +571,7 @@ load instead of mis-running:
 
 | flag | default | gates |
 | --- | --- | --- |
-| `SUPPORTS_MCP` | `True` | exposes the task's MCP tools to the model (set `False` for a harness with no MCP client) |
+| `SUPPORTS_MCP` | `False` | exposes the task's MCP tools to the model (opt in: set `True` for a harness with an MCP client) |
 | `SUPPORTS_USER_SIM` | `False` | drives a task's user simulator (multi-turn user injection) |
 | `SUPPORTS_MESSAGE_PROMPT` | `False` | accepts a `Messages`-list `task.prompt` (e.g. image-bearing) |
 | `APPENDS_SYSTEM_PROMPT` | `False` | emits `task.system_prompt` as a real system message (else it's folded into the user prompt with a warning) |

--- a/verifiers/v1/harness.py
+++ b/verifiers/v1/harness.py
@@ -68,8 +68,8 @@ class Harness(ABC, Generic[ConfigT]):
 
     APPENDS_SYSTEM_PROMPT: ClassVar[bool] = False
     """Emit task.system_prompt as a system message (else fold into the user message)."""
-    SUPPORTS_MCP: ClassVar[bool] = True
-    """Expose a task's MCP tool servers to the model; set False for harnesses without an MCP client."""
+    SUPPORTS_MCP: ClassVar[bool] = False
+    """Expose a task's MCP tool servers to the model; opt in (set True) for harnesses with an MCP client."""
     SUPPORTS_USER_SIM: ClassVar[bool] = False
     """Drive a task's user simulator (multi-turn user injection); opt in per harness."""
     SUPPORTS_MESSAGE_PROMPT: ClassVar[bool] = False

--- a/verifiers/v1/harnesses/bash/harness.py
+++ b/verifiers/v1/harnesses/bash/harness.py
@@ -28,6 +28,7 @@ class BashHarnessConfig(HarnessConfig):
 
 class BashHarness(Harness[BashHarnessConfig]):
     APPENDS_SYSTEM_PROMPT = True
+    SUPPORTS_MCP = True
     SUPPORTS_USER_SIM = True
     SUPPORTS_MESSAGE_PROMPT = True
 

--- a/verifiers/v1/harnesses/bash_edit/harness.py
+++ b/verifiers/v1/harnesses/bash_edit/harness.py
@@ -34,6 +34,7 @@ class BashEditHarnessConfig(HarnessConfig):
 
 class BashEditHarness(Harness[BashEditHarnessConfig]):
     APPENDS_SYSTEM_PROMPT = True
+    SUPPORTS_MCP = True
     SUPPORTS_USER_SIM = True
     SUPPORTS_MESSAGE_PROMPT = True
 

--- a/verifiers/v1/harnesses/default/harness.py
+++ b/verifiers/v1/harnesses/default/harness.py
@@ -25,6 +25,7 @@ class DefaultHarnessConfig(HarnessConfig):
 
 class DefaultHarness(Harness[DefaultHarnessConfig]):
     APPENDS_SYSTEM_PROMPT = True
+    SUPPORTS_MCP = True
     SUPPORTS_USER_SIM = True
     SUPPORTS_MESSAGE_PROMPT = True
 

--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -57,6 +57,7 @@ class RLMHarnessConfig(HarnessConfig):
 
 class RLMHarness(Harness[RLMHarnessConfig]):
     APPENDS_SYSTEM_PROMPT = True
+    SUPPORTS_MCP = True
 
     async def setup(self, runtime: Runtime) -> None:
         # install.sh fetches curl/uv itself; add git only when the image lacks it.


### PR DESCRIPTION
## Summary
- Flip `Harness.SUPPORTS_MCP` from `True` → `False` on the base class, making MCP (task tool-server) support **opt-in**: a harness with an MCP client declares `SUPPORTS_MCP = True`, instead of every non-MCP harness having to remember to set it `False`. Matches how `SUPPORTS_USER_SIM` / `SUPPORTS_MESSAGE_PROMPT` already work.
- All concrete harnesses keep their current behavior. The four that relied on the `True` default now opt in explicitly: `default`, `bash`, `bash_edit`, `rlm`. The rest already declared a value (`kimi_code`/`compact` = `True`; `codex`/`mini_swe_agent`/`terminus_2` = `False`), so they're untouched.
- Updated the `GUIDE.md` capability-flag table (default `False`, opt-in wording). The enforcement in `env.py` (`not harness.SUPPORTS_MCP` → reject a tool-bearing taskset) is unchanged.

| harness | before | after |
| --- | --- | --- |
| default, bash, bash_edit, rlm | `True` (inherited) | `True` (explicit) |
| kimi_code, compact | `True` | `True` |
| codex, mini_swe_agent, terminus_2 | `False` | `False` |

## Breaking
- **Any out-of-tree harness that opted into MCP via the `True` default now loses it.** A harness that exposes the task's MCP tool servers must now declare `SUPPORTS_MCP = True` explicitly; otherwise it inherits `False` and running it against a tool-bearing taskset raises (`harness does not support task tools`). Migration: add `SUPPORTS_MCP = True` to any such harness. Harnesses that set `SUPPORTS_MCP = False` can drop the line (it's now the default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default `SUPPORTS_MCP` to `False` in `Harness` to make MCP support opt-in
> Changes the `SUPPORTS_MCP` class variable default from `True` to `False` in the base [`Harness`](https://github.com/PrimeIntellect-ai/verifiers/pull/1881/files#diff-05e981bb3680a934fbc6865d9dff3b25fc692d0c9970684bf8d41f4aea7ee384) class, so subclasses must explicitly opt in to MCP tool server exposure. [`BashHarness`](https://github.com/PrimeIntellect-ai/verifiers/pull/1881/files#diff-1544e2ee3426241d8c97940a3e8daf25b2eeeeb95f8abb27e88bed4af420e609), [`BashEditHarness`](https://github.com/PrimeIntellect-ai/verifiers/pull/1881/files#diff-23a81ba227704c9a098ec2513a06a9f85f4bfb3744cd855b75b332de90127fb1), [`DefaultHarness`](https://github.com/PrimeIntellect-ai/verifiers/pull/1881/files#diff-8da7b2f062c6d46854a8e31ee1b3b3dc34cd62aa9e8e8fd282a5607a585912c8), and [`RLMHarness`](https://github.com/PrimeIntellect-ai/verifiers/pull/1881/files#diff-3955da24b5fd88f62482297bbda7ba0936f633927f15576db27fed6e58f668ec) each set `SUPPORTS_MCP = True` to preserve their existing behavior. Behavioral Change: any custom harness subclass that previously inherited MCP support implicitly will no longer expose MCP tool servers unless it sets `SUPPORTS_MCP = True`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 82d8d93.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> In-tree harnesses are covered explicitly, but third-party harnesses that implicitly depended on MCP default True will silently lose tool support until they opt in.
> 
> **Overview**
> **MCP tool exposure on harnesses is now opt-in**, aligned with `SUPPORTS_USER_SIM` and `SUPPORTS_MESSAGE_PROMPT`.
> 
> The base `Harness` class changes `SUPPORTS_MCP` from `True` to `False`. In-tree harnesses that actually wire task MCP servers (`default`, `bash`, `bash_edit`, `rlm`) set `SUPPORTS_MCP = True` explicitly so behavior is unchanged. Load-time pairing in `env.py` is the same: a tool-bearing taskset still fails fast when the harness does not support MCP.
> 
> `GUIDE.md` updates the capability-flag table and wording to describe opt-in MCP.
> 
> **Breaking:** custom harnesses that relied on the old default must add `SUPPORTS_MCP = True` or tool tasksets will error at load.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82d8d93942a3e0c5bd07af508033412b18902637. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->