### PR TITLE
feat(default): add an optional search tool

### DIFF
--- a/verifiers/v1/GUIDE.md
+++ b/verifiers/v1/GUIDE.md
@@ -552,7 +552,7 @@ Otherwise pick a built-in, selected with `--harness.id`:
 
 | id | what it is |
 | --- | --- |
-| `default` | a `bash` + `edit` coding agent (the `edit` tool is on by default — `--harness.edit false` for bash-only) — the fallback when no harness is given |
+| `default` | a `bash` + `edit` coding agent (`edit` on by default — `--harness.edit false` for bash-only; `--harness.web-search true` adds a serper.dev `web_search` tool) — the fallback when no harness is given |
 | `null` | a tiny OpenAI chat loop (MCP tools only, no tools of its own) |
 | `rlm` | the RLM CLI agent |
 | `codex` | the Codex CLI (Responses dialect + SSE relay) |

--- a/verifiers/v1/GUIDE.md
+++ b/verifiers/v1/GUIDE.md
@@ -552,7 +552,7 @@ Otherwise pick a built-in, selected with `--harness.id`:
 
 | id | what it is |
 | --- | --- |
-| `default` | a `bash` + `edit` coding agent (`edit` on by default — `--harness.edit false` for bash-only; `--harness.web-search true` adds a serper.dev `web_search` tool) — the fallback when no harness is given |
+| `default` | a `bash` + `edit` coding agent (`edit` on by default — `--harness.edit false` for bash-only; `--harness.search true` adds a serper.dev `search` tool) — the fallback when no harness is given |
 | `null` | a tiny OpenAI chat loop (MCP tools only, no tools of its own) |
 | `rlm` | the RLM CLI agent |
 | `codex` | the Codex CLI (Responses dialect + SSE relay) |

--- a/verifiers/v1/harnesses/default/harness.py
+++ b/verifiers/v1/harnesses/default/harness.py
@@ -87,14 +87,17 @@ class DefaultHarness(Harness[DefaultHarnessConfig]):
         if self.config.edit:
             args.append("--edit")
         if self.config.search:
-            # Resolve the key from the harness env (--harness.env / forward_env) or the host, and
-            # keep it OUT of the program env: it's handed to the program over argv (--serper-key), so
-            # popping it here stops the agent's `bash` subprocesses from also inheriting it via
-            # $SERPER_API_KEY / /proc/self/environ. Only when search is enabled — otherwise env is
-            # left untouched, so a key forwarded for the agent's own bash-side use survives.
-            serper_key = env.pop("SERPER_API_KEY", None) or os.environ.get(
-                "SERPER_API_KEY"
-            )
+            # Resolve the key and keep it OUT of the program env: it's handed to the program over
+            # argv (--serper-key), so popping it here stops the agent's `bash` subprocesses from
+            # inheriting it via $SERPER_API_KEY / /proc/self/environ. Prefer a key set in the harness
+            # env (--harness.env / forward_env); fall back to the host env only when the key is
+            # *absent* (None), not present-but-empty — a rollout setting SERPER_API_KEY="" is
+            # deliberately masking the host secret, so honor that (the check below then fails loudly
+            # rather than leaking the host key). The pop is scoped to search=true, so an unrelated
+            # key forwarded for the agent's own bash-side use is left untouched.
+            serper_key = env.pop("SERPER_API_KEY", None)
+            if serper_key is None:
+                serper_key = os.environ.get("SERPER_API_KEY")
             if not serper_key:
                 raise ValueError(
                     "default search=true requires SERPER_API_KEY in the eval environment "

--- a/verifiers/v1/harnesses/default/harness.py
+++ b/verifiers/v1/harnesses/default/harness.py
@@ -87,12 +87,20 @@ class DefaultHarness(Harness[DefaultHarnessConfig]):
         if self.config.edit:
             args.append("--edit")
         if self.config.web_search:
-            key = os.environ.get("SERPER_API_KEY")
-            if not key:
+            # Resolve the key from the harness env (--harness.env / forward_env) or the host, and
+            # keep it OUT of the program env: it's handed to the program over argv (--serper-key), so
+            # popping it here stops the agent's `bash` subprocesses from also inheriting it via
+            # $SERPER_API_KEY / /proc/self/environ. Only when web_search is enabled — otherwise env
+            # is left untouched, so a key forwarded for the agent's own bash-side use survives.
+            serper_key = env.pop("SERPER_API_KEY", None) or os.environ.get(
+                "SERPER_API_KEY"
+            )
+            if not serper_key:
                 raise ValueError(
-                    "default web_search=true requires SERPER_API_KEY in the eval environment"
+                    "default web_search=true requires SERPER_API_KEY in the eval environment "
+                    "(the host env or --harness.env)"
                 )
-            args += ["--web-search", f"--serper-key={key}"]
+            args += ["--web-search", f"--serper-key={serper_key}"]
         if mcp_urls:
             # The program connects to the tool servers over HTTP; hand it a standard
             # `mcpServers` URL config (the `mcp` client itself comes from the uv deps).

--- a/verifiers/v1/harnesses/default/harness.py
+++ b/verifiers/v1/harnesses/default/harness.py
@@ -3,9 +3,8 @@
 A growing-message-list chat loop with a local `bash` tool that runs shell commands in the runtime,
 the taskset's MCP tools, and two optional local tools: `edit` (single-occurrence string replacement
 in a file, ported from the rlm `edit` skill; on by default — a model handles it more reliably than
-hand-built `sed`/heredoc shell) and `search` (Google results via serper.dev, ported from the rlm
-`search` skill; off by default, needs `SERPER_API_KEY`). This is the fallback harness when no
-`--harness.id` is given. Its uv script
+hand-built `sed`/heredoc shell) and `search` (Google results via serper.dev; off by default, needs
+`SERPER_API_KEY`). This is the fallback harness when no `--harness.id` is given. Its uv script
 (deps: openai, mcp) is prepared during setup, then launched as the harness program. For a pure chat
 loop with no local tools, use the `null` harness.
 """
@@ -46,9 +45,9 @@ class DefaultHarnessConfig(HarnessConfig):
     `bash`. On by default; set `--harness.edit false` for a bash-only agent."""
 
     search: bool = False
