### PR TITLE
fix: download sandbox logs in PrimeRuntime.run to avoid read-file 10MB limit

### DIFF
--- a/verifiers/v1/runtimes/prime.py
+++ b/verifiers/v1/runtimes/prime.py
@@ -120,6 +120,8 @@ class PrimeRuntime(Runtime):
             raise SandboxError(f"prime sandbox provisioning failed: {e}") from e
 
     async def run(self, argv: list[str], env: dict[str, str]) -> ProgramResult:
+        from prime_sandboxes import SandboxFileNotFoundError
+
         try:
             # Poll directly so the rollout stage owns the execution timeout; the SDK helper
             # otherwise imposes its own 15-minute limit.
@@ -131,20 +133,35 @@ class PrimeRuntime(Runtime):
             )
             delay = 0.1
             while True:
-                result = await self._client.get_background_job(self._sandbox_id, job)
-                if result.completed:
-                    break
+                # Poll the (tiny) exit file directly. get_background_job would instead read the
+                # stdout/stderr logs inline, which 413 once they pass the gateway read-file size
+                # limit (e.g. a verbose test runner emitting tens of MB).
+                try:
+                    exit_content = (
+                        await self._client.read_file(self._sandbox_id, job.exit_file)
+                    ).content.strip()
+                except SandboxFileNotFoundError:
+                    exit_content = ""
+                if exit_content:
+                    try:
+                        exit_code = int(exit_content)
+                        break
+                    except ValueError:
+                        pass  # exit file mid-write — keep polling
                 await asyncio.sleep(delay)
                 delay = min(delay * 2, 3)
+            # Download the logs (no read-file size limit) rather than reading them inline.
+            stdout = (await self._download_bytes(job.stdout_log_file)).decode(
+                "utf-8", "replace"
+            )
+            stderr = (await self._download_bytes(job.stderr_log_file)).decode(
+                "utf-8", "replace"
+            )
         except (
             Exception
         ) as e:  # a sandbox/API failure is one rollout's problem, not the eval's
             raise SandboxError(f"prime exec failed: {e}") from e
-        return ProgramResult(
-            exit_code=result.exit_code or 0,
-            stdout=result.stdout or "",
-            stderr=result.stderr or "",
-        )
+        return ProgramResult(exit_code=exit_code, stdout=stdout, stderr=stderr)
 
     async def expose(self, port: int) -> str | None:
         # Publish a server hosted IN the sandbox via the SDK's native port exposure → a public
@@ -175,21 +192,22 @@ class PrimeRuntime(Runtime):
                 f"prime background launch failed: {result.stderr.strip()}"
             )
 
-    async def read(self, path: str) -> bytes:
-        # Avoid background-job log limits and base64 overhead by downloading binary data directly.
+    async def _download_bytes(self, path: str) -> bytes:
+        # Avoid the gateway read-file size limit and base64 overhead by downloading directly.
         # The temporary file is removed on every exit, and its byte read stays off the event loop.
+        with tempfile.TemporaryDirectory() as directory:
+            download = Path(directory) / "download"
+            await self._client.download_file(self._sandbox_id, path, str(download))
+            return await asyncio.to_thread(download.read_bytes)
+
+    async def read(self, path: str) -> bytes:
         target = (
             path
             if path.startswith("/")
             else f"{self.config.workdir.rstrip('/')}/{path}"
         )
         try:
-            with tempfile.TemporaryDirectory() as directory:
-                download = Path(directory) / "download"
-                await self._client.download_file(
-                    self._sandbox_id, target, str(download)
-                )
-                return await asyncio.to_thread(download.read_bytes)
+            return await self._download_bytes(target)
         except Exception as e:
             raise SandboxError(f"read {path!r}: {e}") from e
 


### PR DESCRIPTION
## Summary

- `PrimeRuntime.run` polled `get_background_job`, which reads the job's stdout/stderr logs **inline** via the SDK's `read_file` → gateway `/read-file` endpoint. That endpoint caps reads at 10MB and returns **HTTP 413** (`File size (...) exceeds max read size (10485760 bytes). Use /download instead`). Any command emitting >10MB of output (e.g. a verbose test runner) therefore killed the whole rollout with `SandboxError: prime exec failed: Read file failed: HTTP 413 ...`.
- Fix: poll the tiny exit file directly with `read_file`, then fetch stdout/stderr via `download_file` (no size limit) once the job completes. This mirrors `read()`, which already downloads to dodge this exact limit. The download is factored into a shared `_download_bytes` helper that `read()` now reuses.

This is a latent bug for **any** env whose program emits >10MB on stdout/stderr; it surfaced first in `scaleswe_v1` (its `pytest -vv` scorer produced ~28MB of stdout).

## Verification

Before: a scaleswe-v1 rollout whose scorer emitted 28MB of stdout failed with
```
SandboxError: prime exec failed: Read file failed: HTTP 413 GET .../read-file?path=%2Ftmp%2Fjob_d370cedb.stdout.log: {"error":"File size (28135205 bytes) exceeds max read size (10485760 bytes). Use /download instead."}
```
After: stdout/stderr are downloaded rather than read inline, so the 10MB read-file cap no longer applies. (No behavior change for small output; the background-job wrapper always creates both log files via redirection, so the download cannot 404.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Download sandbox logs in `PrimeRuntime.run` to avoid the 10MB read-file limit
> - Replaces the `get_background_job` polling approach in [`prime.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1890/files#diff-d22d61279ff7587a2b14c72ab1a0fc9d3f805a735338a70f8efc7fe19aaa8502) with direct polling of the job's exit file via `client.read_file`, parsing the exit code from its contents.
> - After detecting job completion, stdout and stderr are fetched via a new `_download_bytes` helper that uses `client.download_file` to a temp location, bypassing the gateway's inline read-file size limit.
> - Refactors `PrimeRuntime.read` to delegate to the same `_download_bytes` helper for consistency.
> - Behavioral Change: `run` now returns stdout/stderr decoded from downloaded files rather than inline API responses; large log outputs that previously failed or were truncated will now be returned in full.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8d5cc55.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->