### PR TITLE
[codex] add GEPA v1 support

### DIFF
--- a/docs/training.md
+++ b/docs/training.md
@@ -127,6 +127,11 @@ prime gepa run wiki-search --model google/gemini-3-flash-preview
 
 This will optimize the system prompt for the `wiki-search` environment using the specified model for both evaluation rollouts and reflection. Results are saved to `environments/wiki-search/outputs/gepa/`.
 
+Native v1 tasksets use the same taskset/harness shape as v1 eval:
+```bash
+prime gepa run wiki-search-v1 --model google/gemini-3-flash-preview
+```
+
 Key options:
 - `--model` / `-m`: Model for evaluation rollouts
 - `--reflection-model` / `-M`: Teacher model for prompt reflection (defaults to `--model`)
@@ -137,7 +142,7 @@ Key options:
 - `--perfect-score`: Maximum score for a rollout in your environment (if applicable); minibatches achieving this score are skipped during reflection (useful if your environment has a known max score)
 - `--state-columns`: Additional state columns to copy into the reflection dataset. By default, `query`, `completion`, `expected_answer`, `reward`, and `error` are included. Use this to add environment-specific state fields (e.g., `--state-columns tool_calls reasoning_trace`)
 
-In TOML configs, set GEPA parameters such as `max_calls`, `num_train`, `num_val`, `minibatch_size`, and `max_concurrent` under `[gepa]`. Put generation parameters such as `max_tokens` and `temperature` under `[sampling]`; the CLI passes that table through as `sampling_args`. Use `[[env]]` for one or more environments; GEPA samples train and validation examples uniformly by environment. A single `[env]` table is still accepted for older configs.
+In TOML configs, set GEPA parameters such as `max_calls`, `num_train`, `num_val`, `minibatch_size`, and `max_concurrent` under `[gepa]`. Put generation parameters such as `max_tokens` and `temperature` under `[sampling]`. For native v1, use `[taskset]` and optional `[harness]` tables just like eval configs. Legacy v0 configs use `[[env]]` for one or more environments; GEPA samples train and validation examples uniformly by environment. A single `[env]` table is still accepted for older configs.
 
 ### Output
 

