### PR TITLE
fix: don't prefix rlm harness metrics with rlm_

### DIFF
--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -147,7 +147,7 @@ class RLMHarness(Harness[RLMHarnessConfig]):
         # rlm writes a session meta.json with a rich `metrics` block (turns, token
         # stats, compactions, tool-call counts). There's one top-level session dir
         # (sub-harnesses nest as sub-*/), so the glob matches a single file. Surface
-        # its numeric metrics under an `rlm_` prefix; non-numeric fields (e.g.
+        # its numeric metrics under their own names; non-numeric fields (e.g.
         # stop_reason) don't fit the float-only trace metrics, so they're skipped.
         result = await runtime.run(
             ["sh", "-c", f"cat {RLM_HOME}/sessions/*/meta.json"], {}
@@ -159,7 +159,7 @@ class RLMHarness(Harness[RLMHarnessConfig]):
         except json.JSONDecodeError:
             return {}
         return {
-            f"rlm_{key}": float(value)
+            key: float(value)
             for key, value in meta.get("metrics", {}).items()
             if isinstance(value, (int, float)) and not isinstance(value, bool)
         }


### PR DESCRIPTION
## Summary

- The rlm harness's `rlm` `@metric` scraped rlm's session `meta.json` and recorded each numeric metric under an `rlm_` prefix (`rlm_turns`, `rlm_prompt_tokens`, `rlm_completion_tokens`, `rlm_compactions_count`, ...).
- Drop the prefix so the metrics are recorded under their own names (`turns`, `prompt_tokens`, `completion_tokens`, `compactions_count`, ...). Non-numeric fields (e.g. `stop_reason`) are still skipped.

## Breaking

- Metric keys emitted by the v1 `RLMHarness` lose their `rlm_` prefix. Anything consuming these (dashboards, filters, downstream analysis) must migrate `rlm_<name>` → `<name>` (e.g. `rlm_turns` → `turns`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change to metric key names for v1 RLM harness rollouts; consumers must update from `rlm_<name>` to `<name>`.
> 
> **Overview**
> **Breaking:** The v1 `RLMHarness` `rlm` `@metric` no longer prefixes numeric fields from session `meta.json` with `rlm_`. Keys such as `turns`, `prompt_tokens`, and `compactions_count` are recorded under their original names instead of `rlm_turns`, `rlm_prompt_tokens`, etc.
> 
> Non-numeric metrics (e.g. `stop_reason`) are still omitted. Downstream dashboards, filters, or analysis that keyed on `rlm_*` names need to migrate to the unprefixed keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7a74353baefbe4279711c9d0ba19ae3b7c308d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `rlm_` prefix from RLM harness metric keys
> The `RLMHarness.rlm` method in [harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1909/files#diff-3955da24b5fd88f62482297bbda7ba0936f633927f15576db27fed6e58f668ec) was prefixing each metric key with `rlm_` before returning. It now returns the original key names from `meta['metrics']` unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized b7a7435. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->