### PR TITLE
Use Harbor library for taskset downloads

### DIFF
--- a/verifiers/v1/tasksets/harbor/taskset.py
+++ b/verifiers/v1/tasksets/harbor/taskset.py
@@ -1,7 +1,7 @@
 """harbor: run a Harbor (Terminal-Bench) dataset.
 
 `dataset` is a Harbor Hub package id (e.g. "org/name" or "org/name@ref"),
-downloaded through the installed Harbor CLI and cached on first use. Each task
+downloaded through the installed Harbor library and cached on first use. Each task
 dir ships task.toml + instruction.md (+ tests/, solution/, environment/).
 Defaults to the registry `harbor/hello-world` dataset.
 
@@ -20,9 +20,6 @@ no environment at all also runs on that image, unless `require_image`.
 
 import hashlib
 import io
-import shutil
-import subprocess
-import sys
 import tarfile
 import tempfile
 import tomllib
@@ -30,6 +27,14 @@ from functools import lru_cache
 from pathlib import Path
 
 from pydantic import Field
+
+try:
+    from harbor.cli.download import download_command
+except ImportError as e:
+    raise ImportError(
+        "Harbor tasksets require Harbor. Install it with: "
+        "`uv sync --python 3.12 --extra harbor`"
+    ) from e
 
 from verifiers.v1.decorators import reward
 from verifiers.v1.errors import SandboxError
@@ -40,7 +45,6 @@ from verifiers.v1.trace import Trace
 from verifiers.v1.types import StrictBaseModel
 
 CACHE = Path.home() / ".cache" / "harbor"
-HARBOR_INSTALL_HINT = "uv sync --python 3.12 --extra harbor"
 
 
 class HarborConfig(TasksetConfig):
@@ -92,18 +96,6 @@ class HarborTask(Task):
     """Host path to the task dir; used to stage tests/ to verify, not serialized."""
 
 
-def harbor_cli() -> str:
-    """Return the Harbor CLI installed in the active Python environment."""
-    scripts_dir = Path(sys.executable).parent
-    harbor_bin = shutil.which("harbor", path=str(scripts_dir))
-    if harbor_bin is None:
-        raise RuntimeError(
-            "Harbor tasksets require the Harbor CLI from the `harbor` extra. "
-            f"Install it with: `{HARBOR_INSTALL_HINT}`"
-        )
-    return harbor_bin
-
-
 def cache_dir(config: HarborConfig) -> Path:
     selector_parts = [config.dataset]
     if config.repo is not None:
@@ -125,60 +117,33 @@ def cache_dir(config: HarborConfig) -> Path:
     return CACHE / name
 
 
-def download_command(config: HarborConfig, output_dir: Path) -> list[str]:
-    command = [
-        harbor_cli(),
-        "download",
-        config.dataset,
-        "--export",
-        "-o",
-        str(output_dir),
-    ]
-    if config.repo is not None:
-        command.extend(["--repo", config.repo])
-    if config.registry_path is not None:
-        registry_path = (
-            config.registry_path
-            if config.repo is not None
-            else config.registry_path.expanduser()
-        )
-        command.extend(["--registry-path", str(registry_path)])
-    if config.registry_url is not None:
-        command.extend(["--registry-url", config.registry_url])
-    return command
-
-
 def dataset_dir(config: HarborConfig) -> Path:
     """Download a Harbor task or dataset package, cached on first use.
 
     Harbor Hub refs are tags, integer revisions, or ``sha256:`` digests. Legacy registry
-    refs are selected through Harbor's CLI selectors (`repo`, `registry_path`,
-    `registry_url`).
+    refs are selected through `repo`, `registry_path`, or `registry_url`.
     """
     out = cache_dir(config)
     if out.is_dir():
         return out
 
     CACHE.mkdir(parents=True, exist_ok=True)
-    # Publish only a complete CLI export to the cache.
+    # Publish only a complete Harbor export to the cache.
     with tempfile.TemporaryDirectory(dir=CACHE) as temp:
         export_dir = Path(temp) / "export"
-        command = download_command(config, export_dir)
-        try:
-            subprocess.run(command, check=True, capture_output=True, text=True)
-        except subprocess.CalledProcessError as exc:
-            message = (
-                f"Harbor download failed for {config.dataset!r} with exit code "
-                f"{exc.returncode}"
-            )
-            outputs = [
-                output.strip()
-                for output in (exc.stdout, exc.stderr)
-                if isinstance(output, str) and output.strip()
-            ]
-            if output := "\n".join(outputs):
-                message = f"{message}:\n{output}"
-            raise RuntimeError(message) from exc
+        registry_path = config.registry_path
+        if registry_path is not None and config.repo is None:
+            registry_path = registry_path.expanduser()
+        download_command(
+            name=config.dataset,
+            output_dir=export_dir,
+            overwrite=False,
+            registry_url=config.registry_url,
+            registry_path=registry_path,
+            repo=config.repo,
+            export=True,
+            cache=False,
+        )
         try:
             export_dir.rename(out)
         except OSError:


### PR DESCRIPTION
## Overview

Use Harbor's installed Python library directly for v1 taskset downloads, replacing the subprocess-based CLI execution introduced in #1882.

## Details

- Import Harbor's Python download entrypoint and raise a clear `ImportError` when the optional dependency is unavailable.
- Delegate package detection, selector handling, and downloads to Harbor without resolving or spawning a CLI executable.
- Preserve the existing atomic cache publication and registry-specific cache keys.

This is a focused follow-up stacked on #1882.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the dataset fetch integration path for Harbor tasksets; behavior should match the CLI but errors and edge cases now depend on the library instead of wrapped subprocess output.
> 
> **Overview**
> Harbor v1 taskset caching no longer shells out to the `harbor` CLI. **`dataset_dir`** now calls Harbor’s **`harbor.cli.download.download_command`** in-process with the same dataset/registry selectors (`repo`, `registry_path`, `registry_url`) and export options.
> 
> The local **`harbor_cli()`** helper and subprocess-based argv builder are removed. Missing the optional Harbor dependency fails at import time with an **`ImportError`** pointing at **`uv sync --python 3.12 --extra harbor`**. Atomic cache publication and registry-specific cache keys are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee6d53fd9b3bfece207f9ac6453f0170254c63e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace subprocess-based Harbor CLI calls with the Harbor Python library for taskset downloads
> - Replaces `subprocess` invocations of the Harbor CLI with direct calls to `harbor.cli.download.download_command` in [taskset.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1884/files#diff-2bff5dabcb9a41f4d830e8bbb890e8cc6f5b8331ef2ac4c3b19ffad0e046fe00).
> - The `harbor_cli` helper and the local `download_command` function are removed; the module-level `download_command` name now refers to the imported library function with a different signature.
> - Download errors now surface as exceptions from the Harbor library rather than a synthesized `RuntimeError` from subprocess output.
> - Risk: importing the taskset module now raises `ImportError` immediately if the Harbor library is not installed, rather than deferring the error to runtime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ee6d53f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->