### PR TITLE
chore: drop rlm_ prefix from rlm harness metrics

### DIFF
--- a/verifiers/v1/harnesses/rlm/harness.py
+++ b/verifiers/v1/harnesses/rlm/harness.py
@@ -144,10 +144,10 @@ class RLMHarness(Harness[RLMHarnessConfig]):
 
     @metric
     async def rlm(self, trace: Trace, runtime: Runtime) -> dict[str, float]:
-        # rlm writes a session meta.json with a rich `metrics` block (turns, token
-        # stats, compactions, tool-call counts). There's one top-level session dir
-        # (sub-harnesses nest as sub-*/), so the glob matches a single file. Surface
-        # its numeric metrics under an `rlm_` prefix; non-numeric fields (e.g.
+        # rlm writes a session meta.json with a rich `metrics` block (compactions,
+        # ipython input size, programmatic tool-call counts). There's one top-level
+        # session dir (sub-harnesses nest as sub-*/), so the glob matches a single
+        # file. Surface its numeric metrics as-is; non-numeric fields (e.g.
         # stop_reason) don't fit the float-only trace metrics, so they're skipped.
         result = await runtime.run(
             ["sh", "-c", f"cat {RLM_HOME}/sessions/*/meta.json"], {}
@@ -159,7 +159,7 @@ class RLMHarness(Harness[RLMHarnessConfig]):
         except json.JSONDecodeError:
             return {}
         return {
-            f"rlm_{key}": float(value)
+            key: float(value)
             for key, value in meta.get("metrics", {}).items()
             if isinstance(value, (int, float)) and not isinstance(value, bool)
         }


### PR DESCRIPTION
## Summary

Surface rlm's `meta.json` metrics under their own names instead of prefixing them with `rlm_` (`verifiers/v1/harnesses/rlm/harness.py`). The metric keys are already rlm-specific (`num_compactions`, `ipython_input_*_mean`, `num_ptc_calls`, ...), so the prefix was redundant.

Pairs with PrimeIntellect-ai/rlm-harness#110, which prunes the rlm metric set down to only what verifiers v1 can't derive natively (compaction volume, ipython input size, programmatic tool calls) and renames the survivors.

## Breaking

- rlm harness metrics now appear on the trace as e.g. `num_compactions` instead of `rlm_num_compactions`. Any dashboard/query keyed on `rlm_*` for rlm runs must drop the prefix.

## Verification

Ran `terminal-bench-2-v1` `fix-git` on the `prime` runtime with rlm installed from the rlm-harness#110 branch (`--harness.version chore/prune-redundant-metrics`) and this prefix drop active.

- Task **solved** (`solved: 1.0`, `agent_completed`, 15 turns).
- Metrics logged on the trace (bare names — prefix drop confirmed):
  `num_compactions`, `turns_since_last_compaction`, `turns_between_compactions_mean`, `compaction_chars_dropped_mean`, `compaction_summary_chars_mean`, `ipython_input_chars_mean` (81.5), `ipython_input_loc_mean` (2.2), `num_ptc_calls`, `num_ptc_calls_bash`.
- The removed rlm metrics are covered natively by the v1 trace on the same rollout: `num_branches=1`, `num_turns=15`, `completion_tokens=2248` (sum of node usage).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Drop `rlm_` prefix from RLM harness metric keys
> In [harness.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1911/files#diff-3955da24b5fd88f62482297bbda7ba0936f633927f15576db27fed6e58f668ec), the `RLMHarness.rlm` coroutine now returns metrics using the raw keys from `meta['metrics']` instead of prefixing each key with `rlm_`. Behavioral Change: any consumer reading prefixed keys like `rlm_accuracy` must update to use the unprefixed form (e.g. `accuracy`).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c396dd6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Renaming trace metric keys is a breaking change for any consumer keyed on `rlm_*`, though runtime behavior is unchanged.
> 
> **Overview**
> **RLM harness metrics** now use the same keys as `meta.json` (`num_compactions`, `ipython_input_chars_mean`, etc.) instead of prefixing every value with `rlm_`.
> 
> The `RLMHarness.rlm` metric coroutine only changes how keys are named when numeric fields from `sessions/*/meta.json` are merged onto the trace; filtering of non-numeric metrics is unchanged. Comments were updated to match the slimmer rlm metric set (compactions, ipython input size, programmatic tool calls).
> 
> **Breaking:** dashboards or queries that expect `rlm_*` keys must switch to the unprefixed names. This pairs with rlm-harness pruning redundant metrics that v1 already derives from the trace.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c396dd6fcf7a89c8aed865e006f843cb2219bd13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->