### PR TITLE
feat(v1): add Trace.last_reply and adopt it across v1 envs

### DIFF
--- a/environments/code_golf_v1/code_golf_v1/taskset.py
+++ b/environments/code_golf_v1/code_golf_v1/taskset.py
@@ -29,7 +29,7 @@ SYSTEM = (
 
 def extract_program(trace: vf.Trace) -> str:
     """The python from the last assistant message's code block (or its raw text)."""
-    text = trace.assistant_messages[-1].content if trace.assistant_messages else ""
+    text = trace.last_reply
     match = re.search(r"```(?:python)?\n(.*?)```", text or "", re.DOTALL)
     return (match.group(1) if match else text or "").strip()
 

--- a/environments/deepwiki_v1/deepwiki_v1/taskset.py
+++ b/environments/deepwiki_v1/deepwiki_v1/taskset.py
@@ -53,5 +53,5 @@ class DeepWikiTaskset(vf.Taskset[DeepWikiTask, DeepWikiConfig]):
     async def answered(
         self, task: DeepWikiTask, trace: vf.Trace, runtime: vf.Runtime
     ) -> float:
-        last = trace.assistant_messages[-1].content if trace.assistant_messages else ""
+        last = trace.last_reply
         return float(task.answer.lower() in (last or "").lower())

--- a/environments/glossary_v1/glossary_v1/taskset.py
+++ b/environments/glossary_v1/glossary_v1/taskset.py
@@ -44,5 +44,5 @@ class GlossaryTaskset(vf.Taskset[GlossaryTask, GlossaryConfig]):
         self, task: GlossaryTask, trace: vf.Trace, runtime: vf.Runtime
     ) -> float:
         # The fact only reaches the answer if the model called the MCP tool.
-        last = trace.assistant_messages[-1].content if trace.assistant_messages else ""
+        last = trace.last_reply
         return float(task.answer.lower() in (last or "").lower())

--- a/environments/gsm8k_v1/gsm8k_v1/taskset.py
+++ b/environments/gsm8k_v1/gsm8k_v1/taskset.py
@@ -47,9 +47,7 @@ class GSM8KTaskset(vf.Taskset[GSM8KTask, GSM8KConfig]):
     async def correct(
         self, task: GSM8KTask, trace: vf.Trace, runtime: vf.Runtime
     ) -> float:
-        prediction = (
-            trace.assistant_messages[-1].content if trace.assistant_messages else ""
-        )
+        prediction = trace.last_reply
         result = await runtime.run_uv_script(
             VERIFY, args=[task.answer, prediction or ""]
         )

--- a/environments/reverse_text_v1/reverse_text_v1/taskset.py
+++ b/environments/reverse_text_v1/reverse_text_v1/taskset.py
@@ -49,9 +49,7 @@ class ReverseTextTaskset(vf.Taskset[ReverseTextTask, ReverseTextConfig]):
 
     @vf.reward(weight=1.0)
     async def lcs(self, task: ReverseTextTask, trace: vf.Trace) -> float:
-        completion = (
-            trace.assistant_messages[-1].content if trace.assistant_messages else ""
-        )
+        completion = trace.last_reply
         match = _TAG.search(completion or "")
         response = match.group(1).strip() if match else ""
         return SequenceMatcher(None, response, task.answer).ratio()

