### PR TITLE
feat: agentic group judge for v1 tasksets (AgenticGroupJudge)

### DIFF
--- a/environments/swe_group_judge_v1/pyproject.toml
+++ b/environments/swe_group_judge_v1/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "swe-group-judge-v1"
+version = "0.1.0"
+description = "swe-group-judge-v1 — agentic group judge over SWE-style tasks (showcases AgenticGroupJudge)."
+requires-python = ">=3.10"
+dependencies = ["verifiers"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["swe_group_judge_v1"]

--- a/environments/swe_group_judge_v1/swe_group_judge_v1/__init__.py
+++ b/environments/swe_group_judge_v1/swe_group_judge_v1/__init__.py
@@ -1,0 +1,3 @@
+from swe_group_judge_v1.taskset import SweGroupJudgeTaskset, SweJudge
+
+__all__ = ["SweGroupJudgeTaskset", "SweJudge"]

--- a/environments/swe_group_judge_v1/swe_group_judge_v1/tasks/example/tests/test.sh
+++ b/environments/swe_group_judge_v1/swe_group_judge_v1/tasks/example/tests/test.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Pristine test suite for the example task — staged into each candidate's _tests/ and run by the
+# judge against that candidate's /repo. Exit non-zero on failure. Replace with the real suite.
+set -e
+python3 -c "from repo.config import parse_config; assert parse_config('') == {}, 'empty file should parse to {}'"
+echo "ok"

--- a/environments/swe_group_judge_v1/swe_group_judge_v1/taskset.py
+++ b/environments/swe_group_judge_v1/swe_group_judge_v1/taskset.py
@@ -1,0 +1,86 @@
+"""swe_group_judge: an agentic group judge over SWE-style tasks (showcases AgenticGroupJudge).
+
+The policy edits a repo in a sandbox; rollouts are NOT scored per-rollout. After each rollout
+(runtime still live) ``finalize`` snapshots the agent's diff + transcript onto the trace, since
+the runtime is torn down before group scoring. The single ``@group_reward`` then hands the whole
+group to an agentic LLM judge (``vf.AgenticGroupJudge``): it rebuilds each candidate (base + that
+rollout's patch) in a fresh sandbox from ``task.image``, runs the *pristine* tests against each,
+and returns one comparative score per rollout. Those become the group's rewards — GRPO baselines
+them in prime-rl.
+
+Run with ``-r 2`` or more (group rewards compare a task's rollouts), a container runtime
+(docker/prime — the judge rebuilds from ``task.image``), and a judge endpoint, e.g.::
+
+    prime eval run swe-group-judge-v1 -r 4 \\
+        --taskset.judge.model <model> --taskset.judge.base_url <url>
+
+``load_tasks`` below ships one illustrative task; replace it with your SWE rows (each sets its
+container ``image`` and a host ``tests_dir`` holding the pristine suite).
+"""
+
+import functools
+import io
+import tarfile
+from pathlib import Path
+
+import verifiers.v1 as vf
+
+EXAMPLE_TESTS = str(Path(__file__).parent / "tasks" / "example" / "tests")
+
+
+def make_tar(directory: str) -> bytes:
+    """Tar a directory's contents (arcname='.') — the pristine tests staged into each candidate."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        tar.add(directory, arcname=".")
+    return buf.getvalue()
+
+
+class SweTask(vf.Task):
+    instruction: str
+    """The change to make (becomes the rollout prompt)."""
+    tests_dir: str
+    """Host path to the pristine test suite, staged into each candidate's ``_tests/``."""
+
+
+class JudgedConfig(vf.TasksetConfig):
+    judge: vf.JudgeConfig = vf.JudgeConfig()
+    """The judge model/endpoint (its own endpoint, not the policy)."""
+    judge_runtime: vf.RuntimeConfig = vf.DockerConfig()
+    """The judge sandbox; ``task.image`` is injected per group so it carries the task toolchain."""
+
+
+class SweJudge(vf.AgenticGroupJudge):
+    """The repo lives at ``/repo`` in the task image; tests come from the task's host dir."""
+
+    repo_path = "/repo"
+
+    def tests_tar(self, task: SweTask) -> bytes:
+        return make_tar(task.tests_dir)
+
+
+class SweGroupJudgeTaskset(vf.Taskset[SweTask, JudgedConfig]):
+    def load_tasks(self) -> list[SweTask]:
+        return [
+            SweTask(
+                idx=0,
+                name="example",
+                image="ghcr.io/your-org/your-repo:base",  # repo checked out at /repo
+                prompt="Fix parse_config() so it returns {} on an empty file instead of raising.",
+                instruction="Fix parse_config() on empty input.",
+                tests_dir=EXAMPLE_TESTS,
+            )
+        ]
+
+    @functools.cached_property
+    def judge(self) -> SweJudge:
+        return SweJudge(self.config.judge, self.config.judge_runtime)
+
+    async def finalize(self, task: SweTask, trace: vf.Trace, runtime: vf.Runtime) -> None:
+        """Runtime still live: snapshot the agent's diff + transcript for the group judge."""
+        diff = await runtime.run(["sh", "-c", "cd /repo && git add -A && git diff --cached --binary"], {})
+        trace.info["judge"] = {"patch": diff.stdout, "transcript": vf.render_transcript(trace)}
+
+    @vf.group_reward(weight=1.0)
+    async def panel(self, traces: list[vf.Trace], task: SweTask) -> list[float]:
+        return await self.judge.score(traces, task)

--- a/environments/swe_group_judge_v1/swe_group_judge_v1/taskset.py
+++ b/environments/swe_group_judge_v1/swe_group_judge_v1/taskset.py
@@ -37,8 +37,6 @@ def make_tar(directory: str) -> bytes:
 
 
 class SweTask(vf.Task):
-    instruction: str
-    """The change to make (becomes the rollout prompt)."""
     tests_dir: str
     """Host path to the pristine test suite, staged into each candidate's ``_tests/``."""
 
@@ -67,7 +65,6 @@ class SweGroupJudgeTaskset(vf.Taskset[SweTask, JudgedConfig]):
                 name="example",
                 image="ghcr.io/your-org/your-repo:base",  # repo checked out at /repo
                 prompt="Fix parse_config() so it returns {} on an empty file instead of raising.",
-                instruction="Fix parse_config() on empty input.",
                 tests_dir=EXAMPLE_TESTS,
             )
         ]

