### PR TITLE
feat(v1): resume dashboard counts the whole run, not just resumed rollouts

### DIFF
--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -209,15 +209,24 @@ def Overview(config: EvalConfig) -> Table:
 
 
 def Progress(
-    rollouts: list[Rollout], start: float, page: tuple[int, int] | None = None
+    rollouts: list[Rollout],
+    start: float,
+    page: tuple[int, int] | None = None,
+    finished: list[Trace] | None = None,
 ) -> Group:
-    done = [r.trace for r in rollouts if r.phase == Phase.DONE]  # fully scored
+    # On resume, `finished` holds the kept on-disk rollouts (reloaded as finished traces); count
+    # them alongside this session's so progress, reward, err, and the breakdown cover the whole
+    # run. `rollouts` is only this session's (owed) work, so the total adds the kept ones back.
+    done = (finished or []) + [
+        r.trace for r in rollouts if r.phase == Phase.DONE
+    ]  # fully scored
+    total = len(finished or []) + len(rollouts)
     # Headline reward = mean over non-errored; when any errored, `format_mean` appends the
     # global avg (errored count as 0) in parens. `err` is the share that errored.
     reward = format_mean(done, lambda t: t.reward)
     err = f"{sum(t.has_error for t in done) / len(done):.2f}" if done else "—"
     stats = (
-        f"{len(done)}/{len(rollouts)} · {format_time(time.time() - start)} · "
+        f"{len(done)}/{total} · {format_time(time.time() - start)} · "
         f"reward {reward} · err {err}"
     )
     if page is not None:  # overflowing — show which page, and that the arrows page
