### PR TITLE
fix: make experimental file locks importable on Windows

### DIFF
--- a/verifiers/envs/experimental/utils/file_locks.py
+++ b/verifiers/envs/experimental/utils/file_locks.py
@@ -1,7 +1,18 @@
 from collections.abc import Iterator
 from contextlib import contextmanager
-import fcntl
 from pathlib import Path
+
+try:
+    import fcntl
+
+    _HAVE_FCNTL = True
+except ImportError:
+    # fcntl is Unix-only. On Windows, fall back to msvcrt byte-range locking.
+    # msvcrt has no shared locks, so shared locks degrade to exclusive locks
+    # there, which is strictly more conservative.
+    import msvcrt
+
+    _HAVE_FCNTL = False
 
 
 def sibling_lock_path(path: Path, suffix: str = ".lock") -> Path:
@@ -10,8 +21,39 @@ def sibling_lock_path(path: Path, suffix: str = ".lock") -> Path:
 
 
 @contextmanager
+def _msvcrt_file_lock(lock_path: Path, *, nonblocking: bool = False) -> Iterator[None]:
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a+") as lock_file:
+        lock_file.seek(0)
+        if nonblocking:
+            try:
+                msvcrt.locking(lock_file.fileno(), msvcrt.LK_NBLCK, 1)
+            except OSError as exc:
+                # Match the fcntl path, which raises BlockingIOError when a
+                # nonblocking lock is contended; msvcrt raises a plain OSError.
+                raise BlockingIOError(
+                    exc.errno,
+                    f"lock is held by another process: {lock_path}",
+                ) from exc
+        else:
+            msvcrt.locking(lock_file.fileno(), msvcrt.LK_LOCK, 1)
+        try:
+            yield
+        finally:
+            try:
+                lock_file.seek(0)
+                msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
+            except OSError:
+                pass
+
+
+@contextmanager
 def shared_file_lock(lock_path: Path) -> Iterator[None]:
     lock_path = lock_path.expanduser().resolve()
+    if not _HAVE_FCNTL:
+        with _msvcrt_file_lock(lock_path):
+            yield
+        return
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     with lock_path.open("a+") as lock_file:
         fcntl.flock(lock_file.fileno(), fcntl.LOCK_SH)
@@ -25,6 +67,10 @@ def exclusive_file_lock(
     nonblocking: bool = False,
 ) -> Iterator[None]:
     lock_path = lock_path.expanduser().resolve()
+    if not _HAVE_FCNTL:
+        with _msvcrt_file_lock(lock_path, nonblocking=nonblocking):
+            yield
+        return
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     flags = fcntl.LOCK_EX | (fcntl.LOCK_NB if nonblocking else 0)
     with lock_path.open("a+") as lock_file:

--- a/verifiers/envs/experimental/utils/git_checkout_cache.py
+++ b/verifiers/envs/experimental/utils/git_checkout_cache.py
@@ -1,4 +1,3 @@
-import fcntl
 import hashlib
 import logging
 import os
@@ -14,6 +13,17 @@ from verifiers.envs.experimental.utils.file_locks import (
     exclusive_path_lock,
     sibling_lock_path,
 )
+
+try:
+    import fcntl
+
+    _HAVE_FCNTL = True
+except ImportError:
+    # fcntl is Unix-only; on Windows fall back to msvcrt byte-range locking.
+    # See verifiers.envs.experimental.utils.file_locks.
+    import msvcrt
+
+    _HAVE_FCNTL = False
 
 _IN_USE_LOCK_SUFFIX = ".in-use.lock"
 
@@ -293,7 +303,13 @@ def _acquire_in_use_lock(checkout: Path) -> None:
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     fh = lock_path.open("a+")
     try:
-        fcntl.flock(fh.fileno(), fcntl.LOCK_SH)
+        if _HAVE_FCNTL:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_SH)
+        else:
+            # msvcrt has no shared locks; an exclusive byte lock is strictly
+            # more conservative and preserves the pruning contract.
+            fh.seek(0)
+            msvcrt.locking(fh.fileno(), msvcrt.LK_LOCK, 1)
     except Exception:
         fh.close()
         raise


### PR DESCRIPTION
verifiers.envs.experimental.utils.file_locks and .git_checkout_cache import fcntl unconditionally, so importing verifiers (and therefore vf.load_environment and the entire vf-eval CLI) crashes on Windows with "ModuleNotFoundError: No module named 'fcntl'", surfaced misleadingly as a prompt to install verifiers[all].

