### PR TITLE
refactor: consolidate Trace/Branch length properties under num_ prefix

### DIFF
--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -273,19 +273,21 @@ def _tokens(trace: Trace) -> tuple[int, int, int | None, int | None, int]:
     (completion) token generated across its turns and input is its last turn's prompt — the full
     final context the model saw. A rollout yields one training sample per branch (a linear trace
     is a single branch; compaction and subagents add more), so the totals sum them — matching
-    `Trace.prompt_len` / `Trace.completion_len`. (Output can exceed the final context — reasoning
-    tokens count toward completions but aren't re-fed — so it's not derived by subtraction.)
+    `Trace.num_input_tokens` / `Trace.num_output_tokens`. (Output can exceed the final context —
+    reasoning tokens count toward completions but aren't re-fed — so it's not derived by
+    subtraction.)
 
-    Prefers the token-id counts; falls back to provider-reported usage when the endpoint returns
-    no token ids (e.g. plain OpenAI completions), so the counts aren't shown as 0/0. Returns
-    the branch count from the same derived view so each dashboard tick materializes it once."""
+    Both counts read token ids when present and fall back to provider-reported usage when the
+    endpoint returns no token ids (e.g. plain OpenAI completions), so the counts aren't shown as
+    0/0. Returns the branch count from the same derived view so each dashboard tick materializes
+    it once."""
     usage = trace.usage
     cached = usage.cached_input_tokens if usage else None
     reasoning = usage.reasoning_tokens if usage else None
     branches = trace.branches
     nbranches = len(branches)
-    prompt = sum(b.input_len for b in branches)
-    completion = sum(b.output_len for b in branches)
+    prompt = sum(b.num_input_tokens for b in branches)
+    completion = sum(b.num_output_tokens for b in branches)
     return prompt, completion, cached, reasoning, nbranches
 
 

--- a/verifiers/v1/env.py
+++ b/verifiers/v1/env.py
@@ -106,13 +106,13 @@ class EnvConfig(BaseConfig):
     capping is a framework concern, never an harness or task field."""
     max_input_tokens: int | None = None
     """Max input (prompt) tokens per rollout (None = no limit). Caps the trace's
-    `prompt_len`; framework-enforced between turns."""
+    `num_input_tokens`; framework-enforced between turns."""
     max_output_tokens: int | None = None
     """Max output (completion) tokens per rollout (None = no limit). Caps the trace's
-    `completion_len`; framework-enforced between turns."""
+    `num_output_tokens`; framework-enforced between turns."""
     max_total_tokens: int | None = None
     """Max total (prompt + completion) tokens per rollout (None = no limit). Caps the
-    trace's `total_tokens`; framework-enforced between turns."""
+    trace's `num_total_tokens`; framework-enforced between turns."""
     multiplex: int = Field(32, ge=1)
     """Rollouts that share one interception server (and, behind a remote runtime, one
     tunnel). N concurrent rollouts use ~N/multiplex servers + tunnels instead of one each —

--- a/verifiers/v1/interception/server.py
+++ b/verifiers/v1/interception/server.py
@@ -90,8 +90,8 @@ class RolloutLimits:
     """Per-rollout framework limits (None = no cap), checked before each turn is served.
     The first limit reached refuses the turn — halting any harness, the same mechanism as
     a @stop — and becomes the trace's stop condition. Each caps a trace computed property:
-    `max_turns` -> num_turns, `max_input_tokens` -> prompt_len, `max_output_tokens` ->
-    completion_len, `max_total_tokens` -> total_tokens. Token caps are soft by one turn:
+    `max_turns` -> num_turns, `max_input_tokens` -> num_input_tokens, `max_output_tokens` ->
+    num_output_tokens, `max_total_tokens` -> num_total_tokens. Token caps are soft by one turn:
     they're checked between turns, so the turn that crosses a cap still completes."""
 
     max_turns: int | None = None
@@ -105,17 +105,17 @@ class RolloutLimits:
             return "max_turns"
         if (
             self.max_input_tokens is not None
-            and trace.prompt_len >= self.max_input_tokens
+            and trace.num_input_tokens >= self.max_input_tokens
         ):
             return "max_input_tokens"
         if (
             self.max_output_tokens is not None
-            and trace.completion_len >= self.max_output_tokens
+            and trace.num_output_tokens >= self.max_output_tokens
         ):
             return "max_output_tokens"
         if (
             self.max_total_tokens is not None
-            and trace.total_tokens >= self.max_total_tokens
+            and trace.num_total_tokens >= self.max_total_tokens
         ):
             return "max_total_tokens"
         return None

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -165,22 +165,9 @@ class Branch(StrictBaseModel):
         return merged if merged.shape[0] == total else None
 
     @property
