### PR TITLE
feat: paginate the eval --rich dashboard with left/right arrow keys

### DIFF
--- a/verifiers/v1/cli/dashboard/base.py
+++ b/verifiers/v1/cli/dashboard/base.py
@@ -47,27 +47,37 @@ def _key_reader(
     fd = sys.stdin.fileno()
     loop = asyncio.get_running_loop()
     old = termios.tcgetattr(fd)
-    tty.setcbreak(fd)
+    # carries a partial escape across reads — cbreak can split a key's 3 bytes over callbacks
+    buf = bytearray()
 
     def _read() -> None:
         try:
             data = os.read(fd, 32)
         except OSError:
             return
+        if not data:
+            return
+        buf.extend(data)
         fired = False
         i = 0
-        while i < len(data):  # a burst may hold several presses; scan the whole chunk
-            if key := _ARROWS.get(data[i : i + 3]):
+        while i < len(buf):  # a chunk may hold several presses; scan the whole buffer
+            if key := _ARROWS.get(bytes(buf[i : i + 3])):
                 on_key(key)
                 fired = True
                 i += 3
+            elif buf[i] == 0x1B and len(buf) - i < 3:
+                break  # incomplete escape at the tail — hold it for the next read
             else:
                 i += 1
+        del buf[:i]
         if fired:
             refresh()
 
-    loop.add_reader(fd, _read)
+    # setcbreak inside the try so the finally always restores the terminal, even if it (or
+    # add_reader) raises — otherwise stdin could be left in cbreak with echo off after we exit.
     try:
+        tty.setcbreak(fd)
+        loop.add_reader(fd, _read)
         yield
     finally:
         loop.remove_reader(fd)

--- a/verifiers/v1/cli/dashboard/base.py
+++ b/verifiers/v1/cli/dashboard/base.py
@@ -1,20 +1,85 @@
 """The shared dashboard engine: a rich `Live` view on a fixed refresh tick.
 
 The eval and validate dashboards each build their own frame; `live_view` just drives whichever
-`render` it's given — refreshing on a timer and drawing a final frame on exit.
+`render` it's given — refreshing on a timer and drawing a final frame on exit. When given an
+`on_key` handler it also reads left/right arrow presses from the terminal (see `_key_reader`).
 """
 
 import asyncio
 import contextlib
-from collections.abc import Callable
+import os
+import sys
+from collections.abc import Callable, Iterator
 
 from rich.console import Group
 from rich.live import Live
 
+try:  # POSIX-only terminal control; absent on Windows, where key reading is skipped.
+    import termios
+    import tty
+
+    _HAS_TTY = True
+except ImportError:
+    _HAS_TTY = False
+
+# Arrow-key escape sequences → direction, covering both the normal (`ESC [`) and application
+# (`ESC O`) cursor-key modes a terminal might send.
+_ARROWS = {
+    b"\x1b[C": "right",
+    b"\x1bOC": "right",
+    b"\x1b[D": "left",
+    b"\x1bOD": "left",
+}
+
+
+@contextlib.contextmanager
+def _key_reader(
+    on_key: Callable[[str], None] | None, refresh: Callable[[], None]
+) -> Iterator[None]:
+    """Dispatch left/right arrow presses to `on_key`, redrawing immediately after each so the
+    view feels instant rather than waiting for the next refresh tick. A no-op unless `on_key` is
+    given and stdin is a real terminal. Puts stdin in cbreak mode (char-at-a-time, no echo, Ctrl+C
+    still interrupts) and reads it via the event loop — no extra thread — restoring the terminal on
+    exit."""
+    if on_key is None or not _HAS_TTY or not sys.stdin.isatty():
+        yield
+        return
+    fd = sys.stdin.fileno()
+    loop = asyncio.get_running_loop()
+    old = termios.tcgetattr(fd)
+    tty.setcbreak(fd)
+
+    def _read() -> None:
+        try:
+            data = os.read(fd, 32)
+        except OSError:
+            return
+        fired = False
+        i = 0
+        while i < len(data):  # a burst may hold several presses; scan the whole chunk
+            if key := _ARROWS.get(data[i : i + 3]):
+                on_key(key)
+                fired = True
+                i += 3
+            else:
+                i += 1
+        if fired:
+            refresh()
+
+    loop.add_reader(fd, _read)
+    try:
+        yield
+    finally:
+        loop.remove_reader(fd)
+        termios.tcsetattr(fd, termios.TCSADRAIN, old)
+
 
 @contextlib.asynccontextmanager
-async def live_view(render: Callable[[], Group]):
-    """Refresh `render()` every 0.25s until the block exits, then draw one final frame."""
+async def live_view(
+    render: Callable[[], Group], on_key: Callable[[str], None] | None = None
+):
+    """Refresh `render()` every 0.25s until the block exits, then draw one final frame. When
+    `on_key` is given, left/right arrow presses are dispatched to it (and redraw at once)."""
     with Live(render(), auto_refresh=False) as live:
 
         async def loop() -> None:
@@ -23,10 +88,11 @@ async def live_view(render: Callable[[], Group]):
                 live.update(render(), refresh=True)
 
         task = asyncio.create_task(loop())
-        try:
-            yield
-        finally:
-            task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await task
-            live.update(render(), refresh=True)
+        with _key_reader(on_key, lambda: live.update(render(), refresh=True)):
+            try:
+                yield
+            finally:
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await task
+                live.update(render(), refresh=True)

--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -217,8 +217,8 @@ def Progress(
         f"{len(done)}/{len(rollouts)} · {format_time(time.time() - start)} · "
         f"reward {reward} · err {err}"
     )
-    if page is not None:  # rollouts overflow the screen — show which page is on screen
-        stats += f"  (page {page[0]}/{page[1]})"
+    if page is not None:  # overflowing — show which page, and that the arrows page
+        stats += f"  (page {page[0]}/{page[1]} ◄ ►)"
     row = Table.grid(expand=True, padding=(0, 1))
     row.add_column(ratio=1)  # bar stretches to fill the width left of the stats
     row.add_column(justify="right", no_wrap=True)
@@ -469,12 +469,37 @@ def Rows(groups: list[list[Rollout]], now: float, runtime_type: str) -> Table:
     return grid
 
 
+class Pager:
+    """Which page of overflowing rollout rows is on screen. Auto-advances on a timer until the
+    user takes over with the left/right arrows, after which it stays where they leave it. Page
+    count only grows (rollouts are never removed), so a chosen page stays valid; it's clamped
+    anyway to survive a terminal resize (fewer rows per page → more pages, or vice versa)."""
+
+    def __init__(self) -> None:
+        self.page = 0
+        self.manual = False
+
+    def on_key(self, key: str) -> None:
+        if key in ("left", "right"):
+            self.manual = True
+            self.page += 1 if key == "right" else -1
+
+    def index(self, count: int, now: float) -> int:
+        # Track the auto page while it drives, so the first arrow continues from what's on screen
+        # rather than jumping back to page 1. Clamp in manual mode (page count can shrink on resize).
+        if not self.manual:
+            self.page = int(now / _PAGE_SECONDS) % count
+        else:
+            self.page = max(0, min(self.page, count - 1))
+        return self.page
+
+
 def _paginate(
-    groups: list[list[Rollout]], rows_per_page: int, now: float
+    groups: list[list[Rollout]], rows_per_page: int, pager: Pager, now: float
 ) -> tuple[list[list[Rollout]], int, int]:
     """Pack groups (a task's rollouts kept together) into pages of at most `rows_per_page` rows,
-    cycling to the next page every `_PAGE_SECONDS`. Returns (this page's groups, 0-based index,
-    page count) — a single page when everything already fits."""
+    selecting the one `pager` points at. Returns (this page's groups, 0-based index, page count) —
+    a single page when everything already fits."""
     if sum(len(g) for g in groups) <= rows_per_page:
         return groups, 0, 1
     pages: list[list[list[Rollout]]] = []
@@ -488,20 +513,23 @@ def _paginate(
         used += len(group)
     if current:
         pages.append(current)
-    index = int(now / _PAGE_SECONDS) % len(pages)
+    index = pager.index(len(pages), now)
     return pages[index], index, len(pages)
 
 
-def _render(rollouts: list[Rollout], config: EvalConfig, start: float) -> Group:
+def _render(
+    rollouts: list[Rollout], config: EvalConfig, start: float, pager: Pager
+) -> Group:
     now = time.time()
     warning = _warning(config)
     # `{warning}\n\n{overview}` — the caution sits at the very top, blank line, then the overview.
     header = Group(warning, Text(""), Overview(config)) if warning else Overview(config)
     # Measure the fixed top (header + progress + rule) so the rollout rows fill the rest of the
-    # screen; page through them on a timer when they'd overflow (rich would otherwise truncate).
+    # screen; page through them (timer, or the left/right arrows) when they'd overflow (rich would
+    # otherwise truncate).
     top = Group(header, Progress(rollouts, start), Rule(style="dim"))
     rows_per_page = max(1, _CONSOLE.size.height - len(_CONSOLE.render_lines(top)) - 1)
-    page_groups, index, count = _paginate(_groups(rollouts), rows_per_page, now)
+    page_groups, index, count = _paginate(_groups(rollouts), rows_per_page, pager, now)
     progress = Progress(rollouts, start, page=(index + 1, count) if count > 1 else None)
     return Group(
         header,
@@ -513,6 +541,10 @@ def _render(rollouts: list[Rollout], config: EvalConfig, start: float) -> Group:
 
 @contextlib.asynccontextmanager
 async def dashboard(rollouts: list[Rollout], config: EvalConfig, start: float):
-    """Refresh the live eval view until the `with` block exits, then a final frame."""
-    async with live_view(lambda: _render(rollouts, config, start)):
+    """Refresh the live eval view until the `with` block exits, then a final frame. Left/right
+    arrows page through rollout rows when they overflow the screen."""
+    pager = Pager()
+    async with live_view(
+        lambda: _render(rollouts, config, start, pager), on_key=pager.on_key
+    ):
         yield

--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -471,26 +471,29 @@ def Rows(groups: list[list[Rollout]], now: float, runtime_type: str) -> Table:
 
 class Pager:
     """Which page of overflowing rollout rows is on screen. Auto-advances on a timer until the
-    user takes over with the left/right arrows, after which it stays where they leave it. Page
-    count only grows (rollouts are never removed), so a chosen page stays valid; it's clamped
-    anyway to survive a terminal resize (fewer rows per page → more pages, or vice versa)."""
+    user takes over with the left/right arrows, after which it stays where they leave it. `count`
+    (the page count, set each render by `_paginate`) gates the arrows: they're inert while a single
+    page fits, so a stray press before rollouts overflow can't switch off auto-advance or offset the
+    starting page once paging begins. The chosen page is clamped to `count` (it can shrink on a
+    resize; it otherwise only grows, as rollouts are never removed)."""
 
     def __init__(self) -> None:
         self.page = 0
         self.manual = False
+        self.count = 1
 
     def on_key(self, key: str) -> None:
-        if key in ("left", "right"):
+        if key in ("left", "right") and self.count > 1:
             self.manual = True
             self.page += 1 if key == "right" else -1
 
-    def index(self, count: int, now: float) -> int:
+    def index(self, now: float) -> int:
         # Track the auto page while it drives, so the first arrow continues from what's on screen
-        # rather than jumping back to page 1. Clamp in manual mode (page count can shrink on resize).
+        # rather than jumping back to page 1. Clamp in manual mode (count can shrink on resize).
         if not self.manual:
-            self.page = int(now / _PAGE_SECONDS) % count
+            self.page = int(now / _PAGE_SECONDS) % self.count
         else:
-            self.page = max(0, min(self.page, count - 1))
+            self.page = max(0, min(self.page, self.count - 1))
         return self.page
 
 
@@ -501,6 +504,7 @@ def _paginate(
     selecting the one `pager` points at. Returns (this page's groups, 0-based index, page count) —
     a single page when everything already fits."""
     if sum(len(g) for g in groups) <= rows_per_page:
+        pager.count = 1  # everything fits on one page — arrows stay inert
         return groups, 0, 1
     pages: list[list[list[Rollout]]] = []
     current: list[list[Rollout]] = []
@@ -513,7 +517,8 @@ def _paginate(
         used += len(group)
     if current:
         pages.append(current)
-    index = pager.index(len(pages), now)
+    pager.count = len(pages)
+    index = pager.index(now)
     return pages[index], index, len(pages)
 
 


### PR DESCRIPTION
## Summary

- When rollout rows overflow the eval `--rich` dashboard, the **left/right arrow keys** now page through them.
- Auto-advance is preserved: the 5s timer drives paging until the first arrow press, then hands off seamlessly (continuing from the page currently on screen) and stays where the user leaves it. The page count only grows as rollouts start, and the manual page is clamped so a terminal resize can't leave it out of range.
- Arrows are inert until there's more than one page: the `Pager` tracks the page count (set each render by `_paginate`) and ignores presses while a single page fits, so a stray arrow before rollouts overflow can't disable auto-advance or offset the starting page once paging begins.
- Key reading lives in the shared `live_view` engine (`dashboard/base.py`) behind an optional `on_key` handler: stdin is put in cbreak mode and read via the asyncio event loop (no extra thread), buffering a partial escape across reads (cbreak can split a key's 3 bytes over callbacks). Each press redraws immediately (rather than waiting for the next 0.25s refresh tick) so there's no lag. Because updates go through the same `live.update(..., refresh=True)` path as the timer, there's no extra flicker. `setcbreak` runs inside the `try`, so the terminal is always restored on exit even if setup raises.
- No-op when stdin isn't a terminal (POSIX-only), so non-interactive/legacy runs are unaffected. `validate_dashboard`, which shares `live_view`, is untouched (it passes no `on_key`).
- The page indicator gains a discreet `◄ ►` hint (`(page 2/6 ◄ ►)`) so the controls are discoverable.

## Verification

Drove the real `dashboard`/`live_view` pipeline inside a pseudo-terminal (real cbreak, real asyncio `add_reader`, real arrow-sequence parsing, `Pager` + `_paginate`, rich `Live`) with real arrow-key bytes:

- initial (no keypress): auto-advance active (`manual=False`), page rotates on the timer
- `→` read within 0.12s (< the 0.25s tick): page already advanced — confirms the immediate redraw (no lag)
- `→ →`, `←`: step correctly through pages, continuing from the on-screen auto page
- `←` ×9 and `→` ×20: clamp at page 1 and the last page (no wrap, no out-of-range)
- **split escape**: `ESC` and `[C` sent in separate writes with a 0.35s gap (past a refresh tick) — still pages
- **single-page gate**: with rows that fit one page, right/right/left leave `manual=False` and the page at 1/1
- **restore-after-raise**: forcing `add_reader` to raise after `setcbreak` in a real pty — ICANON and ECHO are restored afterward
- stdin = `/dev/null` (non-tty): key reader no-ops, auto-advance still runs, clean exit — no crash

`ruff check`, `ruff format`, and `ty check verifiers` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add left/right arrow key pagination to the `eval` rich dashboard
> - Adds a `Pager` class in [eval.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1912/files#diff-0a27b905958929f3ae9e01937dd7e3cf97a60dec137caddcbf87792784fc9035) that tracks pagination state: auto-advances pages every `_PAGE_SECONDS` until the user presses an arrow key, after which it follows manual input and clamps within bounds.
> - Adds a `_key_reader` context manager in [base.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1912/files#diff-fb360a9433a4bee692a56c4539e1f78cbf911a5c7fe2f735f3b67c4f85d95419) that, on POSIX TTY stdin, uses `cbreak` mode and an asyncio reader to detect left/right arrow escape sequences and dispatch them to an `on_key` callback with an immediate redraw.
> - The page indicator in the stats line now shows `(page X/Y ◄ ►)` when pagination is active.
> - Behavioral Change: key reading is a no-op when `on_key` is not provided, `termios` is unavailable, or stdin is not a TTY, so non-interactive environments are unaffected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 54acea6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->