-    """Offer a `search` tool (Google web results via serper.dev, ported from the rlm `search`
-    skill). Requires `SERPER_API_KEY` in the eval environment; the key is handed to the program over
-    argv (like the interception secret) so the agent's `bash` subprocesses don't inherit it."""
+    """Offer a `search` tool (Google web results via serper.dev). Requires `SERPER_API_KEY` in the
+    eval environment; the key is handed to the program over argv (like the interception secret) so
+    the agent's `bash` subprocesses don't inherit it."""
 
 
 class DefaultHarness(Harness[DefaultHarnessConfig]):

--- a/verifiers/v1/harnesses/default/harness.py
+++ b/verifiers/v1/harnesses/default/harness.py
@@ -1,10 +1,11 @@
-"""The built-in default harness: a chat loop with a local `bash` tool, plus optional `edit`/`web_search`.
+"""The built-in default harness: a chat loop with a local `bash` tool, plus optional `edit`/`search`.
 
 A growing-message-list chat loop with a local `bash` tool that runs shell commands in the runtime,
 the taskset's MCP tools, and two optional local tools: `edit` (single-occurrence string replacement
 in a file, ported from the rlm `edit` skill; on by default — a model handles it more reliably than
-hand-built `sed`/heredoc shell) and `web_search` (Google results via serper.dev; off by default,
-needs `SERPER_API_KEY`). This is the fallback harness when no `--harness.id` is given. Its uv script
+hand-built `sed`/heredoc shell) and `search` (Google results via serper.dev, ported from the rlm
+`search` skill; off by default, needs `SERPER_API_KEY`). This is the fallback harness when no
+`--harness.id` is given. Its uv script
 (deps: openai, mcp) is prepared during setup, then launched as the harness program. For a pure chat
 loop with no local tools, use the `null` harness.
 """
@@ -29,10 +30,10 @@ BASH_SYSTEM_PROMPT = (
 EDIT_SYSTEM_PROMPT = (
     "You also have an edit tool for single-occurrence string replacement in a file."
 )
-# Appended when web_search is enabled, so the model knows the extra tool exists.
-WEB_SEARCH_PROMPT = (
-    "You also have a web_search tool that returns Google results (title, URL, snippet) for a "
-    "query; use it to research, and use bash (e.g. curl) to read result pages in full when needed."
+# Appended when search is enabled, so the model knows the extra tool exists.
+SEARCH_PROMPT = (
+    "You also have a search tool that returns Google results (title, URL, snippet) for a query; "
+    "use it to research, and use bash (e.g. curl) to read result pages in full when needed."
 )
 
 
@@ -44,10 +45,10 @@ class DefaultHarnessConfig(HarnessConfig):
     """Offer the local `edit` tool (single-occurrence string replacement in a file) alongside
     `bash`. On by default; set `--harness.edit false` for a bash-only agent."""
 
-    web_search: bool = False
-    """Offer a `web_search` tool (Google results via serper.dev). Requires `SERPER_API_KEY` in the
-    eval environment; the key is handed to the program over argv (like the interception secret) so
-    the agent's `bash` subprocesses don't inherit it."""
+    search: bool = False
+    """Offer a `search` tool (Google web results via serper.dev, ported from the rlm `search`
+    skill). Requires `SERPER_API_KEY` in the eval environment; the key is handed to the program over
+    argv (like the interception secret) so the agent's `bash` subprocesses don't inherit it."""
 
 
 class DefaultHarness(Harness[DefaultHarnessConfig]):
@@ -72,8 +73,8 @@ class DefaultHarness(Harness[DefaultHarnessConfig]):
         fragments = [BASH_SYSTEM_PROMPT]
         if self.config.edit:
             fragments.append(EDIT_SYSTEM_PROMPT)
-        if self.config.web_search:
-            fragments.append(WEB_SEARCH_PROMPT)
+        if self.config.search:
+            fragments.append(SEARCH_PROMPT)
         system_prompt = "\n\n".join(
             p for p in (" ".join(fragments), system_prompt) if p
         )
@@ -86,21 +87,21 @@ class DefaultHarness(Harness[DefaultHarnessConfig]):
         ]
         if self.config.edit:
             args.append("--edit")
-        if self.config.web_search:
+        if self.config.search:
             # Resolve the key from the harness env (--harness.env / forward_env) or the host, and
             # keep it OUT of the program env: it's handed to the program over argv (--serper-key), so
             # popping it here stops the agent's `bash` subprocesses from also inheriting it via
-            # $SERPER_API_KEY / /proc/self/environ. Only when web_search is enabled — otherwise env
-            # is left untouched, so a key forwarded for the agent's own bash-side use survives.
+            # $SERPER_API_KEY / /proc/self/environ. Only when search is enabled — otherwise env is
+            # left untouched, so a key forwarded for the agent's own bash-side use survives.
             serper_key = env.pop("SERPER_API_KEY", None) or os.environ.get(
                 "SERPER_API_KEY"
             )
             if not serper_key:
                 raise ValueError(
-                    "default web_search=true requires SERPER_API_KEY in the eval environment "
+                    "default search=true requires SERPER_API_KEY in the eval environment "
                     "(the host env or --harness.env)"
                 )
-            args += ["--web-search", f"--serper-key={serper_key}"]
+            args += ["--search", f"--serper-key={serper_key}"]
         if mcp_urls:
             # The program connects to the tool servers over HTTP; hand it a standard
             # `mcpServers` URL config (the `mcp` client itself comes from the uv deps).

--- a/verifiers/v1/harnesses/default/harness.py
+++ b/verifiers/v1/harnesses/default/harness.py
@@ -1,14 +1,16 @@
-"""The built-in default harness: a chat loop with a local `bash` tool and an optional `edit` tool.
+"""The built-in default harness: a chat loop with a local `bash` tool, plus optional `edit`/`web_search`.
 
 A growing-message-list chat loop with a local `bash` tool that runs shell commands in the runtime,
-the taskset's MCP tools, and — on by default, gated by the `edit` config flag — a local `edit`
-tool for single-occurrence string replacement in a file (ported from the rlm `edit` skill; a model
-handles it more reliably than hand-built `sed`/heredoc shell). This is the fallback harness when no
-`--harness.id` is given. Its uv script (deps: openai, mcp) is prepared during setup, then launched
-as the harness program. For a pure chat loop with no local tools, use the `null` harness.
+the taskset's MCP tools, and two optional local tools: `edit` (single-occurrence string replacement
+in a file, ported from the rlm `edit` skill; on by default — a model handles it more reliably than
+hand-built `sed`/heredoc shell) and `web_search` (Google results via serper.dev; off by default,
+needs `SERPER_API_KEY`). This is the fallback harness when no `--harness.id` is given. Its uv script
+(deps: openai, mcp) is prepared during setup, then launched as the harness program. For a pure chat
+loop with no local tools, use the `null` harness.
 """
 
 import json
