### PR TITLE
[codex] Fix train renderer pool cache

### DIFF
--- a/tests/v1/test_train_client.py
+++ b/tests/v1/test_train_client.py
@@ -1,0 +1,43 @@
+from unittest.mock import call, patch
+
+from verifiers.v1.clients.train import TrainClient
+
+
+def test_train_client_renderer_pool_cache_splits_chat_template_kwargs() -> None:
+    client = TrainClient(openai=object(), pool_size=2)
+    pools = [object(), object(), object()]
+
+    with patch("renderers.create_renderer_pool", side_effect=pools) as create_pool:
+        first = client._renderer_pool(
+            "Qwen/Qwen3-8B",
+            chat_template_kwargs={"enable_thinking": False},
+        )
+        same = client._renderer_pool(
+            "Qwen/Qwen3-8B",
+            chat_template_kwargs={"enable_thinking": False},
+        )
+        changed = client._renderer_pool(
+            "Qwen/Qwen3-8B",
+            chat_template_kwargs={"enable_thinking": True},
+        )
+        default = client._renderer_pool("Qwen/Qwen3-8B")
+
+    assert first is pools[0]
+    assert same is first
+    assert changed is pools[1]
+    assert default is pools[2]
+    assert create_pool.call_args_list == [
+        call(
+            "Qwen/Qwen3-8B",
+            None,
+            size=2,
+            chat_template_kwargs={"enable_thinking": False},
+        ),
+        call(
+            "Qwen/Qwen3-8B",
+            None,
+            size=2,
+            chat_template_kwargs={"enable_thinking": True},
+        ),
+        call("Qwen/Qwen3-8B", None, size=2),
+    ]

--- a/verifiers/v1/clients/train.py
+++ b/verifiers/v1/clients/train.py
@@ -191,7 +191,7 @@ class TrainClient(Client):
         self.pool_size = pool_size
         self.config = config
         self.renderer_model_name = renderer_model_name
-        self._pool = None
+        self._pools: dict[tuple[str, str | None], Any] = {}
 
     def _renderer_pool(
         self,
@@ -200,18 +200,24 @@ class TrainClient(Client):
         chat_template_kwargs: Mapping[str, Any] | None = None,
     ):
         renderer_model = self.renderer_model_name or model
-        if self._pool is None:
+        kwargs_key = (
+            json.dumps(chat_template_kwargs, sort_keys=True, separators=(",", ":"))
+            if chat_template_kwargs
+            else None
+        )
+        cache_key = (renderer_model, kwargs_key)
+        if cache_key not in self._pools:
             from renderers import create_renderer_pool
 
             pool_kwargs: dict[str, Any] = {"size": self.pool_size}
             if chat_template_kwargs:
                 pool_kwargs["chat_template_kwargs"] = chat_template_kwargs
-            self._pool = create_renderer_pool(
+            self._pools[cache_key] = create_renderer_pool(
                 renderer_model,
                 self.config,
                 **pool_kwargs,
             )
-        return self._pool
+        return self._pools[cache_key]
 
     async def get_response(
         self,


### PR DESCRIPTION
## Summary

- Cache v1 `TrainClient` renderer pools by effective renderer model and serialized `chat_template_kwargs`.
- Add a regression test proving identical kwargs reuse a pool while changed or absent kwargs get distinct pools.

## Root Cause

Commit `a8036b441` / PR #1876 threaded per-request `chat_template_kwargs` into `create_renderer_pool`, but `TrainClient` still cached a single `self._pool`. The first request could therefore lock in one renderer pool and leak its chat-template settings into later requests with different kwargs or no kwargs.

## Impact

Training/eval paths using the v1 train renderer client can now safely mix requests with different chat-template options, such as Qwen thinking settings, without cross-request pool contamination.

## Validation

- `uv run pytest tests/v1/test_train_client.py`
- `uv run ruff check --fix verifiers/v1/clients/train.py tests/v1/test_train_client.py`
- `git diff --check`

Note: repo-wide `uv run ruff check --fix` is currently blocked by an unrelated existing Python 3.11 f-string parse issue in `verifiers/v1/cli/dashboard/eval.py:194`. The pre-commit/pre-push hooks also reintroduced unrelated `uv.lock` exclude-newer churn, so the commit and push used the already-passing targeted checks while keeping `uv.lock` out of the PR.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `TrainClient._renderer_pool` to cache pools per model and chat template kwargs
> - Replaces the single shared `_pool` attribute in [train.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1889/files#diff-c9bcd6c691890b1de6942fe012d2e74678460b22bf335721a8bba5e939d139c3) with a `_pools` dict keyed by `(renderer_model, serialized_chat_template_kwargs)`.
> - Creates a new renderer pool when the key is absent, and reuses the existing pool when the key matches — enabling distinct pools per unique combination of model and chat template kwargs.
> - Adds a unit test in [test_train_client.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1889/files#diff-d0c0196d41fedc1080f5045dd27459b47ac6c42b7fbd6d03cc5c728ababcb3ac) verifying that identical kwargs reuse the same pool, differing kwargs (e.g. `enable_thinking`) produce a new pool, and omitting kwargs produces a third pool.
> - Behavioral Change: callers that previously shared one pool across all invocations will now get distinct pools when `chat_template_kwargs` differ.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e8dce84.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->