### PR TITLE
feat: forward_env on HarnessConfig to pass host env vars into the runtime

### DIFF
--- a/verifiers/v1/harness.py
+++ b/verifiers/v1/harness.py
@@ -8,6 +8,7 @@ runtime and the interception server are owned by the Rollout.
 
 import asyncio
 import logging
+import os
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
 from typing import ClassVar, Generic, TypeVar
@@ -50,6 +51,11 @@ class HarnessConfig(BaseConfig):
     env: dict[str, str] = Field(default_factory=dict)
     """Additional environment variables for the harness program. Harness-owned endpoint,
     authentication, and model variables take precedence."""
+    forward_env: list[str] = Field(default_factory=list)
+    """Names of environment variables to forward from the orchestrator process into the harness
+    program's runtime (e.g. `["SERPER_API_KEY"]`), for secrets that must not be written into a
+    checked-in config. Resolved from `os.environ` at launch — names absent from the environment
+    are skipped, and an explicit `env` value takes precedence over a forwarded one."""
     disabled_tools: list[str] | None = None
     """Harness-specific tool names to disable."""
 
@@ -57,6 +63,14 @@ class HarnessConfig(BaseConfig):
     def name(self) -> str:
         """The harness's package name (the id with any org / version stripped)."""
         return env_name(self.id)
+
+    @property
+    def resolved_env(self) -> dict[str, str]:
+        """`env` merged with the `forward_env` variables present in the current process
+        environment (explicit `env` wins). This is the environment the harness program runs
+        with; harnesses pass it to the runtime instead of `env` directly."""
+        forwarded = {k: os.environ[k] for k in self.forward_env if k in os.environ}
+        return {**forwarded, **self.env}
 
 
 ConfigT = TypeVar("ConfigT", bound=HarnessConfig)

--- a/verifiers/v1/harness.py
+++ b/verifiers/v1/harness.py
@@ -52,10 +52,10 @@ class HarnessConfig(BaseConfig):
     """Additional environment variables for the harness program. Harness-owned endpoint,
     authentication, and model variables take precedence."""
     forward_env: list[str] = Field(default_factory=list)
-    """Names of environment variables to forward from the orchestrator process into the harness
-    program's runtime (e.g. `["SERPER_API_KEY"]`), for secrets that must not be written into a
-    checked-in config. Resolved from `os.environ` at launch — names absent from the environment
-    are skipped, and an explicit `env` value takes precedence over a forwarded one."""
+    """Names of environment variables to forward into the harness program's runtime, for
+    secrets that must not be written into a checked-in config. Resolved from `os.environ` at
+    launch — names absent from the environment are skipped, and an explicit `env` value takes
+    precedence over a forwarded one."""
     disabled_tools: list[str] | None = None
     """Harness-specific tool names to disable."""
 

--- a/verifiers/v1/harnesses/bash/harness.py
+++ b/verifiers/v1/harnesses/bash/harness.py
@@ -33,7 +33,7 @@ class BashHarness(Harness[BashHarnessConfig]):
     SUPPORTS_MESSAGE_PROMPT = True
 
     async def setup(self, runtime: Runtime) -> None:
-        await runtime.prepare_uv_script(PROGRAM_SOURCE, self.config.env)
+        await runtime.prepare_uv_script(PROGRAM_SOURCE, self.config.resolved_env)
 
     async def launch(
         self,
@@ -46,7 +46,7 @@ class BashHarness(Harness[BashHarnessConfig]):
     ) -> ProgramResult:
         system_prompt, prompt = self.resolve_prompt(trace.task)
         system_prompt = "\n\n".join(p for p in (BASH_SYSTEM_PROMPT, system_prompt) if p)
