### PR TITLE
fix(router): clear request bookkeeping on cancel (forward_cancel leak)

### DIFF
--- a/tests/test_env_router_cancel.py
+++ b/tests/test_env_router_cancel.py
@@ -1,0 +1,55 @@
+"""Regression: EnvRouter.forward_cancel must clear request bookkeeping (no leak).
+
+A cancel that yields no terminal response would otherwise leave
+``request_to_worker`` + the worker's ``active_requests`` populated forever — the
+``complete_request`` cleaner runs only on the response path, which never fires
+for a request cancelled before it responds. (Upstream #1055; surfaced in the
+prime-rl #76 PR1 review as F3.)
+
+Builds the router via ``__new__`` to skip the ZMQ-IPC ``__init__`` —
+``forward_cancel`` only touches ``self.workers`` + ``self.request_to_worker``.
+"""
+
+import asyncio
+
+from verifiers.serve.server.env_router import ActiveRequestInfo, EnvRouter, WorkerHandle
+
+
+class FakeSock:
+    def __init__(self) -> None:
+        self.sent: list = []
+
+    async def send_multipart(self, frames) -> None:
+        self.sent.append(frames)
+
+
+def _router_with_inflight_request():
+    router = EnvRouter.__new__(EnvRouter)
+    sock = FakeSock()
+    router.workers = {
+        0: WorkerHandle(worker_id=0, process=None, address="ipc://x", socket=sock)
+    }
+    router.request_to_worker = {}
+    rid, cid = b"req-1", b"cli-1"
+    router.workers[0].active_requests[rid] = ActiveRequestInfo(
+        client_id=cid, request_id=rid, worker_id=0, payload=b""
+    )
+    router.request_to_worker[rid] = 0
+    return router, sock, rid, cid
+
+
+def test_forward_cancel_clears_bookkeeping():
+    router, sock, rid, cid = _router_with_inflight_request()
+    asyncio.run(router.forward_cancel(rid, cid))
+    # cancel forwarded to the worker...
+    assert sock.sent == [[cid, rid, b""]]
+    # ...and both bookkeeping dicts cleared (the leak fix)
+    assert rid not in router.request_to_worker
+    assert rid not in router.workers[0].active_requests
+
+
+def test_forward_cancel_unknown_request_is_noop():
+    router, sock, rid, _cid = _router_with_inflight_request()
+    asyncio.run(router.forward_cancel(b"unknown", b"cli-x"))
+    assert sock.sent == []  # nothing forwarded
+    assert rid in router.request_to_worker  # the known request is untouched

--- a/verifiers/serve/server/env_router.py
+++ b/verifiers/serve/server/env_router.py
@@ -343,7 +343,14 @@ class EnvRouter:
         self.request_to_worker[request_id] = worker_id
 
     async def forward_cancel(self, request_id: bytes, client_id: bytes) -> None:
-        """Forward a cancel signal to the worker owning this request."""
+        """Forward a cancel to the owning worker and drop the request's bookkeeping.
+
+        A cancelled request is terminal — the worker stops and no response will
+        arrive — so its ``request_to_worker`` / ``active_requests`` entries must be
+        cleared here. ``complete_request`` (the only other cleaner) runs solely on
+        the response path, which never fires for a request cancelled before it
+        responds; without this, both dicts leak on every such cancel.
+        """
         worker_id = self.request_to_worker.get(request_id)
         if worker_id is not None:
             worker = self.workers.get(worker_id)
@@ -352,6 +359,9 @@ class EnvRouter:
                     await worker.socket.send_multipart([client_id, request_id, b""])
                 except zmq.ZMQError:
                     pass
+        # Idempotent pop of both dicts; a late in-flight response that also calls
+        # complete_request is harmless (pop with default).
+        self.complete_request(request_id)
 
     def complete_request(self, request_id: bytes) -> ActiveRequestInfo | None:
         """Update bookkeeping after a response is received. Returns the info or None."""


### PR DESCRIPTION
### Problem
`EnvRouter.forward_cancel` (added in #1055) forwards the cancel signal to the owning worker but never clears its tracking entries — `request_to_worker[request_id]` and `worker.active_requests[request_id]`. The only code that clears them, `complete_request`, runs solely on the response path. A request cancelled *before* it produces a response therefore never gets cleaned up, so both dicts leak one entry per such cancel. Routers that routinely cancel in-flight requests (e.g. off-policy / lag-based RL that cancels stale rollouts) accumulate stale entries unboundedly.

### Fix
`forward_cancel` calls `complete_request(request_id)` after forwarding the cancel. The pop is idempotent, so a late in-flight response that also calls `complete_request` is harmless.

### Test
`tests/test_env_router_cancel.py` — constructs the router via `__new__` (no ZMQ), asserts a cancel clears both dicts, and that an unknown request is a no-op. Fails on `main` (entries retained), passes with the fix.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix request bookkeeping leak in `EnvRouter.forward_cancel`
> - `forward_cancel` in [env_router.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1888/files#diff-5f42e5c44b82aeddf6020de01b59c5480cac9144a3f6ffc79c3ee01683ad92ec) now calls `complete_request` after forwarding the cancel frame, removing the request from `request_to_worker` and the worker's `active_requests`.
> - Previously, cancelled requests were never cleaned up, causing a permanent bookkeeping leak since no response arrives to trigger normal cleanup.
> - Cleanup runs unconditionally (outside the send conditional) and uses idempotent `pop` calls, so late responses that arrive after cancellation still clean up safely.
> - Adds regression tests in [test_env_router_cancel.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1888/files#diff-2b3766ba6ca4585aba67e9493c2c4c291343f84dc51f11842b2b716335b7b025) covering both the cleanup path and the no-op behavior for unknown request IDs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 051b399.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->