### PR TITLE
Forward provider feature headers for all dialects

### DIFF
--- a/verifiers/v1/clients/eval.py
+++ b/verifiers/v1/clients/eval.py
@@ -19,7 +19,7 @@ import httpx
 from pydantic_core import from_json, to_json
 
 from verifiers.v1.clients.client import SESSION_ID_HEADER, Client, RelayReply
-from verifiers.v1.dialects import ChatDialect, Dialect
+from verifiers.v1.dialects import Dialect
 from verifiers.v1.errors import model_error
 from verifiers.v1.graph import PendingTurn
 from verifiers.v1.types import Response, SamplingConfig
@@ -108,11 +108,11 @@ class EvalClient(Client):
     ) -> httpx.Headers:
         """Build provider headers from the intercepted request.
 
-        Preserve provider feature headers such as `openai-beta`, discard localhost auth and
-        transport framing, then apply endpoint-configured headers, session routing, and real
-        provider auth.
+        Preserve provider feature headers such as `openai-beta` / `anthropic-beta`,
+        discard localhost auth and transport framing, then apply endpoint-configured headers,
+        session routing, and real provider auth.
         """
-        headers = httpx.Headers(incoming if isinstance(dialect, ChatDialect) else None)
+        headers = httpx.Headers(incoming)
         connection = headers.pop("connection", "")
         for name in _BLOCKED_REQUEST_HEADERS | set(
             map(str.strip, connection.lower().split(","))


### PR DESCRIPTION
## Overview

Updates the eval relay so eligible provider feature headers are preserved consistently across wire dialects.

## Details

The relay already removes localhost auth, body-framing, and connection headers before applying endpoint headers and provider authentication. This change removes the chat-only gate when seeding incoming headers, so Anthropic and other non-chat dialects can receive provider feature headers through the same filtering path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single conditional removal in header forwarding with unchanged auth and blocklist behavior; no security or data-model changes.
> 
> **Overview**
> The eval relay’s `_headers` path no longer drops intercepted request headers for non-chat dialects.
> 
> **Before**, incoming headers were only copied when the dialect was `ChatDialect`, so Anthropic and other wire formats never received forwarded provider feature headers (e.g. `anthropic-beta`). **Now** all dialects start from the intercepted headers, then the same blocked-header filter, endpoint overrides, session routing, and `dialect.auth_headers` apply as before.
> 
> The docstring now calls out `anthropic-beta` alongside `openai-beta`. The unused `ChatDialect` import is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82657f7cfd0a6e82ac8fbdeea5bb9b1fb2f6fce8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Forward provider feature headers for all dialects in `EvalClient`
> Previously, `EvalClient._headers` only forwarded incoming request headers (e.g. `openai-beta`, `anthropic-beta`) when the dialect was a `ChatDialect` instance. The `isinstance` check is removed so all dialects now preserve and forward these headers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 82657f7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->