### PR TITLE
Make Harbor library downloads async-safe

### DIFF
--- a/verifiers/v1/tasksets/harbor/taskset.py
+++ b/verifiers/v1/tasksets/harbor/taskset.py
@@ -22,19 +22,12 @@ import hashlib
 import io
 import tarfile
 import tempfile
+import threading
 import tomllib
 from functools import lru_cache
 from pathlib import Path
 
 from pydantic import Field
-
-try:
-    from harbor.cli.download import download_command
-except ImportError as e:
-    raise ImportError(
-        "Harbor tasksets require Harbor. Install it with: "
-        "`uv sync --python 3.12 --extra harbor`"
-    ) from e
 
 from verifiers.v1.decorators import reward
 from verifiers.v1.errors import SandboxError
@@ -45,6 +38,7 @@ from verifiers.v1.trace import Trace
 from verifiers.v1.types import StrictBaseModel
 
 CACHE = Path.home() / ".cache" / "harbor"
+HARBOR_INSTALL_HINT = "uv sync --python 3.12 --extra harbor"
 
 
 class HarborConfig(TasksetConfig):
@@ -117,6 +111,61 @@ def cache_dir(config: HarborConfig) -> Path:
     return CACHE / name
 
 
+def download_with_harbor(config: HarborConfig, output_dir: Path) -> None:
+    try:
+        from harbor.cli import download as harbor_download
+    except ImportError as exc:
+        raise ImportError(
+            f"Harbor tasksets require Harbor. Install it with: `{HARBOR_INSTALL_HINT}`"
+        ) from exc
+
+    registry_path = config.registry_path
+    if registry_path is not None and config.repo is None:
+        registry_path = registry_path.expanduser()
+
+    error: Exception | None = None
+    output = ""
+
+    def run_download() -> None:
+        nonlocal error, output
+        capture = harbor_download.console.capture()
+        try:
+            with capture:
+                harbor_download.download_command(
+                    name=config.dataset,
+                    output_dir=output_dir,
+                    overwrite=False,
+                    registry_url=config.registry_url,
+                    registry_path=registry_path,
+                    repo=config.repo,
+                    export=True,
+                    cache=False,
+                )
+        except Exception as exc:
+            error = exc
+        finally:
+            output = capture.get().strip()
+
+    thread = threading.Thread(target=run_download, name="harbor-download")
+    thread.start()
+    thread.join()
+
+    if error is None:
+        return
+
+    exit_code = getattr(error, "exit_code", None)
+    message = f"Harbor download failed for {config.dataset!r}"
+    if exit_code is not None:
+        message = f"{message} with exit code {exit_code}"
+    details = [output] if output else []
+    error_text = str(error).strip()
+    if error_text and exit_code is None:
+        details.append(error_text)
+    if details:
+        message = f"{message}:\n" + "\n".join(details)
+    raise RuntimeError(message) from error
+
+
 def dataset_dir(config: HarborConfig) -> Path:
     """Download a Harbor task or dataset package, cached on first use.
 
@@ -131,19 +180,7 @@ def dataset_dir(config: HarborConfig) -> Path:
     # Publish only a complete Harbor export to the cache.
     with tempfile.TemporaryDirectory(dir=CACHE) as temp:
         export_dir = Path(temp) / "export"
-        registry_path = config.registry_path
-        if registry_path is not None and config.repo is None:
-            registry_path = registry_path.expanduser()
-        download_command(
-            name=config.dataset,
-            output_dir=export_dir,
-            overwrite=False,
-            registry_url=config.registry_url,
-            registry_path=registry_path,
-            repo=config.repo,
-            export=True,
-            cache=False,
-        )
+        download_with_harbor(config, export_dir)
         try:
             export_dir.rename(out)
         except OSError:


### PR DESCRIPTION
## Summary

- Keep #1884's in-process Harbor download path, but import Harbor lazily only when a download is needed.
- Run Harbor's Typer download callback in a worker thread so its internal `asyncio.run(...)` does not collide with Verifiers' async eval/validate loop.
- Capture Harbor's Rich console output and include it in the raised Verifiers `RuntimeError` on download failures.

## Validation

- `uv run --frozen --python 3.12 --extra harbor` async smoke: uncached `harbor/hello-world` download inside `asyncio.run(...)` loaded `hello-world/hello-world`.
- `uv run --frozen --python 3.12 --extra harbor` selector-error smoke: `repo + registry_url` raised a Verifiers `RuntimeError` containing Harbor's own `Error: --repo and --registry-url are mutually exclusive`.
- `uv run --frozen --python 3.12 --extra harbor` local registry smoke: `registry_path=Path("~/harbor-registry-test-1884.json")` expanded and loaded `3d_print_shop_t0` from `general-agent@2026-06-25`.
- Fresh core `uv run --frozen --python 3.12 python`: `import verifiers.v1.tasksets` succeeds without Harbor installed.
- Fresh core `uv run --frozen --python 3.11 python`: `import verifiers.v1.tasksets` succeeds without Harbor installed.
- `uv lock --check --python 3.11`
- `uv lock --check --python 3.12`
- `uv run --python 3.13 ty check verifiers`
- `uv run --frozen --python 3.12 pre-commit run --files verifiers/v1/tasksets/harbor/taskset.py`
- `git push` pre-push hook: ruff check, ruff format, sync check, `ty (ci parity)`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make Harbor library downloads async-safe by running them in a dedicated thread
> - Harbor downloads in [`taskset.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1887/files#diff-2bff5dabcb9a41f4d830e8bbb890e8cc6f5b8331ef2ac4c3b19ffad0e046fe00) are now executed in a separate thread via a new `download_with_harbor` helper, making them safe to call from async contexts.
> - The module no longer eagerly imports `harbor.cli.download` at import time; Harbor presence is validated at call time, raising `ImportError` with an install hint if missing.
> - Download failures now raise a `RuntimeError` with the exit code and captured console output for easier debugging.
> - Behavioral Change: code that previously caught `ImportError` at import time must now handle it at call time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 636a96f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how and when Harbor is loaded and how download errors surface; behavior is localized to Harbor taskset caching but affects any async path that triggers uncached downloads.
> 
> **Overview**
> Harbor dataset fetching no longer imports Harbor at module load time, so core Verifiers can import tasksets without the optional `harbor` extra until a download actually runs.
> 
> Downloads are routed through a new **`download_with_harbor`** helper that lazy-imports Harbor, runs **`download_command`** on a dedicated **`harbor-download`** thread (so Harbor’s internal **`asyncio.run`** does not clash with Verifiers’ async eval loop), and wraps failures in a **`RuntimeError`** that includes exit codes and captured Rich console output when available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 636a96fd87dce7b534a69d6eee699e856f5f29b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->