-    def completion_len(self) -> int:
-        """All assistant-generated (model-sampled) tokens across this branch."""
-        return sum(sum(n.mask) for n in self.nodes)
-
-    @property
-    def total_tokens(self) -> int:
+    def num_total_tokens(self) -> int:
         """This branch's full sequence length (final-turn prompt + every completion)."""
         return sum(len(n.token_ids) for n in self.nodes)
-
-    @property
-    def prompt_len(self) -> int:
-        """Input context size: the final-turn prompt = full sequence minus the last completion."""
-        last_completion = next(
-            (sum(n.mask) for n in reversed(self.nodes) if any(n.mask)), 0
-        )
-        return self.total_tokens - last_completion
 
     @property
     def usage(self) -> Usage | None:
@@ -188,36 +175,31 @@ class Branch(StrictBaseModel):
         return Usage.aggregate(n.usage for n in self.nodes if n.usage is not None)
 
     @property
-    def num_prompt_tokens(self) -> int:
-        """Final-turn input tokens from provider-reported usage — a fallback for display when
-        the endpoint returns no token ids (so `prompt_len` is 0); 0 if no usage was reported."""
+    def num_input_tokens(self) -> int:
+        """Input-context size: the final-turn prompt (full sequence minus the last completion).
+        Read from token ids when present (training), else from provider-reported usage so eval
+        clients that return no token ids don't report 0."""
+        last_completion = next(
+            (sum(n.mask) for n in reversed(self.nodes) if any(n.mask)), 0
+        )
+        token_len = self.num_total_tokens - last_completion
+        if token_len:
+            return token_len
         last = next(
             (n.usage for n in reversed(self.nodes) if n.usage is not None), None
         )
         return last.input_tokens if last else 0
 
     @property
-    def num_completion_tokens(self) -> int:
-        """All completion tokens across the branch from provider-reported usage — a fallback for
-        display when the endpoint returns no token ids; 0 if no usage was reported."""
+    def num_output_tokens(self) -> int:
+        """All assistant-generated (completion) tokens across this branch (reasoning included, so
+        it can exceed the final context). Read from token ids when present (training), else from
+        provider-reported usage so eval clients that return no token ids don't report 0."""
+        token_len = sum(sum(n.mask) for n in self.nodes)
+        if token_len:
+            return token_len
         usage = self.usage
         return usage.completion_tokens if usage else 0