--- a/verifiers/v1/__init__.py
+++ b/verifiers/v1/__init__.py
@@ -19,8 +19,8 @@ from verifiers.v1.decorators import group_reward, metric, reward, stop, tool
 from verifiers.v1.env import (
     ElasticPoolConfig,
     EnvConfig,
-    EnvServerConfig,
     Environment,
+    EnvServerConfig,
     StaticPoolConfig,
     TimeoutConfig,
     pool_serve_kwargs,
@@ -37,6 +37,8 @@ from verifiers.v1.errors import (
     TunnelError,
     UserError,
 )
+from verifiers.v1.graph import MessageNode
+from verifiers.v1.group_judge import AgenticGroupJudge, render_transcript
 from verifiers.v1.harness import Harness, HarnessConfig
 from verifiers.v1.judge import Judge, JudgeConfig, JudgeResponse, JudgeSamplingConfig
 from verifiers.v1.loaders import (
@@ -48,6 +50,12 @@ from verifiers.v1.loaders import (
     load_taskset,
     task_type,
     taskset_config_type,
+)
+from verifiers.v1.mcp import (
+    Toolset,
+    ToolsetConfig,
+    User,
+    UserConfig,
 )
 from verifiers.v1.retries import RetryConfig, RolloutRetryConfig
 from verifiers.v1.rollout import Rollout
@@ -62,13 +70,6 @@ from verifiers.v1.runtimes import (
 from verifiers.v1.state import State, StateT
 from verifiers.v1.task import Task, TaskResources, TaskTimeout, WireTask
 from verifiers.v1.taskset import Taskset, TasksetConfig
-from verifiers.v1.mcp import (
-    Toolset,
-    ToolsetConfig,
-    User,
-    UserConfig,
-)
-from verifiers.v1.graph import MessageNode
 from verifiers.v1.trace import (
     Branch,
     Error,
@@ -94,8 +95,8 @@ from verifiers.v1.types import (
     TextContentPart,
     Tool,
     ToolCall,
-    TurnTokens,
     ToolMessage,
+    TurnTokens,
     Usage,
     UserMessage,
 )
@@ -195,6 +196,8 @@ __all__ = [
     "JudgeConfig",
     "JudgeSamplingConfig",
     "JudgeResponse",
+    "AgenticGroupJudge",
+    "render_transcript",
     # mcp
     "Toolset",
     "ToolsetConfig",

--- a/verifiers/v1/group_judge.py
+++ b/verifiers/v1/group_judge.py
@@ -39,9 +39,11 @@ task's pristine test suite — then call `score` from `@group_reward`. The shape
                 return await self.judge.score(traces, task)
 
 The scores returned by ``@group_reward`` are summed (× weight) into each ``trace.reward``; in
-prime-rl those become the group's rewards and GRPO baselines them. Any failure — the judge
-times out, returns the wrong count, a snapshot is missing — propagates, which marks the group
-errored and (in prime-rl) drops it. The judge model/endpoint is a ``JudgeConfig`` (its own
+prime-rl those become the group's rewards and GRPO baselines them. A hard failure — the judge
+never submits valid scores within ``max_turns``, the sandbox/clone fails, or a rollout's snapshot
+is missing — propagates, marking the group errored (dropped in prime-rl); recoverable tool/format
+mistakes (bad JSON, wrong count, a missing file) are fed back for the judge to retry. The judge
+model/endpoint is a ``JudgeConfig`` (its own
 endpoint, not the policy); the judge sandbox is a ``RuntimeConfig`` resolved per task so it
 carries the task's toolchain (the candidates' tests actually run).
 """
@@ -195,10 +197,11 @@ class AgenticGroupJudge:
             await asyncio.gather(
                 *(self._stage_rollout(runtime, displayed, traces[real], tests) for displayed, real in enumerate(order))
             )
-            displayed_scores = await self._run_agent(runtime, n)
+            displayed_scores, displayed_rationale = await self._run_agent(runtime, n)
             scores = [0.0] * n
             for displayed, real in enumerate(order):
                 scores[real] = displayed_scores[displayed]
+                traces[real].info["judge_rationale"] = displayed_rationale[displayed]  # audit trail
             return scores
         finally:
             await runtime.stop()
@@ -230,7 +233,10 @@ class AgenticGroupJudge:
             ["sh", "-c", f"cd {d} && mkdir -p _tests && tar xf _tests.tar -C _tests && rm _tests.tar"], {}
         )
 
-    async def _run_agent(self, runtime: Runtime, n: int) -> list[float]:
+    async def _run_agent(self, runtime: Runtime, n: int) -> tuple[list[float], list[str]]:
+        """Drive the judge tool-loop until it submits valid scores. Recoverable tool/format
+        mistakes are fed back for the judge to retry; running out of turns raises (group dropped).
+        Returns (scores, rationale), both length ``n`` in displayed order."""
         messages: list[dict[str, Any]] = [{"role": "system", "content": self.system_prompt.format(n=n, last=n - 1)}]
         sampling = self.config.sampling.model_dump(exclude_none=True)
         for _ in range(self.max_turns):
@@ -243,20 +249,45 @@ class AgenticGroupJudge:
                 messages.append({"role": "user", "content": "Use the tools to investigate, then call submit_scores."})
                 continue
             for call in message.tool_calls:
-                args = json.loads(call.function.arguments or "{}")
-                if call.function.name == "submit_scores":
-                    scores = args.get("scores")
-                    if not isinstance(scores, list) or len(scores) != n:
-                        raise RuntimeError(f"submit_scores expected {n} scores, got {scores!r}")
-                    return [float(s) for s in scores]
-                result = await self._dispatch(runtime, call.function.name, args)
-                messages.append({"role": "tool", "tool_call_id": call.id, "content": result})
-        raise RuntimeError(f"judge did not submit scores within {self.max_turns} turns")
+                verdict, feedback = await self._handle_call(runtime, call, n)
+                if verdict is not None:
+                    return verdict
+                messages.append({"role": "tool", "tool_call_id": call.id, "content": feedback})
+        raise RuntimeError(f"judge did not submit valid scores within {self.max_turns} turns")
+
+    async def _handle_call(
+        self, runtime: Runtime, call: Any, n: int
+    ) -> tuple[tuple[list[float], list[str]] | None, str]:
+        """Run one tool call. A non-None first element is the final (scores, rationale) from
+        submit_scores; otherwise the string is the tool message fed back to the judge. Tool and
+        format errors return feedback (retryable) rather than raising, so a single fumble doesn't
+        drop the whole group."""
+        try:
+            args = json.loads(call.function.arguments or "{}")
+        except json.JSONDecodeError as e:
+            return None, f"invalid JSON arguments: {e}"
+        if call.function.name == "submit_scores":
+            scores = args.get("scores")
+            if not isinstance(scores, list) or len(scores) != n:
+                return None, f"submit_scores needs exactly {n} scores (one per rollout); got {scores!r}"
+            try:
+                scores = [float(s) for s in scores]
+            except (TypeError, ValueError):
+                return None, "scores must be numbers; investigate and resubmit"
+            rationale = [str(r) for r in (args.get("rationale") or [])]
+            rationale = rationale[:n] + [""] * (n - len(rationale))
+            return (scores, rationale), ""
+        return None, await self._dispatch(runtime, call.function.name, args)
 
     async def _dispatch(self, runtime: Runtime, name: str, args: dict[str, Any]) -> str:
         if name == "run_command":
             res = await runtime.run(["sh", "-c", str(args.get("command", ""))], {})
             return truncate_output(f"exit={res.exit_code}\n{res.stdout}{res.stderr}")
         if name == "read_file":
-            return truncate_output((await runtime.read(str(args.get("path", "")))).decode(errors="replace"))
-        raise RuntimeError(f"unknown judge tool {name!r}")
+            path = str(args.get("path", ""))
+            try:
+                data = await runtime.read(path)
+            except Exception as e:  # a judge probing a bad path shouldn't drop the group
+                return f"error reading {path}: {e}"
+            return truncate_output(data.decode(errors="replace"))
+        return f"unknown tool {name!r}"

--- a/verifiers/v1/group_judge.py
+++ b/verifiers/v1/group_judge.py
@@ -1,0 +1,251 @@
+"""A reusable *agentic, group-level* LLM judge for v1 tasksets.
+
+Where `Judge` (judge.py) is one chat call that scores one rollout from text in its prompt,
+`AgenticGroupJudge` scores a whole *group* of a task's rollouts at once, by letting the judge
+**investigate them with tools inside a sandbox** and emit one score per rollout. It is the
+runtime behind a taskset's ``@group_reward``.
+
+Subclass it like `Judge` — set the class fields you want and override `tests_tar` to supply the
+task's pristine test suite — then call `score` from `@group_reward`. The shape, end to end:
+
+  1. While each rollout's runtime is still live, the taskset's ``finalize`` snapshots what the
+     judge will need onto the trace — the agent's diff and a transcript — since the runtime is
+     torn down before group scoring runs (see episode.py). Use ``render_transcript``:
+
+        async def finalize(self, task, trace, runtime):
+            diff = await runtime.run(
+                ["sh", "-c", f"cd {REPO} && git add -A && git diff --cached --binary"], {}
+            )
+            trace.info["judge"] = {"patch": diff.stdout, "transcript": render_transcript(trace)}
+
+  2. ``@group_reward`` delegates to the judge, which provisions ONE fresh runtime from the
+     task's image (``resolve_runtime_config`` injects ``task.image``), rebuilds each rollout as
+     ``base + that rollout's patch`` under ``/judge/rollouts/<i>`` (shuffled, to defeat position
+     bias), stages the *pristine* test suite alongside each, and runs the judge agent. The agent
+     runs commands / reads files (e.g. runs the pristine tests against each candidate, inspects
+     the diffs for tampering or regressions) and finishes by calling ``submit_scores``:
+
+        class SweJudge(vf.AgenticGroupJudge):
+            repo_path = "/repo"
+            def tests_tar(self, task): return make_tar(task.tests_dir)
+
+        class SweJudgedTaskset(vf.Taskset[SweTask, JudgedConfig]):
+            @functools.cached_property
+            def judge(self):                          # taskset wires the judge from its config
+                return SweJudge(self.config.judge, self.config.judge_runtime)
+
+            @vf.group_reward(weight=1.0)
+            async def panel(self, traces, task) -> list[float]:
+                return await self.judge.score(traces, task)
+
+The scores returned by ``@group_reward`` are summed (× weight) into each ``trace.reward``; in
+prime-rl those become the group's rewards and GRPO baselines them. Any failure — the judge
+times out, returns the wrong count, a snapshot is missing — propagates, which marks the group
+errored and (in prime-rl) drops it. The judge model/endpoint is a ``JudgeConfig`` (its own
+endpoint, not the policy); the judge sandbox is a ``RuntimeConfig`` resolved per task so it
+carries the task's toolchain (the candidates' tests actually run).
+"""
+
+from __future__ import annotations
+
+import json
+import random
+import uuid
+from typing import TYPE_CHECKING, Any
+
+from openai import AsyncOpenAI
+
+from verifiers.v1.clients.config import build_async_openai
+from verifiers.v1.judge import JudgeConfig
+from verifiers.v1.runtimes import Runtime, RuntimeConfig, make_runtime
+
+if TYPE_CHECKING:
+    from verifiers.v1.task import Task
+    from verifiers.v1.trace import Trace
+
+
+DEFAULT_JUDGE_PROMPT = """\
+You are comparing {n} candidate solutions to the SAME task, laid out in the sandbox as
+/judge/rollouts/0 .. /judge/rollouts/{last}. Each is the base repository with that candidate's
+patch applied; the candidate could NOT see or edit the test suite, a pristine copy of which is
+in each rollout's _tests/ directory. Each rollout's agent transcript is in _transcript.txt, and
+_apply.log shows whether that candidate's patch applied cleanly (a non-zero exit means its
+changes did NOT land — it is the untouched base).
+
+Investigate with the tools: run the pristine tests against each candidate (e.g.
+`cd /judge/rollouts/<i> && <how this repo runs its tests>`), read the diffs and transcripts,
+and watch for regressions, for solutions that don't address the root cause, and for any attempt
+to tamper with or hard-code around the tests.
+
+Then score the candidates RELATIVE TO EACH OTHER — spread your scores and avoid ties; only the
+within-group ordering and spacing matter. Finish by calling submit_scores with one score and one
+short rationale per rollout, in displayed order (index 0..{last}).
+"""
+
+_OUTPUT_LIMIT = 8_000
+
+_TOOLS: list[dict[str, Any]] = [
+    {
+        "type": "function",
+        "function": {
+            "name": "run_command",
+            "description": "Run a shell command in the judge sandbox and return its output.",
+            "parameters": {
+                "type": "object",
+                "properties": {"command": {"type": "string"}},
+                "required": ["command"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "read_file",
+            "description": "Read a file from the judge sandbox.",
+            "parameters": {
+                "type": "object",
+                "properties": {"path": {"type": "string"}},
+                "required": ["path"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "submit_scores",
+            "description": "Submit one comparative score and rationale per rollout, in displayed order.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "scores": {"type": "array", "items": {"type": "number"}},
+                    "rationale": {"type": "array", "items": {"type": "string"}},
+                },
+                "required": ["scores", "rationale"],
+            },
+        },
+    },
+]
+
+
+def truncate_output(text: str, limit: int = _OUTPUT_LIMIT) -> str:
+    """Clip tool output before it goes back into the judge's context."""
+    return text if len(text) <= limit else text[:limit] + "\n...<truncated>"
+
+
+def render_transcript(trace: "Trace") -> str:
+    """Render a rollout's conversation to plain text for the judge to read. Walks the trace's
+    branches; assistant tool calls are included so the judge sees what the agent *did*."""
+    lines: list[str] = []
+    for branch in trace.branches:
+        for message in branch.messages:
+            lines.append(f"## {getattr(message, 'role', '?')}")
+            content = getattr(message, "content", None)
+            if isinstance(content, str):
+                lines.append(content)
+            elif content is not None:
+                lines.append(json.dumps(content, default=str))
+            for call in getattr(message, "tool_calls", None) or []:
+                lines.append(f"[tool_call] {call.function.name}({call.function.arguments})")
+    return "\n".join(lines)
+
+
+class AgenticGroupJudge:
+    """Scores a group of a task's rollouts by letting an LLM judge investigate them with tools
+    in a sandbox. Subclass to override `tests_tar` (and any class field), construct from a
+    `JudgeConfig` + `RuntimeConfig` on the owning taskset, and call :meth:`score` from
+    ``@group_reward``.
+    """
+
+    system_prompt: str = DEFAULT_JUDGE_PROMPT
+    """Comparative judging prompt; ``{n}``/``{last}`` are formatted in per call."""
+    repo_path: str = "/testbed"
+    """Where the base repository lives inside the task image (image-dependent, e.g. ``/testbed``
+    for SWE-bench-style images); each candidate is ``git clone``d from here."""
+    max_turns: int = 25
+    """Hard cap on judge tool-use turns before the group is failed."""
+
+    def __init__(self, config: JudgeConfig, runtime: RuntimeConfig) -> None:
+        self.config = config
+        self.runtime_config = runtime
+        self.client: AsyncOpenAI = build_async_openai(config)
+
+    def tests_tar(self, task: "Task") -> bytes:
+        """Override: the task's pristine test suite as a tar archive, staged into each
+        candidate's ``_tests/`` for the judge to run."""
+        raise NotImplementedError(f"{type(self).__name__} must implement tests_tar(task)")
+
+    async def score(self, traces: list["Trace"], task: "Task") -> list[float]:
+        """Provision the judge sandbox from ``task.image``, rebuild every rollout as base + its
+        patch (shuffled) with the pristine tests staged, run the judge agent, and return one
+        score per trace in the original order. Raises on any failure (→ the group is dropped)."""
+        from verifiers.v1.env import resolve_runtime_config
+
+        n = len(traces)
+        name = f"group-judge-{uuid.uuid4().hex}"  # unique: groups are scored concurrently
+        runtime = make_runtime(resolve_runtime_config(self.runtime_config, task), name=name)
+        await runtime.start()
+        try:
+            order = list(range(n))
+            random.Random(repr(task.idx)).shuffle(order)  # deterministic per task, hides identity
+            tests = self.tests_tar(task)
+            await runtime.run(["sh", "-c", "mkdir -p /judge/rollouts"], {})
+            for displayed, real in enumerate(order):
+                await self._stage_rollout(runtime, displayed, traces[real], tests)
+            displayed_scores = await self._run_agent(runtime, n)
+            scores = [0.0] * n
+            for displayed, real in enumerate(order):
+                scores[real] = displayed_scores[displayed]
+            return scores
+        finally:
+            await runtime.stop()
+
+    async def _stage_rollout(self, runtime: Runtime, idx: int, trace: "Trace", tests: bytes) -> None:
+        info = trace.info.get("judge")
+        if not info or "patch" not in info:
+            raise RuntimeError(
+                f"rollout {trace.idx} has no judge snapshot in trace.info['judge']; "
+                "does the taskset's finalize() capture it?"
+            )
+        d = f"/judge/rollouts/{idx}"
+        clone = await runtime.run(["sh", "-c", f"rm -rf {d} && git clone -q {self.repo_path} {d}"], {})
+        if clone.exit_code != 0:
+            raise RuntimeError(f"judge clone of {self.repo_path} failed: {truncate_output(clone.stderr)}")
+        await runtime.write(f"{d}/_cand.patch", info["patch"].encode())
+        apply = await runtime.run(["sh", "-c", f"cd {d} && git apply --binary _cand.patch"], {})
+        # Don't fail the group if a patch is messy — record the outcome so the judge sees whether
+        # this candidate's changes actually landed (vs. being scored as the untouched base).
+        await runtime.write(f"{d}/_apply.log", f"exit={apply.exit_code}\n{apply.stderr}".encode())
+        await runtime.write(f"{d}/_transcript.txt", info.get("transcript", "").encode())
+        await runtime.write(f"{d}/_tests.tar", tests)
+        await runtime.run(["sh", "-c", f"cd {d} && mkdir -p _tests && tar xf _tests.tar -C _tests"], {})
+
+    async def _run_agent(self, runtime: Runtime, n: int) -> list[float]:
+        messages: list[dict[str, Any]] = [{"role": "system", "content": self.system_prompt.format(n=n, last=n - 1)}]
+        sampling = self.config.sampling.model_dump(exclude_none=True)
+        for _ in range(self.max_turns):
+            completion = await self.client.chat.completions.create(
+                model=self.config.model, messages=messages, tools=_TOOLS, **sampling
+            )
+            message = completion.choices[0].message
+            messages.append(message.model_dump(exclude_none=True))
+            if not message.tool_calls:
+                messages.append({"role": "user", "content": "Use the tools to investigate, then call submit_scores."})
+                continue
+            for call in message.tool_calls:
+                args = json.loads(call.function.arguments or "{}")
+                if call.function.name == "submit_scores":
+                    scores = args.get("scores")
+                    if not isinstance(scores, list) or len(scores) != n:
+                        raise RuntimeError(f"submit_scores expected {n} scores, got {scores!r}")
+                    return [float(s) for s in scores]
+                result = await self._dispatch(runtime, call.function.name, args)
+                messages.append({"role": "tool", "tool_call_id": call.id, "content": result})
+        raise RuntimeError(f"judge did not submit scores within {self.max_turns} turns")
+
+    async def _dispatch(self, runtime: Runtime, name: str, args: dict[str, Any]) -> str:
+        if name == "run_command":
+            res = await runtime.run(["sh", "-c", str(args.get("command", ""))], {})
+            return truncate_output(f"exit={res.exit_code}\n{res.stdout}{res.stderr}")
+        if name == "read_file":
+            return truncate_output((await runtime.read(str(args.get("path", "")))).decode(errors="replace"))
+        raise RuntimeError(f"unknown judge tool {name!r}")

--- a/verifiers/v1/group_judge.py
+++ b/verifiers/v1/group_judge.py
@@ -188,8 +188,8 @@ class AgenticGroupJudge:
         n = len(traces)
         name = f"group-judge-{uuid.uuid4().hex}"  # unique: groups are scored concurrently
         runtime = make_runtime(resolve_runtime_config(self.runtime_config, task), name=name)
-        await runtime.start()
         try:
+            await runtime.start()  # inside try: stop() (idempotent) still runs if start half-provisions
             order = list(range(n))
             random.Random(task.idx).shuffle(order)  # deterministic per task, hides identity
             tests = self.tests_tar(task)

--- a/verifiers/v1/group_judge.py
+++ b/verifiers/v1/group_judge.py
@@ -48,6 +48,7 @@ carries the task's toolchain (the candidates' tests actually run).
 
 from __future__ import annotations
 
+import asyncio
 import json
 import random
 import uuid
@@ -75,7 +76,9 @@ changes did NOT land — it is the untouched base).
 Investigate with the tools: run the pristine tests against each candidate (e.g.
 `cd /judge/rollouts/<i> && <how this repo runs its tests>`), read the diffs and transcripts,
 and watch for regressions, for solutions that don't address the root cause, and for any attempt
