### PR TITLE
feat(v1): lazy task resolution + forced group dispatch hooks for tasksets

### DIFF
--- a/tests/v1/test_replay.py
+++ b/tests/v1/test_replay.py
@@ -1,0 +1,287 @@
+"""Unit tests for the replay taskset base's pure logic: message-graph surgery and the
+buffer's scan/pick/read plumbing. Derivation packages (which bind anchors + prompts)
+are tested where they live."""
+
+import json
+from pathlib import Path
+
+import pytest
+from verifiers.v1.tasksets.replay import (
+    ReplayBuffer,
+    build_children,
+    compaction_forks,
+    continue_seed,
+    final_leaf,
+    main_tree,
+    recheck_seed,
+    tool_call_anchors,
+    unwrap_source_task,
+    usable,
+)
+
+# ------------------------------------------------------------------ surgery
+
+
+def _node(parent: int | None, sampled: bool, message: dict) -> dict:
+    return {"parent": parent, "sampled": sampled, "message": message}
+
+
+@pytest.fixture
+def forest() -> list[dict]:
+    """A synthetic message forest exercising every structure surgery must tell apart.
+
+    Main tree (root 0): a compaction fork off the system root (node 6), a retried-assistant
+    twin fork (nodes 2/3), a duplicated tool-result fork (nodes 4/5), and a final assistant
+    truncated mid-tool-call (node 9, empty content). Subagent tree (root 10): its own
+    compaction-shaped fork (node 12) and the forest's highest leaf index (node 13).
+    """
+    return [
+        _node(None, False, {"role": "system", "content": "You are an agent."}),  # 0
+        _node(0, False, {"role": "user", "content": "Original task: sort the list."}),  # 1
+        _node(1, True, {"role": "assistant", "content": "first attempt"}),  # 2
+        _node(1, True, {"role": "assistant", "content": "retried attempt"}),  # 3: retry twin fork
+        _node(3, False, {"role": "tool", "content": "tool output"}),  # 4
+        _node(3, False, {"role": "tool", "content": "tool output"}),  # 5: duplicated tool result
+        _node(0, False, {"role": "user", "content": "Summary: the agent was sorting a list."}),  # 6: compaction
+        _node(
+            6,
+            True,
+            {
+                "role": "assistant",
+                "content": "resuming work",
+                "tool_calls": [{"id": "c1", "name": "search", "arguments": '{"q": "sort"}'}],
+            },
+        ),  # 7
+        _node(7, False, {"role": "tool", "tool_call_id": "c1", "content": "x" * 300}),  # 8
+        _node(
+            8,
+            True,
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{"id": "c2", "name": "search", "arguments": '{"q": "again"}'}],
+            },
+        ),  # 9: final main-tree leaf, truncated mid-tool-call
+        _node(None, False, {"role": "user", "content": "subagent task"}),  # 10: subagent root
+        _node(10, True, {"role": "assistant", "content": "subagent answer"}),  # 11
+        _node(10, False, {"role": "user", "content": "subagent summary"}),  # 12: compaction-shaped, outside main
+        _node(12, True, {"role": "assistant", "content": "subagent resumed"}),  # 13: global max leaf
+    ]
+
+
+def test_main_tree_excludes_subagent_roots(forest):
+    children, roots = build_children(forest)
+    assert roots == [0, 10]
+    assert main_tree(children) == set(range(10))
+
+
+def test_compaction_forks_finds_only_the_compaction_child(forest):
+    children, _ = build_children(forest)
+    tree = main_tree(children)
+    # Not node 3 (assistant retry), not node 5 (duplicated tool result), not node 12
+    # (compaction-shaped but in the subagent tree).
+    assert compaction_forks(forest, children, tree) == [6]
+
+
+def test_final_leaf_stays_in_the_main_tree(forest):
+    children, _ = build_children(forest)
+    tree = main_tree(children)
+    assert final_leaf(children, tree) == 9  # not 13, the subagent's higher-index leaf
+
+
+def test_continue_seed_is_root_to_anchor(forest):
+    assert continue_seed(forest, 6) == [forest[0]["message"], forest[6]["message"]]
+    # A tool-call anchor seeds down to (and including) the tool result.
+    assert [m["role"] for m in continue_seed(forest, 8)] == ["system", "user", "assistant", "tool"]
+
+
+def test_tool_call_anchors_require_resolved_calls():
+    call = {"name": "t", "arguments": "{}"}
+    nodes = [
+        _node(None, False, {"role": "system", "content": "s"}),  # 0
+        _node(0, False, {"role": "user", "content": "task"}),  # 1
+        _node(1, True, {"role": "assistant", "content": "", "tool_calls": [call | {"id": "a"}, call | {"id": "b"}]}),  # 2
+        _node(2, False, {"role": "tool", "tool_call_id": "a", "content": "ra"}),  # 3: "b" still pending
+        _node(3, False, {"role": "tool", "tool_call_id": "b", "content": "rb"}),  # 4: all resolved -> anchor
+        _node(4, True, {"role": "assistant", "content": "", "tool_calls": [call | {"id": "c"}]}),  # 5
+        _node(5, False, {"role": "tool", "tool_call_id": "c", "content": "rc"}),  # 6: anchor
+        _node(None, False, {"role": "user", "content": "subagent"}),  # 7: subagent root
+        _node(7, True, {"role": "assistant", "content": "", "tool_calls": [call | {"id": "z"}]}),  # 8
+        _node(8, False, {"role": "tool", "tool_call_id": "z", "content": "rz"}),  # 9: outside main tree
+    ]
+    children, _ = build_children(nodes)
+    tree = main_tree(children)
+    assert tool_call_anchors(nodes, children, tree) == [4, 6]
+    seed = continue_seed(nodes, 6)
+    assert [m["role"] for m in seed] == ["system", "user", "assistant", "tool", "tool", "assistant", "tool"]
+
+
+def test_recheck_seed_drops_truncated_assistant_and_appends_instruction(forest):
+    children, _ = build_children(forest)
+    tree = main_tree(children)
+    messages = recheck_seed(forest, children, tree, "Check your work.")
+    # Final branch is [0, 6, 7, 8, 9]; node 9 (empty content, pending tool_calls) is dropped.
+    assert [m["role"] for m in messages] == ["system", "user", "assistant", "tool", "user"]
+    assert messages[-1] == {"role": "user", "content": "Check your work."}
+    assert messages[2]["tool_calls"]  # only the trailing assistant is stripped
+    assert forest[9]["message"]["tool_calls"]  # the saved nodes are not mutated
+
+
+def test_recheck_seed_strips_tool_calls_but_keeps_nonempty_assistant():
+    nodes = [
+        _node(None, False, {"role": "system", "content": "sys"}),
+        _node(
+            0,
+            True,
+            {
+                "role": "assistant",
+                "content": "final answer",
+                "tool_calls": [{"id": "c1", "name": "search", "arguments": "{}"}],
+            },
+        ),
+    ]
+    children, _ = build_children(nodes)
+    messages = recheck_seed(nodes, children, main_tree(children), "Check your work.")
+    assert [m["role"] for m in messages] == ["system", "assistant", "user"]
+    assert messages[1]["content"] == "final answer"
+    assert messages[1]["tool_calls"] is None
+    assert nodes[1]["message"]["tool_calls"]  # original untouched
+
+
+def test_usable_screens_bad_records(forest):
+    assert usable({"nodes": forest, "errors": None})
+    assert not usable({"nodes": forest, "errors": ["timeout"]})
+    assert not usable({"nodes": [], "errors": None})
+    unsampled = [_node(None, False, {"role": "system", "content": "sys"})]
+    assert not usable({"nodes": unsampled, "errors": None})
+
+
+def test_unwrap_source_task_resolves_chains():
+    original = {"prompt": "sort the list", "image": "sandbox:1"}
+    depth_2 = {
+        "source_id": "b",
+        "source_task": {"source_id": "a", "source_task": original},
+    }
+    assert unwrap_source_task(depth_2) == original
+    assert unwrap_source_task(original) == original  # non-derived tasks pass through
+
+
+# ------------------------------------------------------------------ buffer
+
+
+def _record(record_id: str, reward: float) -> dict:
+    return {
+        "id": record_id,
+        "nodes": [
+            _node(None, False, {"role": "system", "content": "sys"}),
+            _node(0, False, {"role": "user", "content": f"task {record_id}"}),
+            _node(1, True, {"role": "assistant", "content": f"answer {record_id}"}),
+        ],
+        "errors": None,
+        "rewards": {"correct": reward},
+        "stop_condition": "agent_completed",
+        "task": {},
+        "info": {},
+    }
+
+
+@pytest.fixture
+def buffer_dir(tmp_path: Path) -> tuple[Path, dict[str, dict]]:
+    """Two step dirs: step_1 is barrier-complete (train_rollouts.bin present), step_2 is
+    not. step_2 also carries an errored record that must never become a candidate."""
+    records = {
+        "aaa": _record("aaa", 1.0),
+        "bbb": _record("bbb", 1.0),
+        "ccc": _record("ccc", 0.0),
+        "ddd": _record("ddd", 1.0),
+    }
+    errored = _record("eee", 0.0) | {"errors": ["timeout"]}
+    step_1 = tmp_path / "step_1"
+    step_1.mkdir()
+    (step_1 / "train_rollouts.jsonl").write_text("".join(json.dumps(records[i]) + "\n" for i in ("aaa", "bbb", "ccc")))
+    (step_1 / "train_rollouts.bin").touch()
+    step_2 = tmp_path / "step_2"
+    step_2.mkdir()
+    (step_2 / "train_rollouts.jsonl").write_text(json.dumps(records["ddd"]) + "\n" + json.dumps(errored) + "\n")
+    return tmp_path, records
+
+
+def _make_buffer(path: Path, online: bool = False, **overrides) -> ReplayBuffer:
+    kwargs = dict(
+        buffer_dir=str(path),
+        anchors=lambda record: [None],  # one task per rollout, like recheck
+        online=online,
+        source_envs=None,
+        allow_container=False,
+    )
+    kwargs.update(overrides)
+    return ReplayBuffer(**kwargs)
+
+
+def test_online_scan_requires_barrier(buffer_dir):
+    path, _ = buffer_dir
+    candidates = _make_buffer(path, online=True).scan()
+    assert {c.step for c in candidates} == {1}  # step_2 has no train_rollouts.bin yet
+
+
+def test_offline_scan_skips_barrier_and_errored_records(buffer_dir):
+    path, _ = buffer_dir
+    candidates = _make_buffer(path).scan()
+    assert [c.source_id for c in candidates] == ["ddd", "aaa", "bbb", "ccc"]  # newest step first, no "eee"
+
+
+def test_rescan_accumulates_new_steps(buffer_dir):
+    path, _ = buffer_dir
+    buffer = _make_buffer(path, online=True)
+    assert [c.source_id for c in buffer.scan()] == ["aaa", "bbb", "ccc"]
+    step_3 = path / "step_3"
+    step_3.mkdir()
+    step_3.joinpath("train_rollouts.jsonl").write_text(json.dumps(_record("fff", 0.0)) + "\n")
+    step_3.joinpath("train_rollouts.bin").touch()
+    assert [c.source_id for c in buffer.scan()] == ["fff", "aaa", "bbb", "ccc"]  # newest first
+
+
+def test_anchor_enumerator_mints_one_candidate_per_anchor(buffer_dir):
+    path, _ = buffer_dir
+    buffer = _make_buffer(path, anchors=lambda record: [1, 2])
+    assert [(c.source_id, c.anchor_node) for c in buffer.scan() if c.step == 1] == [
+        ("aaa", 1),
+        ("aaa", 2),
+        ("bbb", 1),
+        ("bbb", 2),
+        ("ccc", 1),
+        ("ccc", 2),
+    ]
+    assert _make_buffer(path, anchors=lambda record: []).scan() == []
+
+
+def test_pick_is_deterministic_and_wraps(buffer_dir):
+    path, _ = buffer_dir
+    buffer = _make_buffer(path)
+    buffer.scan()
+    assert buffer.pick(2) == buffer.pick(2)
+    assert buffer.pick(2) == buffer.pick(2 + len(buffer))
+
+
+def test_read_record_round_trips(buffer_dir):
+    path, records = buffer_dir
+    buffer = _make_buffer(path)
+    for candidate in buffer.scan():
+        assert buffer.read_record(candidate) == records[candidate.source_id]
+
+
+def test_replay_derived_records_skipped_by_default_but_listable(buffer_dir):
+    """A "self" buffer sees the replay envs' own saved rollouts. By default replaying a
+    replay is a feedback loop and is screened out; explicitly listing the replay env in
+    source_envs is the deliberate opt-in for chained derivations."""
+    path, _ = buffer_dir
+    nested = _record("zzz", 1.0)
+    nested["task"] = {"source_id": "yyy", "source_task": {"prompt": "original"}, "prompt": None}
+    nested["info"] = {"prime_rl": {"env_name": "replay-recheck"}}
+    step_1 = path / "step_1"
+    with open(step_1 / "train_rollouts.jsonl", "a") as f:
+        f.write(json.dumps(nested) + "\n")
+    by_default = _make_buffer(path).scan()
+    assert "zzz" not in {c.source_id for c in by_default}
+    opted_in = _make_buffer(path, source_envs=["replay-recheck"]).scan()
+    assert {c.source_id for c in opted_in} == {"zzz"}