## Description
Guard the fcntl import and fall back to msvcrt byte-range locking on Windows:
- Shared locks degrade to exclusive locks (msvcrt has no shared locks) — strictly more conservative, preserves the worktree pruning contract.
- Contended nonblocking acquisitions raise BlockingIOError, matching flock(LOCK_EX | LOCK_NB) semantics, so _prune_stale_worktrees keeps skipping in-use checkouts instead of crashing (msvcrt raises bare OSError on contention, which the pruning code doesn't catch — the fallback translates it).
- No behavior change on POSIX; the fcntl paths are untouched.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test improvement

## Testing
Verified on Windows 11 / Python 3.10.9 against this branch's modules loaded by path:
- exclusive_file_lock acquire / release / re-acquire; shared_file_lock; shared/exclusive_path_lock (nonblocking)
- Cross-process contention: second process holding the lock → nonblocking acquisition raises BlockingIOError as the pruning code expects
- git_checkout_cache._acquire_in_use_lock / _release_all_in_use_locks (process-lifetime lock, idempotent re-entry)
- Reproduced the original crash against a pristine 0.1.14 wheel on the same machine; with this patch the modules import and locks work
- py_compile on both files. Full `uv run pytest` not run locally (Windows box; POSIX paths untouched and byte-identical in behavior).

## Checklist
- [x] My code follows the style guidelines of this project as outlined in [AGENTS.md](https://github.com/PrimeIntellect-ai/verifiers/blob/main/AGENTS.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (N/A — no user-facing docs cover these internals)
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published (N/A)

## Additional Notes
- verifiers/v1/runtimes/limiters.py also has a module-level `import fcntl`, but only loads with the v1 prime/modal runtimes (off the default import path) — left untouched; happy to guard it the same way if wanted.
- Known related Windows issue, not addressed here: the ZMQ env server never becomes healthy on Windows, so vf-eval needs --disable-env-server. With that flag plus this patch, vf-eval runs end to end on Windows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cross-process locking semantics on Windows (shared locks become exclusive) in git checkout pruning and experimental env utilities; POSIX behavior is untouched but concurrency contracts differ on the new platform.
> 
> **Overview**
> Fixes **Windows import crashes** (`ModuleNotFoundError: fcntl`) for `verifiers.envs.experimental.utils.file_locks` and `git_checkout_cache`, which blocked `vf.load_environment` and the eval CLI on that platform.
> 
> **`file_locks.py`** now probes `fcntl` at import time and, when missing, uses **`msvcrt` byte-range locking** via a new `_msvcrt_file_lock` helper wired into `shared_file_lock` and `exclusive_file_lock`. On Windows, **shared locks become exclusive** (no shared mode in `msvcrt`), which the PR treats as stricter but safe. **Nonblocking** contention is normalized to **`BlockingIOError`**, matching `flock(LOCK_NB)` so callers like `_prune_stale_worktrees` keep skipping in-use checkouts instead of failing on bare `OSError`.
> 
> **`git_checkout_cache.py`** applies the same `_HAVE_FCNTL` guard for **process-lifetime in-use locks** in `_acquire_in_use_lock`, using `msvcrt.LK_LOCK` when `fcntl` is unavailable. **POSIX paths are unchanged** when `fcntl` imports successfully.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c307163989795dec12057d84d6d11a5fd8f87c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix file lock imports in experimental utils to work on Windows
> - Replaces unconditional `fcntl` imports in [file_locks.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1927/files#diff-51d877f1aad460f3f5fedfd8cb8bc8a7ab31dcfb52b9ea45569069bbe2b5c4f6) and [git_checkout_cache.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1927/files#diff-61451382532b0a9e9e10039e7e3541153a30e084409514aad4d70341b6505287) with try/except blocks that fall back to `msvcrt` on Windows, gated by a `_HAVE_FCNTL` flag.
> - Adds a `_msvcrt_file_lock` context manager that implements byte-range locking via `msvcrt.locking`, with blocking and nonblocking modes and `BlockingIOError` on contention to mirror `fcntl` semantics.
> - Behavioral Change: on Windows, both `shared_file_lock` and `exclusive_file_lock` use exclusive 1-byte locks since `msvcrt` has no shared lock primitive.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0c30716.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->