--- a/tests/test_gepa_v1.py
+++ b/tests/test_gepa_v1.py
@@ -1,0 +1,156 @@
+import asyncio
+from pathlib import Path
+
+import verifiers.v1 as vf
+from verifiers.gepa.config import GEPAV1Config
+from verifiers.gepa.v1_adapter import (
+    VerifiersV1GEPAAdapter,
+    make_v1_gepa_dataset,
+    shared_initial_prompt_v1,
+)
+from verifiers.scripts import gepa as gepa_script
+from verifiers.scripts.gepa import (
+    ResolvedGEPAClients,
+    _rewrite_positional_target,
+    _run_v1_or_legacy_gepa,
+    _uses_v1_config,
+)
+from verifiers.types import ClientConfig
+
+
+class FakeEpisode:
+    def __init__(self, task: vf.Task) -> None:
+        self.task = task
+
+    async def run(self, semaphore=None):
+        async with semaphore:
+            trace = vf.Trace(task=self.task)
+            trace.record_reward("system_prompt_seen", self.task.system_prompt == "new")
+            trace.stop("done")
+            return [trace]
+
+
+class FakeEnv:
+    def __init__(self) -> None:
+        self.seen_tasks: list[vf.Task] = []
+
+    def episode(self, task, ctx, n=1):
+        assert n == 1
+        self.seen_tasks.append(task)
+        return FakeEpisode(task)
+
+
+class FakeClient(vf.Client):
+    async def get_response(self, *args, **kwargs):  # pragma: no cover - not called here
+        raise AssertionError("fake env should not call the client")
+
+
+def test_gepa_v1_config_parses_native_env_shape():
+    config = GEPAV1Config.model_validate(
+        {
+            "taskset": {"id": "echo-v1"},
+            "harness": {"id": "null"},
+            "model": "test-model",
+            "gepa": {"max_calls": 3, "num_train": 2, "num_val": 1},
+            "sampling": {"temperature": 0, "max_tokens": 16},
+        }
+    )
+
+    assert config.taskset.id == "echo-v1"
+    assert config.harness.id == "null"
+    assert config.environment_label == "echo-v1"
+    assert config.gepa.max_calls == 3
+    assert config.sampling.max_tokens == 16
+
+
+def test_gepa_cli_routes_v1_taskset_ids_to_taskset_config(tmp_path: Path):
+    config_path = tmp_path / "gepa.toml"
+    config_path.write_text(
+        'model = "test-model"\n[taskset]\nid = "echo-v1"\n[gepa]\nmax_calls = 3\n'
+    )
+
+    assert _rewrite_positional_target(["echo-v1"]) == ["--taskset.id", "echo-v1"]
+    assert _rewrite_positional_target(["--id", "echo-v1"]) == [
+        "--taskset.id",
+        "echo-v1",
+    ]
+    assert _rewrite_positional_target(["echo-v0"]) == ["--id", "echo-v0"]
+    assert _uses_v1_config(["@", str(config_path)])
+
+
+def test_gepa_v1_shape_falls_back_to_legacy_env(monkeypatch):
+    config = GEPAV1Config.model_validate(
+        {
+            "taskset": {"id": "echo-v0"},
+            "model": "test-model",
+            "save_results": False,
+            "gepa": {"max_calls": 3, "num_train": 2, "num_val": 1},
+            "sampling": {"temperature": 0, "max_tokens": 16},
+        }
+    )
+    calls = []
+
+    def fake_v0_run(**kwargs):
+        calls.append(kwargs)
+
+    def fake_v1_run(**kwargs):
+        raise AssertionError("legacy env should not enter the v1 GEPA runner")
+
+    monkeypatch.setattr(gepa_script, "run_gepa_optimization", fake_v0_run)
+    monkeypatch.setattr(gepa_script, "run_gepa_v1_optimization", fake_v1_run)
+
+    _run_v1_or_legacy_gepa(
+        config,
+        ResolvedGEPAClients(
+            model="test-model",
+            reflection_model="teacher-model",
+            client_config=ClientConfig(),
+            reflection_client_config=ClientConfig(),
+        ),
+    )
+
+    assert config.is_legacy
+    assert calls[0]["env_id"] == "echo-v0"
+    assert calls[0]["env_configs"][0].id == "echo-v0"
+    assert calls[0]["sampling_args"] == {"temperature": 0.0, "max_tokens": 16}
+
+
+def test_v1_gepa_dataset_repeats_tiny_tasksets_deterministically():
+    tasks = [
+        vf.Task(idx=0, prompt="a", system_prompt="sys"),
+        vf.Task(idx=1, prompt="b", system_prompt="sys"),
+    ]
+
+    first = make_v1_gepa_dataset(tasks, n=5, seed=0)
+    second = make_v1_gepa_dataset(tasks, n=5, seed=0)
+
+    assert [row["example_id"] for row in first] == [0, 1, 2, 3, 4]
+    assert [row["task"].idx for row in first] == [row["task"].idx for row in second]
+    assert shared_initial_prompt_v1(tasks) == "sys"
+
+
+def test_v1_gepa_adapter_injects_candidate_system_prompt():
+    task = vf.Task(idx=0, prompt="question", system_prompt="old")
+    runner = asyncio.Runner()
+    env = FakeEnv()
+    try:
+        adapter = VerifiersV1GEPAAdapter(
+            env=env,
+            client=FakeClient(),
+            model="test-model",
+            sampling=vf.SamplingConfig(max_tokens=16),
+            runner=runner,
+            max_concurrent=1,
+        )
+        batch = adapter.evaluate(
+            [{"example_id": 7, "task": task}],
+            {"system_prompt": "new"},
+            capture_traces=True,
+        )
+    finally:
+        runner.close()
+
+    assert batch.scores == [1.0]
+    assert batch.outputs[0]["example_id"] == 7
+    assert batch.outputs[0]["task"]["system_prompt"] == "new"
+    assert env.seen_tasks[0].system_prompt == "new"

--- a/verifiers/gepa/__init__.py
+++ b/verifiers/gepa/__init__.py
@@ -1,13 +1,21 @@
 from verifiers.gepa.adapter import VerifiersGEPAAdapter, make_reflection_lm
 from verifiers.gepa.gepa_utils import save_gepa_results
-from verifiers.gepa.config import GEPAConfig, GEPAEnvConfig, GEPAOptimizationConfig
+from verifiers.gepa.config import (
+    GEPAConfig,
+    GEPAEnvConfig,
+    GEPAOptimizationConfig,
+    GEPAV1Config,
+)
 from verifiers.gepa.display import GEPADisplay