-to tamper with or hard-code around the tests.
+to tamper with or hard-code around the tests. The _-prefixed files above are added by this
+harness and are git-excluded, so `git -C /judge/rollouts/<i> diff` shows only that candidate's
+own change.
 
 Then score the candidates RELATIVE TO EACH OTHER — spread your scores and avoid ties; only the
 within-group ordering and spacing matter. Finish by calling submit_scores with one score and one
@@ -186,11 +189,12 @@ class AgenticGroupJudge:
         await runtime.start()
         try:
             order = list(range(n))
-            random.Random(repr(task.idx)).shuffle(order)  # deterministic per task, hides identity
+            random.Random(task.idx).shuffle(order)  # deterministic per task, hides identity
             tests = self.tests_tar(task)
             await runtime.run(["sh", "-c", "mkdir -p /judge/rollouts"], {})
-            for displayed, real in enumerate(order):
-                await self._stage_rollout(runtime, displayed, traces[real], tests)
+            await asyncio.gather(
+                *(self._stage_rollout(runtime, displayed, traces[real], tests) for displayed, real in enumerate(order))
+            )
             displayed_scores = await self._run_agent(runtime, n)
             scores = [0.0] * n
             for displayed, real in enumerate(order):
@@ -210,6 +214,11 @@ class AgenticGroupJudge:
         clone = await runtime.run(["sh", "-c", f"rm -rf {d} && git clone -q {self.repo_path} {d}"], {})
         if clone.exit_code != 0:
             raise RuntimeError(f"judge clone of {self.repo_path} failed: {truncate_output(clone.stderr)}")
