### PR TITLE
fix: default v1 judge model to openai/gpt-5.4-nano

### DIFF
--- a/verifiers/v1/judge.py
+++ b/verifiers/v1/judge.py
@@ -80,7 +80,7 @@ class JudgeConfig(BaseClientConfig):
     defaults to the id's package name. Set it to disambiguate two plugged judges sharing an id."""
     weight: float = 1.0
     """How a plugged judge's verdict weighs into `trace.reward` (like `@vf.reward(weight=...)`)."""
-    model: str = "deepseek/deepseek-v4-flash"
+    model: str = "openai/gpt-5.4-nano"
     sampling: JudgeSamplingConfig = JudgeSamplingConfig()
     prompt: str | None = None
     """Prompt-template override for `build_messages` (None = the judge class's own `prompt`),


### PR DESCRIPTION
## Summary

- Change the default v1 `JudgeConfig.model` from `deepseek/deepseek-v4-flash` to `openai/gpt-5.4-nano`.
- This is the single default inherited by every v1 judge — the config-plugged `ReferenceJudge`/`RubricJudge` and any code-level `vf.Judge` that doesn't set its own model.
- Motivation: `deepseek/deepseek-v4-flash` was flaky in prior environment tests; `openai/gpt-5.4-nano` is a more reliable default grader. Both route through the same Prime Inference endpoint (`PRIME_API_KEY`), so no key/provider change is required.

## Breaking

- Evals that relied on the default judge model now grade with `openai/gpt-5.4-nano` instead of `deepseek/deepseek-v4-flash`. Migration: pin the old model explicitly if needed, e.g. `--taskset.judges.0.model deepseek/deepseek-v4-flash` (or `model` on a code-level `JudgeConfig`).

## Verification

- `uv run pytest tests/v1/test_judges.py` → 28 passed. Judge model calls are faked in these tests, so the change is behaviorally covered without live calls.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default grading behavior for all evals that do not pin a judge model, which can shift scores and costs even though auth/provider setup is unchanged.
> 
> **Overview**
> Updates the default **`JudgeConfig.model`** in `verifiers/v1/judge.py` from `deepseek/deepseek-v4-flash` to **`openai/gpt-5.4-nano`**.
> 
> That default applies to every v1 judge that does not set `model` explicitly—config-plugged judges (`ReferenceJudge`, `RubricJudge`, etc.) and code-level `vf.Judge` instances. Evals that depended on the old default will now grade with the new model unless they pin `model` (e.g. `--taskset.judges.0.model` or `JudgeConfig.model`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 531bf18f6f5400bc74ab46615330e1ebf53e34bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Change default `JudgeConfig.model` to `openai/gpt-5.4-nano`
> Updates the default model in [`JudgeConfig`](https://github.com/PrimeIntellect-ai/verifiers/pull/1931/files#diff-0e1e3671e09d4b88a199baa90ea1f6044c2ecaefa8c4a7f6b1b75eac606aca56) from `deepseek/deepseek-v4-flash` to `openai/gpt-5.4-nano`. Any judge instantiated without an explicit model will now call the OpenAI endpoint instead of DeepSeek.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 531bf18.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->