### PR TITLE
docs: per-task image naming convention in harbor.md

### DIFF
--- a/docs/harbor.md
+++ b/docs/harbor.md
@@ -44,6 +44,12 @@ class OpenThoughtsTBLiteTaskset(HarborTaskset, vf.Taskset[HarborTask, OpenThough
 
 To create & re-use images for your environments, you can use `prime images push` from the Prime CLI ([Documentation](https://docs.primeintellect.ai/sandboxes/images)) for the given Dockerfiles.
 
+When pushing per-task images for a benchmark, name them `<benchmark>.<task_id>` with the tag `latest` — the image *name* carries the task id, the tag stays mutable — e.g. `prime/primeintellect/tmax.task_000000_c19dda5b:latest`. Do not encode the task id in the tag (`<benchmark>:<task_id>`): a stable per-task name keeps re-pushes an in-place replace and matches the existing benchmark image corpora. Push under your team context (`PRIME_TEAM_ID`) so the images are team-owned rather than personal.
+
+```python
+IMAGE_TEMPLATE = "prime/<team-slug>/<benchmark>.{task}:latest"
+```
+
 ## Additional features
 
 Every Harbor taskset can also be modified with a `timeout_multiplier` and a `resource_multiplier`:


### PR DESCRIPTION
Stacks on #1916. Adds the settled per-task image naming convention to the new `docs/harbor.md`:

- `<benchmark>.<task_id>` as the image **name**, tag pinned to `latest` (e.g. `prime/primeintellect/tmax.task_000000_c19dda5b:latest`) — not `<benchmark>:<task_id>`
- push under the team context (`PRIME_TEAM_ID`) so images are team-owned
- an `IMAGE_TEMPLATE` snippet matching the doc's existing `load_tasks` image-override example

Motivation: the convention previously lived only in scratch notes, and senior-swe-bench's images were just pushed under the wrong shape (`<benchmark>:<task_id>`) because of it. One paragraph in the doc that harbor-taskset authors actually read closes that gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document per-task image naming convention for benchmark tasks in Harbor
> Adds guidance to [harbor.md](https://github.com/PrimeIntellect-ai/verifiers/pull/1926/files#diff-c417c64a1ea45e07009312facb5c5def258a1ed24a9968354fe6916b6853f9cd) for naming and tagging per-task benchmark images. Images should use the form `<benchmark>.<task_id>:latest`, pushed under the team context (`PRIME_TEAM_ID`). Includes a Python snippet defining `IMAGE_TEMPLATE = "prime/<team-slug>/<benchmark>.{task}:latest"`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 94d9ed9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->