+        # Keep the candidate's git state pristine: our scaffolding must not show up when the judge
+        # inspects `git diff`/`git status` for the candidate's real change (or for test tampering).
+        await runtime.run(
+            ["sh", "-c", f"printf '%s\\n' _cand.patch _apply.log _transcript.txt _tests >> {d}/.git/info/exclude"], {}
+        )
         await runtime.write(f"{d}/_cand.patch", info["patch"].encode())
         apply = await runtime.run(["sh", "-c", f"cd {d} && git apply --binary _cand.patch"], {})
         # Don't fail the group if a patch is messy — record the outcome so the judge sees whether
@@ -217,7 +226,9 @@ class AgenticGroupJudge:
         await runtime.write(f"{d}/_apply.log", f"exit={apply.exit_code}\n{apply.stderr}".encode())
         await runtime.write(f"{d}/_transcript.txt", info.get("transcript", "").encode())
         await runtime.write(f"{d}/_tests.tar", tests)
-        await runtime.run(["sh", "-c", f"cd {d} && mkdir -p _tests && tar xf _tests.tar -C _tests"], {})
+        await runtime.run(
+            ["sh", "-c", f"cd {d} && mkdir -p _tests && tar xf _tests.tar -C _tests && rm _tests.tar"], {}
+        )
 
     async def _run_agent(self, runtime: Runtime, n: int) -> list[float]:
         messages: list[dict[str, Any]] = [{"role": "system", "content": self.system_prompt.format(n=n, last=n - 1)}]


