### PR TITLE
fix: make uv-script prep hermetic to image uv config (--no-config)

### DIFF
--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -191,11 +191,6 @@ class Runtime(ABC):
                         ["sh", "-c", f"mv -f {shlex.quote(tmp)} {shlex.quote(path)}"],
                         {},
                     )
-                    # --no-config: ignore any uv config (uv.toml / pyproject [tool.uv]) discovered
-                    # in the runtime's cwd or HOME. Task images/repos can pin `required-version`
-                    # (e.g. `~=0.9.0`), which the freshly installed latest uv would otherwise violate,
-                    # failing the resolve. Our PEP 723 scripts declare deps inline, so discovered
-                    # project config is irrelevant to staging them.
                     command = (
                         f"{_ENSURE_UV}; uv sync --script {shlex.quote(path)} -q --no-config "
                         f"&& uv python find --script {shlex.quote(path)} --no-config"

--- a/verifiers/v1/runtimes/base.py
+++ b/verifiers/v1/runtimes/base.py
@@ -191,9 +191,14 @@ class Runtime(ABC):
                         ["sh", "-c", f"mv -f {shlex.quote(tmp)} {shlex.quote(path)}"],
                         {},
                     )
+                    # --no-config: ignore any uv config (uv.toml / pyproject [tool.uv]) discovered
+                    # in the runtime's cwd or HOME. Task images/repos can pin `required-version`
+                    # (e.g. `~=0.9.0`), which the freshly installed latest uv would otherwise violate,
+                    # failing the resolve. Our PEP 723 scripts declare deps inline, so discovered
+                    # project config is irrelevant to staging them.
                     command = (
-                        f"{_ENSURE_UV}; uv sync --script {shlex.quote(path)} -q "
-                        f"&& uv python find --script {shlex.quote(path)}"
+                        f"{_ENSURE_UV}; uv sync --script {shlex.quote(path)} -q --no-config "
+                        f"&& uv python find --script {shlex.quote(path)} --no-config"
                     )
                     result = await self.run(["sh", "-c", command], env or {})
                     if result.exit_code != 0:


### PR DESCRIPTION
## Summary

- Make PEP 723 script preparation in `Runtime.prepare_uv_script` hermetic to whatever uv configuration the runtime environment carries, by passing `--no-config` to both `uv sync --script` and `uv python find --script`.

## Problem

`prepare_uv_script` installs the latest `uv` into `~/.local/bin` (via `_ENSURE_UV`) and runs it ahead of any uv the image ships. It then resolves the script with:

```
uv sync --script <path> -q && uv python find --script <path>
```

`uv` discovers configuration (`uv.toml`, `pyproject.toml [tool.uv]`) from the runtime's cwd / HOME and applies `required-version` from it. When a task image or repo pins an older uv (e.g. `required-version = "~=0.9.0"`), the freshly installed latest uv fails the resolve:

```
HarnessError: harness setup: RuntimeError: failed to prepare uv script: downloading uv 0.11.25 x86_64-unknown-linux-gnu
error: Required uv version `~=0.9.0` does not match the running version `0.11.25`
```

This showed up as intermittent `harness setup` failures during **scaleswe** training, where rollouts run inside SWE task containers whose repos pin older uv versions. It is non-deterministic across the dataset because only some task repos carry such a pin.

## Fix

Pass `--no-config` to both subcommands so script staging ignores any discovered `uv.toml` / `pyproject [tool.uv]` (including `required-version`, custom indexes, etc.). Our PEP 723 scripts declare their dependencies inline, so discovered project config is irrelevant to staging them. `--no-config` only ignores config *files* — environment-variable settings (`UV_INDEX_*`, …) still apply.

## Verification

Reproduced the exact failure and confirmed the fix, with a `required-version` pin discovered from the cwd:

```console
$ printf 'required-version = "~=0.9.0"\n' > uv.toml      # simulates a task repo's pin

# before — discovered config rejects the running uv
$ uv sync --script script.py -q
error: Required uv version `~=0.9.0` does not match the running version `0.11.24`

# after — config files ignored, resolve succeeds
$ uv sync --script script.py -q --no-config && uv python find --script script.py --no-config
/home/.../environments-v2/script-<hash>/bin/python3
```

Same result when the pin lives in `pyproject.toml [tool.uv]` instead of `uv.toml`.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make uv-script interpreter prep hermetic by adding `--no-config` to `uv sync` and `uv python find`
> Appends `--no-config` to both `uv sync --script` and `uv python find --script` calls in [base.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1891/files#diff-0811c040a163eb5a3212208f1e3a6c6388d7690fcc4780c081cc7754036232b9), causing uv to ignore any configuration files present in the image during script preparation. This ensures the script environment is not affected by image-level uv config.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 494d1b7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Two-flag change on an isolated infra path; reduces failure modes without altering auth, data, or rollout logic.
> 
> **Overview**
> **PEP 723 script staging** in `Runtime.prepare_uv_script` now passes **`--no-config`** to both `uv sync --script` and `uv python find --script`, so uv ignores `uv.toml` / `pyproject.toml [tool.uv]` discovered from the runtime cwd or `HOME`.
> 
> That stops freshly bootstrapped uv (latest) from failing when task images or SWE repos pin an older `required-version`, which was causing intermittent **harness setup** errors during rollouts. Inline PEP 723 deps remain the source of truth for staging; env-based uv settings still apply.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 494d1b7f782eaa9e8673cacf87ee07c1bab43f6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->