--- a/environments/scratchpad_v1/scratchpad_v1/taskset.py
+++ b/environments/scratchpad_v1/scratchpad_v1/taskset.py
@@ -57,7 +57,5 @@ class ScratchpadTaskset(vf.Taskset[ScratchpadTask, ScratchpadConfig, ScratchpadS
 
     @vf.reward(weight=1.0)
     async def isolated(self, task: ScratchpadTask, trace: vf.Trace) -> float:
-        answer = (
-            trace.assistant_messages[-1].content if trace.assistant_messages else ""
-        )
+        answer = trace.last_reply
         return float(task.word in (answer or ""))

--- a/environments/wiki_search_v1/wiki_search_v1/taskset.py
+++ b/environments/wiki_search_v1/wiki_search_v1/taskset.py
@@ -86,9 +86,7 @@ class WikiSearchTaskset(vf.Taskset[TriviaTask, WikiSearchConfig]):
     async def judged(
         self, task: TriviaTask, trace: vf.Trace, runtime: vf.Runtime
     ) -> float:
-        response = (
-            trace.assistant_messages[-1].content if trace.assistant_messages else ""
-        )
+        response = trace.last_reply
         prompt = JUDGE_PROMPT.format(
             question=task.question, answer=task.answer, response=response or ""
         )

--- a/verifiers/v1/GUIDE.md
+++ b/verifiers/v1/GUIDE.md
@@ -66,7 +66,7 @@ class ReverseTaskset(vf.Taskset[ReverseTask, ReverseConfig]):
 
     @vf.reward()
     async def exact_match(self, task: ReverseTask, trace: vf.Trace) -> float:
-        return float(trace.assistant_messages[-1].content.strip() == task.answer)
+        return float(trace.last_reply == task.answer)
 
 
 __all__ = ["ReverseTaskset"]   # vf resolves the taskset by finding this Taskset subclass
@@ -250,7 +250,7 @@ VERIFY = (Path(__file__).parent / "verify.py").read_text()   # PEP 723 header de
 
 @vf.reward()
 async def verify(self, task, trace, runtime) -> float:
-    r = await runtime.run_uv_script(VERIFY, args=[task.answer, trace.assistant_messages[-1].content])
+    r = await runtime.run_uv_script(VERIFY, args=[task.answer, trace.last_reply])
     return float(r.stdout.strip() == "1.0")
 ```
 
@@ -317,7 +317,7 @@ a taskset `@vf.stop` fires. A stop is an `async (self, trace) -> bool` checked b
 ```python
 @vf.stop
 async def saw_answer(self, trace) -> bool:
-    last = trace.assistant_messages[-1].content or ""
+    last = trace.last_reply
     return "FINAL:" in last
 ```
 

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -365,6 +365,15 @@ class Trace(StrictBaseModel, Generic[TaskT, StateT]):
         ]
 
     @property
+    def last_reply(self) -> str:
+        """The model's final reply as plain text — the last assistant message's
+        `content` (whitespace-stripped), or ``""`` when there are no assistant
+        messages or the last one has no text. Convenience over
+        ``(assistant_messages[-1].content or "").strip()`` for last-turn scoring."""
+        msgs = self.assistant_messages
+        return (msgs[-1].content or "").strip() if msgs else ""
+
+    @property
     def tool_messages(self) -> list[ToolMessage]:
         """The tool results in the latest full context — the main (last) branch's
         conversation. For a linear rollout that's every tool result."""


### PR DESCRIPTION
## Description

Adds `Trace.last_reply` — the stripped text of the final sampled assistant message (or `""` when there are no assistant messages / the last one has no text) — and adopts it across the v1 envs and docs that read the model's final reply as text for scoring/judging.

Every scoring reward that wants "the answer" hand-rolled the same idiom (`assistant_messages[-1].content if assistant_messages else ""`, or the unguarded `[-1].content`). `last_reply` is the typed convenience over that, and safe by default — it returns `""` instead of `IndexError` on an empty trace, and `AssistantMessage.content` is `str | None`, so the `None` case is handled too.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Test improvement
- [x] Documentation update

## What changed
- `verifiers/v1/trace.py` — new `last_reply` property (`@property`, next to `assistant_messages`): `(msgs[-1].content or "").strip() if msgs else ""`.
- `tests/v1/test_trace.py` — `test_last_reply`: newest sampled turn wins (`"  a1  "` then `"a2"` → `"a2"`), no turns → `""`, `None` content → `""`.
- v1 envs migrated to `trace.last_reply` (each previously hand-rolled the guard): `reverse-text-v1`, `gsm8k-v1`, `glossary-v1`, `deepwiki-v1`, `code-golf-v1`, `scratchpad-v1`, `wiki-search-v1`.
- `verifiers/v1/GUIDE.md` — the canonical reverse-text reward and two other snippets now use `trace.last_reply`.
- **Not migrated** (intentionally): `alphabet-sort-v1` iterates *every* assistant turn (`[m.content or "" for m in trace.assistant_messages]`); `color-codeword-v1` takes the `AssistantMessage` objects themselves. Neither is "last reply" semantics, so they stay on `assistant_messages`.

## Testing
- [x] New tests have been added to cover the changes — `tests/v1/test_trace.py::test_last_reply` (passes; full `test_trace.py` green, 4/4).
- [x] All migrated env tasksets import against the patched source (syntactically + semantically valid against the new `Trace.last_reply`).
- [x] `ruff check` clean on all changed files.
- The `@pytest.mark.e2e` env runs (real model rollouts + runtimes) are not executed locally; the change is a read-only property with no new imports and is covered by the unit test + import check.

## Checklist
- [x] My code follows the style guidelines (AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code (docstring on the property; inline rationale in the test)
- [x] I have made corresponding changes to the documentation (GUIDE.md)
- [x] My changes generate no new warnings (ruff clean)

## Additional Notes
Companion to the Prime CLI v1 work (PrimeIntellect-ai/prime#766). `last_reply` is purely additive; the env swaps are behavior-preserving (the only behavioral change is an outer `.strip()` on the final reply, which is benign for the substring/regex/judge checks these rewards use — and matches what the GUIDE's reverse-text example already did).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive trace helper plus mechanical reward refactors; only scoring input normalization changes (strip / empty-string fallback), with no auth, runtime, or wire-format changes.
> 
> **Overview**
> Introduces **`Trace.last_reply`** on `verifiers/v1/trace.py` as the canonical way to read the model’s final sampled assistant text: whitespace-stripped `content`, or `""` when there are no assistant messages or content is `None`.
> 
> **Seven v1 tasksets** (`code-golf`, `deepwiki`, `glossary`, `gsm8k`, `reverse-text`, `scratchpad`, `wiki-search`) and **`verifiers/v1/GUIDE.md`** examples now use `trace.last_reply` instead of hand-rolled `assistant_messages[-1].content` guards.
> 
> Scoring and stop hooks therefore get **normalized, safe** final-reply text (including an outer `.strip()`); empty traces no longer risk `IndexError` on `[-1]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d76f20addce21c4bbdcbd9c1d695c90aef5b552b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `Trace.last_reply` property and adopt it across v1 environments
> - Adds `Trace.last_reply` to [trace.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1897/files#diff-834820c3aa80d87ee1c1c57fb54c74f09c66ac727036d964e6005c8613c00b5e) as a convenience property returning the last assistant message content, whitespace-stripped, or an empty string when no assistant messages exist.
> - Replaces manual `trace.assistant_messages[-1].content` access in reward functions across all v1 environments (`code_golf`, `deepwiki`, `glossary`, `gsm8k`, `reverse_text`, `scratchpad`, `wiki_search`) with `trace.last_reply`.
> - Updates the [GUIDE.md](https://github.com/PrimeIntellect-ai/verifiers/pull/1897/files#diff-c2ca7f62523b24001d6019e37e36351dc73dd3e91a9ac126847e7eb5c55d63a1) examples to reflect the new pattern.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d76f20a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->