### PR TITLE
Add v1 shared scoring helpers

### DIFF
--- a/tests/v1/test_scoring.py
+++ b/tests/v1/test_scoring.py
@@ -12,9 +12,9 @@ def test_compare_stdout_results_keeps_numeric_tolerance() -> None:
 def test_parse_pytest_outcomes_strips_xfail_xpass_reasons() -> None:
     output = "\n".join(
         [
-            "XFAIL tests/test_mod.py::test_xfail - known bug",
-            "XPASS tests/test_mod.py::test_xpass - always xfail",
-            "FAILED tests/test_mod.py::test_param[a - b] - assert False",
+            "XFAIL tests/test_mod.py::test_xfail - known bug - still tracked",
+            "XPASS tests/test_mod.py::test_xpass - always xfail - unexpectedly passed",
+            "FAILED tests/test_mod.py::test_param[a - b] - assert left - right",
             "PASSED tests/test_mod.py::test_ok",
         ]
     )
@@ -25,3 +25,9 @@ def test_parse_pytest_outcomes_strips_xfail_xpass_reasons() -> None:
         "tests/test_mod.py::test_param[a - b]": "FAILED",
         "tests/test_mod.py::test_ok": "PASSED",
     }
+
+
+def test_parse_judge_choice_uses_first_choice_after_verdict_marker() -> None:
+    response = "Final Judgment: B because it is a better answer"
+
+    assert vf.parse_judge_choice(response, choices=("A", "B")) == "B"

--- a/tests/v1/test_scoring.py
+++ b/tests/v1/test_scoring.py
@@ -1,0 +1,27 @@
+import verifiers.v1 as vf
+
+
+def test_compare_stdout_results_accepts_token_equal_text() -> None:
+    assert vf.compare_stdout_results("hello   world\n", "hello world\n")
+
+
+def test_compare_stdout_results_keeps_numeric_tolerance() -> None:
+    assert vf.compare_stdout_results("1.0001 2.0\n", "1.0002 2.0009\n")
+
+
+def test_parse_pytest_outcomes_strips_xfail_xpass_reasons() -> None:
+    output = "\n".join(
+        [
+            "XFAIL tests/test_mod.py::test_xfail - known bug",
+            "XPASS tests/test_mod.py::test_xpass - always xfail",
+            "FAILED tests/test_mod.py::test_param[a - b] - assert False",
+            "PASSED tests/test_mod.py::test_ok",
+        ]
+    )
+
+    assert vf.parse_pytest_outcomes(output) == {
+        "tests/test_mod.py::test_xfail": "XFAIL",
+        "tests/test_mod.py::test_xpass": "XPASS",
+        "tests/test_mod.py::test_param[a - b]": "FAILED",
+        "tests/test_mod.py::test_ok": "PASSED",
+    }

