### PR TITLE
show user-set configs in eval

### DIFF
--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -125,17 +125,13 @@ def _warning(config: EvalConfig) -> Text | None:
 
 # Field names whose dict *values* may be secrets (tokens / API keys passed as the harness's
 # process env). The override row shows only their KEYS (`env={HF_TOKEN, RLM_FOO}`) so a secret
-# never lands on the live terminal. (Headers — the other secret-bearing dict — live on
-# `config.client`, which this row doesn't render; redacting the config.toml dump + INFO-level
-# config log that *do* expose both is a separate, broader change.)
+# never lands on the live terminal.
 _KEYS_ONLY_FIELDS = frozenset({"env"})
 
 
 def fmt_override(value: object, keys_only: bool = False) -> str:
-    """Render an overridden value as a single compact segment: a dict as `{k=v,k=v}` (or `{k,k}`
-    when `keys_only`, so a secret-bearing field shows which keys are set, never their values) and
-    a list/tuple as `[a,b]` — the delimiters mark it as a collection, so `env={K}` reads as a
-    dict rather than a bare `env=K`. Anything else renders as its `str`."""
+    """Render a value as one compact segment: a dict as `{k=v,k=v}` (or `{k,k}` when `keys_only`),
+    a list/tuple as `[a,b]`, anything else as its `str`."""
     if isinstance(value, dict):
         if keys_only:
             return "{" + ",".join(str(k) for k in value) + "}"
@@ -146,9 +142,7 @@ def fmt_override(value: object, keys_only: bool = False) -> str:
 
 
 def field_default(field: FieldInfo) -> object:
-    """A field's declared default — calling its `default_factory` (so `env`'s default reads as
-    `{}`, not the factory) or its plain `default` (`PydanticUndefined` for a required field,
-    which equals no value, so a required field always reads as set)."""
+    """A field's declared default."""
     if field.default_factory is not None:
         # All config defaults use the no-arg factory form; the validated-data form isn't used here.
         return field.default_factory()  # type: ignore[call-arg]