--- a/verifiers/v1/cli/eval/runner.py
+++ b/verifiers/v1/cli/eval/runner.py
@@ -25,10 +25,15 @@ _SHUFFLE_SEED = (
 async def run_eval(env: Environment, config: EvalConfig) -> list[Trace]:
     logger.info("eval config:\n%s", config.model_dump_json(indent=2))
     client = resolve_client(config.client)
-    tasks = env.taskset.load_tasks()
+    all_tasks = env.taskset.load_tasks()
+    tasks = list(all_tasks)
     if config.shuffle:
         random.Random(_SHUFFLE_SEED).shuffle(tasks)
     tasks = tasks if config.num_tasks is None else tasks[: config.num_tasks]
+    # Lazy tasksets bind task content at request time (Taskset.resolve_task); resolve each
+    # selected task once, mirroring the env server's one-bind-per-episode semantics. The
+    # default resolve returns the identical objects, so eager tasksets are unchanged.
+    tasks = [await env.taskset.resolve_task(task.idx, all_tasks) for task in tasks]
     ctx = RolloutContext(client=client, model=config.model, sampling=config.sampling)
     # One episode of `num_rollouts` rollouts per task; the shared semaphore bounds total
     # concurrent rollouts (across episodes), so group rewards still see their whole episode.

--- a/verifiers/v1/cli/eval/runner.py
+++ b/verifiers/v1/cli/eval/runner.py
@@ -25,15 +25,14 @@ _SHUFFLE_SEED = (
 async def run_eval(env: Environment, config: EvalConfig) -> list[Trace]:
     logger.info("eval config:\n%s", config.model_dump_json(indent=2))
     client = resolve_client(config.client)
-    all_tasks = env.taskset.load_tasks()
-    tasks = list(all_tasks)
+    tasks = env.taskset.load_tasks()
     if config.shuffle:
         random.Random(_SHUFFLE_SEED).shuffle(tasks)
     tasks = tasks if config.num_tasks is None else tasks[: config.num_tasks]
     # Lazy tasksets bind task content at request time (Taskset.resolve_task); resolve each
     # selected task once, mirroring the env server's one-bind-per-episode semantics. The
     # default resolve returns the identical objects, so eager tasksets are unchanged.
-    tasks = [await env.taskset.resolve_task(task.idx, all_tasks) for task in tasks]
+    tasks = [await env.taskset.resolve_task(task) for task in tasks]
     ctx = RolloutContext(client=client, model=config.model, sampling=config.sampling)
     # One episode of `num_rollouts` rollouts per task; the shared semaphore bounds total
     # concurrent rollouts (across episodes), so group rewards still see their whole episode.

--- a/verifiers/v1/cli/validate.py
+++ b/verifiers/v1/cli/validate.py
@@ -108,11 +108,15 @@ async def run_validate(config: ValidateConfig) -> list[dict]:
     """Run each task's `validate` hook with bounded concurrency, showing progress live. Returns
     the result rows in memory — nothing is persisted."""
     taskset = vf.load_taskset(config.taskset)
-    tasks = taskset.load_tasks()
+    all_tasks = taskset.load_tasks()
+    tasks = list(all_tasks)
     if config.shuffle:
         random.Random(0).shuffle(tasks)
     if config.num_tasks is not None:
         tasks = tasks[: config.num_tasks]
+    # Lazy tasksets bind task content at request time (Taskset.resolve_task); resolve before
+    # validating so hooks see real tasks, not stubs. Eager tasksets are unchanged.
+    tasks = [await taskset.resolve_task(task.idx, all_tasks) for task in tasks]
     if isinstance(config.runtime, vf.SubprocessConfig) and (
         taskset.NEEDS_CONTAINER or any(t.image for t in tasks)
     ):

--- a/verifiers/v1/cli/validate.py
+++ b/verifiers/v1/cli/validate.py
@@ -108,15 +108,14 @@ async def run_validate(config: ValidateConfig) -> list[dict]:
     """Run each task's `validate` hook with bounded concurrency, showing progress live. Returns
     the result rows in memory — nothing is persisted."""
     taskset = vf.load_taskset(config.taskset)
-    all_tasks = taskset.load_tasks()
-    tasks = list(all_tasks)
+    tasks = taskset.load_tasks()
     if config.shuffle:
         random.Random(0).shuffle(tasks)
     if config.num_tasks is not None:
         tasks = tasks[: config.num_tasks]
     # Lazy tasksets bind task content at request time (Taskset.resolve_task); resolve before
     # validating so hooks see real tasks, not stubs. Eager tasksets are unchanged.
-    tasks = [await taskset.resolve_task(task.idx, all_tasks) for task in tasks]
+    tasks = [await taskset.resolve_task(task) for task in tasks]
     if isinstance(config.runtime, vf.SubprocessConfig) and (
         taskset.NEEDS_CONTAINER or any(t.image for t in tasks)
     ):

--- a/verifiers/v1/harness.py
+++ b/verifiers/v1/harness.py
@@ -7,6 +7,7 @@ runtime and the interception server are owned by the Rollout.
 """
 
 import asyncio
+import json
 import logging
 import os
 from abc import ABC, abstractmethod
@@ -125,6 +126,23 @@ class Harness(ABC, Generic[ConfigT]):
             self.config.id,
         )
         return None, f"{system}\n\n{prompt}"
+
+    async def stage_message_prompt(
+        self, prompt: Messages, env: dict[str, str], runtime: Runtime
+    ) -> None:
+        """Hand a Messages prompt to the harness program as OpenAI wire dicts, via the
+        `INITIAL_MESSAGES` env var — or, when the JSON would overflow the kernel's
+        per-env-string limit (execve caps each string at MAX_ARG_STRLEN, 128KiB on
+        Linux), via a workspace file named by `INITIAL_MESSAGES_FILE`. The program side
+        of this contract is duplicated per harness program (standalone uv scripts)."""
+        from verifiers.v1.dialects.chat import message_to_wire
+
+        blob = json.dumps([message_to_wire(m) for m in prompt])
+        if len(blob) > 100_000:
+            await runtime.write("initial_messages.json", blob.encode())
+            env["INITIAL_MESSAGES_FILE"] = "initial_messages.json"
+        else:
+            env["INITIAL_MESSAGES"] = blob
 
     async def setup(self, runtime: Runtime) -> None:
         """Provision this harness in `runtime` before its execution timeout starts."""

--- a/verifiers/v1/harnesses/default/harness.py
+++ b/verifiers/v1/harnesses/default/harness.py
@@ -15,7 +15,6 @@ from pathlib import Path
 
 from verifiers.v1.harness import Harness, HarnessConfig
 from verifiers.v1.clients import RolloutContext
-from verifiers.v1.dialects.chat import message_to_wire
 from verifiers.v1.runtimes import ProgramResult, Runtime
 from verifiers.v1.trace import Trace
 
@@ -123,14 +122,7 @@ class DefaultHarness(Harness[DefaultHarnessConfig]):
         if isinstance(prompt, str):
             args.append(f"--prompt={prompt}")
         elif prompt is not None:
-            blob = json.dumps([message_to_wire(m) for m in prompt])
-            # execve caps a single env string at MAX_ARG_STRLEN (128KiB on Linux); hand a
-            # large seeded conversation over as a workspace file instead.
-            if len(blob) > 100_000:
-                await runtime.write("initial_messages.json", blob.encode())
-                env["INITIAL_MESSAGES_FILE"] = "initial_messages.json"
-            else:
-                env["INITIAL_MESSAGES"] = blob
+            await self.stage_message_prompt(prompt, env, runtime)
         program = await runtime.prepare_uv_script(
             PROGRAM_SOURCE, self.config.resolved_env
         )

--- a/verifiers/v1/harnesses/default/harness.py
+++ b/verifiers/v1/harnesses/default/harness.py
@@ -123,7 +123,14 @@ class DefaultHarness(Harness[DefaultHarnessConfig]):
         if isinstance(prompt, str):
             args.append(f"--prompt={prompt}")
         elif prompt is not None:
-            env["INITIAL_MESSAGES"] = json.dumps([message_to_wire(m) for m in prompt])
+            blob = json.dumps([message_to_wire(m) for m in prompt])
+            # execve caps a single env string at MAX_ARG_STRLEN (128KiB on Linux); hand a
+            # large seeded conversation over as a workspace file instead.
+            if len(blob) > 100_000:
+                await runtime.write("initial_messages.json", blob.encode())
+                env["INITIAL_MESSAGES_FILE"] = "initial_messages.json"
+            else:
+                env["INITIAL_MESSAGES"] = blob
         program = await runtime.prepare_uv_script(
             PROGRAM_SOURCE, self.config.resolved_env
         )

--- a/verifiers/v1/harnesses/default/program.py
+++ b/verifiers/v1/harnesses/default/program.py
@@ -289,9 +289,16 @@ async def main() -> None:
         )
         # A Messages prompt (e.g. an image-bearing prompt) arrives pre-built as OpenAI wire dicts
         # via INITIAL_MESSAGES (kept in env: it can be large multimodal content that overflows
-        # argv, and it's prompt content, not a credential); otherwise --prompt is the opening
+        # argv, and it's prompt content, not a credential) — or, when it would overflow the
+        # kernel's per-env-string limit, as a workspace file named by INITIAL_MESSAGES_FILE;
+        # otherwise --prompt is the opening
         # message. Both empty means the task has no prompt — the user simulator seeds the opening.
-        initial = json.loads(os.environ.get("INITIAL_MESSAGES", "[]"))
+        initial_file = os.environ.get("INITIAL_MESSAGES_FILE")
+        if initial_file:
+            with open(initial_file) as f:
+                initial = json.load(f)
+        else:
+            initial = json.loads(os.environ.get("INITIAL_MESSAGES", "[]"))
         if initial:
             messages.extend(initial)
         elif args.prompt:

--- a/verifiers/v1/harnesses/null/harness.py
+++ b/verifiers/v1/harnesses/null/harness.py
@@ -70,7 +70,14 @@ class NullHarness(Harness[NullHarnessConfig]):
         if isinstance(prompt, str):
             args.append(f"--prompt={prompt}")
         elif prompt is not None:
-            env["INITIAL_MESSAGES"] = json.dumps([message_to_wire(m) for m in prompt])
+            blob = json.dumps([message_to_wire(m) for m in prompt])
+            # execve caps a single env string at MAX_ARG_STRLEN (128KiB on Linux); hand a
+            # large seeded conversation over as a workspace file instead.
+            if len(blob) > 100_000:
+                await runtime.write("initial_messages.json", blob.encode())
+                env["INITIAL_MESSAGES_FILE"] = "initial_messages.json"
+            else:
+                env["INITIAL_MESSAGES"] = blob
         program = await runtime.prepare_uv_script(
             PROGRAM_SOURCE, self.config.resolved_env
         )

--- a/verifiers/v1/harnesses/null/harness.py
+++ b/verifiers/v1/harnesses/null/harness.py
@@ -12,7 +12,6 @@ from pathlib import Path
 
 from verifiers.v1.harness import Harness, HarnessConfig
 from verifiers.v1.clients import RolloutContext
-from verifiers.v1.dialects.chat import message_to_wire
 from verifiers.v1.runtimes import ProgramResult, Runtime
 from verifiers.v1.trace import Trace
 
@@ -70,14 +69,7 @@ class NullHarness(Harness[NullHarnessConfig]):
         if isinstance(prompt, str):
             args.append(f"--prompt={prompt}")
         elif prompt is not None:
-            blob = json.dumps([message_to_wire(m) for m in prompt])
-            # execve caps a single env string at MAX_ARG_STRLEN (128KiB on Linux); hand a
-            # large seeded conversation over as a workspace file instead.
-            if len(blob) > 100_000:
-                await runtime.write("initial_messages.json", blob.encode())
-                env["INITIAL_MESSAGES_FILE"] = "initial_messages.json"
-            else:
-                env["INITIAL_MESSAGES"] = blob
+            await self.stage_message_prompt(prompt, env, runtime)
         program = await runtime.prepare_uv_script(
             PROGRAM_SOURCE, self.config.resolved_env
         )

--- a/verifiers/v1/harnesses/null/program.py
+++ b/verifiers/v1/harnesses/null/program.py
@@ -117,9 +117,16 @@ async def main() -> None:
         )
         # A Messages prompt (e.g. an image-bearing prompt) arrives pre-built as OpenAI wire dicts
         # via INITIAL_MESSAGES (kept in env: it can be large multimodal content that overflows
-        # argv, and it's prompt content, not a credential); otherwise --prompt is the opening
+        # argv, and it's prompt content, not a credential) — or, when it would overflow the
+        # kernel's per-env-string limit, as a workspace file named by INITIAL_MESSAGES_FILE;
+        # otherwise --prompt is the opening
         # message. Both empty means the task has no prompt — the user simulator seeds the opening.
-        initial = json.loads(os.environ.get("INITIAL_MESSAGES", "[]"))
+        initial_file = os.environ.get("INITIAL_MESSAGES_FILE")
+        if initial_file:
+            with open(initial_file) as f:
+                initial = json.load(f)
+        else:
+            initial = json.loads(os.environ.get("INITIAL_MESSAGES", "[]"))
         if initial:
             messages.extend(initial)
         elif args.prompt:

--- a/verifiers/v1/serve/server.py
+++ b/verifiers/v1/serve/server.py
@@ -56,8 +56,9 @@ class EnvServer:
         self.env = Environment(config)
         # Load tasks once; the index range is fixed for the server's lifetime.
         self.tasks = self.env.taskset.load_tasks()
-        self.requires_group_scoring = bool(
-            discover_decorated(self.env.taskset, "group_reward")
+        self.requires_group_scoring = (
+            bool(discover_decorated(self.env.taskset, "group_reward"))
+            or self.env.taskset.REQUIRES_GROUP_ROLLOUTS
         )
         self._clients: dict[
             tuple[str, str], Client
@@ -120,14 +121,16 @@ class EnvServer:
 
     async def _run_rollout(self, req: RunRolloutRequest) -> RunRolloutResponse:
         ctx = self._context(req.client, req.model, req.sampling)
-        episode = self.env.episode(self.tasks[req.task_idx], ctx, n=1)
+        task = await self.env.taskset.resolve_task(req.task_idx, self.tasks)
+        episode = self.env.episode(task, ctx, n=1)
         traces = await episode.run()
         # Trust the concrete trace; serialize it once before client-side re-typing.
         return RunRolloutResponse.model_construct(trace=traces[0])
 
     async def _run_group(self, req: RunGroupRequest) -> RunGroupResponse:
         ctx = self._context(req.client, req.model, req.sampling)
-        episode = self.env.episode(self.tasks[req.task_idx], ctx, n=req.n)
+        task = await self.env.taskset.resolve_task(req.task_idx, self.tasks)
+        episode = self.env.episode(task, ctx, n=req.n)
         traces = await episode.run()
         # Avoid a dump-and-validate copy for every trusted trace in the group.
         return RunGroupResponse.model_construct(traces=traces)

--- a/verifiers/v1/serve/server.py
+++ b/verifiers/v1/serve/server.py
@@ -121,7 +121,7 @@ class EnvServer:
 
     async def _run_rollout(self, req: RunRolloutRequest) -> RunRolloutResponse:
         ctx = self._context(req.client, req.model, req.sampling)
-        task = await self.env.taskset.resolve_task(req.task_idx, self.tasks)
+        task = await self.env.taskset.resolve_task(self.tasks[req.task_idx])
         episode = self.env.episode(task, ctx, n=1)
         traces = await episode.run()
         # Trust the concrete trace; serialize it once before client-side re-typing.
@@ -129,7 +129,7 @@ class EnvServer:
 
     async def _run_group(self, req: RunGroupRequest) -> RunGroupResponse:
         ctx = self._context(req.client, req.model, req.sampling)
-        task = await self.env.taskset.resolve_task(req.task_idx, self.tasks)
+        task = await self.env.taskset.resolve_task(self.tasks[req.task_idx])
         episode = self.env.episode(task, ctx, n=req.n)
         traces = await episode.run()
         # Avoid a dump-and-validate copy for every trusted trace in the group.

--- a/verifiers/v1/taskset.py
+++ b/verifiers/v1/taskset.py
@@ -17,7 +17,7 @@ For a heterogeneous taskset (different verification per task), have a single
 
 import asyncio
 from collections.abc import Mapping
-from typing import ClassVar, Generic, TypeVar
+from typing import Generic, TypeVar
 
 from pydantic_config import BaseConfig
 
@@ -55,16 +55,18 @@ class Taskset(Generic[TaskT, ConfigT, StateT]):
     taskset that doesn't customize state writes just `Taskset[MyTask, MyConfig]`. Subclass: implement
     `load_tasks`, add @reward/@metric."""
 
-    NEEDS_CONTAINER: ClassVar[bool] = False
+    NEEDS_CONTAINER: bool = False
     """Whether this taskset only runs in a container runtime (docker/prime). When True the
     Environment refuses the subprocess runtime — for tasksets whose work only makes sense
-    inside a per-task image (e.g. a SWE repo sandbox)."""
+    inside a per-task image (e.g. a SWE repo sandbox). A plain (not ClassVar) attribute:
+    always read off the instance, so a taskset may set it per instance from its config."""
 
-    REQUIRES_GROUP_ROLLOUTS: ClassVar[bool] = False
+    REQUIRES_GROUP_ROLLOUTS: bool = False
     """Whether all rollouts of a task must arrive as a single `run_group` request even
     without `@group_reward`s — for tasksets whose `resolve_task` binds per-request state
     the whole group must share (e.g. a replay buffer sampling a source rollout per group).
-    The env server advertises it as `requires_group_scoring` in its `info` response."""
+    The env server advertises it as `requires_group_scoring` in its `info` response.
+    Like `NEEDS_CONTAINER`, read off the instance and settable per instance."""
 
     def __init__(self, config: ConfigT) -> None:
         self.config = config
@@ -72,13 +74,13 @@ class Taskset(Generic[TaskT, ConfigT, StateT]):
     def load_tasks(self) -> list[TaskT]:
         raise NotImplementedError
 
-    async def resolve_task(self, idx: int, tasks: list[TaskT]) -> TaskT:
-        """Bind the task served for `idx` at request time. Default: index the eagerly
-        loaded list (the env server's `load_tasks()` result), so existing tasksets are
-        unchanged. Override to materialize tasks lazily — `load_tasks` may then return
-        lightweight stubs that only fix the index range. Called once per `run_rollout` /
+    async def resolve_task(self, task: TaskT) -> TaskT:
+        """Bind the task actually served for a loaded task at request time. Default:
+        the task itself, so existing tasksets are unchanged. Override to materialize
+        tasks lazily — `load_tasks` may then return lightweight stubs (carrying their
+        `idx`) that only fix the index range. Called once per `run_rollout` /
         `run_group` request, so every rollout of a group binds one resolved task."""
-        return tasks[idx]
+        return task
 
     def tools(self, task: TaskT) -> list[Toolset]:
         """Tool servers exposing this task's tools to the model — `vf.Toolset`s (classes with

--- a/verifiers/v1/taskset.py
+++ b/verifiers/v1/taskset.py
@@ -60,11 +60,25 @@ class Taskset(Generic[TaskT, ConfigT, StateT]):
     Environment refuses the subprocess runtime — for tasksets whose work only makes sense
     inside a per-task image (e.g. a SWE repo sandbox)."""
 
+    REQUIRES_GROUP_ROLLOUTS: ClassVar[bool] = False
+    """Whether all rollouts of a task must arrive as a single `run_group` request even
+    without `@group_reward`s — for tasksets whose `resolve_task` binds per-request state
+    the whole group must share (e.g. a replay buffer sampling a source rollout per group).
+    The env server advertises it as `requires_group_scoring` in its `info` response."""
+
     def __init__(self, config: ConfigT) -> None:
         self.config = config
 
     def load_tasks(self) -> list[TaskT]:
         raise NotImplementedError
+
+    async def resolve_task(self, idx: int, tasks: list[TaskT]) -> TaskT:
+        """Bind the task served for `idx` at request time. Default: index the eagerly
+        loaded list (the env server's `load_tasks()` result), so existing tasksets are
+        unchanged. Override to materialize tasks lazily — `load_tasks` may then return
+        lightweight stubs that only fix the index range. Called once per `run_rollout` /
+        `run_group` request, so every rollout of a group binds one resolved task."""
+        return tasks[idx]
 
     def tools(self, task: TaskT) -> list[Toolset]:
         """Tool servers exposing this task's tools to the model — `vf.Toolset`s (classes with

--- a/verifiers/v1/tasksets/replay/__init__.py
+++ b/verifiers/v1/tasksets/replay/__init__.py
@@ -1,0 +1,36 @@
+from verifiers.v1.tasksets.replay.buffer import Candidate, ReplayBuffer
+from verifiers.v1.tasksets.replay.surgery import (
+    build_children,
+    compaction_forks,
+    continue_seed,
+    final_leaf,
+    is_replay_derived,
+    main_tree,
+    path_messages,
+    path_to_root,
+    recheck_seed,
+    tool_call_anchors,
+    unwrap_source_task,
+    usable,
+)
+from verifiers.v1.tasksets.replay.taskset import ReplayTask, ReplayTaskset, ReplayTasksetConfig
+
+__all__ = [
+    "Candidate",
+    "ReplayBuffer",
+    "ReplayTask",
+    "ReplayTaskset",
+    "ReplayTasksetConfig",
+    "build_children",
+    "compaction_forks",
+    "continue_seed",
+    "final_leaf",
+    "is_replay_derived",
+    "main_tree",
+    "path_messages",
+    "path_to_root",
+    "recheck_seed",
+    "tool_call_anchors",
+    "unwrap_source_task",
+    "usable",
+]

--- a/verifiers/v1/tasksets/replay/buffer.py
+++ b/verifiers/v1/tasksets/replay/buffer.py
@@ -1,0 +1,239 @@
+"""The replay buffer: an index over saved rollout files, sampled into candidates.
+
+The index holds only ``(path, offset, length)`` handles plus the few fields selection
+needs — saved lines average ~1MB, so records are read back lazily, one line at a time,
+when a task is materialized. Steps are scanned newest-first under the recency window
+and candidate cap, which doubles as eviction for online buffers.
+"""
+
+import asyncio
+import json
+import logging
+import random
+import re
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+from verifiers.v1.tasksets.replay.surgery import is_replay_derived, unwrap_source_task, usable
+
+logger = logging.getLogger(__name__)
+
+ROLLOUT_FILE = "train_rollouts.jsonl"
+BARRIER_FILE = "train_rollouts.bin"
+MAX_CANDIDATES = 4096
+RESCAN_SECONDS = 10.0
+EMPTY_POLL_SECONDS = 5.0
+EMPTY_WAIT_SECONDS = 60.0
+_STEP_RE = re.compile(r"^step_(\d+)$")
+
+
+@dataclass(frozen=True)
+class Candidate:
+    """One replayable task: a lazy handle onto a saved rollout line (plus, for continue
+    derivations, which anchor node of it to resume from)."""
+
+    path: str
+    offset: int
+    length: int
+    step: int
+    original_reward: float
+    source_id: str
+    anchor_node: int | None = None
+
+
+def resolve_rollout_dir(buffer_dir: str) -> Path:
+    """Accept either a rollouts dir (containing step_*) or a run dir containing one."""
+    path = Path(buffer_dir)
+    if (path / "rollouts").is_dir() and not any(_STEP_RE.match(p.name) for p in path.glob("step_*")):
+        return path / "rollouts"
+    return path
+
+
+def complete_steps(
+    rollout_dir: Path,
+    require_barrier: bool,
+    skip: set[int] = frozenset(),
+) -> list[tuple[int, Path]]:
+    """(step, jsonl path) for every step whose rollout file is safe to read, newest first.
+    Steps in `skip` (already scanned) are pruned by dirname alone, before any file stat —
+    rescans run every few seconds over runs with thousands of steps, all but a handful
+    already scanned.
+
+    The jsonl itself is written non-atomically, but the orchestrator writes and closes it
+    strictly before the atomic rename that creates the sibling ``train_rollouts.bin`` —
+    so for online buffers the barrier file marks the jsonl complete. Offline buffers
+    (finished runs) skip the barrier: their files are complete by definition, and a run
+    with a non-filesystem rollout transport never writes the .bin at all."""
+    steps = []
+    for step_dir in rollout_dir.glob("step_*"):
+        match = _STEP_RE.match(step_dir.name)
+        if match is None or int(match.group(1)) in skip:
+            continue
+        if not (step_dir / ROLLOUT_FILE).is_file():
+            continue
+        if require_barrier and not (step_dir / BARRIER_FILE).is_file():
+            continue
+        steps.append((int(match.group(1)), step_dir / ROLLOUT_FILE))
+    return sorted(steps, reverse=True)
+
+
+class ReplayBuffer:
+    """Scans rollout files into candidates and picks one per resolved task.
+
+    Offline: the index is built once and ``pick(idx)`` is deterministic, so GRPO group
+    members dispatched as independent rollouts still bind the same source. Online: the
+    index is rescanned (throttled) as the run writes new steps, ``sample()`` draws
+    freshly — which is why online replay envs force group dispatch.
+
+    Concurrency: rescans run in a thread while the event loop keeps sampling, so the
+    index is swapped atomically (fresh lists, single attribute assignment), never
+    mutated in place.
+    """
+
+    def __init__(
+        self,
+        buffer_dir: str,
+        anchors: Callable[[dict], list[int | None]],
+        online: bool,
+        source_envs: list[str] | None,
+        allow_container: bool,
+    ) -> None:
+        self.rollout_dir = resolve_rollout_dir(buffer_dir)
+        self.anchors = anchors  # the derivation's resume points for one record (see ReplayTaskset)
+        self.online = online
+        self.source_envs = set(source_envs) if source_envs else None
+        self.allow_container = allow_container
+        # Pool workers each hold their own buffer instance; a fresh OS-entropy rng per
+        # instance keeps online sampling uncorrelated across worker processes.
+        self._rng = random.Random()
+        self._all: list[Candidate] = []  # retained candidates, newest step first
+        self._scanned_steps: set[int] = set()
+        self._last_scan = 0.0
+        self._rescan_lock = asyncio.Lock()
+        self._warned_empty = False
+
+    # ------------------------------------------------------------------ scanning
+
+    def scan(self) -> list[Candidate]:
+        """Index all unscanned complete steps, newest first, under the capacity cap
+        (which doubles as recency eviction: newest candidates win). Synchronous file
+        IO — called directly at server startup, via a thread during rollouts. The
+        retained index keeps every candidate under the cap."""
+        steps = complete_steps(self.rollout_dir, require_barrier=self.online, skip=self._scanned_steps)
+        retained = list(self._all)
+        fresh = 0
+        for i, (step, path) in enumerate(steps):
+            candidates = self._scan_file(step, path)
+            retained.extend(candidates)
+            fresh += len(candidates)
+            self._scanned_steps.add(step)
+            if fresh >= MAX_CANDIDATES:
+                # Steps iterate newest-first, so everything older is evictable now and
+                # forever (candidates only get newer) — never worth scanning.
+                self._scanned_steps.update(step for step, _ in steps[i + 1 :])
+                break
+        if fresh:
+            # Newest steps win the cap; this evicts the oldest candidates. The sorted
+            # fresh list is swapped in atomically (rescans run in a thread while the
+            # event loop keeps sampling).
+            retained.sort(key=lambda c: c.step, reverse=True)
+            del retained[MAX_CANDIDATES:]
+            self._all = retained
+        self._last_scan = time.monotonic()
+        return self._all
+
+    def _scan_file(self, step: int, path: Path) -> list[Candidate]:
+        candidates: list[Candidate] = []
+        offset = 0
+        with open(path, "rb") as f:
+            for raw in f:
+                try:
+                    record = json.loads(raw)
+                except json.JSONDecodeError:
+                    logger.warning("skipping malformed line at %s:%d", path, offset)
+                else:
+                    candidates.extend(self._candidates_from(record, str(path), offset, len(raw), step))
+                offset += len(raw)
+        return candidates
+
+    def _candidates_from(self, record: dict, path: str, offset: int, length: int, step: int) -> list[Candidate]:
+        task = record.get("task") or {}
+        if self.source_envs is None:
+            # Default: replay any env EXCEPT replay envs — online "self" buffers see the
+            # replay envs' own saved rollouts (judge-of-judge), a compounding feedback
+            # loop unless chosen deliberately by listing the replay env in source_envs.
+            if is_replay_derived(task):
+                return []
+        else:
+            stamped = (record.get("info") or {}).get("prime_rl", {}).get("env_name")
+            if stamped not in self.source_envs:
+                return []
+        if not usable(record):
+            return []
+        # Container provisioning is keyed on the innermost original task, however deep
+        # the derivation chain.
+        if not self.allow_container and unwrap_source_task(task).get("image"):
+            return []
+        reward = sum((record.get("rewards") or {}).values())
+        base = dict(
+            path=path,
+            offset=offset,
+            length=length,
+            step=step,
+            original_reward=reward,
+            source_id=record.get("id", ""),
+        )
+        return [Candidate(**base, anchor_node=anchor) for anchor in self.anchors(record)]
+
+    # ------------------------------------------------------------------ picking
+
+    def __len__(self) -> int:
+        return len(self._all)
+
+    def pick(self, idx: int) -> Candidate:
+        """Deterministic candidate for a task index (offline buffers)."""
+        candidates = self._all
+        return candidates[idx % len(candidates)]
+
+    def discard(self, candidate: Candidate) -> None:
+        """Drop a candidate whose source line is gone (its run was resumed or cleaned)."""
+        self._all = [c for c in self._all if c != candidate]
+
+    async def sample(self) -> Candidate:
+        """A fresh draw for online buffers: rescan when stale, then sample uniformly.
+        While the run has not
+        produced any replayable rollouts yet (early steps), wait briefly, then fail the
+        request — the errored group releases its dispatch permits and is retried later,
+        instead of hoarding capacity the run needs to produce the first rollouts."""
+        waited = 0.0
+        while True:
+            if time.monotonic() - self._last_scan > RESCAN_SECONDS or not self._all:
+                async with self._rescan_lock:
+                    if time.monotonic() - self._last_scan > RESCAN_SECONDS or not self._all:
+                        await asyncio.to_thread(self.scan)
+            candidates = self._all
+            if candidates:
+                return self._rng.choice(candidates)
+            if waited >= EMPTY_WAIT_SECONDS:
+                raise RuntimeError(
+                    f"replay buffer at {self.rollout_dir} has no replayable candidates "
+                    f"after {waited:.0f}s; failing this request so its permits free up"
+                )
+            if not self._warned_empty:
+                logger.warning(
+                    "replay buffer at %s is empty (no replayable candidates yet); replay requests "
+                    "will fail and retry until the run writes its first rollouts",
+                    self.rollout_dir,
+                )
+                self._warned_empty = True
+            await asyncio.sleep(EMPTY_POLL_SECONDS)
+            waited += EMPTY_POLL_SECONDS
+
+    def read_record(self, candidate: Candidate) -> dict:
+        """Load the candidate's saved rollout line (~1MB). Synchronous — callers on the
+        event loop run it (with materialization) in a thread."""
+        with open(candidate.path, "rb") as f:
+            f.seek(candidate.offset)
+            return json.loads(f.read(candidate.length))

--- a/verifiers/v1/tasksets/replay/surgery.py
+++ b/verifiers/v1/tasksets/replay/surgery.py
@@ -1,0 +1,156 @@
+"""Pure functions over saved rollout records (WireTrace jsonl lines, as raw dicts).
+
+A saved trace's ``nodes`` list is a message *forest*: parent pointers form trees, the main
+conversation is rooted at node 0, and subagent conversations (or bare probe calls) get their
+own roots appended to the same list, interleaved by index. Compaction leaves no marker — it
+is a fork in the main tree whose new child is a non-sampled user message (the summary the
+harness restarted from) with sampled turns beneath it. Everything here works on the raw
+dicts so the buffer scan never pays pydantic validation for megabyte-sized lines.
+"""
+
+from collections import defaultdict
+from typing import Any
+
+Node = dict[str, Any]
+
+
+def usable(record: dict) -> bool:
+    """Whether a saved rollout is replayable at all. Saved step files contain the full
+    arrival window: errored rollouts and synthesized cancel markers (empty ``nodes``,
+    ``errors`` set) ride along and must be screened out."""
+    return bool(record.get("nodes")) and not record.get("errors") and any(n["sampled"] for n in record["nodes"])
+
+
+def is_replay_derived(task: dict) -> bool:
+    """Whether a saved task dict came from a replay taskset — it carries the replay
+    lineage keys (`ReplayTask.source_task`/`source_id`), whatever the derivation."""
+    return isinstance(task.get("source_task"), dict) and bool(task.get("source_id"))
+
+
+def unwrap_source_task(task: dict) -> dict:
+    """The innermost original task under any chain of replay derivations — what inner-taskset
+    scoring, tools, and container provisioning must be keyed on, however deep the chain."""
+    while is_replay_derived(task) and task["source_task"]:
+        task = task["source_task"]
+    return task
+
+
+def build_children(nodes: list[Node]) -> tuple[dict[int, list[int]], list[int]]:
+    """Child lists (in node-index order, i.e. creation order) and roots of the forest."""
+    children: dict[int, list[int]] = defaultdict(list)
+    roots: list[int] = []
+    for i, node in enumerate(nodes):
+        parent = node["parent"]
+        if parent is None:
+            roots.append(i)
+        else:
+            children[parent].append(i)
+    return children, roots
+
+
+def main_tree(children: dict[int, list[int]]) -> set[int]:
+    """Node indices of the main conversation: the component rooted at node 0. Subagent
+    trees have their own roots and must not leak into seeds or transcripts."""
+    seen: set[int] = set()
+    stack = [0]
+    while stack:
+        i = stack.pop()
+        seen.add(i)
+        stack.extend(children.get(i, []))
+    return seen
+
+
+def _subtree_has_sampled(nodes: list[Node], children: dict[int, list[int]], start: int) -> bool:
+    stack = [start]
+    while stack:
+        i = stack.pop()
+        if nodes[i]["sampled"]:
+            return True
+        stack.extend(children.get(i, []))
+    return False
+
+
+def compaction_forks(nodes: list[Node], children: dict[int, list[int]], tree: set[int]) -> list[int]:
+    """Compaction points in the main tree, as the post-compaction child node indices.
+
+    A fork child is a compaction iff it is a non-sampled user message whose subtree
+    contains sampled turns — the harness rewrote its prompt to a summary and kept going.
+    The detector is structural, not marker-based; other fork kinds (duplicated tool
+    results re-appended after retries, retried assistant twins) don't match it."""
+    forks: list[int] = []
+    for parent, siblings in children.items():
+        if len(siblings) < 2 or parent not in tree:
+            continue
+        for child in siblings[1:]:
+            message = nodes[child]["message"]
+            if (
+                message["role"] == "user"
+                and not nodes[child]["sampled"]
+                and _subtree_has_sampled(nodes, children, child)
+            ):
+                forks.append(child)
+    return sorted(forks)
+
+
+def tool_call_anchors(nodes: list[Node], children: dict[int, list[int]], tree: set[int]) -> list[int]:
+    """Resumable tool-result nodes in the main tree: points where the conversation up to
+    and including the node is a well-formed prefix (every tool call issued so far has its
+    result), so the model can continue right after the tool output. A result whose
+    issuing assistant still has sibling calls pending is not resumable — the seed would
+    carry a dangling call."""
+    anchors: list[int] = []
+    for i in sorted(tree):
+        if nodes[i]["message"]["role"] != "tool":
+            continue
+        pending: set[str] = set()
+        for j in path_to_root(nodes, i):
+            message = nodes[j]["message"]
+            if message["role"] == "assistant":
+                pending.update(call["id"] for call in message.get("tool_calls") or [])
+            elif message["role"] == "tool":
+                pending.discard(message.get("tool_call_id"))
+        if not pending:
+            anchors.append(i)
+    return anchors
+
+
+def path_to_root(nodes: list[Node], leaf: int) -> list[int]:
+    path = []
+    i: int | None = leaf
+    while i is not None:
+        path.append(i)
+        i = nodes[i]["parent"]
+    return path[::-1]
+
+
+def final_leaf(children: dict[int, list[int]], tree: set[int]) -> int:
+    """The last-written leaf of the main tree — the conversation's final state. The
+    global max-index leaf may sit in a subagent tree, so restrict to the main tree."""
+    return max(i for i in tree if i not in children)
+
+
+def path_messages(nodes: list[Node], path: list[int]) -> list[dict]:
+    return [nodes[i]["message"] for i in path]
+
+
+def continue_seed(nodes: list[Node], anchor: int) -> list[dict]:
+    """CONTINUE seed: messages from the root down to (and including) the anchor node —
+    the post-compaction user message (the exact prompt the original harness restarted
+    from), or a tool result (the model resumes right after seeing it)."""
+    return path_messages(nodes, path_to_root(nodes, anchor))
+
+
+def recheck_seed(nodes: list[Node], children: dict[int, list[int]], tree: set[int], instruction: str) -> list[dict]:
+    """RECHECK seed: the final branch's messages plus an appended check-your-work user turn.
+
+    Rollouts routinely end truncated mid-tool-call (timeouts, context length); a trailing
+    assistant's pending ``tool_calls`` must be stripped or the seed is API-malformed, and
+    if that leaves it with no content it is dropped entirely."""
+    path = path_to_root(nodes, final_leaf(children, tree))
+    messages = [dict(m) for m in path_messages(nodes, path)]
+    if messages and messages[-1]["role"] == "assistant" and messages[-1].get("tool_calls"):
+        messages[-1]["tool_calls"] = None
+        if not messages[-1].get("content"):
+            messages.pop()
+    messages.append({"role": "user", "content": instruction})
+    return messages

--- a/verifiers/v1/tasksets/replay/taskset.py
+++ b/verifiers/v1/tasksets/replay/taskset.py
@@ -1,0 +1,262 @@
+"""The replay taskset base: turn saved rollouts back into training tasks.
+
+Reads a run's saved rollout files (``<output>/rollouts/step_*/train_rollouts.jsonl``,
+one ``Trace.to_record()`` line each — the prime-rl orchestrator's rollout output) as a
+buffer and serves tasks derived from them. Like ``harbor`` or ``textarena``, this is a
+base for thin subclass packages: a derivation subclasses `ReplayTaskset` (binding its
+narrowed config in the generic, so the loader picks it up) and implements two hooks —
+
+- ``record_anchors(nodes, children, roots, tree)``: the resume points one saved rollout
+  offers (each becomes one task; ``None`` anchors at the rollout's final state).
+- ``build_prompt(record, anchor)``: the seeded conversation for one anchor.
+
+Everything else is shared: the lazy buffer (tasks bind per request from (file, offset)
+handles — saved lines average ~1MB), online semantics over a growing run dir, scoring/
+tools/setup/finalize delegation to the original (``inner``) taskset, and lineage so
+replay-derived records aren't re-replayed by default. Run replay tasksets under the
+source env's harness (it must support message prompts).
+"""
+
+import asyncio
+import logging
+
+from pydantic import PrivateAttr, SerializeAsAny, model_validator
+
+from verifiers.v1.decorators import discover_decorated, metric
+from verifiers.v1.loaders import narrow_plugin_field, task_type, taskset_class, taskset_config_type
+from verifiers.v1.mcp import Toolset
+from verifiers.v1.runtimes import Runtime
+from verifiers.v1.state import State, state_cls
+from verifiers.v1.task import Task
+from verifiers.v1.taskset import ConfigT, Taskset, TasksetConfig
+from verifiers.v1.tasksets.replay.buffer import ReplayBuffer
+from verifiers.v1.tasksets.replay.surgery import build_children, main_tree, unwrap_source_task
+from verifiers.v1.trace import Trace
+
+logger = logging.getLogger(__name__)
+
+
+class ReplayTasksetConfig(TasksetConfig):
+    """Shared config of every replay derivation: where the buffer is, whose rollouts to
+    replay, and the original taskset that scores the derived rollouts."""
+
+    buffer_dir: str = ""
+    """The saved-rollout dir to replay: a run's `rollouts` dir (or the run dir containing
+    it). Under prime-rl the literal `"self"` resolves to this run's own rollout dir (an
+    online buffer over the run's freshly written rollouts)."""
+
+    inner: SerializeAsAny[TasksetConfig]
+    """The original taskset's config — it scores the derived rollouts and provides
+    their tools, so it must reproduce the source run's taskset config."""
+
+    source_envs: list[str] | None = None
+    """Which envs' rollouts to replay, by their stamped name (`info.prime_rl.env_name`).
+    None (the default) replays every env except replay envs — deriving from a replay
+    env's own outputs is a feedback loop unless chosen deliberately. Listing env names
+    replays exactly those, and naming a replay env is that deliberate choice: chained
+    derivations (recheck a recheck) are expressed as one replay env sourcing another.
+    With an explicit list, records without the stamp never match."""
+
+    allow_container: bool = False
+    """Allow sources whose task ran in a container image. The container state the
+    transcript references is gone — a fresh container is provisioned from the same
+    image, so the model resumes in a reset world. Off until that's fair (sandbox
+    snapshotting)."""
+
+    online: bool = False
+    """Treat the buffer as growing: rescan for new steps during training, read only
+    barrier-complete steps, and sample a fresh source per request (which forces
+    whole-group dispatch so GRPO groups share one source). Set automatically for
+    `buffer_dir = "self"`; set it yourself only to watch another still-running run's
+    dir. Offline buffers are indexed once, deterministically per task index."""
+
+    @model_validator(mode="before")
+    @classmethod
+    def _narrow_inner(cls, data):
+        if isinstance(data, dict) and data.get("inner"):
+            narrow_plugin_field(data, "inner", taskset_config_type)
+        return data
+
+    @model_validator(mode="after")
+    def _resolve(self):
+        if not self.buffer_dir:
+            raise ValueError('replay tasksets need `buffer_dir` (a run\'s rollouts dir, or "self" under prime-rl)')
+        if self.buffer_dir == "self":
+            # prime-rl rewrites the sentinel to a resolved path before the env server
+            # spawns, so onlineness must be pinned while the sentinel is visible.
+            self.online = True
+        return self
+
+
+class ReplayTask(Task):
+    """A derived task plus the lazy handle onto its source rollout. Stubs (from
+    `load_tasks`) carry `prompt=None` and an empty `source_task`; `resolve_task`
+    materializes the real thing. `source_task`/`source_id` double as the lineage
+    marker replay buffers use to skip replay-derived records by default."""
+
+    kind: str = ""
+    """The derivation that minted this task (its taskset id)."""
+    source_task: dict = {}
+    """The source rollout's saved task dict, verbatim — rebuilt into the original typed
+    task for scoring/tool delegation."""
+    original_reward: float = 0.0
+    """The reward the source rollout actually received."""
+    source_id: str = ""
+    source_step: int = -1
+
+    # The rebuilt typed original task, cached at materialization so the per-rollout
+    # hooks (tools/setup/finalize/score) don't re-validate the dict. Private attrs
+    # bypass frozen and never serialize.
+    _inner: Task | None = PrivateAttr(default=None)
+
+
+class ReplayTaskset(Taskset[ReplayTask, ConfigT, State]):
+    """Base for replay derivations; subclass with a narrowed config bound in the
+    generic (`class MyTaskset(ReplayTaskset, Taskset[ReplayTask, MyConfig])`) and
+    implement `record_anchors` + `build_prompt`."""
+
+    def __init__(self, config: ConfigT) -> None:
+        super().__init__(config)
+        inner_config = config.inner
+        self.inner: Taskset = taskset_class(inner_config.id)(inner_config)
+        if discover_decorated(self.inner, "group_reward"):
+            raise ValueError(
+                f"taskset {inner_config.id!r} defines @group_reward(s); replay cannot delegate group "
+                "scoring (the group would score against the replay task, not the original)"
+            )
+        if state_cls(type(self.inner)) is not State:
+            raise ValueError(
+                f"taskset {inner_config.id!r} uses a custom State; replay rollouts build the base "
+                "State, so its typed state would never be populated"
+            )
+        if type(self.inner).user is not Taskset.user:
+            raise ValueError(f"taskset {inner_config.id!r} defines a user simulator; replay does not support one")
+        self.inner_task_type = task_type(inner_config.id)
+        self.NEEDS_CONTAINER = self.inner.NEEDS_CONTAINER
+        # Online buffers sample a fresh source per request; the whole GRPO group must
+        # share that draw, so all its rollouts must arrive as one run_group request.
+        self.REQUIRES_GROUP_ROLLOUTS = config.online
+        self.buffer = ReplayBuffer(
+            buffer_dir=config.buffer_dir,
+            anchors=self._anchors,
+            online=config.online,
+            source_envs=config.source_envs,
+            allow_container=config.allow_container,
+        )
+
+    # ------------------------------------------------------------- derivation hooks
+
+    def record_anchors(
+        self, record: dict, children: dict[int, list[int]], roots: list[int], tree: set[int]
+    ) -> list[int | None]:
+        """The resume points one saved rollout offers this derivation — each becomes one
+        task. Return node indices (see `surgery` for enumerators), `[None]` to anchor at
+        the rollout's final state, or `[]` when the rollout offers nothing."""
+        raise NotImplementedError
+
+    def build_prompt(self, record: dict, anchor: int | None) -> str | list[dict]:
+        """The seeded conversation for one (source record, anchor) pair."""
+        raise NotImplementedError
+
+    def _anchors(self, record: dict) -> list[int | None]:
+        children, roots = build_children(record["nodes"])
+        return self.record_anchors(record, children, roots, main_tree(children))
+
+    # ------------------------------------------------------------------ tasks
+
+    def load_tasks(self) -> list[ReplayTask]:
+        if self.config.buffer_dir == "self":
+            raise ValueError(
+                'buffer_dir = "self" is resolved by the prime-rl orchestrator before env servers '
+                "spawn; when serving this taskset standalone, pass an explicit rollouts dir"
+            )
+        candidates = self.buffer.scan()
+        if self.config.online:
+            # Sampling ignores the task index, so an online buffer serves exactly one
+            # virtual task. (prime-rl's no-ratio fallback weights envs by task count —
+            # replay envs need an explicit ratio regardless.)
+            num_tasks = 1
+        else:
+            if not candidates:
+                raise ValueError(f"replay buffer at {self.buffer.rollout_dir} has no replayable candidates")
+            num_tasks = len(candidates)
+        return [ReplayTask(idx=i, kind=self.config.id, prompt=None) for i in range(num_tasks)]
+
+    async def resolve_task(self, task: ReplayTask) -> ReplayTask:
+        # The read (~1MB line), graph walk, and prompt build all run off the event loop.
+        if not self.config.online:
+            candidate = self.buffer.pick(task.idx)
+            return await asyncio.to_thread(self._materialize, task.idx, candidate)
+        # An online source line can vanish under us (its run resumed and cleaned future
+        # steps): drop the dangling candidate and draw again instead of failing forever.
+        for _ in range(8):
+            candidate = await self.buffer.sample()
+            try:
+                return await asyncio.to_thread(self._materialize, task.idx, candidate)
+            except FileNotFoundError:
+                logger.warning("replay source %s vanished; discarding candidate", candidate.path)
+                self.buffer.discard(candidate)
+        raise RuntimeError(f"replay buffer at {self.buffer.rollout_dir} keeps serving vanished source files")
+
+    def _materialize(self, idx: int, candidate) -> ReplayTask:
+        record = self.buffer.read_record(candidate)
+        prompt = self.build_prompt(record, candidate.anchor_node)
+        # A chained source (a replay env sourcing another replay env) nests its lineage;
+        # scoring, tools, and provisioning are always keyed on the innermost original.
+        source_task = unwrap_source_task(record["task"])
+        provision = {
+            key: value for key in ("image", "workdir", "timeout", "resources") if (value := source_task.get(key))
+        }
+        task = ReplayTask(
+            idx=idx,
+            name=f"{self.config.id}:{candidate.source_id[:8]}",
+            prompt=prompt,
+            kind=self.config.id,
+            source_task=source_task,
+            original_reward=candidate.original_reward,
+            source_id=candidate.source_id,
+            source_step=candidate.step,
+            **provision,
+        )
+        # Rebuild the typed original task now — inner-taskset schema drift fails loudly
+        # here, before any generation is spent — and cache it for the per-rollout hooks.
+        task._inner = self.inner_task_type.model_validate(source_task)
+        return task
+
+    def _inner_task(self, task: ReplayTask) -> Task:
+        if task._inner is None:
+            task._inner = self.inner_task_type.model_validate(task.source_task)
+        return task._inner
+
+    # ---------------------------------------------------- original-world hooks
+
+    def tools(self, task: ReplayTask) -> list[Toolset]:
+        # Stubs (env serving inspects tools(tasks[0]) for shared placement) get none;
+        # inner tasksets with shared-placement toolsets are therefore unsupported.
+        if not task.source_task:
+            return []
+        return self.inner.tools(self._inner_task(task))
+
+    async def setup(self, task: ReplayTask, runtime: Runtime) -> None:
+        await self.inner.setup(self._inner_task(task), runtime)
+
+    async def finalize(self, task: ReplayTask, trace: Trace, runtime: Runtime) -> None:
+        inner_task = self._inner_task(task)
+        # The shallow copy shares nodes/info/state with the real trace, so anything the
+        # inner taskset scrapes for its rewards lands where scoring will read it.
+        await self.inner.finalize(inner_task, trace.model_copy(update={"task": inner_task}), runtime)
+
+    # ------------------------------------------------------------------ scoring
+
+    async def score(self, trace: Trace, runtime: Runtime) -> None:
+        # Score with the original taskset, seen through a view whose `task` is the
+        # rebuilt original: the shallow copy shares the rewards/metrics/info dicts,
+        # so the inner rewards land on the real trace with their original names and
+        # weights, while `trace.task` stays the ReplayTask for everything else.
+        inner_task = self._inner_task(trace.task)
+        await self.inner.score(trace.model_copy(update={"task": inner_task}), runtime)
+        await super().score(trace, runtime)
+
+    @metric
+    async def replay_stats(self, task: ReplayTask, trace: Trace) -> dict[str, float]:
+        return {"replay/source_reward": task.original_reward, "replay/source_step": float(task.source_step)}

--- a/verifiers/v1/tasksets/replay/taskset.py
+++ b/verifiers/v1/tasksets/replay/taskset.py
@@ -4,11 +4,11 @@ Reads a run's saved rollout files (``<output>/rollouts/step_*/train_rollouts.jso
 one ``Trace.to_record()`` line each — the prime-rl orchestrator's rollout output) as a
 buffer and serves tasks derived from them. Like ``harbor`` or ``textarena``, this is a
 base for thin subclass packages: a derivation subclasses `ReplayTaskset` (binding its
-narrowed config in the generic, so the loader picks it up) and implements two hooks —
-
-- ``record_anchors(nodes, children, roots, tree)``: the resume points one saved rollout
-  offers (each becomes one task; ``None`` anchors at the rollout's final state).
-- ``build_prompt(record, anchor)``: the seeded conversation for one anchor.
+narrowed config in the generic, so the loader picks it up) and implements
+``build_prompt(record, anchor)`` — the seeded conversation for one anchor. Derivations
+that resume mid-rollout also override ``record_anchors`` (the resume points one saved
+rollout offers, each becoming one task; the default is one task per rollout, anchored
+at its final state).
 
 Everything else is shared: the lazy buffer (tasks bind per request from (file, offset)
 handles — saved lines average ~1MB), online semantics over a growing run dir, scoring/
@@ -150,9 +150,10 @@ class ReplayTaskset(Taskset[ReplayTask, ConfigT, State]):
         self, record: dict, children: dict[int, list[int]], roots: list[int], tree: set[int]
     ) -> list[int | None]:
         """The resume points one saved rollout offers this derivation — each becomes one
-        task. Return node indices (see `surgery` for enumerators), `[None]` to anchor at
-        the rollout's final state, or `[]` when the rollout offers nothing."""
-        raise NotImplementedError
+        task. Default: one task per rollout, anchored at its final state (`None`).
+        Override for mid-rollout derivations: return node indices (see `surgery` for
+        enumerators), or `[]` when the rollout offers nothing."""
+        return [None]
 
     def build_prompt(self, record: dict, anchor: int | None) -> str | list[dict]:
         """The seeded conversation for one (source record, anchor) pair."""


### PR DESCRIPTION
Hooks for lazily-bound tasksets, a replay taskset base built on them, and two fixes surfaced while building the first consumer (prime-rl's replay envs, PrimeIntellect-ai/prime-rl#2941).

## Changes

- **`Taskset.resolve_task(task)`**: called by the env server once per `run_rollout` / `run_group` request; defaults to returning the loaded task, so existing tasksets are byte-for-byte unchanged. Overriding it lets `load_tasks()` return lightweight stubs while the real task content binds per request. `run_group` resolves one task per request, so every rollout of a GRPO group binds the same resolved task. The in-process eval runner and `validate` CLI resolve through the same hook.
- **`Taskset.REQUIRES_GROUP_ROLLOUTS`**: OR-ed into the server's advertised `requires_group_scoring`, for tasksets whose `resolve_task` binds per-request state the whole group must share, even without `@group_reward`s. Both this and `NEEDS_CONTAINER` are plain (non-ClassVar) attributes — read off instances, settable per instance from config.
- **`verifiers.v1.tasksets.replay`** — a base taskset in the harbor/textarena mold: reads saved rollout files (`Trace.to_record()` jsonl lines, the prime-rl orchestrator's rollout output) as a lazy buffer and serves derived tasks. A derivation subclasses `ReplayTaskset` and implements `record_anchors` (the resume points one saved rollout offers) + `build_prompt` (the seeded conversation for one anchor); the base owns the (file, offset) candidate index over barrier-complete steps, online semantics (throttled rescans, fresh sampling with forced group dispatch, capacity-as-recency eviction, fail-fast on empty buffers), forest-aware trace surgery (main-tree isolation, compaction-fork and resumable-tool-result enumerators, recheck seeds), scoring/tools/setup/finalize delegation to the original (`inner`) taskset via a task-swapped trace view, and lineage so replay-derived records aren't re-replayed by default (chains opt in via `source_envs`). First derivations: `replay-continue-v1` / `replay-recheck-v1` in prime-rl.
- **Large Messages prompts no longer E2BIG at launch**: a seeded conversation over ~100KB is handed to the null/default harness programs as a workspace file (`INITIAL_MESSAGES_FILE`) instead of the `INITIAL_MESSAGES` env var — execve caps a single env string at `MAX_ARG_STRLEN` (128KiB on Linux), which crashed every launch for the majority of real resumed-conversation seeds. The staging lives in a shared `Harness.stage_message_prompt`.

## Verification

`tests/v1/test_replay.py` (16 tests: graph surgery on synthetic forests, buffer scan/barrier/eviction/pick determinism, lineage skipping). Empirically reproduced the E2BIG failure and the fix path. Trace-surgery algorithms validated against real production rollout files. End-to-end resolution exercised by the prime-rl derivation packages. The legacy v0 bridge overrides both server request paths and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
