### PR TITLE
feat: list every rollout in the eval dashboard, queued ones as pending

### DIFF
--- a/verifiers/v1/cli/dashboard/eval.py
+++ b/verifiers/v1/cli/dashboard/eval.py
@@ -1,13 +1,14 @@
 """The eval `--rich` dashboard: a config overview, a progress bar, and one line per rollout.
 
 Reads each `Rollout.trace`/`phase` every tick — no extra plumbing. Each row carries a bracketed
-phase marker that reads at a glance — `[setup]` (yellow), `[rollout]` (cyan), `[finalize]`
-(magenta), `[scoring]` (blue), `[success]` (green), `[error]` (red) — padded so the brackets
-line up in a column down the left edge. The reward shows only once a rollout is fully scored
-(phase DONE), so it never flips as scoring lands. A task's rollouts are grouped adjacently and joined
-by a left brace (╭│╰), so an episode (a task's n rollouts) reads as a unit. Every started
-rollout stays on screen (finished ones keep their result); the overview + progress sit on top,
-above a rule.
+phase marker that reads at a glance — `[pending]` (dim), `[setup]` (yellow), `[rollout]` (cyan),
+`[finalize]` (magenta), `[scoring]` (blue), `[success]` (green), `[error]` (red) — padded so the
+brackets line up in a column down the left edge. The reward shows only once a rollout is fully
+scored (phase DONE), so it never flips as scoring lands. A task's rollouts are grouped adjacently
+and joined by a left brace (╭│╰), so an episode (a task's n rollouts) reads as a unit. Every
+rollout is on screen from the start: one still queued behind the concurrency cap reads `[pending]`
+(its task is all that's known yet) until it begins, and finished ones keep their result. The
+overview + progress sit on top, above a rule.
 """
 
 import contextlib