+import os
 from pathlib import Path
 
 from verifiers.v1.harness import Harness, HarnessConfig
@@ -27,6 +29,11 @@ BASH_SYSTEM_PROMPT = (
 EDIT_SYSTEM_PROMPT = (
     "You also have an edit tool for single-occurrence string replacement in a file."
 )
+# Appended when web_search is enabled, so the model knows the extra tool exists.
+WEB_SEARCH_PROMPT = (
+    "You also have a web_search tool that returns Google results (title, URL, snippet) for a "
+    "query; use it to research, and use bash (e.g. curl) to read result pages in full when needed."
+)
 
 
 class DefaultHarnessConfig(HarnessConfig):
@@ -36,6 +43,11 @@ class DefaultHarnessConfig(HarnessConfig):
     edit: bool = True
     """Offer the local `edit` tool (single-occurrence string replacement in a file) alongside
     `bash`. On by default; set `--harness.edit false` for a bash-only agent."""
+
+    web_search: bool = False
+    """Offer a `web_search` tool (Google results via serper.dev). Requires `SERPER_API_KEY` in the
+    eval environment; the key is handed to the program over argv (like the interception secret) so
+    the agent's `bash` subprocesses don't inherit it."""
 
 
 class DefaultHarness(Harness[DefaultHarnessConfig]):
@@ -57,10 +69,14 @@ class DefaultHarness(Harness[DefaultHarnessConfig]):
         mcp_urls: dict[str, str],
     ) -> ProgramResult:
         system_prompt, prompt = self.resolve_prompt(trace.task)
