### PR TITLE
feat(eval): add --prune to drop errored rollout rows (parallel to retry types)

### DIFF
--- a/tests/v1/test_prune.py
+++ b/tests/v1/test_prune.py
@@ -1,0 +1,193 @@
+"""`--prune` drops errored rows from a finished run's results.jsonl, and composes with `--resume`.
+
+Type selection mirrors `--retries.rollout.include`/`exclude`: `--prune-include` keeps the prune to
+listed error types, `--prune-exclude` spares them (exclude wins), and an empty include prunes all
+errored rows. `--resume <dir> --prune` prunes first, then resumes the same dir.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from verifiers.v1.cli.eval import main as eval_main
+from verifiers.v1.cli.eval.prune import prune_results, split_prune
+
+ROWS = [
+    {"task": {"idx": 0}, "rewards": {"solved": 1.0}},
+    {"task": {"idx": 1}, "errors": [{"type": "SandboxError"}]},
+    {"task": {"idx": 2}, "errors": [{"type": "ProviderError"}]},
+    {"task": {"idx": 3}, "rewards": {"solved": 0.0}},  # clean, reward 0 (not errored)
+]
+
+
+def _write(d: Path) -> Path:
+    (d / "results.jsonl").write_text("".join(json.dumps(r) + "\n" for r in ROWS))
+    return d
+
+
+def _kept(d: Path) -> list[int]:
+    lines = (d / "results.jsonl").read_text().splitlines()
+    return [json.loads(line)["task"]["idx"] for line in lines if line.strip()]
+
+
+def test_prune_drops_all_errored_by_default(tmp_path: Path) -> None:
+    prune_results(_write(tmp_path), [], [])
+    assert _kept(tmp_path) == [0, 3]
+
+
+def test_prune_include_limits_to_listed(tmp_path: Path) -> None:
+    prune_results(_write(tmp_path), ["SandboxError"], [])
+    assert _kept(tmp_path) == [0, 2, 3]  # the ProviderError row survives
+
+
+def test_prune_exclude_spares_listed(tmp_path: Path) -> None:
+    prune_results(_write(tmp_path), [], ["ProviderError"])
+    assert _kept(tmp_path) == [
+        0,
+        2,
+        3,
+    ]  # every errored row pruned except the excluded one
+
+
+def test_prune_exclude_wins_over_include(tmp_path: Path) -> None:
+    prune_results(
+        _write(tmp_path), ["SandboxError", "ProviderError"], ["ProviderError"]
+    )
+    assert _kept(tmp_path) == [
+        0,
+        2,
+        3,
+    ]  # ProviderError excluded even though it's in include
+
+
+def test_prune_keeps_everything_when_type_absent(tmp_path: Path) -> None:
+    prune_results(_write(tmp_path), ["NopeError"], [])
+    assert _kept(tmp_path) == [0, 1, 2, 3]
+
+
+def test_prune_missing_results_dir(tmp_path: Path) -> None:
+    with pytest.raises(SystemExit):
+        prune_results(tmp_path, [], [])  # no results.jsonl
+
+
+def test_split_prune_forms() -> None:
+    assert split_prune(["--prune", "/d"]) == (True, Path("/d"), [], [], [])
+    assert split_prune(["--prune=/d"]) == (True, Path("/d"), [], [], [])
+    # bare `--prune` (next token is a flag) leaves the dir to `--resume`
+    assert split_prune(["--prune", "--prune-include", "A,B"]) == (
+        True,
+        None,
+        ["A", "B"],
+        [],
+        [],
+    )
+    assert split_prune(["--prune=/d", "--prune-exclude=C"]) == (
+        True,
+        Path("/d"),
+        [],
+        ["C"],
+        [],
+    )
+    assert split_prune(["foo", "--prune", "bar"]) == (
+        True,
+        Path("bar"),
+        [],
+        [],
+        ["foo"],
+    )
+    assert split_prune(["x", "y"]) == (False, None, [], [], ["x", "y"])
+
+
+def test_split_prune_rejects_empty_values() -> None:
+    # empty `--prune=` / `--prune-include=` / `--prune-exclude=` must fail explicitly, not
+    # default to cwd or vanish silently
+    for argv in (
+        ["--prune="],
+        ["--prune", "/d", "--prune-include="],
+        ["--prune", "/d", "--prune-exclude="],
+    ):
+        with pytest.raises(SystemExit):
+            split_prune(argv)
+
+
+class _Cfg:
+    is_legacy = False
+
+
+class _Stop(Exception):
+    pass
+
+
+def _patch_resume_and_prune(monkeypatch: pytest.MonkeyPatch, order: list) -> None:
+    """Record (and stop after) `load_resume_config` / `prune_results` calls in `order`."""
+
+    def _load(d):
+        order.append(("load", str(d)))
+        return _Cfg()
+
+    def _prune(d, inc, exc):
+        order.append(("prune", str(d), inc, exc))
+        raise _Stop()
+
+    monkeypatch.setattr(eval_main, "load_resume_config", _load)
+    monkeypatch.setattr(eval_main, "prune_results", _prune)
+
+
+def test_main_prune_only_does_not_load_resume(monkeypatch: pytest.MonkeyPatch) -> None:
+    order: list = []
+    _patch_resume_and_prune(monkeypatch, order)
+    with pytest.raises(_Stop):
+        eval_main.main(["--prune", "/d"])
+    assert order == [("prune", "/d", [], [])]  # no resume-config load
+
+
+def test_main_loads_resume_before_pruning(monkeypatch: pytest.MonkeyPatch) -> None:
+    # `--resume --prune` must load the config (legacy guard) before rewriting anything
+    order: list = []
+    _patch_resume_and_prune(monkeypatch, order)
+    with pytest.raises(_Stop):
+        eval_main.main(["--resume", "/d", "--prune", "--prune-include", "SandboxError"])
+    assert order == [("load", "/d"), ("prune", "/d", ["SandboxError"], [])]
+
+
+def test_main_accepts_equivalent_resume_prune_dirs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # `out` and `./out` resolve to the same dir, so the combined form isn't a mismatch
+    order: list = []
+    _patch_resume_and_prune(monkeypatch, order)
+    with pytest.raises(_Stop):
+        eval_main.main(["--resume", "out", "--prune", "./out"])
+    assert [step[0] for step in order] == ["load", "prune"]
+
+
+def test_main_rejects_legacy_resume_before_pruning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # a legacy (v0) `--resume --prune` errors without rewriting results.jsonl
+    pruned: list = []
+
+    class _Legacy:
+        is_legacy = True
+
+    monkeypatch.setattr(eval_main, "load_resume_config", lambda d: _Legacy())
+    monkeypatch.setattr(
+        eval_main, "prune_results", lambda d, inc, exc: pruned.append(str(d))
+    )
+    with pytest.raises(SystemExit):
+        eval_main.main(["--resume", "/legacy", "--prune"])
+    assert pruned == []
+
+
+def test_main_rejects_bad_prune_combos(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(eval_main, "prune_results", lambda d, inc, exc: None)
+    monkeypatch.setattr(eval_main, "load_resume_config", lambda d: None)
+    with pytest.raises(
+        SystemExit
+    ):  # bare --prune, no dir and no --resume to supply one
+        eval_main.main(["--prune"])
+    with pytest.raises(SystemExit):  # --prune-include without --prune
+        eval_main.main(["--resume", "/d", "--prune-include", "X"])
+    with pytest.raises(SystemExit):  # --prune and --resume disagree on the dir
+        eval_main.main(["--resume", "/a", "--prune", "/b"])

--- a/verifiers/v1/cli/eval/__init__.py
+++ b/verifiers/v1/cli/eval/__init__.py
@@ -1,1 +1,1 @@
-"""The eval command: `uv run eval` — the entry (`main`), the rollout `runner`, and `resume`."""
+"""The eval command: `uv run eval` — the entry (`main`), the rollout `runner`, `resume`, and `prune`."""

--- a/verifiers/v1/cli/eval/main.py
+++ b/verifiers/v1/cli/eval/main.py
@@ -26,6 +26,7 @@ from verifiers.v1.cli.resolve import (
     references_config_file,
     with_positional_taskset,
 )
+from verifiers.v1.cli.eval.prune import prune_results, split_prune
 from verifiers.v1.cli.eval.resume import load_resume_config, split_resume
 from verifiers.v1.cli.eval.runner import run_eval
 from verifiers.v1.configs.eval import EvalConfig
@@ -34,7 +35,9 @@ logger = logging.getLogger(__name__)
 
 USAGE = (
     "usage: uv run eval [<taskset-id>] [--harness.id <id>] [--id <env-id> (legacy)] [options] [@ file.toml]\n"
-    "       uv run eval --resume <output-dir>   (re-run a previous run's missing/errored rollouts)"
+    "       uv run eval --resume <output-dir>   (re-run a previous run's missing/errored rollouts)\n"
+    "       uv run eval --prune <output-dir> [--prune-include/--prune-exclude <csv>]   (drop errored rows from results.jsonl)\n"
+    "       uv run eval --resume <output-dir> --prune [--prune-include/--prune-exclude <csv>]   (prune errored rows, then resume)"
 )
 
 
@@ -48,14 +51,43 @@ def main(argv: list[str] | None = None) -> None:
             narrow_config(EvalConfig, argv)
         )  # full option help, narrowed to the given ids
         return
+    # `--prune` and `--resume` are standalone pre-parse paths (not the normal taskset/harness
+    # config parse) and compose: `--prune` alone cleans errored rows and stops; `--resume` alone
+    # re-runs owed rollouts; `--resume --prune` prunes first, then resumes the same dir.
     resume_dir, rest = split_resume(argv)
-    # re-run a previous run's missing/errored rollouts, in place
-    if resume_dir is not None:
+    prune, prune_dir, prune_include, prune_exclude, rest = split_prune(rest)
+    if (prune_include or prune_exclude) and not prune:
+        raise SystemExit(f"{USAGE}\n--prune-include/--prune-exclude require --prune")
+    if prune or resume_dir is not None:
         if rest:
             raise SystemExit(
-                f"{USAGE}\n--resume re-runs a saved config verbatim and takes no other arguments"
+                f"{USAGE}\n--resume/--prune run a saved config verbatim and take no other "
+                "arguments (besides each other and --prune-include/--prune-exclude)"
             )
-        config = load_resume_config(resume_dir)
+        prune_target = prune_dir or resume_dir
+        if prune and prune_target is None:
+            raise SystemExit(
+                f"{USAGE}\n--prune needs an output dir, or combine it with --resume <dir>"
+            )
+        if (
+            prune
+            and prune_dir is not None
+            and resume_dir is not None
+            and prune_dir.resolve() != resume_dir.resolve()
+        ):
+            raise SystemExit(
+                f"{USAGE}\n--prune and --resume must target the same output dir"
+            )
+        if resume_dir is not None:
+            # Load + reject a legacy (v0) resume *before* pruning, so `--resume <legacy> --prune`
+            # fails without first rewriting results.jsonl on disk.
+            config = load_resume_config(resume_dir)
+            if config.is_legacy:
+                raise SystemExit("--resume is not supported for legacy (v0) evals")
+        if prune:  # drop errored rows (after the legacy guard, so nothing is rewritten on error)
+            prune_results(prune_target, prune_include, prune_exclude)
+        if resume_dir is None:  # prune-only: nothing more to do
+            return
     else:
         legacy_id = any(a == "--id" or a.startswith("--id=") for a in argv)  # v0 env id
         if (
@@ -74,8 +106,6 @@ def main(argv: list[str] | None = None) -> None:
             setup_logging("DEBUG" if config.verbose else "INFO")
             logger.info("wrote config to %s", write_config(config, output_path(config)))
             return
-    if config.is_legacy and config.resume is not None:
-        raise SystemExit("--resume is not supported for legacy (v0) evals")
     # Execution path: in-process by default; `--server` opts into the env-server worker pool
     # (the path prime-rl trains through). The `--rich` dashboard reads live in-process Rollout
     # state, so it's in-process only (`server + rich` is rejected at config validation). Legacy

--- a/verifiers/v1/cli/eval/prune.py
+++ b/verifiers/v1/cli/eval/prune.py
@@ -1,0 +1,150 @@
+"""Prune errored rollouts from a finished eval's `results.jsonl`, in place.
+
+A run leaves permanent reward-0 rows when rollouts error (SandboxError/ProviderError/...).
+`--prune <dir>` drops every row that ended with an error; `--prune-include` / `--prune-exclude`
+narrow that by the error's exception type, with the same include/exclude semantics as
+`--retries.rollout.include` / `exclude` and matched against the same most-recent `errors[].type`
+(via the shared `error_type_selected`), so prune and retry stay parallel. It rewrites the file
+atomically (reusing `resume.rewrite_results`) and prints a summary - no model, no config.
+"""
+
+import json
+from collections import Counter
+from collections.abc import Iterator
+from pathlib import Path
+
+from pydantic_core import from_json
+
+from verifiers.v1.cli.eval.resume import rewrite_results
+from verifiers.v1.retries import error_type_selected
+
+
+def _take_value(arg: str, argv: list[str], i: int, flag: str) -> tuple[bool, str, int]:
+    """If `arg` is `flag` (value in the next token) or `flag=<value>`, return
+    (True, value, next index); otherwise (False, "", i) unchanged."""
+    if arg == flag:
+        if i + 1 >= len(argv):
+            raise SystemExit(
+                f"{flag} needs a comma-separated list, e.g. {flag} SandboxError,ProviderError"
+            )
+        return True, argv[i + 1], i + 2
+    if arg.startswith(flag + "="):
+        return True, arg.split("=", 1)[1], i + 1
+    return False, "", i
+
+
+def split_prune(
+    argv: list[str],
+) -> tuple[bool, Path | None, list[str], list[str], list[str]]:
+    """Pull `--prune [<dir>]`, `--prune-include <csv>`, and `--prune-exclude <csv>` out of argv,
+    returning (prune requested, dir or None, include, exclude, the other args). `--prune` takes an
+    output dir when standalone (`uv run eval --prune <dir>`), or is a bare modifier when combined
+    with `--resume`, which then supplies the dir (`uv run eval --resume <dir> --prune`). `include`/
+    `exclude` are comma-separated exception type names mirroring `--retries.rollout.include`/
+    `exclude` (empty `include` = all error types not excluded). Modeled on `split_resume`."""
+    prune = False
+    prune_dir: Path | None = None
+    include: list[str] = []
+    exclude: list[str] = []
+    rest: list[str] = []
+    i = 0
+    while i < len(argv):
+        arg = argv[i]
+        if arg == "--prune":
+            prune = True
+            # A following non-flag token is the dir; otherwise `--prune` is a bare modifier
+            # (combined with `--resume`, which supplies the dir).
+            if i + 1 < len(argv) and not argv[i + 1].startswith("-"):
+                prune_dir = Path(argv[i + 1])
+                i += 2
+            else:
+                i += 1
+            continue
+        if arg.startswith("--prune="):
+            prune = True
+            value = arg.split("=", 1)[1]
+            if not value:  # `--prune=` would otherwise become Path("") == cwd
+                raise SystemExit("--prune needs an output dir, e.g. --prune=<dir>")
+            prune_dir = Path(value)
+            i += 1
+            continue
+        consumed, value, i = _take_value(arg, argv, i, "--prune-include")
+        if consumed:
+            include = _parse_csv(value)
+            if (
+                not include
+            ):  # empty (e.g. `--prune-include=`) must fail, not vanish silently
+                raise SystemExit(
+                    "--prune-include needs a comma-separated list, e.g. --prune-include SandboxError"
+                )
+            continue
+        consumed, value, i = _take_value(arg, argv, i, "--prune-exclude")
+        if consumed:
+            exclude = _parse_csv(value)
+            if not exclude:
+                raise SystemExit(
+                    "--prune-exclude needs a comma-separated list, e.g. --prune-exclude ProviderError"
+                )
+            continue
+        rest.append(arg)
+        i += 1
+    return prune, prune_dir, include, exclude, rest
+
+
+def _parse_csv(csv: str) -> list[str]:
+    return [t.strip() for t in csv.split(",") if t.strip()]
+
+
+def _read_rows(results_path: Path) -> Iterator[tuple[int, str | None]]:
+    """Stream `(byte offset, most-recent error type or None)` per row without retaining decoded
+    traces. The most-recent error (`errors[-1]`) is the one retry matches on (`trace.error`), so
+    prune selects the same way. Our own reader so the `resume` rewrite of `_read_results` can land
+    independently."""
+    with results_path.open("rb") as results:
+        while True:
+            offset = results.tell()
+            line = results.readline()
+            if not line:
+                break
+            if line.strip():
+                try:
+                    row = from_json(line)
+                except ValueError:
+                    row = json.loads(line)
+                errors = row.get("errors") or []
+                yield offset, (errors[-1]["type"] if errors else None)
+
+
+def prune_results(prune_dir: Path, include: list[str], exclude: list[str]) -> None:
+    """Drop errored rows from `<prune_dir>/results.jsonl`, in place. A row is pruned when it ended
+    with an error whose type is selected by `include`/`exclude` (`error_type_selected` - the same
+    rule as retry matching); clean rows and unselected errors are kept. Reuses
+    `resume.rewrite_results` for the atomic write, then prints a summary."""
+    if not prune_dir.is_dir():
+        raise SystemExit(f"--prune: {prune_dir} is not a directory")
+    results_path = prune_dir / "results.jsonl"
+    if not results_path.exists():
+        raise SystemExit(
+            f"--prune: no results.jsonl in {prune_dir} - not an eval output dir"
+        )
+
+    keep: list[int] = []
+    pruned: Counter[str] = Counter()
+    total = 0
+    for offset, error_type in _read_rows(results_path):
+        total += 1
+        if error_type is not None and error_type_selected(error_type, include, exclude):
+            pruned[error_type] += 1
+            continue
+        keep.append(offset)
+
+    rewrite_results(prune_dir, keep)
+
+    pruned_rows = total - len(keep)
+    if pruned_rows:
+        breakdown = ", ".join(f"{t} {n}" for t, n in pruned.most_common())
+        print(
+            f"pruned {pruned_rows} errored rows ({breakdown}); kept {len(keep)} of {total}"
+        )
+    else:
+        print(f"nothing to prune in {prune_dir}: all {total} rows kept")

--- a/verifiers/v1/retries.py
+++ b/verifiers/v1/retries.py
@@ -90,17 +90,27 @@ class RetryConfig(BaseConfig):
     """Retries of the whole rollout, on a captured retryable error."""
 
 
+def error_type_selected(
+    error_type: str, include: list[str], exclude: list[str]
+) -> bool:
+    """Whether an error's exception type name is selected by an `include`/`exclude` pair: an
+    excluded type is never selected (`exclude` wins), a non-empty `include` selects only listed
+    types, and an empty `include` selects everything not excluded. The shared rule behind both
+    retry (`should_retry`) and `--prune` error-type matching, so the two stay parallel."""
+    if error_type in exclude:
+        return False
+    if include:
+        return error_type in include
+    return True
+
+
 def should_retry(trace: Trace, retry: RolloutRetryConfig) -> bool:
     """Whether a finished rollout should be retried: it ended with an error whose
     exception type is included (and not excluded)."""
     error = trace.error
     if error is None:
         return False
-    if error.type in retry.exclude:
-        return False
-    if retry.include:
-        return error.type in retry.include
-    return True
+    return error_type_selected(error.type, retry.include, retry.exclude)
 
 
 async def run_with_retry(


### PR DESCRIPTION
## What

Adds `uv run eval --prune <dir> [--prune-include <csv>] [--prune-exclude <csv>]` — a post-hoc cleanup that drops errored rollout rows from a finished run's `results.jsonl`, reusing `resume.rewrite_results` for the atomic write. No model, no config.

**Error-type selection is parallel to retries.** This extracts `error_type_selected(error_type, include, exclude)` (exclude wins; empty `include` = all not excluded; matched on the **most-recent** `errors[].type`, the same error `should_retry` keys off via `trace.error`) and shares it between `should_retry` and `--prune`. So `--prune-include`/`--prune-exclude` name the same exception classes (`SandboxError`, `ProviderError`, `HarnessError`, …) as `--retries.rollout.include`/`exclude`, with identical semantics:

| | retries | prune |
|---|---|---|
| selector | `--retries.rollout.include` / `exclude` | `--prune-include` / `--prune-exclude` |
| empty include | retry all not excluded | prune all errored not excluded |
| exclude | wins over include | wins over include |
| matches | `trace.error.type` (most recent) | most-recent `errors[].type` |

**Composes with `--resume`:**
- `--prune <dir>` alone → clean and stop.
- `--resume <dir>` alone → re-run owed rollouts (unchanged).
- `--resume <dir> --prune [--prune-include/--prune-exclude …]` → **prune first, then resume** the same dir.

## How

- New `verifiers/v1/cli/eval/prune.py` — `split_prune` (handles `--prune <dir>`, `--prune=<dir>`, bare `--prune` when combined with `--resume`, plus `--prune-include`/`--prune-exclude`) + `prune_results`; own byte-offset streamer; reuses `resume.rewrite_results`.
- `verifiers/v1/retries.py` — extracts `error_type_selected`; `should_retry` now delegates to it (no behaviour change).
- `main.py` dispatch parses `--resume` then `--prune`, reconciles the target dir (rejecting a mismatch), and runs prune→resume / prune-only / resume-only.

## Testing

- `tests/v1/test_prune.py` (9 tests): default / include / exclude / exclude-wins / absent-type pruning, missing-dir error, `split_prune` forms, and the `--resume --prune` ordering + bad-combo rejections.
- `should_retry` + `error_type_selected` re-verified; `ruff check` + `ruff format` clean. (Pre-push `ty` not run locally — env not synced; CI covers it.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `--prune` flag to drop errored rows from `results.jsonl` in eval CLI
> - Adds a new `--prune` mode to the eval CLI that rewrites `results.jsonl`, removing rows whose error type matches include/exclude filters (parallel to existing retry selectors).
> - Implements argument parsing in [prune.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1893/files#diff-9c2b8c4b5278de68ac80a59f1589ae22896ffd5123697b092960e8180497379e) supporting `--prune [dir]`, `--prune-include`, and `--prune-exclude` with validation that rejects empty inline values.
> - Supports a combined `--resume --prune` workflow that prunes first, then resumes; validates that both flags agree on the output directory when both specify one.
> - Refactors `should_retry` in [retries.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1893/files#diff-dd324cbc3488c3521fea600c7be4001a3f62becf8988cb8290ccbf4c9a487106) to share selection logic with prune via a new `error_type_selected` helper.
> - Behavioral Change: `--include`/`--exclude` flags now require `--prune` to be present, and `--resume`/`--prune` cannot be combined with other arguments.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8612336.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The change rewrites eval output files in place on disk and extends eval CLI dispatch alongside resume, but uses atomic rewrites, validates legacy resume before pruning, and is covered by targeted tests.
> 
> **Overview**
> Adds **`uv run eval --prune`** to remove errored rollout rows from a finished run’s **`results.jsonl`** in place, with optional **`--prune-include`** / **`--prune-exclude`** CSV filters that mirror **`--retries.rollout.include`/`exclude`** semantics (exclude wins; empty include = all errored types not excluded), keyed off the most recent **`errors[].type`**.
> 
> **`error_type_selected`** is extracted in **`retries.py`** and shared by **`should_retry`** and prune so retry and prune stay aligned; **`should_retry`** behavior is unchanged.
> 
> Eval **`main.py`** parses **`--resume`** then **`--prune`**: prune-only exits after cleanup; **`--resume <dir> --prune`** loads resume config (including legacy rejection **before** any rewrite), prunes, then continues resume; mismatched dirs and invalid flag combos exit with usage errors. Pruning reuses **`resume.rewrite_results`** for atomic writes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8612336c727a2fe320c2fd66e28d139362065148. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->