### PR DESCRIPTION
## What

Adds `vf.AgenticGroupJudge` — a reusable, **agentic, group-level** LLM judge for v1 tasksets.

Where `Judge` (`judge.py`) is one chat call that scores **one** rollout from text in its prompt, `AgenticGroupJudge` scores a whole **group** of a task's rollouts at once: it gives the judge a sandbox containing every candidate, lets it **investigate with tools** (run the pristine tests, read diffs/transcripts, look for regressions or test-tampering), and emit **one comparative score per rollout**. It is the runtime behind a taskset's `@group_reward`.

## Why

For RL we want to run a group of rollouts and have a judge return a list of scores (one per rollout) that become the group's rewards (GRPO baselines them downstream). A prompt-stuffing judge can't run code or inspect a filesystem; an agentic judge in a sandbox can — e.g. run the *hidden* tests itself instead of us wiring a bespoke verifier, and catch a rollout that passed the shown tests by editing them.

This reuses the existing seams rather than adding new ones: `@group_reward` already exists and already flips `requires_group_rollouts`, and `Runtime`/`make_runtime` already provision sandboxes. The judge collapses into the taskset's group scoring as a reusable component (no new env/router machinery).

## How it's used

Two wiring points on the taskset (see `environments/swe_group_judge_v1/`):

