### PR TITLE
feat: per-episode group_id threaded through Rollout to Trace

### DIFF
--- a/verifiers/v1/GUIDE.md
+++ b/verifiers/v1/GUIDE.md
@@ -231,6 +231,7 @@ A reward reads the finished trajectory off `trace`. The most useful members, by 
 | `trace.usage` | `Usage \| None` | provider-reported token usage |
 | `trace.timing` | `Timing` | per-stage durations |
 | `trace.id` | `str` | unique rollout id |
+| `trace.group_id` | `str` | id shared by a task's group; the join key for grouping traces in `results.jsonl` |
 
 `trace.reward` / `trace.rewards` / `trace.metrics` are scoring *outputs*, filled in during the
 scoring pass — don't read them from inside a `@reward`/`@metric`; a `@group_reward` reads metrics

--- a/verifiers/v1/env.py
+++ b/verifiers/v1/env.py
@@ -347,8 +347,6 @@ class Environment:
             else task.timeout.scoring
         )
         retries = self.config.retries
-        # One id per episode, shared across its rollouts (the group).
-        group_id = uuid.uuid4().hex
         rollouts = [
             Rollout(
                 task=task,
@@ -363,7 +361,7 @@ class Environment:
                 limits=self.limits,
                 shared_urls=self._shared_urls,
                 interception=self._interception,
-                group_id=group_id,
+                group_id=uuid.uuid4().hex,
             )
             for _ in range(n)
         ]

--- a/verifiers/v1/env.py
+++ b/verifiers/v1/env.py
@@ -347,6 +347,7 @@ class Environment:
             else task.timeout.scoring
         )
         retries = self.config.retries
+        group_id = uuid.uuid4().hex
         rollouts = [
             Rollout(
                 task=task,
@@ -361,7 +362,7 @@ class Environment:
                 limits=self.limits,
                 shared_urls=self._shared_urls,
                 interception=self._interception,
-                group_id=uuid.uuid4().hex,
+                group_id=group_id,
             )
             for _ in range(n)
         ]

--- a/verifiers/v1/env.py
+++ b/verifiers/v1/env.py
@@ -13,6 +13,7 @@ compare a task's rollouts.
 
 import contextlib
 import logging
+import uuid
 from typing import Annotated, Literal
 
 from pydantic import Field, SerializeAsAny, model_validator
@@ -346,6 +347,8 @@ class Environment:
             else task.timeout.scoring
         )
         retries = self.config.retries
+        # One id per episode, shared across its rollouts (the group).
+        group_id = uuid.uuid4().hex
         rollouts = [
             Rollout(
                 task=task,
@@ -360,6 +363,7 @@ class Environment:
                 limits=self.limits,
                 shared_urls=self._shared_urls,
                 interception=self._interception,
+                group_id=group_id,
             )
             for _ in range(n)
         ]

--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -101,18 +101,6 @@ class RLMHarness(Harness[RLMHarnessConfig]):
         if result.exit_code != 0:
             raise RuntimeError(f"rlm install failed: {result.stderr.strip()[-500:]}")
 
-    def summarize_threshold(self, task_idx: int) -> str:
-        """The `RLM_SUMMARIZE_AT_TOKENS` value: a range draws per-group (seeded by task index, so
-        a task's rollouts share one threshold). Always set — "" when disabled — so the typed field,
-        not a host var the subprocess runtime would inherit, wins."""
-        value = self.config.summarize_at_tokens
-        if value is None:
-            return ""
-        if isinstance(value, tuple):
-            lo, hi = value
-            return str(random.Random(task_idx).randint(lo, hi))
-        return str(value)
-
     async def launch(
         self,
         ctx: RolloutContext,
@@ -123,6 +111,11 @@ class RLMHarness(Harness[RLMHarnessConfig]):
         mcp_urls: dict[str, str],
     ) -> ProgramResult:
         system_prompt, prompt = self.resolve_prompt(trace.task)