@@ -157,14 +151,9 @@ def field_default(field: FieldInfo) -> object:
 
 def overrides(config: BaseModel, skip: frozenset[str] = frozenset()) -> list[str]:
     """`field=value` segments for the fields whose value differs from the field's default — the
-    knobs actually in effect, so the row never overwhelms with defaults. Compares against the
-    declared default rather than `model_fields_set`: a config rebuilt from a saved run's
-    `config.toml` (`--resume` / `@ file.toml`) has *every* persisted field marked as set, so
-    `model_fields_set` would show defaults as overrides — the value comparison is stable across
-    that round-trip. A nested config (e.g. a non-`subprocess` `runtime`) flattens as
-    `runtime.<field>=…`, sorted for a stable order. `skip` holds dotted paths, so a caller can
-    hide a single nested field (e.g. `harness.runtime.type`, already in the `env` row) without
-    hiding the same discriminator on a *different* nested runtime (`taskset.user.runtime.type`)."""
+    knobs in effect, sorted. Comparing values (not `model_fields_set`) stays stable across a
+    saved-config round-trip (`--resume` / `@ file.toml` re-mark every persisted field as set).
+    `skip` holds dotted paths, so a nested field hides by full path (`harness.runtime.type`)."""
     segments: list[str] = []
     fields = type(config).model_fields
     for field in sorted(fields):

--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -123,11 +123,22 @@ def _warning(config: EvalConfig) -> Text | None:
     return None
 
 
-def fmt_override(value: object) -> str:
-    """Render an overridden value as a single compact segment: a dict as `{k=v,k=v}` and a
-    list/tuple as `[a,b]` (the delimiters mark it as a collection, so `env={K=v}` reads as a
-    dict rather than a bare `env=K=v`), anything else as its `str`."""
+# Field names whose dict *values* may be secrets (tokens / API keys passed as the harness's
+# process env). The override row shows only their KEYS (`env={HF_TOKEN, RLM_FOO}`) so a secret
+# never lands on the live terminal. (Headers — the other secret-bearing dict — live on
+# `config.client`, which this row doesn't render; redacting the config.toml dump + INFO-level
+# config log that *do* expose both is a separate, broader change.)
+_KEYS_ONLY_FIELDS = frozenset({"env"})
+
+
+def fmt_override(value: object, keys_only: bool = False) -> str:
+    """Render an overridden value as a single compact segment: a dict as `{k=v,k=v}` (or `{k,k}`
+    when `keys_only`, so a secret-bearing field shows which keys are set, never their values) and
+    a list/tuple as `[a,b]` — the delimiters mark it as a collection, so `env={K}` reads as a
+    dict rather than a bare `env=K`. Anything else renders as its `str`."""
     if isinstance(value, dict):
+        if keys_only:
+            return "{" + ",".join(str(k) for k in value) + "}"
         return "{" + ",".join(f"{k}={v}" for k, v in value.items()) + "}"
     if isinstance(value, (list, tuple)):
         return "[" + ",".join(str(v) for v in value) + "]"
@@ -180,7 +191,10 @@ def overrides(config: BaseModel, skip: frozenset[str] = frozenset()) -> list[str
                 f"{field}.{seg}" for seg in overrides(value, skip=child_skip)
             )
         elif value != field_default(fields[field]):
-            segments.append(f"{field}={fmt_override(value)}")
+            # A secret-bearing field (e.g. `env`) shows keys only — never its values on-screen.
+            segments.append(
+                f"{field}={fmt_override(value, keys_only=field in _KEYS_ONLY_FIELDS)}"
+            )
     return segments
 
 

--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -13,6 +13,7 @@ above a rule.
 import contextlib
 import time
 
+from pydantic import BaseModel
 from rich.console import Console, Group
 from rich.markup import escape
 from rich.progress_bar import ProgressBar
@@ -121,6 +122,43 @@ def _warning(config: EvalConfig) -> Text | None:
     return None
 
 
+def fmt_override(value: object) -> str:
+    """Render an overridden value as a single compact segment: a dict as `{k=v,k=v}` and a
+    list/tuple as `[a,b]` (the delimiters mark it as a collection, so `env={K=v}` reads as a
+    dict rather than a bare `env=K=v`), anything else as its `str`."""
+    if isinstance(value, dict):
+        return "{" + ",".join(f"{k}={v}" for k, v in value.items()) + "}"
+    if isinstance(value, (list, tuple)):
+        return "[" + ",".join(str(v) for v in value) + "]"
+    return str(value)
+
+
+def overrides(config: BaseModel, skip: frozenset[str] = frozenset()) -> list[str]:
+    """`field=value` segments for the fields the user actually set on a config (pydantic's
+    `model_fields_set` — the discriminator/defaults a user never touched stay hidden, so the
+    row never overwhelms). A nested config (e.g. a non-`subprocess` `runtime`) recurses with
+    its `type` discriminator dropped, flattened as `runtime.<field>=…`. Sorted for a stable
+    order (`model_fields_set` is a set)."""
+    segments: list[str] = []
+    for field in sorted(config.model_fields_set):
+        if field in skip:
+            continue
+        value = getattr(config, field)
+        if (
+            value is None
+        ):  # an explicitly-cleared optional reads as a default — nothing to show
+            continue
+        if isinstance(
+            value, BaseModel
+        ):  # nested config: flatten, hiding its `type` discriminator
+            segments.extend(
+                f"{field}.{seg}" for seg in overrides(value, skip=frozenset({"type"}))
+            )
+        else:
+            segments.append(f"{field}={fmt_override(value)}")
+    return segments
+
+
 def Overview(config: EvalConfig) -> Table:
     sampling = ", ".join(
         f"{k}={v}" for k, v in config.sampling.model_dump(exclude_none=True).items()
@@ -134,6 +172,13 @@ def Overview(config: EvalConfig) -> Table:
     )
     model = f"{config.model}  ({sampling})" if sampling else config.model
     grid.add_row("model", f"{model}  via {config.client.base_url}")
+    # Non-default taskset/harness knobs the user set (`id`/`name` are in the `env` row above;
+    # `harness.runtime` is shown here only when its sub-fields were customized — the runtime
+    # `type` already reads in the `env` row). Each row appears only when there's an override.
+    if taskset_over := overrides(config.taskset, skip=frozenset({"id"})):
+        grid.add_row("taskset", "  ·  ".join(taskset_over))
+    if harness_over := overrides(config.harness, skip=frozenset({"id"})):
+        grid.add_row("harness", "  ·  ".join(harness_over))
     limits, timeouts = _aligned([_limits(config), _timeouts(config)])
     grid.add_row("limits", limits)
     grid.add_row("timeouts", timeouts)

--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -185,10 +185,12 @@ def Overview(config: EvalConfig) -> Table:
     # Non-default taskset/harness knobs the user set (`id`/`name` are in the `env` row above;
     # `harness.runtime` is shown here only when its sub-fields were customized — the runtime
     # `type` already reads in the `env` row). Each row appears only when there's an override.
+    # `escape` the joined cell: an override value (or our `[...]`/`{...}` delimiters) can contain
+    # Rich markup — without it `env={TOKEN=[red]x[/red]}` would be parsed as styling and dropped.
     if taskset_over := overrides(config.taskset, skip=frozenset({"id"})):
-        grid.add_row("taskset", "  ·  ".join(taskset_over))
+        grid.add_row("taskset", escape("  ·  ".join(taskset_over)))
     if harness_over := overrides(config.harness, skip=frozenset({"id"})):
-        grid.add_row("harness", "  ·  ".join(harness_over))
+        grid.add_row("harness", escape("  ·  ".join(harness_over)))
     limits, timeouts = _aligned([_limits(config), _timeouts(config)])
     grid.add_row("limits", limits)
     grid.add_row("timeouts", timeouts)

--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -150,19 +150,34 @@ def overrides(config: BaseModel, skip: frozenset[str] = frozenset()) -> list[str
     declared default rather than `model_fields_set`: a config rebuilt from a saved run's
     `config.toml` (`--resume` / `@ file.toml`) has *every* persisted field marked as set, so
     `model_fields_set` would show defaults as overrides — the value comparison is stable across
-    that round-trip. A nested config (e.g. a non-`subprocess` `runtime`) recurses with its
-    `type` discriminator dropped, flattened as `runtime.<field>=…`. Sorted for a stable order."""
+    that round-trip. A nested config (e.g. a non-`subprocess` `runtime`) flattens as
+    `runtime.<field>=…`, sorted for a stable order. `skip` holds dotted paths, so a caller can
+    hide a single nested field (e.g. `harness.runtime.type`, already in the `env` row) without
+    hiding the same discriminator on a *different* nested runtime (`taskset.user.runtime.type`)."""
     segments: list[str] = []
     fields = type(config).model_fields
     for field in sorted(fields):
         if field in skip:
             continue
         value = getattr(config, field)
-        if isinstance(
-            value, BaseModel
-        ):  # nested config: flatten, hiding its `type` discriminator
+        if isinstance(value, BaseModel):  # nested config: flatten, descending the dotted skip
+            child_skip = frozenset(
+                s[len(field) + 1 :] for s in skip if s.startswith(f"{field}.")
+            )
+            # A discriminated nested config (e.g. a `runtime`) whose concrete class differs from
+            # the field default's class is itself an override — surface its `type` discriminator.
+            # The per-field comparison below can't: within the new class `type` equals that
+            # class's own default (e.g. a `DockerConfig` always has `type="docker"`), so it never
+            # reads as changed. `runtime.type` lives in `child_skip` only for the harness (the
+            # `env` row already shows it); a taskset's `user.runtime.type` still surfaces here.
+            if (
+                type(value) is not type(field_default(fields[field]))
+                and "type" not in child_skip
+                and (discriminator := getattr(value, "type", None)) is not None
+            ):
+                segments.append(f"{field}.type={fmt_override(discriminator)}")
             segments.extend(
-                f"{field}.{seg}" for seg in overrides(value, skip=frozenset({"type"}))
+                f"{field}.{seg}" for seg in overrides(value, skip=child_skip)
             )
         elif value != field_default(fields[field]):
             segments.append(f"{field}={fmt_override(value)}")
@@ -189,7 +204,11 @@ def Overview(config: EvalConfig) -> Table:
     # Rich markup — without it `env={TOKEN=[red]x[/red]}` would be parsed as styling and dropped.
     if taskset_over := overrides(config.taskset, skip=frozenset({"id"})):
         grid.add_row("taskset", escape("  ·  ".join(taskset_over)))
-    if harness_over := overrides(config.harness, skip=frozenset({"id"})):
+    # `runtime.type` is already in the `env` row, so hide it here — but only for the harness's
+    # own runtime (a taskset's `user.runtime.type` has no other display and must still show).
+    if harness_over := overrides(
+        config.harness, skip=frozenset({"id", "runtime.type"})
+    ):
         grid.add_row("harness", escape("  ·  ".join(harness_over)))
     limits, timeouts = _aligned([_limits(config), _timeouts(config)])
     grid.add_row("limits", limits)

--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -14,6 +14,7 @@ import contextlib
 import time
 
 from pydantic import BaseModel
+from pydantic.fields import FieldInfo
 from rich.console import Console, Group
 from rich.markup import escape
 from rich.progress_bar import ProgressBar
@@ -133,28 +134,37 @@ def fmt_override(value: object) -> str:
     return str(value)
 
 
+def field_default(field: FieldInfo) -> object:
+    """A field's declared default — calling its `default_factory` (so `env`'s default reads as
+    `{}`, not the factory) or its plain `default` (`PydanticUndefined` for a required field,
+    which equals no value, so a required field always reads as set)."""
+    if field.default_factory is not None:
+        # All config defaults use the no-arg factory form; the validated-data form isn't used here.
+        return field.default_factory()  # type: ignore[call-arg]
+    return field.default
+
+
 def overrides(config: BaseModel, skip: frozenset[str] = frozenset()) -> list[str]:
-    """`field=value` segments for the fields the user actually set on a config (pydantic's
-    `model_fields_set` — the discriminator/defaults a user never touched stay hidden, so the
-    row never overwhelms). A nested config (e.g. a non-`subprocess` `runtime`) recurses with
-    its `type` discriminator dropped, flattened as `runtime.<field>=…`. Sorted for a stable
-    order (`model_fields_set` is a set)."""
+    """`field=value` segments for the fields whose value differs from the field's default — the
+    knobs actually in effect, so the row never overwhelms with defaults. Compares against the
+    declared default rather than `model_fields_set`: a config rebuilt from a saved run's
+    `config.toml` (`--resume` / `@ file.toml`) has *every* persisted field marked as set, so
+    `model_fields_set` would show defaults as overrides — the value comparison is stable across
+    that round-trip. A nested config (e.g. a non-`subprocess` `runtime`) recurses with its
+    `type` discriminator dropped, flattened as `runtime.<field>=…`. Sorted for a stable order."""
     segments: list[str] = []
-    for field in sorted(config.model_fields_set):
+    fields = type(config).model_fields
+    for field in sorted(fields):
         if field in skip:
             continue
         value = getattr(config, field)
-        if (
-            value is None
-        ):  # an explicitly-cleared optional reads as a default — nothing to show
-            continue
         if isinstance(
             value, BaseModel
         ):  # nested config: flatten, hiding its `type` discriminator
             segments.extend(
                 f"{field}.{seg}" for seg in overrides(value, skip=frozenset({"type"}))
             )
-        else:
+        elif value != field_default(fields[field]):
             segments.append(f"{field}={fmt_override(value)}")
     return segments
 

--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -27,7 +27,12 @@ from verifiers.v1.configs.eval import EvalConfig
 from verifiers.v1.rollout import Phase, Rollout
 from verifiers.v1.trace import Trace
 from verifiers.v1.types import Usage
-from verifiers.v1.utils.format import format_count, format_mean, format_time
+from verifiers.v1.utils.format import (
+    format_count,
+    format_mean,
+    format_override,
+    format_time,
+)
 from verifiers.utils.pricing_utils import format_cost_usd
 
 # For sizing pages to the terminal: detects the real terminal height/width each access (the live
@@ -122,62 +127,43 @@ def _warning(config: EvalConfig) -> Text | None:
     return None
 
 
-def fmt_override(value: object) -> str:
-    """Render a value as one compact segment: a dict as `{k=v,k=v}`, a list/tuple as `[a,b]`,
-    anything else as its `str`."""
-    if isinstance(value, dict):
-        return "{" + ",".join(f"{k}={v}" for k, v in value.items()) + "}"
-    if isinstance(value, (list, tuple)):
-        return "[" + ",".join(str(v) for v in value) + "]"
-    return str(value)
-
-
 def overrides(
     config: BaseModel,
     default: BaseModel | None = None,
     skip: frozenset[str] = frozenset(),
 ) -> list[str]:
     """`field=value` segments for the fields the *user* customized, sorted, diffed against each