```python
class SweJudge(vf.AgenticGroupJudge):
    repo_path = "/repo"
    def tests_tar(self, task): return make_tar(task.tests_dir)

class SweGroupJudgeTaskset(vf.Taskset[SweTask, JudgedConfig]):
    @functools.cached_property
    def judge(self): return SweJudge(self.config.judge, self.config.judge_runtime)

    async def finalize(self, task, trace, runtime):     # runtime still live → snapshot
        diff = await runtime.run(["sh","-c","cd /repo && git add -A && git diff --cached --binary"], {})
        trace.info["judge"] = {"patch": diff.stdout, "transcript": vf.render_transcript(trace)}

    @vf.group_reward(weight=1.0)                         # → requires_group_rollouts
    async def panel(self, traces, task) -> list[float]:
        return await self.judge.score(traces, task)
```

Lifecycle: each rollout tears down its own runtime before group scoring (episode.py), so `finalize` snapshots the diff + transcript onto the trace while the runtime is live; `score()` then provisions **one** fresh runtime from `task.image` (`resolve_runtime_config` injects it), rebuilds each candidate (concurrently) as `base + that rollout's patch` under `/judge/rollouts/<i>` (shuffled to defeat position bias), stages the pristine tests, runs the judge agent, and returns one score per trace.

