### PR TITLE
refactor(v1): rename the tool-less `default` harness to `null`

### DIFF
--- a/configs/alphabet_sort.toml
+++ b/configs/alphabet_sort.toml
@@ -11,4 +11,4 @@ min_turns = 2
 max_turns = 2
 
 [harness]
-id = "default"
+id = "null"

--- a/configs/textarena.toml
+++ b/configs/textarena.toml
@@ -14,4 +14,4 @@ game = "Wordle-v0"
 num_tasks = 50  # pool of seeded episodes to draw the eval's tasks from
 
 [harness]
-id = "default"
+id = "null"

--- a/configs/wordle.toml
+++ b/configs/wordle.toml
@@ -10,4 +10,4 @@ id = "wordle-v1"
 num_tasks = 50  # pool of seeded episodes to draw the eval's tasks from
 
 [harness]
-id = "default"
+id = "null"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -249,7 +249,7 @@ markers = [
     "modal: v1 e2e cases touching the modal runtime (local-only setup; excluded in CI)",
     "colocated: v1 e2e cases with a user/tool server colocated in the harness runtime",
     "shared: v1 e2e cases with a shared (one-per-eval) tool server",
-    "default: v1 e2e cases on the default harness",
+    "null: v1 e2e cases on the null harness",
     "bash: v1 e2e cases on the bash harness",
     "rlm: v1 e2e cases on the rlm harness",
     "kimi_code: v1 e2e cases on the kimi-code harness",

--- a/tests/v1/conftest.py
+++ b/tests/v1/conftest.py
@@ -20,7 +20,7 @@ Every matrix value carries a pytest mark, so subsets select with `-m`:
     uv run pytest tests/v1 -n auto -m modal                       # only modal (needs local setup)
 
 Marks: runtimes `subprocess` / `docker` / `prime` / `modal`, placements `colocated` / `shared`,
-harnesses `default` / `bash` / `rlm` / `kimi_code` / `codex`. A mark is applied per axis, so it
+harnesses `null` / `bash` / `rlm` / `kimi_code` / `codex`. A mark is applied per axis, so it
 selects every case touching that value on ANY axis; for one exact combination use `-k` on the test
 id (e.g. `-k "harness-in-docker-with-tool-in-subprocess"`). prime/modal provision real remote
 sandboxes (slow, infra-flaky, need setup), so they're local-only — CI runs `-m "not prime and not modal"`.
@@ -111,11 +111,11 @@ def tool_runtime(request) -> dict:
 # Harnesses, composed with the runtime fixtures, each carrying its harness mark (`-m bash`, ...).
 # Built-ins are bundled in the `harnesses` package; the agent CLIs (`rlm` / `kimi-code` / `codex`)
 # install their dependencies at rollout. `compact` (an example harness) and `terminus-2` (drives
-# the host tmux) are excluded. `test_agentic` skips `default` (a chat loop with no shell);
+# the host tmux) are excluded. `test_agentic` skips `null` (a chat loop with no shell);
 # `test_single_turn` skips `codex` (a coding agent, unreliable on a no-op echo).
 @pytest.fixture(
     params=[
-        pytest.param("default", marks=pytest.mark.default, id="default"),
+        pytest.param("null", marks=pytest.mark.null, id="null"),
         pytest.param("bash", marks=pytest.mark.bash, id="bash"),
         pytest.param("rlm", marks=pytest.mark.rlm, id="rlm"),
         pytest.param("kimi-code", marks=pytest.mark.kimi_code, id="kimi-code"),
@@ -167,7 +167,7 @@ def _eval_config(
     taskset: str,
     *,
     output_dir: Path,
-    harness: str = "default",
+    harness: str = "null",
     n: int = 1,
     num_tasks: int = 1,
     max_tokens: int = 2048,

--- a/tests/v1/test_e2e.py
+++ b/tests/v1/test_e2e.py
@@ -51,7 +51,7 @@ async def test_user(run_v1, harness_runtime, user_runtime, tmp_path):
         )
     (trace,) = await run_v1(
         "echo-user-sim-v1",
-        harness="default",
+        harness="null",
         harness_overrides={"runtime": {"type": harness_runtime}},
         output_dir=tmp_path,
         max_turns=6,
@@ -83,7 +83,7 @@ async def test_tool(run_v1, run_v1_server, harness_runtime, tool_runtime, tmp_pa
     run = run_v1_server if tool_runtime.get("shared") else run_v1
     (trace,) = await run(
         "echo-tool-v1",
-        harness="default",
+        harness="null",
         harness_overrides={"runtime": {"type": harness_runtime}},
         output_dir=tmp_path,
         max_turns=6,
@@ -114,7 +114,7 @@ async def test_tool_state(run_v1, harness_runtime, tool_runtime, tmp_path):
         )
     (trace,) = await run_v1(
         "counter-tool-v1",
-        harness="default",
+        harness="null",
         harness_overrides={"runtime": {"type": harness_runtime}},
         output_dir=tmp_path,
         max_turns=8,
@@ -167,7 +167,7 @@ async def test_shared_tool_isolation(
         )
     traces = await run_v1_server(
         "scratchpad-v1",
-        harness="default",
+        harness="null",
         harness_overrides={"runtime": {"type": harness_runtime}},
         output_dir=tmp_path,
         num_tasks=2,  # two distinct words, run concurrently against the one shared server
@@ -195,7 +195,7 @@ async def test_tool_response_image(run_v1, tmp_path):
     """MCP image content from a tool result survives into the v1 trace (needs a vision model)."""
     (trace,) = await run_v1(
         "tool-response-image-v1",
-        harness="default",
+        harness="null",
         harness_overrides={"runtime": {"type": "subprocess"}},
         model="qwen/qwen3-vl-8b-instruct",
         output_dir=tmp_path,
@@ -209,9 +209,9 @@ async def test_tool_response_image(run_v1, tmp_path):
 @pytest.mark.e2e
 async def test_agentic(run_v1, harness, harness_runtime, tmp_path):
     """Agentic: write a phrase to a file with the agent's shell, checked in the runtime."""
-    if harness == "default":
+    if harness == "null":
         pytest.skip(
-            "default is a chat loop with no shell — it can't do the file-write task"
+            "null is a chat loop with no shell — it can't do the file-write task"
         )
     (trace,) = await run_v1(
         "echo-agentic-v1",

--- a/verifiers/v1/GUIDE.md
+++ b/verifiers/v1/GUIDE.md
@@ -552,15 +552,15 @@ Otherwise pick a built-in, selected with `--harness.id`:
 
 | id | what it is |
 | --- | --- |
-| `default` | a tiny OpenAI chat loop (MCP tools only, no tools of its own) |
-| `bash` | the `default` chat loop plus a local `bash` tool, for shell-driving agents |
+| `null` | a tiny OpenAI chat loop (MCP tools only, no tools of its own) — the fallback when no harness is given |
+| `bash` | the `null` chat loop plus a local `bash` tool, for shell-driving agents |
 | `rlm` | the RLM CLI agent |
 | `codex` | the Codex CLI (Responses dialect + SSE relay) |
 | `mini-swe-agent` | the mini-swe-agent CLI (a minimal SWE agent) |
 | `kimi-code` | the Kimi Code CLI agent |
 
 ```bash
-uv run eval gsm8k-v1 -n 1                    # default harness
+uv run eval gsm8k-v1 -n 1                    # null harness (the fallback when none is given)
 uv run eval gsm8k-v1 -n 1 --harness.id rlm   # same taskset, different driver
 ```
 
@@ -707,7 +707,7 @@ uv run eval gsm8k-v1 -n 5 -r 3 \
 
 | group | flags |
 | --- | --- |
-| selection | `<taskset-id>` / `--taskset.id`, `--harness.id` (`default`), `-m`/`--model` |
+| selection | `<taskset-id>` / `--taskset.id`, `--harness.id` (`null`), `-m`/`--model` |
 | counts | `-n`/`--num-tasks` (all), `-r`/`--num-rollouts` (1; `@group_reward` needs ≥2), `-s`/`--shuffle` |
 | budgets | `--max-turns`, `--max-input-tokens`, `--max-output-tokens`, `--max-total-tokens` (all None) |
 | sampling | `--sampling.temperature`, `--sampling.top-p`, `--sampling.max-tokens`, `--sampling.reasoning-effort` (provider keys pass through) |
@@ -792,7 +792,7 @@ form. In a prime-rl config:
 [[orchestrator.train.env]]
 name    = "gsm8k"
 taskset = { id = "gsm8k-v1", dataset_name = "..." }                 # any v1 taskset id
-harness = { id = "default", runtime = { type = "subprocess" } }
+harness = { id = "null", runtime = { type = "subprocess" } }
 timeout = { scoring = 10 }                                          # per-stage cap (default: no limit)
 # pool  = { type = "elastic", max_workers = 8, multiplex = 128 }    # env-server pool (default elastic, self-sizing)
 ```

--- a/verifiers/v1/README.md
+++ b/verifiers/v1/README.md
@@ -96,7 +96,7 @@ Harness examples (under `environments/`):
 The program that drives the rollout — same taskset, different driver:
 
 ```bash
-uv run eval gsm8k-v1 -n 1                     # default: bare agent (MCP tools only)
+uv run eval gsm8k-v1 -n 1                     # null harness (fallback): bare agent (MCP tools only)
 uv run eval gsm8k-v1 -n 1 --harness.id rlm    # the rlm harness
 uv run eval gsm8k-v1 -n 1 --harness.id codex  # the codex harness
 ```

--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -109,9 +109,9 @@ def _aligned(rows: list[list[str]]) -> list[str]:
 
 
 def _warning(config: EvalConfig) -> Text | None:
-    """A local-runtime caution for a code-running harness (none for the tool-less `default`),
+    """A local-runtime caution for a code-running harness (none for the tool-less `null`),
     shown above the overview rather than as a row in it."""
-    if config.harness.id != "default" and config.harness.runtime.type == "subprocess":
+    if config.harness.id != "null" and config.harness.runtime.type == "subprocess":
         return Text(
             "warning  Runs on the local system; local files and settings may affect this "
             "evaluation. Use subprocess only for debugging, or use docker or prime for an "
@@ -190,10 +190,12 @@ def _breakdown(done: list[Trace]) -> Table | None:
             names.extend(n for n in getattr(trace, source) if n not in names)
         if not names:
             continue
-        segments = [
-            f"{name} {format_mean(done, lambda t, n=name, s=source: getattr(t, s).get(n, 0.0))}"
-            for name in names
-        ]
+        segments = []
+        for name in names:
+            mean = format_mean(
+                done, lambda t, n=name, s=source: getattr(t, s).get(n, 0.0)
+            )
+            segments.append(f"{name} {mean}")
         grid.add_row(label, "  ·  ".join(segments))
 
     # Resource use over every completed rollout (errored ones still spent tokens/time): tokens and

--- a/verifiers/v1/env.py
+++ b/verifiers/v1/env.py
@@ -93,11 +93,11 @@ class EnvConfig(BaseConfig):
     time, not by the env — only `taskset` is narrowed per env (to its config type,
     inferred from `load_taskset`). Tool-server placement lives on `taskset.tools`."""
 
-    # SerializeAsAny: these hold resolved subclasses (e.g. MathConfig, DefaultHarnessConfig);
+    # SerializeAsAny: these hold resolved subclasses (e.g. MathConfig, NullHarnessConfig);
     # without it model_dump() narrows to the base type and drops the subclass fields, so the
     # env-server subconfig the orchestrator writes would lose taskset/harness-specific knobs.
     taskset: SerializeAsAny[TasksetConfig] = TasksetConfig()
-    harness: SerializeAsAny[HarnessConfig] = HarnessConfig(id="default")
+    harness: SerializeAsAny[HarnessConfig] = HarnessConfig(id="null")
     timeout: TimeoutConfig = TimeoutConfig()
     retries: RetryConfig = RetryConfig()
     max_turns: int | None = None
@@ -243,7 +243,7 @@ class Environment:
             raise ValueError(
                 f"Harness {self.harness.config.id!r} does not support MCP tools, but taskset "
                 f"{self.taskset.config.id!r} exposes tool servers (MCP). Run it with a harness "
-                f"that supports MCP (e.g. --harness.id default), or use a taskset without tools."
+                f"that supports MCP (e.g. --harness.id null), or use a taskset without tools."
             )
         if (
             not self.harness.SUPPORTS_USER_SIM
@@ -252,7 +252,7 @@ class Environment:
             raise ValueError(
                 f"Harness {self.harness.config.id!r} does not drive a user simulator, but taskset "
                 f"{self.taskset.config.id!r} defines one (Taskset.user). Run it with a harness that "
-                f"supports user simulation (e.g. --harness.id default), or use a taskset without one."
+                f"supports user simulation (e.g. --harness.id null), or use a taskset without one."
             )
         if self.taskset.NEEDS_CONTAINER and isinstance(
             self.harness.config.runtime, SubprocessConfig
@@ -262,7 +262,9 @@ class Environment:
                 "(NEEDS_CONTAINER), but the harness runs on the subprocess runtime; "
                 "use --harness.runtime.type docker or prime."
             )
-        if self.harness.config.id != "default" and isinstance(
+        # Every harness except the tool-less `null` chat loop runs code locally on the subprocess
+        # runtime, so warn there (no warning for `null`, which only talks to remote MCP servers).
+        if self.harness.config.id != "null" and isinstance(
             self.harness.config.runtime, SubprocessConfig
         ):
             logger.warning(

--- a/verifiers/v1/harness.py
+++ b/verifiers/v1/harness.py
@@ -39,7 +39,7 @@ class HarnessConfig(BaseConfig):
     id is supplied by the caller (`--harness.id` / toml / a taskset's bundled harness), never
     pinned on the subclass."""
 
-    id: EnvId = "default"
+    id: EnvId = "null"
     """The harness id, which selects this harness: a local package, or an
     `org/name[@version]` package installed on demand from the Environments Hub (see
     `EnvId`). Set via `--harness.id`."""

--- a/verifiers/v1/harnesses/__init__.py
+++ b/verifiers/v1/harnesses/__init__.py
@@ -4,12 +4,12 @@ Re-exports each harness's class + config off the package."""
 
 from verifiers.v1.harnesses.bash import BashHarness, BashHarnessConfig
 from verifiers.v1.harnesses.codex import CodexHarness, CodexHarnessConfig
-from verifiers.v1.harnesses.default import DefaultHarness, DefaultHarnessConfig
 from verifiers.v1.harnesses.kimi_code import KimiCodeHarness, KimiCodeHarnessConfig
 from verifiers.v1.harnesses.mini_swe_agent import (
     MiniSWEAgentHarness,
     MiniSWEAgentHarnessConfig,
 )
+from verifiers.v1.harnesses.null import NullHarness, NullHarnessConfig
 from verifiers.v1.harnesses.rlm import RLMHarness, RLMHarnessConfig
 from verifiers.v1.harnesses.terminus_2 import Terminus2Harness, Terminus2HarnessConfig
 
@@ -18,10 +18,10 @@ __all__ = [
     "BashHarnessConfig",
     "CodexHarness",
     "CodexHarnessConfig",
-    "DefaultHarness",
-    "DefaultHarnessConfig",
     "KimiCodeHarness",
     "KimiCodeHarnessConfig",
+    "NullHarness",
+    "NullHarnessConfig",
     "MiniSWEAgentHarness",
     "MiniSWEAgentHarnessConfig",
     "RLMHarness",

--- a/verifiers/v1/harnesses/default/__init__.py
+++ b/verifiers/v1/harnesses/default/__init__.py
@@ -1,6 +1,0 @@
-"""default — v1's built-in harness: its `harness.py` (class + config) and the
-`program.py` script it stages into the runtime. Resolved by id via `load_harness`."""
-
-from verifiers.v1.harnesses.default.harness import DefaultHarness, DefaultHarnessConfig
-
-__all__ = ["DefaultHarness", "DefaultHarnessConfig"]

--- a/verifiers/v1/harnesses/null/__init__.py
+++ b/verifiers/v1/harnesses/null/__init__.py
@@ -1,0 +1,7 @@
+"""null — v1's built-in tool-less harness: its `harness.py` (class + config) and the
+`program.py` script it stages into the runtime. A plain chat loop with the taskset's MCP tools
+and no tools of its own. Resolved by id via `load_harness`."""
+
+from verifiers.v1.harnesses.null.harness import NullHarness, NullHarnessConfig
+
+__all__ = ["NullHarness", "NullHarnessConfig"]

--- a/verifiers/v1/harnesses/null/harness.py
+++ b/verifiers/v1/harnesses/null/harness.py
@@ -1,9 +1,10 @@
-"""The built-in default harness: runs a small chat-loop program as a uv script.
+"""The built-in null harness: runs a small chat-loop program as a uv script, no tools of its own.
 
 A growing-message-list chat loop with the taskset's MCP tools (host-side, resolved to URLs by
-the Environment) — and no tools of its own. Its uv script (deps: openai, mcp) is prepared
-during setup, then launched as the harness program. For a shell-driving agent, use a
-dedicated agentic harness (e.g. `mini-swe-agent`).
+the Environment) — and no tools of its own (it's "null" precisely because it adds no
+harness-side tooling). Its uv script (deps: openai, mcp) is prepared during setup, then launched
+as the harness program. For a shell-driving agent, use a dedicated agentic harness (e.g.
+`mini-swe-agent`).
 """
 
 import json
@@ -18,12 +19,12 @@ from verifiers.v1.trace import Trace
 PROGRAM_SOURCE = (Path(__file__).resolve().parent / "program.py").read_text()
 
 
-class DefaultHarnessConfig(HarnessConfig):
-    """The built-in harness. A uv script (deps: openai, mcp), so it runs in any runtime that
+class NullHarnessConfig(HarnessConfig):
+    """The built-in null harness. A uv script (deps: openai, mcp), so it runs in any runtime that
     has `uv` (the harness bootstraps it) with no other setup."""
 
 
-class DefaultHarness(Harness[DefaultHarnessConfig]):
+class NullHarness(Harness[NullHarnessConfig]):
     APPENDS_SYSTEM_PROMPT = True
     SUPPORTS_MCP = True
     SUPPORTS_USER_SIM = True

--- a/verifiers/v1/harnesses/null/program.py
+++ b/verifiers/v1/harnesses/null/program.py
@@ -2,7 +2,7 @@
 # requires-python = ">=3.10"
 # dependencies = ["openai", "mcp"]
 # ///
-"""The default harness's program: a chat loop with the taskset's MCP tools (and none of its own).
+"""The null harness's program: a chat loop with the taskset's MCP tools (and none of its own).
 
 A growing-message-list chat loop. When the harness sets MCP_CONFIG (a standard `mcpServers` URL
 map) it connects to those servers over streamable HTTP, exposes their tools to the model as

--- a/verifiers/v1/loaders.py
+++ b/verifiers/v1/loaders.py
@@ -130,15 +130,15 @@ def harness_class(harness_id: str) -> type[Harness]:
 def default_harness_id(taskset_id: str) -> str:
     """The harness id to use when none is given. A taskset that bundles its own harness — its
     module also exports a `Harness` subclass via `__all__`, so the taskset id doubles as the
-    harness id — runs with that harness by default; otherwise the shared `default` harness. An
+    harness id — runs with that harness by default; otherwise the shared `null` harness. An
     explicit `--harness.id` / toml id always takes precedence (this only supplies the fallback)."""
     if not taskset_id:
-        return "default"
+        return "null"
     try:
         module = import_taskset(taskset_id)
         _plugin_class(module, Harness, "harness")
     except (ModuleNotFoundError, TypeError, AttributeError):
-        return "default"
+        return "null"
     return taskset_id
 
 


### PR DESCRIPTION
## What

The built-in `default` harness is a bare OpenAI chat loop that exposes the taskset's MCP tools and adds **no tools of its own** — it's literally *no harness*. This renames it to **`NullHarness` / `null`** so the name says what it is, and frees the `default` name for a more capable agentic harness (next PR in the stack).

This is **PR 1 of 3**:
1. **this PR** — `default` → `null` (pure rename, behavior-preserving)
2. delete the `bash` harness; rename `bash_edit` → `default` (edit gated behind a flag, on by default)
3. rebase #1900 onto (2): add an opt-in `web_search` tool to the new `default`

## The subtlety: `"default"` meant three things

The id string `"default"` was overloaded. Each follows the rename:

- **the harness directory/classes** → `null/`, `NullHarness`, `NullHarnessConfig`
- **the fallback when no `--harness.id` is given** (`default_harness_id`, `HarnessConfig.id`, `EnvConfig.harness`) → now `null`
- **the "tool-less, safe on the local subprocess runtime" proxy** in the two local-runtime warnings (`env.py`, dashboard) → now keyed off `!= "null"` (null only talks to remote MCP servers; every other harness runs code locally)

Behavior is unchanged: a harness-less taskset still gets the same bare chat loop, now spelled `null`.

## Also updated

- harness package exports, loaders, env validation/warning messages (`--harness.id null` in the examples)
- the user-sim configs that pinned the harness explicitly (`textarena` / `wordle` / `alphabet_sort`) → `id = "null"`
- v1 `GUIDE.md` / `README.md` harness tables and examples
- the v1 e2e test matrix: `default` mark → `null`, fixture param, and the hardcoded ids in the non-agentic tests

One unrelated drive-by: an over-long f-string in the dashboard breakdown is lifted out of its replacement field so the current ruff formatter keeps it on 3.11-valid syntax (the file gets reformatted into 3.12-only syntax on any touch otherwise).

## Validation

`uv run ruff check` clean; `uv run pytest tests/v1/test_configs.py` and the e2e collection (marker resolution under `--strict-markers`) pass. Import smoke test confirms `default_harness_id("") == "null"` and `null` resolves to `NullHarness`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking rename of the public harness id (`default` → `null`); saved configs and scripts that pin `harness.id = "default"` must be updated, though runtime behavior of the fallback harness is unchanged.
> 
> **Overview**
> Renames the built-in **tool-less chat-loop harness** from `default` to **`null`**, including the package (`harnesses/null`), **`NullHarness` / `NullHarnessConfig`**, and every place that treated `"default"` as the fallback harness id (`HarnessConfig`, `EnvConfig`, `default_harness_id`, sample TOMLs, loaders, and error/warning text).
> 
> **Behavior is unchanged** for harness-less evals: the same MCP-only loop still runs when no `--harness.id` is set; only the id and names differ. Subprocess safety warnings and the eval dashboard still treat this harness as the one that does not run local shell code (now keyed on `harness.id != "null"`). The v1 e2e matrix pytest mark and fixtures use `null` instead of `default`.
> 
> Docs (`GUIDE.md`, `README.md`) and `pyproject.toml` markers are updated accordingly. The eval dashboard breakdown refactors a long f-string out of a lambda (ruff/format compatibility).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a96fdd971a98eb7024a8be986ff672087f9f546c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename the tool-less `default` harness to `null` across v1
> - Renames the `DefaultHarness`/`DefaultHarnessConfig` classes to `NullHarness`/`NullHarnessConfig` and moves the module from `verifiers/v1/harnesses/default/` to [`verifiers/v1/harnesses/null/`](https://github.com/PrimeIntellect-ai/verifiers/pull/1903/files#diff-25d736bab19f2dc1a724b5452be4bff6a1f694d42cda79f2a582b3daa820b32f).
> - Updates all harness id strings from `"default"` to `"null"` in configs, loaders, env defaults, CLI dashboard, docs, and tests.
> - Behavioral Change: any code or config referencing harness id `"default"` will no longer resolve to this harness; callers must use `"null"`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized a96fdd9. 13 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->