-    field's declared default. We compare *values* rather than `model_fields_set` on purpose: a
-    `--resume` run rebuilds its config via `EvalConfig.model_validate(config.toml)`
-    (`cli/eval/resume.py`), and that `config.toml` is dumped with `exclude_none` (every field, not
-    just the set ones), so `model_fields_set` would mark *all* of them as user overrides. `default`
-    is the reference instance, threaded through recursion so a pinned nested default (e.g. a
-    taskset's `user=UserConfig(colocated=True)`) reads as unchanged. `skip` holds dotted paths, so
-    a nested field hides by full path (`harness.runtime.type`)."""
+    field's declared default. Not `model_fields_set`: a `--resume` run reloads its config via
+    `model_validate(config.toml)`, and that toml is dumped with `exclude_none` (every field), so
+    `model_fields_set` would flag them all. `default` is the reference instance, threaded through
+    recursion so a pinned nested default (a taskset's `user=UserConfig(colocated=True)`) reads as
+    unchanged. `skip` holds dotted paths (`harness.runtime.type`)."""
     segments: list[str] = []
     fields = type(config).model_fields
     for field in sorted(fields):
         if field in skip:
             continue
         value = getattr(config, field)
-        # Baseline to diff against: the field's own declared default, or the parent default's
-        # sub-value when recursing. `get_default` returns `PydanticUndefined` for a required field
-        # (no default), so a required field always reads as set.
+        # `get_default` returns `PydanticUndefined` for a required field, so it always reads as set.
         field_def = (
             fields[field].get_default(call_default_factory=True)
             if default is None
             else getattr(default, field, None)
         )
-        if isinstance(
-            value, BaseModel
-        ):  # nested config: flatten, descending the dotted skip
+        if isinstance(value, BaseModel):  # nested config: flatten as `field.<sub>`
             child_skip = frozenset(
                 s[len(field) + 1 :] for s in skip if s.startswith(f"{field}.")
             )
-            # A switched discriminator (the nested class itself changed, e.g. subprocess→docker)
-            # is an override the per-field diff misses — within the new class `type` equals its
-            # own default — so surface it explicitly. `child_skip` lets the harness hide its own
-            # `runtime.type` (the `env` row already shows it).
+            # A switched discriminator (e.g. subprocess→docker) is an override the per-field diff
+            # misses — within the new class `type` equals its own default — so surface it.
             class_changed = type(value) is not type(field_def)
             if (
                 class_changed
                 and "type" not in child_skip
                 and (discriminator := getattr(value, "type", None)) is not None
             ):
-                segments.append(f"{field}.type={fmt_override(discriminator)}")
-            # A switched class is a different shape, so diff its sub-fields against their own
-            # class defaults; otherwise against the default instance.
+                segments.append(f"{field}.type={format_override(discriminator)}")
+            # A switched class is a new shape, so diff against its own defaults, not the instance.
             segments.extend(
                 f"{field}.{seg}"
                 for seg in overrides(
@@ -185,7 +171,7 @@ def overrides(
                 )
             )
         elif value != field_def:
-            segments.append(f"{field}={fmt_override(value)}")
+            segments.append(f"{field}={format_override(value)}")
     return segments
 
 
@@ -202,15 +188,12 @@ def Overview(config: EvalConfig) -> Table:
     )
     model = f"{config.model}  ({sampling})" if sampling else config.model
     grid.add_row("model", f"{model}  via {config.client.base_url}")
-    # Non-default taskset/harness knobs the user set (`id`/`name` are in the `env` row above;
-    # `harness.runtime` is shown here only when its sub-fields were customized — the runtime
-    # `type` already reads in the `env` row). Each row appears only when there's an override.
-    # `escape` the joined cell: an override value (or our `[...]`/`{...}` delimiters) can contain
-    # Rich markup — without it `env={TOKEN=[red]x[/red]}` would be parsed as styling and dropped.
+    # Non-default knobs the user set, one row each when non-empty. `escape` the cell: an override
+    # value (or our `[...]`/`{...}` delimiters) can carry Rich markup that would otherwise be
+    # parsed as styling and dropped. `id` is in the `env` row; harness `runtime.type` too (hidden
+    # here), but only for the harness — a taskset's `user.runtime.type` has no other display.
     if taskset_over := overrides(config.taskset, skip=frozenset({"id"})):
         grid.add_row("taskset", escape("  ·  ".join(taskset_over)))
-    # `runtime.type` is already in the `env` row, so hide it here — but only for the harness's
-    # own runtime (a taskset's `user.runtime.type` has no other display and must still show).
     if harness_over := overrides(
         config.harness, skip=frozenset({"id", "runtime.type"})
     ):

--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -122,9 +122,6 @@ def _warning(config: EvalConfig) -> Text | None:
     return None
 
 
-# Field names whose dict *values* may be secrets (tokens / API keys passed as the harness's
-# process env). The override row shows only their KEYS (`env={HF_TOKEN, RLM_FOO}`) so a secret
-# never lands on the live terminal.
 def fmt_override(value: object) -> str:
     """Render a value as one compact segment: a dict as `{k=v,k=v}`, a list/tuple as `[a,b]`,
     anything else as its `str`."""

--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -149,39 +149,56 @@ def field_default(field: FieldInfo) -> object:
     return field.default
 
 
-def overrides(config: BaseModel, skip: frozenset[str] = frozenset()) -> list[str]:
-    """`field=value` segments for the fields whose value differs from the field's default — the
-    knobs in effect, sorted. Comparing values (not `model_fields_set`) stays stable across a
-    saved-config round-trip (`--resume` / `@ file.toml` re-mark every persisted field as set).
-    `skip` holds dotted paths, so a nested field hides by full path (`harness.runtime.type`)."""
+def overrides(
+    config: BaseModel,
+    default: BaseModel | None = None,
+    skip: frozenset[str] = frozenset(),
+) -> list[str]:
+    """`field=value` segments for the fields the *user* customized, sorted. Diffs values (not
+    `model_fields_set`, which a saved-config round-trip re-marks wholesale) against the enclosing
+    field's declared default — `default` is that reference instance, threaded through recursion so
+    a pinned nested default (e.g. a taskset's `user=UserConfig(colocated=True)`) reads as
+    unchanged. `skip` holds dotted paths, so a nested field hides by full path
+    (`harness.runtime.type`)."""
     segments: list[str] = []
     fields = type(config).model_fields
     for field in sorted(fields):
         if field in skip:
             continue
         value = getattr(config, field)
+        # Baseline to diff against: the field's own declared default, or the parent default's
+        # sub-value when recursing.
+        field_def = (
+            field_default(fields[field])
+            if default is None
+            else getattr(default, field, None)
+        )
         if isinstance(
             value, BaseModel
         ):  # nested config: flatten, descending the dotted skip
             child_skip = frozenset(
                 s[len(field) + 1 :] for s in skip if s.startswith(f"{field}.")
             )
-            # A discriminated nested config (e.g. a `runtime`) whose concrete class differs from
-            # the field default's class is itself an override — surface its `type` discriminator.
-            # The per-field comparison below can't: within the new class `type` equals that
-            # class's own default (e.g. a `DockerConfig` always has `type="docker"`), so it never
-            # reads as changed. `runtime.type` lives in `child_skip` only for the harness (the
-            # `env` row already shows it); a taskset's `user.runtime.type` still surfaces here.
+            # A switched discriminator (the nested class itself changed, e.g. subprocess→docker)
+            # is an override the per-field diff misses — within the new class `type` equals its
+            # own default — so surface it explicitly. `child_skip` lets the harness hide its own
+            # `runtime.type` (the `env` row already shows it).
+            class_changed = type(value) is not type(field_def)
             if (
-                type(value) is not type(field_default(fields[field]))
+                class_changed
                 and "type" not in child_skip
                 and (discriminator := getattr(value, "type", None)) is not None
             ):
                 segments.append(f"{field}.type={fmt_override(discriminator)}")
+            # A switched class is a different shape, so diff its sub-fields against their own
+            # class defaults; otherwise against the default instance.
             segments.extend(
-                f"{field}.{seg}" for seg in overrides(value, skip=child_skip)
+                f"{field}.{seg}"
+                for seg in overrides(
+                    value, default=None if class_changed else field_def, skip=child_skip
+                )
             )
-        elif value != field_default(fields[field]):
+        elif value != field_def:
             # A secret-bearing field (e.g. `env`) shows keys only — never its values on-screen.
             segments.append(
                 f"{field}={fmt_override(value, keys_only=field in _KEYS_ONLY_FIELDS)}"

--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -171,7 +171,9 @@ def overrides(config: BaseModel, skip: frozenset[str] = frozenset()) -> list[str
         if field in skip:
             continue
         value = getattr(config, field)
-        if isinstance(value, BaseModel):  # nested config: flatten, descending the dotted skip
+        if isinstance(
+            value, BaseModel
+        ):  # nested config: flatten, descending the dotted skip
             child_skip = frozenset(
                 s[len(field) + 1 :] for s in skip if s.startswith(f"{field}.")
             )

--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -14,7 +14,6 @@ import contextlib
 import time
 
 from pydantic import BaseModel
-from pydantic.fields import FieldInfo
 from rich.console import Console, Group
 from rich.markup import escape
 from rich.progress_bar import ProgressBar
@@ -126,27 +125,14 @@ def _warning(config: EvalConfig) -> Text | None:
 # Field names whose dict *values* may be secrets (tokens / API keys passed as the harness's
 # process env). The override row shows only their KEYS (`env={HF_TOKEN, RLM_FOO}`) so a secret
 # never lands on the live terminal.
-_KEYS_ONLY_FIELDS = frozenset({"env"})
-
-
-def fmt_override(value: object, keys_only: bool = False) -> str:
-    """Render a value as one compact segment: a dict as `{k=v,k=v}` (or `{k,k}` when `keys_only`),
-    a list/tuple as `[a,b]`, anything else as its `str`."""
+def fmt_override(value: object) -> str:
+    """Render a value as one compact segment: a dict as `{k=v,k=v}`, a list/tuple as `[a,b]`,
+    anything else as its `str`."""
     if isinstance(value, dict):
-        if keys_only:
-            return "{" + ",".join(str(k) for k in value) + "}"
         return "{" + ",".join(f"{k}={v}" for k, v in value.items()) + "}"
     if isinstance(value, (list, tuple)):
         return "[" + ",".join(str(v) for v in value) + "]"
     return str(value)
-
-
-def field_default(field: FieldInfo) -> object:
-    """A field's declared default."""
-    if field.default_factory is not None:
-        # All config defaults use the no-arg factory form; the validated-data form isn't used here.
-        return field.default_factory()  # type: ignore[call-arg]
-    return field.default
 
 
 def overrides(
@@ -154,12 +140,14 @@ def overrides(
     default: BaseModel | None = None,
     skip: frozenset[str] = frozenset(),
 ) -> list[str]:
-    """`field=value` segments for the fields the *user* customized, sorted. Diffs values (not
-    `model_fields_set`, which a saved-config round-trip re-marks wholesale) against the enclosing
-    field's declared default — `default` is that reference instance, threaded through recursion so
-    a pinned nested default (e.g. a taskset's `user=UserConfig(colocated=True)`) reads as
-    unchanged. `skip` holds dotted paths, so a nested field hides by full path
-    (`harness.runtime.type`)."""
+    """`field=value` segments for the fields the *user* customized, sorted, diffed against each
+    field's declared default. We compare *values* rather than `model_fields_set` on purpose: a
+    `--resume` run rebuilds its config via `EvalConfig.model_validate(config.toml)`
+    (`cli/eval/resume.py`), and that `config.toml` is dumped with `exclude_none` (every field, not
+    just the set ones), so `model_fields_set` would mark *all* of them as user overrides. `default`
+    is the reference instance, threaded through recursion so a pinned nested default (e.g. a
+    taskset's `user=UserConfig(colocated=True)`) reads as unchanged. `skip` holds dotted paths, so
+    a nested field hides by full path (`harness.runtime.type`)."""
     segments: list[str] = []
     fields = type(config).model_fields
     for field in sorted(fields):
@@ -167,9 +155,10 @@ def overrides(
             continue
         value = getattr(config, field)
         # Baseline to diff against: the field's own declared default, or the parent default's
-        # sub-value when recursing.
+        # sub-value when recursing. `get_default` returns `PydanticUndefined` for a required field
+        # (no default), so a required field always reads as set.
         field_def = (
-            field_default(fields[field])
+            fields[field].get_default(call_default_factory=True)
             if default is None
             else getattr(default, field, None)
         )
@@ -199,10 +188,7 @@ def overrides(
                 )
             )
         elif value != field_def:
-            # A secret-bearing field (e.g. `env`) shows keys only — never its values on-screen.
-            segments.append(
-                f"{field}={fmt_override(value, keys_only=field in _KEYS_ONLY_FIELDS)}"
-            )
+            segments.append(f"{field}={fmt_override(value)}")
     return segments
 
 

--- a/verifiers/v1/utils/format.py
+++ b/verifiers/v1/utils/format.py
@@ -34,6 +34,15 @@ def format_count(n: int) -> str:
     return f"{n / 1e6:.1f}M"
 
 
+def format_override(value: object) -> str:
+    """A value as one compact segment: dict `{k=v,k=v}`, list/tuple `[a,b]`, else `str`."""
+    if isinstance(value, dict):
+        return "{" + ",".join(f"{k}={v}" for k, v in value.items()) + "}"
+    if isinstance(value, (list, tuple)):
+        return "[" + ",".join(str(v) for v in value) + "]"
+    return str(value)
+
+
 def format_mean(
     traces: list[Trace], value: Callable[[Trace], float], digits: int = 2
 ) -> str:


### PR DESCRIPTION
## Description

Show config values if they are actively set by the user.

Example:

<img width="960" height="358" alt="image" src="https://github.com/user-attachments/assets/4f935696-4dab-4e3c-981e-4f5b04974a28" />

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [ ] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the PR here -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only CLI dashboard changes with no auth, persistence, or eval execution logic affected.
> 
> **Overview**
> The eval **Overview** table now includes optional **`taskset`** and **`harness`** rows that list only configuration fields changed from their declared defaults, joined as `field=value` segments.
> 
> A new **`overrides()`** helper recursively compares a Pydantic model to reference defaults (not `model_fields_set`, so `--resume` from a full TOML does not mark everything customized). It supports nested models, dotted **`skip`** paths, and surfaces discriminator **`type`** when the nested class changes. **`format_override()`** formats dicts, lists, and scalars for display; override text is **`escape`**d for Rich.
> 
> **`id`** is omitted on the taskset row; harness skips **`id`** and **`runtime.type`** (already shown in the env row).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cda9b4b766022c84b182c38cefdd73fa99b2a77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> <!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
> <!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show user-set config overrides in eval Overview table
> - Adds `taskset` and `harness` rows to the eval [Overview](https://github.com/PrimeIntellect-ai/verifiers/pull/1899/files#diff-0a27b905958929f3ae9e01937dd7e3cf97a60dec137caddcbf87792784fc9035) table, showing only fields the user has changed from their defaults.
> - Implements `overrides()`, a recursive diff function that compares a pydantic model's current values against declared defaults, supporting nested models with dotted paths and discriminator/class changes.
> - Dict fields listed in `_KEYS_ONLY_FIELDS` (e.g. `env`) display only their keys to avoid leaking secret values.
> - The `harness` row suppresses `id` and `runtime.type`; the `taskset` row suppresses `id`. Both rows escape output via `rich.escape`.
> >
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1899 opened
>
> - Removed secret-masking behavior for dictionary-valued configuration fields in the eval dashboard [754eb6c]
> - Replaced custom default value retrieval logic with Pydantic's built-in method [754eb6c]
> - Extracted local `fmt_override` function from `verifiers.v1.cli.dashboard.eval` module into shared `verifiers.v1.utils.format.format_override` utility function [4cda9b4]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
> >
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7a22ec6.</sup>
> <!-- Macroscope's review summary ends here -->
> >
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->