+from verifiers.gepa.v1_adapter import VerifiersV1GEPAAdapter
 
 __all__ = [
     "VerifiersGEPAAdapter",
+    "VerifiersV1GEPAAdapter",
     "GEPAConfig",
     "GEPAEnvConfig",
     "GEPAOptimizationConfig",
+    "GEPAV1Config",
     "GEPADisplay",
     "make_reflection_lm",
     "save_gepa_results",

--- a/verifiers/gepa/config.py
+++ b/verifiers/gepa/config.py
@@ -3,7 +3,11 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from verifiers.v1.clients import ClientConfig as V1ClientConfig
+from verifiers.v1.clients import EvalClientConfig
+from verifiers.v1.env import EnvConfig
 from verifiers.v1.types import EnvId
+from verifiers.v1.types import SamplingConfig
 
 
 class GEPAEnvConfig(BaseModel):
@@ -72,3 +76,25 @@ class GEPAConfig(BaseModel):
         if self.id:
             return self.id
         return "+".join(env.id for env in self.env)
+
+
+class GEPAV1Config(EnvConfig):
+    """GEPA config for native v1 taskset/harness environments."""
+
+    model: str = "openai/gpt-4.1-mini"
+    reflection_model: str | None = None
+    endpoints_path: Path = Path("./configs/endpoints.toml")
+    api_key_var: str | None = None
+    api_base_url: str | None = None
+    env_dir_path: Path = Path("./environments")
+    client: V1ClientConfig = EvalClientConfig()
+    gepa: GEPAOptimizationConfig = Field(default_factory=GEPAOptimizationConfig)
+    sampling: SamplingConfig = SamplingConfig()
+    verbose: bool = False
+    run_dir: Path | None = None
+    save_results: bool = True
+    tui: bool = False
+
+    @property
+    def environment_label(self) -> str:
+        return self.env_id

--- a/verifiers/gepa/v1_adapter.py
+++ b/verifiers/gepa/v1_adapter.py
@@ -1,0 +1,182 @@
+import asyncio
+import logging
+import random
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Callable, TypedDict
+
+from gepa.core.adapter import EvaluationBatch
+
+from verifiers.utils.save_utils import make_serializable
+from verifiers.v1.clients import Client, RolloutContext
+from verifiers.v1.decorators import discover_decorated
+from verifiers.v1.env import Environment
+from verifiers.v1.task import Task
+from verifiers.v1.trace import Trace
+from verifiers.v1.types import SamplingConfig
+
+if TYPE_CHECKING:
+    from verifiers.gepa.display import GEPADisplay
+
+logger = logging.getLogger(__name__)
+
+
+class V1GEPARow(TypedDict):
+    example_id: int
+    task: Task
+
+
+def make_v1_gepa_dataset(
+    tasks: list[Task], n: int, seed: int, example_offset: int = 0
+) -> list[V1GEPARow]:
+    """Select v1 tasks for GEPA. Repeats tiny tasksets so GEPA's requested count is honored."""
+    if not tasks:
+        return []
+
+    shuffled = list(tasks)
+    random.Random(seed).shuffle(shuffled)
+    selected = (
+        shuffled if n < 0 else [shuffled[idx % len(shuffled)] for idx in range(n)]
+    )
+    return [
+        {"example_id": example_offset + idx, "task": task}
+        for idx, task in enumerate(selected)
+    ]
+
+
+def shared_initial_prompt_v1(tasks: list[Task]) -> str:
+    prompts = [task.system_prompt or "" for task in tasks]
+    initial_prompt = prompts[0] if prompts else ""
+    if len(set(prompts)) > 1:
+        logger.warning(
+            "Multiple v1 task system prompts detected; GEPA will optimize one "
+            "shared prompt initialized from the first task."
+        )
+    return initial_prompt
+
+
+def ensure_v1_gepa_supported(env: Environment) -> None:
+    if discover_decorated(env.taskset, "group_reward"):
+        raise ValueError("v1 GEPA does not support tasksets with @group_reward yet.")
+
+
+@dataclass
+class VerifiersV1GEPAAdapter:
+    """Bridges GEPA optimization with native v1 Environment/Episode execution."""
+
+    env: Environment
+    client: Client
+    model: str
+    sampling: SamplingConfig
+    runner: asyncio.Runner
+    max_concurrent: int = 32
+    state_columns: list[str] = field(default_factory=list)
+    display: "GEPADisplay | None" = None
+
+    # GEPA adapter protocol: None means use default proposer with reflection_lm.
+    propose_new_texts: Callable[..., dict[str, str]] | None = None
+
+    _seen_prompts: dict[str, int] = field(default_factory=dict)
+
+    def evaluate(
+        self,
+        batch: list[V1GEPARow],
+        candidate: dict[str, str],
+        capture_traces: bool = False,
+    ) -> EvaluationBatch[dict[str, Any], dict[str, Any]]:
+        outputs = self.runner.run(self._evaluate(batch, candidate))
+        example_ids = [output["example_id"] for output in outputs]
+        rewards = [output["reward"] for output in outputs]
+
+        if self.display is not None:
+            prompt_text = candidate.get("system_prompt", "")
+            if prompt_text not in self._seen_prompts:
+                self._seen_prompts[prompt_text] = len(self._seen_prompts)
+            self.display.update_eval(
+                candidate_idx=self._seen_prompts[prompt_text],
+                scores=rewards,
+                example_ids=example_ids,
+                capture_traces=capture_traces,
+            )
+
+        return EvaluationBatch(
+            outputs=outputs,
+            scores=rewards,
+            trajectories=outputs if capture_traces else None,
+        )
+
+    async def _evaluate(
+        self, batch: list[V1GEPARow], candidate: dict[str, str]
+    ) -> list[dict[str, Any]]:
+        semaphore = asyncio.Semaphore(self.max_concurrent)
+        system_prompt = candidate.get("system_prompt", "")
+        ctx = RolloutContext(
+            client=self.client,
+            model=self.model,
+            sampling=self.sampling,
+        )
+
+        async def run_one(row: V1GEPARow) -> dict[str, Any]:
+            task = row["task"].model_copy(update={"system_prompt": system_prompt})
+            episode = self.env.episode(task, ctx, n=1)
+            (trace,) = await episode.run(semaphore)
+            return self._trace_output(row, trace)
+
+        return await asyncio.gather(*(run_one(row) for row in batch))
+
+    def _trace_output(self, row: V1GEPARow, trace: Trace) -> dict[str, Any]:
+        error = trace.error.model_dump(mode="json") if trace.error else None
+        task_dump = trace.task.model_dump(mode="json")
+        output: dict[str, Any] = {
+            "example_id": row["example_id"],
+            "prompt": trace.task.prompt_text,
+            "completion": trace.last_reply,
+            "transcript": trace.transcript,
+            "answer": task_dump.get("answer", ""),
+            "reward": trace.reward,
+            "rewards": dict(trace.rewards),
+            "metrics": dict(trace.metrics),
+            "stop_condition": trace.stop_condition,
+            "error": error,
+            "task": task_dump,
+            "trace": trace.to_record(),
+        }
+        for col in self.state_columns:
+            if col in trace.info:
+                output[col] = make_serializable(trace.info[col])
+            elif col in trace.metrics:
+                output[col] = trace.metrics[col]
+            elif col in trace.rewards:
+                output[col] = trace.rewards[col]
+        return output
+
+    def make_reflective_dataset(
+        self,
+        candidate: dict[str, str],  # noqa: ARG002 - required by GEPA adapter protocol
+        eval_batch: EvaluationBatch[dict[str, Any], dict[str, Any]],
+        components_to_update: list[str],
+    ) -> Mapping[str, Sequence[Mapping[str, Any]]]:
+        records: list[dict[str, Any]] = []
+        trajectories = eval_batch.trajectories or eval_batch.outputs
+        for output, trajectory, score in zip(
+            eval_batch.outputs, trajectories, eval_batch.scores
+        ):
+            record: dict[str, Any] = {
+                "query": output["prompt"],
+                "completion": output["completion"],
+                "transcript": output["transcript"],
+                "expected_answer": output.get("answer", ""),
+                "reward": score,
+                "rewards": output.get("rewards", {}),
+                "metrics": output.get("metrics", {}),
+            }
+            if trajectory.get("error"):
+                record["error"] = trajectory["error"]
+            if trajectory.get("stop_condition"):
+                record["stop_condition"] = trajectory["stop_condition"]
+            for col in self.state_columns:
+                if col in output:
+                    record[col] = make_serializable(output[col])
+            records.append(record)
+
+        return {comp: records for comp in components_to_update}

--- a/verifiers/gepa/v1_runner.py
+++ b/verifiers/gepa/v1_runner.py
@@ -1,0 +1,146 @@
+import asyncio
+import logging
+from pathlib import Path
+
+from gepa.api import optimize
+
+from verifiers.gepa.adapter import make_reflection_lm
+from verifiers.gepa.config import GEPAV1Config
+from verifiers.gepa.display import GEPADisplay
+from verifiers.gepa.gepa_utils import save_gepa_results
+from verifiers.gepa.v1_adapter import (
+    VerifiersV1GEPAAdapter,
+    ensure_v1_gepa_supported,
+    make_v1_gepa_dataset,
+    shared_initial_prompt_v1,
+)
+from verifiers.types import ClientConfig
+from verifiers.v1.clients import BaseClientConfig, resolve_client
+from verifiers.v1.env import Environment
+
+logger = logging.getLogger(__name__)
+
+
+def run_gepa_v1_optimization(
+    config: GEPAV1Config,
+    model: str,
+    reflection_model: str,
+    client_config: BaseClientConfig,
+    reflection_client_config: ClientConfig,
+    run_dir: Path | None,
+):
+    if run_dir:
+        run_dir.mkdir(parents=True, exist_ok=True)
+
+    display = GEPADisplay(
+        env_id=config.environment_label,
+        model=model,
+        reflection_model=reflection_model,
+        max_metric_calls=config.gepa.max_calls,
+        num_train=config.gepa.num_train,
+        num_val=config.gepa.num_val,
+        log_file=run_dir / "gepa.log" if run_dir else None,
+        perfect_score=config.gepa.perfect_score,
+        screen=config.tui,
+    )
+
+    with display:
+        env = Environment(config)
+        ensure_v1_gepa_supported(env)
+        tasks = env.taskset.load_tasks()
+        if not tasks:
+            raise ValueError(f"No tasks available for v1 GEPA env {config.env_id!r}.")
+
+        initial_prompt = shared_initial_prompt_v1(tasks)
+        if not initial_prompt:
+            logger.warning("No system prompt attached to v1 tasks.")
+            logger.warning(
+                "GEPA will add a system prompt to each task during candidate evaluation."
+            )
+
+        trainset = make_v1_gepa_dataset(tasks, config.gepa.num_train, config.gepa.seed)
+        valset = make_v1_gepa_dataset(tasks, config.gepa.num_val, config.gepa.seed + 1)
+        if not trainset:
+            raise ValueError("No train examples available for v1 GEPA.")
+        if not valset:
+            raise ValueError("No validation examples available for v1 GEPA.")
+
+        valset_example_ids = [
+            item.get("example_id", i) for i, item in enumerate(valset)
+        ]
+        display.set_valset_info(len(valset), valset_example_ids)
+        display.num_train = len(trainset)
+        display.num_val = len(valset)
+
+        client = resolve_client(client_config)
+        runner = asyncio.Runner()
+        serving = env.serving([row["task"] for row in [*trainset, *valset]])
+        serving_entered = False
+        try:
+            runner.run(serving.__aenter__())
+            serving_entered = True
+            adapter = VerifiersV1GEPAAdapter(
+                env=env,
+                client=client,
+                model=model,
+                sampling=config.sampling,
+                runner=runner,
+                max_concurrent=config.gepa.max_concurrent,
+                state_columns=config.gepa.state_columns,
+                display=display,
+            )
+            reflection_lm = make_reflection_lm(
+                client_config=reflection_client_config, model=reflection_model
+            )
+            optimize_kwargs: dict = {
+                "seed_candidate": {"system_prompt": initial_prompt},
+                "trainset": trainset,
+                "valset": valset,
+                "adapter": adapter,
+                "reflection_lm": reflection_lm,
+                "max_metric_calls": config.gepa.max_calls,
+                "reflection_minibatch_size": config.gepa.minibatch_size,
+                "run_dir": str(run_dir) if run_dir else None,
+                "seed": config.gepa.seed,
+                "display_progress_bar": False,
+                "skip_perfect_score": config.gepa.perfect_score is not None,
+                "logger": display,
+            }
+            if config.gepa.perfect_score is not None:
+                optimize_kwargs["perfect_score"] = config.gepa.perfect_score
+            result = optimize(**optimize_kwargs)
+        finally:
+            if serving_entered:
+                runner.run(serving.__aexit__(None, None, None))
+            runner.run(client.close())
+            runner.close()
+
+        save_path = None
+        if run_dir and config.save_results:
+            save_gepa_results(
+                run_dir, result, config=_run_config(config, model, reflection_model)
+            )
+            save_path = str(run_dir)
+            logger.debug(f"Results saved to {run_dir}")
+
+        best_prompt = result.best_candidate.get("system_prompt", "")  # type: ignore[unresolved-attribute]
+        display.set_result(best_prompt=best_prompt, save_path=save_path)
+
+    return result
+
+
+def _run_config(config: GEPAV1Config, model: str, reflection_model: str) -> dict:
+    return {
+        "env_id": config.environment_label,
+        "v1": True,
+        "env_config": config.model_dump(mode="json"),
+        "model": model,
+        "reflection_model": reflection_model,
+        "num_train": config.gepa.num_train,
+        "num_val": config.gepa.num_val,
+        "max_metric_calls": config.gepa.max_calls,
+        "minibatch_size": config.gepa.minibatch_size,
+        "perfect_score": config.gepa.perfect_score,
+        "state_columns": config.gepa.state_columns,
+        "seed": config.gepa.seed,
+    }

--- a/verifiers/scripts/gepa.py
+++ b/verifiers/scripts/gepa.py
@@ -1,11 +1,13 @@
-"""Typed CLI for V0 GEPA prompt optimization."""
+"""Typed CLI for GEPA prompt optimization."""
 
 from collections.abc import Mapping
+from dataclasses import dataclass
 import json
 import logging
 import os
 from pathlib import Path
 import sys
+import tomllib
 from typing import Any, cast
 
 from gepa.api import optimize
@@ -13,15 +15,18 @@ from pydantic_config import cli
 
 import verifiers as vf
 from verifiers import setup_logging
-from verifiers.clients import resolve_client
+from verifiers.clients import resolve_client as resolve_v0_client
 from verifiers.envs.env_group import ENV_GROUP_INFO_KEY
 from verifiers.gepa.adapter import VerifiersGEPAAdapter, make_reflection_lm
-from verifiers.gepa.config import GEPAConfig, GEPAEnvConfig
+from verifiers.gepa.config import GEPAConfig, GEPAEnvConfig, GEPAV1Config
 from verifiers.gepa.display import GEPADisplay
 from verifiers.gepa.gepa_utils import save_gepa_results
+from verifiers.gepa.v1_runner import run_gepa_v1_optimization
 from verifiers.types import ClientConfig, EndpointConfig
 from verifiers.utils.eval_utils import load_endpoints
 from verifiers.utils.path_utils import get_gepa_results_path
+from verifiers.v1.cli.resolve import extract_id, narrow_config
+from verifiers.v1.loaders import taskset_class
 
 logger = logging.getLogger(__name__)
 
@@ -41,11 +46,66 @@ def _gepa_extra_headers_from_group(
 
 DEFAULT_API_KEY_VAR = "PRIME_API_KEY"
 DEFAULT_API_BASE_URL = "https://api.pinference.ai/api/v1"
-USAGE = "usage: vf-gepa <env-id> [options] | vf-gepa @ config.toml"
+USAGE = (
+    "usage: vf-gepa <env-id> [options] | vf-gepa --taskset.id <v1-id> [options] | "
+    "vf-gepa @ config.toml"
+)
 
 
-def main(argv: list[str] | None = None) -> None:
-    argv = list(sys.argv[1:]) if argv is None else list(argv)
+@dataclass(frozen=True)
+class ResolvedGEPAClients:
+    model: str
+    reflection_model: str
+    client_config: ClientConfig
+    reflection_client_config: ClientConfig
+
+
+def _is_v1_taskset_id(env_id: str) -> bool:
+    try:
+        taskset_class(env_id)
+    except (AttributeError, ModuleNotFoundError, TypeError):
+        return False
+    return True
+
+
+def _rewrite_v1_id_flags(argv: list[str]) -> list[str]:
+    rewritten = list(argv)
+    for idx, arg in enumerate(rewritten):
+        if (
+            arg == "--id"
+            and idx + 1 < len(rewritten)
+            and _is_v1_taskset_id(rewritten[idx + 1])
+        ):
+            rewritten[idx] = "--taskset.id"
+        elif arg.startswith("--id="):
+            value = arg.split("=", 1)[1]
+            if _is_v1_taskset_id(value):
+                rewritten[idx] = f"--taskset.id={value}"
+    return rewritten
+
+
+def _config_path(argv: list[str]) -> Path | None:
+    for idx, arg in enumerate(argv):
+        if arg == "@" and idx + 1 < len(argv):
+            return Path(argv[idx + 1])
+        if arg.startswith("@") and len(arg) > 1:
+            return Path(arg[1:])
+    return None
+
+
+def _config_file_uses_v1(argv: list[str]) -> bool:
+    path = _config_path(argv)
+    if path is None or not path.is_file():
+        return False
+    raw = tomllib.loads(path.read_text(encoding="utf-8"))
+    return isinstance(raw.get("taskset"), dict)
+
+
+def _uses_v1_config(argv: list[str]) -> bool:
+    return bool(extract_id(argv, "taskset")) or _config_file_uses_v1(argv)
+
+
+def _rewrite_positional_target(argv: list[str]) -> list[str]:
     target_idx = None
     bool_flags = {
         "--verbose",
@@ -65,23 +125,26 @@ def main(argv: list[str] | None = None) -> None:
         if idx == 0 or (followed_by_flag and (follows_value or follows_bool)):
             target_idx = idx
             break
-    if target_idx is not None:
-        target = argv.pop(target_idx)
-        argv = (
-            ["@", target] if Path(target).suffix == ".toml" else ["--id", target]
-        ) + argv
-    if not argv or any(arg in ("-h", "--help") for arg in argv):
-        print(USAGE)
-        cli(GEPAConfig, args=argv or ["--help"])
-        return
+    if target_idx is None:
+        return _rewrite_v1_id_flags(argv)
 
-    config = cli(GEPAConfig, args=argv)
-    setup_logging("DEBUG" if config.verbose else os.getenv("VF_LOG_LEVEL", "INFO"))
-    env_configs = config.environments
-    env_id = config.environment_label
+    target = argv.pop(target_idx)
+    if Path(target).suffix == ".toml":
+        return ["@", target, *argv]
+    if _is_v1_taskset_id(target):
+        return ["--taskset.id", target, *argv]
+    return ["--id", target, *argv]
 
+
+def _resolve_gepa_clients(
+    config: GEPAConfig | GEPAV1Config,
+    *,
+    default_api_key_var: str,
+    default_api_base_url: str,
+    default_extra_headers: Mapping[str, str] | None = None,
+) -> ResolvedGEPAClients:
     endpoints = load_endpoints(str(config.endpoints_path))
-    main_extra_headers: dict[str, str] = {}
+    main_extra_headers = dict(default_extra_headers or {})
     if config.model in endpoints:
         endpoint_group = endpoints[config.model]
         endpoint = endpoint_group[0]
@@ -112,8 +175,8 @@ def main(argv: list[str] | None = None) -> None:
             )
         model = endpoint.model
     else:
-        api_key_var = config.api_key_var or DEFAULT_API_KEY_VAR
-        api_base_url = config.api_base_url or DEFAULT_API_BASE_URL
+        api_key_var = config.api_key_var or default_api_key_var
+        api_base_url = config.api_base_url or default_api_base_url
         model = config.model
 
     reflection_extra_headers = main_extra_headers
@@ -139,13 +202,7 @@ def main(argv: list[str] | None = None) -> None:
         reflection_api_key_var = api_key_var
         reflection_api_base_url = api_base_url
 
-    run_dir = config.run_dir
-    if run_dir is None and config.save_results:
-        run_dir = get_gepa_results_path(env_id, model, str(config.env_dir_path))
-
-    run_gepa_optimization(
-        env_id=env_id,
-        env_configs=env_configs,
+    return ResolvedGEPAClients(
         model=model,
         reflection_model=reflection_model,
         client_config=ClientConfig(
@@ -158,6 +215,110 @@ def main(argv: list[str] | None = None) -> None:
             api_base_url=reflection_api_base_url,
             extra_headers=reflection_extra_headers,
         ),
+    )
+
+
+def _run_v1_or_legacy_gepa(config: GEPAV1Config, resolved: ResolvedGEPAClients) -> None:
+    run_dir = config.run_dir
+    if run_dir is None and config.save_results:
+        run_dir = get_gepa_results_path(
+            config.environment_label, resolved.model, str(config.env_dir_path)
+        )
+
+    if config.is_legacy:
+        run_gepa_optimization(
+            env_id=config.env_id,
+            env_configs=[
+                GEPAEnvConfig(
+                    id=config.env_id,
+                    args=config.args,
+                    extra_env_kwargs=config.extra_env_kwargs,
+                )
+            ],
+            model=resolved.model,
+            reflection_model=resolved.reflection_model,
+            client_config=resolved.client_config,
+            reflection_client_config=resolved.reflection_client_config,
+            max_metric_calls=config.gepa.max_calls,
+            minibatch_size=config.gepa.minibatch_size,
+            perfect_score=config.gepa.perfect_score,
+            state_columns=config.gepa.state_columns,
+            num_train=config.gepa.num_train,
+            num_val=config.gepa.num_val,
+            max_concurrent=config.gepa.max_concurrent,
+            sampling_args=config.sampling.model_dump(exclude_none=True),
+            seed=config.gepa.seed,
+            run_dir=run_dir,
+            save_results=config.save_results,
+            tui_mode=config.tui,
+        )
+        return
+
+    client_config = config.client.model_copy(
+        update={
+            "api_key_var": resolved.client_config.api_key_var,
+            "base_url": resolved.client_config.api_base_url,
+            "headers": resolved.client_config.extra_headers,
+        }
+    )
+    run_gepa_v1_optimization(
+        config=config,
+        model=resolved.model,
+        reflection_model=resolved.reflection_model,
+        client_config=client_config,
+        reflection_client_config=resolved.reflection_client_config,
+        run_dir=run_dir,
+    )
+
+
+def main(argv: list[str] | None = None) -> None:
+    argv = _rewrite_positional_target(
+        list(sys.argv[1:]) if argv is None else list(argv)
+    )
+    if not argv or any(arg in ("-h", "--help") for arg in argv):
+        print(USAGE)
+        config_cls = (
+            narrow_config(GEPAV1Config, argv) if _uses_v1_config(argv) else GEPAConfig
+        )
+        cli(config_cls, args=argv or ["--help"])
+        return
+
+    if _uses_v1_config(argv):
+        config = cast(GEPAV1Config, cli(narrow_config(GEPAV1Config, argv), args=argv))
+        setup_logging("DEBUG" if config.verbose else os.getenv("VF_LOG_LEVEL", "INFO"))
+        resolved = _resolve_gepa_clients(
+            config,
+            default_api_key_var=config.client.api_key_var,
+            default_api_base_url=config.client.base_url,
+            default_extra_headers=config.client.headers,
+        )
+        _run_v1_or_legacy_gepa(config, resolved)
+        return
+
+    config = cast(GEPAConfig, cli(GEPAConfig, args=argv))
+    setup_logging("DEBUG" if config.verbose else os.getenv("VF_LOG_LEVEL", "INFO"))
+    env_configs = config.environments
+    env_id = config.environment_label
+
+    resolved = _resolve_gepa_clients(
+        config,
+        default_api_key_var=DEFAULT_API_KEY_VAR,
+        default_api_base_url=DEFAULT_API_BASE_URL,
+    )
+
+    run_dir = config.run_dir
+    if run_dir is None and config.save_results:
+        run_dir = get_gepa_results_path(
+            env_id, resolved.model, str(config.env_dir_path)
+        )
+
+    run_gepa_optimization(
+        env_id=env_id,
+        env_configs=env_configs,
+        model=resolved.model,
+        reflection_model=resolved.reflection_model,
+        client_config=resolved.client_config,
+        reflection_client_config=resolved.reflection_client_config,
         max_metric_calls=config.gepa.max_calls,
         minibatch_size=config.gepa.minibatch_size,
         perfect_score=config.gepa.perfect_score,
@@ -394,7 +555,7 @@ def run_gepa_optimization(
         display.num_val = len(valset)
 
         # Set up client
-        client = resolve_client(client_config)
+        client = resolve_v0_client(client_config)
 
         logger.debug(f"Results will be saved to: {run_dir}")
 


### PR DESCRIPTION
## Summary

Adds native GEPA support for v1 taskset/harness environments while preserving the existing v0 GEPA path.

## What changed

- Adds `GEPAV1Config`, reusing the v1 `EnvConfig` shape so GEPA configs can use `[taskset]`, `[harness]`, v1 client, timeout, token limit, and sampling fields.
- Adds a v1 GEPA adapter that evaluates candidate system prompts through the native v1 `Environment.episode(...)` rollout path.
- Adds a v1 GEPA runner that keeps v1 serving resources open across the optimization loop.
- Updates GEPA CLI dispatch so native v1 tasksets route to the v1 runner and v1-shaped configs that resolve to legacy envs fall back to the existing v0 GEPA runner.
- Adds tests covering v1 config parsing, CLI routing, legacy fallback, deterministic task selection, and candidate system prompt injection.
- Documents the v1 GEPA taskset/harness config shape.

## Why

GEPA previously loaded environments only through the legacy `vf.load_environment(...)` path and evaluated with the v0 `env.generate(...)` API, so native v1 tasksets could not be optimized directly.

## Validation

- `uv run ruff format --check`
- `uv run ruff check --fix`
- `uv run ty check verifiers/scripts/gepa.py`
- `uv run pytest tests/test_gepa_v1.py tests/test_gepa_cli.py`
- pre-commit and pre-push hooks passed with `UV_FROZEN=1` to avoid `uv.lock` churn from local exclude-newer resolution.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add GEPA v1 support with pydantic-config CLI and native v1 taskset execution
> - Introduces `GEPAV1Config` and `VerifiersV1GEPAAdapter` in [verifiers/gepa/](https://github.com/PrimeIntellect-ai/verifiers/pull/1929/files#diff-b806fcdec1bb7366bc402134a74c9d7e6604dfdab962c37a58c712ea3b0ac4e7) to run GEPA optimization against native v1 tasksets, alongside the existing legacy v0 path.
> - Rewrites [verifiers/scripts/gepa.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1929/files#diff-c832830df3f042f3bfc052be3c349c10c90d74be62ff7623d43f8ad3385dcf36) from argparse to pydantic-config CLI; accepts a bare positional env/taskset id or `@ file.toml`, auto-detects v1 vs legacy, and dispatches to `run_gepa_v1_optimization` or `run_gepa_optimization` accordingly.
> - Adds `EnvId` type in [verifiers/v1/types.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1929/files#diff-88a4e4ee0c58ac5dc7344161a011374082a3767eda2ad32af97c942dca982112) that rejects hub-style `org/name@version` ids; all v1 config `id` fields now enforce local-only identifiers.
> - Auto-routes v0 legacy environments when a legacy `env_id` is passed via `--taskset.id` or a v1 TOML, setting `EnvConfig.id` and bypassing taskset resolution in [verifiers/v1/env.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1929/files#diff-69be10bd5960e88d88f219d4f261d0bdd16586857f9126451b04d05bac4c2cbb).
> - Removes hub installation logic from [verifiers/v1/loaders.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1929/files#diff-92ba7115e533e43b64d42954e0df924532585d2ebdabaa5fa6bd59bb34510087) and [verifiers/v1/legacy.py](https://github.com/PrimeIntellect-ai/verifiers/pull/1929/files#diff-96c5091f7d2968ddfbe984f433163f21cab745ea95174158e924984d55abbfed); plugins must now be locally importable.
> - Renames CLI entrypoints from `vf-eval`/`vf-init` etc. to `eval`/`init`/`validate`/`serve` in [pyproject.toml](https://github.com/PrimeIntellect-ai/verifiers/pull/1929/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711).
> - Risk: `vf-eval`, `vf-init`, and other `vf-*` commands are removed; any scripts or docs referencing them will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 1474a21. 60 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->