@@ -44,6 +45,7 @@ _PAGE_SECONDS = 5.0  # rotate to the next page of rollouts this often when they 
 _LABEL_WIDTH = len("timeouts")
 
 _STYLE = {
+    "pending": "dim",
     "setup": "yellow",
     "running": "cyan",
     "finalize": "magenta",
@@ -52,6 +54,7 @@ _STYLE = {
     "error": "red",
 }
 _MARK_LABEL = {
+    "pending": "pending",
     "setup": "setup",
     "running": "rollout",
     "finalize": "finalize",
@@ -357,17 +360,26 @@ def _tokens(trace: Trace) -> tuple[int, int, int | None, int | None, int]:
     return prompt, completion, cached, reasoning, nbranches
 
 
+def _started(rollout: Rollout) -> float:
+    # Sort key: when a rollout began (its setup start). A still-pending rollout has no trace
+    # yet, so it sorts last (+inf) — behind everything already in flight, in task order.
+    return (
+        rollout.trace.timing.setup.start if rollout.trace is not None else float("inf")
+    )
+
+
 def _groups(rollouts: list[Rollout]) -> list[list[Rollout]]:
     # The n rollouts of each task, grouped together (so they sit adjacent); groups ordered by
-    # earliest start, rollouts within a group by start. Finished ones stay (never removed).
+    # earliest start, rollouts within a group by start. Every rollout carries its `task` from
+    # construction, so ones still queued behind the concurrency cap (no trace yet) are grouped
+    # and shown too — as `[pending]`. Finished ones stay (never removed).
     by_task: dict[int, list[Rollout]] = {}
     for rollout in rollouts:
-        if rollout.trace is not None:
-            by_task.setdefault(rollout.trace.task.idx, []).append(rollout)
+        by_task.setdefault(rollout.task.idx, []).append(rollout)
     groups = list(by_task.values())
     for group in groups:
-        group.sort(key=lambda r: r.trace.timing.setup.start)
-    groups.sort(key=lambda g: g[0].trace.timing.setup.start)
+        group.sort(key=_started)
+    groups.sort(key=lambda g: _started(g[0]))
     return groups
 
 
@@ -385,6 +397,21 @@ def Rows(groups: list[list[Rollout]], now: float, runtime_type: str) -> Table:
     for group in groups:
         for i, rollout in enumerate(group):
             t = rollout.trace
+            task = rollout.task
+            label = f"name={task.name[:32]}" if task.name else f"idx={task.idx}"
+            if (
+                t is None
+            ):  # queued behind the concurrency cap — only its task is known yet
+                rows.append(
+                    (
+                        _brace(i, len(group)),
+                        "pending",
+                        [f"task {label}", *[""] * 7],
+                        "",
+                        "",
+                    )
+                )
+                continue
             if rollout.phase == Phase.DONE:  # fully scored — reward is final
                 state = "error" if t.has_error else "success"
                 result = t.error.type if t.has_error else f"reward={t.reward:.2f}"
@@ -398,7 +425,6 @@ def Rows(groups: list[list[Rollout]], now: float, runtime_type: str) -> Table:
                         stop = f"{stop} (truncated)".strip()
             else:
                 state, result, stop = rollout.phase, "", ""
-            label = f"name={t.task.name[:32]}" if t.task.name else f"idx={t.task.idx}"
             descriptor = (
                 rollout.runtime.descriptor if rollout.runtime is not None else None
             )

--- a/verifiers/v1/rollout.py
+++ b/verifiers/v1/rollout.py
@@ -51,9 +51,11 @@ logger = logging.getLogger(__name__)
 
 
 class Phase(StrEnum):
-    """A rollout's lifecycle phase (for display): provisioning, the harness driving,
-    post-run finalize, per-rollout + group scoring, then fully scored."""
+    """A rollout's lifecycle phase (for display): queued behind the concurrency cap,
+    provisioning, the harness driving, post-run finalize, per-rollout + group scoring,
+    then fully scored."""
 
+    PENDING = "pending"
     SETUP = "setup"
     RUNNING = "running"
     FINALIZE = "finalize"
@@ -93,9 +95,11 @@ class Rollout:
         `Environment.serving` context — so a rollout always has them and no runner has to thread
         them in."""
         self.interception = interception
-        self.phase = Phase.SETUP
-        """Lifecycle phase for display (see `Phase`); advanced through the rollout, and
-        set to DONE by the Episode once group scoring has run."""
+        self.phase = Phase.PENDING
+        """Lifecycle phase for display (see `Phase`); starts PENDING (queued behind the
+        concurrency cap) so the --rich dashboard can list it before it begins, advances to
+        SETUP the moment `run()` starts, and is set to DONE by the Episode once group
+        scoring has run."""
         self.runtime: Runtime | None = None
         """The runtime, set the moment `run()` creates it (so it's always tearable-down
         even if setup crashes) and torn down in `run()`'s `finally`; the --rich dashboard
@@ -139,6 +143,7 @@ class Rollout:
         `self.shared_urls` / `self.interception`)."""
         trace: Trace = Trace(task=self.task, state=state_cls(type(self.taskset))())
         self.trace = trace  # expose for the --rich dashboard
+        self.phase = Phase.SETUP  # leaving the queue: provisioning starts now
         trace.timing.setup.start = time.time()
         self.runtime = make_runtime(
             self.runtime_config, name=trace.id


### PR DESCRIPTION
## Summary

- The `--rich` eval dashboard only rendered rollouts that had already started — `_groups` filtered on `rollout.trace is not None` — so with a low `--max-concurrent` the queued rollouts were invisible until they began. `eval <taskset> -n 8 -c 1` showed only the single rollout in flight.
- Added a `PENDING` phase to `Rollout`: a rollout now starts `PENDING` (queued behind the concurrency cap) and advances to `SETUP` the moment `run()` begins.
- The dashboard now lists **every** rollout from the first frame, keyed off the `task` each `Rollout` already carries at construction. Queued rollouts render as `[pending]` (dim) — only the task is known yet — until they leave the queue, then progress through the normal lifecycle.
- `_groups` groups by `rollout.task.idx` (always available) and sorts still-pending rollouts last (no start time), so in-flight/finished ones stay on top and pending ones trail in task order.

## Verification

Ran `eval reverse_text_v1 -n 8 -c 1` end-to-end (real Prime inference model, `max_concurrent=1`) and snapshotted the live dashboard as it progressed.

Timelines across frames:
- pending: `[8, 7, 6, 5, 4, 3, 2, 1, 0, 0]`
- done: `[0, 0, 1, 2, 3, 4, 5, 6, 7, 8]`

First frame (t=0.0s) — all eight register as pending immediately:

```
0/8 · 0.0s · reward — · err —
────────────────────────────────────────────────────────────────
  [pending ] task idx=0
  [pending ] task idx=1
  [pending ] task idx=2
  [pending ] task idx=3
  [pending ] task idx=4
  [pending ] task idx=5
  [pending ] task idx=6
  [pending ] task idx=7
```

Mid-run (t=20.6s) — processed one by one under `-c 1`: three done, one running, four still pending:

```
3/8 · 21s · reward 0.33 · err 0.00
  [success ] task idx=0 · … · agent_completed  reward=1.00 ·  8s
  [success ] task idx=1 · … · single_turn      reward=0.00 ·  8s
  [success ] task idx=2 · … · single_turn      reward=0.00 ·  5s
  [rollout ] task idx=3 · … · 0 turns · 0 branches               0.1s
  [pending ] task idx=4
  [pending ] task idx=5
  [pending ] task idx=6
  [pending ] task idx=7
```

Final frame (t=79.1s) — all eight processed: `8/8`.

Before this change the first two frames would show only `task idx=0`; the rest of the batch was invisible until each one started.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display and lifecycle labeling only; no changes to scoring, concurrency, or rollout execution semantics beyond initial phase default and SETUP transition timing.
> 
> **Overview**
> The `--rich` eval dashboard now lists **every** rollout from the first frame, including ones still waiting on `--max-concurrent`. Previously `_groups` only included rollouts with a trace, so queued work was invisible until `run()` started.
> 
> **Rollout lifecycle:** New `Phase.PENDING`. Each rollout begins `PENDING` and switches to `SETUP` when `run()` creates the trace.
> 
> **Dashboard:** `[pending]` (dim) rows show only the task (`rollout.task`); grouping uses `task.idx` instead of trace timing. Pending rollouts sort last via `_started` (+inf when no trace).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed8e0db3704b2a22a7428859fa587735b96c28ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### List queued rollouts as pending in the eval dashboard
> - Adds a `PENDING` phase to `Rollout` in [rollout.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1913/files#diff-f886b7f4717cf8fce9270bd4ff4790f3182aa1016abb9efb7f6e57efe18d1bf2); newly constructed rollouts start in this phase and transition to `SETUP` when `run()` begins.
> - Updates grouping in [eval.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1913/files#diff-0a27b905958929f3ae9e01937dd7e3cf97a60dec137caddcbf87792784fc9035) to use `rollout.task.idx` instead of `rollout.trace.task.idx`, so rollouts without a trace are included and sorted after in-flight ones.
> - Renders pending rollouts as dimmed rows showing the task identity and `[pending]` marker, with no result or elapsed time.
> - Behavioral Change: rollouts now start in `PENDING` rather than `SETUP`, which affects any code that inspects the initial phase before `run()` is called.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ed8e0db.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->