@@ -226,7 +235,7 @@ def Progress(
     row.add_column(ratio=1)  # bar stretches to fill the width left of the stats
     row.add_column(justify="right", no_wrap=True)
     row.add_row(
-        ProgressBar(total=len(rollouts) or 1, completed=len(done)),
+        ProgressBar(total=total or 1, completed=len(done)),
         Text(stats),
     )
     breakdown = _breakdown(done)
@@ -561,7 +570,11 @@ def _paginate(
 
 
 def _render(
-    rollouts: list[Rollout], config: EvalConfig, start: float, pager: Pager
+    rollouts: list[Rollout],
+    config: EvalConfig,
+    start: float,
+    pager: Pager,
+    finished: list[Trace] | None = None,
 ) -> Group:
     now = time.time()
     warning = _warning(config)
@@ -570,10 +583,15 @@ def _render(
     # Measure the fixed top (header + progress + rule) so the rollout rows fill the rest of the
     # screen; page through them (timer, or the left/right arrows) when they'd overflow (rich would
     # otherwise truncate).
-    top = Group(header, Progress(rollouts, start), Rule(style="dim"))
+    top = Group(header, Progress(rollouts, start, finished=finished), Rule(style="dim"))
     rows_per_page = max(1, _CONSOLE.size.height - len(_CONSOLE.render_lines(top)) - 1)
     page_groups, index, count = _paginate(_groups(rollouts), rows_per_page, pager, now)
-    progress = Progress(rollouts, start, page=(index + 1, count) if count > 1 else None)
+    progress = Progress(
+        rollouts,
+        start,
+        page=(index + 1, count) if count > 1 else None,
+        finished=finished,
+    )
     return Group(
         header,
         progress,
@@ -583,11 +601,18 @@ def _render(
 
 
 @contextlib.asynccontextmanager
-async def dashboard(rollouts: list[Rollout], config: EvalConfig, start: float):
+async def dashboard(
+    rollouts: list[Rollout],
+    config: EvalConfig,
+    start: float,
+    finished: list[Trace] | None = None,
+):
     """Refresh the live eval view until the `with` block exits, then a final frame. Left/right
-    arrows page through rollout rows when they overflow the screen."""
+    arrows page through rollout rows when they overflow the screen. On resume, `finished` carries
+    the kept on-disk rollouts (reloaded as finished traces) so the counts and scores cover the
+    whole run, not just this session's re-run rollouts."""
     pager = Pager()
     async with live_view(
-        lambda: _render(rollouts, config, start, pager), on_key=pager.on_key
+        lambda: _render(rollouts, config, start, pager, finished), on_key=pager.on_key
     ):
         yield

--- a/verifiers/v1/cli/eval/resume.py
+++ b/verifiers/v1/cli/eval/resume.py
@@ -16,7 +16,12 @@ from pathlib import Path
 
 from pydantic_core import from_json
 
+from verifiers.v1.cli.output import read_traces
 from verifiers.v1.configs.eval import EvalConfig
+from verifiers.v1.state import state_cls
+from verifiers.v1.task import WireTask
+from verifiers.v1.taskset import Taskset
+from verifiers.v1.trace import Trace
 
 
 def split_resume(argv: list[str]) -> tuple[Path | None, list[str]]:
@@ -114,6 +119,14 @@ def rewrite_results(resume_dir: Path, keep: list[int]) -> None:
             if not raw.endswith(b"\n"):
                 output.write(b"\n")
     tmp.replace(path)
+
+
+def load_kept(resume_dir: Path, taskset: Taskset) -> list[Trace]:
+    """Reload the kept (good) traces as finished `Trace`s, so a resumed run's live dashboard counts
+    them toward the whole run (progress, reward, err, and the usage/time breakdown). Call *after*
+    `rewrite_results`, which leaves only the kept rows on disk. `WireTask` reads any taskset's saved
+    task without a runtime or its `Task` type (mirrors `replay`)."""
+    return read_traces(resume_dir, Trace[WireTask, state_cls(type(taskset))])
 
 
 def nothing_to_resume_msg(resume_dir: Path, num_tasks: int, num_rollouts: int) -> str:

--- a/verifiers/v1/cli/eval/runner.py
+++ b/verifiers/v1/cli/eval/runner.py
@@ -41,6 +41,10 @@ async def run_eval(env: Environment, config: EvalConfig) -> list[Trace]:
     # run only the owed rollouts. One lock serializes worker-thread appends from concurrent
     # rollouts while keeping large trace serialization off the event loop.
     owed: dict[str, int] | None = None
+    # On resume, the kept (good) on-disk rollouts, reloaded as finished traces so the live
+    # dashboard counts the whole run (progress, reward, err, usage/time) rather than only this
+    # session's re-run rollouts. Only the --rich dashboard reads them, so skip the load otherwise.
+    finished: list[Trace] = []
     if config.resume is not None:
         group = bool(discover_decorated(env.taskset, "group_reward"))
         keep, owed = resume.plan(
@@ -51,6 +55,8 @@ async def run_eval(env: Environment, config: EvalConfig) -> list[Trace]:
             raise SystemExit(0)
         tasks = [task for task in tasks if owed.get(task.idx)]
         resume.rewrite_results(out, keep)
+        if config.rich:
+            finished = resume.load_kept(out, env.taskset)
         logger.info(
             "resuming %s: %d task(s), %d rollout(s) owed",
             out,
@@ -84,7 +90,7 @@ async def run_eval(env: Environment, config: EvalConfig) -> list[Trace]:
         ]
         rollouts = [rollout for episode in episodes for rollout in episode.rollouts]
         display = (
-            dashboard(rollouts, config, start)
+            dashboard(rollouts, config, start, finished=finished)
             if config.rich
             else contextlib.nullcontext()
         )


### PR DESCRIPTION
## What

On `--resume`, the live eval dashboard counted only the **re-run** rollouts and ignored the ones already kept on disk. This makes it reflect the **whole run**.

The runner hands the dashboard only the *owed* (missing + errored) rollouts on resume, so:

- **Before** — the counter's numerator *and denominator* covered only that resumed slice. The bar started empty and filled to full, but "full" only ever meant the re-run rollouts, and the reward / err / breakdown reflected just those.
- **After** — the kept rollouts seed the counter and scores. The bar starts **already partly filled** at the kept count and fills to the true total, and the headline reward / err share / reward-metric breakdown / usage / time all fold in the kept on-disk rows.

Concretely, a 100-rollout run resumed with 40 kept / 60 re-run:

| | start | end | denominator | reward covers |
|---|---|---|---|---|
| **before** | `0/60` | `60/60` | remaining (60) | 60 resumed only |
| **after** | `40/100` | `100/100` | all (100) | all 100 |

So the counter goes from `0/remaining` to `done/all` — it starts at `40/100` instead of `0/60`.

## How

Rather than keep score aggregates around, reload the kept traces once and treat them as finished rollouts (per review discussion):

- After `resume.rewrite_results` leaves only the kept (good) rows on disk, `resume.load_kept` reloads them as finished `Trace`s — via `read_traces` + `WireTask`, the same offline-load path `replay` uses (no runtime, no taskset `Task` type needed).
- The runner passes them to the dashboard as `finished`; `Progress` folds them into its `done` list (`done = finished + this session's done`) and adds them back into the total. Reward, err, and the per-component / usage / time breakdown then fall out of the **existing** code with no special-casing — `format_mean` and `_breakdown` are untouched.
- Only the `--rich` dashboard loads the traces (skipped otherwise); non-resume runs pass an empty list and are unchanged.
- **Behavioral note:** the usage/time breakdown now covers the whole run, not just this session. Token/cost totals are **summed** over the kept rollouts too (so they include their original generation spend); each timing phase is **averaged** over the whole run (the kept rollouts pull the average). Both were session-scoped before. Happy to gate back to session-only if reviewers prefer.

Net **+55/−11** across 3 files (vs. ~+236 for the earlier score-aggregate version).

## Testing

Drove the resume path offline (no model needed): built real `Trace`s — with rewards, metrics, per-node `usage`, and timing — for a prior run, wrote them in the on-disk format, then ran the actual `plan → rewrite_results → load_kept` and rendered `Progress`. Observed session-only → whole-run:

| row | before (session-only) | after (kept folded in) |
|---|---|---|
| counter | `1/2` | `4/5` |
| reward | `0.00` | `0.75` (mean of `[1,1,1,0]`) |
| metric `len` | `3.00` | `1.50` (mean of `[0,1,2,3]`) |
| usage | `100/20 · $0.0010` | `400/80 · $0.0040` (summed) |
| time | `generation 6s` | `generation 3s` (avg of `[2,2,2,6]`) |

This also confirms `load_kept` round-trips the full trace (nodes/usage/timing), not just scores.

- `ruff check` + `ruff format` clean; `ty check` reports no new diagnostics vs. `main` (`load_kept` mirrors `replay`'s existing `Trace[WireTask, state_cls(...)]` pattern).
- Existing `tests/v1` unit suite passes (53, non-e2e).
- **Not** run: a full end-to-end `--resume` against a live model (no endpoint available here); the runner wiring that calls `load_kept` and passes `finished` to the dashboard is exercised only by the piecewise test above, not a live run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Include kept rollouts from resumed runs in eval dashboard counts and means
> - Introduces a `Baseline` dataclass in [`resume.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1892/files#diff-fa57536955ac6c644296a0f3317271ffdc94b2611e7ad3d0c2266c436b96a4f8) that aggregates non-errored kept rollouts (count, reward sum, per-key component sums); `resume.plan` now returns this alongside keep offsets and owed counts.
> - Updates [`format_mean`](https://github.com/PrimeIntellect-ai/verifiers/pull/1892/files#diff-d29ec5b44e74af4fcb516857a1700368c3c32c14d1ed3092baef1307fafb163c) to accept `base_sum`/`base_n` kwargs, folding prior rollouts into both the clean mean and the parenthesized global mean.
> - Updates the dashboard's `Progress` and `_breakdown` components in [`eval.py`](https://github.com/PrimeIntellect-ai/verifiers/pull/1892/files#diff-0a27b905958929f3ae9e01937dd7e3cf97a60dec137caddcbf87792784fc9035) to accept and apply the `Baseline`, so counts, error rates, rewards, and per-key metrics reflect the entire run rather than only the current session.
> - Behavioral Change: resumed run dashboards now show cumulative statistics; callers that do not pass `base_sum`/`base_n` are unaffected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3c764e2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display and aggregation-only for the resume dashboard path; `format_mean` defaults preserve existing callers, and persisted results logic is unchanged aside from reading reward/metric dicts when planning keeps.
> 
> **Overview**
> On `--resume`, the rich eval dashboard now treats **kept on-disk rollouts** as part of the run for progress and scoring stats, instead of showing only the rollouts re-executed in the current session.
> 
> `resume.plan` returns a new **`Baseline`** (count, summed headline reward, per-`@reward`/`@metric` sums) built while scanning `results.jsonl` for rows to keep. The runner passes that baseline into the dashboard. **`format_mean`** accepts optional `base_sum`/`base_n` so error-corrected and parenthesized global means include those kept rows. Progress shows **`kept+done / kept+total`**, and reward/err/breakdown reward-metric rows use the combined denominators. **Usage and time** in the breakdown stay **session-only** (no token/time re-derivation from disk). Non-resume runs are unchanged (empty baseline).
> 
> Adds **`tests/v1/test_resume_baseline.py`** for `format_mean` baseline folding and `plan` aggregation (including group-scored incomplete groups).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c764e2a956684303a30763a0431cf6ba3cc8222. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