--- a/verifiers/v1/__init__.py
+++ b/verifiers/v1/__init__.py
@@ -203,6 +203,13 @@ __all__ = [
     "JudgeConfig",
     "JudgeSamplingConfig",
     "JudgeResponse",
+    # scoring
+    "compare_stdout_results",
+    "extract_boxed_answer",
+    "parse_judge_choice",
+    "parse_pytest_outcomes",
+    "read_answer_file_or_last_reply",
+    "verify_boxed_math_answer",
     # mcp
     "Toolset",
     "ToolsetConfig",

--- a/verifiers/v1/__init__.py
+++ b/verifiers/v1/__init__.py
@@ -49,6 +49,14 @@ from verifiers.v1.loaders import (
     task_type,
     taskset_config_type,
 )
+from verifiers.v1.scoring import (
+    compare_stdout_results as compare_stdout_results,
+    extract_boxed_answer as extract_boxed_answer,
+    parse_judge_choice as parse_judge_choice,
+    parse_pytest_outcomes as parse_pytest_outcomes,
+    read_answer_file_or_last_reply as read_answer_file_or_last_reply,
+    verify_boxed_math_answer as verify_boxed_math_answer,
+)
 from verifiers.v1.retries import RetryConfig, RolloutRetryConfig
 from verifiers.v1.rollout import Rollout
 from verifiers.v1.runtimes import (

--- a/verifiers/v1/scoring.py
+++ b/verifiers/v1/scoring.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+from decimal import Decimal, InvalidOperation
+from typing import TYPE_CHECKING
+
+from math_verify import parse, verify
+from math_verify.errors import TimeoutException as MathVerifyTimeout
+
+from verifiers.v1.errors import SandboxError
+
+if TYPE_CHECKING:
+    from verifiers.v1.runtimes import Runtime
+    from verifiers.v1.trace import Trace
+
+BOXED_START = "\\boxed{"
+ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+PYTEST_OUTCOME_RE = re.compile(
+    r"^(PASSED|FAILED|ERROR|XFAIL|XPASS)\s+(.+?)(?:\s+-\s+.*)?$"
+)
+
+
+def extract_boxed_answer(text: str, strict: bool = False) -> str:
+    start = text.rfind(BOXED_START)
+    if start == -1:
+        return "" if strict else text
+
+    # Regex is the wrong tool for nested braces, so walk the final box by hand.
+    answer_start = start + len(BOXED_START)
+    depth = 1
+    for index, char in enumerate(text[answer_start:], start=answer_start):
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+        if depth == 0:
+            return text[answer_start:index]
+
+    return ""
+
+
+async def read_answer_file_or_last_reply(
+    runtime: "Runtime",
+    path: str,
+    trace: "Trace",
+) -> str:
+    try:
+        answer = (await runtime.read(path)).decode(errors="replace").strip()
+    except (FileNotFoundError, OSError, SandboxError):
+        answer = ""
+    return answer or trace.last_reply
+
+
+def parse_judge_choice(
+    content: str | None,
+    choices: Sequence[str] = ("A", "B", "C"),
+) -> str | None:
+    text = (content or "").rsplit("</think>", 1)[-1].strip()
+    text = extract_boxed_answer(text, strict=True).strip() or text
+
+    choices_by_upper = {choice.upper(): choice for choice in choices}
+    allowed = "|".join(re.escape(choice) for choice in choices_by_upper)
+    match = re.search(rf"(?<![A-Z])({allowed})(?![A-Z])", text.upper())
+    return choices_by_upper.get(match.group(1)) if match else None
+
+
+def verify_boxed_math_answer(
+    response: str | None,
+    answer: str,
+    *,
+    timeout_seconds: int = 5,
+) -> float:
+    if not response or ("<think>" in response and "</think>" not in response):
+        return 0.0
+
+    prediction_text = response.rsplit("</think>", 1)[-1]
+    prediction = extract_boxed_answer(prediction_text, strict=True).strip()
+    gold = (extract_boxed_answer(answer, strict=True) or answer).strip()
+    if not prediction or not gold:
+        return 0.0
+
+    # math-verify expects both sides as boxed math expressions.
+    try:
+        parsed_gold = parse(f"\\boxed{{{gold}}}", parsing_timeout=timeout_seconds)
+        parsed_prediction = parse(
+            f"\\boxed{{{prediction}}}",
+            parsing_timeout=timeout_seconds,
+        )
+        return float(
+            verify(
+                parsed_gold,
+                parsed_prediction,
+                timeout_seconds=timeout_seconds,
+            )
+        )
+    except (Exception, MathVerifyTimeout):
+        return 0.0
+
+
+def compare_stdout_results(
+    exec_stdout: str,
+    expected: str,
+    *,
+    tolerance: float = 1e-3,
+) -> bool:
+    if exec_stdout.strip() == expected.strip():
+        return True
+
+    actual_lines = [line.strip() for line in exec_stdout.splitlines() if line.strip()]
+    expected_lines = [line.strip() for line in expected.splitlines() if line.strip()]
+    if actual_lines == expected_lines:
+        return True
+
+    actual_tokens = [token for line in actual_lines for token in line.split()]
+    expected_tokens = [token for line in expected_lines for token in line.split()]
+    if len(actual_tokens) != len(expected_tokens) or not actual_tokens:
+        return False
+
+    # Code datasets often allow tiny floating-point drift in stdout.
+    try:
+        actual_numbers = [Decimal(token) for token in actual_tokens]
+        expected_numbers = [Decimal(token) for token in expected_tokens]
+    except (InvalidOperation, ValueError):
+        return False
+
+    limit = Decimal(str(tolerance))
+    return all(
+        abs(actual - expected) <= limit
+        for actual, expected in zip(actual_numbers, expected_numbers)
+    )
+
+
+def parse_pytest_outcomes(output: str | None) -> dict[str, str]:
+    outcomes: dict[str, str] = {}
+    for line in ANSI_RE.sub("", output or "").splitlines():
+        match = PYTEST_OUTCOME_RE.match(line.strip())
+        if match:
+            outcome, test_id = match.groups()
+            outcomes[test_id.rstrip()] = outcome
+    return outcomes

--- a/verifiers/v1/scoring.py
+++ b/verifiers/v1/scoring.py
@@ -16,9 +16,7 @@ if TYPE_CHECKING:
 
 BOXED_START = "\\boxed{"
 ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
-PYTEST_OUTCOME_RE = re.compile(
-    r"^(PASSED|FAILED|ERROR|XFAIL|XPASS)\s+(.+?)(?:\s+-\s+.*)?$"
-)
+PYTEST_OUTCOMES = ("PASSED", "FAILED", "ERROR", "SKIPPED", "XFAIL", "XPASS")
 
 
 def extract_boxed_answer(text: str, strict: bool = False) -> str:
@@ -37,13 +35,11 @@ def extract_boxed_answer(text: str, strict: bool = False) -> str:
         if depth == 0:
             return text[answer_start:index]
 
-    return ""
+    return "" if strict else text
 
 
 async def read_answer_file_or_last_reply(
-    runtime: "Runtime",
-    path: str,
-    trace: "Trace",
+    runtime: "Runtime", path: str, trace: "Trace"
 ) -> str:
     try:
         answer = (await runtime.read(path)).decode(errors="replace").strip()
@@ -53,23 +49,22 @@ async def read_answer_file_or_last_reply(
 
 
 def parse_judge_choice(
-    content: str | None,
-    choices: Sequence[str] = ("A", "B", "C"),
+    content: str | None, choices: Sequence[str] = ("A", "B", "C")
 ) -> str | None:
-    text = (content or "").rsplit("</think>", 1)[-1].strip()
+    if not content or ("<think>" in content and "</think>" not in content):
+        return None
+
+    text = content.rsplit("</think>", 1)[-1].strip()
     text = extract_boxed_answer(text, strict=True).strip() or text
 
     choices_by_upper = {choice.upper(): choice for choice in choices}
     allowed = "|".join(re.escape(choice) for choice in choices_by_upper)
-    match = re.search(rf"(?<![A-Z])({allowed})(?![A-Z])", text.upper())
-    return choices_by_upper.get(match.group(1)) if match else None
+    matches = re.findall(rf"(?<!\w)({allowed})(?!\w)", text.upper())
+    return choices_by_upper.get(matches[-1]) if matches else None
 
 
 def verify_boxed_math_answer(
-    response: str | None,
-    answer: str,
-    *,
-    timeout_seconds: int = 5,
+    response: str | None, answer: str, *, timeout_seconds: int = 5
 ) -> float:
     if not response or ("<think>" in response and "</think>" not in response):
         return 0.0
@@ -99,10 +94,7 @@ def verify_boxed_math_answer(
 
 
 def compare_stdout_results(
-    exec_stdout: str,
-    expected: str,
-    *,
-    tolerance: float = 1e-3,
+    exec_stdout: str, expected: str, *, tolerance: float = 1e-3
 ) -> bool:
     if exec_stdout.strip() == expected.strip():
         return True
@@ -123,6 +115,8 @@ def compare_stdout_results(
         expected_numbers = [Decimal(token) for token in expected_tokens]
     except (InvalidOperation, ValueError):
         return False
+    if not all(number.is_finite() for number in actual_numbers + expected_numbers):
+        return False
 
     limit = Decimal(str(tolerance))
     return all(
@@ -133,9 +127,19 @@ def compare_stdout_results(
 
 def parse_pytest_outcomes(output: str | None) -> dict[str, str]:
     outcomes: dict[str, str] = {}
-    for line in ANSI_RE.sub("", output or "").splitlines():
-        match = PYTEST_OUTCOME_RE.match(line.strip())
-        if match:
-            outcome, test_id = match.groups()
-            outcomes[test_id.rstrip()] = outcome
+    for raw_line in ANSI_RE.sub("", output or "").splitlines():
+        parts = raw_line.strip().split(maxsplit=1)
+        if len(parts) != 2:
+            continue
+
+        outcome, test_id = parts
+        if outcome not in PYTEST_OUTCOMES:
+            continue
+
+        # FAILED/ERROR summary lines append " - <reason>"; passing node ids do not.
+        if outcome in ("FAILED", "ERROR") and " - " in test_id:
+            node_id = test_id.rsplit(" - ", 1)[0]
+            if node_id.count("[") == node_id.count("]"):
+                test_id = node_id
+        outcomes[test_id.rstrip()] = outcome
     return outcomes

--- a/verifiers/v1/scoring.py
+++ b/verifiers/v1/scoring.py
@@ -57,9 +57,21 @@ def parse_judge_choice(
     text = content.rsplit("</think>", 1)[-1].strip()
     text = extract_boxed_answer(text, strict=True).strip() or text
 
+    text_upper = text.upper()
     choices_by_upper = {choice.upper(): choice for choice in choices}
     allowed = "|".join(re.escape(choice) for choice in choices_by_upper)
-    matches = re.findall(rf"(?<!\w)({allowed})(?!\w)", text.upper())
+    choice_re = rf"(?<!\w)({allowed})(?!\w)"
+    verdict_re = (
+        r"(?:^|\n)\s*(?:FINAL\s+JUDGMENT|FINAL\s+ANSWER|FINAL\s+VERDICT|"
+        r"JUDGMENT|VERDICT|ANSWER)\s*(?:IS\s*)?[:\-]?\s*"
+    )
+
+    verdict = re.search(verdict_re, text_upper)
+    if verdict:
+        match = re.search(choice_re, text_upper[verdict.end() :])
+        return choices_by_upper.get(match.group(1)) if match else None
+
+    matches = re.findall(choice_re, text_upper)
     return choices_by_upper.get(matches[-1]) if matches else None
 
 
@@ -144,8 +156,11 @@ def parse_pytest_outcomes(output: str | None) -> dict[str, str]:
 
         # These summary rows append " - <reason>"; passing node ids do not.
         if outcome in ("FAILED", "ERROR", "XFAIL", "XPASS") and " - " in test_id:
-            node_id = test_id.rsplit(" - ", 1)[0]
-            if node_id.count("[") == node_id.count("]"):
-                test_id = node_id
+            parts = test_id.split(" - ")
+            for index in range(1, len(parts)):
+                node_id = " - ".join(parts[:index])
+                if node_id.count("[") == node_id.count("]"):
+                    test_id = node_id
+                    break
         outcomes[test_id.rstrip()] = outcome
     return outcomes

--- a/verifiers/v1/scoring.py
+++ b/verifiers/v1/scoring.py
@@ -106,6 +106,8 @@ def compare_stdout_results(
 
     actual_tokens = [token for line in actual_lines for token in line.split()]
     expected_tokens = [token for line in expected_lines for token in line.split()]
+    if actual_tokens == expected_tokens:
+        return True
     if len(actual_tokens) != len(expected_tokens) or not actual_tokens:
         return False
 
@@ -140,8 +142,8 @@ def parse_pytest_outcomes(output: str | None) -> dict[str, str]:
         if test_id.startswith("["):
             continue
 
-        # FAILED/ERROR summary lines append " - <reason>"; passing node ids do not.
-        if outcome in ("FAILED", "ERROR") and " - " in test_id:
+        # These summary rows append " - <reason>"; passing node ids do not.
+        if outcome in ("FAILED", "ERROR", "XFAIL", "XPASS") and " - " in test_id:
             node_id = test_id.rsplit(" - ", 1)[0]
             if node_id.count("[") == node_id.count("]"):
                 test_id = node_id

--- a/verifiers/v1/scoring.py
+++ b/verifiers/v1/scoring.py
@@ -136,6 +136,10 @@ def parse_pytest_outcomes(output: str | None) -> dict[str, str]:
         if outcome not in PYTEST_OUTCOMES:
             continue
 
+        # SKIPPED short-summary rows use "[N] file.py:line: reason", not a node id.
+        if test_id.startswith("["):
+            continue
+
         # FAILED/ERROR summary lines append " - <reason>"; passing node ids do not.
         if outcome in ("FAILED", "ERROR") and " - " in test_id:
             node_id = test_id.rsplit(" - ", 1)[0]


### PR DESCRIPTION
## Overview
Adds one readable v1 scoring helper module for recurring environment idioms.

## Details
- Adds `verifiers.v1.scoring` with boxed answer extraction, answer-file fallback, simple judge-choice parsing, boxed math verification, stdout comparison, and pytest outcome parsing.
- Re-exports those helpers through `verifiers.v1` and includes them in `verifiers.v1.__all__` for the usual environment import style.
- Keeps the parsing and comparison behavior aligned with recurring environment needs, including boxed passthroughs, final judge choices, digit-labelled choices, non-finite stdout tokens, and pytest parameterized node IDs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive library utilities with no changes to existing rollout or auth paths; scoring edge cases are covered by new tests.
> 
> **Overview**
> Introduces **`verifiers.v1.scoring`** so v1 environments can share the same scoring idioms via `import verifiers.v1 as vf`.
> 
> The module adds **`extract_boxed_answer`** (last `\boxed{…}` with nested-brace handling), **`read_answer_file_or_last_reply`** (sandbox file read with **`trace.last_reply`** fallback), **`parse_judge_choice`** (verdict markers, `<think>` stripping, boxed strict mode), **`verify_boxed_math_answer`** (**`math_verify`** with timeouts), **`compare_stdout_results`** (whitespace/token equality plus numeric tolerance), and **`parse_pytest_outcomes`** (ANSI strip, reason trimming, parameterized node IDs). All six are re-exported from **`verifiers.v1`** and **`__all__`**.
> 
> **`tests/v1/test_scoring.py`** covers stdout leniency, numeric tolerance, pytest outcome parsing, and judge choice after a verdict marker.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 349f0c57f8a39e49d98fc268d6d76a07b39febbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add shared scoring helpers to the `verifiers.v1` package
> - Adds [scoring.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1907/files#diff-12aeb6693b9bcb1ec5230be5cc55bd35170a03cb44fcd091021e56448b998b21) with six utilities: `extract_boxed_answer`, `read_answer_file_or_last_reply`, `parse_judge_choice`, `verify_boxed_math_answer`, `compare_stdout_results`, and `parse_pytest_outcomes`.
> - `compare_stdout_results` tolerates minor formatting and numeric differences (default tolerance 1e-3) when comparing stdout output.
> - `verify_boxed_math_answer` uses `math-verify` with timeout handling to produce a float score for boxed math answers.
> - `parse_judge_choice` and `parse_pytest_outcomes` extract structured results from judge responses and pytest summary text respectively.
> - Exports all six helpers from `verifiers.v1.__init__` via `__all__`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 349f0c5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->