+        if isinstance(self.config.summarize_at_tokens, tuple):
+            lo, hi = self.config.summarize_at_tokens
+            summarize_at_tokens = random.Random(trace.group_id).randint(lo, hi)
+        else:
+            summarize_at_tokens = self.config.summarize_at_tokens or ""
         env = {
             **self.config.resolved_env,
             "RLM_BASE_URL": endpoint,
@@ -130,7 +123,7 @@ class RLMHarness(Harness[RLMHarnessConfig]):
             "RLM_MODEL": ctx.model,
             "RLM_MAX_DEPTH": str(self.config.max_depth),
             "RLM_HOME": RLM_HOME,
-            "RLM_SUMMARIZE_AT_TOKENS": self.summarize_threshold(trace.task.idx),
+            "RLM_SUMMARIZE_AT_TOKENS": str(summarize_at_tokens),
         }
         if system_prompt is not None:
             env["RLM_APPEND_TO_SYSTEM_PROMPT"] = system_prompt

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -15,6 +15,7 @@ even if `run()` crashes.
 import asyncio
 import logging
 import time
+import uuid
 from contextlib import asynccontextmanager
 from enum import StrEnum
 
@@ -76,8 +77,12 @@ class Rollout:
         limits: RolloutLimits | None = None,
         shared_urls: dict[str, str] | None = None,
         interception: InterceptionPool | None = None,
+        group_id: str | None = None,
     ) -> None:
         self.task = task
+        self.group_id = group_id or uuid.uuid4().hex
+        """Id of the group (episode) this rollout belongs to; shared with its siblings when
+        `Environment.episode` passes one in, else its own (a lone rollout is a group of one)."""
         self.taskset = taskset
         self.harness = harness
         self.ctx = ctx