-
-    @property
-    def input_len(self) -> int:
-        """Best-available input-context size: the token-id `prompt_len`, falling back to
-        provider-reported `num_prompt_tokens` when the endpoint returns no token ids (so it isn't
-        reported as 0). For display/metrics — use `prompt_len` when you need the strict token-id
-        count (e.g. token-cap enforcement)."""
-        return self.prompt_len or self.num_prompt_tokens
-
-    @property
-    def output_len(self) -> int:
-        """Best-available completion size: the token-id `completion_len`, falling back to
-        provider-reported `num_completion_tokens` when the endpoint returns no token ids (so it
-        isn't reported as 0). For display/metrics — use `completion_len` when you need the strict
-        token-id count (e.g. training, token-cap enforcement)."""
-        return self.completion_len or self.num_completion_tokens
 
 
 _NODE_DUMP_EXCLUDE: dict = {
@@ -264,7 +246,7 @@ class Trace(StrictBaseModel, Generic[TaskT, StateT]):
     extra_usage: list[Usage] = Field(default_factory=list)
     """Token usage from model calls that aren't part of the message graph — LLM judges and other
     auxiliary scoring calls (see `verifiers.v1.judge`). Kept separate from `usage` (the agent's own
-    spend) and off the graph, so branch/turn counts and the trainer's token math (`total_tokens`,
+    spend) and off the graph, so branch/turn counts and the trainer's token math (`num_total_tokens`,
     `branches`) see only sampled nodes; consumers that want a grand total add the two (e.g. the eval
     dashboard shows the agent's usage and `+judge` separately)."""
 
@@ -298,22 +280,22 @@ class Trace(StrictBaseModel, Generic[TaskT, StateT]):
         return next((n for n in reversed(self.nodes) if n.sampled), None)
 
     @property
-    def prompt_len(self) -> int:
+    def num_input_tokens(self) -> int:
         """Total input context summed over branches (each branch's final-turn prompt) —
         the trajectory yields one training sample per branch, so totals aggregate them."""
-        return sum(branch.prompt_len for branch in self.branches)
+        return sum(branch.num_input_tokens for branch in self.branches)
 
     @property
-    def completion_len(self) -> int:
+    def num_output_tokens(self) -> int:
         """Total assistant-generated (completion) tokens summed over branches — every token
         the model produced (reasoning included), so it can exceed the final context size."""
-        return sum(branch.completion_len for branch in self.branches)
+        return sum(branch.num_output_tokens for branch in self.branches)
 
     @property
-    def total_tokens(self) -> int:
+    def num_total_tokens(self) -> int:
         """Total sequence length summed over branches (each branch's final-turn prompt +
         completion) — used for token batching."""
-        return sum(branch.total_tokens for branch in self.branches)
+        return sum(branch.num_total_tokens for branch in self.branches)
 
     @property
     def usage(self) -> Usage | None:


### PR DESCRIPTION
## Summary

Consolidates the token-length computed properties on `Trace` and `Branch` (`verifiers/v1/trace.py`) into a minimal, consistently-named set. The six overlapping length properties become two best-available counts, and every count now carries the `num_` prefix to match the existing `num_branches`:

| before | after |
| --- | --- |
| `prompt_len`, `input_len`, `num_prompt_tokens` | `num_input_tokens` |
| `completion_len`, `output_len`, `num_completion_tokens` | `num_output_tokens` |
| `total_tokens` | `num_total_tokens` |

- `num_input_tokens` / `num_output_tokens` read the token-id counts when present (training) and fall back to provider-reported `usage` when the endpoint returns no token ids (eval clients) — a single property works for both, so callers no longer pick between a strict and a display variant.
- On the training path (token ids present) the new properties are identical to the old strict `prompt_len` / `completion_len`, so token-cap enforcement (`RolloutLimits.reached`) and the trainer's batching are unchanged.
- Updated all in-repo consumers: the interception server's limit checks + docstrings, the `EnvConfig.max_*_tokens` field docs, the rollout log line, and the eval dashboard's `_tokens`.

## Breaking

`Trace` / `Branch` public API. Migrate property accesses:

- `prompt_len` / `input_len` / `num_prompt_tokens` → `num_input_tokens`
- `completion_len` / `output_len` / `num_completion_tokens` → `num_output_tokens`
- `total_tokens` → `num_total_tokens`

`Usage.input_tokens` / `Usage.total_tokens` (the per-response usage object) are unaffected. Downstream repos that read these off a `Trace`/`Rollout` (e.g. prime-rl orchestrator/trainer, monitors) need the corresponding rename.

## Verification

- `pytest tests/v1/test_trace.py tests/v1/test_graph.py` pass against the new code.
- Functional check of both paths: token-id rollout yields strict counts (final-turn prompt for input, all completions for output); a usage-only rollout (no token ids) falls back to `usage` for input/output and reports `num_total_tokens == 0`.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consolidate token length properties under `num_input_tokens`, `num_output_tokens`, and `num_total_tokens` on `Trace` and `Branch`
> - Renames `prompt_len`/`completion_len`/`total_tokens` on `Trace` and `Branch` to `num_input_tokens`, `num_output_tokens`, and `num_total_tokens` in [trace.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1894/files#diff-834820c3aa80d87ee1c1c57fb54c74f09c66ac727036d964e6005c8613c00b5e).
> - `Branch.num_input_tokens` and `Branch.num_output_tokens` now fall back to provider-reported usage when token IDs are unavailable, and `num_output_tokens` includes reasoning tokens.
> - Updates rollout limit enforcement in [server.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1894/files#diff-84e2f8d027d609e8760ef6d533535ec9d99dfc6384d5ddb6111b4001b2010f35) and token aggregation in [eval.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1894/files#diff-0a27b905958929f3ae9e01937dd7e3cf97a60dec137caddcbf87792784fc9035) to use the new property names.
> - Risk: callers using the old `prompt_len`, `completion_len`, or `total_tokens` names will break; token counts may differ from previous values when token IDs are absent or reasoning tokens are present.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0a00045.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking public **`Trace`/`Branch`** API for downstream consumers; token-cap behavior should stay equivalent when token ids are present, but usage-only eval paths now share the same properties as enforcement/display.
> 
> **Overview**
> Renames and merges overlapping **`Trace`** / **`Branch`** token-length APIs into three **`num_*`** properties: **`num_input_tokens`**, **`num_output_tokens`**, and **`num_total_tokens`**, replacing **`prompt_len`**, **`completion_len`**, **`total_tokens`**, **`input_len`**, **`output_len`**, **`num_prompt_tokens`**, and **`num_completion_tokens`**.
> 
> On **`Branch`**, **`num_input_tokens`** and **`num_output_tokens`** now prefer token-id math when ids exist and otherwise fall back to provider **`usage`**, so one property covers training and eval-without-ids instead of separate “strict” vs “display” accessors. **`Trace`** aggregates those branch properties the same way as before.
> 
> In-repo callers are updated: **`RolloutLimits.reached`** and **`EnvConfig`** docs reference the new names; the eval dashboard **`_tokens`** helper sums **`b.num_input_tokens`** / **`b.num_output_tokens`** per branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a000456bd846c4bc4c8652ddbae09678fc6f661. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->