Failure handling: a group is N full agentic rollouts, so a single judge fumble doesn't drop it — recoverable tool/format errors (bad JSON args, wrong score count, non-numeric scores, `read_file` on a bad path, unknown tool) are fed back to the judge to retry within `max_turns`. Only a hard failure — never submitting valid scores within `max_turns`, an infra/clone failure, or a missing snapshot — propagates and drops the group. The judge's per-rollout rationale is recorded onto `trace.info["judge_rationale"]` for auditability.

The harness scaffolding (`_cand.patch`, `_apply.log`, `_transcript.txt`, `_tests/`) is git-excluded inside each candidate clone, so the judge's `git diff`/`git status` reflect only that candidate's own change — keeping the diff/tamper inspection clean.

## Changes

- `verifiers/v1/group_judge.py` — `AgenticGroupJudge` + `render_transcript`.
- `verifiers/v1/__init__.py` — export both.
- `environments/swe_group_judge_v1/` — example taskset, modeled on `code_golf_v1`.

## Validation

- ruff + repo pre-commit clean.
- Imports and all dependent seams resolve against the package; the example taskset loads and its `@group_reward` is discovered.
- **Runtime smoke** (`SubprocessRuntime`, stubbed judge LLM): builds a base git repo + N candidate patches where each candidate prints its true id, runs `score()` end to end (clone → apply → stage tests → tool-loop → `submit_scores`), and asserts: (a) the scores unshuffle back to `[0, 1, 2]` — exercising staging, dispatch, and the shuffle→unshuffle mapping; (b) the candidate's `git status` shows only its own change, confirming the scaffolding is git-excluded; (c) a deliberately wrong-count `submit_scores` is fed back and retried (not dropped) and the rationale is recorded on the traces.

Not yet exercised: a live judge model doing tool-calls and a real container image (`task.image` with the repo at `repo_path`) — i.e. a full `prime eval run`. Image-dependent knobs (`repo_path`, the `finalize` diff path, where the pristine tests live) are documented and overridable.

## Notes / open questions

- Score scale: the judge returns raw comparative floats (GRPO uses only within-group spread); we could normalize for log readability.
- Test-run hygiene (per-test timeouts, flaky reruns) and transcript anonymization depth are left to follow-ups.
- The example env uses a placeholder image so it won't `prime eval run` as-is — it's a wiring template.