@@ -137,7 +142,11 @@ class Rollout:
         the runtime is live, then tears the runtime down in a `finally`. Reuses the
         eval-level shared tool servers / interception pool injected at construction (see
         `self.shared_urls` / `self.interception`)."""
-        trace: Trace = Trace(task=self.task, state=state_cls(type(self.taskset))())
+        trace: Trace = Trace(
+            task=self.task,
+            group_id=self.group_id,
+            state=state_cls(type(self.taskset))(),
+        )
         self.trace = trace  # expose for the --rich dashboard
         trace.timing.setup.start = time.time()
         self.runtime = make_runtime(

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -81,8 +81,7 @@ class Rollout:
     ) -> None:
         self.task = task
         self.group_id = group_id or uuid.uuid4().hex
-        """Id of the group (episode) this rollout belongs to; shared with its siblings when
-        `Environment.episode` passes one in, else its own (a lone rollout is a group of one)."""
+        """Id of the group (episode) this rollout belongs to."""
         self.taskset = taskset
         self.harness = harness
         self.ctx = ctx

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -218,9 +218,7 @@ class Trace(StrictBaseModel, Generic[TaskT, StateT]):
     id: str = Field(default_factory=lambda: uuid.uuid4().hex)
     """Unique id for this rollout, auto-generated per trace."""
     group_id: str = Field(default_factory=lambda: uuid.uuid4().hex)
-    """Id shared by the rollouts of one `Episode` (a task's group), assigned at group construction
-    (`Environment.episode`) — the join key for grouping traces in `results.jsonl`.
-    A trace built ad hoc (no episode) gets its own unique id."""
+    """Id shared by the rollouts of one `Episode` (a task's group), assigned at group construction."""
     task: TaskT
     """The (immutable) task being solved — fully typed, flows into scoring."""
     nodes: list[MessageNode] = Field(default_factory=list)

--- a/verifiers/v1/trace.py
+++ b/verifiers/v1/trace.py
@@ -217,6 +217,10 @@ class Trace(StrictBaseModel, Generic[TaskT, StateT]):
 
     id: str = Field(default_factory=lambda: uuid.uuid4().hex)
     """Unique id for this rollout, auto-generated per trace."""
+    group_id: str = Field(default_factory=lambda: uuid.uuid4().hex)
+    """Id shared by the rollouts of one `Episode` (a task's group), assigned at group construction
+    (`Environment.episode`) — the join key for grouping traces in `results.jsonl`.
+    A trace built ad hoc (no episode) gets its own unique id."""
     task: TaskT
     """The (immutable) task being solved — fully typed, flows into scoring."""
     nodes: list[MessageNode] = Field(default_factory=list)


### PR DESCRIPTION
Assign a uuid `group_id` once per `Environment.episode`, shared across the episode's rollouts and carried onto each `Trace`. It is the join key for a task's group in *results.jsonl*, distinct across the task's groups even when `task.idx` repeats.

The rlm harness seeds its `(lo, hi)` `summarize_at_tokens` draw from `trace.group_id`, so a group's rollouts share one compaction threshold while the same task drawn into another group varies.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] All existing tests pass when running `uv run pytest` locally.
- [ ] New tests have been added to cover the changes

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new serialized `Trace` field (minor schema change for dump consumers) and adjusts RLM env seeding only; no auth, scoring, or runtime lifecycle changes.
> 
> **Overview**
> Introduces a **`group_id`** assigned once per `Environment.episode()` and shared by every rollout in that episode. It flows through `Rollout` onto each **`Trace`**, so serialized traces (e.g. `results.jsonl`) can group rollouts from the same task run even when `task.idx` repeats across episodes.
> 
> The **RLM harness** no longer seeds `(lo, hi)` **`summarize_at_tokens`** draws from `task.idx`; it uses **`trace.group_id`** instead, so all rollouts in one episode share one compaction threshold while different episodes for the same task can differ. The old `summarize_threshold()` helper is inlined into `launch`.
> 
> **GUIDE** documents `trace.group_id` as the join key for grouping traces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1caf4c3aa90c9d25e52a6d568f178d7f42a38918. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-episode `group_id` field threaded from `Rollout` through to `Trace`
> - Adds a `group_id` field to [`Trace`](https://github.com/PrimeIntellect-ai/verifiers/pull/1906/files#diff-834820c3aa80d87ee1c1c57fb54c74f09c66ac727036d964e6005c8613c00b5e) and [`Rollout`](https://github.com/PrimeIntellect-ai/verifiers/pull/1906/files#diff-f886b7f4717cf8fce9270bd4ff4790f3182aa1016abb9efb7f6e57efe18d1bf2); each `Rollout` accepts an optional `group_id` or generates one, and passes it to the `Trace` it produces.
> - [`Environment.episode`](https://github.com/PrimeIntellect-ai/verifiers/pull/1906/files#diff-69be10bd5960e88d88f219d4f261d0bdd16586857f9126451b04d05bac4c2cbb) generates a single `group_id` per episode and shares it across all `Rollout` instances created in that episode, making it the join key for grouping traces in `results.jsonl`.
> - [`RLMHarness.launch`](https://github.com/PrimeIntellect-ai/verifiers/pull/1906/files#diff-3955da24b5fd88f62482297bbda7ba0936f633927f15576db27fed6e58f668ec) now seeds `RLM_SUMMARIZE_AT_TOKENS` randomization with `trace.group_id` instead of the task index, so the value is consistent within a group.
> - [`GUIDE.md`](https://github.com/PrimeIntellect-ai/verifiers/pull/1906/files#diff-c2ca7f62523b24001d6019e37e36351dc73dd3e91a9ac126847e7eb5c55d63a1) documents the new `trace.group_id` field in the counts/tokens/timing reference table.
> - Behavioral Change: `RLM_SUMMARIZE_AT_TOKENS` is now randomized per group rather than per task index when a range is configured.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1caf4c3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->