-        harness_prompt = BASH_SYSTEM_PROMPT
+        fragments = [BASH_SYSTEM_PROMPT]
         if self.config.edit:
-            harness_prompt = f"{BASH_SYSTEM_PROMPT} {EDIT_SYSTEM_PROMPT}"
-        system_prompt = "\n\n".join(p for p in (harness_prompt, system_prompt) if p)
+            fragments.append(EDIT_SYSTEM_PROMPT)
+        if self.config.web_search:
+            fragments.append(WEB_SEARCH_PROMPT)
+        system_prompt = "\n\n".join(
+            p for p in (" ".join(fragments), system_prompt) if p
+        )
         env = {**self.config.resolved_env}
         args = [
             f"--base-url={endpoint}",
@@ -70,6 +86,13 @@ class DefaultHarness(Harness[DefaultHarnessConfig]):
         ]
         if self.config.edit:
             args.append("--edit")
+        if self.config.web_search:
+            key = os.environ.get("SERPER_API_KEY")
+            if not key:
+                raise ValueError(
+                    "default web_search=true requires SERPER_API_KEY in the eval environment"
+                )
+            args += ["--web-search", f"--serper-key={key}"]
         if mcp_urls:
             # The program connects to the tool servers over HTTP; hand it a standard
             # `mcpServers` URL config (the `mcp` client itself comes from the uv deps).

--- a/verifiers/v1/harnesses/default/program.py
+++ b/verifiers/v1/harnesses/default/program.py
@@ -2,11 +2,11 @@
 # requires-python = ">=3.10"
 # dependencies = ["openai", "mcp", "httpx"]
 # ///
-"""The default harness's program: a chat loop with a local `bash` tool (+ optional `edit`, `web_search`, MCP).
+"""The default harness's program: a chat loop with a local `bash` tool (+ optional `edit`, `search`, MCP).
 
 A growing-message-list chat loop. It always offers a local `bash` tool that runs shell commands in
 the runtime; with `--edit` it also offers a local `edit` tool that replaces a unique string in a
-file, and with `--web-search` a `web_search` tool (Serper Google search). When the harness sets
+file, and with `--search` a `search` tool (Serper Google search). When the harness sets
 MCP_CONFIG (a standard `mcpServers` URL map) it also connects to those servers over streamable
 HTTP, exposes their tools to the model as `<server>_<tool>`, and routes those calls to the server.
 The loop runs until the model answers without a tool call.
@@ -70,14 +70,14 @@ EDIT_TOOL = {
 }
 
 