-        env = {**self.config.env}
+        env = {**self.config.resolved_env}
         args = [
             f"--base-url={endpoint}",
             f"--api-key={secret}",
@@ -73,5 +73,7 @@ class BashHarness(Harness[BashHarnessConfig]):
             args.append(f"--prompt={prompt}")
         elif prompt is not None:
             env["INITIAL_MESSAGES"] = json.dumps([message_to_wire(m) for m in prompt])
-        program = await runtime.prepare_uv_script(PROGRAM_SOURCE, self.config.env)
+        program = await runtime.prepare_uv_script(
+            PROGRAM_SOURCE, self.config.resolved_env
+        )
         return await runtime.run_program([*program, *args], env)

--- a/verifiers/v1/harnesses/bash_edit/harness.py
+++ b/verifiers/v1/harnesses/bash_edit/harness.py
@@ -39,7 +39,7 @@ class BashEditHarness(Harness[BashEditHarnessConfig]):
     SUPPORTS_MESSAGE_PROMPT = True
 
     async def setup(self, runtime: Runtime) -> None:
-        await runtime.prepare_uv_script(PROGRAM_SOURCE, self.config.env)
+        await runtime.prepare_uv_script(PROGRAM_SOURCE, self.config.resolved_env)
 
     async def launch(
         self,
@@ -54,7 +54,7 @@ class BashEditHarness(Harness[BashEditHarnessConfig]):
         system_prompt = "\n\n".join(
             p for p in (BASH_EDIT_SYSTEM_PROMPT, system_prompt) if p
         )
-        env = {**self.config.env}
+        env = {**self.config.resolved_env}
         args = [
             f"--base-url={endpoint}",
             f"--api-key={secret}",
@@ -81,5 +81,7 @@ class BashEditHarness(Harness[BashEditHarnessConfig]):
             args.append(f"--prompt={prompt}")
         elif prompt is not None:
             env["INITIAL_MESSAGES"] = json.dumps([message_to_wire(m) for m in prompt])
-        program = await runtime.prepare_uv_script(PROGRAM_SOURCE, self.config.env)
+        program = await runtime.prepare_uv_script(
+            PROGRAM_SOURCE, self.config.resolved_env
+        )
         return await runtime.run_program([*program, *args], env)

--- a/verifiers/v1/harnesses/codex/harness.py
+++ b/verifiers/v1/harnesses/codex/harness.py
@@ -75,7 +75,7 @@ class CodexHarness(Harness[CodexHarnessConfig]):
         _, prompt = self.resolve_prompt(trace.task)
         # codex authenticates to the interception server with the session secret (its provider
         # api key) and posts Responses calls to `{endpoint}/responses`.
-        env = {**self.config.env, KEY_VAR: secret}
+        env = {**self.config.resolved_env, KEY_VAR: secret}
         # Values are Codex feature names such as `shell_tool`; Codex owns validation.
         # https://developers.openai.com/codex/config-reference#features
         tool_config = [

--- a/verifiers/v1/harnesses/default/harness.py
+++ b/verifiers/v1/harnesses/default/harness.py
@@ -30,7 +30,7 @@ class DefaultHarness(Harness[DefaultHarnessConfig]):
     SUPPORTS_MESSAGE_PROMPT = True
 
     async def setup(self, runtime: Runtime) -> None:
-        await runtime.prepare_uv_script(PROGRAM_SOURCE, self.config.env)
+        await runtime.prepare_uv_script(PROGRAM_SOURCE, self.config.resolved_env)
 
     async def launch(
         self,
@@ -42,7 +42,7 @@ class DefaultHarness(Harness[DefaultHarnessConfig]):
         mcp_urls: dict[str, str],
     ) -> ProgramResult:
         system_prompt, prompt = self.resolve_prompt(trace.task)
-        env = {**self.config.env}
+        env = {**self.config.resolved_env}
         args = [
             f"--base-url={endpoint}",
             f"--api-key={secret}",
@@ -70,5 +70,7 @@ class DefaultHarness(Harness[DefaultHarnessConfig]):
             args.append(f"--prompt={prompt}")
         elif prompt is not None:
             env["INITIAL_MESSAGES"] = json.dumps([message_to_wire(m) for m in prompt])
-        program = await runtime.prepare_uv_script(PROGRAM_SOURCE, self.config.env)
+        program = await runtime.prepare_uv_script(
+            PROGRAM_SOURCE, self.config.resolved_env
+        )
         return await runtime.run_program([*program, *args], env)

--- a/verifiers/v1/harnesses/kimi_code/harness.py
+++ b/verifiers/v1/harnesses/kimi_code/harness.py
@@ -73,7 +73,7 @@ class KimiCodeHarness(Harness[KimiCodeHarnessConfig]):
     ) -> ProgramResult:
         _, prompt = self.resolve_prompt(trace.task)
         env = {
-            **self.config.env,
+            **self.config.resolved_env,
             "KIMI_CODE_HOME": KIMI_HOME,
             "KIMI_MODEL_NAME": ctx.model,
             "KIMI_MODEL_API_KEY": secret,

--- a/verifiers/v1/harnesses/mini_swe_agent/harness.py
+++ b/verifiers/v1/harnesses/mini_swe_agent/harness.py
@@ -23,7 +23,7 @@ class MiniSWEAgentHarness(Harness[MiniSWEAgentHarnessConfig]):
 
     async def setup(self, runtime: Runtime) -> None:
         source = PROGRAM_SOURCE.replace("{version}", self.config.version)
-        await runtime.prepare_uv_script(source, self.config.env)
+        await runtime.prepare_uv_script(source, self.config.resolved_env)
 
     async def launch(
         self,
@@ -66,9 +66,9 @@ class MiniSWEAgentHarness(Harness[MiniSWEAgentHarnessConfig]):
             f"model.model_kwargs.api_key={secret}",
         ]
         env = {
-            **self.config.env,
+            **self.config.resolved_env,
             "MSWEA_CONFIGURED": "true",
             "MSWEA_SILENT_STARTUP": "true",
         }
-        program = await runtime.prepare_uv_script(source, self.config.env)
+        program = await runtime.prepare_uv_script(source, self.config.resolved_env)
         return await runtime.run_program([*program, *args], env)

--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -72,7 +72,7 @@ class RLMHarness(Harness[RLMHarnessConfig]):
         logger.info("rlm: ensuring rlm is installed (version=%s)", self.config.version)
         ensure = shlex.quote(f"[ -x {RLM_BIN} ] || ({install})")
         guarded = f"mkdir -p {RLM_DIR} && flock {RLM_DIR}/install.lock sh -c {ensure}"
-        env = {**self.config.env, "RLM_HOME": RLM_HOME}
+        env = {**self.config.resolved_env, "RLM_HOME": RLM_HOME}
         result = await runtime.run(["sh", "-c", guarded], env)
         if result.exit_code != 0:
             raise RuntimeError(f"rlm install failed: {result.stderr.strip()[-500:]}")
@@ -88,7 +88,7 @@ class RLMHarness(Harness[RLMHarnessConfig]):
     ) -> ProgramResult:
         system_prompt, prompt = self.resolve_prompt(trace.task)
         env = {
-            **self.config.env,
+            **self.config.resolved_env,
             "RLM_BASE_URL": endpoint,
             "RLM_API_KEY": secret,
             "RLM_MODEL": ctx.model,

--- a/verifiers/v1/harnesses/terminus_2/harness.py
+++ b/verifiers/v1/harnesses/terminus_2/harness.py
@@ -35,7 +35,7 @@ class Terminus2Harness(Harness[Terminus2HarnessConfig]):
                 "(--harness.runtime.type docker|prime|modal)."
             )
         source = PROGRAM_SOURCE.replace("{version}", self.config.version)
-        await runtime.prepare_uv_script(source, self.config.env)
+        await runtime.prepare_uv_script(source, self.config.resolved_env)
 
     async def launch(
         self,
@@ -55,7 +55,7 @@ class Terminus2Harness(Harness[Terminus2HarnessConfig]):
             )
         tmux_dir = f"/tmp/vf-terminus-2-{trace.id}"
         env = {
-            **self.config.env,
+            **self.config.resolved_env,
             "TMUX_TMPDIR": tmux_dir,
         }
         args = [
@@ -67,7 +67,7 @@ class Terminus2Harness(Harness[Terminus2HarnessConfig]):
         ]
         try:
             source = PROGRAM_SOURCE.replace("{version}", self.config.version)
-            program = await runtime.prepare_uv_script(source, self.config.env)
+            program = await runtime.prepare_uv_script(source, self.config.resolved_env)
             return await runtime.run_program([*program, *args], env)
         finally:
             # Harbor normally destroys its whole sandbox; this adapter borrows the


### PR DESCRIPTION
## Summary

- Add `forward_env: list[str]` to `HarnessConfig` (alongside `env`): the names of environment variables the harness forwards from the orchestrator process into its runtime/sandbox — for secrets (e.g. `SERPER_API_KEY` for the rlm `search` skill) that must not be hard-coded into a checked-in config.
- Resolution lives in a new `HarnessConfig.resolved_env` property: it reads the named vars from `os.environ` at launch and merges them *under* the explicit `env` (explicit `env` wins; names absent from the environment are skipped). Because it's a property and not a field, the resolved secret values never enter the serialized config (`model_dump`).
- All harnesses now build their runtime env from `self.config.resolved_env` instead of `self.config.env` (default, bash, bash_edit, rlm, codex, kimi_code, mini_swe_agent, terminus_2).

## Usage

```toml
[harness]
id = "rlm"
skills = ["search"]
forward_env = ["SERPER_API_KEY"]   # value read from the orchestrator's env at launch
```

or on the CLI (kebab-case path + JSON list): `--harness.forward-env '["SERPER_API_KEY"]'`.

## Validation

Validated live with a `deepdive-v1` rollout on `z-ai/glm-4.5-air` through the rlm harness on a prime sandbox: with `forward_env=["SERPER_API_KEY"]`, the rlm `search` skill made 13 successful `await search(...)` calls returning real web results, and the `SERPER_API_KEY environment variable is not set` error (present *without* `forward_env`) was gone. `model_dump()` of the config does not contain the secret value.

`ruff check` / `ruff format --check` clean.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `forward_env` field to `HarnessConfig` to pass host environment variables into harness runtimes
> - Adds a `forward_env: list[str]` field to [`HarnessConfig`](https://github.com/PrimeIntellect-ai/verifiers/pull/1901/files#diff-05e981bb3680a934fbc6865d9dff3b25fc692d0c9970684bf8d41f4aea7ee384) that specifies host environment variable names to forward into the runtime.
> - Adds a `resolved_env` property that merges selected host env vars (`os.environ`) with the configured `env` dict, where `env` values take precedence.
> - Updates all harness implementations (`bash`, `bash_edit`, `codex`, `default`, `kimi_code`, `mini_swe_agent`, `rlm`, `terminus_2`) to use `resolved_env` instead of `env` in both `setup` and `launch` methods.
> - Behavioral Change: harnesses that previously received only explicitly configured env vars will now also receive any host env vars named in `forward_env`; existing `env` values still override forwarded ones.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d8ea13d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how every harness builds runtime environment and can inject host secrets into sandboxes; misconfigured `forward_env` could leak or omit expected credentials, though explicit `env` still overrides.
> 
> **Overview**
> Adds **`forward_env`** on `HarnessConfig`: a list of variable names to pull from the orchestrator’s `os.environ` at launch (for secrets like API keys that should not live in checked-in TOML). A **`resolved_env`** property merges forwarded values under explicit **`env`** entries (explicit wins; missing host vars are skipped). Because `resolved_env` is a property, secret values are not stored in serialized config dumps.
> 
> All built-in harnesses (`default`, `bash`, `bash_edit`, `rlm`, `codex`, `kimi_code`, `mini_swe_agent`, `terminus_2`) now pass **`resolved_env`** into `prepare_uv_script` and `run_program` instead of **`env`**, so forwarded secrets reach the sandbox when configured.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8ea13d8e644ab9766f042046610f7d6924735f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->