-WEB_SEARCH_TOOL = {
+SEARCH_TOOL = {
     "type": "function",
     "function": {
-        "name": "web_search",
+        "name": "search",
         "description": (
-            "Search the web with Google (via serper.dev). Returns the top organic results as "
-            "title, URL, and snippet. Issue focused queries and call several times to cover "
-            "different angles; use the bash tool (e.g. curl) to read a result page in full."
+            "Run a web search via Serper (Google) and return the top organic results as title, "
+            "URL, and snippet. Issue focused queries and call it several times to cover different "
+            "angles; use the bash tool (e.g. curl) to read a result page in full."
         ),
         "parameters": {
             "type": "object",
@@ -94,23 +94,41 @@ WEB_SEARCH_TOOL = {
 }
 
 
-def run_web_search(query: str, api_key: str, num_results: int = 5) -> str:
-    """Serper Google web search -> formatted organic results (ported from the rlm `search` skill).
+def format_results(results, query: str) -> str:
+    """Format Serper organic results as title/URL/snippet blocks (verbatim from the rlm skill)."""
+    sections = []
+    for i, result in enumerate(results, 1):
+        title = (result.get("title") or "").strip() or "Untitled"
+        lines = [f"Result {i}: {title}"]
+        link = (result.get("link") or "").strip()
+        if link:
+            lines.append(f"URL: {link}")
+        snippet = (result.get("snippet") or "").strip()
+        if snippet:
+            lines.append(f"  - {snippet}")
+        sections.append("\n".join(lines))
+    if not sections:
+        return f"No results returned for query: {query}"
+    return "\n\n---\n\n".join(sections)
 
-    The key arrives as an argument (handed in by the harness over argv, like the interception
-    secret) rather than from the env, so the agent's `bash` subprocesses never inherit it."""
-    if not query:
-        return "error: 'query' is required"
+
+def run_search(query: str, api_key: str, num_results: int = 5) -> str:
+    """Serper Google web search -> formatted organic results.
+
+    A faithful port of the rlm `search` skill (rlm-harness `src/rlm/skills/search.py`): same
+    Serper request and `format_results` output. Two deliberate differences from rlm: the key
+    arrives as an argument (handed in by the harness over argv, like the interception secret)
+    instead of from `$SERPER_API_KEY`, so the agent's `bash` subprocesses never inherit it; and the
+    call is wrapped so a bad query or malformed payload becomes a tool error rather than a dead
+    rollout — rlm leans on the IPython kernel to catch that, but this chat loop must catch it here."""
     if not api_key:
-        return "error: SERPER_API_KEY is not set in the eval environment"
-    # num_results arrives straight from model tool JSON, so it may be a non-int (e.g. "ten");
-    # coerce defensively — `organic[:num_results]` below would otherwise raise on a bad slice.
+        return "Error: no Serper API key (SERPER_API_KEY was not set in the eval environment)"
+    # num_results comes straight from model tool JSON, so it may be a non-int (e.g. "ten"); coerce
+    # defensively — `organic[:num_results]` would otherwise raise on a bad slice.
     try:
         num_results = max(1, int(num_results))
     except (TypeError, ValueError):
         num_results = 5
-    # Wrap the request AND the response parsing/formatting: a malformed payload (non-list
-    # `organic`, non-dict items) should surface as a tool error, not crash the chat loop.
     try:
         response = httpx.post(
             SERPER_URL,
@@ -120,22 +138,9 @@ def run_web_search(query: str, api_key: str, num_results: int = 5) -> str:
         )
         response.raise_for_status()
         organic = response.json().get("organic") or []
-        sections = []
-        for i, result in enumerate(organic[:num_results], 1):
-            title = (result.get("title") or "").strip() or "Untitled"
-            lines = [f"Result {i}: {title}"]
-            if link := (result.get("link") or "").strip():
-                lines.append(f"URL: {link}")
-            if snippet := (result.get("snippet") or "").strip():
-                lines.append(f"  - {snippet}")
-            sections.append("\n".join(lines))
+        return format_results(organic[:num_results], query)
     except Exception as e:
-        return f"web_search failed ({e}). Try again or rephrase the query."
-    return (
-        "\n\n---\n\n".join(sections)
-        if sections
-        else f"No results returned for query: {query}"
-    )
+        return f"search failed ({e}). Try again or rephrase the query."
 
 
 def run_bash(command: str) -> str:
@@ -255,7 +260,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--prompt", default="")
     parser.add_argument("--mcp-config", default="")
     parser.add_argument("--edit", action="store_true")
-    parser.add_argument("--web-search", action="store_true")
+    parser.add_argument("--search", action="store_true")
     parser.add_argument("--serper-key", default="")
     return parser.parse_args()
 
@@ -276,8 +281,8 @@ async def main() -> None:
         tools = [BASH_TOOL]
         if args.edit:
             tools.append(EDIT_TOOL)
-        if args.web_search:
-            tools.append(WEB_SEARCH_TOOL)
+        if args.search:
+            tools.append(SEARCH_TOOL)
         tools += mcp_tools
         messages = (
             [{"role": "system", "content": args.system_prompt}]
@@ -335,9 +340,9 @@ async def main() -> None:
                         tool_args.get("old_str"),
                         tool_args.get("new_str"),
                     )
-                elif name == "web_search" and args.web_search:
+                elif name == "search" and args.search:
                     content = await asyncio.to_thread(
-                        run_web_search,
+                        run_search,
                         tool_args.get("query", ""),
                         args.serper_key,
                         tool_args.get("num_results", 5),

--- a/verifiers/v1/harnesses/default/program.py
+++ b/verifiers/v1/harnesses/default/program.py
@@ -95,7 +95,7 @@ SEARCH_TOOL = {
 
 
 def format_results(results, query: str) -> str:
-    """Format Serper organic results as title/URL/snippet blocks (verbatim from the rlm skill)."""
+    """Format Serper organic results as title/URL/snippet blocks."""
     sections = []
     for i, result in enumerate(results, 1):
         title = (result.get("title") or "").strip() or "Untitled"
@@ -115,12 +115,10 @@ def format_results(results, query: str) -> str:
 def run_search(query: str, api_key: str, num_results: int = 5) -> str:
     """Serper Google web search -> formatted organic results.
 
-    A faithful port of the rlm `search` skill (rlm-harness `src/rlm/skills/search.py`): same
-    Serper request and `format_results` output. Two deliberate differences from rlm: the key
-    arrives as an argument (handed in by the harness over argv, like the interception secret)
-    instead of from `$SERPER_API_KEY`, so the agent's `bash` subprocesses never inherit it; and the
-    call is wrapped so a bad query or malformed payload becomes a tool error rather than a dead
-    rollout — rlm leans on the IPython kernel to catch that, but this chat loop must catch it here."""
+    The key arrives as an argument (handed in by the harness over argv, like the interception
+    secret) instead of from `$SERPER_API_KEY`, so the agent's `bash` subprocesses never inherit it.
+    The whole call is wrapped so a bad query or malformed payload becomes a tool error rather than
+    raising out of the chat loop and killing the rollout."""
     if not api_key:
         return "Error: no Serper API key (SERPER_API_KEY was not set in the eval environment)"
     # num_results comes straight from model tool JSON, so it may be a non-int (e.g. "ten"); coerce

--- a/verifiers/v1/harnesses/default/program.py
+++ b/verifiers/v1/harnesses/default/program.py
@@ -1,18 +1,19 @@
 # /// script
 # requires-python = ">=3.10"
-# dependencies = ["openai", "mcp"]
+# dependencies = ["openai", "mcp", "httpx"]
 # ///
-"""The default harness's program: a chat loop with a local `bash` tool (+ optional `edit`, MCP).
+"""The default harness's program: a chat loop with a local `bash` tool (+ optional `edit`, `web_search`, MCP).
 
 A growing-message-list chat loop. It always offers a local `bash` tool that runs shell commands in
 the runtime; with `--edit` it also offers a local `edit` tool that replaces a unique string in a
-file. When the harness sets MCP_CONFIG (a standard `mcpServers` URL map) it also connects to those
-servers over streamable HTTP, exposes their tools to the model as `<server>_<tool>`, and routes
-those calls to the server. The loop runs until the model answers without a tool call.
+file, and with `--web-search` a `web_search` tool (Serper Google search). When the harness sets
+MCP_CONFIG (a standard `mcpServers` URL map) it also connects to those servers over streamable
+HTTP, exposes their tools to the model as `<server>_<tool>`, and routes those calls to the server.
+The loop runs until the model answers without a tool call.
 
-It runs as a uv script (deps: openai, mcp), so the chat + tool plumbing is just the SDKs — the
-harness bootstraps `uv` in the runtime. The interception endpoint, per-rollout secret, and model
-arrive as argv (not env), so the local tools' subprocesses never inherit them.
+It runs as a uv script (deps: openai, mcp, httpx), so the chat + tool plumbing is just the SDKs —
+the harness bootstraps `uv` in the runtime. The interception endpoint, per-rollout secret, model,
+and serper key arrive as argv (not env), so the local tools' subprocesses never inherit them.
 """
 
 import argparse
@@ -23,7 +24,10 @@ import subprocess
 from contextlib import AsyncExitStack
 from pathlib import Path
 
+import httpx
 from openai import AsyncOpenAI
+
+SERPER_URL = "https://google.serper.dev/search"
 
 BASH_TOOL = {
     "type": "function",
@@ -64,6 +68,72 @@ EDIT_TOOL = {
         },
     },
 }
+
+
+WEB_SEARCH_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "web_search",
+        "description": (
+            "Search the web with Google (via serper.dev). Returns the top organic results as "
+            "title, URL, and snippet. Issue focused queries and call several times to cover "
+            "different angles; use the bash tool (e.g. curl) to read a result page in full."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "The search query."},
+                "num_results": {
+                    "type": "integer",
+                    "description": "Number of results to return (default 5).",
+                },
+            },
+            "required": ["query"],
+        },
+    },
+}
+
+
+def run_web_search(query: str, api_key: str, num_results: int = 5) -> str:
+    """Serper Google web search -> formatted organic results (ported from the rlm `search` skill).
+
+    The key arrives as an argument (handed in by the harness over argv, like the interception
+    secret) rather than from the env, so the agent's `bash` subprocesses never inherit it."""
+    if not query:
+        return "error: 'query' is required"
+    if not api_key:
+        return "error: SERPER_API_KEY is not set in the eval environment"
+    # num_results arrives straight from model tool JSON, so it may be a non-int (e.g. "ten");
+    # coerce defensively — `organic[:num_results]` below would otherwise raise on a bad slice.
+    try:
+        num_results = max(1, int(num_results))
+    except (TypeError, ValueError):
+        num_results = 5
+    try:
+        response = httpx.post(
+            SERPER_URL,
+            json={"q": query},
+            headers={"X-API-KEY": api_key, "Content-Type": "application/json"},
+            timeout=45,
+        )
+        response.raise_for_status()
+        organic = response.json().get("organic") or []
+    except Exception as e:
+        return f"web_search failed ({e}). Try again or rephrase the query."
+    sections = []
+    for i, result in enumerate(organic[:num_results], 1):
+        title = (result.get("title") or "").strip() or "Untitled"
+        lines = [f"Result {i}: {title}"]
+        if link := (result.get("link") or "").strip():
+            lines.append(f"URL: {link}")
+        if snippet := (result.get("snippet") or "").strip():
+            lines.append(f"  - {snippet}")
+        sections.append("\n".join(lines))
+    return (
+        "\n\n---\n\n".join(sections)
+        if sections
+        else f"No results returned for query: {query}"
+    )
 
 
 def run_bash(command: str) -> str:
@@ -183,12 +253,19 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--prompt", default="")
     parser.add_argument("--mcp-config", default="")
     parser.add_argument("--edit", action="store_true")
+    parser.add_argument("--web-search", action="store_true")
+    parser.add_argument("--serper-key", default="")
     return parser.parse_args()
 
 
 async def main() -> None:
     args = parse_args()
-    client = AsyncOpenAI(base_url=args.base_url, api_key=args.api_key)
+    # No client-side retries: re-sending a request whose turn the interception already committed
+    # re-samples it and forks the trace into an extra dead-end branch. A generous timeout lets a
+    # slow turn finish instead of timing out and re-sending; genuine failures surface as error rows.
+    client = AsyncOpenAI(
+        base_url=args.base_url, api_key=args.api_key, timeout=1800.0, max_retries=0
+    )
     config = json.loads(args.mcp_config or "{}")
     async with AsyncExitStack() as stack:
         mcp_tools, dispatch = (
@@ -197,6 +274,8 @@ async def main() -> None:
         tools = [BASH_TOOL]
         if args.edit:
             tools.append(EDIT_TOOL)
+        if args.web_search:
+            tools.append(WEB_SEARCH_TOOL)
         tools += mcp_tools
         messages = (
             [{"role": "system", "content": args.system_prompt}]
@@ -253,6 +332,13 @@ async def main() -> None:
                         tool_args.get("path"),
                         tool_args.get("old_str"),
                         tool_args.get("new_str"),
+                    )
+                elif name == "web_search" and args.web_search:
+                    content = await asyncio.to_thread(
+                        run_web_search,
+                        tool_args.get("query", ""),
+                        args.serper_key,
+                        tool_args.get("num_results", 5),
                     )
                 else:
                     content = f"error: unknown tool {name!r}"

--- a/verifiers/v1/harnesses/default/program.py
+++ b/verifiers/v1/harnesses/default/program.py
@@ -109,6 +109,8 @@ def run_web_search(query: str, api_key: str, num_results: int = 5) -> str:
         num_results = max(1, int(num_results))
     except (TypeError, ValueError):
         num_results = 5
+    # Wrap the request AND the response parsing/formatting: a malformed payload (non-list
+    # `organic`, non-dict items) should surface as a tool error, not crash the chat loop.
     try:
         response = httpx.post(
             SERPER_URL,
@@ -118,17 +120,17 @@ def run_web_search(query: str, api_key: str, num_results: int = 5) -> str:
         )
         response.raise_for_status()
         organic = response.json().get("organic") or []
+        sections = []
+        for i, result in enumerate(organic[:num_results], 1):
+            title = (result.get("title") or "").strip() or "Untitled"
+            lines = [f"Result {i}: {title}"]
+            if link := (result.get("link") or "").strip():
+                lines.append(f"URL: {link}")
+            if snippet := (result.get("snippet") or "").strip():
+                lines.append(f"  - {snippet}")
+            sections.append("\n".join(lines))
     except Exception as e:
         return f"web_search failed ({e}). Try again or rephrase the query."
-    sections = []
-    for i, result in enumerate(organic[:num_results], 1):
-        title = (result.get("title") or "").strip() or "Untitled"
-        lines = [f"Result {i}: {title}"]
-        if link := (result.get("link") or "").strip():
-            lines.append(f"URL: {link}")
-        if snippet := (result.get("snippet") or "").strip():
-            lines.append(f"  - {snippet}")
-        sections.append("\n".join(lines))
     return (
         "\n\n---\n\n".join(sections)
         if sections


### PR DESCRIPTION
## What

**PR 2 of 2** — this is #1900 rebased on top of the harness rename (#1904 → this).

Adds an opt-in `search` tool to the **`default`** harness (the bash + edit agent, formerly `bash_edit`) so it can drive "bring your own search" tasksets (`openseeker_v1`, `redsearcher_v1`) that ship no search tool of their own. **Off by default.**

### Re-aligned with the rlm `search` skill
Per review, the search implementation is now ported from the canonical `rlm/skills/search.py` (the same place the `edit` tool came from) instead of the original ad-hoc version:
- Serper Google search via **`httpx`** (added to the uv-script deps), organic results formatted as `Result N: title / URL / - snippet`, `num_results=5`.
- Two harness-local adaptations kept from the original #1900 design (justified by the harness context, where rlm's skill runs in an IPython kernel):
  - the `SERPER_API_KEY` is handed to the program over **argv** (`--serper-key`), not the env, so the agent's `bash` subprocesses don't inherit it (same treatment as the interception secret);
  - failures **return an error string** (like `run_bash`/`run_edit`) rather than raising, so a transient search failure can't kill the rollout.

### `search` tool
With `--harness.search true`:
- `DefaultHarnessConfig.search: bool = False` gates it.
- The harness requires `SERPER_API_KEY` in the eval env, passes it via `--serper-key` on argv, and appends a tool note to the injected system prompt.
- The program registers a `search` function tool dispatched on the same `asyncio.to_thread` path as `bash`/`edit`. Function tools are forwarded by the v1 dialects, so any model works.

### Client: no retries + generous timeout
The program's OpenAI client is pinned to `max_retries=0` with a long `timeout`. A client-side retry that re-sends a request whose turn the interception already committed re-samples it and **forks the trace into an extra dead-end branch** — and every branch becomes a training sample, silently polluting the data. No retries keeps each rollout's trace linear; the long timeout lets a slow turn finish. Transient model failures surface as error rows that `--resume`/`--prune` recover.

## Validation
`ruff check` clean; program compiles and `--help` shows the new flags; `run_search` unit-exercised against a mock Serper response (format, empty, no-key, and error paths). Live validation from the original #1900 (glm against a self-hosted deployment) still applies to the search/trace behavior.

## Usage
```bash
uv run eval <search-taskset> --harness.id default --harness.search true --harness.runtime.type prime
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches rollout tracing behavior (no client retries) for all default-harness runs, and handles a third-party API secret via argv stripping; misconfiguration fails at launch rather than silently leaking the key into bash.
> 
> **Overview**
> Adds an **opt-in** `search` tool to the **`default`** harness so search-oriented tasksets can run without shipping their own search MCP server. Enable with `--harness.search true` and `SERPER_API_KEY` in the host or `--harness.env`.
> 
> **Harness:** `DefaultHarnessConfig.search` defaults to `false`. When enabled, the harness appends `SEARCH_PROMPT` to the injected system text, passes `--search` and `--serper-key` on argv, and **pops** `SERPER_API_KEY` from the program env so `bash` subprocesses do not inherit the key (empty env value is treated as intentional masking, not a host fallback). Missing key raises `ValueError` at launch.
> 
> **Program:** Adds `httpx`, a `search` function tool, and `run_search` (Serper organic results formatted as title/URL/snippet; failures return tool error strings). The OpenAI client is set to **`max_retries=0`** and a **1800s timeout** so retries do not re-sample turns already committed by interception and fork training traces.
> 
> **Docs:** `GUIDE.md` documents `--harness.search true` on the built-in `default` harness row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43ac0eac4a83216ef1ca087733cfc02c349950a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add optional `web_search` tool to the `default` harness backed by serper.dev
> - Adds a `web_search` boolean field to `DefaultHarnessConfig` (default `false`) that, when enabled, exposes a serper.dev-powered search tool to the model.
> - The harness reads `SERPER_API_KEY` from the environment, strips it from the subprocess environment to prevent bash subprocess leakage, and passes it to the program via `--web-search` and `--serper-key` argv flags.
> - `program.py` gains a `run_web_search` function that POSTs to `https://google.serper.dev/search` using `httpx`, parses organic results, and returns formatted title/URL/snippet strings or an error message.
> - The chat loop in `program.py` now uses a fixed 1800s timeout with `max_retries=0` instead of retrying client requests.
> - Risk: if `web_search` is enabled but `SERPER_API_KEY` is missing, `DefaultHarness.launch` raises a `ValueError` at startup.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1900 opened
>
> - Renamed the exposed tool from `web_search` to `search` in the tool schema definition `SEARCH_TOOL`, updated the function name field in the schema, and modified the tool description text to reference Serper and Google [e056d66]
> - Renamed the CLI flag from `--web-search` to `--search` in the argument parser, and updated the main async entrypoint to conditionally wire and dispatch the `search` tool based on `args.search` instead of `args.web_search` [e056d66]
> - Renamed the configuration field from `web_search` to `search` in the `DefaultHarnessConfig` dataclass, updated the harness launch handler to use `config.search`, pass `--search` and `--serper-key` flags to the program instead of `--web-search`, and modified error messages and comments to reference 'search' [e056d66]
> - Replaced `run_web_search` with `run_search` function, extracted result formatting logic into a new `format_results` helper function, and updated error messages to use 'search failed' wording [e056d66]
> - Renamed the constant from `WEB_SEARCH_PROMPT` to `SEARCH_PROMPT` in the harness module and updated module docstrings across harness and program modules to refer to 'search' instead of 'web_search' [e056d66]
> - Updated documentation in `GUIDE.md` to refer to the tool as 'search' instead of 'web_search', changing the harness description, CLI flag from `--harness.web-search true` to `--harness.search true`, and the tool name from 'web_search' to 'search' [e056d66]
> - Removed references to the rlm `search` skill from docstrings [1ae7e4d]
> - Modified `SERPER_API_KEY` resolution logic in `DefaultHarness.launch` handler to pop the key from harness environment and fall back to host environment only when the key is absent (None), treating empty strings as present values that trigger `ValueError` instead of falling back to host environment [43ac0ea]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fb6daf9.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
